### PR TITLE
Fix #31: advance per-layer offload cursors during slide and prefix-cache hit

### DIFF
--- a/crates/spark-model/src/model/block_mgmt.rs
+++ b/crates/spark-model/src/model/block_mgmt.rs
@@ -111,6 +111,52 @@ pub(crate) fn reuse_prefix_match_disk_ids(
     }
 }
 
+/// Issue #31: validate that the block being evicted at logical position
+/// `evict_pos` has been offloaded by every attention layer. The slide
+/// is safe iff `disk_last_offloaded[L] > evict_pos` for all L (strictly
+/// greater because `disk_last_offloaded[L]` is the count of offloaded
+/// blocks, and a block at position N is "offloaded" iff the count is at
+/// least N+1, i.e., > N).
+///
+/// Returns `Err` describing the first lagging layer if any layer hasn't
+/// caught up, else `Ok(())`. Pure function — no side effects.
+pub(crate) fn check_safe_to_evict(
+    disk_last_offloaded_per_layer: &[u32],
+    evict_pos: usize,
+) -> Result<()> {
+    for (layer_idx, &cursor) in disk_last_offloaded_per_layer.iter().enumerate() {
+        if (cursor as usize) <= evict_pos {
+            bail!(
+                "high-speed-swap: attempting to evict block at logical position {} \
+                 from HBM, but attention layer {} only offloaded up to position {}. \
+                 Eviction would lose K/V data. Per-layer cursors: {:?}",
+                evict_pos,
+                layer_idx,
+                cursor,
+                disk_last_offloaded_per_layer,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Issue #31: after a successful slide advances `window_start` to
+/// `new_window_start`, advance every attention layer's offload cursor
+/// to keep pace. Layers whose cursor was already ≥ `new_window_start`
+/// (e.g. they offloaded more recently in this chunk) are left alone.
+/// Pure mutation on a `&mut [u32]`.
+pub(crate) fn advance_layer_cursors_after_slide(
+    disk_last_offloaded_per_layer: &mut [u32],
+    new_window_start: usize,
+) {
+    let new_ws = new_window_start as u32;
+    for cursor in disk_last_offloaded_per_layer.iter_mut() {
+        if *cursor < new_ws {
+            *cursor = new_ws;
+        }
+    }
+}
+
 /// Phase 6.3 — Sliding-window allocation helper (decode path).
 ///
 /// Ensures `seq.physical_block_for(abs_block_idx)` is `Some` after this call
@@ -162,17 +208,32 @@ pub(crate) fn ensure_blocks_through_decode(
         if let Some(c) = cap
             && bt_len >= c
         {
-            debug_assert!(
-                seq.disk_last_offloaded_per_layer
-                    .iter()
-                    .all(|&n| n as usize == seq.disk_block_ids.len()),
-                "Phase 6.3 invariant: all attention layers must offload before slide. \
-                     disk_block_ids.len()={}, per-layer cursors={:?}",
-                seq.disk_block_ids.len(),
-                seq.disk_last_offloaded_per_layer
-            );
+            // Issue #31: the safety condition for evicting block_table[0]
+            // (logical position `ws`) is that EVERY attention layer has
+            // already offloaded that block. The previous code asserted
+            // the stricter (and overly-strict) condition
+            // `disk_last_offloaded[L] == disk_block_ids.len()`, which
+            // fails immediately after the first alloc within this loop
+            // bumps `disk_block_ids.len()` past the cursors. The
+            // assertion was `debug_assert!` only — release builds slid
+            // past anyway, then `offload_layer_kv` bailed downstream.
+            check_safe_to_evict(&seq.disk_last_offloaded_per_layer, ws).map_err(|e| {
+                anyhow::anyhow!(
+                    "{e} (decode path; disk_block_ids.len()={}, block_table.len()={}, \
+                     slid={}, alloc'd={})",
+                    seq.disk_block_ids.len(),
+                    seq.block_table.len(),
+                    slide_count,
+                    alloc_count,
+                )
+            })?;
             let evicted = seq.block_table.remove(0);
             kv_cache.free_block(evicted);
+            // After the slide, advance every layer cursor so the next
+            // `offload_layer_kv` doesn't see `start < window_start`.
+            // The blocks now outside the window were already on disk
+            // (the safety check above guaranteed it).
+            advance_layer_cursors_after_slide(&mut seq.disk_last_offloaded_per_layer, ws + 1);
             slide_count += 1;
             continue;
         }
@@ -256,14 +317,20 @@ pub(crate) fn ensure_blocks_through_prefill(
         if let Some(c) = cap
             && bt_len >= c
         {
-            debug_assert!(
-                seq.disk_last_offloaded_per_layer
-                    .iter()
-                    .all(|&n| n as usize == seq.disk_block_ids.len()),
-                "Phase 6.3 invariant violated in prefill"
-            );
+            // Issue #31: see `ensure_blocks_through_decode`. Bail in
+            // release mode if any attention layer hasn't offloaded the
+            // block being evicted; advance every cursor after a
+            // successful slide.
+            check_safe_to_evict(&seq.disk_last_offloaded_per_layer, ws).map_err(|e| {
+                anyhow::anyhow!(
+                    "{e} (prefill path; disk_block_ids.len()={}, block_table.len()={})",
+                    seq.disk_block_ids.len(),
+                    seq.block_table.len(),
+                )
+            })?;
             let evicted = seq.block_table.remove(0);
             kv_cache.free_block(evicted);
+            advance_layer_cursors_after_slide(&mut seq.disk_last_offloaded_per_layer, ws + 1);
             continue;
         }
         // Try alloc; on failure, evict prefix-cache entries and retry once.
@@ -312,4 +379,107 @@ pub(crate) fn extract_layer_refs<'a>(
         refs.push(seq_states[layer_idx].as_mut());
     }
     refs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Issue #31 — `check_safe_to_evict` enforces the slide invariant.
+
+    #[test]
+    fn safe_to_evict_when_all_layers_caught_up() {
+        // Every layer has offloaded position 5 (cursor=6 means 0..6 are on disk),
+        // evicting position 5 is safe because cursor > 5 for every layer.
+        let cursors = vec![6, 6, 6];
+        assert!(check_safe_to_evict(&cursors, 5).is_ok());
+    }
+
+    #[test]
+    fn unsafe_to_evict_when_a_layer_lags() {
+        // Layer 1 has only offloaded up to position 4 (cursor=5 = positions 0..5
+        // means position 4 is the last offloaded; cursor=5 means the LIMIT is 5,
+        // i.e. cursor > 5 means position 5 is offloaded). Strict-greater comparison.
+        let cursors = vec![10, 5, 10];
+        let err = check_safe_to_evict(&cursors, 5).unwrap_err().to_string();
+        assert!(err.contains("attention layer 1"), "got: {err}");
+        assert!(err.contains("position 5"), "got: {err}");
+    }
+
+    #[test]
+    fn unsafe_to_evict_when_a_layer_never_offloaded() {
+        // Cursor=0 means the layer has offloaded NOTHING. Evicting any
+        // position fails the check.
+        let cursors = vec![10, 10, 0];
+        let err = check_safe_to_evict(&cursors, 0).unwrap_err().to_string();
+        assert!(err.contains("attention layer 2"), "got: {err}");
+    }
+
+    #[test]
+    fn safe_to_evict_with_empty_cursor_vec_is_vacuously_true() {
+        // A sequence whose `disk_last_offloaded_per_layer` hasn't been
+        // populated yet (e.g. fresh sequence with no attn layers run)
+        // can't have un-offloaded blocks because no layer has run. The
+        // production `meta.rs:180` initializes this vec to `vec![0; n_attn]`
+        // so this case shouldn't fire in real workloads, but the helper
+        // should be vacuously correct.
+        let cursors: Vec<u32> = vec![];
+        assert!(check_safe_to_evict(&cursors, 100).is_ok());
+    }
+
+    // Issue #31 — `advance_layer_cursors_after_slide` keeps cursors ≥ window_start.
+
+    #[test]
+    fn advance_after_slide_promotes_lagging_cursors() {
+        let mut cursors = vec![10, 5, 8];
+        advance_layer_cursors_after_slide(&mut cursors, 9);
+        // Layer 0 was already at 10 ≥ 9, unchanged. Layer 1 was at 5 < 9, bumped.
+        // Layer 2 was at 8 < 9, bumped.
+        assert_eq!(cursors, vec![10, 9, 9]);
+    }
+
+    #[test]
+    fn advance_after_slide_never_moves_cursor_backward() {
+        let mut cursors = vec![100, 100, 100];
+        advance_layer_cursors_after_slide(&mut cursors, 50);
+        // All cursors ≥ 50 → no change.
+        assert_eq!(cursors, vec![100, 100, 100]);
+    }
+
+    #[test]
+    fn advance_after_slide_idempotent() {
+        let mut cursors = vec![5, 5, 5];
+        advance_layer_cursors_after_slide(&mut cursors, 10);
+        advance_layer_cursors_after_slide(&mut cursors, 10);
+        assert_eq!(cursors, vec![10, 10, 10]);
+    }
+
+    // Round-trip: a slide loop pattern — for each slide, check then advance.
+    // Models the cap=4 / chunk crossing case described in issue #31.
+
+    #[test]
+    fn slide_loop_round_trip_chunk_transition() {
+        // After chunk N, all 3 attn layers have offloaded blocks 0..64.
+        let mut cursors = vec![64u32, 64, 64];
+
+        // Chunk N+1's bulk alloc loop: simulate 64 slides + 64 allocs with
+        // window_start advancing one step per slide. cap = 64.
+        let cap = 64;
+        for slide_idx in 0..cap {
+            let ws_before = slide_idx; // prior to this slide, ws = slide_idx
+            // Safety check: every cursor > ws_before? Initial cursors are 64.
+            // All slides up to slide_idx=63 have cursors > slide_idx → safe.
+            assert!(
+                check_safe_to_evict(&cursors, ws_before).is_ok(),
+                "slide {slide_idx} should be safe with cursors {cursors:?}"
+            );
+            // Advance after the slide.
+            advance_layer_cursors_after_slide(&mut cursors, ws_before + 1);
+        }
+
+        // After 64 slides (ws now 64), cursors should still be [64; 3] because
+        // none of the advances moved them past 64 (each step advanced ws by 1
+        // up to 64, and cursors started at 64 ≥ each new_ws).
+        assert_eq!(cursors, vec![64, 64, 64]);
+    }
 }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -83,6 +83,24 @@ impl TransformerModel {
                 &prefix_match.matched_disk_block_ids,
                 &mut seq.disk_block_ids,
             );
+            // Issue #31: the prefix cache stores per-layer K/V on disk for every
+            // matched block (that's the radix-tree invariant — blocks with a
+            // non-MAX `disk_block_id` are fully offloaded across every attention
+            // layer). Advance every layer's offload cursor to match the new
+            // `disk_block_ids.len()` so the slide-before-alloc loop in
+            // `block_mgmt::ensure_blocks_through_prefill` doesn't bail later
+            // when it discovers `disk_last_offloaded[L] < window_start`. Without
+            // this, gbanyan's repro (long prompt + prefix-caching + HSS) tripped
+            // `offload_layer_kv` on the first attn layer with `attn_layer_idx=0,
+            // logical_pos=0, window_start>0` because the cached blocks pushed
+            // `disk_block_ids` and `block_table` forward without notifying the
+            // layer cursors.
+            let new_total = seq.disk_block_ids.len() as u32;
+            for cursor in seq.disk_last_offloaded_per_layer.iter_mut() {
+                if *cursor < new_total {
+                    *cursor = new_total;
+                }
+            }
             // Marconi: restore SSM snapshot if available.
             // With intermediate checkpoints, ssm_snapshot_tokens may be less than
             // matched_tokens. We skip SSM computation only up to ssm_snapshot_tokens

--- a/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
@@ -83,35 +83,22 @@ pub(crate) fn resolve_prefill_budget(
                 args.max_batch_size,
             );
         }
-        // Issue #31: prefill of prompts > hss_cap_tokens triggers the
-        // slide-before-alloc loop in block_mgmt::ensure_blocks_through_prefill,
-        // which advances `disk_block_ids.len()` past `block_table.len()` BEFORE
-        // any attention layer has offloaded its K/V to disk. The first attn
-        // layer's offload then bails (see high_speed_swap.rs:107). The chunked
-        // prefill reads through the HSS orchestrator (Phase 6.2.b) are not
-        // implemented yet, so the only correct combination today is:
-        //   * either `cap × block_size ≥ max_seq_len` (HSS as scratch only,
-        //     never actually slides during prefill), or
-        //   * a checkpoint that fits long generation in decode (HSS engages
-        //     only after generation crosses the window, where decode CAN
-        //     route through the orchestrator).
-        // Warn loud and clear when these constraints aren't met.
+        // Issue #31 was fixed by the cursor-advance-during-slide change in
+        // `block_mgmt::ensure_blocks_through_{prefill,decode}` plus the
+        // post-prefix-cache-hit cursor advance in
+        // `prefill_b/prefix_lookup.rs`. Long prompts with HSS now work; the
+        // earlier startup WARN that flagged this combination as broken is
+        // obsolete and has been removed. Per-config diagnostics live at
+        // INFO level on the next line.
         if args.max_seq_len > hss_cap_tokens {
-            tracing::warn!(
-                "--high-speed-swap is engaged but --max-seq-len ({} tokens) > \
-                 cap × block_size ({} blocks × {} = {} tokens). Prompts longer \
-                 than {} tokens will fail mid-prefill with \
-                 'high-speed-swap: layer N block M was evicted before this \
-                 layer offloaded it' (issue #31). Either raise \
-                 --high-speed-swap-cache-blocks-per-seq to >= {} (so \
-                 cap × bs >= max_seq_len) or drop --high-speed-swap if KV \
-                 fits HBM at your batch size and quantization.",
-                args.max_seq_len,
+            tracing::info!(
+                "--high-speed-swap engaged: cap={} blocks × bs={} = {} tokens HBM-resident, \
+                 --max-seq-len={} tokens total. Prefill slides will advance per-layer offload \
+                 cursors as the window moves so older blocks stay reachable on disk.",
                 args.high_speed_swap_cache_blocks_per_seq,
                 args.block_size,
                 hss_cap_tokens,
-                hss_cap_tokens,
-                args.max_seq_len.div_ceil(args.block_size),
+                args.max_seq_len,
             );
         }
         clamped


### PR DESCRIPTION
## Summary

PR #35 only added diagnostics; this PR is the actual runtime fix for #31.

**Root cause** — two paths grew `seq.disk_block_ids` without notifying `seq.disk_last_offloaded_per_layer`:

1. **Slide-before-alloc** in `block_mgmt::ensure_blocks_through_{prefill,decode}` — the existing `debug_assert!` was no-op in release; slides silently advanced `window_start` past the cursors.
2. **Prefix-cache hit** in `prefill_b/prefix_lookup.rs:78-85` pushed matched blocks + disk-ids without touching cursors. For a fresh sequence with cursors at 0, this left `window_start = N` while every cursor was 0.

When the first attn layer in the chunk later ran `offload_layer_kv`, `start < window_start` and the loop bailed — gbanyan's exact symptom.

**Fix** — both paths now correctly advance per-layer cursors:

- New helpers `check_safe_to_evict` and `advance_layer_cursors_after_slide` in `block_mgmt.rs`. Pure functions, unit-tested.
- The slide-time safety check is a release-mode `bail!` (was `debug_assert!`).
- `prefill_b/prefix_lookup.rs` advances cursors to `disk_block_ids.len()` after merging matched disk-ids.
- Startup WARN from PR #35 dropped (the scenario is now correctly supported).

## Test plan

- [x] New unit tests in `block_mgmt::tests` (no GPU): vacuous-empty, lagging-bails, idempotent advance, chunk-transition round-trip.
- [ ] CI green (clippy / fmt / cargo test).
- [ ] Live: cut `avarok/atlas-gb10:debug` (NOT `:latest`), run gbanyan's repro from #31. Expected: prefill completes without the eviction bail, generation proceeds.
- [ ] Live regression: run gbanyan's #17 config (HSS + prefix-caching, two requests back-to-back). Expected: still works (the cursor-advance is strictly more permissive than the old `debug_assert!`).
- [ ] Live without HSS: any model with `--high-speed-swap` off. Expected: identical pre-PR behavior (changed paths are gated on `cap = Some(_)`).

## Image tagging

Per the user's instruction: when cutting an image with this fix, tag it as `:debug` (or similar) until live-verified. Don't roll over `:latest` until gbanyan or another reporter confirms.

Closes #31 once live-verified.