### PR TITLE
feat(kernels): add qwen3.5-397b-a17b NVFP4 EP=4 kernel target

### DIFF
--- a/docker/gb10/qwen3.5-397b-a17b/nvfp4/Dockerfile
+++ b/docker/gb10/qwen3.5-397b-a17b/nvfp4/Dockerfile
@@ -1,0 +1,69 @@
+# Atlas Spark — Qwen3.5-397B-A17B-NVFP4 on GB10 (4-node EP=4)
+#
+# Build from repo root:
+#   docker build -f docker/gb10/qwen3.5-397b-a17b/nvfp4/Dockerfile -t atlas-397b .
+#
+# Run — this is a 4-node deployment. The NVFP4 weights (~200 GB) exceed a single
+# GB10's 120 GB, and num_key_value_heads=2 cannot shard across 4 TP ranks, so the
+# only viable topology is expert-parallel EP=4 / TP=1 across all four nodes:
+#
+#   /home/cluster/launch-atlas-ep4.sh          # orchestrates ranks 0..3 on the 4 nodes
+#
+# (launch-atlas-ep4.sh passes `--tp-size 1 --ep-size 4 --world-size 4` plus the
+# RoCE/NCCL env — NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0 — to each rank.) A
+# single-node `docker run` will OOM at weight-load preflight.
+
+# ── Build stage ──────────────────────────────────────────────────
+FROM nvidia/cuda:13.0.0-devel-ubuntu24.04 AS builder
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq curl build-essential pkg-config git cmake libclang-dev && \
+    # Pin the builder's NCCL to match the runtime stage (2.30.4). Not required
+    # to link — the devel image's bundled 2.27.7 already exports the symbols
+    # spark-comm uses (ncclMemAlloc/ncclMemFree, verified) and `-lnccl` is a
+    # dynamic link — but keeping builder == runtime avoids any symmetric-memory
+    # (NCCL >= 2.28) ABI surprises and keeps the image reproducible.
+    apt-get install -y -qq --allow-change-held-packages libnccl-dev libnccl2 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV CUDA_HOME=/usr/local/cuda
+
+WORKDIR /build
+
+# Dependencies are fetched from crates.io at build time (no vendored tree).
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ crates/
+COPY kernels/ kernels/
+
+ENV ATLAS_TARGET_HW=gb10
+ENV ATLAS_TARGET_MODEL=qwen3.5-397b-a17b
+ENV ATLAS_TARGET_QUANT=nvfp4
+
+RUN cargo build --release -p spark-server
+
+# ── Runtime stage ────────────────────────────────────────────────
+FROM nvidia/cuda:13.0.0-runtime-ubuntu24.04
+
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
+
+# NCCL for multi-node EP=4, RDMA userspace for the RoCE transport.
+# NCCL >= 2.28 is required for ncclMemAlloc/ncclMemFree symmetric memory.
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends --allow-change-held-packages \
+      libnccl2 libibverbs1 librdmacm1 ibverbs-providers \
+      libnl-3-200 libnl-route-3-200 && \
+    rm -rf /var/lib/apt/lists/* && \
+    NCCL_VER=$(dpkg-query -W -f='${Version}' libnccl2) && \
+    echo "Linked NCCL: $NCCL_VER" && \
+    dpkg --compare-versions "$NCCL_VER" ge "2.28" || \
+      (echo "ERROR: NCCL $NCCL_VER < 2.28 — symmetric memory APIs unavailable" && exit 1)
+
+COPY --from=builder /build/target/release/spark /usr/local/bin/spark
+COPY LICENSE /LICENSE
+
+ENV RUST_LOG=info
+EXPOSE 8888
+
+ENTRYPOINT ["spark"]

--- a/docker/gb10/qwen3.5-397b-a17b/nvfp4/QUICKSTART.md
+++ b/docker/gb10/qwen3.5-397b-a17b/nvfp4/QUICKSTART.md
@@ -1,0 +1,57 @@
+# Qwen3.5-397B-A17B-NVFP4 on GB10 — Quickstart (4-node EP=4)
+
+The largest Qwen3.5 MoE checkpoint (397B total / ~17B active, 512 experts,
+top-10). The NVFP4 weights are ~200 GB, so this model **only** runs across all
+four GB10 nodes in expert-parallel (EP=4, TP=1). Tensor parallelism is not an
+option — `num_key_value_heads = 2` cannot shard across 4 TP ranks.
+
+## 1. Build the image (from the repo root)
+
+```bash
+docker build -f docker/gb10/qwen3.5-397b-a17b/nvfp4/Dockerfile -t atlas-397b .
+```
+
+The builder stage compiles only the `qwen3.5-397b-a17b` kernel target
+(`ATLAS_TARGET_MODEL=qwen3.5-397b-a17b`, `ATLAS_TARGET_QUANT=nvfp4`); the runtime
+stage carries `libnccl2 (>= 2.28)` + RDMA userspace for the RoCE transport.
+
+Make the image available on all four nodes (build on each, or `docker save | ssh
+nodeN docker load`).
+
+## 2. Launch 4-node EP=4
+
+```bash
+/home/cluster/launch-atlas-ep4.sh          # orchestrates ranks 0..3 across the 4 nodes
+```
+
+The launcher starts rank 0 (HTTP + scheduler) on the head node and ranks 1-3 as
+EP workers, passing `--tp-size 1 --ep-size 4 --world-size 4` plus the cluster's
+RoCE/NCCL env:
+
+```
+NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0      # both ConnectX-7 halves
+```
+
+Weights are read from the shared HF cache:
+`~/.cache/huggingface/hub/models--nvidia--Qwen3.5-397B-A17B-NVFP4`.
+
+## 3. Verify
+
+```bash
+curl http://localhost:8888/v1/models
+curl http://localhost:8888/v1/chat/completions -d \
+  '{"model":"nvidia/Qwen3.5-397B-A17B-NVFP4",
+    "messages":[{"role":"user","content":"What is 2+2?"}]}'
+```
+
+Rank-0 logs should show the NCCL ring forming (`NCCL INFO Channel X/Y`) and the
+kernel target selected as `qwen3.5-397b-a17b`. Thinking is **off by default**
+(server default); opt in per request with `thinking_token_budget` — 128 is the
+tested sweet spot (256 is non-monotonically worse). MTP is omitted (it regresses
+throughput on the NVFP4 checkpoint).
+
+## Notes
+
+- A single-node `docker run` will OOM at the weight-load preflight (weights > 120 GB).
+- Driver must stay on 580.x — 590.x triggers a CUDAGraph deadlock on GB10.
+- vLLM and Atlas are mutually exclusive on the cluster (both reserve unified memory).

--- a/kernels/gb10/qwen3.5-397b-a17b/MODEL.toml
+++ b/kernels/gb10/qwen3.5-397b-a17b/MODEL.toml
@@ -1,0 +1,126 @@
+# Atlas kernel target: nvidia/Qwen3.5-397B-A17B-NVFP4 — GB10 / NVFP4 / EP=4.
+#
+# Largest Qwen3.5 MoE checkpoint. Same Gated DeltaNet + Full Attention + MoE
+# hybrid architecture as qwen3.5-35b-a3b / qwen3.5-122b-a10b, scaled to 512
+# experts and hidden_size 4096. The NVFP4 weights (~200 GB) require 4-node
+# expert parallelism (EP=4, TP=1) on the 4x GB10 cluster — num_key_value_heads=2
+# cannot shard across 4 TP ranks.
+#
+# Kernel sources: this target reuses the qwen3.5-35b-a3b/nvfp4 overrides (copied
+# — kernels/ has no symlinks, so copies match repo convention) layered over the
+# shared kernels/gb10/common base. The overridden GEMMs (moe_w4a16_grouped_gemm,
+# w4a16_gemm) are byte-identical to the 122B's; gated_delta_rule carries the 35B's
+# faster register-tiled GDN decode. All three tile over runtime M/N/K and branch
+# on a runtime `num_experts` arg. The softmax router path used by the MoE EP
+# forward (moe_topk_softmax, kernels/gb10/common/moe_topk.cu) is sized
+# MAX_EXPERTS=512 — exactly fits this model's 512 experts.
+#
+# build.rs parses ONLY [[model_types]] / [sampling.*] / [behavior] below; the
+# dimension keys in [model] are documentation that mirrors config.json.
+
+[model]
+name = "qwen3.5-397b-a17b"
+hf_id = "nvidia/Qwen3.5-397B-A17B-NVFP4"
+params = "397B"
+active_params = "17B"
+architecture = "Gated DeltaNet + Full Attention + MoE"
+
+layers_total = 60
+layers_linear_attention = 45
+layers_full_attention = 15
+layer_pattern = "3:1 (linear, linear, linear, full)"  # full_attention_interval = 4
+
+moe_experts = 512
+moe_topk = 10
+moe_intermediate = 1024
+shared_expert_intermediate = 1024
+
+hidden_dim = 4096
+head_dim = 256
+q_heads = 32
+kv_heads = 2
+
+linear_attn_key_heads = 16
+linear_attn_key_dim = 128
+linear_attn_value_heads = 64
+linear_attn_value_dim = 128
+linear_conv_kernel = 4
+
+vocab_size = 248320
+max_position_embeddings = 262144
+rope_theta = 10000000
+partial_rotary_factor = 0.25
+attn_output_gate = true
+
+# MRoPE: the NVFP4 checkpoint sets mrope_interleaved + mrope_section in
+# config.json (text_config.rope_parameters), so parse_config rewrites
+# model_type qwen3_5_moe -> qwen3_6_moe at runtime (see [[model_types]]).
+# Text-only serving keeps H/W position IDs at zero.
+mrope_interleaved = true
+mrope_section = [11, 11, 10]
+
+mtp_layers = 1
+mtp_type = "full_attention"
+# Vision tower present in checkpoint, but the qwen3_6_moe path uses the
+# text-only Qwen35WeightLoader — vision weights are unused for text serving.
+vision = true
+
+# Recommended sampling defaults (Qwen3.5 model card). Mirror the
+# qwen3.5-35b-a3b / qwen3.5-122b-a10b base presets; the 35B's experimental
+# anti-repetition stack (lz/dry) is A3B-specific and intentionally omitted.
+[sampling.thinking_text]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+frequency_penalty = 0.0
+
+[sampling.thinking_coding]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+frequency_penalty = 0.0
+
+[sampling.non_thinking]
+temperature = 0.7
+top_p = 0.8
+top_k = 20
+presence_penalty = 0.0
+frequency_penalty = 0.0
+
+[sampling.tools]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+frequency_penalty = 0.0
+
+[behavior]
+# Thinking OFF by default, budget capped at 128. Per the NVFP4 397B thinking-
+# budget sweep (2026-05-07): budget 128 is the sweet spot (~21s, correct
+# judgment); budget 256 is NON-MONOTONIC — WORSE than 128, the model talks
+# itself into wrong answers. Clients opt in per-request via thinking_token_budget.
+thinking_default = false
+thinking_in_tools = false
+max_thinking_budget = 128
+# A10B/A17B-class MoE finishes cleanly on long prompts (no period-N loops);
+# the content-loop watchdog is only needed on the dense Qwen 27B variants.
+enable_loop_watchdog = false
+# MTP is a confirmed dead end on the NVFP4 397B (2026-05-22): excellent
+# acceptance (80-97%) but accepted throughput collapses to 4-5 tok/s vs
+# ~19 tok/s without. NVFP4 checkpoint ships no MTP head weights → no drafts.
+default_num_drafts = 0
+
+[[model_types]]
+model_type = "qwen3_5_moe"
+hidden_size = 4096
+
+# mrope-interleaved MoE checkpoints get their model_type rewritten
+# qwen3_5_moe -> qwen3_6_moe by parse_config
+# (crates/atlas-core/src/config/dispatch.rs:116). The NVFP4 397B trips this
+# rewrite (the 2026-05-21 smoke test reported model_type 'qwen3_6_moe'), so
+# accept both forms at hidden_size 4096 — mirrors qwen3.5-122b-a10b.
+[[model_types]]
+model_type = "qwen3_6_moe"
+hidden_size = 4096

--- a/kernels/gb10/qwen3.5-397b-a17b/nvfp4/KERNEL.md
+++ b/kernels/gb10/qwen3.5-397b-a17b/nvfp4/KERNEL.md
@@ -1,0 +1,91 @@
+# GB10 / Qwen3.5-397B-A17B / NVFP4 — Kernel Context
+
+> AI instruction context for optimizing kernels in this (H, M, Q) target.
+
+## Hardware: GB10 (SM121)
+
+- **Architecture**: SM121 (Blackwell, compute capability 12.1)
+- **Memory**: 120 GB LPDDR5X @ 273 GB/s peak bandwidth
+- **Practical bandwidth**: ~65-70% of peak (178-191 GB/s) due to memory controller overhead
+- **No multi-CTA clusters**: ClusterShape forced to 1x1x1
+- **No HBM**: LPDDR5X has higher latency, lower per-pin bandwidth than HBM3e
+- **FP4 tensor cores**: SM120_16x8x64_TN_VS (native E2M1 support)
+- **Missing PTX**: `cvt.rn.satfinite.e2m1x2.f32` not available on SM121
+
+## Compilation
+
+```bash
+nvcc --ptx -arch=sm_121f -O3 --use_fast_math <file>.cu
+```
+
+## Model: Qwen3.5-397B-A17B-NVFP4
+
+- **Parameters**: 397B total, ~17B active per token (MoE)
+- **Architecture**: Hybrid — 15 full attention + 45 linear attention (Gated DeltaNet)
+- **Layer pattern**: 3:1 (linear, linear, linear, full) — `full_attention_interval = 4`, 60 layers
+- **Full Attention**: GQA 32:2 (32 query heads, 2 KV heads), head_dim=256
+- **Linear Attention**: 16 key heads (dim 128), 64 value heads (dim 128)
+- **DeltaNet**: Gated delta rule with causal Conv1d (kernel=4)
+- **MoE**: 512 experts, top-10 routing per token + 1 shared expert (intermediate 1024)
+- **Hidden dim**: 4096
+- **Vocab**: 248,320 tokens
+- **MRoPE**: `mrope_interleaved=true`, `mrope_section=[11, 11, 10]` — `parse_config`
+  rewrites `model_type` qwen3_5_moe → qwen3_6_moe (interleaved 3-axis RoPE on the
+  full-attention layers; text-only serving keeps H/W position IDs at zero)
+- **Vision**: ViT tower present in the checkpoint, but the qwen3_6_moe path loads
+  via the text-only Qwen35WeightLoader — vision weights are unused for text serving
+- **MTP**: 1 full-attention MTP layer in the config, but the NVFP4 checkpoint ships
+  no usable MTP head and MTP regresses throughput here — served without speculation
+- **Q/Gate interleaving**: HF q_proj output is per-head interleaved
+  `[Q_h0, G_h0, Q_h1, G_h1, ...]`; deinterleave before RoPE/norm
+
+## Multi-node: EP=4, TP=1 (mandatory)
+
+The NVFP4 weights (~200 GB) exceed a single GB10's 120 GB, so this target runs
+**expert-parallel across all four GB10 nodes** (EP=4). Tensor parallelism is not
+an option: `num_key_value_heads = 2` cannot shard across 4 TP ranks. Launch via
+`/home/cluster/launch-atlas-ep4.sh` (`--tp-size 1 --ep-size 4 --world-size 4`).
+
+## Quantization: Mixed NVFP4 + BF16 (ModelOpt)
+
+`quantization_config.quant_algo = NVFP4` (ModelOpt export). As with the smaller
+Qwen3.5 MoE targets, not all tensors are NVFP4: full-attention and MoE-expert
+projections are NVFP4, while linear-attention projections, the LM head, conv1d,
+norms, and gates remain BF16 (the quantizer skips them).
+
+## Kernel reuse (why this dir is thin)
+
+This target carries only three `.cu` overrides — `gated_delta_rule.cu`,
+`moe_w4a16_grouped_gemm.cu`, `w4a16_gemm.cu` — copied verbatim from
+`qwen3.5-35b-a3b/nvfp4/` (the repo stores copies, not symlinks). Everything else
+comes from `kernels/gb10/common/`. This is correct because:
+
+- The MoE grouped GEMMs (`moe_w4a16_grouped_gemm`, `w4a16_gemm`) are
+  **byte-identical** between the 35B and 122B targets — they tile over runtime
+  M/N/K and branch on a runtime `unsigned int num_experts` (no compile-time
+  expert count), so 512 experts work unchanged.
+- `gated_delta_rule.cu` takes `num_v_heads`/`num_k_heads`/`v_dim`/`k_dim` as
+  runtime args; the 35B copy additionally has a register-tiled decode path that
+  assumes per-head `K_DIM = v_dim = 128`, which holds here
+  (`linear_key_head_dim = linear_value_head_dim = 128`). 64 value heads vs the
+  35B's 32 only scale the launch grid (`grid.x = num_v_heads`).
+
+## MoE Dispatch (512 experts, top-10)
+
+- 3D grid `(expert_idx, row_chunk, col_chunk)`; expert GEMV fuses gate_up + SiLU + down.
+- Routing uses the **softmax** top-k path (`moe_topk_softmax`,
+  `kernels/gb10/common/moe_topk.cu`), whose `__shared__` selection buffers are
+  sized `MAX_EXPERTS = 512` — this model's 512 experts fit **exactly** at that
+  ceiling. (The single-CTA `moe_gate_topk_fused`, capped at 256, is not used.)
+- `norm_topk_prob = true` (Qwen3.5 MoE normalizes top-k expert weights).
+
+## DeltaNet Linear Attention (45 layers)
+
+- 64 value heads × 16 key heads, all dim 128; depthwise causal Conv1d (kernel=4).
+- Recurrent FP32 state per layer: 64 heads × 128 × 128 ≈ 4.19 MB; ×45 layers ≈ 189 MB.
+
+## Full Attention (15 layers)
+
+- GQA 32:2, head_dim=256, partial_rotary_factor=0.25, MRoPE-interleaved.
+- Paged KV cache (block_size=16), FP8 with cache_stride.
+- Q/Gate interleaving requires the deinterleave_qg kernel.

--- a/kernels/gb10/qwen3.5-397b-a17b/nvfp4/KERNEL.toml
+++ b/kernels/gb10/qwen3.5-397b-a17b/nvfp4/KERNEL.toml
@@ -1,0 +1,38 @@
+[build]
+extra_nvcc_flags = ["--fmad=false"]
+
+# File stem → module name overrides.
+# Any .cu file not listed here uses its file stem as the module name.
+[modules]
+e2m1_branchless = "e2m1"
+moe_permute = "moe"
+dense_gemm_bf16 = "gemm"
+rms_norm = "norm"
+argmax_bf16 = "argmax"
+dense_gemv_bf16 = "gemv"
+dense_gemv_fp8w = "gemv_fp8w"
+moe_shared_expert_fused_batch2 = "moe_fused_batch2"
+moe_shared_expert_fused_batch3 = "moe_fused_batch3"
+quantize_bf16_to_nvfp4 = "quantize_nvfp4"
+paged_decode_attn = "paged_decode"
+paged_decode_attn_fp8 = "paged_decode_fp8"
+paged_decode_attn_nvfp4 = "paged_decode_nvfp4"
+w4a16_gemm = "w4a16"
+kv_cache_append = "kv_cache"
+moe_w4a16_grouped_gemm = "moe_w4a16"
+moe_sorted_prefill = "moe_sorted"
+inferspark_prefill_paged = "prefill_paged"
+inferspark_prefill_paged_fp8 = "prefill_paged_fp8"
+inferspark_prefill_paged_nvfp4 = "prefill_paged_nvfp4"
+inferspark_prefill_fp8kv = "prefill_fp8kv"
+gated_delta_rule = "gated_delta_rule"
+reshape_and_cache_turbo = "reshape_and_cache_turbo"
+paged_decode_attn_turbo4 = "paged_decode_turbo4"
+wht_bf16 = "wht_bf16"
+paged_decode_attn_turbo8 = "paged_decode_turbo8"
+paged_decode_attn_turbo4_512 = "paged_decode_turbo4_512"
+paged_decode_attn_turbo8_512 = "paged_decode_turbo8_512"
+paged_decode_attn_turbo3 = "paged_decode_turbo3"
+paged_decode_attn_turbo3_128 = "paged_decode_turbo3_128"
+paged_decode_attn_turbo4_128 = "paged_decode_turbo4_128"
+paged_decode_attn_turbo8_128 = "paged_decode_turbo8_128"

--- a/kernels/gb10/qwen3.5-397b-a17b/nvfp4/gated_delta_rule.cu
+++ b/kernels/gb10/qwen3.5-397b-a17b/nvfp4/gated_delta_rule.cu
@@ -1,0 +1,1084 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Atlas Register-Tiled Gated Delta Rule Prefill — 35B model shadow.
+//
+// Each thread holds its H column (128 floats) entirely in registers.
+// Eliminates all shared memory latency for H access (0-cycle vs ~20-cycle).
+//
+// Optimizations over parent:
+// - __launch_bounds__(128, 1): forces minBlocksPerSM=1, allowing compiler to
+//   allocate up to 512 registers/thread (vs 42 with default occupancy target
+//   of 12 blocks/SM on SM121). Without this, H_reg[128] spills to L1 cache
+//   (28-cycle latency) causing ~8× slowdown vs ideal register access.
+// - 4-way independent accumulators for hk_dot and q_dot reductions
+//   (breaks serial FMA dependency chain: 512 cycles → ~140 cycles per pass)
+// - Double-buffered smem for k/q (eliminates 1 syncthreads per token,
+//   overlaps next token's L2 loads with current token's compute)
+//
+// Grid: (num_v_heads, batch, 1)   Block: (128, 1, 1)
+
+#include <cuda_bf16.h>
+
+#define K_DIM 128
+
+extern "C" __global__ void __launch_bounds__(128, 1)
+gated_delta_rule_prefill(
+    float* __restrict__ h_state,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int seq_len,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    // Double-buffered k[128] + q[128] (512 floats = 2 KB)
+    extern __shared__ float smem[];
+    float* smem_k0 = smem;
+    float* smem_q0 = smem + K_DIM;
+    float* smem_k1 = smem + 2 * K_DIM;
+    float* smem_q1 = smem + 3 * K_DIM;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    // Load H column into registers — each thread owns one column of H[128×128]
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+
+    if (seq_len == 0) goto store_h;
+
+    // Load first token's k/q into buffer 0
+    {
+        unsigned long long qk_off = (unsigned long long)0 * qk_stride + kh * k_dim;
+        smem_k0[tid] = (float)key[qk_off + tid];
+        smem_q0[tid] = (float)query[qk_off + tid];
+    }
+    __syncthreads();
+
+    // Process tokens with double-buffered k/q loads
+    for (unsigned int t = 0; t < seq_len; t++) {
+        // Select current and next buffers
+        float* cur_k = (t & 1) ? smem_k1 : smem_k0;
+        float* cur_q = (t & 1) ? smem_q1 : smem_q0;
+        float* nxt_k = (t & 1) ? smem_k0 : smem_k1;
+        float* nxt_q = (t & 1) ? smem_q0 : smem_q1;
+
+        // Issue loads for NEXT token into other buffer (overlaps with compute)
+        if (t + 1 < seq_len) {
+            unsigned long long qk_off_nxt = (unsigned long long)(t + 1) * qk_stride + kh * k_dim;
+            nxt_k[tid] = (float)key[qk_off_nxt + tid];
+            nxt_q[tid] = (float)query[qk_off_nxt + tid];
+        }
+
+        float v_i = (float)value[(unsigned long long)t * v_stride + vh * v_dim + tid];
+        float g_t = fminf(fmaxf(gate[(unsigned long long)t * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+        float bt_t = beta[(unsigned long long)t * gb_stride + vh];
+
+        // Pass 1: hk_dot = H_reg^T · k
+        // 4 independent accumulators break serial FMA dependency chain
+        float hk0 = 0.0f, hk1 = 0.0f, hk2 = 0.0f, hk3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            hk0 += H_reg[j]     * cur_k[j];
+            hk1 += H_reg[j + 1] * cur_k[j + 1];
+            hk2 += H_reg[j + 2] * cur_k[j + 2];
+            hk3 += H_reg[j + 3] * cur_k[j + 3];
+        }
+        float hk_dot = (hk0 + hk1) + (hk2 + hk3);
+
+        float v_new = (v_i - g_t * hk_dot) * bt_t;
+
+        // Pass 2: update H_reg, compute q_dot = H_new^T · q
+        // 4 independent accumulators for q_dot
+        float qd0 = 0.0f, qd1 = 0.0f, qd2 = 0.0f, qd3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            float h0 = g_t * H_reg[j]     + cur_k[j]     * v_new;
+            float h1 = g_t * H_reg[j + 1] + cur_k[j + 1] * v_new;
+            float h2 = g_t * H_reg[j + 2] + cur_k[j + 2] * v_new;
+            float h3 = g_t * H_reg[j + 3] + cur_k[j + 3] * v_new;
+            H_reg[j]     = h0;
+            H_reg[j + 1] = h1;
+            H_reg[j + 2] = h2;
+            H_reg[j + 3] = h3;
+            qd0 += h0 * cur_q[j];
+            qd1 += h1 * cur_q[j + 1];
+            qd2 += h2 * cur_q[j + 2];
+            qd3 += h3 * cur_q[j + 3];
+        }
+        float q_dot = (qd0 + qd1) + (qd2 + qd3);
+
+        output[((unsigned long long)(b * seq_len + t) * num_v_heads + vh) * v_dim + tid] =
+            __float2bfloat16(q_dot * inv_sqrt_d);
+
+        __syncthreads();  // Ensures next token's k/q are fully loaded
+    }
+
+store_h:
+    // ── SSM state normalization (Stuffed Mamba mitigation) ──
+    // Only during decode (seq_len <= 1). During prefill the state legitimately
+    // grows large to compress context; clamping would destroy information.
+    if (seq_len <= 1) {
+        float local_sq = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j++) {
+            local_sq += H_reg[j] * H_reg[j];
+        }
+        unsigned int mask = __activemask();
+        float ws = local_sq;
+        ws += __shfl_down_sync(mask, ws, 16);
+        ws += __shfl_down_sync(mask, ws, 8);
+        ws += __shfl_down_sync(mask, ws, 4);
+        ws += __shfl_down_sync(mask, ws, 2);
+        ws += __shfl_down_sync(mask, ws, 1);
+        __shared__ float ns[4];
+        if (tid % 32 == 0) ns[tid / 32] = ws;
+        __syncthreads();
+        if (tid < 4) {
+            float s = ns[tid];
+            s += __shfl_down_sync(0xf, s, 2);
+            s += __shfl_down_sync(0xf, s, 1);
+            ns[0] = s;
+        }
+        __syncthreads();
+        const float MAX_NORM = 50.0f;
+        float norm_sq = ns[0];
+        if (norm_sq > MAX_NORM * MAX_NORM) {
+            float scale = MAX_NORM * rsqrtf(norm_sq);
+            #pragma unroll
+            for (int j = 0; j < K_DIM; j++) {
+                H_reg[j] *= scale;
+            }
+        }
+    }
+
+    // Write H from registers → global
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Split-v_dim prefill: 2 CTAs per v-head, 64 threads each.
+//
+// Identical math to gated_delta_rule_prefill, but splits v_dim across
+// 2 independent CTAs per v-head. Doubles SM utilization (64 CTAs on
+// 48 SMs vs 32 CTAs on 32 SMs) and allows cross-block latency hiding
+// on SMs that host 2 independent blocks.
+//
+// Thread tid_local (0..63) handles v_dim column (split*64 + tid_local).
+// Each thread still loads H_reg[K_DIM=128] — no register pressure change.
+// Each thread loads 2 smem elements per k/q buffer (stride blockDim.x=64).
+//
+// Grid: (num_v_heads * 2, batch, 1)   Block: (64, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void __launch_bounds__(64, 1)
+gated_delta_rule_prefill_split(
+    float* __restrict__ h_state,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int seq_len,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    // blockIdx.x = vh * 2 + split  (0..num_v_heads*2 - 1)
+    const unsigned int vh    = blockIdx.x / 2;
+    const unsigned int split = blockIdx.x % 2;
+    const unsigned int b     = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid_local  = threadIdx.x;               // 0..63
+    const unsigned int half       = blockDim.x;                 // 64
+    const unsigned int tid        = split * half + tid_local;   // 0..127
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    // Double-buffered k[K_DIM] + q[K_DIM] in smem (same footprint as original).
+    extern __shared__ float smem[];
+    float* smem_k0 = smem;
+    float* smem_q0 = smem + K_DIM;
+    float* smem_k1 = smem + 2 * K_DIM;
+    float* smem_q1 = smem + 3 * K_DIM;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    // Load H column for tid into registers.
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+
+    if (seq_len == 0) goto store_h_split;
+
+    // Load first token's k/q into buffer 0.
+    // Each thread loads 2 elements (indices tid_local and tid_local+half=tid_local+64).
+    {
+        unsigned long long qk_off = (unsigned long long)0 * qk_stride + kh * k_dim;
+        smem_k0[tid_local]        = (float)key[qk_off + tid_local];
+        smem_k0[tid_local + half] = (float)key[qk_off + tid_local + half];
+        smem_q0[tid_local]        = (float)query[qk_off + tid_local];
+        smem_q0[tid_local + half] = (float)query[qk_off + tid_local + half];
+    }
+    __syncthreads();
+
+    for (unsigned int t = 0; t < seq_len; t++) {
+        float* cur_k = (t & 1) ? smem_k1 : smem_k0;
+        float* cur_q = (t & 1) ? smem_q1 : smem_q0;
+        float* nxt_k = (t & 1) ? smem_k0 : smem_k1;
+        float* nxt_q = (t & 1) ? smem_q0 : smem_q1;
+
+        if (t + 1 < seq_len) {
+            unsigned long long qk_off_nxt = (unsigned long long)(t + 1) * qk_stride + kh * k_dim;
+            nxt_k[tid_local]        = (float)key[qk_off_nxt + tid_local];
+            nxt_k[tid_local + half] = (float)key[qk_off_nxt + tid_local + half];
+            nxt_q[tid_local]        = (float)query[qk_off_nxt + tid_local];
+            nxt_q[tid_local + half] = (float)query[qk_off_nxt + tid_local + half];
+        }
+
+        float v_i  = (float)value[(unsigned long long)t * v_stride + vh * v_dim + tid];
+        float g_t  = fminf(fmaxf(gate[(unsigned long long)t * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+        float bt_t = beta[(unsigned long long)t * gb_stride + vh];
+
+        float hk0 = 0.0f, hk1 = 0.0f, hk2 = 0.0f, hk3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            hk0 += H_reg[j]     * cur_k[j];
+            hk1 += H_reg[j + 1] * cur_k[j + 1];
+            hk2 += H_reg[j + 2] * cur_k[j + 2];
+            hk3 += H_reg[j + 3] * cur_k[j + 3];
+        }
+        float hk_dot = (hk0 + hk1) + (hk2 + hk3);
+
+        float v_new = (v_i - g_t * hk_dot) * bt_t;
+
+        float qd0 = 0.0f, qd1 = 0.0f, qd2 = 0.0f, qd3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            float h0 = g_t * H_reg[j]     + cur_k[j]     * v_new;
+            float h1 = g_t * H_reg[j + 1] + cur_k[j + 1] * v_new;
+            float h2 = g_t * H_reg[j + 2] + cur_k[j + 2] * v_new;
+            float h3 = g_t * H_reg[j + 3] + cur_k[j + 3] * v_new;
+            H_reg[j]     = h0;
+            H_reg[j + 1] = h1;
+            H_reg[j + 2] = h2;
+            H_reg[j + 3] = h3;
+            qd0 += h0 * cur_q[j];
+            qd1 += h1 * cur_q[j + 1];
+            qd2 += h2 * cur_q[j + 2];
+            qd3 += h3 * cur_q[j + 3];
+        }
+        float q_dot = (qd0 + qd1) + (qd2 + qd3);
+
+        output[((unsigned long long)(b * seq_len + t) * num_v_heads + vh) * v_dim + tid] =
+            __float2bfloat16(q_dot * inv_sqrt_d);
+
+        __syncthreads();
+    }
+
+store_h_split:
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4-way split prefill: 4 CTAs per v-head, 32 threads each (128 total).
+//
+// 128 CTAs on 48 SMs: ~2.67 blocks/SM average → SMs run 2-3 independent
+// blocks, enabling cross-block latency hiding even with 1 warp per block.
+// Each thread loads 4 smem elements per k/q buffer (stride 32).
+//
+// Grid: (num_v_heads * 4, batch, 1)   Block: (32, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void __launch_bounds__(32, 1)
+gated_delta_rule_prefill_split4(
+    float* __restrict__ h_state,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int seq_len,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    // blockIdx.x = vh * 4 + split  (0..num_v_heads*4 - 1)
+    const unsigned int vh    = blockIdx.x / 4;
+    const unsigned int split = blockIdx.x % 4;
+    const unsigned int b     = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid_local  = threadIdx.x;               // 0..31
+    const unsigned int quarter    = blockDim.x;                 // 32
+    const unsigned int tid        = split * quarter + tid_local; // 0..127
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    // Double-buffered k[K_DIM] + q[K_DIM] in smem (same footprint as original).
+    extern __shared__ float smem[];
+    float* smem_k0 = smem;
+    float* smem_q0 = smem + K_DIM;
+    float* smem_k1 = smem + 2 * K_DIM;
+    float* smem_q1 = smem + 3 * K_DIM;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+
+    if (seq_len == 0) goto store_h_split4;
+
+    // Load first token's k/q into buffer 0 — each thread loads 4 elements.
+    {
+        unsigned long long qk_off = (unsigned long long)0 * qk_stride + kh * k_dim;
+        smem_k0[tid_local]            = (float)key[qk_off + tid_local];
+        smem_k0[tid_local + quarter]  = (float)key[qk_off + tid_local + quarter];
+        smem_k0[tid_local + 2*quarter]= (float)key[qk_off + tid_local + 2*quarter];
+        smem_k0[tid_local + 3*quarter]= (float)key[qk_off + tid_local + 3*quarter];
+        smem_q0[tid_local]            = (float)query[qk_off + tid_local];
+        smem_q0[tid_local + quarter]  = (float)query[qk_off + tid_local + quarter];
+        smem_q0[tid_local + 2*quarter]= (float)query[qk_off + tid_local + 2*quarter];
+        smem_q0[tid_local + 3*quarter]= (float)query[qk_off + tid_local + 3*quarter];
+    }
+    __syncthreads();
+
+    for (unsigned int t = 0; t < seq_len; t++) {
+        float* cur_k = (t & 1) ? smem_k1 : smem_k0;
+        float* cur_q = (t & 1) ? smem_q1 : smem_q0;
+        float* nxt_k = (t & 1) ? smem_k0 : smem_k1;
+        float* nxt_q = (t & 1) ? smem_q0 : smem_q1;
+
+        if (t + 1 < seq_len) {
+            unsigned long long qk_off_nxt = (unsigned long long)(t + 1) * qk_stride + kh * k_dim;
+            nxt_k[tid_local]            = (float)key[qk_off_nxt + tid_local];
+            nxt_k[tid_local + quarter]  = (float)key[qk_off_nxt + tid_local + quarter];
+            nxt_k[tid_local + 2*quarter]= (float)key[qk_off_nxt + tid_local + 2*quarter];
+            nxt_k[tid_local + 3*quarter]= (float)key[qk_off_nxt + tid_local + 3*quarter];
+            nxt_q[tid_local]            = (float)query[qk_off_nxt + tid_local];
+            nxt_q[tid_local + quarter]  = (float)query[qk_off_nxt + tid_local + quarter];
+            nxt_q[tid_local + 2*quarter]= (float)query[qk_off_nxt + tid_local + 2*quarter];
+            nxt_q[tid_local + 3*quarter]= (float)query[qk_off_nxt + tid_local + 3*quarter];
+        }
+
+        float v_i  = (float)value[(unsigned long long)t * v_stride + vh * v_dim + tid];
+        float g_t  = fminf(fmaxf(gate[(unsigned long long)t * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+        float bt_t = beta[(unsigned long long)t * gb_stride + vh];
+
+        float hk0 = 0.0f, hk1 = 0.0f, hk2 = 0.0f, hk3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            hk0 += H_reg[j]     * cur_k[j];
+            hk1 += H_reg[j + 1] * cur_k[j + 1];
+            hk2 += H_reg[j + 2] * cur_k[j + 2];
+            hk3 += H_reg[j + 3] * cur_k[j + 3];
+        }
+        float hk_dot = (hk0 + hk1) + (hk2 + hk3);
+
+        float v_new = (v_i - g_t * hk_dot) * bt_t;
+
+        float qd0 = 0.0f, qd1 = 0.0f, qd2 = 0.0f, qd3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            float h0 = g_t * H_reg[j]     + cur_k[j]     * v_new;
+            float h1 = g_t * H_reg[j + 1] + cur_k[j + 1] * v_new;
+            float h2 = g_t * H_reg[j + 2] + cur_k[j + 2] * v_new;
+            float h3 = g_t * H_reg[j + 3] + cur_k[j + 3] * v_new;
+            H_reg[j]     = h0;
+            H_reg[j + 1] = h1;
+            H_reg[j + 2] = h2;
+            H_reg[j + 3] = h3;
+            qd0 += h0 * cur_q[j];
+            qd1 += h1 * cur_q[j + 1];
+            qd2 += h2 * cur_q[j + 2];
+            qd3 += h3 * cur_q[j + 3];
+        }
+        float q_dot = (qd0 + qd1) + (qd2 + qd3);
+
+        output[((unsigned long long)(b * seq_len + t) * num_v_heads + vh) * v_dim + tid] =
+            __float2bfloat16(q_dot * inv_sqrt_d);
+
+        __syncthreads();
+    }
+
+store_h_split4:
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Q12 Phase 2b: same-chunk-len batched split4. h_state per-stream via
+// h_state_ptrs[b]; QKV/gate/beta/output stacked with `b * seq_len * stride`
+// offset; otherwise byte-identical to gated_delta_rule_prefill_split4.
+// Single-stream variant above unchanged.
+// ───────────────────────────────────────────────────────────────────────
+extern "C" __global__ void __launch_bounds__(32, 1)
+gated_delta_rule_prefill_split4_batched(
+    float* const* __restrict__ h_state_ptrs,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int seq_len,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    const unsigned int vh    = blockIdx.x / 4;
+    const unsigned int split = blockIdx.x % 4;
+    const unsigned int b     = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid_local  = threadIdx.x;
+    const unsigned int quarter    = blockDim.x;
+    const unsigned int tid        = split * quarter + tid_local;
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    const unsigned long long qk_batch_off = (unsigned long long)b * seq_len * qk_stride;
+    const unsigned long long v_batch_off  = (unsigned long long)b * seq_len * v_stride;
+    const unsigned long long gb_batch_off = (unsigned long long)b * seq_len * gb_stride;
+    const unsigned long long out_batch_off = (unsigned long long)b * seq_len * num_v_heads * v_dim;
+
+    extern __shared__ float smem[];
+    float* smem_k0 = smem;
+    float* smem_q0 = smem + K_DIM;
+    float* smem_k1 = smem + 2 * K_DIM;
+    float* smem_q1 = smem + 3 * K_DIM;
+
+    float* H_global = h_state_ptrs[b] + ((unsigned long long)vh * K_DIM * v_dim);
+
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+
+    if (seq_len == 0) goto store_h_split4_batched;
+
+    {
+        unsigned long long qk_off = qk_batch_off + kh * k_dim;
+        smem_k0[tid_local]            = (float)key[qk_off + tid_local];
+        smem_k0[tid_local + quarter]  = (float)key[qk_off + tid_local + quarter];
+        smem_k0[tid_local + 2*quarter]= (float)key[qk_off + tid_local + 2*quarter];
+        smem_k0[tid_local + 3*quarter]= (float)key[qk_off + tid_local + 3*quarter];
+        smem_q0[tid_local]            = (float)query[qk_off + tid_local];
+        smem_q0[tid_local + quarter]  = (float)query[qk_off + tid_local + quarter];
+        smem_q0[tid_local + 2*quarter]= (float)query[qk_off + tid_local + 2*quarter];
+        smem_q0[tid_local + 3*quarter]= (float)query[qk_off + tid_local + 3*quarter];
+    }
+    __syncthreads();
+
+    for (unsigned int t = 0; t < seq_len; t++) {
+        float* cur_k = (t & 1) ? smem_k1 : smem_k0;
+        float* cur_q = (t & 1) ? smem_q1 : smem_q0;
+        float* nxt_k = (t & 1) ? smem_k0 : smem_k1;
+        float* nxt_q = (t & 1) ? smem_q0 : smem_q1;
+
+        if (t + 1 < seq_len) {
+            unsigned long long qk_off_nxt = qk_batch_off + (unsigned long long)(t + 1) * qk_stride + kh * k_dim;
+            nxt_k[tid_local]            = (float)key[qk_off_nxt + tid_local];
+            nxt_k[tid_local + quarter]  = (float)key[qk_off_nxt + tid_local + quarter];
+            nxt_k[tid_local + 2*quarter]= (float)key[qk_off_nxt + tid_local + 2*quarter];
+            nxt_k[tid_local + 3*quarter]= (float)key[qk_off_nxt + tid_local + 3*quarter];
+            nxt_q[tid_local]            = (float)query[qk_off_nxt + tid_local];
+            nxt_q[tid_local + quarter]  = (float)query[qk_off_nxt + tid_local + quarter];
+            nxt_q[tid_local + 2*quarter]= (float)query[qk_off_nxt + tid_local + 2*quarter];
+            nxt_q[tid_local + 3*quarter]= (float)query[qk_off_nxt + tid_local + 3*quarter];
+        }
+
+        float v_i  = (float)value[v_batch_off + (unsigned long long)t * v_stride + vh * v_dim + tid];
+        float g_t  = fminf(fmaxf(gate[gb_batch_off + (unsigned long long)t * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+        float bt_t = beta[gb_batch_off + (unsigned long long)t * gb_stride + vh];
+
+        float hk0 = 0.0f, hk1 = 0.0f, hk2 = 0.0f, hk3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            hk0 += H_reg[j]     * cur_k[j];
+            hk1 += H_reg[j + 1] * cur_k[j + 1];
+            hk2 += H_reg[j + 2] * cur_k[j + 2];
+            hk3 += H_reg[j + 3] * cur_k[j + 3];
+        }
+        float hk_dot = (hk0 + hk1) + (hk2 + hk3);
+
+        float v_new = (v_i - g_t * hk_dot) * bt_t;
+
+        float qd0 = 0.0f, qd1 = 0.0f, qd2 = 0.0f, qd3 = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K_DIM; j += 4) {
+            float h0 = g_t * H_reg[j]     + cur_k[j]     * v_new;
+            float h1 = g_t * H_reg[j + 1] + cur_k[j + 1] * v_new;
+            float h2 = g_t * H_reg[j + 2] + cur_k[j + 2] * v_new;
+            float h3 = g_t * H_reg[j + 3] + cur_k[j + 3] * v_new;
+            H_reg[j]     = h0;
+            H_reg[j + 1] = h1;
+            H_reg[j + 2] = h2;
+            H_reg[j + 3] = h3;
+            qd0 += h0 * cur_q[j];
+            qd1 += h1 * cur_q[j + 1];
+            qd2 += h2 * cur_q[j + 2];
+            qd3 += h3 * cur_q[j + 3];
+        }
+        float q_dot = (qd0 + qd1) + (qd2 + qd3);
+
+        output[out_batch_off + ((unsigned long long)t * num_v_heads + vh) * v_dim + tid] =
+            __float2bfloat16(q_dot * inv_sqrt_d);
+
+        __syncthreads();
+    }
+
+store_h_split4_batched:
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+
+// ═══════════════════════════════════════════════════════════════════
+// Register-Tiled Decode — eliminates redundant H global reads.
+//
+// Original decode reads H[128×128] from global memory TWICE per head:
+//   Pass 1: hk_dot = H^T · k  (128 global reads per thread)
+//   Pass 2: H_new, q_dot      (128 global reads + 128 writes per thread)
+//   Total: 256 reads + 128 writes = 384 transactions per thread
+//
+// Register-tiled version:
+//   Load: H → H_reg[128]      (128 global reads)
+//   Pass 1: hk_dot from H_reg (0 global reads — registers)
+//   Pass 2: update + q_dot    (0 global reads — registers)
+//   Store: H_reg → H          (128 global writes)
+//   Total: 128 reads + 128 writes = 256 transactions per thread
+//
+// 33% less global memory traffic for GDN state per layer.
+// At 30 SSM layers × 32 v_heads × 64KB/head = 60 MB saved per decode step.
+//
+// __launch_bounds__(128, 1) forces max register allocation (512 regs/thread)
+// to keep H_reg[128] entirely in registers (no spill to L1).
+//
+// Grid: (num_v_heads, batch, 1)   Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void __launch_bounds__(128, 1)
+gated_delta_rule_decode(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,       // FP32 (was BF16) — prevents recurrent precision drift
+    const float* __restrict__ key,         // FP32 (was BF16)
+    const float* __restrict__ value,       // FP32 (was BF16)
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    // Load k, q into shared memory (broadcast across all 128 threads)
+    __shared__ float smem_k[K_DIM];
+    __shared__ float smem_q[K_DIM];
+    const float* k_ptr = key + (b * num_k_heads + kh) * k_dim;
+    const float* q_ptr = query + (b * num_k_heads + kh) * k_dim;
+    smem_k[tid] = k_ptr[tid];  // Already FP32, no conversion needed
+    smem_q[tid] = q_ptr[tid];
+    __syncthreads();
+
+    // Load H column into registers — ONE global read per element
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float v_i = value[(b * num_v_heads + vh) * v_dim + tid];  // Already FP32
+    float g = fminf(fmaxf(gate[b * num_v_heads + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt = beta[b * num_v_heads + vh];
+
+    // Pass 1: hk_dot = H_reg^T · k (from registers, zero global reads)
+    float hk0 = 0.0f, hk1 = 0.0f, hk2 = 0.0f, hk3 = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        hk0 += H_reg[j]     * smem_k[j];
+        hk1 += H_reg[j + 1] * smem_k[j + 1];
+        hk2 += H_reg[j + 2] * smem_k[j + 2];
+        hk3 += H_reg[j + 3] * smem_k[j + 3];
+    }
+    float hk_dot = (hk0 + hk1) + (hk2 + hk3);
+
+    float v_new = (v_i - g * hk_dot) * bt;
+
+    // Pass 2: update H_reg + compute q_dot (from registers, zero global reads)
+    float qd0 = 0.0f, qd1 = 0.0f, qd2 = 0.0f, qd3 = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g * H_reg[j]     + smem_k[j]     * v_new;
+        float h1 = g * H_reg[j + 1] + smem_k[j + 1] * v_new;
+        float h2 = g * H_reg[j + 2] + smem_k[j + 2] * v_new;
+        float h3 = g * H_reg[j + 3] + smem_k[j + 3] * v_new;
+        H_reg[j]     = h0;
+        H_reg[j + 1] = h1;
+        H_reg[j + 2] = h2;
+        H_reg[j + 3] = h3;
+        qd0 += h0 * smem_q[j];
+        qd1 += h1 * smem_q[j + 1];
+        qd2 += h2 * smem_q[j + 2];
+        qd3 += h3 * smem_q[j + 3];
+    }
+    float q_dot = (qd0 + qd1) + (qd2 + qd3);
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+    output[(b * num_v_heads + vh) * v_dim + tid] = __float2bfloat16(q_dot * inv_sqrt_d);
+
+    // Write H from registers → global — ONE global write per element
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// FP32 OUTPUT VARIANT — eliminates BF16 truncation in recurrent path.
+// Prevents cumulative precision drift at 15K+ decode tokens.
+// Identical to gated_delta_rule_decode except output is float*.
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void __launch_bounds__(128, 1)
+gated_delta_rule_decode_f32(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    float* __restrict__ output,            // FP32 output (was BF16)
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    __shared__ float smem_k[K_DIM];
+    __shared__ float smem_q[K_DIM];
+    const float* k_ptr = key + (b * num_k_heads + kh) * k_dim;
+    const float* q_ptr = query + (b * num_k_heads + kh) * k_dim;
+    smem_k[tid] = k_ptr[tid];
+    smem_q[tid] = q_ptr[tid];
+    __syncthreads();
+
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float v_i = value[(b * num_v_heads + vh) * v_dim + tid];
+    float g = fminf(fmaxf(gate[b * num_v_heads + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt = beta[b * num_v_heads + vh];
+
+    float hk0 = 0.0f, hk1 = 0.0f, hk2 = 0.0f, hk3 = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        hk0 += H_reg[j]     * smem_k[j];
+        hk1 += H_reg[j + 1] * smem_k[j + 1];
+        hk2 += H_reg[j + 2] * smem_k[j + 2];
+        hk3 += H_reg[j + 3] * smem_k[j + 3];
+    }
+    float hk_dot = (hk0 + hk1) + (hk2 + hk3);
+
+    float v_new = (v_i - g * hk_dot) * bt;
+
+    float qd0 = 0.0f, qd1 = 0.0f, qd2 = 0.0f, qd3 = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g * H_reg[j]     + smem_k[j]     * v_new;
+        float h1 = g * H_reg[j + 1] + smem_k[j + 1] * v_new;
+        float h2 = g * H_reg[j + 2] + smem_k[j + 2] * v_new;
+        float h3 = g * H_reg[j + 3] + smem_k[j + 3] * v_new;
+        H_reg[j]     = h0;
+        H_reg[j + 1] = h1;
+        H_reg[j + 2] = h2;
+        H_reg[j + 3] = h3;
+        qd0 += h0 * smem_q[j];
+        qd1 += h1 * smem_q[j + 1];
+        qd2 += h2 * smem_q[j + 2];
+        qd3 += h3 * smem_q[j + 3];
+    }
+    float q_dot = (qd0 + qd1) + (qd2 + qd3);
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+    output[(b * num_v_heads + vh) * v_dim + tid] = q_dot * inv_sqrt_d;  // FP32 direct
+
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Register-Tiled Chunk2 — MTP K=2 verify path.
+//
+// Original chunk2 uses h_state_intermediate as a global-memory
+// ping-pong buffer between token 0 and token 1:
+//   Token 0: read H (128), update → write H_inter (128)
+//   Token 1: read H_inter (128), update → write H (128)
+//   Total: 256 reads + 256 writes = 512 transactions per thread
+//
+// Register-tiled version:
+//   Load H → H_reg[128]         (128 reads)
+//   Token 0: hk_dot + update    (0 reads — registers)
+//   Token 1: hk_dot + update    (0 reads — registers)
+//   Store H_reg → H             (128 writes)
+//   Total: 128 reads + 128 writes = 256 transactions per thread
+//
+// 50% less global memory traffic. h_state_intermediate is NOT USED
+// (parameter kept for ABI compatibility with Rust launcher).
+//
+// Grid: (num_v_heads, batch, 1)   Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void __launch_bounds__(128, 1)
+gated_delta_rule_chunk2(
+    float* __restrict__ h_state,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    float* __restrict__ h_state_intermediate,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    // Load k/q for both tokens into shared memory
+    __shared__ float sk0[K_DIM], sq0[K_DIM], sk1[K_DIM], sq1[K_DIM];
+    {
+        unsigned long long qk0 = (unsigned long long)(b * 2) * qk_stride + kh * k_dim;
+        unsigned long long qk1 = (unsigned long long)(b * 2 + 1) * qk_stride + kh * k_dim;
+        sk0[tid] = (float)key[qk0 + tid];   sq0[tid] = (float)query[qk0 + tid];
+        sk1[tid] = (float)key[qk1 + tid];   sq1[tid] = (float)query[qk1 + tid];
+    }
+    __syncthreads();
+
+    // Load H column into registers — ONE read
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float vi0 = (float)value[(unsigned long long)(b * 2) * v_stride + vh * v_dim + tid];
+    float vi1 = (float)value[(unsigned long long)(b * 2 + 1) * v_stride + vh * v_dim + tid];
+    float g0 = fminf(fmaxf(gate[(unsigned long long)(b * 2) * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt0 = beta[(unsigned long long)(b * 2) * gb_stride + vh];
+    float g1 = fminf(fmaxf(gate[(unsigned long long)(b * 2 + 1) * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt1 = beta[(unsigned long long)(b * 2 + 1) * gb_stride + vh];
+
+    // ── Token 0 ──
+    // Pass 1: hk_dot from registers
+    float hk_a = 0.0f, hk_b = 0.0f, hk_c = 0.0f, hk_d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        hk_a += H_reg[j]     * sk0[j];
+        hk_b += H_reg[j + 1] * sk0[j + 1];
+        hk_c += H_reg[j + 2] * sk0[j + 2];
+        hk_d += H_reg[j + 3] * sk0[j + 3];
+    }
+    float v_new_0 = (vi0 - g0 * ((hk_a + hk_b) + (hk_c + hk_d))) * bt0;
+
+    // Pass 2: update H_reg, compute q0_dot and hk1_dot simultaneously
+    float qd0a = 0.0f, qd0b = 0.0f, qd0c = 0.0f, qd0d = 0.0f;
+    float hk1a = 0.0f, hk1b = 0.0f, hk1c = 0.0f, hk1d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g0 * H_reg[j]     + sk0[j]     * v_new_0;
+        float h1 = g0 * H_reg[j + 1] + sk0[j + 1] * v_new_0;
+        float h2 = g0 * H_reg[j + 2] + sk0[j + 2] * v_new_0;
+        float h3 = g0 * H_reg[j + 3] + sk0[j + 3] * v_new_0;
+        H_reg[j]     = h0;
+        H_reg[j + 1] = h1;
+        H_reg[j + 2] = h2;
+        H_reg[j + 3] = h3;
+        qd0a += h0 * sq0[j];     qd0b += h1 * sq0[j + 1];
+        qd0c += h2 * sq0[j + 2]; qd0d += h3 * sq0[j + 3];
+        hk1a += h0 * sk1[j];     hk1b += h1 * sk1[j + 1];
+        hk1c += h2 * sk1[j + 2]; hk1d += h3 * sk1[j + 3];
+    }
+    float q0_dot = (qd0a + qd0b) + (qd0c + qd0d);
+    float v_new_1 = (vi1 - g1 * ((hk1a + hk1b) + (hk1c + hk1d))) * bt1;
+
+    // ── Token 1 ──
+    // Update H_reg, compute q1_dot
+    float qd1a = 0.0f, qd1b = 0.0f, qd1c = 0.0f, qd1d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g1 * H_reg[j]     + sk1[j]     * v_new_1;
+        float h1 = g1 * H_reg[j + 1] + sk1[j + 1] * v_new_1;
+        float h2 = g1 * H_reg[j + 2] + sk1[j + 2] * v_new_1;
+        float h3 = g1 * H_reg[j + 3] + sk1[j + 3] * v_new_1;
+        H_reg[j]     = h0;
+        H_reg[j + 1] = h1;
+        H_reg[j + 2] = h2;
+        H_reg[j + 3] = h3;
+        qd1a += h0 * sq1[j];     qd1b += h1 * sq1[j + 1];
+        qd1c += h2 * sq1[j + 2]; qd1d += h3 * sq1[j + 3];
+    }
+    float q1_dot = (qd1a + qd1b) + (qd1c + qd1d);
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+    output[((unsigned long long)(b * 2) * num_v_heads + vh) * v_dim + tid] =
+        __float2bfloat16(q0_dot * inv_sqrt_d);
+    output[((unsigned long long)(b * 2 + 1) * num_v_heads + vh) * v_dim + tid] =
+        __float2bfloat16(q1_dot * inv_sqrt_d);
+
+    // Write H from registers → global — ONE write
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Register-Tiled Chunk3 — MTP K=3 verify path.
+//
+// Original chunk3 uses TWO intermediate buffers in global memory:
+//   Token 0: read H → write Hi0    (128 reads + 128 writes)
+//   Token 1: read Hi0 → write Hi1  (128 reads + 128 writes)
+//   Token 2: read Hi1 → write H    (128 reads + 128 writes)
+//   Total: 384 reads + 384 writes = 768 transactions per thread
+//
+// Register-tiled: all 3 tokens from H_reg, no intermediate buffers.
+//   Total: 128 reads + 128 writes = 256 transactions per thread
+//   67% reduction in global memory traffic.
+//
+// Grid: (num_v_heads, batch, 1)   Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void __launch_bounds__(128, 1)
+gated_delta_rule_chunk3(
+    float* __restrict__ h_state,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    float* __restrict__ h_state_inter0,
+    float* __restrict__ h_state_inter1,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H_global = h_state + ((unsigned long long)(b * num_v_heads + vh) * K_DIM * v_dim);
+
+    // Load k/q for all 3 tokens
+    __shared__ float sk0[K_DIM], sq0[K_DIM], sk1[K_DIM], sq1[K_DIM], sk2[K_DIM], sq2[K_DIM];
+    {
+        unsigned long long qk0 = (unsigned long long)(b * 3) * qk_stride + kh * k_dim;
+        unsigned long long qk1 = (unsigned long long)(b * 3 + 1) * qk_stride + kh * k_dim;
+        unsigned long long qk2 = (unsigned long long)(b * 3 + 2) * qk_stride + kh * k_dim;
+        sk0[tid] = (float)key[qk0 + tid]; sq0[tid] = (float)query[qk0 + tid];
+        sk1[tid] = (float)key[qk1 + tid]; sq1[tid] = (float)query[qk1 + tid];
+        sk2[tid] = (float)key[qk2 + tid]; sq2[tid] = (float)query[qk2 + tid];
+    }
+    __syncthreads();
+
+    // Load H column into registers — ONE read
+    float H_reg[K_DIM];
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_reg[j] = H_global[j * v_dim + tid];
+    }
+
+    float vi0 = (float)value[(unsigned long long)(b * 3) * v_stride + vh * v_dim + tid];
+    float vi1 = (float)value[(unsigned long long)(b * 3 + 1) * v_stride + vh * v_dim + tid];
+    float vi2 = (float)value[(unsigned long long)(b * 3 + 2) * v_stride + vh * v_dim + tid];
+    float g0 = fminf(fmaxf(gate[(unsigned long long)(b * 3) * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt0 = beta[(unsigned long long)(b * 3) * gb_stride + vh];
+    float g1 = fminf(fmaxf(gate[(unsigned long long)(b * 3 + 1) * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt1 = beta[(unsigned long long)(b * 3 + 1) * gb_stride + vh];
+    float g2 = fminf(fmaxf(gate[(unsigned long long)(b * 3 + 2) * gb_stride + vh], 1e-6f), 1.0f - 1e-6f);
+    float bt2 = beta[(unsigned long long)(b * 3 + 2) * gb_stride + vh];
+
+    // ── Token 0 ──
+    float hk_a = 0.0f, hk_b = 0.0f, hk_c = 0.0f, hk_d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        hk_a += H_reg[j]     * sk0[j];
+        hk_b += H_reg[j + 1] * sk0[j + 1];
+        hk_c += H_reg[j + 2] * sk0[j + 2];
+        hk_d += H_reg[j + 3] * sk0[j + 3];
+    }
+    float v_new_0 = (vi0 - g0 * ((hk_a + hk_b) + (hk_c + hk_d))) * bt0;
+
+    // Update H_reg, compute q0_dot + hk1_dot
+    float qd0a = 0.0f, qd0b = 0.0f, qd0c = 0.0f, qd0d = 0.0f;
+    float hk1a = 0.0f, hk1b = 0.0f, hk1c = 0.0f, hk1d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g0 * H_reg[j]     + sk0[j]     * v_new_0;
+        float h1 = g0 * H_reg[j + 1] + sk0[j + 1] * v_new_0;
+        float h2 = g0 * H_reg[j + 2] + sk0[j + 2] * v_new_0;
+        float h3 = g0 * H_reg[j + 3] + sk0[j + 3] * v_new_0;
+        H_reg[j] = h0; H_reg[j+1] = h1; H_reg[j+2] = h2; H_reg[j+3] = h3;
+        qd0a += h0 * sq0[j];     qd0b += h1 * sq0[j + 1];
+        qd0c += h2 * sq0[j + 2]; qd0d += h3 * sq0[j + 3];
+        hk1a += h0 * sk1[j];     hk1b += h1 * sk1[j + 1];
+        hk1c += h2 * sk1[j + 2]; hk1d += h3 * sk1[j + 3];
+    }
+    float q0_dot = (qd0a + qd0b) + (qd0c + qd0d);
+    float v_new_1 = (vi1 - g1 * ((hk1a + hk1b) + (hk1c + hk1d))) * bt1;
+
+    // ── Token 1 ──
+    // Update H_reg, compute q1_dot + hk2_dot
+    float qd1a = 0.0f, qd1b = 0.0f, qd1c = 0.0f, qd1d = 0.0f;
+    float hk2a = 0.0f, hk2b = 0.0f, hk2c = 0.0f, hk2d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g1 * H_reg[j]     + sk1[j]     * v_new_1;
+        float h1 = g1 * H_reg[j + 1] + sk1[j + 1] * v_new_1;
+        float h2 = g1 * H_reg[j + 2] + sk1[j + 2] * v_new_1;
+        float h3 = g1 * H_reg[j + 3] + sk1[j + 3] * v_new_1;
+        H_reg[j] = h0; H_reg[j+1] = h1; H_reg[j+2] = h2; H_reg[j+3] = h3;
+        qd1a += h0 * sq1[j];     qd1b += h1 * sq1[j + 1];
+        qd1c += h2 * sq1[j + 2]; qd1d += h3 * sq1[j + 3];
+        hk2a += h0 * sk2[j];     hk2b += h1 * sk2[j + 1];
+        hk2c += h2 * sk2[j + 2]; hk2d += h3 * sk2[j + 3];
+    }
+    float q1_dot = (qd1a + qd1b) + (qd1c + qd1d);
+    float v_new_2 = (vi2 - g2 * ((hk2a + hk2b) + (hk2c + hk2d))) * bt2;
+
+    // ── Token 2 ──
+    // Update H_reg, compute q2_dot
+    float qd2a = 0.0f, qd2b = 0.0f, qd2c = 0.0f, qd2d = 0.0f;
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j += 4) {
+        float h0 = g2 * H_reg[j]     + sk2[j]     * v_new_2;
+        float h1 = g2 * H_reg[j + 1] + sk2[j + 1] * v_new_2;
+        float h2 = g2 * H_reg[j + 2] + sk2[j + 2] * v_new_2;
+        float h3 = g2 * H_reg[j + 3] + sk2[j + 3] * v_new_2;
+        H_reg[j] = h0; H_reg[j+1] = h1; H_reg[j+2] = h2; H_reg[j+3] = h3;
+        qd2a += h0 * sq2[j];     qd2b += h1 * sq2[j + 1];
+        qd2c += h2 * sq2[j + 2]; qd2d += h3 * sq2[j + 3];
+    }
+    float q2_dot = (qd2a + qd2b) + (qd2c + qd2d);
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+    output[((unsigned long long)(b * 3) * num_v_heads + vh) * v_dim + tid] =
+        __float2bfloat16(q0_dot * inv_sqrt_d);
+    output[((unsigned long long)(b * 3 + 1) * num_v_heads + vh) * v_dim + tid] =
+        __float2bfloat16(q1_dot * inv_sqrt_d);
+    output[((unsigned long long)(b * 3 + 2) * num_v_heads + vh) * v_dim + tid] =
+        __float2bfloat16(q2_dot * inv_sqrt_d);
+
+    // Write H from registers → global — ONE write
+    #pragma unroll
+    for (int j = 0; j < K_DIM; j++) {
+        H_global[j * v_dim + tid] = H_reg[j];
+    }
+}
+

--- a/kernels/gb10/qwen3.5-397b-a17b/nvfp4/moe_w4a16_grouped_gemm.cu
+++ b/kernels/gb10/qwen3.5-397b-a17b/nvfp4/moe_w4a16_grouped_gemm.cu
@@ -1,0 +1,1369 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Atlas Grouped W4A16 GEMM for MoE — 35B model shadow.
+//
+// Optimizations over parent:
+// - Transposed kernel: cp.async 2-stage double-buffered pipeline
+// - Vectorized uint4 (128-bit) B_packed loads
+// - Both-nibble extraction: one packed byte → 2 dequanted BF16 values
+// - N_TILE=128 for reduced A bandwidth
+// - K_STEP_T=32 (halves outer loop iterations)
+// - Preloaded sorted_token_ids in smem for A indirection
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#define M_TILE 64
+#define N_TILE_SM 64
+#define N_TILE_LG 128
+#define K_STEP 16
+#define K_STEP_T 32
+#define PAD 2
+#define PAD_T 8        // cp.async needs 16-byte aligned rows: (32+8)*2=80, 80%16=0
+#define BP_PAD 16
+#define GROUP_SIZE 16
+
+__device__ __constant__ float E2M1_LUT_MOE[16] = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// Original N_TILE=64 pointer-table variant — kept for decode.
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned long long* __restrict__ B_packed_ptrs,
+    const unsigned long long* __restrict__ B_scale_ptrs,
+    const float* __restrict__ scale2_vals,
+    __nv_bfloat16* __restrict__ C,
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ sorted_token_ids,
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int expert_id = blockIdx.z;
+    if (expert_id >= num_experts) return;
+
+    const int m_start = expert_offsets[expert_id];
+    const int m_end = expert_offsets[expert_id + 1];
+    const int M_expert = m_end - m_start;
+    if (M_expert <= 0) return;
+
+    const int cta_m_local = blockIdx.y * M_TILE;
+    if (cta_m_local >= M_expert) return;
+
+    const unsigned int cta_m = m_start + cta_m_local;
+    const unsigned int cta_n = blockIdx.x * N_TILE_SM;
+
+    const unsigned char* B_expert = (const unsigned char*)B_packed_ptrs[expert_id];
+    const unsigned char* S_expert = (const unsigned char*)B_scale_ptrs[expert_id];
+    const float scale2 = scale2_vals[expert_id];
+
+    if (B_expert == 0) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[M_TILE][K_STEP + PAD];
+    __shared__ __nv_bfloat16 smem_B[K_STEP][N_TILE_SM + PAD];
+
+    float acc[8][4];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int a_stride = K_STEP + PAD;
+    const unsigned int b_stride = N_TILE_SM + PAD;
+    const unsigned int M_eff = (unsigned int)M_expert;
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+
+    for (unsigned int k_base = 0; k_base < K; k_base += K_STEP) {
+        {
+            const unsigned int ept = (M_TILE * K_STEP) / 128;
+            #pragma unroll
+            for (unsigned int i = 0; i < ept; i++) {
+                unsigned int idx = threadIdx.x * ept + i;
+                unsigned int row = idx / K_STEP;
+                unsigned int col = idx % K_STEP;
+                unsigned int gc = k_base + col;
+                bool valid = (cta_m_local + row) < M_eff && gc < K;
+                if (valid) {
+                    unsigned int a_row = sorted_token_ids
+                        ? (unsigned int)sorted_token_ids[cta_m + row]
+                        : (cta_m + row);
+                    smem_A[row][col] = A[a_row * K + gc];
+                } else {
+                    smem_A[row][col] = __float2bfloat16(0.0f);
+                }
+            }
+        }
+
+        {
+            const unsigned int ept = (K_STEP * N_TILE_SM) / 128;
+            unsigned int scale_group = k_base / GROUP_SIZE;
+            #pragma unroll
+            for (unsigned int i = 0; i < ept; i++) {
+                unsigned int idx = threadIdx.x * ept + i;
+                unsigned int k = idx / N_TILE_SM;
+                unsigned int n = idx % N_TILE_SM;
+                unsigned int gk = k_base + k;
+                unsigned int gn = cta_n + n;
+                if (gk < K && gn < N) {
+                    unsigned int k_pair = gk / 2;
+                    unsigned char packed_byte = B_expert[(unsigned long long)gn * half_K + k_pair];
+                    unsigned int nibble = (gk & 1) ? (packed_byte >> 4) : (packed_byte & 0xF);
+                    unsigned char sb = S_expert[(unsigned long long)gn * num_groups + scale_group];
+                    __nv_fp8_e4m3 fp8; *(unsigned char*)&fp8 = sb;
+                    smem_B[k][n] = __float2bfloat16(E2M1_LUT_MOE[nibble] * (float)fp8 * scale2);
+                } else {
+                    smem_B[k][n] = __float2bfloat16(0.0f);
+                }
+            }
+        }
+        __syncthreads();
+
+        const unsigned short* sA = (const unsigned short*)smem_A;
+        const unsigned short* sB = (const unsigned short*)smem_B;
+        unsigned int fr0 = warp_m_offset + group_id;
+        unsigned int fr1 = fr0 + 8;
+        unsigned int fc0 = tid * 2, fc1 = fc0 + 8;
+        unsigned int a0 = ((unsigned int)sA[fr0*a_stride+fc0+1]<<16) | (unsigned int)sA[fr0*a_stride+fc0];
+        unsigned int a1 = ((unsigned int)sA[fr1*a_stride+fc0+1]<<16) | (unsigned int)sA[fr1*a_stride+fc0];
+        unsigned int a2 = ((unsigned int)sA[fr0*a_stride+fc1+1]<<16) | (unsigned int)sA[fr0*a_stride+fc1];
+        unsigned int a3 = ((unsigned int)sA[fr1*a_stride+fc1+1]<<16) | (unsigned int)sA[fr1*a_stride+fc1];
+
+        #pragma unroll
+        for (int nt = 0; nt < 8; nt++) {
+            unsigned int nc = nt * 8 + group_id;
+            unsigned int k0 = tid * 2, k1 = k0 + 8;
+            unsigned int b0 = ((unsigned int)sB[(k0+1)*b_stride+nc]<<16) | (unsigned int)sB[k0*b_stride+nc];
+            unsigned int b1 = ((unsigned int)sB[(k1+1)*b_stride+nc]<<16) | (unsigned int)sB[k1*b_stride+nc];
+            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};"
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3])
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1),
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3]));
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int nt = 0; nt < 8; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        bool r0v = (int)(warp_m_offset + group_id + cta_m_local) < M_expert;
+        bool r1v = (int)(warp_m_offset + group_id + 8 + cta_m_local) < M_expert;
+        if (r0v && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0v && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1v && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1v && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// FP8-MMA transposed MoE GEMM.
+//
+// Dequant B to FP8 E4M3 (not BF16). Convert A from BF16→FP8 in
+// registers. Use mma.sync.m16n8k32.e4m3.e4m3 — full K=32 per
+// instruction (2x fewer MMA instructions vs BF16 m16n8k16).
+//
+// smem layout:
+//   A:      2 × 64 × 40 × 2B = 10240B  (double-buffered)
+//   Bp:     2 × 16 × 144     =  4608B  (double-buffered)
+//   Bs:     2 × 2  × 144     =   576B  (double-buffered)
+//   B_fp8:  128 × 32          =  4096B  (single, FP8 E4M3)
+//   LUT: 64B  tok: 256B
+//   Total: ~19.8KB
+// ═══════════════════════════════════════════════════════════════════
+
+__device__ __forceinline__ void moe_cp_async_pred_16(void* dst_smem, const void* src_gmem, bool pred) {
+    unsigned int dst = __cvta_generic_to_shared(dst_smem);
+    unsigned int src_bytes = pred ? 16 : 0;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;"
+                 :: "r"(dst), "l"(src_gmem), "r"(src_bytes));
+}
+
+__device__ __forceinline__ void moe_cp_async_commit() {
+    asm volatile("cp.async.commit_group;");
+}
+
+__device__ __forceinline__ void moe_cp_async_wait_all() {
+    asm volatile("cp.async.wait_group 0;");
+}
+
+// Convert 4 BF16 values from smem to packed uint32 of 4 E4M3 values
+__device__ __forceinline__ unsigned int moe_bf16x4_to_e4m3x4(const unsigned short* src) {
+    unsigned int p0 = *(const unsigned int*)src;
+    unsigned int p1 = *(const unsigned int*)(src + 2);
+    unsigned short bf0 = (unsigned short)(p0 & 0xFFFFu);
+    unsigned short bf1 = (unsigned short)(p0 >> 16);
+    unsigned short bf2 = (unsigned short)(p1 & 0xFFFFu);
+    unsigned short bf3 = (unsigned short)(p1 >> 16);
+    float f0, f1, f2, f3;
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f0) : "h"(bf0));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f1) : "h"(bf1));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f2) : "h"(bf2));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f3) : "h"(bf3));
+    unsigned short h0, h1;
+    asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" : "=h"(h0) : "f"(f1), "f"(f0));
+    asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" : "=h"(h1) : "f"(f3), "f"(f2));
+    return ((unsigned int)h1 << 16) | (unsigned int)h0;
+}
+
+extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned long long* __restrict__ B_packed_ptrs,
+    const unsigned long long* __restrict__ B_scale_ptrs,
+    const float* __restrict__ scale2_vals,
+    __nv_bfloat16* __restrict__ C,
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ sorted_token_ids,
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int expert_id = blockIdx.z;
+    if (expert_id >= num_experts) return;
+
+    const int m_start = expert_offsets[expert_id];
+    const int m_end = expert_offsets[expert_id + 1];
+    const int M_expert = m_end - m_start;
+    if (M_expert <= 0) return;
+
+    const int cta_m_local = blockIdx.y * M_TILE;
+    if (cta_m_local >= M_expert) return;
+
+    const unsigned int cta_m = m_start + cta_m_local;
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+
+    const unsigned char* B_expert = (const unsigned char*)B_packed_ptrs[expert_id];
+    const unsigned char* S_expert = (const unsigned char*)B_scale_ptrs[expert_id];
+    const float scale2 = scale2_vals[expert_id];
+
+    if (B_expert == 0) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[2][M_TILE][K_STEP_T + PAD_T];
+    __shared__ unsigned char smem_Bp[2][K_STEP_T / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs[2][K_STEP_T / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    // +4 pad: row stride = 36 bytes (stride_words=9, gcd(9,32)=1).
+    // Thread t's DEQUANT write: bank = (t*9 + kp/2) % 32 — all 32 distinct → 0 conflicts.
+    // MMA reads: (nc*9 + tid) % 32 — 3 conflict pairs vs 16 without padding.
+    __shared__ unsigned char smem_B_fp8[N_TILE_LG][K_STEP_T + 4];
+    __shared__ float smem_LUT[16];
+    __shared__ int smem_tok[M_TILE];
+
+    if (threadIdx.x < 16) {
+        smem_LUT[threadIdx.x] = E2M1_LUT_MOE[threadIdx.x];
+    }
+    if (threadIdx.x < M_TILE) {
+        int local_row = threadIdx.x;
+        if (sorted_token_ids && (cta_m_local + local_row) < (unsigned int)M_expert) {
+            smem_tok[local_row] = sorted_token_ids[cta_m + local_row];
+        } else {
+            smem_tok[local_row] = (int)(cta_m + local_row);
+        }
+    }
+    __syncthreads();
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+    const unsigned int M_eff = (unsigned int)M_expert;
+
+    #define MOE_ISSUE_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int row = rnd * 32 + a_row_base; \
+                bool valid = (cta_m_local + row) < M_eff && (gc + 7 < K); \
+                unsigned int a_row = (unsigned int)smem_tok[row]; \
+                moe_cp_async_pred_16(&smem_A[(buf)][row][a_col], \
+                    &A[(unsigned long long)a_row * K + gc], valid); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gke = (kb) + (kp << 1); \
+            unsigned int gns = cta_n + ns; \
+            moe_cp_async_pred_16(&smem_Bp[(buf)][kp][ns], \
+                &B_expert[(unsigned long long)(gke >> 1) * N + gns], \
+                (gke + 1 <= K) && (gns + 15 < N)); \
+            if (kp < K_STEP_T / GROUP_SIZE) { \
+                unsigned int sg = (kb) / GROUP_SIZE + kp; \
+                moe_cp_async_pred_16(&smem_Bs[(buf)][kp][ns], \
+                    &S_expert[(unsigned long long)sg * N + gns], \
+                    (gns + 15 < N)); \
+            } \
+        } \
+    } while(0)
+
+    // Dequant B: FP4 → FP8 E4M3
+    #define MOE_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; \
+        *(unsigned char*)&f1 = sb1; \
+        float sv0 = (float)f0 * scale2; \
+        float sv1 = (float)f1 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv0; \
+            float hi = smem_LUT[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv1; \
+            float hi = smem_LUT[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    // FP8 MMA: convert A BF16→E4M3 in registers, single m16n8k32 per N-tile
+    #define MOE_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = moe_bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        unsigned int a1 = moe_bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        unsigned int a2 = moe_bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        unsigned int a3 = moe_bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8[nc][16 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
+                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
+                 "r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
+                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    MOE_ISSUE_LOADS(0, 0);
+    moe_cp_async_commit();
+    moe_cp_async_wait_all();
+    __syncthreads();
+    MOE_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+
+        MOE_ISSUE_LOADS(nxt, k_base);
+        moe_cp_async_commit();
+
+        MOE_COMPUTE_MMA(cur);
+
+        moe_cp_async_wait_all();
+        __syncthreads();
+
+        MOE_DEQUANT(nxt);
+        __syncthreads();
+
+        cur = nxt;
+    }
+
+    MOE_COMPUTE_MMA(cur);
+
+    #undef MOE_ISSUE_LOADS
+    #undef MOE_DEQUANT
+    #undef MOE_COMPUTE_MMA
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        bool r0v = (int)(warp_m_offset + group_id + cta_m_local) < M_expert;
+        bool r1v = (int)(warp_m_offset + group_id + 8 + cta_m_local) < M_expert;
+        if (r0v && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0v && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1v && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1v && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// K64 variant of FP8-MMA transposed MoE GEMM.
+//
+// K_STEP_T=64: doubles the K tile size so compute time per step
+// (2×16 MMAs × 4 cycles = 128 cycles) exceeds the cp.async load
+// latency (~100 cycles), eliminating all pipeline stall.
+//
+// For the down GEMM (K=inter=512): 8 K-steps (vs 16 with K32).
+// For gate/up (K=h=2048): 32 K-steps (vs 64 with K32).
+//
+// smem layout (K64):
+//   A:      2 × 64 × 72 × 2B = 18432B  (double-buffered, BF16)
+//   Bp:     2 × 32 × 144     =  9216B  (double-buffered, packed NVFP4)
+//   Bs:     2 × 4  × 144     =  1152B  (double-buffered, FP8 scales)
+//   B_fp8:  128 × 64          =  8192B  (single, FP8 E4M3)
+//   LUT: 64B  tok: 256B
+//   Total: ~37.4KB
+// ═══════════════════════════════════════════════════════════════════
+
+#define K_STEP_T64 64
+#define PAD_T64 8  // (64+8)*2 = 144 bytes, 144%16 = 0 ✓
+
+extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t_k64(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned long long* __restrict__ B_packed_ptrs,
+    const unsigned long long* __restrict__ B_scale_ptrs,
+    const float* __restrict__ scale2_vals,
+    __nv_bfloat16* __restrict__ C,
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ sorted_token_ids,
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int expert_id = blockIdx.z;
+    if (expert_id >= num_experts) return;
+
+    const int m_start = expert_offsets[expert_id];
+    const int m_end = expert_offsets[expert_id + 1];
+    const int M_expert = m_end - m_start;
+    if (M_expert <= 0) return;
+
+    const int cta_m_local = blockIdx.y * M_TILE;
+    if (cta_m_local >= M_expert) return;
+
+    const unsigned int cta_m = m_start + cta_m_local;
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+
+    const unsigned char* B_expert = (const unsigned char*)B_packed_ptrs[expert_id];
+    const unsigned char* S_expert = (const unsigned char*)B_scale_ptrs[expert_id];
+    const float scale2 = scale2_vals[expert_id];
+
+    if (B_expert == 0) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    // B_fp8 padding: row stride 80 bytes (K64+16) gives zero bank conflicts.
+    // Without pad: 64-byte rows (16 banks/row) → 4-way conflicts for nc spaced 2 apart.
+    // With pad: 80-byte rows (20 banks/row) → nc*20 % 32 hits all distinct banks for nc=0..7.
+    __shared__ __nv_bfloat16 smem_A_k64[2][M_TILE][K_STEP_T64 + PAD_T64];
+    __shared__ unsigned char smem_Bp_k64[2][K_STEP_T64 / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs_k64[2][K_STEP_T64 / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_B_fp8_k64[N_TILE_LG][K_STEP_T64 + 16];
+    __shared__ float smem_LUT_k64[16];
+    __shared__ int smem_tok_k64[M_TILE];
+
+    if (threadIdx.x < 16) smem_LUT_k64[threadIdx.x] = E2M1_LUT_MOE[threadIdx.x];
+    if (threadIdx.x < M_TILE) {
+        int local_row = threadIdx.x;
+        if (sorted_token_ids && (cta_m_local + local_row) < (unsigned int)M_expert)
+            smem_tok_k64[local_row] = sorted_token_ids[cta_m + local_row];
+        else
+            smem_tok_k64[local_row] = (int)(cta_m + local_row);
+    }
+    __syncthreads();
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int ast64 = K_STEP_T64 + PAD_T64;
+    const unsigned int M_eff = (unsigned int)M_expert;
+
+    // A: 4 rounds × 128 threads × 16 bytes = 8192B = 64×64 BF16
+    // Bp: 2 rounds × 128 threads × 16 bytes = 4096B = 32×128 packed bytes
+    // Bs: 4 scale groups × 8 ns per group × 16 bytes = 512B per buffer
+    #define K64_ISSUE_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 3; \
+            unsigned int a_col = (threadIdx.x & 7) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 4; rnd++) { \
+                unsigned int row = rnd * 16 + a_row_base; \
+                bool valid = (cta_m_local + row) < M_eff && (gc + 7 < K); \
+                unsigned int a_row = (unsigned int)smem_tok_k64[row]; \
+                moe_cp_async_pred_16(&smem_A_k64[(buf)][row][a_col], \
+                    &A[(unsigned long long)a_row * K + gc], valid); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gns = cta_n + ns; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int kp_cur = rnd * 16 + kp; \
+                unsigned int gke = (kb) + (kp_cur << 1); \
+                moe_cp_async_pred_16(&smem_Bp_k64[(buf)][kp_cur][ns], \
+                    &B_expert[(unsigned long long)(gke >> 1) * N + gns], \
+                    (gke + 1 < K) && (gns + 15 < N)); \
+                if (kp_cur < K_STEP_T64 / GROUP_SIZE) { \
+                    unsigned int sg = (kb) / GROUP_SIZE + kp_cur; \
+                    moe_cp_async_pred_16(&smem_Bs_k64[(buf)][kp_cur][ns], \
+                        &S_expert[(unsigned long long)sg * N + gns], \
+                        (gns + 15 < N)); \
+                } \
+            } \
+        } \
+    } while(0)
+
+    // Dequant B: FP4 → FP8 E4M3, 4 scale groups for K64
+    #define K64_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        __nv_fp8_e4m3 f0, f1, f2, f3; \
+        *(unsigned char*)&f0 = smem_Bs_k64[(buf)][0][my_n]; \
+        *(unsigned char*)&f1 = smem_Bs_k64[(buf)][1][my_n]; \
+        *(unsigned char*)&f2 = smem_Bs_k64[(buf)][2][my_n]; \
+        *(unsigned char*)&f3 = smem_Bs_k64[(buf)][3][my_n]; \
+        float sv0 = (float)f0 * scale2; \
+        float sv1 = (float)f1 * scale2; \
+        float sv2 = (float)f2 * scale2; \
+        float sv3 = (float)f3 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv0; \
+            float hi = smem_LUT_k64[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv1; \
+            float hi = smem_LUT_k64[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 16; kp < 24; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv2; \
+            float hi = smem_LUT_k64[packed >> 4] * sv2; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 24; kp < 32; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv3; \
+            float hi = smem_LUT_k64[packed >> 4] * sv3; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    // Two m16n8k32 MMA calls per N-tile: first covers k=0..31, second k=32..63.
+    // a0..a3 loaded first, all N-tile first-half MMAs done, then a4..a7, then second-half.
+    // This keeps max 4 A registers live at once (same as K32 variant).
+    #define K64_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A_k64[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast64 + tid * 4]); \
+        unsigned int a1 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast64 + tid * 4]); \
+        unsigned int a2 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 16 + tid * 4]); \
+        unsigned int a3 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_k64[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_k64[nc][16 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+        unsigned int a4 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 32 + tid * 4]); \
+        unsigned int a5 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 32 + tid * 4]); \
+        unsigned int a6 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 48 + tid * 4]); \
+        unsigned int a7 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 48 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_k64[nc][32 + 4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_k64[nc][48 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a4),"r"(a5),"r"(a6),"r"(a7),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    K64_ISSUE_LOADS(0, 0);
+    moe_cp_async_commit();
+    moe_cp_async_wait_all();
+    __syncthreads();
+    K64_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T64; k_base < K; k_base += K_STEP_T64) {
+        int nxt = 1 - cur;
+        K64_ISSUE_LOADS(nxt, k_base);
+        moe_cp_async_commit();
+        K64_COMPUTE_MMA(cur);
+        moe_cp_async_wait_all();
+        __syncthreads();
+        K64_DEQUANT(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+    K64_COMPUTE_MMA(cur);
+
+    #undef K64_ISSUE_LOADS
+    #undef K64_DEQUANT
+    #undef K64_COMPUTE_MMA
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        bool r0v = (int)(warp_m_offset + group_id + cta_m_local) < M_expert;
+        bool r1v = (int)(warp_m_offset + group_id + 8 + cta_m_local) < M_expert;
+        if (r0v && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0v && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1v && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1v && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// K64 fused gate+up MoE GEMM — same K64 pipeline as down GEMM above.
+//
+// Replaces moe_w4a16_fused_gate_up_t for both gate+up projections
+// when K=h=2048 (64 → 32 K-steps, zero pipeline stall).
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__ void moe_w4a16_fused_gate_up_t_k64(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned long long* __restrict__ gate_packed_ptrs,
+    const unsigned long long* __restrict__ gate_scale_ptrs,
+    const float* __restrict__ gate_scale2_vals,
+    const unsigned long long* __restrict__ up_packed_ptrs,
+    const unsigned long long* __restrict__ up_scale_ptrs,
+    const float* __restrict__ up_scale2_vals,
+    __nv_bfloat16* __restrict__ C_gate,
+    __nv_bfloat16* __restrict__ C_up,
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ sorted_token_ids,
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int expert_id = blockIdx.z;
+    if (expert_id >= num_experts) return;
+
+    const int m_start = expert_offsets[expert_id];
+    const int m_end = expert_offsets[expert_id + 1];
+    const int M_expert = m_end - m_start;
+    if (M_expert <= 0) return;
+
+    const int cta_m_local = blockIdx.y * M_TILE;
+    if (cta_m_local >= M_expert) return;
+
+    const unsigned int global_n = blockIdx.x * N_TILE_LG;
+    const bool is_up = (global_n >= N);
+    const unsigned int cta_n = is_up ? (global_n - N) : global_n;
+
+    const unsigned char* B_expert;
+    const unsigned char* S_expert;
+    float scale2;
+    __nv_bfloat16* C;
+    if (is_up) {
+        B_expert = (const unsigned char*)up_packed_ptrs[expert_id];
+        S_expert = (const unsigned char*)up_scale_ptrs[expert_id];
+        scale2 = up_scale2_vals[expert_id];
+        C = C_up;
+    } else {
+        B_expert = (const unsigned char*)gate_packed_ptrs[expert_id];
+        S_expert = (const unsigned char*)gate_scale_ptrs[expert_id];
+        scale2 = gate_scale2_vals[expert_id];
+        C = C_gate;
+    }
+
+    if (B_expert == 0) return;
+
+    const unsigned int cta_m = m_start + cta_m_local;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A_fgu64[2][M_TILE][K_STEP_T64 + PAD_T64];
+    __shared__ unsigned char smem_Bp_fgu64[2][K_STEP_T64 / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs_fgu64[2][K_STEP_T64 / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    // B_fp8 row stride 80 bytes → zero smem bank conflicts (see K64_DEQUANT comment above).
+    __shared__ unsigned char smem_B_fp8_fgu64[N_TILE_LG][K_STEP_T64 + 16];
+    __shared__ float smem_LUT_fgu64[16];
+    __shared__ int smem_tok_fgu64[M_TILE];
+
+    if (threadIdx.x < 16) smem_LUT_fgu64[threadIdx.x] = E2M1_LUT_MOE[threadIdx.x];
+    if (threadIdx.x < M_TILE) {
+        int local_row = threadIdx.x;
+        if (sorted_token_ids && (cta_m_local + local_row) < (unsigned int)M_expert)
+            smem_tok_fgu64[local_row] = sorted_token_ids[cta_m + local_row];
+        else
+            smem_tok_fgu64[local_row] = (int)(cta_m + local_row);
+    }
+    __syncthreads();
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int ast_fgu64 = K_STEP_T64 + PAD_T64;
+    const unsigned int M_eff = (unsigned int)M_expert;
+
+    #define FGU64_ISSUE_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 3; \
+            unsigned int a_col = (threadIdx.x & 7) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 4; rnd++) { \
+                unsigned int row = rnd * 16 + a_row_base; \
+                bool valid = (cta_m_local + row) < M_eff && (gc + 7 < K); \
+                unsigned int a_row = (unsigned int)smem_tok_fgu64[row]; \
+                moe_cp_async_pred_16(&smem_A_fgu64[(buf)][row][a_col], \
+                    &A[(unsigned long long)a_row * K + gc], valid); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gns = cta_n + ns; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int kp_cur = rnd * 16 + kp; \
+                unsigned int gke = (kb) + (kp_cur << 1); \
+                moe_cp_async_pred_16(&smem_Bp_fgu64[(buf)][kp_cur][ns], \
+                    &B_expert[(unsigned long long)(gke >> 1) * N + gns], \
+                    (gke + 1 < K) && (gns + 15 < N)); \
+                if (kp_cur < K_STEP_T64 / GROUP_SIZE) { \
+                    unsigned int sg = (kb) / GROUP_SIZE + kp_cur; \
+                    moe_cp_async_pred_16(&smem_Bs_fgu64[(buf)][kp_cur][ns], \
+                        &S_expert[(unsigned long long)sg * N + gns], \
+                        (gns + 15 < N)); \
+                } \
+            } \
+        } \
+    } while(0)
+
+    #define FGU64_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        __nv_fp8_e4m3 f0, f1, f2, f3; \
+        *(unsigned char*)&f0 = smem_Bs_fgu64[(buf)][0][my_n]; \
+        *(unsigned char*)&f1 = smem_Bs_fgu64[(buf)][1][my_n]; \
+        *(unsigned char*)&f2 = smem_Bs_fgu64[(buf)][2][my_n]; \
+        *(unsigned char*)&f3 = smem_Bs_fgu64[(buf)][3][my_n]; \
+        float sv0 = (float)f0 * scale2; \
+        float sv1 = (float)f1 * scale2; \
+        float sv2 = (float)f2 * scale2; \
+        float sv3 = (float)f3 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_fgu64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_fgu64[packed & 0xF] * sv0; \
+            float hi = smem_LUT_fgu64[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_fgu64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_fgu64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_fgu64[packed & 0xF] * sv1; \
+            float hi = smem_LUT_fgu64[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_fgu64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 16; kp < 24; kp++) { \
+            unsigned char packed = smem_Bp_fgu64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_fgu64[packed & 0xF] * sv2; \
+            float hi = smem_LUT_fgu64[packed >> 4] * sv2; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_fgu64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 24; kp < 32; kp++) { \
+            unsigned char packed = smem_Bp_fgu64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_fgu64[packed & 0xF] * sv3; \
+            float hi = smem_LUT_fgu64[packed >> 4] * sv3; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_fgu64[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    #define FGU64_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A_fgu64[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast_fgu64 + tid * 4]); \
+        unsigned int a1 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast_fgu64 + tid * 4]); \
+        unsigned int a2 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast_fgu64 + 16 + tid * 4]); \
+        unsigned int a3 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast_fgu64 + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_fgu64[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_fgu64[nc][16 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+        unsigned int a4 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast_fgu64 + 32 + tid * 4]); \
+        unsigned int a5 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast_fgu64 + 32 + tid * 4]); \
+        unsigned int a6 = moe_bf16x4_to_e4m3x4(&sA[fr0 * ast_fgu64 + 48 + tid * 4]); \
+        unsigned int a7 = moe_bf16x4_to_e4m3x4(&sA[fr1 * ast_fgu64 + 48 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_fgu64[nc][32 + 4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_fgu64[nc][48 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a4),"r"(a5),"r"(a6),"r"(a7),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    FGU64_ISSUE_LOADS(0, 0);
+    moe_cp_async_commit();
+    moe_cp_async_wait_all();
+    __syncthreads();
+    FGU64_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T64; k_base < K; k_base += K_STEP_T64) {
+        int nxt = 1 - cur;
+        FGU64_ISSUE_LOADS(nxt, k_base);
+        moe_cp_async_commit();
+        FGU64_COMPUTE_MMA(cur);
+        moe_cp_async_wait_all();
+        __syncthreads();
+        FGU64_DEQUANT(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+    FGU64_COMPUTE_MMA(cur);
+
+    #undef FGU64_ISSUE_LOADS
+    #undef FGU64_DEQUANT
+    #undef FGU64_COMPUTE_MMA
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        bool r0v = (int)(warp_m_offset + group_id + cta_m_local) < M_expert;
+        bool r1v = (int)(warp_m_offset + group_id + 8 + cta_m_local) < M_expert;
+        if (r0v && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0v && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1v && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1v && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Fused gate+up MoE GEMM.
+//
+// Single launch replaces two separate gate/up GEMM launches.
+// Grid x tiles across 2*N: first N columns use gate weights, last N
+// columns use up weights. A is loaded once per (expert, m_tile) and
+// shared across both projections via L2 cache reuse.
+//
+// Grid: (ceil(2*N / N_TILE_LG), max_m_tiles, num_experts)
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__ void moe_w4a16_fused_gate_up_t(
+    const __nv_bfloat16* __restrict__ A,
+    // Gate weights
+    const unsigned long long* __restrict__ gate_packed_ptrs,
+    const unsigned long long* __restrict__ gate_scale_ptrs,
+    const float* __restrict__ gate_scale2_vals,
+    // Up weights
+    const unsigned long long* __restrict__ up_packed_ptrs,
+    const unsigned long long* __restrict__ up_scale_ptrs,
+    const float* __restrict__ up_scale2_vals,
+    // Two output buffers
+    __nv_bfloat16* __restrict__ C_gate,
+    __nv_bfloat16* __restrict__ C_up,
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ sorted_token_ids,
+    unsigned int num_experts,
+    unsigned int N,            // per-projection N (gate and up have same N)
+    unsigned int K
+) {
+    const unsigned int expert_id = blockIdx.z;
+    if (expert_id >= num_experts) return;
+
+    const int m_start = expert_offsets[expert_id];
+    const int m_end = expert_offsets[expert_id + 1];
+    const int M_expert = m_end - m_start;
+    if (M_expert <= 0) return;
+
+    const int cta_m_local = blockIdx.y * M_TILE;
+    if (cta_m_local >= M_expert) return;
+
+    // Determine if this CTA handles gate (first N cols) or up (second N cols)
+    const unsigned int global_n = blockIdx.x * N_TILE_LG;
+    const bool is_up = (global_n >= N);
+    const unsigned int cta_n = is_up ? (global_n - N) : global_n;
+
+    // Select the right weight pointers and output buffer
+    const unsigned char* B_expert;
+    const unsigned char* S_expert;
+    float scale2;
+    __nv_bfloat16* C;
+    if (is_up) {
+        B_expert = (const unsigned char*)up_packed_ptrs[expert_id];
+        S_expert = (const unsigned char*)up_scale_ptrs[expert_id];
+        scale2 = up_scale2_vals[expert_id];
+        C = C_up;
+    } else {
+        B_expert = (const unsigned char*)gate_packed_ptrs[expert_id];
+        S_expert = (const unsigned char*)gate_scale_ptrs[expert_id];
+        scale2 = gate_scale2_vals[expert_id];
+        C = C_gate;
+    }
+
+    if (B_expert == 0) return;
+
+    const unsigned int cta_m = m_start + cta_m_local;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[2][M_TILE][K_STEP_T + PAD_T];
+    __shared__ unsigned char smem_Bp[2][K_STEP_T / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs[2][K_STEP_T / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    // Same +4 padding as grouped_gemm_ptrtable_t: eliminates 8-way DEQUANT write conflicts.
+    __shared__ unsigned char smem_B_fp8[N_TILE_LG][K_STEP_T + 4];
+    __shared__ float smem_LUT[16];
+    __shared__ int smem_tok[M_TILE];
+
+    if (threadIdx.x < 16) {
+        smem_LUT[threadIdx.x] = E2M1_LUT_MOE[threadIdx.x];
+    }
+    if (threadIdx.x < M_TILE) {
+        int local_row = threadIdx.x;
+        if (sorted_token_ids && (cta_m_local + local_row) < (unsigned int)M_expert) {
+            smem_tok[local_row] = sorted_token_ids[cta_m + local_row];
+        } else {
+            smem_tok[local_row] = (int)(cta_m + local_row);
+        }
+    }
+    __syncthreads();
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+    const unsigned int M_eff = (unsigned int)M_expert;
+
+    // Reuse exact same macros as moe_w4a16_grouped_gemm_ptrtable_t
+    #define FGU_ISSUE_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int row = rnd * 32 + a_row_base; \
+                bool valid = (cta_m_local + row) < M_eff && (gc + 7 < K); \
+                unsigned int a_row = (unsigned int)smem_tok[row]; \
+                moe_cp_async_pred_16(&smem_A[(buf)][row][a_col], \
+                    &A[(unsigned long long)a_row * K + gc], valid); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gke = (kb) + (kp << 1); \
+            unsigned int gns = cta_n + ns; \
+            moe_cp_async_pred_16(&smem_Bp[(buf)][kp][ns], \
+                &B_expert[(unsigned long long)(gke >> 1) * N + gns], \
+                (gke + 1 <= K) && (gns + 15 < N)); \
+            if (kp < K_STEP_T / GROUP_SIZE) { \
+                unsigned int sg = (kb) / GROUP_SIZE + kp; \
+                moe_cp_async_pred_16(&smem_Bs[(buf)][kp][ns], \
+                    &S_expert[(unsigned long long)sg * N + gns], \
+                    (gns + 15 < N)); \
+            } \
+        } \
+    } while(0)
+
+    #define FGU_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; \
+        *(unsigned char*)&f1 = sb1; \
+        float sv0 = (float)f0 * scale2; \
+        float sv1 = (float)f1 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv0; \
+            float hi = smem_LUT[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv1; \
+            float hi = smem_LUT[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    #define FGU_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = moe_bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        unsigned int a1 = moe_bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        unsigned int a2 = moe_bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        unsigned int a3 = moe_bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8[nc][16 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
+                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
+                 "r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
+                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    FGU_ISSUE_LOADS(0, 0);
+    moe_cp_async_commit();
+    moe_cp_async_wait_all();
+    __syncthreads();
+    FGU_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        FGU_ISSUE_LOADS(nxt, k_base);
+        moe_cp_async_commit();
+        FGU_COMPUTE_MMA(cur);
+        moe_cp_async_wait_all();
+        __syncthreads();
+        FGU_DEQUANT(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+    FGU_COMPUTE_MMA(cur);
+
+    #undef FGU_ISSUE_LOADS
+    #undef FGU_DEQUANT
+    #undef FGU_COMPUTE_MMA
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        bool r0v = (int)(warp_m_offset + group_id + cta_m_local) < M_expert;
+        bool r1v = (int)(warp_m_offset + group_id + 8 + cta_m_local) < M_expert;
+        if (r0v && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0v && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1v && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1v && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// FP8-input MoE GEMM: A [M, K] FP8 × B_expert NVFP4 → C [M, N] BF16
+//
+// A is pre-converted to FP8 E4M3 — no BF16→FP8 in the inner loop.
+// B is still NVFP4 (dequanted to FP8 in smem per tile).
+// Same tiling as _t variant: M_TILE=64, N_TILE=128, K_STEP=32.
+// A smem is FP8 (2 KB/buf vs 5 KB/buf BF16) — saves smem bandwidth.
+// Grid: (ceil(N/128), max_m_tiles, num_experts)
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__ void moe_fp8_grouped_gemm_ptrtable_t(
+    const unsigned char* __restrict__ A_fp8,  // [total_tokens, K] FP8 E4M3
+    const unsigned long long* __restrict__ B_packed_ptrs,
+    const unsigned long long* __restrict__ B_scale_ptrs,
+    const float* __restrict__ scale2_vals,
+    __nv_bfloat16* __restrict__ C,
+    const int* __restrict__ expert_offsets,
+    const int* __restrict__ sorted_token_ids,
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int expert_id = blockIdx.z;
+    if (expert_id >= num_experts) return;
+
+    const int m_start = expert_offsets[expert_id];
+    const int m_end = expert_offsets[expert_id + 1];
+    const int M_expert = m_end - m_start;
+    if (M_expert <= 0) return;
+
+    const int cta_m_local = blockIdx.y * M_TILE;
+    if (cta_m_local >= M_expert) return;
+
+    const unsigned int cta_m = m_start + cta_m_local;
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+
+    const unsigned char* B_exp = (const unsigned char*)B_packed_ptrs[expert_id];
+    const unsigned char* S_exp = (const unsigned char*)B_scale_ptrs[expert_id];
+    const float scale2 = scale2_vals[expert_id];
+
+    if (B_exp == 0) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ unsigned char smem_Af2[2][M_TILE][K_STEP_T];
+    __shared__ unsigned char smem_Bp2[2][K_STEP_T / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs2[2][K_STEP_T / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_B2_fp8[N_TILE_LG][K_STEP_T];
+    __shared__ float smem_LUT2[16];
+    __shared__ int smem_tok2[M_TILE];
+
+    if (threadIdx.x < 16) {
+        smem_LUT2[threadIdx.x] = E2M1_LUT_MOE[threadIdx.x];
+    }
+    if (threadIdx.x < M_TILE) {
+        int local_row = threadIdx.x;
+        if (sorted_token_ids && (cta_m_local + local_row) < (unsigned int)M_expert) {
+            smem_tok2[local_row] = sorted_token_ids[cta_m + local_row];
+        } else {
+            smem_tok2[local_row] = (int)(cta_m + local_row);
+        }
+    }
+    __syncthreads();
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int M_eff = (unsigned int)M_expert;
+
+    #define MOE_FF_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 1; \
+            unsigned int a_col = (threadIdx.x & 1) << 4; \
+            unsigned int gc = (kb) + a_col; \
+            unsigned int row = a_row_base; \
+            bool valid = (cta_m_local + row) < M_eff && (gc + 15 < K); \
+            unsigned int a_row = (unsigned int)smem_tok2[row]; \
+            moe_cp_async_pred_16(&smem_Af2[(buf)][row][a_col], \
+                &A_fp8[(unsigned long long)a_row * K + gc], valid); \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gke = (kb) + (kp << 1); \
+            unsigned int gns = cta_n + ns; \
+            moe_cp_async_pred_16(&smem_Bp2[(buf)][kp][ns], \
+                &B_exp[(unsigned long long)(gke >> 1) * N + gns], \
+                (gke + 1 <= K) && (gns + 15 < N)); \
+            if (kp < K_STEP_T / GROUP_SIZE) { \
+                unsigned int sg = (kb) / GROUP_SIZE + kp; \
+                moe_cp_async_pred_16(&smem_Bs2[(buf)][kp][ns], \
+                    &S_exp[(unsigned long long)sg * N + gns], \
+                    (gns + 15 < N)); \
+            } \
+        } \
+    } while(0)
+
+    #define MOE_FF_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs2[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs2[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; \
+        *(unsigned char*)&f1 = sb1; \
+        float sv0 = (float)f0 * scale2; \
+        float sv1 = (float)f1 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp2[(buf)][kp][my_n]; \
+            float lo = smem_LUT2[packed & 0xF] * sv0; \
+            float hi = smem_LUT2[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B2_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp2[(buf)][kp][my_n]; \
+            float lo = smem_LUT2[packed & 0xF] * sv1; \
+            float hi = smem_LUT2[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B2_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    #define MOE_FF_COMPUTE(a_buf) do { \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = *(const unsigned int*)&smem_Af2[(a_buf)][fr0][4 * tid]; \
+        unsigned int a1 = *(const unsigned int*)&smem_Af2[(a_buf)][fr1][4 * tid]; \
+        unsigned int a2 = *(const unsigned int*)&smem_Af2[(a_buf)][fr0][16 + 4 * tid]; \
+        unsigned int a3 = *(const unsigned int*)&smem_Af2[(a_buf)][fr1][16 + 4 * tid]; \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B2_fp8[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B2_fp8[nc][16 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
+                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
+                 "r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
+                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    MOE_FF_LOADS(0, 0);
+    moe_cp_async_commit();
+    moe_cp_async_wait_all();
+    __syncthreads();
+    MOE_FF_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        MOE_FF_LOADS(nxt, k_base);
+        moe_cp_async_commit();
+        MOE_FF_COMPUTE(cur);
+        moe_cp_async_wait_all();
+        __syncthreads();
+        MOE_FF_DEQUANT(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+    MOE_FF_COMPUTE(cur);
+
+    #undef MOE_FF_LOADS
+    #undef MOE_FF_DEQUANT
+    #undef MOE_FF_COMPUTE
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        bool r0v = (int)(warp_m_offset + group_id + cta_m_local) < M_expert;
+        bool r1v = (int)(warp_m_offset + group_id + 8 + cta_m_local) < M_expert;
+        if (r0v && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0v && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1v && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1v && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}

--- a/kernels/gb10/qwen3.5-397b-a17b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/qwen3.5-397b-a17b/nvfp4/w4a16_gemm.cu
@@ -1,0 +1,1399 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Atlas W4A16 GEMM — 35B model shadow.
+//
+// Optimizations:
+// - w4a16_gemm_t: cp.async 2-stage double-buffered pipeline (overlaps next tile
+//   loads with current tile compute), prmt BF16 packing, BP_PAD bank conflict fix
+// - Vectorized uint4 (128-bit) B_packed loads
+// - Both-nibble extraction from packed bytes
+// - N_TILE=128 for reduced A bandwidth
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#define M_TILE 64
+#define N_TILE_SM 64
+#define N_TILE_LG 128
+#define K_STEP 16
+#define K_STEP_T 32
+#define PAD 2
+#define PAD_T 8        // cp.async needs 16-byte aligned rows: (32+8)*2=80, 80%16=0
+#define BP_PAD 16      // smem_Bp row padding: stride 144 is 16-byte aligned, eliminates 4-way bank conflict
+#define B_PAD 2        // BF16 padding for bank-conflict-free smem_B_bf16 (stride 17 coprime with 32)
+#define GROUP_SIZE 16
+
+__device__ __constant__ float E2M1_LUT[16] = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f
+};
+
+// Original layout w4a16_gemm: unchanged, N_TILE=64
+extern "C" __global__ void w4a16_gemm(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int cta_n = blockIdx.x * N_TILE_SM;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[M_TILE][K_STEP + PAD];
+    __shared__ __nv_bfloat16 smem_B[K_STEP][N_TILE_SM + PAD];
+
+    float acc[8][4];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int a_stride = K_STEP + PAD;
+    const unsigned int b_stride = N_TILE_SM + PAD;
+
+    for (unsigned int k_base = 0; k_base < K; k_base += K_STEP) {
+        {
+            const unsigned int ept = (M_TILE * K_STEP) / 128;
+            #pragma unroll
+            for (unsigned int i = 0; i < ept; i++) {
+                unsigned int idx = threadIdx.x * ept + i;
+                unsigned int row = idx / K_STEP;
+                unsigned int col = idx % K_STEP;
+                unsigned int gr = cta_m + row;
+                unsigned int gc = k_base + col;
+                smem_A[row][col] = (gr < M && gc < K) ? A[gr * K + gc] : __float2bfloat16(0.0f);
+            }
+        }
+        {
+            #pragma unroll
+            for (unsigned int i = 0; i < 8; i++) {
+                unsigned int idx = threadIdx.x * 8 + i;
+                unsigned int k = idx / N_TILE_SM;
+                unsigned int n = idx % N_TILE_SM;
+                unsigned int gk = k_base + k;
+                unsigned int gn = cta_n + n;
+                if (gk < K && gn < N) {
+                    unsigned int k_pair = gk / 2;
+                    unsigned char packed_byte = B_packed[(unsigned long long)gn * half_K + k_pair];
+                    unsigned int nibble = (gk & 1) ? (packed_byte >> 4) : (packed_byte & 0xF);
+                    unsigned int sg = gk / GROUP_SIZE;
+                    unsigned char sb = B_scale[(unsigned long long)gn * num_groups + sg];
+                    __nv_fp8_e4m3 fp8; *(unsigned char*)&fp8 = sb;
+                    smem_B[k][n] = __float2bfloat16(E2M1_LUT[nibble] * (float)fp8 * scale2);
+                } else {
+                    smem_B[k][n] = __float2bfloat16(0.0f);
+                }
+            }
+        }
+        __syncthreads();
+
+        const unsigned short* sA = (const unsigned short*)smem_A;
+        const unsigned short* sB = (const unsigned short*)smem_B;
+        unsigned int fr0 = warp_m_offset + group_id;
+        unsigned int fr1 = fr0 + 8;
+        unsigned int fc0 = tid * 2, fc1 = fc0 + 8;
+        unsigned int a0 = *(const unsigned int*)&sA[fr0 * a_stride + fc0];
+        unsigned int a1 = *(const unsigned int*)&sA[fr1 * a_stride + fc0];
+        unsigned int a2 = *(const unsigned int*)&sA[fr0 * a_stride + fc1];
+        unsigned int a3 = *(const unsigned int*)&sA[fr1 * a_stride + fc1];
+        #pragma unroll
+        for (int nt = 0; nt < 8; nt++) {
+            unsigned int nc = nt * 8 + group_id;
+            unsigned int k0 = tid * 2, k1 = k0 + 8;
+            unsigned int b0 = ((unsigned int)sB[(k0+1)*b_stride+nc]<<16) | (unsigned int)sB[k0*b_stride+nc];
+            unsigned int b1 = ((unsigned int)sB[(k1+1)*b_stride+nc]<<16) | (unsigned int)sB[k1*b_stride+nc];
+            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};"
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3])
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1),
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3]));
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int nt = 0; nt < 8; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// cp.async 2-stage double-buffered transposed GEMM.
+//
+// Overlaps global→smem loads for tile N+1 with MMA compute on tile N.
+// All loads (A, Bp, Bs) use cp.async.16 for register-free transfers.
+//
+// smem (double-buffered):
+//   A:  2 × 64 × 40 × 2B = 10240B
+//   Bp: 2 × 16 × 144     =  4608B
+//   Bs: 2 × 2  × 144     =   576B
+//   LUT: 64B
+//   Total: ~15.5KB → register-limited at ~6 CTAs/SM (unchanged)
+//
+// B_packed[K/2, N], B_scale[K/GROUP_SIZE, N].
+// ═══════════════════════════════════════════════════════════════════
+
+// cp.async helpers (SM80+)
+__device__ __forceinline__ void cp_async_pred_16(void* dst_smem, const void* src_gmem, bool pred) {
+    unsigned int dst = __cvta_generic_to_shared(dst_smem);
+    unsigned int src_bytes = pred ? 16 : 0;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;"
+                 :: "r"(dst), "l"(src_gmem), "r"(src_bytes));
+}
+
+__device__ __forceinline__ void cp_async_commit() {
+    asm volatile("cp.async.commit_group;");
+}
+
+__device__ __forceinline__ void cp_async_wait_all() {
+    asm volatile("cp.async.wait_group 0;");
+}
+
+__device__ __forceinline__ unsigned int pack_bf16_pair(float lo, float hi) {
+    unsigned int result;
+    asm("prmt.b32 %0, %1, %2, 0x7632;" : "=r"(result)
+        : "r"(__float_as_uint(lo)), "r"(__float_as_uint(hi)));
+    return result;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// FP8-MMA transposed dense GEMM.
+//
+// Dequant B to FP8 E4M3 (not BF16). Convert A from BF16→FP8 in
+// registers. Use mma.sync.m16n8k32.e4m3.e4m3 — processes full K=32
+// per instruction (2x fewer MMA instructions vs BF16 m16n8k16).
+//
+// Pipeline: load[nxt] || MMA[cur] → wait → dequant[nxt] → sync
+//
+// smem: A 2×64×40×2=10240B, Bp 2×16×144=4608B, Bs 2×2×144=576B,
+//       B_fp8 128×32=4096B, LUT 64B = ~19.6KB
+// ═══════════════════════════════════════════════════════════════════
+
+// Convert 4 BF16 values from smem to packed uint32 of 4 E4M3 values
+__device__ __forceinline__ unsigned int bf16x4_to_e4m3x4(const unsigned short* src) {
+    unsigned int p0 = *(const unsigned int*)src;
+    unsigned int p1 = *(const unsigned int*)(src + 2);
+    unsigned short bf0 = (unsigned short)(p0 & 0xFFFFu);
+    unsigned short bf1 = (unsigned short)(p0 >> 16);
+    unsigned short bf2 = (unsigned short)(p1 & 0xFFFFu);
+    unsigned short bf3 = (unsigned short)(p1 >> 16);
+    float f0, f1, f2, f3;
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f0) : "h"(bf0));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f1) : "h"(bf1));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f2) : "h"(bf2));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f3) : "h"(bf3));
+    unsigned short h0, h1;
+    asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" : "=h"(h0) : "f"(f1), "f"(f0));
+    asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" : "=h"(h1) : "f"(f3), "f"(f2));
+    return ((unsigned int)h1 << 16) | (unsigned int)h0;
+}
+
+extern "C" __global__ void w4a16_gemm_t(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[2][M_TILE][K_STEP_T + PAD_T];
+    __shared__ unsigned char smem_Bp[2][K_STEP_T / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs[2][K_STEP_T / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_B_fp8[N_TILE_LG][K_STEP_T];
+    __shared__ float smem_LUT[16];
+
+    if (threadIdx.x < 16) smem_LUT[threadIdx.x] = E2M1_LUT[threadIdx.x];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+
+    #define ISSUE_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int row = rnd * 32 + a_row_base; \
+                unsigned int gr = cta_m + row; \
+                cp_async_pred_16(&smem_A[(buf)][row][a_col], \
+                    &A[gr * K + gc], (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gke = (kb) + (kp << 1); \
+            unsigned int gns = cta_n + ns; \
+            cp_async_pred_16(&smem_Bp[(buf)][kp][ns], \
+                &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
+                (gke + 1 <= K) && (gns + 15 < N)); \
+            if (kp < K_STEP_T / GROUP_SIZE) { \
+                unsigned int sg = (kb) / GROUP_SIZE + kp; \
+                cp_async_pred_16(&smem_Bs[(buf)][kp][ns], \
+                    &B_scale[(unsigned long long)sg * N + gns], \
+                    (gns + 15 < N)); \
+            } \
+        } \
+    } while(0)
+
+    // Dequant B: FP4 → FP8 E4M3 (cvt.rn.satfinite.e4m3x2.f32)
+    #define DEQUANT_T(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; *(unsigned char*)&f1 = sb1; \
+        float sv0 = (float)f0 * scale2, sv1 = (float)f1 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv0; \
+            float hi = smem_LUT[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv1; \
+            float hi = smem_LUT[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    // FP8 MMA: convert A BF16→E4M3 in registers, single m16n8k32 per N-tile
+    #define COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        unsigned int a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        unsigned int a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        unsigned int a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8[nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    ISSUE_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+    DEQUANT_T(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        ISSUE_LOADS(nxt, k_base);
+        cp_async_commit();
+        COMPUTE_MMA(cur);
+        cp_async_wait_all();
+        __syncthreads();
+        DEQUANT_T(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+
+    COMPUTE_MMA(cur);
+
+    #undef ISSUE_LOADS
+    #undef DEQUANT_T
+    #undef COMPUTE_MMA
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Pre-dequanted FP8 GEMM (prefill).
+//
+// B_fp8 is pre-dequanted at load time: NVFP4 → FP8 E4M3 once.
+// Eliminates the per-inference DEQUANT phase entirely.
+// B_fp8[N, K] layout — each row is one output neuron, K consecutive.
+//
+// Pipeline: LOAD(A+B_fp8) || COMPUTE_MMA — only 1 sync per K step.
+//
+// smem: A 2×64×40×2=10240B, B_fp8 2×128×32=8192B = ~18.4KB
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void fp8_gemm_t(
+    const __nv_bfloat16* __restrict__ A,       // [M, K] BF16
+    const unsigned char* __restrict__ B_fp8,   // [N, K] FP8 E4M3
+    __nv_bfloat16* __restrict__ C,             // [M, N] BF16
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[2][M_TILE][K_STEP_T + PAD_T];
+    __shared__ unsigned char smem_B[2][N_TILE_LG][K_STEP_T];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+
+    // Load A (BF16) + B (FP8, pre-dequanted) via cp.async
+    #define FP8_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int row = rnd * 32 + a_row_base; \
+                unsigned int gr = cta_m + row; \
+                cp_async_pred_16(&smem_A[(buf)][row][a_col], \
+                    &A[(unsigned long long)gr * K + gc], \
+                    (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int my_n = threadIdx.x; \
+            unsigned int gn = cta_n + my_n; \
+            bool valid = (gn < N) && ((kb) + 31 < K); \
+            cp_async_pred_16(&smem_B[(buf)][my_n][0], \
+                &B_fp8[(unsigned long long)gn * K + (kb)], valid); \
+            cp_async_pred_16(&smem_B[(buf)][my_n][16], \
+                &B_fp8[(unsigned long long)gn * K + (kb) + 16], valid); \
+        } \
+    } while(0)
+
+    // FP8 MMA — identical to w4a16_gemm_t COMPUTE_MMA
+    #define FP8_COMPUTE(a_buf, b_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        unsigned int a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        unsigned int a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        unsigned int a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B[(b_buf)][nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B[(b_buf)][nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
+                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
+                 "r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
+                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    // Prolog: load first tile, wait, no dequant needed
+    FP8_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+
+    // Main loop: LOAD(nxt) || COMPUTE(cur) → wait → sync
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        FP8_LOADS(nxt, k_base);
+        cp_async_commit();
+        FP8_COMPUTE(cur, cur);
+        cp_async_wait_all();
+        __syncthreads();
+        cur = nxt;
+    }
+    FP8_COMPUTE(cur, cur);
+
+    #undef FP8_LOADS
+    #undef FP8_COMPUTE
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Pre-dequant: NVFP4 [N, K/2] + scales [N, K/GROUP_SIZE] → FP8 [N, K]
+//
+// One-time conversion at model load. Each thread processes 1 packed
+// byte (2 FP4 values) → 2 FP8 E4M3 values.
+// Grid: (ceil(N * K/2 / 256), 1, 1)  Block: (256, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__ void predequant_nvfp4_to_fp8(
+    const unsigned char* __restrict__ B_packed,  // [N, K/2]
+    const unsigned char* __restrict__ B_scale,   // [N, K/GROUP_SIZE]
+    float scale2,
+    unsigned char* __restrict__ B_fp8,           // [N, K]
+    unsigned int N, unsigned int K
+) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int half_K = K / 2;
+    unsigned int total = N * half_K;
+    if (idx >= total) return;
+
+    unsigned int n = idx / half_K;
+    unsigned int k_pair = idx % half_K;
+    unsigned int k_even = k_pair * 2;
+
+    unsigned char packed = B_packed[(unsigned long long)n * half_K + k_pair];
+    unsigned int group = k_even / GROUP_SIZE;
+    unsigned char sb = B_scale[(unsigned long long)n * (K / GROUP_SIZE) + group];
+    __nv_fp8_e4m3 fp8_scale;
+    *(unsigned char*)&fp8_scale = sb;
+    float sv = (float)fp8_scale * scale2;
+
+    float val_lo = E2M1_LUT[packed & 0xF] * sv;
+    float val_hi = E2M1_LUT[packed >> 4] * sv;
+
+    unsigned short fp8_pair;
+    asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;"
+                 : "=h"(fp8_pair) : "f"(val_hi), "f"(val_lo));
+
+    *(unsigned short*)&B_fp8[(unsigned long long)n * K + k_even] = fp8_pair;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// BF16 → FP8 E4M3 activation conversion.
+// Converts [M, K] BF16 activations to [M, K] FP8 E4M3 in-place or
+// out-of-place. Grid: (ceil(M*K/2 / 256), 1, 1)  Block: (256, 1, 1)
+// Each thread converts 2 BF16 values → 2 FP8 values via cvt.e4m3x2.
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__ void bf16_to_fp8(
+    const __nv_bfloat16* __restrict__ src,   // [M, K] BF16
+    unsigned char* __restrict__ dst,          // [M, K] FP8 E4M3
+    unsigned int total_elements               // M * K (must be even)
+) {
+    unsigned int idx = (blockIdx.x * blockDim.x + threadIdx.x) * 2;
+    if (idx >= total_elements) return;
+
+    unsigned int p = *(const unsigned int*)&src[idx];
+    unsigned short bf0 = (unsigned short)(p & 0xFFFFu);
+    unsigned short bf1 = (unsigned short)(p >> 16);
+    float f0, f1;
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f0) : "h"(bf0));
+    asm volatile("cvt.f32.bf16 %0, %1;" : "=f"(f1) : "h"(bf1));
+    unsigned short fp8_pair;
+    asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;"
+                 : "=h"(fp8_pair) : "f"(f1), "f"(f0));
+    *(unsigned short*)&dst[idx] = fp8_pair;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// FP8×FP8 GEMM: A [M, K] FP8 E4M3 × B [N, K] FP8 E4M3 → C [M, N] BF16
+//
+// Both A and B are pre-converted to FP8. No BF16→FP8 conversion in
+// the inner loop — pure cp.async loads + FP8 MMA.
+// Same tiling as fp8_gemm_t: M_TILE=64, N_TILE=128, K_STEP=32.
+// A smem is FP8 (half the size of BF16 variant), no PAD needed.
+// Grid: (ceil(N/128), ceil(M/64))  Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+#define A_FP8_STRIDE 32  // K_STEP_T = 32 bytes per row for FP8
+
+extern "C" __global__ void fp8_fp8_gemm_t(
+    const unsigned char* __restrict__ A_fp8,  // [M, K] FP8 E4M3
+    const unsigned char* __restrict__ B_fp8,  // [N, K] FP8 E4M3
+    __nv_bfloat16* __restrict__ C,            // [M, N] BF16
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    // A smem: FP8 [64][32] = 2 KB per buffer (vs 5 KB BF16)
+    __shared__ unsigned char smem_Af[2][M_TILE][A_FP8_STRIDE];
+    __shared__ unsigned char smem_Bf[2][N_TILE_LG][K_STEP_T];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    // Load A (FP8) + B (FP8) via cp.async — both 1 byte per element
+    #define FF_LOADS(buf, kb) do { \
+        { \
+            /* 128 threads load 64 rows × 32 bytes: each thread loads 16 bytes */ \
+            unsigned int a_row_base = threadIdx.x >> 1; \
+            unsigned int a_col = (threadIdx.x & 1) << 4; \
+            unsigned int gc = (kb) + a_col; \
+            unsigned int row = a_row_base; \
+            unsigned int gr = cta_m + row; \
+            cp_async_pred_16(&smem_Af[(buf)][row][a_col], \
+                &A_fp8[(unsigned long long)gr * K + gc], \
+                (gr < M) && (gc + 15 < K)); \
+        } \
+        { \
+            unsigned int my_n = threadIdx.x; \
+            unsigned int gn = cta_n + my_n; \
+            bool valid = (gn < N) && ((kb) + 31 < K); \
+            cp_async_pred_16(&smem_Bf[(buf)][my_n][0], \
+                &B_fp8[(unsigned long long)gn * K + (kb)], valid); \
+            cp_async_pred_16(&smem_Bf[(buf)][my_n][16], \
+                &B_fp8[(unsigned long long)gn * K + (kb) + 16], valid); \
+        } \
+    } while(0)
+
+    // FP8×FP8 MMA — no conversion needed, read A directly as FP8
+    #define FF_COMPUTE(a_buf, b_buf) do { \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        /* A fragments: 4 bytes = 4 FP8 elements per register, need 8 regs (m16×k32) */ \
+        unsigned int a0 = *(const unsigned int*)&smem_Af[(a_buf)][fr0][4 * tid]; \
+        unsigned int a1 = *(const unsigned int*)&smem_Af[(a_buf)][fr1][4 * tid]; \
+        unsigned int a2 = *(const unsigned int*)&smem_Af[(a_buf)][fr0][16 + 4 * tid]; \
+        unsigned int a3 = *(const unsigned int*)&smem_Af[(a_buf)][fr1][16 + 4 * tid]; \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_Bf[(b_buf)][nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_Bf[(b_buf)][nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
+                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
+                 "r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
+                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    // Prolog: load first tile, wait
+    FF_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+
+    // Main loop: LOAD(nxt) || COMPUTE(cur) → wait → sync
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        FF_LOADS(nxt, k_base);
+        cp_async_commit();
+        FF_COMPUTE(cur, cur);
+        cp_async_wait_all();
+        __syncthreads();
+        cur = nxt;
+    }
+    FF_COMPUTE(cur, cur);
+
+    #undef FF_LOADS
+    #undef FF_COMPUTE
+
+    // Write results
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// K64 FP8-MMA transposed dense GEMM — halves outer K-loop vs K32.
+//
+// Same algorithm as w4a16_gemm_t but K_STEP_T64=64: 32 outer iterations
+// instead of 64 for K=2048. Two m16n8k32 MMAs per N-tile per step.
+// Reduces loop overhead and better amortizes DMA startup cost.
+//
+// K must be divisible by 64.
+//
+// smem: A 2×64×72×2=18432B, Bp 2×32×144=9216B, Bs 2×4×144=1152B,
+//       B_fp8 128×80=10240B, LUT 64B = ~38.4KB
+// ═══════════════════════════════════════════════════════════════════
+#define K_STEP_T64 64
+#define PAD_T64    8   // (64+8)*2=144, 144%16=0 ✓
+
+extern "C" __global__ void w4a16_gemm_t_k64(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    // B_fp8 row stride 80 = K64+16: avoids 4-way bank conflicts.
+    __shared__ __nv_bfloat16 smem_A_k64[2][M_TILE][K_STEP_T64 + PAD_T64];
+    __shared__ unsigned char smem_Bp_k64[2][K_STEP_T64 / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs_k64[2][K_STEP_T64 / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_B_fp8_k64[N_TILE_LG][K_STEP_T64 + 16];
+    __shared__ float smem_LUT_k64[16];
+
+    if (threadIdx.x < 16) smem_LUT_k64[threadIdx.x] = E2M1_LUT[threadIdx.x];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int ast64 = K_STEP_T64 + PAD_T64;
+
+    // A: 4 rounds × 16 rows = 64 rows (M_TILE); each thread: 8 BF16 = 16 bytes.
+    // Bp: 2 rounds × 16 rows = 32 rows (K64/2); each thread: 16 bytes per ns chunk.
+    // Bs: inline with Bp when kp_cur < K_STEP_T64/GROUP_SIZE (4 scale groups).
+    #define K64_ISSUE_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 3; \
+            unsigned int a_col = (threadIdx.x & 7) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 4; rnd++) { \
+                unsigned int row = rnd * 16 + a_row_base; \
+                unsigned int gr = cta_m + row; \
+                cp_async_pred_16(&smem_A_k64[(buf)][row][a_col], \
+                    &A[(unsigned long long)gr * K + gc], \
+                    (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gns = cta_n + ns; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int kp_cur = rnd * 16 + kp; \
+                unsigned int gke = (kb) + (kp_cur << 1); \
+                cp_async_pred_16(&smem_Bp_k64[(buf)][kp_cur][ns], \
+                    &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
+                    (gke + 1 <= K) && (gns + 15 < N)); \
+                if (kp_cur < K_STEP_T64 / GROUP_SIZE) { \
+                    unsigned int sg = (kb) / GROUP_SIZE + kp_cur; \
+                    cp_async_pred_16(&smem_Bs_k64[(buf)][kp_cur][ns], \
+                        &B_scale[(unsigned long long)sg * N + gns], \
+                        (gns + 15 < N)); \
+                } \
+            } \
+        } \
+    } while(0)
+
+    // 4 scale groups, 32 dequant iters: sv0→K{0..15}, sv1→K{16..31},
+    // sv2→K{32..47}, sv3→K{48..63}.
+    #define K64_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        __nv_fp8_e4m3 f0, f1, f2, f3; \
+        *(unsigned char*)&f0 = smem_Bs_k64[(buf)][0][my_n]; \
+        *(unsigned char*)&f1 = smem_Bs_k64[(buf)][1][my_n]; \
+        *(unsigned char*)&f2 = smem_Bs_k64[(buf)][2][my_n]; \
+        *(unsigned char*)&f3 = smem_Bs_k64[(buf)][3][my_n]; \
+        float sv0 = (float)f0 * scale2, sv1 = (float)f1 * scale2; \
+        float sv2 = (float)f2 * scale2, sv3 = (float)f3 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv0; \
+            float hi = smem_LUT_k64[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv1; \
+            float hi = smem_LUT_k64[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 16; kp < 24; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv2; \
+            float hi = smem_LUT_k64[packed >> 4] * sv2; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 24; kp < 32; kp++) { \
+            unsigned char packed = smem_Bp_k64[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64[packed & 0xF] * sv3; \
+            float hi = smem_LUT_k64[packed >> 4] * sv3; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    // Two m16n8k32 MMA calls per N-tile: first covers K=0..31, second K=32..63.
+    #define K64_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A_k64[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + tid * 4]); \
+        unsigned int a1 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + tid * 4]); \
+        unsigned int a2 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 16 + tid * 4]); \
+        unsigned int a3 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_k64[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_k64[nc][16 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+        unsigned int a4 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 32 + tid * 4]); \
+        unsigned int a5 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 32 + tid * 4]); \
+        unsigned int a6 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 48 + tid * 4]); \
+        unsigned int a7 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 48 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_k64[nc][32 + 4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_k64[nc][48 + 4 * tid]; \
+            asm volatile( \
+                "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a4),"r"(a5),"r"(a6),"r"(a7),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+
+    K64_ISSUE_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+    K64_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T64; k_base < K; k_base += K_STEP_T64) {
+        int nxt = 1 - cur;
+        K64_ISSUE_LOADS(nxt, k_base);
+        cp_async_commit();
+        K64_COMPUTE_MMA(cur);
+        cp_async_wait_all();
+        __syncthreads();
+        K64_DEQUANT(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+    K64_COMPUTE_MMA(cur);
+
+    #undef K64_ISSUE_LOADS
+    #undef K64_DEQUANT
+    #undef K64_COMPUTE_MMA
+    #undef K_STEP_T64
+    #undef PAD_T64
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// M128 variant: 2 consecutive 64-row M-chunks per CTA.
+//
+// For large-M prefill (e.g. ISL=1016, N=12288):
+//   M_TILE=64: grid=(96,16,1)=1536 blocks, 16 weight re-reads  → 227MB B DRAM
+//   M_TILE2=128: grid=(96,8,1)=768 blocks, 8 weight re-reads   → 114MB B DRAM
+//
+// SMEM: A 2×128×40×2=20480B, Bp 2×16×144=4608B, Bs 2×2×144=576B,
+//       B_fp8 128×32=4096B, LUT 64B ≈ 29.8KB → 3 blocks/SM.
+//
+// For qkvz (K=2048,N=12288): ~2× speedup at ISL>128 vs w4a16_gemm_t.
+// ═══════════════════════════════════════════════════════════════════
+
+extern "C" __global__
+__launch_bounds__(128, 3)
+void w4a16_gemm_t_m128(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n  = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m  = blockIdx.y * (2 * M_TILE);  // base row for this block
+    if (cta_m >= M) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    // A is 2× larger (128 rows instead of 64); B/LUT/dequant identical to w4a16_gemm_t.
+    __shared__ __nv_bfloat16 smem_A[2][2 * M_TILE][K_STEP_T + PAD_T];   // 20480 B
+    __shared__ unsigned char smem_Bp[2][K_STEP_T / 2][N_TILE_LG + BP_PAD]; // 4608 B
+    __shared__ unsigned char smem_Bs[2][K_STEP_T / GROUP_SIZE][N_TILE_LG + BP_PAD]; // 576 B
+    __shared__ unsigned char smem_B_fp8[N_TILE_LG][K_STEP_T];             // 4096 B
+    __shared__ float smem_LUT[16];                                         //   64 B
+    // Total ≈ 29.8 KB → 3 blocks/SM
+
+    if (threadIdx.x < 16) smem_LUT[threadIdx.x] = E2M1_LUT[threadIdx.x];
+
+    // Two sets of accumulators: chunk0 = rows [cta_m..cta_m+63],
+    //                           chunk1 = rows [cta_m+64..cta_m+127].
+    float acc0[16][4], acc1[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc0[i][0] = 0.f; acc0[i][1] = 0.f; acc0[i][2] = 0.f; acc0[i][3] = 0.f;
+        acc1[i][0] = 0.f; acc1[i][1] = 0.f; acc1[i][2] = 0.f; acc1[i][3] = 0.f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+
+    // Load A (4 rounds → 128 rows) + B (same as w4a16_gemm_t).
+    #define M128_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col      = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 4; rnd++) { \
+                unsigned int row = (unsigned int)(rnd * 32) + a_row_base; \
+                unsigned int gr  = cta_m + row; \
+                cp_async_pred_16(&smem_A[(buf)][row][a_col], \
+                    &A[(unsigned long long)gr * K + gc], \
+                    (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int kp  = threadIdx.x >> 3; \
+            unsigned int ns  = (threadIdx.x & 7) << 4; \
+            unsigned int gke = (kb) + (kp << 1); \
+            unsigned int gns = cta_n + ns; \
+            cp_async_pred_16(&smem_Bp[(buf)][kp][ns], \
+                &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
+                (gke + 1 <= K) && (gns + 15 < N)); \
+            if (kp < K_STEP_T / GROUP_SIZE) { \
+                unsigned int sg = (kb) / GROUP_SIZE + kp; \
+                cp_async_pred_16(&smem_Bs[(buf)][kp][ns], \
+                    &B_scale[(unsigned long long)sg * N + gns], \
+                    (gns + 15 < N)); \
+            } \
+        } \
+    } while(0)
+
+    // Dequant B tile: identical to w4a16_gemm_t's DEQUANT_T.
+    #define M128_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; *(unsigned char*)&f1 = sb1; \
+        float sv0 = (float)f0 * scale2, sv1 = (float)f1 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv0; \
+            float hi = smem_LUT[packed >> 4]  * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp[(buf)][kp][my_n]; \
+            float lo = smem_LUT[packed & 0xF] * sv1; \
+            float hi = smem_LUT[packed >> 4]  * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    // MMA for both M-chunks; B tile (smem_B_fp8) loaded once, reused by both.
+    #define M128_COMPUTE(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A[(a_buf)]; \
+        unsigned int fr0, fr1, a0, a1, a2, a3; \
+        /* Chunk 0: smem rows 0..63 */ \
+        fr0 = warp_m_offset + group_id; \
+        fr1 = fr0 + 8; \
+        a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8[nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc0[nt][0]),"=f"(acc0[nt][1]),"=f"(acc0[nt][2]),"=f"(acc0[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc0[nt][0]),"f"(acc0[nt][1]),"f"(acc0[nt][2]),"f"(acc0[nt][3])); \
+        } \
+        /* Chunk 1: smem rows 64..127 (offset M_TILE=64) */ \
+        fr0 = M_TILE + warp_m_offset + group_id; \
+        fr1 = fr0 + 8; \
+        a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8[nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc1[nt][0]),"=f"(acc1[nt][1]),"=f"(acc1[nt][2]),"=f"(acc1[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc1[nt][0]),"f"(acc1[nt][1]),"f"(acc1[nt][2]),"f"(acc1[nt][3])); \
+        } \
+    } while(0)
+
+    // Pipeline: same double-buffer structure as w4a16_gemm_t.
+    M128_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+    M128_DEQUANT(0);
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        M128_LOADS(nxt, k_base);
+        cp_async_commit();
+        M128_COMPUTE(cur);
+        cp_async_wait_all();
+        __syncthreads();
+        M128_DEQUANT(nxt);
+        __syncthreads();
+        cur = nxt;
+    }
+    M128_COMPUTE(cur);
+
+    #undef M128_LOADS
+    #undef M128_DEQUANT
+    #undef M128_COMPUTE
+
+    // Write chunk 0: rows [cta_m..cta_m+63]
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt * 8 + tid * 2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0 * N + c0] = __float2bfloat16(acc0[nt][0]);
+        if (r0 < M && c1 < N) C[r0 * N + c1] = __float2bfloat16(acc0[nt][1]);
+        if (r1 < M && c0 < N) C[r1 * N + c0] = __float2bfloat16(acc0[nt][2]);
+        if (r1 < M && c1 < N) C[r1 * N + c1] = __float2bfloat16(acc0[nt][3]);
+    }
+    // Write chunk 1: rows [cta_m+64..cta_m+127]
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt * 8 + tid * 2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + M_TILE + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0 * N + c0] = __float2bfloat16(acc1[nt][0]);
+        if (r0 < M && c1 < N) C[r0 * N + c1] = __float2bfloat16(acc1[nt][1]);
+        if (r1 < M && c0 < N) C[r1 * N + c0] = __float2bfloat16(acc1[nt][2]);
+        if (r1 < M && c1 < N) C[r1 * N + c1] = __float2bfloat16(acc1[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// M128 variant of fp8_gemm_t: BF16 A × FP8 B, 2 M-chunks per CTA.
+//
+// For out_proj (K=2048, N=2048) and paged Q/K/V: halves the number of
+// times B is read from DRAM (8 m-tile groups vs 16 at M=1015).
+//
+// SMEM: A 2×128×40×2=20480B, B 2×128×32=8192B ≈ 28.7KB → 3 blocks/SM.
+// Grid: (ceil(N/128), ceil(M/128), 1)  Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__
+__launch_bounds__(128, 3)
+void fp8_gemm_t_m128(
+    const __nv_bfloat16* __restrict__ A,       // [M, K] BF16
+    const unsigned char* __restrict__ B_fp8,   // [N, K] FP8 E4M3
+    __nv_bfloat16* __restrict__ C,             // [M, N] BF16
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * (2 * M_TILE);
+    if (cta_m >= M) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A[2][2 * M_TILE][K_STEP_T + PAD_T];  // 20480 B
+    __shared__ unsigned char  smem_B[2][N_TILE_LG][K_STEP_T];            //  8192 B
+
+    float acc0[16][4], acc1[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc0[i][0] = 0.f; acc0[i][1] = 0.f; acc0[i][2] = 0.f; acc0[i][3] = 0.f;
+        acc1[i][0] = 0.f; acc1[i][1] = 0.f; acc1[i][2] = 0.f; acc1[i][3] = 0.f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+
+    // Load A (BF16, 4 rounds → 128 rows) + B (FP8, same as fp8_gemm_t).
+    #define FGM128_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 4; rnd++) { \
+                unsigned int row = (unsigned int)(rnd * 32) + a_row_base; \
+                unsigned int gr  = cta_m + row; \
+                cp_async_pred_16(&smem_A[(buf)][row][a_col], \
+                    &A[(unsigned long long)gr * K + gc], \
+                    (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int my_n = threadIdx.x; \
+            unsigned int gn = cta_n + my_n; \
+            bool valid = (gn < N) && ((kb) + 31 < K); \
+            cp_async_pred_16(&smem_B[(buf)][my_n][0], \
+                &B_fp8[(unsigned long long)gn * K + (kb)], valid); \
+            cp_async_pred_16(&smem_B[(buf)][my_n][16], \
+                &B_fp8[(unsigned long long)gn * K + (kb) + 16], valid); \
+        } \
+    } while(0)
+
+    // FP8 MMA for both M-chunks; B tile loaded once and reused.
+    #define FGM128_COMPUTE(a_buf, b_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A[(a_buf)]; \
+        unsigned int fr0, fr1, a0, a1, a2, a3; \
+        /* Chunk 0: smem rows 0..63 */ \
+        fr0 = warp_m_offset + group_id; \
+        fr1 = fr0 + 8; \
+        a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B[(b_buf)][nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B[(b_buf)][nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc0[nt][0]),"=f"(acc0[nt][1]),"=f"(acc0[nt][2]),"=f"(acc0[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc0[nt][0]),"f"(acc0[nt][1]),"f"(acc0[nt][2]),"f"(acc0[nt][3])); \
+        } \
+        /* Chunk 1: smem rows 64..127 */ \
+        fr0 = M_TILE + warp_m_offset + group_id; \
+        fr1 = fr0 + 8; \
+        a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B[(b_buf)][nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B[(b_buf)][nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc1[nt][0]),"=f"(acc1[nt][1]),"=f"(acc1[nt][2]),"=f"(acc1[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc1[nt][0]),"f"(acc1[nt][1]),"f"(acc1[nt][2]),"f"(acc1[nt][3])); \
+        } \
+    } while(0)
+
+    FGM128_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        FGM128_LOADS(nxt, k_base);
+        cp_async_commit();
+        FGM128_COMPUTE(cur, cur);
+        cp_async_wait_all();
+        __syncthreads();
+        cur = nxt;
+    }
+    FGM128_COMPUTE(cur, cur);
+
+    #undef FGM128_LOADS
+    #undef FGM128_COMPUTE
+
+    // Write chunk 0: rows [cta_m..cta_m+63]
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt * 8 + tid * 2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0 * N + c0] = __float2bfloat16(acc0[nt][0]);
+        if (r0 < M && c1 < N) C[r0 * N + c1] = __float2bfloat16(acc0[nt][1]);
+        if (r1 < M && c0 < N) C[r1 * N + c0] = __float2bfloat16(acc0[nt][2]);
+        if (r1 < M && c1 < N) C[r1 * N + c1] = __float2bfloat16(acc0[nt][3]);
+    }
+    // Write chunk 1: rows [cta_m+64..cta_m+127]
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt * 8 + tid * 2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + M_TILE + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0 * N + c0] = __float2bfloat16(acc1[nt][0]);
+        if (r0 < M && c1 < N) C[r0 * N + c1] = __float2bfloat16(acc1[nt][1]);
+        if (r1 < M && c0 < N) C[r1 * N + c0] = __float2bfloat16(acc1[nt][2]);
+        if (r1 < M && c1 < N) C[r1 * N + c1] = __float2bfloat16(acc1[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// M128 variant of fp8_fp8_gemm_t: FP8 A × FP8 B, 2 M-chunks per CTA.
+//
+// For Q/K/V projections in cache-skip prefill path (FP8 activations):
+// halves B re-reads. Uses 3 blocks/SM (not 6) to avoid register spilling:
+// dual acc0+acc1 need ~145 regs/thread; 3 blocks allows 170 regs/thread.
+//
+// SMEM: Af 2×128×32=8192B, Bf 2×128×32=8192B ≈ 16KB, 3 blocks → 48KB/SM.
+// Grid: (ceil(N/128), ceil(M/128), 1)  Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__
+__launch_bounds__(128, 3)
+void fp8_fp8_gemm_t_m128(
+    const unsigned char* __restrict__ A_fp8,  // [M, K] FP8 E4M3
+    const unsigned char* __restrict__ B_fp8,  // [N, K] FP8 E4M3
+    __nv_bfloat16* __restrict__ C,            // [M, N] BF16
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * (2 * M_TILE);
+    if (cta_m >= M) return;
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ unsigned char smem_Af[2][2 * M_TILE][A_FP8_STRIDE];  //  8192 B
+    __shared__ unsigned char smem_Bf[2][N_TILE_LG][K_STEP_T];        //  8192 B
+
+    float acc0[16][4], acc1[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc0[i][0] = 0.f; acc0[i][1] = 0.f; acc0[i][2] = 0.f; acc0[i][3] = 0.f;
+        acc1[i][0] = 0.f; acc1[i][1] = 0.f; acc1[i][2] = 0.f; acc1[i][3] = 0.f;
+    }
+
+    // Load A (FP8, 2 rounds → 128 rows) + B (FP8, same as fp8_fp8_gemm_t).
+    #define FFM128_LOADS(buf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 1; \
+            unsigned int a_col = (threadIdx.x & 1) << 4; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int row = (unsigned int)(rnd * 64) + a_row_base; \
+                unsigned int gr  = cta_m + row; \
+                cp_async_pred_16(&smem_Af[(buf)][row][a_col], \
+                    &A_fp8[(unsigned long long)gr * K + gc], \
+                    (gr < M) && (gc + 15 < K)); \
+            } \
+        } \
+        { \
+            unsigned int my_n = threadIdx.x; \
+            unsigned int gn = cta_n + my_n; \
+            bool valid = (gn < N) && ((kb) + 31 < K); \
+            cp_async_pred_16(&smem_Bf[(buf)][my_n][0], \
+                &B_fp8[(unsigned long long)gn * K + (kb)], valid); \
+            cp_async_pred_16(&smem_Bf[(buf)][my_n][16], \
+                &B_fp8[(unsigned long long)gn * K + (kb) + 16], valid); \
+        } \
+    } while(0)
+
+    // FP8×FP8 MMA for both M-chunks; B loaded once, reused by both.
+    #define FFM128_COMPUTE(a_buf, b_buf) do { \
+        unsigned int fr0, fr1, a0, a1, a2, a3; \
+        /* Chunk 0: smem rows 0..63 */ \
+        fr0 = warp_m_offset + group_id; \
+        fr1 = fr0 + 8; \
+        a0 = *(const unsigned int*)&smem_Af[(a_buf)][fr0][4 * tid]; \
+        a1 = *(const unsigned int*)&smem_Af[(a_buf)][fr1][4 * tid]; \
+        a2 = *(const unsigned int*)&smem_Af[(a_buf)][fr0][16 + 4 * tid]; \
+        a3 = *(const unsigned int*)&smem_Af[(a_buf)][fr1][16 + 4 * tid]; \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_Bf[(b_buf)][nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_Bf[(b_buf)][nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc0[nt][0]),"=f"(acc0[nt][1]),"=f"(acc0[nt][2]),"=f"(acc0[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc0[nt][0]),"f"(acc0[nt][1]),"f"(acc0[nt][2]),"f"(acc0[nt][3])); \
+        } \
+        /* Chunk 1: smem rows 64..127 */ \
+        fr0 = M_TILE + warp_m_offset + group_id; \
+        fr1 = fr0 + 8; \
+        a0 = *(const unsigned int*)&smem_Af[(a_buf)][fr0][4 * tid]; \
+        a1 = *(const unsigned int*)&smem_Af[(a_buf)][fr1][4 * tid]; \
+        a2 = *(const unsigned int*)&smem_Af[(a_buf)][fr0][16 + 4 * tid]; \
+        a3 = *(const unsigned int*)&smem_Af[(a_buf)][fr1][16 + 4 * tid]; \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_Bf[(b_buf)][nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_Bf[(b_buf)][nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc1[nt][0]),"=f"(acc1[nt][1]),"=f"(acc1[nt][2]),"=f"(acc1[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc1[nt][0]),"f"(acc1[nt][1]),"f"(acc1[nt][2]),"f"(acc1[nt][3])); \
+        } \
+    } while(0)
+
+    FFM128_LOADS(0, 0);
+    cp_async_commit();
+    cp_async_wait_all();
+    __syncthreads();
+
+    int cur = 0;
+    for (unsigned int k_base = K_STEP_T; k_base < K; k_base += K_STEP_T) {
+        int nxt = 1 - cur;
+        FFM128_LOADS(nxt, k_base);
+        cp_async_commit();
+        FFM128_COMPUTE(cur, cur);
+        cp_async_wait_all();
+        __syncthreads();
+        cur = nxt;
+    }
+    FFM128_COMPUTE(cur, cur);
+
+    #undef FFM128_LOADS
+    #undef FFM128_COMPUTE
+
+    // Write chunk 0: rows [cta_m..cta_m+63]
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt * 8 + tid * 2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0 * N + c0] = __float2bfloat16(acc0[nt][0]);
+        if (r0 < M && c1 < N) C[r0 * N + c1] = __float2bfloat16(acc0[nt][1]);
+        if (r1 < M && c0 < N) C[r1 * N + c0] = __float2bfloat16(acc0[nt][2]);
+        if (r1 < M && c1 < N) C[r1 * N + c1] = __float2bfloat16(acc0[nt][3]);
+    }
+    // Write chunk 1: rows [cta_m+64..cta_m+127]
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt * 8 + tid * 2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + M_TILE + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0 * N + c0] = __float2bfloat16(acc1[nt][0]);
+        if (r0 < M && c1 < N) C[r0 * N + c1] = __float2bfloat16(acc1[nt][1]);
+        if (r1 < M && c0 < N) C[r1 * N + c0] = __float2bfloat16(acc1[nt][2]);
+        if (r1 < M && c1 < N) C[r1 * N + c1] = __float2bfloat16(acc1[nt][3]);
+    }
+}

