### PR TITLE
feat(spark-server): inject tool-call parser system prompt

### DIFF
--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -103,20 +103,18 @@ pub(crate) async fn chat_completions_inner(
     // Inject parser-specific behavioral system prompt when tools are active.
     // Each ToolCallParser defines guardrails (e.g. "emit <tool_call> immediately,
     // do not narrate") that the Jinja chat template alone does not enforce.
-    if tools_active {
-        if let Some(ref parser) = state.tool_call_parser {
-            let default_choice = crate::tool_parser::ToolChoice::Mode("auto".to_string());
-            let tool_choice = req.tool_choice.as_ref().unwrap_or(&default_choice);
-            let tool_prompt =
-                parser.system_prompt(req.tools.as_deref().unwrap_or(&[]), tool_choice);
-            if let Some(first) = req.messages.first_mut().filter(|m| m.role == "system") {
-                first.content.text = format!("{}\n\n{}", tool_prompt, first.content.text);
-            } else {
-                req.messages.insert(
-                    0,
-                    crate::openai::IncomingMessage::synthetic_system(tool_prompt),
-                );
-            }
+    if tools_active && let Some(ref parser) = state.tool_call_parser {
+        let default_choice = crate::tool_parser::ToolChoice::Mode("auto".to_string());
+        let tool_choice = req.tool_choice.as_ref().unwrap_or(&default_choice);
+        let tool_prompt =
+            parser.system_prompt(req.tools.as_deref().unwrap_or(&[]), tool_choice);
+        if let Some(first) = req.messages.first_mut().filter(|m| m.role == "system") {
+            first.content.text = format!("{}\n\n{}", tool_prompt, first.content.text);
+        } else {
+            req.messages.insert(
+                0,
+                crate::openai::IncomingMessage::synthetic_system(tool_prompt),
+            );
         }
     }
 

--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -100,6 +100,26 @@ pub(crate) async fn chat_completions_inner(
         && req.tools.as_ref().is_some_and(|t| !t.is_empty())
         && !req.tool_choice.as_ref().is_some_and(|tc| tc.is_none());
 
+    // Inject parser-specific behavioral system prompt when tools are active.
+    // Each ToolCallParser defines guardrails (e.g. "emit <tool_call> immediately,
+    // do not narrate") that the Jinja chat template alone does not enforce.
+    if tools_active {
+        if let Some(ref parser) = state.tool_call_parser {
+            let default_choice = crate::tool_parser::ToolChoice::Mode("auto".to_string());
+            let tool_choice = req.tool_choice.as_ref().unwrap_or(&default_choice);
+            let tool_prompt =
+                parser.system_prompt(req.tools.as_deref().unwrap_or(&[]), tool_choice);
+            if let Some(first) = req.messages.first_mut().filter(|m| m.role == "system") {
+                first.content.text = format!("{}\n\n{}", tool_prompt, first.content.text);
+            } else {
+                req.messages.insert(
+                    0,
+                    crate::openai::IncomingMessage::synthetic_system(tool_prompt),
+                );
+            }
+        }
+    }
+
     tracing::info!(
         "Request: model={}, messages={}, tools={}, tools_active={}, tool_choice={:?}, stream={}, temp={:?}, max_tokens={}, freq_pen={:?}, rep_pen={:?}",
         req.model,


### PR DESCRIPTION
<!--
Thanks for contributing to Atlas! A few reminders:

- Read CONTRIBUTING.md if you haven't yet.
- CI runs cargo fmt, cargo clippy -Dwarnings, the SPDX-header check, typos,
  and cargo-deny (via the security workflow). Please run `cargo fmt --all` 
  and `bash scripts/check-license-headers.sh` locally before pushing.
- If you add a new source file, it needs `// SPDX-License-Identifier: AGPL-3.0-only` 
  on line 1.
-->

## Summary

Wire up [ToolCallParser::system_prompt](cci:1://file:///Users/angelespiritu/Dev/github/atlas/crates/spark-server/src/tool_parser/qwen3_coder.rs:29:4-102:5) so parser-specific behavioral guardrails are actually injected into tool-active chat requests. Every parser (Hermes, Qwen3-Coder, Mistral, Gemma-4, MiniMax) already defines this method, but it was dead code — never called in production. The Jinja template alone does not provide strong enough instructions (the qwen3_5_moe template explicitly permits narration), causing models to narrate instead of emitting `<tool_call>` blocks.

## Test plan

- [x] `cargo fmt --all -- --check` 
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` (requires rustc 1.88+ for current lockfile; blocked on host toolchain)
- [x] `bash scripts/check-license-headers.sh` (no new files added)
- [ ] Tested against a real model / hardware if the change affects runtime behaviour — **I do not have a DGX Spark / CUDA host available. Please verify with a tool-calling prompt on Qwen3.6-35B-A3B-FP8 before merge.**
- [ ] Added or updated tests where applicable — **Happy to add an integration test if you point me to the right harness; the unit tests in `tool_parser/tests/` exercise [system_prompt](cci:1://file:///Users/angelespiritu/Dev/github/atlas/crates/spark-server/src/tool_parser/qwen3_coder.rs:29:4-102:5) but do not cover the request-injection path.**

## Notes for reviewers

- The change is generic over the [ToolCallParser](cci:2://file:///Users/angelespiritu/Dev/github/atlas/crates/spark-server/src/tool_parser.rs:184:0-263:1) trait, so all parsers benefit without individual modifications. The [system_prompt()](cci:1://file:///Users/angelespiritu/Dev/github/atlas/crates/spark-server/src/tool_parser/qwen3_coder.rs:29:4-102:5) implementations already exist and are well-tested in isolation.
- The injection happens after [apply_failure_guards](cci:1://file:///Users/angelespiritu/Dev/github/atlas/crates/spark-server/src/api/chat_phases.rs:94:0-201:1) so the parser prompt sits before (and therefore higher priority than) the client's system message. If no system message exists, a synthetic one is created.
- Risk to other parsers is low: every parser's [system_prompt](cci:1://file:///Users/angelespiritu/Dev/github/atlas/crates/spark-server/src/tool_parser/qwen3_coder.rs:29:4-102:5) is idempotent text generation. Hermes, Mistral, and Gemma-4 parsers will now receive their own instructions instead of relying solely on the Jinja template.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).