### PR TITLE
ci: run required docs + cargo-deny checks on every PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,14 +9,11 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/docs.yml'
+  # No path filter on pull_request: this check is in the required set, and a
+  # path-filtered required check never reports on PRs outside its paths
+  # (kernel-only diffs), leaving them permanently "expected" and unmergeable.
   pull_request:
     branches: [main, master]
-    paths:
-      - 'book/**'
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/docs.yml'
 
 concurrency:
   group: docs-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,11 @@
 name: Security Audit
 
 on:
+  # No path filter on pull_request: cargo deny is a required check, and a
+  # path-filtered required check never reports on PRs outside its paths
+  # (kernel-only diffs), leaving them permanently "expected" and unmergeable.
+  # The job itself takes well under a minute.
   pull_request:
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - 'deny.toml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Required status checks must not be path-filtered: when a PR touches none of the filtered paths the check never reports and GitHub holds the PR at 'expected' forever. This is currently blocking #124 (kernel-only diff, all triggered checks green) and would hit any future kernels/-only or docs-only PR.

This drops the paths filter from the pull_request triggers of docs.yml (Build mdBook + rustdoc) and security.yml (cargo deny). Push triggers keep their filters. Cost: ~1 min of extra CI per PR for cargo deny plus the mdBook/rustdoc build, both already cached on runners.

Verification: this PR touches both workflow files, so all nine required checks report on it directly.