### PR TITLE
fix(#110 RC3): drop evictable mid-prefill checkpoint tree nodes (KV use-after-evict)

### DIFF
--- a/crates/spark-model/src/model/block_mgmt.rs
+++ b/crates/spark-model/src/model/block_mgmt.rs
@@ -54,6 +54,18 @@ pub(crate) fn apply_evicted_blocks(
     kv_cache: &mut PagedKvCache,
 ) {
     for block in &evicted.physical {
+        // #110 RC3 tripwire: eviction force-zeroes the physical block, so a
+        // block reaching here must be held only by the cache's own baseline
+        // ref (count <= 1). A live sequence's inc_ref (prefill/adopt/cache)
+        // pushes the count >= 2; force-zeroing such a block is a
+        // use-after-evict. Fail loud in debug if a future change re-creates
+        // an evictable live block (the class of bug RC3 closed).
+        debug_assert!(
+            kv_cache.ref_count(*block) <= 1,
+            "evicting block {} still referenced (ref_count={}) — use-after-evict",
+            block,
+            kv_cache.ref_count(*block),
+        );
         kv_cache.return_evicted_block(*block);
     }
     if !evicted.disk_block_ids.is_empty()

--- a/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
@@ -122,21 +122,27 @@ impl TransformerModel {
         } else {
             &[][..]
         };
-        // Intermediate checkpoint inserts tree nodes as a placeholder for
-        // the snapshot boundary — the final chunk's insert will bump
-        // ref_counts for seq-ownership over the full tokens range. Passing
-        // matched_tokens = end_token here makes is_seq_owned=false for every
-        // block in this checkpoint, avoiding a double-bump that would leak
-        // the cache's baseline ref by +1 per checkpointed block after the
-        // eventual release().
-        let acquired = self.prefix_cache.insert(
-            boundary_tokens,
-            boundary_blocks,
-            boundary_disk,
-            bs,
-            end_token,
-        );
-        super::super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
+        // #110 RC3 fix: do NOT insert radix tree nodes for the mid-prefill
+        // checkpoint boundary. Those nodes were created with
+        // matched_tokens=end_token => is_seq_owned=false => ref_count=1, which
+        // makes them immediately evictable WHILE this sequence is still
+        // mid-prefill (more chunks pending) and its device block-table —
+        // uploaded delta-only — still points at those physical blocks. Under
+        // block pressure (concurrency>=4 + deep multi-chunk prefills, the
+        // #110 regime) the next chunk's ensure_blocks->evict force-zeroes and
+        // reallocates a live block => use-after-evict / batch=4 brick.
+        //
+        // The tree nodes were redundant: the SSM snapshot is found via the
+        // independent SsmSnapshotIndex (insert_intermediate_snapshot below),
+        // keyed by hash_token_prefix and gated only by token_count <=
+        // matched_tokens — it does not read tree nodes. The matched path that
+        // lets a future warm hit reach this boundary is supplied by the
+        // full-range leaf insert in cache_sequence after this sequence
+        // finishes. Dropping the insert removes the evictable-live-block
+        // window with zero refcount-accounting change (no leak): the seq's
+        // blocks stay pinned by their alloc ref in seq.block_table and only
+        // become radix-visible at cache_sequence, after the seq is no longer
+        // in-flight.
         if let Some(old) = self.prefix_cache.insert_intermediate_snapshot(
             boundary_tokens,
             boundary_blocks,

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -42,6 +42,40 @@ fn test_intermediate_snapshot_on_partial_match() {
 }
 
 #[test]
+fn test_intermediate_snapshot_found_without_checkpoint_tree_nodes() {
+    // #110 RC3: the mid-prefill checkpoint no longer inserts radix tree
+    // nodes (they were evictable while the sequence was live -> UAF). This
+    // reproduces the new production order: the intermediate snapshot is
+    // registered at the boundary FIRST (no tree insert), and only later does
+    // the finish-leaf insert (cache_sequence) supply the matched path. The
+    // snapshot must still be found on the next warm lookup.
+    let tree = RadixTree::new();
+
+    // Mid-prefill: register the boundary snapshot at block 2 — NO tree insert.
+    let tokens_at_2: Vec<u32> = (0..32).collect();
+    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0);
+
+    // Before the finish-leaf insert there are no tree nodes, so a lookup of
+    // the boundary prefix matches nothing (snapshot unreachable — bounded,
+    // self-healing per the fix's abort-orphan note).
+    let pre = tree.lookup(&tokens_at_2, 16, 0);
+    assert_eq!(pre.matched_tokens, 0);
+    assert_eq!(pre.ssm_snapshot, None);
+
+    // Sequence finishes -> cache_sequence inserts the full range, supplying
+    // the matched path the snapshot lookup needs.
+    let tokens: Vec<u32> = (0..64).collect();
+    tree.insert(&tokens, &[10, 20, 30, 40], &[], 16, 0);
+
+    // Warm hit next turn: the intermediate snapshot at block 2 is found.
+    let m = tree.lookup(&tokens, 16, 0);
+    assert_eq!(m.matched_tokens, 64);
+    assert_eq!(m.ssm_snapshot, Some(50));
+    assert_eq!(m.ssm_snapshot_tokens, 32);
+    tree.release(&tokens, 16);
+}
+
+#[test]
 fn test_intermediate_snapshot_deepest_wins() {
     let tree = RadixTree::new();
 


### PR DESCRIPTION
Closes the KV-block use-after-evict behind the #110 "batch=4 brick" (RC3 from the mixed-batch swarm). Independent of PR #157 (RC1/RC2 mixed-batch scratch race); both are needed to lift the recipe's `max_batch_size: 2` cap.

## Root cause
The mid-prefill SSM-snapshot checkpoint (`save_checkpoint.rs`) inserted radix tree nodes with `matched_tokens=end_token` ⇒ `is_seq_owned=false` ⇒ node `ref_count=1` ⇒ **immediately evictable while the sequence is still mid-prefill** and its delta-uploaded device block-table still points at those physical blocks. Under block pressure (concurrency≥4 + deep multi-chunk prefills) the next chunk's `ensure_blocks → evict` force-zeroes and reallocates a live block → use-after-evict.

## Fix
Drop the tree-node `insert` entirely. The SSM snapshot is found via the independent `SsmSnapshotIndex` (`insert_intermediate_snapshot`, kept) — keyed by `hash_token_prefix`, gated by `token_count ≤ matched_tokens`, reads no tree nodes. The matched path a future warm hit needs is supplied by `cache_sequence`'s full-range leaf insert after the sequence finishes. **Zero refcount-accounting change → no leak**: the seq's blocks stay pinned by their alloc ref in `seq.block_table` and become radix-visible only at `cache_sequence`, when the seq is no longer in-flight.

## Why NOT the swarm's original FIX-2
The swarm proposed `return_evicted_block → dec_ref`. That would **leak** here: this codebase is not balanced-refcounted — `release()` only decrements the radix *node* ref_count, never `kv_cache.block_ref_counts`, which is freed solely by eviction's force-zero. `dec_ref` semantics would strand blocks at count 1 forever. The swarm read the tree pre-#156; this PR is re-grounded on the current tree.

## Scope
Sub-bugs (c) `partial_suffix` and (d) `cache_sequence` over-inc verified **not** real on the current tree (force-zero collapses transient over-counts; partial blocks are freed only with their parent node). Left as a separate refactor-toward-balanced-refcounting, not bundled.

## Verification
- Compiles clean (image `2af98e1a`).
- Regression unit test (`radix_tree/tests/snapshot.rs`): intermediate snapshot registered with no tree insert is still found after the finish-leaf insert supplies the path.
- `debug_assert` tripwire in `apply_evicted_blocks`: any force-evicted block must have kv `ref_count ≤ 1` (catches re-introduction of an evictable live block).
- System gate (running): concurrency-4 + deep multi-chunk prefills under forced block pressure, asserting no CUDA-700 + no decode corruption; no-regression warm-hit check (Marconi intermediate hit still fires).

@aceangel3k KV-cache lifecycle change — worth a look at the snapshot-index decoupling argument (does any non-snapshot consumer rely on the dropped checkpoint tree nodes?).