### PR TITLE
Fix #31 (real): ensure_blocks_through_prefill must NEVER slide

### DIFF
--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -252,25 +252,35 @@ pub fn build_model(
     // blocks live on disk under the orchestrator's control.
     let num_kv_blocks = match hss_cache_blocks_per_seq {
         Some(cap) => {
-            // Phase 6.3: pool = max_batch × cap + 1 dummy + 1 spare per seq.
-            // Reasons:
-            //   * +1 dummy: the dummy_kv_block (allocated once at model init,
-            //     used for OOB-safe paged-kernel reads) permanently consumes
-            //     one slot.
-            //   * +1 spare per seq: the slide-then-alloc round-trip in
-            //     `ensure_blocks_through_decode` needs the just-freed block
-            //     back from the LIFO free list. With exactly cap blocks, the
-            //     last grow-to-cap step has zero free blocks, and the next
-            //     step's alloc fires before the slide can free one (the loop
-            //     orders slide-before-alloc, but alloc-without-slide hits the
-            //     final block first).
+            // Phase 6.3 (original): pool = max_batch × cap + 1 dummy + 1 spare per seq.
+            // Issue #31 (2026-05-08): the cap×bs sizing assumed prefill would
+            // fit in cap blocks AND the slide-during-prefill path would handle
+            // any overflow. Live-tested: slides during prefill produce silently
+            // wrong attention output (the orchestrator-fed disk-read path is
+            // wired up for DECODE attention only — Phase 6.2.a — not for
+            // prefill — Phase 6.2.b deferred). The companion change in
+            // `block_mgmt::ensure_blocks_through_prefill` removes the broken
+            // slide; this change resizes the pool so prefill can grow up to
+            // `max_seq_len` blocks without hitting "no free blocks". HBM-shrink
+            // remains in effect post-prefill: the FIRST decode step finds
+            // bt_len > cap and slides down via the orchestrator-aware path
+            // (which IS correct).
             //
-            // The +1-per-seq covers the gap between bt_len=cap-1 (last
-            // pre-slide alloc) and bt_len=cap (slide-then-alloc steady state).
-            let n = max_batch_size * (cap as usize + 1) + 1;
+            // Sizing rationale:
+            //   * Per-seq blocks: `max(cap + 1, ceil(max_seq_len / block_size))`
+            //     so prefill of any prompt up to max_seq_len fits in HBM.
+            //   * +1 dummy slot for OOB-safe paged-kernel reads.
+            //
+            // For multi-seq HSS where the user wanted strict HBM-shrink, this
+            // increases pool size by `(max_seq_len_blocks - cap) × max_batch`
+            // bytes per block. The existing post-load OOM check (line 304+)
+            // catches infeasible configs at startup with a clear message.
+            let max_seq_blocks = max_seq_len.div_ceil(kv_block_size);
+            let per_seq = (cap as usize + 1).max(max_seq_blocks);
+            let n = max_batch_size * per_seq + 1;
             tracing::info!(
-                "--high-speed-swap: HBM cache sized to {n} blocks ({} batch × ({cap}+1 spare) + 1 dummy); \
-                 older blocks stream from disk via the orchestrator",
+                "--high-speed-swap: HBM cache sized to {n} blocks ({} batch × max(cap={cap}+1, max_seq_len_blocks={max_seq_blocks}) + 1 dummy); \
+                 prefill grows monotonically, decode shrinks to cap × bs and streams older blocks from disk via the orchestrator",
                 max_batch_size
             );
             n

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_attn.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_attn.rs
@@ -55,6 +55,26 @@ impl Qwen3AttentionLayer {
         ctx: &ForwardContext,
         args: &mut PagedAttnArgs,
     ) -> Result<PagedAttnOutcome> {
+        // Issue #31 (2026-05-08): the HSS streaming prefill branch
+        // (`hss.attend_layer_on_stream_with_q_pos`) was an early attempt at
+        // Phase 6.2.b. It reads K/V from DISK for every prior position via
+        // `disk_block_ids[..n_blocks]`. But the CURRENT chunk's blocks
+        // haven't been offloaded yet at attention-compute time (offload
+        // runs after attention in `prefill_inner`), so the disk reads for
+        // those blocks return zeros/stale bytes → silently-wrong output
+        // (gbanyan's repro: prompt > cap×bs produces garbage even after
+        // the slide-during-prefill fix).
+        //
+        // With the companion change in `factory/build.rs` (HSS pool sized
+        // to `max(cap+1, max_seq_len_blocks)` per seq) plus the no-slide-
+        // during-prefill change in `block_mgmt`, every prior chunk's K/V
+        // remains HBM-resident through the entire prefill. Fall through
+        // to the normal paged-attention paths which read from
+        // `kv_cache.{k,v}_pool_ptr` (HBM) and produce correct output.
+        //
+        // The `high_speed_swap_offload_new_blocks` call still runs at the
+        // end of `prefill_inner` so blocks reach disk for the orchestrator-
+        // tiled DECODE attention (which IS correctly wired up).
         let PagedAttnArgs {
             q_contiguous,
             k_contiguous: _,
@@ -62,12 +82,12 @@ impl Qwen3AttentionLayer {
             attn_out,
             n,
             seq_len_start,
-            num_tokens,
+            num_tokens: _,
             nq,
             nkv,
             hd,
             bs,
-            bf16,
+            bf16: _,
             inv_sqrt_d,
             kv_len,
             meta,
@@ -76,68 +96,10 @@ impl Qwen3AttentionLayer {
             ref mut disk_last_offloaded_per_layer,
             stream,
         } = *args;
+        let _ = &disk_block_ids; // unused after issue #31 (HSS-streaming branch removed)
+        let _ = &disk_last_offloaded_per_layer;
 
         let bs_u = bs as u32;
-
-        if seq_len_start > 0 && self.high_speed_swap_engaged(kv_cache) {
-            self.high_speed_swap_offload_new_blocks(
-                kv_cache,
-                block_table,
-                disk_block_ids,
-                disk_last_offloaded_per_layer,
-                ctx,
-                stream,
-                nkv,
-                hd,
-                bs,
-            )?;
-            let is_turbo = matches!(
-                self.kv_dtype,
-                KvCacheDtype::Turbo3 | KvCacheDtype::Turbo4 | KvCacheDtype::Turbo8
-            );
-            let needs_wht =
-                is_turbo && self.wht_bf16_k.0 != 0 && (hd == 128 || hd == 256 || hd == 512);
-            if needs_wht {
-                use spark_runtime::kernel_args::KernelLaunch;
-                KernelLaunch::new(ctx.gpu, self.wht_bf16_k)
-                    .grid([nq * (num_tokens as u32), 1, 1])
-                    .block([32, 1, 1])
-                    .arg_ptr(q_contiguous)
-                    .arg_u32(hd)
-                    .launch(stream)?;
-            }
-            let nq_hd_bytes: u64 = (nq as u64) * (hd as u64) * (bf16 as u64);
-            let result = spark_storage::with_local(|hss| {
-                for q_idx in 0..num_tokens {
-                    let abs_pos = seq_len_start + q_idx;
-                    let n_blocks = (abs_pos / bs) + 1;
-                    let n_blocks = n_blocks.min(disk_block_ids.len());
-                    let q_offset = (q_idx as u64) * nq_hd_bytes;
-                    let out_offset = (q_idx as u64) * nq_hd_bytes;
-                    let last_block_valid_slots = ((abs_pos % bs) + 1) as i32;
-                    hss.attend_layer_on_stream_with_q_pos(
-                        stream,
-                        self.attn_layer_idx as u32,
-                        &disk_block_ids[..n_blocks],
-                        q_contiguous.0 + q_offset,
-                        attn_out.0 + out_offset,
-                        last_block_valid_slots,
-                    )?;
-                }
-                Ok(())
-            });
-            result.expect("HSS local installed but with_local returned None")?;
-            if needs_wht {
-                use spark_runtime::kernel_args::KernelLaunch;
-                KernelLaunch::new(ctx.gpu, self.wht_bf16_k)
-                    .grid([nq * (num_tokens as u32), 1, 1])
-                    .block([32, 1, 1])
-                    .arg_ptr(attn_out)
-                    .arg_u32(hd)
-                    .launch(stream)?;
-            }
-            return Ok(PagedAttnOutcome::EarlyReturn(attn_out));
-        }
 
         // HDIM=512 path: Gemma-4 long-attention layers.
         if hd > 256 && self.prefill_attn_512_k.0 != 0 && seq_len_start == 0 {

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_attn.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_attn.rs
@@ -15,6 +15,7 @@ use crate::layer::{AttnMetadataDev, ForwardContext};
 use crate::layers::ops;
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub(super) struct PagedAttnArgs<'a> {
     pub q_contiguous: DevicePtr,
     pub k_contiguous: DevicePtr,
@@ -41,6 +42,7 @@ pub(super) struct PagedAttnArgs<'a> {
 /// short-circuit (HSS streaming branch, which already produced the final
 /// output). `Continue` means the caller should run sections 9 + 10
 /// (sigmoid-gate × attn_out + O-projection).
+#[allow(dead_code)]
 pub(super) enum PagedAttnOutcome {
     EarlyReturn(DevicePtr),
     Continue,
@@ -91,7 +93,7 @@ impl Qwen3AttentionLayer {
             inv_sqrt_d,
             kv_len,
             meta,
-            block_table,
+            block_table: _,
             ref mut disk_block_ids,
             ref mut disk_last_offloaded_per_layer,
             stream,

--- a/crates/spark-model/src/model/block_mgmt.rs
+++ b/crates/spark-model/src/model/block_mgmt.rs
@@ -293,10 +293,25 @@ pub(crate) fn ensure_blocks_through_decode(
 /// Same as `ensure_blocks_through_decode` but with a prefix-cache eviction
 /// fallback: if `kv_cache.alloc_block()` would fail (no free physical
 /// blocks AND not at HSS cap), it asks the prefix cache to evict LRU
-/// entries before retrying. With HSS off, this matches the existing
-/// `try_alloc_block` → evict-prefix-cache → `alloc_block` pattern at
-/// every prefill site. With HSS on, the slide path takes priority over
-/// the prefix-cache evict (cap is the binding constraint).
+/// entries before retrying.
+///
+/// Issue #31 (2026-05-08): the previous version of this helper slid the
+/// HBM window forward when `block_table.len() >= cap` to make room for
+/// new prefill allocs. That was wrong — slid-out blocks have their K/V
+/// on disk via the per-layer offload, but the attention KERNEL during
+/// prefill reads K/V from `block_table[bt_idx]` only (HBM), and the
+/// orchestrator-fed disk-read path is wired up for DECODE attention
+/// only (Phase 6.2.a), not for prefill (Phase 6.2.b deferred). So a
+/// prefill that slid produced silently-wrong attention output for any
+/// position outside the post-slide window. The original author's design
+/// comment in `qwen3_attention/trait_impl/prefill_inner.rs:138-145`
+/// states the intended invariant: "Sliding-window eviction is NOT
+/// triggered here — prefill grows HBM monotonically; the cap kicks in
+/// during decode." This helper now enforces that invariant by never
+/// sliding during prefill. Cap-bound HBM is restored once the first
+/// `ensure_blocks_through_decode` call hits the `bt_len >= cap` branch
+/// (where attention reads through the orchestrator's tiled path, so
+/// slides are correctness-safe).
 pub(crate) fn ensure_blocks_through_prefill(
     seq: &mut SequenceState,
     abs_block_idx: usize,
@@ -313,26 +328,14 @@ pub(crate) fn ensure_blocks_through_prefill(
         if in_window {
             return Ok(());
         }
-        // Slide first when at HSS cap.
-        if let Some(c) = cap
-            && bt_len >= c
-        {
-            // Issue #31: see `ensure_blocks_through_decode`. Bail in
-            // release mode if any attention layer hasn't offloaded the
-            // block being evicted; advance every cursor after a
-            // successful slide.
-            check_safe_to_evict(&seq.disk_last_offloaded_per_layer, ws).map_err(|e| {
-                anyhow::anyhow!(
-                    "{e} (prefill path; disk_block_ids.len()={}, block_table.len()={})",
-                    seq.disk_block_ids.len(),
-                    seq.block_table.len(),
-                )
-            })?;
-            let evicted = seq.block_table.remove(0);
-            kv_cache.free_block(evicted);
-            advance_layer_cursors_after_slide(&mut seq.disk_last_offloaded_per_layer, ws + 1);
-            continue;
-        }
+        // Issue #31: NEVER slide during prefill. block_table grows
+        // monotonically until the chunk's full token range is in-window.
+        // HBM headroom is preserved by the existing prefix-cache eviction
+        // fallback below when `try_alloc_block` returns None. The cap
+        // (when HSS is engaged) is enforced lazily on the first decode
+        // step, where attention reads through the orchestrator's tiled
+        // path and slides are correctness-safe.
+
         // Try alloc; on failure, evict prefix-cache entries and retry once.
         let blk = match kv_cache.try_alloc_block() {
             Some(b) => b,


### PR DESCRIPTION
## Summary

PR #36 prevented the cryptic bail; live-test on hardware revealed the actual functional bug. Slides during prefill produce silently-wrong attention output because the orchestrator-fed disk-read path is wired up for decode only (Phase 6.2.a), not prefill (Phase 6.2.b deferred).

## Live test (on `:debug` from PR #36 source — same as current main):

| Prompt | Slides? | Output |
|---|---|---|
| 295 tok (fits cap) | no | `"The fox jumps."` ✓ |
| 2728 tok (> cap) | **yes** | `"fond my..."` ✗ |
| 2728 tok (HSS off) | n/a | `"The fox jumps in this passage."` ✓ |

## Root cause

Author's original design comment in `prefill_inner.rs:138-145`:

> "Sliding-window eviction is NOT triggered here — prefill grows HBM monotonically; the cap kicks in during decode."

The slide branch in `ensure_blocks_through_prefill` violated that invariant. Prefill attention reads K/V from `block_table[bt_idx]` (HBM) only — slid-out blocks become unreachable to the prefill kernel even though they're on disk.

## Fix

`ensure_blocks_through_prefill` now never slides. block_table grows monotonically. Cap-bound HBM is restored on the first `ensure_blocks_through_decode` call: it sees `bt_len > cap`, hits its slide branch, shrinks block_table via the safety check + cursor advance from PR #36. Each slide passes the safety check because at end of prefill all attn layers' cursors equal `disk_block_ids.len()`.

Decode attention reads through the orchestrator's tiled-attention path (Phase 6.2.a), so post-shrink decode correctness is preserved.

## Verification before merge (PER THE MEMORY RULE)

This PR will NOT be merged until I rebuild `:debug`, re-run gbanyan's repro on hardware, and paste a coherent-output log into this PR confirming the fix.