### PR TITLE
spark-server: add --default-chat-template-kwargs CLI flag

### DIFF
--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -149,10 +149,10 @@ pub(crate) async fn chat_completions_inner(
     // the request so the existing resolve_thinking() chain sees them as
     // normal request-body fields. We don't mutate the resolution logic —
     // we just pre-populate the field it already checks.
-    if let Some(ref default_kw) = state.default_chat_template_kwargs {
-        if !req.thinking_explicitly_requested() {
-            req.chat_template_kwargs = Some(default_kw.clone());
-        }
+    if let Some(ref default_kw) = state.default_chat_template_kwargs
+        && !req.thinking_explicitly_requested()
+    {
+        req.chat_template_kwargs = Some(default_kw.clone());
     }
 
     // ── Phase 2: thinking resolution (pre-template) ─────────────

--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -143,6 +143,18 @@ pub(crate) async fn chat_completions_inner(
         Err(resp) => return resp,
     };
 
+    // ── Phase 1.5: merge server-level chat_template_kwargs default ─
+    // When the client sends no thinking parameters and the server has a
+    // --default-chat-template-kwargs flag set, inject those kwargs into
+    // the request so the existing resolve_thinking() chain sees them as
+    // normal request-body fields. We don't mutate the resolution logic —
+    // we just pre-populate the field it already checks.
+    if let Some(ref default_kw) = state.default_chat_template_kwargs {
+        if !req.thinking_explicitly_requested() {
+            req.chat_template_kwargs = Some(default_kw.clone());
+        }
+    }
+
     // ── Phase 2: thinking resolution (pre-template) ─────────────
     let (enable_thinking, thinking_budget) = thinking::resolve_thinking(&state, &req, tools_active);
 

--- a/crates/spark-server/src/cli.rs
+++ b/crates/spark-server/src/cli.rs
@@ -95,6 +95,16 @@ pub struct ServeArgs {
     #[arg(long)]
     pub max_thinking_budget: Option<u32>,
 
+    /// Default chat template kwargs applied when the client sends no
+    /// thinking parameters (no `reasoning.effort`, `chat_template_kwargs`,
+    /// or `enable_thinking` in the request body). A JSON object with
+    /// optional keys: `enable_thinking` (bool), `thinking_budget` (u32).
+    ///
+    /// Precedence (highest wins): request body → this flag → MODEL.toml.
+    /// Example: `--default-chat-template-kwargs '{"enable_thinking":true}'`
+    #[arg(long, value_name = "JSON")]
+    pub default_chat_template_kwargs: Option<String>,
+
     /// Currently slower than regular decode for hybrid SSM models.
     #[arg(long, default_value_t = false)]
     pub speculative: bool,

--- a/crates/spark-server/src/main_modules/app_state.rs
+++ b/crates/spark-server/src/main_modules/app_state.rs
@@ -72,6 +72,10 @@ pub struct AppState {
     /// thinking is forced OFF regardless of the request body or the
     /// model's MODEL.toml default. Wired from `--disable-thinking`.
     pub disable_thinking: bool,
+    /// Server-level default chat template kwargs applied when the client
+    /// sends no thinking parameters. Overridden per-request by the request
+    /// body. Wired from `--default-chat-template-kwargs`.
+    pub default_chat_template_kwargs: Option<crate::openai::ChatTemplateKwargs>,
     /// Shared in-memory store for stateful Responses API resume
     /// (`previous_response_id`) and opt-in Chat-Completions storage
     /// (`store: true`). Bounded LRU + TTL; env-configured at startup.

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -463,7 +463,8 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
             b
         },
         disable_thinking: args.disable_thinking,
-        default_chat_template_kwargs: args.default_chat_template_kwargs
+        default_chat_template_kwargs: args
+            .default_chat_template_kwargs
             .as_ref()
             .and_then(|s| crate::openai::ChatTemplateKwargs::from_json(s)),
         response_store,

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -463,6 +463,9 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
             b
         },
         disable_thinking: args.disable_thinking,
+        default_chat_template_kwargs: args.default_chat_template_kwargs
+            .as_ref()
+            .and_then(|s| crate::openai::ChatTemplateKwargs::from_json(s)),
         response_store,
         rate_limiter,
         conversation_store,

--- a/crates/spark-server/src/openai/chat_request.rs
+++ b/crates/spark-server/src/openai/chat_request.rs
@@ -240,10 +240,20 @@ pub struct ReasoningConfig {
 }
 
 /// vLLM-style chat template kwargs.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ChatTemplateKwargs {
     pub enable_thinking: Option<bool>,
     pub thinking_budget: Option<u32>,
+}
+
+impl ChatTemplateKwargs {
+    /// Parse from a JSON string. Returns `None` if parsing fails or string is empty.
+    pub fn from_json(s: &str) -> Option<Self> {
+        if s.trim().is_empty() {
+            return None;
+        }
+        serde_json::from_str(s).ok()
+    }
 }
 
 /// Default thinking budget when thinking is enabled but no explicit budget set.

--- a/crates/spark-server/src/openai/tests.rs
+++ b/crates/spark-server/src/openai/tests.rs
@@ -215,10 +215,8 @@ fn responses_in_progress_event_name() {
 
 #[test]
 fn chat_template_kwargs_parse() {
-    let kw = ChatTemplateKwargs::from_json(
-        r#"{"enable_thinking":true,"thinking_budget":1024}"#,
-    )
-    .expect("should parse");
+    let kw = ChatTemplateKwargs::from_json(r#"{"enable_thinking":true,"thinking_budget":1024}"#)
+        .expect("should parse");
     assert_eq!(kw.enable_thinking, Some(true));
     assert_eq!(kw.thinking_budget, Some(1024));
 

--- a/crates/spark-server/src/openai/tests.rs
+++ b/crates/spark-server/src/openai/tests.rs
@@ -210,3 +210,65 @@ fn responses_in_progress_event_name() {
     };
     assert_eq!(responses_event_name(&ev), "response.in_progress");
 }
+
+// ── ChatTemplateKwargs ────────────────────────────────────────────
+
+#[test]
+fn chat_template_kwargs_parse() {
+    let kw = ChatTemplateKwargs::from_json(
+        r#"{"enable_thinking":true,"thinking_budget":1024}"#,
+    )
+    .expect("should parse");
+    assert_eq!(kw.enable_thinking, Some(true));
+    assert_eq!(kw.thinking_budget, Some(1024));
+
+    assert!(ChatTemplateKwargs::from_json("").is_none());
+}
+
+fn empty_chat_request() -> ChatCompletionRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }))
+    .expect("valid chat request")
+}
+
+#[test]
+fn server_default_merged_when_request_silent() {
+    let mut req = empty_chat_request();
+    assert!(req.chat_template_kwargs.is_none());
+
+    let server_kw = ChatTemplateKwargs {
+        enable_thinking: Some(true),
+        thinking_budget: None,
+    };
+    if !req.thinking_explicitly_requested() {
+        req.chat_template_kwargs = Some(server_kw);
+    }
+    assert!(req.chat_template_kwargs.is_some());
+
+    let (enabled, budget) = req.resolve_thinking(false);
+    assert!(enabled);
+    assert!(budget.is_some());
+}
+
+#[test]
+fn server_default_not_merged_when_request_explicit() {
+    let mut req: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "enable_thinking": true,
+    }))
+    .expect("valid chat request");
+    assert!(req.thinking_explicitly_requested());
+
+    let server_kw = ChatTemplateKwargs {
+        enable_thinking: Some(false),
+        thinking_budget: None,
+    };
+    if !req.thinking_explicitly_requested() {
+        req.chat_template_kwargs = Some(server_kw);
+    }
+    assert!(req.chat_template_kwargs.is_none());
+    assert!(req.resolve_thinking(false).0);
+}


