### PR TITLE
fix(docker): repair per-model Dockerfiles broken from a clean checkout

### DIFF
--- a/docker/gb10/Dockerfile
+++ b/docker/gb10/Dockerfile
@@ -31,7 +31,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 COPY jinja-templates/ jinja-templates/
 

--- a/docker/gb10/nemotron-3-nano-30b-a3b/nvfp4/Dockerfile
+++ b/docker/gb10/nemotron-3-nano-30b-a3b/nvfp4/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -40,7 +39,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/nemotron-super-120b-a12b/nvfp4/Dockerfile
+++ b/docker/gb10/nemotron-super-120b-a12b/nvfp4/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 COPY jinja-templates/ jinja-templates/
 
@@ -41,7 +40,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/qwen3-next-80b-a3b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3-next-80b-a3b/nvfp4/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -40,7 +39,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/qwen3-vl-30b-a3b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3-vl-30b-a3b/nvfp4/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -40,7 +39,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/qwen3.5-122b-a10b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3.5-122b-a10b/nvfp4/Dockerfile
@@ -30,7 +30,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -47,7 +46,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/qwen3.5-27b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3.5-27b/nvfp4/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -40,7 +39,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/qwen3.5-35b-a3b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3.5-35b-a3b/nvfp4/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -40,7 +39,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \

--- a/docker/gb10/qwen3.6-27b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3.6-27b/nvfp4/Dockerfile
@@ -30,7 +30,6 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
-COPY vendor/ vendor/
 COPY kernels/ kernels/
 
 ENV ATLAS_TARGET_HW=gb10
@@ -47,7 +46,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 # NCCL for multi-GPU (EP=2), RDMA userspace for RoCE transport
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
-      "libnccl2 (>= 2.28)" libibverbs1 librdmacm1 ibverbs-providers \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
       libnl-3-200 libnl-route-3-200 && \
     rm -rf /var/lib/apt/lists/* && \
     NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \


### PR DESCRIPTION
## What
Repairs the per-model GB10 Dockerfiles so they build from a clean checkout. Two bugs, fixed across `docker/gb10/**/Dockerfile`:

1. **`COPY vendor/ vendor/`** — the vendored dependency tree no longer exists in the repo (dependencies are fetched from crates.io), so the COPY aborts every build. Removed from all 9 Dockerfiles (including the top-level `docker/gb10/Dockerfile`).
2. **`apt-get install "libnccl2 (>= 2.28)"`** — apt cannot parse this inline version-constraint form (`E: Unable to locate package libnccl2 (>`). Replaced with a plain `libnccl2`; the existing `dpkg --compare-versions "$NCCL_VER" ge "2.28"` guard still enforces the minimum (the `cuda:13.0-runtime` repo upgrades `libnccl2` to 2.30.4). Fixed in the 8 per-model Dockerfiles.

## Why
A fresh `docker build -f docker/gb10/<model>/nvfp4/Dockerfile .` fails for every model today — first at the `vendor/` COPY, then at the `libnccl2` apt step. These two minimal per-file fixes unblock the entire per-model image matrix.

## Benchmarks / Verification
Not a performance change. Verified end-to-end by building `docker/gb10/qwen3.5-35b-a3b/nvfp4/Dockerfile` from a clean checkout to completion:
- builder `cargo build --release -p spark-server` links `-lnccl` against the devel image's bundled NCCL 2.27.7 and succeeds (~178s),
- runtime stage installs `libnccl2` (upgraded to 2.30.4), the `ge 2.28` check passes,
- image exports cleanly (`atlas-35b-warmuptest:nvfp4`).

NCCL linking is unaffected by fix #2: NCCL 2.27.7 already exports `ncclMemAlloc` / `ncclMemFree` / `ncclCommWindowRegister` (confirmed with a standalone link test), and `-lnccl` is a dynamic link resolved at runtime against the runtime stage's NCCL.

## Authorship
AI-generated using Claude Code (Opus 4.7).
