### PR TITLE
Fix MCP tool-call "Unknown tool" on separator/case drift

### DIFF
--- a/crates/spark-server/src/tool_parser.rs
+++ b/crates/spark-server/src/tool_parser.rs
@@ -342,6 +342,7 @@ impl ToolCallFormat {
 
 // ── Sub-modules (split from monolithic file) ──
 mod bare_json;
+mod fuzzy_match;
 mod gemma4;
 mod helpers_a;
 mod helpers_b;
@@ -357,7 +358,6 @@ mod pipeline_helpers;
 mod qwen3_coder;
 mod streaming;
 mod streaming_impl;
-mod fuzzy_match;
 mod validation;
 
 pub use bare_json::*;

--- a/crates/spark-server/src/tool_parser.rs
+++ b/crates/spark-server/src/tool_parser.rs
@@ -357,6 +357,7 @@ mod pipeline_helpers;
 mod qwen3_coder;
 mod streaming;
 mod streaming_impl;
+mod fuzzy_match;
 mod validation;
 
 pub use bare_json::*;

--- a/crates/spark-server/src/tool_parser/fuzzy_match.rs
+++ b/crates/spark-server/src/tool_parser/fuzzy_match.rs
@@ -23,10 +23,7 @@ use super::ToolDefinition;
 /// 3. Single-tool fallback — model clearly intended *something*.
 ///
 /// Only returns a match if exactly one tool matches (ambiguous = reject).
-pub(super) fn fuzzy_match_tool_name(
-    model_name: &str,
-    tools: &[ToolDefinition],
-) -> Option<String> {
+pub(super) fn fuzzy_match_tool_name(model_name: &str, tools: &[ToolDefinition]) -> Option<String> {
     if tools.is_empty() || model_name.is_empty() {
         return None;
     }

--- a/crates/spark-server/src/tool_parser/fuzzy_match.rs
+++ b/crates/spark-server/src/tool_parser/fuzzy_match.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Fuzzy tool-name repair for the validation pipeline.
+//!
+//! When a quantized / MTP-driven model emits a tool name that doesn't
+//! match any registered tool exactly, the validator falls back to fuzzy
+//! matching here. The strategies are deliberately ordered cheap → loose
+//! and each strategy only returns a hit if exactly one tool matches —
+//! ambiguous matches drop through so the final caller emits a clean
+//! `Unknown tool` error rather than silently coercing.
+
+use super::ToolDefinition;
+
+/// Fuzzy match a hallucinated tool name to the closest available tool.
+///
+/// Strategies (in priority order):
+/// 0. Separator-normalized exact match — handles MCP names where the
+///    quantized model dropped or duplicated an underscore (e.g.
+///    `mcp_discord__discord_send` → `mcp__discord__discord_send`) and
+///    case / dash↔underscore drift.
+/// 1. Substring containment — model name is substring of a tool name.
+/// 2. Available tool name is substring of the model's name.
+/// 3. Single-tool fallback — model clearly intended *something*.
+///
+/// Only returns a match if exactly one tool matches (ambiguous = reject).
+pub(super) fn fuzzy_match_tool_name(
+    model_name: &str,
+    tools: &[ToolDefinition],
+) -> Option<String> {
+    if tools.is_empty() || model_name.is_empty() {
+        return None;
+    }
+
+    let lower = model_name.to_lowercase();
+
+    // Strategy 0: separator-normalized exact match. MCP tool names commonly
+    // contain double-underscores (e.g. `mcp__discord__discord_send`); MTP /
+    // FP8 quantized models occasionally drop or duplicate one of those
+    // underscores, producing `mcp_discord__discord_send` or
+    // `mcp__discord_discord_send`. The substring strategies below miss
+    // those because the missing/extra underscore makes neither side a
+    // strict substring of the other. Collapsing runs of `_` and `-` and
+    // lowercasing both sides recovers the intended match while still
+    // requiring every other character to line up exactly. Discord report
+    // `_trithemius` (2026-05-08): Qwen3.6-35B-A3B-FP8 + MCP — "Unknown
+    // tool XXX" where XXX is in the registered list.
+    let norm_model = normalize_tool_name(model_name);
+    if !norm_model.is_empty() {
+        let exact_norm: Vec<&str> = tools
+            .iter()
+            .filter(|t| normalize_tool_name(&t.function.name) == norm_model)
+            .map(|t| t.function.name.as_str())
+            .collect();
+        if exact_norm.len() == 1 {
+            return Some(exact_norm[0].to_string());
+        }
+    }
+
+    // Strategy 1: exact substring — model name is substring of a tool name
+    let matches: Vec<&str> = tools
+        .iter()
+        .filter(|t| t.function.name.to_lowercase().contains(&lower))
+        .map(|t| t.function.name.as_str())
+        .collect();
+    if matches.len() == 1 {
+        return Some(matches[0].to_string());
+    }
+
+    // Strategy 2: tool name is substring of model's name
+    let matches: Vec<&str> = tools
+        .iter()
+        .filter(|t| lower.contains(&t.function.name.to_lowercase()))
+        .map(|t| t.function.name.as_str())
+        .collect();
+    if matches.len() == 1 {
+        return Some(matches[0].to_string());
+    }
+
+    // Strategy 3: if only one tool available, use it (model clearly intended to call a tool)
+    if tools.len() == 1 {
+        return Some(tools[0].function.name.clone());
+    }
+
+    None
+}
+
+/// Lowercase and collapse runs of `_` / `-` to a single `_`, trimming
+/// leading and trailing underscores. Used by fuzzy tool-name repair to
+/// match across separator-count drift introduced by MTP / quantization
+/// errors (e.g. `mcp_discord__discord_send` → `mcp__discord__discord_send`).
+fn normalize_tool_name(s: &str) -> String {
+    let lower = s.trim().to_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut prev_sep = false;
+    for c in lower.chars() {
+        if c == '_' || c == '-' {
+            if !prev_sep {
+                out.push('_');
+            }
+            prev_sep = true;
+        } else {
+            out.push(c);
+            prev_sep = false;
+        }
+    }
+    out.trim_matches('_').to_string()
+}

--- a/crates/spark-server/src/tool_parser/tests/group_c.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_c.rs
@@ -370,3 +370,89 @@ fn leak_markers_minimax_has_invoke_open() {
     assert!(m.close.contains(&"</minimax:tool_call>"));
     assert!(m.close.contains(&"</tool_call>"));
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// MCP separator-drift fuzzy match (Discord report 2026-05-08, _trithemius)
+//
+// Qwen3.6-35B-A3B-FP8 + MCP: "Unknown tool XXX" where XXX is registered.
+// Root cause: MTP / FP8 quantization occasionally drops or duplicates an
+// underscore in MCP-style names (`mcp__discord__...`). Strict equality
+// then misses, the substring fuzzy strategies miss because neither side
+// is a clean substring of the other once the separator count drifts.
+// `validate_tool_calls` should repair these via the normalize-separators
+// strategy before failing.
+// ────────────────────────────────────────────────────────────────────────
+
+fn _mcp_tool(name: &str) -> ToolDefinition {
+    ToolDefinition {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: name.to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({})),
+        },
+    }
+}
+
+fn _mcp_call(name: &str) -> ToolCall {
+    ToolCall {
+        id: "call_test".to_string(),
+        call_type: "function".to_string(),
+        function: FunctionCall {
+            name: name.to_string(),
+            arguments: "{}".to_string(),
+        },
+    }
+}
+
+#[test]
+fn fuzzy_repair_mcp_double_underscore_dropped() {
+    let tools = vec![_mcp_tool("mcp__discord__discord_send")];
+    let calls = vec![_mcp_call("mcp_discord__discord_send")];
+    let v = validate_tool_calls(calls, &tools);
+    assert!(v.errors.is_empty(), "errors: {:?}", v.errors);
+    assert_eq!(v.valid.len(), 1);
+    assert_eq!(v.valid[0].function.name, "mcp__discord__discord_send");
+}
+
+#[test]
+fn fuzzy_repair_mcp_double_underscore_added() {
+    let tools = vec![_mcp_tool("mcp_discord_send")];
+    let calls = vec![_mcp_call("mcp__discord__send")];
+    let v = validate_tool_calls(calls, &tools);
+    assert!(v.errors.is_empty(), "errors: {:?}", v.errors);
+    assert_eq!(v.valid.len(), 1);
+    assert_eq!(v.valid[0].function.name, "mcp_discord_send");
+}
+
+#[test]
+fn fuzzy_repair_dash_vs_underscore() {
+    let tools = vec![_mcp_tool("read-file")];
+    let calls = vec![_mcp_call("read_file")];
+    let v = validate_tool_calls(calls, &tools);
+    assert!(v.errors.is_empty(), "errors: {:?}", v.errors);
+    assert_eq!(v.valid.len(), 1);
+    assert_eq!(v.valid[0].function.name, "read-file");
+}
+
+#[test]
+fn fuzzy_repair_case_insensitive() {
+    let tools = vec![_mcp_tool("get_weather")];
+    let calls = vec![_mcp_call("Get_Weather")];
+    let v = validate_tool_calls(calls, &tools);
+    assert!(v.errors.is_empty(), "errors: {:?}", v.errors);
+    assert_eq!(v.valid.len(), 1);
+    assert_eq!(v.valid[0].function.name, "get_weather");
+}
+
+#[test]
+fn fuzzy_repair_no_false_positive_on_distinct_names() {
+    let tools = vec![_mcp_tool("get_weather"), _mcp_tool("get_news")];
+    let calls = vec![_mcp_call("get_unknown")];
+    let v = validate_tool_calls(calls, &tools);
+    // Neither tool is a separator-normalized exact match for "get_unknown".
+    // Substring strategies also reject. Should error cleanly.
+    assert_eq!(v.valid.len(), 0);
+    assert_eq!(v.errors.len(), 1);
+    assert!(v.errors[0].contains("Unknown tool"));
+}

--- a/crates/spark-server/src/tool_parser/validation.rs
+++ b/crates/spark-server/src/tool_parser/validation.rs
@@ -331,6 +331,29 @@ fn fuzzy_match_tool_name(model_name: &str, tools: &[ToolDefinition]) -> Option<S
 
     let lower = model_name.to_lowercase();
 
+    // Strategy 0: separator-normalized exact match. MCP tool names commonly
+    // contain double-underscores (e.g. `mcp__discord__discord_send`); MTP /
+    // FP8 quantized models occasionally drop or duplicate one of those
+    // underscores, producing `mcp_discord__discord_send` or
+    // `mcp__discord_discord_send`. The substring strategies below miss
+    // those because the missing/extra underscore makes neither side a
+    // strict substring of the other. Collapsing runs of `_` and `-` and
+    // lowercasing both sides recovers the intended match while still
+    // requiring every other character to line up exactly. Discord report
+    // `_trithemius` (2026-05-08): Qwen3.6-35B-A3B-FP8 + MCP — "Unknown
+    // tool XXX" where XXX is in the registered list.
+    let norm_model = normalize_tool_name(model_name);
+    if !norm_model.is_empty() {
+        let exact_norm: Vec<&str> = tools
+            .iter()
+            .filter(|t| normalize_tool_name(&t.function.name) == norm_model)
+            .map(|t| t.function.name.as_str())
+            .collect();
+        if exact_norm.len() == 1 {
+            return Some(exact_norm[0].to_string());
+        }
+    }
+
     // Strategy 1: exact substring — model name is substring of a tool name
     let matches: Vec<&str> = tools
         .iter()
@@ -357,6 +380,28 @@ fn fuzzy_match_tool_name(model_name: &str, tools: &[ToolDefinition]) -> Option<S
     }
 
     None
+}
+
+/// Lowercase and collapse runs of `_` / `-` to a single `_`, trimming
+/// leading and trailing underscores. Used by fuzzy tool-name repair to
+/// match across separator-count drift introduced by MTP / quantization
+/// errors (e.g. `mcp_discord__discord_send` → `mcp__discord__discord_send`).
+fn normalize_tool_name(s: &str) -> String {
+    let lower = s.trim().to_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut prev_sep = false;
+    for c in lower.chars() {
+        if c == '_' || c == '-' {
+            if !prev_sep {
+                out.push('_');
+            }
+            prev_sep = true;
+        } else {
+            out.push(c);
+            prev_sep = false;
+        }
+    }
+    out.trim_matches('_').to_string()
 }
 
 /// Validate a single tool call. Returns `Ok(())` if valid,

