### PR TITLE
spark-model: handle FP32 MiniMax ModelOpt dense weights

### DIFF
--- a/crates/spark-model/src/weight_loader/minimax.rs
+++ b/crates/spark-model/src/weight_loader/minimax.rs
@@ -160,13 +160,12 @@ impl ModelWeightLoader for MinimaxM2WeightLoader {
              -> Result<(DenseWeight, QuantizedWeight)> {
                 let wkey = format!("{p}.{name}.weight");
                 let scale_key = format!("{p}.{name}.weight_scale_inv");
-                let (src_ptr, src_is_fp8) = {
+                let (src_ptr, src_dtype) = {
                     let t = store.get(&wkey)?;
-                    (
-                        t.ptr,
-                        t.dtype == spark_runtime::weights::WeightDtype::FP8E4M3,
-                    )
+                    (t.ptr, t.dtype)
                 };
+                let src_is_fp8 = src_dtype == spark_runtime::weights::WeightDtype::FP8E4M3;
+                let src_is_f32 = src_dtype == spark_runtime::weights::WeightDtype::FP32;
                 let scale_ptr = if src_is_fp8 && store.contains(&scale_key) {
                     Some(store.get(&scale_key)?.ptr)
                 } else {
@@ -202,15 +201,14 @@ impl ModelWeightLoader for MinimaxM2WeightLoader {
                     }
                 } else {
                     // M2.7-NVFP4 path: source is BF16 and dense_auto
-                    // returned the raw mmap'd store ptr (no dequant
-                    // alloc). After NVFP4 quantization the BF16 source
-                    // is no longer needed. Free it to recover ~22 GB
-                    // per rank (4 projections × 62 layers × ~88 MB),
-                    // which is the headroom needed for the MoE prefill
-                    // transpose to fit on a 122 GB GB10. WeightStore
-                    // retains a stale ptr — safe because nothing reads
-                    // attention weights by name after load_layers
-                    // returns.
+                    // or FP32. For FP32, dense_auto allocated a BF16
+                    // conversion buffer that is no longer needed once
+                    // NVFP4 is built. The original dense source can also
+                    // be released because attention forward only reads
+                    // q/k/v/o_nvfp4 after load_layers returns.
+                    if src_is_f32 {
+                        gpu.free(dense_w.weight)?;
+                    }
                     gpu.free(src_ptr)?;
                 }
                 Ok((

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -229,10 +229,13 @@ pub(crate) fn quantized_any(
             qctx.stream,
         ),
         Nvfp4Variant::Bf16Raw => {
-            // Raw BF16/FP16 fine-tune: load the dense weight then runtime-quantize.
-            let w = store.get(&format!("{prefix}.weight"))?;
-            let bf16 = DenseWeight { weight: w.ptr };
-            quantize_to_nvfp4(
+            // Raw BF16/FP32 fine-tune: load the dense weight then runtime-quantize.
+            let weight_key = format!("{prefix}.weight");
+            let source = store.get(&weight_key)?;
+            let source_dtype = source.dtype;
+            let source_ptr = source.ptr;
+            let bf16 = dense_auto(store, &weight_key, gpu)?;
+            let result = quantize_to_nvfp4(
                 &bf16,
                 n,
                 k,
@@ -240,7 +243,12 @@ pub(crate) fn quantized_any(
                 qctx.absmax_k,
                 qctx.quantize_k,
                 qctx.stream,
-            )
+            )?;
+            if source_dtype != WeightDtype::BF16 {
+                gpu.free(bf16.weight)?;
+                gpu.free(source_ptr)?;
+            }
+            Ok(result)
         }
     }
 }

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -201,24 +201,28 @@ pub(super) fn bf16_bytes_to_f32(bytes: [u8; 2]) -> f32 {
     f32::from_bits((bits as u32) << 16)
 }
 
-/// Load a dense weight, auto-detecting FP8 block-scaled vs BF16.
+/// Load a dense weight, auto-detecting FP8 block-scaled vs BF16/FP32.
 ///
 /// If the tensor is FP8E4M3 and a `{name_without_.weight}.weight_scale_inv` key exists,
-/// performs block-scaled dequantization to BF16. Otherwise returns the raw pointer (BF16).
+/// performs block-scaled dequantization to BF16. FP32 dense tensors are converted
+/// to BF16 because Atlas dense kernels consume BF16.
 pub(crate) fn dense_auto(
     store: &WeightStore,
     name: &str,
     gpu: &dyn GpuBackend,
 ) -> Result<DenseWeight> {
     let w = store.get(name)?;
-    if w.dtype == WeightDtype::FP8E4M3 {
-        // Derive prefix: "foo.q_proj.weight" → "foo.q_proj"
-        let prefix = name
-            .strip_suffix(".weight")
-            .ok_or_else(|| anyhow::anyhow!("FP8 tensor {name} doesn't end with .weight"))?;
-        dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)
-    } else {
-        Ok(DenseWeight { weight: w.ptr })
+    match w.dtype {
+        WeightDtype::BF16 => Ok(DenseWeight { weight: w.ptr }),
+        WeightDtype::FP32 => dense_f32_safe(store, name, gpu),
+        WeightDtype::FP8E4M3 => {
+            // Derive prefix: "foo.q_proj.weight" -> "foo.q_proj".
+            let prefix = name
+                .strip_suffix(".weight")
+                .ok_or_else(|| anyhow::anyhow!("FP8 tensor {name} doesn't end with .weight"))?;
+            dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)
+        }
+        other => anyhow::bail!("dense_auto: unsupported dtype {:?} for {name}", other),
     }
 }
 


### PR DESCRIPTION
## What
- Treat FP32 dense tensors from ModelOpt checkpoints as convertible dense weights instead of assuming every non-FP8 tensor is already BF16.
- Route MiniMax ignored attention projections through `dense_auto` before NVFP4 quantization and free converted/source buffers correctly.

## Why
The NVIDIA MiniMax M2.7 NVFP4 checkpoint can store ignored attention projections as FP32. Atlas previously treated all non-FP8 dense tensors as BF16, which corrupts those projections before NVFP4 quantization and breaks generation.

## Benchmarks
- `cargo fmt --all -- --check`
- `ATLAS_SKIP_BUILD=1 cargo check -p spark-model`
- `LIBRARY_PATH=/tmp/atlas-nccl-link LD_LIBRARY_PATH=/tmp/atlas-nccl-link ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=minimax-m2-229b ATLAS_TARGET_QUANT=nvfp4 cargo build --release -p spark-server`
- Runtime smoke on EP=2 across `godspeed` and `savitar` with `nvidia/MiniMax-M2.7-NVFP4`: `/v1/models` listed the model, and chat prompts for `capital of Japan` and `2+2` returned expected answers.

This is a correctness fix, so I did not collect before/after performance timings.

## Authorship
AI-generated with Codex under operator direction. No human-only authored sections.
