### PR TITLE
fix(decode): never synchronize during CUDA graph capture in debug dumps (#106)

### DIFF
--- a/crates/spark-model/src/layers/moe/forward.rs
+++ b/crates/spark-model/src/layers/moe/forward.rs
@@ -148,7 +148,7 @@ impl MoeLayer {
             })?;
         }
 
-        if tracing::enabled!(tracing::Level::DEBUG) {
+        if tracing::enabled!(tracing::Level::DEBUG) && !ctx.graph_capture {
             ctx.gpu.synchronize(stream)?;
             // Read expert indices (u32[top_k]) and weights (f32[top_k])
             let k = top_k as usize;
@@ -310,7 +310,7 @@ impl MoeLayer {
                 )
             })?;
 
-            if tracing::enabled!(tracing::Level::DEBUG) {
+            if tracing::enabled!(tracing::Level::DEBUG) && !ctx.graph_capture {
                 ctx.gpu.synchronize(stream)?;
                 // Dump gate/up outputs for expert slot 0
                 let mut gate_buf = vec![0u8; 16];
@@ -376,7 +376,7 @@ impl MoeLayer {
             })?;
         }
 
-        if tracing::enabled!(tracing::Level::DEBUG) {
+        if tracing::enabled!(tracing::Level::DEBUG) && !ctx.graph_capture {
             ctx.gpu.synchronize(stream)?;
             // Dump down outputs for expert slot 0
             let mut down_buf = vec![0u8; 16];
@@ -472,7 +472,7 @@ impl MoeLayer {
             }
         }
 
-        if tracing::enabled!(tracing::Level::DEBUG) {
+        if tracing::enabled!(tracing::Level::DEBUG) && !ctx.graph_capture {
             ctx.gpu.synchronize(stream)?;
             let mut buf = vec![0u8; 8];
             ctx.gpu.copy_d2h(output, &mut buf)?;

--- a/crates/spark-model/src/layers/qwen3_ssm/ssm_forward.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/ssm_forward.rs
@@ -19,7 +19,10 @@ impl Qwen3SsmLayer {
         let nv = ctx.config.linear_num_value_heads;
         let vd = ctx.config.linear_value_head_dim;
         let vpg = nv / nk; // vheads_per_group = 2
-        let debug = tracing::enabled!(tracing::Level::DEBUG);
+        // Suppress debug synchronize+dump while capturing a CUDA graph:
+        // cuStreamSynchronize during capture is illegal (CUDA 900) and
+        // bricks the context (issue #106).
+        let debug = tracing::enabled!(tracing::Level::DEBUG) && !ctx.graph_capture;
         let profile = ctx.profile;
 
         macro_rules! prof {

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode.rs
@@ -20,7 +20,12 @@ impl Qwen3SsmLayer {
     ) -> Result<()> {
         let h = ctx.config.hidden_size;
         let eps = ctx.config.rms_norm_eps as f32;
-        let debug = tracing::enabled!(tracing::Level::DEBUG);
+        // Never synchronize while a CUDA graph is being captured: a
+        // cuStreamSynchronize during capture is illegal (CUDA error 900,
+        // STREAM_CAPTURE_UNSUPPORTED) and bricks the context. The debug
+        // dumps below are diagnostic-only, so suppress them under capture
+        // (issue #106: RUST_LOG=trace + --speculative crashed here).
+        let debug = tracing::enabled!(tracing::Level::DEBUG) && !ctx.graph_capture;
         let trace = false;
 
         let ssm_state = state


### PR DESCRIPTION
Fixes #106.

## Problem
The readme recipe on Qwen3.6-35B-A3B-FP8 (single GB10, `--speculative`) crashes with `cuStreamSynchronize failed: CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED (900)` on the first decode step, cascading into 901 / `zero_slot` failures and a dead server.

## Root cause
The recipe sets `RUST_LOG=trace`, which enables DEBUG. The SSM/MoE decode forwards gate diagnostic `synchronize` + `copy_d2h` dumps on DEBUG level, and those fire **inside** the per-layer CUDA graph capture region (`decode_a.rs` `begin_capture`). A `cuStreamSynchronize` during capture is illegal -> error 900, which invalidates the capture.

## Fix
Gate every DEBUG-level dump on `!ctx.graph_capture` across `qwen3_ssm/trait_decode.rs`, `qwen3_ssm/ssm_forward.rs`, and `moe/forward.rs` (all six sites). The dumps still fire in eager / non-captured paths; no behavior change at `RUST_LOG=info` or below. Workaround for users on current images: `RUST_LOG=info` instead of `trace`.

Verified: every `tracing::enabled!(DEBUG)` site in the decode path is now capture-guarded; `spark-model` builds clean. The crash repro needs a live GB10 with capture + `RUST_LOG=trace`.