### PR TITLE
fix(streaming): finish_reason=length when a tool-loop guard caps the response

### DIFF
--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -148,7 +148,18 @@ pub(super) fn handle_done(
         }
     }
 
-    let fr = if state.detector.as_ref().is_some_and(|d| d.has_tool_calls())
+    let fr = if state.tool_loop_capped {
+        // A tool-call loop guard (Bug-2 name-run cap, F11 within-dedup,
+        // F5 cross-flush dedup, or F44 perm-fail) forcibly ended the
+        // response. Signal "length" — OpenAI's slot for a truncated
+        // response — so agent clients can break their outer retry
+        // loop. Without this override the response otherwise looks like
+        // a normal "tool_calls" completion (tool calls *were* emitted)
+        // and agents (opencode, etc.) cheerfully run the tools and ask
+        // the model to continue, perpetuating the loop one round at a
+        // time.
+        "length"
+    } else if state.detector.as_ref().is_some_and(|d| d.has_tool_calls())
         || state.salvaged_tool_call
     {
         "tool_calls"
@@ -212,6 +223,7 @@ pub(super) fn handle_done(
             "usage": usage_for_dump,
             "stop_string_triggered": state.stop_string_triggered,
             "loop_watchdog_triggered": state.loop_watchdog_triggered,
+            "tool_loop_capped": state.tool_loop_capped,
             "_note": "Synthesized from post-sanitizer accumulators; \
                       per-chunk capture is a follow-up.",
         });

--- a/crates/spark-server/src/api/chat_stream/state.rs
+++ b/crates/spark-server/src/api/chat_stream/state.rs
@@ -82,6 +82,18 @@ pub(super) struct StreamState {
     /// `(last_name, run_length)`. `last_name = None` means the run
     /// was just broken by a different tool name.
     pub(super) name_run: Option<(String, u32)>,
+    /// Set true when ANY tool-call loop guard forcibly ends the
+    /// response: the Bug-2 name-run cap, F11 within-response dedup,
+    /// F5 cross-flush dedup, or F44 permanent-failure circuit-breaker.
+    /// `handle_done` reads this and overrides `finish_reason` to
+    /// `"length"` — without the override the response otherwise looks
+    /// like a normal `"tool_calls"` completion (because tool calls
+    /// were emitted), and agent clients (opencode, etc.) cheerfully
+    /// run the tools and send the next request, perpetuating the loop
+    /// from the outside. `"length"` is the OpenAI-spec slot for
+    /// "response was forcibly truncated" and gives every agent a
+    /// clean hook to break its outer retry loop.
+    pub(super) tool_loop_capped: bool,
     /// Streaming tool-call detector (`Some` iff `tools_active`).
     pub(super) detector: Option<tool_parser::StreamingToolDetector>,
     /// True iff the reasoning/`<think>` phase has finished. Starts
@@ -114,6 +126,7 @@ impl StreamState {
             streaming_tool_args: HashMap::new(),
             tool_calls_emitted_count: 0,
             name_run: None,
+            tool_loop_capped: false,
             detector: if tools_active {
                 Some(tool_parser::StreamingToolDetector::new())
             } else {

--- a/crates/spark-server/src/api/chat_stream/tool_handlers.rs
+++ b/crates/spark-server/src/api/chat_stream/tool_handlers.rs
@@ -62,6 +62,7 @@ pub(super) fn handle_complete_tool_call(
             "tool-arg dedup tripped: refusing redundant tool_call and ending response"
         );
         state.stop_string_triggered = true;
+        state.tool_loop_capped = true;
     } else {
         // Bug-2 name-run cap (mirrors handle_tool_call_end): catches
         // runaway loops in the complete-tool-call path that
@@ -79,6 +80,7 @@ pub(super) fn handle_complete_tool_call(
                 tc.function.name
             );
             state.stop_string_triggered = true;
+            state.tool_loop_capped = true;
         }
         bump_f12_tool_call_count(
             &mut state.tool_calls_emitted_count,
@@ -245,6 +247,7 @@ pub(super) fn handle_tool_call_end(state: &mut StreamState, ctx: &StreamCtx, idx
                 "F11 within-response dedup tripped: 2+ identical streaming tool calls; ending response"
             );
             state.stop_string_triggered = true;
+            state.tool_loop_capped = true;
         } else if ctx.f44_cache_active
             && f44_check_permanent_failure(&ctx.f44_cache, &name, &args_json)
         {
@@ -253,6 +256,7 @@ pub(super) fn handle_tool_call_end(state: &mut StreamState, ctx: &StreamCtx, idx
                 "F44 streaming circuit-breaker tripped: tool_call matches a permanently-failed prior call; ending response"
             );
             state.stop_string_triggered = true;
+            state.tool_loop_capped = true;
         }
         let run_len = match &state.name_run {
             Some((prev, n)) if prev == &name => n + 1,
@@ -266,6 +270,7 @@ pub(super) fn handle_tool_call_end(state: &mut StreamState, ctx: &StreamCtx, idx
                 "Bug-2 name-run cap tripped: {run_len} successive `{name}` tool calls; ending response (F11 missed because args drift)"
             );
             state.stop_string_triggered = true;
+            state.tool_loop_capped = true;
         }
         if !state.stop_string_triggered {
             // Successful streaming tool call — log + metric to match the


### PR DESCRIPTION
**Problem.** Live reproduction with `Qwen3.6-35B-A3B-FP8` under opencode: the model spiraled into a tool-discovery loop (`which cargo`, `which curl`, `which lsof`, `which f`…), Atlas's Bug-2 name-run cap correctly tripped at 6 successive `bash` calls and ended the response — but with `finish_reason: "tool_calls"`, which opencode reads as a normal completion. It runs the (degenerate) tools, sends the next request, the model loops again. Atlas was breaking the loop one round at a time without ever telling the agent client.

**Fix.** New `tool_loop_capped: bool` on `StreamState`, set true by every tool-call loop guard (Bug-2 name-run cap × 2 sites, F11 within-response dedup, F5 cross-flush dedup, F44 perm-fail circuit-breaker). `handle_done` overrides `finish_reason` to `"length"` — OpenAI's spec slot for "forcibly truncated" — when the flag is set, ahead of the existing `"tool_calls"` fall-through. Spec-compliant hook for every agent client to break its outer retry loop without needing Atlas-specific signaling.

**Scope.** Streaming chat path only (where the cap lives). Also surfaced in the `--dump` synthesized-response body.

**Verification.** Local: `cargo check -p spark-server`, `cargo clippy -p spark-server --tests`, `cargo fmt --all --check` all clean. Live end-to-end verification against the loop repro to follow image rebuild.