### PR TITLE
chat_stream: backfill+validate streaming tool-call args (Path B parity)

### DIFF
--- a/crates/spark-server/src/api/chat_stream/tool_handlers.rs
+++ b/crates/spark-server/src/api/chat_stream/tool_handlers.rs
@@ -169,9 +169,7 @@ pub(super) fn handle_tool_call_delta(
         if let Some(ref cwd) = ctx.cwd_for_normalize {
             tool_parser::normalize_paths(std::slice::from_mut(&mut tc), cwd);
         }
-        if let Err(e) =
-            tool_parser::validate_single_tool_call(&tc, &ctx.tool_defs_for_backfill)
-        {
+        if let Err(e) = tool_parser::validate_single_tool_call(&tc, &ctx.tool_defs_for_backfill) {
             tracing::warn!(
                 tool = %name,
                 "tool call validation error (stream Δ): {e}; replacing with content and ending"

--- a/crates/spark-server/src/api/chat_stream/tool_handlers.rs
+++ b/crates/spark-server/src/api/chat_stream/tool_handlers.rs
@@ -127,6 +127,23 @@ pub(super) fn handle_tool_call_start(
 }
 
 /// `DetectorOutput::ToolCallDelta` — incremental: append args.
+///
+/// For qwen3_coder XML the streaming detector emits a single Delta with
+/// the full parsed-and-canonicalised JSON arguments at the `</tool_call>`
+/// boundary (see `streaming_impl.rs::process` line ~67 — args can't be
+/// streamed character-by-character because XML parameter blocks must
+/// finish before they convert to JSON). This is the natural spot to run
+/// the same `backfill_required_params` + `validate_single_tool_call`
+/// chain that the complete-tool-call path runs at `handle_complete_tool_call`,
+/// so that streaming and non-streaming responses behave identically.
+///
+/// Without this, a model that emits `<function=NAME></function>` with no
+/// `<parameter=>` blocks (observed under qwen3_coder + multi-turn agentic
+/// loops with 21 tools, OpenClaw 2026.5.7) streams literal `"{}"` to the
+/// client even when required parameters are declared in the schema —
+/// while the non-streaming path would have backfilled `{"required_key": ""}`
+/// and at least logged a warning. Issue #40 (iromu) called out this
+/// "Opencode breaks tool calling more often" symptom.
 pub(super) fn handle_tool_call_delta(
     state: &mut StreamState,
     ctx: &StreamCtx,
@@ -134,11 +151,48 @@ pub(super) fn handle_tool_call_delta(
     idx: usize,
     sse_events: &mut SseVec,
 ) {
+    let mut emit_args = args.clone();
     if let Some(entry) = state.streaming_tool_args.get_mut(&idx) {
-        entry.1.push_str(&args);
+        let name = entry.0.clone();
+        let mut tc = tool_parser::ToolCall {
+            id: format!("call_{:016x}", idx),
+            call_type: "function".into(),
+            function: tool_parser::FunctionCall {
+                name: name.clone(),
+                arguments: args.clone(),
+            },
+        };
+        tool_parser::backfill_required_params(
+            std::slice::from_mut(&mut tc),
+            &ctx.tool_defs_for_backfill,
+        );
+        if let Some(ref cwd) = ctx.cwd_for_normalize {
+            tool_parser::normalize_paths(std::slice::from_mut(&mut tc), cwd);
+        }
+        if let Err(e) =
+            tool_parser::validate_single_tool_call(&tc, &ctx.tool_defs_for_backfill)
+        {
+            tracing::warn!(
+                tool = %name,
+                "tool call validation error (stream Δ): {e}; replacing with content and ending"
+            );
+            let msg = format!("[atlas] Tool call rejected: {e}");
+            let chunk = ChatCompletionChunk::content_chunk(&ctx.model, &ctx.id, msg);
+            sse_events.push(Ok(
+                Event::default().data(serde_json::to_string(&chunk).unwrap_or_default())
+            ));
+            state.stop_string_triggered = true;
+            entry.1.push_str(&args);
+            return;
+        }
+        emit_args = tc.function.arguments.clone();
+        entry.1.push_str(&emit_args);
+    } else if !args.is_empty() {
+        // No prior ToolCallStart for this idx — keep legacy passthrough.
     }
-    if !args.is_empty() {
-        let frag = ChatCompletionChunk::tool_call_args_fragment(&ctx.model, &ctx.id, idx, &args);
+    if !emit_args.is_empty() {
+        let frag =
+            ChatCompletionChunk::tool_call_args_fragment(&ctx.model, &ctx.id, idx, &emit_args);
         sse_events.push(Ok(
             Event::default().data(serde_json::to_string(&frag).unwrap_or_default())
         ));

--- a/crates/spark-server/src/tool_parser/tests/group_a.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_a.rs
@@ -385,6 +385,65 @@ use super::super::*;
     // ── Qwen3-Coder format ──
 
     #[test]
+    fn parse_qwen3_coder_empty_body_then_backfill() {
+        // Repro of OpenClaw 2026.5.7 + Qwen3.6-35B-A3B-NVFP4 + 21 tools
+        // multi-turn agentic regression (issue #40 / Discord #bugs
+        // 2026-05-08 universe06608): the model emits the `exec`
+        // function with NO `<parameter=>` blocks under long-context
+        // tool-saturation pressure. The parser correctly returns
+        // arguments=`{}`. The streaming path (path B in
+        // chat_stream/tool_handlers.rs) was emitting that `{}` directly
+        // to the client without running backfill_required_params, so
+        // tools that declare `required: [command]` reached OpenClaw as
+        // bare `{}` and were rejected ("must have required properties
+        // command"). The non-streaming path always ran backfill, so the
+        // two code paths diverged.
+        //
+        // This test verifies the recovery semantics: parse → empty
+        // args → backfill adds the required string field with empty
+        // value (mirroring path A) → validator passes (only
+        // WRITE_FAMILY rejects empty paths; `exec` is not in that
+        // list). The chat_stream::tool_handlers fix calls this same
+        // chain inside handle_tool_call_delta so streaming behaviour
+        // matches.
+        let input = "<tool_call>\n\
+            <function=exec>\n\
+            </function>\n\
+            </tool_call>";
+        let (_c, mut calls) = parse_tool_calls(input);
+        assert_eq!(calls.len(), 1, "parser must yield the named call even with no params");
+        assert_eq!(calls[0].function.name, "exec");
+        assert_eq!(
+            calls[0].function.arguments, "{}",
+            "no params → empty JSON object"
+        );
+
+        let tool = ToolDefinition {
+            tool_type: "function".to_string(),
+            function: FunctionDefinition {
+                name: "exec".to_string(),
+                description: None,
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"]
+                })),
+            },
+        };
+        backfill_required_params(&mut calls, std::slice::from_ref(&tool));
+        let args: serde_json::Value =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(
+            args["command"], "",
+            "backfill must add the required string key with an empty default"
+        );
+        assert!(
+            validate_single_tool_call(&calls[0], std::slice::from_ref(&tool)).is_ok(),
+            "validator passes once required key is present (non-WRITE-family)"
+        );
+    }
+
+    #[test]
     fn parse_qwen3_coder_single_param() {
         let input = "<tool_call>\n\
             <function=get_weather>\n\


### PR DESCRIPTION
## Summary

Issue #40 (iromu, 2026-05-08) reports Qwen3.6-35B-A3B-FP8 + qwen3_coder "breaks tool calling more often" against Opencode vs the same model on vLLM. Reproduced locally with **OpenClaw 2026.5.7** against \`atlas-gb10:debug\` on \`AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4\` with \`--speculative\` + \`--tool-call-parser qwen3_coder\` + 21 OpenClaw tools.

Under the multi-turn agentic context (>16K prompt with the full tool registry), the model intermittently emits a malformed call with NO \`<parameter=>\` blocks:

\`\`\`
<tool_call>
<function=exec>
</function>
</tool_call>
\`\`\`

— even though \`command\` is a required parameter. The parser correctly returns \`arguments={}\`, but the streaming pipeline emitted that \`{}\` verbatim to the client.

## Root cause

Path A (\`DetectorOutput::ToolCall\` → \`handle_complete_tool_call\`) already runs \`backfill_required_params\` + \`validate_single_tool_call\` before emitting the args fragment (\`tool_handlers.rs:41-83\`).

Path B (\`DetectorOutput::ToolCallStart\` → \`Delta\` → \`End\` → \`handle_tool_call_delta\`) emitted the parsed args verbatim with no backfill or validation, so streaming and non-streaming responses diverged. Streaming clients (OpenClaw, Opencode) saw bare \`{}\` and rejected on schema validation; the non-streaming path saw \`{"command":""}\` after backfill and degraded gracefully.

## Fix

Apply the same backfill → validate → emit chain in \`handle_tool_call_delta\`. On validation failure, mirror Path A's "replace with content + end" behaviour.

## Test

\`parse_qwen3_coder_empty_body_then_backfill\` (in \`tool_parser/tests/group_a.rs\`) feeds \`<function=exec>\n</function>\` to the parser, asserts args=\`{}\`, runs backfill against an \`exec\`/\`command\` schema, asserts the result has \`command: ""\`, and asserts validation passes (validator is permissive on empty strings outside WRITE_FAMILY per the existing Theia-getWorkspaceFileList carve-out).

## Live verification on hardware

\`\`\`
docker build -f docker/gb10/Dockerfile -t avarok/atlas-gb10:debug .
docker run -d --gpus all --ipc=host --network host --security-opt seccomp=unconfined --ulimit memlock=-1 \
  -v ~/.cache/huggingface:/root/.cache/huggingface \
  avarok/atlas-gb10:debug serve AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 \
    --port 8888 --bind 0.0.0.0 --served-model-name qwen3.6 \
    --max-seq-len 32768 --kv-cache-dtype fp8 --kv-high-precision-layers auto \
    --gpu-memory-utilization 0.90 --scheduling-policy slai \
    --tool-call-parser qwen3_coder --enable-prefix-caching --speculative --num-drafts 2

# repro: openclaw agent --local --agent main --message "..."
\`\`\`

Pre-fix trajectory: Atlas streams \`{"type":"toolCall","name":"exec","arguments":{}}\` for the first \`exec\` call; OpenClaw rejects with "Validation failed for tool 'exec': command must have required properties command".

Post-fix: Atlas streams \`{"type":"toolCall","name":"exec","arguments":{"command":""}}\` (empty-string default from backfill); OpenClaw still rejects since the empty string violates its schema, but Atlas's behaviour now matches the non-streaming path. The deeper grammar fix (qwen_xml_parameter must REQUIRE at least one parameter block when the schema declares \`required\`) is upstream xgrammar work and tracked separately.

## Test plan

- [x] CI \`cargo test --workspace\` (includes new test).
- [x] CI clippy + fmt + LoC cap.
- [x] Live OpenClaw repro confirms Atlas now backfills + validates streaming tool-call deltas symmetrically with the non-streaming path.
- [ ] Awaiting iromu (issue #40) confirmation that the next \`:latest\` cut behaves better in their Opencode setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)