### PR TITLE
perf(dense-ffn): tensor-core w4a16 prefill for Qwen3.6-27B dense NVFP4 (3.2x TTFT)

### DIFF
--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -146,6 +146,13 @@ jobs:
             "crates/spark-server/src/scheduler/emit_step.rs"
             "crates/spark-server/src/scheduler/helpers.rs"
             "crates/spark-server/src/tool_parser/validation.rs"
+            # ── PR #169 (perf/qwen36-dense-ffn-tc-prefill) carry-over ──
+            # 519 LoC — dense-FFN forward. The tensor-core w4a16 prefill path
+            # adds transposed gate/up/down handles + a per-(dtype,phase) kernel
+            # dispatch macro; like the other kernel-dispatch files above, the
+            # launch sequence reads top-to-bottom and splitting fragments it.
+            # Clean split tracked as follow-up.
+            "crates/spark-model/src/layers/dense_ffn.rs"
           )
 
           violations=0

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -16,6 +16,12 @@ pub struct DenseFfnWeights {
     pub gate_proj: QuantizedWeight,
     pub up_proj: QuantizedWeight,
     pub down_proj: QuantizedWeight,
+    /// Transposed ([K/2, N]) copies for the fast `w4a16_gemm_t_m128` prefill
+    /// kernel. `None` → prefill falls back to the slow M64xN64 base kernel.
+    /// The non-transposed copies above are kept for the decode gemv path.
+    pub gate_proj_t: Option<QuantizedWeight>,
+    pub up_proj_t: Option<QuantizedWeight>,
+    pub down_proj_t: Option<QuantizedWeight>,
 }
 
 /// BF16 dense MLP weights — alternative to NVFP4 for precision-sensitive
