### PR TITLE
fix: OpenClaw issue #40 follow-up — runaway loop salvage + hard-stop finish_reason

### DIFF
--- a/crates/spark-server/src/api/chat/sampling_setup.rs
+++ b/crates/spark-server/src/api/chat/sampling_setup.rs
@@ -148,22 +148,47 @@ pub(super) fn build_sampling(
         }) || parser_is_minimax_xml
             || parser_is_bare_json);
 
-    // response_format vs tools mutual exclusion.
+    // response_format + tools coexistence.
+    //
+    // OpenAI's API allows both fields in the same request; agentic pipelines
+    // routinely set both (the model emits a tool call on turn N, then a
+    // schema-shaped final answer on turn N+1). XGrammar's structural-tag
+    // grammar enforces *one* shape per request, so we pick which one wins:
+    //   * `tool_choice="none"` → tools won't be called, enforce response_format
+    //   * any other tool_choice → enforce tool-call grammar; the schema text
+    //     is conventionally embedded in the user/system message by the
+    //     caller, and capable models (Qwen3.6, etc.) follow it without
+    //     server-side enforcement on free-text turns.
     let has_response_format = req
         .response_format
         .as_ref()
         .is_some_and(|rf| !matches!(rf, crate::openai::ResponseFormat::Text));
-    if has_response_format && tools_active {
-        return Err(openai_error_response(
-            StatusCode::BAD_REQUEST,
-            "Cannot use both 'response_format' (json_object/json_schema) and 'tools' in the same request"
-                .to_string(),
-        ));
-    }
+    let tool_choice_none = req
+        .tool_choice
+        .as_ref()
+        .is_some_and(|tc| matches!(tc, tool_parser::ToolChoice::Mode(m) if m == "none"));
+    let response_format_only = has_response_format && (!tools_active || tool_choice_none);
 
     // Grammar spec (XGrammar structural-tag enforcement).
     let use_triggers = !tool_choice_required;
