### PR TITLE
serve_router: hint about --bind 0.0.0.0 when listener is on loopback

### DIFF
--- a/crates/spark-server/src/main_modules/serve_router.rs
+++ b/crates/spark-server/src/main_modules/serve_router.rs
@@ -140,6 +140,16 @@ pub(crate) async fn build_and_serve(
              --bind 127.0.0.1 (or set --require-auth and a real firewall) before \
              accepting traffic."
         );
+    } else if bind == "127.0.0.1" || bind == "localhost" || bind == "::1" {
+        // m00ch13 (Discord 2026-05-07): combined `--network host` with `-p 8000`
+        // expecting LAN reachability and got refused from another machine. The
+        // default loopback bind is correct for security, but the failure mode
+        // ("connection refused from $LAN_IP") is opaque without this hint.
+        tracing::info!(
+            "API reachable only from this machine (loopback). To expose on the \
+             LAN pass --bind 0.0.0.0; combine with --require-auth and \
+             --auth-tokens-file for non-trusted networks."
+        );
     }
     tracing::info!("Listening on {addr}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;


### PR DESCRIPTION
## Summary

Tiny UX fix triggered by m00ch13's Discord report (2026-05-07). When the listener defaults to `127.0.0.1` and a user expects LAN reachability (e.g. they're running with Docker `--network host` and a `-p 8000` flag), the failure mode is an opaque "connection refused from \$LAN_IP". Adds an `info!` line right after `Listening on ...` that names `--bind 0.0.0.0` and the recommended auth-token plumbing for non-trusted networks. Existing `0.0.0.0` WARN is unchanged.

## Test plan
- [ ] CI green.
- [ ] Live: `serve <model>` (default `--bind`) and confirm the new INFO line appears once after the existing `Listening on 127.0.0.1:8888`.
- [ ] Live: `serve <model> --bind 0.0.0.0` and confirm the existing WARN appears (no regression).