### PR TITLE
fix(build): merge common + model KERNEL.toml instead of shadowing — activates TQ_PLUS_SIGNS on gb10

### DIFF
--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -474,15 +474,31 @@ fn resolve_targets(workspace_root: &std::path::Path) -> Vec<Target> {
                 common_kernel_dir.display(),
             );
 
-            // KERNEL.toml: prefer model-specific, fall back to common
-            let toml_dir = if has_model_dir && model_kernel_dir.join("KERNEL.toml").exists() {
-                &model_kernel_dir
-            } else if has_common_dir {
-                &common_kernel_dir
-            } else {
-                &model_kernel_dir
-            };
-            let (extra_flags, module_overrides) = parse_kernel_toml(toml_dir, &target_vendor);
+            // KERNEL.toml: MERGE common + model-specific. The old
+            // prefer-model-else-common selection meant a model toml fully
+            // SHADOWED common — silently dropping common's build flags
+            // (gb10 model targets lost -DTQ_PLUS_SIGNS; the metal per-quant
+            // toml lost -ffast-math) and common's [modules] overrides (the
+            // chunk>=2 prefill misdispatch class, previously worked around
+            // by propagating mappings into all 13 model tomls). Semantics
+            // now: common parses first as the base; the model toml appends
+            // flags (deduped, model last) and wins per-key on [modules].
+            let mut extra_flags: Vec<String> = Vec::new();
+            let mut module_overrides: HashMap<String, String> = HashMap::new();
+            if has_common_dir && common_kernel_dir.join("KERNEL.toml").exists() {
+                let (f, m) = parse_kernel_toml(&common_kernel_dir, &target_vendor);
+                extra_flags.extend(f);
+                module_overrides.extend(m);
+            }
+            if has_model_dir && model_kernel_dir.join("KERNEL.toml").exists() {
+                let (f, m) = parse_kernel_toml(&model_kernel_dir, &target_vendor);
+                for flag in f {
+                    if !extra_flags.contains(&flag) {
+                        extra_flags.push(flag);
+                    }
+                }
+                module_overrides.extend(m);
+            }
 
             // Parse sampling presets, behavior, and model_types from MODEL.toml
             let (s_tt, s_tc, s_nt, s_tools) = parse_sampling_presets(&model_dir);

--- a/docs/METAL_BACKEND.md
+++ b/docs/METAL_BACKEND.md
@@ -118,9 +118,10 @@ Mechanics, mirroring the CUDA write path and decode bookends:
   dequantization — the benefit grows with context length).
 - `Qwen35Kernels::resolve` hard-requires all turbo kernel handles, so
   a turbo cache can never silently fall back to the bf16 kernels.
-- ⚠ Per-quant `KERNEL.toml` `extra_metal_flags` fully SHADOWS the
-  common list — keep `-ffast-math` and `-DTQ_PLUS_SIGNS` in sync when
-  adding model targets.
+- Per-quant `KERNEL.toml` `[build]` flags and `[modules]` entries are
+  MERGED onto the common KERNEL.toml's (common first, model additions
+  appended/winning per key) — model targets inherit `-ffast-math` and
+  `-DTQ_PLUS_SIGNS` automatically.
 
 Quality eval: `ATLAS_LOGITS_OUT=path` dumps per-step bf16 logits;
 `tests/metal_kv_kld_compare.py` reports KLD + top-1 agreement between

--- a/kernels/metal/qwen3-5-4b-vlm-mlx-int8/mlx_int8/KERNEL.toml
+++ b/kernels/metal/qwen3-5-4b-vlm-mlx-int8/mlx_int8/KERNEL.toml
@@ -1,9 +1,7 @@
 [build]
-# NOTE: this list fully SHADOWS the common KERNEL.toml's flags (no
-# merge) — keep -ffast-math in sync with kernels/metal/common.
-# -DTQ_PLUS_SIGNS enables the two-sided Rademacher rotation in
-# wht_bf16.metal (canonical TurboQuant form; the Lloyd-Max codebooks
-# assume Gaussianized post-rotation coordinates).
-extra_metal_flags = ["-ffast-math", "-DTQ_PLUS_SIGNS"]
+# Per-quant ADDITIONS to the common KERNEL.toml's flags (build.rs merges
+# common first, then this list, deduped). Empty = inherit common
+# (-ffast-math, -DTQ_PLUS_SIGNS).
+extra_metal_flags = []
 
 [modules]


### PR DESCRIPTION
A model-specific `KERNEL.toml` fully replaced the common one in `build.rs`'s target resolution: common's build flags and `[modules]` overrides were silently dropped for every model target. Two real consequences had shipped from this:

- All 13 gb10 model targets compiled without common's `-DTQ_PLUS_SIGNS`, so the production CUDA `wht_bf16` ran the plain (sign-free) WHT instead of the canonical two-sided Rademacher rotation S2·H·S1 the Lloyd-Max codebooks are optimized for. The metal per-quant toml likewise dropped common's `-ffast-math`.
- A `[modules]` mapping present only in `common/` silently registered the module under its file stem and kernel lookup failed at first dispatch — the chunk≥2 prefill misdispatch class found during #133's review, worked around at the time by hand-propagating mappings into all 13 model tomls.

`build.rs` now parses common first as the base, then the model toml: flags are appended (deduped, model last), `[modules]` merges with the model winning per key. The metal per-quant toml's duplicated flags are dropped in favor of inheritance; the gb10 model tomls' duplicated `[modules]` entries are left as harmless duplicates.

## Effect: canonical rotation goes live on gb10

`-DTQ_PLUS_SIGNS` becomes active for all gb10 model targets — `wht_bf16_inplace` becomes S2·H·S1 and `wht_bf16_inplace_inv`'s reversed sign order starts mattering (the bookends from #133 already use the correct inverse handle). The KV cache is process-local, so there is no format-migration concern: old and new builds simply quantize into different rotated bases.

## Validation (GB10, Qwen3.6-35B-FP8, head_dim 256, 32K, hp=0)

Signs-on build, same suite as the #133-era signs-off baseline:

| dtype | short prompt | needle @2,065 tok | needle @10,486 tok (chunk≥2) |
|---|---|---|---|
| turbo8 | coherent, factually exact | exact | exact |
| turbo4 | coherent, factually exact | exact | exact |

Matches the signs-off baseline on every probe (turbo8 needle results identical; turbo4 long-needle is newly verified here). The metal backend has run the signed rotation since #147 with byte-verified sign tables — this PR brings the CUDA side to the same canonical form.

`cargo test --workspace` and the full metal parity suite pass on the merged-flag builds (metal target now inherits `-ffast-math` + `-DTQ_PLUS_SIGNS` from common with an empty per-quant addition list).