### PR TITLE
grammar/compile_tools: demote qwen_xml_parameter fallback to INFO + name the tools

### DIFF
--- a/crates/spark-server/src/grammar/compile_tools.rs
+++ b/crates/spark-server/src/grammar/compile_tools.rs
@@ -249,10 +249,8 @@ impl GrammarEngine {
                 // narrow down which schema triggered xgrammar's EBNF parser
                 // (Discord 2026-05-07 a1vadfs report on
                 // mmangkad/Qwen3.6-27B-NVFP4: "EBNF parser error at line N").
-                let tool_names: Vec<&str> = sanitized_tools
-                    .iter()
-                    .map(|st| st.name.as_str())
-                    .collect();
+                let tool_names: Vec<&str> =
+                    sanitized_tools.iter().map(|st| st.name.as_str()).collect();
                 tracing::info!(
                     "qwen_xml_parameter grammar fell back to json_schema ({e:?}). \
                      Functional but slightly looser tool-call grammar. Tools in \

--- a/crates/spark-server/src/grammar/compile_tools.rs
+++ b/crates/spark-server/src/grammar/compile_tools.rs
@@ -240,9 +240,26 @@ impl GrammarEngine {
         ) {
             Ok(compiled) => Ok(compiled),
             Err(e) => {
-                // Fall back to json_schema content type if qwen_xml_parameter not supported.
-                tracing::warn!(
-                    "qwen_xml_parameter grammar failed ({e:?}), retrying with json_schema"
+                // Fall back to json_schema content type if qwen_xml_parameter
+                // EBNF generation hits an edge case for one of these tool
+                // schemas. The fallback path is fully functional — accuracy
+                // is comparable, just the grammar is JSON-shaped instead of
+                // XML-parameter-shaped under the hood. Emit at INFO with the
+                // tool list so a follow-up bug report has the context to
+                // narrow down which schema triggered xgrammar's EBNF parser
+                // (Discord 2026-05-07 a1vadfs report on
+                // mmangkad/Qwen3.6-27B-NVFP4: "EBNF parser error at line N").
+                let tool_names: Vec<&str> = sanitized_tools
+                    .iter()
+                    .map(|st| st.name.as_str())
+                    .collect();
+                tracing::info!(
+                    "qwen_xml_parameter grammar fell back to json_schema ({e:?}). \
+                     Functional but slightly looser tool-call grammar. Tools in \
+                     this batch: [{}]. If you want to help narrow this down, \
+                     set RUST_LOG=trace and re-run — the rejected schema is \
+                     emitted at trace level by xgrammar.",
+                    tool_names.join(", "),
                 );
                 let tag_entries_fallback: Vec<serde_json::Value> = sanitized_tools
                     .iter()


### PR DESCRIPTION
## Summary

Discord 2026-05-07: `@a1vadfs_49901` reported a noisy WARN on `mmangkad/Qwen3.6-27B-NVFP4`:

```
WARN spark::grammar::compile_tools: qwen_xml_parameter grammar failed
(Compilation("EBNF parser error at line 16, column 1: Expect element, but got \n")),
retrying with json_schema
```

The fallback to `json_schema` content type already runs and produces a fully functional constrained-decoding grammar. The WARN made the fallback look like a hard failure.

This PR:
1. Demotes the log to `INFO` since the fallback is the recovery path, not an error.
2. Includes the tool-name batch in the message, so subsequent reproductions can identify which specific tool schema the xgrammar EBNF generator choked on.
3. Adds a `RUST_LOG=trace` hint so users helping us narrow down the root cause have a path to forward.

The underlying xgrammar EBNF-generation bug is upstream (in the `qwen_xml_parameter` content-type emitter for `QwenXMLToolCallingToEBNF`) and out of scope here. Functional behavior is unchanged.

## Test plan
- [ ] CI green.
- [ ] Live: serve the affected model and confirm the log appears at INFO with the tool list, not WARN.