### PR TITLE
fix(scheduler): never wrap the generation budget at 0 (issue #94 runaway)

### DIFF
--- a/crates/spark-server/src/scheduler/decode_logits_content.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_content.rs
@@ -64,7 +64,7 @@ fn describe_content_token_loop(tokens: &[u32]) -> Option<(usize, usize)> {
 /// SSM recurrent state on hybrid models (see
 /// [`super::rollback::rollback_to_boundary`]).
 pub fn handle_content_token(a: &mut ActiveSeq, model: &dyn Model) {
-    a.remaining -= 1;
+    a.consume_generation_budget();
     a.content_started = true;
     a.content_tokens = a.content_tokens.saturating_add(1);
     // F1 (2026-06-02): unconditional per-generation post-think content

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -206,7 +206,7 @@ pub fn emit_token(a: &mut ActiveSeq, tok: u32, logprobs: Option<crate::api::Toke
             }
         }
     } else {
-        a.remaining -= 1;
+        a.consume_generation_budget();
         // Clear think_just_ended one-shot now that we've consumed the
         // token after </think>.
         a.think_just_ended = false;

--- a/crates/spark-server/src/scheduler/types.rs
+++ b/crates/spark-server/src/scheduler/types.rs
@@ -303,7 +303,6 @@ pub(super) fn consume_budget(remaining: &mut usize) -> bool {
     true
 }
 
-
 /// A sequence that has been swapped out to disk (KV + SSM state saved to file).
 pub(super) struct SwappedSeq {
     pub tokens: Vec<u32>,
@@ -400,4 +399,3 @@ mod budget_tests {
         assert_eq!(r, 0);
     }
 }
-

--- a/crates/spark-server/src/scheduler/types.rs
+++ b/crates/spark-server/src/scheduler/types.rs
@@ -266,6 +266,44 @@ pub(super) struct ActiveSeq {
     pub cached_prompt_tokens: u32,
 }
 
+impl ActiveSeq {
+    /// Consume one token of generation budget (SSOT for the two decode
+    /// paths: MTP `emit_step::emit_token` and non-MTP
+    /// `decode_logits_content::handle_content_token`).
+    ///
+    /// `remaining` reaching 0 must finish the sequence at the next
+    /// `remaining == 0` check. A second decrement at 0 means a budget
+    /// desync (e.g. a token processed after the length stop should have
+    /// fired): in release builds the old bare `-= 1` wrapped to
+    /// usize::MAX, unbounding generation entirely (issue #94's
+    /// never-terminating ngram loop; debug builds panicked with
+    /// 'attempt to subtract with overflow'). Saturate, log, and finish
+    /// instead — never wrap, never hide the desync.
+    pub fn consume_generation_budget(&mut self) {
+        if !consume_budget(&mut self.remaining) {
+            tracing::warn!(
+                output_tokens = self.output_tokens.len(),
+                "generation budget decremented at 0 (token processed after \
+                 length stop should have fired) — finishing sequence instead \
+                 of wrapping"
+            );
+            self.finished = true;
+        }
+    }
+}
+
+/// Decrement `remaining` by one. Returns false (without touching
+/// `remaining`) when it is already 0 — the caller must finish the
+/// sequence rather than wrap.
+pub(super) fn consume_budget(remaining: &mut usize) -> bool {
+    if *remaining == 0 {
+        return false;
+    }
+    *remaining -= 1;
+    true
+}
+
+
 /// A sequence that has been swapped out to disk (KV + SSM state saved to file).
 pub(super) struct SwappedSeq {
     pub tokens: Vec<u32>,
@@ -338,3 +376,28 @@ pub(super) struct SwappedSeq {
     pub timeout_at: Option<Instant>,
     pub swap_id: u64,
 }
+
+#[cfg(test)]
+mod budget_tests {
+    use super::consume_budget;
+
+    #[test]
+    fn consume_budget_decrements_to_zero() {
+        let mut r = 2usize;
+        assert!(consume_budget(&mut r));
+        assert_eq!(r, 1);
+        assert!(consume_budget(&mut r));
+        assert_eq!(r, 0);
+    }
+
+    #[test]
+    fn consume_budget_at_zero_signals_finish_and_never_wraps() {
+        // Regression: a bare `remaining -= 1` at 0 wrapped to usize::MAX in
+        // release builds, unbounding generation (issue #94 ngram runaway),
+        // and panicked in debug builds.
+        let mut r = 0usize;
+        assert!(!consume_budget(&mut r));
+        assert_eq!(r, 0);
+    }
+}
+


### PR DESCRIPTION
Found live while validating the #131 fix on dgx1: a strict json_schema request on the FP8 flagship panicked the debug-build scheduler at decode_logits_content.rs:67 with 'attempt to subtract with overflow', hanging the server. The same code in release builds wraps ActiveSeq.remaining to usize::MAX, which unbounds generation. That is exactly the failure shape camerono reported in #94 for --ngram-speculative: seq_len keeps growing past max_tokens, never terminates, GPU pinned until docker kill.

Fix: centralize the budget decrement in ActiveSeq::consume_generation_budget, used by both decode paths (MTP emit_step::emit_token and non-MTP decode_logits_content::handle_content_token). At 0 it warns (keeping the underlying desync visible in logs) and finishes the sequence cleanly instead of wrapping or panicking. Pure helper unit-tested for the decrement and the at-zero regression.

This is the safety half of #94 (terminate cleanly at the budget). Why the budget desyncs in the first place under spec decode and deferred think-end is a separate investigation; this PR guarantees the failure mode is a length-stop, not a runaway.

cargo test -p spark-server: 519 passed, 0 failed on GB10.