### PR TITLE
feat(tq-metal): teacher-forced KLD eval mode

### DIFF
--- a/crates/spark-model/examples/metal_qwen35_inference/alloc.rs
+++ b/crates/spark-model/examples/metal_qwen35_inference/alloc.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Scratch / state buffer allocation for the inference driver.
+
+use anyhow::Result;
+use spark_model::forward::qwen3_5::{
+    FullAttentionScratch, LinearAttentionScratch, LinearAttentionState,
+};
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::metal_backend::MetalGpuBackend;
+
+use super::CFG;
+
+pub fn alloc_full_attention_scratch(backend: &MetalGpuBackend) -> Result<FullAttentionScratch> {
+    let alloc_bf16 = |n: u32| -> Result<DevicePtr> { Ok(backend.alloc(n as usize * 2)?) };
+    Ok(FullAttentionScratch {
+        x_norm: alloc_bf16(CFG.hidden)?,
+        q_full: alloc_bf16(CFG.q_total())?,
+        q_split: alloc_bf16(CFG.q_only())?,
+        gate_split: alloc_bf16(CFG.q_only())?,
+        k: alloc_bf16(CFG.kv_dim())?,
+        v: alloc_bf16(CFG.kv_dim())?,
+        q_norm_out: alloc_bf16(CFG.q_only())?,
+        k_norm_out: alloc_bf16(CFG.kv_dim())?,
+        attn_out: alloc_bf16(CFG.q_only())?,
+        gated_attn: alloc_bf16(CFG.q_only())?,
+        o: alloc_bf16(CFG.hidden)?,
+        x_resid: alloc_bf16(CFG.hidden)?,
+        x_norm2: alloc_bf16(CFG.hidden)?,
+        gate_act: alloc_bf16(CFG.intermediate)?,
+        up_act: alloc_bf16(CFG.intermediate)?,
+        x_out: alloc_bf16(CFG.hidden)?,
+    })
+}
+
+pub fn alloc_linear_attention_scratch(backend: &MetalGpuBackend) -> Result<LinearAttentionScratch> {
+    let alloc_bf16 = |n: u32| -> Result<DevicePtr> { Ok(backend.alloc(n as usize * 2)?) };
+    let alloc_f32 = |n: u32| -> Result<DevicePtr> { Ok(backend.alloc(n as usize * 4)?) };
+    Ok(LinearAttentionScratch {
+        x_norm: alloc_bf16(CFG.hidden)?,
+        dt_raw: alloc_bf16(CFG.num_state_heads())?,
+        b_raw: alloc_bf16(CFG.num_state_heads())?,
+        qkv: alloc_bf16(CFG.qkv_total_lin())?,
+        qkv_smooth: alloc_bf16(CFG.qkv_total_lin())?,
+        z: alloc_bf16(CFG.z_dim_lin())?,
+        gate: alloc_f32(CFG.num_state_heads())?,
+        beta: alloc_f32(CFG.num_state_heads())?,
+        y: alloc_bf16(CFG.z_dim_lin())?,
+        y_norm: alloc_bf16(CFG.z_dim_lin())?,
+        out: alloc_bf16(CFG.hidden)?,
+        x_resid: alloc_bf16(CFG.hidden)?,
+        x_norm2: alloc_bf16(CFG.hidden)?,
+        gate_act: alloc_bf16(CFG.intermediate)?,
+        up_act: alloc_bf16(CFG.intermediate)?,
+        x_final: alloc_bf16(CFG.hidden)?,
+    })
+}
+
+pub fn alloc_linear_attention_state(backend: &MetalGpuBackend) -> Result<LinearAttentionState> {
+    let conv_state_bytes = (CFG.qkv_total_lin() * CFG.conv_kernel_size) as usize * 4;
+    let gdn_state_floats = (CFG.num_v_heads_lin * CFG.k_head_dim_lin * CFG.v_head_dim_lin) as usize;
+    let conv1d_state = backend.alloc(conv_state_bytes)?;
+    let gdn_state = backend.alloc(gdn_state_floats * 4)?;
+    backend.memset(conv1d_state, 0, conv_state_bytes)?;
+    backend.memset(gdn_state, 0, gdn_state_floats * 4)?;
+    Ok(LinearAttentionState {
+        conv1d_state,
+        gdn_state,
+    })
+}