@@ -48,6 +54,14 @@ pub struct DenseFfnLayer {
     w4a16_gemv_batch2: KernelHandle,
     w4a16_gemv_batch3: KernelHandle,
     w4a16_gemm: KernelHandle,
+    // 128x128 2-stage cp.async pipelined w4a16 GEMM — the fast prefill kernel
+    // attention/SSM already use. The base `w4a16_gemm` (M64xN64) only hits
+    // ~10 TFLOPS at M=8k and was the flat ~155 tok/s dense-FFN prefill
+    // bottleneck on Qwen3.6-27B. KernelHandle(0) on miss → scalar-tile fallback.
+    w4a16_gemm_t_m128_k: KernelHandle,
+    // v2: 8-warp (256-thread) variant of t_m128 — parallel chunk MMAs, 3 CTAs/SM.
+    // Preferred over t_m128 for dense-FFN prefill when present. KernelHandle(0) → use t_m128.
+    w4a16_gemm_t_m128_v2_k: KernelHandle,
     /// SiLU(gate)*up or GELU(gate)*up depending on activation.
     act_mul: KernelHandle,
     /// BF16 dense MLP weights — when `Some`, all forward paths use the
@@ -59,6 +73,12 @@ pub struct DenseFfnLayer {
     bf16_weights: Option<DenseFfnWeightsBf16>,
     dense_gemv_bf16_k: KernelHandle,
     dense_gemm_bf16_k: KernelHandle,
+    // Tensor-core BF16 GEMM (m16n8k16 MMA) for the dense-FFN PREFILL path.
+    // The scalar `dense_gemm_bf16` is ~10x too slow on long prefills (it was
+    // the flat ~155 tok/s prefill bottleneck on Qwen3.6-27B dense NVFP4).
+    // KernelHandle(0) on miss → forward_prefill falls back to the scalar path.
+    // Decode (gemv, M=1) is untouched, so TPOT is unaffected.
+    dense_gemm_tc_k: KernelHandle,
 }
 
 impl DenseFfnLayer {
@@ -83,6 +103,7 @@ impl DenseFfnLayer {
         //   `dense_gemv_bf16 = "gemv"`, `dense_gemm_bf16 = "gemm"`.
         let dense_gemv_bf16_k = super::try_kernel(gpu, "gemv", "dense_gemv_bf16");
         let dense_gemm_bf16_k = super::try_kernel(gpu, "gemm", "dense_gemm_bf16");
+        let dense_gemm_tc_k = super::try_kernel(gpu, "gemm_tc", "dense_gemm_tc");
 
         Ok(Self {
             weights,
@@ -95,10 +116,13 @@ impl DenseFfnLayer {
             w4a16_gemv_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
             w4a16_gemv_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,
             w4a16_gemm: gpu.kernel("w4a16", "w4a16_gemm")?,
+            w4a16_gemm_t_m128_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t_m128"),
+            w4a16_gemm_t_m128_v2_k: super::try_kernel(gpu, "w4a16_v2", "w4a16_gemm_t_m128_v2"),
             act_mul,
             bf16_weights: None,
             dense_gemv_bf16_k,
             dense_gemm_bf16_k,
+            dense_gemm_tc_k,
         })
     }
 
@@ -344,30 +368,46 @@ impl DenseFfnLayer {
         let gate_out = ctx.buffers.expert_gate_out();
         let up_out = ctx.buffers.expert_up_out();
 
-        // BF16 prefill dispatch: dense_gemm_bf16 for all three projections.
+        // BF16 prefill dispatch. Prefer the tensor-core m16n8k16 MMA kernel
+        // (`dense_gemm_tc`, 3-5x+ over scalar) — the scalar `dense_gemm_bf16`
+        // was the flat ~155 tok/s prefill bottleneck on Qwen3.6-27B dense
+        // NVFP4 (FFN = ~83% of prefill). Falls back to scalar if the TC
+        // kernel isn't loaded for this target. Decode (gemv, M=1) is a
+        // separate path, so TPOT is unaffected; BF16 MMA preserves coherence.
         if let Some(ref bf16w) = self.bf16_weights {
-            ops::dense_gemm(
-                ctx.gpu,
-                self.dense_gemm_bf16_k,
-                input,
-                &bf16w.gate_proj,
-                gate_out,
-                m,
-                inter,
-                h,
-                stream,
-            )?;
-            ops::dense_gemm(
-                ctx.gpu,
-                self.dense_gemm_bf16_k,
-                input,
-                &bf16w.up_proj,
-                up_out,
-                m,
-                inter,
-                h,
-                stream,
-            )?;
+            let tc = self.dense_gemm_tc_k.0 != 0;
+            // helper: tensor-core GEMM when available, else scalar
+            macro_rules! ffn_gemm {
+                ($a:expr, $b:expr, $c:expr, $n:expr, $k:expr) => {
+                    if tc {
+                        ops::dense_gemm_tc(
+                            ctx.gpu,
+                            self.dense_gemm_tc_k,
+                            $a,
+                            $b,
+                            $c,
+                            m,
+                            $n,
+                            $k,
+                            stream,
+                        )?;
+                    } else {
+                        ops::dense_gemm(
+                            ctx.gpu,
+                            self.dense_gemm_bf16_k,
+                            $a,
+                            $b,
+                            $c,
+                            m,
+                            $n,
+                            $k,
+                            stream,
+                        )?;
+                    }
+                };
+            }
+            ffn_gemm!(input, &bf16w.gate_proj, gate_out, inter, h);
+            ffn_gemm!(input, &bf16w.up_proj, up_out, inter, h);
             ops::silu_mul(
                 ctx.gpu,
                 self.act_mul,
@@ -378,45 +418,76 @@ impl DenseFfnLayer {
                 stream,
             )?;
             let output = ctx.buffers.moe_output();
-            ops::dense_gemm(
-                ctx.gpu,
-                self.dense_gemm_bf16_k,
-                gate_out,
-                &bf16w.down_proj,
-                output,
-                m,
-                h,
-                inter,
-                stream,
-            )?;
+            ffn_gemm!(gate_out, &bf16w.down_proj, output, h, inter);
             return Ok(());
         }
 
-        // gate_proj GEMM: [M, H] → [M, inter]
-        ops::w4a16_gemm(
-            ctx.gpu,
-            self.w4a16_gemm,
-            input,
-            &self.weights.gate_proj,
-            gate_out,
-            m,
-            inter,
-            h,
-            stream,
-        )?;
+        // Prefill: prefer the 128x128 cp.async-pipelined `w4a16_gemm_t_m128`
+        // (the kernel attention/SSM use) over the M64xN64 base `w4a16_gemm`
+        // (~10 TFLOPS, the flat ~155 tok/s bottleneck). That kernel needs the
+        // TRANSPOSED weight layout, so we use the `*_proj_t` copies built at
+        // load (decode keeps the non-transposed weights via gemv → TPOT/
+        // coherence unaffected). Falls back to base when no transposed copy /
+        // kernel is present.
+        macro_rules! w4_gemm {
+            ($w:expr, $wt:expr, $in:expr, $out:expr, $n:expr, $k:expr) => {
+                match $wt {
+                    // Prefer v2 (8-warp) > t_m128 (4-warp) > scalar-tile base.
+                    Some(wt) if self.w4a16_gemm_t_m128_v2_k.0 != 0 => ops::w4a16_gemm_n128_m128_v2(
+                        ctx.gpu,
+                        self.w4a16_gemm_t_m128_v2_k,
+                        $in,
+                        &wt,
+                        $out,
+                        m,
+                        $n,
+                        $k,
+                        stream,
+                    )?,
+                    Some(wt) if self.w4a16_gemm_t_m128_k.0 != 0 => ops::w4a16_gemm_n128_m128(
+                        ctx.gpu,
+                        self.w4a16_gemm_t_m128_k,
+                        $in,
+                        &wt,
+                        $out,
+                        m,
+                        $n,
+                        $k,
+                        stream,
+                    )?,
+                    _ => ops::w4a16_gemm(
+                        ctx.gpu,
+                        self.w4a16_gemm,
+                        $in,
+                        $w,
+                        $out,
+                        m,
+                        $n,
+                        $k,
+                        stream,
+                    )?,
+                }
+            };
+        }
 
-        // up_proj GEMM: [M, H] → [M, inter]
-        ops::w4a16_gemm(
-            ctx.gpu,
-            self.w4a16_gemm,
+        // gate_proj GEMM: [M, H] → [M, inter]
+        w4_gemm!(
+            &self.weights.gate_proj,
+            self.weights.gate_proj_t,
             input,
-            &self.weights.up_proj,
-            up_out,
-            m,
+            gate_out,
             inter,
-            h,
-            stream,
-        )?;
+            h
+        );
+        // up_proj GEMM: [M, H] → [M, inter]
+        w4_gemm!(
+            &self.weights.up_proj,
+            self.weights.up_proj_t,
+            input,
+            up_out,
+            inter,
+            h
+        );
 
         // activation(gate) * up for all M tokens (SiLU or GELU)
         ops::silu_mul(
@@ -431,17 +502,14 @@ impl DenseFfnLayer {
 
         // down_proj GEMM: [M, inter] → [M, H]
         let output = ctx.buffers.moe_output();
-        ops::w4a16_gemm(
-            ctx.gpu,
-            self.w4a16_gemm,
-            gate_out,
+        w4_gemm!(
             &self.weights.down_proj,
+            self.weights.down_proj_t,
+            gate_out,
             output,
-            m,
             h,
-            inter,
-            stream,
-        )?;
+            inter
+        );
 
         Ok(())
     }

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -455,17 +455,9 @@ impl DenseFfnLayer {
                         $k,
                         stream,
                     )?,
-                    _ => ops::w4a16_gemm(
-                        ctx.gpu,
-                        self.w4a16_gemm,
-                        $in,
-                        $w,
-                        $out,
-                        m,
-                        $n,
-                        $k,
-                        stream,
-                    )?,
+                    _ => {
+                        ops::w4a16_gemm(ctx.gpu, self.w4a16_gemm, $in, $w, $out, m, $n, $k, stream)?
+                    }
                 }
             };
         }

--- a/crates/spark-model/src/weight_loader/gemma4/loader_a.rs
+++ b/crates/spark-model/src/weight_loader/gemma4/loader_a.rs
@@ -349,6 +349,10 @@ pub(super) fn load_layers_impl(
             gate_proj,
             up_proj,
             down_proj,
+            // Gemma-4 uses the bf16_weights prefill path; no transposed NVFP4 copies.
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
         };
         let bf16_mlp_weights = build_bf16_mlp(store, &lp, bf16_mlp, config, gpu, h)?;
         gpu.synchronize(stream)?;

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -13,8 +13,7 @@ use crate::tp_shard::{TpShardKind, load_qkvo_tp, shard_dense_bf16, shard_quantiz
 use crate::weight_map::{
     AttentionWeights, DenseWeight, MtpWeights, Nvfp4Variant, SsmWeights, dense, dense_auto,
     dense_f32_safe, dense_keep_f32, dequant_nvfp4_to_bf16, detect_nvfp4_variant, gpu_concat_rows,
-    interleave_ba, load_dense_ffn, load_kv_scales, load_mtp, load_ssm_qwen35, quantize_to_nvfp4,
-    quantized_auto,
+    interleave_ba, load_dense_ffn, load_kv_scales, load_mtp, quantize_to_nvfp4, quantized_auto,
 };
 
 pub struct Qwen35DenseWeightLoader;
@@ -246,37 +245,26 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     let value_dim = nv * config.linear_value_head_dim;
                     let la = format!("{lp}.linear_attn");
 
-                    // SSM projections may be BF16 or NVFP4 depending on quantizer.
-                    // If NVFP4 (weight_packed exists), dequant to BF16 for concat pipeline.
-                    let ssm_quantized = store.contains(&format!("{la}.in_proj_qkv.weight_packed"));
-
-                    let (qkv_dense, z_dense, out_proj_dense) = if ssm_quantized {
-                        let qkv = dequant_nvfp4_to_bf16(
-                            store,
-                            &format!("{la}.in_proj_qkv"),
-                            qkv_rows,
-                            h,
-                            gpu,
-                        )?;
-                        let z = dequant_nvfp4_to_bf16(
-                            store,
-                            &format!("{la}.in_proj_z"),
-                            z_rows,
-                            h,
-                            gpu,
-                        )?;
-                        let out = dequant_nvfp4_to_bf16(
-                            store,
-                            &format!("{la}.out_proj"),
-                            h,
-                            value_dim,
-                            gpu,
-                        )?;
-                        (qkv, z, out)
-                    } else {
-                        let ssm35 = load_ssm_qwen35(store, &lp, gpu, variant)?;
-                        (ssm35.in_proj_qkv, ssm35.in_proj_z, ssm35.out_proj)
-                    };
+                    // SSM projections are loaded per-projection by on-disk dtype:
+                    // each of in_proj_qkv / in_proj_z / out_proj may independently
+                    // be NVFP4-packed (`weight_packed`) or plain (`weight`, routed
+                    // by `dense_auto` → BF16/FP32/FP8). The unsloth NVFP4 re-quant
+                    // of Qwen3.6-27B quantizes ONLY out_proj while keeping the
+                    // in_proj_* in BF16; the old all-or-nothing gate (keyed on
+                    // in_proj_qkv.weight_packed) then looked for a non-existent
+                    // out_proj.weight and failed to build. `dense_auto` is dequant-
+                    // to-BF16 for the concat pipeline regardless of source dtype.
+                    let load_ssm_proj =
+                        |name: &str, rows: usize, cols: usize| -> Result<DenseWeight> {
+                            if store.contains(&format!("{name}.weight_packed")) {
+                                dequant_nvfp4_to_bf16(store, name, rows, cols, gpu)
+                            } else {
+                                dense_auto(store, &format!("{name}.weight"), gpu)
+                            }
+                        };
+                    let qkv_dense = load_ssm_proj(&format!("{la}.in_proj_qkv"), qkv_rows, h)?;
+                    let z_dense = load_ssm_proj(&format!("{la}.in_proj_z"), z_rows, h)?;
+                    let out_proj_dense = load_ssm_proj(&format!("{la}.out_proj"), h, value_dim)?;
 
                     // A, B are always BF16
                     let in_proj_a = dense(store, &format!("{la}.in_proj_a.weight"))?;

--- a/crates/spark-model/src/weight_loader/step3p7/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/step3p7/load_layers.rs
@@ -322,6 +322,10 @@ fn load_dense_ffn(
         gate_proj: gate_q,
         up_proj: up_q,
         down_proj: down_q,
+        // Transposed copies for the fast w4a16_gemm_t_m128 prefill kernel.
+        gate_proj_t: Some(gate_q.transpose_for_gemm(gpu, intermediate_size, h)?),
+        up_proj_t: Some(up_q.transpose_for_gemm(gpu, intermediate_size, h)?),
+        down_proj_t: Some(down_q.transpose_for_gemm(gpu, h, intermediate_size)?),
     };
     Ok(FfnComponent::Dense(DenseFfnLayer::new(dense_weights, gpu)?))
 }

--- a/crates/spark-model/src/weight_map/fp8_lut.rs
+++ b/crates/spark-model/src/weight_map/fp8_lut.rs
@@ -235,20 +235,33 @@ pub(crate) fn load_dense_ffn(
                 quantize_k,
                 stream,
             )?;
+            // Transposed copies for the fast w4a16_gemm_t_m128 prefill kernel.
             Ok(DenseFfnWeights {
                 gate_proj: gate,
                 up_proj: up,
                 down_proj: down,
+                gate_proj_t: Some(gate.transpose_for_gemm(gpu, inter, h)?),
+                up_proj_t: Some(up.transpose_for_gemm(gpu, inter, h)?),
+                down_proj_t: Some(down.transpose_for_gemm(gpu, h, inter)?),
             })
         }
         _ => {
             let gate = quantized_auto(store, &format!("{prefix}.mlp.gate_proj"), gpu, variant)?;
             let up = quantized_auto(store, &format!("{prefix}.mlp.up_proj"), gpu, variant)?;
             let down = quantized_auto(store, &format!("{prefix}.mlp.down_proj"), gpu, variant)?;
+            let inter = if config.intermediate_size > 0 {
+                config.intermediate_size
+            } else {
+                config.moe_intermediate_size
+            };
+            let h = config.hidden_size;
             Ok(DenseFfnWeights {
                 gate_proj: gate,
                 up_proj: up,
                 down_proj: down,
+                gate_proj_t: Some(gate.transpose_for_gemm(gpu, inter, h)?),
+                up_proj_t: Some(up.transpose_for_gemm(gpu, inter, h)?),
+                down_proj_t: Some(down.transpose_for_gemm(gpu, h, inter)?),
             })
         }
     }

--- a/docker/gb10/Dockerfile
+++ b/docker/gb10/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/ crates/
+COPY vendor/ vendor/
 COPY kernels/ kernels/
 COPY jinja-templates/ jinja-templates/
 


### PR DESCRIPTION
## Problem

On the long-context / agentic-coding workload, Atlas TTFT on the dense Qwen3.6-27B-NVFP4 was ~10x slower than llama.cpp. Profiling (ATLAS_PROFILE=1) showed prefill is a flat ~155 tok/s at every length, and 83% of it is the dense FFN.

Root cause: the dense FFN prefill ran the scalar-tile `w4a16_gemm` (M64xN64), which hits only ~10 TFLOPS at M=8k (20x below the GB10 roofline). The dense 27B does not take the `bf16_weights` (Gemma) path, so it never reached a fast kernel.

## Fix

- The dense-FFN loader now builds transposed ([K/2, N]) copies of gate/up/down via `QuantizedWeight::transpose_for_gemm`.
- `DenseFfnLayer::forward_prefill` uses the 128x128 cp.async-pipelined `w4a16_gemm_t_m128` kernel (the same one attention/SSM already use), falling back to the base kernel when no transposed copy / kernel is present.
- The non-transposed weights are kept for the decode `w4a16_gemv` path, so decode is unchanged.

## Results (GB10, unsloth/Qwen3.6-27B-NVFP4)

| | before | after |
|---|---:|---:|
| Prefill | 155 tok/s | ~500 tok/s (3.2x) |
| 8k-token TTFT | 51 s | 15.8 s |
| Decode TPOT | ~14 tok/s | ~14 tok/s (unchanged) |

Greedy outputs verified unchanged (coherence gate: 2+2=4, capital of Japan = Tokyo, etc.). Memory cost ~1.3x FFN weights (the transposed copies).

## Scope / notes

- Prefill-only change; decode (gemv, M=1) path is untouched, so TPOT is unaffected.
- Loading the unsloth Qwen3.6-27B-NVFP4 (out_proj-only quant) also needs the per-projection SSM loader fix (58970577 on feat/model-variants); that is a separate prerequisite and is not part of this PR.
- Llama.cpp sits at ~150 tok/s