--- a/tests/run_all_models.py
+++ b/tests/run_all_models.py
@@ -231,6 +231,24 @@ TPEP_ROUNDS = [
 ]
 
 
+# ─── EP=4 rounds (4-node) ────────────────────────────────────────────────
+# The 397B NVFP4 (~200 GB across 512 experts) only fits with all four GB10
+# nodes in expert-parallel (EP=4, TP=1) — num_key_value_heads=2 can't shard
+# across 4 TP ranks. This harness's multi-rank driver (run_ep2_round) launches
+# exactly 2 ranks (head + one worker via ATLAS_WORKER_IP), so it CANNOT bring
+# up a 4-node EP=4 deployment as-is; generalizing the driver to N ranks is a
+# separate change.
+#
+# These specs are therefore recorded but SKIPPED by default. The real 4-node
+# smoke test runs via /home/cluster/launch-atlas-ep4.sh (see the notavault-atlas
+# notes / docs/DEPLOYMENT.md). Once the driver gains N-rank support, set
+# ATLAS_ENABLE_EP4=1 to execute these here.
+EP4_ROUNDS: List[TestSpec] = [
+    TestSpec("397B-nvfp4-ep4", "nvidia/Qwen3.5-397B-A17B-NVFP4",
+             ep_size=4, skip_longctx=True),
+]
+
+
 # ─── Docker helpers ────────────────────────────────────────────────────
 
 def sh(cmd, check=True, capture=False, timeout=None):
