### PR TITLE
fix(grammar): cap json_schema inter-token whitespace at 8 (issue #131)

### DIFF
--- a/crates/spark-server/src/grammar/compile_misc.rs
+++ b/crates/spark-server/src/grammar/compile_misc.rs
@@ -38,6 +38,17 @@ impl GrammarEngine {
 
     // ── JSON schema grammar ──
 
+    /// Cap on consecutive inter-token whitespace characters in
+    /// response_format json_schema grammars. Unlimited whitespace
+    /// (`None`) gives a degenerating model a grammar-legal runway:
+    /// measured on the FP8 flagship (issue #131, N=8 strict json_schema
+    /// at temp 0), 5/8 requests padded hundreds of \n/\t between JSON
+    /// tokens until max_tokens, leaving unterminated JSON. 8 permits
+    /// normal pretty-printing (newline + indent) while making runaway
+    /// whitespace grammar-illegal, so the matcher forces a structural
+    /// token instead.
+    const MAX_JSON_SCHEMA_WHITESPACE: i32 = 8;
+
     /// Compile a grammar that enforces a JSON schema.
     pub fn compile_json_schema(&mut self, schema: &str) -> Result<CompiledGrammar, GrammarError> {
         self.compiler
@@ -47,7 +58,7 @@ impl GrammarEngine {
                 None,                 // indent
                 None::<(&str, &str)>, // separators
                 true,                 // strict_mode
-                None,                 // max_whitespace_cnt
+                Some(Self::MAX_JSON_SCHEMA_WHITESPACE),
             )
             .map_err(GrammarError::Compilation)
     }


### PR DESCRIPTION
Closes the degenerate-whitespace half of #131. response_format json_schema grammars were compiled with unlimited max_whitespace_cnt, so a degenerating model has a grammar-legal runway: measured N=8 on the FP8 flagship at temp 0, 5/8 strict json_schema requests padded hundreds of newline/tab characters between JSON tokens until max_tokens and left unterminated JSON. The vendored xgrammar already supports max_whitespace_cnt; we just never set it.

Cap is 8 consecutive whitespace characters: normal pretty-printing (newline plus indent) stays legal, runaway padding becomes grammar-illegal and the matcher forces the next structural token.

Verified live on GB10 with the #131 repro, N=8 before/after on the same build base:
- before: 5/8 responses contain multi-hundred-char whitespace runs inside the JSON
- after: 0/8 whitespace runs; every response is dense, clean JSON text

Remaining non-conformance in the repro is a different mechanism: at the reporter's max_tokens=800 the FP8 flagship enumerates 25+ tools and overruns the budget before closing the object (finish_reason=length, pure verbosity, no repetition; content-loop watchdog fires 0-2 times across 8 runs). Tracked separately in #131 discussion with a budget-aware close-forcing idea.

grammar tests 42 passed, xgrammar 803 passed, fmt clean.