### PR TITLE
chore: AzeezIsh CLA signature added

### DIFF
--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -7,6 +7,14 @@
       "created_at": "2026-05-06T14:06:10Z",
       "repoId": 1230084743,
       "pullRequestNo": 8
+    },
+    {
+      "name": "AzeezIsh",
+      "id": 95100110,
+      "comment_id": 4392492035,
+      "created_at": "2026-05-06T21:56:52Z",
+      "repoId": 1230084743,
+      "pullRequestNo": 13
     }
   ]
 }


### PR DESCRIPTION
Records AzeezIsh's CLA signature manually.

AzeezIsh signed via the standard magic-comment workflow on PR #13 (comment_id 4392492035, 2026-05-06T21:56:52Z), but the CLA Assistant action could not persist the signature to \`signatures/version1/cla.json\` because the default \`GITHUB_TOKEN\` cannot push directly to the branch-protected \`main\` (rule \`GH013\` — every change must go through a PR).

This PR opens that PR on the bot's behalf so PR #13 can pass its CLA check and merge.

References:
- AzeezIsh signing comment: https://github.com/Avarok-Cybersecurity/atlas/pull/13#issuecomment-4392492035
- Failing CLA Assistant run: https://github.com/Avarok-Cybersecurity/atlas/actions/runs/25463737007/job/74712413718