### PR TITLE
fix(ssm): use try_kernel + warn for optional FP32 conv1d

### DIFF
--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -50,18 +50,27 @@ impl Qwen3SsmLayer {
             deinterleave_k: gpu.kernel("ssm_preprocess", "deinterleave_qkvz")?,
             conv1d_k: gpu.kernel("causal_conv1d", "causal_conv1d_update")?,
             conv1d_l2norm_k: gpu.kernel("causal_conv1d", "causal_conv1d_update_l2norm")?,
+            // FP32 conv1d output prevents BF16 truncation in the recurrent
+            // path from compounding past ~8k tokens. The Metal backend
+            // (kernels/metal/common/causal_conv1d_update_l2norm.metal) only
+            // ships the BF16 variant; on those targets we fall back to the
+            // BF16 kernel via the `.0 != 0` gate at the use site
+            // (ssm_forward.rs). Warn instead of error: missing-on-Metal is
+            // expected, and a startup `error!` would page on benign cases.
             conv1d_l2norm_f32_k: {
-                let k = gpu.kernel("causal_conv1d", "causal_conv1d_update_l2norm_f32");
-                match k {
-                    Ok(h) => h,
-                    Err(_) => {
-                        tracing::error!(
-                            "FP32 conv1d kernel not found — SSM long-context coherence \
-                             WILL degrade after ~8k tokens due to BF16 precision loss"
-                        );
-                        KernelHandle(0)
-                    }
+                let h = super::super::try_kernel(
+                    gpu,
+                    "causal_conv1d",
+                    "causal_conv1d_update_l2norm_f32",
+                );
+                if h.0 == 0 {
+                    tracing::warn!(
+                        "FP32 conv1d kernel not loaded; SSM uses BF16 conv \
+                         output. Expect long-context coherence drift past ~8k \
+                         tokens on this backend."
+                    );
                 }
+                h
             },
             gdn_k: gpu.kernel("gated_delta_rule", "gated_delta_rule_decode")?,
             gdn_f32_k: super::super::try_kernel(


### PR DESCRIPTION
## Summary

`Qwen3SsmLayer::new` in `crates/spark-model/src/layers/qwen3_ssm/init.rs` was loading the optional FP32 `causal_conv1d_update_l2norm_f32` kernel with a bespoke `match` block: on miss it emitted `tracing::error!` and synthesized `KernelHandle(0)`.

Two issues:

1. The Metal backend (`kernels/metal/common/causal_conv1d_update_l2norm.metal`) only ships the BF16 variant, so the "missing" path is the expected path on Metal — an `error!`-level log per launch is too loud.
2. Every other optional kernel in the same file uses the existing `try_kernel` helper (debug-level miss log + null sentinel), so the bespoke block was an inconsistency.

Use `try_kernel`, then `warn!` once if the handle is null with a brief description of the long-context BF16-precision impact. The use site (`ssm_forward.rs`, `if k.0 != 0`) is unchanged, so the BF16 fallback continues to work the same way.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests`
- [ ] Launch an SSM model on CUDA and confirm no startup `error!` (was emitted previously when FP32 kernel was found-OK; new code stays silent on success).
- [ ] Launch on Metal (or simulate a missing-kernel path) and confirm the `warn!` fires once at startup, then BF16 conv1d is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)