--- a/crates/spark-server/src/tool_parser/validation.rs
+++ b/crates/spark-server/src/tool_parser/validation.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports, dead_code)]
 
 use super::*;
+use super::fuzzy_match::fuzzy_match_tool_name;
 
 /// Fix tool call arguments: schema-aware type coercion + backfill missing params.
 ///
@@ -314,94 +315,6 @@ pub fn validate_tool_calls(
     }
 
     ValidatedToolCalls { valid, errors }
-}
-
-/// Fuzzy match a hallucinated tool name to the closest available tool.
-///
-/// Strategies (in priority order):
-/// 1. Substring containment: "weather" matches "get_weather"
-/// 2. Available tool name contains the model's name: "get_weather" contains "weather"
-/// 3. Model's name contains available tool: "weather_report" contains "weather"
-///
-/// Only returns a match if exactly one tool matches (ambiguous = reject).
-fn fuzzy_match_tool_name(model_name: &str, tools: &[ToolDefinition]) -> Option<String> {
-    if tools.is_empty() || model_name.is_empty() {
-        return None;
-    }
-
-    let lower = model_name.to_lowercase();
-
-    // Strategy 0: separator-normalized exact match. MCP tool names commonly
-    // contain double-underscores (e.g. `mcp__discord__discord_send`); MTP /
-    // FP8 quantized models occasionally drop or duplicate one of those
-    // underscores, producing `mcp_discord__discord_send` or
-    // `mcp__discord_discord_send`. The substring strategies below miss
-    // those because the missing/extra underscore makes neither side a
-    // strict substring of the other. Collapsing runs of `_` and `-` and
-    // lowercasing both sides recovers the intended match while still
-    // requiring every other character to line up exactly. Discord report
-    // `_trithemius` (2026-05-08): Qwen3.6-35B-A3B-FP8 + MCP — "Unknown
-    // tool XXX" where XXX is in the registered list.
-    let norm_model = normalize_tool_name(model_name);
-    if !norm_model.is_empty() {
-        let exact_norm: Vec<&str> = tools
-            .iter()
-            .filter(|t| normalize_tool_name(&t.function.name) == norm_model)
-            .map(|t| t.function.name.as_str())
-            .collect();
-        if exact_norm.len() == 1 {
-            return Some(exact_norm[0].to_string());
-        }
-    }
-
-    // Strategy 1: exact substring — model name is substring of a tool name
-    let matches: Vec<&str> = tools
-        .iter()
-        .filter(|t| t.function.name.to_lowercase().contains(&lower))
-        .map(|t| t.function.name.as_str())
-        .collect();
-    if matches.len() == 1 {
-        return Some(matches[0].to_string());
-    }
-
-    // Strategy 2: tool name is substring of model's name
-    let matches: Vec<&str> = tools
-        .iter()
-        .filter(|t| lower.contains(&t.function.name.to_lowercase()))
-        .map(|t| t.function.name.as_str())
-        .collect();
-    if matches.len() == 1 {
-        return Some(matches[0].to_string());
-    }
-
-    // Strategy 3: if only one tool available, use it (model clearly intended to call a tool)
-    if tools.len() == 1 {
-        return Some(tools[0].function.name.clone());
-    }
-
-    None
-}
-
-/// Lowercase and collapse runs of `_` / `-` to a single `_`, trimming
-/// leading and trailing underscores. Used by fuzzy tool-name repair to
-/// match across separator-count drift introduced by MTP / quantization
-/// errors (e.g. `mcp_discord__discord_send` → `mcp__discord__discord_send`).
-fn normalize_tool_name(s: &str) -> String {
-    let lower = s.trim().to_lowercase();
-    let mut out = String::with_capacity(lower.len());
-    let mut prev_sep = false;
-    for c in lower.chars() {
-        if c == '_' || c == '-' {
-            if !prev_sep {
-                out.push('_');
-            }
-            prev_sep = true;
-        } else {
-            out.push(c);
-            prev_sep = false;
-        }
-    }
-    out.trim_matches('_').to_string()
 }
 
 /// Validate a single tool call. Returns `Ok(())` if valid,

