### PR TITLE
fix(weights): allow BF16 ignore-list shared experts in Qwen3.5 NVFP4 loader (#97)

### DIFF
--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -97,6 +97,15 @@ pub(crate) fn load_moe_qwen35(
         quantize_to_nvfp4(&bf16, n, k, gpu, absmax_k, quantize_k, stream)
     };
 
+    // Runtime-quant context for the `quantized_any` BF16 fallback used when a
+    // shared/routed expert ships as raw BF16 (no weight_scale) per the
+    // checkpoint's ModelOpt ignore list (issue #97).
+    let qctx = QuantizeCtx {
+        absmax_k,
+        quantize_k,
+        stream,
+    };
+
     // Qwen3.6-35B-A3B BF16 release ships a FUSED MoE layout: one
     // `experts.gate_up_proj: [num_experts, 2*inter, hidden]` and one
     // `experts.down_proj: [num_experts, hidden, inter]` per layer. Slice
@@ -173,10 +182,43 @@ pub(crate) fn load_moe_qwen35(
                     stream,
                 )?,
             }),
+            // `quantized_any` (not `quantized_auto`): some NVFP4 checkpoints
+            // keep the shared expert in BF16 via the ModelOpt quant_config
+            // `ignore` list (e.g. Qwen3.5-397B-A17B-NVFP4, whose 184-entry
+            // ignore list covers `*.mlp.shared_expert.*`), so no weight_scale
+            // ships for it. `quantized_any`'s per-key `has_only_dense` fallback
+            // runtime-quantizes the raw BF16 — the same path the routed experts
+            // already take — instead of hard-failing on the absent scale
+            // (issue #97). For checkpoints whose shared expert IS quantized
+            // (35B/122B), the scale is present so this is identical to before.
             _ => Ok(ExpertWeight {
-                gate_proj: quantized_auto(store, &format!("{prefix}.gate_proj"), gpu, variant)?,
-                up_proj: quantized_auto(store, &format!("{prefix}.up_proj"), gpu, variant)?,
-                down_proj: quantized_auto(store, &format!("{prefix}.down_proj"), gpu, variant)?,
+                gate_proj: quantized_any(
+                    store,
+                    &format!("{prefix}.gate_proj"),
+                    inter,
+                    h,
+                    gpu,
+                    variant,
+                    qctx,
+                )?,
+                up_proj: quantized_any(
+                    store,
+                    &format!("{prefix}.up_proj"),
+                    inter,
+                    h,
+                    gpu,
+                    variant,
+                    qctx,
+                )?,
+                down_proj: quantized_any(
+                    store,
+                    &format!("{prefix}.down_proj"),
+                    h,
+                    inter,
+                    gpu,
+                    variant,
+                    qctx,
+                )?,
             }),
         }
     };


### PR DESCRIPTION
Fixes #97.

## Problem
`Qwen35WeightLoader` fails to build `nvidia/Qwen3.5-397B-A17B-NVFP4`:

    Weight 'model.language_model.layers.0.mlp.shared_expert.gate_proj.weight_scale' not found in store

## Root cause
`load_moe_qwen35`'s `load_expert` took the catch-all NVFP4 arm via `quantized_auto`, which unconditionally requires a `weight_scale`. The checkpoint's ModelOpt NVFP4 `quantization_config` ignore list keeps `*.mlp.shared_expert.*` in BF16, so no scale ships and the build hard-fails.

## Fix
Route the expert `_` arm through `quantized_any`, whose per-key `has_only_dense` fallback runtime-quantizes a raw-BF16 projection to NVFP4 (the same path the `Bf16Raw` and routed-expert loads already use, and the same fallback added for RedHatAI/Qwen3-Coder-Next-NVFP4's BF16 `linear_attn.out_proj`). For checkpoints whose shared expert IS quantized (35B/122B), `weight_scale` is present so `has_only_dense` is false and the path is **byte-identical to before** (no regression).

Companion to the merged kernel target #98. Verified: `spark-model` suite green (65), builds clean. The change is additive (only adds a fallback where there was previously a hard error); full 397B EP=4 load verification needs the 4-node GB10 rig from the report.