### PR TITLE
fix(#110): serialize mixed decode+prefill batch (cross-stream scratch race → CUDA-700)

### DIFF
--- a/crates/spark-model/src/model/trait_impl/decode_b.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b.rs
@@ -28,10 +28,64 @@ use crate::layer::{
 };
 use crate::layers::ops;
 use crate::speculative::DraftProposer;
-use crate::traits::{ChunkedPrefillPageMetadata, Model, SequenceState};
+use crate::traits::{
+    ChunkedPrefillPageMetadata, MixedBatchResult, Model, PrefillSlice, SequenceState,
+};
 use crate::weight_map::{DenseWeight, MtpWeights, QuantizedWeight};
 
 impl TransformerModel {
+    /// #110: fully-batched mixed step (M decode + N prefill chunks).
+    ///
+    /// The previous trait DEFAULT (`Model::mixed_forward_batch`) ran the
+    /// decode half via `decode_batch` (which hardcodes `default_stream` in
+    /// `decode_batch_compute_main`) and the prefill half via
+    /// `prefill_batch_chunk` on the caller's separate `prefill_stream`, with
+    /// NO event ordering them. Both halves carve the SAME singleton
+    /// `buffers.scratch()` (decode metadata at +32768) and `buffers.logits()`.
+    /// At concurrency >= 4 the prefill half's chunk-0 `zero_all` + MoE top-k
+    /// staging clobbered the decode half's metadata/logits mid-flight ->
+    /// torn KV-slot read -> CUDA_ERROR_ILLEGAL_ACCESS (700), or silently
+    /// corrupted decode logits. (Same class fixed for the single-prefill
+    /// fused path on 2026-05-10; never propagated here.)
+    ///
+    /// Fix: force BOTH halves onto `default_stream` so they serialize
+    /// (decode completes — including its scratch-metadata attention reads
+    /// and LM head — before the prefill half reuses those buffers), and copy
+    /// the decode logits into a private staging buffer before the prefill
+    /// half overwrites `logits`. The two halves cannot overlap anyway (shared
+    /// arena), so single-stream costs nothing vs the old serial default.
+    pub(super) fn mixed_forward_batch_dispatch(
+        &self,
+        decode_tokens: &[u32],
+        decode_seqs: &mut [&mut SequenceState],
+        prefill_streams: &mut [PrefillSlice<'_>],
+        _stream: u64,
+    ) -> Result<MixedBatchResult> {
+        let stream = self.gpu.default_stream();
+        let decode_logits = if !decode_tokens.is_empty() {
+            let raw = self.decode_batch(decode_tokens, decode_seqs, stream)?;
+            if raw != DevicePtr::NULL {
+                // Decode logits are [n_decode, vocab] BF16, contiguous from
+                // row 0. Stage them out of `buffers.logits()` (same stream,
+                // ordered after the decode LM head) before the prefill half's
+                // zero_all / finalize_last overwrite that buffer.
+                let staging = self.buffers.decode_logits_staging();
+                let bytes = decode_tokens.len() * self.config.vocab_size * 2;
+                self.gpu.copy_d2d_async(raw, staging, bytes, stream)?;
+                staging
+            } else {
+                raw
+            }
+        } else {
+            DevicePtr::NULL
+        };
+        let prefill_logits = self.prefill_batch_chunk(prefill_streams, stream)?;
+        Ok(MixedBatchResult {
+            decode_logits,
+            prefill_logits,
+        })
+    }
+
     pub(super) fn mixed_forward_dispatch(
         &self,
         decode_tokens: &[u32],

--- a/crates/spark-model/src/model/trait_impl/decode_b.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b.rs
@@ -28,64 +28,10 @@ use crate::layer::{
 };
 use crate::layers::ops;
 use crate::speculative::DraftProposer;
-use crate::traits::{
-    ChunkedPrefillPageMetadata, MixedBatchResult, Model, PrefillSlice, SequenceState,
-};
+use crate::traits::{ChunkedPrefillPageMetadata, Model, SequenceState};
 use crate::weight_map::{DenseWeight, MtpWeights, QuantizedWeight};
 
 impl TransformerModel {
-    /// #110: fully-batched mixed step (M decode + N prefill chunks).
-    ///
-    /// The previous trait DEFAULT (`Model::mixed_forward_batch`) ran the
-    /// decode half via `decode_batch` (which hardcodes `default_stream` in
-    /// `decode_batch_compute_main`) and the prefill half via
-    /// `prefill_batch_chunk` on the caller's separate `prefill_stream`, with
-    /// NO event ordering them. Both halves carve the SAME singleton
-    /// `buffers.scratch()` (decode metadata at +32768) and `buffers.logits()`.
-    /// At concurrency >= 4 the prefill half's chunk-0 `zero_all` + MoE top-k
-    /// staging clobbered the decode half's metadata/logits mid-flight ->
-    /// torn KV-slot read -> CUDA_ERROR_ILLEGAL_ACCESS (700), or silently
-    /// corrupted decode logits. (Same class fixed for the single-prefill
-    /// fused path on 2026-05-10; never propagated here.)
-    ///
-    /// Fix: force BOTH halves onto `default_stream` so they serialize
-    /// (decode completes — including its scratch-metadata attention reads
-    /// and LM head — before the prefill half reuses those buffers), and copy
-    /// the decode logits into a private staging buffer before the prefill
-    /// half overwrites `logits`. The two halves cannot overlap anyway (shared
-    /// arena), so single-stream costs nothing vs the old serial default.
-    pub(super) fn mixed_forward_batch_dispatch(
-        &self,
-        decode_tokens: &[u32],
-        decode_seqs: &mut [&mut SequenceState],
-        prefill_streams: &mut [PrefillSlice<'_>],
-        _stream: u64,
-    ) -> Result<MixedBatchResult> {
-        let stream = self.gpu.default_stream();
-        let decode_logits = if !decode_tokens.is_empty() {
-            let raw = self.decode_batch(decode_tokens, decode_seqs, stream)?;
-            if raw != DevicePtr::NULL {
-                // Decode logits are [n_decode, vocab] BF16, contiguous from
-                // row 0. Stage them out of `buffers.logits()` (same stream,
-                // ordered after the decode LM head) before the prefill half's
-                // zero_all / finalize_last overwrite that buffer.
-                let staging = self.buffers.decode_logits_staging();
-                let bytes = decode_tokens.len() * self.config.vocab_size * 2;
-                self.gpu.copy_d2d_async(raw, staging, bytes, stream)?;
-                staging
-            } else {
-                raw
-            }
-        } else {
-            DevicePtr::NULL
-        };
-        let prefill_logits = self.prefill_batch_chunk(prefill_streams, stream)?;
-        Ok(MixedBatchResult {
-            decode_logits,
-            prefill_logits,
-        })
-    }
-
     pub(super) fn mixed_forward_dispatch(
         &self,
         decode_tokens: &[u32],

--- a/crates/spark-model/src/model/trait_impl/mixed_batch.rs
+++ b/crates/spark-model/src/model/trait_impl/mixed_batch.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! #110: fully-batched mixed step (M decode + N prefill chunks) dispatch.
+
+#![allow(clippy::too_many_arguments)]
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+use super::super::types::TransformerModel;
+use crate::traits::{MixedBatchResult, Model, PrefillSlice, SequenceState};
+
+impl TransformerModel {
+    /// #110: fully-batched mixed step (M decode + N prefill chunks).
+    ///
+    /// The previous trait DEFAULT (`Model::mixed_forward_batch`) ran the
+    /// decode half via `decode_batch` (which hardcodes `default_stream` in
+    /// `decode_batch_compute_main`) and the prefill half via
+    /// `prefill_batch_chunk` on the caller's separate `prefill_stream`, with
+    /// NO event ordering them. Both halves carve the SAME singleton
+    /// `buffers.scratch()` (decode metadata at +32768) and `buffers.logits()`.
+    /// At concurrency >= 4 the prefill half's chunk-0 `zero_all` + MoE top-k
+    /// staging clobbered the decode half's metadata/logits mid-flight ->
+    /// torn KV-slot read -> CUDA_ERROR_ILLEGAL_ACCESS (700), or silently
+    /// corrupted decode logits. (Same class fixed for the single-prefill
+    /// fused path on 2026-05-10; never propagated here.)
+    ///
+    /// Fix: force BOTH halves onto `default_stream` so they serialize
+    /// (decode completes — including its scratch-metadata attention reads
+    /// and LM head — before the prefill half reuses those buffers), and copy
+    /// the decode logits into a private staging buffer before the prefill
+    /// half overwrites `logits`. The two halves cannot overlap anyway (shared
+    /// arena), so single-stream costs nothing vs the old serial default.
+    pub(super) fn mixed_forward_batch_dispatch(
+        &self,
+        decode_tokens: &[u32],
+        decode_seqs: &mut [&mut SequenceState],
+        prefill_streams: &mut [PrefillSlice<'_>],
+        _stream: u64,
+    ) -> Result<MixedBatchResult> {
+        let stream = self.gpu.default_stream();
+        let decode_logits = if !decode_tokens.is_empty() {
+            let raw = self.decode_batch(decode_tokens, decode_seqs, stream)?;
+            if raw != DevicePtr::NULL {
+                // Decode logits are [n_decode, vocab] BF16, contiguous from
+                // row 0. Stage them out of `buffers.logits()` (same stream,
+                // ordered after the decode LM head) before the prefill half's
+                // zero_all / finalize_last overwrite that buffer.
+                let staging = self.buffers.decode_logits_staging();
+                let bytes = decode_tokens.len() * self.config.vocab_size * 2;
+                self.gpu.copy_d2d_async(raw, staging, bytes, stream)?;
+                staging
+            } else {
+                raw
+            }
+        } else {
+            DevicePtr::NULL
+        };
+        let prefill_logits = self.prefill_batch_chunk(prefill_streams, stream)?;
+        Ok(MixedBatchResult {
+            decode_logits,
+            prefill_logits,
+        })
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -98,6 +98,19 @@ impl Model for TransformerModel {
         )
     }
 
+    /// #110: override the trait default (which raced decode on `default_stream`
+    /// against prefill on `prefill_stream` over shared scratch/logits). The
+    /// dispatch serializes both halves on one stream and stages decode logits.
+    fn mixed_forward_batch(
+        &self,
+        decode_tokens: &[u32],
+        decode_seqs: &mut [&mut SequenceState],
+        prefill_streams: &mut [crate::traits::PrefillSlice<'_>],
+        stream: u64,
+    ) -> Result<crate::traits::MixedBatchResult> {
+        self.mixed_forward_batch_dispatch(decode_tokens, decode_seqs, prefill_streams, stream)
+    }
+
     /// Q12 Phase 4b override: try the model-level batched dispatch
     /// (`prefill_batch_chunk_dispatch`) first; on the not-yet-implemented
     /// stub failure, fall back to the trait's default per-stream loop.

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -25,6 +25,7 @@ mod decode_b2;
 mod decode_checkpoint;
 mod ep_misc;
 mod meta;
+mod mixed_batch;
 mod prefill_a;
 mod prefill_b;
 mod prefill_c;

--- a/crates/spark-runtime/src/buffers.rs
+++ b/crates/spark-runtime/src/buffers.rs
@@ -40,6 +40,9 @@ pub struct BufferArena {
     moe_output: DevicePtr,
     /// Logits: [M, vocab_size] in BF16.
     logits: DevicePtr,
+    /// #110: private staging for decode-half logits in a mixed batch step
+    /// (the prefill half overwrites `logits` before the scheduler samples).
+    decode_logits_staging: DevicePtr,
     /// SSM QKVZ projection: [M, ssm_qkvz_size] in BF16.
     ssm_qkvz: DevicePtr,
     /// SSM beta-alpha projection: [M, ssm_ba_size] in BF16.
@@ -91,6 +94,7 @@ impl BufferArena {
         let gate_logits = gpu.alloc(sizes.gate_logits)?;
         let moe_output = gpu.alloc(sizes.moe_output)?;
         let logits = gpu.alloc(sizes.logits)?;
+        let decode_logits_staging = gpu.alloc(sizes.decode_logits_staging)?;
         let ssm_qkvz = gpu.alloc(sizes.ssm_qkvz)?;
         let ssm_ba = gpu.alloc(sizes.ssm_ba)?;
         let ssm_deinterleaved = gpu.alloc(sizes.ssm_deinterleaved)?;
@@ -127,6 +131,7 @@ impl BufferArena {
             gate_logits,
             moe_output,
             logits,
+            decode_logits_staging,
             ssm_qkvz,
             ssm_ba,
             ssm_deinterleaved,
@@ -166,6 +171,10 @@ impl BufferArena {
     }
     pub fn logits(&self) -> DevicePtr {
         self.logits
+    }
+    /// #110: private decode-logits staging for mixed batch steps.
+    pub fn decode_logits_staging(&self) -> DevicePtr {
+        self.decode_logits_staging
     }
     pub fn ssm_qkvz(&self) -> DevicePtr {
         self.ssm_qkvz

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -15,6 +15,7 @@ pub struct BufferSizes {
     pub gate_logits: usize,
     pub moe_output: usize,
     pub logits: usize,
+    pub decode_logits_staging: usize,
     pub ssm_qkvz: usize,
     pub ssm_ba: usize,
     pub ssm_deinterleaved: usize,
@@ -183,6 +184,12 @@ impl BufferSizes {
             },
             moe_output: m * h * bf16,
             logits: logits_tokens * config.vocab_size * bf16, // BF16 from LM head kernel
+            // #110: private staging for the decode half of a mixed batch step.
+            // The decode and prefill halves share `logits`; the prefill half's
+            // zero_all + finalize_last overwrite decode logits before the
+            // scheduler samples them. Decode logits are copied here (8 = max
+            // batched-decode rows) so they survive the prefill half.
+            decode_logits_staging: 8 * config.vocab_size * bf16,
             // SSM buffers are also reused by attention prefill/multi-seq as scratch:
             //   ssm_qkvz: K+V contiguous storage in prefill [M, 2*kv_dim]
             //             Mamba-2 in_proj output [M, in_proj_size]
@@ -247,6 +254,7 @@ impl BufferSizes {
             + self.gate_logits
             + self.moe_output
             + self.logits
+            + self.decode_logits_staging
             + self.ssm_qkvz
             + self.ssm_ba
             + self.ssm_deinterleaved

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -41,10 +41,10 @@ fn test_buffer_arena_alloc() {
     assert!(!arena.hidden_states().is_null());
     assert!(!arena.logits().is_null());
     assert_eq!(arena.max_batch_tokens(), 128);
-    // 19 allocations for 19 buffers (12 data + 1 scratch + 3 expert + 2 splitk
-    // + 1 gdn_fla_scratch). Bump from 18 reflects the GDN FLA chunked-prefill
-    // scratch buffer added when ATLAS_GDN_FLA was wired into the arena.
-    assert_eq!(gpu.alloc_count(), 19);
+    // 20 allocations: 19 prior (12 data + 1 scratch + 3 expert + 2 splitk +
+    // 1 gdn_fla_scratch) + 1 decode_logits_staging (#110 mixed-batch fix:
+    // private staging so the prefill half can't clobber decode logits).
+    assert_eq!(gpu.alloc_count(), 20);
 }
 
 #[test]


### PR DESCRIPTION
Root-causes and fixes the concurrency>=4 + deep-context CUDA-700 / brick (#110), found via a 43-agent forensic swarm (14/18 findings 2-lens verified). **Verdict: real engine bug, not a config constraint** — \`--max-batch-size 2\` is stable only because \`can_batch_mixed\` (>=2 prefilling AND >=1 active, minus single-active-spec) first fires at exactly 2 decode + 2 prefill.

## Root cause (RC1 + RC2)
The trait-default \`mixed_forward_batch\` runs the decode half on \`default_stream\` (hardcoded in \`decode_batch_compute_main\`) and the prefill half on the caller's \`prefill_stream\` with **no event ordering**. Both carve the same singleton \`buffers.scratch()\` (decode metadata at +32768) and \`buffers.logits()\`. At concurrency>=4 the prefill half's chunk-0 \`zero_all\` + MoE top-k staging clobber the decode half's metadata/logits mid-flight → torn KV-slot read → \`CUDA_ERROR_ILLEGAL_ADDRESS\` (sticky, surfaces at the next HtoD; ~32-min MTBF live), or silently corrupted decode logits (RC2, survives any serialization-only fix).

The **identical race was fixed for the single-prefill fused path on 2026-05-10** (\`decode_b.rs\`: metadata → \`logits+65536\`, one stream) and never propagated to the Q12 N-prefill batched path.

## Fix
\`TransformerModel::mixed_forward_batch\` override: both halves on \`default_stream\` (they cannot overlap anyway — shared arena — so this is the old serial default minus the race), and decode logits copied to a private \`decode_logits_staging\` buffer before the prefill half overwrites \`buffers.logits()\`. Neutral for decode-only / prefill-only / batch<=2 / EP.

## Verification
- Compiles clean; correct-by-construction + matches the proven sibling precedent + swarm 2-lens review.
- The CUDA-700 is a ~32-min-MTBF heisenbug (probabilistic torn read at the exact 2+2 interleaving) — not reliably reproducible in a short synthetic window, so this ships with a concurrent soak (in progress) rather than a deterministic before/after. Reviewer note below.
- Recipe \`max_batch_size: 2\` cap stays in place until this is reviewed + merged; lifting it is the payoff (full batch throughput restored).

@aceangel3k cross-stream + shared-arena change in the hot path — worth a look at the override in \`decode_b.rs\` and the staging-buffer sizing in \`buffers/sizes.rs\`. Independent follow-ups (separate PRs): RC3 eviction/refcount (the batch=4 brick), RC4/RC5 slot-compaction-targets-vec-position.