### PR TITLE
Fix #31: route MTP verify through HSS orchestrator (PR #37 follow-up)

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/decode/high_speed_swap.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/decode/high_speed_swap.rs
@@ -96,14 +96,33 @@ impl Qwen3AttentionLayer {
         // Window of HBM-resident blocks: block_table[0..block_table.len()]
         // covers logical positions [total - block_table.len(), total).
         let window_start = total.saturating_sub(block_table.len());
-        // Always re-offload the ACTIVE (last) block on every call. Decode
-        // writes one new slot per step into the existing last block — its
-        // HBM contents change without disk_block_ids.len() growing, so the
-        // naive `last..total` range would skip it and the streaming kernel
-        // would read stale (zero-init) bytes for slots 1..15 → degenerate
-        // attention → "the the the" loop. Setting `start = last.min(total-1)`
-        // guarantees the active block is re-pushed every step.
-        let start = last.min(total - 1);
+        // Always re-offload the BOUNDARY block (one before `last`) on every
+        // call, in addition to all blocks in `last..total`. Two cases:
+        //
+        // (1) Decode case: `last == total` (no new block this step). Slots in
+        //     the active block keep getting written one-per-step without
+        //     `disk_block_ids.len()` growing. `start = total - 1` ensures the
+        //     active block is re-pushed every step. Without this the streaming
+        //     kernel reads stale (zero-init) bytes for the unwritten slots
+        //     → degenerate attention → "the the the" loop.
+        //
+        // (2) Chunked-prefill boundary case (issue #31, follow-up to PR #37):
+        //     `last < total` after a new chunk advanced `disk_block_ids`. The
+        //     PREVIOUS chunk's last block (`last - 1`) typically has unwritten
+        //     tail slots — `reshape_and_cache_flash` writes only the chunk's
+        //     own token slots, so when chunk N ended mid-block it left the
+        //     tail slots zero on disk after the post-chunk-N offload. Chunk
+        //     N+1 fills those tail slots in HBM but the offload's `start =
+        //     last` skipped re-pushing the boundary block, so disk's
+        //     boundary-block tail stays permanently zeroed. Decode reads the
+        //     full history from disk via `attend_layer_on_stream`, so the
+        //     zeroed slots silently corrupt attention for the chunk-boundary
+        //     positions (manifests as needle-in-haystack precision loss in
+        //     long-context recall — see issue #31 differential tests).
+        //
+        // `last.saturating_sub(1).min(total - 1)` covers both cases at the
+        // cost of ~one extra D2H per layer per chunk (negligible).
+        let start = last.saturating_sub(1).min(total - 1);
         for logical_pos in start..total {
             if logical_pos < window_start {
                 // Issue #31: the slide-before-alloc loop in

--- a/crates/spark-model/src/model/trait_impl/verify_b.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_b.rs
@@ -214,24 +214,55 @@ impl TransformerModel {
                 let layer_type = self.config.layer_type(layer_idx);
 
                 if layer_type == LayerType::FullAttention {
-                    // Attention: treat 2 tokens as 2 virtual sequences via
-                    // decode_multi_seq. EmptyLayerState has no actual state.
-                    let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
-                        .map(|_| layer.alloc_state(self.gpu.as_ref()))
-                        .collect::<Result<_>>()?;
-                    let mut refs: Vec<&mut (dyn LayerState + 'static)> =
-                        dummy_states.iter_mut().map(|s| s.as_mut()).collect();
-                    layer.decode_multi_seq(
-                        hidden,
-                        residual,
-                        k,
-                        &mut refs,
-                        &mut kv_cache,
-                        &seq_lens_vec,
-                        &block_tables_vec,
-                        &ctx,
-                        stream,
-                    )?;
+                    if hss_engaged {
+                        // HSS path: `decode_multi_seq` calls the production
+                        // paged-decode kernel which reads K/V from HBM only
+                        // (`meta.block_table`). Under HSS, HBM is capped to
+                        // `cache_blocks_per_seq` blocks, so older context
+                        // lives only on disk and is unreachable from the
+                        // multi-Q kernel — Q/V attends only over the recent
+                        // ~cap×bs tokens, missing the long-context history.
+                        // The single-token `decode` path routes through the
+                        // HSS orchestrator (`attend_layer_on_stream`) which
+                        // reads the full history from disk. Fall back to
+                        // `decode_batched` (N sequential single-token
+                        // decodes via the orchestrator) at the cost of
+                        // ~k× attention launches per verify step. Mirrors
+                        // the SSM branch below which already uses
+                        // decode_batched for the same correctness reason.
+                        layer.decode_batched(
+                            hidden,
+                            residual,
+                            k,
+                            seq.layer_states[layer_idx].as_mut(),
+                            &mut kv_cache,
+                            seq.seq_len,
+                            &mut seq.block_table,
+                            &mut seq.disk_block_ids,
+                            &mut seq.disk_last_offloaded_per_layer,
+                            &ctx,
+                            stream,
+                        )?;
+                    } else {
+                        // Attention: treat 2 tokens as 2 virtual sequences via
+                        // decode_multi_seq. EmptyLayerState has no actual state.
+                        let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
+                            .map(|_| layer.alloc_state(self.gpu.as_ref()))
+                            .collect::<Result<_>>()?;
+                        let mut refs: Vec<&mut (dyn LayerState + 'static)> =
+                            dummy_states.iter_mut().map(|s| s.as_mut()).collect();
+                        layer.decode_multi_seq(
+                            hidden,
+                            residual,
+                            k,
+                            &mut refs,
+                            &mut kv_cache,
+                            &seq_lens_vec,
+                            &block_tables_vec,
+                            &ctx,
+                            stream,
+                        )?;
+                    }
                 } else {
                     // SSM: process K=2 tokens for one sequence via decode_batched.
                     layer.decode_batched(

--- a/crates/spark-model/src/model/trait_impl/verify_c.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c.rs
@@ -199,22 +199,43 @@ impl TransformerModel {
                 let layer_type = self.config.layer_type(layer_idx);
 
                 if layer_type == LayerType::FullAttention {
-                    let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
-                        .map(|_| layer.alloc_state(self.gpu.as_ref()))
-                        .collect::<Result<_>>()?;
-                    let mut refs: Vec<&mut (dyn LayerState + 'static)> =
-                        dummy_states.iter_mut().map(|s| s.as_mut()).collect();
-                    layer.decode_multi_seq(
-                        hidden,
-                        residual,
-                        k,
-                        &mut refs,
-                        &mut kv_cache,
-                        &seq_lens_vec,
-                        &block_tables_vec,
-                        &ctx,
-                        stream,
-                    )?;
+                    if hss_engaged {
+                        // HSS path: decode_multi_seq's paged-decode kernel
+                        // reads K/V from HBM only, missing the long-context
+                        // history on disk. Fall back to decode_batched
+                        // (sequential single-token decodes via the HSS
+                        // orchestrator). See verify_b.rs for full rationale.
+                        layer.decode_batched(
+                            hidden,
+                            residual,
+                            k,
+                            seq.layer_states[layer_idx].as_mut(),
+                            &mut kv_cache,
+                            seq.seq_len,
+                            &mut seq.block_table,
+                            &mut seq.disk_block_ids,
+                            &mut seq.disk_last_offloaded_per_layer,
+                            &ctx,
+                            stream,
+                        )?;
+                    } else {
+                        let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
+                            .map(|_| layer.alloc_state(self.gpu.as_ref()))
+                            .collect::<Result<_>>()?;
+                        let mut refs: Vec<&mut (dyn LayerState + 'static)> =
+                            dummy_states.iter_mut().map(|s| s.as_mut()).collect();
+                        layer.decode_multi_seq(
+                            hidden,
+                            residual,
+                            k,
+                            &mut refs,
+                            &mut kv_cache,
+                            &seq_lens_vec,
+                            &block_tables_vec,
+                            &ctx,
+                            stream,
+                        )?;
+                    }
                 } else {
                     layer.decode_batched(
                         hidden,

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -189,22 +189,43 @@ impl TransformerModel {
                 let layer_type = self.config.layer_type(layer_idx);
 
                 if layer_type == LayerType::FullAttention {
-                    let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
-                        .map(|_| layer.alloc_state(self.gpu.as_ref()))
-                        .collect::<Result<_>>()?;
-                    let mut refs: Vec<&mut (dyn LayerState + 'static)> =
-                        dummy_states.iter_mut().map(|s| s.as_mut()).collect();
-                    layer.decode_multi_seq(
-                        hidden,
-                        residual,
-                        k,
-                        &mut refs,
-                        &mut kv_cache,
-                        &seq_lens_vec,
-                        &block_tables_vec,
-                        &ctx,
-                        stream,
-                    )?;
+                    if hss_engaged {
+                        // HSS path: decode_multi_seq's paged-decode kernel
+                        // reads K/V from HBM only, missing the long-context
+                        // history on disk. Fall back to decode_batched
+                        // (sequential single-token decodes via the HSS
+                        // orchestrator). See verify_b.rs for full rationale.
+                        layer.decode_batched(
+                            hidden,
+                            residual,
+                            k,
+                            seq.layer_states[layer_idx].as_mut(),
+                            &mut kv_cache,
+                            seq.seq_len,
+                            &mut seq.block_table,
+                            &mut seq.disk_block_ids,
+                            &mut seq.disk_last_offloaded_per_layer,
+                            &ctx,
+                            stream,
+                        )?;
+                    } else {
+                        let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
+                            .map(|_| layer.alloc_state(self.gpu.as_ref()))
+                            .collect::<Result<_>>()?;
+                        let mut refs: Vec<&mut (dyn LayerState + 'static)> =
+                            dummy_states.iter_mut().map(|s| s.as_mut()).collect();
+                        layer.decode_multi_seq(
+                            hidden,
+                            residual,
+                            k,
+                            &mut refs,
+                            &mut kv_cache,
+                            &seq_lens_vec,
+                            &block_tables_vec,
+                            &ctx,
+                            stream,
+                        )?;
+                    }
                 } else {
                     layer.decode_batched(
                         hidden,

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -195,22 +195,43 @@ impl TransformerModel {
                 let layer_type = self.config.layer_type(layer_idx);
 
                 if layer_type == LayerType::FullAttention {
-                    let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
-                        .map(|_| layer.alloc_state(self.gpu.as_ref()))
-                        .collect::<Result<_>>()?;
-                    let mut refs: Vec<&mut (dyn LayerState + 'static)> =
-                        dummy_states.iter_mut().map(|s| s.as_mut()).collect();
-                    layer.decode_multi_seq(
-                        hidden,
-                        residual,
-                        k,
-                        &mut refs,
-                        &mut kv_cache,
-                        &seq_lens_vec,
-                        &block_tables_vec,
-                        &ctx,
-                        stream,
-                    )?;
+                    if hss_engaged {
+                        // HSS path: decode_multi_seq's paged-decode kernel
+                        // reads K/V from HBM only, missing the long-context
+                        // history on disk. Fall back to decode_batched
+                        // (sequential single-token decodes via the HSS
+                        // orchestrator). See verify_b.rs for full rationale.
+                        layer.decode_batched(
+                            hidden,
+                            residual,
+                            k,
+                            seq.layer_states[layer_idx].as_mut(),
+                            &mut kv_cache,
+                            seq.seq_len,
+                            &mut seq.block_table,
+                            &mut seq.disk_block_ids,
+                            &mut seq.disk_last_offloaded_per_layer,
+                            &ctx,
+                            stream,
+                        )?;
+                    } else {
+                        let mut dummy_states: Vec<Box<dyn LayerState>> = (0..k)
+                            .map(|_| layer.alloc_state(self.gpu.as_ref()))
+                            .collect::<Result<_>>()?;
+                        let mut refs: Vec<&mut (dyn LayerState + 'static)> =
+                            dummy_states.iter_mut().map(|s| s.as_mut()).collect();
+                        layer.decode_multi_seq(
+                            hidden,
+                            residual,
+                            k,
+                            &mut refs,
+                            &mut kv_cache,
+                            &seq_lens_vec,
+                            &block_tables_vec,
+                            &ctx,
+                            stream,
+                        )?;
+                    }
                 } else {
                     layer.decode_batched(
                         hidden,


### PR DESCRIPTION
## Summary

Issue #31 (HSS + chunked-prefill silent output corruption on long prompts) was claimed fixed by PR #37, but on hardware the bug still reproduces with `--high-speed-swap` + `--speculative` + long prompts. Root cause is a *different* missing HSS orchestrator routing — in the K-token verify path, not the prefill path #37 patched.

## Repro

Sehyo/Qwen3.5-122B-A10B-NVFP4 on a single GB10, ` :3.0.0` image semantics:

```
spark serve ... \
  --high-speed-swap \
  --high-speed-swap-cache-blocks-per-seq 64 \
  --max-seq-len 16384 \
  --speculative --num-drafts 1 \
  --kv-cache-dtype nvfp4 --kv-high-precision-layers auto
```

Send an 8569-token NIAH prompt with the needle ``ZEBRA-1947-MOONFISH`` placed near a chunk-3 boundary (~position 4084), `temperature=0`:

| Configuration                              | Output                        |
|--------------------------------------------|-------------------------------|
| main + HSS on  + MTP on (3 runs)           | ``ZEBRA-1947-M`` / ``ZEBRA-1944`` (non-deterministic) |
| **this PR + HSS on + MTP on** (4 runs)     | ``ZEBRA-1947-MOONFISH`` (deterministic) |
| any image + HSS off + MTP on               | ``ZEBRA-1947-MOONFISH``       |
| any image + HSS on + MTP off               | ``ZEBRA-1947-MOONFISH``       |

Notice the matrix isolates the bug to **HSS on × MTP on**.

## Root cause

`decode_multi_seq` (the K-token verify entry used by `verify_a/b/c/c2/d`) calls the production paged-decode kernel directly, which reads K/V from `meta.block_table` (HBM). Under HSS, HBM is capped at `cache_blocks_per_seq × block_size` tokens (~1024 at default cap=64), so verify attention sees only the recent context window and misses the long-context history that lives only on disk.

The single-token decode at `decode/attention_forward.rs:424` *does* check `high_speed_swap_engaged` and routes through the orchestrator (`attend_layer_on_stream`). The multi-Q tile kernel doesn't exist (Phase 6.2.b), and the trait signature for `decode_multi_seq` doesn't even pass `disk_block_ids` / `disk_last_offloaded_per_layer`, so routing through the orchestrator from the multi-seq path needs a sweeping signature change.

## Fix (commit 1)

Surgical workaround: when HSS is engaged, fall back to `decode_batched` (which by default loops over N sequential single-token `decode` calls — each properly routed through the orchestrator). This mirrors what the SSM branch immediately below already does for the same correctness reason.

Cost: ~k× attention launches per verify step under HSS. Functional correctness restored.

Patches applied to all four verify modules (K=2/3/γ/4) for defense-in-depth even though only K=2 is exercised by ``--num-drafts 1``.

## Bonus fix (commit 2)

While instrumenting offload state I found a separate latent bug. The offload's `start = last.min(total - 1)` heuristic was designed for decode ("re-offload the active block since new slots get written into it") and silently misses the analogous case during chunked prefill where the boundary block's tail slots get filled by the *next* chunk.

Verified via instrumentation:
```
chunk-1 offload (block 127): zero_slots_K=4/16  (slots 12..15)
chunk-2 offload (block 127): zero_slots_K=0/16  (after fix — re-offloaded)
chunk-2 offload (block 191): zero_slots_K=8/16  (slots 8..15)
chunk-3 offload (block 191): zero_slots_K=0/16  (after fix)
```

This fix alone doesn't change end-to-end output on #31 (the verify-routing fix dominates), but the partial-block-on-disk state was wrong and worth fixing.

## Out of scope

`decode_b.rs:413` has the same `decode_multi_seq` pattern but for **multi-sequence batched** decode+prefill. Different fix shape — needs per-sequence loop. Doesn't fire at ``max_batch_size=1`` so didn't affect the repro. Worth a follow-up PR.

## Test plan

- [x] 8569-token NIAH, needle at chunk-3 boundary: ``ZEBRA-1947-MOONFISH`` returned 4/4 deterministic runs
- [x] 8569-token NIAH, needle at chunk-1 boundary (position ~2046): correct
- [x] HSS off + MTP on: still correct (no regression on non-HSS path)
- [ ] Author verification on a `:debug` image before merge — recommended given PR #37's history (merged unverified). I'd suggest the same 8569-token NIAH I used; happy to share the exact prompt construction if useful.

## Closes

#31 (the part PR #37 missed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)