--- a/crates/spark-model/examples/metal_qwen35_inference/eval_io.rs
+++ b/crates/spark-model/examples/metal_qwen35_inference/eval_io.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Eval-comparison IO knobs for the inference driver: per-step logit
+//! dumps (`ATLAS_LOGITS_OUT`), argmax-sequence dumps
+//! (`ATLAS_DUMP_TOKENS`), and teacher-forced token lists
+//! (`ATLAS_FORCE_TOKENS_FILE`). Used by `tests/metal_kv_kld_compare.py`
+//! to compare KV dtypes with identical contexts at every position.
+
+use anyhow::Result;
+
+/// Open the per-step logits sink when `ATLAS_LOGITS_OUT` is set. Raw
+/// little-endian bf16, `[n_steps, vocab]`.
+pub fn logits_writer() -> Option<std::cell::RefCell<std::io::BufWriter<std::fs::File>>> {
+    std::env::var("ATLAS_LOGITS_OUT").ok().map(|p| {
+        std::cell::RefCell::new(std::io::BufWriter::new(
+            std::fs::File::create(p).expect("create ATLAS_LOGITS_OUT"),
+        ))
+    })
+}
+
+/// Load the teacher-forcing list from `ATLAS_FORCE_TOKENS_FILE`
+/// (newline-separated token ids; position 0 replaces the first sampled
+/// token). Two runs fed the same list share an identical context at
+/// every position, so their logit dumps are KLD-comparable end to end.
+pub fn forced_tokens() -> Option<Vec<u32>> {
+    std::env::var("ATLAS_FORCE_TOKENS_FILE").ok().map(|p| {
+        std::fs::read_to_string(&p)
+            .unwrap_or_else(|e| panic!("read ATLAS_FORCE_TOKENS_FILE {p}: {e}"))
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.trim().parse().expect("token id"))
+            .collect()
+    })
+}
+
+/// Write the argmax sequence (one id per line) when `ATLAS_DUMP_TOKENS`
+/// is set — the output feeds `ATLAS_FORCE_TOKENS_FILE` in later runs.
+pub fn maybe_dump_tokens(generated_ids: &[u32]) -> Result<()> {
+    if let Ok(path) = std::env::var("ATLAS_DUMP_TOKENS") {
+        let body: String = generated_ids.iter().map(|t| format!("{t}\n")).collect();
+        std::fs::write(&path, body)?;
+        println!("  (dumped {} token ids to {path})", generated_ids.len());
+    }
+    Ok(())
+}

