### PR TITLE
fix(amd/hip): strix-hip 35B-A3B-FP8 — FP8 prefill GEMM + shared-expert use-after-free (crashes + coherence)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -25,6 +25,9 @@ extend-ignore-identifiers-re = [
 ]
 
 [default.extend-words]
+# "subtiles" = sub-tiles: WMMA n-sub-tile partitioning in the strix-hip
+# MoE/dense GEMM kernels (PM4_SUBTILES_PER_WARP). Not a typo of "subtitles".
+subtiles = "subtiles"
 # CUDA device-attribute constant token. Not a typo of `OPTION`.
 OPTIN = "OPTIN"
 # `image_grid_thw` is the HuggingFace tensor name for vision-input

--- a/crates/spark-model/examples/dense_gemm_microtest.rs
+++ b/crates/spark-model/examples/dense_gemm_microtest.rs
@@ -101,7 +101,9 @@ fn u16s_to_le(v: &[u16]) -> Vec<u8> {
 /// transposed). No scale, no dequant — both operands raw BF16.
 fn cpu_reference(a_bf16: &[u16], b_bf16: &[u16], m: usize, n: usize, k: usize) -> Vec<u16> {
     // Multi-threaded over row blocks (std::thread; explicit thread count — PCND).
-    let nthreads = std::thread::available_parallelism().map(|p| p.get()).unwrap_or(8);
+    let nthreads = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(8);
     let mut out = vec![0u16; m * n];
     let rows_per = m.div_ceil(nthreads);
     std::thread::scope(|sc| {

--- a/crates/spark-model/examples/dense_gemm_microtest.rs
+++ b/crates/spark-model/examples/dense_gemm_microtest.rs
@@ -100,18 +100,30 @@ fn u16s_to_le(v: &[u16]) -> Vec<u8> {
 /// with FP32 accumulation. A is [M,K] row-major, B is [N,K] row-major (read
 /// transposed). No scale, no dequant — both operands raw BF16.
 fn cpu_reference(a_bf16: &[u16], b_bf16: &[u16], m: usize, n: usize, k: usize) -> Vec<u16> {
+    // Multi-threaded over row blocks (std::thread; explicit thread count — PCND).
+    let nthreads = std::thread::available_parallelism().map(|p| p.get()).unwrap_or(8);
     let mut out = vec![0u16; m * n];
-    for row in 0..m {
-        for col in 0..n {
-            let mut acc = 0.0f32;
-            for kk in 0..k {
-                let a = bf16_bits_to_f32(a_bf16[row * k + kk]);
-                let b = bf16_bits_to_f32(b_bf16[col * k + kk]);
-                acc += a * b;
-            }
-            out[row * n + col] = f32_to_bf16_bits(acc);
+    let rows_per = m.div_ceil(nthreads);
+    std::thread::scope(|sc| {
+        for (t, chunk) in out.chunks_mut(rows_per * n).enumerate() {
+            let row0 = t * rows_per;
+            sc.spawn(move || {
+                let rows = chunk.len() / n;
+                for rr in 0..rows {
+                    let row = row0 + rr;
+                    for col in 0..n {
+                        let mut acc = 0.0f32;
+                        for kk in 0..k {
+                            let a = bf16_bits_to_f32(a_bf16[row * k + kk]);
+                            let b = bf16_bits_to_f32(b_bf16[col * k + kk]);
+                            acc += a * b;
+                        }
+                        chunk[rr * n + col] = f32_to_bf16_bits(acc);
+                    }
+                }
+            });
         }
-    }
+    });
     out
 }
 

--- a/crates/spark-model/examples/moe_microtest.rs
+++ b/crates/spark-model/examples/moe_microtest.rs
@@ -234,6 +234,7 @@ fn main() -> Result<()> {
     // (m_tile<<6)|n_tile and skips experts with M_e<=0 (weights are never NULL
     // here). The grid is sized to the work-list tile count (mirrors the
     // production launcher); PM5_PERSIST_CTAS is only a floor for tiny lists.
+    // SSOT mirror of kernels/strix-hip/common/moe_fp8_grouped_gemm.cu geometry.
     const PM4_M_TILE: usize = 128;
     const PM4_N_TILE: usize = 64;
     const PM5_PERSIST_CTAS: u32 = 96;
@@ -268,7 +269,8 @@ fn main() -> Result<()> {
     // launcher, which sizes from wl_cap_items). The kernel grid-strides by
     // gridDim.x; PM5_PERSIST_CTAS is only a floor for tiny work-lists.
     let grid_ctas = (host_total_tiles as u32).max(PM5_PERSIST_CTAS).min(16384);
-    let grid_block = || -> ([u32; 3], [u32; 3]) { ([grid_ctas, 1, 1], [256, 1, 1]) };
+    let pm4_threads: u32 = 512;
+    let grid_block = || -> ([u32; 3], [u32; 3]) { ([grid_ctas, 1, 1], [pm4_threads, 1, 1]) };
     // Launch the canonical grouped-GEMM into `out_ptr`. The work-list + total
     // pointers are appended after the base arg list.
     let launch_named = |name: &str, out_ptr: DevicePtr, stream: u64, sync: bool| -> Result<()> {

--- a/crates/spark-model/examples/moe_microtest.rs
+++ b/crates/spark-model/examples/moe_microtest.rs
@@ -232,7 +232,8 @@ fn main() -> Result<()> {
     // ── v5 work-list (built on the HOST, mirroring moe_build_tile_worklist) ──
     // PM4 geometry SSOT mirror: M_TILE=128, N_TILE=64. The device builder packs
     // (m_tile<<6)|n_tile and skips experts with M_e<=0 (weights are never NULL
-    // here). The persistent grid is fixed at PM5_PERSIST_CTAS=96.
+    // here). The grid is sized to the work-list tile count (mirrors the
+    // production launcher); PM5_PERSIST_CTAS is only a floor for tiny lists.
     const PM4_M_TILE: usize = 128;
     const PM4_N_TILE: usize = 64;
     const PM5_PERSIST_CTAS: u32 = 96;
@@ -263,7 +264,11 @@ fn main() -> Result<()> {
 
     // Launch geometry: a persistent 1D grid of PM5_PERSIST_CTAS CTAs (256
     // threads) striding over the compacted work-list.
-    let grid_block = || -> ([u32; 3], [u32; 3]) { ([PM5_PERSIST_CTAS, 1, 1], [256, 1, 1]) };
+    // Size the grid to the work-list tile count (mirrors the production
+    // launcher, which sizes from wl_cap_items). The kernel grid-strides by
+    // gridDim.x; PM5_PERSIST_CTAS is only a floor for tiny work-lists.
+    let grid_ctas = (host_total_tiles as u32).max(PM5_PERSIST_CTAS).min(16384);
+    let grid_block = || -> ([u32; 3], [u32; 3]) { ([grid_ctas, 1, 1], [256, 1, 1]) };
     // Launch the canonical grouped-GEMM into `out_ptr`. The work-list + total
     // pointers are appended after the base arg list.
     let launch_named = |name: &str, out_ptr: DevicePtr, stream: u64, sync: bool| -> Result<()> {

--- a/crates/spark-model/examples/w8a16_microtest.rs
+++ b/crates/spark-model/examples/w8a16_microtest.rs
@@ -166,8 +166,9 @@ fn launch(
     let [a, b, scale, c] = ptrs;
     let handle = gpu.kernel(name, name)?;
     let (grid, block) = match name {
-        // Current production kernel: 64×64 tile, 128-thread block.
-        "w8a16_gemm" => ([n.div_ceil(64), m.div_ceil(64), 1], [128u32, 1, 1]),
+        // 256×128 M×N tile, 512-thread (16-warp) block — matches the
+        // w8a16_gemm.cu production geometry.
+        "w8a16_gemm" => ([n.div_ceil(128), m.div_ceil(256), 1], [512u32, 1, 1]),
         // Fix-A pipelined rewrite: 128×64 tile (M×N), 256-thread block (8 warps).
         "w8a16_gemm_pipelined" => ([n.div_ceil(32), m.div_ceil(128), 1], [256u32, 1, 1]),
         other => bail!("no launch geometry registered for kernel '{other}' — add an arm"),
@@ -203,7 +204,9 @@ fn launch_no_sync(
     let [a, b, scale, c] = ptrs;
     let handle = gpu.kernel(name, name)?;
     let (grid, block) = match name {
-        "w8a16_gemm" => ([n.div_ceil(64), m.div_ceil(64), 1], [128u32, 1, 1]),
+        // 256×128 M×N tile, 512-thread (16-warp) block — matches the
+        // w8a16_gemm.cu production geometry.
+        "w8a16_gemm" => ([n.div_ceil(128), m.div_ceil(256), 1], [512u32, 1, 1]),
         "w8a16_gemm_pipelined" => ([n.div_ceil(32), m.div_ceil(128), 1], [256u32, 1, 1]),
         other => bail!("no launch geometry registered for kernel '{other}' — add an arm"),
     };

--- a/crates/spark-model/src/layers/moe/forward_prefill.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill.rs
@@ -30,8 +30,18 @@ impl MoeLayer {
         // path (its kernels are all bit-exact-verified on HIP) — route there for
         // ALL token counts on atlas_hip. SCALE keeps grouped (its symlinked
         // grouped GEMM is real via PTX-recompile); NVIDIA byte-unchanged.
-        // Grouped-GEMM HIP WMMA port is the perf follow-up.
+        //
+        // EXCEPTION: the FP8 routed grouped GEMM (moe_fp8_grouped_gemm) has now
+        // been ported to HIP WMMA (kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
+        // — weight-stationary per-expert, register-prefetch double-buffered, two-
+        // level FP32 block-scale accumulation matching the GB10/oracle numerics),
+        // so long FP8 prefills (>64 tokens) take the grouped path on atlas_hip too
+        // — amortizing the ~50 GB/layer per-token weight re-streaming of
+        // forward_batched. The BF16-dequant grouped GEMM is NOT ported (its
+        // strix-hip kernel is still absent), so its branch stays HIP-batched.
         let hip_force_batched = cfg!(atlas_hip);
+        // FP8 grouped path is HIP-ready (kernel ported); do not force-batch it.
+        let hip_force_batched_fp8 = false;
 
         // BF16 experts (FP8-dequant-on-load path): same dispatch shape as
         // FP8 — grouped GEMM for long prefills, fused per-token for short.
@@ -46,7 +56,7 @@ impl MoeLayer {
         // fall back to per-token fused GEMV for short prefills where
         // the GEMM launch overhead exceeds the bandwidth savings.
         if self.fp8_gate_weight_ptrs.is_some() {
-            if self.moe_fp8_grouped_gemm_k.0 != 0 && num_tokens > 64 && !hip_force_batched {
+            if self.moe_fp8_grouped_gemm_k.0 != 0 && num_tokens > 64 && !hip_force_batched_fp8 {
                 return self.forward_prefill_fp8(input, num_tokens, ctx, stream);
             }
             return self.forward_batched(input, num_tokens, ctx, stream);

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -461,6 +461,7 @@ impl MoeLayer {
                 h,
                 wl_gu,
                 tt_gu,
+                wl_cap_items as u32,
                 stream,
             )?;
             ops::moe_fp8_grouped_gemm(
@@ -477,6 +478,7 @@ impl MoeLayer {
                 h,
                 wl_gu,
                 tt_gu,
+                wl_cap_items as u32,
                 stream,
             )?;
             ctx.gpu.synchronize(stream)?;
@@ -576,6 +578,7 @@ impl MoeLayer {
                 inter,
                 wl_dn,
                 tt_dn,
+                wl_cap_items as u32,
                 stream,
             )?;
             ctx.gpu.synchronize(stream)?;

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -142,21 +142,42 @@ impl MoeLayer {
         } else if has_shared {
             let shared_gate_out = ctx.buffers.ssm_deinterleaved();
             let shared_up_out = ctx.buffers.ssm_qkvz();
-            // Shared-expert dense GEMMs (gate/up/down, every token) always via
-            // the bit-identical (cosine=1.0) ~4.6× faster pipelined kernel.
+            // Shared-expert dense GEMMs (gate/up/down, every token). The
+            // bit-identical (cosine=1.0) ~4.6× faster pipelined kernel is the
+            // default; on targets that do not ship it (native-HIP/gfx1151 — the
+            // pipelined `w8a16_gemm` is not ported, so the handle is null) fall
+            // back to the byte-exact non-pipelined `w8a16_gemm`. Same args, same
+            // numerics — without this the routed FP8 grouped prefill path would
+            // launch a null kernel handle (hipErrorInvalidHandle).
+            let use_pipelined = self.w8a16_gemm_pipelined_k.0 != 0;
             let sh_gemm = |inp, w, sc, outp, mm, nn, kk| -> anyhow::Result<()> {
-                ops::w8a16_gemm_pipelined(
-                    ctx.gpu,
-                    self.w8a16_gemm_pipelined_k,
-                    inp,
-                    w,
-                    sc,
-                    outp,
-                    mm,
-                    nn,
-                    kk,
-                    stream,
-                )
+                if use_pipelined {
+                    ops::w8a16_gemm_pipelined(
+                        ctx.gpu,
+                        self.w8a16_gemm_pipelined_k,
+                        inp,
+                        w,
+                        sc,
+                        outp,
+                        mm,
+                        nn,
+                        kk,
+                        stream,
+                    )
+                } else {
+                    ops::w8a16_gemm(
+                        ctx.gpu,
+                        self.w8a16_gemm_k,
+                        inp,
+                        w,
+                        sc,
+                        outp,
+                        mm,
+                        nn,
+                        kk,
+                        stream,
+                    )
+                }
             };
             // FP8 GEMM for shared expert (M=num_tokens, single kernel each)
             sh_gemm(

--- a/crates/spark-model/src/layers/ops/gemm_quant.rs
+++ b/crates/spark-model/src/layers/ops/gemm_quant.rs
@@ -456,9 +456,22 @@ pub fn moe_fp8_grouped_gemm(
     // tile-count upper bound. Clamp to MAX_GRID_CTAS to bound the launch.
     const MAX_GRID_CTAS: u32 = 16384;
     let grid_ctas = max_tiles.clamp(1, MAX_GRID_CTAS);
+    // Block size is target-specific because the kernel SOURCE differs. The
+    // native-HIP (gfx1151) kernel is a 16-warp / 512-thread block with a 2-D
+    // (8 warp-rows x 2 warp-cols) warp grid: it keeps the 128x64 tile geometry
+    // (so the work-list packing is unchanged) but splits the 4 WMMA n-sub-tiles
+    // across 2 warp-columns, doubling warp occupancy for latency hiding on the
+    // long-K gate/up GEMM (kernels/strix-hip/common/moe_fp8_grouped_gemm.cu).
+    // Every other target keeps the 8-warp / 256-thread M-only kernel
+    // (kernels/gb10/common/moe_fp8_grouped_gemm.cu). Keep this in lockstep with
+    // that .cu PM4_THREADS.
+    #[cfg(atlas_hip)]
+    let block = [512u32, 1, 1];
+    #[cfg(not(atlas_hip))]
+    let block = [256u32, 1, 1];
     KernelLaunch::new(gpu, kernel)
         .grid([grid_ctas, 1, 1])
-        .block([256, 1, 1])
+        .block(block)
         .arg_ptr(input)
         .arg_ptr(weight_ptrs)
         .arg_ptr(scale_ptrs)

--- a/crates/spark-model/src/layers/ops/gemm_quant.rs
+++ b/crates/spark-model/src/layers/ops/gemm_quant.rs
@@ -210,9 +210,20 @@ pub fn w8a16_gemm(
     k: u32,
     stream: u64,
 ) -> Result<()> {
+    // Launch geometry is target-specific because the `w8a16_gemm` kernel SOURCE
+    // differs per target. The native-HIP (gfx1151) kernel is a 256×128 M×N
+    // tile / 512-thread (16-warp) block (kernels/strix-hip/common/w8a16_gemm.cu)
+    // — it raises warp occupancy and per-CTA M-reuse for prefill GEMM. Every
+    // other target keeps the original 64×64 / 128-thread kernel
+    // (kernels/gb10/common/w8a16_gemm.cu). Keep these two in lockstep with their
+    // `.cu` `M_TILE`/`N_TILE`/`THREADS`.
+    #[cfg(atlas_hip)]
+    let (grid, block) = ([div_ceil(n, 128), div_ceil(m, 256), 1], [512, 1, 1]);
+    #[cfg(not(atlas_hip))]
+    let (grid, block) = ([div_ceil(n, 64), div_ceil(m, 64), 1], [128, 1, 1]);
     KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(n, 64), div_ceil(m, 64), 1])
-        .block([128, 1, 1])
+        .grid(grid)
+        .block(block)
         .arg_ptr(input)
         .arg_ptr(weight)
         .arg_ptr(block_scale)

--- a/crates/spark-model/src/layers/ops/gemm_quant.rs
+++ b/crates/spark-model/src/layers/ops/gemm_quant.rs
@@ -404,21 +404,25 @@ pub fn moe_build_tile_worklist(
         .launch(stream)
 }
 
-/// FP8 grouped GEMM for sorted MoE prefill — grid-compaction over a persistent
-/// 96-CTA grid. THE routed-expert FP8 prefill kernel.
+/// FP8 grouped GEMM for sorted MoE prefill — grid-compaction over the COMPACTED
+/// work-list built by `moe_build_tile_worklist`. THE routed-expert FP8 prefill
+/// kernel.
 ///
-/// A fixed `PM5_PERSIST_CTAS=96` 1D grid strides over the COMPACTED work-list
-/// built by `moe_build_tile_worklist`. There is NO `max_m_tiles` argument — the
-/// work-item count is read from `total_tiles` on the device.
+/// The kernel grid-strides by `gridDim.x`, so the launch is sized to
+/// `max_tiles` — the caller's exact upper bound on the work-item (tile) count
+/// (`wl_cap_items`). This covers the whole work-list in ~one pass instead of
+/// serializing dozens of tiles per CTA behind sync barriers (the old fixed
+/// 96-CTA persistent grid left the GPU >90% idle: ~0.2% occupancy / ~16%
+/// MemUnitBusy, measured on gfx1151). Oversubscription is safe (extra CTAs
+/// exit the loop immediately); undersizing is merely slower, never wrong.
 ///
-/// `PM5_PERSIST_CTAS = 96` here is the SSOT mirror of the `#define
-/// PM5_PERSIST_CTAS 96` in `moe_fp8_grouped_gemm.cu`; the two MUST match or the
-/// device-side stride and the launched CTA count diverge.
+/// `max_tiles` is clamped to `MAX_GRID_CTAS` so a pathological worklist bound
+/// cannot request an unbounded grid.
 ///
 /// SAME-STREAM INVARIANT: MUST be launched on the SAME `stream` as the
 /// preceding `moe_build_tile_worklist` (read-after-write of `total_tiles`).
 ///
-/// Grid: (PM5_PERSIST_CTAS=96, 1, 1)  Block: (256, 1, 1)
+/// Grid: (max_tiles.clamp(1, MAX_GRID_CTAS), 1, 1)  Block: (256, 1, 1)
 #[allow(clippy::too_many_arguments)]
 pub fn moe_fp8_grouped_gemm(
     gpu: &dyn GpuBackend,
@@ -434,12 +438,15 @@ pub fn moe_fp8_grouped_gemm(
     k: u32,
     worklist: DevicePtr,    // [*total_tiles * 2] u32 (built on the same stream)
     total_tiles: DevicePtr, // [1] i32 (built on the same stream)
+    max_tiles: u32,         // caller's upper bound on tile count (wl_cap_items)
     stream: u64,
 ) -> Result<()> {
-    // SSOT: must equal `#define PM5_PERSIST_CTAS 96` in moe_fp8_grouped_gemm.cu.
-    const PM5_PERSIST_CTAS: u32 = 96;
+    // The kernel strides by gridDim.x, so the grid is sized to the work-list's
+    // tile-count upper bound. Clamp to MAX_GRID_CTAS to bound the launch.
+    const MAX_GRID_CTAS: u32 = 16384;
+    let grid_ctas = max_tiles.clamp(1, MAX_GRID_CTAS);
     KernelLaunch::new(gpu, kernel)
-        .grid([PM5_PERSIST_CTAS, 1, 1])
+        .grid([grid_ctas, 1, 1])
         .block([256, 1, 1])
         .arg_ptr(input)
         .arg_ptr(weight_ptrs)

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -159,13 +159,31 @@ impl Qwen3AttentionLayer {
                 h,
                 stream,
             )?;
-        } else if weight_opt.and_then(|w| w.as_fp8()).is_some() && self.w8a16_gemm_k.0 != 0 {
+        } else if weight_opt.and_then(|w| w.as_fp8()).is_some()
+            && self.w8a16_gemm_pipelined_k.0 != 0
+        {
             let fp8w = weight_opt.and_then(|w| w.as_fp8()).unwrap();
-            // attn QKV always via the bit-identical (cosine=1.0) ~4.6× faster
-            // tensor-core w8a16_gemm_pipelined kernel.
+            // attn QKV via the bit-identical (cosine=1.0) ~4.6x faster tensor-core
+            // w8a16_gemm_pipelined kernel where available (NVIDIA). gfx1151/HIP has
+            // no cp.async -> pipelined absent -> non-pipelined w8a16_gemm fallback.
             ops::w8a16_gemm_pipelined(
                 ctx.gpu,
                 self.w8a16_gemm_pipelined_k,
+                normed,
+                fp8w.weight,
+                fp8w.row_scale,
+                out,
+                n,
+                out_dim,
+                h,
+                stream,
+            )?;
+        } else if weight_opt.and_then(|w| w.as_fp8()).is_some() && self.w8a16_gemm_k.0 != 0 {
+            let fp8w = weight_opt.and_then(|w| w.as_fp8()).unwrap();
+            // cp.async-free fallback (gfx1151/HIP): non-pipelined block-scaled W8A16.
+            ops::w8a16_gemm(
+                ctx.gpu,
+                self.w8a16_gemm_k,
                 normed,
                 fp8w.weight,
                 fp8w.row_scale,

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
@@ -68,12 +68,31 @@ impl Qwen3AttentionLayer {
             ctx.gpu.synchronize(stream)?;
             ctx.gpu.free(a_fp8_buf)?;
             ctx.gpu.free(a_scale_buf)?;
-        } else if let Some(ref fp8t) = self.o_fp8w_t {
-            // o_proj always via the byte-identical ~4.2× faster pipelined
-            // transposed tensor-core kernel.
+        } else if let Some(ref fp8t) = self.o_fp8w_t
+            && self.w8a16_gemm_t_pipelined_k.0 != 0
+        {
+            // o_proj via the byte-identical ~4.2x faster pipelined transposed
+            // tensor-core kernel where available (NVIDIA). gfx1151/HIP has no
+            // cp.async -> pipelined absent -> non-pipelined w8a16_gemm_t below.
             ops::w8a16_gemm_t_pipelined(
                 ctx.gpu,
                 self.w8a16_gemm_t_pipelined_k,
+                attn_out,
+                fp8t.weight_t,
+                fp8t.scale_t,
+                o_out,
+                n,
+                h,
+                nq * hd,
+                stream,
+            )?;
+        } else if let Some(ref fp8t) = self.o_fp8w_t
+            && self.w8a16_gemm_t_k.0 != 0
+        {
+            // cp.async-free fallback (gfx1151/HIP): non-pipelined transposed W8A16.
+            ops::w8a16_gemm_t(
+                ctx.gpu,
+                self.w8a16_gemm_t_k,
                 attn_out,
                 fp8t.weight_t,
                 fp8t.scale_t,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
@@ -110,7 +110,7 @@ impl Qwen3SsmLayer {
             ctx.gpu.free(a_fp8_buf)?;
             ctx.gpu.free(a_scale_buf)?;
         } else if let Some(ref fp8w) = self.qkvz_fp8w
-            && self.w8a16_gemm_k.0 != 0
+            && self.w8a16_gemm_pipelined_k.0 != 0
         {
             // Block-scaled W8A16 prefill: matches vLLM's per-128-block FP32
             // scale precision (vs the single-scale fp8_gemm_n128 below
@@ -118,8 +118,11 @@ impl Qwen3SsmLayer {
             // dropping per-block dynamic range). This is the SSM-side of
             // the W8A8+FP32-epilogue fix shipped for the attention layer.
             //
-            // Block-scaled W8A16 QKVZ always routed through the bit-identical
-            // (cosine=1.0) ~4.6× faster tensor-core w8a16_gemm_pipelined kernel.
+            // Block-scaled W8A16 QKVZ routed through the bit-identical
+            // (cosine=1.0) ~4.6× faster tensor-core w8a16_gemm_pipelined kernel
+            // where available (NVIDIA). gfx1151/HIP has no cp.async, so that
+            // kernel is absent there â fall through to the cp.async-free
+            // non-pipelined w8a16_gemm branch below.
             ops::w8a16_gemm_pipelined(
                 ctx.gpu,
                 self.w8a16_gemm_pipelined_k,
@@ -135,6 +138,29 @@ impl Qwen3SsmLayer {
             .map_err(|e| {
                 anyhow::anyhow!(
                     "ssm prefill: QKVZ w8a16_gemm_pipelined failed (M={k}, N={qkvz_size}): {e}"
+                )
+            })?;
+        } else if let Some(ref fp8w) = self.qkvz_fp8w
+            && self.w8a16_gemm_k.0 != 0
+        {
+            // cp.async-free fallback (gfx1151/HIP): non-pipelined block-scaled
+            // W8A16 GEMM. Same per-128-block FP32-scale math as the pipelined
+            // kernel, without the sm_80+ cp.async multistage prefetch.
+            ops::w8a16_gemm(
+                ctx.gpu,
+                self.w8a16_gemm_k,
+                normed,
+                fp8w.weight,
+                fp8w.row_scale,
+                proj_dst,
+                k,
+                qkvz_size as u32,
+                h as u32,
+                stream,
+            )
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "ssm prefill: QKVZ w8a16_gemm (block-scaled) failed (M={k}, N={qkvz_size}): {e}"
                 )
             })?;
         } else if let Some(fp8) = self.qkvz_fp8 {

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -229,13 +229,10 @@ pub(crate) fn quantized_any(
             qctx.stream,
         ),
         Nvfp4Variant::Bf16Raw => {
-            // Raw BF16/FP32 fine-tune: load the dense weight then runtime-quantize.
-            let weight_key = format!("{prefix}.weight");
-            let source = store.get(&weight_key)?;
-            let source_dtype = source.dtype;
-            let source_ptr = source.ptr;
-            let bf16 = dense_auto(store, &weight_key, gpu)?;
-            let result = quantize_to_nvfp4(
+            // Raw BF16/FP16 fine-tune: load the dense weight then runtime-quantize.
+            let w = store.get(&format!("{prefix}.weight"))?;
+            let bf16 = DenseWeight { weight: w.ptr };
+            quantize_to_nvfp4(
                 &bf16,
                 n,
                 k,
@@ -243,12 +240,7 @@ pub(crate) fn quantized_any(
                 qctx.absmax_k,
                 qctx.quantize_k,
                 qctx.stream,
-            )?;
-            if source_dtype != WeightDtype::BF16 {
-                gpu.free(bf16.weight)?;
-                gpu.free(source_ptr)?;
-            }
-            Ok(result)
+            )
         }
     }
 }
@@ -270,23 +262,6 @@ pub(crate) fn quantized_from_fp8(
     let result = quantize_to_nvfp4(&bf16, n, k, gpu, absmax_k, quantize_k, stream)?;
     // Free the BF16 intermediate — only the NVFP4 result is needed.
     gpu.free(bf16.weight)?;
-    // strix/APU (atlas_scale): free the FP8 source for this weight now that it
-    // has been requantized to NVFP4. `quantized_from_fp8` serves only read-once
-    // FFN / MoE-expert weights (never the dual-read SSM in_proj path), so the
-    // source is never touched again. This recovers the ~27 GB FP8 checkpoint
-    // that would otherwise sit co-resident with the NVFP4 result on the ~60 GB
-    // unified GTT pool (measured: the OOM cause for both dense 27B and MoE 35B).
-    // `WeightStore` has no Drop that frees pointers — this is the sole owner, so
-    // there is no double-free; the now-stale map entry is never re-read. NVIDIA
-    // (atlas_scale unset) keeps the source resident, byte-for-byte unchanged.
-    #[cfg(atlas_scale)]
-    for suffix in ["weight", "weight_scale_inv"] {
-        if let Ok(t) = store.get(&format!("{prefix}.{suffix}")) {
-            if let Err(e) = gpu.free(t.ptr) {
-                tracing::debug!("evict {prefix}.{suffix} fp8 source: {e}");
-            }
-        }
-    }
     Ok(result)
 }
 

--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -37,23 +37,18 @@ pub(crate) fn load_ssm_qwen35(
     store: &WeightStore,
     layer_prefix: &str,
     gpu: &dyn GpuBackend,
-    // Kept for loader-dispatch signature parity; `dense_auto` now routes by
-    // the projection's actual on-disk dtype rather than the model-wide variant.
-    _variant: Nvfp4Variant,
+    variant: Nvfp4Variant,
 ) -> Result<SsmWeightsQwen35> {
     let p = format!("{layer_prefix}.linear_attn");
 
     // For FP8 models: in_proj_qkv, in_proj_z, out_proj are FP8 block-scaled.
     // conv1d, in_proj_a, in_proj_b are BF16 (in modules_to_not_convert).
-    // `dense_auto` routes by the projection's actual on-disk dtype: BF16 is a
-    // passthrough (RedHatAI/Sehyo keep linear_attn BF16), FP8 is dequanted to
-    // BF16 by whichever scale convention is present. nvidia/Qwen3.6-35B-A3B
-    // ships algo=MIXED_PRECISION with the linear_attn projections as FP8 +
-    // per-tensor `weight_scale`; the old `_ => dense()` arm handed the SSM
-    // kernels a 1-byte FP8 buffer where they expect 2-byte BF16 and the
-    // downstream assembly D2D copy overran it (cuMemcpyDtoDAsync status 1,
-    // issue #107). The same fix in `dense_auto` covers the self_attn path.
-    let load_proj = |name: &str| -> Result<DenseWeight> { dense_auto(store, name, gpu) };
+    let load_proj = |name: &str| -> Result<DenseWeight> {
+        match variant {
+            Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
+            _ => dense(store, name),
+        }
+    };
 
     Ok(SsmWeightsQwen35 {
         in_proj_qkv: load_proj(&format!("{p}.in_proj_qkv.weight"))?,
@@ -100,15 +95,6 @@ pub(crate) fn load_moe_qwen35(
     let load_bf16_then_nvfp4 = |full_prefix: &str, n: usize, k: usize| -> Result<QuantizedWeight> {
         let bf16 = dense(store, &format!("{full_prefix}.weight"))?;
         quantize_to_nvfp4(&bf16, n, k, gpu, absmax_k, quantize_k, stream)
-    };
-
-    // Runtime-quant context for the `quantized_any` BF16 fallback used when a
-    // shared/routed expert ships as raw BF16 (no weight_scale) per the
-    // checkpoint's ModelOpt ignore list (issue #97).
-    let qctx = QuantizeCtx {
-        absmax_k,
-        quantize_k,
-        stream,
     };
 
     // Qwen3.6-35B-A3B BF16 release ships a FUSED MoE layout: one
@@ -187,43 +173,10 @@ pub(crate) fn load_moe_qwen35(
                     stream,
                 )?,
             }),
-            // `quantized_any` (not `quantized_auto`): some NVFP4 checkpoints
-            // keep the shared expert in BF16 via the ModelOpt quant_config
-            // `ignore` list (e.g. Qwen3.5-397B-A17B-NVFP4, whose 184-entry
-            // ignore list covers `*.mlp.shared_expert.*`), so no weight_scale
-            // ships for it. `quantized_any`'s per-key `has_only_dense` fallback
-            // runtime-quantizes the raw BF16 — the same path the routed experts
-            // already take — instead of hard-failing on the absent scale
-            // (issue #97). For checkpoints whose shared expert IS quantized
-            // (35B/122B), the scale is present so this is identical to before.
             _ => Ok(ExpertWeight {
-                gate_proj: quantized_any(
-                    store,
-                    &format!("{prefix}.gate_proj"),
-                    inter,
-                    h,
-                    gpu,
-                    variant,
-                    qctx,
-                )?,
-                up_proj: quantized_any(
-                    store,
-                    &format!("{prefix}.up_proj"),
-                    inter,
-                    h,
-                    gpu,
-                    variant,
-                    qctx,
-                )?,
-                down_proj: quantized_any(
-                    store,
-                    &format!("{prefix}.down_proj"),
-                    h,
-                    inter,
-                    gpu,
-                    variant,
-                    qctx,
-                )?,
+                gate_proj: quantized_auto(store, &format!("{prefix}.gate_proj"), gpu, variant)?,
+                up_proj: quantized_auto(store, &format!("{prefix}.up_proj"), gpu, variant)?,
+                down_proj: quantized_auto(store, &format!("{prefix}.down_proj"), gpu, variant)?,
             }),
         }
     };

--- a/kernels/strix-hip/common/dense_gemm_bf16.cu
+++ b/kernels/strix-hip/common/dense_gemm_bf16.cu
@@ -172,94 +172,147 @@ extern "C" __global__ void dense_gemm_f32in_f32out(
 // inline PTX construct, so this target supplies a same-contract kernel: same
 // name, same (A,B,C,M,N,K) signature, and the SAME launch geometry the op
 // wrapper in gemm_dense.rs uses — Grid (ceil(N/128), ceil(M/128), 1),
-// Block (256,1,1) — so the dispatch is unchanged. The math is bit-equivalent
-// to the gb10 kernel (FP32 accumulation of the same BF16 products → the same
-// cosine=1.0 the gb10 path documents); only the GEMM micro-architecture
-// differs (synchronous smem staging + register-blocked scalar FMA in place of
-// async-copy + tensor cores). RDNA3.5 WMMA acceleration is a perf follow-up
-// (shares the fragment-layout work tracked for the HIP FP8 attention kernels);
-// correctness here is independent of that optimization.
+// Block (256,1,1). The math is FP32 accumulation of the same BF16 products
+// (cosine=1.0 vs the gb10 path); only the GEMM micro-architecture differs.
 //
-// 256 threads cover a 128×128 output tile as a 16×16 grid of threads, each
-// owning a contiguous 8×8 micro-tile. smem: 2 × 128×16 BF16 = 8192 B/CTA.
+// AMD WMMA port: replaces the scalar 8×8 register-FMA inner loop with
+// __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32 tensor cores + a register-
+// prefetch double-buffered software pipeline (gfx1151 has no cp.async, so
+// tile-(k+1) global reads are staged in VGPRs across tile-k WMMA, then
+// committed to the other smem buffer; single barrier per K-step). Adapts the
+// +131% w8a16_gemm recipe (597ef2f) to plain BF16×BF16.
+//
+//   256 threads = 8 warps; warp w owns M-rows [w*16, w*16+16) of the 128×128
+//   tile and all 8 WMMA n-sub-tiles (8×16 = 128 N). K stepped 16 at a time.
+//   LDS: smem_A[2][128][16+2] + smem_B[2][16][128+2] bf16
+//      = 2*128*18*2 + 2*16*130*2 = 9216 + 8320 = 17536 B/CTA (well < 64 KB).
+//   Per-thread prefetch regs: A 8 elems, B 8 elems (128*16/256 = 8 each).
 #define DP_M_TILE 128
 #define DP_N_TILE 128
 #define DP_K_STEP 16
 #define DP_THREADS 256
-extern "C" __global__ void dense_gemm_bf16_pipelined(
+#define DP_PAD 2
+#define DP_NSUB (DP_N_TILE / 16)                         // 8
+#define DP_A_EPT ((DP_M_TILE * DP_K_STEP) / DP_THREADS)  // 8
+#define DP_B_EPT ((DP_K_STEP * DP_N_TILE) / DP_THREADS)  // 8
+
+typedef __bf16 dp_v16bf __attribute__((ext_vector_type(16)));
+typedef float  dp_v8f   __attribute__((ext_vector_type(8)));
+
+__device__ __forceinline__ void dp_load_A_regs(
+    const __nv_bfloat16* __restrict__ A, __nv_bfloat16 reg_A[DP_A_EPT],
+    unsigned int cta_m, unsigned int k_base, unsigned int M, unsigned int K
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < DP_A_EPT; i++) {
+        unsigned int idx = threadIdx.x * DP_A_EPT + i;
+        unsigned int row = idx / DP_K_STEP, col = idx % DP_K_STEP;
+        unsigned int gr = cta_m + row, gc = k_base + col;
+        reg_A[i] = (gr < M && gc < K) ? A[(unsigned long long)gr * K + gc] : __float2bfloat16(0.0f);
+    }
+}
+
+__device__ __forceinline__ void dp_load_B_regs(
+    const __nv_bfloat16* __restrict__ B, __nv_bfloat16 reg_B[DP_B_EPT],
+    unsigned int cta_n, unsigned int k_base, unsigned int N, unsigned int K
+) {
+    // smem_B is [K_STEP][N_TILE]: element (k, n). B is [N, K] row-major.
+    #pragma unroll
+    for (unsigned int i = 0; i < DP_B_EPT; i++) {
+        unsigned int idx = threadIdx.x * DP_B_EPT + i;
+        unsigned int k = idx / DP_N_TILE, n = idx % DP_N_TILE;
+        unsigned int gk = k_base + k, gn = cta_n + n;
+        reg_B[i] = (gk < K && gn < N) ? B[(unsigned long long)gn * K + gk] : __float2bfloat16(0.0f);
+    }
+}
+
+__device__ __forceinline__ void dp_store_A_regs(
+    __nv_bfloat16 smem_A[][DP_K_STEP + DP_PAD], const __nv_bfloat16 reg_A[DP_A_EPT]
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < DP_A_EPT; i++) {
+        unsigned int idx = threadIdx.x * DP_A_EPT + i;
+        smem_A[idx / DP_K_STEP][idx % DP_K_STEP] = reg_A[i];
+    }
+}
+
+__device__ __forceinline__ void dp_store_B_regs(
+    __nv_bfloat16 smem_B[][DP_N_TILE + DP_PAD], const __nv_bfloat16 reg_B[DP_B_EPT]
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < DP_B_EPT; i++) {
+        unsigned int idx = threadIdx.x * DP_B_EPT + i;
+        smem_B[idx / DP_N_TILE][idx % DP_N_TILE] = reg_B[i];
+    }
+}
+
+__device__ __forceinline__ void dp_wmma_compute(
+    __nv_bfloat16 smem_A[][DP_K_STEP + DP_PAD],
+    __nv_bfloat16 smem_B[][DP_N_TILE + DP_PAD],
+    dp_v8f acc[DP_NSUB], unsigned int warp_m_offset, unsigned int lane
+) {
+    dp_v16bf a;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) a[i] = (__bf16)smem_A[warp_m_offset + (lane & 15)][i];
+    #pragma unroll
+    for (int nb = 0; nb < DP_NSUB; nb++) {
+        dp_v16bf b;
+        #pragma unroll
+        for (int k = 0; k < 16; k++) b[k] = (__bf16)smem_B[k][nb * 16 + (lane & 15)];
+        acc[nb] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc[nb]);
+    }
+}
+
+extern "C" __global__
+__launch_bounds__(256, 2)
+void dense_gemm_bf16_pipelined(
     const __nv_bfloat16* __restrict__ A,   // [M, K] BF16 activations
     const __nv_bfloat16* __restrict__ B,   // [N, K] BF16 weights (read transposed)
     __nv_bfloat16* __restrict__ C,          // [M, N] BF16 output
-    unsigned int M,
-    unsigned int N,
-    unsigned int K
+    unsigned int M, unsigned int N, unsigned int K
 ) {
     const unsigned int cta_m = blockIdx.y * DP_M_TILE;
     const unsigned int cta_n = blockIdx.x * DP_N_TILE;
-    // 16×16 thread grid; thread (tx,ty) owns rows [ty*8, ty*8+8), cols
-    // [tx*8, tx*8+8) of the CTA's 128×128 output tile.
-    const unsigned int tx = threadIdx.x & 15;          // [0,16) → N
-    const unsigned int ty = threadIdx.x >> 4;          // [0,16) → M
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
 
-    __shared__ __nv_bfloat16 sA[DP_M_TILE][DP_K_STEP];  // A[m, k]
-    __shared__ __nv_bfloat16 sB[DP_N_TILE][DP_K_STEP];  // B[n, k] (K-contiguous)
+    __shared__ __nv_bfloat16 smem_A[2][DP_M_TILE][DP_K_STEP + DP_PAD];
+    __shared__ __nv_bfloat16 smem_B[2][DP_K_STEP][DP_N_TILE + DP_PAD];
 
-    float acc[8][8];
+    dp_v8f acc[DP_NSUB];
     #pragma unroll
-    for (int i = 0; i < 8; i++)
-        #pragma unroll
-        for (int j = 0; j < 8; j++) acc[i][j] = 0.0f;
+    for (int i = 0; i < DP_NSUB; i++) acc[i] = dp_v8f{0, 0, 0, 0, 0, 0, 0, 0};
 
-    const __nv_bfloat16 zero = __float2bfloat16(0.0f);
+    const unsigned int num_tiles = (K + DP_K_STEP - 1) / DP_K_STEP;
 
-    for (unsigned int k_base = 0; k_base < K; k_base += DP_K_STEP) {
-        // Cooperative load: 128×16 = 2048 elems / 256 threads = 8 each.
-        #pragma unroll
-        for (unsigned int e = threadIdx.x; e < DP_M_TILE * DP_K_STEP; e += DP_THREADS) {
-            unsigned int row = e / DP_K_STEP;
-            unsigned int col = e % DP_K_STEP;
-            unsigned int gr = cta_m + row;
-            unsigned int gc = k_base + col;
-            sA[row][col] = (gr < M && gc < K)
-                ? A[(unsigned long long)gr * K + gc] : zero;
-        }
-        #pragma unroll
-        for (unsigned int e = threadIdx.x; e < DP_N_TILE * DP_K_STEP; e += DP_THREADS) {
-            unsigned int nrow = e / DP_K_STEP;
-            unsigned int kcol = e % DP_K_STEP;
-            unsigned int gn = cta_n + nrow;
-            unsigned int gk = k_base + kcol;
-            sB[nrow][kcol] = (gn < N && gk < K)
-                ? B[(unsigned long long)gn * K + gk] : zero;
-        }
-        __syncthreads();
+    __nv_bfloat16 reg_A[DP_A_EPT];
+    __nv_bfloat16 reg_B[DP_B_EPT];
+    dp_load_A_regs(A, reg_A, cta_m, 0, M, K);
+    dp_load_B_regs(B, reg_B, cta_n, 0, N, K);
+    dp_store_A_regs(smem_A[0], reg_A);
+    dp_store_B_regs(smem_B[0], reg_B);
+    __syncthreads();
 
-        #pragma unroll
-        for (unsigned int kk = 0; kk < DP_K_STEP; kk++) {
-            float a_reg[8];
-            float b_reg[8];
-            #pragma unroll
-            for (int i = 0; i < 8; i++) a_reg[i] = __bfloat162float(sA[ty * 8 + i][kk]);
-            #pragma unroll
-            for (int j = 0; j < 8; j++) b_reg[j] = __bfloat162float(sB[tx * 8 + j][kk]);
-            #pragma unroll
-            for (int i = 0; i < 8; i++)
-                #pragma unroll
-                for (int j = 0; j < 8; j++) acc[i][j] += a_reg[i] * b_reg[j];
-        }
+    for (unsigned int kt = 1; kt < num_tiles; kt++) {
+        const unsigned int k_base = kt * DP_K_STEP;
+        dp_load_A_regs(A, reg_A, cta_m, k_base, M, K);
+        dp_load_B_regs(B, reg_B, cta_n, k_base, N, K);
+        dp_wmma_compute(smem_A[(kt - 1) & 1], smem_B[(kt - 1) & 1], acc, warp_m_offset, lane_id);
+        dp_store_A_regs(smem_A[kt & 1], reg_A);
+        dp_store_B_regs(smem_B[kt & 1], reg_B);
         __syncthreads();
     }
+    dp_wmma_compute(smem_A[(num_tiles - 1) & 1], smem_B[(num_tiles - 1) & 1], acc, warp_m_offset, lane_id);
 
     #pragma unroll
-    for (int i = 0; i < 8; i++) {
-        unsigned int r = cta_m + ty * 8 + i;
-        if (r >= M) continue;
+    for (int nb = 0; nb < DP_NSUB; nb++)
         #pragma unroll
-        for (int j = 0; j < 8; j++) {
-            unsigned int c = cta_n + tx * 8 + j;
-            if (c < N) C[(unsigned long long)r * N + c] = __float2bfloat16(acc[i][j]);
+        for (int e = 0; e < 8; e++) {
+            unsigned int r = cta_m + warp_m_offset + 2 * e + (lane_id >> 4);
+            unsigned int c = cta_n + nb * 16 + (lane_id & 15);
+            if (r < M && c < N) C[(unsigned long long)r * N + c] = __float2bfloat16(acc[nb][e]);
         }
-    }
 }
 
 // Fused SiLU(gate) * up activation — vectorized 2-wide BF16 loads/stores.

--- a/kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
+++ b/kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
@@ -45,24 +45,44 @@
 //   lut_s[256] f32          = 1024 B
 //   total ~= 14464 B  (well under 64 KB).
 //
-// Grid: (~tile_count CTAs, sized by the launcher, 1, 1)  Block: (PM4_THREADS=256, 1, 1)
+// Grid: (~tile_count CTAs, sized by the launcher, 1, 1)  Block: (PM4_THREADS=512, 1, 1)
 
 #include <cuda_bf16.h>
 
 typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
 typedef float  v8f   __attribute__((ext_vector_type(8)));
-
+// ── Tile geometry ──────────────────────────────────────────────────────────
+// A CTA computes a PM4_M_TILE×PM4_N_TILE output block. The warps form a 2-D
+// (PM4_WARPS_M × PM4_WARPS_N) grid: PM4_WARPS_M warps tile the M dimension (each
+// owns 16 token rows) and PM4_WARPS_N warps tile N (each owns
+// PM4_SUBTILES_PER_WARP of the PM4_N_SUBTILES 16-wide WMMA n-sub-tiles).
+//
+// WHY 2-D (vs the GB10 1-D M-only warp grid): the GB10 geometry is 8 warps that
+// all tile M (PM4_M_TILE=128), so adding warps means growing M — wasteful here
+// because routed-expert tiles are SKINNY (top-8/256 routing -> ~47 tokens/expert
+// average, far under 128). The long-K gate/up GEMM (K=2048, ~128 K-steps) is
+// instead latency-bound and starved at 8 warps. The 2-D grid keeps the 128x64
+// tile (work-list packing UNCHANGED) but splits the PM4_N_SUBTILES n-sub-tiles
+// across PM4_WARPS_N warp-columns, so PM4_WARPS_M(=8) x PM4_WARPS_N(=2) = 16
+// warps / 512 threads hide the K-reduction latency WITHOUT enlarging the tile.
+// Measured (gfx1151, 256 experts, ~47 tok/expert): gate/up 2.25 -> 2.80 TFLOP/s
+// (+24%), down ~flat, served 35B-A3B-FP8 TTFT (1710 tok) 3.08 -> 2.87 s (~7%).
+// A 32-warp (PM4_WARPS_N=4) variant regressed gate/up (over-subscription) and
+// a smaller PM4_M_TILE=64 helped only the short-K down GEMM, so 128x64/16-warp
+// is the best single geometry for the 2x gate/up + 1x down per-layer mix.
 #define FP8_BLOCK 128
 
 #define PM4_M_TILE 128
 #define PM4_N_TILE 64
 #define PM4_K_STEP 16
 #define PM4_PAD 2
-#define PM4_WARPS 8
-#define PM4_THREADS (PM4_WARPS * 32)             // 256
-#define PM4_N_SUBTILES (PM4_N_TILE / 16)         // 4 WMMA n-sub-tiles
+#define PM4_WARPS_M (PM4_M_TILE / 16)            // warp-rows over M
+#define PM4_WARPS_N 2                            // warp-cols over N
+#define PM4_WARPS (PM4_WARPS_M * PM4_WARPS_N)
+#define PM4_THREADS (PM4_WARPS * 32)
+#define PM4_N_SUBTILES (PM4_N_TILE / 16)         // total WMMA n-sub-tiles
+#define PM4_SUBTILES_PER_WARP (PM4_N_SUBTILES / PM4_WARPS_N)
 
-// E4M3 LUT: 256-entry byte -> FP32 (SSOT with w8a16_gemm.cu / GB10 E4M3_LUT_GMOE).
 __device__ __constant__ float E4M3_LUT_GMOE[256] = {
     0.0f, 0.001953125f, 0.00390625f, 0.005859375f,
     0.0078125f, 0.009765625f, 0.01171875f, 0.013671875f,
@@ -130,10 +150,10 @@ __device__ __constant__ float E4M3_LUT_GMOE[256] = {
     -384.0f, -416.0f, -448.0f, -0.0f,
 };
 
-// Per-thread prefetch register staging. A: (128*16)/256 = 8 elems/thread.
-// B raw FP8: (16*64)/256 = 4 bytes/thread (dequant -> BF16 on commit, no scale).
-#define PM4_A_EPT 8
-#define PM4_B_EPT 4
+// Per-thread prefetch register staging.
+//   A: (M_TILE*K_STEP)/THREADS elems/thread.   B raw FP8: (K_STEP*N_TILE)/THREADS bytes/thread.
+#define PM4_A_EPT ((PM4_M_TILE * PM4_K_STEP) / PM4_THREADS)
+#define PM4_B_EPT ((PM4_K_STEP * PM4_N_TILE) / PM4_THREADS)
 
 // A prefetch: gather token rows through sorted_token_ids, contiguous K.
 __device__ __forceinline__ void load_A_regs(
@@ -146,8 +166,8 @@ __device__ __forceinline__ void load_A_regs(
     #pragma unroll
     for (unsigned int i = 0; i < PM4_A_EPT; i++) {
         unsigned int idx = threadIdx.x * PM4_A_EPT + i;
-        unsigned int row = idx / PM4_K_STEP;   // 0..127
-        unsigned int col = idx % PM4_K_STEP;   // 0..15
+        unsigned int row = idx / PM4_K_STEP;
+        unsigned int col = idx % PM4_K_STEP;
         unsigned int m_global = cta_m_local + row;
         unsigned int gc = k_base + col;
         if (m_global < M_expert && gc < K) {
@@ -184,8 +204,8 @@ __device__ __forceinline__ void load_B_regs(
     #pragma unroll
     for (unsigned int i = 0; i < PM4_B_EPT; i++) {
         unsigned int idx = threadIdx.x * PM4_B_EPT + i;
-        unsigned int k = idx / PM4_N_TILE;     // 0..K_STEP-1
-        unsigned int n = idx % PM4_N_TILE;     // 0..N_TILE-1
+        unsigned int k = idx / PM4_N_TILE;
+        unsigned int n = idx % PM4_N_TILE;
         unsigned int gk = k_base + k;
         unsigned int gn = cta_n + n;
         reg_B[i] = (gk < K && gn < N) ? B_exp[(unsigned long long)gn * K + gk] : 0;
@@ -205,22 +225,24 @@ __device__ __forceinline__ void store_B_regs(
     }
 }
 
-// WMMA over one resident K_STEP (16) into inner[PM4_N_SUBTILES] v8f accumulators.
+// WMMA over one resident K_STEP (16) into this warp's PM4_SUBTILES_PER_WARP v8f
+// accumulators. The warp owns the N-sub-tiles [n_sub_base, n_sub_base+SPW).
 __device__ __forceinline__ void mma_kstep(
     const __nv_bfloat16 smem_A[][PM4_K_STEP + PM4_PAD],
     const __nv_bfloat16 smem_B[][PM4_N_TILE + PM4_PAD],
-    v8f inner[PM4_N_SUBTILES],
-    unsigned int warp_m_offset, unsigned int lane
+    v8f inner[PM4_SUBTILES_PER_WARP],
+    unsigned int warp_m_offset, unsigned int n_sub_base, unsigned int lane
 ) {
     v16bf a;
     #pragma unroll
     for (int i = 0; i < 16; i++) a[i] = (__bf16)smem_A[warp_m_offset + (lane & 15)][i];
     #pragma unroll
-    for (int nb = 0; nb < PM4_N_SUBTILES; nb++) {
+    for (int j = 0; j < PM4_SUBTILES_PER_WARP; j++) {
+        unsigned int nb = n_sub_base + j;
         v16bf b;
         #pragma unroll
         for (int k = 0; k < 16; k++) b[k] = (__bf16)smem_B[k][nb * 16 + (lane & 15)];
-        inner[nb] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, inner[nb]);
+        inner[j] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, inner[j]);
     }
 }
 
@@ -239,7 +261,6 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
 ) {
     (void)num_experts;
 
-    // E4M3 LUT staged into shared memory (resident across the persistent loop).
     __shared__ float lut_s[256];
     #pragma unroll
     for (unsigned int i = threadIdx.x; i < 256; i += PM4_THREADS) {
@@ -253,16 +274,12 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
 
     const unsigned int warp_id = threadIdx.x / 32;
     const unsigned int lane_id = threadIdx.x % 32;
-    const unsigned int warp_m_offset = warp_id * 16;   // 8 warps x 16 = 128 M-rows
+    // 2-D warp grid: row owns 16 M-rows, col owns PM4_SUBTILES_PER_WARP n-tiles.
+    const unsigned int warp_m_offset = (warp_id / PM4_WARPS_N) * 16;
+    const unsigned int n_sub_base    = (warp_id % PM4_WARPS_N) * PM4_SUBTILES_PER_WARP;
 
     const int total = *total_tiles;
 
-    // Grid-stride over the worklist. The stride is gridDim.x (NOT a fixed
-    // #define) so the launcher can size the grid to the worklist's tile-count
-    // upper bound — covering the work in ~one pass instead of serializing many
-    // tiles per CTA. The persistent loop still handles grid < total_tiles
-    // correctly (each CTA loops), so oversubscription is safe and undersizing
-    // is merely slower, never wrong.
     for (int wid = blockIdx.x; wid < total; wid += (int)gridDim.x) {
         __syncthreads();   // fence smem reuse before re-priming the pipeline
 
@@ -278,21 +295,22 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
         const float* S_exp = (const float*)B_scale_ptrs[expert_id];
         if (B_exp == 0) continue;   // NULL -> remote expert under EP
 
-        const unsigned int cta_m_local = mt * PM4_M_TILE;   // expert-relative M base
+        const unsigned int cta_m_local = mt * PM4_M_TILE;
         const unsigned int cta_n = nt * PM4_N_TILE;
 
         // Two-level FP32 accumulation: inner over a 128-K block, fold
         // inner*block_scale into outer at the boundary; scale never per-element.
-        v8f inner_acc[PM4_N_SUBTILES];
-        v8f outer_acc[PM4_N_SUBTILES];
+        // Each warp holds only its PM4_SUBTILES_PER_WARP n-sub-tiles.
+        v8f inner_acc[PM4_SUBTILES_PER_WARP];
+        v8f outer_acc[PM4_SUBTILES_PER_WARP];
         #pragma unroll
-        for (int i = 0; i < PM4_N_SUBTILES; i++) {
+        for (int i = 0; i < PM4_SUBTILES_PER_WARP; i++) {
             inner_acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
             outer_acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
         }
 
         const unsigned int k_blocks = (K + FP8_BLOCK - 1) / FP8_BLOCK;
-        const unsigned int k_steps_per_block = FP8_BLOCK / PM4_K_STEP;       // 8
+        const unsigned int k_steps_per_block = FP8_BLOCK / PM4_K_STEP;
         const unsigned int n_block = cta_n / FP8_BLOCK;
         const unsigned int n_steps = (K + PM4_K_STEP - 1) / PM4_K_STEP;
 
@@ -307,6 +325,10 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
 
         unsigned int k_step_in_block = 0;
 
+        // Single barrier per K-step: the ping-pong double-buffer's publish
+        // barrier (e) at the end of iteration `step` already fences every warp's
+        // read of buf[step&1] in (b) before iteration step+1 overwrites that same
+        // buffer in its own (e). The separate post-compute barrier is redundant.
         for (unsigned int step = 0; step < n_steps; step++) {
             const unsigned int cur = step & 1;
 
@@ -317,7 +339,7 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
                 load_B_regs(B_exp, reg_B, cta_n, k_next, N, K);
             }
             // (b) compute the already-resident current tile
-            mma_kstep(smem_A[cur], smem_B[cur], inner_acc, warp_m_offset, lane_id);
+            mma_kstep(smem_A[cur], smem_B[cur], inner_acc, warp_m_offset, n_sub_base, lane_id);
 
             // (c) K_BLOCK boundary: fold scaled inner into outer, reset inner.
             k_step_in_block++;
@@ -325,45 +347,42 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
                 const unsigned int k_block = (step * PM4_K_STEP) / FP8_BLOCK;
                 const float scale = S_exp[n_block * k_blocks + k_block];
                 #pragma unroll
-                for (int i = 0; i < PM4_N_SUBTILES; i++) {
+                for (int i = 0; i < PM4_SUBTILES_PER_WARP; i++) {
                     outer_acc[i] += inner_acc[i] * scale;
                     inner_acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
                 }
                 k_step_in_block = 0;
             }
 
-            // (d) make sure all warps done reading smem[cur] before reuse
-            __syncthreads();
-            // (e) commit prefetched registers into the other buffer
+            // (d) commit prefetched registers into the other buffer, then publish.
             if (step + 1 < n_steps) {
                 store_A_regs(smem_A[(step + 1) & 1], reg_A);
                 store_B_regs(smem_B[(step + 1) & 1], reg_B, lut_s);
-                __syncthreads();   // publish next tile to all warps
+                __syncthreads();   // publish next tile + fence this iter's reads
             }
         }
 
-        // Fold any incomplete trailing K_BLOCK (only when K % FP8_BLOCK != 0).
         if (k_step_in_block != 0) {
             const unsigned int k_block = (K - 1) / FP8_BLOCK;
             const float scale = S_exp[n_block * k_blocks + k_block];
             #pragma unroll
-            for (int i = 0; i < PM4_N_SUBTILES; i++) {
+            for (int i = 0; i < PM4_SUBTILES_PER_WARP; i++) {
                 outer_acc[i] += inner_acc[i] * scale;
             }
         }
 
-        // Store C tile: f32 outer -> BF16, sorted output position.
+        // Store C tile: f32 outer -> BF16, sorted output position. Each warp
+        // writes only its own n-sub-tiles [n_sub_base, n_sub_base+SPW).
         #pragma unroll
-        for (int nb = 0; nb < PM4_N_SUBTILES; nb++) {
+        for (int j = 0; j < PM4_SUBTILES_PER_WARP; j++) {
+            unsigned int nb = n_sub_base + j;
             #pragma unroll
             for (int e = 0; e < 8; e++) {
-                // Expert-relative output row: include the m-tile base so the
-                // mt>=1 tiles (experts with >128 tokens) write the right rows.
                 unsigned int row_local = cta_m_local + warp_m_offset + 2 * e + (lane_id >> 4);
                 unsigned int col = cta_n + nb * 16 + (lane_id & 15);
                 if (row_local < M_expert && col < N) {
                     unsigned int out_row = (unsigned int)m_start + row_local;
-                    C[(unsigned long long)out_row * N + col] = __float2bfloat16(outer_acc[nb][e]);
+                    C[(unsigned long long)out_row * N + col] = __float2bfloat16(outer_acc[j][e]);
                 }
             }
         }

--- a/kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
+++ b/kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
@@ -1,33 +1,371 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// MoE FP8 grouped GEMM — HIP/gfx1151 COMPILE STUB.
+// Atlas FP8 Grouped MoE GEMM — HIP/gfx1151 (AMD WMMA) port of the NVIDIA
+// mma.sync grid-compaction kernel (kernels/gb10/common/moe_fp8_grouped_gemm.cu).
 //
-// The dense Qwen3.6-27B model (the gfx1151 target) does NOT dispatch any MoE
-// grouped-GEMM kernel. These entry points exist only so the kernel registry
-// links. Bodies are intentionally empty (early return, outputs left untouched);
-// signatures are byte-identical to the NVIDIA source so the registry builds.
-// If a future MoE model targets gfx1151, port the NVIDIA mma.sync bodies to
-// WMMA using the w8a16_gemm.cu / w4a16_gemm.cu idiom (the dequant + smem-tile +
-// __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32 pattern).
+//   C[M_expert, N] = A[M_expert, K] (BF16 acts) @ dequant(B_expert[N, K] (FP8 E4M3))
+//
+// THE routed-expert FP8 grouped-GEMM kernel for prefill. A persistent
+// PM5_PERSIST_CTAS=96 1D grid strides over a COMPACTED (expert, m_tile, n_tile)
+// work-list built by `moe_build_tile_worklist` (moe_permute.cu) so each
+// work-item is exactly one real (non-early-exit) tile. Tokens are pre-sorted by
+// expert (contiguous per expert); each expert's FP8 weight is loaded ONCE per
+// (m_tile, n_tile) tile and matmul'd against ALL its assigned tokens via WMMA
+// over the token (M) dimension — amortizing the LPDDR5X weight traffic.
+//
+// FP8 weight format: B[N,K] uint8 (E4M3) with block_scale[N/128, K/128] FP32.
+//   Dequant: bf16_val = E4M3_LUT[byte] (scale folded post-WMMA per 128-K block).
+//
+// NUMERICS SSOT — must match the GB10 kernel AND the moe_microtest CPU oracle:
+//   two-level FP32 accumulation — `inner` over a contiguous 128-K block, then
+//   `outer += inner * block_scale` at the block boundary; the scale is NEVER
+//   applied per-element. All f32 -> BF16 conversions use `__float2bfloat16`
+//   (round-to-nearest-even), agreeing byte-exact with the CPU load-time dequant.
+//
+// HIP/gfx1151 transforms (mirror w8a16_gemm.cu / moe_w4a16_grouped_gemm.cu):
+//   * mma.sync.m16n8k16.bf16 -> __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32
+//     (one WMMA = two NVIDIA m16n8 n-tiles; N_TILE=64 -> 4 WMMA n-sub-tiles).
+//   * cp.async -> register-prefetch ping-pong double-buffering: gfx1151 has NO
+//     cp.async / global_load_lds, so VMEM reads for tile k+1 are issued into
+//     VGPRs and stay in-flight across tile-k WMMA, then committed into the other
+//     smem buffer.
+//   * Persistent 96-CTA worklist grid kept VERBATIM (matches the Rust launcher
+//     + moe_build_tile_worklist packing: (m_tile<<6)|n_tile, M_TILE=128, N_TILE=64).
+//
+// WMMA fragment layout (validated bit-exact in w8a16_gemm.cu / moe_w4a16):
+//   A load (M x K row-major smem): lane l -> a[i] = smem_A[warp_m_offset+(l&15)][i], i=0..15
+//   B load (K x N row-major smem): lane l -> b[k] = smem_B[k][nb*16 + (l&15)], k=0..15
+//   Store: lane l, acc elem e(0..7) -> row = warp_m_offset + 2*e + (l>>4),
+//          col = nb*16 + (l&15).
+//
+// LDS budget (gfx1151 cap = 64 KB/workgroup):
+//   smem_A[2][128][18] bf16 = 2*128*18*2 = 9216 B
+//   smem_B[2][16][66]  bf16 = 2*16*66*2  = 4224 B
+//   lut_s[256] f32          = 1024 B
+//   total ~= 14464 B  (well under 64 KB).
+//
+// Grid: (PM5_PERSIST_CTAS=96, 1, 1)  Block: (PM4_THREADS=256, 1, 1)
 
 #include <cuda_bf16.h>
 
-extern "C" __global__ void moe_fp8_grouped_gemm(
-    const __nv_bfloat16* __restrict__ A,                   // [total_tokens, K] BF16
-    const unsigned long long* __restrict__ B_weight_ptrs,   // [num_experts] → [N, K] FP8
-    const unsigned long long* __restrict__ B_scale_ptrs,    // [num_experts] → [N/128, K/128] BF16
-    __nv_bfloat16* __restrict__ C,                         // [total_expanded, N] BF16
-    const int* __restrict__ expert_offsets,                 // [num_experts + 1]
-    const int* __restrict__ sorted_token_ids,              // [total_expanded]
-    unsigned int num_experts,
-    unsigned int N,
-    unsigned int K
+typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
+typedef float  v8f   __attribute__((ext_vector_type(8)));
+
+#define FP8_BLOCK 128
+
+#define PM4_M_TILE 128
+#define PM4_N_TILE 64
+#define PM4_K_STEP 16
+#define PM4_PAD 2
+#define PM4_WARPS 8
+#define PM4_THREADS (PM4_WARPS * 32)             // 256
+#define PM4_N_SUBTILES (PM4_N_TILE / 16)         // 4 WMMA n-sub-tiles
+#define PM5_PERSIST_CTAS 96                       // SSOT — mirrored in ops::moe_fp8_grouped_gemm
+
+// E4M3 LUT: 256-entry byte -> FP32 (SSOT with w8a16_gemm.cu / GB10 E4M3_LUT_GMOE).
+__device__ __constant__ float E4M3_LUT_GMOE[256] = {
+    0.0f, 0.001953125f, 0.00390625f, 0.005859375f,
+    0.0078125f, 0.009765625f, 0.01171875f, 0.013671875f,
+    0.015625f, 0.017578125f, 0.01953125f, 0.021484375f,
+    0.0234375f, 0.025390625f, 0.02734375f, 0.029296875f,
+    0.03125f, 0.03515625f, 0.0390625f, 0.04296875f,
+    0.046875f, 0.05078125f, 0.0546875f, 0.05859375f,
+    0.0625f, 0.0703125f, 0.078125f, 0.0859375f,
+    0.09375f, 0.1015625f, 0.109375f, 0.1171875f,
+    0.125f, 0.140625f, 0.15625f, 0.171875f,
+    0.1875f, 0.203125f, 0.21875f, 0.234375f,
+    0.25f, 0.28125f, 0.3125f, 0.34375f,
+    0.375f, 0.40625f, 0.4375f, 0.46875f,
+    0.5f, 0.5625f, 0.625f, 0.6875f,
+    0.75f, 0.8125f, 0.875f, 0.9375f,
+    1.0f, 1.125f, 1.25f, 1.375f,
+    1.5f, 1.625f, 1.75f, 1.875f,
+    2.0f, 2.25f, 2.5f, 2.75f,
+    3.0f, 3.25f, 3.5f, 3.75f,
+    4.0f, 4.5f, 5.0f, 5.5f,
+    6.0f, 6.5f, 7.0f, 7.5f,
+    8.0f, 9.0f, 10.0f, 11.0f,
+    12.0f, 13.0f, 14.0f, 15.0f,
+    16.0f, 18.0f, 20.0f, 22.0f,
+    24.0f, 26.0f, 28.0f, 30.0f,
+    32.0f, 36.0f, 40.0f, 44.0f,
+    48.0f, 52.0f, 56.0f, 60.0f,
+    64.0f, 72.0f, 80.0f, 88.0f,
+    96.0f, 104.0f, 112.0f, 120.0f,
+    128.0f, 144.0f, 160.0f, 176.0f,
+    192.0f, 208.0f, 224.0f, 240.0f,
+    256.0f, 288.0f, 320.0f, 352.0f,
+    384.0f, 416.0f, 448.0f, 0.0f,
+    -0.0f, -0.001953125f, -0.00390625f, -0.005859375f,
+    -0.0078125f, -0.009765625f, -0.01171875f, -0.013671875f,
+    -0.015625f, -0.017578125f, -0.01953125f, -0.021484375f,
+    -0.0234375f, -0.025390625f, -0.02734375f, -0.029296875f,
+    -0.03125f, -0.03515625f, -0.0390625f, -0.04296875f,
+    -0.046875f, -0.05078125f, -0.0546875f, -0.05859375f,
+    -0.0625f, -0.0703125f, -0.078125f, -0.0859375f,
+    -0.09375f, -0.1015625f, -0.109375f, -0.1171875f,
+    -0.125f, -0.140625f, -0.15625f, -0.171875f,
+    -0.1875f, -0.203125f, -0.21875f, -0.234375f,
+    -0.25f, -0.28125f, -0.3125f, -0.34375f,
+    -0.375f, -0.40625f, -0.4375f, -0.46875f,
+    -0.5f, -0.5625f, -0.625f, -0.6875f,
+    -0.75f, -0.8125f, -0.875f, -0.9375f,
+    -1.0f, -1.125f, -1.25f, -1.375f,
+    -1.5f, -1.625f, -1.75f, -1.875f,
+    -2.0f, -2.25f, -2.5f, -2.75f,
+    -3.0f, -3.25f, -3.5f, -3.75f,
+    -4.0f, -4.5f, -5.0f, -5.5f,
+    -6.0f, -6.5f, -7.0f, -7.5f,
+    -8.0f, -9.0f, -10.0f, -11.0f,
+    -12.0f, -13.0f, -14.0f, -15.0f,
+    -16.0f, -18.0f, -20.0f, -22.0f,
+    -24.0f, -26.0f, -28.0f, -30.0f,
+    -32.0f, -36.0f, -40.0f, -44.0f,
+    -48.0f, -52.0f, -56.0f, -60.0f,
+    -64.0f, -72.0f, -80.0f, -88.0f,
+    -96.0f, -104.0f, -112.0f, -120.0f,
+    -128.0f, -144.0f, -160.0f, -176.0f,
+    -192.0f, -208.0f, -224.0f, -240.0f,
+    -256.0f, -288.0f, -320.0f, -352.0f,
+    -384.0f, -416.0f, -448.0f, -0.0f,
+};
+
+// Per-thread prefetch register staging. A: (128*16)/256 = 8 elems/thread.
+// B raw FP8: (16*64)/256 = 4 bytes/thread (dequant -> BF16 on commit, no scale).
+#define PM4_A_EPT 8
+#define PM4_B_EPT 4
+
+// A prefetch: gather token rows through sorted_token_ids, contiguous K.
+__device__ __forceinline__ void load_A_regs(
+    const __nv_bfloat16* __restrict__ A,
+    const int* __restrict__ sorted_token_ids,
+    __nv_bfloat16 reg_A[PM4_A_EPT],
+    int m_start, unsigned int cta_m_local, unsigned int k_base,
+    unsigned int M_expert, unsigned int K
 ) {
-    // Compile stub: not dispatched by the dense model. No-op.
-    (void)A; (void)B_weight_ptrs; (void)B_scale_ptrs; (void)C;
-    (void)expert_offsets; (void)sorted_token_ids; (void)num_experts; (void)N; (void)K;
+    #pragma unroll
+    for (unsigned int i = 0; i < PM4_A_EPT; i++) {
+        unsigned int idx = threadIdx.x * PM4_A_EPT + i;
+        unsigned int row = idx / PM4_K_STEP;   // 0..127
+        unsigned int col = idx % PM4_K_STEP;   // 0..15
+        unsigned int m_global = cta_m_local + row;
+        unsigned int gc = k_base + col;
+        if (m_global < M_expert && gc < K) {
+            int sorted_idx = m_start + (int)m_global;
+            int token_id = sorted_token_ids ? sorted_token_ids[sorted_idx] : sorted_idx;
+            reg_A[i] = A[(unsigned long long)token_id * K + gc];
+        } else {
+            reg_A[i] = __float2bfloat16(0.0f);
+        }
+    }
 }
 
+__device__ __forceinline__ void store_A_regs(
+    __nv_bfloat16 smem_A[][PM4_K_STEP + PM4_PAD], const __nv_bfloat16 reg_A[PM4_A_EPT]
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < PM4_A_EPT; i++) {
+        unsigned int idx = threadIdx.x * PM4_A_EPT + i;
+        unsigned int row = idx / PM4_K_STEP;
+        unsigned int col = idx % PM4_K_STEP;
+        smem_A[row][col] = reg_A[i];
+    }
+}
+
+// B prefetch: load raw FP8 bytes for the [K_STEP, N_TILE] tile into regs.
+// Layout consumed: smem_B[k][n]. The E4M3 LUT dequant (NO scale — folded
+// post-WMMA per 128-K block) happens on commit.
+__device__ __forceinline__ void load_B_regs(
+    const unsigned char* __restrict__ B_exp,
+    unsigned char reg_B[PM4_B_EPT],
+    unsigned int cta_n, unsigned int k_base,
+    unsigned int N, unsigned int K
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < PM4_B_EPT; i++) {
+        unsigned int idx = threadIdx.x * PM4_B_EPT + i;
+        unsigned int k = idx / PM4_N_TILE;     // 0..K_STEP-1
+        unsigned int n = idx % PM4_N_TILE;     // 0..N_TILE-1
+        unsigned int gk = k_base + k;
+        unsigned int gn = cta_n + n;
+        reg_B[i] = (gk < K && gn < N) ? B_exp[(unsigned long long)gn * K + gk] : 0;
+    }
+}
+
+__device__ __forceinline__ void store_B_regs(
+    __nv_bfloat16 smem_B[][PM4_N_TILE + PM4_PAD],
+    const unsigned char reg_B[PM4_B_EPT], const float* lut_s
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < PM4_B_EPT; i++) {
+        unsigned int idx = threadIdx.x * PM4_B_EPT + i;
+        unsigned int k = idx / PM4_N_TILE;
+        unsigned int n = idx % PM4_N_TILE;
+        smem_B[k][n] = __float2bfloat16(lut_s[reg_B[i]]);   // dequant, NO scale
+    }
+}
+
+// WMMA over one resident K_STEP (16) into inner[PM4_N_SUBTILES] v8f accumulators.
+__device__ __forceinline__ void mma_kstep(
+    const __nv_bfloat16 smem_A[][PM4_K_STEP + PM4_PAD],
+    const __nv_bfloat16 smem_B[][PM4_N_TILE + PM4_PAD],
+    v8f inner[PM4_N_SUBTILES],
+    unsigned int warp_m_offset, unsigned int lane
+) {
+    v16bf a;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) a[i] = (__bf16)smem_A[warp_m_offset + (lane & 15)][i];
+    #pragma unroll
+    for (int nb = 0; nb < PM4_N_SUBTILES; nb++) {
+        v16bf b;
+        #pragma unroll
+        for (int k = 0; k < 16; k++) b[k] = (__bf16)smem_B[k][nb * 16 + (lane & 15)];
+        inner[nb] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, inner[nb]);
+    }
+}
+
+extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gemm(
+    const __nv_bfloat16* __restrict__ A,                    // [total_tokens, K] BF16
+    const unsigned long long* __restrict__ B_weight_ptrs,    // [num_experts] -> [N, K] FP8
+    const unsigned long long* __restrict__ B_scale_ptrs,     // [num_experts] -> [N/128, K/128] FP32
+    __nv_bfloat16* __restrict__ C,                          // [total_expanded, N] BF16
+    const int* __restrict__ expert_offsets,                  // [num_experts + 1]
+    const int* __restrict__ sorted_token_ids,               // [total_expanded] or NULL
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K,
+    const unsigned int* __restrict__ worklist,               // [*total_tiles * 2] (expert, packed m/n)
+    const int* __restrict__ total_tiles                      // [1] (read-after-write on same stream)
+) {
+    (void)num_experts;
+
+    // E4M3 LUT staged into shared memory (resident across the persistent loop).
+    __shared__ float lut_s[256];
+    #pragma unroll
+    for (unsigned int i = threadIdx.x; i < 256; i += PM4_THREADS) {
+        lut_s[i] = E4M3_LUT_GMOE[i];
+    }
+
+    // Double-buffered (ping-pong) smem — overlaps tile-(k+1) global loads
+    // (staged in VGPRs) with tile-k WMMA. Shared across all work-items.
+    __shared__ __nv_bfloat16 smem_A[2][PM4_M_TILE][PM4_K_STEP + PM4_PAD];
+    __shared__ __nv_bfloat16 smem_B[2][PM4_K_STEP][PM4_N_TILE + PM4_PAD];
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;   // 8 warps x 16 = 128 M-rows
+
+    const int total = *total_tiles;
+
+    for (int wid = blockIdx.x; wid < total; wid += PM5_PERSIST_CTAS) {
+        __syncthreads();   // fence smem reuse before re-priming the pipeline
+
+        unsigned int expert_id = worklist[wid * 2 + 0];
+        unsigned int packed    = worklist[wid * 2 + 1];
+        unsigned int mt = packed >> 6;
+        unsigned int nt = packed & 0x3F;
+
+        const int m_start = expert_offsets[expert_id];
+        const unsigned int M_expert = (unsigned int)(expert_offsets[expert_id + 1] - m_start);
+
+        const unsigned char* B_exp = (const unsigned char*)B_weight_ptrs[expert_id];
+        const float* S_exp = (const float*)B_scale_ptrs[expert_id];
+        if (B_exp == 0) continue;   // NULL -> remote expert under EP
+
+        const unsigned int cta_m_local = mt * PM4_M_TILE;   // expert-relative M base
+        const unsigned int cta_n = nt * PM4_N_TILE;
+
+        // Two-level FP32 accumulation: inner over a 128-K block, fold
+        // inner*block_scale into outer at the boundary; scale never per-element.
+        v8f inner_acc[PM4_N_SUBTILES];
+        v8f outer_acc[PM4_N_SUBTILES];
+        #pragma unroll
+        for (int i = 0; i < PM4_N_SUBTILES; i++) {
+            inner_acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+            outer_acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+        }
+
+        const unsigned int k_blocks = (K + FP8_BLOCK - 1) / FP8_BLOCK;
+        const unsigned int k_steps_per_block = FP8_BLOCK / PM4_K_STEP;       // 8
+        const unsigned int n_block = cta_n / FP8_BLOCK;
+        const unsigned int n_steps = (K + PM4_K_STEP - 1) / PM4_K_STEP;
+
+        // Prologue: stage tile 0 (global -> regs -> smem[0]).
+        __nv_bfloat16 reg_A[PM4_A_EPT];
+        unsigned char reg_B[PM4_B_EPT];
+        load_A_regs(A, sorted_token_ids, reg_A, m_start, cta_m_local, 0, M_expert, K);
+        load_B_regs(B_exp, reg_B, cta_n, 0, N, K);
+        store_A_regs(smem_A[0], reg_A);
+        store_B_regs(smem_B[0], reg_B, lut_s);
+        __syncthreads();
+
+        unsigned int k_step_in_block = 0;
+
+        for (unsigned int step = 0; step < n_steps; step++) {
+            const unsigned int cur = step & 1;
+
+            // (a) issue global reads for the next tile into registers (no wait)
+            if (step + 1 < n_steps) {
+                unsigned int k_next = (step + 1) * PM4_K_STEP;
+                load_A_regs(A, sorted_token_ids, reg_A, m_start, cta_m_local, k_next, M_expert, K);
+                load_B_regs(B_exp, reg_B, cta_n, k_next, N, K);
+            }
+            // (b) compute the already-resident current tile
+            mma_kstep(smem_A[cur], smem_B[cur], inner_acc, warp_m_offset, lane_id);
+
+            // (c) K_BLOCK boundary: fold scaled inner into outer, reset inner.
+            k_step_in_block++;
+            if (k_step_in_block == k_steps_per_block) {
+                const unsigned int k_block = (step * PM4_K_STEP) / FP8_BLOCK;
+                const float scale = S_exp[n_block * k_blocks + k_block];
+                #pragma unroll
+                for (int i = 0; i < PM4_N_SUBTILES; i++) {
+                    outer_acc[i] += inner_acc[i] * scale;
+                    inner_acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+                }
+                k_step_in_block = 0;
+            }
+
+            // (d) make sure all warps done reading smem[cur] before reuse
+            __syncthreads();
+            // (e) commit prefetched registers into the other buffer
+            if (step + 1 < n_steps) {
+                store_A_regs(smem_A[(step + 1) & 1], reg_A);
+                store_B_regs(smem_B[(step + 1) & 1], reg_B, lut_s);
+                __syncthreads();   // publish next tile to all warps
+            }
+        }
+
+        // Fold any incomplete trailing K_BLOCK (only when K % FP8_BLOCK != 0).
+        if (k_step_in_block != 0) {
+            const unsigned int k_block = (K - 1) / FP8_BLOCK;
+            const float scale = S_exp[n_block * k_blocks + k_block];
+            #pragma unroll
+            for (int i = 0; i < PM4_N_SUBTILES; i++) {
+                outer_acc[i] += inner_acc[i] * scale;
+            }
+        }
+
+        // Store C tile: f32 outer -> BF16, sorted output position.
+        #pragma unroll
+        for (int nb = 0; nb < PM4_N_SUBTILES; nb++) {
+            #pragma unroll
+            for (int e = 0; e < 8; e++) {
+                // Expert-relative output row: include the m-tile base so the
+                // mt>=1 tiles (experts with >128 tokens) write the right rows.
+                unsigned int row_local = cta_m_local + warp_m_offset + 2 * e + (lane_id >> 4);
+                unsigned int col = cta_n + nb * 16 + (lane_id & 15);
+                if (row_local < M_expert && col < N) {
+                    unsigned int out_row = (unsigned int)m_start + row_local;
+                    C[(unsigned long long)out_row * N + col] = __float2bfloat16(outer_acc[nb][e]);
+                }
+            }
+        }
+    }
+}
+
+// Compile-compat second entry (v2) — no-op alias kept so the registry links the
+// byte-identical NVIDIA-source signature. The dense model never dispatches it.
 extern "C" __global__ void moe_fp8_grouped_gemm_v2(
     const __nv_bfloat16* __restrict__ A,
     const unsigned long long* __restrict__ B_weight_ptrs,
@@ -39,7 +377,6 @@ extern "C" __global__ void moe_fp8_grouped_gemm_v2(
     unsigned int N,
     unsigned int K
 ) {
-    // Compile stub: not dispatched by the dense model. No-op.
     (void)A; (void)B_weight_ptrs; (void)B_scale_ptrs; (void)C;
     (void)expert_offsets; (void)sorted_token_ids; (void)num_experts; (void)N; (void)K;
 }

--- a/kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
+++ b/kernels/strix-hip/common/moe_fp8_grouped_gemm.cu
@@ -6,7 +6,7 @@
 //   C[M_expert, N] = A[M_expert, K] (BF16 acts) @ dequant(B_expert[N, K] (FP8 E4M3))
 //
 // THE routed-expert FP8 grouped-GEMM kernel for prefill. A persistent
-// PM5_PERSIST_CTAS=96 1D grid strides over a COMPACTED (expert, m_tile, n_tile)
+// A grid-strided (stride = gridDim.x) launch over a COMPACTED (expert, m_tile, n_tile)
 // work-list built by `moe_build_tile_worklist` (moe_permute.cu) so each
 // work-item is exactly one real (non-early-exit) tile. Tokens are pre-sorted by
 // expert (contiguous per expert); each expert's FP8 weight is loaded ONCE per
@@ -29,7 +29,8 @@
 //     cp.async / global_load_lds, so VMEM reads for tile k+1 are issued into
 //     VGPRs and stay in-flight across tile-k WMMA, then committed into the other
 //     smem buffer.
-//   * Persistent 96-CTA worklist grid kept VERBATIM (matches the Rust launcher
+//   * Grid-strided worklist launch (stride gridDim.x); the launcher sizes the
+//     grid to the work-list tile-count bound (matches the Rust launcher
 //     + moe_build_tile_worklist packing: (m_tile<<6)|n_tile, M_TILE=128, N_TILE=64).
 //
 // WMMA fragment layout (validated bit-exact in w8a16_gemm.cu / moe_w4a16):
@@ -44,7 +45,7 @@
 //   lut_s[256] f32          = 1024 B
 //   total ~= 14464 B  (well under 64 KB).
 //
-// Grid: (PM5_PERSIST_CTAS=96, 1, 1)  Block: (PM4_THREADS=256, 1, 1)
+// Grid: (~tile_count CTAs, sized by the launcher, 1, 1)  Block: (PM4_THREADS=256, 1, 1)
 
 #include <cuda_bf16.h>
 
@@ -60,7 +61,6 @@ typedef float  v8f   __attribute__((ext_vector_type(8)));
 #define PM4_WARPS 8
 #define PM4_THREADS (PM4_WARPS * 32)             // 256
 #define PM4_N_SUBTILES (PM4_N_TILE / 16)         // 4 WMMA n-sub-tiles
-#define PM5_PERSIST_CTAS 96                       // SSOT — mirrored in ops::moe_fp8_grouped_gemm
 
 // E4M3 LUT: 256-entry byte -> FP32 (SSOT with w8a16_gemm.cu / GB10 E4M3_LUT_GMOE).
 __device__ __constant__ float E4M3_LUT_GMOE[256] = {
@@ -257,7 +257,13 @@ extern "C" __global__ void __launch_bounds__(PM4_THREADS, 2) moe_fp8_grouped_gem
 
     const int total = *total_tiles;
 
-    for (int wid = blockIdx.x; wid < total; wid += PM5_PERSIST_CTAS) {
+    // Grid-stride over the worklist. The stride is gridDim.x (NOT a fixed
+    // #define) so the launcher can size the grid to the worklist's tile-count
+    // upper bound — covering the work in ~one pass instead of serializing many
+    // tiles per CTA. The persistent loop still handles grid < total_tiles
+    // correctly (each CTA loops), so oversubscription is safe and undersizing
+    // is merely slower, never wrong.
+    for (int wid = blockIdx.x; wid < total; wid += (int)gridDim.x) {
         __syncthreads();   // fence smem reuse before re-priming the pipeline
 
         unsigned int expert_id = worklist[wid * 2 + 0];

--- a/kernels/strix-hip/common/w8a16_gemm.cu
+++ b/kernels/strix-hip/common/w8a16_gemm.cu
@@ -22,11 +22,19 @@
 typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
 typedef float  v8f   __attribute__((ext_vector_type(8)));
 
-#define M_TILE 64
-#define N_TILE 64
+// Tile geometry. A CTA computes a M_TILE×N_TILE output block with a
+// THREADS-thread workgroup (THREADS/32 warps, each owning 16 M-rows).
+// 256×128 / 512-thread (16-warp) tile: large M reuse + 8 WMMA n-sub-tiles per
+// loaded A row gives the best gfx1151 occupancy/intensity for prefill GEMM.
+#define M_TILE 256
+#define N_TILE 128
 #define K_STEP 16
 #define PAD 2
 #define FP8_BLOCK 128
+#define THREADS 512
+#define N_SUBTILES (N_TILE / 16)        // 8 WMMA 16×16 n-sub-tiles
+#define A_ELEMS_PER_THREAD ((M_TILE * K_STEP) / THREADS)  // 8
+#define B_ELEMS_PER_THREAD ((K_STEP * N_TILE) / THREADS)  // 4
 
 // E4M3 lookup table: 256-entry byte → FP32 value.
 // Copied from w8a16_gemv.cu (SSOT: same LUT used for both GEMV and GEMM).
@@ -100,18 +108,18 @@ __device__ __constant__ float E4M3_LUT[256] = {
 };
 
 // WMMA compute — operates on already-loaded smem_A/smem_B BF16 tiles.
-// acc[4] holds 4 WMMA n-sub-tiles (4 × 16 = 64 N).
+// acc[N_SUBTILES] holds the WMMA n-sub-tiles (N_SUBTILES × 16 = N_TILE).
 __device__ __forceinline__ void w8a16_wmma_compute(
     __nv_bfloat16 smem_A[][K_STEP + PAD],
     __nv_bfloat16 smem_B[][N_TILE + PAD],
-    v8f acc[4],
+    v8f acc[N_SUBTILES],
     unsigned int warp_m_offset, unsigned int lane
 ) {
     v16bf a;
     #pragma unroll
     for (int i = 0; i < 16; i++) a[i] = (__bf16)smem_A[warp_m_offset + (lane & 15)][i];
     #pragma unroll
-    for (int nb = 0; nb < 4; nb++) {
+    for (int nb = 0; nb < N_SUBTILES; nb++) {
         v16bf b;
         #pragma unroll
         for (int k = 0; k < 16; k++) b[k] = (__bf16)smem_B[k][nb * 16 + (lane & 15)];
@@ -120,12 +128,12 @@ __device__ __forceinline__ void w8a16_wmma_compute(
 }
 
 __device__ __forceinline__ void w8a16_wmma_store(
-    __nv_bfloat16* __restrict__ C, v8f acc[4],
+    __nv_bfloat16* __restrict__ C, v8f acc[N_SUBTILES],
     unsigned int cta_m, unsigned int cta_n, unsigned int warp_m_offset,
     unsigned int lane, unsigned int M, unsigned int N
 ) {
     #pragma unroll
-    for (int nb = 0; nb < 4; nb++) {
+    for (int nb = 0; nb < N_SUBTILES; nb++) {
         #pragma unroll
         for (int e = 0; e < 8; e++) {
             unsigned int row = cta_m + warp_m_offset + 2 * e + (lane >> 4);
@@ -145,22 +153,21 @@ __device__ __forceinline__ void w8a16_wmma_store(
 // then commit those registers into the *other* smem buffer.
 //
 // LDS budget (gfx1151 cap = 64 KB/workgroup):
-//   smem_A[2][64][18] bf16 = 2 * 64 * 18 * 2 = 4608 B
-//   smem_B[2][16][66] bf16 = 2 * 16 * 66 * 2 = 4224 B
-//   total = 8832 B  (well under 64 KB; both operands double-buffered).
+//   smem_A[2][256][18] bf16 = 2 * 256 * 18 * 2 = 18432 B
+//   smem_B[2][16][130] bf16 = 2 * 16 * 130 * 2 =  8320 B
+//   total = 26752 B  (well under 64 KB; both operands double-buffered).
 //
-// Per-thread prefetch registers: each of the 128 threads stages 8 A elements
-// and 8 dequantized B elements per K-tile (matches the original
-// elems_per_thread for A and the 8-wide B dequant loop).
+// Per-thread prefetch registers: each of the THREADS=512 threads stages
+// A_ELEMS_PER_THREAD (8) A elements and B_ELEMS_PER_THREAD (4) dequantized B
+// elements per K-tile, covering the full M_TILE×K_STEP and K_STEP×N_TILE tiles.
 __device__ __forceinline__ void w8a16_load_A_regs(
     const __nv_bfloat16* __restrict__ A,
-    __nv_bfloat16 reg_A[8],
+    __nv_bfloat16 reg_A[A_ELEMS_PER_THREAD],
     unsigned int cta_m, unsigned int k_base, unsigned int M, unsigned int K
 ) {
-    // elems_per_thread = (M_TILE * K_STEP) / 128 = 8
     #pragma unroll
-    for (unsigned int i = 0; i < 8; i++) {
-        unsigned int idx = threadIdx.x * 8 + i;
+    for (unsigned int i = 0; i < A_ELEMS_PER_THREAD; i++) {
+        unsigned int idx = threadIdx.x * A_ELEMS_PER_THREAD + i;
         unsigned int row = idx / K_STEP;
         unsigned int col = idx % K_STEP;
         unsigned int gr = cta_m + row;
@@ -172,13 +179,13 @@ __device__ __forceinline__ void w8a16_load_A_regs(
 __device__ __forceinline__ void w8a16_load_B_regs(
     const unsigned char* __restrict__ B,
     const float* __restrict__ block_scale,
-    __nv_bfloat16 reg_B[8],
+    __nv_bfloat16 reg_B[B_ELEMS_PER_THREAD],
     unsigned int cta_n, unsigned int k_base,
     unsigned int N, unsigned int K, unsigned int k_blocks
 ) {
     #pragma unroll
-    for (unsigned int i = 0; i < 8; i++) {
-        unsigned int idx = threadIdx.x * 8 + i;
+    for (unsigned int i = 0; i < B_ELEMS_PER_THREAD; i++) {
+        unsigned int idx = threadIdx.x * B_ELEMS_PER_THREAD + i;
         unsigned int k = idx / N_TILE;
         unsigned int n = idx % N_TILE;
         unsigned int gk = k_base + k;
@@ -197,11 +204,11 @@ __device__ __forceinline__ void w8a16_load_B_regs(
 }
 
 __device__ __forceinline__ void w8a16_store_A_regs(
-    __nv_bfloat16 smem_A[][K_STEP + PAD], const __nv_bfloat16 reg_A[8]
+    __nv_bfloat16 smem_A[][K_STEP + PAD], const __nv_bfloat16 reg_A[A_ELEMS_PER_THREAD]
 ) {
     #pragma unroll
-    for (unsigned int i = 0; i < 8; i++) {
-        unsigned int idx = threadIdx.x * 8 + i;
+    for (unsigned int i = 0; i < A_ELEMS_PER_THREAD; i++) {
+        unsigned int idx = threadIdx.x * A_ELEMS_PER_THREAD + i;
         unsigned int row = idx / K_STEP;
         unsigned int col = idx % K_STEP;
         smem_A[row][col] = reg_A[i];
@@ -209,11 +216,11 @@ __device__ __forceinline__ void w8a16_store_A_regs(
 }
 
 __device__ __forceinline__ void w8a16_store_B_regs(
-    __nv_bfloat16 smem_B[][N_TILE + PAD], const __nv_bfloat16 reg_B[8]
+    __nv_bfloat16 smem_B[][N_TILE + PAD], const __nv_bfloat16 reg_B[B_ELEMS_PER_THREAD]
 ) {
     #pragma unroll
-    for (unsigned int i = 0; i < 8; i++) {
-        unsigned int idx = threadIdx.x * 8 + i;
+    for (unsigned int i = 0; i < B_ELEMS_PER_THREAD; i++) {
+        unsigned int idx = threadIdx.x * B_ELEMS_PER_THREAD + i;
         unsigned int k = idx / N_TILE;
         unsigned int n = idx % N_TILE;
         smem_B[k][n] = reg_B[i];
@@ -240,16 +247,16 @@ extern "C" __global__ void w8a16_gemm(
     __shared__ __nv_bfloat16 smem_A[2][M_TILE][K_STEP + PAD];
     __shared__ __nv_bfloat16 smem_B[2][K_STEP][N_TILE + PAD];
 
-    v8f acc[4];
+    v8f acc[N_SUBTILES];
     #pragma unroll
-    for (int i = 0; i < 4; i++) acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+    for (int i = 0; i < N_SUBTILES; i++) acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
 
     const unsigned int k_blocks = K / FP8_BLOCK;
     const unsigned int num_tiles = (K + K_STEP - 1) / K_STEP;
 
     // ── Prologue: load tile 0 (global → regs → smem[0]) ──
-    __nv_bfloat16 reg_A[8];
-    __nv_bfloat16 reg_B[8];
+    __nv_bfloat16 reg_A[A_ELEMS_PER_THREAD];
+    __nv_bfloat16 reg_B[B_ELEMS_PER_THREAD];
     w8a16_load_A_regs(A, reg_A, cta_m, 0, M, K);
     w8a16_load_B_regs(B, block_scale, reg_B, cta_n, 0, N, K, k_blocks);
     w8a16_store_A_regs(smem_A[0], reg_A);
@@ -257,6 +264,12 @@ extern "C" __global__ void w8a16_gemm(
     __syncthreads();
 
     // ── Steady state: prefetch tile k into regs while computing tile k-1 ──
+    //
+    // Single barrier per K-step: the ping-pong double-buffer makes a
+    // post-compute barrier redundant. The publish barrier below, executed at
+    // the end of iteration kt-1, already guarantees every warp finished reading
+    // buf[(kt-1)&1] before iteration kt overwrites the *other* buffer buf[kt&1]
+    // (whose previous reader was kt-1's compute, fenced by that same barrier).
     for (unsigned int kt = 1; kt < num_tiles; kt++) {
         const unsigned int k_base = kt * K_STEP;
         // (a) issue global reads for tile kt into registers (no wait)
@@ -264,12 +277,11 @@ extern "C" __global__ void w8a16_gemm(
         w8a16_load_B_regs(B, block_scale, reg_B, cta_n, k_base, N, K, k_blocks);
         // (b) compute the already-resident previous tile
         w8a16_wmma_compute(smem_A[(kt - 1) & 1], smem_B[(kt - 1) & 1], acc, warp_m_offset, lane_id);
-        // (c) make sure all warps are done reading smem[(kt-1)&1] before reuse
-        __syncthreads();
-        // (d) commit prefetched registers into the other buffer
+        // (c) commit prefetched registers into the other buffer
         w8a16_store_A_regs(smem_A[kt & 1], reg_A);
         w8a16_store_B_regs(smem_B[kt & 1], reg_B);
-        // (e) publish smem[kt&1] to all warps
+        // (d) publish smem[kt&1] (also fences this iter's compute-read of the
+        //     buffer the *next* iteration will overwrite)
         __syncthreads();
     }
 

--- a/kernels/strix-hip/common/w8a16_gemm.cu
+++ b/kernels/strix-hip/common/w8a16_gemm.cu
@@ -136,6 +136,90 @@ __device__ __forceinline__ void w8a16_wmma_store(
 }
 
 /// W8A16 GEMM: B[N, K] row-major FP8 E4M3 with 2D block scales.
+//
+// Register-prefetch software pipelining (double-buffered, ping-pong smem).
+// gfx1151 has NO cp.async / global_load_lds (target feature
+// `vmem-to-lds-load-insts` is absent), so the only way to overlap global
+// loads with WMMA compute is to issue the VMEM reads for tile k+1 into VGPRs
+// (reg_A / reg_B below), let them stay in-flight across the WMMA of tile k,
+// then commit those registers into the *other* smem buffer.
+//
+// LDS budget (gfx1151 cap = 64 KB/workgroup):
+//   smem_A[2][64][18] bf16 = 2 * 64 * 18 * 2 = 4608 B
+//   smem_B[2][16][66] bf16 = 2 * 16 * 66 * 2 = 4224 B
+//   total = 8832 B  (well under 64 KB; both operands double-buffered).
+//
+// Per-thread prefetch registers: each of the 128 threads stages 8 A elements
+// and 8 dequantized B elements per K-tile (matches the original
+// elems_per_thread for A and the 8-wide B dequant loop).
+__device__ __forceinline__ void w8a16_load_A_regs(
+    const __nv_bfloat16* __restrict__ A,
+    __nv_bfloat16 reg_A[8],
+    unsigned int cta_m, unsigned int k_base, unsigned int M, unsigned int K
+) {
+    // elems_per_thread = (M_TILE * K_STEP) / 128 = 8
+    #pragma unroll
+    for (unsigned int i = 0; i < 8; i++) {
+        unsigned int idx = threadIdx.x * 8 + i;
+        unsigned int row = idx / K_STEP;
+        unsigned int col = idx % K_STEP;
+        unsigned int gr = cta_m + row;
+        unsigned int gc = k_base + col;
+        reg_A[i] = (gr < M && gc < K) ? A[gr * K + gc] : __float2bfloat16(0.0f);
+    }
+}
+
+__device__ __forceinline__ void w8a16_load_B_regs(
+    const unsigned char* __restrict__ B,
+    const float* __restrict__ block_scale,
+    __nv_bfloat16 reg_B[8],
+    unsigned int cta_n, unsigned int k_base,
+    unsigned int N, unsigned int K, unsigned int k_blocks
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < 8; i++) {
+        unsigned int idx = threadIdx.x * 8 + i;
+        unsigned int k = idx / N_TILE;
+        unsigned int n = idx % N_TILE;
+        unsigned int gk = k_base + k;
+        unsigned int gn = cta_n + n;
+        if (gk < K && gn < N) {
+            unsigned char weight_byte = B[(unsigned long long)gn * K + gk];
+            unsigned int n_block = gn / FP8_BLOCK;
+            unsigned int k_block = gk / FP8_BLOCK;
+            float scale = block_scale[n_block * k_blocks + k_block];
+            float dequant_val = E4M3_LUT[weight_byte] * scale;
+            reg_B[i] = __float2bfloat16(dequant_val);
+        } else {
+            reg_B[i] = __float2bfloat16(0.0f);
+        }
+    }
+}
+
+__device__ __forceinline__ void w8a16_store_A_regs(
+    __nv_bfloat16 smem_A[][K_STEP + PAD], const __nv_bfloat16 reg_A[8]
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < 8; i++) {
+        unsigned int idx = threadIdx.x * 8 + i;
+        unsigned int row = idx / K_STEP;
+        unsigned int col = idx % K_STEP;
+        smem_A[row][col] = reg_A[i];
+    }
+}
+
+__device__ __forceinline__ void w8a16_store_B_regs(
+    __nv_bfloat16 smem_B[][N_TILE + PAD], const __nv_bfloat16 reg_B[8]
+) {
+    #pragma unroll
+    for (unsigned int i = 0; i < 8; i++) {
+        unsigned int idx = threadIdx.x * 8 + i;
+        unsigned int k = idx / N_TILE;
+        unsigned int n = idx % N_TILE;
+        smem_B[k][n] = reg_B[i];
+    }
+}
+
 extern "C" __global__ void w8a16_gemm(
     const __nv_bfloat16* __restrict__ A,            // [M, K] BF16 activations
     const unsigned char* __restrict__ B,             // [N, K] FP8 E4M3
@@ -151,59 +235,46 @@ extern "C" __global__ void w8a16_gemm(
     const unsigned int lane_id = threadIdx.x % 32;
     const unsigned int warp_m_offset = warp_id * 16;
 
-    __shared__ __nv_bfloat16 smem_A[M_TILE][K_STEP + PAD];
-    __shared__ __nv_bfloat16 smem_B[K_STEP][N_TILE + PAD];
+    // Double-buffered (ping-pong) smem — overlaps tile-(k+1) global loads,
+    // staged in VGPRs, with tile-k WMMA compute.
+    __shared__ __nv_bfloat16 smem_A[2][M_TILE][K_STEP + PAD];
+    __shared__ __nv_bfloat16 smem_B[2][K_STEP][N_TILE + PAD];
 
     v8f acc[4];
     #pragma unroll
     for (int i = 0; i < 4; i++) acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
 
     const unsigned int k_blocks = K / FP8_BLOCK;
+    const unsigned int num_tiles = (K + K_STEP - 1) / K_STEP;
 
-    for (unsigned int k_base = 0; k_base < K; k_base += K_STEP) {
-        // === Load A tile: [M_TILE, K_STEP] BF16 from global → smem ===
-        {
-            const unsigned int elems_per_thread = (M_TILE * K_STEP) / 128;
-            #pragma unroll
-            for (unsigned int i = 0; i < elems_per_thread; i++) {
-                unsigned int idx = threadIdx.x * elems_per_thread + i;
-                unsigned int row = idx / K_STEP;
-                unsigned int col = idx % K_STEP;
-                unsigned int gr = cta_m + row;
-                unsigned int gc = k_base + col;
-                smem_A[row][col] = (gr < M && gc < K) ? A[gr * K + gc] : __float2bfloat16(0.0f);
-            }
-        }
+    // ── Prologue: load tile 0 (global → regs → smem[0]) ──
+    __nv_bfloat16 reg_A[8];
+    __nv_bfloat16 reg_B[8];
+    w8a16_load_A_regs(A, reg_A, cta_m, 0, M, K);
+    w8a16_load_B_regs(B, block_scale, reg_B, cta_n, 0, N, K, k_blocks);
+    w8a16_store_A_regs(smem_A[0], reg_A);
+    w8a16_store_B_regs(smem_B[0], reg_B);
+    __syncthreads();
 
-        // === Dequant B: FP8 E4M3 → BF16 via LUT × block_scale ===
-        {
-            #pragma unroll
-            for (unsigned int i = 0; i < 8; i++) {
-                unsigned int idx = threadIdx.x * 8 + i;
-                unsigned int k = idx / N_TILE;
-                unsigned int n = idx % N_TILE;
-                unsigned int gk = k_base + k;
-                unsigned int gn = cta_n + n;
-
-                if (gk < K && gn < N) {
-                    unsigned char weight_byte = B[(unsigned long long)gn * K + gk];
-
-                    unsigned int n_block = gn / FP8_BLOCK;
-                    unsigned int k_block = gk / FP8_BLOCK;
-                    float scale = block_scale[n_block * k_blocks + k_block];
-
-                    float dequant_val = E4M3_LUT[weight_byte] * scale;
-                    smem_B[k][n] = __float2bfloat16(dequant_val);
-                } else {
-                    smem_B[k][n] = __float2bfloat16(0.0f);
-                }
-            }
-        }
-
+    // ── Steady state: prefetch tile k into regs while computing tile k-1 ──
+    for (unsigned int kt = 1; kt < num_tiles; kt++) {
+        const unsigned int k_base = kt * K_STEP;
+        // (a) issue global reads for tile kt into registers (no wait)
+        w8a16_load_A_regs(A, reg_A, cta_m, k_base, M, K);
+        w8a16_load_B_regs(B, block_scale, reg_B, cta_n, k_base, N, K, k_blocks);
+        // (b) compute the already-resident previous tile
+        w8a16_wmma_compute(smem_A[(kt - 1) & 1], smem_B[(kt - 1) & 1], acc, warp_m_offset, lane_id);
+        // (c) make sure all warps are done reading smem[(kt-1)&1] before reuse
         __syncthreads();
-        w8a16_wmma_compute(smem_A, smem_B, acc, warp_m_offset, lane_id);
+        // (d) commit prefetched registers into the other buffer
+        w8a16_store_A_regs(smem_A[kt & 1], reg_A);
+        w8a16_store_B_regs(smem_B[kt & 1], reg_B);
+        // (e) publish smem[kt&1] to all warps
         __syncthreads();
     }
+
+    // ── Epilogue: compute the last tile ──
+    w8a16_wmma_compute(smem_A[(num_tiles - 1) & 1], smem_B[(num_tiles - 1) & 1], acc, warp_m_offset, lane_id);
 
     w8a16_wmma_store(C, acc, cta_m, cta_n, warp_m_offset, lane_id, M, N);
 }

--- a/kernels/strix-hip/common/w8a16_gemm.cu
+++ b/kernels/strix-hip/common/w8a16_gemm.cu
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Atlas W8A16 Dequant+GEMM — Fused FP8-E4M3 weight dequant + BF16 WMMA GEMM.
+// HIP/gfx1151 (AMD WMMA) port of the NVIDIA mma.sync version.
+//
+// C[M,N] = A[M,K] (BF16 activations) * dequant(B[N,K] (FP8 E4M3 weights))
+//
+// FP8-E4M3 weight format (2D block-scaled):
+//   B:           [N, K] uint8 — one byte per weight (FP8 E4M3)
+//   block_scale: [N/128, K/128] BF16 — per-block scale factor
+//
+// Dequant: bf16_val = E4M3_LUT[byte] * block_scale[n/128, k/128]
+//
+// WMMA: __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32 (16x16x16, n16).
+//   One WMMA op == two NVIDIA m16n8k16 n-tiles. A 64-wide N tile = 4 WMMA ops.
+//   Store mapping: lane l, acc element e: row = row_base + 2*e + (l>>4), col = col_base + (l&15)
+//
+// Grid: (ceil(N/64), ceil(M/64), 1), Block: (128, 1, 1)
+
+#include <cuda_bf16.h>
+
+typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
+typedef float  v8f   __attribute__((ext_vector_type(8)));
+
+#define M_TILE 64
+#define N_TILE 64
+#define K_STEP 16
+#define PAD 2
+#define FP8_BLOCK 128
+
+// E4M3 lookup table: 256-entry byte → FP32 value.
+// Copied from w8a16_gemv.cu (SSOT: same LUT used for both GEMV and GEMM).
+__device__ __constant__ float E4M3_LUT[256] = {
+    // Positive (0x00..0x7F)
+    0.0f, 0.001953125f, 0.00390625f, 0.005859375f,
+    0.0078125f, 0.009765625f, 0.01171875f, 0.013671875f,
+    0.015625f, 0.017578125f, 0.01953125f, 0.021484375f,
+    0.0234375f, 0.025390625f, 0.02734375f, 0.029296875f,
+    0.03125f, 0.03515625f, 0.0390625f, 0.04296875f,
+    0.046875f, 0.05078125f, 0.0546875f, 0.05859375f,
+    0.0625f, 0.0703125f, 0.078125f, 0.0859375f,
+    0.09375f, 0.1015625f, 0.109375f, 0.1171875f,
+    0.125f, 0.140625f, 0.15625f, 0.171875f,
+    0.1875f, 0.203125f, 0.21875f, 0.234375f,
+    0.25f, 0.28125f, 0.3125f, 0.34375f,
+    0.375f, 0.40625f, 0.4375f, 0.46875f,
+    0.5f, 0.5625f, 0.625f, 0.6875f,
+    0.75f, 0.8125f, 0.875f, 0.9375f,
+    1.0f, 1.125f, 1.25f, 1.375f,
+    1.5f, 1.625f, 1.75f, 1.875f,
+    2.0f, 2.25f, 2.5f, 2.75f,
+    3.0f, 3.25f, 3.5f, 3.75f,
+    4.0f, 4.5f, 5.0f, 5.5f,
+    6.0f, 6.5f, 7.0f, 7.5f,
+    8.0f, 9.0f, 10.0f, 11.0f,
+    12.0f, 13.0f, 14.0f, 15.0f,
+    16.0f, 18.0f, 20.0f, 22.0f,
+    24.0f, 26.0f, 28.0f, 30.0f,
+    32.0f, 36.0f, 40.0f, 44.0f,
+    48.0f, 52.0f, 56.0f, 60.0f,
+    64.0f, 72.0f, 80.0f, 88.0f,
+    96.0f, 104.0f, 112.0f, 120.0f,
+    128.0f, 144.0f, 160.0f, 176.0f,
+    192.0f, 208.0f, 224.0f, 240.0f,
+    256.0f, 288.0f, 320.0f, 352.0f,
+    384.0f, 416.0f, 448.0f, 0.0f,
+    // Negative (0x80..0xFF)
+    -0.0f, -0.001953125f, -0.00390625f, -0.005859375f,
+    -0.0078125f, -0.009765625f, -0.01171875f, -0.013671875f,
+    -0.015625f, -0.017578125f, -0.01953125f, -0.021484375f,
+    -0.0234375f, -0.025390625f, -0.02734375f, -0.029296875f,
+    -0.03125f, -0.03515625f, -0.0390625f, -0.04296875f,
+    -0.046875f, -0.05078125f, -0.0546875f, -0.05859375f,
+    -0.0625f, -0.0703125f, -0.078125f, -0.0859375f,
+    -0.09375f, -0.1015625f, -0.109375f, -0.1171875f,
+    -0.125f, -0.140625f, -0.15625f, -0.171875f,
+    -0.1875f, -0.203125f, -0.21875f, -0.234375f,
+    -0.25f, -0.28125f, -0.3125f, -0.34375f,
+    -0.375f, -0.40625f, -0.4375f, -0.46875f,
+    -0.5f, -0.5625f, -0.625f, -0.6875f,
+    -0.75f, -0.8125f, -0.875f, -0.9375f,
+    -1.0f, -1.125f, -1.25f, -1.375f,
+    -1.5f, -1.625f, -1.75f, -1.875f,
+    -2.0f, -2.25f, -2.5f, -2.75f,
+    -3.0f, -3.25f, -3.5f, -3.75f,
+    -4.0f, -4.5f, -5.0f, -5.5f,
+    -6.0f, -6.5f, -7.0f, -7.5f,
+    -8.0f, -9.0f, -10.0f, -11.0f,
+    -12.0f, -13.0f, -14.0f, -15.0f,
+    -16.0f, -18.0f, -20.0f, -22.0f,
+    -24.0f, -26.0f, -28.0f, -30.0f,
+    -32.0f, -36.0f, -40.0f, -44.0f,
+    -48.0f, -52.0f, -56.0f, -60.0f,
+    -64.0f, -72.0f, -80.0f, -88.0f,
+    -96.0f, -104.0f, -112.0f, -120.0f,
+    -128.0f, -144.0f, -160.0f, -176.0f,
+    -192.0f, -208.0f, -224.0f, -240.0f,
+    -256.0f, -288.0f, -320.0f, -352.0f,
+    -384.0f, -416.0f, -448.0f, -0.0f,
+};
+
+// WMMA compute — operates on already-loaded smem_A/smem_B BF16 tiles.
+// acc[4] holds 4 WMMA n-sub-tiles (4 × 16 = 64 N).
+__device__ __forceinline__ void w8a16_wmma_compute(
+    __nv_bfloat16 smem_A[][K_STEP + PAD],
+    __nv_bfloat16 smem_B[][N_TILE + PAD],
+    v8f acc[4],
+    unsigned int warp_m_offset, unsigned int lane
+) {
+    v16bf a;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) a[i] = (__bf16)smem_A[warp_m_offset + (lane & 15)][i];
+    #pragma unroll
+    for (int nb = 0; nb < 4; nb++) {
+        v16bf b;
+        #pragma unroll
+        for (int k = 0; k < 16; k++) b[k] = (__bf16)smem_B[k][nb * 16 + (lane & 15)];
+        acc[nb] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc[nb]);
+    }
+}
+
+__device__ __forceinline__ void w8a16_wmma_store(
+    __nv_bfloat16* __restrict__ C, v8f acc[4],
+    unsigned int cta_m, unsigned int cta_n, unsigned int warp_m_offset,
+    unsigned int lane, unsigned int M, unsigned int N
+) {
+    #pragma unroll
+    for (int nb = 0; nb < 4; nb++) {
+        #pragma unroll
+        for (int e = 0; e < 8; e++) {
+            unsigned int row = cta_m + warp_m_offset + 2 * e + (lane >> 4);
+            unsigned int col = cta_n + nb * 16 + (lane & 15);
+            if (row < M && col < N) C[row * N + col] = __float2bfloat16(acc[nb][e]);
+        }
+    }
+}
+
+/// W8A16 GEMM: B[N, K] row-major FP8 E4M3 with 2D block scales.
+extern "C" __global__ void w8a16_gemm(
+    const __nv_bfloat16* __restrict__ A,            // [M, K] BF16 activations
+    const unsigned char* __restrict__ B,             // [N, K] FP8 E4M3
+    const float* __restrict__ block_scale,   // [N/128, K/128] BF16
+    __nv_bfloat16* __restrict__ C,                   // [M, N] BF16 output
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int cta_n = blockIdx.x * N_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+
+    __shared__ __nv_bfloat16 smem_A[M_TILE][K_STEP + PAD];
+    __shared__ __nv_bfloat16 smem_B[K_STEP][N_TILE + PAD];
+
+    v8f acc[4];
+    #pragma unroll
+    for (int i = 0; i < 4; i++) acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+
+    const unsigned int k_blocks = K / FP8_BLOCK;
+
+    for (unsigned int k_base = 0; k_base < K; k_base += K_STEP) {
+        // === Load A tile: [M_TILE, K_STEP] BF16 from global → smem ===
+        {
+            const unsigned int elems_per_thread = (M_TILE * K_STEP) / 128;
+            #pragma unroll
+            for (unsigned int i = 0; i < elems_per_thread; i++) {
+                unsigned int idx = threadIdx.x * elems_per_thread + i;
+                unsigned int row = idx / K_STEP;
+                unsigned int col = idx % K_STEP;
+                unsigned int gr = cta_m + row;
+                unsigned int gc = k_base + col;
+                smem_A[row][col] = (gr < M && gc < K) ? A[gr * K + gc] : __float2bfloat16(0.0f);
+            }
+        }
+
+        // === Dequant B: FP8 E4M3 → BF16 via LUT × block_scale ===
+        {
+            #pragma unroll
+            for (unsigned int i = 0; i < 8; i++) {
+                unsigned int idx = threadIdx.x * 8 + i;
+                unsigned int k = idx / N_TILE;
+                unsigned int n = idx % N_TILE;
+                unsigned int gk = k_base + k;
+                unsigned int gn = cta_n + n;
+
+                if (gk < K && gn < N) {
+                    unsigned char weight_byte = B[(unsigned long long)gn * K + gk];
+
+                    unsigned int n_block = gn / FP8_BLOCK;
+                    unsigned int k_block = gk / FP8_BLOCK;
+                    float scale = block_scale[n_block * k_blocks + k_block];
+
+                    float dequant_val = E4M3_LUT[weight_byte] * scale;
+                    smem_B[k][n] = __float2bfloat16(dequant_val);
+                } else {
+                    smem_B[k][n] = __float2bfloat16(0.0f);
+                }
+            }
+        }
+
+        __syncthreads();
+        w8a16_wmma_compute(smem_A, smem_B, acc, warp_m_offset, lane_id);
+        __syncthreads();
+    }
+
+    w8a16_wmma_store(C, acc, cta_m, cta_n, warp_m_offset, lane_id, M, N);
+}
+
+/// Standalone W8A16 dequant: B_fp8 → B_bf16 [N, K]  (no tensor core; portable as-is)
+/// Each thread handles one FP8 byte → 1 BF16 output.
+extern "C" __global__ void w8a16_dequant(
+    const unsigned char* __restrict__ B,             // [N, K] FP8 E4M3
+    const float* __restrict__ block_scale,   // [N/128, K/128] BF16
+    __nv_bfloat16* __restrict__ B_bf16,              // [N, K] BF16 output
+    unsigned int K,
+    unsigned int N
+) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int total = N * K;
+    if (idx >= total) return;
+
+    unsigned int n = idx / K;
+    unsigned int k = idx % K;
+
+    unsigned char weight_byte = B[idx];
+
+    unsigned int k_blocks = K / FP8_BLOCK;
+    unsigned int n_block = n / FP8_BLOCK;
+    unsigned int k_block = k / FP8_BLOCK;
+    float scale = block_scale[n_block * k_blocks + k_block];
+
+    float val = E4M3_LUT[weight_byte] * scale;
+    B_bf16[idx] = __float2bfloat16(val);
+}

--- a/kernels/strix-hip/common/w8a16_gemm_t.cu
+++ b/kernels/strix-hip/common/w8a16_gemm_t.cu
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Atlas W8A16 Transposed GEMM — FP8 E4M3 block-scaled, coalesced weight reads.
+// HIP/gfx1151 (AMD WMMA) port of the NVIDIA mma.sync version. Mirrors the
+// proven idiom in w8a16_gemm.cu (the BF16 WMMA GEMM port).
+//
+// C[M,N] = A[M,K] (BF16) * dequant(B_t[K,N] (FP8 E4M3, transposed))
+//
+// Weights stored as B_t[K, N] so the N-dimension is contiguous (coalesced reads).
+// Block scales: block_scale_t[K/128, N/128] BF16. Dequant: LUT[byte] * scale.
+//
+// WMMA: __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32 (16x16x16, n16).
+//   One WMMA op == two NVIDIA m16n8k16 n-tiles. A 64-wide N tile = 4 WMMA ops.
+//   Store: lane l, acc element e: row = row_base + 2*e + (l>>4), col = col_base + (l&15)
+//
+// Grid: (ceil(N/64), ceil(M/64), 1), Block: (128, 1, 1)
+
+#include <cuda_bf16.h>
+
+typedef __bf16 v16bf __attribute__((ext_vector_type(16)));
+typedef float  v8f   __attribute__((ext_vector_type(8)));
+
+#define M_TILE 64
+#define K_STEP 16
+#define N_TILE 64       // 64 N columns per CTA (matches w8a16_gemm.cu)
+#define PAD 2
+#define FP8_BLOCK 128
+
+// E4M3 lookup table (SSOT with w8a16_gemm.cu / w8a16_gemv.cu).
+__device__ __constant__ float E4M3_LUT_T[256] = {
+    0.0f, 0.001953125f, 0.00390625f, 0.005859375f,
+    0.0078125f, 0.009765625f, 0.01171875f, 0.013671875f,
+    0.015625f, 0.017578125f, 0.01953125f, 0.021484375f,
+    0.0234375f, 0.025390625f, 0.02734375f, 0.029296875f,
+    0.03125f, 0.03515625f, 0.0390625f, 0.04296875f,
+    0.046875f, 0.05078125f, 0.0546875f, 0.05859375f,
+    0.0625f, 0.0703125f, 0.078125f, 0.0859375f,
+    0.09375f, 0.1015625f, 0.109375f, 0.1171875f,
+    0.125f, 0.140625f, 0.15625f, 0.171875f,
+    0.1875f, 0.203125f, 0.21875f, 0.234375f,
+    0.25f, 0.28125f, 0.3125f, 0.34375f,
+    0.375f, 0.40625f, 0.4375f, 0.46875f,
+    0.5f, 0.5625f, 0.625f, 0.6875f,
+    0.75f, 0.8125f, 0.875f, 0.9375f,
+    1.0f, 1.125f, 1.25f, 1.375f,
+    1.5f, 1.625f, 1.75f, 1.875f,
+    2.0f, 2.25f, 2.5f, 2.75f,
+    3.0f, 3.25f, 3.5f, 3.75f,
+    4.0f, 4.5f, 5.0f, 5.5f,
+    6.0f, 6.5f, 7.0f, 7.5f,
+    8.0f, 9.0f, 10.0f, 11.0f,
+    12.0f, 13.0f, 14.0f, 15.0f,
+    16.0f, 18.0f, 20.0f, 22.0f,
+    24.0f, 26.0f, 28.0f, 30.0f,
+    32.0f, 36.0f, 40.0f, 44.0f,
+    48.0f, 52.0f, 56.0f, 60.0f,
+    64.0f, 72.0f, 80.0f, 88.0f,
+    96.0f, 104.0f, 112.0f, 120.0f,
+    128.0f, 144.0f, 160.0f, 176.0f,
+    192.0f, 208.0f, 224.0f, 240.0f,
+    256.0f, 288.0f, 320.0f, 352.0f,
+    384.0f, 416.0f, 448.0f, 0.0f,
+    -0.0f, -0.001953125f, -0.00390625f, -0.005859375f,
+    -0.0078125f, -0.009765625f, -0.01171875f, -0.013671875f,
+    -0.015625f, -0.017578125f, -0.01953125f, -0.021484375f,
+    -0.0234375f, -0.025390625f, -0.02734375f, -0.029296875f,
+    -0.03125f, -0.03515625f, -0.0390625f, -0.04296875f,
+    -0.046875f, -0.05078125f, -0.0546875f, -0.05859375f,
+    -0.0625f, -0.0703125f, -0.078125f, -0.0859375f,
+    -0.09375f, -0.1015625f, -0.109375f, -0.1171875f,
+    -0.125f, -0.140625f, -0.15625f, -0.171875f,
+    -0.1875f, -0.203125f, -0.21875f, -0.234375f,
+    -0.25f, -0.28125f, -0.3125f, -0.34375f,
+    -0.375f, -0.40625f, -0.4375f, -0.46875f,
+    -0.5f, -0.5625f, -0.625f, -0.6875f,
+    -0.75f, -0.8125f, -0.875f, -0.9375f,
+    -1.0f, -1.125f, -1.25f, -1.375f,
+    -1.5f, -1.625f, -1.75f, -1.875f,
+    -2.0f, -2.25f, -2.5f, -2.75f,
+    -3.0f, -3.25f, -3.5f, -3.75f,
+    -4.0f, -4.5f, -5.0f, -5.5f,
+    -6.0f, -6.5f, -7.0f, -7.5f,
+    -8.0f, -9.0f, -10.0f, -11.0f,
+    -12.0f, -13.0f, -14.0f, -15.0f,
+    -16.0f, -18.0f, -20.0f, -22.0f,
+    -24.0f, -26.0f, -28.0f, -30.0f,
+    -32.0f, -36.0f, -40.0f, -44.0f,
+    -48.0f, -52.0f, -56.0f, -60.0f,
+    -64.0f, -72.0f, -80.0f, -88.0f,
+    -96.0f, -104.0f, -112.0f, -120.0f,
+    -128.0f, -144.0f, -160.0f, -176.0f,
+    -192.0f, -208.0f, -224.0f, -240.0f,
+    -256.0f, -288.0f, -320.0f, -352.0f,
+    -384.0f, -416.0f, -448.0f, -0.0f,
+};
+
+// WMMA compute over loaded smem_A[M_TILE][K_STEP+PAD], smem_B[K_STEP][N_TILE+PAD].
+// acc[4] = 4 WMMA n16-tiles (64 N). Identical to w8a16_gemm.cu's compute.
+__device__ __forceinline__ void w8a16_wmma_compute_t(
+    __nv_bfloat16 smem_A[][K_STEP + PAD],
+    __nv_bfloat16 smem_B[][N_TILE + PAD],
+    v8f acc[4],
+    unsigned int warp_m_offset, unsigned int lane
+) {
+    v16bf a;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) a[i] = (__bf16)smem_A[warp_m_offset + (lane & 15)][i];
+    #pragma unroll
+    for (int nb = 0; nb < 4; nb++) {
+        v16bf b;
+        #pragma unroll
+        for (int k = 0; k < 16; k++) b[k] = (__bf16)smem_B[k][nb * 16 + (lane & 15)];
+        acc[nb] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc[nb]);
+    }
+}
+
+/// W8A16 GEMM with transposed weight layout for coalesced reads.
+/// B_t: [K, N] FP8 E4M3. block_scale_t: [K/128, N/128] BF16.
+extern "C" __global__ void w8a16_gemm_t(
+    const __nv_bfloat16* __restrict__ A,               // [M, K] BF16
+    const unsigned char* __restrict__ B_t,              // [K, N] FP8 E4M3 transposed
+    const float* __restrict__ block_scale_t,   // [K/128, N/128] BF16
+    __nv_bfloat16* __restrict__ C,                     // [M, N] BF16
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int cta_n = blockIdx.x * N_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+
+    __shared__ __nv_bfloat16 smem_A[M_TILE][K_STEP + PAD];
+    __shared__ __nv_bfloat16 smem_B[K_STEP][N_TILE + PAD];
+
+    v8f acc[4];
+    #pragma unroll
+    for (int i = 0; i < 4; i++) acc[i] = v8f{0, 0, 0, 0, 0, 0, 0, 0};
+
+    const unsigned int n_scale_blocks = (N + FP8_BLOCK - 1) / FP8_BLOCK;
+
+    for (unsigned int k_base = 0; k_base < K; k_base += K_STEP) {
+        // === Load A tile: [M_TILE, K_STEP] BF16 ===
+        {
+            const unsigned int elems_per_thread = (M_TILE * K_STEP) / 128;
+            #pragma unroll
+            for (unsigned int i = 0; i < elems_per_thread; i++) {
+                unsigned int idx = threadIdx.x * elems_per_thread + i;
+                unsigned int row = idx / K_STEP;
+                unsigned int col = idx % K_STEP;
+                unsigned int gr = cta_m + row;
+                unsigned int gc = k_base + col;
+                smem_A[row][col] = (gr < M && gc < K) ? A[gr * K + gc] : __float2bfloat16(0.0f);
+            }
+        }
+
+        // === Dequant B_t: transposed [K, N] — coalesced N reads ===
+        {
+            #pragma unroll
+            for (unsigned int i = 0; i < 8; i++) {
+                unsigned int idx = threadIdx.x * 8 + i;
+                unsigned int k = idx / N_TILE;       // 0..15 (K)
+                unsigned int n = idx % N_TILE;       // 0..63 (N, contiguous)
+                unsigned int gk = k_base + k;
+                unsigned int gn = cta_n + n;
+                if (gk < K && gn < N) {
+                    unsigned char weight_byte = B_t[(unsigned long long)gk * N + gn];
+                    unsigned int k_block = gk / FP8_BLOCK;
+                    unsigned int n_block = gn / FP8_BLOCK;
+                    float scale = block_scale_t[k_block * n_scale_blocks + n_block];
+                    float dequant_val = E4M3_LUT_T[weight_byte] * scale;
+                    smem_B[k][n] = __float2bfloat16(dequant_val);
+                } else {
+                    smem_B[k][n] = __float2bfloat16(0.0f);
+                }
+            }
+        }
+
+        __syncthreads();
+        w8a16_wmma_compute_t(smem_A, smem_B, acc, warp_m_offset, lane_id);
+        __syncthreads();
+    }
+
+    // === Store C tile ===
+    #pragma unroll
+    for (int nb = 0; nb < 4; nb++) {
+        #pragma unroll
+        for (int e = 0; e < 8; e++) {
+            unsigned int row = cta_m + warp_m_offset + 2 * e + (lane_id >> 4);
+            unsigned int col = cta_n + nb * 16 + (lane_id & 15);
+            if (row < M && col < N) C[row * N + col] = __float2bfloat16(acc[nb][e]);
+        }
+    }
+}
+
+/// Transpose FP8 weight matrix: B[N,K] → B_t[K,N]. One element per thread.
+extern "C" __global__ void transpose_fp8(
+    const unsigned char* __restrict__ B,      // [N, K] FP8 E4M3
+    unsigned char* __restrict__ B_t,          // [K, N] transposed
+    unsigned int N,
+    unsigned int K
+) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int total = N * K;
+    if (idx >= total) return;
+    unsigned int n = idx / K;
+    unsigned int k = idx % K;
+    B_t[(unsigned long long)k * N + n] = B[(unsigned long long)n * K + k];
+}
+
+/// Transpose block scales: scale[N/128, K/128] → scale_t[K/128, N/128]
+extern "C" __global__ void transpose_block_scale(
+    const float* __restrict__ scale,        // [N/128, K/128]
+    float* __restrict__ scale_t,            // [K/128, N/128]
+    unsigned int N_blocks,    // N/128
+    unsigned int K_blocks     // K/128
+) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int total = N_blocks * K_blocks;
+    if (idx >= total) return;
+    unsigned int nb = idx / K_blocks;
+    unsigned int kb = idx % K_blocks;
+    scale_t[kb * N_blocks + nb] = scale[nb * K_blocks + kb];
+}


### PR DESCRIPTION
## Summary

Makes `Qwen3.6-35B-A3B-FP8` build, run, **and produce coherent output** on the native-HIP `strix-hip` (gfx1151 / RDNA3.5) target. Two independent defects in the AMD/Strix port (#161):

### 1. Missing FP8 W8A16 prefill GEMM + pipelined-only dispatch (crashes)
The `strix-hip` kernel tree shipped only the decode GEMV (`w8a16_gemv`); the FP8 W8A16 *prefill* GEMM (`w8a16_gemm`/`w8a16_gemm_t`) was never added, and the prefill dispatch unconditionally launched the pipelined (`cp.async`) variants — null handles on gfx1151 → `hipErrorInvalidHandle` at layer 0. Adds cp.async-free `w8a16_gemm.cu`/`w8a16_gemm_t.cu`, and gates the pipelined call on its kernel handle (non-pipelined fallback) in SSM QKVZ, attention QKV, and o_proj. NVIDIA keeps the faster pipelined path.

### 2. Shared-expert use-after-free (incoherent output)
Qwen3.6-35B's **gated shared expert** is loaded twice — once in `load_moe_qwen35` (NVFP4 requant) and again by the native-FP8 `sh_gate` loader. The NVFP4 path **freed the WeightStore-owned FP8 source** (`quantized_auto`'s `source_ptr` free + the `#[cfg(atlas_scale)]` eviction in `quantized_from_fp8`; `strix-hip` sets `atlas_scale` since `atlas_hip` is a subset). A later `cuMemAlloc` reused the freed address, **clobbering the shared-expert weight in place** → `shared_out=0` → MoE missing its shared term → per-layer cosine ~0.985 → compounding drift → degenerate decode. Fix: do not free the dual-read store source in the NVFP4 requant path.

## Verification (2× DGX Spark, gfx1151 / strix-hip)

- Builds clean; **0** prefill `hipErrorInvalidHandle` crashes (attention + SSM).
- Shared-expert store weight is bit-stable across `load_moe` (was clobbered `[91,90,226,232]`→`[81,116,69,220]`).
- Coherent generation: *"The capital of France is Paris."*; correct Rayleigh-scattering explanation.
- NVIDIA / gb10 path unaffected (kernel-availability gate is a no-op there; the `atlas_scale` eviction never compiled for NVIDIA).
