### PR TITLE
fix(site,docs): replace expired Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <a href="LICENSE"><img alt="License: AGPLv3" src="https://img.shields.io/badge/license-AGPLv3-yellow?style=flat-square"></a>
     <a href="#quick-start"><img alt="Pure Rust" src="https://img.shields.io/badge/runtime-pure%20Rust-orange?style=flat-square"></a>
     <a href="https://hub.docker.com/r/avarok/atlas-gb10"><img alt="Docker Hub" src="https://img.shields.io/badge/Docker%20Hub-avarok%2Fatlas--gb10-2496ED?style=flat-square&logo=docker&logoColor=white"></a>
-    <a href="https://discord.gg/DwF3brBMpw"><img alt="Discord" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FDwF3brBMpw%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&label=discord&suffix=%20members&style=flat-square&logo=discord&logoColor=white&color=5865F2"></a>
+    <a href="https://discord.gg/6vDbKaKrKD"><img alt="Discord" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2F6vDbKaKrKD%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&label=discord&suffix=%20members&style=flat-square&logo=discord&logoColor=white&color=5865F2"></a>
   </p>
 </p>
 

--- a/site/src/lib/components/Contact.svelte
+++ b/site/src/lib/components/Contact.svelte
@@ -37,7 +37,7 @@
           href={discordUrl}
           style="color: var(--cyan); text-decoration: none; font-weight: 600; font-size: 0.88rem; display: inline-block; margin-top: 0.5rem;"
         >
-          discord.gg/DwF3brBMpw
+          {discordUrl.replace('https://', '')}
         </a>
       </div>
       <div class="card">

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -1,7 +1,7 @@
 // Central data source for all site content.
 // Any copy changes land here. Components are just presentation.
 
-export const discordUrl = 'https://discord.gg/DwF3brBMpw';
+export const discordUrl = 'https://discord.gg/6vDbKaKrKD';
 // The post that started it all.
 export const firstPostUrl = 'https://www.reddit.com/r/LocalLLaMA/comments/1rkefjw/solved_the_dgx_spark_102_stable_toks_qwen3535ba3b/';
 // Second Atlas post; testimonial comments came from this thread.


### PR DESCRIPTION
The old invite `discord.gg/DwF3brBMpw` is **expired** — the Discord API returns `"Invite is expired"`, so the README member-count badge breaks and every Discord link on atlasinference.io is dead. The new invite `discord.gg/6vDbKaKrKD` is valid (verified live; ~598 members).

## Changes
- **README.md** — badge `href` + the dynamic member-count API URL (both occurrences on the badge line)
- **site/src/lib/data.js** — the `discordUrl` SSOT constant (drives Hero, Nav, Footer, Contact, testimonial sources)
- **site/src/lib/components/Contact.svelte** — derive the displayed link text from `discordUrl` instead of hardcoding it, so the text can't drift from the href again

3 files, 3 lines. Branched off `origin/main` (not my `feat/stream-token-ids` branch) so the site deploys cleanly via the `site.yml` workflow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)