### PR TITLE
fix(prefix-cache): don't admit vision prefills to the radix cache in two-phase SSM prefill (#58)

### DIFF
--- a/crates/spark-model/src/model/trait_impl/prefill_d.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_d.rs
@@ -217,24 +217,36 @@ impl TransformerModel {
                 }
             };
             if let Some(snap_id) = snap_result {
-                tracing::info!(
-                    "Saved SSM snapshot {} for {} tokens ({} blocks) [twophase]",
-                    snap_id,
-                    tokens.len(),
-                    seq.block_table.len(),
-                );
-                let (displaced, acquired) = self.prefix_cache.insert_with_snapshot(
-                    tokens,
-                    &seq.block_table,
-                    &seq.disk_block_ids,
-                    bs,
-                    snap_id,
-                    seq.session_hash,
-                    seq.cached_prefix_tokens,
-                );
-                super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
-                if let Some(old) = displaced {
-                    self.ssm_snapshots.free(old);
+                if self.tokens_have_vision_pad(tokens) {
+                    // Vision prefill: the SSM snapshot is image-tainted and
+                    // the token stream collides across distinct images (the
+                    // prefix-cache key hashes token IDs only, and image-pad
+                    // placeholders are identical regardless of pixel content),
+                    // so admitting this entry returns a stale image's result
+                    // on the next same-prompt request (issue #58). Free the
+                    // snapshot and skip the radix insert, matching the gated
+                    // standard path in `prefill_save_snapshot_with_vision_gate`.
+                    self.ssm_snapshots.free(snap_id);
+                } else {
+                    tracing::info!(
+                        "Saved SSM snapshot {} for {} tokens ({} blocks) [twophase]",
+                        snap_id,
+                        tokens.len(),
+                        seq.block_table.len(),
+                    );
+                    let (displaced, acquired) = self.prefix_cache.insert_with_snapshot(
+                        tokens,
+                        &seq.block_table,
+                        &seq.disk_block_ids,
+                        bs,
+                        snap_id,
+                        seq.session_hash,
+                        seq.cached_prefix_tokens,
+                    );
+                    super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
+                    if let Some(old) = displaced {
+                        self.ssm_snapshots.free(old);
+                    }
                 }
             } else if !self.tokens_have_vision_pad(tokens) {
                 let acquired = self.prefix_cache.insert(

--- a/crates/spark-runtime/src/radix_tree/tests/basic.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/basic.rs
@@ -373,3 +373,38 @@ fn test_ssm_snapshot_overwrite_returns_displaced() {
     assert_eq!(m.ssm_snapshot_tokens, 16);
     tree.release(&tokens, 16);
 }
+
+/// Issue #58: the prefix-cache key is derived from token IDs only, so two
+/// vision requests that differ ONLY in image pixel content but share the same
+/// text prompt and image-pad placeholder run produce a byte-identical token
+/// stream, and therefore collide on the same cache entry. This pins the
+/// image-blind-key invariant the model-layer vision-pad gate depends on: if a
+/// vision prefill were admitted here, the next page's identical token stream
+/// would reuse the previous page's KV/snapshot and return the wrong page's
+/// answer (the "returns the previous picture" report).
+#[test]
+fn test_vision_pad_tokens_are_image_blind_collision() {
+    let tree = RadixTree::new();
+    const IMAGE_PAD: u32 = 151655; // <|image_pad|>
+
+    // Page A: 3 prompt tokens followed by a run of image-pad placeholders.
+    let page_a: Vec<u32> = [1u32, 2, 3]
+        .into_iter()
+        .chain(std::iter::repeat(IMAGE_PAD).take(29))
+        .collect(); // 32 tokens == 2 blocks of 16
+    // Page B is a DIFFERENT image but the same prompt and same pad count, so
+    // pixels never enter the token IDs: the stream is identical to page A.
+    let page_b = page_a.clone();
+
+    // Admitting page A's blocks would let page B match them in full.
+    tree.insert(&page_a, &[10, 20], &[], 16, 0);
+    let m = tree.lookup(&page_b, 16, 0);
+
+    assert_eq!(
+        m.matched_tokens, 32,
+        "distinct images with identical prompt+pad token streams collide on \
+         the same prefix-cache key (issue #58); the model layer must not admit \
+         vision prefills into the radix cache"
+    );
+    assert_eq!(m.matched_blocks, vec![10, 20]);
+}


### PR DESCRIPTION
Fixes #58.

## Problem
On Qwen3.6-35B-A3B-FP8 (a vision model) doing PDF-page to markdown with `--enable-prefix-caching`, changing the input image (page 95 -> 102) while keeping the prompt returns the **previous image's** result on the first try, correcting only on a retry.

## Root cause
The prefix-cache key is derived from token IDs only, and `<|image_pad|>` placeholders hash identically regardless of pixel content, so two different images with the same prompt + pad count produce a byte-identical token stream and collide on the same cache entry. The standard prefill path guards against this (`prefill_save_snapshot_with_vision_gate` frees the snapshot and skips the radix insert for vision prompts), but the **two-phase SSM prefill** path (`prefill_c.rs:508` -> `prefill_save_snapshot_and_insert`) admitted the snapshot + block unconditionally. Large prompts with a full-page image route through two-phase prefill, which is exactly the reporter's config (`ATLAS_PREFILL_CHUNK_SIZE=4096`).

## Fix
Add the same `tokens_have_vision_pad` gate to the two-phase function so vision prefills free the snapshot and skip the radix insert, matching the proven standard path. Adds a GPU-free radix-tree regression test pinning the image-blind-key invariant the gate depends on.

Verified: `spark-runtime` radix tests green (incl. the new one), `spark-model` builds. End-to-end (two distinct PDF pages return distinct markdown) needs a live vision model on GB10.