### PR TITLE
fix(grammar): make qwen3_coder auto-mode tool triggers prefix-free (#88)

### DIFF
--- a/crates/spark-server/src/grammar/compile_tools.rs
+++ b/crates/spark-server/src/grammar/compile_tools.rs
@@ -225,12 +225,26 @@ impl GrammarEngine {
         // Trigger selection depends on `use_triggers` (i.e. tool_choice mode):
         //
         // * tool_choice="auto" (use_triggers=true): per-tool LATE triggers
-        //   `<tool_call>\n<function=NAME`. The model is free to emit a
+        //   `<tool_call>\n<function=NAME>`. The model is free to emit a
         //   `<tool_call>` token and then *not* commit (e.g. by emitting
         //   plain prose afterwards), which is the ergonomic behaviour
         //   most pass-not-fail scenarios depend on (TC-11 mental math,
         //   TC-39 restraint, TC-43 ask-for-missing-arg, TC-48 multi-turn
         //   email composition). Late triggers preserve that freedom.
+        //
+        //   The closing `>` is part of the trigger so the trigger set is
+        //   prefix-free. Issue #88: when one tool name is a textual prefix
+        //   of another (`mcp_scrapling_get` vs `mcp_scrapling_get_prompt`
+        //   — the natural `mcp_{server}_{tool}` MCP pattern), a trigger
+        //   without the `>` (`…=mcp_scrapling_get`) is a prefix of the
+        //   longer tool's tag begin (`…=mcp_scrapling_get_prompt>\n`), so
+        //   that tag matches TWO triggers and xgrammar's triggered-tags
+        //   converter rejects the entire grammar ("One tag matches
+        //   multiple triggers"), silently disabling constrained decoding
+        //   and letting the model concatenate/hallucinate tool names. The
+        //   `>` terminator cannot appear inside a tool name, so `NAME>` is
+        //   never a prefix of another tool's `NAME2>` — each tag matches
+        //   exactly its own trigger.
         //
         // * tool_choice="required"/specific (use_triggers=false): SHORT
         //   shared trigger `<tool_call>`. Without it, the model can — and
@@ -246,9 +260,16 @@ impl GrammarEngine {
         //   construction. Mirrors compile_minimax_xml_tool_grammar's F67
         //   fix for the same xgrammar behaviour pattern.
         let triggers: Vec<String> = if use_triggers {
+            // Dedup defensively: two tools sharing a name would otherwise
+            // produce duplicate triggers, which the converter also rejects
+            // as "multiple triggers" (the OpenAI/MCP contract requires
+            // unique names, but a malformed tool list must not hard-disable
+            // the grammar).
+            let mut seen = HashMap::<String, bool>::new();
             sanitized_tools
                 .iter()
-                .map(|st| format!("<tool_call>\n<function={}", st.name))
+                .map(|st| format!("<tool_call>\n<function={}>", st.name))
+                .filter(|trigger| seen.insert(trigger.clone(), true).is_none())
                 .collect()
         } else {
             vec!["<tool_call>".to_string()]

--- a/crates/spark-server/src/grammar/tests/qwen3_coder_required.rs
+++ b/crates/spark-server/src/grammar/tests/qwen3_coder_required.rs
@@ -70,6 +70,67 @@ fn qwen3_coder_grammar_accepts_canonical() {
     );
 }
 
+/// Regression test for issue #88 (Qwen3.6-27B-FP8, DGX Spark): when the
+/// registered tools have shared name prefixes — the natural
+/// `mcp_{server}_{tool}` MCP pattern where `mcp_scrapling_get` is a
+/// textual prefix of `mcp_scrapling_get_prompt` — the per-tool auto-mode
+/// triggers must stay prefix-free (closing `>` included) so xgrammar's
+/// triggered-tags converter does NOT reject the whole grammar with "One
+/// tag matches multiple triggers". Before the fix this hard-disabled
+/// constrained decoding and the model concatenated/hallucinated tool
+/// names (`skills_listskills_list`).
+#[test]
+fn qwen3_coder_grammar_compiles_with_shared_tool_name_prefixes() {
+    fn mcp_tool(name: &str) -> ToolDefinition {
+        ToolDefinition {
+            tool_type: "function".to_string(),
+            function: crate::tool_parser::FunctionDefinition {
+                name: name.to_string(),
+                description: Some(format!("MCP tool {name}")),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": { "query": {"type": "string"} }
+                })),
+            },
+        }
+    }
+
+    // `get` ⊂ `get_prompt` and `fetch` shares the `bulk_fetch` server
+    // prefix — exactly the conflicting set reported in issue #88.
+    let tools = vec![
+        mcp_tool("mcp_scrapling_get"),
+        mcp_tool("mcp_scrapling_get_prompt"),
+        mcp_tool("mcp_scrapling_fetch"),
+        mcp_tool("mcp_scrapling_bulk_fetch"),
+    ];
+
+    let vocab = test_vocab();
+    let stop_ids = vec![130i32];
+    let mut engine = GrammarEngine::new(&vocab, &stop_ids).unwrap();
+
+    // AUTO mode (use_triggers=true) is the path that builds per-tool
+    // triggers. Pre-fix this returned Err (both the qwen_xml_parameter
+    // attempt and the json_schema fallback reuse the colliding triggers).
+    let compiled = engine
+        .compile_qwen3_coder_tool_grammar(&tools, true)
+        .expect("grammar with shared-prefix tool names must compile (issue #88)");
+
+    // The longer, prefix-colliding tool must be reachable — not shadowed
+    // by the shorter `mcp_scrapling_get` trigger.
+    let long_call = "<tool_call>\n<function=mcp_scrapling_get_prompt>\n<parameter=query>\nhi\n</parameter>\n</function>\n</tool_call>";
+    assert!(
+        grammar_accepts(&compiled, long_call),
+        "longer prefix-colliding tool must be accepted; input: {long_call:?}"
+    );
+
+    // The shorter tool is still reachable too.
+    let short_call = "<tool_call>\n<function=mcp_scrapling_get>\n<parameter=query>\nhi\n</parameter>\n</function>\n</tool_call>";
+    assert!(
+        grammar_accepts(&compiled, short_call),
+        "shorter tool must remain accepted; input: {short_call:?}"
+    );
+}
+
 /// Regression test for issue #40 / OpenClaw: when the schema declares
 /// `required: ["command"]`, the grammar must REJECT a tool call body
 /// with zero `<parameter=>` blocks.


