### PR TITLE
fix(deps): bump transitive rand 0.9.2 -> 0.9.3 (security advisory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2344,7 +2344,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "rayon-cond",
  "regex",


### PR DESCRIPTION
Clears the open Dependabot security alert (dependabot alert 5, low severity) and the failing Dependabot Updates job on main. The advisory affects rand >=0.9.0,<0.9.3; Dependabot's auto-fix kept erroring because its existing PR #66 targets 0.9.2 which is still inside the affected range. Lockfile-only change (cargo update -p rand@0.9.2 --precise 0.9.3); the direct rand 0.8.6 pin is already safe. cargo check passes locally; the Security Audit (cargo deny) workflow triggers on Cargo.lock and will validate here.