### PR TITLE
fix(gpu-mem): enforce --gpu-memory-utilization as a total-memory ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ behind specific subsystems — see the
 
 ## [Unreleased]
 
+### Fixed
+
+- `--gpu-memory-utilization` now enforces a hard ceiling on total GPU
+  memory (weights + buffers + KV cache + reserves), matching the vLLM /
+  sparkrun convention.  Previously the fraction was applied only to
+  post-weight free memory, causing the KV cache to over-allocate by
+  20-27 GB when values below the ~0.88 default were used.  This blocked
+  multi-service co-residency on shared-memory systems (e.g. DGX Spark
+  GB10).  The flag now behaves as documented: `0.50` on a 120 GB device
+  caps Atlas at ~60 GB total.  (#170)
+
 ## [0.1.0] — 2026-05-06
 
 Initial public release. Atlas is a pure-Rust LLM inference engine

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -250,9 +250,26 @@ pub fn build_model(
             summary.join(" + ")
         );
     }
+    // ── gpu_memory_utilization as fraction of TOTAL GPU memory ──
+    //
+    // User-facing contract (matches vLLM / sparkrun convention):
+    //   total_memory × gpu_memory_utilization = hard ceiling on everything
+    //   this process consumes (weights + buffers + KV cache + reserves).
+    //
+    // KV cache gets whatever remains inside that ceiling after deducting
+    // prior allocations (model weights, buffer arena, CUDA context/driver)
+    // and the inference reserve (SSM state pools, CUDA headroom).  A safety
+    // clamp ensures we never exceed what the device can physically provide
+    // right now (handles external memory pressure on shared-memory /
+    // unified-memory systems like GB10).
+    let total_mem = gpu.total_memory()?;
     let actual_free = gpu.free_memory()?;
-    let allocatable = actual_free.saturating_sub(inference_reserve);
-    let kv_budget = (allocatable as f64 * gpu_memory_utilization) as usize;
+    let used_so_far = total_mem.saturating_sub(actual_free);
+    let total_budget = (total_mem as f64 * gpu_memory_utilization) as usize;
+    let kv_budget = total_budget
+        .saturating_sub(used_so_far)
+        .saturating_sub(inference_reserve)
+        .min(actual_free.saturating_sub(inference_reserve));
     // Phase 6.1.f: when HBM-shrink is active, size the production cache to
     // `max_batch_size × cache_blocks_per_seq` rather than the unbounded
     // budget-driven sum. This is the *whole point* of the HBM-shrink
