### PR TITLE
spark-server: avoid orphan tool messages in F32

### DIFF
--- a/crates/spark-server/src/api/chat_phases.rs
+++ b/crates/spark-server/src/api/chat_phases.rs
@@ -136,9 +136,10 @@ pub(super) fn apply_failure_guards(req: &mut ChatCompletionRequest) -> F23Progre
         );
     }
 
-    // F32: duplicate failed tool_result at conversation tail.
+    // F32: surface the most recent failed tool_result without creating
+    // an orphan role=tool message that vendor templates reject.
     if f32_reposition_failed_tool_result(&mut req.messages) {
-        tracing::info!("F32: duplicated most-recent failed tool_result at conversation tail");
+        tracing::info!("F32: surfaced most-recent failed tool_result in a runtime reminder");
     }
 
     // F39: cross-turn permanent-failure circuit breaker.

--- a/crates/spark-server/src/api/failures/circuit.rs
+++ b/crates/spark-server/src/api/failures/circuit.rs
@@ -90,8 +90,14 @@ pub fn f32_reposition_failed_tool_result(
     {
         return false;
     }
-    let dup = messages[idx].clone();
-    messages.push(dup);
+    let failed_tool_result = messages[idx].content.text.trim();
+    let reminder = format!(
+        "\n\n<system-reminder>\nThe most recent failed tool result is still relevant. \
+         Treat it as an observed tool failure and do not retry the same call unless \
+         the approach materially changes.\n<failed_tool_result>\n{failed_tool_result}\n\
+         </failed_tool_result>\n</system-reminder>"
+    );
+    append_f7_reminder_to_last_user(messages, &reminder);
     true
 }
 

--- a/crates/spark-server/src/api/failures/circuit_tests.rs
+++ b/crates/spark-server/src/api/failures/circuit_tests.rs
@@ -5,10 +5,91 @@
 //! `circuit.rs` stays under the 500-LoC file-size-cap.
 
 use super::circuit::{
-    F39PermanentFailureMatch, f39_build_circuit_breaker_banner, f39_class_label,
-    f39_extract_binary_name,
+    F39PermanentFailureMatch, f32_reposition_failed_tool_result, f39_build_circuit_breaker_banner,
+    f39_class_label, f39_extract_binary_name,
 };
 use super::classification::F37FailureClass;
+
+fn msg(role: &str, text: &str) -> crate::openai::IncomingMessage {
+    crate::openai::IncomingMessage {
+        role: role.to_string(),
+        content: crate::openai::ParsedContent {
+            text: text.to_string(),
+            images: Vec::new(),
+        },
+        tool_calls: None,
+        tool_call_id: None,
+        name: None,
+    }
+}
+
+fn assistant_tool_call(id: &str) -> crate::openai::IncomingMessage {
+    crate::openai::IncomingMessage {
+        role: "assistant".to_string(),
+        content: crate::openai::ParsedContent::default(),
+        tool_calls: Some(vec![crate::tool_parser::IncomingToolCall {
+            id: Some(id.to_string()),
+            function: crate::tool_parser::IncomingFunction {
+                name: "Bash".to_string(),
+                arguments: r#"{"command":"cargo"}"#.to_string(),
+            },
+        }]),
+        tool_call_id: None,
+        name: None,
+    }
+}
+
+fn tool_result(id: &str, text: &str) -> crate::openai::IncomingMessage {
+    crate::openai::IncomingMessage {
+        role: "tool".to_string(),
+        content: crate::openai::ParsedContent {
+            text: text.to_string(),
+            images: Vec::new(),
+        },
+        tool_calls: None,
+        tool_call_id: Some(id.to_string()),
+        name: None,
+    }
+}
+
+// ── f32_reposition_failed_tool_result ────────────────────────────
+
+#[test]
+fn f32_surfaces_error_without_orphan_tool_message() {
+    let mut messages = vec![
+        msg("user", "do it"),
+        assistant_tool_call("toolu_1"),
+        tool_result("toolu_1", "[tool error]\ncargo: command not found"),
+        msg("user", "intervening 1"),
+        msg("user", "intervening 2"),
+    ];
+    let before = messages.len();
+
+    assert!(f32_reposition_failed_tool_result(&mut messages));
+
+    assert_eq!(messages.len(), before);
+    let last = messages.last().unwrap();
+    assert_eq!(last.role, "user");
+    assert!(last.content.text.contains("<failed_tool_result>"));
+    assert!(
+        last.content
+            .text
+            .contains("[tool error]\ncargo: command not found")
+    );
+}
+
+#[test]
+fn f32_no_op_when_failed_tool_is_already_fresh() {
+    let mut messages = vec![
+        msg("user", "do it"),
+        assistant_tool_call("toolu_1"),
+        tool_result("toolu_1", "[tool error]\ncargo: command not found"),
+    ];
+    let before = messages.len();
+
+    assert!(!f32_reposition_failed_tool_result(&mut messages));
+    assert_eq!(messages.len(), before);
+}
 
 // ── f39_extract_binary_name ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary

F32 no longer clones an old failed `role: tool` message onto the end of the conversation. It now surfaces the failed tool result in a runtime reminder, preserving OpenAI tool-message ordering so MiniMax and other vendor templates do not reject the prompt as an orphan tool result.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `LIBRARY_PATH=/opt/vllm/nccl-blackwell/lib LD_LIBRARY_PATH=/opt/vllm/nccl-blackwell/lib ATLAS_SKIP_BUILD=1 cargo test -p spark-server f32 -- --nocapture`
- [x] `LIBRARY_PATH=/opt/vllm/nccl-blackwell/lib LD_LIBRARY_PATH=/opt/vllm/nccl-blackwell/lib ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p spark-server --tests -- -Dwarnings`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` still fails on this Linux host before this patch because the workspace pulls `objc2`, which requires an Apple target.
- [ ] `bash scripts/check-license-headers.sh` could not run because `scripts/check-license-headers.sh` is not present in this checkout.
- [ ] `typos` could not run because `typos` is not installed on this host.
- [x] Tested against a real model / hardware: deployed on godspeed + savitar with `nvidia/MiniMax-M2.7-NVFP4` EP=2; a synthetic F32 regression request now returns HTTP 200 and logs `F32: surfaced most-recent failed tool_result in a runtime reminder`; Hermes smoke test no longer hits the MiniMax template 400.
- [x] Added focused unit coverage for stale failed-tool surfacing and the already-fresh no-op case.

## Notes for reviewers

The previous F32 behavior attempted to make a stale failure fresh by duplicating the original tool result. That creates invalid OpenAI history whenever messages after the original assistant/tool pair are not assistant tool calls, and MiniMax's template rejects it with "Message has tool role, but there was no previous assistant message with a tool call".

This keeps the guard's intent while staying inside the template contract: the stale failure is copied into a system-reminder appended to the latest user/tool message instead of being represented as a new `role: tool` turn.

Benchmarks: not run; this is a prompt-history correctness fix, not a performance-oriented change.

Authorship: AI-generated by Codex under human operator direction; no human-written code sections are claimed.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
