### PR TITLE
fix(vision): order vision encode before chunk-0 embedding injection

### DIFF
--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -124,6 +124,17 @@ pub fn start_chunked_prefill(
         // Vision: encode images and store embeddings for chunk 0 token overwrite.
         if !image_pixels.is_empty() {
             model.prepare_vision_embed(&image_pixels)?;
+            // prepare_vision_embed() runs the vision encoder asynchronously on
+            // the default stream, writing this request's patch embeddings into
+            // the encoder's buf_out. The chunk-0 embedding injection inside
+            // prefill_chunk() runs on prefill_stream and reads buf_out. Without
+            // ordering between the two streams, the injection reads buf_out
+            // BEFORE this request's encode lands and overlays the PREVIOUS
+            // request's image embeddings — lag-by-one cross-image contamination
+            // (and torn reads / illegal access under interleaved load). Make
+            // prefill_stream wait for the encode to complete before injecting.
+            model.record_event(prefill_event, model.default_stream())?;
+            model.stream_wait_event(prefill_stream, prefill_event)?;
         }
 
         // EP: broadcast chunk 0 tokens to worker.


### PR DESCRIPTION
## Problem

On the chunked-prefill path, multimodal (image) requests showed lag-by-one cross-image contamination: the first request after switching images returned the PREVIOUS image's description. Under concurrent or interleaved load it produced torn garbage output and could crash the server with an illegal memory access. It reproduced with prefix caching disabled, so it is not the radix or SSM-snapshot cache (those are already skipped for vision via tokens_have_vision_pad).

## Root cause

prepare_vision_embed() runs the vision encoder asynchronously on the default stream, writing this request's patch embeddings into the encoder's buf_out, then returns immediately (the encoder forward has no internal sync). The chunk-0 embedding injection inside prefill_chunk() runs on a separate prefill_stream and reads buf_out. There was no event ordering the two streams (the only syncs happen after prefill), so the injection read buf_out while it still held the previous request's completed encode.

The non-chunked path (prefill_b_step to model.prefill) injects on default_stream, the same stream as the encode, so it was already correctly ordered and unaffected. That is why only the chunked path was hit.

## Fix

Make prefill_stream wait for the encode to complete before the injection runs, using the same record_event / stream_wait_event idiom already present later in the same function.

## Verification

GB10 (Qwen3.6-35B-A3B-FP8), transparent-PNG brand assets, single-client interleaved probe alternating two images:

  baseline (no fix): 0/6 correct   every request returns the previous image
  with fix:          6/6 correct   every request reads its own image, no crash

A/B built from the same tree with and without the two added lines.