@@ -294,13 +311,33 @@ pub fn build_model(
             n
         }
         None => {
+            if kv_budget == 0 {
+                anyhow::bail!(
+                    "No memory left for KV cache: total GPU = {:.1} GB, \
+                     --gpu-memory-utilization {:.0}% → budget {:.1} GB, \
+                     but {:.1} GB already consumed + {:.1} GB inference reserve \
+                     = {:.1} GB committed.  Raise --gpu-memory-utilization or \
+                     use a smaller model.",
+                    total_mem as f64 / (1024.0 * 1024.0 * 1024.0),
+                    gpu_memory_utilization * 100.0,
+                    total_budget as f64 / (1024.0 * 1024.0 * 1024.0),
+                    used_so_far as f64 / (1024.0 * 1024.0 * 1024.0),
+                    inference_reserve as f64 / (1024.0 * 1024.0 * 1024.0),
+                    (used_so_far + inference_reserve) as f64 / (1024.0 * 1024.0 * 1024.0),
+                );
+            }
             let n = PagedKvCache::compute_num_blocks(&kv_config, kv_budget)?;
             let max_kv_tokens = n * kv_block_size;
             tracing::info!(
-                "KV cache (post-construction): {:.1} GB free, {:.1} GB allocatable, \
-                 {} blocks × {} tok/block = {} max tokens",
-                actual_free as f64 / (1024.0 * 1024.0 * 1024.0),
-                allocatable as f64 / (1024.0 * 1024.0 * 1024.0),
+                "KV cache: {:.1} GB total × {:.0}% util = {:.1} GB budget; \
+                 {:.1} GB pre-KV + {:.1} GB reserve → {:.1} GB for KV \
+                 → {} blocks × {} tok/block = {} max KV tokens",
+                total_mem as f64 / (1024.0 * 1024.0 * 1024.0),
+                gpu_memory_utilization * 100.0,
+                total_budget as f64 / (1024.0 * 1024.0 * 1024.0),
+                used_so_far as f64 / (1024.0 * 1024.0 * 1024.0),
+                inference_reserve as f64 / (1024.0 * 1024.0 * 1024.0),
+                kv_budget as f64 / (1024.0 * 1024.0 * 1024.0),
                 n,
                 kv_block_size,
                 max_kv_tokens,

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -81,7 +81,10 @@ pub struct ServeArgs {
     #[arg(long, default_value = "0")]
     pub kv_high_precision_layers: String,
 
-    /// GPU memory utilization (0.0-1.0).
+    /// Fraction of total GPU memory this process may consume (0.0-1.0).
+    /// Weights, buffers, KV cache, and reserves all count against this cap.
+    /// Matches vLLM / sparkrun semantics: 0.50 on a 120 GB device means
+    /// Atlas will use at most ~60 GB in total.
     #[arg(long, default_value_t = 0.90)]
     pub gpu_memory_utilization: f64,
 


### PR DESCRIPTION
## Summary

`--gpu-memory-utilization` was not enforced as a ceiling on total GPU memory.
The fraction was applied to *free-after-weights* memory when sizing the KV cache,
so weights/buffers/reserve fell outside the cap and the real footprint overshot
the requested fraction — the lower you set it, the worse the overshoot (≈0 GB at
the 0.88 default, +20 GB at 0.52, +27 GB at 0.40 on GB10).

This makes the flag a hard ceiling on **total** memory (vLLM / sparkrun
semantics): the realized footprint now scales with the requested fraction.

Closes #179
Refs #170 (auto-utilization feature — separate; correct ceiling enforcement is a
prerequisite, this PR does not implement or close it)

## Root cause

`crates/spark-model/src/factory/build.rs` computed the KV budget as
`(free_after_weights - inference_reserve) * gpu_memory_utilization`, so the
fraction scaled only leftover memory after weights loaded; weights, buffers and
the inference reserve were never counted against the cap.

## The fix

New budget formula in `build.rs`:

```rust
let total_mem    = gpu.total_memory()?;
let actual_free  = gpu.free_memory()?;
let used_so_far  = total_mem.saturating_sub(actual_free);
let total_budget = (total_mem as f64 * gpu_memory_utilization) as usize;
let kv_budget = total_budget
    .saturating_sub(used_so_far)
    .saturating_sub(inference_reserve)
    .min(actual_free.saturating_sub(inference_reserve));
```

- **Total-memory ceiling:** `u × total_memory`, minus everything already
  resident, minus the inference reserve, clamped to actual free memory.
- **Zero-budget guard:** when `kv_budget == 0`, build bails with a GB-formatted
  feasibility diagnostic (what's needed vs. available) instead of failing
  opaquely deeper in KV allocation.
- **CLI doc update** (`crates/spark-server/src/cli/serve_args.rs`): the
  `--gpu-memory-utilization` help now states it is a fraction of *total* GPU
  memory that weights + buffers + KV + reserves all count against.

Default is unchanged (0.90).

## Notes for reviewers

**Semantics (honest):** on GB10 unified memory, `free_memory()` returns
`max(cuda_free, /proc/meminfo MemAvailable)` — a whole-system figure. So
`used_so_far` folds in the CUDA context, the driver, and any co-resident host or
GPU process, not just Atlas's own prior allocations. This makes the cap a
**total-memory / system-level ceiling that also accounts for co-resident
processes**, which is *stricter* than vLLM's per-process device accounting under
memory pressure (the `.min(actual_free - reserve)` clamp shrinks KV further). The
PR does not claim byte-exact vLLM-process equivalence.

**Test coverage:** the budget formula itself is not covered by an automated test;
existing tests assert only the unchanged 0.90 default and are unaffected.
Validation was on hardware (below). Flagging in case coverage is a review concern.

**Authorship:** AI-generated (Claude Opus, under human direction). Diagnosis, fix,
and validation produced by AI; memory/throughput results verified on DGX Spark
GB10 hardware.

## Benchmarks (measured on DGX Spark GB10, ~119.6 GB total)

Model nvidia/Qwen3.6-35B-A3B-NVFP4.

Before (stock, docs/diagnostics.md; note these used the recipe's shorter context,
not 256k) — overshoot GROWS as `u` falls:

| u    | actual footprint |
|------|------------------|
| 0.52 | ~83 GB (+20 over u×total) |
| 0.40 | ~75 GB (+27 over u×total) |

After (this PR; max-seq-len 262144, max-batch-size 4) — footprint SCALES with `u`:

| u    | computed budget | result | nvidia-smi actual |
|------|-----------------|--------|-------------------|
| 0.50 | 59.8 GB | refuses with clear feasibility diagnostic (1.1 GB KV after 51.8 pre-KV + 6.9 reserve) | — |
| 0.60 | 71.8 GB | serves | 63.9 GB |
| 0.80 | 95.7 GB | serves | 87.8 GB |

(The before/after rows use different context/batch settings; the point is the
direction — pre-fix, low `u` overshot to a HIGH footprint; post-fix, low `u`
yields a correspondingly LOW footprint.)

### Reproducibility on current `main` (FP8)

The benchmark model above (`nvidia/Qwen3.6-35B-A3B-NVFP4`) currently fails to
**build** on `main` — `cuMemcpyDtoDAsync_v2 failed: status 1` during weight
build, before any KV allocation. This is **independent of this PR**: building
pristine `main` (none of this PR's changes) reproduces the identical crash. It
is tracked separately.

So the fix here is reproducible on current `main`, here is the same u-scaling on
the FP8 model (`Qwen/Qwen3.6-35B-A3B-FP8`), which builds and serves on `main`
(GB10, max-seq-len 131072, max-batch-size 4):

| u    | result           | nvidia-smi actual |
|------|------------------|-------------------|
| 0.60 | serves (fp8 KV)  | 63.3 GB           |
| 0.80 | serves (bf16 KV) | 85.8 GB           |

Footprint scales with the requested fraction — the realized total stays under
`u × 119.6 GB`.

## Test plan

Verified locally on the repo-pinned toolchain (rustc 1.93.1 — what CI's
`dtolnay/rust-toolchain@stable` resolves to in-repo, since rust-toolchain.toml
overrides `rustup default`), CI env `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000`:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --tests` (workspace lints: deny warnings + clippy::all) — clean
- [x] SPDX license headers (`apache/skywalking-eyes`) — modified files retain headers; no new files
- [x] `cargo test --workspace --locked`
- [x] `typos` (`crate-ci/typos`) — clean
- [x] cargo-deny — unaffected (no dependency/manifest changes)
- [x] Tested against a real model on hardware (DGX Spark GB10 — table above; release image builds clean)

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).