### PR TITLE
fix(ep): guard per-seq broadcast so single-GPU generation doesn't panic (regression from #101)

### DIFF
--- a/crates/spark-model/src/model/impl_a2.rs
+++ b/crates/spark-model/src/model/impl_a2.rs
@@ -188,6 +188,17 @@ impl TransformerModel {
     /// command code and is the kind of misconfiguration we want to fail
     /// loudly in development — there's no graceful fallback.
     pub(super) fn ep_broadcast_seq_and_cmd(&self, seq_id: u32, cmd: u32, v2: bool) -> Result<()> {
+        // No-op unless EP is actually active. The per-seq broadcast helpers
+        // (`ep_broadcast_cmd_for_seq`) are called unconditionally from the
+        // head's prefill / decode / mtp / lifecycle paths, exactly like the
+        // original `ep_broadcast_cmd` which no-ops here via
+        // `ep_broadcast_cmd_dispatch`. Without this guard `ep_broadcast_u32`
+        // panics ("ep_broadcast_u32 without comm") on every single-GPU
+        // generation, since `self.comm` is `None`. (Regression from the EP=2
+        // slot-mux work, which only exercised the 2-rank path.)
+        if !(self.comm.is_some() && self.config.ep_world_size > 1) {
+            return Ok(());
+        }
         if v2 {
             self.ep_broadcast_u32(seq_id)?;
         }


### PR DESCRIPTION
## Regression
#101 (EP=2 slot-mux) is correct on 2 ranks but broke single-GPU serving. `ep_broadcast_seq_and_cmd` (reached via `ep_broadcast_cmd_for_seq` from the head's prefill / decode / mtp / lifecycle paths) calls `ep_broadcast_u32` unconditionally. On single-GPU `self.comm` is `None`, so the first generation panics:

```
thread panicked at crates/spark-model/src/model/impl_a2.rs: ep_broadcast_u32 without comm
```

which kills the scheduler worker thread and bricks the server. The original `ep_broadcast_cmd` never had this problem because `ep_broadcast_cmd_dispatch` guards `if self.comm.is_some() && self.config.ep_world_size > 1` before broadcasting; the per-seq variant added for the slot-mux protocol lost that guard.

## Fix
Add the identical guard to `ep_broadcast_seq_and_cmd` so every `ep_broadcast_cmd_for_seq` site no-ops when EP is not active. EP=2 is unaffected (the guard condition is exactly 'EP active', so with comm present it broadcasts as before).

## Validation (live, dgx1)
- Single-GPU Qwen3.6-35B-A3B-FP8 + `--speculative` (the exact repro): 3 sequential + 2 concurrent (batch=2) generations all complete, 28-82 tok/s, no panic, no 'without comm'. Pre-fix this panicked on the first request.
- EP=2 path is unchanged by construction and was validated live on 2x GB10 with the #101 work.

This is why single-GPU should always be smoke-tested alongside EP changes; the original #101 validation (and mine) only exercised the 2-rank path.