### PR TITLE
sec(codeowners): lock .github/ to maintainers + clarify precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,17 @@
 # Atlas CODEOWNERS
 #
-# Lines starting with `#` are comments. The first matching pattern wins.
-# Replace the placeholder usernames below with real GitHub handles before
-# enabling required-reviewer enforcement on the repo.
+# Lines starting with `#` are comments. The LAST matching pattern wins
+# (per GitHub's CODEOWNERS spec — be careful adding broader patterns
+# at the bottom of this file, they will override more specific ones
+# above).
+#
+# SECURITY: every path under .github/ — workflows, dependabot config,
+# CODEOWNERS itself, issue/PR templates — is owner-only and must stay
+# that way. A malicious workflow change can exfiltrate secrets through
+# `pull_request_target` (it runs from the PR branch with secrets
+# access), so do NOT add patterns below the `.github/` block that
+# loosen ownership of anything inside that tree. Branch-protection on
+# `main` enforces this by requiring CODEOWNER review on every PR.
 #
 # Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
@@ -24,8 +33,15 @@ crates/spark-comm/                           @tbraun96 @azeezish
 # Storage / NVMe-backed swap.
 crates/spark-storage/                        @tbraun96 @azeezish
 
-# Build, CI, governance.
+# Build, CI, governance. Belt-and-suspenders: the broad `.github/`
+# pattern catches everything in the tree, and the more specific entries
+# below are restated explicitly so a future contributor adding a more
+# specific override (e.g. `.github/workflows/scratch.yml @someone-else`)
+# notices they're working against an explicit ownership decision.
 .github/                                     @tbraun96 @azeezish
+.github/workflows/                           @tbraun96 @azeezish
+.github/CODEOWNERS                           @tbraun96 @azeezish
+.github/dependabot.yml                       @tbraun96 @azeezish
 docs/adr/                                    @tbraun96 @azeezish
 Cargo.toml                                   @tbraun96 @azeezish
 LICENSE                                      @tbraun96 @azeezish


### PR DESCRIPTION
## Summary
- Fix wrong "first matching pattern wins" comment — GitHub's spec is **last matching wins**.
- Add a SECURITY section explaining `pull_request_target` exfiltration risk.
- Belt-and-suspenders: explicit entries for `.github/workflows/`, `.github/CODEOWNERS`, `.github/dependabot.yml` so a future override (e.g. `.github/workflows/scratch.yml @other-user`) is visibly working against a deliberate decision.

## Action item for maintainers
CODEOWNERS only blocks merges when branch protection on `main` has **Require review from Code Owners** enabled. That is a paid feature on private repos (current branch-protection API returns 403). Flip it on once the repo is public:

> Settings → Branches → Branch protection rule for `main` → Require a pull request before merging → Require review from Code Owners ✅

## Test plan
- [ ] Repo is public
- [ ] Branch protection requires review from Code Owners
- [ ] Test PR from a non-owner that touches `.github/workflows/ci.yml` is blocked from merging until @tbraun96 or @azeezish reviews