### PR TITLE
fix(loop-detect): stop spinning heuristic from masking <tool_call> during exploration

### DIFF
--- a/crates/spark-server/src/api/chat/loop_detect.rs
+++ b/crates/spark-server/src/api/chat/loop_detect.rs
@@ -13,13 +13,61 @@ use crate::openai::ChatCompletionRequest;
 use super::msg_entry::MsgEntry;
 
 pub(super) struct LoopDetectOut {
-    /// True when the verdict was Suppress OR spinning detection
-    /// fired. Caller flips the `<tool_call>` token bias to avoid
-    /// re-emitting tool calls for one turn.
+    /// True ONLY when the content-similarity detector returns
+    /// [`crate::loop_detector::LoopState::Suppress`] — i.e. strong,
+    /// *measured* repetition across recent turns. The caller flips the
+    /// `<tool_call>` token bias to break a genuine loop.
+    ///
+    /// The size-based "spinning" signal deliberately does NOT set this.
+    /// A run of short *distinct* tool calls (reading files one at a
+    /// time) is legitimate agentic exploration, not a loop; masking
+    /// `<tool_call>` there strands the model — it narrates "let me read
+    /// X" with the tool token biased to -inf, never progresses, never
+    /// emits EOS, and is finally truncated mid-sentence by the
+    /// inter-tool prose budget (the opencode "silent death").
     pub(super) suppress_tool_call: bool,
     /// Run-length of the most recent loop (or 0). Caller threads
     /// this into the exponential `<tool_call>` logit-bias decay.
     pub(super) tool_call_repeat_count: usize,
+}
+
+/// A turn is "short" (low-signal) when it carries little prose AND
+/// little tool-call payload. These bounds are deliberately generous: a
+/// single `read`/`grep`/`glob` call — the bread-and-butter of agentic
+/// exploration — is short, so a run of them is normal progress, not a
+/// loop. See [`leading_short_turn_run`].
+const SHORT_TURN_CONTENT_MAX: usize = 500;
+const SHORT_TURN_TOOL_ARGS_MAX: usize = 100;
+
+/// `recent_short >= this` raises the (weak) size-based spinning signal.
+const SPINNING_RUN_THRESHOLD: usize = 5;
+
+/// How far back the spinning scan walks — it only needs to learn
+/// whether the leading run reaches [`SPINNING_RUN_THRESHOLD`].
+const SPINNING_SCAN_CAP: usize = 8;
+
+/// Length of the leading run of consecutive "short" assistant turns,
+/// newest-first, stopping at the first substantial turn. Pure and
+/// allocation-free so it is unit-testable without an openai request.
+///
+/// Each item is `(content_len, tool_args_len)` for one assistant turn.
+fn leading_short_turn_run<I>(assistant_turns_newest_first: I) -> usize
+where
+    I: IntoIterator<Item = (usize, usize)>,
+{
+    let mut run = 0usize;
+    for (content_len, tool_args_len) in assistant_turns_newest_first {
+        let substantial =
+            content_len >= SHORT_TURN_CONTENT_MAX || tool_args_len >= SHORT_TURN_TOOL_ARGS_MAX;
+        if substantial {
+            break;
+        }
+        run += 1;
+        if run >= SPINNING_SCAN_CAP {
+            break;
+        }
+    }
+    run
 }
 
 pub(super) fn check_loops(
@@ -57,27 +105,24 @@ pub(super) fn check_loops(
         .collect();
     let verdict = crate::loop_detector::detect(&signatures);
 
-    // Spinning detection — independent signal: if the model has
-    // produced ≥5 consecutive short, low-content responses,
-    // something is structurally wrong even if no two are similar.
-    let mut recent_short: usize = 0;
-    for m in req.messages.iter().rev() {
-        if m.role != "assistant" {
-            continue;
-        }
-        let tool_args_len: usize = m.tool_calls.as_ref().map_or(0, |tcs| {
-            tcs.iter().map(|tc| tc.function.arguments.len()).sum()
-        });
-        let is_substantial = m.content.text.len() >= 500 || tool_args_len >= 100;
-        if is_substantial {
-            break;
-        }
-        recent_short += 1;
-        if recent_short >= 8 {
-            break;
-        }
-    }
-    let spinning = recent_short >= 5;
+    // Size-based "spinning" signal: a leading run of consecutive
+    // short, low-content assistant turns (newest-first). WEAK by
+    // design — see `leading_short_turn_run` and the suppression note
+    // below. It feeds only the soft hint + goal re-anchor, never the
+    // hard `<tool_call>` mask.
+    let recent_short = leading_short_turn_run(
+        req.messages
+            .iter()
+            .rev()
+            .filter(|m| m.role == "assistant")
+            .map(|m| {
+                let tool_args_len: usize = m.tool_calls.as_ref().map_or(0, |tcs| {
+                    tcs.iter().map(|tc| tc.function.arguments.len()).sum()
+                });
+                (m.content.text.len(), tool_args_len)
+            }),
+    );
+    let spinning = recent_short >= SPINNING_RUN_THRESHOLD;
 
     match &verdict {
         crate::loop_detector::LoopState::Suppress {
@@ -120,11 +165,24 @@ pub(super) fn check_loops(
         }
     }
     if spinning {
+        // Spinning is a SIZE signal, not a repetition signal. A run of
+        // short *distinct* tool calls is legitimate exploration
+        // (reading files one at a time), so we must NOT hard-mask
+        // `<tool_call>` here: doing so strands the model — it keeps
+        // narrating "let me read X" with the tool token biased to -inf
+        // (decode_logits_seq.rs), never progresses, never emits EOS,
+        // and is finally truncated mid-sentence by the inter-tool prose
+        // budget (NoSsmSnapshot hard stop) — the opencode "silent
+        // death". Hard suppression stays gated on the content-similarity
+        // verdict (`LoopState::Suppress`) above, which measures ACTUAL
+        // repetition. Spinning only contributes the soft hint + goal
+        // re-anchor below.
         tracing::warn!(
             recent_short,
-            "Spinning detection fired — suppressing <tool_call>"
+            "Spinning detection fired (many short turns) — injecting hint + \
+             goal re-anchor only; NOT masking <tool_call> (distinct short tool \
+             calls are legitimate exploration)"
         );
-        suppress_tool_call = true;
     }
 
     // Single hint, used for both Suppress and Hint verdicts.
@@ -184,5 +242,36 @@ pub(super) fn check_loops(
     LoopDetectOut {
         suppress_tool_call,
         tool_call_repeat_count,
+    }
+}
+
+#[cfg(test)]
+mod spinning_tests {
+    use super::{SPINNING_RUN_THRESHOLD, leading_short_turn_run};
+
+    #[test]
+    fn run_of_five_short_reads_reaches_spinning_threshold() {
+        // The opencode failure shape (dump line 21): five short, distinct
+        // read/glob turns, then a substantial `task` turn ends the run.
+        // Items are (content_len, tool_args_len), newest-first.
+        let turns: [(usize, usize); 6] =
+            [(2, 98), (2, 89), (0, 79), (123, 45), (2, 47), (2, 1607)];
+        let run = leading_short_turn_run(turns);
+        assert_eq!(run, 5, "five leading short turns before the substantial task");
+        assert!(run >= SPINNING_RUN_THRESHOLD);
+    }
+
+    #[test]
+    fn substantial_turn_stops_the_run() {
+        // A long prose answer (>= content bound) ends the run...
+        assert_eq!(leading_short_turn_run([(2usize, 98usize), (600, 0), (2, 1)]), 1);
+        // ...as does a large tool-call payload (>= args bound).
+        assert_eq!(leading_short_turn_run([(2usize, 98usize), (0, 100), (2, 1)]), 1);
+    }
+
+    #[test]
+    fn empty_history_has_no_run() {
+        let none: [(usize, usize); 0] = [];
+        assert_eq!(leading_short_turn_run(none), 0);
     }
 }

--- a/crates/spark-server/src/api/chat/loop_detect.rs
+++ b/crates/spark-server/src/api/chat/loop_detect.rs
@@ -185,22 +185,50 @@ pub(super) fn check_loops(
         );
     }
 
-    // Single hint, used for both Suppress and Hint verdicts.
+    // Inject a soft hint for the loop verdict OR the spinning signal —
+    // but the two diagnoses are DIFFERENT, so the wording must be too.
+    // The content-similarity verdict means the model is *repeating*
+    // itself; spinning means short, *distinct* low-progress turns
+    // (reading files one at a time) that aren't converging. Telling a
+    // legitimately-exploring model its "output is very similar to
+    // earlier turns" is false and misleading, so spinning gets its own
+    // convergence-oriented copy that does NOT discourage tool use.
     let loop_active = !matches!(verdict, crate::loop_detector::LoopState::None);
-    let inject_hint = loop_active || spinning;
-    if inject_hint {
-        let hint = "\n\n<IMPORTANT>\nYour recent turns have produced \
-                    output very similar to earlier turns. Before \
-                    continuing: (1) inspect the CURRENT state with \
-                    read-only tools so you can see what is already \
-                    done; (2) if the user's request is already \
-                    satisfied, summarise and stop; (3) otherwise \
-                    identify the SPECIFIC remaining gap and address \
-                    only that — do not retry the same approach or \
-                    regenerate work that already exists.\n</IMPORTANT>";
-        if let Some(last) = messages.last_mut() {
-            last.content.push_str(hint);
-        }
+    let hint = if loop_active {
+        // Repetition verdict (Suppress or Hint): break the loop.
+        Some(
+            "\n\n<IMPORTANT>\nYour recent turns have produced \
+             output very similar to earlier turns. Before \
+             continuing: (1) inspect the CURRENT state with \
+             read-only tools so you can see what is already \
+             done; (2) if the user's request is already \
+             satisfied, summarise and stop; (3) otherwise \
+             identify the SPECIFIC remaining gap and address \
+             only that — do not retry the same approach or \
+             regenerate work that already exists.\n</IMPORTANT>",
+        )
+    } else if spinning {
+        // Spinning only (no repetition): many short distinct steps,
+        // not converging. Nudge toward consolidating and acting —
+        // never imply repetition, never discourage tool calls.
+        Some(
+            "\n\n<IMPORTANT>\nYour recent turns have each made only \
+             small steps (short reads/searches) without converging. \
+             Before continuing: (1) consolidate what you have already \
+             learned from those steps; (2) if you now have enough to \
+             act, stop gathering and take the substantive next step \
+             (edit, answer, or run a command); (3) otherwise make your \
+             next tool call count — gather the remaining information \
+             in as few, targeted calls as possible rather than one \
+             file at a time.\n</IMPORTANT>",
+        )
+    } else {
+        None
+    };
+    if let Some(hint) = hint
+        && let Some(last) = messages.last_mut()
+    {
+        last.content.push_str(hint);
     }
 
     // Goal re-anchor (P1.3 + #4 per-turn spread).

--- a/crates/spark-server/src/api/chat/loop_detect.rs
+++ b/crates/spark-server/src/api/chat/loop_detect.rs
@@ -254,19 +254,27 @@ mod spinning_tests {
         // The opencode failure shape (dump line 21): five short, distinct
         // read/glob turns, then a substantial `task` turn ends the run.
         // Items are (content_len, tool_args_len), newest-first.
-        let turns: [(usize, usize); 6] =
-            [(2, 98), (2, 89), (0, 79), (123, 45), (2, 47), (2, 1607)];
+        let turns: [(usize, usize); 6] = [(2, 98), (2, 89), (0, 79), (123, 45), (2, 47), (2, 1607)];
         let run = leading_short_turn_run(turns);
-        assert_eq!(run, 5, "five leading short turns before the substantial task");
+        assert_eq!(
+            run, 5,
+            "five leading short turns before the substantial task"
+        );
         assert!(run >= SPINNING_RUN_THRESHOLD);
     }
 
     #[test]
     fn substantial_turn_stops_the_run() {
         // A long prose answer (>= content bound) ends the run...
-        assert_eq!(leading_short_turn_run([(2usize, 98usize), (600, 0), (2, 1)]), 1);
+        assert_eq!(
+            leading_short_turn_run([(2usize, 98usize), (600, 0), (2, 1)]),
+            1
+        );
         // ...as does a large tool-call payload (>= args bound).
-        assert_eq!(leading_short_turn_run([(2usize, 98usize), (0, 100), (2, 1)]), 1);
+        assert_eq!(
+            leading_short_turn_run([(2usize, 98usize), (0, 100), (2, 1)]),
+            1
+        );
     }
 
     #[test]

--- a/crates/spark-server/src/loop_detector/tests.rs
+++ b/crates/spark-server/src/loop_detector/tests.rs
@@ -76,6 +76,31 @@ fn different_tool_args_with_same_name_do_not_fire() {
 }
 
 #[test]
+fn distinct_file_reads_are_not_a_loop() {
+    // opencode silent-death repro (PR: spinning-detector fix). A run of
+    // short `read` calls on DIFFERENT files is agentic exploration, not
+    // a loop. The content-similarity detector must NOT escalate distinct
+    // reads to `Suppress` — that hard-masks <tool_call> and strands the
+    // model. `Hint`/`None` are fine; `Suppress` is the bug.
+    let paths = [
+        "/home/u/src/atlas/crates/spark-server/src/tool_parser/streaming_impl.rs",
+        "/home/u/src/atlas/crates/spark-server/src/scheduler/decode_logits_seq.rs",
+        "/home/u/src/atlas/crates/spark-server/src/grammar/compile_tools.rs",
+        "/home/u/src/atlas/README.md",
+        "/home/u/src/atlas/crates/xgrammar/src/lib.rs",
+    ];
+    let recent: Vec<Signature> = paths
+        .iter()
+        .map(|p| sig_with_tool("", "read", &format!(r#"{{"filePath":"{p}"}}"#)))
+        .collect();
+    let v = detect(&recent);
+    assert!(
+        !matches!(v, LoopState::Suppress { .. }),
+        "distinct file reads must not be suppressed (legitimate exploration): {v:?}"
+    );
+}
+
+#[test]
 fn slightly_varied_intros_still_fire() {
     // The model often paraphrases its intro slightly — must
     // catch this too.


### PR DESCRIPTION
opencode / Claude-Code sessions intermittently **"silently die"** on **Atlas Recipe A latest** — the assistant turn ends mid-sentence with `finish_reason="length"` and no error. The root cause is **not** the prose-budget watchdog that shows up in the logs; that's just the executioner.

The real trigger is the **spinning detector** in `loop_detect.rs`: it misclassifies normal file-by-file exploration (5+ short `read`/`glob` calls in a row) as a degenerate loop and **hard-masks the `<tool_call>` token** for the turn. The model then can't call a tool, has no reason to emit EOS, narrates until the inter-tool prose budget trips, and gets truncated.

This PR makes the spinning signal **advisory** (it still injects the soft hint + goal re-anchor). Hard `<tool_call>` suppression now requires the **content-similarity** verdict (`LoopState::Suppress`) — i.e. *measured* repetition, not mere turn brevity.

## What the user sees

A turn dies with no output to act on. In the server log it looks like this (one request):

```
WARN  loop_detect: Spinning detection fired — suppressing <tool_call> recent_short=5
...
WARN  handle_token: SimHash semantic-loop watchdog fired (paraphrased sentence repeat) ring_len=3
WARN  decode_logits_content: Inter-tool prose budget exhausted, ending response
      (rollback declined) prose_tokens=385 max=384 reason=NoSsmSnapshot
INFO  lifecycle: Done: 445 tokens (length) 22.6 tok/s
```

## Root cause (the chain)

1. opencode explores by reading files **one at a time** → a run of "short" assistant turns (`content < 500 chars` **and** `tool_args < 100 chars`).
2. `loop_detect.rs` flags `spinning` at `recent_short >= 5`. **Five distinct file reads are progress, not a loop** — false positive.
3. `spinning` set `suppress_tool_call = true`, which applies a **−12.0 logit bias** to the `<tool_call>` start token in `decode_logits_seq.rs` — effectively banning tool calls for the turn.
4. The model still wants to read files. It narrates *"Let me read X / I'll read Y"* but can't emit the tool call, and it isn't trying to *finish*, so it never samples EOS.
5. Redundant prose accumulates → inter-tool prose budget (384) trips → the Phase-C rollback finds no SSM snapshot at a boundary (`NoSsmSnapshot`) → hard stop, `finish_reason=length`, truncated mid-sentence. To the client, the turn just dies.

## Evidence

- **Log:** the `Spinning detection fired … recent_short=5` line is immediately followed (same request) by `Inter-tool prose budget exhausted … reason=NoSsmSnapshot` and `Done: 445 tokens (length)`.
- **`--dump`:** the killed response was preceded by exactly five short, **distinct** turns — `read(98) ← read(89) ← read(79) ← glob(45) ← read(47)` — then a substantial `task(1607)`. The truncated content was a genuine, useful analysis cut off mid-sentence (*"…which runs once per request but can be"*), not gibberish.
- The content-similarity detector returned **neither `Suppress` nor `Hint`** for those distinct reads (no `Loop detector → SUPPRESS/HINT` line) — only the size-based spinning heuristic fired. So the fatal suppression came purely from `spinning`.

## The fix

`crates/spark-server/src/api/chat/loop_detect.rs`:

- `spinning` **no longer sets `suppress_tool_call`.** It still drives the soft hint + goal re-anchor (unchanged steering).
- Hard `<tool_call>` masking stays gated on `LoopState::Suppress` from the content-similarity detector, which measures *actual* repetition.
- Extracted the run-length scan into a pure, allocation-free `leading_short_turn_run` helper (unit-tested).

This aligns with the detector's **own documented philosophy** — the `LoopState::Hint` variant explicitly says moderate repetition should *not* hard-suppress tools "because the model often needs verification tools to escape", which is exactly what got starved here.

## Why it's safe

- Genuine loops (same tool + similar args, or repeated prose) still escalate to `Suppress` via the unchanged content-similarity path — see existing `loop_detector` tests (`identical_tool_args_fire_loop`, `moderate_similarity_3_turns_now_suppress`, …).
- The only behavior removed is hard tool-call masking on the *size-only* signal. The hint/re-anchor that spinning injects is unchanged.

## Relationship to #125

Independent of #125 (`backfill subagent_type` so opencode's `task` works). The spinning trigger is 5 consecutive short *tool calls*, which is the universal agentic exploration pattern — **any** agent that reads 5+ files in a row trips it. #125 simply made opencode functional enough to reach this failure, which is how it was caught.

## Testing

- Added unit tests for `leading_short_turn_run` (the opencode failure shape → run of 5; substantial turn stops the run; empty history).
- Added a `loop_detector` regression: distinct file reads must **not** escalate to `Suppress`.
- `cargo check -p spark-server --tests` is clean (0 warnings).
- ⚠️ I could not **run** the suite on my dev host (no `nvcc` / `libnccl`, so the `spark-server` bin test target won't link). Please run `cargo test -p spark-server` on a CUDA box to confirm.

## Follow-up (out of scope)

The inter-tool prose-budget + `NoSsmSnapshot` rollback is the *executioner* in this chain and remains in place. Its premise — that the `tool_choice="auto"` grammar "can never self-terminate" — is empirically false: the stop token is legal at the free-text root and accepting it terminates the matcher (verified against `xgrammar`). Worth revisiting separately, as it can also truncate legitimate long-form text answers (> 384 tokens) whenever tools are active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
