### PR TITLE
fix(step3p7): default KV cache to bf16 to stop FP8-scale repetition runaway

### DIFF
--- a/kernels/gb10/step3p7-flash/MODEL.toml
+++ b/kernels/gb10/step3p7-flash/MODEL.toml
@@ -71,6 +71,15 @@ top_k = 20
 thinking_default = true
 thinking_in_tools = false
 max_thinking_budget = 2048
+# BF16 KV cache default — Step 3.7's large final-norm weights push K/V values
+# beyond the FP8 E4M3 range (±448). With no scales configured the cache falls
+# through to the static default=1.0 scale, which silently clips BF16 values and
+# destroys dynamic range, producing a degenerate repetition runaway. Mirrors the
+# gemma-4-26b-a4b fix; fp8_kv_calibration_tokens feeds the turbo8 (online
+# per-group BF16 scale) path when that dtype is selected instead.
+# Scope: FP8-KV-scale path only — not the separate </think> parser artifacts.
+default_kv_dtype = "bf16"
+fp8_kv_calibration_tokens = 256
 
 [[model_types]]
 model_type = "step3p7"


### PR DESCRIPTION
As discussed on #136 — the config-only fix for the Step 3.7 Flash FP8-KV-scale repetition runaway.

## Problem

`kernels/gb10/step3p7-flash/MODEL.toml` `[behavior]` set no KV cache dtype, so the cache falls through to `fp8` with the static `default=1.0` scale. Step 3.7's large final-norm weights push K/V values past the FP8 E4M3 range (±448); with the 1.0 scale those values are silently clipped, destroying dynamic range and producing a degenerate repetition runaway — the same failure the serve log warns about (*"Without scales (default=1.0), BF16 values are silently clipped to E4M3 [-448,448], destroying dynamic range"*).

## Fix

Mirror the existing `gemma-4-26b-a4b/MODEL.toml` fix, which solved the identical E4M3 overflow with exactly the two keys Step 3.7 was missing:

```toml
default_kv_dtype = "bf16"
fp8_kv_calibration_tokens = 256
```

**Config-only — no kernel or engine code touched**, just the model descriptor.

## Verification

On our 4-node GB10 (SM121) rig, EP=2: a band3 repeater prompt dropped from **2868 → 16** repeated chunks switching `fp8` → `bf16` KV. (Detailed in #136.)

## Scope boundary

This is **scoped strictly to the FP8-KV-scale path** — the degenerate-repetition runaway that bf16-KV resolves. The `</think>` parser artifacts (output via `reasoning_content`, bare leading `</think>`) are a **separate** issue and are not touched here.

## Follow-up

@marksunner asked for **bf16-vs-turbo8 A/B numbers** in the PR. `turbo8` (FP8 data + online per-group BF16 scales) should keep most of the memory saving while avoiding the static-scale clipping; the `fp8_kv_calibration_tokens` key above feeds that path. We'll run the A/B (repetition + tok/s) on the rig and post the table as a follow-up comment here once a cluster window opens — flagging it now rather than holding the known-good fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)