### PR TITLE
README: clarify --speculative trade-off + HSS option for 122B

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ sudo docker run -d --name atlas \
     --tool-call-parser qwen3_coder
 ```
 
+**Note:** `--speculative` (MTP) on single-Spark 122B costs ~1.5 GB for the draft head + draft KV and forces `--max-seq-len` down to ~4 K. Either run without `--speculative` at 16 K (the recipe above), or move to EP=2 across two Sparks ([`QUICKSTART.md`](QUICKSTART.md) §5) for both speculative decoding *and* a 16 K+ window.
+
+For longer contexts on a single Spark, add `--high-speed-swap --high-speed-swap-dir /path/on/nvme --high-speed-swap-cache-blocks-per-seq 64`. HSS keeps a rolling 1024-token KV window in HBM and streams older blocks to NVMe through an io_uring orchestrator — works with any `--max-seq-len` you can fit on disk. The Docker container needs `--security-opt seccomp=unconfined --ulimit memlock=-1` for io_uring access.
+
 That's it. Anything OpenAI-compatible — `curl`, the OpenAI SDK, Open WebUI, opencode — points at port 8888:
 
 ```bash


### PR DESCRIPTION
## Summary

Forum [#19](https://forums.developer.nvidia.com/t/atlas-open-source-inference-engine-for-dgx-spark-2minute-cold-start-100-tok-s-on-qwen3-6-35b-fp8-13-supported-models/369263/19) (whpthomas) hit \`--max-seq-len 4096\` as the largest config that would load on single-Spark 122B because their command added \`--speculative\` on top of the documented recipe. The MTP draft head + draft KV consume ~1.5 GB, which kills the 16K-context budget.

The README's 122B single-Spark recipe is correct as-is at 16K *without* \`--speculative\`, but the trade-off wasn't called out and HSS as a long-context fallback wasn't mentioned anywhere.

Two minimal additions to the existing 122B section:

1. **Note** on \`--speculative\`: drop it on single-Spark for 16K, or use EP=2 for both speculative + 16K+.
2. **Pointer** to \`--high-speed-swap\` for users who need longer than 16K on a single Spark.

## Test plan

- [x] Diff is README-only, +4 lines, +0 -0 elsewhere.
- [ ] Forum #19 reporter verifies the 16K recipe (without --speculative) works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)