### PR TITLE
feat(serve): --lm-head-dtype CLI flag (bf16/nvfp4/fp8 LM head)

### DIFF
--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -82,6 +82,17 @@ jobs:
             # the launch-day allow-list pending a free-function
             # `ops/{alloc,copy,launch,events}.rs` extraction.
             "crates/spark-runtime/src/metal_backend.rs"
+            # 546 LoC — single-token decode forward (`impl_a2`). Pre-existing
+            # carry-over (already over-cap on main): a compute-heavy linear
+            # kernel-launch + buffer ping-pong sequence whose order is critical
+            # for CUDA-graph capture; splitting fragments the launch order.
+            # Tracked for a later `decode/{prefill,sample}.rs` extraction.
+            "crates/spark-model/src/model/impl_a2.rs"
+            # 510 LoC — grammar tool-call compiler. Pre-existing carry-over
+            # (already over-cap on main): one cohesive XGrammar schema->GBNF
+            # compile path; marginally over and awaiting a clean rule-emitter
+            # split. Tracked under the launch-day allow-list.
+            "crates/spark-server/src/grammar/compile_tools.rs"
           )
 
           violations=0

--- a/crates/atlas-core/src/config.rs
+++ b/crates/atlas-core/src/config.rs
@@ -120,6 +120,18 @@ pub struct ModelConfig {
     pub eos_token_id: u32,
     #[serde(default)]
     pub tie_word_embeddings: bool,
+    /// CLI override (`--lm-head-dtype`) for LM-head quantization, set at serve time
+    /// (not from config.json). `Some(true)` = force BF16 lm_head; `Some(false)` = force
+    /// the model's quantized lm_head; `None` = use the model-config-driven default.
+    /// Consumed by `skip_lm_head_quantization()`. Replaces the ATLAS_LMHEAD_BF16 env var.
+    #[serde(default)]
+    pub lm_head_bf16_override: Option<bool>,
+    /// When `skip_lm_head_quantization()` == false, quantize the LM head to FP8
+    /// (E4M3, per-row scales, decoded via `w8a16_gemv`) instead of NVFP4.
+    /// Set by `--lm-head-dtype fp8`. Additive: leaves the NVFP4/BF16 paths
+    /// byte-identical when false.
+    #[serde(default)]
+    pub lm_head_fp8: bool,
 
     // ── Model type ──
     #[serde(default)]

--- a/crates/atlas-core/src/config/factory.rs
+++ b/crates/atlas-core/src/config/factory.rs
@@ -47,6 +47,8 @@ impl ModelConfig {
             bos_token_id: 151643,
             eos_token_id: 151645,
             tie_word_embeddings: false,
+            lm_head_bf16_override: None,
+            lm_head_fp8: false,
             model_type: "qwen3_next".to_string(),
             mtp_num_hidden_layers: 1,
             weight_prefix: String::new(),

--- a/crates/atlas-core/src/config/methods.rs
+++ b/crates/atlas-core/src/config/methods.rs
@@ -216,6 +216,14 @@ impl ModelConfig {
     /// FP32 lm_head path (gated by `ATLAS_GEMMA4_FP32_LMHEAD=1`) can
     /// then act on full-precision weights without the NVFP4 floor.
     pub fn skip_lm_head_quantization(&self) -> bool {
+        // CLI override (`--lm-head-dtype`, set into `lm_head_bf16_override` at serve
+        // time) wins. `bf16` keeps the LM head in BF16 instead of runtime-quantizing it
+        // to NVFP4 — the 4-bit floor on the final vocab projection is a prime suspect for
+        // argmax flips in long structured generation; vLLM keeps lm_head at checkpoint
+        // precision. (Replaces the former ATLAS_LMHEAD_BF16 env var; PCND: explicit arg.)
+        if let Some(force_bf16) = self.lm_head_bf16_override {
+            return force_bf16;
+        }
         if self.kv_lora_rank > 0 {
             return true;
         }

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -18,7 +18,7 @@ use crate::layers::MtpQuantization;
 use crate::model::TransformerModel;
 use crate::traits::Model;
 use crate::weight_loader::load_dflash_weights;
-use crate::weight_map::quantize_to_nvfp4;
+use crate::weight_map::{Fp8DenseWeight, quantize_to_fp8, quantize_to_nvfp4};
 
 pub fn build_model(
     mut config: ModelConfig,
@@ -158,8 +158,32 @@ pub fn build_model(
         .and_then(|k| store.get(k).ok())
         .is_some_and(|w| w.dtype == spark_runtime::weights::WeightDtype::UInt8);
 
+    // FP8 lm_head signal (`--lm-head-dtype fp8`): when we are NOT skipping
+    // quantization, route the runtime LM-head quantization to FP8 (E4M3,
+    // per-row scales, w8a16_gemv decode) instead of NVFP4. Additive: when
+    // `config.lm_head_fp8` is false the NVFP4/BF16 paths below are unchanged.
+    let mut lm_head_fp8: Option<Fp8DenseWeight> = None;
     let lm_head_nvfp4 = if config.skip_lm_head_quantization() {
         tracing::info!("LM head kept as BF16 (skip NVFP4 quantization per model config)");
+        None
+    } else if config.lm_head_fp8 {
+        // Runtime FP8 head. `quantize_bf16_to_fp8` (module `gemv_fp8w`) writes
+        // FP8 E4M3 bytes + per-row f32 scales, consumed by `w8a16_gemv` at
+        // decode. The NVFP4 head stays `None` on this path.
+        let quantize_fp8_k = gpu.kernel("gemv_fp8w", "quantize_bf16_to_fp8")?;
+        let q = quantize_to_fp8(
+            &lm_head,
+            config.vocab_size,
+            config.hidden_size,
+            gpu.as_ref(),
+            quantize_fp8_k,
+            stream,
+        )?;
+        tracing::info!(
+            "LM head quantized to FP8 (w8a16, vocab={})",
+            config.vocab_size
+        );
+        lm_head_fp8 = Some(q);
         None
     } else if lm_head_prepacked_nvfp4 {
         let prefix = lm_head_key.unwrap().strip_suffix(".weight").unwrap();
@@ -181,6 +205,41 @@ pub fn build_model(
         )?;
         tracing::info!("LM head quantized to NVFP4 (vocab={})", config.vocab_size);
         Some(q)
+    };
+
+    // ── Step 3a: Separate NVFP4 draft head (BF16-main + MTP decouple) ──
+    //
+    // When the main LM head is kept BF16 for argmax precision
+    // (`skip_lm_head_quantization()`), the MTP draft proposer still needs an
+    // NVFP4 vocab projection: `MtpHead::forward_one` hard-wires the final
+    // hidden→vocab projection to `w4a16_gemv` over a `QuantizedWeight`. Build
+    // a SEPARATE NVFP4 copy used ONLY for drafting. This is correctness-safe
+    // because every draft is VERIFIED by the main BF16 `lm_head_batched`
+    // (verify_*.rs) — an approximate draft head only affects acceptance rate,
+    // never an emitted/accepted token. Only built when speculative decoding is
+    // actually active and the checkpoint ships an MTP head; otherwise `None`.
+    //
+    // When the main head is NVFP4 (`lm_head_nvfp4.is_some()`), this stays
+    // `None` and the proposer falls back to the main NVFP4 head — byte-for-byte
+    // unchanged from the pre-decouple behavior.
+    let mtp_lm_head_nvfp4 = if lm_head_nvfp4.is_none() && use_speculative && !mtp_weights.is_empty()
+    {
+        let q = quantize_to_nvfp4(
+            &lm_head,
+            config.vocab_size,
+            config.hidden_size,
+            gpu.as_ref(),
+            absmax_k,
+            quantize_k,
+            stream,
+        )?;
+        tracing::info!(
+            "Draft-only NVFP4 LM head built for MTP (main head stays BF16, vocab={})",
+            config.vocab_size,
+        );
+        Some(q)
+    } else {
+        None
     };
 
     // ── Step 3b: Post-load MoE prefill transpose (MiniMax EP=2 TTFT fix) ──
@@ -380,6 +439,8 @@ pub fn build_model(
         final_norm,
         lm_head,
         lm_head_nvfp4,
+        lm_head_fp8,
+        mtp_lm_head_nvfp4,
         layers,
         buffers,
         kv_cache,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -34,6 +34,12 @@ impl TransformerModel {
         final_norm: DenseWeight,
         lm_head_weight: DenseWeight,
         lm_head_nvfp4: Option<QuantizedWeight>,
+        // Runtime FP8 LM head (`--lm-head-dtype fp8`); `None` on NVFP4/BF16 paths.
+        lm_head_fp8: Option<crate::weight_map::Fp8DenseWeight>,
+        // Draft-only NVFP4 head for MTP when the main head is BF16; `None`
+        // otherwise (the proposer then falls back to `lm_head_nvfp4`). Drafts
+        // are verified by the main head, so it never affects an accepted token.
+        mtp_lm_head_nvfp4: Option<QuantizedWeight>,
         layers: Vec<Box<dyn TransformerLayer>>,
         buffers: BufferArena,
         kv_cache: PagedKvCache,
@@ -80,6 +86,8 @@ impl TransformerModel {
         let w4a16_gemv_logits_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_logits")?;
         let w4a16_gemm_kernel = gpu.kernel("w4a16", "w4a16_gemm")?;
         let w4a16_gemv_batch2_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?;
+        // FP8 E4M3 LUT GEMV for the `--lm-head-dtype fp8` head (cheap handle; only used when set).
+        let dense_gemv_fp8w_kernel = gpu.kernel("gemv_fp8w", "dense_gemv_fp8w")?;
         let dense_gemm_kernel = gpu.kernel("gemm", "dense_gemm_bf16")?;
         let argmax_kernel = gpu.kernel("argmax", "argmax_bf16")?;
         let argmax_logits_kernel = gpu.kernel("argmax", "argmax_fp32")?;
@@ -123,8 +131,12 @@ impl TransformerModel {
         // or lm_head quantization — its K=γ verify path checkpoints SSM state
         // for partial-accept rollback. Force `has_mtp` on whenever DFlash is
         // active so the checkpoint pools exist.
+        // The MTP proposer needs an NVFP4 vocab head for drafting: either the
+        // main head (NVFP4 default) or the draft-only head built when the main
+        // head is BF16. `draft_lm_head_nvfp4` resolves to whichever is present.
+        let draft_lm_head_nvfp4 = mtp_lm_head_nvfp4.or(lm_head_nvfp4);
         let has_mtp = self_speculative
-            || (use_speculative && !mtp_weights.is_empty() && lm_head_nvfp4.is_some())
+            || (use_speculative && !mtp_weights.is_empty() && draft_lm_head_nvfp4.is_some())
             || dflash_kgamma > 0;
         let num_intermediates = if has_mtp {
             (num_drafts + 1).max(dflash_kgamma)
@@ -187,7 +199,7 @@ impl TransformerModel {
             use_speculative,
             mtp_weights,
             embed_tokens,
-            lm_head_nvfp4,
+            draft_lm_head_nvfp4,
             &config,
             gpu.as_ref(),
             mtp_quant,
@@ -411,6 +423,7 @@ impl TransformerModel {
             final_norm,
             lm_head_weight,
             lm_head_nvfp4,
+            lm_head_fp8,
             layers,
             buffers,
             kv_cache: Mutex::new(kv_cache),
@@ -423,6 +436,7 @@ impl TransformerModel {
             w4a16_gemv_logits_kernel,
             w4a16_gemm_kernel,
             w4a16_gemv_batch2_kernel,
+            dense_gemv_fp8w_kernel,
             dense_gemm_kernel,
             argmax_kernel,
             argmax_logits_kernel,

--- a/crates/spark-model/src/model/impl_a3.rs
+++ b/crates/spark-model/src/model/impl_a3.rs
@@ -132,7 +132,24 @@ impl TransformerModel {
         let h = self.config.hidden_size as u32;
         let v = self.config.vocab_size as u32;
         let logits = self.buffers.logits();
-        if num_tokens == 2 {
+        if let Some(ref fp8) = self.lm_head_fp8 {
+            // FP8 E4M3 LM head. `w8a16_gemv` is M=1 only (no batch2/GEMM
+            // variant), so loop one GEMV per token. hidden is BF16 [K,H]
+            // (stride h*2 bytes); logits is BF16 [K,V] (stride v*2 bytes).
+            let bf16 = 2usize;
+            for i in 0..num_tokens as usize {
+                ops::dense_gemv_fp8w(
+                    self.gpu.as_ref(),
+                    self.dense_gemv_fp8w_kernel,
+                    hidden.offset(i * h as usize * bf16),
+                    fp8,
+                    logits.offset(i * v as usize * bf16),
+                    v,
+                    h,
+                    stream,
+                )?;
+            }
+        } else if num_tokens == 2 {
             // Double-GEMV: reads weights once, computes 2 outputs.
             // GEMM M=2 with 64×64 tiles wastes 97% of M-dimension → ~3× slower.
             if let Some(ref nvfp4) = self.lm_head_nvfp4 {
@@ -218,7 +235,22 @@ impl TransformerModel {
         } else {
             (self.buffers.logits(), false)
         };
-        if let Some(ref nvfp4) = self.lm_head_nvfp4 {
+        if let Some(ref fp8) = self.lm_head_fp8 {
+            // FP8 E4M3 LM head (`--lm-head-dtype fp8`). `w8a16_gemv` has no
+            // FP32-output variant — it writes to whichever buffer is passed.
+            // `use_fp32_logits` is false in production, so `logits` is the
+            // shared BF16 buffer; the FP32-logits path is unused here.
+            ops::dense_gemv_fp8w(
+                self.gpu.as_ref(),
+                self.dense_gemv_fp8w_kernel,
+                hidden,
+                fp8,
+                logits,
+                v,
+                h,
+                stream,
+            )?;
+        } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
             // Pick FP32-output variant when the FP32 logits buffer is the
             // destination. Same packed-NVFP4 weights, same activation, but the
             // accumulator is NOT downcast to BF16 — closes the 0.125-logit

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -350,7 +350,18 @@ impl TransformerModel {
             for i in 0..padded_n {
                 let normed_i = normed.offset(i * h * bf16);
                 let logits_i = logits.offset(i * v * bf16);
-                if let Some(ref nvfp4) = self.lm_head_nvfp4 {
+                if let Some(ref fp8) = self.lm_head_fp8 {
+                    ops::dense_gemv_fp8w(
+                        self.gpu.as_ref(),
+                        self.dense_gemv_fp8w_kernel,
+                        normed_i,
+                        fp8,
+                        logits_i,
+                        v as u32,
+                        h as u32,
+                        stream,
+                    )?;
+                } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
                     ops::w4a16_gemv(
                         self.gpu.as_ref(),
                         self.w4a16_gemv_kernel,

--- a/crates/spark-model/src/model/trait_impl/decode_b2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b2.rs
@@ -60,7 +60,18 @@ impl TransformerModel {
         for i in 0..padded_n {
             let normed_i = normed.offset(i * h * bf16);
             let logits_i = logits.offset(i * v * bf16);
-            if let Some(ref nvfp4) = self.lm_head_nvfp4 {
+            if let Some(ref fp8) = self.lm_head_fp8 {
+                ops::dense_gemv_fp8w(
+                    self.gpu.as_ref(),
+                    self.dense_gemv_fp8w_kernel,
+                    normed_i,
+                    fp8,
+                    logits_i,
+                    v as u32,
+                    h as u32,
+                    stream,
+                )?;
+            } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
                 ops::w4a16_gemv(
                     self.gpu.as_ref(),
                     self.w4a16_gemv_kernel,
@@ -105,7 +116,18 @@ impl TransformerModel {
 
             // Place prefill logits after decode logits
             let prefill_logits_ptr = logits.offset(padded_n * v * bf16);
-            if let Some(ref nvfp4) = self.lm_head_nvfp4 {
+            if let Some(ref fp8) = self.lm_head_fp8 {
+                ops::dense_gemv_fp8w(
+                    self.gpu.as_ref(),
+                    self.dense_gemv_fp8w_kernel,
+                    prefill_normed,
+                    fp8,
+                    prefill_logits_ptr,
+                    v as u32,
+                    h as u32,
+                    stream,
+                )?;
+            } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
                 ops::w4a16_gemv(
                     self.gpu.as_ref(),
                     self.w4a16_gemv_kernel,

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -20,7 +20,7 @@ use crate::layer::{
 use crate::layers::ops;
 use crate::speculative::DraftProposer;
 use crate::traits::{ChunkedPrefillPageMetadata, Model, SequenceState};
-use crate::weight_map::{DenseWeight, MtpWeights, QuantizedWeight};
+use crate::weight_map::{DenseWeight, Fp8DenseWeight, MtpWeights, QuantizedWeight};
 
 /// Architecture-agnostic transformer model.
 ///
@@ -34,6 +34,11 @@ pub struct TransformerModel {
     pub(super) final_norm: DenseWeight,
     pub(super) lm_head_weight: DenseWeight,
     pub(super) lm_head_nvfp4: Option<QuantizedWeight>,
+    /// Runtime FP8 E4M3 LM head (per-row scales), decoded via `w8a16_gemv`.
+    /// `Some` only when `--lm-head-dtype fp8` was requested; mutually exclusive
+    /// with `lm_head_nvfp4` (that stays `None` on the FP8 path). Additive: when
+    /// `None`, the NVFP4/BF16 LM-head dispatch is byte-identical to before.
+    pub(super) lm_head_fp8: Option<Fp8DenseWeight>,
     pub(super) layers: Vec<Box<dyn TransformerLayer>>,
     pub(super) buffers: BufferArena,
     pub(super) kv_cache: Mutex<PagedKvCache>,
@@ -52,6 +57,10 @@ pub struct TransformerModel {
     pub(super) w4a16_gemv_logits_kernel: KernelHandle, // FP32 output for LM head
     pub(super) w4a16_gemm_kernel: KernelHandle,
     pub(super) w4a16_gemv_batch2_kernel: KernelHandle,
+    /// FP8 E4M3 LUT GEMV (M=1) for the FP8 LM head. Only used when
+    /// `lm_head_fp8.is_some()`; loaded unconditionally (cheap handle) so the
+    /// dispatch in `lm_head` / batched-decode / verify can reference it.
+    pub(super) dense_gemv_fp8w_kernel: KernelHandle,
     pub(super) dense_gemm_kernel: KernelHandle,
     pub(super) argmax_kernel: KernelHandle,
     pub(super) argmax_logits_kernel: KernelHandle, // FP32 argmax for logits

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -187,9 +187,15 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                             gpu.free(o_dense.weight)?;
 
                             let attn = AttentionWeights {
-                                q_proj: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
-                                k_proj: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
-                                v_proj: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
+                                q_proj: DenseWeight {
+                                    weight: spark_runtime::gpu::DevicePtr::NULL,
+                                },
+                                k_proj: DenseWeight {
+                                    weight: spark_runtime::gpu::DevicePtr::NULL,
+                                },
+                                v_proj: DenseWeight {
+                                    weight: spark_runtime::gpu::DevicePtr::NULL,
+                                },
                                 o_proj: o_nvfp4,
                                 q_norm: dense(store, &format!("{p}.q_norm.weight"))?,
                                 k_norm: dense(store, &format!("{p}.k_norm.weight"))?,
@@ -356,7 +362,9 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     gpu.free(out_proj_dense.weight)?;
 
                     let ssm = SsmWeights {
-                        in_proj_qkvz: DenseWeight { weight: spark_runtime::gpu::DevicePtr::NULL },
+                        in_proj_qkvz: DenseWeight {
+                            weight: spark_runtime::gpu::DevicePtr::NULL,
+                        },
                         in_proj_ba: ba_dense,
                         conv1d,
                         a_log,

--- a/crates/spark-runtime/src/radix_tree/tests/basic.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/basic.rs
@@ -390,7 +390,7 @@ fn test_vision_pad_tokens_are_image_blind_collision() {
     // Page A: 3 prompt tokens followed by a run of image-pad placeholders.
     let page_a: Vec<u32> = [1u32, 2, 3]
         .into_iter()
-        .chain(std::iter::repeat(IMAGE_PAD).take(29))
+        .chain(std::iter::repeat_n(IMAGE_PAD, 29))
         .collect(); // 32 tokens == 2 blocks of 16
     // Page B is a DIFFERENT image but the same prompt and same pad count, so
     // pixels never enter the token IDs: the stream is identical to page A.

--- a/crates/spark-server/src/anthropic/tests/translator_a.rs
+++ b/crates/spark-server/src/anthropic/tests/translator_a.rs
@@ -226,10 +226,8 @@ fn translator_tool_result_is_error_default_serde() {
         }
         _ => panic!("wrong variant"),
     }
-    let no_field: ContentBlock = serde_json::from_str(
-        r#"{"type":"tool_result","tool_use_id":"x","content":"ok"}"#,
-    )
-    .unwrap();
+    let no_field: ContentBlock =
+        serde_json::from_str(r#"{"type":"tool_result","tool_use_id":"x","content":"ok"}"#).unwrap();
     match no_field {
         ContentBlock::ToolResult { is_error, .. } => {
             assert_eq!(is_error, None);
@@ -324,4 +322,3 @@ fn response_translator_text_only() {
         other => panic!("unexpected block: {:?}", other),
     }
 }
-

--- a/crates/spark-server/src/anthropic/tests/translator_b.rs
+++ b/crates/spark-server/src/anthropic/tests/translator_b.rs
@@ -275,9 +275,8 @@ pub(super) fn load_claude_code_tools() -> serde_json::Value {
         env!("CARGO_MANIFEST_DIR"),
         "/../../scripts/fixtures/claude_code_tools.json"
     );
-    let raw = std::fs::read_to_string(path).unwrap_or_else(|e| {
-        panic!("claude_code_tools.json fixture missing at {path}: {e}")
-    });
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("claude_code_tools.json fixture missing at {path}: {e}"));
     serde_json::from_str(&raw).expect("claude_code_tools.json must be valid JSON")
 }
 
@@ -296,11 +295,7 @@ fn fixture_load_smoke_test() {
     );
     let tools = load_claude_code_tools();
     let arr = tools.as_array().expect("tools is a JSON array");
-    assert_eq!(
-        arr.len(),
-        70,
-        "real Claude Code session declares 70 tools"
-    );
+    assert_eq!(arr.len(), 70, "real Claude Code session declares 70 tools");
 }
 
 #[test]

--- a/crates/spark-server/src/anthropic/tests/types_convert.rs
+++ b/crates/spark-server/src/anthropic/tests/types_convert.rs
@@ -24,9 +24,7 @@ fn test_convert_tool_choice() {
         choice_type: "auto".to_string(),
         name: None,
     };
-    assert!(
-        matches!(convert_tool_choice(&auto), tool_parser::ToolChoice::Mode(s) if s == "auto")
-    );
+    assert!(matches!(convert_tool_choice(&auto), tool_parser::ToolChoice::Mode(s) if s == "auto"));
 
     let specific = AnthropicToolChoice {
         choice_type: "tool".to_string(),

--- a/crates/spark-server/src/api/tests/f28_f32.rs
+++ b/crates/spark-server/src/api/tests/f28_f32.rs
@@ -9,11 +9,7 @@
 
 mod f28_f32_tests {
     use super::super::super::*;
-    use super::super::common::{
-    mk_assistant_with_tool_call,
-    mk_msg,
-    mk_tool_msg,
-};
+    use super::super::common::{mk_assistant_with_tool_call, mk_msg, mk_tool_msg};
 
     // ── F28-F32 tests (tool-error-forgetfulness fixes) ──
     // (mk_msg / mk_tool_msg / mk_assistant_with_tool_call hoisted to
@@ -80,9 +76,7 @@ mod f28_f32_tests {
     fn f29_extract_facts_filters_below_threshold() {
         // F36 (2026-04-26): threshold is now 2; one occurrence should
         // NOT yield a fact (transient, could be a typo or path issue).
-        let msgs = vec![
-            mk_tool_msg("c1", "[tool error]\ncargo: command not found"),
-        ];
+        let msgs = vec![mk_tool_msg("c1", "[tool error]\ncargo: command not found")];
         let facts = f29_extract_environment_facts(&msgs);
         assert!(facts.is_empty(), "got {facts:?}");
     }
@@ -146,7 +140,11 @@ mod f28_f32_tests {
         let mut msgs = vec![mk_msg("system", "you are helpful"), mk_msg("user", "hi")];
         prepend_reminder_to_system(&mut msgs, "first reminder");
         prepend_reminder_to_system(&mut msgs, "second reminder");
-        let count = msgs[0].content.text.matches("<atlas_runtime_notice>").count();
+        let count = msgs[0]
+            .content
+            .text
+            .matches("<atlas_runtime_notice>")
+            .count();
         assert_eq!(count, 1);
         assert!(msgs[0].content.text.contains("second reminder"));
         assert!(!msgs[0].content.text.contains("first reminder"));
@@ -156,7 +154,10 @@ mod f28_f32_tests {
     #[test]
     fn f31_no_anchor_no_inject() {
         let mut msgs = vec![mk_msg("user", "hi")];
-        let metrics = F23ProgressMetrics { score: -3, attempts: 10 };
+        let metrics = F23ProgressMetrics {
+            score: -3,
+            attempts: 10,
+        };
         assert!(!f31_inject_hard_refusal(&mut msgs, metrics));
     }
 
@@ -167,7 +168,10 @@ mod f28_f32_tests {
             mk_assistant_with_tool_call("toolu_1", "Bash", "{\"command\":\"x\"}"),
             mk_tool_msg("toolu_1", "[tool error]\ncargo: command not found"),
         ];
-        let metrics = F23ProgressMetrics { score: -1, attempts: 3 };
+        let metrics = F23ProgressMetrics {
+            score: -1,
+            attempts: 3,
+        };
         assert!(!f31_inject_hard_refusal(&mut msgs, metrics));
     }
 
@@ -178,7 +182,10 @@ mod f28_f32_tests {
             mk_assistant_with_tool_call("toolu_1", "Bash", "{\"command\":\"x\"}"),
             mk_tool_msg("toolu_1", "[tool error]\ncargo: command not found"),
         ];
-        let metrics = F23ProgressMetrics { score: -3, attempts: 10 };
+        let metrics = F23ProgressMetrics {
+            score: -3,
+            attempts: 10,
+        };
         assert!(f31_inject_hard_refusal(&mut msgs, metrics));
         let last = msgs.last().unwrap();
         assert_eq!(last.role, "tool");
@@ -193,14 +200,19 @@ mod f28_f32_tests {
             mk_assistant_with_tool_call("toolu_1", "Bash", "{\"command\":\"x\"}"),
             mk_tool_msg("toolu_1", "[tool error]\ncargo: command not found"),
         ];
-        let metrics = F23ProgressMetrics { score: -3, attempts: 10 };
+        let metrics = F23ProgressMetrics {
+            score: -3,
+            attempts: 10,
+        };
         assert!(f31_inject_hard_refusal(&mut msgs, metrics));
         assert!(!f31_inject_hard_refusal(&mut msgs, metrics));
         let count = msgs
             .iter()
             .filter(|m| {
                 m.role == "tool"
-                    && m.content.text.starts_with("[tool error]\n[atlas-stall-guard]")
+                    && m.content
+                        .text
+                        .starts_with("[tool error]\n[atlas-stall-guard]")
             })
             .count();
         assert_eq!(count, 1);
@@ -262,7 +274,9 @@ mod f28_f32_tests {
     #[test]
     fn f37_classify_invalid_arg() {
         assert_eq!(
-            f37_classify_failure("Error: You must read file /tmp/f.toml before overwriting it. Use the Read tool first"),
+            f37_classify_failure(
+                "Error: You must read file /tmp/f.toml before overwriting it. Use the Read tool first"
+            ),
             Some(F37FailureClass::InvalidArgument)
         );
         assert_eq!(

--- a/crates/spark-server/src/api/tests/f49.rs
+++ b/crates/spark-server/src/api/tests/f49.rs
@@ -9,11 +9,7 @@
 
 mod f49_tests {
     use super::super::super::*;
-    use super::super::common::{
-    mk_assistant_with_tool_call,
-    mk_msg,
-    mk_tool_msg,
-};
+    use super::super::common::{mk_assistant_with_tool_call, mk_msg, mk_tool_msg};
 
     // ── F49 / F50 / F44 (fix35) tests ──
 
@@ -67,14 +63,8 @@ mod f49_tests {
     fn f51_primary_arg_handles_lowercase_bash() {
         // opencode bash tool name with `command` arg — must extract
         // the same primary_arg as Claude Code's "Bash".
-        let p_lower = primary_arg_for_tool(
-            "bash",
-            "{\"command\":\"cd /tmp && cargo init\"}",
-        );
-        let p_upper = primary_arg_for_tool(
-            "Bash",
-            "{\"command\":\"cd /tmp && cargo init\"}",
-        );
+        let p_lower = primary_arg_for_tool("bash", "{\"command\":\"cd /tmp && cargo init\"}");
+        let p_upper = primary_arg_for_tool("Bash", "{\"command\":\"cd /tmp && cargo init\"}");
         assert_eq!(p_lower, p_upper);
         assert_eq!(p_lower.as_deref(), Some("cargo init"));
     }
@@ -124,7 +114,10 @@ mod f49_tests {
         let mut msgs = vec![
             mk_msg("user", "run tests"),
             mk_assistant_with_tool_call("c0", "Bash", "{\"command\":\"cargo test\"}"),
-            mk_tool_msg("c0", "[tool error]\nerror: couldn't read src/main.rs: No such file or directory"),
+            mk_tool_msg(
+                "c0",
+                "[tool error]\nerror: couldn't read src/main.rs: No such file or directory",
+            ),
             mk_assistant_with_tool_call("c1", "Write", args),
             mk_tool_msg("c1", "Wrote file successfully."),
             mk_assistant_with_tool_call("c2", "Write", args),

--- a/crates/spark-server/src/api/tests/sanitizer.rs
+++ b/crates/spark-server/src/api/tests/sanitizer.rs
@@ -11,11 +11,7 @@
 
 mod sanitizer_tests {
     use super::super::super::*;
-    use crate::tool_parser::{
-    LeakMarkers,
-    Qwen3CoderParser,
-    ToolCallParser,
-};
+    use crate::tool_parser::{LeakMarkers, Qwen3CoderParser, ToolCallParser};
 
     /// F73 (2026-04-29): test wrapper that defaults the new
     /// `inside_envelope: &mut bool` parameter. Tests in this module
@@ -53,9 +49,7 @@ mod sanitizer_tests {
         // tracks what the parser actually exports.
         let markers = crate::tool_parser::MinimaxXmlParser.leak_markers();
 
-        for envelope_open in
-            &["<minimax:tool_call>", "<minimax:_call>", "<tool_call>"]
-        {
+        for envelope_open in &["<minimax:tool_call>", "<minimax:_call>", "<tool_call>"] {
             let envelope_close = match *envelope_open {
                 "<minimax:tool_call>" => "</minimax:tool_call>",
                 "<minimax:_call>" => "</minimax:_call>",
@@ -67,9 +61,8 @@ mod sanitizer_tests {
             let mut buf = String::new();
             let mut suppress = false;
             let mut env = false;
-            let out = super::sanitize_content_chunk(
-                &body, &mut buf, &mut suppress, &mut env, &markers,
-            );
+            let out =
+                super::sanitize_content_chunk(&body, &mut buf, &mut suppress, &mut env, &markers);
             // Inner content + envelope tags survive — the parser
             // downstream extracts the tool call from this stream.
             assert!(
@@ -111,10 +104,11 @@ mod sanitizer_tests {
         let mut buf = String::new();
         let mut suppress = false;
         let mut env = false;
-        let out = super::sanitize_content_chunk(
-            body, &mut buf, &mut suppress, &mut env, &markers,
+        let out = super::sanitize_content_chunk(body, &mut buf, &mut suppress, &mut env, &markers);
+        assert!(
+            out.starts_with("prefix"),
+            "non-orphan prefix emits: {out:?}"
         );
-        assert!(out.starts_with("prefix"), "non-orphan prefix emits: {out:?}");
         assert!(
             !out.contains("<invoke"),
             "stray <invoke> must still be suppressed: {out:?}"
@@ -195,9 +189,18 @@ mod sanitizer_tests {
         // Fusion: `<parameter=x>` found in the combined buffer.
         // "abc" prefix emits; body suppressed; `</parameter>` ends
         // suppression; "tail" stays buffered (too short to flush).
-        assert!(out2.starts_with("abc"), "prefix emits after fusion: {out2:?}");
-        assert!(!out2.contains("body"), "suppressed body must not leak: {out2:?}");
-        assert!(!out2.contains("<parameter="), "orphan open must not leak: {out2:?}");
+        assert!(
+            out2.starts_with("abc"),
+            "prefix emits after fusion: {out2:?}"
+        );
+        assert!(
+            !out2.contains("body"),
+            "suppressed body must not leak: {out2:?}"
+        );
+        assert!(
+            !out2.contains("<parameter="),
+            "orphan open must not leak: {out2:?}"
+        );
         assert!(!suppress, "close tag exits suppression state");
     }
 
@@ -253,12 +256,22 @@ mod sanitizer_tests {
         ];
         let content = "\n\nLet me create the Rust calculator module with the source files first.\n\n<read>\n<filePath>\n/tmp/calc-test40/src/lib.rs\n</filePath>\n<offset>\n1\n</offset>\n<limit>\n100\n</limit>\n</read>";
         let out = strip_xml_leaks_from_assistant_content(content, &tool_defs);
-        assert!(out.contains("Let me create the Rust calculator module"),
-            "prose must survive: {out:?}");
-        assert!(!out.contains("<read>"), "read leak must be stripped: {out:?}");
-        assert!(!out.contains("<filePath>"), "inner tags must be stripped: {out:?}");
-        assert!(!out.contains("/tmp/calc-test40/src/lib.rs"),
-            "leaked path must be removed: {out:?}");
+        assert!(
+            out.contains("Let me create the Rust calculator module"),
+            "prose must survive: {out:?}"
+        );
+        assert!(
+            !out.contains("<read>"),
+            "read leak must be stripped: {out:?}"
+        );
+        assert!(
+            !out.contains("<filePath>"),
+            "inner tags must be stripped: {out:?}"
+        );
+        assert!(
+            !out.contains("/tmp/calc-test40/src/lib.rs"),
+            "leaked path must be removed: {out:?}"
+        );
     }
 
     #[test]
@@ -314,12 +327,15 @@ mod sanitizer_tests {
                 },
             },
         ];
-        let content = "A <read><filePath>/a</filePath></read> B <write><filePath>/b</filePath></write> C";
+        let content =
+            "A <read><filePath>/a</filePath></read> B <write><filePath>/b</filePath></write> C";
         let out = strip_xml_leaks_from_assistant_content(content, &tool_defs);
         assert!(!out.contains("<read>"));
         assert!(!out.contains("<write>"));
-        assert!(out.contains('A') && out.contains('B') && out.contains('C'),
-            "prose between blocks must survive: {out:?}");
+        assert!(
+            out.contains('A') && out.contains('B') && out.contains('C'),
+            "prose between blocks must survive: {out:?}"
+        );
     }
 
     #[test]

--- a/crates/spark-server/src/api/tests/watchdog_f7.rs
+++ b/crates/spark-server/src/api/tests/watchdog_f7.rs
@@ -24,7 +24,9 @@ mod watchdog_f7_tests {
         // Five copies of phrase + ~1500 chars of unique filler each =
         // ~7.5 KB total — fits in the 8 KB window but would have
         // rolled out of the previous 3 KB.
-        let filler: String = (0..1500).map(|i| (b'a' + ((i % 26) as u8)) as char).collect();
+        let filler: String = (0..1500)
+            .map(|i| (b'a' + ((i % 26) as u8)) as char)
+            .collect();
         let mut feed = String::new();
         for _ in 0..5 {
             feed.push_str(phrase);
@@ -80,18 +82,9 @@ mod watchdog_f7_tests {
 
     // ── F7 (2026-04-26): cross-turn tool-arg-path stall guard tests ──
 
-    fn make_assistant_tool_call(
-        name: &str,
-        args_json: &str,
-    ) -> crate::openai::IncomingMessage {
-        use crate::openai::{
-    IncomingMessage,
-    ParsedContent,
-};
-        use crate::tool_parser::{
-    IncomingFunction,
-    IncomingToolCall,
-};
+    fn make_assistant_tool_call(name: &str, args_json: &str) -> crate::openai::IncomingMessage {
+        use crate::openai::{IncomingMessage, ParsedContent};
+        use crate::tool_parser::{IncomingFunction, IncomingToolCall};
         IncomingMessage {
             role: "assistant".to_string(),
             content: ParsedContent::default(),
@@ -108,10 +101,7 @@ mod watchdog_f7_tests {
     }
 
     fn make_user(text: &str) -> crate::openai::IncomingMessage {
-        use crate::openai::{
-    IncomingMessage,
-    ParsedContent,
-};
+        use crate::openai::{IncomingMessage, ParsedContent};
         IncomingMessage {
             role: "user".to_string(),
             content: ParsedContent {
@@ -166,7 +156,12 @@ mod watchdog_f7_tests {
         assert!(!reminder.contains("Do NOT call any tool"));
         append_f7_reminder_to_last_user(&mut msgs, &reminder);
         let last_user = msgs.iter().rev().find(|m| m.role == "user").unwrap();
-        assert!(last_user.content.text.contains("Write(/tmp/x/Cargo.toml) × 4"));
+        assert!(
+            last_user
+                .content
+                .text
+                .contains("Write(/tmp/x/Cargo.toml) × 4")
+        );
         assert!(last_user.content.text.starts_with("now what?"));
     }
 
@@ -188,10 +183,7 @@ mod watchdog_f7_tests {
             .map(|i| {
                 make_assistant_tool_call(
                     "Write",
-                    &format!(
-                        r#"{{"file_path":"/tmp/x/Cargo.toml","content":"v{}"}}"#,
-                        i
-                    ),
+                    &format!(r#"{{"file_path":"/tmp/x/Cargo.toml","content":"v{}"}}"#, i),
                 )
             })
             .collect();
@@ -217,22 +209,10 @@ mod watchdog_f7_tests {
         // BASH_COMMAND_PREFIX_LEN. Four identical (post-F14
         // threshold of 4) trips the warn level.
         let msgs = vec![
-            make_assistant_tool_call(
-                "Bash",
-                r#"{"command":"cd /tmp/x && cargo init --name a"}"#,
-            ),
-            make_assistant_tool_call(
-                "Bash",
-                r#"{"command":"cd /tmp/x && cargo init --name a"}"#,
-            ),
-            make_assistant_tool_call(
-                "Bash",
-                r#"{"command":"cd /tmp/x && cargo init --name a"}"#,
-            ),
-            make_assistant_tool_call(
-                "Bash",
-                r#"{"command":"cd /tmp/x && cargo init --name a"}"#,
-            ),
+            make_assistant_tool_call("Bash", r#"{"command":"cd /tmp/x && cargo init --name a"}"#),
+            make_assistant_tool_call("Bash", r#"{"command":"cd /tmp/x && cargo init --name a"}"#),
+            make_assistant_tool_call("Bash", r#"{"command":"cd /tmp/x && cargo init --name a"}"#),
+            make_assistant_tool_call("Bash", r#"{"command":"cd /tmp/x && cargo init --name a"}"#),
         ];
         let buckets = collect_f7_stall_buckets(&msgs);
         assert_eq!(

--- a/crates/spark-server/src/cli.rs
+++ b/crates/spark-server/src/cli.rs
@@ -62,6 +62,27 @@ pub struct ServeArgs {
     #[arg(long, default_value = "fp8")]
     pub kv_cache_dtype: String,
 
+    /// LM-head precision: `default` (model-config-driven), `bf16` (final vocab projection
+    /// in BF16 — the SAFE DEFAULT, matches vLLM checkpoint precision), `nvfp4` (force the
+    /// model's NVFP4-packed lm_head), or `fp8` (runtime-quantize the lm_head to FP8 E4M3
+    /// per-row, w8a16_gemv decode). The big vocab projection (~1.78 GB/token BF16 at a
+    /// 248K vocab) is the single largest per-token weight read; `fp8` halves it and `nvfp4`
+    /// quarters it for a real decode speedup (measured Qwen3.6-35B-A3B: bf16 72 → fp8 86
+    /// (+20%) → nvfp4 97 (+35%) tok/s).
+    ///
+    /// ⚠️  WARNING — reducing lm-head precision below BF16 can be CATASTROPHIC on some
+    /// models. Low-margin argmax flips in the final vocab projection COMPOUND over LONG
+    /// structured generation and derail the output entirely, even when SHORT responses look
+    /// perfectly clean. MEASURED on Qwen3.6-35B-A3B (webserver_ok agentic harness, N=10):
+    /// bf16 = 10/10; BOTH fp8 and nvfp4 COLLAPSE (cargo-invalid output, 360s timeouts)
+    /// despite clean short-prompt coherence. ALWAYS quality-gate per-model with a
+    /// long-generation harness before enabling nvfp4/fp8 — do not trust a short smoke.
+    /// (An FP32-accumulate logits path would cut the flips but forces host-side sampling
+    /// → ~6 tok/s; making nvfp4/fp8 both fast AND safe needs a GPU-side FP32 sampler.)
+    /// Replaces the former ATLAS_LMHEAD_BF16 env var.
+    #[arg(long, default_value = "default")]
+    pub lm_head_dtype: String,
+
     /// Boundary attention layers to keep at BF16 KV cache precision (first N + last N).
     /// Protects attention sink tokens (early layers) and output quality (final layers)
     /// from quantization error while saving memory on middle layers.

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -36,6 +36,30 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     // 1. Load model config (supports HF config.json and Mistral params.json)
     let (mut config, config_json) = serve_phases::load_model_config(&model_dir)?;
 
+    // CLI `--lm-head-dtype` override (replaces ATLAS_LMHEAD_BF16). Validate eagerly (PCND).
+    // Sets both `lm_head_bf16_override` (skip/keep-quantized signal consumed by
+    // `skip_lm_head_quantization()`) and `lm_head_fp8` (when quantizing, pick FP8 w8a16
+    // over NVFP4). `fp8` reuses `Some(false)` ("force quantized lm_head") and additionally
+    // routes that quantization to FP8 — additive, leaves nvfp4/bf16/default byte-identical.
+    let (lm_head_bf16_override, lm_head_fp8) = match args.lm_head_dtype.as_str() {
+        "default" => (None, false),
+        "bf16" => (Some(true), false),
+        // `Some(false)` = force the model's NVFP4-packed lm_head (skip_lm_head_quantization
+        // returns false). BF16-out fast path (w4a16_gemv) — NOT use_fp32_logits, which would
+        // force host-side sampling (~6 tok/s). Decode-speed lever; quality-gate for argmax flips.
+        "nvfp4" => (Some(false), false),
+        // FP8: force a quantized lm_head, but use runtime FP8 (E4M3, per-row scales,
+        // w8a16_gemv decode) instead of NVFP4. Mirrors the NVFP4 path's structure.
+        "fp8" => (Some(false), true),
+        other => {
+            anyhow::bail!(
+                "--lm-head-dtype must be 'default', 'bf16', 'nvfp4', or 'fp8', got '{other}'"
+            )
+        }
+    };
+    config.lm_head_bf16_override = lm_head_bf16_override;
+    config.lm_head_fp8 = lm_head_fp8;
+
     // ModelOpt-exported checkpoints drop a sibling `hf_quant_config.json`
     // whose TOP LEVEL is already the quantization block.
     serve_phases::merge_sidecar_quant_config(&model_dir, &mut config);

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -59,8 +59,7 @@ pub fn start_chunked_prefill(
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
     let grammar_state = compile_grammar_state(grammar_engine, &grammar_spec);
-    let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req
-    {
+    let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req {
         InferenceRequest::Streaming {
             prompt_tokens,
             max_tokens,

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -57,8 +57,7 @@ pub fn prefill_request(
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
     let grammar_state = compile_grammar_state(grammar_engine, &grammar_spec);
-    let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req
-    {
+    let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req {
         InferenceRequest::Streaming {
             prompt_tokens,
             max_tokens,

--- a/crates/spark-server/src/tool_parser/tests/group_a.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_a.rs
@@ -3,289 +3,305 @@
 
 use super::super::*;
 
-    use super::*;
+use super::*;
 
-    // ── Hermes format ──
+// ── Hermes format ──
 
-    #[test]
-    fn parse_minimax_xml_drops_write_with_empty_filepath() {
-        // F80b: parser-side defense. The model self-truncates a long
-        // `content` then JSON-completes `<parameter name="filePath">
-        // </parameter>` (empty). Without this, parse_minimax_xml_call
-        // would return Some(ToolCall) with filePath="" — F78 catches
-        // it downstream but only after the call has already been
-        // emitted into the stream. Returning None here aborts cleanly.
-        let body = "<invoke name=\"write\">\n\
+#[test]
+fn parse_minimax_xml_drops_write_with_empty_filepath() {
+    // F80b: parser-side defense. The model self-truncates a long
+    // `content` then JSON-completes `<parameter name="filePath">
+    // </parameter>` (empty). Without this, parse_minimax_xml_call
+    // would return Some(ToolCall) with filePath="" — F78 catches
+    // it downstream but only after the call has already been
+    // emitted into the stream. Returning None here aborts cleanly.
+    let body = "<invoke name=\"write\">\n\
             <parameter name=\"content\">some code</parameter>\n\
             <parameter name=\"filePath\"></parameter>\n\
             </invoke>";
-        let res = parse_minimax_xml_call(body, 0);
-        assert!(res.is_none(), "expected drop, got {res:?}");
-    }
+    let res = parse_minimax_xml_call(body, 0);
+    assert!(res.is_none(), "expected drop, got {res:?}");
+}
 
-    #[test]
-    fn parse_minimax_xml_drops_write_with_whitespace_filepath() {
-        let body = "<invoke name=\"write\">\n\
+#[test]
+fn parse_minimax_xml_drops_write_with_whitespace_filepath() {
+    let body = "<invoke name=\"write\">\n\
             <parameter name=\"content\">x</parameter>\n\
             <parameter name=\"filePath\">   </parameter>\n\
             </invoke>";
-        let res = parse_minimax_xml_call(body, 0);
-        assert!(res.is_none(), "expected whitespace-only path drop, got {res:?}");
-    }
+    let res = parse_minimax_xml_call(body, 0);
+    assert!(
+        res.is_none(),
+        "expected whitespace-only path drop, got {res:?}"
+    );
+}
 
-    #[test]
-    fn parse_minimax_xml_keeps_bash_with_empty_path_field() {
-        // bash isn't a write/edit tool — F80b does NOT apply to it.
-        // (`path` field appearing on bash would be unusual but should
-        // pass through.)
-        let body = "<invoke name=\"bash\">\n\
+#[test]
+fn parse_minimax_xml_keeps_bash_with_empty_path_field() {
+    // bash isn't a write/edit tool — F80b does NOT apply to it.
+    // (`path` field appearing on bash would be unusual but should
+    // pass through.)
+    let body = "<invoke name=\"bash\">\n\
             <parameter name=\"command\">ls</parameter>\n\
             </invoke>";
-        let res = parse_minimax_xml_call(body, 0);
-        assert!(res.is_some(), "bash should pass even without path");
-    }
+    let res = parse_minimax_xml_call(body, 0);
+    assert!(res.is_some(), "bash should pass even without path");
+}
 
-    #[test]
-    fn parse_minimax_xml_keeps_write_with_valid_filepath() {
-        let body = "<invoke name=\"write\">\n\
+#[test]
+fn parse_minimax_xml_keeps_write_with_valid_filepath() {
+    let body = "<invoke name=\"write\">\n\
             <parameter name=\"content\">hi</parameter>\n\
             <parameter name=\"filePath\">/tmp/x.rs</parameter>\n\
             </invoke>";
-        let res = parse_minimax_xml_call(body, 0);
-        assert!(res.is_some());
-        let args: serde_json::Value =
-            serde_json::from_str(&res.unwrap().function.arguments).unwrap();
-        assert_eq!(args["filePath"], "/tmp/x.rs");
-    }
+    let res = parse_minimax_xml_call(body, 0);
+    assert!(res.is_some());
+    let args: serde_json::Value = serde_json::from_str(&res.unwrap().function.arguments).unwrap();
+    assert_eq!(args["filePath"], "/tmp/x.rs");
+}
 
-    #[test]
-    fn validate_rejects_write_with_empty_filepath() {
-        // F78: opencode loop reproduction — model emitted
-        // `{"content":"...","filePath":""}` and the Write tool failed
-        // with EISDIR forever. Validation must reject this.
-        let tool = ToolDefinition {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "write".to_string(),
-                description: None,
-                parameters: Some(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "content": {"type": "string"},
-                        "filePath": {"type": "string"}
-                    },
-                    "required": ["content", "filePath"]
-                })),
-            },
-        };
-        let call = ToolCall {
-            id: "x".to_string(),
-            call_type: "function".to_string(),
-            function: FunctionCall {
-                name: "write".to_string(),
-                arguments: r#"{"content":"some code","filePath":""}"#.to_string(),
-            },
-        };
-        let res = validate_single_tool_call(&call, &[tool]);
-        assert!(res.is_err(), "expected reject, got {res:?}");
-        assert!(
-            res.as_ref().unwrap_err().contains("non-empty"),
-            "error should mention non-empty: {}", res.unwrap_err()
-        );
-    }
+#[test]
+fn validate_rejects_write_with_empty_filepath() {
+    // F78: opencode loop reproduction — model emitted
+    // `{"content":"...","filePath":""}` and the Write tool failed
+    // with EISDIR forever. Validation must reject this.
+    let tool = ToolDefinition {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: "write".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string"},
+                    "filePath": {"type": "string"}
+                },
+                "required": ["content", "filePath"]
+            })),
+        },
+    };
+    let call = ToolCall {
+        id: "x".to_string(),
+        call_type: "function".to_string(),
+        function: FunctionCall {
+            name: "write".to_string(),
+            arguments: r#"{"content":"some code","filePath":""}"#.to_string(),
+        },
+    };
+    let res = validate_single_tool_call(&call, &[tool]);
+    assert!(res.is_err(), "expected reject, got {res:?}");
+    assert!(
+        res.as_ref().unwrap_err().contains("non-empty"),
+        "error should mention non-empty: {}",
+        res.unwrap_err()
+    );
+}
 
-    #[test]
-    fn validate_allows_read_with_empty_path() {
-        // Theia getWorkspaceFileList passes path="" — must keep
-        // working. Only WRITE_FAMILY rejects empty paths.
-        let tool = ToolDefinition {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "read".to_string(),
-                description: None,
-                parameters: Some(serde_json::json!({
-                    "type": "object",
-                    "properties": {"path": {"type": "string"}},
-                    "required": ["path"]
-                })),
-            },
-        };
-        let call = ToolCall {
-            id: "x".to_string(),
-            call_type: "function".to_string(),
-            function: FunctionCall {
-                name: "read".to_string(),
-                arguments: r#"{"path":""}"#.to_string(),
-            },
-        };
-        assert!(validate_single_tool_call(&call, &[tool]).is_ok());
-    }
+#[test]
+fn validate_allows_read_with_empty_path() {
+    // Theia getWorkspaceFileList passes path="" — must keep
+    // working. Only WRITE_FAMILY rejects empty paths.
+    let tool = ToolDefinition {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: "read".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"]
+            })),
+        },
+    };
+    let call = ToolCall {
+        id: "x".to_string(),
+        call_type: "function".to_string(),
+        function: FunctionCall {
+            name: "read".to_string(),
+            arguments: r#"{"path":""}"#.to_string(),
+        },
+    };
+    assert!(validate_single_tool_call(&call, &[tool]).is_ok());
+}
 
-    #[test]
-    fn parse_hermes_single_call() {
-        let (c, calls) =
-            parse_tool_calls("<tool_call>\n{\"name\":\"f\",\"arguments\":{\"x\":1}}\n</tool_call>");
-        assert!(c.is_none());
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "f");
-        assert_eq!(calls[0].function.arguments, "{\"x\":1}");
-    }
+#[test]
+fn parse_hermes_single_call() {
+    let (c, calls) =
+        parse_tool_calls("<tool_call>\n{\"name\":\"f\",\"arguments\":{\"x\":1}}\n</tool_call>");
+    assert!(c.is_none());
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "f");
+    assert_eq!(calls[0].function.arguments, "{\"x\":1}");
+}
 
-    #[test]
-    fn parse_hermes_with_content_and_multiple() {
-        let (c, calls) = parse_tool_calls(
-            "Hello\n<tool_call>\n{\"name\":\"a\",\"arguments\":{}}\n</tool_call>\n\
+#[test]
+fn parse_hermes_with_content_and_multiple() {
+    let (c, calls) = parse_tool_calls(
+        "Hello\n<tool_call>\n{\"name\":\"a\",\"arguments\":{}}\n</tool_call>\n\
              <tool_call>\n{\"name\":\"b\",\"arguments\":{}}\n</tool_call>",
-        );
-        assert_eq!(c.unwrap(), "Hello");
-        assert_eq!(calls.len(), 2);
-        // IDs are globally-unique 16-hex-digit counter values; don't
-        // assert on specific numbers (test order affects counter).
-        assert!(calls[0].id.starts_with("call_"));
-        assert!(calls[1].id.starts_with("call_"));
-        assert_ne!(calls[0].id, calls[1].id);
-        assert_eq!(calls[0].function.name, "a");
-        assert_eq!(calls[1].function.name, "b");
-    }
+    );
+    assert_eq!(c.unwrap(), "Hello");
+    assert_eq!(calls.len(), 2);
+    // IDs are globally-unique 16-hex-digit counter values; don't
+    // assert on specific numbers (test order affects counter).
+    assert!(calls[0].id.starts_with("call_"));
+    assert!(calls[1].id.starts_with("call_"));
+    assert_ne!(calls[0].id, calls[1].id);
+    assert_eq!(calls[0].function.name, "a");
+    assert_eq!(calls[1].function.name, "b");
+}
 
-    #[test]
-    fn parse_no_calls() {
-        let (c, calls) = parse_tool_calls("just text");
-        assert_eq!(c.unwrap(), "just text");
-        assert!(calls.is_empty());
-    }
+#[test]
+fn parse_no_calls() {
+    let (c, calls) = parse_tool_calls("just text");
+    assert_eq!(c.unwrap(), "just text");
+    assert!(calls.is_empty());
+}
 
-    #[test]
-    fn streaming_detector_hermes() {
-        let mut det = StreamingToolDetector::new();
-        let out = det.process("Hi <tool_call>\n{\"name\":\"f\",\"arguments\":{}}\n</tool_call>");
-        assert!(out.len() >= 2);
-        assert!(matches!(&out[0], DetectorOutput::Content(s) if s.contains("Hi")));
-        assert!(matches!(&out[1], DetectorOutput::ToolCall(tc, 0) if tc.function.name == "f"));
-        assert!(det.has_tool_calls());
-    }
+#[test]
+fn streaming_detector_hermes() {
+    let mut det = StreamingToolDetector::new();
+    let out = det.process("Hi <tool_call>\n{\"name\":\"f\",\"arguments\":{}}\n</tool_call>");
+    assert!(out.len() >= 2);
+    assert!(matches!(&out[0], DetectorOutput::Content(s) if s.contains("Hi")));
+    assert!(matches!(&out[1], DetectorOutput::ToolCall(tc, 0) if tc.function.name == "f"));
+    assert!(det.has_tool_calls());
+}
 
-    /// F73 (2026-04-29): the streaming detector must recognise all three
-    /// envelope forms produced by MiniMax M2.7 (canonical via the
-    /// 200052 special-token, BPE-broken via the `:_` straddler, and
-    /// the `<tool_call>` shape that downstream code normalises to).
-    /// Before F73 the detector only saw `<tool_call>`/`<|tool_call>`,
-    /// so the model's `<minimax:_call>...<invoke ...></invoke>...</minimax:tool_call>`
-    /// passed straight through as content and `tool_calls` ended up
-    /// `None` — the bug observed live in opencode session
-    /// `ses_225891319ffeu33G5iHCMGwvgV`.
-    #[test]
-    fn streaming_detector_minimax_envelope_canonical() {
-        let mut det = StreamingToolDetector::new();
-        let body = "<minimax:tool_call>\n\
+/// F73 (2026-04-29): the streaming detector must recognise all three
+/// envelope forms produced by MiniMax M2.7 (canonical via the
+/// 200052 special-token, BPE-broken via the `:_` straddler, and
+/// the `<tool_call>` shape that downstream code normalises to).
+/// Before F73 the detector only saw `<tool_call>`/`<|tool_call>`,
+/// so the model's `<minimax:_call>...<invoke ...></invoke>...</minimax:tool_call>`
+/// passed straight through as content and `tool_calls` ended up
+/// `None` — the bug observed live in opencode session
+/// `ses_225891319ffeu33G5iHCMGwvgV`.
+#[test]
+fn streaming_detector_minimax_envelope_canonical() {
+    let mut det = StreamingToolDetector::new();
+    let body = "<minimax:tool_call>\n\
             <invoke name=\"bash\">\n\
             <parameter name=\"command\">uname -r</parameter>\n\
             </invoke>\n\
             </minimax:tool_call>";
-        let out = det.process(body);
-        let names: Vec<String> = out.iter().filter_map(|o| match o {
+    let out = det.process(body);
+    let names: Vec<String> = out
+        .iter()
+        .filter_map(|o| match o {
             DetectorOutput::ToolCall(tc, _) => Some(tc.function.name.clone()),
             DetectorOutput::ToolCallStart { name, .. } => Some(name.clone()),
             _ => None,
-        }).collect();
-        assert!(
-            det.has_tool_calls(),
-            "detector must report a tool_call, got names={names:?}"
-        );
-        assert!(
-            names.iter().any(|n| n == "bash"),
-            "expected bash tool, got names={names:?}"
-        );
-    }
+        })
+        .collect();
+    assert!(
+        det.has_tool_calls(),
+        "detector must report a tool_call, got names={names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "bash"),
+        "expected bash tool, got names={names:?}"
+    );
+}
 
-    #[test]
-    fn streaming_detector_minimax_envelope_bpe_broken() {
-        // The exact failure shape from opencode-session.md
-        // `ses_225891319ffeu33G5iHCMGwvgV`: open is the BPE-broken
-        // `<minimax:_call>`, close is the canonical
-        // `</minimax:tool_call>`. Detector still extracts a valid
-        // tool call.
-        let mut det = StreamingToolDetector::new();
-        let body = "<minimax:_call>\n\
+#[test]
+fn streaming_detector_minimax_envelope_bpe_broken() {
+    // The exact failure shape from opencode-session.md
+    // `ses_225891319ffeu33G5iHCMGwvgV`: open is the BPE-broken
+    // `<minimax:_call>`, close is the canonical
+    // `</minimax:tool_call>`. Detector still extracts a valid
+    // tool call.
+    let mut det = StreamingToolDetector::new();
+    let body = "<minimax:_call>\n\
             <invoke name=\"bash\">\n\
             <parameter name=\"command\">mkdir -p /tmp/calc-test74/src /tmp/calc-test74/tests</parameter>\n\
             <parameter name=\"description\">Create project directories</parameter>\n\
             </invoke>\n\
             </minimax:tool_call>";
-        let out = det.process(body);
-        let tc = out.iter().find_map(|o| match o {
+    let out = det.process(body);
+    let tc = out.iter().find_map(|o| match o {
+        DetectorOutput::ToolCall(tc, _) => Some(tc.clone()),
+        _ => None,
+    });
+    assert!(
+        det.has_tool_calls(),
+        "broken-envelope detector must still extract a tool_call (tc found: {})",
+        tc.is_some()
+    );
+    let tc = tc.expect("ToolCall output expected");
+    assert_eq!(tc.function.name, "bash");
+    let args: serde_json::Value =
+        serde_json::from_str(&tc.function.arguments).expect("args must be JSON");
+    assert!(
+        args["command"]
+            .as_str()
+            .unwrap()
+            .contains("/tmp/calc-test74"),
+        "command arg lost: {args}"
+    );
+}
+
+/// F75 chunk-split safety: the BPE-broken `<minimax:_call>` open
+/// tag arrives split across stream chunks. Before adding it to
+/// `safe_emit_len`'s prefix list, the detector emitted the
+/// `<minimax:` trailing prefix as content (because none of the
+/// listed tags started with `<minimax:`), then on the next chunk
+/// the rest landed in an empty buffer and the open tag was lost.
+/// Result: the full envelope leaked to `content` and
+/// `has_tool_calls=false` — exactly opencode-session.md
+/// `ses_224cc79f4ffeUtq7NFV9YMTVMH`.
+#[test]
+fn streaming_detector_minimax_bpe_broken_split_chunks() {
+    let mut det = StreamingToolDetector::new();
+    // Simulate per-token chunked arrival of the broken envelope.
+    // The `:_` BPE token splits the open tag at byte 9.
+    let chunks = [
+        "<minimax",
+        ":_call>",
+        "\n<invoke name=\"bash\">\n",
+        "<parameter name=\"command\">",
+        "mkdir -p /tmp/calc-test74/src",
+        "</parameter>\n</invoke>\n",
+        "</minimax:tool_call>",
+    ];
+    let mut all_outputs = Vec::new();
+    for c in chunks {
+        all_outputs.extend(det.process(c));
+    }
+    let tcs: Vec<_> = all_outputs
+        .iter()
+        .filter_map(|o| match o {
             DetectorOutput::ToolCall(tc, _) => Some(tc.clone()),
             _ => None,
-        });
-        assert!(
-            det.has_tool_calls(),
-            "broken-envelope detector must still extract a tool_call (tc found: {})",
-            tc.is_some()
-        );
-        let tc = tc.expect("ToolCall output expected");
-        assert_eq!(tc.function.name, "bash");
-        let args: serde_json::Value =
-            serde_json::from_str(&tc.function.arguments).expect("args must be JSON");
-        assert!(
-            args["command"].as_str().unwrap().contains("/tmp/calc-test74"),
-            "command arg lost: {args}"
-        );
-    }
-
-    /// F75 chunk-split safety: the BPE-broken `<minimax:_call>` open
-    /// tag arrives split across stream chunks. Before adding it to
-    /// `safe_emit_len`'s prefix list, the detector emitted the
-    /// `<minimax:` trailing prefix as content (because none of the
-    /// listed tags started with `<minimax:`), then on the next chunk
-    /// the rest landed in an empty buffer and the open tag was lost.
-    /// Result: the full envelope leaked to `content` and
-    /// `has_tool_calls=false` — exactly opencode-session.md
-    /// `ses_224cc79f4ffeUtq7NFV9YMTVMH`.
-    #[test]
-    fn streaming_detector_minimax_bpe_broken_split_chunks() {
-        let mut det = StreamingToolDetector::new();
-        // Simulate per-token chunked arrival of the broken envelope.
-        // The `:_` BPE token splits the open tag at byte 9.
-        let chunks = [
-            "<minimax", ":_call>",
-            "\n<invoke name=\"bash\">\n",
-            "<parameter name=\"command\">",
-            "mkdir -p /tmp/calc-test74/src",
-            "</parameter>\n</invoke>\n",
-            "</minimax:tool_call>",
-        ];
-        let mut all_outputs = Vec::new();
-        for c in chunks {
-            all_outputs.extend(det.process(c));
-        }
-        let tcs: Vec<_> = all_outputs.iter().filter_map(|o| match o {
-            DetectorOutput::ToolCall(tc, _) => Some(tc.clone()),
-            _ => None,
-        }).collect();
-        assert!(det.has_tool_calls(), "envelope missed under chunked arrival");
-        assert_eq!(tcs.len(), 1, "expected 1 ToolCall");
-        assert_eq!(tcs[0].function.name, "bash");
-        // No content output should leak the envelope opener.
-        for o in &all_outputs {
-            if let DetectorOutput::Content(s) = o {
-                assert!(
-                    !s.contains("<minimax:"),
-                    "envelope text leaked to content: {s:?}"
-                );
-            }
+        })
+        .collect();
+    assert!(
+        det.has_tool_calls(),
+        "envelope missed under chunked arrival"
+    );
+    assert_eq!(tcs.len(), 1, "expected 1 ToolCall");
+    assert_eq!(tcs[0].function.name, "bash");
+    // No content output should leak the envelope opener.
+    for o in &all_outputs {
+        if let DetectorOutput::Content(s) = o {
+            assert!(
+                !s.contains("<minimax:"),
+                "envelope text leaked to content: {s:?}"
+            );
         }
     }
+}
 
-    /// F75 (2026-04-29): the actual opencode-session.md
-    /// `ses_224cc79f4ffeUtq7NFV9YMTVMH` failure shape — TWO `<invoke>`
-    /// blocks inside the BPE-broken envelope. Before F75 the detector
-    /// extracted only one and dropped the second; live response had
-    /// `has_tool_calls=false` because parse_one_call short-circuits to
-    /// the first `<invoke>` and the rest fall through as content.
-    #[test]
-    fn streaming_detector_minimax_envelope_bpe_broken_two_invokes() {
-        let mut det = StreamingToolDetector::new();
-        let body = "<minimax:_call>\n\
+/// F75 (2026-04-29): the actual opencode-session.md
+/// `ses_224cc79f4ffeUtq7NFV9YMTVMH` failure shape — TWO `<invoke>`
+/// blocks inside the BPE-broken envelope. Before F75 the detector
+/// extracted only one and dropped the second; live response had
+/// `has_tool_calls=false` because parse_one_call short-circuits to
+/// the first `<invoke>` and the rest fall through as content.
+#[test]
+fn streaming_detector_minimax_envelope_bpe_broken_two_invokes() {
+    let mut det = StreamingToolDetector::new();
+    let body = "<minimax:_call>\n\
             <invoke name=\"bash\">\n\
             <parameter name=\"command\">mkdir -p /tmp/calc-test74/src</parameter>\n\
             <parameter name=\"description\">Create project directory structure</parameter>\n\
@@ -295,166 +311,182 @@ use super::super::*;
             <parameter name=\"description\">Create tests directory</parameter>\n\
             </invoke>\n\
             </minimax:tool_call>";
-        let out = det.process(body);
-        let tcs: Vec<_> = out.iter().filter_map(|o| match o {
+    let out = det.process(body);
+    let tcs: Vec<_> = out
+        .iter()
+        .filter_map(|o| match o {
             DetectorOutput::ToolCall(tc, _) => Some(tc.clone()),
             _ => None,
-        }).collect();
-        assert!(det.has_tool_calls(), "no tool_calls extracted at all");
-        assert_eq!(tcs.len(), 2, "expected 2 ToolCall outputs, got {}", tcs.len());
-        for (i, tc) in tcs.iter().enumerate() {
-            assert_eq!(tc.function.name, "bash", "call {i} wrong name");
-            let args: serde_json::Value =
-                serde_json::from_str(&tc.function.arguments).expect("args must be JSON");
-            let cmd = args["command"].as_str().unwrap_or("");
-            if i == 0 {
-                assert!(cmd.contains("src"), "first call should be src dir, got {cmd}");
-            } else {
-                assert!(cmd.contains("tests"), "second call should be tests dir, got {cmd}");
-            }
+        })
+        .collect();
+    assert!(det.has_tool_calls(), "no tool_calls extracted at all");
+    assert_eq!(
+        tcs.len(),
+        2,
+        "expected 2 ToolCall outputs, got {}",
+        tcs.len()
+    );
+    for (i, tc) in tcs.iter().enumerate() {
+        assert_eq!(tc.function.name, "bash", "call {i} wrong name");
+        let args: serde_json::Value =
+            serde_json::from_str(&tc.function.arguments).expect("args must be JSON");
+        let cmd = args["command"].as_str().unwrap_or("");
+        if i == 0 {
+            assert!(
+                cmd.contains("src"),
+                "first call should be src dir, got {cmd}"
+            );
+        } else {
+            assert!(
+                cmd.contains("tests"),
+                "second call should be tests dir, got {cmd}"
+            );
         }
     }
+}
 
-    // ── MiniMax XML format ──
+// ── MiniMax XML format ──
 
-    #[test]
-    fn parse_minimax_xml_single_param() {
-        let input = "<minimax:tool_call>\n\
+#[test]
+fn parse_minimax_xml_single_param() {
+    let input = "<minimax:tool_call>\n\
             <invoke name=\"get_weather\">\n\
             <parameter name=\"location\">Paris</parameter>\n\
             </invoke>\n\
             </minimax:tool_call>";
-        let (content, calls) = parse_tool_calls(input);
-        assert!(
-            content.is_none(),
-            "expected no leading content, got {content:?}"
-        );
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "get_weather");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["location"], "Paris");
-    }
+    let (content, calls) = parse_tool_calls(input);
+    assert!(
+        content.is_none(),
+        "expected no leading content, got {content:?}"
+    );
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Paris");
+}
 
-    #[test]
-    fn parse_minimax_xml_multiple_params() {
-        let input = "<minimax:tool_call>\n\
+#[test]
+fn parse_minimax_xml_multiple_params() {
+    let input = "<minimax:tool_call>\n\
             <invoke name=\"search\">\n\
             <parameter name=\"query\">rust async</parameter>\n\
             <parameter name=\"limit\">10</parameter>\n\
             </invoke>\n\
             </minimax:tool_call>";
-        let (_, calls) = parse_tool_calls(input);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "search");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["query"], "rust async");
-        assert_eq!(args["limit"], "10");
-    }
+    let (_, calls) = parse_tool_calls(input);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "search");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["query"], "rust async");
+    assert_eq!(args["limit"], "10");
+}
 
-    #[test]
-    fn parse_minimax_xml_with_content_prefix() {
-        let input = "Let me check. <minimax:tool_call>\n\
+#[test]
+fn parse_minimax_xml_with_content_prefix() {
+    let input = "Let me check. <minimax:tool_call>\n\
             <invoke name=\"ls\">\n\
             <parameter name=\"path\">/tmp</parameter>\n\
             </invoke>\n\
             </minimax:tool_call>";
-        let (content, calls) = parse_tool_calls(input);
-        assert_eq!(content.as_deref(), Some("Let me check."));
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "ls");
-    }
+    let (content, calls) = parse_tool_calls(input);
+    assert_eq!(content.as_deref(), Some("Let me check."));
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "ls");
+}
 
-    #[test]
-    fn minimax_xml_format_tool_calls_roundtrip() {
-        let parser = MinimaxXmlParser;
-        let call = IncomingToolCall {
-            id: None,
-            function: IncomingFunction {
-                name: "get_weather".into(),
-                arguments: "{\"location\":\"Tokyo\"}".into(),
-            },
-        };
-        let formatted = parser.format_tool_calls(&[call]);
-        let (_, parsed) = parse_tool_calls(&formatted);
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].function.name, "get_weather");
-        let args: serde_json::Value = serde_json::from_str(&parsed[0].function.arguments).unwrap();
-        assert_eq!(args["location"], "Tokyo");
-    }
+#[test]
+fn minimax_xml_format_tool_calls_roundtrip() {
+    let parser = MinimaxXmlParser;
+    let call = IncomingToolCall {
+        id: None,
+        function: IncomingFunction {
+            name: "get_weather".into(),
+            arguments: "{\"location\":\"Tokyo\"}".into(),
+        },
+    };
+    let formatted = parser.format_tool_calls(&[call]);
+    let (_, parsed) = parse_tool_calls(&formatted);
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].function.name, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&parsed[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+}
 
-    // ── Qwen3-Coder format ──
+// ── Qwen3-Coder format ──
 
-    #[test]
-    fn parse_qwen3_coder_empty_body_then_backfill() {
-        // Repro of OpenClaw 2026.5.7 + Qwen3.6-35B-A3B-NVFP4 + 21 tools
-        // multi-turn agentic regression (issue #40 / Discord #bugs
-        // 2026-05-08 universe06608): the model emits the `exec`
-        // function with NO `<parameter=>` blocks under long-context
-        // tool-saturation pressure. The parser correctly returns
-        // arguments=`{}`. The streaming path (path B in
-        // chat_stream/tool_handlers.rs) was emitting that `{}` directly
-        // to the client without running backfill_required_params, so
-        // tools that declare `required: [command]` reached OpenClaw as
-        // bare `{}` and were rejected ("must have required properties
-        // command"). The non-streaming path always ran backfill, so the
-        // two code paths diverged.
-        //
-        // This test verifies the recovery semantics: parse → empty
-        // args → backfill adds the required string field with empty
-        // value (mirroring path A) → validator passes (only
-        // WRITE_FAMILY rejects empty paths; `exec` is not in that
-        // list). The chat_stream::tool_handlers fix calls this same
-        // chain inside handle_tool_call_delta so streaming behaviour
-        // matches.
-        let input = "<tool_call>\n\
+#[test]
+fn parse_qwen3_coder_empty_body_then_backfill() {
+    // Repro of OpenClaw 2026.5.7 + Qwen3.6-35B-A3B-NVFP4 + 21 tools
+    // multi-turn agentic regression (issue #40 / Discord #bugs
+    // 2026-05-08 universe06608): the model emits the `exec`
+    // function with NO `<parameter=>` blocks under long-context
+    // tool-saturation pressure. The parser correctly returns
+    // arguments=`{}`. The streaming path (path B in
+    // chat_stream/tool_handlers.rs) was emitting that `{}` directly
+    // to the client without running backfill_required_params, so
+    // tools that declare `required: [command]` reached OpenClaw as
+    // bare `{}` and were rejected ("must have required properties
+    // command"). The non-streaming path always ran backfill, so the
+    // two code paths diverged.
+    //
+    // This test verifies the recovery semantics: parse → empty
+    // args → backfill adds the required string field with empty
+    // value (mirroring path A) → validator passes (only
+    // WRITE_FAMILY rejects empty paths; `exec` is not in that
+    // list). The chat_stream::tool_handlers fix calls this same
+    // chain inside handle_tool_call_delta so streaming behaviour
+    // matches.
+    let input = "<tool_call>\n\
             <function=exec>\n\
             </function>\n\
             </tool_call>";
-        let (_c, mut calls) = parse_tool_calls(input);
-        assert_eq!(calls.len(), 1, "parser must yield the named call even with no params");
-        assert_eq!(calls[0].function.name, "exec");
-        assert_eq!(
-            calls[0].function.arguments, "{}",
-            "no params → empty JSON object"
-        );
+    let (_c, mut calls) = parse_tool_calls(input);
+    assert_eq!(
+        calls.len(),
+        1,
+        "parser must yield the named call even with no params"
+    );
+    assert_eq!(calls[0].function.name, "exec");
+    assert_eq!(
+        calls[0].function.arguments, "{}",
+        "no params → empty JSON object"
+    );
 
-        let tool = ToolDefinition {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "exec".to_string(),
-                description: None,
-                parameters: Some(serde_json::json!({
-                    "type": "object",
-                    "properties": {"command": {"type": "string"}},
-                    "required": ["command"]
-                })),
-            },
-        };
-        backfill_required_params(&mut calls, std::slice::from_ref(&tool));
-        let args: serde_json::Value =
-            serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(
-            args["command"], "",
-            "backfill must add the required string key with an empty default"
-        );
-        assert!(
-            validate_single_tool_call(&calls[0], std::slice::from_ref(&tool)).is_ok(),
-            "validator passes once required key is present (non-WRITE-family)"
-        );
-    }
+    let tool = ToolDefinition {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: "exec".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"]
+            })),
+        },
+    };
+    backfill_required_params(&mut calls, std::slice::from_ref(&tool));
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(
+        args["command"], "",
+        "backfill must add the required string key with an empty default"
+    );
+    assert!(
+        validate_single_tool_call(&calls[0], std::slice::from_ref(&tool)).is_ok(),
+        "validator passes once required key is present (non-WRITE-family)"
+    );
+}
 
-    #[test]
-    fn parse_qwen3_coder_single_param() {
-        let input = "<tool_call>\n\
+#[test]
+fn parse_qwen3_coder_single_param() {
+    let input = "<tool_call>\n\
             <function=get_weather>\n\
             <parameter=location>\nParis\n</parameter>\n\
             </function>\n\
             </tool_call>";
-        let (c, calls) = parse_tool_calls(input);
-        assert!(c.is_none());
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "get_weather");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["location"], "Paris");
-    }
-
+    let (c, calls) = parse_tool_calls(input);
+    assert!(c.is_none());
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Paris");
+}


### PR DESCRIPTION
## Summary

Adds a serve-time `--lm-head-dtype` flag for the final vocab projection:

- `default` — model-config-driven (unchanged behavior)
- `bf16` — keep the LM head in BF16 (checkpoint precision; safe default)
- `nvfp4` — force the model's NVFP4-packed lm_head (w4a16_gemv decode)
- `fp8` — runtime-quantize the lm_head to FP8 E4M3 per-row (w8a16_gemv decode)

The big vocab projection is the largest per-token weight read, so nvfp4/fp8
give a real decode speedup; bf16 is the safe default. Replaces the former
`ATLAS_LMHEAD_BF16` env var.

## Why this PR

This feature was buried inside commit 2006d56 on `fix/in-think-tool-call-leak`
(mixed with the overnight completion harness and the CC1-5 loop fixes). Splitting
it onto `main` here gives a clean, isolated unit to review and a conflict-free
base to build on. The model-side decode plumbing in that commit is interwoven
line-by-line with five unrelated changes (FP32-residual removal, the GDN rollback
ring, concurrent-decode determinism, EP protocol v2, ssm-pool refactors); those
are intentionally left out of this PR, so it contains only the lm-head feature.

## Plumbing

cli.rs arg -> serve.rs parse -> ModelConfig.{lm_head_bf16_override, lm_head_fp8}
-> skip_lm_head_quantization() -> factory/build.rs dispatch (FP8 / pre-packed
NVFP4 / runtime NVFP4 / BF16) -> TransformerModel ctor (lm_head_fp8 + a draft-only
mtp_lm_head_nvfp4 for the BF16-main + MTP case) -> decode dispatch (impl_a3 /
decode_a2 / decode_b2). Additive: with `default`/`bf16` the NVFP4/BF16 paths are
byte-identical to before.

## Verification (all green locally, toolchain 1.93.1, edition 2024)

- cargo fmt --check
- cargo clippy --workspace --tests (deny warnings)
- cargo check -p spark-server -p spark-model
- cargo test --workspace --locked (41 result blocks, 0 failed)
- file-size cap: impl_a1.rs at 497 LoC (under the 500 cap)

## Quality note

The nvfp4 lm-head was measured 10/10 on the webserver_ok agentic harness for
qwen3.6-35B-A3B. It has NOT yet been separately validated on qwen3.6-27B; a
lightweight coherence-suite check on 27B is pending and will be reported
separately. Reducing lm-head precision below bf16 should always be quality-gated
per model with a long-generation harness (short prompts can look clean while long
structured generation collapses).

Co-Authored-By: Azeez Ishaqui <debaterishaqui@gmail.com>