### PR DESCRIPTION


<!--
Thanks for contributing to Atlas! A few reminders:

- Read CONTRIBUTING.md if you haven't yet.
- CI runs cargo fmt, cargo clippy -Dwarnings, the SPDX-header check, typos,
  and cargo-deny (via the security workflow). Please run `cargo fmt --all`
  and `bash scripts/check-license-headers.sh` locally before pushing.
- If you add a new source file, it needs `// SPDX-License-Identifier: AGPL-3.0-only`
  on line 1.
-->

## Summary

Add a CLI option for chat template kwargs `--default-chat-template-kwargs`, allowing users to set thinking defaults at startup without per-request configuration or MODEL.toml rebuilds.

Precedence (highest wins): request body → this flag → MODEL.toml.

Usage:
  spark serve --default-chat-template-kwargs '{"enable_thinking":true}' /path/to/model



## Test plan
Tested it via `sparkrun` recipe
```yaml
recipe_version: '2'
model: RedHatAI/Qwen3.6-35B-A3B-NVFP4
runtime: atlas
max_nodes: 1
container: atlas-gb10:kwargs # my builded container
metadata:
  category: agent
  description: |
    Qwen3.6-35B-A3B (RedHatAI NVFP4) with MTP K=2 on the Atlas runtime.
    Mirrors the qwen3.5-35b-a3b-nvfp4 recipe but uses the qwen3_5_moe
    architecture from Qwen3.6, served on a single GB10. NVFP4 weights +
    NVFP4 KV cache + NVFP4 MTP-quantized draft head.
  head_dim: 256
  kv_dtype: nvfp4
  maintainer: avarok
  model_dtype: nvfp4
  model_params: 35B
  num_kv_heads: 2
  num_layers: 40
  quant_bits: 4
  quantization: nvfp4
defaults:
  gpu_memory_utilization: 0.5
  host: 0.0.0.0
  kv_cache_dtype: nvfp4
  max_model_len: 262144
  mtp_quantization: nvfp4
  port: 8000
  scheduling_policy: slai
  tool-call-parser: qwen3_coder
  served_model_name: qwen-coder
command: |
          spark serve {model} \
          --port {port} \
          --host {host} \
          --gpu-memory-utilization {gpu_memory_utilization} \
          --max-seq-len {max_model_len} \
          --kv-cache-dtype {kv_cache_dtype} \
          --scheduling-policy {scheduling_policy} \
          --mtp-quantization {mtp_quantization} \
          --enable-prefix-caching \
          --speculative \
          --model-name {served_model_name} \
          --default-chat-template-kwargs '{"enable_thinking": true}'
```
So thinking was enabled without custom opts in requests.

<!-- Concrete checklist of how you verified this. Logs/benchmarks welcome. -->

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [x] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable

## Notes for reviewers
### Authorship
This PR was AI-generated (OpenAgent / DeepSeek-v4), with human review and testing by Marat Kharitonov.


## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
