### PR TITLE
ci(docs): add paths filter so docs workflow only fires on docs-relevant changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,20 @@ name: Docs
 on:
   push:
     branches: [main, master]
+    paths:
+      - 'book/**'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches: [main, master]
+    paths:
+      - 'book/**'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: docs-${{ github.ref }}


### PR DESCRIPTION
## Summary

`.github/workflows/docs.yml` currently triggers on every push and every PR regardless of file scope, so e.g. PR #10 (site-only) still ran a full ~3-minute mdBook + rustdoc build with no purpose. This PR adds matching \`paths:\` filters on both \`push\` and \`pull_request\` triggers so docs only rebuilds when docs-relevant files change:

- \`book/**\` — mdBook source
- \`crates/**\` — rustdoc reads doc comments throughout the crate tree
- \`Cargo.toml\`, \`Cargo.lock\` — workspace metadata + dep pins
- \`.github/workflows/docs.yml\` — the workflow itself

## Why this is safe

- The \`build\` job still runs on every PR that touches docs files — pre-merge validation preserved.
- The \`deploy\` job's existing job-level \`if: github.event_name == 'push' && ...\` gate is unchanged. Skipping noise reduction in PR check lists is the side benefit, not the goal.
- \`site.yml\` already follows this pattern (\`paths: site/**\` + workflow file). This brings docs.yml in line so the two workflows have symmetric trigger semantics.

## Test plan

- [x] YAML syntactically valid (visual review).
- [ ] CI on this PR: docs.yml DOES fire (because the PR touches \`.github/workflows/docs.yml\` itself, which is in the new \`paths:\` list — so the filter doesn't accidentally make the workflow stop validating itself). Expectation: CI / Site green; Docs build green; Docs deploy "skipping".
- [ ] After merge: a follow-up PR that only touches \`README.md\` or \`site/\` should NOT trigger Docs.