### PR TITLE
Fix #15: auto-chunk prefill so SSM snapshots land at reusable boundaries

### DIFF
--- a/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
@@ -33,6 +33,40 @@ pub(crate) fn resolve_prefill_budget(
     } else {
         args.max_seq_len
     };
+    // Issue #15: when prefix caching + SSM snapshots are both enabled, the
+    // SSM snapshot taken at finalize_last (token_count = full prompt length)
+    // is unreachable from future requests because the radix-tree match for
+    // a different prompt length will be < tokens.len(). Intermediate
+    // checkpoints are saved by `prefill_b_save_checkpoint` only at chunk
+    // ends whose end_block is a multiple of `ssm_checkpoint_interval`, so a
+    // single-chunk prefill produces zero reachable snapshots. Auto-clamp
+    // the prefill budget to a checkpoint-aligned size so chunked prefill
+    // actually fires and downstream agentic conversations get cache hits.
+    let prefill_budget_pre_hss = if !user_set_prefill
+        && args.enable_prefix_caching
+        && args.ssm_checkpoint_interval > 0
+        && args.ssm_cache_slots > 0
+    {
+        let target = args.ssm_checkpoint_interval * args.block_size;
+        if prefill_budget_pre_hss > target && target > 0 {
+            tracing::info!(
+                "--enable-prefix-caching with --ssm-checkpoint-interval={} \
+                 and --block-size={}: auto-clamping max_prefill_tokens \
+                 from {} to {} so chunked prefill fires at SSM-checkpoint \
+                 boundaries (issue #15). Override with --max-prefill-tokens \
+                 to keep the larger value.",
+                args.ssm_checkpoint_interval,
+                args.block_size,
+                prefill_budget_pre_hss,
+                target,
+            );
+            target
+        } else {
+            prefill_budget_pre_hss
+        }
+    } else {
+        prefill_budget_pre_hss
+    };
     let prefill_budget = if args.high_speed_swap {
         let hss_cap_tokens = args.high_speed_swap_cache_blocks_per_seq as usize * args.block_size;
         let hss_chunk_max = hss_cap_tokens.saturating_sub(args.max_batch_size);

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -52,6 +52,23 @@ pub(crate) fn preflight_reserve(
     } else {
         args.max_seq_len
     };
+    // Mirror of the auto-clamp in resolve_prefill_budget (kv_cache.rs).
+    // See issue #15: when prefix caching + SSM snapshots are both on,
+    // single-chunk prefill produces no reachable intermediate snapshots.
+    let prefill_budget_pre = if !user_set_prefill_pre
+        && args.enable_prefix_caching
+        && args.ssm_checkpoint_interval > 0
+        && args.ssm_cache_slots > 0
+    {
+        let target = args.ssm_checkpoint_interval * args.block_size;
+        if prefill_budget_pre > target && target > 0 {
+            target
+        } else {
+            prefill_budget_pre
+        }
+    } else {
+        prefill_budget_pre
+    };
     let max_batch_tokens_pre = prefill_budget_pre
         .max(spec_tokens_pre)
         .max(args.max_batch_size);


### PR DESCRIPTION
## Summary

Fixes #15 — KV cache "always recomputing" on Qwen3.6-35B-A3B-FP8 with `--enable-prefix-caching`.

**Root cause:** the SSM snapshot saved by `prefill_b_finalize_last` is keyed at `token_count = tokens.len()` (full prompt length). The radix-tree match for any future request with a *different* prompt length is bounded by the last block-aligned position ≤ the previous prompt length, so the snapshot lookup's `entry.token_count > matched_tokens` filter rejects it. Intermediate snapshots are only saved per non-last chunk by `prefill_b_save_checkpoint`. With the default `--max-prefill-tokens=8192` and a typical 7–8K agentic prompt, prefill is single-chunk → zero intermediate snapshots → every multi-turn request logs `"Prefix cache hit: N tokens but no SSM snapshot — recomputing all KV"`. Exactly the reporter's symptom.

**Fix:** when `--enable-prefix-caching` and `--ssm-checkpoint-interval > 0` and `--ssm-cache-slots > 0` are all on (all default), auto-clamp `max_prefill_tokens` to `ssm_checkpoint_interval * block_size` (default 4096) unless the user explicitly overrode it. This forces chunked prefill at SSM-checkpoint boundaries, so intermediate snapshots accumulate at radix-aligned positions and second-turn KV reuse just works. Mirrored in `preflight.rs` so the buffer-arena estimate matches.

## Test plan

- [ ] CI green (clippy / fmt / cargo test).
- [ ] In Docker on a single Spark, run `serve Qwen/Qwen3.6-35B-A3B-FP8 ... --enable-prefix-caching --speculative` and issue two near-identical chat completions back to back. Expected: second request logs `Prefix cache hit: N tokens (M blocks)` followed by **no** "no SSM snapshot — recomputing all KV", and TTFT drops to a fraction of the first.
- [ ] Log line at start should include `Prefill config: ... prefill_budget=4096` and an `info!` explaining the auto-clamp.
- [ ] Single-chunk benchmarks unaffected: pass `--max-prefill-tokens 16384` or `--enable-prefix-caching false` and the clamp is bypassed.

## Workaround for users on the current image

`--max-prefill-tokens=4096` (per Azeez's reply on the issue) — same effect as this auto-clamp.