### PR TITLE
fix(kernels): dynamic s_act in batched MoE silu-down kernels (issue #85)

### DIFF
--- a/crates/spark-model/src/layers/ops/moe_expert_more.rs
+++ b/crates/spark-model/src/layers/ops/moe_expert_more.rs
@@ -145,9 +145,13 @@ pub fn moe_expert_silu_down_shared_batch2(
     block_size: u32,
     stream: u64,
 ) -> Result<()> {
+    // s_act is extern shared: K floats (issue #85 -- static 1024 overflowed
+    // for Mistral-Small-4's expert_hidden_dim=2048).
+    let smem_bytes = (k as usize * std::mem::size_of::<f32>()) as u32;
     KernelLaunch::new(gpu, kernel)
         .grid([div_ceil(n, 8), 2 * (top_k + 1), 1])
         .block([block_size, 1, 1])
+        .shared_mem(smem_bytes)
         .arg_ptr(gate_out)
         .arg_ptr(up_out)
         .arg_ptr(packed_ptrs)
@@ -279,9 +283,13 @@ pub fn moe_expert_silu_down_shared_batch3(
     top_k: u32,
     stream: u64,
 ) -> Result<()> {
+    // s_act is extern shared: K floats (issue #85 -- static 1024 overflowed
+    // for expert inter dims > 1024).
+    let smem_bytes = (k as usize * std::mem::size_of::<f32>()) as u32;
     KernelLaunch::new(gpu, kernel)
         .grid([div_ceil(n, 8), 3 * (top_k + 1), 1])
         .block([128, 1, 1])
+        .shared_mem(smem_bytes)
         .arg_ptr(gate_out)
         .arg_ptr(up_out)
         .arg_ptr(packed_ptrs)

--- a/kernels/gb10/common/moe_shared_expert_fused_batch2.cu
+++ b/kernels/gb10/common/moe_shared_expert_fused_batch2.cu
@@ -250,7 +250,11 @@ extern "C" __global__ void moe_expert_silu_down_shared_batch2(
     const unsigned int K8 = K / 8;
 
     __shared__ float s_lut[16];
-    __shared__ float s_act[1024];
+    // Dynamic: K floats, sized by the launcher (issue #85 -- the old
+    // static s_act[1024] overflowed for Mistral-Small-4's
+    // expert_hidden_dim=2048, illegal-addressing on the first batched
+    // K=2 FFN; matches the extern pattern the _t variant already uses).
+    extern __shared__ float s_act[];
 
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_BATCH2[threadIdx.x];
 

--- a/kernels/gb10/common/moe_shared_expert_fused_batch3.cu
+++ b/kernels/gb10/common/moe_shared_expert_fused_batch3.cu
@@ -246,7 +246,11 @@ extern "C" __global__ void moe_expert_silu_down_shared_batch3(
     const unsigned int K8 = K / 8;
 
     __shared__ float s_lut[16];
-    __shared__ float s_act[1024];
+    // Dynamic: K floats, sized by the launcher (issue #85 -- the old
+    // static s_act[1024] overflowed for expert inter dims > 1024,
+    // e.g. Mistral-Small-4's expert_hidden_dim=2048, illegal-addressing
+    // the batched FFN; matches the extern pattern the _t variant uses).
+    extern __shared__ float s_act[];
 
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_BATCH3[threadIdx.x];
 

--- a/kernels/gb10/gemma-4-26b-a4b/nvfp4/moe_shared_expert_fused_batch2.cu
+++ b/kernels/gb10/gemma-4-26b-a4b/nvfp4/moe_shared_expert_fused_batch2.cu
@@ -250,7 +250,11 @@ extern "C" __global__ void moe_expert_silu_down_shared_batch2(
     const unsigned int K8 = K / 8;
 
     __shared__ float s_lut[16];
-    __shared__ float s_act[1024];
+    // Dynamic: K floats, sized by the launcher (issue #85 -- the old
+    // static s_act[1024] overflowed for expert inter dims > 1024,
+    // e.g. Mistral-Small-4's expert_hidden_dim=2048, illegal-addressing
+    // the batched FFN; matches the extern pattern the _t variant uses).
+    extern __shared__ float s_act[];
 
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_BATCH2[threadIdx.x];
 

--- a/kernels/gb10/gemma-4-26b-a4b/nvfp4/moe_shared_expert_fused_batch3.cu
+++ b/kernels/gb10/gemma-4-26b-a4b/nvfp4/moe_shared_expert_fused_batch3.cu
@@ -246,7 +246,11 @@ extern "C" __global__ void moe_expert_silu_down_shared_batch3(
     const unsigned int K8 = K / 8;
 
     __shared__ float s_lut[16];
-    __shared__ float s_act[1024];
+    // Dynamic: K floats, sized by the launcher (issue #85 -- the old
+    // static s_act[1024] overflowed for expert inter dims > 1024,
+    // e.g. Mistral-Small-4's expert_hidden_dim=2048, illegal-addressing
+    // the batched FFN; matches the extern pattern the _t variant uses).
+    extern __shared__ float s_act[];
 
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_BATCH3[threadIdx.x];
 

--- a/kernels/gb10/minimax-m2-229b/nvfp4/moe_shared_expert_fused_batch2.cu
+++ b/kernels/gb10/minimax-m2-229b/nvfp4/moe_shared_expert_fused_batch2.cu
@@ -257,7 +257,11 @@ extern "C" __global__ void moe_expert_silu_down_shared_batch2(
     const unsigned int K8 = K / 8;
 
     __shared__ float s_lut[16];
-    __shared__ float s_act[1024]; // SiLU(gate)*up precomputed for reuse across outputs
+    // Dynamic: K floats, sized by the launcher (issue #85 -- the old
+    // static s_act[1024] overflowed for expert inter dims > 1024,
+    // e.g. Mistral-Small-4's expert_hidden_dim=2048, illegal-addressing
+    // the batched FFN; matches the extern pattern the _t variant uses).
+    extern __shared__ float s_act[];
     __shared__ float smem_reduce[N_PER_BLOCK * 4];
 
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_BATCH2[threadIdx.x];

--- a/kernels/gb10/qwen3.5-122b-a10b/nvfp4/moe_shared_expert_fused_batch2.cu
+++ b/kernels/gb10/qwen3.5-122b-a10b/nvfp4/moe_shared_expert_fused_batch2.cu
@@ -257,7 +257,11 @@ extern "C" __global__ void moe_expert_silu_down_shared_batch2(
     const unsigned int K8 = K / 8;
 
     __shared__ float s_lut[16];
-    __shared__ float s_act[1024]; // SiLU(gate)*up precomputed for reuse across outputs
+    // Dynamic: K floats, sized by the launcher (issue #85 -- the old
+    // static s_act[1024] overflowed for expert inter dims > 1024,
+    // e.g. Mistral-Small-4's expert_hidden_dim=2048, illegal-addressing
+    // the batched FFN; matches the extern pattern the _t variant uses).
+    extern __shared__ float s_act[];
     __shared__ float smem_reduce[N_PER_BLOCK * 4];
 
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_BATCH2[threadIdx.x];


### PR DESCRIPTION
Root cause of #85 found and fixed. The batched silu-down kernels stage SiLU(gate)*up in a static __shared__ float s_act[1024] but write K entries; Mistral-Small-4 has expert_hidden_dim=2048, so the first batched K=2 FFN writes 1024 floats past the buffer and illegal-addresses. Every other shipped MoE model has expert inter dim <= 1024, which is exactly why the kernel looked proven until Mistral ran at batch >= 2 (and why #84 worked around it by forcing MLA models onto the sequential FFN path).

Fix: s_act becomes extern __shared__ sized K*4 bytes by the launcher, the same pattern the transposed _t variants already use. Applied to common batch2 + batch3 and the gemma-4-26b / qwen3.5-122b / minimax model-specific copies that carry the identical pattern.

Verification on GB10 (dgx1), standalone nvcc harness at Mistral dims (K=2048, N=4096, top_k=4, 8 experts):
- main: compute-sanitizer memcheck reports 24065 errors, kernel returns unspecified launch failure
- fixed: 0 sanitizer errors, all 32768 outputs finite

All 16 kernel targets compile (139 kernels each where applicable); cargo test -p spark-model 75 passed; fmt and clippy clean.

Not in scope, tracked in #85 as follow-ups: the same static-1024 pattern in the fp8 fused variants and moe_prefill/moe_sorted_prefill (only see K=512 today), and lifting the #84 force_seq_ffn routing once a live batched Mistral-Small-4 run on this kernel is verified end-to-end.