### PR TITLE
Issue #31: actionable diagnostics for HSS + long-prefill incompatibility

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/decode/high_speed_swap.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/decode/high_speed_swap.rs
@@ -106,12 +106,47 @@ impl Qwen3AttentionLayer {
         let start = last.min(total - 1);
         for logical_pos in start..total {
             if logical_pos < window_start {
+                // Issue #31: the slide-before-alloc loop in
+                // `block_mgmt::ensure_blocks_through_prefill` advanced the
+                // sliding window past `logical_pos` before this layer got
+                // a chance to offload. The invariant declared at line 122-127
+                // of `block_mgmt.rs` (every attention layer must catch up
+                // its offloads before any slide) is debug-asserted only —
+                // release builds silently let the slide proceed, then this
+                // check trips at the next offload pass.
+                //
+                // Practical fix until Phase 6.2.b lands chunked-prefill
+                // reads through the HSS orchestrator: ensure
+                // `--high-speed-swap-cache-blocks-per-seq × --block-size`
+                // is large enough that the per-chunk prefill never grows
+                // `disk_block_ids` past `block_table.len()` faster than the
+                // per-layer offload can keep up. Drop --high-speed-swap if
+                // KV fits HBM at this batch size.
                 anyhow::bail!(
                     "high-speed-swap: layer {} block {} was evicted before this layer offloaded \
-                     it. This indicates an out-of-order layer execution bug — every layer must \
-                     offload its K/V before sliding-window eviction runs.",
+                     it (issue #31). \n\
+                     Diagnostic state: attn_layer_idx={}, logical_pos={}, \
+                     window_start={}, total=disk_block_ids.len()={}, \
+                     block_table.len()={}, this_layer.last_offloaded={}, \
+                     all_layer_cursors={:?}.\n\
+                     This means the sliding-window eviction loop advanced past disk slot \
+                     {} before attention layer {} could push its K/V there. The slide-before-alloc \
+                     invariant in block_mgmt.rs (every attention layer must offload before any \
+                     slide) is debug-asserted only — release builds skip it.\n\
+                     Workaround: raise --high-speed-swap-cache-blocks-per-seq so \
+                     `cap × block_size` ≥ your largest prompt, OR drop --high-speed-swap \
+                     entirely if KV fits HBM at this batch/quant.",
                     self.attn_layer_idx,
-                    logical_pos
+                    logical_pos,
+                    self.attn_layer_idx,
+                    logical_pos,
+                    window_start,
+                    total,
+                    block_table.len(),
+                    last,
+                    disk_last_offloaded_per_layer,
+                    logical_pos,
+                    self.attn_layer_idx,
                 );
             }
             let bt_idx = logical_pos - window_start;

--- a/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
@@ -83,6 +83,37 @@ pub(crate) fn resolve_prefill_budget(
                 args.max_batch_size,
             );
         }
+        // Issue #31: prefill of prompts > hss_cap_tokens triggers the
+        // slide-before-alloc loop in block_mgmt::ensure_blocks_through_prefill,
+        // which advances `disk_block_ids.len()` past `block_table.len()` BEFORE
+        // any attention layer has offloaded its K/V to disk. The first attn
+        // layer's offload then bails (see high_speed_swap.rs:107). The chunked
+        // prefill reads through the HSS orchestrator (Phase 6.2.b) are not
+        // implemented yet, so the only correct combination today is:
+        //   * either `cap × block_size ≥ max_seq_len` (HSS as scratch only,
+        //     never actually slides during prefill), or
+        //   * a checkpoint that fits long generation in decode (HSS engages
+        //     only after generation crosses the window, where decode CAN
+        //     route through the orchestrator).
+        // Warn loud and clear when these constraints aren't met.
+        if args.max_seq_len > hss_cap_tokens {
+            tracing::warn!(
+                "--high-speed-swap is engaged but --max-seq-len ({} tokens) > \
+                 cap × block_size ({} blocks × {} = {} tokens). Prompts longer \
+                 than {} tokens will fail mid-prefill with \
+                 'high-speed-swap: layer N block M was evicted before this \
+                 layer offloaded it' (issue #31). Either raise \
+                 --high-speed-swap-cache-blocks-per-seq to >= {} (so \
+                 cap × bs >= max_seq_len) or drop --high-speed-swap if KV \
+                 fits HBM at your batch size and quantization.",
+                args.max_seq_len,
+                args.high_speed_swap_cache_blocks_per_seq,
+                args.block_size,
+                hss_cap_tokens,
+                hss_cap_tokens,
+                args.max_seq_len.div_ceil(args.block_size),
+            );
+        }
         clamped
     } else {
         prefill_budget_pre_hss


### PR DESCRIPTION
## Summary

Targets #31 (gbanyan): with `--high-speed-swap` engaged and a prompt longer than `cap × block_size` tokens, prefill fails with the cryptic `"high-speed-swap: layer N block M was evicted before this layer offloaded it"`. Static traces of the code path show the slide-before-alloc invariant in `block_mgmt::ensure_blocks_through_prefill` is `debug_assert!`-only — release builds silently let slides advance `disk_block_ids.len()` past `block_table.len()` before any attention layer offloads, and the first attn layer's offload pass then trips. The architectural fix is Phase 6.2.b (chunked-prefill reads through the HSS orchestrator), which `prefill_inner.rs:138-145` explicitly defers ("the user must size cache_blocks_per_seq to fit the prefill").

I'm not landing a runtime fix here because:
- The exact failure ordering needs hardware reproduction to verify.
- The wrong fix risks regressing #17 (HSS+prefix-cache, which I just landed in PR #20).

This PR ships the strict UX improvement so the next user hitting this gets actionable guidance instead of a cryptic abort.

## What landed

1. **Startup WARN** in `serve_phases/kv_cache.rs::resolve_prefill_budget`: when HSS is engaged and `max_seq_len > cap × block_size`, emit a clear warning naming the issue, the incompatibility, and two concrete fixes (raise `--high-speed-swap-cache-blocks-per-seq` to `ceil(max_seq_len / block_size)` or drop `--high-speed-swap`).
2. **Diagnostic runtime error** in `qwen3_attention/decode/high_speed_swap.rs::offload_layer_kv`: bail now includes per-layer offload cursors, `block_table.len()`, `disk_block_ids.len()`, `window_start`, `last_offloaded`, and the attn_layer_idx mapping. Inline workaround guidance.

## Test plan
- [ ] CI green.
- [ ] Live: serve any model with `--high-speed-swap --max-seq-len 65536 --high-speed-swap-cache-blocks-per-seq 64` (default cap = 64 = 1024 tokens). Confirm the new WARN fires at startup naming issue #31 and the suggested cap.
- [ ] Live: trigger the original bail (long prompt with HSS); confirm the new error includes all the cursor state.

## Follow-up

Phase 6.2.b: chunked-prefill must call into the HSS orchestrator to load older blocks back from disk during attention forward — at which point sliding-window prefill becomes feasible. Out of scope here; this PR just makes the symptom legible until then.