--- a/crates/spark-model/examples/metal_qwen35_inference/main.rs
+++ b/crates/spark-model/examples/metal_qwen35_inference/main.rs
@@ -451,7 +451,31 @@ fn main() -> Result<()> {
     let mut current_token = next_token_id;
     let mut cur_pos = prompt_len;
 
-    for _ in 0..n_decode {
+    // Teacher forcing: ATLAS_FORCE_TOKENS_FILE points at a
+    // newline-separated token-id list (one per decode step, position 0 =
+    // the token fed in place of the first sampled one). The model's own
+    // argmax is still recorded in `generated_ids` and its logits still
+    // dumped — but the FED token comes from the file, so two runs with
+    // the same file share an identical context at every position and
+    // their logit dumps are KLD-comparable end to end (no greedy-path
+    // divergence). Generate the file from a baseline run with
+    // ATLAS_DUMP_TOKENS=path.
+    let forced_tokens: Option<Vec<u32>> = std::env::var("ATLAS_FORCE_TOKENS_FILE").ok().map(|p| {
+        std::fs::read_to_string(&p)
+            .unwrap_or_else(|e| panic!("read ATLAS_FORCE_TOKENS_FILE {p}: {e}"))
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.trim().parse().expect("token id"))
+            .collect()
+    });
+    if let Some(f) = &forced_tokens {
+        println!("  (teacher forcing {} tokens)", f.len());
+        if let Some(&t0) = f.first() {
+            current_token = t0;
+        }
+    }
+
+    for step in 0..n_decode {
         if cur_pos >= max_seq_len {
             println!("  (reached pre-allocated KV capacity {max_seq_len}, stopping)");
             break;
@@ -460,15 +484,34 @@ fn main() -> Result<()> {
         backend.copy_h2d(&cur_pos.to_le_bytes(), positions_ptr)?;
         run_layer_chain(cur_pos)?;
 
-        current_token = sample_next(x_buf)?;
-        generated_ids.push(current_token);
+        let sampled = sample_next(x_buf)?;
+        generated_ids.push(sampled);
         cur_pos += 1;
 
+        current_token = match &forced_tokens {
+            Some(f) => match f.get(step + 1) {
+                Some(&t) => t,
+                None => {
+                    println!("  (teacher-forcing list exhausted)");
+                    break;
+                }
+            },
+            None => sampled,
+        };
+
         // <|im_end|> per tokenizer_config.json — bail to avoid runaway.
-        if current_token == 248044 {
+        // Teacher-forced runs ignore EOS so every run covers the full list.
+        if forced_tokens.is_none() && current_token == 248044 {
             println!("  (hit <|im_end|>)");
             break;
         }
+    }
+    // ATLAS_DUMP_TOKENS: write the argmax sequence (one id per line) for
+    // use as a teacher-forcing list in comparison runs.
+    if let Ok(path) = std::env::var("ATLAS_DUMP_TOKENS") {
+        let body: String = generated_ids.iter().map(|t| format!("{t}\n")).collect();
+        std::fs::write(&path, body)?;
+        println!("  (dumped {} token ids to {path})", generated_ids.len());
     }
     let dec_ms = t_dec.elapsed().as_secs_f64() * 1000.0;
 

--- a/crates/spark-model/examples/metal_qwen35_inference/main.rs
+++ b/crates/spark-model/examples/metal_qwen35_inference/main.rs
@@ -25,8 +25,7 @@
 use anyhow::{Context, Result, bail};
 use safetensors::SafeTensors;
 use spark_model::forward::qwen3_5::{
-    self, FullAttentionScratch, LayerKvCache, LinearAttentionScratch, LinearAttentionState,
-    Qwen35ForwardConfig, Qwen35Kernels,
+    self, LayerKvCache, LinearAttentionState, Qwen35ForwardConfig, Qwen35Kernels,
 };
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelArg};
 use spark_runtime::metal_backend::MetalGpuBackend;
@@ -34,71 +33,18 @@ use spark_runtime::weights::mlx_int8::MlxInt8Weight;
 use std::time::Instant;
 use tokenizers::Tokenizer;
 
+mod alloc;
+mod eval_io;
 mod full_attention;
 mod linear_attention;
 
+use alloc::{
+    alloc_full_attention_scratch, alloc_linear_attention_scratch, alloc_linear_attention_state,
+};
 use full_attention::FullAttentionLayer;
 use linear_attention::LinearAttentionLayer;
 
-const CFG: Qwen35ForwardConfig = Qwen35ForwardConfig::qwen3_5_4b_mlx_int8();
-
-fn alloc_full_attention_scratch(backend: &MetalGpuBackend) -> Result<FullAttentionScratch> {
-    let alloc_bf16 = |n: u32| -> Result<DevicePtr> { Ok(backend.alloc(n as usize * 2)?) };
-    Ok(FullAttentionScratch {
-        x_norm: alloc_bf16(CFG.hidden)?,
-        q_full: alloc_bf16(CFG.q_total())?,
-        q_split: alloc_bf16(CFG.q_only())?,
-        gate_split: alloc_bf16(CFG.q_only())?,
-        k: alloc_bf16(CFG.kv_dim())?,
-        v: alloc_bf16(CFG.kv_dim())?,
-        q_norm_out: alloc_bf16(CFG.q_only())?,
-        k_norm_out: alloc_bf16(CFG.kv_dim())?,
-        attn_out: alloc_bf16(CFG.q_only())?,
-        gated_attn: alloc_bf16(CFG.q_only())?,
-        o: alloc_bf16(CFG.hidden)?,
-        x_resid: alloc_bf16(CFG.hidden)?,
-        x_norm2: alloc_bf16(CFG.hidden)?,
-        gate_act: alloc_bf16(CFG.intermediate)?,
-        up_act: alloc_bf16(CFG.intermediate)?,
-        x_out: alloc_bf16(CFG.hidden)?,
-    })
-}
-
-fn alloc_linear_attention_scratch(backend: &MetalGpuBackend) -> Result<LinearAttentionScratch> {
-    let alloc_bf16 = |n: u32| -> Result<DevicePtr> { Ok(backend.alloc(n as usize * 2)?) };
-    let alloc_f32 = |n: u32| -> Result<DevicePtr> { Ok(backend.alloc(n as usize * 4)?) };
-    Ok(LinearAttentionScratch {
-        x_norm: alloc_bf16(CFG.hidden)?,
-        dt_raw: alloc_bf16(CFG.num_state_heads())?,
-        b_raw: alloc_bf16(CFG.num_state_heads())?,
-        qkv: alloc_bf16(CFG.qkv_total_lin())?,
-        qkv_smooth: alloc_bf16(CFG.qkv_total_lin())?,
-        z: alloc_bf16(CFG.z_dim_lin())?,
-        gate: alloc_f32(CFG.num_state_heads())?,
-        beta: alloc_f32(CFG.num_state_heads())?,
-        y: alloc_bf16(CFG.z_dim_lin())?,
-        y_norm: alloc_bf16(CFG.z_dim_lin())?,
-        out: alloc_bf16(CFG.hidden)?,
-        x_resid: alloc_bf16(CFG.hidden)?,
-        x_norm2: alloc_bf16(CFG.hidden)?,
-        gate_act: alloc_bf16(CFG.intermediate)?,
-        up_act: alloc_bf16(CFG.intermediate)?,
-        x_final: alloc_bf16(CFG.hidden)?,
-    })
-}
-
-fn alloc_linear_attention_state(backend: &MetalGpuBackend) -> Result<LinearAttentionState> {
-    let conv_state_bytes = (CFG.qkv_total_lin() * CFG.conv_kernel_size) as usize * 4;
-    let gdn_state_floats = (CFG.num_v_heads_lin * CFG.k_head_dim_lin * CFG.v_head_dim_lin) as usize;
-    let conv1d_state = backend.alloc(conv_state_bytes)?;
-    let gdn_state = backend.alloc(gdn_state_floats * 4)?;
-    backend.memset(conv1d_state, 0, conv_state_bytes)?;
-    backend.memset(gdn_state, 0, gdn_state_floats * 4)?;
-    Ok(LinearAttentionState {
-        conv1d_state,
-        gdn_state,
-    })
-}
+pub const CFG: Qwen35ForwardConfig = Qwen35ForwardConfig::qwen3_5_4b_mlx_int8();
 
 fn main() -> Result<()> {
     let prompt =
@@ -362,14 +308,7 @@ fn main() -> Result<()> {
     let x_final = backend.alloc(CFG.hidden as usize * 2)?;
     let logits = backend.alloc(CFG.vocab as usize * 2)?;
     let result_buf = backend.alloc(4)?;
-    // ATLAS_LOGITS_OUT=path dumps the bf16 logits of every sampled
-    // position (raw little-endian, [n_steps, vocab]) for offline KLD /
-    // top-k agreement comparison across kv dtypes.
-    let logits_out = std::env::var("ATLAS_LOGITS_OUT").ok().map(|p| {
-        std::cell::RefCell::new(std::io::BufWriter::new(
-            std::fs::File::create(p).expect("create ATLAS_LOGITS_OUT"),
-        ))
-    });
+    let logits_out = eval_io::logits_writer();
     let sample_next = |x_in: DevicePtr| -> Result<u32> {
         backend.launch_typed(
             kernels.rms,
@@ -451,23 +390,7 @@ fn main() -> Result<()> {
     let mut current_token = next_token_id;
     let mut cur_pos = prompt_len;
 
-    // Teacher forcing: ATLAS_FORCE_TOKENS_FILE points at a
-    // newline-separated token-id list (one per decode step, position 0 =
-    // the token fed in place of the first sampled one). The model's own
-    // argmax is still recorded in `generated_ids` and its logits still
-    // dumped — but the FED token comes from the file, so two runs with
-    // the same file share an identical context at every position and
-    // their logit dumps are KLD-comparable end to end (no greedy-path
-    // divergence). Generate the file from a baseline run with
-    // ATLAS_DUMP_TOKENS=path.
-    let forced_tokens: Option<Vec<u32>> = std::env::var("ATLAS_FORCE_TOKENS_FILE").ok().map(|p| {
-        std::fs::read_to_string(&p)
-            .unwrap_or_else(|e| panic!("read ATLAS_FORCE_TOKENS_FILE {p}: {e}"))
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(|l| l.trim().parse().expect("token id"))
-            .collect()
-    });
+    let forced_tokens = eval_io::forced_tokens();
     if let Some(f) = &forced_tokens {
         println!("  (teacher forcing {} tokens)", f.len());
         if let Some(&t0) = f.first() {
@@ -506,13 +429,7 @@ fn main() -> Result<()> {
             break;
         }
     }
-    // ATLAS_DUMP_TOKENS: write the argmax sequence (one id per line) for
-    // use as a teacher-forcing list in comparison runs.
-    if let Ok(path) = std::env::var("ATLAS_DUMP_TOKENS") {
-        let body: String = generated_ids.iter().map(|t| format!("{t}\n")).collect();
-        std::fs::write(&path, body)?;
-        println!("  (dumped {} token ids to {path})", generated_ids.len());
-    }
+    eval_io::maybe_dump_tokens(&generated_ids)?;
     let dec_ms = t_dec.elapsed().as_secs_f64() * 1000.0;
 
     let full_text = tokenizer

--- a/tests/metal_kv_kld_compare.py
+++ b/tests/metal_kv_kld_compare.py
@@ -37,6 +37,13 @@ def main() -> None:
     ap.add_argument("reference")
     ap.add_argument("candidate")
     ap.add_argument("--vocab", type=int, default=248_320)
+    ap.add_argument(
+        "--teacher-forced",
+        action="store_true",
+        help="both runs fed the same token list (ATLAS_FORCE_TOKENS_FILE): "
+        "contexts match at every position, so do not trim at the first "
+        "argmax divergence",
+    )
     args = ap.parse_args()
 
     ref = load_bf16(args.reference, args.vocab)
@@ -47,9 +54,14 @@ def main() -> None:
     ref_top1 = ref.argmax(axis=-1)
     cand_top1 = cand.argmax(axis=-1)
 
-    # Greedy context stays shared until the first argmax divergence.
+    # Greedy context stays shared until the first argmax divergence;
+    # teacher-forced runs share context everywhere.
     diverge = np.flatnonzero(ref_top1 != cand_top1)
-    valid = int(diverge[0]) + 1 if diverge.size else steps
+    valid = (
+        steps
+        if args.teacher_forced
+        else (int(diverge[0]) + 1 if diverge.size else steps)
+    )
 
     ref_lp = log_softmax(ref[:valid])
     cand_lp = log_softmax(cand[:valid])
@@ -60,7 +72,7 @@ def main() -> None:
     print(f"mean_kld:       {kld.mean():.6f}")
     print(f"max_kld:        {kld.max():.6f}")
     print(f"top1_agree:     {agree:.3f}")
-    if diverge.size:
+    if diverge.size and not args.teacher_forced:
         print(f"first_divergence_at_step: {int(diverge[0])}")
     per = " ".join(f"{v:.4f}" for v in kld[: min(valid, 32)])
     print(f"per_step_kld:   {per}")


### PR DESCRIPTION
The KLD harness from #147 trimmed at the first greedy divergence —
fine for near-lossless dtypes, but the low-bit rows got 3-11 valid
positions before the paths split. Teacher forcing removes the limit:

- ATLAS_DUMP_TOKENS=path writes a run's argmax ids (one per line).
- ATLAS_FORCE_TOKENS_FILE=path feeds that list in place of the
  sampled token each step (logits still dumped, model's own argmax
  still reported, EOS ignored so every run covers the full list).
  Two runs with the same list share an identical context at every
  position, so their logit dumps are KLD-comparable end to end.
- tests/metal_kv_kld_compare.py --teacher-forced skips the
  divergence trim.

Re-measured ladder on Qwen3.5-4B-MLX-8bit (M5 Max, 49 teacher-forced
positions, KLD vs bf16 cache):

  dtype          mean KLD   top-1
  turbo8         0.00037    49/49
  bf16k_turbo4v  0.00134    49/49
  turbo4         0.00158    48/49
  turbo3         0.00428    48/49
  bf16k_turbo2v  0.01523    48/49
  turbo2         0.01963    48/49

Monotone with bit width; safer-asym beats symmetric at equal V-bits
(bf16k_turbo4v < turbo4, bf16k_turbo2v < turbo2) — the K-precision
premise holding at full positional coverage.
