### PR TITLE
fix(common): dense_gemm_tc A-tile cooperative load for M > 8 (from #136)

### DIFF
--- a/kernels/gb10/common/dense_gemm_tc.cu
+++ b/kernels/gb10/common/dense_gemm_tc.cu
@@ -62,9 +62,8 @@ extern "C" __global__ void dense_gemm_tc(
         // Cooperative load: 128 threads load A[16][16] + B[16][64]
         // A: 16*16 = 256 elements, 128 threads → 2 elements per thread
         {
-            unsigned int idx = tid;
-            // Load A tile
-            if (idx < TC_TM * TC_TK) {
+            // Load A tile (loop needed: 256 elements, 128 threads)
+            for (unsigned int idx = tid; idx < TC_TM * TC_TK; idx += TC_BLOCK) {
                 unsigned int r = idx / TC_TK;
                 unsigned int c = idx % TC_TK;
                 unsigned int gr = m_block + r;


### PR DESCRIPTION
Cherry-pick of the standalone kernel fix from #136 by @marksunner, kept under his authorship, so it can land ahead of the Step 3.7 model work.

The Tensor Core BF16 GEMM loads a 16x16 = 256-element A-tile with 128 threads guarded by if (idx < 256): threads only cover elements 0-127, so rows 8-15 of the tile read uninitialized shared memory. Every dense_gemm_tc caller with M > 8 is affected; on main that is the MLA prefill path (cache_skip_mla.rs) plus anything else that adopts the kernel (the Step 3.7 per-head gate in #136 hit it first).

Verified on GB10 (dgx1) with a standalone nvcc harness against a CPU fp32 reference at M=16, N=64, K=128:

- main: rows 0-7 max_rel_err 0.0037, rows 8-15 max_rel_err 1.0 (512/512 elements wrong)
- fixed: all rows max_rel_err 0.0037 (bf16 noise)

This matches the cosine evidence in #136 (cos 0.9997 positions 0-7, cos 0.26 positions 8+).