### PR TITLE
docs: remove dangling SSM_CATASTROPHIC_FORGETTING_TODO.md refs

### DIFF
--- a/book/src/deep-dives/ssm.md
+++ b/book/src/deep-dives/ssm.md
@@ -94,5 +94,4 @@ Each step calls into `spark-runtime::GpuBackend` via the layer's cached `KernelH
 - `kernels/gb10/<model>/<quant>/ssm_preprocess.cu`, `gdr.cu`, `causal_conv1d.cu`
 - `crates/spark-model/src/layers/qwen3_ssm.rs`, `nemotron_mamba2.rs`
 - `crates/spark-runtime/src/prefix_cache.rs` (Marconi SSM snapshot)
-- `docs/history/SSM_CATASTROPHIC_FORGETTING_TODO.md`
 - README "Atlas Spark" section — the SSM/GDN story in narrative form

--- a/crates/spark-server/src/api/failures/duplicate.rs
+++ b/crates/spark-server/src/api/failures/duplicate.rs
@@ -299,8 +299,7 @@ pub fn strip_xml_leaks_from_assistant_content(
     // </content></task>` envelope (dump 2026-04-25 seq=104..111)
     // from polluting the next turn's prompt, which previously
     // taught the model that emitting the prose envelope is a valid
-    // tool-call substitute (Phase-1 leak-then-collapse pattern,
-    // see history/SSM_CATASTROPHIC_FORGETTING_TODO.md).
+    // tool-call substitute (Phase-1 leak-then-collapse pattern).
     const HARNESS_TAGS: &[&str] = &["task", "file", "content", "description", "prompt", "glob"];
     let mut leak_names: Vec<String> = tool_defs
         .iter()

--- a/kernels/gb10/qwen3.5-35b-a3b/MODEL.toml
+++ b/kernels/gb10/qwen3.5-35b-a3b/MODEL.toml
@@ -83,10 +83,8 @@ frequency_penalty = 0.0
 # loops at turn ~7-8 of opencode agentic sessions, even though
 # temperature > 0 prevents strictly-greedy loops. Observed in dump
 # seq=19 (2026-04-24); tracked upstream in QwenLM/Qwen3.5#115,
-# Qwen3.6#88, qwen-code#1403, vllm#27157. Our own
-# docs/history/SSM_CATASTROPHIC_FORGETTING_TODO.md already documents
-# the symptom and recommends enabling a repetition suppressor on the
-# tools preset.
+# Qwen3.6#88, qwen-code#1403, vllm#27157. The repetition suppressor
+# on the tools preset (`presence_penalty` below) is the mitigation.
 #
 # We do NOT raise `repetition_penalty` above 1.0 — Qwen deprecates it
 # for this SKU (Qwen3-VL#1611: "breaks the transcription of naturally


### PR DESCRIPTION
## Summary

Three sites referenced `docs/history/SSM_CATASTROPHIC_FORGETTING_TODO.md`, a file that has never existed in any branch of this repo (`git log --all --diff-filter=A` returns nothing for that path). The surrounding comments stand on their own once the dangling reference is removed.

- `crates/spark-server/src/api/failures/duplicate.rs`: keep the "Phase-1 leak-then-collapse pattern" wording, drop the file pointer.
- `kernels/gb10/qwen3.5-35b-a3b/MODEL.toml`: redirect to the `presence_penalty` knob already defined later in the same file.
- `book/src/deep-dives/ssm.md`: drop the bullet.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests`
- [x] Build the book (`mdbook build book/`) to confirm no broken cross-link warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)