### PR TITLE
feat(mtp): support dense FFN MTP heads (Qwen3.6-27B-FP8) + factory routing fix

### DIFF
--- a/crates/spark-model/src/factory.rs
+++ b/crates/spark-model/src/factory.rs
@@ -49,10 +49,17 @@ pub fn loader_for_config(config: &ModelConfig) -> Result<Box<dyn ModelWeightLoad
         "qwen3_next" => Ok(Box::new(Qwen3WeightLoader)),
         "qwen3_vl_moe" => Ok(Box::new(Qwen3VLWeightLoader)),
         "qwen3_5_moe" | "qwen3_5" | "qwen35_moe" | "qwen35" => {
-            if config.is_qwen3_vl() {
-                Ok(Box::new(Qwen3VLWeightLoader))
-            } else if config.is_qwen35_dense() {
+            // Dense check has to come first. Qwen3.6-27B-FP8 is the dense text
+            // sibling of the Qwen3.6 VL family — its config declares the same
+            // `vision_config` block as the MoE-VL siblings (so `is_qwen3_vl()`
+            // returns true), but the checkpoint ships no vision tower and no
+            // MoE router, so the VL loader panics on a missing `mlp.gate`.
+            // `is_qwen35_dense()` requires `num_experts == 0`, which only the
+            // dense text models satisfy — VL-MoE always has experts.
+            if config.is_qwen35_dense() {
                 Ok(Box::new(Qwen35DenseWeightLoader))
+            } else if config.is_qwen3_vl() {
+                Ok(Box::new(Qwen3VLWeightLoader))
             } else {
                 Ok(Box::new(Qwen35WeightLoader))
             }

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -100,6 +100,16 @@ pub fn build_model(
     let final_norm = loader.load_final_norm(store, &config, gpu.as_ref())?;
     let lm_head = loader.load_lm_head(store, &config)?;
     let mtp_weights = loader.load_mtp_weights_multi(store, &config, gpu.as_ref())?;
+    // Capability warning: user asked for `--speculative` but the model has no
+    // MTP head bundled, so speculative decoding will silently no-op. Surface
+    // this loudly so the user knows the flag was inert.
+    if use_speculative && mtp_weights.is_empty() {
+        tracing::warn!(
+            "`--speculative` was requested but no MTP weights were loaded for this \
+             model — speculative decoding will be disabled. Either drop `--speculative` \
+             or use a checkpoint that ships an MTP head (e.g. `mtp.safetensors`)."
+        );
+    }
     let vision_encoder = loader.load_vision_encoder(store, &config, gpu.as_ref())?;
 
     // If the checkpoint's `quantization_config.ignore_modules` lists MTP

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -106,6 +106,12 @@ pub struct MtpHead {
     moe_gate: DenseWeight,
     shared_expert_gate: DenseWeight,
 
+    /// Dense FFN triple `(gate_proj, up_proj, down_proj)` for MTP heads
+    /// bundled with dense (non-MoE) checkpoints. When `Some`, the forward
+    /// path skips routing/expert dispatch and runs a single MLP. The MoE
+    /// fields above are unused/None in that mode.
+    dense_ffn_generic: Option<(ProjectionWeight, ProjectionWeight, ProjectionWeight)>,
+
     // Precision mode
     quant: MtpQuantization,
 

--- a/crates/spark-model/src/layers/mtp_head/forward.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward.rs
@@ -326,18 +326,23 @@ impl MtpHead {
             stream,
         )?;
 
-        // 10. MoE FFN
-        let moe_out = match self.quant {
-            MtpQuantization::Nvfp4 => self
-                .moe_nvfp4
-                .as_ref()
-                .unwrap()
-                .forward(normed2, ctx, stream)?,
-            MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
-                self.moe_forward_generic(normed2, ctx, stream)?
+        // 10. FFN: dense shortcut for non-MoE MTP heads (Qwen3.6-27B-FP8),
+        //     otherwise routed MoE.
+        let ffn_out = if self.dense_ffn_generic.is_some() {
+            self.dense_ffn_forward_generic(normed2, ctx, stream)?
+        } else {
+            match self.quant {
+                MtpQuantization::Nvfp4 => self
+                    .moe_nvfp4
+                    .as_ref()
+                    .unwrap()
+                    .forward(normed2, ctx, stream)?,
+                MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
+                    self.moe_forward_generic(normed2, ctx, stream)?
+                }
             }
         };
-        ops::residual_add(ctx.gpu, self.residual_add_k, hidden, moe_out, h, stream)?;
+        ops::residual_add(ctx.gpu, self.residual_add_k, hidden, ffn_out, h, stream)?;
 
         // 11. Final norm
         let final_normed = ctx.buffers.norm_output();

--- a/crates/spark-model/src/layers/mtp_head/moe_forward.rs
+++ b/crates/spark-model/src/layers/mtp_head/moe_forward.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 //! Generic per-expert MoE forward path for FP8/BF16 expert weights,
-//! plus the deferred draft-token D2H readback used by the proposer trait impl.
+//! plus the deferred draft-token D2H readback used by the proposer trait impl,
+//! plus a dense-FFN shortcut for non-MoE MTP heads (Qwen3.6-27B-FP8).
 
 use anyhow::Result;
 use spark_runtime::gpu::{DevicePtr, GpuBackend};
@@ -20,6 +21,53 @@ impl MtpHead {
         let mut buf = [0u8; 4];
         gpu.copy_d2h(self.draft_token_id_dev, &mut buf)?;
         Ok(u32::from_le_bytes(buf))
+    }
+
+    /// Dense FFN forward for Qwen3.6-27B-FP8 (and other dense MTP heads):
+    /// `out = down_proj( silu(gate_proj(x)) * up_proj(x) )`.
+    ///
+    /// One MLP, no router, no expert dispatch. Reuses the same FP8/BF16
+    /// kernels (`dense_gemv_*`, `moe_silu_mul`) the per-expert path uses,
+    /// so no new kernel wiring is required.
+    pub(super) fn dense_ffn_forward_generic(
+        &self,
+        input: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        let h = ctx.config.hidden_size as u32;
+        // Dense MTP heads use the main model's dense `intermediate_size`
+        // (Qwen3.6-27B: 17408). `moe_intermediate_size` is 0 for dense
+        // checkpoints and would request a zero-element GEMV.
+        let inter = if ctx.config.intermediate_size > 0 {
+            ctx.config.intermediate_size as u32
+        } else {
+            ctx.config.moe_intermediate_size as u32
+        };
+        let (gate_w, up_w, down_w) = self
+            .dense_ffn_generic
+            .as_ref()
+            .expect("dense_ffn_forward_generic called without dense_ffn_generic populated");
+
+        let gate_out = ctx.buffers.expert_gate_out();
+        let up_out = ctx.buffers.expert_up_out();
+
+        self.gemv(ctx.gpu, input, gate_w, gate_out, inter, h, stream)?;
+        self.gemv(ctx.gpu, input, up_w, up_out, inter, h, stream)?;
+
+        ops::moe_silu_mul(
+            ctx.gpu,
+            self.moe_silu_mul_k.unwrap(),
+            gate_out,
+            up_out,
+            gate_out,
+            inter,
+            stream,
+        )?;
+
+        let output = ctx.buffers.moe_output();
+        self.gemv(ctx.gpu, gate_out, down_w, output, h, inter, stream)?;
+        Ok(output)
     }
 
     /// Generic MoE forward for FP8/BF16 expert weights.

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -31,7 +31,15 @@ impl MtpHead {
         let nq = config.num_attention_heads;
         let nkv = config.num_key_value_heads;
         let hd = config.head_dim;
-        let inter = config.moe_intermediate_size;
+        // Dense MTP heads use the dense `intermediate_size`; MoE MTP heads
+        // use `moe_intermediate_size`. The bundled `mtp.safetensors` always
+        // matches the main model's FFN width (Qwen3.6-27B FP8: 17408 dense;
+        // Qwen3.6-A3B-NVFP4: 1024 per expert).
+        let inter = if config.moe_intermediate_size > 0 {
+            config.moe_intermediate_size
+        } else {
+            config.intermediate_size
+        };
 
         let q = |bf16: &DenseWeight, n: usize, k: usize| -> Result<ProjectionWeight> {
             Self::quantize_proj(bf16, n, k, quant, gpu, absmax_k, nvfp4_k, fp8_k, stream)
@@ -44,8 +52,31 @@ impl MtpHead {
         let v_proj = q(&weights.v_proj, nkv * hd, h)?;
         let o_proj = q(&weights.o_proj, h, nq * hd)?;
 
+        // Dense FFN MTP heads (Qwen3.6-27B-FP8) bypass the MoE setup entirely.
+        // We quantize the dense gate/up/down triple and stash it; the MoE
+        // fields stay None and the forward path takes the dense shortcut.
+        let dense_ffn_generic = if let Some(dense_ffn) = weights.dense_ffn.as_ref() {
+            if matches!(quant, MtpQuantization::Nvfp4) {
+                anyhow::bail!(
+                    "MTP NVFP4 mode is not supported for dense FFN MTP heads yet \
+                     (Qwen3.6-27B-FP8 ships an FP8 MTP head — use \
+                     `--mtp-quantization fp8` or `bf16`)"
+                );
+            }
+            Some((
+                q(&dense_ffn.gate_proj, inter, h)?,
+                q(&dense_ffn.up_proj, inter, h)?,
+                q(&dense_ffn.down_proj, h, inter)?,
+            ))
+        } else {
+            None
+        };
+
         // MoE: NVFP4 uses fused MoeLayer; FP8/BF16 stores per-expert weights
-        let (moe_nvfp4, moe_experts_generic, moe_shared_generic) = match quant {
+        let (moe_nvfp4, moe_experts_generic, moe_shared_generic) = if dense_ffn_generic.is_some() {
+            (None, None, None)
+        } else {
+            match quant {
             MtpQuantization::Nvfp4 => {
                 let gate_nvfp4 = quantize_to_nvfp4(
                     &weights.moe_gate,
@@ -147,6 +178,7 @@ impl MtpHead {
                 );
                 (None, Some(experts_g), Some(shared))
             }
+            }
         };
 
         // MTP KV cache: 1 attention layer
@@ -197,13 +229,21 @@ impl MtpHead {
         } else {
             config.vocab_size
         };
+        let ffn_kind: &str = if dense_ffn_generic.is_some() {
+            "dense FFN"
+        } else if moe_nvfp4.is_some() {
+            "MoE (NVFP4 fused)"
+        } else {
+            "MoE (per-expert)"
+        };
         tracing::info!(
-            "MTP head: quant={:?}, fc=[{h},{h2}], attn Q=[{qd},{h}], {ne} experts, \
-             vocab={ev}/{fv} (LM head {lm:.1} MB)",
+            "MTP head: quant={:?}, fc=[{h},{h2}], attn Q=[{qd},{h}], ffn={ffn}, \
+             {ne} experts, vocab={ev}/{fv} (LM head {lm:.1} MB)",
             quant,
             h2 = h * 2,
             qd = nq * hd * 2,
-            ne = config.num_experts,
+            ffn = ffn_kind,
+            ne = if dense_ffn_generic.is_some() { 0 } else { config.num_experts },
             ev = effective_vocab,
             fv = config.vocab_size,
             lm = (effective_vocab * h / 2) as f64 / (1024.0 * 1024.0),
@@ -227,6 +267,7 @@ impl MtpHead {
             moe_shared_generic,
             moe_gate: weights.moe_gate,
             shared_expert_gate: weights.shared_expert_gate,
+            dense_ffn_generic,
             quant,
             mtp_vocab_size,
             embed_tokens,

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -13,7 +13,7 @@ use crate::tp_shard::{TpShardKind, load_qkvo_tp, shard_dense_bf16, shard_quantiz
 use crate::weight_map::{
     AttentionWeights, DenseWeight, MtpWeights, Nvfp4Variant, SsmWeights, dense, dense_auto,
     dequant_nvfp4_to_bf16, detect_nvfp4_variant, gpu_concat_rows, interleave_ba, load_dense_ffn,
-    load_kv_scales, load_ssm_qwen35, quantize_to_nvfp4, quantized_auto,
+    load_kv_scales, load_mtp, load_ssm_qwen35, quantize_to_nvfp4, quantized_auto,
 };
 
 pub struct Qwen35DenseWeightLoader;
@@ -331,10 +331,34 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
 
     fn load_mtp_weights(
         &self,
-        _store: &WeightStore,
-        _config: &ModelConfig,
-        _gpu: &dyn GpuBackend,
+        store: &WeightStore,
+        config: &ModelConfig,
+        gpu: &dyn GpuBackend,
     ) -> Result<Option<MtpWeights>> {
-        Ok(None)
+        if !store.contains("mtp.fc.weight") {
+            return Ok(None);
+        }
+        let variant = detect_nvfp4_variant(store, config);
+        tracing::info!(
+            "Loading dense MTP weights (variant={:?}, hidden={}, inter={})",
+            variant,
+            config.hidden_size,
+            config.intermediate_size,
+        );
+        // `load_mtp` auto-detects MoE vs dense FFN by inspecting the weight
+        // names. For dense Qwen3.6-27B-FP8 it returns a MtpWeights with
+        // `dense_ffn = Some(...)` and NULL placeholders for the MoE fields.
+        let mtp = load_mtp(store, config.num_experts, gpu, variant)?;
+        if mtp.dense_ffn.is_some() {
+            tracing::info!(
+                "Dense MTP head ready (FP8 e4m3 projections + dense gate/up/down MLP)"
+            );
+        } else {
+            tracing::info!(
+                "MoE MTP head ready ({} experts) — dense loader sees MoE bundle",
+                mtp.experts.len(),
+            );
+        }
+        Ok(Some(mtp))
     }
 }

--- a/crates/spark-model/src/weight_map/loaders_moe.rs
+++ b/crates/spark-model/src/weight_map/loaders_moe.rs
@@ -178,6 +178,13 @@ pub(crate) fn load_moe_mistral(
 /// MTP weights use `mtp.*` prefix. For NVFP4/BF16 models all are BF16 in safetensors.
 /// For FP8 models, projections/experts are FP8 block-scaled → dequanted to BF16 here.
 /// Quantization to NVFP4 happens in the weight_loader, not here.
+///
+/// Two FFN flavors are auto-detected:
+/// - **MoE** (Qwen3.5-MoE / Qwen3.6-A3B): router `mtp.layers.0.mlp.gate.weight`
+///   plus per-expert or stacked expert tensors and a shared expert.
+/// - **Dense** (Qwen3.6-27B-FP8): single `mtp.layers.0.mlp.{gate,up,down}_proj.weight`
+///   triple, no router or experts. Distinguished by absence of `.gate.weight`
+///   and presence of `.gate_proj.weight` directly under `mlp`.
 pub(crate) fn load_mtp(
     store: &WeightStore,
     num_experts: usize,
@@ -196,6 +203,46 @@ pub(crate) fn load_mtp(
             _ => dense(store, name),
         }
     };
+
+    // Dense FFN MTP head: triple of {gate,up,down}_proj directly under
+    // `mtp.layers.0.mlp`, with no `.gate.weight` router. Short-circuit before
+    // any MoE-shaped loads so a dense checkpoint doesn't trip on missing
+    // `shared_expert.*` tensors.
+    let dense_gate_proj = format!("{mlp}.gate_proj.weight");
+    let moe_router = format!("{mlp}.gate.weight");
+    if store.contains(&dense_gate_proj) && !store.contains(&moe_router) {
+        let dense_ffn = DenseExpertWeight {
+            gate_proj: load(&dense_gate_proj)?,
+            up_proj: load(&format!("{mlp}.up_proj.weight"))?,
+            down_proj: load(&format!("{mlp}.down_proj.weight"))?,
+        };
+        let null = DenseWeight {
+            weight: DevicePtr::NULL,
+        };
+        return Ok(MtpWeights {
+            pre_fc_norm_embedding: dense(store, "mtp.pre_fc_norm_embedding.weight")?,
+            pre_fc_norm_hidden: dense(store, "mtp.pre_fc_norm_hidden.weight")?,
+            fc: load("mtp.fc.weight")?,
+            input_layernorm: dense(store, "mtp.layers.0.input_layernorm.weight")?,
+            q_proj: load(&format!("{p}.q_proj.weight"))?,
+            k_proj: load(&format!("{p}.k_proj.weight"))?,
+            v_proj: load(&format!("{p}.v_proj.weight"))?,
+            o_proj: load(&format!("{p}.o_proj.weight"))?,
+            q_norm: dense(store, &format!("{p}.q_norm.weight"))?,
+            k_norm: dense(store, &format!("{p}.k_norm.weight"))?,
+            post_attn_layernorm: dense(store, "mtp.layers.0.post_attention_layernorm.weight")?,
+            moe_gate: null,
+            shared_expert: DenseExpertWeight {
+                gate_proj: null,
+                up_proj: null,
+                down_proj: null,
+            },
+            shared_expert_gate: null,
+            experts: Vec::new(),
+            dense_ffn: Some(dense_ffn),
+            norm: dense(store, "mtp.norm.weight")?,
+        });
+    }
 
     let shared_expert = DenseExpertWeight {
         gate_proj: load(&format!("{mlp}.shared_expert.gate_proj.weight"))?,
@@ -254,6 +301,7 @@ pub(crate) fn load_mtp(
         shared_expert,
         shared_expert_gate: dense(store, &format!("{mlp}.shared_expert_gate.weight"))?,
         experts,
+        dense_ffn: None,
         norm: dense(store, "mtp.norm.weight")?,
     })
 }

--- a/crates/spark-model/src/weight_map/moe.rs
+++ b/crates/spark-model/src/weight_map/moe.rs
@@ -120,13 +120,21 @@ pub struct MtpWeights {
     /// Post-attention layernorm: `[hidden_size]` BF16.
     pub post_attn_layernorm: DenseWeight,
     /// MoE router gate: [num_experts, hidden_size] BF16.
+    /// NULL when `dense_ffn` is `Some` (dense FFN MTP head).
     pub moe_gate: DenseWeight,
-    /// Shared expert (BF16).
+    /// Shared expert (BF16). NULL fields when `dense_ffn` is `Some`.
     pub shared_expert: DenseExpertWeight,
     /// Shared expert gate: [1, hidden_size] BF16.
+    /// NULL when `dense_ffn` is `Some`.
     pub shared_expert_gate: DenseWeight,
     /// Per-expert weights (512 experts, BF16).
+    /// Empty when `dense_ffn` is `Some`.
     pub experts: Vec<DenseExpertWeight>,
+    /// Dense FFN triple (`gate_proj`, `up_proj`, `down_proj`) — used by MTP
+    /// heads bundled with dense (non-MoE) FP8 checkpoints, e.g.
+    /// `Qwen/Qwen3.6-27B-FP8`. When `Some`, the MoE fields above are unused
+    /// and the forward path takes the dense MLP shortcut.
+    pub dense_ffn: Option<DenseExpertWeight>,
     /// Final output RMSNorm: `[hidden_size]` BF16.
     pub norm: DenseWeight,
 }


### PR DESCRIPTION
## Summary

Two commits that together unblock `--speculative` on **Qwen/Qwen3.6-27B-FP8** (and any other dense Qwen3.5/3.6 checkpoint that ships an `mtp.safetensors`):

### 1. `feat(mtp): support dense FFN MTP heads` (ba5c0e3)

The bundled MTP head on Qwen3.6-27B-FP8 is full-attention + a *dense* gate/up/down MLP (no router, no experts). Atlas's MTP loader previously assumed every MTP head was MoE-shaped, so `Qwen35DenseWeightLoader::load_mtp_weights` was a stub returning `Ok(None)` and `--speculative` silently no-opped.

- `MtpWeights` gains `dense_ffn: Option<DenseExpertWeight>`. `load_mtp` auto-detects FFN flavor by inspecting weight names — presence of `mtp.layers.0.mlp.gate_proj.weight` without `.gate.weight` selects the dense path; MoE fields get NULL placeholders.
- `MtpHead` gains `dense_ffn_generic`. Constructor short-circuits all MoE quantization when `weights.dense_ffn.is_some()`. NVFP4 + dense rejected at construction (Qwen3.6-27B-FP8 ships an FP8 e4m3 MTP head, so `--mtp-quantization fp8` is the right knob — `bf16` also fine).
- Step 10 in `forward.rs` dispatches `dense_ffn_forward_generic` when the dense triple is populated. The dense path reuses the existing `dense_gemv_*` and `moe_silu_mul` kernels — no new kernel wiring.
- `factory::build` warns when `--speculative` is requested but no MTP weights load (was: silent no-op).

### 2. `fix(factory): prefer dense loader over VL for qwen3_5 model_type` (5eefb84)

Discovered while bringing up #1. Commit `82f4794` (Apple Metal merge) widened `is_qwen3_vl()` to also match `qwen3_5 + vision_config`. Qwen3.6-27B-FP8's config.json declares the same `vision_config` block as the Qwen3.6-VL family (Qwen ships them under one config family), but the checkpoint has no vision tower and no MoE router. After #30 the routing sends 27B-FP8 to `Qwen3VLWeightLoader` which panics on missing `mlp.gate.weight`.

Fix: swap the order in `loader_for_config` so `is_qwen35_dense()` (requires `num_experts == 0`) runs first. Dense text-only checkpoints are unambiguously distinguishable by `num_experts == 0`; VL-MoE always has experts.

## Test plan

- [x] `scripts/check.sh check -p spark-model -p spark-server` clean.
- [x] Docker build (`docker/gb10/Dockerfile`) succeeds.
- [x] Live `spark serve Qwen/Qwen3.6-27B-FP8 --speculative --mtp-quantization fp8` on dgx1: model loads, dense MTP head log line fires (`Dense MTP head ready (FP8 e4m3 projections + dense gate/up/down MLP)`), coherence test PASSED, first benchmark task completed cleanly with K=2 ACCEPT/REJECT lines confirming speculative decoding is firing through the new path.
- [x] `--speculative` on a Qwen3.6-27B-FP8 server previously errored at model build (`Weight 'model.layers.0.mlp.gate.weight' not found`). With the factory fix, dense loader handles it and now also picks up the bundled MTP head.

## Live throughput note

Numbers from sparkrun arena (dgx1, fp8 KV, `-o max_batch_size=4`):

| d    | c | dense-MTP tg/stream | dense-noMTP tg/stream | Δ        |
|------|---|--------------------:|----------------------:|---------:|
| 0    | 1 | **37.8**            | 25.4                  | **+49%** |
| 4096 | 2 | 21.3                | 25.7                  | -17%     |
| 8192 | 2 | 10.2                | 21.3                  | -52%     |
| 4096 | 5 | 12.2                | 17.95                 | -32%     |

K=2 verify costs ~85ms (≈ a normal decode step) with ~27% acceptance, so dense MTP currently *wins* at c=1 (single-stream decode-bound) and *loses* at c≥2 where the model is already throughput-bound. **Follow-on PR will reduce verify cost** — see the qwen-refactor roadmap (Q07).

## Companion PR

[atlas-recipes #1](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/1) — recipes for Qwen3.6-27B-FP8 no-MTP and MTP variants.