### PR TITLE
site: sparkrun quickstart + SSOT-driven model carousel

### DIFF
--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -106,8 +106,7 @@ pub(crate) async fn chat_completions_inner(
     if tools_active && let Some(ref parser) = state.tool_call_parser {
         let default_choice = crate::tool_parser::ToolChoice::Mode("auto".to_string());
         let tool_choice = req.tool_choice.as_ref().unwrap_or(&default_choice);
-        let tool_prompt =
-            parser.system_prompt(req.tools.as_deref().unwrap_or(&[]), tool_choice);
+        let tool_prompt = parser.system_prompt(req.tools.as_deref().unwrap_or(&[]), tool_choice);
         if let Some(first) = req.messages.first_mut().filter(|m| m.role == "system") {
             first.content.text = format!("{}\n\n{}", tool_prompt, first.content.text);
         } else {

--- a/site/scripts/gen-models.mjs
+++ b/site/scripts/gen-models.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-models.mjs — generate src/lib/models.generated.json from the recipe SSOT
+// -----------------------------------------------------------------------------
+// SSOT: https://github.com/Avarok-Cybersecurity/atlas-recipes
+//   (read-only mirror expected at /workspace/atlas-recipes/recipes on the host
+//    that runs this script — that public repo is the single source of truth for
+//    every supported model + its canonical `sparkrun run` command).
+//
+// Regenerate with:   node site/scripts/gen-models.mjs
+//
+// Every recipes/**/*.yaml MUST appear in the output. The generated array's
+// total recipe count is asserted to equal the number of recipe YAML files.
+// No third-party deps: a tiny hand-rolled reader parses the (deliberately
+// simple) recipe schema — top-level scalars, a `metadata:` block of scalars
+// plus a `description: |` literal block, and a `defaults:` scalar block.
+// =============================================================================
+
+import { readdirSync, statSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname, basename, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RECIPES_ROOT = process.env.ATLAS_RECIPES_ROOT || '/workspace/atlas-recipes/recipes';
+const SSOT_URL = 'https://github.com/Avarok-Cybersecurity/atlas-recipes';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(here, '..', 'src', 'lib', 'models.generated.json');
+
+// --- recursive YAML file discovery ------------------------------------------
+function walkYaml(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkYaml(full));
+    else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) out.push(full);
+  }
+  return out;
+}
+
+// --- minimal recipe reader ---------------------------------------------------
+// Returns: { top: {scalars...}, metadata: {scalars + description}, defaults: {} }
+function parseRecipe(text) {
+  const lines = text.split('\n');
+  const top = {};
+  const metadata = {};
+  const defaults = {};
+  let section = 'top'; // 'top' | 'metadata' | 'defaults'
+  let i = 0;
+
+  const stripComment = (v) => {
+    // strip an unquoted trailing comment, keep quoted/literal values intact
+    if (v.startsWith('"') || v.startsWith("'")) return v;
+    const h = v.indexOf(' #');
+    return (h === -1 ? v : v.slice(0, h)).trim();
+  };
+  const unquote = (v) => {
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
+      return v.slice(1, -1);
+    return v;
+  };
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    const line = raw.replace(/\s+$/, '');
+    i++;
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+
+    // section headers (no indentation, key with empty value)
+    if (/^metadata:\s*$/.test(line)) { section = 'metadata'; continue; }
+    if (/^defaults:\s*$/.test(line)) { section = 'defaults'; continue; }
+    if (/^[a-zA-Z_]/.test(line) && section !== 'top' && /^[a-zA-Z_][\w.-]*:\s*\S/.test(line)) {
+      // a new top-level scalar after a block ends a block section
+      section = 'top';
+    }
+
+    const m = line.match(/^(\s*)([\w.\-]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, indent, key, rest0] = m;
+    const rest = rest0.trim();
+
+    const bucket = section === 'metadata' ? metadata : section === 'defaults' ? defaults : top;
+
+    if (rest === '|' || rest === '|-' || rest === '>' || rest === '>-') {
+      // literal/folded block scalar — collect more-indented lines
+      const baseIndent = indent.length;
+      const block = [];
+      while (i < lines.length) {
+        const bl = lines[i];
+        if (bl.trim() === '') { block.push(''); i++; continue; }
+        const blIndent = bl.match(/^(\s*)/)[1].length;
+        if (blIndent <= baseIndent) break;
+        block.push(bl.slice(baseIndent + 2));
+        i++;
+      }
+      bucket[key] = block.join('\n').replace(/\n+$/, '').trim();
+      continue;
+    }
+
+    if (rest === '') continue; // nested map header we don't need
+    bucket[key] = unquote(stripComment(rest));
+  }
+
+  return { top, metadata, defaults };
+}
+
+// --- family display names ----------------------------------------------------
+const FAMILY_DISPLAY = {
+  'qwen3.5': 'Qwen3.5',
+  'qwen3.6': 'Qwen3.6',
+  'qwen3-next': 'Qwen3-Next',
+  'qwen3-coder-next': 'Qwen3-Coder-Next',
+  'qwen3-vl': 'Qwen3-VL',
+  'gemma4': 'Gemma 4',
+  'nemotron-3-nano': 'Nemotron-3 Nano',
+  'nemotron-3-super': 'Nemotron-3 Super',
+  'mistral-small-4': 'Mistral Small 4',
+  'minimax-m2.7': 'MiniMax M2.7'
+};
+function familyDisplay(fam) {
+  if (FAMILY_DISPLAY[fam]) return FAMILY_DISPLAY[fam];
+  return fam.replace(/[-.]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// --- topology inference ------------------------------------------------------
+// The recipe's *own* topology is encoded in (a) the filename stem suffix
+// (`-ep2` / `-tp2`) and (b) the declared node count. We deliberately do NOT
+// scan the prose description: several single-node recipes mention "Use --tp 2
+// / EP=2 ..." as advisory text, which would false-positive.
+function inferTopology(stem, top) {
+  const s = stem.toLowerCase();
+  if (/(^|-)ep2($|-)/.test(s)) return 'EP=2';
+  if (/(^|-)tp2($|-)/.test(s)) return 'TP=2';
+  const maxN = parseInt(top.max_nodes ?? '1', 10);
+  const minN = parseInt(top.min_nodes ?? top.max_nodes ?? '1', 10);
+  if (maxN >= 2 || minN >= 2) return 'EP=2';
+  return 'single';
+}
+
+// --- per-recipe display label ------------------------------------------------
+function recipeDisplay(stem) {
+  // humanize the file stem into a short variant label
+  const parts = stem.replace(/-atlas$/, '').split('-');
+  const out = parts.map((p) => {
+    const lp = p.toLowerCase();
+    if (lp === 'nvfp4a16' || lp === 'nvfp4') return 'NVFP4';
+    if (lp === 'fp8') return 'FP8';
+    if (lp === 'bf16') return 'BF16';
+    if (lp === 'ep2') return 'EP=2';
+    if (lp === 'tp2') return 'TP=2';
+    if (lp === 'mtp') return 'MTP';
+    if (lp === 'vl') return 'VL';
+    if (lp === 'it') return 'IT';
+    if (lp === 'dense' || lp === 'single') return p[0].toUpperCase() + p.slice(1);
+    // param-style tokens: 80b, a3b, a10b, a12b, 0.8b, 122b -> uppercase
+    if (/^a?\d+(\.\d+)?b$/.test(lp)) return p.toUpperCase();
+    // version-bearing family tokens stay as-is (qwen3.5, gemma, minimax...)
+    return p[0].toUpperCase() + p.slice(1);
+  });
+  return out.join(' ');
+}
+
+// --- main --------------------------------------------------------------------
+const files = walkYaml(RECIPES_ROOT).sort();
+if (files.length === 0) {
+  console.error(`No recipe YAML files found under ${RECIPES_ROOT}`);
+  process.exit(1);
+}
+
+const familyMap = new Map();
+let recipeCount = 0;
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const { top, metadata } = parseRecipe(text);
+  const fam = basename(dirname(file));
+  const stem = basename(file).replace(/\.(ya?ml)$/, '');
+  const topology = inferTopology(stem, top);
+
+  const recipe = {
+    displayName: recipeDisplay(stem),
+    hfId: top.model || '',
+    params: metadata.model_params || '',
+    quant: metadata.quantization || '',
+    topology,
+    recipeStem: stem,
+    command: `sparkrun run @atlas/${stem}`
+  };
+
+  if (!familyMap.has(fam)) {
+    familyMap.set(fam, { family: fam, displayName: familyDisplay(fam), recipes: [] });
+  }
+  familyMap.get(fam).recipes.push(recipe);
+  recipeCount++;
+}
+
+// stable ordering: families alphabetical, recipes by stem
+const families = [...familyMap.values()].sort((a, b) => a.family.localeCompare(b.family));
+for (const f of families) f.recipes.sort((a, b) => a.recipeStem.localeCompare(b.recipeStem));
+
+const json = JSON.stringify(families, null, 2) + '\n';
+writeFileSync(OUT, json);
+
+const emitted = families.reduce((n, f) => n + f.recipes.length, 0);
+if (emitted !== recipeCount || emitted !== files.length) {
+  console.error(
+    `Recipe count mismatch: yaml files=${files.length}, emitted=${emitted}. SSOT: ${SSOT_URL}`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Wrote ${OUT}\n  ${files.length} recipes across ${families.length} families` +
+    ` (SSOT: ${SSOT_URL})`
+);
+for (const f of families) console.log(`  - ${f.displayName}: ${f.recipes.length}`);

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -241,6 +241,94 @@ footer { border-top: 1px solid var(--border); padding: 3rem 2rem; }
 .fcol a:hover { color: #fff; }
 .footer-bottom { max-width: 1200px; margin: 1.5rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); text-align: center; font-size: 0.7rem; color: var(--t3); }
 
+/* Model Slider (SSOT carousel of recipe families) */
+.ms-carousel { position: relative; }
+.ms-controls {
+  display: flex; align-items: center; justify-content: center;
+  gap: 1rem; margin-bottom: 1.25rem;
+}
+.ms-arrow {
+  flex-shrink: 0; width: 38px; height: 38px; border-radius: 50%;
+  background: var(--card); border: 1px solid var(--border); color: var(--t1);
+  font-size: 1.2rem; line-height: 1; cursor: pointer;
+  transition: border-color 0.2s, background 0.2s, transform 0.2s;
+  display: flex; align-items: center; justify-content: center;
+}
+.ms-arrow:hover { border-color: rgba(124,58,237,0.45); background: rgba(124,58,237,0.08); transform: translateY(-1px); }
+.ms-dots { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; justify-content: center; }
+.ms-dot {
+  width: 9px; height: 9px; border-radius: 50%; padding: 0;
+  background: var(--border); border: none; cursor: pointer;
+  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+.ms-dot:hover { background: var(--t3); }
+.ms-dot.is-active { background: var(--grad); box-shadow: 0 0 10px rgba(124,58,237,0.5); transform: scale(1.25); }
+.ms-viewport {
+  width: 100%; overflow-x: hidden; border-radius: 14px;
+  scroll-snap-type: x mandatory;
+}
+.ms-track { display: flex; transition: transform 0.45s cubic-bezier(0.22,0.61,0.36,1); will-change: transform; }
+.ms-slide { flex: 0 0 100%; min-width: 100%; scroll-snap-align: start; padding: 2px; }
+.ms-famcard { position: relative; overflow: hidden; padding: 0; }
+.ms-accent { height: 4px; width: 100%; background: var(--grad); }
+.ms-famhead {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 1rem; padding: 1.5rem 1.75rem 1rem; flex-wrap: wrap;
+}
+.ms-famhead h3 { font-size: 1.2rem; font-weight: 800; letter-spacing: -0.02em; }
+.ms-count {
+  font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.1em; color: var(--cyan);
+}
+.ms-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem; padding: 0 1.75rem 1.75rem;
+}
+.subcard {
+  background: var(--bg2); border: 1px solid var(--border);
+  border-radius: 10px; padding: 1.1rem 1.15rem;
+  transition: border-color 0.25s, transform 0.25s;
+  display: flex; flex-direction: column; gap: 0.6rem;
+}
+.subcard:hover { border-color: rgba(124,58,237,0.3); transform: translateY(-2px); }
+.subcard-label { font-size: 0.92rem; font-weight: 700; color: var(--t1); }
+.subcard-meta { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.chip {
+  display: inline-block; font-size: 0.6rem; font-weight: 700;
+  padding: 0.2rem 0.5rem; border-radius: 4px; letter-spacing: 0.04em;
+  text-transform: uppercase; border: 1px solid transparent;
+}
+.chip-nvfp4 { background: rgba(124,58,237,0.15); color: #a78bfa; border-color: rgba(124,58,237,0.3); }
+.chip-fp8 { background: rgba(6,182,212,0.15); color: var(--cyan); border-color: rgba(6,182,212,0.3); }
+.chip-bf16 { background: rgba(136,136,160,0.14); color: var(--t2); border-color: rgba(136,136,160,0.25); }
+.chip-single { background: rgba(255,255,255,0.04); color: var(--t2); border-color: var(--border); }
+.chip-ep2 { background: rgba(16,185,129,0.15); color: var(--green); border-color: rgba(16,185,129,0.3); }
+.chip-tp2 { background: rgba(251,191,36,0.15); color: #fbbf24; border-color: rgba(251,191,36,0.3); }
+.chip-params { background: rgba(255,255,255,0.04); color: var(--t2); border-color: var(--border); }
+.subcard-hf {
+  font-size: 0.7rem; color: var(--t3);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cmd-pill {
+  display: flex; align-items: center; gap: 0.5rem;
+  background: #0b0b14; border: 1px solid var(--border);
+  border-radius: 7px; padding: 0.45rem 0.45rem 0.45rem 0.7rem;
+  margin-top: auto;
+}
+.cmd-text {
+  flex: 1; min-width: 0; color: var(--cyan); font-size: 0.7rem;
+  overflow-x: auto; white-space: nowrap; scrollbar-width: thin;
+}
+.cmd-copy {
+  flex-shrink: 0; background: rgba(124,58,237,0.15); color: #a78bfa;
+  border: 1px solid rgba(124,58,237,0.35); border-radius: 5px;
+  padding: 0.3rem 0.6rem; font-size: 0.66rem; font-weight: 700;
+  cursor: pointer; transition: background 0.15s, color 0.15s;
+  font-family: 'JetBrains Mono', monospace; letter-spacing: 0.03em;
+}
+.cmd-copy:hover { background: rgba(124,58,237,0.28); color: #fff; }
+.ms-foot { font-size: 0.72rem; color: var(--t3); margin-top: 1.5rem; font-style: italic; line-height: 1.7; }
+
 @media (max-width: 768px) {
   .nav-links { display: none; }
   .pillars { grid-template-columns: 1fr; }
@@ -251,4 +339,10 @@ footer { border-top: 1px solid var(--border); padding: 3rem 2rem; }
   .hero-install { flex-wrap: wrap; gap: 0.5rem; padding: 0.6rem 0.7rem; }
   .hero-install-cmd { width: 100%; font-size: 0.72rem; }
   .hero-install-copy { margin-left: auto; }
+  .ms-grid { grid-template-columns: 1fr; padding: 0 1.1rem 1.25rem; }
+  .ms-famhead { padding: 1.15rem 1.1rem 0.85rem; }
+  .ms-viewport {
+    overflow-x: auto; -webkit-overflow-scrolling: touch;
+    touch-action: pan-x pan-y;
+  }
 }

--- a/site/src/lib/components/Footer.svelte
+++ b/site/src/lib/components/Footer.svelte
@@ -15,6 +15,11 @@
       <a href="#roadmap">Roadmap</a>
     </div>
     <div class="fcol">
+      <h4>Run Atlas</h4>
+      <a href="https://sparkrun.dev/runtimes/atlas/" target="_blank" rel="noopener">sparkrun</a>
+      <a href="https://github.com/Avarok-Cybersecurity/atlas-recipes" target="_blank" rel="noopener">Recipes (SSOT)</a>
+    </div>
+    <div class="fcol">
       <h4>Community</h4>
       <a href={discordUrl}>Discord</a>
       <a href={redditUrl}>Reddit</a>

--- a/site/src/lib/components/Hero.svelte
+++ b/site/src/lib/components/Hero.svelte
@@ -26,15 +26,17 @@
       ~2.5 GB image that runs 3x faster than the status quo.
     </p>
 
-    <div class="hero-install" role="group" aria-label="Quick install">
+    <div class="hero-install" role="group" aria-label="Install sparkrun">
       <span class="hero-install-prompt mono">$</span>
       <code class="hero-install-cmd mono">{quickInstall}</code>
-      <button type="button" class="hero-install-copy" onclick={copy} aria-label="Copy install command">
+      <button type="button" class="hero-install-copy" onclick={copy} aria-label="Copy sparkrun install command">
         {copied ? 'Copied' : 'Copy'}
       </button>
     </div>
     <div class="hero-install-sub">
-      ~2.5 GB image. Run command <a href="#try" class="hero-install-link">below</a>.
+      <a href="https://sparkrun.dev/runtimes/atlas/" class="hero-install-link">sparkrun</a>
+      pulls &amp; runs the ~2.5 GB Atlas image for you. Run command
+      <a href="#try" class="hero-install-link">below</a>.
     </div>
 
     <div class="hero-buttons">

--- a/site/src/lib/components/ModelSlider.svelte
+++ b/site/src/lib/components/ModelSlider.svelte
@@ -1,0 +1,114 @@
+<script>
+  // Data is SSOT-derived from github.com/Avarok-Cybersecurity/atlas-recipes
+  // via site/scripts/gen-models.mjs -> models.generated.json.
+  import families from '$lib/models.generated.json';
+
+  let index = $state(0);
+  let copied = $state('');
+
+  const total = families.length;
+
+  function go(i) {
+    index = ((i % total) + total) % total;
+  }
+  function prev() { go(index - 1); }
+  function next() { go(index + 1); }
+
+  async function copyCmd(cmd) {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      copied = cmd;
+      setTimeout(() => { if (copied === cmd) copied = ''; }, 1600);
+    } catch {}
+  }
+
+  const quantClass = (q) => {
+    const k = (q || '').toLowerCase();
+    if (k === 'nvfp4') return 'chip chip-nvfp4';
+    if (k === 'fp8') return 'chip chip-fp8';
+    if (k === 'bf16') return 'chip chip-bf16';
+    return 'chip';
+  };
+  const quantLabel = (q) => (q && q !== 'none' ? q.toUpperCase() : 'BF16');
+  const topoClass = (t) => (t === 'EP=2' ? 'chip chip-ep2' : t === 'TP=2' ? 'chip chip-tp2' : 'chip chip-single');
+</script>
+
+<section id="models" style="background: var(--bg2);">
+  <div class="container">
+    <div class="slabel">Supported Models</div>
+    <h2 class="stitle">Model matrix</h2>
+    <p class="ssub">
+      Every model gets hand-tuned CUDA kernels. Each card is one model family;
+      every recipe maps to a single
+      <a href="https://github.com/Avarok-Cybersecurity/atlas-recipes" class="ssub-link">sparkrun recipe</a>
+      you can copy and run as-is.
+    </p>
+
+    <div class="ms-carousel">
+      <div class="ms-controls">
+        <button type="button" class="ms-arrow" onclick={prev} aria-label="Previous family">‹</button>
+        <div class="ms-dots" role="tablist" aria-label="Model families">
+          {#each families as f, i}
+            <button
+              type="button"
+              class="ms-dot {i === index ? 'is-active' : ''}"
+              role="tab"
+              aria-selected={i === index}
+              aria-label={f.displayName}
+              onclick={() => go(i)}
+            ></button>
+          {/each}
+        </div>
+        <button type="button" class="ms-arrow" onclick={next} aria-label="Next family">›</button>
+      </div>
+
+      <div class="ms-viewport mtable-scroll">
+        <div class="ms-track" style="transform: translateX(-{index * 100}%);">
+          {#each families as f}
+            <div class="ms-slide">
+              <div class="card ms-famcard">
+                <div class="ms-accent" aria-hidden="true"></div>
+                <div class="ms-famhead">
+                  <h3>{f.displayName}</h3>
+                  <span class="ms-count">{f.recipes.length} recipe{f.recipes.length === 1 ? '' : 's'}</span>
+                </div>
+                <div class="ms-grid">
+                  {#each f.recipes as r}
+                    <div class="subcard">
+                      <div class="subcard-label">{r.displayName}</div>
+                      <div class="subcard-meta">
+                        <span class={quantClass(r.quant)}>{quantLabel(r.quant)}</span>
+                        <span class={topoClass(r.topology)}>{r.topology}</span>
+                        {#if r.params}<span class="chip chip-params">{r.params}</span>{/if}
+                      </div>
+                      <div class="subcard-hf mono" title={r.hfId}>{r.hfId}</div>
+                      <div class="cmd-pill">
+                        <code class="cmd-text mono">{r.command}</code>
+                        <button
+                          type="button"
+                          class="cmd-copy"
+                          onclick={() => copyCmd(r.command)}
+                          aria-label={`Copy ${r.command}`}
+                        >
+                          {copied === r.command ? 'Copied' : 'Copy'}
+                        </button>
+                      </div>
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+
+    <div class="ms-foot">
+      All recipes are the single source of truth in
+      <a href="https://github.com/Avarok-Cybersecurity/atlas-recipes" class="ssub-link">atlas-recipes</a>.
+      Run any of them with
+      <a href="https://sparkrun.dev/runtimes/atlas/" class="ssub-link">sparkrun</a>.
+      EP=2 = Expert Parallelism across two GB10 nodes.
+    </div>
+  </div>
+</section>

--- a/site/src/lib/components/Nav.svelte
+++ b/site/src/lib/components/Nav.svelte
@@ -13,6 +13,7 @@
       <a href="#speed">Why Atlas</a>
       <a href="#models">Models</a>
       <a href="#try">Try It</a>
+      <a href="https://sparkrun.dev/runtimes/atlas/" target="_blank" rel="noopener">sparkrun</a>
       <a href="#community">Community</a>
       <a href="#roadmap">Roadmap</a>
       <a

--- a/site/src/lib/components/TryIt.svelte
+++ b/site/src/lib/components/TryIt.svelte
@@ -16,7 +16,11 @@
     <div class="slabel">Try It Yourself</div>
     <h2 class="stitle">Up and running in two commands</h2>
     <p class="ssub">
-      Don't take our word for it. Pull the image. Run it on your DGX Spark. See the difference.
+      Don't take our word for it. Install
+      <a href="https://sparkrun.dev/runtimes/atlas/" class="ssub-link">sparkrun</a>,
+      run an Atlas recipe on your DGX Spark, and see the difference. sparkrun pulls
+      &amp; runs the Atlas image for you — it uses your existing Docker/Podman +
+      NVIDIA container runtime.
     </p>
 
     <div class="term-card">
@@ -24,8 +28,8 @@
         <div class="term-dots" aria-hidden="true">
           <span></span><span></span><span></span>
         </div>
-        <div class="term-title">Qwen3.5-35B, 130 tok/s on a single Spark</div>
-        <button type="button" class="hero-install-copy" onclick={copy} aria-label="Copy commands">
+        <div class="term-title">Run with sparkrun — Qwen3.6-35B-A3B FP8 + MTP on a single Spark</div>
+        <button type="button" class="hero-install-copy" onclick={copy} aria-label="Copy sparkrun commands">
           {copied ? 'Copied' : 'Copy'}
         </button>
       </div>

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -153,22 +153,12 @@ export const testimonials = [
   }
 ];
 
-// Hero shows the install step (pull). TryIt below shows pull + full run.
-export const quickInstall = `docker pull avarok/atlas-gb10:latest`;
+// Hero shows the install step. TryIt below shows install + run.
+// sparkrun pulls & runs the avarok/atlas-gb10:latest image for you
+// (the recipe declares `container:`); it uses an existing Docker/Podman
+// + NVIDIA container runtime — it does not install the container engine.
+export const quickInstall = `uvx sparkrun setup install`;
 
-export const dockerCommand = `docker pull avarok/atlas-gb10:latest
+export const dockerCommand = `uvx sparkrun setup install
 
-sudo docker run -d --name atlas \\
-  --network host --gpus all --ipc=host \\
-  -v ~/.cache/huggingface:/root/.cache/huggingface \\
-  avarok/atlas-gb10:latest \\
-  serve Qwen/Qwen3.6-35B-A3B-FP8 \\
-    --port 8888 \\
-    --max-seq-len 65536 \\
-    --kv-cache-dtype fp8 \\
-    --kv-high-precision-layers auto \\
-    --gpu-memory-utilization 0.90 \\
-    --scheduling-policy slai \\
-    --tool-call-parser qwen3_coder \\
-    --enable-prefix-caching \\
-    --speculative`;
+sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas`;

--- a/site/src/lib/models.generated.json
+++ b/site/src/lib/models.generated.json
@@ -1,0 +1,233 @@
+[
+  {
+    "family": "gemma4",
+    "displayName": "Gemma 4",
+    "recipes": [
+      {
+        "displayName": "Gemma 4 26B A4B NVFP4",
+        "hfId": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16",
+        "params": "26B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "gemma-4-26b-a4b-nvfp4",
+        "command": "sparkrun run @atlas/gemma-4-26b-a4b-nvfp4"
+      },
+      {
+        "displayName": "Gemma 4 31B NVFP4",
+        "hfId": "nvidia/Gemma-4-31B-IT-NVFP4",
+        "params": "31B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "gemma-4-31b-nvfp4",
+        "command": "sparkrun run @atlas/gemma-4-31b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "minimax-m2.7",
+    "displayName": "MiniMax M2.7",
+    "recipes": [
+      {
+        "displayName": "Minimax M2.7 NVFP4 EP=2",
+        "hfId": "lukealonso/MiniMax-M2.7-NVFP4",
+        "params": "230B",
+        "quant": "nvfp4",
+        "topology": "EP=2",
+        "recipeStem": "minimax-m2.7-nvfp4-ep2",
+        "command": "sparkrun run @atlas/minimax-m2.7-nvfp4-ep2"
+      }
+    ]
+  },
+  {
+    "family": "mistral-small-4",
+    "displayName": "Mistral Small 4",
+    "recipes": [
+      {
+        "displayName": "Mistral Small 4 119B NVFP4",
+        "hfId": "mistralai/Mistral-Small-4-119B-2603-NVFP4",
+        "params": "119B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "mistral-small-4-119b-nvfp4",
+        "command": "sparkrun run @atlas/mistral-small-4-119b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "nemotron-3-nano",
+    "displayName": "Nemotron-3 Nano",
+    "recipes": [
+      {
+        "displayName": "Nemotron 3 Nano 30B A3B NVFP4",
+        "hfId": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
+        "params": "30B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "nemotron-3-nano-30b-a3b-nvfp4",
+        "command": "sparkrun run @atlas/nemotron-3-nano-30b-a3b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "nemotron-3-super",
+    "displayName": "Nemotron-3 Super",
+    "recipes": [
+      {
+        "displayName": "Nemotron 3 Super 120B A12B NVFP4",
+        "hfId": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+        "params": "120B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "nemotron-3-super-120b-a12b-nvfp4",
+        "command": "sparkrun run @atlas/nemotron-3-super-120b-a12b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "qwen3-coder-next",
+    "displayName": "Qwen3-Coder-Next",
+    "recipes": [
+      {
+        "displayName": "Qwen3 Coder Next FP8",
+        "hfId": "Qwen/Qwen3-Coder-Next-FP8",
+        "params": "80B",
+        "quant": "fp8",
+        "topology": "single",
+        "recipeStem": "qwen3-coder-next-fp8",
+        "command": "sparkrun run @atlas/qwen3-coder-next-fp8"
+      }
+    ]
+  },
+  {
+    "family": "qwen3-next",
+    "displayName": "Qwen3-Next",
+    "recipes": [
+      {
+        "displayName": "Qwen3 Next 80B A3B NVFP4",
+        "hfId": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
+        "params": "80B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "qwen3-next-80b-a3b-nvfp4",
+        "command": "sparkrun run @atlas/qwen3-next-80b-a3b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "qwen3-vl",
+    "displayName": "Qwen3-VL",
+    "recipes": [
+      {
+        "displayName": "Qwen3 VL 30B A3B NVFP4",
+        "hfId": "ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4",
+        "params": "30B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "qwen3-vl-30b-a3b-nvfp4",
+        "command": "sparkrun run @atlas/qwen3-vl-30b-a3b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "qwen3.5",
+    "displayName": "Qwen3.5",
+    "recipes": [
+      {
+        "displayName": "Qwen3.5 0.8B BF16",
+        "hfId": "Qwen/Qwen3.5-0.8B",
+        "params": "0.8B",
+        "quant": "none",
+        "topology": "single",
+        "recipeStem": "qwen3.5-0.8b-bf16-atlas",
+        "command": "sparkrun run @atlas/qwen3.5-0.8b-bf16-atlas"
+      },
+      {
+        "displayName": "Qwen3.5 122B A10B NVFP4 EP=2",
+        "hfId": "Sehyo/Qwen3.5-122B-A10B-NVFP4",
+        "params": "122B",
+        "quant": "nvfp4",
+        "topology": "EP=2",
+        "recipeStem": "qwen3.5-122b-a10b-nvfp4-ep2",
+        "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-ep2"
+      },
+      {
+        "displayName": "Qwen3.5 122B A10B NVFP4 Single",
+        "hfId": "Sehyo/Qwen3.5-122B-A10B-NVFP4",
+        "params": "122B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "qwen3.5-122b-a10b-nvfp4-single",
+        "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-single"
+      },
+      {
+        "displayName": "Qwen3.5 27B Dense NVFP4",
+        "hfId": "Kbenkhaled/Qwen3.5-27B-NVFP4",
+        "params": "27B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "qwen3.5-27b-dense-nvfp4",
+        "command": "sparkrun run @atlas/qwen3.5-27b-dense-nvfp4"
+      },
+      {
+        "displayName": "Qwen3.5 35B A3B NVFP4",
+        "hfId": "Sehyo/Qwen3.5-35B-A3B-NVFP4",
+        "params": "35B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "qwen3.5-35b-a3b-nvfp4",
+        "command": "sparkrun run @atlas/qwen3.5-35b-a3b-nvfp4"
+      }
+    ]
+  },
+  {
+    "family": "qwen3.6",
+    "displayName": "Qwen3.6",
+    "recipes": [
+      {
+        "displayName": "Qwen3.6 27B Dense FP8",
+        "hfId": "Qwen/Qwen3.6-27B-FP8",
+        "params": "27B",
+        "quant": "fp8",
+        "topology": "single",
+        "recipeStem": "qwen3.6-27b-dense-fp8-atlas",
+        "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-atlas"
+      },
+      {
+        "displayName": "Qwen3.6 27B Dense FP8 MTP",
+        "hfId": "Qwen/Qwen3.6-27B-FP8",
+        "params": "27B",
+        "quant": "fp8",
+        "topology": "single",
+        "recipeStem": "qwen3.6-27b-dense-fp8-mtp-atlas",
+        "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-mtp-atlas"
+      },
+      {
+        "displayName": "Qwen3.6 27B FP8 MTP",
+        "hfId": "Qwen/Qwen3.6-27B-FP8",
+        "params": "27B",
+        "quant": "fp8",
+        "topology": "single",
+        "recipeStem": "qwen3.6-27b-fp8-mtp-atlas",
+        "command": "sparkrun run @atlas/qwen3.6-27b-fp8-mtp-atlas"
+      },
+      {
+        "displayName": "Qwen3.6 35B A3B FP8 MTP",
+        "hfId": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "params": "35B",
+        "quant": "fp8",
+        "topology": "single",
+        "recipeStem": "qwen3.6-35b-a3b-fp8-mtp-atlas",
+        "command": "sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas"
+      },
+      {
+        "displayName": "Qwen3.6 35B A3B NVFP4",
+        "hfId": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+        "params": "35B",
+        "quant": "nvfp4",
+        "topology": "single",
+        "recipeStem": "qwen3.6-35b-a3b-nvfp4-atlas",
+        "command": "sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4-atlas"
+      }
+    ]
+  }
+]

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import Hero from '$lib/components/Hero.svelte';
   import Stats from '$lib/components/Stats.svelte';
   import Speed from '$lib/components/Speed.svelte';
-  import Models from '$lib/components/Models.svelte';
+  import ModelSlider from '$lib/components/ModelSlider.svelte';
   import Roadmap from '$lib/components/Roadmap.svelte';
   import Community from '$lib/components/Community.svelte';
   import Contact from '$lib/components/Contact.svelte';
@@ -13,13 +13,26 @@
 
 <svelte:head>
   <title>Atlas Inference Engine</title>
+  {@html `<script type="application/ld+json">${JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Atlas Inference Engine',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Linux',
+    description: 'Pure Rust LLM Inference.',
+    url: 'https://atlasinference.io/',
+    sameAs: [
+      'https://sparkrun.dev/runtimes/atlas/',
+      'https://github.com/Avarok-Cybersecurity/atlas-recipes'
+    ]
+  })}<\/script>`}
 </svelte:head>
 
 <Nav />
 <Hero />
 <Stats />
 <Speed />
-<Models />
+<ModelSlider />
 <TryIt />
 <Community />
 <Contact />


### PR DESCRIPTION
Marketing-site cleanup so the public quickstart and model matrix track the sparkrun + atlas-recipes single source of truth.

- `data.js`: `quickInstall` -> `uvx sparkrun setup install`; `dockerCommand` -> install + `sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas` (export names kept). The referenced recipe is now merged in atlas-recipes `main` (PR #4).
- `Hero.svelte` / `TryIt.svelte`: copy + aria labels updated to sparkrun; accurate wording (sparkrun pulls & runs the ~2.5 GB image, uses an existing Docker/Podman + NVIDIA container runtime).
- `scripts/gen-models.mjs` (new, no deps): reads every `atlas-recipes/recipes/**/*.yaml` (SSOT: github.com/Avarok-Cybersecurity/atlas-recipes), groups by family, emits `models.generated.json`.
- `models.generated.json` (new, generated): 19 recipes / 10 families.
- `ModelSlider.svelte` (new): Svelte 5 runes carousel of family cards with per-recipe sub-cards (quant/topology chips, HF id, copyable sparkrun command). Wired into `+page.svelte`; `Models.svelte` left in place but unreferenced.
- `app.css`: carousel/subcard/chip/cmd-pill classes reusing existing CSS variables, `.card` look, `.mtable-scroll` scroll-snap; mobile rules folded into the existing 768px media query.
- SEO: prominent in-content sparkrun anchors, Nav + Footer links to sparkrun.dev/runtimes/atlas and atlas-recipes (no nofollow), JSON-LD SoftwareApplication with sameAs via svelte:head.

Build verified on a GB10: `bun x --bun vite build` exit 0; recipe yaml count == json count (19); sparkrun.dev URL present in build; no `docker pull avarok` in build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)