### PR TITLE
fix: restore op_dump blocks + pipelined w8a16 lost in the #136 squash

### DIFF
--- a/crates/atlas-core/src/config/parsers/step3p7.rs
+++ b/crates/atlas-core/src/config/parsers/step3p7.rs
@@ -71,13 +71,9 @@ pub(crate) fn parse_step3p7(raw: &serde_json::Value) -> Result<ModelConfig> {
         obj.remove("architectures");
         // moe_layers_enum is a comma-separated string, remove it (we detect MoE by probing)
         obj.remove("moe_layers_enum");
-        // Convert layer_types: "sliding_attention" → "full_attention" for serde
-        // (Atlas treats both as FullAttention; sliding window is a separate config property)
-        // layer_types: serde handles "full_attention" and "sliding_attention"
-        // natively via the LayerType enum, so no pre-processing needed.
-        // We just remove the field here to avoid serde errors from unknown
-        // variants ("moe" layers are detected by probing, not from this array).
-        // The actual layer_types are populated below from text_config.
+        // Remove layer_types from serde input — the array may contain
+        // "moe" or other variants that serde can't deserialize into
+        // LayerType. We populate layer_types manually below from text_config.
         obj.remove("layer_types");
         // Also handle moe_num_experts → num_experts for serde (Step 3.7 uses non-standard field names)
         if let Some(mne) = obj.get("moe_num_experts").cloned() {

--- a/crates/spark-model/src/layers/moe/forward_prefill_bf16.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_bf16.rs
@@ -136,7 +136,7 @@ impl MoeLayer {
                 num_experts,
                 top_k,
                 ctx.config.norm_topk_prob,
-                1.0,
+                ctx.config.routed_scaling_factor as f32,
                 n,
                 stream,
             )?;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -50,6 +50,15 @@ impl Qwen3AttentionLayer {
             ctx,
             stream,
         )?;
+        super::super::op_dump::dump_bf16(
+            ctx.gpu,
+            qg_out,
+            (num_tokens - 1) * q_proj_dim * bf16,
+            q_proj_dim,
+            self.attn_layer_idx,
+            "q_proj_full",
+            stream,
+        )?;
         let k_contiguous = ctx.buffers.ssm_qkvz();
         self.cache_skip_one_proj(
             SkipProj::K,
@@ -62,6 +71,15 @@ impl Qwen3AttentionLayer {
             ctx,
             stream,
         )?;
+        super::super::op_dump::dump_bf16(
+            ctx.gpu,
+            k_contiguous,
+            (num_tokens - 1) * kv_dim * bf16,
+            kv_dim,
+            self.attn_layer_idx,
+            "k_proj",
+            stream,
+        )?;
         let v_contiguous = k_contiguous.offset(num_tokens * kv_dim * bf16);
         self.cache_skip_one_proj(
             SkipProj::V,
@@ -72,6 +90,15 @@ impl Qwen3AttentionLayer {
             nkv * hd,
             h,
             ctx,
+            stream,
+        )?;
+        super::super::op_dump::dump_bf16(
+            ctx.gpu,
+            v_contiguous,
+            (num_tokens - 1) * kv_dim * bf16,
+            kv_dim,
+            self.attn_layer_idx,
+            "v_proj",
             stream,
         )?;
         Ok(())
@@ -134,9 +161,11 @@ impl Qwen3AttentionLayer {
             )?;
         } else if weight_opt.and_then(|w| w.as_fp8()).is_some() && self.w8a16_gemm_k.0 != 0 {
             let fp8w = weight_opt.and_then(|w| w.as_fp8()).unwrap();
-            ops::w8a16_gemm(
+            // attn QKV always via the bit-identical (cosine=1.0) ~4.6× faster
+            // tensor-core w8a16_gemm_pipelined kernel.
+            ops::w8a16_gemm_pipelined(
                 ctx.gpu,
-                self.w8a16_gemm_k,
+                self.w8a16_gemm_pipelined_k,
                 normed,
                 fp8w.weight,
                 fp8w.row_scale,

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
@@ -600,6 +600,20 @@ impl Qwen3AttentionLayer {
             )?;
         }
 
+        // ATLAS_OP_DUMP: attn_out AFTER sigmoid gate (input to o_proj linear).
+        if num_tokens > 0 {
+            let nq_hd = (nq * hd) as usize;
+            super::super::op_dump::dump_bf16(
+                ctx.gpu,
+                attn_out,
+                (num_tokens - 1) * nq_hd * bf16,
+                nq_hd,
+                self.attn_layer_idx,
+                "attn_out_post_gate",
+                stream,
+            )?;
+        }
+
         // ── 10. O projection GEMM ── (extracted to paged_oproj.rs)
         let o_out = self.prefill_attention_paged_oproj(attn_out, n, h, nq, hd, ctx, stream)?;
 


### PR DESCRIPTION
@marksunner pushed a final round of restores to the #136 branch a few minutes after the squash merge landed, so they missed main. This carries them over, commit authorship his:

- cache_skip_qkv.rs: the 3 ATLAS_OP_DUMP blocks (q_proj_full, k_proj, v_proj) and the w8a16_gemm_pipelined call back (the rebase had silently downgraded it to plain w8a16_gemm, a prefill perf regression for W8A16 models)
- paged.rs: the attn_out_post_gate dump point
- forward_prefill_bf16.rs: routed_scaling_factor wired into the BF16 prefill path, consistent with the other MoE forwards (config defaults 1.0, no behavior change for existing models)

Verified on GB10: builds, spark-model + atlas-core suites pass (94), fmt clean. Verbatim diff against his branch head 970d2f39.