### PR TITLE
chat_blocking: don't split at </think> when enable_thinking=false

### DIFF
--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -216,19 +216,27 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> Response {
 }
 
 /// Decode `(reasoning_content, output_text)` from the scheduler's
-/// response — split at the last `</think>` token if the tokenizer
-/// resolves it, fall back to text-level extraction otherwise.
+/// response. When `enable_thinking=true`, split at the last `</think>`
+/// token. When `enable_thinking=false`, decode all output_tokens as
+/// content — mirrors streaming's `thinking_done = !enable_thinking`
+/// init in chat_stream/state.rs and recovers the answer Qwen3.x emits
+/// inside `<think>...</think>` when it ignores a closed-thinking
+/// prefill (issue #40).
 fn decode_response_text(
     state: &AppState,
     response: &super::inference_types::InferenceResponse,
     enable_thinking: bool,
 ) -> (Option<String>, String) {
     if let Some(think_tok) = state.think_end_token_id {
-        let last_think_pos = response.output_tokens.iter().rposition(|&t| t == think_tok);
+        let last_think_pos = if enable_thinking {
+            response.output_tokens.iter().rposition(|&t| t == think_tok)
+        } else {
+            None
+        };
         if let Some(pos) = last_think_pos {
             let thinking_tokens = &response.output_tokens[..pos];
             let content_tokens = &response.output_tokens[pos + 1..];
-            let reasoning = if enable_thinking && !thinking_tokens.is_empty() {
+            let reasoning = if !thinking_tokens.is_empty() {
                 state
                     .tokenizer
                     .decode(thinking_tokens)


### PR DESCRIPTION
## Summary

Issue #40 (iromu, 2026-05-08): Atlas's blocking chat-completion path returned literal empty content for 5/11 [codeneedle](https://github.com/alexziskind1/codeneedle) prompts on \`Qwen/Qwen3.6-35B-A3B-FP8\` + \`--speculative\`, while the streaming path on the same prompts returned full coherent answers (153–1500 chars). The model emitted 100–500 tokens per failing turn but the client saw \`content=""\`.

## Root cause

\`api/chat_blocking.rs::decode_response_text\` always called \`rposition(|t| t == </think>)\` on the model's \`output_tokens\`. When the model — despite the chat template prefilling a closed-thinking block via \`<think>\n\n</think>\n\n\` (Qwen3.x's official template does this for \`enable_thinking=false\`) — went on to re-open thinking and emit its entire answer inside \`<think>...</think>\` and then stopped, the rposition split put the answer-as-thinking into the \`reasoning_content\` bucket and \`content_tokens\` (everything after the last \`</think>\`) ended up empty.

The streaming path's \`StreamState::new\` initialises \`thinking_done = !enable_thinking\` — i.e. when thinking is disabled, every emitted token is treated as content from the start, regardless of stray \`</think>\` tokens. The blocking path didn't mirror that.

## Fix

Gate the rposition split on \`enable_thinking == true\`. When thinking is disabled, decode the entire \`output_tokens\` as content, matching streaming semantics.

## Verification on hardware

\`avarok/atlas-gb10:debug\` from this branch, \`Qwen/Qwen3.6-35B-A3B-FP8\` + \`--speculative\` + \`qwen3_coder\` + 65 K seq len.

Pre-fix codeneedle without \`prefill_no_think\`:
\`\`\`
[EMPTY] _url_collapse_path: 0.08s len=3
[EMPTY] parse_request:       0.07s len=3
[EMPTY] handle_one_request:  0.07s len=3
[EMPTY] send_error:          0.07s len=3
[EMPTY] log_message:         0.06s len=3
[OK]    send_head:           8.21s len=103
[OK]    list_directory:      1.51s len=396
[EMPTY] translate_path:      0.07s len=3
[OK]    guess_type:          1.54s len=396
[OK]    is_cgi:            122.47s len=34417
[OK]    run_cgi:           123.91s len=34312
\`\`\`

Post-fix:
\`\`\`
[OK] _url_collapse_path: 0.58s len=155
[OK] parse_request:      3.15s len=958
[OK] handle_one_request: 2.55s len=804
[OK] send_error:         5.09s len=1390
[OK] log_message:        1.60s len=512
[OK] send_head:          1.37s len=418
[OK] list_directory:     0.64s len=206
[OK] translate_path:     2.88s len=800
[OK] guess_type:         2.61s len=757
[OK] is_cgi:             1.47s len=410
[OK] run_cgi:            3.66s len=1059
\`\`\`

11/11 functions return content. Streaming path semantics unchanged.

## Test plan

- [x] Live verification on hardware (Qwen3.6-35B-A3B-FP8 + MTP).
- [x] CI clippy/fmt/typecheck/cargo test --workspace.
- [ ] iromu (issue #40) confirmation against the next \`:latest\` cut — codeneedle scores should jump from 5/8 to 8/8 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)