### PR TITLE
fix(api): accept max_thinking_tokens as alias for thinking_token_budget

### DIFF
--- a/crates/spark-server/src/openai/chat_request.rs
+++ b/crates/spark-server/src/openai/chat_request.rs
@@ -64,7 +64,10 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub thinking: Option<ThinkingConfig>,
     /// vLLM PR-style thinking budget (top-level integer).
-    #[serde(default)]
+    /// `max_thinking_tokens` is accepted as an alias — it's the intuitive
+    /// name several clients send, and silently dropping it left the budget
+    /// unenforced (reasoning ran unbounded). See community report 2026-06.
+    #[serde(default, alias = "max_thinking_tokens")]
     pub thinking_token_budget: Option<u32>,
     /// OpenAI-style reasoning effort: `{"reasoning": {"effort": "low"}}`
     #[serde(default)]
@@ -405,5 +408,32 @@ where
         RawStop::Str(s) => Ok(vec![s]),
         RawStop::Arr(v) => Ok(v),
         RawStop::Null(()) => Ok(Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod alias_tests {
+    use super::ChatCompletionRequest;
+
+    fn base(extra: &str) -> String {
+        format!(
+            r#"{{"model":"m","messages":[{{"role":"user","content":"hi"}}],"max_tokens":16{extra}}}"#
+        )
+    }
+
+    #[test]
+    fn max_thinking_tokens_aliases_thinking_token_budget() {
+        // Several clients send `max_thinking_tokens`; it must map to the
+        // budget instead of being silently dropped (community report 2026-06).
+        let req: ChatCompletionRequest =
+            serde_json::from_str(&base(r#","max_thinking_tokens":128"#)).unwrap();
+        assert_eq!(req.thinking_token_budget, Some(128));
+    }
+
+    #[test]
+    fn canonical_thinking_token_budget_still_works() {
+        let req: ChatCompletionRequest =
+            serde_json::from_str(&base(r#","thinking_token_budget":256"#)).unwrap();
+        assert_eq!(req.thinking_token_budget, Some(256));
     }
 }


### PR DESCRIPTION
## Problem (community report, 2026-06)
A user set a reasoning budget via `extra_body.max_thinking_tokens: 128` on Nemotron, but the thinking continued well past 128 tokens and spilled into `message.content`. Root cause: Atlas only recognizes `thinking_token_budget` (top-level), `thinking.budget_tokens` (Anthropic-style), or `reasoning_effort`. The unknown `max_thinking_tokens` field was **silently dropped** → no budget enforced → reasoning ran unbounded.

## Verified on GB10 (Nemotron-3-Nano-30B-A3B-NVFP4)
| Request | reasoning length | budget enforced? |
|---|---|---|
| `max_thinking_tokens: 128` (before) | ~260 tok | ❌ ignored |
| `thinking_token_budget: 128` | ~128 tok | ✅ |
| `max_thinking_tokens: 128` (**after this PR**) | ~128 tok | ✅ |

## Fix
Add `#[serde(alias = "max_thinking_tokens")]` to `thinking_token_budget`. Additive and backward-compatible — the canonical field name is unchanged. Two deserialization tests added (`cargo test -p spark-server alias_tests` green).

## Not covered here (filed/known separately)
- At a *very small* budget the forced `</think>` relabels continued reasoning as `content` on reasoning-heavy NVFP4 models — recommend an adequate budget. 
- `enable_thinking: false` does not fully suppress reasoning on models that spontaneously emit `<think>` — separate gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)