### PR TITLE
fix(site): add required --hosts to all sparkrun quick-start commands

### DIFF
--- a/site/scripts/gen-models.mjs
+++ b/site/scripts/gen-models.mjs
@@ -221,6 +221,11 @@ for (const file of files) {
   const topology = inferTopology(stem, top);
   const vendor = vendorOf(fam);
 
+  // sparkrun requires --hosts (it errors "No hosts specified" otherwise).
+  // Single-node recipes target one Spark -> localhost. EP=2/TP=2 recipes
+  // span two nodes, so show a two-host placeholder the user fills in.
+  const hostsArg =
+    topology === 'single' ? '--hosts localhost' : '--hosts <spark-1>,<spark-2>';
   const recipe = {
     displayName: recipeDisplay(stem),
     hfId: top.model || '',
@@ -228,7 +233,7 @@ for (const file of files) {
     quant: metadata.quantization || '',
     topology,
     recipeStem: stem,
-    command: `sparkrun run @atlas/${stem}`
+    command: `sparkrun run @atlas/${stem} ${hostsArg}`
   };
 
   if (!vendorMap.has(vendor)) vendorMap.set(vendor, new Map());

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -166,7 +166,7 @@ export const quickInstall = `uvx sparkrun setup install`;
 export const runCommand = 'curl -fsSL https://atlasinference.io/quickstart.sh | sh';
 // What the script does, spelled out (not shown in the terminal card).
 export const runCommandRaw =
-  'uvx sparkrun setup install && sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas';
+  'uvx sparkrun setup install && sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp --hosts localhost';
 
 // X / Twitter handle for Atlas.
 export const xHandle = '@atlasinference';

--- a/site/src/lib/models.generated.json
+++ b/site/src/lib/models.generated.json
@@ -13,7 +13,7 @@
             "quant": "fp8",
             "topology": "single",
             "recipeStem": "qwen3-coder-next-fp8",
-            "command": "sparkrun run @atlas/qwen3-coder-next-fp8"
+            "command": "sparkrun run @atlas/qwen3-coder-next-fp8 --hosts localhost"
           }
         ]
       },
@@ -27,7 +27,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "qwen3-next-80b-a3b-nvfp4",
-            "command": "sparkrun run @atlas/qwen3-next-80b-a3b-nvfp4"
+            "command": "sparkrun run @atlas/qwen3-next-80b-a3b-nvfp4 --hosts localhost"
           }
         ]
       },
@@ -41,7 +41,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "qwen3-vl-30b-a3b-nvfp4",
-            "command": "sparkrun run @atlas/qwen3-vl-30b-a3b-nvfp4"
+            "command": "sparkrun run @atlas/qwen3-vl-30b-a3b-nvfp4 --hosts localhost"
           }
         ]
       },
@@ -55,7 +55,7 @@
             "quant": "none",
             "topology": "single",
             "recipeStem": "qwen3.5-0.8b-bf16-atlas",
-            "command": "sparkrun run @atlas/qwen3.5-0.8b-bf16-atlas"
+            "command": "sparkrun run @atlas/qwen3.5-0.8b-bf16-atlas --hosts localhost"
           },
           {
             "displayName": "Qwen3.5 122B A10B NVFP4 EP=2",
@@ -64,7 +64,7 @@
             "quant": "nvfp4",
             "topology": "EP=2",
             "recipeStem": "qwen3.5-122b-a10b-nvfp4-ep2",
-            "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-ep2"
+            "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-ep2 --hosts <spark-1>,<spark-2>"
           },
           {
             "displayName": "Qwen3.5 122B A10B NVFP4 Single",
@@ -73,7 +73,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "qwen3.5-122b-a10b-nvfp4-single",
-            "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-single"
+            "command": "sparkrun run @atlas/qwen3.5-122b-a10b-nvfp4-single --hosts localhost"
           },
           {
             "displayName": "Qwen3.5 27B Dense NVFP4",
@@ -82,7 +82,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "qwen3.5-27b-dense-nvfp4",
-            "command": "sparkrun run @atlas/qwen3.5-27b-dense-nvfp4"
+            "command": "sparkrun run @atlas/qwen3.5-27b-dense-nvfp4 --hosts localhost"
           },
           {
             "displayName": "Qwen3.5 35B A3B NVFP4",
@@ -91,7 +91,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "qwen3.5-35b-a3b-nvfp4",
-            "command": "sparkrun run @atlas/qwen3.5-35b-a3b-nvfp4"
+            "command": "sparkrun run @atlas/qwen3.5-35b-a3b-nvfp4 --hosts localhost"
           }
         ]
       },
