### PR TITLE
fix(weights): free dead BF16 intermediates in dense loader (#A1)

### DIFF
--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -171,15 +171,25 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                                 (q_dense, q_nvfp4),
                                 (k_dense, k_nvfp4),
                                 (v_dense, v_nvfp4),
-                                (_o_dense, o_nvfp4),
+                                (o_dense, o_nvfp4),
                             ] = load_qkvo_tp(config, load_bf16_then_nvfp4)?;
 
                             let (k_scale, v_scale) = load_kv_scales(store, &p, gpu);
 
+                            // The BF16 q/k/v/o dense tensors are only the intermediate
+                            // fed to the GPU quantize_to_nvfp4 above. Prefill AND decode
+                            // always dispatch the NVFP4 weights, so the BF16 copies are
+                            // dead once quantized. Free them instead of retaining a full
+                            // second copy of every projection (Atlas issue #A1).
+                            gpu.free(q_dense.weight)?;
+                            gpu.free(k_dense.weight)?;
+                            gpu.free(v_dense.weight)?;
+                            gpu.free(o_dense.weight)?;
+
                             let attn = AttentionWeights {
-                                q_proj: q_dense,
-                                k_proj: k_dense,
-                                v_proj: v_dense,
+                                q_proj: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
+                                k_proj: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
+                                v_proj: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
                                 o_proj: o_nvfp4,
                                 q_norm: dense(store, &format!("{p}.q_norm.weight"))?,
                                 k_norm: dense(store, &format!("{p}.k_norm.weight"))?,
@@ -270,6 +280,10 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
 
                     let qkvz_dense =
                         gpu_concat_rows(&qkv_dense, qkv_rows, &z_dense, z_rows, h, gpu)?;
+                    // qkv/z BF16 are only inputs to the concat above; free them now
+                    // rather than leaking them for the layer's lifetime (Atlas issue #A1).
+                    gpu.free(qkv_dense.weight)?;
+                    gpu.free(z_dense.weight)?;
 
                     let ba_dense = interleave_ba(&in_proj_a, &in_proj_b, nv, nk, h, gpu)?;
 
@@ -334,8 +348,15 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                             (None, None)
                         };
 
+                    // SSM prefill/decode always dispatch qkvz_nvfp4/_t and the NVFP4
+                    // out_proj; the BF16 qkvz_dense / out_proj_dense were only quantize
+                    // inputs. Free them rather than keep a third full-precision copy of
+                    // the largest SSM tensor across every layer (Atlas issue #A1).
+                    gpu.free(qkvz_dense.weight)?;
+                    gpu.free(out_proj_dense.weight)?;
+
                     let ssm = SsmWeights {
-                        in_proj_qkvz: qkvz_dense,
+                        in_proj_qkvz: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
                         in_proj_ba: ba_dense,
                         conv1d,
                         a_log,


### PR DESCRIPTION
## Bug (#A1)

The dense Qwen3.5/3.6 weight loader (`crates/spark-model/src/weight_loader/qwen35_dense.rs`) builds the NVFP4 attention and SSM weights from BF16 intermediates, then **retained** those BF16 intermediates in the `AttentionWeights` / `SsmWeights` structs:

- attention: `q_proj` / `k_proj` / `v_proj` held the BF16 `q/k/v_dense`
- SSM: `in_proj_qkvz` held the BF16 `qkvz_dense` — a full **third** full-precision copy of the largest per-layer tensor (BF16 source + NVFP4 + NVFP4-transposed)

Net effect: **~2-3x weight bloat**. It was caught on a 61 GB AMD box during the SCALE port (OOM at layer 50/64), but it is **hardware-agnostic** — it wastes the same memory on GB10/CUDA, where it went unnoticed only because the model fits within 119 GB.

## Fix

The BF16 fields are **provably dead**: once the NVFP4 weights are built, prefill AND decode always dispatch the NVFP4 weights (and, when enabled, the native-FP8 prefill weights built by `bf16_to_fp8`). Nothing reads the BF16 `q/k/v_proj` or `in_proj_qkvz` afterward. This mirrors the existing NULL-stub convention the MLA loaders already use for `q_proj`.

The fix:
1. **Attention block**: free `q/k/v/o_dense.weight` after `quantize_to_nvfp4`; store `DenseWeight { weight: DevicePtr::NULL }` in `q_proj`/`k_proj`/`v_proj` (`o_proj` was already the NVFP4 weight).
2. **SSM concat**: free the concat inputs `qkv_dense.weight` / `z_dense.weight` immediately after `gpu_concat_rows`.
3. **SSM block**: free `qkvz_dense.weight` / `out_proj_dense.weight` **after** their last consumer (the optional native-FP8 prefill `bf16_to_fp8` build + `synchronize`), and NULL-stub `in_proj_qkvz`.

`DevicePtr::NULL` is the codebase's existing sentinel (`spark-runtime/src/gpu.rs:17`, `pub const NULL: Self = Self(0)`); `gpu.free(NULL)` is a tested no-op (`cuda_backend/tests.rs::null_free_is_noop`).

## Verification

- This is **provably-dead-code removal**, verified by `cargo check -p spark-model` (clean — finished in 34.8s, 0 errors) and by review of all dispatch sites for `q/k/v_proj` and `in_proj_qkvz`.
- Confirmed the freed buffers are distinct, freshly-allocated (no aliasing/double-free) and that all reads precede the frees.
- **Runtime verification is pending a free GPU** (both dgx1 and dgx2 are currently occupied).

## Follow-up (not in this PR)

`load_mtp_weights` in this file is a thin wrapper that delegates to `load_mtp` in `weight_map/loaders_moe.rs`; that function uses `dense`/`dense_auto` loads rather than the build-NVFP4-from-BF16-then-retain pattern, so it does not exhibit the same clear bug. Whether MTP has any analogous retain is left as a separate follow-up rather than guessed at here.