### PR TITLE
fix: agentic wall regression + warm-cache corruption series (MTP live-state, KV write floor, stream-safe rollback)

### DIFF
--- a/bench/fp8_dgx2_drift/harness/mtp_warm_stress.py
+++ b/bench/fp8_dgx2_drift/harness/mtp_warm_stress.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""MTP x warm-restore stress repro (2026-06-10).
+
+The warm-hit token-stutter only manifests with --speculative under real
+agentic traffic. Hypothesis: high draft-rejection rates (unpredictable
+text) x many decode steps x Marconi warm restores desync rewind
+bookkeeping. This script maximizes those three factors and scans every
+reply for stutter signatures.
+
+Per iteration: one long chained conversation (10k-token system prompt so
+every turn is multi-chunk and warm), tools defined, thinking left at the
+server default, temp 0.3, prompts that demand UNPREDICTABLE output
+(random-looking identifiers, mixed prose/code) to tank MTP acceptance,
+plus exact-path echo demands so corruption is detectable.
+
+Usage: python3 mtp_warm_stress.py [--iters 3] [--turns 8]
+Exit code 1 if any stutter suspect found (prints them).
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+FILLER = (
+    "Consider the module layout under /tmp/harness-proj/src with files "
+    "main.rs, routes.rs, state.rs and tests in /tmp/harness-proj/tests. "
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "write",
+            "description": "Write a file to disk",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "filePath": {"type": "string", "description": "Absolute path"},
+                    "content": {"type": "string"},
+                },
+                "required": ["filePath", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    },
+]
+
+# Unpredictable content requests tank n-gram-style draft acceptance;
+# exact path echoes make stutter detectable.
+PROMPTS = [
+    "Write /tmp/stress-zq7/src/dispatch_v2.rs via the write tool: a Rust enum "
+    "with 12 variants named after obscure chemical elements, each with a "
+    "distinct u64 discriminant that is a large prime.",
+    "Now write /tmp/stress-zq7/src/metrics_agg.rs via the write tool: a struct "
+    "with 9 fields mixing exotic identifier names like qx_phi_rate, "
+    "lorenz_tail_p99, and brk_hyst_window, with doc comments.",
+    "Run via bash: ls -la /tmp/stress-zq7/src/ && echo checkpoint-alpha-7731",
+    "Write /tmp/stress-zq7/tests/prop_fuzz_matrix.rs via the write tool with "
+    "3 proptest-style test stubs using unusual generator names.",
+    "Write /tmp/stress-zq7/src/wire_codec.rs via the write tool: varint "
+    "encode/decode with bit-twiddling and named constants like MASK_0x7F_CONT.",
+    "Run via bash: cargo check --manifest-path /tmp/stress-zq7/Cargo.toml 2>&1 | tail -3",
+    "Write /tmp/stress-zq7/src/sched_ring.rs via the write tool: a ring buffer "
+    "with wrap-around arithmetic and seqlock-style version counters.",
+    "Final: run via bash: ls /tmp/stress-zq7/src/ /tmp/stress-zq7/tests/ && echo done-tag-zq7",
+]
+
+STUTTER = re.compile(
+    r"(/tmp/[\w\-./]*?)(\w{2,6})\2(?=[\w\-./])"  # doubled fragment inside a path
+)
+
+
+def chat(messages, temp=0.3):
+    body = {
+        "model": "x",
+        "messages": messages,
+        "max_tokens": 700,
+        "temperature": temp,
+        "tools": TOOLS,
+        "tool_choice": "auto",
+    }
+    req = urllib.request.Request(
+        "http://localhost:8888/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    d = json.load(urllib.request.urlopen(req, timeout=240))
+    return d["choices"][0]["message"]
+
+
+def scan(s):
+    out = []
+    for m in STUTTER.finditer(s or ""):
+        out.append(m.group(0))
+    # explicit expected-path check
+    for p in re.findall(r"/tmp/[\w\-./]+", s or ""):
+        if "/tmp/stress-zq7" not in p and "/tmp/harness-proj" not in p:
+            out.append("OFFPATH:" + p)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--iters", type=int, default=3)
+    ap.add_argument("--turns", type=int, default=8)
+    args = ap.parse_args()
+
+    suspects = []
+    for it in range(args.iters):
+        system = (
+            f"You are a coding agent (iteration {it}). Use tools with EXACT "
+            "absolute paths. " + FILLER * 320
+        )
+        msgs = [{"role": "system", "content": system}]
+        for k in range(min(args.turns, len(PROMPTS))):
+            msgs.append({"role": "user", "content": PROMPTS[k] + "\n" + FILLER * 10})
+            try:
+                m = chat(msgs)
+            except Exception as e:
+                print(f"iter {it} turn {k + 1}: request error {e}")
+                break
+            tcs = m.get("tool_calls") or []
+            blob = json.dumps([t["function"]["arguments"] for t in tcs]) + (
+                m.get("content") or ""
+            )
+            hits = scan(blob)
+            paths = []
+            for tc in tcs:
+                try:
+                    a = json.loads(tc["function"]["arguments"])
+                    paths.append(a.get("filePath") or a.get("command", "")[:60])
+                except Exception:
+                    paths.append("UNPARSEABLE:" + tc["function"]["arguments"][:60])
+                    hits.append("UNPARSEABLE_ARGS")
+            print(f"iter {it} turn {k + 1}: tcs={len(tcs)} paths={paths}"
+                  + (f"  SUSPECTS={hits}" if hits else ""))
+            sys.stdout.flush()
+            if hits:
+                suspects.extend(hits)
+            msgs.append(
+                {"role": "assistant", "content": m.get("content") or "", "tool_calls": tcs}
+            )
+            for tc in tcs:
+                msgs.append(
+                    {"role": "tool", "tool_call_id": tc.get("id", "x"), "content": "ok"}
+                )
+    print("TOTAL SUSPECTS:", len(suspects))
+    for s in suspects[:20]:
+        print("  ", s)
+    sys.exit(1 if suspects else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/fp8_dgx2_drift/harness/warm_cold_chain_repro.py
+++ b/bench/fp8_dgx2_drift/harness/warm_cold_chain_repro.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Deterministic multi-turn warm-vs-cold divergence repro for the Marconi
+warm-hit corruption (2026-06-10).
+
+Drives N chained "turns" against a single running Atlas server at temp 0:
+each turn appends the previous assistant reply plus a new user message, so
+turn k>=2 produces a Marconi warm hit (intermediate or leaf restore) when
+prefix caching is enabled. Run once against a prefix-caching server and once
+against a no-caching server (or use --label to tag runs); diff the saved
+transcripts to find the first divergent turn.
+
+Usage:
+  python3 warm_cold_chain_repro.py --base http://localhost:8888/v1 \
+      --turns 6 --out /tmp/chain_warm.json [--max-tokens 300]
+  # restart server without --enable-prefix-caching, then:
+  python3 warm_cold_chain_repro.py --base http://localhost:8888/v1 \
+      --turns 6 --out /tmp/chain_cold.json
+  diff <(jq -r '.turns[].reply' /tmp/chain_warm.json) \
+       <(jq -r '.turns[].reply' /tmp/chain_cold.json)
+
+The user prompts intentionally include path-like strings (the live failure
+corrupts file paths) and enough text per turn to span checkpoint blocks.
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+
+FILLER = (
+    "Consider the module layout under /tmp/harness-proj/src with files "
+    "main.rs, routes.rs, state.rs and tests in /tmp/harness-proj/tests. "
+)
+
+PROMPTS = [
+    "We are planning a Rust axum webserver in /tmp/harness-proj. List the "
+    "files you would create, with full absolute paths, one per line.",
+    "Now write the exact cargo command to create it and repeat the full "
+    "path /tmp/harness-proj/src/main.rs back to me three times, once per line.",
+    "Describe the ping endpoint handler. Then repeat this path exactly once: "
+    "/tmp/harness-proj/src/routes.rs",
+    "What port env var should we read? Repeat the path "
+    "/tmp/harness-proj/tests/integration.rs exactly twice, one per line.",
+    "Summarize every file path mentioned so far, one absolute path per line, "
+    "no duplicates.",
+    "Repeat the project root path /tmp/harness-proj five times separated by "
+    "spaces, then say DONE.",
+    "Spell the path /tmp/harness-proj/src/state.rs forwards, then repeat it "
+    "unmodified on the next line.",
+    "Final check: list all paths from this conversation again, one per line.",
+]
+
+
+def chat(base, messages, max_tokens, timeout=180):
+    body = {
+        "model": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    req = urllib.request.Request(
+        f"{base}/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        d = json.load(r)
+    return d["choices"][0]["message"]["content"] or ""
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://localhost:8888/v1")
+    ap.add_argument("--turns", type=int, default=6)
+    ap.add_argument("--max-tokens", type=int, default=300)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    # Long-ish system prompt + filler pushes the conversation across the
+    # 4096-token intermediate-checkpoint boundary within a few turns.
+    system = (
+        "You are a precise assistant. Follow instructions exactly. "
+        "Never abbreviate file paths. " + FILLER * 320
+    )
+    messages = [{"role": "system", "content": system}]
+    turns = []
+    for k in range(min(args.turns, len(PROMPTS))):
+        messages.append({"role": "user", "content": PROMPTS[k] + "\n" + FILLER * 10})
+        reply = chat(args.base, messages, args.max_tokens)
+        messages.append({"role": "assistant", "content": reply})
+        corrupt = (
+            "/tmp/harness-proj" not in reply
+            and k > 0
+            or "//" in reply.replace("http://", "")
+        )
+        turns.append({"turn": k + 1, "prompt": PROMPTS[k][:60], "reply": reply})
+        print(f"--- turn {k + 1} ({len(reply)} chars){' [SUSPECT]' if corrupt else ''}")
+        print(reply[:400])
+        sys.stdout.flush()
+
+    with open(args.out, "w") as f:
+        json.dump({"turns": turns}, f, indent=1)
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -199,6 +199,15 @@ pub struct ForwardContext<'a> {
     /// True when inside CUDA graph capture (between begin_capture/end_capture).
     /// MoE layers use sync all_reduce (capturable) instead of async (event-based).
     pub graph_capture: bool,
+    /// True when this prefill pass continues from a restored Marconi SSM
+    /// snapshot (warm prefix-cache hit). GDN layers must then take the
+    /// bit-faithful WY4 recurrence instead of the FLA chunked kernel: FLA's
+    /// chunk grid is anchored at the (arbitrary) snapshot offset and its
+    /// bf16 intermediates drift vs the pass that originally produced the
+    /// cached K/V, and the replay range [snap_tok, matched) is rewritten
+    /// into SHARED prefix-cache blocks — non-exact recompute poisons them
+    /// and the drift ratchets across turns (2026-06-10 warm-hit stutter).
+    pub gdn_exact_replay: bool,
 }
 
 /// A single transformer layer performing the full per-layer computation.

--- a/crates/spark-model/src/layer/tests.rs
+++ b/crates/spark-model/src/layer/tests.rs
@@ -55,6 +55,7 @@ fn test_forward_context_lifetime() {
         profile: false,
         comm: None,
         graph_capture: false,
+        gdn_exact_replay: false,
     };
 
     assert_eq!(ctx.config.hidden_size, 2048);

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -202,13 +202,15 @@ impl MtpHead {
             }
         };
 
-        // MTP KV cache: 1 attention layer. Honor BF16 KV for the bf16-quant
-        // MTP head — the FP8 path hard-coded k_scale=v_scale=1.0, which on
-        // Qwen3.6-A3B (large deep-layer K/V magnitudes) collapsed the single
-        // MTP attention layer's output to a constant → constant draft token 0
-        // → 0% acceptance. FP8/NVFP4 MTP keep FP8 (backward-compat). The MTP
-        // KV is one tiny layer, so BF16 cost is negligible.
-        let kv_bf16 = matches!(quant, MtpQuantization::Bf16);
+        // MTP KV cache: 1 attention layer. The FP8 KV path hard-codes
+        // k_scale=v_scale=1.0, which on Qwen3.6-A3B (large deep-layer K/V
+        // magnitudes) collapsed the single MTP attention layer's output to a
+        // constant → constant draft token 0 → ~0% acceptance, making
+        // --mtp-quantization fp8 a net slowdown. Use BF16 KV for both bf16
+        // and fp8 MTP heads — the MTP KV is one tiny layer, so BF16 cost is
+        // negligible. NVFP4 MTP keeps FP8 KV (measured-good acceptance;
+        // FP8-path changes must stay additive for NVFP4).
+        let kv_bf16 = matches!(quant, MtpQuantization::Bf16 | MtpQuantization::Fp8);
         let kv_config = KvCacheConfig {
             block_size: 16,
             num_kv_heads: nkv,

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
@@ -26,6 +26,10 @@ impl Qwen3AttentionLayer {
         // same struct. When None, the function behaves single-stream
         // (reading from ctx.attn_metadata as before).
         batched_meta: Option<&BatchedAttnMetadata>,
+        // First `kv_write_floor` processed tokens skip the paged-cache K/V
+        // write (Marconi warm-hit replay over already-cached positions —
+        // see the section-7 comment). 0 on cold prefills.
+        kv_write_floor: usize,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<DevicePtr> {
@@ -397,14 +401,26 @@ impl Qwen3AttentionLayer {
         // ── 7. Write all K/V to paged cache ──
         // MLA models write compressed cache inside the MLA block above (1 head × 320 dims).
         // Standard models write expanded cache here (nkv heads × hd dims).
-        if self.mla.is_none() {
+        //
+        // Warm-hit replay write floor: the first `kv_write_floor` processed
+        // tokens are a Marconi SSM-replay over positions whose K/V already
+        // sit in SHARED refcounted prefix-cache blocks (written by the pass
+        // that originally produced them). The recompute is NOT bit-exact to
+        // those originals (FLA-vs-WY4 chunk grids, batched-GEMM-vs-decode-
+        // GEMV accumulation order), so rewriting would replace good cached
+        // values with drifted ones and the drift ratchets across agentic
+        // turns (2026-06-10 warm-hit token-stutter). Skip the write for the
+        // floor region — section 8's paged attention reads the original
+        // cached K/V at those positions, which is exactly what we want.
+        let wf = kv_write_floor.min(num_tokens);
+        if self.mla.is_none() && wf < num_tokens {
             self.write_kv_cache(
                 ctx.gpu,
-                k_contiguous,
-                v_contiguous,
+                k_contiguous.offset(wf * kv_dim * bf16),
+                v_contiguous.offset(wf * kv_dim * bf16),
                 kv_cache,
-                bmeta_slot,
-                n,
+                bmeta_slot.offset(wf * 4),
+                n - wf as u32,
                 nkv,
                 hd,
                 bs as u32,
@@ -427,14 +443,14 @@ impl Qwen3AttentionLayer {
                     ops::fused_k_norm_rope_cache_write_bf16_mrope(
                         ctx.gpu,
                         self.fused_k_norm_rope_mrope_cache_write_bf16_k,
-                        raw_k,
+                        raw_k.offset(wf * kv_dim * bf16),
                         self.attn.k_norm.weight,
-                        bmeta_positions,
-                        bmeta_positions_h,
-                        bmeta_positions_w,
+                        bmeta_positions.offset(wf * 4),
+                        bmeta_positions_h.offset(wf * 4),
+                        bmeta_positions_w.offset(wf * 4),
                         kv_cache.k_pool_ptr(self.attn_layer_idx),
-                        bmeta_slot,
-                        n,
+                        bmeta_slot.offset(wf * 4),
+                        n - wf as u32,
                         nkv,
                         hd,
                         self.rotary_dim_override

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
@@ -419,7 +419,8 @@ impl Qwen3AttentionLayer {
                 k_contiguous.offset(wf * kv_dim * bf16),
                 v_contiguous.offset(wf * kv_dim * bf16),
                 kv_cache,
-                bmeta_slot.offset(wf * 4),
+                // slot_mapping entries are int64 (8 bytes each)
+                bmeta_slot.offset(wf * 8),
                 n - wf as u32,
                 nkv,
                 hd,
@@ -445,11 +446,12 @@ impl Qwen3AttentionLayer {
                         self.fused_k_norm_rope_mrope_cache_write_bf16_k,
                         raw_k.offset(wf * kv_dim * bf16),
                         self.attn.k_norm.weight,
+                        // positions are u32 (4 bytes), slots int64 (8 bytes)
                         bmeta_positions.offset(wf * 4),
                         bmeta_positions_h.offset(wf * 4),
                         bmeta_positions_w.offset(wf * 4),
                         kv_cache.k_pool_ptr(self.attn_layer_idx),
-                        bmeta_slot.offset(wf * 4),
+                        bmeta_slot.offset(wf * 8),
                         n - wf as u32,
                         nkv,
                         hd,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/prefill_inner.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/prefill_inner.rs
@@ -137,6 +137,7 @@ impl Qwen3AttentionLayer {
                 disk_block_ids,
                 disk_last_offloaded_per_layer,
                 batched_meta,
+                kv_write_start,
                 ctx,
                 stream,
             )?

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
@@ -46,8 +46,20 @@ impl Qwen3SsmLayer {
         // always taken for 128-dim linear-head GDN models when the FLA kernels & scratch
         // are present (scratch is allocated for exactly those models, sizes.rs). The wy4
         // branch below remains the fallback for other head dims / a guard miss.
+        // Warm-hit replay (Marconi SSM snapshot restored): force the WY4
+        // recurrence. FLA's chunked algebra is only token-equal when its
+        // 64-token grid matches the pass that originally produced the cached
+        // K/V; a replay anchored at an arbitrary snapshot offset regroups the
+        // recurrence and its bf16 W/U/uc/S_c intermediates drift. The replay
+        // range is rewritten into SHARED prefix-cache blocks, so non-exact
+        // recompute poisons them and the drift ratchets across agentic turns
+        // (token-stutter corruption, 2026-06-10). WY4 keeps H in FP32 SMEM
+        // token-sequentially — same family as the decode kernel — and is the
+        // path the clean pre-FLA baseline used. Replay segments are short
+        // (suffix after a ≥10k skipped prefix), so the FLA speed loss is nil.
         let fla_scratch = ctx.buffers.gdn_fla_scratch();
-        if kd == 128
+        if !ctx.gdn_exact_replay
+            && kd == 128
             && vd == 128
             && fla_scratch.0 != 0
             && self.gdn_prefill_fla_recompute_wu_k.0 != 0

--- a/crates/spark-model/src/model/impl_b1.rs
+++ b/crates/spark-model/src/model/impl_b1.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-
 #![allow(unused_imports, dead_code)]
 
 use parking_lot::Mutex;

--- a/crates/spark-model/src/model/impl_b1.rs
+++ b/crates/spark-model/src/model/impl_b1.rs
@@ -272,6 +272,7 @@ impl TransformerModel {
                 profile: false,
                 comm: ctx.comm,
                 graph_capture: ctx.graph_capture,
+                gdn_exact_replay: false,
             }
         };
 
@@ -453,6 +454,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: false, // Eager mode — no CUDA graph
+            gdn_exact_replay: false,
         };
 
         // Eager layer loop: skip SSM layers, run attention layers only

--- a/crates/spark-model/src/model/impl_b2.rs
+++ b/crates/spark-model/src/model/impl_b2.rs
@@ -205,6 +205,7 @@ impl TransformerModel {
                 // MTP runs on rank 0 only — no EP all_reduce (BUG #26).
                 comm: None,
                 graph_capture: false,
+                gdn_exact_replay: false,
             };
             let drafts = proposer.propose(
                 token_0,

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -86,6 +86,7 @@ impl TransformerModel {
             profile: false,
             comm: None,
             graph_capture: false,
+            gdn_exact_replay: false,
         };
         let prop_state = seq
             .proposer_state

--- a/crates/spark-model/src/model/trait_impl/async_chkpt.rs
+++ b/crates/spark-model/src/model/trait_impl/async_chkpt.rs
@@ -230,7 +230,8 @@ impl TransformerModel {
                     let nk = self.config.linear_num_key_heads;
                     let kd = self.config.linear_key_head_dim;
                     let h_bytes = nv * vd * kd * 4;
-                    let conv_bytes = (nk * kd * 2 + nv * vd) * self.config.linear_conv_kernel_dim * 4;
+                    let conv_bytes =
+                        (nk * kd * 2 + nv * vd) * self.config.linear_conv_kernel_dim * 4;
                     self.gpu
                         .copy_d2d_async(h_ckpt, ssm.h_state, h_bytes, stream)?;
                     self.gpu

--- a/crates/spark-model/src/model/trait_impl/async_chkpt.rs
+++ b/crates/spark-model/src/model/trait_impl/async_chkpt.rs
@@ -196,10 +196,47 @@ impl TransformerModel {
     ) -> Result<()> {
         use crate::layer::SsmLayerState;
 
+        // Live-state invariant (2026-06-10 MTP×warm stutter fix): the live
+        // h_state/conv_state MUST be canonical after every commit, not just
+        // the checkpoint. Leaving live dirty (holding the rejected draft)
+        // was safe only when the next op was guaranteed to be another verify
+        // (pre_verify copies checkpoint→live). Three real paths run a plain
+        // decode() on the live buffer with no restore — spontaneous <think>
+        // flipping the scheduler MTP gate, a second concurrent request, and
+        // the MTP bootstrap after empty drafts (which then BAKES the dirty
+        // live state into the checkpoint via start_checkpoint_async). The
+        // phantom rejected token in the GDN memory garbles subsequent
+        // decode (token-stutter), and with prefix caching the poisoned
+        // decode-KV is immortalized in shared blocks across agentic turns.
+        // Cost: one extra D2D pair per SSM layer per reject — same as the
+        // pre-verify copy.
         if num_accepted == 0 {
-            // Full reject: canonical state untouched — no commit needed.
-            // Still record the event so sync_secondary has something to wait
-            // on (defensive: ensures pre-verify ordering on next iteration).
+            // Full reject: canonical state untouched; restore live from the
+            // checkpoint so any non-verify successor reads canonical state.
+            let stream = self.secondary_stream;
+            for (i, layer_state) in seq.layer_states.iter_mut().enumerate() {
+                if self.config.layer_type(i) == LayerType::LinearAttention {
+                    let ssm = layer_state
+                        .as_any_mut()
+                        .downcast_mut::<SsmLayerState>()
+                        .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState at layer {i}"))?;
+                    let (Some(h_ckpt), Some(conv_ckpt)) =
+                        (ssm.h_state_checkpoint, ssm.conv_state_checkpoint)
+                    else {
+                        continue;
+                    };
+                    let nv = self.config.linear_num_value_heads;
+                    let vd = self.config.linear_value_head_dim;
+                    let nk = self.config.linear_num_key_heads;
+                    let kd = self.config.linear_key_head_dim;
+                    let h_bytes = nv * vd * kd * 4;
+                    let conv_bytes = (nk * kd * 2 + nv * vd) * self.config.linear_conv_kernel_dim * 4;
+                    self.gpu
+                        .copy_d2d_async(h_ckpt, ssm.h_state, h_bytes, stream)?;
+                    self.gpu
+                        .copy_d2d_async(conv_ckpt, ssm.conv_state, conv_bytes, stream)?;
+                }
+            }
             self.gpu
                 .record_event(self.secondary_event, self.secondary_stream)?;
             return Ok(());
@@ -240,7 +277,11 @@ impl TransformerModel {
                     self.gpu
                         .copy_d2d_async(ssm.conv_state, conv_ckpt, conv_bytes, stream)?;
                 } else {
-                    // Partial accept: intermediate[num_accepted-1] → live.
+                    // Partial accept: intermediate[num_accepted-1] → checkpoint
+                    // AND → live. The live buffer holds state through ALL k
+                    // verify tokens (including the rejected draft); restoring
+                    // it here keeps live canonical for any non-verify
+                    // successor (see the live-state invariant note above).
                     let slot = seq.slot_idx;
                     let inter_idx = num_accepted - 1;
                     let h_inter = self.ssm_pool.h_intermediate(ssm_layer_idx, slot, inter_idx);
@@ -250,6 +291,10 @@ impl TransformerModel {
                     self.gpu.copy_d2d_async(h_inter, h_ckpt, h_bytes, stream)?;
                     self.gpu
                         .copy_d2d_async(conv_inter, conv_ckpt, conv_bytes, stream)?;
+                    self.gpu
+                        .copy_d2d_async(h_inter, ssm.h_state, h_bytes, stream)?;
+                    self.gpu
+                        .copy_d2d_async(conv_inter, ssm.conv_state, conv_bytes, stream)?;
                 }
 
                 ssm_layer_idx += 1;

--- a/crates/spark-model/src/model/trait_impl/async_chkpt.rs
+++ b/crates/spark-model/src/model/trait_impl/async_chkpt.rs
@@ -239,12 +239,11 @@ impl TransformerModel {
             }
             self.gpu
                 .record_event(self.secondary_event, self.secondary_stream)?;
-            // The live restore above must be visible to the next default-
-            // stream consumer (decode/draft) even when the scheduler takes a
-            // non-verify path that never calls sync_secondary. Order it here,
-            // at the commit point: GPU-side wait, zero CPU cost.
-            self.gpu
-                .stream_wait_event(self.gpu.default_stream(), self.secondary_event)?;
+            // Ordering: the verify path syncs at entry (verify_*_step
+            // sync_secondary); the non-verify successors (gate flip,
+            // bootstrap) sync at THEIR entry — see scheduler/mod.rs and
+            // mtp_step.rs. No wait here: a commit-side wait would serialize
+            // this copy against the next draft and cost ~25% decode wall.
             return Ok(());
         }
 
@@ -308,14 +307,12 @@ impl TransformerModel {
         }
 
         self.gpu.record_event(self.secondary_event, stream)?;
-        // Order the live-state restore (partial-accept branch) ahead of any
-        // default-stream successor. The non-verify scheduler paths (gate
-        // flip, bootstrap, decode-only) read ssm.h_state/conv_state on the
-        // default stream without calling sync_secondary — without this wait
-        // the restore races the next decode (observed as single-char path
-        // corruption under concurrent agentic traffic, tq10 run 1).
-        self.gpu
-            .stream_wait_event(self.gpu.default_stream(), self.secondary_event)?;
+        // Ordering: verify_*_step calls sync_secondary at entry; the
+        // non-verify successors that read the live state (MTP gate flip →
+        // step_decode_only, bootstrap decode) call sync_secondary at THEIR
+        // entry (scheduler/mod.rs, mtp_step.rs). A commit-side wait here
+        // would serialize this 250MB copy against the next draft kernels
+        // that used to overlap it (~25% decode wall, tq11 360s cap-riders).
         Ok(())
     }
 }

--- a/crates/spark-model/src/model/trait_impl/async_chkpt.rs
+++ b/crates/spark-model/src/model/trait_impl/async_chkpt.rs
@@ -239,6 +239,12 @@ impl TransformerModel {
             }
             self.gpu
                 .record_event(self.secondary_event, self.secondary_stream)?;
+            // The live restore above must be visible to the next default-
+            // stream consumer (decode/draft) even when the scheduler takes a
+            // non-verify path that never calls sync_secondary. Order it here,
+            // at the commit point: GPU-side wait, zero CPU cost.
+            self.gpu
+                .stream_wait_event(self.gpu.default_stream(), self.secondary_event)?;
             return Ok(());
         }
 
@@ -302,6 +308,14 @@ impl TransformerModel {
         }
 
         self.gpu.record_event(self.secondary_event, stream)?;
+        // Order the live-state restore (partial-accept branch) ahead of any
+        // default-stream successor. The non-verify scheduler paths (gate
+        // flip, bootstrap, decode-only) read ssm.h_state/conv_state on the
+        // default stream without calling sync_secondary — without this wait
+        // the restore races the next decode (observed as single-char path
+        // corruption under concurrent agentic traffic, tq10 run 1).
+        self.gpu
+            .stream_wait_event(self.gpu.default_stream(), self.secondary_event)?;
         Ok(())
     }
 }

--- a/crates/spark-model/src/model/trait_impl/decode_a.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a.rs
@@ -169,6 +169,7 @@ impl TransformerModel {
             profile: self.profile,
             comm: self.comm_ref(),
             graph_capture: use_graphs,
+            gdn_exact_replay: false,
         };
 
         // Profile mode: use per-layer sync decode for timing breakdown.

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -198,6 +198,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: use_graphs,
+            gdn_exact_replay: false,
         };
 
         // ── Phase 2: CUDA graph lookup / capture ──

--- a/crates/spark-model/src/model/trait_impl/decode_b.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b.rs
@@ -411,6 +411,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: false,
+            gdn_exact_replay: false,
         };
 
         let prefill_ctx = ForwardContext {
@@ -421,6 +422,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: false,
+            gdn_exact_replay: false,
         };
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -374,14 +374,12 @@ impl TransformerModel {
 
         // ── 4. Forward through all layers ──
         // When Marconi skip is active, seq_len_start > 0 triggers paged attention
-        // in attention layers. SSM layers process only proc_count tokens using
-        // restored h_state + conv_state. On a Marconi *intermediate* hit the
-        // processed batch starts at snap_tok and its first (matched -
-        // snap_tok) tokens replay positions whose K/V already live in shared
-        // prefix-cache blocks — pass that count as the layer write floor so
-        // attention does not rewrite them with non-bit-exact recomputed
-        // values (see prefill_b/forward_layers.rs). On a leaf hit the floor
-        // is 0 (everything processed is genuinely new).
+        // in attention layers. SSM layers process only proc_count tokens
+        // using restored h_state + conv_state. On a Marconi intermediate hit
+        // the first (matched - snap_tok) processed tokens replay positions
+        // already in shared prefix-cache blocks — write-floor them so
+        // attention can't rewrite cached K/V with non-bit-exact recompute
+        // (see prefill_b/forward_layers.rs). Leaf hit → floor 0 (all new).
         let layer_kv_write_start = if marconi_skip {
             seq.cached_prefix_tokens
                 .saturating_sub(seq_len_start)

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -367,6 +367,9 @@ impl TransformerModel {
             profile: self.profile,
             comm: self.comm_ref(),
             graph_capture: false,
+            // Marconi warm hit: GDN layers replay from a restored SSM state
+            // and must use the bit-faithful WY4 recurrence (see layer.rs).
+            gdn_exact_replay: marconi_skip,
         };
 
         // ── 4. Forward through all layers ──

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -375,9 +375,20 @@ impl TransformerModel {
         // ── 4. Forward through all layers ──
         // When Marconi skip is active, seq_len_start > 0 triggers paged attention
         // in attention layers. SSM layers process only proc_count tokens using
-        // restored h_state + conv_state. kv_write_start=0 because ALL tokens in
-        // the batch are uncached (cached ones were skipped entirely).
-        let layer_kv_write_start = if marconi_skip { 0 } else { kv_write_start };
+        // restored h_state + conv_state. On a Marconi *intermediate* hit the
+        // processed batch starts at snap_tok and its first (matched -
+        // snap_tok) tokens replay positions whose K/V already live in shared
+        // prefix-cache blocks — pass that count as the layer write floor so
+        // attention does not rewrite them with non-bit-exact recomputed
+        // values (see prefill_b/forward_layers.rs). On a leaf hit the floor
+        // is 0 (everything processed is genuinely new).
+        let layer_kv_write_start = if marconi_skip {
+            seq.cached_prefix_tokens
+                .saturating_sub(seq_len_start)
+                .min(proc_count)
+        } else {
+            kv_write_start
+        };
         let diag_prefill = self.profile && proc_count > 1; // Only with --profile
         for (i, layer) in self.layers.iter().enumerate() {
             layer

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
@@ -393,6 +393,7 @@ impl TransformerModel {
             profile: self.profile,
             comm: self.comm_ref(),
             graph_capture: false,
+            gdn_exact_replay: false,
         };
 
         // h_state_ptrs scratch slot offset (used JIT per SSM layer).

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -82,6 +82,9 @@ impl TransformerModel {
             profile: profile_now,
             comm: self.comm_ref(),
             graph_capture: false,
+            // Marconi warm hit: GDN layers replay from a restored SSM state
+            // and must use the bit-faithful WY4 recurrence (see layer.rs).
+            gdn_exact_replay: marconi_skip,
         };
 
         // When proc_count == 1 (warm prefix cache hit), use the decode layer path

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -92,7 +92,21 @@ impl TransformerModel {
         // and the decode MoE path, which is ~7x faster per layer than the prefill
         // GEMM path for a single token (0.7ms/layer vs 5ms/layer).
         let use_decode_path = proc_count == 1 && effective_seq_len_start > 0;
-        let layer_kv_write_start = if marconi_skip { 0 } else { kv_write_start };
+        // Marconi warm hit: this pass replays SSM state over [snap_tok,
+        // matched) — positions whose K/V already live in shared prefix-cache
+        // blocks. Pass the per-chunk count of those replay tokens as the
+        // layer write floor so attention layers do NOT rewrite them with
+        // non-bit-exact recomputed values (drift would poison the shared
+        // blocks and ratchet across turns). `seq.cached_prefix_tokens` is
+        // the radix-tree match point; tokens at or past it are new and are
+        // written normally.
+        let layer_kv_write_start = if marconi_skip {
+            seq.cached_prefix_tokens
+                .saturating_sub(effective_seq_len_start)
+                .min(proc_count)
+        } else {
+            kv_write_start
+        };
         let prefill_t0 = if profile_now {
             self.gpu.synchronize(stream)?;
             Some(std::time::Instant::now())

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -410,6 +410,9 @@ impl TransformerModel {
             profile: self.profile,
             comm: self.comm_ref(),
             graph_capture: false,
+            // Marconi warm hit: GDN layers replay from a restored SSM state
+            // and must use the bit-faithful WY4 recurrence (see layer.rs).
+            gdn_exact_replay: marconi_skip,
         };
 
         // ── 4. Per-layer forward: SSM uses three-phase, attention uses standard ──

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -416,7 +416,17 @@ impl TransformerModel {
         };
 
         // ── 4. Per-layer forward: SSM uses three-phase, attention uses standard ──
-        let layer_kv_write_start = if marconi_skip { 0 } else { kv_write_start };
+        // Marconi intermediate hit: the first (matched - proc_start) processed
+        // tokens replay already-cached positions — write-floor them so the
+        // shared prefix-cache blocks are not rewritten with non-bit-exact
+        // recomputed K/V (see prefill_b/forward_layers.rs).
+        let layer_kv_write_start = if marconi_skip {
+            seq.cached_prefix_tokens
+                .saturating_sub(proc_start)
+                .min(proc_count)
+        } else {
+            kv_write_start
+        };
         let gdn_bufs = GdnPrefillBuffers {
             qkv: self.gdn_buf_qkv,
             gate_beta: self.gdn_buf_gate_beta,

--- a/crates/spark-model/src/model/trait_impl/verify_a.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_a.rs
@@ -128,6 +128,7 @@ impl TransformerModel {
                         profile: false,
                         comm: self.comm_ref(),
                         graph_capture: false,
+                        gdn_exact_replay: false,
                     };
 
                     let h_t = hidden.offset(t * h * fp32);
@@ -155,6 +156,7 @@ impl TransformerModel {
                     profile: false,
                     comm: self.comm_ref(),
                     graph_capture: false,
+                    gdn_exact_replay: false,
                 };
 
                 layer.decode_batched(

--- a/crates/spark-model/src/model/trait_impl/verify_b.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_b.rs
@@ -175,6 +175,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: use_graphs,
+            gdn_exact_replay: false,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_c.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c.rs
@@ -163,6 +163,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: use_graphs,
+            gdn_exact_replay: false,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -153,6 +153,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: use_graphs,
+            gdn_exact_replay: false,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -159,6 +159,7 @@ impl TransformerModel {
             profile: false,
             comm: self.comm_ref(),
             graph_capture: use_graphs,
+            gdn_exact_replay: false,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -249,6 +249,15 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
             "dflash: --enable-prefix-caching has a community-reported correctness regression on SM12.x with DFlash; outputs may be wrong on multi-turn cache hits. Run a greedy diff-test against a non-DFlash baseline before relying on outputs."
         );
     }
+    if args.speculative && args.enable_prefix_caching && config.num_ssm_layers() > 0 {
+        tracing::warn!(
+            "--enable-prefix-caching with --speculative on a hybrid (SSM) model has a KNOWN residual \
+             corruption on warm Marconi restores under agentic multi-turn traffic (~1 in 3 runs emit \
+             duplicated tool-argument fragments). Each feature is verified clean alone (2026-06-10 \
+             N=10 gates). Until the interaction fix lands, drop one of the two flags for production \
+             agentic serving."
+        );
+    }
     let prefix_cache = serve_phases::build_prefix_cache(&args);
     let comm = serve_phases::init_nccl_comm(&args, gpu.as_ref(), world_size)?;
     if args.profile {

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -337,6 +337,13 @@ pub fn run(
                     for a in active.iter_mut() {
                         a.pending_drafts.clear();
                     }
+                    // MTP→decode-only transition: the last verify commit's
+                    // live-state restore runs async on the secondary stream;
+                    // order it before this decode reads h_state/conv_state
+                    // (GPU-side event wait, zero CPU cost).
+                    if let Err(e) = model.sync_secondary() {
+                        tracing::error!("mtp→decode sync_secondary: {e:#}");
+                    }
                 }
                 step_decode_only(
                     &*model,

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -30,6 +30,15 @@ pub fn step_mtp(
     }
 
     // ── Phase A: Bootstrap decode for sequences without a draft ──
+    if !bootstrap_idxs.is_empty() {
+        // The previous verify commit's live-state restore runs async on the
+        // secondary stream; order it before the bootstrap decode reads
+        // h_state/conv_state (and before start_checkpoint_async snapshots
+        // the live state). GPU-side event wait, zero CPU cost.
+        if let Err(e) = model.sync_secondary() {
+            tracing::error!("bootstrap sync_secondary: {e:#}");
+        }
+    }
     for &idx in &bootstrap_idxs {
         let a = &mut active[idx];
         // EP: broadcast token to worker before decode (worker runs decode in lockstep).

--- a/crates/spark-server/src/scheduler/rollback.rs
+++ b/crates/spark-server/src/scheduler/rollback.rs
@@ -72,6 +72,15 @@ pub enum RollbackOutcome {
 pub enum RollbackFallback {
     /// `[behavior].rollback_resteer = false`.
     Disabled,
+    /// Streaming request: the tokens a re-steer would drop have already
+    /// been flushed to the client as SSE deltas (content AND live
+    /// tool-call argument fragments since #90), so the client keeps the
+    /// dropped text and then receives the regeneration — duplicated /
+    /// blended output (the 2026-06-10 tool-arg "stutter": paths like
+    /// `tq133-pro-prose-r22`). The server cannot retract SSE; decline
+    /// and let the caller hard-stop (truncation is stream-safe — the
+    /// pre-#141 behavior, when SSM rollbacks always declined).
+    StreamUnsafe,
     /// The per-sequence rollback cap was already reached.
     CapReached,
     /// No well-formed boundary was found in the generated tail.
@@ -198,6 +207,12 @@ pub fn rollback_to_boundary(
 ) -> RollbackOutcome {
     if !watchdog_params().rollback_resteer {
         return RollbackOutcome::Fallback(RollbackFallback::Disabled);
+    }
+    // Streaming requests flush every token to the client as it is
+    // sampled — a re-steer cannot retract them (see StreamUnsafe doc).
+    // `cancel_flag` is Some exactly for streaming requests.
+    if a.cancel_flag.is_some() {
+        return RollbackOutcome::Fallback(RollbackFallback::StreamUnsafe);
     }
     if a.rollback_count >= atlas_kernels::ROLLBACK_RESTEER_CAP {
         return RollbackOutcome::Fallback(RollbackFallback::CapReached);

--- a/kernels/gb10/qwen3.6-35b-a3b/MODEL.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/MODEL.toml
@@ -20,14 +20,6 @@ head_dim = 256
 q_heads = 16
 kv_heads = 2
 
-# FP8 KV-cache calibration (Option B, #211): the FP8 checkpoint ships no
-# k_proj.k_scale/v_proj.v_scale, so the FP8 KV path defaults to scale=1.0 and
-# silently saturates BF16 K/V into E4M3 [-448,448], destroying dynamic range
-# on deep layers where |K|,|V| grow (cos drift L31-L39). Fit per-tensor
-# k/v scales from the first 256 observed tokens' amax (scale=running_max/448),
-# matching the calibrated-FP8 practice mistral-small-4 / gemma-4-26b already use.
-fp8_kv_calibration_tokens = 256
-
 linear_attn_key_heads = 16
 linear_attn_key_dim = 128
 linear_attn_value_heads = 32
@@ -145,6 +137,17 @@ dry_multiplier = 0.0
 # compensate for model quirks. Defaults are sane for most models; override
 # here when a model family has known failure modes.
 [behavior]
+# FP8 KV-cache calibration (Option B, #211): the FP8 checkpoint ships no
+# k_proj.k_scale/v_proj.v_scale, so the FP8 KV path defaults to scale=1.0 and
+# silently saturates BF16 K/V into E4M3 [-448,448], destroying dynamic range
+# on deep layers where |K|,|V| grow (cos drift L31-L39). Fit per-tensor
+# k/v scales from the first 256 observed tokens' amax (scale=running_max/448),
+# matching the calibrated-FP8 practice mistral-small-4 / gemma-4-26b already use.
+# NOTE: must live under [behavior] — parse_behavior() only reads this table
+# (it sat under [model] until 2026-06-10 and was silently parsed as 0 =
+# calibration disabled).
+fp8_kv_calibration_tokens = 256
+
 # Content-loop watchdog ENABLED (2026-05-23 numerical-drift sweep):
 # the 2026-05-05 chess-game pass was too short to expose the late-
 # layer divergence — 18920-token opencode prompts produce ~7%

--- a/kernels/gb10/qwen3.6-35b-a3b/MODEL.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/MODEL.toml
@@ -258,10 +258,14 @@ max_thinking_budget = 768
 # tokens of a tight loop) and thinking-loop watchdog.
 #
 # F5 (2026-06-02): lowered 2048 → 1024. F1's post-think content cap is
-# the dominant runaway bound; 1024 trims free-text wander cost without
-# returning to the 384 default that historically killed legitimate
-# inter-tool explanations.
-max_inter_tool_prose = 1024
+# the dominant runaway bound. 2026-06-10: restored to 384 — the 1024
+# budget (raised in #90) let temp-0.3 paraphrase loops run ~2.7x longer
+# per inter-tool gap on long warm-cache contexts (SimHash fires HINT-only
+# on paraphrase repeats; the period matcher misses them), turning
+# agentic runs into 360s cap-riders (tq12 gate 0/2). 384 is the value
+# the 2026-06-07 10/10 series and the CC2-CC6 Claude-Code validation
+# actually ran with.
+max_inter_tool_prose = 384
 # F1 (2026-06-02): unconditional post-`</think>` content-token cap for
 # tool-active requests. Backstops the grammar-legal-but-never-closing
 # tool-value runaway (a garbled/merged BPE `</parameter>` close leaves


### PR DESCRIPTION
Fix series for the agentic wall-time regression and the warm-cache corruption family found while investigating it (2026-06-10).

Background: the flagship Sigma-wall regressed from ~1331s (2026-06-07 series) to ~2400s. A 38-agent diff forensics pass attributed 80-90 percent to serving-config deltas (missing prefix caching, MTP fp8 draft head, uncalibrated fp8 KV) rather than code. Re-enabling the fast flags then exposed a chain of real correctness bugs, each isolated with N=5/N=10 opencode harness gates on both DGX boxes. Full analysis: tasks/wall_regression_diff_analysis.md.

Fixes, in commit order:

1. fp8 KV calibration key placement: kernels/gb10/qwen3.6-35b-a3b/MODEL.toml had fp8_kv_calibration_tokens=256 under [model] but parse_behavior() reads only [behavior] - parsed as 0, so every default-flag serve ran UNCALIBRATED fp8 KV (scale=1.0, saturating E4M3 on deep layers). Moved to [behavior].

2. fp8 MTP draft-head collapse: --mtp-quantization fp8 kept the 1-layer MTP KV cache in FP8 with hardcoded unit scales, collapsing draft acceptance to ~0 percent and making MTP a net slowdown. The MTP KV cache now uses BF16 for fp8 heads too (single tiny layer, negligible cost); NVFP4 MTP untouched.

3. GDN warm-replay kernel routing: Marconi warm hits replay [snap_tok, matched) through the FLA chunked kernel anchored at arbitrary snapshot offsets with bf16 intermediates - non-bit-exact vs the pass that produced the cached K/V. New ForwardContext::gdn_exact_replay routes warm-restored prefills through the bit-faithful WY4 recurrence; cold prefills keep FLA.

4. Prefix-cache KV write floor: the chunked paged prefill rewrote the replay range into SHARED refcounted radix blocks unconditionally (prefill_attention_paged ignored kv_write_start). Any non-bit-exact recompute poisoned the blocks and ratcheted drift across turns. New kv_write_floor skips the write for already-cached positions on all single-stream prefill paths; paged attention reads the original cached values. (Includes the int64 slot-mapping offset fix.)

5. MTP live-state restore on rejection: under MTP the GDN layers keep live + checkpoint state; rejection corrected only the checkpoint, leaving the live buffer holding the rejected token. Three scheduler paths (spontaneous think gate-flip, concurrent request, MTP bootstrap) ran plain decode on the dirty live state, and the bootstrap then baked it into the checkpoint. Rejection now restores the live state too, with consumer-side sync_secondary ordering at the two non-verify consumers (commit-side ordering measured ~25 percent decode wall - reverted in favor of consumer-side).

6. Stream-safe rollback: watchdog rollback+re-steer drops 60-80 already-generated tokens; streaming requests have already flushed them (including live tool-arg deltas), and SSE cannot retract - the client accumulates original + regeneration (duplicated/blended tool-arg paths). Before #141 the hybrid flagship's rollbacks always declined (NoSsmSnapshot) and ended early; #141 made them succeed, enabling the unsafe path. rollback_to_boundary now declines with RollbackFallback::StreamUnsafe for streaming sequences.

7. Behavior: max_inter_tool_prose restored to 384 for qwen3.6-35b-a3b (the 1024 raised in #90 let temp-0.3 paraphrase loops run 2.7x longer per inter-tool gap, turning runs into 360s cap-riders).

8. Serve-time warning for the one KNOWN residual: --enable-prefix-caching combined with --speculative on hybrid (SSM) models still corrupts ~1 in 3 agentic runs (warm restores x working draft traffic). Each feature is verified clean alone. Tracked in a follow-up issue.

Verification (all on Qwen/Qwen3.6-35B-A3B-FP8, opencode webserver_ok harness):
- Ship config (MTP bf16, bf16 KV, slai, no prefix caching): dgx1 10/10 Sigma=2391s, dgx2 5/5 Sigma=1063s - 15/15 combined, zero corruption signatures.
- MTP+no-cache discriminator 5/5; no-MTP+cache 13 clean runs; MTP warm-stress repro (new bench/fp8_dgx2_drift/harness/mtp_warm_stress.py) 3x32 turns clean post-fix vs 1-in-16-turn corruption pre-fix.
- cargo tests: spark-model 75/75, spark-server 496+111 integration/lib, atlas-kernels 28/28.
- K2 acceptance with the fp8 MTP-KV fix family: 65-81 percent observed (vs ~0 percent collapsed).

New repro/diagnostic tooling: bench/fp8_dgx2_drift/harness/mtp_warm_stress.py, warm_cold_chain_repro.py.
