### PR TITLE
fix(weights): load nvidia/Qwen3.6-35B-A3B-NVFP4 (MIXED_PRECISION) (#107)

### DIFF
--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -141,9 +141,34 @@ pub fn build_model(
     let absmax_k = gpu.kernel("quantize_nvfp4", "nvfp4_global_absmax")?;
     let quantize_k = gpu.kernel("quantize_nvfp4", "quantize_bf16_to_nvfp4")?;
     let stream = gpu.default_stream();
+    // nvidia/Qwen3.6-35B-A3B-NVFP4 (algo=MIXED_PRECISION) ships an already
+    // NVFP4-packed lm_head (U8 `weight` + `weight_scale` + `weight_scale_2`).
+    // `load_lm_head` dense-loads those packed bytes, and re-quantizing them as
+    // if they were BF16 reads 2x the buffer and faults
+    // (CUDA_ERROR_ILLEGAL_ADDRESS, issue #107). Detect the packed lm_head and
+    // load it directly as NVFP4 instead of dequant->requantize.
+    let lm_head_key = [
+        "lm_head.weight",
+        "language_model.lm_head.weight",
+        "model.lm_head.weight",
+    ]
+    .into_iter()
+    .find(|k| store.contains(k));
+    let lm_head_prepacked_nvfp4 = lm_head_key
+        .and_then(|k| store.get(k).ok())
+        .is_some_and(|w| w.dtype == spark_runtime::weights::WeightDtype::UInt8);
+
     let lm_head_nvfp4 = if config.skip_lm_head_quantization() {
         tracing::info!("LM head kept as BF16 (skip NVFP4 quantization per model config)");
         None
+    } else if lm_head_prepacked_nvfp4 {
+        let prefix = lm_head_key.unwrap().strip_suffix(".weight").unwrap();
+        let q = crate::weight_map::quantized(store, prefix, gpu.as_ref())?;
+        tracing::info!(
+            "LM head loaded as pre-packed NVFP4 (vocab={}, skipped requantize)",
+            config.vocab_size
+        );
+        Some(q)
     } else {
         let q = quantize_to_nvfp4(
             &lm_head,

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -220,7 +220,17 @@ pub(crate) fn dense_auto(
             let prefix = name
                 .strip_suffix(".weight")
                 .ok_or_else(|| anyhow::anyhow!("FP8 tensor {name} doesn't end with .weight"))?;
-            dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)
+            // Two FP8 scale conventions: block-scaled (DeepSeek / Qwen native
+            // FP8) ships `weight_scale_inv` (2D), while per-tensor FP8 (nvidia
+            // MIXED_PRECISION checkpoints, e.g. Qwen3.6-35B-A3B-NVFP4's attn +
+            // linear_attn projections) ships a scalar `weight_scale`. Pick by
+            // which one is present so MIXED_PRECISION loads instead of erroring
+            // on the absent `weight_scale_inv` (issue #107).
+            if store.contains(&format!("{prefix}.weight_scale_inv")) {
+                dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)
+            } else {
+                dequant_fp8_to_bf16(store, prefix, gpu)
+            }
         }
         other => anyhow::bail!("dense_auto: unsupported dtype {:?} for {name}", other),
     }

--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -37,18 +37,23 @@ pub(crate) fn load_ssm_qwen35(
     store: &WeightStore,
     layer_prefix: &str,
     gpu: &dyn GpuBackend,
-    variant: Nvfp4Variant,
+    // Kept for loader-dispatch signature parity; `dense_auto` now routes by
+    // the projection's actual on-disk dtype rather than the model-wide variant.
+    _variant: Nvfp4Variant,
 ) -> Result<SsmWeightsQwen35> {
     let p = format!("{layer_prefix}.linear_attn");
 
     // For FP8 models: in_proj_qkv, in_proj_z, out_proj are FP8 block-scaled.
     // conv1d, in_proj_a, in_proj_b are BF16 (in modules_to_not_convert).
-    let load_proj = |name: &str| -> Result<DenseWeight> {
-        match variant {
-            Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
-            _ => dense(store, name),
-        }
-    };
+    // `dense_auto` routes by the projection's actual on-disk dtype: BF16 is a
+    // passthrough (RedHatAI/Sehyo keep linear_attn BF16), FP8 is dequanted to
+    // BF16 by whichever scale convention is present. nvidia/Qwen3.6-35B-A3B
+    // ships algo=MIXED_PRECISION with the linear_attn projections as FP8 +
+    // per-tensor `weight_scale`; the old `_ => dense()` arm handed the SSM
+    // kernels a 1-byte FP8 buffer where they expect 2-byte BF16 and the
+    // downstream assembly D2D copy overran it (cuMemcpyDtoDAsync status 1,
+    // issue #107). The same fix in `dense_auto` covers the self_attn path.
+    let load_proj = |name: &str| -> Result<DenseWeight> { dense_auto(store, name, gpu) };
 
     Ok(SsmWeightsQwen35 {
         in_proj_qkv: load_proj(&format!("{p}.in_proj_qkv.weight"))?,


### PR DESCRIPTION
Fixes #107. nvidia/Qwen3.6-35B-A3B-NVFP4 ships algo=MIXED_PRECISION, an unusual mix that hit three separate loader bugs, each surfacing the next. All three fixed; the model now loads and generates.

1. **linear_attn projections** are FP8 with a per-tensor weight_scale scalar (not BF16, not block-scaled). The SSM loader fell through to dense(), handing the kernels a 1-byte FP8 buffer where they expect 2-byte BF16 -> cuMemcpyDtoDAsync status 1 at layer 0.
2. **self_attn projections** are the same per-tensor FP8; dense_auto only handled block-scaled FP8 (weight_scale_inv) and errored 'q_proj.weight_scale_inv not found'.
3. **lm_head** is already NVFP4-packed (U8 weight + weight_scale + weight_scale_2); build.rs dense-loaded the packed bytes then re-quantized them as BF16, reading 2x the buffer -> CUDA 700 illegal address.

Fixes: dense_auto picks the FP8 dequant by scale convention (block weight_scale_inv vs scalar weight_scale via dequant_fp8_to_bf16); load_ssm_qwen35 routes through dense_auto; build.rs detects a UInt8/NVFP4-packed lm_head and loads it directly via quantized() instead of dequant->requantize. All three are gated on the specific format, so BF16 (RedHatAI/Sehyo) and block-scaled FP8 (DeepSeek/Qwen native) paths are unchanged.

Validated live on dgx1 (single GB10): nvidia/Qwen3.6-35B-A3B-NVFP4 loads all 40 layers + MTP + vision and generates coherent output (Paris / Red, 69-93 tok/s, TTFT ~75ms). Regression-checked RedHatAI/Qwen3.6-35B-A3B-NVFP4 on the same build: still loads + generates, no regression.