### PR TITLE
site: 3-level tabbed model nav (vendor → sub-family → recipe) + X links + quickstart.sh

### DIFF
--- a/site/scripts/gen-models.mjs
+++ b/site/scripts/gen-models.mjs
@@ -9,7 +9,13 @@
 //
 // Regenerate with:   node site/scripts/gen-models.mjs
 //
-// Every recipes/**/*.yaml MUST appear in the output. The generated array's
+// Output is a 3-level tree consumed by the model navigation UI:
+//   [{ vendor, icon, subfamilies: [{ name, recipes: [{...}] }] }]
+//   level 1: vendor  = top-level brand (Qwen/Gemma/Nemotron/Mistral/MiniMax)
+//   level 2: subfamily = the recipe directory (e.g. qwen3.6, gemma4)
+//   level 3: recipe  = one recipes/**/*.yaml file
+//
+// Every recipes/**/*.yaml MUST appear in the output. The generated tree's
 // total recipe count is asserted to equal the number of recipe YAML files.
 // No third-party deps: a tiny hand-rolled reader parses the (deliberately
 // simple) recipe schema — top-level scalars, a `metadata:` block of scalars
@@ -103,22 +109,59 @@ function parseRecipe(text) {
   return { top, metadata, defaults };
 }
 
-// --- family display names ----------------------------------------------------
+// --- subfamily display names -------------------------------------------------
+// Keyed by recipe directory name (the SSOT family). This is the 2nd nav level.
 const FAMILY_DISPLAY = {
   'qwen3.5': 'Qwen3.5',
   'qwen3.6': 'Qwen3.6',
   'qwen3-next': 'Qwen3-Next',
   'qwen3-coder-next': 'Qwen3-Coder-Next',
   'qwen3-vl': 'Qwen3-VL',
-  'gemma4': 'Gemma 4',
+  'gemma4': 'Gemma-4',
   'nemotron-3-nano': 'Nemotron-3 Nano',
   'nemotron-3-super': 'Nemotron-3 Super',
-  'mistral-small-4': 'Mistral Small 4',
-  'minimax-m2.7': 'MiniMax M2.7'
+  'mistral-small-4': 'Mistral-Small-4',
+  'minimax-m2.7': 'MiniMax-M2.7'
 };
 function familyDisplay(fam) {
   if (FAMILY_DISPLAY[fam]) return FAMILY_DISPLAY[fam];
   return fam.replace(/[-.]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// --- vendor (top-level brand) mapping ----------------------------------------
+// The 1st nav level. Every recipe directory MUST map to exactly one vendor;
+// an unmapped directory is a hard error (PCND — no silent default bucket).
+// `icon` is a stable key the Svelte component resolves to an inline SVG;
+// the SVG markup itself is NOT emitted into JSON (kept inline in the UI).
+const VENDOR_OF_FAMILY = {
+  'qwen3.5': 'Qwen',
+  'qwen3.6': 'Qwen',
+  'qwen3-next': 'Qwen',
+  'qwen3-coder-next': 'Qwen',
+  'qwen3-vl': 'Qwen',
+  'gemma4': 'Gemma',
+  'nemotron-3-nano': 'Nemotron',
+  'nemotron-3-super': 'Nemotron',
+  'mistral-small-4': 'Mistral',
+  'minimax-m2.7': 'MiniMax'
+};
+// Display + icon key + stable sort order, keyed by vendor brand.
+const VENDOR_META = {
+  Qwen: { icon: 'qwen', order: 0 },
+  Gemma: { icon: 'gemma', order: 1 },
+  Nemotron: { icon: 'nemotron', order: 2 },
+  Mistral: { icon: 'mistral', order: 3 },
+  MiniMax: { icon: 'minimax', order: 4 }
+};
+function vendorOf(fam) {
+  const v = VENDOR_OF_FAMILY[fam];
+  if (!v) {
+    console.error(
+      `Unmapped recipe family "${fam}" — add it to VENDOR_OF_FAMILY. SSOT: ${SSOT_URL}`
+    );
+    process.exit(1);
+  }
+  return v;
 }
 
 // --- topology inference ------------------------------------------------------
@@ -166,15 +209,17 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-const familyMap = new Map();
+// Build a 3-level tree: vendor -> subfamily (recipe dir) -> recipes.
+const vendorMap = new Map(); // vendor -> { subfamilies: Map<famKey, {name,recipes[]}> }
 let recipeCount = 0;
 
 for (const file of files) {
   const text = readFileSync(file, 'utf8');
   const { top, metadata } = parseRecipe(text);
-  const fam = basename(dirname(file));
+  const fam = basename(dirname(file)); // recipe directory == subfamily key
   const stem = basename(file).replace(/\.(ya?ml)$/, '');
   const topology = inferTopology(stem, top);
+  const vendor = vendorOf(fam);
 
   const recipe = {
     displayName: recipeDisplay(stem),
@@ -186,21 +231,34 @@ for (const file of files) {
     command: `sparkrun run @atlas/${stem}`
   };
 
-  if (!familyMap.has(fam)) {
-    familyMap.set(fam, { family: fam, displayName: familyDisplay(fam), recipes: [] });
-  }
-  familyMap.get(fam).recipes.push(recipe);
+  if (!vendorMap.has(vendor)) vendorMap.set(vendor, new Map());
+  const subs = vendorMap.get(vendor);
+  if (!subs.has(fam)) subs.set(fam, { name: familyDisplay(fam), recipes: [] });
+  subs.get(fam).recipes.push(recipe);
   recipeCount++;
 }
 
-// stable ordering: families alphabetical, recipes by stem
-const families = [...familyMap.values()].sort((a, b) => a.family.localeCompare(b.family));
-for (const f of families) f.recipes.sort((a, b) => a.recipeStem.localeCompare(b.recipeStem));
+// Stable ordering: vendors by VENDOR_META.order, subfamilies by their dir key,
+// recipes by stem. This keeps the JSON (and the rendered nav) deterministic.
+const vendors = [...vendorMap.entries()]
+  .map(([vendor, subs]) => {
+    const subfamilies = [...subs.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, sf]) => {
+        sf.recipes.sort((a, b) => a.recipeStem.localeCompare(b.recipeStem));
+        return sf;
+      });
+    return { vendor, icon: VENDOR_META[vendor].icon, subfamilies };
+  })
+  .sort((a, b) => VENDOR_META[a.vendor].order - VENDOR_META[b.vendor].order);
 
-const json = JSON.stringify(families, null, 2) + '\n';
+const json = JSON.stringify(vendors, null, 2) + '\n';
 writeFileSync(OUT, json);
 
-const emitted = families.reduce((n, f) => n + f.recipes.length, 0);
+const emitted = vendors.reduce(
+  (n, v) => n + v.subfamilies.reduce((m, s) => m + s.recipes.length, 0),
+  0
+);
 if (emitted !== recipeCount || emitted !== files.length) {
   console.error(
     `Recipe count mismatch: yaml files=${files.length}, emitted=${emitted}. SSOT: ${SSOT_URL}`
@@ -208,8 +266,13 @@ if (emitted !== recipeCount || emitted !== files.length) {
   process.exit(1);
 }
 
+const subCount = vendors.reduce((n, v) => n + v.subfamilies.length, 0);
 console.log(
-  `Wrote ${OUT}\n  ${files.length} recipes across ${families.length} families` +
-    ` (SSOT: ${SSOT_URL})`
+  `Wrote ${OUT}\n  ${files.length} recipes across ${subCount} subfamilies` +
+    ` / ${vendors.length} vendors (SSOT: ${SSOT_URL})`
 );
-for (const f of families) console.log(`  - ${f.displayName}: ${f.recipes.length}`);
+for (const v of vendors) {
+  const n = v.subfamilies.reduce((m, s) => m + s.recipes.length, 0);
+  console.log(`  - ${v.vendor} (${n}):`);
+  for (const s of v.subfamilies) console.log(`      · ${s.name}: ${s.recipes.length}`);
+}

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -241,34 +241,51 @@ footer { border-top: 1px solid var(--border); padding: 3rem 2rem; }
 .fcol a:hover { color: #fff; }
 .footer-bottom { max-width: 1200px; margin: 1.5rem auto 0; padding-top: 1.25rem; border-top: 1px solid var(--border); text-align: center; font-size: 0.7rem; color: var(--t3); }
 
-/* Model Slider (SSOT carousel of recipe families) */
-.ms-carousel { position: relative; }
-.ms-controls {
-  display: flex; align-items: center; justify-content: center;
-  gap: 1rem; margin-bottom: 1.25rem;
+/* Model navigation (SSOT 3-level tabs: vendor -> subfamily -> recipes) */
+.mnav { position: relative; }
+/* Level 1: vendor brand tabs */
+.mnav-vendors {
+  display: flex; flex-wrap: wrap; gap: 0.6rem;
+  margin-bottom: 1rem;
 }
-.ms-arrow {
-  flex-shrink: 0; width: 38px; height: 38px; border-radius: 50%;
-  background: var(--card); border: 1px solid var(--border); color: var(--t1);
-  font-size: 1.2rem; line-height: 1; cursor: pointer;
-  transition: border-color 0.2s, background 0.2s, transform 0.2s;
-  display: flex; align-items: center; justify-content: center;
+.mnav-vendor {
+  display: inline-flex; align-items: center; gap: 0.55rem;
+  background: var(--card); border: 1px solid var(--border); color: var(--t2);
+  border-radius: 10px; padding: 0.6rem 1rem;
+  font-size: 0.9rem; font-weight: 700; letter-spacing: -0.01em;
+  cursor: pointer; transition: border-color 0.2s, background 0.2s, color 0.2s, transform 0.2s;
 }
-.ms-arrow:hover { border-color: rgba(124,58,237,0.45); background: rgba(124,58,237,0.08); transform: translateY(-1px); }
-.ms-dots { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; justify-content: center; }
-.ms-dot {
-  width: 9px; height: 9px; border-radius: 50%; padding: 0;
-  background: var(--border); border: none; cursor: pointer;
-  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+.mnav-vendor:hover { border-color: rgba(124,58,237,0.4); color: var(--t1); transform: translateY(-1px); }
+.mnav-vendor.is-active {
+  color: #fff; border-color: rgba(124,58,237,0.55);
+  background: rgba(124,58,237,0.14);
+  box-shadow: 0 2px 14px rgba(124,58,237,0.25);
 }
-.ms-dot:hover { background: var(--t3); }
-.ms-dot.is-active { background: var(--grad); box-shadow: 0 0 10px rgba(124,58,237,0.5); transform: scale(1.25); }
-.ms-viewport {
-  width: 100%; overflow-x: hidden; border-radius: 14px;
-  scroll-snap-type: x mandatory;
+.mnav-ico { width: 18px; height: 18px; flex-shrink: 0; }
+.mnav-vendor.is-active .mnav-ico { color: #a78bfa; }
+/* Level 2: subfamily sub-tabs */
+.mnav-subs {
+  display: flex; flex-wrap: wrap; gap: 0.45rem;
+  margin-bottom: 1.25rem;
 }
-.ms-track { display: flex; transition: transform 0.45s cubic-bezier(0.22,0.61,0.36,1); will-change: transform; }
-.ms-slide { flex: 0 0 100%; min-width: 100%; scroll-snap-align: start; padding: 2px; }
+.mnav-sub {
+  display: inline-flex; align-items: center; gap: 0.45rem;
+  background: rgba(255,255,255,0.02); border: 1px solid var(--border); color: var(--t2);
+  border-radius: 7px; padding: 0.4rem 0.75rem;
+  font-size: 0.78rem; font-weight: 600;
+  cursor: pointer; transition: border-color 0.2s, background 0.2s, color 0.2s;
+}
+.mnav-sub:hover { border-color: rgba(6,182,212,0.4); color: var(--t1); }
+.mnav-sub.is-active {
+  color: var(--t1); border-color: rgba(6,182,212,0.5);
+  background: rgba(6,182,212,0.1);
+}
+.mnav-sub-count {
+  font-size: 0.62rem; font-weight: 700;
+  background: rgba(255,255,255,0.06); color: var(--t3);
+  border-radius: 999px; padding: 0.05rem 0.4rem; line-height: 1.4;
+}
+.mnav-sub.is-active .mnav-sub-count { background: rgba(6,182,212,0.2); color: var(--cyan); }
 .ms-famcard { position: relative; overflow: hidden; padding: 0; }
 .ms-accent { height: 4px; width: 100%; background: var(--grad); }
 .ms-famhead {
@@ -341,8 +358,12 @@ footer { border-top: 1px solid var(--border); padding: 3rem 2rem; }
   .hero-install-copy { margin-left: auto; }
   .ms-grid { grid-template-columns: 1fr; padding: 0 1.1rem 1.25rem; }
   .ms-famhead { padding: 1.15rem 1.1rem 0.85rem; }
-  .ms-viewport {
-    overflow-x: auto; -webkit-overflow-scrolling: touch;
-    touch-action: pan-x pan-y;
+  /* Tab rows wrap by default; on very narrow screens allow them to
+     scroll horizontally instead of stacking many rows tall. */
+  .mnav-vendors, .mnav-subs {
+    flex-wrap: nowrap; overflow-x: auto;
+    -webkit-overflow-scrolling: touch; touch-action: pan-x pan-y;
+    scrollbar-width: thin; padding-bottom: 0.35rem;
   }
+  .mnav-vendor, .mnav-sub { flex-shrink: 0; }
 }

--- a/site/src/lib/components/Footer.svelte
+++ b/site/src/lib/components/Footer.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { discordUrl, redditUrl } from '$lib/data.js';
+  import { discordUrl, redditUrl, xUrl, xHandle } from '$lib/data.js';
 </script>
 
 <footer>
@@ -22,6 +22,7 @@
     <div class="fcol">
       <h4>Community</h4>
       <a href={discordUrl}>Discord</a>
+      <a href={xUrl} target="_blank" rel="noopener">X {xHandle}</a>
       <a href={redditUrl}>Reddit</a>
     </div>
     <div class="fcol">

--- a/site/src/lib/components/ModelSlider.svelte
+++ b/site/src/lib/components/ModelSlider.svelte
@@ -1,18 +1,39 @@
 <script>
   // Data is SSOT-derived from github.com/Avarok-Cybersecurity/atlas-recipes
   // via site/scripts/gen-models.mjs -> models.generated.json.
-  import families from '$lib/models.generated.json';
+  // 3-level tree: vendor (brand) -> subfamily (recipe dir) -> recipes.
+  import vendors from '$lib/models.generated.json';
 
-  let index = $state(0);
+  // --- inline brand/model marks (no external URL/CDN — static site) ---------
+  // Monochrome, viewBox 0 0 24 24, fill=currentColor -> inherits the dark
+  // theme + accent. Resolved by the `icon` key emitted in models.generated.json.
+  const ICONS = {
+    qwen:
+      'M12.604 1.34c.393.69.784 1.382 1.174 2.075a.18.18 0 00.157.091h5.552c.174 0 .322.11.446.327l1.454 2.57c.19.337.24.478.024.837-.26.43-.513.864-.76 1.3l-.367.658c-.106.196-.223.28-.04.512l2.652 4.637c.172.301.111.494-.043.77-.437.785-.882 1.564-1.335 2.34-.159.272-.352.375-.68.37-.777-.016-1.552-.01-2.327.016a.099.099 0 00-.081.05 575.097 575.097 0 01-2.705 4.74c-.169.293-.38.363-.725.364-.997.003-2.002.004-3.017.002a.537.537 0 01-.465-.271l-1.335-2.323a.09.09 0 00-.083-.049H4.982c-.285.03-.553-.001-.805-.092l-1.603-2.77a.543.543 0 01-.002-.54l1.207-2.12a.198.198 0 000-.197 550.951 550.951 0 01-1.875-3.272l-.79-1.395c-.16-.31-.173-.496.095-.965.465-.813.927-1.625 1.387-2.436.132-.234.304-.334.584-.335a338.3 338.3 0 012.589-.001.124.124 0 00.107-.063l2.806-4.895a.488.488 0 01.422-.246c.524-.001 1.053 0 1.583-.006L11.704 1c.341-.003.724.032.9.34zm-3.432.403a.06.06 0 00-.052.03L6.254 6.788a.157.157 0 01-.135.078H3.253c-.056 0-.07.025-.041.074l5.81 10.156c.025.042.013.062-.034.063l-2.795.015a.218.218 0 00-.2.116l-1.32 2.31c-.044.078-.021.118.068.118l5.716.008c.046 0 .08.02.104.061l1.403 2.454c.046.081.092.082.139 0l5.006-8.76.783-1.382a.055.055 0 01.096 0l1.424 2.53a.122.122 0 00.107.062l2.763-.02a.04.04 0 00.035-.02.041.041 0 000-.04l-2.9-5.086a.108.108 0 010-.113l.293-.507 1.12-1.977c.024-.041.012-.062-.035-.062H9.2c-.059 0-.073-.026-.043-.077l1.434-2.505a.107.107 0 000-.114L9.225 1.774a.06.06 0 00-.053-.031z',
+    gemma:
+      'M12.34 5.953a8.233 8.233 0 01-.247-1.125V3.72a8.25 8.25 0 015.562 2.232H12.34zm-.69 0c.113-.373.199-.755.257-1.145V3.72a8.25 8.25 0 00-5.562 2.232h5.304zm-5.433.187h5.373a7.98 7.98 0 01-.267.696 8.41 8.41 0 01-1.76 2.65L6.216 6.14zm-.264-.187H2.977v.187h2.915a8.436 8.436 0 00-2.357 5.767H0v.186h3.535a8.436 8.436 0 002.357 5.767H2.977v.186h2.976v2.977h.187v-2.915a8.436 8.436 0 005.767 2.357V24h.186v-3.535a8.436 8.436 0 005.767-2.357v2.915h.186v-2.977h2.977v-.186h-2.915a8.436 8.436 0 002.357-5.767H24v-.186h-3.535a8.436 8.436 0 00-2.357-5.767h2.915v-.187h-2.977V2.977h-.186v2.915a8.436 8.436 0 00-5.767-2.357V0h-.186v3.535A8.436 8.436 0 006.14 5.892V2.977h-.187v2.976zm6.14 14.326a8.25 8.25 0 005.562-2.233H12.34c-.108.367-.19.743-.247 1.126v1.107zm-.186-1.087a8.015 8.015 0 00-.258-1.146H6.345a8.25 8.25 0 005.562 2.233v-1.087zm-8.186-7.285h1.107a8.23 8.23 0 001.125-.247V6.345a8.25 8.25 0 00-2.232 5.562zm1.087.186H3.72a8.25 8.25 0 002.232 5.562v-5.304a8.012 8.012 0 00-1.145-.258zm15.47-.186a8.25 8.25 0 00-2.232-5.562v5.315c.367.108.743.19 1.126.247h1.107zm-1.086.186c-.39.058-.772.144-1.146.258v5.304a8.25 8.25 0 002.233-5.562h-1.087zm-1.332 5.69V12.41a7.97 7.97 0 00-.696.267 8.409 8.409 0 00-2.65 1.76l3.346 3.346zm0-6.18v-5.45l-.012-.013h-5.451c.076.235.162.468.26.696a8.698 8.698 0 001.819 2.688 8.698 8.698 0 002.688 1.82c.228.097.46.183.696.259zM6.14 17.848V12.41c.235.078.468.167.696.267a8.403 8.403 0 012.688 1.799 8.404 8.404 0 011.799 2.688c.1.228.19.46.267.696H6.152l-.012-.012zm0-6.245V6.326l3.29 3.29a8.716 8.716 0 01-2.594 1.728 8.14 8.14 0 01-.696.259zm6.257 6.257h5.277l-3.29-3.29a8.716 8.716 0 00-1.728 2.594 8.135 8.135 0 00-.259.696zm-2.347-7.81a9.435 9.435 0 01-2.88 1.96 9.14 9.14 0 012.88 1.94 9.14 9.14 0 011.94 2.88 9.435 9.435 0 011.96-2.88 9.14 9.14 0 012.88-1.94 9.435 9.435 0 01-2.88-1.96 9.434 9.434 0 01-1.96-2.88 9.14 9.14 0 01-1.94 2.88z',
+    nemotron:
+      'M10.212 8.976V7.62c.127-.01.256-.017.388-.021 3.596-.117 5.957 3.184 5.957 3.184s-2.548 3.647-5.282 3.647a3.227 3.227 0 01-1.063-.175v-4.109c1.4.174 1.681.812 2.523 2.258l1.873-1.627a4.905 4.905 0 00-3.67-1.846 6.594 6.594 0 00-.729.044m0-4.476v2.025c.13-.01.259-.019.388-.024 5.002-.174 8.261 4.226 8.261 4.226s-3.743 4.69-7.643 4.69c-.338 0-.675-.031-1.007-.092v1.25c.278.038.558.057.838.057 3.629 0 6.253-1.91 8.794-4.169.421.347 2.146 1.193 2.501 1.564-2.416 2.083-8.048 3.763-11.24 3.763-.308 0-.603-.02-.894-.048V19.5H24v-15H10.21zm0 9.756v1.068c-3.356-.616-4.287-4.21-4.287-4.21a7.173 7.173 0 014.287-2.138v1.172h-.005a3.182 3.182 0 00-2.502 1.178s.615 2.276 2.507 2.931m-5.961-3.3c1.436-1.935 3.604-3.148 5.961-3.336V6.523C5.81 6.887 2 10.723 2 10.723s2.158 6.427 8.21 7.015v-1.166C5.77 16 4.25 10.958 4.25 10.958h-.002z',
+    mistral:
+      'M3.428 3.4h3.429v3.428h3.429v3.429h-.002 3.431V6.828h3.427V3.4h3.43v13.714H24v3.429H13.714v-3.428h-3.428v-3.429h-3.43v3.428h3.43v3.429H0v-3.429h3.428V3.4zm10.286 13.715h3.428v-3.429h-3.427v3.429z',
+    minimax:
+      'M16.278 2c1.156 0 2.093.927 2.093 2.07v12.501a.74.74 0 00.744.709.74.74 0 00.743-.709V9.099a2.06 2.06 0 012.071-2.049A2.06 2.06 0 0124 9.1v6.561a.649.649 0 01-.652.645.649.649 0 01-.653-.645V9.1a.762.762 0 00-.766-.758.762.762 0 00-.766.758v7.472a2.037 2.037 0 01-2.048 2.026 2.037 2.037 0 01-2.048-2.026v-12.5a.785.785 0 00-.788-.753.785.785 0 00-.789.752l-.001 15.904A2.037 2.037 0 0113.441 22a2.037 2.037 0 01-2.048-2.026V18.04c0-.356.292-.645.652-.645.36 0 .652.289.652.645v1.934c0 .263.142.506.372.638.23.131.514.131.744 0a.734.734 0 00.372-.638V4.07c0-1.143.937-2.07 2.093-2.07zm-5.674 0c1.156 0 2.093.927 2.093 2.07v11.523a.648.648 0 01-.652.645.648.648 0 01-.652-.645V4.07a.785.785 0 00-.789-.78.785.785 0 00-.789.78v14.013a2.06 2.06 0 01-2.07 2.048 2.06 2.06 0 01-2.071-2.048V9.1a.762.762 0 00-.766-.758.762.762 0 00-.766.758v3.8a2.06 2.06 0 01-2.071 2.049A2.06 2.06 0 010 12.9v-1.378c0-.357.292-.646.652-.646.36 0 .653.29.653.646V12.9c0 .418.343.757.766.757s.766-.339.766-.757V9.099a2.06 2.06 0 012.07-2.048 2.06 2.06 0 012.071 2.048v8.984c0 .419.343.758.767.758.423 0 .766-.339.766-.758V4.07c0-1.143.937-2.07 2.093-2.07z'
+  };
+
+  // selected vendor + per-vendor selected subfamily (Svelte 5 runes)
+  let selectedVendor = $state(0);
+  let selectedSub = $state(vendors.map(() => 0));
   let copied = $state('');
 
-  const total = families.length;
+  const vendor = $derived(vendors[selectedVendor]);
+  const sub = $derived(vendor.subfamilies[selectedSub[selectedVendor]] ?? vendor.subfamilies[0]);
 
-  function go(i) {
-    index = ((i % total) + total) % total;
+  function pickVendor(i) {
+    selectedVendor = i;
   }
-  function prev() { go(index - 1); }
-  function next() { go(index + 1); }
+  function pickSub(i) {
+    selectedSub[selectedVendor] = i;
+  }
 
   async function copyCmd(cmd) {
     try {
@@ -38,64 +59,74 @@
     <div class="slabel">Supported Models</div>
     <h2 class="stitle">Model matrix</h2>
     <p class="ssub">
-      Every model gets hand-tuned CUDA kernels. Each card is one model family;
-      every recipe maps to a single
+      Every model gets hand-tuned CUDA kernels. Pick a vendor, then a model
+      family; every recipe maps to a single
       <a href="https://github.com/Avarok-Cybersecurity/atlas-recipes" class="ssub-link">sparkrun recipe</a>
       you can copy and run as-is.
     </p>
 
-    <div class="ms-carousel">
-      <div class="ms-controls">
-        <button type="button" class="ms-arrow" onclick={prev} aria-label="Previous family">‹</button>
-        <div class="ms-dots" role="tablist" aria-label="Model families">
-          {#each families as f, i}
-            <button
-              type="button"
-              class="ms-dot {i === index ? 'is-active' : ''}"
-              role="tab"
-              aria-selected={i === index}
-              aria-label={f.displayName}
-              onclick={() => go(i)}
-            ></button>
-          {/each}
-        </div>
-        <button type="button" class="ms-arrow" onclick={next} aria-label="Next family">›</button>
+    <div class="mnav">
+      <!-- Level 1: vendor brand tabs -->
+      <div class="mnav-vendors" role="tablist" aria-label="Model vendors">
+        {#each vendors as v, i}
+          <button
+            type="button"
+            class="mnav-vendor {i === selectedVendor ? 'is-active' : ''}"
+            role="tab"
+            aria-selected={i === selectedVendor}
+            onclick={() => pickVendor(i)}
+          >
+            <svg class="mnav-ico" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+              <path d={ICONS[v.icon]} />
+            </svg>
+            <span>{v.vendor}</span>
+          </button>
+        {/each}
       </div>
 
-      <div class="ms-viewport mtable-scroll">
-        <div class="ms-track" style="transform: translateX(-{index * 100}%);">
-          {#each families as f}
-            <div class="ms-slide">
-              <div class="card ms-famcard">
-                <div class="ms-accent" aria-hidden="true"></div>
-                <div class="ms-famhead">
-                  <h3>{f.displayName}</h3>
-                  <span class="ms-count">{f.recipes.length} recipe{f.recipes.length === 1 ? '' : 's'}</span>
-                </div>
-                <div class="ms-grid">
-                  {#each f.recipes as r}
-                    <div class="subcard">
-                      <div class="subcard-label">{r.displayName}</div>
-                      <div class="subcard-meta">
-                        <span class={quantClass(r.quant)}>{quantLabel(r.quant)}</span>
-                        <span class={topoClass(r.topology)}>{r.topology}</span>
-                        {#if r.params}<span class="chip chip-params">{r.params}</span>{/if}
-                      </div>
-                      <div class="subcard-hf mono" title={r.hfId}>{r.hfId}</div>
-                      <div class="cmd-pill">
-                        <code class="cmd-text mono">{r.command}</code>
-                        <button
-                          type="button"
-                          class="cmd-copy"
-                          onclick={() => copyCmd(r.command)}
-                          aria-label={`Copy ${r.command}`}
-                        >
-                          {copied === r.command ? 'Copied' : 'Copy'}
-                        </button>
-                      </div>
-                    </div>
-                  {/each}
-                </div>
+      <!-- Level 2: subfamily sub-tabs (within the selected vendor) -->
+      <div class="mnav-subs" role="tablist" aria-label={`${vendor.vendor} model families`}>
+        {#each vendor.subfamilies as sf, i}
+          <button
+            type="button"
+            class="mnav-sub {i === (selectedSub[selectedVendor] ?? 0) ? 'is-active' : ''}"
+            role="tab"
+            aria-selected={i === (selectedSub[selectedVendor] ?? 0)}
+            onclick={() => pickSub(i)}
+          >
+            {sf.name}
+            <span class="mnav-sub-count">{sf.recipes.length}</span>
+          </button>
+        {/each}
+      </div>
+
+      <!-- Level 3: recipe sub-cards (within the selected subfamily) -->
+      <div class="card ms-famcard">
+        <div class="ms-accent" aria-hidden="true"></div>
+        <div class="ms-famhead">
+          <h3>{vendor.vendor} · {sub.name}</h3>
+          <span class="ms-count">{sub.recipes.length} recipe{sub.recipes.length === 1 ? '' : 's'}</span>
+        </div>
+        <div class="ms-grid">
+          {#each sub.recipes as r (r.recipeStem)}
+            <div class="subcard">
+              <div class="subcard-label">{r.displayName}</div>
+              <div class="subcard-meta">
+                <span class={quantClass(r.quant)}>{quantLabel(r.quant)}</span>
+                <span class={topoClass(r.topology)}>{r.topology}</span>
+                {#if r.params}<span class="chip chip-params">{r.params}</span>{/if}
+              </div>
+              <div class="subcard-hf mono" title={r.hfId}>{r.hfId}</div>
+              <div class="cmd-pill">
+                <code class="cmd-text mono">{r.command}</code>
+                <button
+                  type="button"
+                  class="cmd-copy"
+                  onclick={() => copyCmd(r.command)}
+                  aria-label={`Copy ${r.command}`}
+                >
+                  {copied === r.command ? 'Copied' : 'Copy'}
+                </button>
               </div>
             </div>
           {/each}

--- a/site/src/lib/components/Nav.svelte
+++ b/site/src/lib/components/Nav.svelte
@@ -1,6 +1,7 @@
 <script>
-  import { discordUrl } from '$lib/data.js';
+  import { discordUrl, xUrl } from '$lib/data.js';
   import GithubIcon from './GithubIcon.svelte';
+  import XIcon from './XIcon.svelte';
 </script>
 
 <nav>
@@ -24,6 +25,15 @@
         aria-label="Atlas on GitHub"
       >
         <GithubIcon size={20} />
+      </a>
+      <a
+        href={xUrl}
+        class="nav-icon-link"
+        target="_blank"
+        rel="noopener"
+        aria-label="Atlas on X (@atlasinference)"
+      >
+        <XIcon size={18} />
       </a>
       <a href={discordUrl} class="nav-cta">Join Discord</a>
     </div>

--- a/site/src/lib/components/TryIt.svelte
+++ b/site/src/lib/components/TryIt.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { dockerCommand } from '$lib/data.js';
+  import { runCommand } from '$lib/data.js';
 
   let copied = $state(false);
   async function copy() {
     try {
-      await navigator.clipboard.writeText(dockerCommand);
+      await navigator.clipboard.writeText(runCommand);
       copied = true;
       setTimeout(() => (copied = false), 1600);
     } catch {}
@@ -14,12 +14,15 @@
 <section id="try" class="try-section">
   <div class="container">
     <div class="slabel">Try It Yourself</div>
-    <h2 class="stitle">Up and running in two commands</h2>
+    <h2 class="stitle">Up and running in one command</h2>
     <p class="ssub">
-      Don't take our word for it. Install
-      <a href="https://sparkrun.dev/runtimes/atlas/" class="ssub-link">sparkrun</a>,
-      run an Atlas recipe on your DGX Spark, and see the difference. sparkrun pulls
-      &amp; runs the Atlas image for you — it uses your existing Docker/Podman +
+      Don't take our word for it. One command on your DGX Spark and you're
+      serving. The
+      <a href="/quickstart.sh" class="ssub-link">quickstart script</a>
+      installs
+      <a href="https://sparkrun.dev/runtimes/atlas/" class="ssub-link">sparkrun</a>
+      only if it isn't already present, then runs the recipe. sparkrun pulls
+      &amp; runs the Atlas image for you using your existing Docker/Podman +
       NVIDIA container runtime.
     </p>
 
@@ -29,11 +32,11 @@
           <span></span><span></span><span></span>
         </div>
         <div class="term-title">Run with sparkrun — Qwen3.6-35B-A3B FP8 + MTP on a single Spark</div>
-        <button type="button" class="hero-install-copy" onclick={copy} aria-label="Copy sparkrun commands">
+        <button type="button" class="hero-install-copy" onclick={copy} aria-label="Copy install command">
           {copied ? 'Copied' : 'Copy'}
         </button>
       </div>
-      <pre class="term-body">{dockerCommand}</pre>
+      <pre class="term-body">$ {runCommand}</pre>
     </div>
 
     <p class="try-foot">

--- a/site/src/lib/components/XIcon.svelte
+++ b/site/src/lib/components/XIcon.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { size = 20 } = $props();
+</script>
+
+<svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/>
+</svg>

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -159,6 +159,15 @@ export const testimonials = [
 // + NVIDIA container runtime — it does not install the container engine.
 export const quickInstall = `uvx sparkrun setup install`;
 
-export const dockerCommand = `uvx sparkrun setup install
+// The command users see and copy: curl the static quickstart script and pipe
+// it to sh. The script (static/quickstart.sh, served at /quickstart.sh) checks
+// whether sparkrun is already installed before installing it via uvx, then
+// runs the default recipe. The raw equivalent is kept below for reference.
+export const runCommand = 'curl -fsSL https://atlasinference.io/quickstart.sh | sh';
+// What the script does, spelled out (not shown in the terminal card).
+export const runCommandRaw =
+  'uvx sparkrun setup install && sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas';
 
-sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas`;
+// X / Twitter handle for Atlas.
+export const xHandle = '@atlasinference';
+export const xUrl = 'https://x.com/atlasinference';

--- a/site/src/lib/models.generated.json
+++ b/site/src/lib/models.generated.json
@@ -1,232 +1,252 @@
 [
   {
-    "family": "gemma4",
-    "displayName": "Gemma 4",
-    "recipes": [
+    "vendor": "Qwen",
+    "icon": "qwen",
+    "subfamilies": [
       {
-        "displayName": "Gemma 4 26B A4B NVFP4",
-        "hfId": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16",
-        "params": "26B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "gemma-4-26b-a4b-nvfp4",
-        "command": "sparkrun run @atlas/gemma-4-26b-a4b-nvfp4"
+        "name": "Qwen3-Coder-Next",
+        "recipes": [
+          {
+            "displayName": "Qwen3 Coder Next FP8",
+            "hfId": "Qwen/Qwen3-Coder-Next-FP8",
+            "params": "80B",
+            "quant": "fp8",
+            "topology": "single",
+            "recipeStem": "qwen3-coder-next-fp8",
+            "command": "sparkrun run @atlas/qwen3-coder-next-fp8"
+          }
+        ]
       },
       {
-        "displayName": "Gemma 4 31B NVFP4",
-        "hfId": "nvidia/Gemma-4-31B-IT-NVFP4",
-        "params": "31B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "gemma-4-31b-nvfp4",
-        "command": "sparkrun run @atlas/gemma-4-31b-nvfp4"
+        "name": "Qwen3-Next",
+        "recipes": [
+          {
+            "displayName": "Qwen3 Next 80B A3B NVFP4",
+            "hfId": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
+            "params": "80B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "qwen3-next-80b-a3b-nvfp4",
+            "command": "sparkrun run @atlas/qwen3-next-80b-a3b-nvfp4"
+          }
+        ]
+      },
+      {
+        "name": "Qwen3-VL",
+        "recipes": [
+          {
+            "displayName": "Qwen3 VL 30B A3B NVFP4",
+            "hfId": "ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4",
+            "params": "30B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "qwen3-vl-30b-a3b-nvfp4",
+            "command": "sparkrun run @atlas/qwen3-vl-30b-a3b-nvfp4"
+          }
+        ]
+      },
+      {
+        "name": "Qwen3.5",
+        "recipes": [
+          {
+            "displayName": "Qwen3.5 0.8B BF16",
+            "hfId": "Qwen/Qwen3.5-0.8B",
+            "params": "0.8B",
+            "quant": "none",
+            "topology": "single",
+            "recipeStem": "qwen3.5-0.8b-bf16-atlas",
+            "command": "sparkrun run @atlas/qwen3.5-0.8b-bf16-atlas"
+          },
+          {
+            "displayName": "Qwen3.5 122B A10B NVFP4 EP=2",
+            "hfId": "Sehyo/Qwen3.5-122B-A10B-NVFP4",
+            "params": "122B",
+            "quant": "nvfp4",
+            "topology": "EP=2",
+            "recipeStem": "qwen3.5-122b-a10b-nvfp4-ep2",
+            "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-ep2"
+          },
+          {
+            "displayName": "Qwen3.5 122B A10B NVFP4 Single",
+            "hfId": "Sehyo/Qwen3.5-122B-A10B-NVFP4",
+            "params": "122B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "qwen3.5-122b-a10b-nvfp4-single",
+            "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-single"
+          },
+          {
+            "displayName": "Qwen3.5 27B Dense NVFP4",
+            "hfId": "Kbenkhaled/Qwen3.5-27B-NVFP4",
+            "params": "27B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "qwen3.5-27b-dense-nvfp4",
+            "command": "sparkrun run @atlas/qwen3.5-27b-dense-nvfp4"
+          },
+          {
+            "displayName": "Qwen3.5 35B A3B NVFP4",
+            "hfId": "Sehyo/Qwen3.5-35B-A3B-NVFP4",
+            "params": "35B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "qwen3.5-35b-a3b-nvfp4",
+            "command": "sparkrun run @atlas/qwen3.5-35b-a3b-nvfp4"
+          }
+        ]
+      },
+      {
+        "name": "Qwen3.6",
+        "recipes": [
+          {
+            "displayName": "Qwen3.6 27B Dense FP8",
+            "hfId": "Qwen/Qwen3.6-27B-FP8",
+            "params": "27B",
+            "quant": "fp8",
+            "topology": "single",
+            "recipeStem": "qwen3.6-27b-dense-fp8-atlas",
+            "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-atlas"
+          },
+          {
+            "displayName": "Qwen3.6 27B Dense FP8 MTP",
+            "hfId": "Qwen/Qwen3.6-27B-FP8",
+            "params": "27B",
+            "quant": "fp8",
+            "topology": "single",
+            "recipeStem": "qwen3.6-27b-dense-fp8-mtp-atlas",
+            "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-mtp-atlas"
+          },
+          {
+            "displayName": "Qwen3.6 27B FP8 MTP",
+            "hfId": "Qwen/Qwen3.6-27B-FP8",
+            "params": "27B",
+            "quant": "fp8",
+            "topology": "single",
+            "recipeStem": "qwen3.6-27b-fp8-mtp-atlas",
+            "command": "sparkrun run @atlas/qwen3.6-27b-fp8-mtp-atlas"
+          },
+          {
+            "displayName": "Qwen3.6 35B A3B FP8 MTP",
+            "hfId": "Qwen/Qwen3.6-35B-A3B-FP8",
+            "params": "35B",
+            "quant": "fp8",
+            "topology": "single",
+            "recipeStem": "qwen3.6-35b-a3b-fp8-mtp-atlas",
+            "command": "sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas"
+          },
+          {
+            "displayName": "Qwen3.6 35B A3B NVFP4",
+            "hfId": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
+            "params": "35B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "qwen3.6-35b-a3b-nvfp4-atlas",
+            "command": "sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4-atlas"
+          }
+        ]
       }
     ]
   },
   {
-    "family": "minimax-m2.7",
-    "displayName": "MiniMax M2.7",
-    "recipes": [
+    "vendor": "Gemma",
+    "icon": "gemma",
+    "subfamilies": [
       {
-        "displayName": "Minimax M2.7 NVFP4 EP=2",
-        "hfId": "lukealonso/MiniMax-M2.7-NVFP4",
-        "params": "230B",
-        "quant": "nvfp4",
-        "topology": "EP=2",
-        "recipeStem": "minimax-m2.7-nvfp4-ep2",
-        "command": "sparkrun run @atlas/minimax-m2.7-nvfp4-ep2"
+        "name": "Gemma-4",
+        "recipes": [
+          {
+            "displayName": "Gemma 4 26B A4B NVFP4",
+            "hfId": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16",
+            "params": "26B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "gemma-4-26b-a4b-nvfp4",
+            "command": "sparkrun run @atlas/gemma-4-26b-a4b-nvfp4"
+          },
+          {
+            "displayName": "Gemma 4 31B NVFP4",
+            "hfId": "nvidia/Gemma-4-31B-IT-NVFP4",
+            "params": "31B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "gemma-4-31b-nvfp4",
+            "command": "sparkrun run @atlas/gemma-4-31b-nvfp4"
+          }
+        ]
       }
     ]
   },
   {
-    "family": "mistral-small-4",
-    "displayName": "Mistral Small 4",
-    "recipes": [
+    "vendor": "Nemotron",
+    "icon": "nemotron",
+    "subfamilies": [
       {
-        "displayName": "Mistral Small 4 119B NVFP4",
-        "hfId": "mistralai/Mistral-Small-4-119B-2603-NVFP4",
-        "params": "119B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "mistral-small-4-119b-nvfp4",
-        "command": "sparkrun run @atlas/mistral-small-4-119b-nvfp4"
+        "name": "Nemotron-3 Nano",
+        "recipes": [
+          {
+            "displayName": "Nemotron 3 Nano 30B A3B NVFP4",
+            "hfId": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
+            "params": "30B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "nemotron-3-nano-30b-a3b-nvfp4",
+            "command": "sparkrun run @atlas/nemotron-3-nano-30b-a3b-nvfp4"
+          }
+        ]
+      },
+      {
+        "name": "Nemotron-3 Super",
+        "recipes": [
+          {
+            "displayName": "Nemotron 3 Super 120B A12B NVFP4",
+            "hfId": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+            "params": "120B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "nemotron-3-super-120b-a12b-nvfp4",
+            "command": "sparkrun run @atlas/nemotron-3-super-120b-a12b-nvfp4"
+          }
+        ]
       }
     ]
   },
   {
-    "family": "nemotron-3-nano",
-    "displayName": "Nemotron-3 Nano",
-    "recipes": [
+    "vendor": "Mistral",
+    "icon": "mistral",
+    "subfamilies": [
       {
-        "displayName": "Nemotron 3 Nano 30B A3B NVFP4",
-        "hfId": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
-        "params": "30B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "nemotron-3-nano-30b-a3b-nvfp4",
-        "command": "sparkrun run @atlas/nemotron-3-nano-30b-a3b-nvfp4"
+        "name": "Mistral-Small-4",
+        "recipes": [
+          {
+            "displayName": "Mistral Small 4 119B NVFP4",
+            "hfId": "mistralai/Mistral-Small-4-119B-2603-NVFP4",
+            "params": "119B",
+            "quant": "nvfp4",
+            "topology": "single",
+            "recipeStem": "mistral-small-4-119b-nvfp4",
+            "command": "sparkrun run @atlas/mistral-small-4-119b-nvfp4"
+          }
+        ]
       }
     ]
   },
   {
-    "family": "nemotron-3-super",
-    "displayName": "Nemotron-3 Super",
-    "recipes": [
+    "vendor": "MiniMax",
+    "icon": "minimax",
+    "subfamilies": [
       {
-        "displayName": "Nemotron 3 Super 120B A12B NVFP4",
-        "hfId": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-        "params": "120B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "nemotron-3-super-120b-a12b-nvfp4",
-        "command": "sparkrun run @atlas/nemotron-3-super-120b-a12b-nvfp4"
-      }
-    ]
-  },
-  {
-    "family": "qwen3-coder-next",
-    "displayName": "Qwen3-Coder-Next",
-    "recipes": [
-      {
-        "displayName": "Qwen3 Coder Next FP8",
-        "hfId": "Qwen/Qwen3-Coder-Next-FP8",
-        "params": "80B",
-        "quant": "fp8",
-        "topology": "single",
-        "recipeStem": "qwen3-coder-next-fp8",
-        "command": "sparkrun run @atlas/qwen3-coder-next-fp8"
-      }
-    ]
-  },
-  {
-    "family": "qwen3-next",
-    "displayName": "Qwen3-Next",
-    "recipes": [
-      {
-        "displayName": "Qwen3 Next 80B A3B NVFP4",
-        "hfId": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
-        "params": "80B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "qwen3-next-80b-a3b-nvfp4",
-        "command": "sparkrun run @atlas/qwen3-next-80b-a3b-nvfp4"
-      }
-    ]
-  },
-  {
-    "family": "qwen3-vl",
-    "displayName": "Qwen3-VL",
-    "recipes": [
-      {
-        "displayName": "Qwen3 VL 30B A3B NVFP4",
-        "hfId": "ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4",
-        "params": "30B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "qwen3-vl-30b-a3b-nvfp4",
-        "command": "sparkrun run @atlas/qwen3-vl-30b-a3b-nvfp4"
-      }
-    ]
-  },
-  {
-    "family": "qwen3.5",
-    "displayName": "Qwen3.5",
-    "recipes": [
-      {
-        "displayName": "Qwen3.5 0.8B BF16",
-        "hfId": "Qwen/Qwen3.5-0.8B",
-        "params": "0.8B",
-        "quant": "none",
-        "topology": "single",
-        "recipeStem": "qwen3.5-0.8b-bf16-atlas",
-        "command": "sparkrun run @atlas/qwen3.5-0.8b-bf16-atlas"
-      },
-      {
-        "displayName": "Qwen3.5 122B A10B NVFP4 EP=2",
-        "hfId": "Sehyo/Qwen3.5-122B-A10B-NVFP4",
-        "params": "122B",
-        "quant": "nvfp4",
-        "topology": "EP=2",
-        "recipeStem": "qwen3.5-122b-a10b-nvfp4-ep2",
-        "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-ep2"
-      },
-      {
-        "displayName": "Qwen3.5 122B A10B NVFP4 Single",
-        "hfId": "Sehyo/Qwen3.5-122B-A10B-NVFP4",
-        "params": "122B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "qwen3.5-122b-a10b-nvfp4-single",
-        "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-single"
-      },
-      {
-        "displayName": "Qwen3.5 27B Dense NVFP4",
-        "hfId": "Kbenkhaled/Qwen3.5-27B-NVFP4",
-        "params": "27B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "qwen3.5-27b-dense-nvfp4",
-        "command": "sparkrun run @atlas/qwen3.5-27b-dense-nvfp4"
-      },
-      {
-        "displayName": "Qwen3.5 35B A3B NVFP4",
-        "hfId": "Sehyo/Qwen3.5-35B-A3B-NVFP4",
-        "params": "35B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "qwen3.5-35b-a3b-nvfp4",
-        "command": "sparkrun run @atlas/qwen3.5-35b-a3b-nvfp4"
-      }
-    ]
-  },
-  {
-    "family": "qwen3.6",
-    "displayName": "Qwen3.6",
-    "recipes": [
-      {
-        "displayName": "Qwen3.6 27B Dense FP8",
-        "hfId": "Qwen/Qwen3.6-27B-FP8",
-        "params": "27B",
-        "quant": "fp8",
-        "topology": "single",
-        "recipeStem": "qwen3.6-27b-dense-fp8-atlas",
-        "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-atlas"
-      },
-      {
-        "displayName": "Qwen3.6 27B Dense FP8 MTP",
-        "hfId": "Qwen/Qwen3.6-27B-FP8",
-        "params": "27B",
-        "quant": "fp8",
-        "topology": "single",
-        "recipeStem": "qwen3.6-27b-dense-fp8-mtp-atlas",
-        "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-mtp-atlas"
-      },
-      {
-        "displayName": "Qwen3.6 27B FP8 MTP",
-        "hfId": "Qwen/Qwen3.6-27B-FP8",
-        "params": "27B",
-        "quant": "fp8",
-        "topology": "single",
-        "recipeStem": "qwen3.6-27b-fp8-mtp-atlas",
-        "command": "sparkrun run @atlas/qwen3.6-27b-fp8-mtp-atlas"
-      },
-      {
-        "displayName": "Qwen3.6 35B A3B FP8 MTP",
-        "hfId": "Qwen/Qwen3.6-35B-A3B-FP8",
-        "params": "35B",
-        "quant": "fp8",
-        "topology": "single",
-        "recipeStem": "qwen3.6-35b-a3b-fp8-mtp-atlas",
-        "command": "sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas"
-      },
-      {
-        "displayName": "Qwen3.6 35B A3B NVFP4",
-        "hfId": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
-        "params": "35B",
-        "quant": "nvfp4",
-        "topology": "single",
-        "recipeStem": "qwen3.6-35b-a3b-nvfp4-atlas",
-        "command": "sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4-atlas"
+        "name": "MiniMax-M2.7",
+        "recipes": [
+          {
+            "displayName": "Minimax M2.7 NVFP4 EP=2",
+            "hfId": "lukealonso/MiniMax-M2.7-NVFP4",
+            "params": "230B",
+            "quant": "nvfp4",
+            "topology": "EP=2",
+            "recipeStem": "minimax-m2.7-nvfp4-ep2",
+            "command": "sparkrun run @atlas/minimax-m2.7-nvfp4-ep2"
+          }
+        ]
       }
     ]
   }

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -23,7 +23,8 @@
     url: 'https://atlasinference.io/',
     sameAs: [
       'https://sparkrun.dev/runtimes/atlas/',
-      'https://github.com/Avarok-Cybersecurity/atlas-recipes'
+      'https://github.com/Avarok-Cybersecurity/atlas-recipes',
+      'https://x.com/atlasinference'
     ]
   })}<\/script>`}
 </svelte:head>

--- a/site/static/quickstart.sh
+++ b/site/static/quickstart.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# =============================================================================
+# Atlas quickstart — https://atlasinference.io/quickstart.sh
+# -----------------------------------------------------------------------------
+# Installs sparkrun (only if it is not already present) and runs the default
+# Atlas recipe. Intended to be piped from curl:
+#
+#   curl -fsSL https://atlasinference.io/quickstart.sh | sh
+#
+# It does NOT install Docker/Podman or the NVIDIA container runtime — sparkrun
+# uses whatever container engine you already have (the recipe declares its
+# `container:`). Re-running is safe: if sparkrun is already installed it is
+# left untouched.
+# =============================================================================
+set -eu
+
+# The recipe to launch. Keep in lockstep with the site copy + atlas-recipes
+# SSOT (https://github.com/Avarok-Cybersecurity/atlas-recipes).
+RECIPE="qwen3.6-35b-a3b-fp8-mtp-atlas"
+
+log() { printf '\033[1;36m[atlas]\033[0m %s\n' "$1" >&2; }
+err() { printf '\033[1;31m[atlas]\033[0m %s\n' "$1" >&2; }
+
+if command -v sparkrun >/dev/null 2>&1; then
+  log "sparkrun already installed ($(command -v sparkrun)) — skipping install."
+else
+  log "sparkrun not found — installing via uvx ..."
+  if ! command -v uvx >/dev/null 2>&1; then
+    err "uvx is required to install sparkrun but was not found on PATH."
+    err "Install uv first: https://docs.astral.sh/uv/  (then re-run this script)."
+    exit 1
+  fi
+  uvx sparkrun setup install
+fi
+
+log "Running @atlas/${RECIPE} ..."
+exec sparkrun run "@atlas/${RECIPE}"


### PR DESCRIPTION
Follow-up to #68 (merged). Replaces the model **carousel** with a **3-level tabbed navigation**, SSOT-driven, plus the mid-task additions requested during the work.

## Carousel → tabbed nav (primary)
- Top: **vendor family tabs** with inline official SVG marks (LobeHub static set, `currentColor`, no CDN/runtime fetch): **Qwen, Gemma, Nemotron (NVIDIA mark), Mistral, MiniMax**.
- Within a vendor: **sub-family sub-tabs** (Qwen → Qwen3.5 / Qwen3.6 / Qwen3-Next / Qwen3-VL / Qwen3-Coder-Next; Nemotron → Nano / Super; Gemma → Gemma-4; Mistral → Mistral-Small-4; MiniMax → MiniMax-M2.7).
- Within a sub-tab: existing **recipe sub-cards** (HF id, quant/topology chips, `sparkrun run @atlas/<recipe>` copy-pill). All **19 recipes** reachable.
- prev/next + dots removed. `gen-models.mjs` extended to a vendor→subfamily→recipe tree (unmapped recipe dir = hard fail); `models.generated.json` regenerated (19 == yaml count). Svelte 5 `$state`/`$derived`; mobile tab rows wrap/scroll.

## Mid-task additions (requested during the task)
- **X/Twitter**: `XIcon.svelte`, link in `Nav` + `Footer` (Community), and `https://x.com/atlasinference` added to the JSON-LD `sameAs`.
- **One-command quickstart**: `dockerCommand`→`runCommand` (curl one-liner; raw kept as `runCommandRaw`); `TryIt` heading "one command".
- **`site/static/quickstart.sh`** served at `/quickstart.sh` (`set -eu`; installs sparkrun via `uvx sparkrun setup install` only if absent, then `exec sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas`). NOTE: this is a `curl … | sh`-style installer — flagging since it pipes a remote script to a shell.

## Verify (dgx2)
`bun install --frozen-lockfile` + `bun x --bun vite build` → exit 0, `build/` produced. All 5 vendors, 10 sub-families, 19/19 sparkrun commands present in build; no `docker pull avarok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)