### PR TITLE
fix(nvfp4): restore dtype-aware SSM projection loading (regressed by #176)

### DIFF
--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -37,18 +37,15 @@ pub(crate) fn load_ssm_qwen35(
     store: &WeightStore,
     layer_prefix: &str,
     gpu: &dyn GpuBackend,
-    variant: Nvfp4Variant,
+    // Kept for loader-dispatch signature parity; `dense_auto` routes by the
+    // projection's actual on-disk dtype rather than the model-wide variant.
+    _variant: Nvfp4Variant,
 ) -> Result<SsmWeightsQwen35> {
     let p = format!("{layer_prefix}.linear_attn");
 
     // For FP8 models: in_proj_qkv, in_proj_z, out_proj are FP8 block-scaled.
     // conv1d, in_proj_a, in_proj_b are BF16 (in modules_to_not_convert).
-    let load_proj = |name: &str| -> Result<DenseWeight> {
-        match variant {
-            Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
-            _ => dense(store, name),
-        }
-    };
+    let load_proj = |name: &str| -> Result<DenseWeight> { dense_auto(store, name, gpu) };
 
     Ok(SsmWeightsQwen35 {
         in_proj_qkv: load_proj(&format!("{p}.in_proj_qkv.weight"))?,


### PR DESCRIPTION
## Summary

`load_ssm_qwen35` is restored to loading its `linear_attn` projections through the dtype-aware `dense_auto()` unconditionally, instead of the variant-gated loader introduced by #176 that routed the NVFP4 `Standard` variant through the dtype-blind `dense()`. This fixes a hard build-time crash (`cuMemcpyDtoDAsync_v2 failed: status 1`) on `nvidia/Qwen3.6-35B-A3B-NVFP4`.

Closes #181
Refs #176, #107

## Root cause

#176 changed the projection loader from `dense_auto(store, name, gpu)` to:

```rust
match variant {
    Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
    _ => dense(store, name),
}
```

`nvidia/Qwen3.6-35B-A3B-NVFP4` loads as `variant = Standard`, hitting the `_ => dense()` arm. `dense()` hands back the raw on-disk pointer with no dtype inspection; on this checkpoint ≥1 `linear_attn` projection ships as FP8 (1-byte), so the BF16 SSM-assembly kernels receive a 1-byte buffer where they expect 2-byte BF16 and the downstream D2D copy overruns. This reverts the fix for #107 (the pre-#176 code documented exactly this failure in a comment that #176 deleted). Bisect: `eac36a2` (#172, parent) builds+serves; `acf11be` (#176) and `7ba1a0a` (#178) crash.

## The fix

```diff
-    let load_proj = |name: &str| -> Result<DenseWeight> {
-        match variant {
-            Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
-            _ => dense(store, name),
-        }
-    };
+    let load_proj = |name: &str| -> Result<DenseWeight> { dense_auto(store, name, gpu) };
```

(The `variant` parameter is renamed `_variant` since it is no longer read — this matches the pre-#176 signature in `eac36a2` and keeps the build clean under `#![deny(warnings)]`.) One file, +4/−7.

## Notes for reviewers

- **`dense_auto` is a strict superset of `dense`.** For an on-disk BF16 weight, `dense_auto` returns the identical `DenseWeight { weight: w.ptr }` passthrough as `dense` (`quant_helpers.rs` BF16 arm == `model_a.rs` `dense`). It additionally converts FP32 and FP8E4M3 to BF16. So no variant that worked before can regress.
- **AMD/strix-hip safety.** All conversion in `dense_auto` goes through the `&dyn GpuBackend` trait (`gpu.alloc`/`copy_*`/`kernel`/`synchronize`) with no direct `cu*` calls; the FP8 dequant kernel is resolved by name per active backend. #176 *already* routes `Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu)`, so this widens an already-exercised strix-hip path rather than adding new untested AMD code. I could not test on gfx1151 hardware — this argument is from code review, flagged for a maintainer with AMD access.
- **One non-blocking edge.** Neither `dense` nor `dense_auto` handles genuinely NVFP4-*packed* (`UInt8`/`weight_packed`) SSM projections; `dense_auto` would `bail!` with `unsupported dtype UInt8` (loud) where `dense` crashes downstream (silent). `load_ssm_qwen35`'s own comments state these specific projections are BF16/FP8 (quantizer skipped them), so this is not exercised by the checkpoints in play. If a future `CompressedTensors` checkpoint ships packed SSM projections, the correct follow-up is a `quantized_auto` branch — not bare `dense`.

## Benchmarks / validation

Built `docker/gb10/Dockerfile` at commit `f3c7d33` and served the previously-crashing configuration on 1× GB10:

```
docker run ... atlas-gb10:fix-nvfp4 serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
  --gpu-memory-utilization 0.60 --max-seq-len 262144 --max-batch-size 4 --kv-cache-dtype nvfp4
```

| Metric | Before (#176/main) | After (this PR) |
|---|---|---|
| Model build | **crash** `cuMemcpyDtoDAsync_v2 status 1` at layer 0 | passes all 40 layers' `dense_keep_f32` promotion |
| Serve | never reached | `Listening on 127.0.0.1:8888`, scheduler started |
| Output coherence | n/a | correct — "The capital of France is Paris." |
| Throughput | n/a | 81.9 tok/s, TTFT 68 ms (single short request) |
| Footprint | n/a | 90,760 MiB (~88.6 GiB) process RSS; 63.6 GB KV allocatable; 38.1 GB KV allocated; no OOM (119.6 GB total) |

_Footprint note: this branch is based on current `main` (HEAD), which does **not** include the separate `--gpu-memory-utilization` ceiling fix (#180); the ~88.6 GB above reflects `main`'s existing memory behaviour and simply shows the model loads and serves without OOM. Enforcing a tighter total-memory ceiling is out of scope for this crash fix and is handled by #180._

## Test plan

Verified locally on the repo-pinned toolchain (rustc 1.93.1 — what CI's
`dtolnay/rust-toolchain@stable` resolves to in-repo, since rust-toolchain.toml
overrides `rustup default`), CI env `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000`:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --tests` (workspace lints: deny warnings + clippy::all) — clean
- [x] SPDX license headers (`apache/skywalking-eyes`) — no new files; the modified file retains its header
- [x] `cargo test --workspace --locked`
- [x] `typos` (`crate-ci/typos`) — clean
- [x] cargo-deny — unaffected (no dependency/manifest changes)
- [x] Tested against a real model on hardware — built on GB10 and served `nvidia/Qwen3.6-35B-A3B-NVFP4`; crash gone, coherent output (see Benchmarks). Tests n/a beyond this: a one-line revert to the prior-working loader, covered by the served-model regression above.

## Authorship

AI-generated (Claude Opus, under human direction). The root-cause bisect, the fix, and the GB10 validation were performed by an AI agent; a human directed the investigation and will review before merge.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
