### PR TITLE
grammar: short-circuit accept_token after matcher termination

### DIFF
--- a/crates/spark-server/src/grammar/state.rs
+++ b/crates/spark-server/src/grammar/state.rs
@@ -98,7 +98,20 @@ impl GrammarState {
     /// Returns `true` if the token was accepted by the grammar.
     /// Returns `false` if the token violates the grammar (should not happen
     /// if the bitmask was applied correctly).
+    ///
+    /// Short-circuits with `true` once the matcher has reached its
+    /// terminated (accepting) state — feeding tokens past the stop into
+    /// xgrammar emits a `grammar_matcher.cc:493` warning ("matcher has
+    /// terminated, but is trying to accept new token") for every trailing
+    /// token in spec-decode draft runs (Discord 2026-05-08 universe06608).
+    /// Returning `true` keeps the spec-decode boundary heuristic in
+    /// `truncate_drafts_at_grammar_boundary` consistent — drafts past a
+    /// completed grammar are not "rejected by grammar"; they are simply
+    /// past the stop, which the EOS handler will terminate independently.
     pub fn accept_token(&mut self, token_id: u32) -> bool {
+        if self.matcher.is_terminated() {
+            return true;
+        }
         self.matcher.accept_token(token_id as i32)
     }
 

--- a/crates/spark-server/src/grammar/tests/misc.rs
+++ b/crates/spark-server/src/grammar/tests/misc.rs
@@ -3,6 +3,40 @@
 use super::*;
 
 #[test]
+fn test_accept_token_after_termination_short_circuits() {
+    let vocab = test_vocab();
+    let stop_ids = vec![130i32];
+    let mut engine = GrammarEngine::new(&vocab, &stop_ids).unwrap();
+
+    let compiled = engine.compile_json_grammar().unwrap();
+    let mut state = GrammarState::new(&compiled, engine.vocab_size()).unwrap();
+    assert!(state.accept_token(b'{' as u32));
+    assert!(state.accept_token(b'}' as u32));
+    let _ = state.accept_token(130);
+    assert!(
+        state.is_terminated(),
+        "grammar must reach terminated state for this test to be meaningful"
+    );
+
+    // Discord 2026-05-08 universe06608: xgrammar emits a
+    // `grammar_matcher.cc:493` warning when a token is fed to a
+    // terminated matcher (happens under --speculative when the verifier
+    // has accepted a stop token but more drafts in the same step still
+    // feed into accept_token via the emit_step path). The short-circuit
+    // must return true (accept) so spec-decode draft truncation doesn't
+    // treat post-stop tokens as grammar rejections.
+    assert!(
+        state.accept_token(198),
+        "post-termination accept_token must short-circuit to true (token id 198 \
+         was the specific id from the user report; any id should behave the same)"
+    );
+    assert!(
+        state.accept_token(0),
+        "post-termination accept_token must remain a no-op for any token id"
+    );
+}
+
+#[test]
 fn test_fill_bitmask_after_stop_token() {
     let vocab = test_vocab();
     let stop_ids = vec![130i32]; // <eos>


### PR DESCRIPTION
## Summary

Discord 2026-05-08 18:38 (universe06608, #bugs) reported:

\`\`\`
grammar_matcher.cc:493: Warning: The matcher has terminated after
accepting the stop token, but is trying to accept new token with id 198.
\`\`\`

on \`Kbenkhaled/Qwen3.5-35B-A3B-NVFP4\` + \`--speculative\` + \`--tool-call-parser qwen3_coder\`.

Under speculative decoding the verifier may accept a stop token while draft tokens later in the same step still flow through \`emit_step\` and \`decode_logits_step\`, both of which call \`gs.accept_token()\`. xgrammar warns once per call when fed a token after the matcher reached its terminated state.

\`GrammarState::fill_bitmask\` already had an \`is_terminated()\` short-circuit. \`accept_token\` did not, so the warn fired on every post-stop draft. Add the symmetric guard at the single SSOT in \`GrammarState::accept_token\`: return \`true\` so that \`truncate_drafts_at_grammar_boundary\` doesn't treat post-stop tokens as grammar rejections — termination is the EOS handler's job, not the grammar's.

## Test plan

- [x] New \`test_accept_token_after_termination_short_circuits\` exercises the exact failure path: drive JSON grammar to \`{}\` + EOS, verify \`is_terminated()\`, then assert \`accept_token(198)\` and \`accept_token(0)\` short-circuit to \`true\` without warning.
- [x] Existing \`test_fill_bitmask_after_stop_token\` continues to pass (companion guard).
- [ ] Awaiting CI \`cargo test --workspace\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)