### PR TITLE
fix(scheduler): SSM decode-ring slot reuse after rollback truncation

### DIFF
--- a/crates/spark-server/src/scheduler/ssm_decode_ring.rs
+++ b/crates/spark-server/src/scheduler/ssm_decode_ring.rs
@@ -102,13 +102,18 @@ impl SsmDecodeRing {
         let slot = self.next_slot;
         self.next_slot = (self.next_slot + 1) % self.capacity;
 
-        if self.entries.len() == self.capacity {
-            // Full: drop the oldest entry; its slot is `slot` (the ring
-            // reuses slots in insertion order, so the oldest live entry
-            // always holds the slot we are about to hand out).
-            debug_assert_eq!(self.entries[0].snapshot_slot, slot);
-            self.entries.remove(0);
-        }
+        // Evict whichever live entry owns the slot being handed out. With
+        // pure round-robin flow that is the oldest entry, but after a
+        // rollback's `truncate_after` the cursor and the live set desync
+        // (truncation removes entries without moving the cursor), so the
+        // colliding entry is not necessarily `entries[0]` — the old
+        // `entries.remove(0)` + debug_assert here panicked debug builds
+        // and, in release, left a live entry pointing at a slot the
+        // caller's `save` was about to overwrite. Two entries sharing a
+        // slot means a later rollback restores overwritten state: silent
+        // SSM corruption. Evicting by slot ownership keeps the no-shared-
+        // slot invariant under every flow.
+        self.entries.retain(|e| e.snapshot_slot != slot);
         self.entries.push(SsmRingEntry {
             token_position,
             snapshot_slot: slot,
@@ -143,6 +148,19 @@ impl SsmDecodeRing {
     /// just restored) is kept — generation resumes from it.
     pub fn truncate_after(&mut self, keep_len: usize) {
         self.entries.retain(|e| e.token_position <= keep_len);
+        // Resume slot assignment right after the newest surviving
+        // snapshot. Without this the cursor keeps pointing into the
+        // truncated tail's slots; that is *correct* under `record`'s
+        // by-slot eviction, but it can land on a surviving entry and
+        // evict a snapshot that is still useful (in the worst case the
+        // boundary just restored, leaving the next rollback nothing to
+        // anchor on). Following the newest survivor reuses the freed
+        // tail slots first and preserves maximal rollback depth.
+        if let Some(newest) = self.entries.last() {
+            self.next_slot = (newest.snapshot_slot + 1) % self.capacity;
+        } else if self.capacity > 0 {
+            self.next_slot = 0;
+        }
     }
 
     /// Number of live snapshots. Test/diagnostic helper.

--- a/crates/spark-server/src/scheduler/ssm_decode_ring_tests.rs
+++ b/crates/spark-server/src/scheduler/ssm_decode_ring_tests.rs
@@ -144,3 +144,64 @@ fn decline_when_no_boundary_has_snapshot() {
         .find(|&b| ring.slot_for_position(b).is_some());
     assert_eq!(chosen, None);
 }
+
+#[test]
+fn record_after_truncate_does_not_panic_or_share_slots() {
+    // Regression for the live 2026-06-10 panic: rollback truncation
+    // removes entries without the cursor knowing, so the next full-ring
+    // record() collided with a non-oldest entry and the old
+    // debug_assert_eq!(entries[0].snapshot_slot, slot) fired
+    // (left: 1, right: 5 shape). Release builds instead let two live
+    // entries share a slot — the save overwrote a snapshot another entry
+    // still pointed at.
+    let mut ring = SsmDecodeRing::new(5);
+    for (i, pos) in [10, 20, 30, 40, 50].iter().enumerate() {
+        assert_eq!(ring.record(*pos), Some(i));
+    }
+    // Rollback keeps only position 10 (slot 0).
+    ring.truncate_after(10);
+    assert_eq!(ring.len(), 1);
+    // Refill past capacity twice over; every step must keep the
+    // no-shared-slot invariant and never panic.
+    let mut pos = 60;
+    for _ in 0..12 {
+        ring.record(pos);
+        let mut slots: Vec<usize> = ring.snapshot_positions().collect();
+        slots.sort_unstable();
+        slots.dedup();
+        assert_eq!(slots.len(), ring.len(), "duplicate token_position");
+        pos += 10;
+    }
+    assert_eq!(ring.len(), 5);
+}
+
+#[test]
+fn truncate_rewinds_cursor_to_preserve_survivors() {
+    // After truncation the cursor resumes after the newest survivor, so
+    // freed tail slots are reused before any surviving snapshot is
+    // evicted — the just-restored boundary must stay restorable.
+    let mut ring = SsmDecodeRing::new(3);
+    ring.record(10); // slot 0
+    ring.record(20); // slot 1
+    ring.record(30); // slot 2
+    ring.truncate_after(20); // survivors: 10/s0, 20/s1
+    // Next record must take slot 2 (the freed tail), not evict 10 or 20.
+    ring.record(40);
+    assert_eq!(ring.slot_for_position(10), Some(0));
+    assert_eq!(ring.slot_for_position(20), Some(1));
+    assert_eq!(ring.slot_for_position(40), Some(2));
+    // One more wraps to slot 0, evicting the oldest (10) as usual.
+    ring.record(50);
+    assert_eq!(ring.slot_for_position(10), None);
+    assert_eq!(ring.slot_for_position(50), Some(0));
+}
+
+#[test]
+fn truncate_to_empty_resets_cursor() {
+    let mut ring = SsmDecodeRing::new(3);
+    ring.record(10);
+    ring.record(20);
+    ring.truncate_after(0);
+    assert_eq!(ring.len(), 0);
+    assert_eq!(ring.record(30), Some(0));
+}


### PR DESCRIPTION
Second bug caught live during the #131 verification pass on dgx1 (same session that produced #140). When the content-loop watchdog rolls back a degenerate tail, SsmDecodeRing::truncate_after removes entries without moving the round-robin slot cursor. The next time the ring fills, record() evicted entries[0] while handing out a slot actually owned by a different live entry: debug builds panic on the assert at ssm_decode_ring.rs:109 (killing the scheduler thread), release builds silently let two entries share a snapshot slot. The caller's save then overwrites GPU state the other entry still references, and a later rollback restores corrupted SSM state. On hybrid models that is invisible until the output degrades, and it plausibly contributes to the #110 corruption class.

Fix is at the invariant level: record() evicts by slot ownership instead of by position, and truncate_after rewinds the cursor to just after the newest surviving snapshot so freed tail slots are reused first and the just-restored boundary stays restorable. Three regression tests: the live panic shape (truncate then refill past capacity twice), survivor preservation, truncate-to-empty.

cargo test -p spark-server: 520 passed, 0 failed on GB10. Verified live: the strict json_schema repro that previously panicked the scheduler now survives the watchdog rollback (verification run in flight, will post results on #131).