-    let grammar_spec: Option<GrammarSpec> = if tools_active {
+    let grammar_spec: Option<GrammarSpec> = if response_format_only {
+        match req.response_format.as_ref().unwrap() {
+            crate::openai::ResponseFormat::JsonObject => Some(GrammarSpec::JsonObject),
+            crate::openai::ResponseFormat::JsonSchema { json_schema } => {
+                Some(GrammarSpec::JsonSchema {
+                    schema: json_schema.schema.to_string(),
+                })
+            }
+            crate::openai::ResponseFormat::Text => None,
+        }
+    } else if tools_active {
+        if has_response_format {
+            tracing::info!(
+                "response_format + tools both set; enforcing tool-call grammar. \
+                 Schema-shape compliance falls to the model (embed schema text in \
+                 the user/system message for best results)."
+            );
+        }
         let parser = state.tool_call_parser.as_ref().map(std::sync::Arc::clone);
         let mut tools = req.tools.as_ref().cloned().unwrap_or_default();
         if let Some(tool_parser::ToolChoice::Specific { ref function }) = req.tool_choice {
@@ -174,16 +199,6 @@ pub(super) fn build_sampling(
             parser: p,
             use_triggers,
         })
-    } else if has_response_format {
-        match req.response_format.as_ref().unwrap() {
-            crate::openai::ResponseFormat::JsonObject => Some(GrammarSpec::JsonObject),
-            crate::openai::ResponseFormat::JsonSchema { json_schema } => {
-                Some(GrammarSpec::JsonSchema {
-                    schema: json_schema.schema.to_string(),
-                })
-            }
-            crate::openai::ResponseFormat::Text => None,
-        }
     } else {
         None
     };

--- a/crates/spark-server/src/api/chat_stream/state.rs
+++ b/crates/spark-server/src/api/chat_stream/state.rs
@@ -71,6 +71,17 @@ pub(super) struct StreamState {
     pub(super) streaming_tool_args: HashMap<usize, (String, String)>,
     /// F12: per-response total tool-call count.
     pub(super) tool_calls_emitted_count: usize,
+    /// Bug-2 (OpenClaw 2026-05-08): per-tool-name consecutive-call
+    /// guard. F11 keys on `(name, canonical_args)` and is defeated by
+    /// runaway loops where the model varies args slightly each
+    /// iteration (e.g. timestamps, sequence numbers, IDs). This
+    /// counter trips whenever the same tool name fires in N
+    /// successive `ToolCallEnd` events regardless of args drift,
+    /// catching the `cron`+`exec` alternation pattern observed when
+    /// the streaming detector did successfully classify the calls.
+    /// `(last_name, run_length)`. `last_name = None` means the run
+    /// was just broken by a different tool name.
+    pub(super) name_run: Option<(String, u32)>,
     /// Streaming tool-call detector (`Some` iff `tools_active`).
     pub(super) detector: Option<tool_parser::StreamingToolDetector>,
     /// True iff the reasoning/`<think>` phase has finished. Starts
@@ -102,6 +113,7 @@ impl StreamState {
             tool_arg_dedup_within: crate::tool_arg_dedup::ToolArgDedup::with_params(4, 2, 3),
             streaming_tool_args: HashMap::new(),
             tool_calls_emitted_count: 0,
+            name_run: None,
             detector: if tools_active {
                 Some(tool_parser::StreamingToolDetector::new())
             } else {

--- a/crates/spark-server/src/api/chat_stream/tool_handlers.rs
+++ b/crates/spark-server/src/api/chat_stream/tool_handlers.rs
@@ -63,6 +63,23 @@ pub(super) fn handle_complete_tool_call(
         );
         state.stop_string_triggered = true;
     } else {
+        // Bug-2 name-run cap (mirrors handle_tool_call_end): catches
+        // runaway loops in the complete-tool-call path that
+        // tool_arg_dedup misses because of args drift.
+        let run_len = match &state.name_run {
+            Some((prev, n)) if prev == &tc.function.name => n + 1,
+            _ => 1,
+        };
+        state.name_run = Some((tc.function.name.clone(), run_len));
+        if run_len >= MAX_CONSEC_SAME_NAME_CALLS {
+            tracing::warn!(
+                tool = %tc.function.name,
+                run = run_len,
+                "Bug-2 name-run cap tripped (complete-call path): {run_len} successive `{}` tool calls; ending response",
+                tc.function.name
+            );
+            state.stop_string_triggered = true;
+        }
         bump_f12_tool_call_count(
             &mut state.tool_calls_emitted_count,
             ctx.max_tool_calls_per_response,
@@ -198,7 +215,18 @@ pub(super) fn handle_tool_call_delta(
 }
 
 /// `DetectorOutput::ToolCallEnd` — F11 within-response dedup +
-/// F44 cross-turn permanent-failure check.
+/// F44 cross-turn permanent-failure check + Bug-2 name-run cap.
+///
+/// Bug-2 cap (`MAX_CONSEC_SAME_NAME_CALLS`): trips when the same tool
+/// name fires N times in a row regardless of args. F11 keys on
+/// `(name, canonical_args)` and is defeated by runaway loops where
+/// the model rolls a fresh timestamp / sequence number / id into the
+/// payload each iteration; the F12 total cap (default 12) is the
+/// only other server-side circuit, but a runaway can already have
+/// flooded the SSE channel before F12 fires. The name-run cap is
+/// strictly tighter than F11 and F12 for the runaway pattern.
+const MAX_CONSEC_SAME_NAME_CALLS: u32 = 6;
+
 pub(super) fn handle_tool_call_end(state: &mut StreamState, ctx: &StreamCtx, idx: usize) {
     if let Some((name, args_json)) = state.streaming_tool_args.remove(&idx) {
         if state.tool_arg_dedup_within.check(&name, &args_json) {
@@ -213,6 +241,19 @@ pub(super) fn handle_tool_call_end(state: &mut StreamState, ctx: &StreamCtx, idx
             tracing::warn!(
                 tool = %name,
                 "F44 streaming circuit-breaker tripped: tool_call matches a permanently-failed prior call; ending response"
+            );
+            state.stop_string_triggered = true;
+        }
+        let run_len = match &state.name_run {
+            Some((prev, n)) if prev == &name => n + 1,
+            _ => 1,
+        };
+        state.name_run = Some((name.clone(), run_len));
+        if run_len >= MAX_CONSEC_SAME_NAME_CALLS && !state.stop_string_triggered {
+            tracing::warn!(
+                tool = %name,
+                run = run_len,
+                "Bug-2 name-run cap tripped: {run_len} successive `{name}` tool calls; ending response (F11 missed because args drift)"
             );
             state.stop_string_triggered = true;
         }

--- a/crates/spark-server/src/grammar/compile_tools.rs
+++ b/crates/spark-server/src/grammar/compile_tools.rs
@@ -172,8 +172,6 @@ impl GrammarEngine {
         }
 
         let mut tag_entries = Vec::with_capacity(tools.len());
-        let mut triggers = Vec::new();
-        let mut seen_triggers = HashMap::<String, bool>::new();
 
         // Pre-sanitize all schemas so the fallback path can reuse them.
         struct SanitizedTool {
@@ -218,16 +216,43 @@ impl GrammarEngine {
                 "content": {"type": "qwen_xml_parameter", "json_schema": st.schema},
                 "end": end,
             }));
-            let trigger = format!("<tool_call>\n<function={}", st.name);
-            if !seen_triggers.contains_key(&trigger) {
-                seen_triggers.insert(trigger.clone(), true);
-                triggers.push(trigger);
-            }
         }
 
         if tag_entries.is_empty() {
             return Err(GrammarError::NoTools);
         }
+
+        // Trigger selection depends on `use_triggers` (i.e. tool_choice mode):
+        //
+        // * tool_choice="auto" (use_triggers=true): per-tool LATE triggers
+        //   `<tool_call>\n<function=NAME`. The model is free to emit a
+        //   `<tool_call>` token and then *not* commit (e.g. by emitting
+        //   plain prose afterwards), which is the ergonomic behaviour
+        //   most pass-not-fail scenarios depend on (TC-11 mental math,
+        //   TC-39 restraint, TC-43 ask-for-missing-arg, TC-48 multi-turn
+        //   email composition). Late triggers preserve that freedom.
+        //
+        // * tool_choice="required"/specific (use_triggers=false): SHORT
+        //   shared trigger `<tool_call>`. Without it, the model can — and
+        //   does — emit `<tool_call><tool_call>…` indefinitely under
+        //   required mode (`at_least_one=true` only suppresses EOS, it
+        //   does not constrain content); LATE triggers stay in
+        //   free-preamble forever because the `<tool_call>` special
+        //   token never extends to the required `\n<function=` prefix.
+        //   The SHORT trigger engages the moment the open token is
+        //   sampled, locking xgrammar's `triggered_tags` alternation onto
+        //   one of `\n<function=NAME>` for each registered tool — the
+        //   `<tool_call><tool_call>…` lockup is unreachable by
+        //   construction. Mirrors compile_minimax_xml_tool_grammar's F67
+        //   fix for the same xgrammar behaviour pattern.
+        let triggers: Vec<String> = if use_triggers {
+            sanitized_tools
+                .iter()
+                .map(|st| format!("<tool_call>\n<function={}", st.name))
+                .collect()
+        } else {
+            vec!["<tool_call>".to_string()]
+        };
 
         let at_least_one = !use_triggers;
         let stop_after_first = !use_triggers;

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -27,6 +27,18 @@ pub fn emit_token(a: &mut ActiveSeq, tok: u32, logprobs: Option<crate::api::Toke
     if let Some(ims) = im_start_hard_stop()
         && tok == ims
     {
+        // Push the hard-stop token to output_tokens so lifecycle.rs reports
+        // `finish_reason="stop"` (because `<|im_start|>` is registered in
+        // `eos_tokens` at startup — see tokenizer_runtime.rs::im_start_id).
+        // Without this push, `last_tok = output_tokens.last()` is the prior
+        // content token, lifecycle's `is_eos` check fails, and the response
+        // is mis-reported as `finish_reason="length"` (Bug 3 from OpenClaw
+        // 2026-05-08 session: "Done: 13 tokens (length) despite max_tokens=
+        // 8192" — clients then misinterpret the truncation as a real
+        // length-limit hit and either retry or surface a wrong error).
+        // The streamed-text path strips stop tokens server-side, so the
+        // client never sees the literal `<|im_start|>` bytes.
+        a.output_tokens.push(tok);
         a.finished = true;
         tracing::debug!(
             "<|im_start|> hard-stop fired (id={ims}); ending turn before grammar/suppress_eos"

--- a/crates/spark-server/src/tool_parser/parse_dispatch.rs
+++ b/crates/spark-server/src/tool_parser/parse_dispatch.rs
@@ -307,6 +307,45 @@ pub fn parse_tool_calls(text: &str) -> (Option<String>, Vec<ToolCall>) {
         }
     }
 
+    // Fallback 2c: BARE `<invoke name="X">…<parameter name="K">V</parameter>…</invoke>`
+    // blocks without any envelope (no `<tool_call>`, no `<minimax:tool_call>`).
+    // Triggered by Qwen3.6 cross-format contamination — observed
+    // 2026-05-09 OpenClaw stress run where the model issued 5 well-formed
+    // qwen3_coder envelopes then switched mid-response to MiniMax-style
+    // bare `<invoke>` blocks. The non-streaming chat_blocking path has
+    // no separate salvage hook (unlike chat_stream's tool_salvage),
+    // so we recover here using the existing `parse_minimax_xml_calls_all`
+    // — same function the streaming detector uses for the inner body
+    // of a MiniMax envelope.
+    if calls.is_empty() && text.contains("<invoke name=") {
+        let bare_invoke_calls = super::parse_minimax_xml_calls_all(text);
+        if !bare_invoke_calls.is_empty() {
+            // Strip the recovered invoke blocks from content so the
+            // client doesn't see both the structured tool_calls and
+            // the literal XML in `content`.
+            let mut clean = text.to_string();
+            let mut search = 0usize;
+            while let Some(rel) = clean[search..].find("<invoke name=") {
+                let start = search + rel;
+                match clean[start..].find("</invoke>") {
+                    Some(e) => {
+                        let end = start + e + "</invoke>".len();
+                        clean.drain(start..end);
+                        search = start;
+                    }
+                    None => break,
+                }
+            }
+            let trimmed = clean.trim();
+            let content = if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            };
+            return (content, bare_invoke_calls);
+        }
+    }
+
     // Fallback 3: look for JSON tool calls in code blocks or bare JSON.
     // When the model ignores the XML format entirely and writes tool invocations
     // as JSON in markdown code blocks or bare Hermes-style JSON, catch them here.

--- a/crates/spark-server/src/tool_salvage.rs
+++ b/crates/spark-server/src/tool_salvage.rs
@@ -115,6 +115,18 @@ pub fn salvage(content: &str, tools: &[ToolDefinition]) -> Vec<ToolCall> {
     for tc in extract::extract_header_body(content, &matchers) {
         emit_unique(tc, &mut out);
     }
+    // `<invoke name="TOOL">…<parameter name="K">V</parameter>…</invoke>` —
+    // MiniMax / Anthropic-style XML invocation form. Runs after the
+    // qwen3_coder-shape XML extractor so a properly-formed
+    // `<TOOL>...</TOOL>` block wins; only the cross-format
+    // contamination cases (Qwen3.6 emitting MiniMax syntax mid-
+    // multi-tool-call burst, observed 2026-05-09 OpenClaw run) need
+    // the looser `<invoke>` shape. Higher priority than
+    // bare_tool_invocation because the body is structurally more
+    // explicit.
+    for tc in extract_more::extract_invoke_blocks(content, &matchers) {
+        emit_unique(tc, &mut out);
+    }
     // Outer-boundary prose-pseudotool catch (#3, 2026-04-25). Looks
     // for "<ToolName> <arg>" or "<ToolName>(<arg>)" lines that ARE
     // the bare prose form of a tool invocation. Catches the failure

--- a/crates/spark-server/src/tool_salvage/extract_more.rs
+++ b/crates/spark-server/src/tool_salvage/extract_more.rs
@@ -303,6 +303,135 @@ pub(super) fn looks_like_path(line: &str) -> Option<String> {
     Some(stem.to_string())
 }
 
+/// `<invoke name="TOOL"> <parameter name="KEY">VAL</parameter>... </invoke>` —
+/// MiniMax / Anthropic-style XML invocation form. The qwen3_coder
+/// streaming detector only recognises `<tool_call>\n<function=…>` so
+/// when Qwen3.6 cross-contaminates and emits MiniMax syntax mid-
+/// response (observed 2026-05-09 OpenClaw stress run after 5 successful
+/// qwen3_coder envelopes — model switched to `<_calls>\n<invoke name=
+/// "write">\n<parameter name="path">…` for the next batch and Atlas's
+/// inter-tool prose budget stopped the response with `length` after
+/// ~386 tokens of "content"), salvage rescues the calls so the
+/// finish_reason settles on `tool_calls` and the orchestrator gets
+/// usable structured output instead of partial XML in `content`.
+///
+/// Strategy: scan for `<invoke name="X">`, find the matching
+/// `</invoke>`, walk inner `<parameter name="K">VAL</parameter>`
+/// blocks. Tolerates BPE-broken openers (`<invoke name="…"`,
+/// `<_calls>`, `<minimax:_call>`, etc.) — only the inner shape needs
+/// to be intact.
+pub(super) fn extract_invoke_blocks(content: &str, matchers: &[ToolShape]) -> Vec<ToolCall> {
+    let mut out = Vec::new();
+    let mut search = 0usize;
+    while let Some(rel) = content[search..].find("<invoke name=") {
+        let invoke_open = search + rel;
+        let after_attr = invoke_open + "<invoke name=".len();
+        // Read the quoted name.
+        let bytes = content.as_bytes();
+        if after_attr >= bytes.len() {
+            break;
+        }
+        let quote = bytes[after_attr];
+        if quote != b'"' && quote != b'\'' {
+            search = after_attr;
+            continue;
+        }
+        let name_start = after_attr + 1;
+        let Some(name_end_rel) = content[name_start..].find(quote as char) else {
+            break;
+        };
+        let name = &content[name_start..name_start + name_end_rel];
+        // Match against declared tools (case-insensitive).
+        let lower = name.to_ascii_lowercase();
+        let Some(shape) = matchers.iter().find(|m| m.name_lower() == lower) else {
+            // Not a declared tool; skip this <invoke> entirely.
+            search = name_start + name_end_rel + 1;
+            continue;
+        };
+        // Find matching </invoke> close.
+        let after_open_tag = name_start + name_end_rel + 1; // past closing quote
+        // Skip to '>' of the open tag.
+        let Some(gt_rel) = content[after_open_tag..].find('>') else {
+            break;
+        };
+        let body_start = after_open_tag + gt_rel + 1;
+        let Some(close_rel) = content[body_start..].find("</invoke>") else {
+            // No close tag — bail (response was truncated mid-invoke).
+            break;
+        };
+        let body_end = body_start + close_rel;
+        let body = &content[body_start..body_end];
+        if let Some(args) = parse_parameter_blocks(body, shape)
+            && let Some(tc) = synthesise(shape.name(), &args, "invoke")
+        {
+            out.push(tc);
+        }
+        search = body_end + "</invoke>".len();
+    }
+    out
+}
+
+/// Body of an `<invoke>` block parsed as `<parameter name="K">VAL
+/// </parameter>` pairs. Keys are matched case-insensitively against
+/// the tool's declared properties; values are JSON-stringified.
+/// Tolerates the BPE-broken `<parameter name="…"` form (the closing
+/// quote of `name="..."` is sometimes followed directly by content
+/// without `>`).
+fn parse_parameter_blocks(
+    body: &str,
+    shape: &ToolShape,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let mut out = serde_json::Map::new();
+    let needle = "<parameter name=";
+    let mut search = 0usize;
+    while let Some(rel) = body[search..].find(needle) {
+        let pos = search + rel;
+        let after = pos + needle.len();
+        let bytes = body.as_bytes();
+        if after >= bytes.len() {
+            break;
+        }
+        let quote = bytes[after];
+        if quote != b'"' && quote != b'\'' {
+            search = after;
+            continue;
+        }
+        let key_start = after + 1;
+        let Some(key_end_rel) = body[key_start..].find(quote as char) else {
+            break;
+        };
+        let key = &body[key_start..key_start + key_end_rel];
+        let after_key_close_quote = key_start + key_end_rel + 1;
+        // Find the value start: after a `>` (well-formed) or directly
+        // after the closing quote (BPE-broken — strip leading
+        // whitespace/newline).
+        let val_start = match body[after_key_close_quote..].find('>') {
+            Some(g) if g <= 2 => after_key_close_quote + g + 1,
+            _ => after_key_close_quote,
+        };
+        // Find end: prefer `</parameter>`, fall back to the next
+        // `<parameter` opener (BPE-broken closer scenarios).
+        let next_close = body[val_start..]
+            .find("</parameter>")
+            .map(|p| (p, "</parameter>".len()));
+        let next_open = body[val_start..].find("<parameter").map(|p| (p, 0usize));
+        let (end_rel, advance) = match (next_close, next_open) {
+            (Some(c), Some(o)) if c.0 <= o.0 => c,
+            (Some(c), None) => c,
+            (None, Some(o)) => o,
+            (Some(c), Some(_)) => c,
+            (None, None) => break,
+        };
+        let value = body[val_start..val_start + end_rel].trim().to_string();
+        let lower = key.to_ascii_lowercase();
+        if let Some(prop) = shape.original_property(&lower) {
+            out.insert(prop, serde_json::Value::String(value));
+        }
+        search = val_start + end_rel + advance;
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
 pub(super) fn synthesise(
     name: &str,
     args: &serde_json::Map<String, serde_json::Value>,


### PR DESCRIPTION
## Summary

Three Atlas fixes that surfaced in the OpenClaw 2026-05-08 repro session for issue #40 (PR #41 already covered streaming Path B backfill parity; the two open follow-ups + a tool-eval-bench session leftover are addressed here):

- **Bug 3** (`scheduler/emit_step.rs`) — `<|im_start|>` hard-stop now pushes the token to `output_tokens` so lifecycle reports `finish_reason="stop"` instead of mis-reporting `"length"` (was OpenClaw's confusing "Done: 13 tokens (length) despite max_tokens=8192").
- **Bug 2** (`tool_parser/parse_dispatch.rs`, `tool_salvage*`, `chat_stream/{state,tool_handlers}.rs`) — bare-`<invoke>` salvage in both streaming and non-streaming paths recovers the MiniMax-style `<invoke name="X"><parameter name="K">V</parameter></invoke>` blocks Qwen3.6 cross-emits mid-multi-tool-call burst, plus a per-tool-name run cap (`MAX_CONSEC_SAME_NAME_CALLS=6`) tighter than F11 for the runaway pattern where args drift defeats `(name, canonical_args)` dedup.
- **tool-eval-bench session leftovers** (`api/chat/sampling_setup.rs`, `grammar/compile_tools.rs`) — allow `response_format + tools` in the same request (was 400'ing) and switch qwen3_coder grammar to a SHORT trigger only under `tool_choice="required"` so the matcher actually engages (`auto` keeps LATE triggers so the model retains opt-out freedom).

## Test plan

- [x] Live OpenClaw 2026.5.7 + Qwen3.6-35B-A3B-FP8 served as `qwen3.6` against `--tool-call-parser qwen3_coder --enable-prefix-caching --speculative`.
- [x] Pre-fix vs post-fix on the "create 15 files via write" stress prompt: pre-fix = 5 calls then `length`-truncated turn with 386 tokens of broken `<invoke>` content; post-fix = 11 calls across 6 turns, including a 6-call batch in turn 6 recovered through the salvage, finishes `stop`. Files 1-11 actually exist on disk (the missing 12-15 is a model-side count drift, not Atlas-fixable).
- [x] Lobster reminder cron stress: completes cleanly, no runaway, no `length` mis-report.
- [x] Multi-step Python project + pytest: 10 calls (write + exec) with model self-correcting `python` → `python3`, finishes `stop`.
- [x] Direct-API smoke: `curl …` with bare `<invoke name="write">…</invoke>` blocks returns `tool_calls: [...]` (was empty `content` previously).
- [x] tool-eval-bench v1.6.0: net score 85 → 87 (★★★★ Good) on Qwen3.6-FP8. TC-45 (`tool_choice="required"`), TC-65/66/67/69 (`response_format + tools`) flip from fail/partial to pass.

## What's NOT in this PR

- The PR is layered on top of `master` so it picks up the prior PR #41/#44 work.
- The atlas-builder:r8 image (used to produce the binary in `atlas-gb10:openclaw-fix3`) predates PR #41; the binary I tested with carries my changes _on top of_ PR #41 already merged in master, so the live verification is representative of post-merge behaviour.