@@ -99,22 +99,13 @@
         "name": "Qwen3.6",
         "recipes": [
           {
-            "displayName": "Qwen3.6 27B Dense FP8",
+            "displayName": "Qwen3.6 27B FP8",
             "hfId": "Qwen/Qwen3.6-27B-FP8",
             "params": "27B",
             "quant": "fp8",
             "topology": "single",
-            "recipeStem": "qwen3.6-27b-dense-fp8-atlas",
-            "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-atlas"
-          },
-          {
-            "displayName": "Qwen3.6 27B Dense FP8 MTP",
-            "hfId": "Qwen/Qwen3.6-27B-FP8",
-            "params": "27B",
-            "quant": "fp8",
-            "topology": "single",
-            "recipeStem": "qwen3.6-27b-dense-fp8-mtp-atlas",
-            "command": "sparkrun run @atlas/qwen3.6-27b-dense-fp8-mtp-atlas"
+            "recipeStem": "qwen3.6-27b-fp8",
+            "command": "sparkrun run @atlas/qwen3.6-27b-fp8 --hosts localhost"
           },
           {
             "displayName": "Qwen3.6 27B FP8 MTP",
@@ -122,8 +113,8 @@
             "params": "27B",
             "quant": "fp8",
             "topology": "single",
-            "recipeStem": "qwen3.6-27b-fp8-mtp-atlas",
-            "command": "sparkrun run @atlas/qwen3.6-27b-fp8-mtp-atlas"
+            "recipeStem": "qwen3.6-27b-fp8-mtp",
+            "command": "sparkrun run @atlas/qwen3.6-27b-fp8-mtp --hosts localhost"
           },
           {
             "displayName": "Qwen3.6 35B A3B FP8 MTP",
@@ -131,8 +122,8 @@
             "params": "35B",
             "quant": "fp8",
             "topology": "single",
-            "recipeStem": "qwen3.6-35b-a3b-fp8-mtp-atlas",
-            "command": "sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp-atlas"
+            "recipeStem": "qwen3.6-35b-a3b-fp8-mtp",
+            "command": "sparkrun run @atlas/qwen3.6-35b-a3b-fp8-mtp --hosts localhost"
           },
           {
             "displayName": "Qwen3.6 35B A3B NVFP4",
@@ -140,8 +131,8 @@
             "params": "35B",
             "quant": "nvfp4",
             "topology": "single",
-            "recipeStem": "qwen3.6-35b-a3b-nvfp4-atlas",
-            "command": "sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4-atlas"
+            "recipeStem": "qwen3.6-35b-a3b-nvfp4",
+            "command": "sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4 --hosts localhost"
           }
         ]
       }
@@ -161,7 +152,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "gemma-4-26b-a4b-nvfp4",
-            "command": "sparkrun run @atlas/gemma-4-26b-a4b-nvfp4"
+            "command": "sparkrun run @atlas/gemma-4-26b-a4b-nvfp4 --hosts localhost"
           },
           {
             "displayName": "Gemma 4 31B NVFP4",
@@ -170,7 +161,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "gemma-4-31b-nvfp4",
-            "command": "sparkrun run @atlas/gemma-4-31b-nvfp4"
+            "command": "sparkrun run @atlas/gemma-4-31b-nvfp4 --hosts localhost"
           }
         ]
       }
@@ -190,7 +181,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "nemotron-3-nano-30b-a3b-nvfp4",
-            "command": "sparkrun run @atlas/nemotron-3-nano-30b-a3b-nvfp4"
+            "command": "sparkrun run @atlas/nemotron-3-nano-30b-a3b-nvfp4 --hosts localhost"
           }
         ]
       },
