### PR TITLE
fix(step3p7): restore accidentally removed instrumentation + extend routed_scaling_factor

### DIFF
--- a/crates/spark-model/src/layers/moe/forward_prefill_bf16.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_bf16.rs
@@ -136,7 +136,7 @@ impl MoeLayer {
                 num_experts,
                 top_k,
                 ctx.config.norm_topk_prob,
-                1.0,
+                ctx.config.routed_scaling_factor as f32,
                 n,
                 stream,
             )?;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -50,6 +50,15 @@ impl Qwen3AttentionLayer {
             ctx,
             stream,
         )?;
+        super::super::op_dump::dump_bf16(
+            ctx.gpu,
+            qg_out,
+            (num_tokens - 1) * q_proj_dim * bf16,
+            q_proj_dim,
+            self.attn_layer_idx,
+            "q_proj_full",
+            stream,
+        )?;
         let k_contiguous = ctx.buffers.ssm_qkvz();
         self.cache_skip_one_proj(
             SkipProj::K,
@@ -62,6 +71,15 @@ impl Qwen3AttentionLayer {
             ctx,
             stream,
         )?;
+        super::super::op_dump::dump_bf16(
+            ctx.gpu,
+            k_contiguous,
+            (num_tokens - 1) * kv_dim * bf16,
+            kv_dim,
+            self.attn_layer_idx,
+            "k_proj",
+            stream,
+        )?;
         let v_contiguous = k_contiguous.offset(num_tokens * kv_dim * bf16);
         self.cache_skip_one_proj(
             SkipProj::V,
@@ -72,6 +90,15 @@ impl Qwen3AttentionLayer {
             nkv * hd,
             h,
             ctx,
+            stream,
+        )?;
+        super::super::op_dump::dump_bf16(
+            ctx.gpu,
+            v_contiguous,
+            (num_tokens - 1) * kv_dim * bf16,
+            kv_dim,
+            self.attn_layer_idx,
+            "v_proj",
             stream,
         )?;
         Ok(())
@@ -134,9 +161,11 @@ impl Qwen3AttentionLayer {
             )?;
         } else if weight_opt.and_then(|w| w.as_fp8()).is_some() && self.w8a16_gemm_k.0 != 0 {
             let fp8w = weight_opt.and_then(|w| w.as_fp8()).unwrap();
-            ops::w8a16_gemm(
+            // attn QKV always via the bit-identical (cosine=1.0) ~4.6× faster
+            // tensor-core w8a16_gemm_pipelined kernel.
+            ops::w8a16_gemm_pipelined(
                 ctx.gpu,
-                self.w8a16_gemm_k,
+                self.w8a16_gemm_pipelined_k,
                 normed,
                 fp8w.weight,
                 fp8w.row_scale,

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
@@ -600,6 +600,20 @@ impl Qwen3AttentionLayer {
             )?;
         }
 
+        // ATLAS_OP_DUMP: attn_out AFTER sigmoid gate (input to o_proj linear).
+        if num_tokens > 0 {
+            let nq_hd = (nq * hd) as usize;
+            super::super::op_dump::dump_bf16(
+                ctx.gpu,
+                attn_out,
+                (num_tokens - 1) * nq_hd * bf16,
+                nq_hd,
+                self.attn_layer_idx,
+                "attn_out_post_gate",
+                stream,
+            )?;
+        }
+
         // ── 10. O projection GEMM ── (extracted to paged_oproj.rs)
         let o_out = self.prefill_attention_paged_oproj(attn_out, n, h, nq, hd, ctx, stream)?;
 


### PR DESCRIPTION
Follow-up to #136. Three issues found during post-merge review:

### 1. `cache_skip_qkv.rs` — restore removed instrumentation + kernel

Reverts accidental changes from the #136 rebase:
- Restores 3 `ATLAS_OP_DUMP` blocks (`q_proj_full`, `k_proj`, `v_proj`) that were removed
- Restores `w8a16_gemm_pipelined` kernel (was incorrectly changed to `w8a16_gemm`, a performance regression for FP8 models)

No Step 3.7 changes are needed in this file — the modifications were unintended rebase artifacts.

### 2. `paged.rs` — restore `ATLAS_OP_DUMP` alongside g_proj gate

The `attn_out_post_gate` dump point was replaced by the g_proj gate code instead of being kept alongside it. Now matches `cache_skip.rs` ordering: section 9b (g_proj) → OP_DUMP → section 10 (O proj).

### 3. `forward_prefill_bf16.rs` — extend `routed_scaling_factor`

The BF16 dequant-on-load prefill path was the only remaining hardcoded `1.0` across 7 `moe_topk_sigmoid` call sites. Now uses `ctx.config.routed_scaling_factor as f32` for consistency (defaults to 1.0 via `default_one_f64`, so existing models are unaffected).

### CLA

I have read the CLA Document and I hereby sign the CLA