### PR DESCRIPTION
Fixes #88.

## Problem

With `--tool-call-parser qwen3_coder` and `tool_choice=auto`, the grammar builds a per-tool late trigger `<tool_call>\n<function=NAME` with no closing `>`. When one tool name is a textual prefix of another (the natural `mcp_{server}_{tool}` MCP pattern, e.g. `mcp_scrapling_get` vs `mcp_scrapling_get_prompt`), the longer tool's tag `begin` matches BOTH triggers, so xgrammar's triggered-tags converter rejects the whole grammar with `One tag matches multiple triggers in a triggered tags format`.

Both the `qwen_xml_parameter` attempt and the `json_schema` fallback reuse the same colliding triggers, so compilation fails outright and constrained decoding is silently disabled. The model then concatenates/hallucinates tool names (`skills_listskills_list`), exactly as reported.

## Fix

Append the closing `>` to the per-tool late trigger so the trigger set is prefix-free (`>` cannot appear inside a tool name, so `NAME>` is never a prefix of `NAME2>`), and dedup defensively. Hermes/bare_json/minimax already use a single shared trigger and were never affected, which is why the `--tool-call-parser hermes` workaround in the issue sidestepped it.

## Test

Adds `qwen3_coder_grammar_compiles_with_shared_tool_name_prefixes` exercising the reported conflicting MCP set in auto mode: it asserts compilation succeeds and that the longer, prefix-colliding tool stays reachable. The test fails pre-fix with the exact `multiple triggers` error and passes after. Full spark-server suite green.