### PR TITLE
fix(#110): Q12 batched-prefill dynamic-smem sizing (CUDA-700 under concurrency)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -113,3 +113,7 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "gdn_recompute_wu_gateb"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "gdn_batched_repro"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/gdn_batched_repro.rs
+++ b/crates/spark-model/examples/gdn_batched_repro.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! #110 standalone reproducer for the Q12 batched GDN prefill kernel.
+//! Calls `gated_delta_rule_prefill_wy64_batched` directly with batch_size=2
+//! and synthetic inputs, isolated from the 70GB model + scheduler timing, so
+//! compute-sanitizer can pin the exact illegal access in seconds.
+//!   compute-sanitizer --tool memcheck \
+//!     cargo run -p spark-model --release --example gdn_batched_repro
+
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::KernelLaunch;
+
+// Real qwen3.6-35b-a3b GDN dims.
+const NK: usize = 16;
+const NV: usize = 32;
+const KD: usize = 128;
+const VD: usize = 128;
+
+fn main() -> Result<()> {
+    let batch_size: u32 = std::env::var("BATCH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2);
+    let seq_len: u32 = std::env::var("SEQ")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(96);
+    let bs = batch_size as usize;
+    let sl = seq_len as usize;
+
+    let key_dim = NK * KD; // 2048
+    let value_dim = NV * VD; // 4096
+    let conv_dim = key_dim * 2 + value_dim; // 8192
+    let gb_stride = NV * 2; // 64
+    let h_numel = NV * KD * VD; // 524288 floats = 2 MiB per stream
+
+    eprintln!(
+        "gdn_batched_repro: batch={batch_size} seq_len={seq_len} key_dim={key_dim} \
+         value_dim={value_dim} conv_dim={conv_dim} h_numel={h_numel}"
+    );
+
+    let set = atlas_kernels::ptx_for_config("qwen3_6_moe", 2048).expect("no ptx set");
+    let backend = AtlasCudaBackend::new(0, &set.modules)?;
+    let g: &dyn GpuBackend = &backend;
+    let k: KernelHandle = g.kernel(
+        "gated_delta_rule_wy64_prefill",
+        "gated_delta_rule_prefill_wy64_batched",
+    )?;
+
+    // Stacked qkv [bs*sl, conv_dim] bf16, packed [Q(key_dim)|K(key_dim)|V(value_dim)].
+    let qkv_n = bs * sl * conv_dim;
+    let qkv_host: Vec<u8> = (0..qkv_n)
+        .flat_map(|i| {
+            bf16::from_f32(((i % 17) as f32 - 8.0) * 0.01)
+                .to_bits()
+                .to_le_bytes()
+        })
+        .collect();
+    let qkv = g.alloc(qkv_host.len())?;
+    g.copy_h2d(&qkv_host, qkv)?;
+
+    // gate_beta [bs*sl, NV*2] f32, [gate(NV)|beta(NV)].
+    let gb_n = bs * sl * gb_stride;
+    let gb_host: Vec<u8> = (0..gb_n)
+        .flat_map(|i| (0.5f32 + ((i % 7) as f32) * 0.01).to_le_bytes())
+        .collect();
+    let gate_beta = g.alloc(gb_host.len())?;
+    g.copy_h2d(&gb_host, gate_beta)?;
+
+    // output [bs*sl, value_dim] bf16.
+    let out = g.alloc(bs * sl * value_dim * 2)?;
+    g.memset(out, 0, bs * sl * value_dim * 2)?;
+
+    // Per-stream h_state (2 MiB each, FP32), zeroed.
+    let mut h_ptrs: Vec<u64> = Vec::with_capacity(bs);
+    for _ in 0..bs {
+        let h = g.alloc(h_numel * 4)?;
+        g.memset(h, 0, h_numel * 4)?;
+        h_ptrs.push(h.0);
+    }
+    // h_state_ptrs device array [bs] of float* (u64).
+    let hp_host: Vec<u8> = h_ptrs.iter().flat_map(|p| p.to_le_bytes()).collect();
+    let h_state_ptrs = g.alloc(hp_host.len())?;
+    g.copy_h2d(&hp_host, h_state_ptrs)?;
+
+    // q/k/v pointers into qkv (byte offsets, matching the dispatcher).
+    let q_ptr = qkv;
+    let k_ptr = qkv.offset(key_dim * 2); // key_dim bf16 elements
+    let v_ptr = qkv.offset(key_dim * 2 * 2);
+    let gate_ptr = gate_beta;
+    let beta_ptr = gate_beta.offset(NV * 4);
+
+    let default_smem = (KD * VD * 4 + 32 * KD * 2 + 32 * KD * 2 + 32 * 32 * 4 + 256) as u32;
+    let smem: u32 = std::env::var("SMEM")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default_smem);
+
+    eprintln!(
+        "launching gated_delta_rule_prefill_wy64_batched grid=[{NV},{batch_size},1] smem={smem}"
+    );
+    KernelLaunch::new(g, k)
+        .grid([NV as u32, batch_size, 1])
+        .block([128, 1, 1])
+        .shared_mem(smem)
+        .arg_ptr(h_state_ptrs)
+        .arg_ptr(q_ptr)
+        .arg_ptr(k_ptr)
+        .arg_ptr(v_ptr)
+        .arg_ptr(gate_ptr)
+        .arg_ptr(beta_ptr)
+        .arg_ptr(out)
+        .arg_u32(batch_size)
+        .arg_u32(seq_len)
+        .arg_u32(NK as u32)
+        .arg_u32(NV as u32)
+        .arg_u32(KD as u32)
+        .arg_u32(VD as u32)
+        .arg_u32(conv_dim as u32)
+        .arg_u32(conv_dim as u32)
+        .arg_u32(gb_stride as u32)
+        .launch(0)?;
+
+    g.synchronize(0)?;
+    eprintln!("gdn_batched_repro: kernel completed cleanly (no fault at batch={batch_size})");
+    Ok(())
+}

--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -151,6 +151,13 @@ pub struct BatchedAttnMetadata {
     /// bounds checking; per-stream block_table reads via the pointer
     /// array dereference).
     pub max_blocks_per_seq: u32,
+    /// Exact byte footprint of this metadata block within the scratch
+    /// buffer (from `scratch_offset_bytes` to the end of `seq_len_ptrs`).
+    /// SSOT for the caller's scratch-cursor advance — the per-SSM-layer
+    /// `h_state_ptrs` slot is placed at `scratch_cursor + staged_bytes`, so
+    /// an under-estimate here would overwrite the live `slot_stacked` array
+    /// with device pointers and produce wild KV-cache slots (#110 bug #2).
+    pub staged_bytes: usize,
 }
 
 /// Device pointers to full-sequence GDN input/output buffers.

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_gdn.rs
@@ -51,7 +51,14 @@ impl Qwen3SsmLayer {
             self.gdn_prefill_split4_k.0 != 0
         );
         if self.gdn_prefill_wy32_k.0 != 0 && total > 32 {
-            let smem = (kd * vd * 4 + 32 * kd * 2 + 32 * kd * 2 + 32 * 32 * 4 + 256) as u32;
+            // #110: dynamic smem must cover the FULL kernel layout (H + smem_k +
+            // smem_q + smem_warp[4] + smem_kd[C*C] + smem_g[C] + smem_bt[C], C=32).
+            // The old `+256` slack under-counted the smem_warp(16)+smem_g(128)+
+            // smem_bt(128)=272 trailer by 16 B, so the kernel's smem_bt tail wrote
+            // past the requested allocation → CUDA illegal access under live
+            // occupancy (compute-sanitizer: Invalid __shared__ write at +0xce0).
+            let smem =
+                (kd * vd * 4 + 32 * kd * 2 + 32 * kd * 2 + 32 * 32 * 4 + (4 + 32 + 32) * 4) as u32;
             ops::gdn_prefill_persistent_smem(
                 ctx.gpu,
                 self.gdn_prefill_wy32_k,
@@ -248,7 +255,14 @@ impl Qwen3SsmLayer {
         // is `chunk_len`; the kernel internally processes `batch_size` such
         // streams (grid dim Y).
         if self.gdn_prefill_wy32_batched_k.0 != 0 && chunk_len > 32 {
-            let smem = (kd * vd * 4 + 32 * kd * 2 + 32 * kd * 2 + 32 * 32 * 4 + 256) as u32;
+            // #110: dynamic smem must cover the FULL kernel layout (H + smem_k +
+            // smem_q + smem_warp[4] + smem_kd[C*C] + smem_g[C] + smem_bt[C], C=32).
+            // The old `+256` slack under-counted the smem_warp(16)+smem_g(128)+
+            // smem_bt(128)=272 trailer by 16 B, so the kernel's smem_bt tail wrote
+            // past the requested allocation → CUDA illegal access under live
+            // occupancy (compute-sanitizer: Invalid __shared__ write at +0xce0).
+            let smem =
+                (kd * vd * 4 + 32 * kd * 2 + 32 * kd * 2 + 32 * 32 * 4 + (4 + 32 + 32) * 4) as u32;
             ops::gdn_prefill_persistent_smem_batched(
                 ctx.gpu,
                 self.gdn_prefill_wy32_batched_k,

--- a/crates/spark-model/src/model/trait_impl/ep_misc.rs
+++ b/crates/spark-model/src/model/trait_impl/ep_misc.rs
@@ -88,4 +88,8 @@ impl TransformerModel {
     pub(super) fn stream_wait_event_dispatch(&self, stream: u64, event: u64) -> Result<()> {
         self.gpu.stream_wait_event(stream, event)
     }
+
+    pub(super) fn synchronize_dispatch(&self, stream: u64) -> Result<()> {
+        self.gpu.synchronize(stream)
+    }
 }

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -392,4 +392,7 @@ impl Model for TransformerModel {
     fn stream_wait_event(&self, stream: u64, event: u64) -> Result<()> {
         self.stream_wait_event_dispatch(stream, event)
     }
+    fn synchronize(&self, stream: u64) -> Result<()> {
+        self.synchronize_dispatch(stream)
+    }
 }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
@@ -23,7 +23,7 @@
 //!   - No MLA / HDIM=512 / HSS-engaged layer in the model
 //!   - All batched kernel handles loaded
 //!
-//! Validation status: compile-only. Hardware validation pending.
+//! Validation: hardware-validated (#110 — conc repro 80/80, sanitizer-clean).
 
 #![allow(unused_imports, dead_code, clippy::too_many_arguments)]
 
@@ -53,6 +53,9 @@ impl TransformerModel {
             self.buffers.max_batch_tokens(),
             &self.config.model_type,
             self.config.head_dim,
+            self.buffers.scratch_bytes(),
+            self.config.num_experts_per_tok,
+            self.config.mrope_interleaved,
         )
     }
 }
@@ -60,12 +63,16 @@ impl TransformerModel {
 /// Pure-data predicate extracted from [`TransformerModel::kernel_batched_eligible`]
 /// so the gating rules are unit-testable without a real `TransformerModel`.
 /// Caller materialises per-stream tuples `(chunk_len, chunk_start, is_last_chunk)`.
+#[allow(clippy::too_many_arguments)]
 pub(in crate::model) fn check_kernel_batched_eligible<I>(
     streams: I,
     n: usize,
     arena_cap: usize,
     model_type: &str,
     head_dim: usize,
+    scratch_cap: usize,
+    top_k: usize,
+    mrope: bool,
 ) -> bool
 where
     I: IntoIterator<Item = (usize, usize, bool)>,
@@ -102,8 +109,16 @@ where
         }
         total += chunk_len;
     }
-    // Total stacked tokens fit in arena.
-    total <= arena_cap
+    // Total stacked tokens fit in the token arena (hidden_states buffer).
+    if total > arena_cap {
+        return false;
+    }
+    // #110: the kernel-batched staging footprint must fit in scratch. PURE
+    // pre-flight — runs before any stream mutation, so a false routes to the
+    // per-stream path from a clean state (a mid-dispatch overrun would leave
+    // streams dirty and the fallback would re-run setup → corruption).
+    let chunk_len = first.map(|(cl, _, _)| cl).unwrap_or(0);
+    spark_runtime::buffers::q12_batched_scratch_bytes(n, chunk_len, top_k, mrope) <= scratch_cap
 }
 
 impl TransformerModel {
@@ -349,18 +364,15 @@ impl TransformerModel {
             scratch_cursor,
             stream,
         )?;
-        // Advance cursor past the staged BatchedAttnMetadata. Generous
-        // upper bound for the staging size: positions(MRoPE ×3) + slots
-        // + pointer arrays.
-        let stage_size = (proc_count * n * 16) + (n * 32) + 256;
+        // Advance cursor by the EXACT staged footprint (#110): the prior
+        // heuristic under-estimated it, placing h_state_ptrs_off inside the
+        // live slot_stacked array → corrupted KV slots → CUDA-700.
+        // `staged_bytes` is the SSOT matching `q12_batched_scratch_bytes`.
+        let stage_size = meta.staged_bytes;
         scratch_cursor += stage_size;
 
-        // Q12 safety: assert scratch headroom before consuming the
-        // h_state_ptrs JIT slot per SSM layer. h_state_ptrs is N*8 bytes.
-        // The scratch budget for batched dispatch is dominated by the
-        // per-stream meta blocks + stacked BatchedAttnMetadata; bail if
-        // we'd exceed scratch capacity rather than overrun into another
-        // buffer.
+        // Q12 safety: bail if the h_state_ptrs JIT slot (N*8 B) would exceed
+        // scratch rather than overrun into another buffer.
         let scratch_bytes = self.buffers.sizes().scratch;
         let projected_usage = scratch_cursor + (n * std::mem::size_of::<u64>());
         if projected_usage > scratch_bytes {

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel_tests.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel_tests.rs
@@ -11,6 +11,13 @@ fn s(chunk_len: usize, chunk_start: usize, is_last: bool) -> (usize, usize, bool
     (chunk_len, chunk_start, is_last)
 }
 
+// Scratch capacity large enough that the #110 footprint check never trips for
+// the structural-eligibility tests below (those assert the chunk_len/start/
+// is_last/arena/model gates, not the scratch fit). 8 MiB ≫ any footprint here.
+const BIG_SCRATCH: usize = 8 * 1024 * 1024;
+const TOP_K: usize = 8;
+const MROPE: bool = false;
+
 #[test]
 fn rejects_under_two_streams() {
     assert!(!check_kernel_batched_eligible(
@@ -18,14 +25,20 @@ fn rejects_under_two_streams() {
         0,
         8192,
         "qwen3_next",
-        256
+        256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
     assert!(!check_kernel_batched_eligible(
         vec![s(4096, 0, false)],
         1,
         8192,
         "qwen3_next",
-        256
+        256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -37,6 +50,9 @@ fn accepts_uniform_n_2() {
         8192,
         "qwen3_next",
         256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -48,6 +64,9 @@ fn rejects_mismatched_chunk_len() {
         16384,
         "qwen3_next",
         256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -61,6 +80,9 @@ fn rejects_mismatched_chunk_start() {
         16384,
         "qwen3_next",
         256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -72,6 +94,9 @@ fn rejects_mismatched_is_last() {
         8192,
         "qwen3_next",
         256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -84,6 +109,9 @@ fn rejects_arena_overflow() {
         4100,
         "qwen3_next",
         256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -95,6 +123,9 @@ fn rejects_mla_model() {
         8192,
         "mistral",
         128,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -107,6 +138,9 @@ fn rejects_large_head_dim() {
         8192,
         "gemma4",
         512,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
 }
 
@@ -118,5 +152,48 @@ fn accepts_n_4_uniform() {
         8192,
         "qwen3_next",
         256,
+        BIG_SCRATCH,
+        TOP_K,
+        MROPE,
     ));
+}
+
+#[test]
+fn rejects_scratch_footprint_overflow() {
+    // #110 regression lock: the staging footprint must fit in scratch even
+    // when the token-arena check passes. The deterministic crash repro was
+    // n=4, chunk_len=935, top_k=8, MRoPE → 374_352 B footprint vs a 348_840 B
+    // scratch. With that exact (too-small) scratch the batch is INELIGIBLE
+    // (routes to per-stream from clean state, no mid-Phase-A bail), but with
+    // the #110 enlarged scratch sizing it becomes eligible again.
+    let streams = [s(935, 0, false); 4];
+    let arena = 4096; // 4×935 = 3740 ≤ 4096 → arena check passes
+    let too_small = 348_840;
+    let enlarged = spark_runtime::buffers::q12_batched_scratch_bytes(4, 935, 8, true);
+    assert!(
+        !check_kernel_batched_eligible(
+            streams.iter().copied(),
+            4,
+            arena,
+            "qwen3_next",
+            256,
+            too_small,
+            8,
+            true,
+        ),
+        "footprint must NOT fit in the old 348_840 B scratch"
+    );
+    assert!(
+        check_kernel_batched_eligible(
+            streams.iter().copied(),
+            4,
+            arena,
+            "qwen3_next",
+            256,
+            enlarged,
+            8,
+            true,
+        ),
+        "footprint must fit once scratch is sized to it"
+    );
 }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/stage_batched.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/stage_batched.rs
@@ -119,11 +119,33 @@ impl TransformerModel {
         let seq_len_ptrs_aligned = (block_ptrs_bytes + 7) & !7;
         let total_meta_bytes = seq_len_ptrs_off + seq_len_ptrs_aligned - scratch_offset_bytes;
 
-        // Sanity: meta footprint within scratch.
-        // Scratch is sized for ample MoE topk + meta — refer to BufferArena
-        // sizing in spark-runtime/src/buffers/sizes.rs. The fit check at
-        // dispatch entry guarantees total_tokens ≤ arena_cap.
-        let _ = total_meta_bytes;
+        // #110 defense-in-depth: bounds-check the metadata footprint against
+        // the scratch allocation. This should NEVER fire — the dispatch-entry
+        // predicate `check_kernel_batched_eligible` now pre-flights the full
+        // batched footprint (`q12_batched_scratch_bytes`) against scratch_cap
+        // BEFORE any stream state is mutated, and the scratch buffer is sized
+        // for `Q12_SIZING_STREAMS` streams. If this guard ever trips, the
+        // eligibility predicate and the staging layout have diverged (an SSOT
+        // violation in `q12_batched_scratch_bytes`): bail rather than overrun
+        // (out-of-range HtoD → corruption → sticky CUDA-700). Note this bail
+        // is mid-Phase-A, so the per-stream fallback re-runs setup on
+        // partially-mutated streams — strictly worse than the clean pre-flight
+        // bail, hence "should never reach here".
+        let scratch_cap = self.buffers.scratch_bytes();
+        if scratch_offset_bytes + total_meta_bytes > scratch_cap {
+            tracing::error!(
+                "stage_batched_attn_metadata SSOT violation: n={n} chunk_len={chunk_len} \
+                 meta_bytes={total_meta_bytes} scratch_offset={scratch_offset_bytes} \
+                 scratch_cap={scratch_cap} — eligibility pre-flight should have prevented this"
+            );
+            anyhow::bail!(
+                "batched attn metadata footprint {} B at offset {} exceeds scratch \
+                 capacity {} B (n={n}, chunk_len={chunk_len}) — fall back to per-stream",
+                total_meta_bytes,
+                scratch_offset_bytes,
+                scratch_cap,
+            );
+        }
 
         // Build host-side staging buffers, then upload via the model's
         // pinned-staging area.
@@ -250,6 +272,7 @@ impl TransformerModel {
             chunk_len: chunk_len as u32,
             total_tokens: total_tokens as u32,
             max_blocks_per_seq: max_blocks,
+            staged_bytes: total_meta_bytes,
         })
     }
 }

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -154,7 +154,21 @@ pub trait Model: Send + Sync {
     ) -> Result<MixedBatchResult> {
         // Default: serial execution.
         let decode_logits = if !decode_tokens.is_empty() {
-            self.decode_batch(decode_tokens, decode_seqs, stream)?
+            let lg = self.decode_batch(decode_tokens, decode_seqs, stream)?;
+            // #110: decode_batch runs its whole forward on the DEFAULT stream
+            // — both `decode_batch_compute_main` (n>=2) and the n==1 graph path
+            // ignore the `stream` arg and hardcode `gpu.default_stream()`. The
+            // batched prefill below reuses the SAME shared arena buffers
+            // (hidden_states/residual/scratch/gdn) but submits on `stream`
+            // (prefill_stream). With no barrier the two sub-passes execute
+            // concurrently on two different streams and race over those
+            // buffers — corrupting the batched prefill's slot table into wild
+            // KV-cache indices and faulting with a CUDA illegal access
+            // (status 700). Synchronize the decode stream so its buffer use is
+            // fully retired before prefill overwrites them. This runs once per
+            // mixed step (active+prefilling), never in the hot decode loop.
+            self.synchronize(self.default_stream())?;
+            lg
         } else {
             spark_runtime::gpu::DevicePtr::NULL
         };
@@ -678,6 +692,14 @@ pub trait Model: Send + Sync {
 
     /// Make a stream wait for an event (GPU-side sync, CPU does not block).
     fn stream_wait_event(&self, _stream: u64, _event: u64) -> Result<()> {
+        Ok(())
+    }
+
+    /// Block the host until all work submitted to `stream` has completed.
+    /// Used by `mixed_forward_batch` to retire the decode pass (which runs on
+    /// the default stream) before the batched prefill reuses the shared arena
+    /// buffers on another stream (#110). Default no-op for non-CUDA mocks.
+    fn synchronize(&self, _stream: u64) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/spark-runtime/src/buffers.rs
+++ b/crates/spark-runtime/src/buffers.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use atlas_core::config::ModelConfig;
 
 mod sizes;
-pub use sizes::BufferSizes;
+pub use sizes::{BufferSizes, Q12_SIZING_STREAMS, q12_batched_scratch_bytes};
 
 /// Pre-allocated GPU buffers for a single forward pass.
 ///
@@ -188,6 +188,11 @@ impl BufferArena {
     /// Scratch buffer for MoE routing + kernel metadata uploads.
     pub fn scratch(&self) -> DevicePtr {
         self.scratch
+    }
+    /// Allocated byte size of the scratch buffer (#110: bounds-check
+    /// batched metadata-staging uploads against this).
+    pub fn scratch_bytes(&self) -> usize {
+        self.sizes.scratch
     }
     /// Batched expert gate projection output.
     pub fn expert_gate_out(&self) -> DevicePtr {

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -4,6 +4,39 @@
 
 use atlas_core::config::ModelConfig;
 
+/// Streams assumed when provisioning scratch for the Q12 kernel-batched
+/// prefill path. The per-stream metadata region scales with N, so the
+/// scratch buffer must be sized for a realistic max concurrent batched
+/// streams. Beyond this, `check_kernel_batched_eligible` falls the dispatch
+/// back to the per-stream path (which respects the same arena cap), so this
+/// bound only governs how often the fast path is available — never safety.
+pub const Q12_SIZING_STREAMS: usize = 8;
+
+/// Exact scratch footprint (bytes) of the Q12 kernel-batched prefill staging
+/// for `n` streams of `chunk_len` tokens each. SSOT for both scratch sizing
+/// (`BufferSizes::from_config`) and the pre-flight eligibility check
+/// (`check_kernel_batched_eligible`), so the two can never disagree about
+/// whether a batch fits. Mirrors the staging layout in `batch_kernel.rs`
+/// (MoE topk area + N per-stream meta blocks) and `stage_batched.rs`
+/// (stacked positions ×(3 if MRoPE) + slots + block/seq_len pointer arrays)
+/// plus the per-SSM-layer `h_state_ptrs` JIT slot.
+pub fn q12_batched_scratch_bytes(n: usize, chunk_len: usize, top_k: usize, mrope: bool) -> usize {
+    let total = n * chunk_len;
+    // MoE topk staging (indices+weights, both ×n streams), 64-byte aligned.
+    let moe = ((total * top_k * 4 * 2) + 63) & !63;
+    // Per-stream meta block — same formula as batch_kernel.rs.
+    let per_stream_meta = ((chunk_len * 16) + 64).max(4096);
+    // Stacked BatchedAttnMetadata (stage_batched.rs layout).
+    let pos = (total * 4 + 7) & !7;
+    let pos_streams = if mrope { 3 } else { 1 };
+    let slot = (total * 8 + 7) & !7;
+    let ptrs = ((n * std::mem::size_of::<u64>()) + 7) & !7;
+    let stage_meta = pos_streams * pos + slot + 2 * ptrs;
+    // h_state_ptrs JIT slot consumed per SSM layer (N device pointers).
+    let h_state_ptrs = n * std::mem::size_of::<u64>();
+    moe + n * per_stream_meta + stage_meta + h_state_ptrs
+}
+
 /// Byte sizes of each buffer, derived from ModelConfig.
 #[derive(Debug, Clone)]
 pub struct BufferSizes {
@@ -98,7 +131,24 @@ impl BufferSizes {
         let bt_rows = 32usize; // headroom for K=γ DFlash verify (typical γ=16, K=17)
         let bt_meta = 32768 + 768 + bt_rows * max_blocks * 4;
         let scratch_min = 64 * 1024;
-        let scratch = scratch_min.max(moe_scratch + prefill_meta).max(bt_meta);
+        // Q12 kernel-batched prefill stages N per-stream meta blocks plus a
+        // stacked BatchedAttnMetadata block — a strictly larger footprint than
+        // the single-stream `prefill_meta`. Provision for `Q12_SIZING_STREAMS`
+        // streams splitting the full token arena so the fast path stays
+        // available for deep-context concurrent prefills without overrunning
+        // scratch (#110: the unprovisioned N-stream multiplication overran the
+        // buffer, producing an out-of-range HtoD → sticky CUDA-700).
+        let q12_chunk = m.div_ceil(Q12_SIZING_STREAMS).max(1);
+        let q12_batched = q12_batched_scratch_bytes(
+            Q12_SIZING_STREAMS,
+            q12_chunk,
+            top_k,
+            config.mrope_interleaved,
+        );
+        let scratch = scratch_min
+            .max(moe_scratch + prefill_meta)
+            .max(bt_meta)
+            .max(q12_batched);
 
         // Batched expert output buffers for MoE (or dense FFN).
         // Sized for max(K=3 verify, prefill chunk) × top_k experts.


### PR DESCRIPTION
## #110 — CUDA-700 when max_batch_size < max_seq_len

Fixes the `CUDA_ERROR_ILLEGAL_ADDRESS (700)` crash that surfaced under concurrency once the Q12 chunked-prefill batched dispatch activated (e.g. `--max-batch-size 4 --max-seq-len 32768`).

### Root cause
Pinned with compute-sanitizer on an isolated batched-GDN kernel harness (`gdn_batched_repro`): the batched GDN recurrence kernel `gated_delta_rule_prefill_wy64_batched` requested 16 bytes too little dynamic shared memory. The binding's `+256` trailer slack undercounts the kernel's real `smem_warp(16) + smem_g(128) + smem_bt(128) = 272` B trailer, so the kernel wrote `smem_bt`'s tail past the requested allocation. Hardware rounding hid it in isolation; under live-server occupancy the 16 B fell outside the block's shared memory and faulted. This is why it only bit the eligible mixed batched step under concurrency.

### Fixes
- `trait_prefill_gdn.rs`: size dynamic smem to the exact kernel layout (both single-stream and batched GDN-prefill dispatch). This is the crash fix.
- SSOT scratch footprint (`q12_batched_scratch_bytes`, `Q12_SIZING_STREAMS`) + a pure pre-flight footprint check in `check_kernel_batched_eligible` — the batched staging never overruns scratch and bails before any stream-state mutation (prevents the dirty-state per-stream fallback).
- `staged_bytes` on `BatchedAttnMetadata`: advance the scratch cursor by the exact staged footprint instead of an under-estimating heuristic that placed `h_state_ptrs` inside the live `slot_stacked` array.
- `Model::synchronize` barrier in `mixed_forward_batch` (decode_batch runs on the default stream; stops it racing the batched prefill over shared arena buffers).
- `gdn_batched_repro`: standalone batched-GDN kernel harness for compute-sanitizer validation.

### Verification
- Deterministic concurrency repro (conc=6 staggered deep prompts, gpu-util 0.55): 80/80 with `cuda700=0`, Q12 batched path ON. Previously crashed (`ok=0`) by request ~6.
- `webserver_ok` N=10: 10/10, all 6/6 directed steps, on the flagship config with `--max-prefill-tokens 4096` so deep prompts chunk and exercise the batched path. Sigma-wall 1732s.