--- a/crates/spark-server/src/tool_parser/validation.rs
+++ b/crates/spark-server/src/tool_parser/validation.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 #![allow(unused_imports, dead_code)]
 
-use super::*;
 use super::fuzzy_match::fuzzy_match_tool_name;
+use super::*;
 
 /// Fix tool call arguments: schema-aware type coercion + backfill missing params.
 ///


### PR DESCRIPTION
## Summary

Fixes the Discord report from `_trithemius` (2026-05-08) and NVIDIA forum post #5: on Qwen3.6-35B-A3B-FP8 with an MCP agent, after 1–2 successful tool calls subsequent calls fail with:

> `spark::api::chat_stream::tool_handlers: tool call validation error: Error: Unknown tool XXX`

— and XXX is in fact in the listed registered tools.

**Root cause.** MTP/FP8 quantized models occasionally drop or duplicate one of the underscores in MCP-style names (`mcp__discord__discord_send` → `mcp_discord__discord_send` or `mcp__discord_discord_send`). `validate_single_tool_call` does strict equality, so it misses. The existing fuzzy substring strategies don't help: once the separator count drifts, neither side is a clean substring of the other.

**Fix.** Add a separator-normalized exact-match strategy at the front of `fuzzy_match_tool_name`: lowercase, collapse runs of `_`/`-` to a single `_`, trim, then require an exact equality match against exactly one tool. Still requires every other character to align, so distinct names don't get silently coerced. Ambiguous normalizations fall through to the existing substring strategies and ultimately to a clean `Unknown tool` error.

Also covers:
- case-insensitivity (`Get_Weather` ↔ `get_weather`)
- dash ↔ underscore drift (`read-file` ↔ `read_file`)

## Test plan

- [x] Five new unit tests in `tool_parser/tests/group_c.rs` cover dropped underscore, added underscore, dash↔underscore, case-insensitivity, and the no-false-positive case for distinct names.
- [ ] CI green.
- [ ] Live Docker re-test by `_trithemius` once an alpha lands with this PR — multi-turn MCP session should stop emitting `Unknown tool` for separator/case drift.