@@ -204,7 +195,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "nemotron-3-super-120b-a12b-nvfp4",
-            "command": "sparkrun run @atlas/nemotron-3-super-120b-a12b-nvfp4"
+            "command": "sparkrun run @atlas/nemotron-3-super-120b-a12b-nvfp4 --hosts localhost"
           }
         ]
       }
@@ -224,7 +215,7 @@
             "quant": "nvfp4",
             "topology": "single",
             "recipeStem": "mistral-small-4-119b-nvfp4",
-            "command": "sparkrun run @atlas/mistral-small-4-119b-nvfp4"
+            "command": "sparkrun run @atlas/mistral-small-4-119b-nvfp4 --hosts localhost"
           }
         ]
       }
@@ -244,7 +235,7 @@
             "quant": "nvfp4",
             "topology": "EP=2",
             "recipeStem": "minimax-m2.7-nvfp4-ep2",
-            "command": "sparkrun run @atlas/minimax-m2.7-nvfp4-ep2"
+            "command": "sparkrun run @atlas/minimax-m2.7-nvfp4-ep2 --hosts <spark-1>,<spark-2>"
           }
         ]
       }

--- a/site/static/quickstart.sh
+++ b/site/static/quickstart.sh
@@ -16,7 +16,12 @@ set -eu
 
 # The recipe to launch. Keep in lockstep with the site copy + atlas-recipes
 # SSOT (https://github.com/Avarok-Cybersecurity/atlas-recipes).
-RECIPE="qwen3.6-35b-a3b-fp8-mtp-atlas"
+RECIPE="qwen3.6-35b-a3b-fp8-mtp"
+
+# sparkrun requires a target host list (it errors "No hosts specified"
+# otherwise). Default to the local Spark; override with ATLAS_HOSTS for a
+# remote or multi-node target, e.g. ATLAS_HOSTS=10.0.0.1,10.0.0.2.
+HOSTS="${ATLAS_HOSTS:-localhost}"
 
 log() { printf '\033[1;36m[atlas]\033[0m %s\n' "$1" >&2; }
 err() { printf '\033[1;31m[atlas]\033[0m %s\n' "$1" >&2; }
@@ -33,5 +38,5 @@ else
   uvx sparkrun setup install
 fi
 
-log "Running @atlas/${RECIPE} ..."
-exec sparkrun run "@atlas/${RECIPE}"
+log "Running @atlas/${RECIPE} on ${HOSTS} ..."
+exec sparkrun run "@atlas/${RECIPE}" --hosts "${HOSTS}"


### PR DESCRIPTION
## Problem
sparkrun's `run` now **requires** a target host list. Every `sparkrun run @atlas/...` command on atlasinference.io/#try (and in the per-model grid) fails out of the box for new users:

> Error: No hosts specified. Use --hosts or configure defaults.

(Reported in the community thread.)

## Fix
Verified live on a DGX Spark that `--hosts localhost` is the correct single-node value (every sparkrun launch on the box used it successfully).

- **gen-models.mjs**: append `--hosts` to the generated per-model command — single-node → `--hosts localhost`; EP=2/TP=2 → `--hosts <spark-1>,<spark-2>` placeholder (they span two nodes).
- **models.generated.json**: regenerated. Also reflects the qwen3.6 family rename from atlas-recipes (drops the `-atlas` suffix).
- **quickstart.sh**: pass `--hosts` (default `localhost`, override via `ATLAS_HOSTS=ip1,ip2`) + track the renamed default recipe stem.
- **data.js** (`runCommandRaw`): same `--hosts` + renamed stem.

Built clean with vite; `quickstart.sh` passes `sh -n`.

## ⚠️ Merge order
This regenerates commands against the **renamed** qwen3.6 recipe stems, so it should land **together with / after** the atlas-recipes rename PR (Avarok-Cybersecurity/atlas-recipes#8 / #6). The qwen3.6 commands here reference the de-suffixed names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)