@@ -743,6 +761,24 @@ def main():
                 all_results[spec.label] = res
             with open(os.path.join(RESULTS_DIR, "_partial.json"), "w") as f:
                 json.dump(all_results, f, indent=2, default=str)
+
+    # EP=4 (4-node). Recorded in EP4_ROUNDS but skipped by default: run_ep2_round
+    # launches only 2 ranks, so it can't bring up a 4-node deployment. The real
+    # smoke test is /home/cluster/launch-atlas-ep4.sh. Opt in with ATLAS_ENABLE_EP4=1
+    # ONLY after run_ep2_round is generalized to N ranks (separate change).
+    if EP4_ROUNDS:
+        if os.environ.get("ATLAS_ENABLE_EP4") == "1":
+            for spec in EP4_ROUNDS:
+                res = run_ep2_round(spec)  # NOTE: requires N-rank driver support
+                if res:
+                    all_results[spec.label] = res
+                with open(os.path.join(RESULTS_DIR, "_partial.json"), "w") as f:
+                    json.dump(all_results, f, indent=2, default=str)
+        else:
+            labels = ", ".join(s.label for s in EP4_ROUNDS)
+            print(f"\n[skip] EP=4 round(s) [{labels}]: need a 4-node EP=4 deployment "
+                  f"(this harness launches 2 ranks). Run /home/cluster/launch-atlas-ep4.sh, "
+                  f"or set ATLAS_ENABLE_EP4=1 after the driver gains N-rank support.")
 
     # Final dump
     with open(os.path.join(RESULTS_DIR, "all_results.json"), "w") as f:


### PR DESCRIPTION
## What
Adds the `qwen3.5-397b-a17b` NVFP4 kernel target for `nvidia/Qwen3.5-397B-A17B-NVFP4`, so a GB10 4-node EP=4 deployment resolves to a compiled kernel target instead of failing dispatch.

- `kernels/gb10/qwen3.5-397b-a17b/MODEL.toml` (model root): two `[[model_types]]` entries — `qwen3_5_moe` and `qwen3_6_moe`, both at `hidden_size = 4096`. The NVFP4 checkpoint is mrope-interleaved, so `parse_config` rewrites its `model_type` to `qwen3_6_moe` (mirrors the `qwen3.5-122b-a10b` dual-entry pattern). `[behavior]` matches the model's tested profile: thinking off by default, `max_thinking_budget=128`, no MTP.
- `kernels/gb10/qwen3.5-397b-a17b/nvfp4/`: `gated_delta_rule.cu`, `moe_w4a16_grouped_gemm.cu`, `w4a16_gemm.cu`, `KERNEL.toml` copied from `qwen3.5-35b-a3b/nvfp4/` (these tile over runtime M/N/K and branch on a runtime `num_experts`; the softmax router `moe_topk_softmax` is sized `MAX_EXPERTS=512`, fitting the 512 experts exactly). `KERNEL.md` rewritten for the 397B.
- `docker/gb10/qwen3.5-397b-a17b/nvfp4/{Dockerfile,QUICKSTART.md}`: per-model image for the 4-node EP=4 deployment.
- `tests/run_all_models.py`: a recorded-but-skipped EP4 round (the harness's multi-rank driver launches 2 ranks; the real EP=4 test runs via the 4-node launcher).

## Why
Launching `nvidia/Qwen3.5-397B-A17B-NVFP4` on 4×GB10 (EP=4/TP=1) currently fails at dispatch:
```
Error: No compiled kernel target matches model_type 'qwen3_6_moe' / hidden_size=4096
```
No existing target declares `qwen3_6_moe @ 4096` (the 35B is a `qwen3_5_moe` wildcard; the 3.6-35B is `qwen3_6_moe @ 2048`). EP=4/TP=1 is required because `num_key_value_heads=2` cannot shard across 4 TP ranks.

## Benchmarks / Verification
Built the per-model image and ran a 4-node EP=4 smoke test. The dispatch failure is resolved and the model initializes end-to-end up to weight loading:
```
Quantization config: method="modelopt", algo="NVFP4", 184 module(s) in ignore list
Model config: 60 layers, 15 attention, 45 SSM, 512 experts, head_dim=256
Selected kernel target: (sm_121, qwen3.5-397b-a17b, nvfp4) (88 modules)
Parallelism: global rank 0/4 (tp_rank=0/1, ep_rank=0/4), local experts [0, 128)
NCCL INFO comm ... rank 0 nRanks 4 nNodes 4 ...
NCCL INFO Channel 00/08 ... 07/08 : 0 1 2 3
NCCL INFO ncclCommInitRank ... Init COMPLETE
Fast-loading shard 10/11 ...
```
- `No compiled kernel target matches` errors: **0** (was the blocker)
- Kernel target selected: `qwen3.5-397b-a17b` (88 PTX modules)
- NCCL ring formed across all 4 nodes (8 channels, `Init COMPLETE`)
- All 4 rank containers started; 10/11 weight shards loaded — the target is reachable and exercised end-to-end up to the separate loader issue below.

Throughput vs the vLLM baseline (~19.6 tok/s, no-MTP, same 4×GB10) is not yet measured — see the known limitation.

## Known limitation (separate, pre-existing — not introduced here)
Full serving is blocked downstream of dispatch by a weight-loader gap: the NVFP4 checkpoint keeps shared experts in BF16 (184-module `ignore` list), but `Qwen35WeightLoader` requires a `weight_scale` for `shared_expert.gate_proj`:
```
Error: Failed to build model
Caused by: Weight 'model.language_model.layers.0.mlp.shared_expert.gate_proj.weight_scale' not found in store
```
Independent of the kernel target added here; involves an Atlas design decision. Tracked in #97.

## Authorship
AI-generated using Claude Code (Opus 4.7).
