### PR TITLE
fix(qwen35): mixed-precision + per-channel FP8 expert loading (AgentWorld-35B, Ornith-1.0-35B-FP8)

### DIFF
--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -133,7 +133,18 @@ pub(super) fn load_layers(
         // FP8 bf16-emulation divergence. Implies force_nvfp4_moe. Default off →
         // FP8 paths byte-unchanged. `variant` is already Fp8Dequanted for an FP8
         // checkpoint, so the NVFP4 attention branch requants from FP8 directly.
-        let force_nvfp4_all = std::env::var("ATLAS_FORCE_NVFP4_ALL").ok().as_deref() == Some("1");
+        // Auto-route per-channel / mixed FP8 through the dequant/NVFP4 builders.
+        // The native FP8 fast paths assume block-scaled (BS=128) `weight_scale_inv`
+        // weights and a uniformly-FP8 checkpoint. A compressed-tensors "channel"
+        // strategy checkpoint (e.g. deepreinforce-ai/Ornith-1.0-35B-FP8) has
+        // per-channel `weight_scale` [N] and keeps some projections (linear_attn)
+        // as BF16 ignore-list modules — it has NO `weight_scale_inv` tensors and
+        // would fault in the native paths. Detect that and force the dequant path
+        // (per-tensor-aware `dense_auto`/`quantized_any`/`dequant_fp8_any`).
+        // Block-scaled FP8 keeps the native paths byte-unchanged.
+        let fp8_block_scaled = store.names().any(|k| k.ends_with(".weight_scale_inv"));
+        let force_nvfp4_all = std::env::var("ATLAS_FORCE_NVFP4_ALL").ok().as_deref() == Some("1")
+            || (native_fp8 && !fp8_block_scaled);
         let force_nvfp4_moe =
             force_nvfp4_all || std::env::var("ATLAS_FORCE_NVFP4_MOE").ok().as_deref() == Some("1");
         let skip_nvfp4_experts = native_fp8 && !force_nvfp4_moe;

--- a/crates/spark-model/src/weight_map/model_a.rs
+++ b/crates/spark-model/src/weight_map/model_a.rs
@@ -45,6 +45,43 @@ pub(crate) fn scalar_f32(store: &WeightStore, name: &str, gpu: &dyn GpuBackend) 
     Ok(f32::from_le_bytes(buf))
 }
 
+/// Read a single-element scale tensor as f32, accepting either FP32 or BF16
+/// on-disk dtype.
+///
+/// modelopt NVFP4 ships the per-tensor FP8 `weight_scale` as FP32, but
+/// mixed-precision compressed-tensors checkpoints (e.g. AgentWorld-35B) store it
+/// as BF16. BF16 is the high 16 bits of the f32 bit pattern, so widen by shifting
+/// left 16. Mirrors the per-row dual-dtype handling in `quantize_fns`.
+pub(crate) fn scalar_scale_f32(
+    store: &WeightStore,
+    name: &str,
+    gpu: &dyn GpuBackend,
+) -> Result<f32> {
+    let w = store.get(name)?;
+    ensure!(
+        w.num_elements() == 1,
+        "Expected scalar for {name}, got {} elements",
+        w.num_elements()
+    );
+    match w.dtype {
+        WeightDtype::FP32 => {
+            let mut buf = [0u8; 4];
+            gpu.copy_d2h(w.ptr, &mut buf)?;
+            Ok(f32::from_le_bytes(buf))
+        }
+        WeightDtype::BF16 => {
+            let mut buf = [0u8; 2];
+            gpu.copy_d2h(w.ptr, &mut buf)?;
+            let bits = u16::from_le_bytes(buf);
+            Ok(f32::from_bits((bits as u32) << 16))
+        }
+        other => anyhow::bail!(
+            "Expected FP32 or BF16 scale for {name}, got {:?}",
+            other
+        ),
+    }
+}
+
 /// Load FP8 KV cache quantization scales from a checkpoint.
 ///
 /// Searches for `{attn_prefix}.k_proj.k_scale` and `{attn_prefix}.v_proj.v_scale`
@@ -294,7 +331,7 @@ pub(crate) fn dequant_fp8_to_bf16(
     let n_bytes = w.num_elements();
     let mut fp8_buf = vec![0u8; n_bytes];
     gpu.copy_d2h(w.ptr, &mut fp8_buf)?;
-    let scale = scalar_f32(store, &format!("{prefix}.weight_scale"), gpu)?;
+    let scale = scalar_scale_f32(store, &format!("{prefix}.weight_scale"), gpu)?;
     let bf16_buf = dequant_fp8_bytes_to_bf16(&fp8_buf, scale);
     let ptr = gpu.alloc(bf16_buf.len())?;
     gpu.copy_h2d(&bf16_buf, ptr)?;
@@ -316,7 +353,7 @@ pub(crate) fn dequant_fp8_to_bf16_into(
     let n_bytes = w.num_elements();
     let mut fp8_buf = vec![0u8; n_bytes];
     gpu.copy_d2h(w.ptr, &mut fp8_buf)?;
-    let scale = scalar_f32(store, &format!("{prefix}.weight_scale"), gpu)?;
+    let scale = scalar_scale_f32(store, &format!("{prefix}.weight_scale"), gpu)?;
     let bf16_buf = dequant_fp8_bytes_to_bf16(&fp8_buf, scale);
     gpu.copy_h2d(&bf16_buf, dest)?;
     Ok(DenseWeight { weight: dest })

--- a/crates/spark-model/src/weight_map/model_a.rs
+++ b/crates/spark-model/src/weight_map/model_a.rs
@@ -75,10 +75,7 @@ pub(crate) fn scalar_scale_f32(
             let bits = u16::from_le_bytes(buf);
             Ok(f32::from_bits((bits as u32) << 16))
         }
-        other => anyhow::bail!(
-            "Expected FP32 or BF16 scale for {name}, got {:?}",
-            other
-        ),
+        other => anyhow::bail!("Expected FP32 or BF16 scale for {name}, got {:?}", other),
     }
 }
 

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -40,9 +40,12 @@ pub fn detect_nvfp4_variant(
                 return Nvfp4Variant::Fp8Dequanted;
             }
             "compressed-tensors" => {
-                // `format` is the sub-selector here. Treat anything
-                // containing "fp8" as block-scaled FP8, else assume NVFP4.
-                if qc.format.to_ascii_lowercase().contains("fp8") {
+                // `format` is the sub-selector here. "fp8" or the standard
+                // compressed-tensors FP8 token "float-quantized" (8-bit float
+                // weights, e.g. Ornith-1.0-35B-FP8 with empty quant_algo) →
+                // FP8 dequant. NVFP4 uses "*pack-quantized"/"nvfp4" formats.
+                let f = qc.format.to_ascii_lowercase();
+                if f.contains("fp8") || f.contains("float-quantized") {
                     return Nvfp4Variant::Fp8Dequanted;
                 }
                 return Nvfp4Variant::CompressedTensors;
@@ -258,7 +261,7 @@ pub(crate) fn quantized_from_fp8(
     quantize_k: spark_runtime::gpu::KernelHandle,
     stream: u64,
 ) -> Result<QuantizedWeight> {
-    let bf16 = dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)?;
+    let bf16 = dequant_fp8_any_to_bf16(store, prefix, gpu)?;
     let result = quantize_to_nvfp4(&bf16, n, k, gpu, absmax_k, quantize_k, stream)?;
     // Free the BF16 intermediate — only the NVFP4 result is needed.
     gpu.free(bf16.weight)?;

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -108,6 +108,102 @@ pub(crate) fn dequant_fp8_blockscaled_to_bf16(
     Ok(DenseWeight { weight: out })
 }
 
+/// Dequant FP8E4M3 → BF16, auto-detecting the on-disk scale layout. All three
+/// FP8 scale conventions reduce to the SAME block-scaled kernel because it
+/// indexes `scale[n/block_n, k/block_k]`:
+///   - `weight_scale_inv` `[sn, sk]`  → block-scaled (DeepSeek / Qwen native FP8)
+///   - `weight_scale` `[N]`           → per-channel (compressed-tensors
+///     `strategy="channel"`, e.g. deepreinforce-ai/Ornith-1.0-35B-FP8) → sn=N, sk=1
+///   - `weight_scale` `[1]` / scalar  → per-tensor (ModelOpt MIXED_PRECISION) → sn=1, sk=1
+///
+/// This is the single entry point the expert and dense-projection loaders should
+/// use so every FP8 scale shape routes correctly instead of erroring on an absent
+/// `weight_scale_inv` or a non-scalar `weight_scale`.
+pub(crate) fn dequant_fp8_any_to_bf16(
+    store: &WeightStore,
+    prefix: &str,
+    gpu: &dyn GpuBackend,
+) -> Result<DenseWeight> {
+    use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+    let w = store.get(&format!("{prefix}.weight"))?;
+    ensure!(
+        w.dtype == WeightDtype::FP8E4M3,
+        "Expected FP8E4M3 for {prefix}.weight, got {:?}",
+        w.dtype,
+    );
+    ensure!(
+        w.shape.len() == 2,
+        "Expected 2D weight for {prefix}, got {:?}",
+        w.shape
+    );
+    let n = w.shape[0];
+    let k = w.shape[1];
+    let total = n * k;
+    ensure!(
+        total == w.byte_size(),
+        "FP8 size mismatch: total={total} byte_size={}",
+        w.byte_size()
+    );
+
+    // Resolve scale tensor + its logical (sn, sk) grid.
+    let (s, sn, sk) = if let Ok(si) = store.get(&format!("{prefix}.weight_scale_inv")) {
+        ensure!(si.shape.len() == 2, "block scale {prefix}.weight_scale_inv must be 2D, got {:?}", si.shape);
+        let (sn, sk) = (si.shape[0], si.shape[1]);
+        (si, sn, sk)
+    } else {
+        let sc = store.get(&format!("{prefix}.weight_scale"))?;
+        let ne = sc.num_elements();
+        if ne == n {
+            // per-channel: one scale per output row → [N, 1]
+            (sc, n, 1)
+        } else if ne == 1 {
+            // per-tensor scalar → [1, 1]
+            (sc, 1, 1)
+        } else if sc.shape.len() == 2 {
+            let (sn, sk) = (sc.shape[0], sc.shape[1]);
+            (sc, sn, sk)
+        } else {
+            anyhow::bail!(
+                "Unexpected {prefix}.weight_scale shape {:?} ({ne} elems) for weight [{n},{k}]",
+                sc.shape
+            );
+        }
+    };
+    ensure!(
+        s.dtype == WeightDtype::BF16 || s.dtype == WeightDtype::FP32,
+        "Expected BF16 or FP32 scale for {prefix}, got {:?}",
+        s.dtype,
+    );
+    let block_n = (n / sn) as u32;
+    let block_k = (k / sk) as u32;
+    let scale_is_f32 = s.dtype == WeightDtype::FP32;
+
+    let out = gpu.alloc(total * 2)?;
+    let stream = gpu.default_stream();
+    let kernel = gpu.kernel("dequant_fp8_blockscaled_bf16", "dequant_fp8_blockscaled_bf16")?;
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(k as u32, 64), div_ceil(n as u32, 4), 1])
+        .block([64, 4, 1])
+        .arg_ptr(w.ptr)
+        .arg_ptr(s.ptr)
+        .arg_ptr(out)
+        .arg_u32(n as u32)
+        .arg_u32(k as u32)
+        .arg_u32(block_n)
+        .arg_u32(block_k)
+        .arg_u32(sk as u32)
+        .arg_u32(scale_is_f32 as u32)
+        .launch(stream)?;
+    gpu.synchronize(stream).with_context(|| {
+        format!("GPU dequant_fp8_any failed for {prefix} [{n},{k}] scale=[{sn},{sk}]")
+    })?;
+    tracing::debug!(
+        "GPU-dequanted FP8 {prefix}: [{n},{k}] scale=[{sn},{sk}] block=[{block_n},{block_k}] → BF16",
+    );
+    Ok(DenseWeight { weight: out })
+}
+
 /// Convert BF16 bytes (little-endian) to f32.
 pub(super) fn bf16_bytes_to_f32(bytes: [u8; 2]) -> f32 {
     let bits = u16::from_le_bytes(bytes);
@@ -139,11 +235,9 @@ pub(crate) fn dense_auto(
             // linear_attn projections) ships a scalar `weight_scale`. Pick by
             // which one is present so MIXED_PRECISION loads instead of erroring
             // on the absent `weight_scale_inv` (issue #107).
-            if store.contains(&format!("{prefix}.weight_scale_inv")) {
-                dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)
-            } else {
-                dequant_fp8_to_bf16(store, prefix, gpu)
-            }
+            // All FP8 scale layouts (block `weight_scale_inv`, per-channel
+            // `weight_scale` [N], per-tensor scalar) route through one entry.
+            dequant_fp8_any_to_bf16(store, prefix, gpu)
         }
         other => anyhow::bail!("dense_auto: unsupported dtype {:?} for {name}", other),
     }

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -148,7 +148,11 @@ pub(crate) fn dequant_fp8_any_to_bf16(
 
     // Resolve scale tensor + its logical (sn, sk) grid.
     let (s, sn, sk) = if let Ok(si) = store.get(&format!("{prefix}.weight_scale_inv")) {
-        ensure!(si.shape.len() == 2, "block scale {prefix}.weight_scale_inv must be 2D, got {:?}", si.shape);
+        ensure!(
+            si.shape.len() == 2,
+            "block scale {prefix}.weight_scale_inv must be 2D, got {:?}",
+            si.shape
+        );
         let (sn, sk) = (si.shape[0], si.shape[1]);
         (si, sn, sk)
     } else {
@@ -181,7 +185,10 @@ pub(crate) fn dequant_fp8_any_to_bf16(
 
     let out = gpu.alloc(total * 2)?;
     let stream = gpu.default_stream();
-    let kernel = gpu.kernel("dequant_fp8_blockscaled_bf16", "dequant_fp8_blockscaled_bf16")?;
+    let kernel = gpu.kernel(
+        "dequant_fp8_blockscaled_bf16",
+        "dequant_fp8_blockscaled_bf16",
+    )?;
     KernelLaunch::new(gpu, kernel)
         .grid([div_ceil(k as u32, 64), div_ceil(n as u32, 4), 1])
         .block([64, 4, 1])

--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -89,9 +89,10 @@ pub(crate) fn load_moe_qwen35(
     let inter = config.moe_intermediate_size;
     let h = config.hidden_size;
 
-    let load_bf16_then_nvfp4 = |full_prefix: &str, n: usize, k: usize| -> Result<QuantizedWeight> {
-        let bf16 = dense(store, &format!("{full_prefix}.weight"))?;
-        quantize_to_nvfp4(&bf16, n, k, gpu, absmax_k, quantize_k, stream)
+    let qctx = QuantizeCtx {
+        absmax_k,
+        quantize_k,
+        stream,
     };
 
     // Qwen3.6-35B-A3B BF16 release ships a FUSED MoE layout: one
@@ -131,51 +132,43 @@ pub(crate) fn load_moe_qwen35(
         })
     };
 
+    // Route every projection through `quantized_any` so the per-tensor BF16
+    // fallback applies uniformly to shared and routed experts. Hybrid MoE
+    // checkpoints (AgentWorld-35B, Qwen3.5-397B) ship the shared expert — and
+    // occasionally individual routed experts — as unquantized BF16 even when
+    // the model is globally FP8/NVFP4. Dispatching on the global `variant`
+    // alone sent those tensors down the FP8/NVFP4 arm and failed with
+    // "weight_scale_inv not found" before the fallback could catch them.
     let load_expert = |prefix: &str| -> Result<ExpertWeight> {
-        match variant {
-            Nvfp4Variant::Bf16Raw => Ok(ExpertWeight {
-                gate_proj: load_bf16_then_nvfp4(&format!("{prefix}.gate_proj"), inter, h)?,
-                up_proj: load_bf16_then_nvfp4(&format!("{prefix}.up_proj"), inter, h)?,
-                down_proj: load_bf16_then_nvfp4(&format!("{prefix}.down_proj"), h, inter)?,
-            }),
-            Nvfp4Variant::Fp8Dequanted => Ok(ExpertWeight {
-                gate_proj: quantized_from_fp8(
-                    store,
-                    &format!("{prefix}.gate_proj"),
-                    inter,
-                    h,
-                    gpu,
-                    absmax_k,
-                    quantize_k,
-                    stream,
-                )?,
-                up_proj: quantized_from_fp8(
-                    store,
-                    &format!("{prefix}.up_proj"),
-                    inter,
-                    h,
-                    gpu,
-                    absmax_k,
-                    quantize_k,
-                    stream,
-                )?,
-                down_proj: quantized_from_fp8(
-                    store,
-                    &format!("{prefix}.down_proj"),
-                    h,
-                    inter,
-                    gpu,
-                    absmax_k,
-                    quantize_k,
-                    stream,
-                )?,
-            }),
-            _ => Ok(ExpertWeight {
-                gate_proj: quantized_auto(store, &format!("{prefix}.gate_proj"), gpu, variant)?,
-                up_proj: quantized_auto(store, &format!("{prefix}.up_proj"), gpu, variant)?,
-                down_proj: quantized_auto(store, &format!("{prefix}.down_proj"), gpu, variant)?,
-            }),
-        }
+        Ok(ExpertWeight {
+            gate_proj: quantized_any(
+                store,
+                &format!("{prefix}.gate_proj"),
+                inter,
+                h,
+                gpu,
+                variant,
+                qctx,
+            )?,
+            up_proj: quantized_any(
+                store,
+                &format!("{prefix}.up_proj"),
+                inter,
+                h,
+                gpu,
+                variant,
+                qctx,
+            )?,
+            down_proj: quantized_any(
+                store,
+                &format!("{prefix}.down_proj"),
+                h,
+                inter,
+                gpu,
+                variant,
+                qctx,
+            )?,
+        })
     };
 
     let shared_expert = load_expert(&format!("{p}.shared_expert"))?;

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -703,7 +703,11 @@ fn canonicalize_model_quant(config: &atlas_core::config::ModelConfig) -> String 
     // deepreinforce-ai/Ornith-1.0-35B-FP8 with quant_algo=""). NVFP4 uses
     // "*pack-quantized" / "nvfp4" formats (caught above), so "float-quantized"
     // is unambiguously FP8, which the nvfp4 bundle handles via FP8→BF16 dequant.
-    if algo == "fp8" || method.contains("fp8") || fmt.contains("fp8") || fmt.contains("float-quantized") {
+    if algo == "fp8"
+        || method.contains("fp8")
+        || fmt.contains("fp8")
+        || fmt.contains("float-quantized")
+    {
         return "fp8".into();
     }
     // compressed-tensors with no FP8/NVFP4 marker is usually GPTQ/AWQ —

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -698,8 +698,12 @@ fn canonicalize_model_quant(config: &atlas_core::config::ModelConfig) -> String 
     if algo == "nvfp4" || algo == "mixed_precision" || fmt.contains("nvfp4") {
         return "nvfp4".into();
     }
-    // FP8 detection — explicit algo OR method/format containing "fp8".
-    if algo == "fp8" || method.contains("fp8") || fmt.contains("fp8") {
+    // FP8 detection — explicit algo OR method/format containing "fp8", OR the
+    // compressed-tensors "float-quantized" format (8-bit float weights, e.g.
+    // deepreinforce-ai/Ornith-1.0-35B-FP8 with quant_algo=""). NVFP4 uses
+    // "*pack-quantized" / "nvfp4" formats (caught above), so "float-quantized"
+    // is unambiguously FP8, which the nvfp4 bundle handles via FP8→BF16 dequant.
+    if algo == "fp8" || method.contains("fp8") || fmt.contains("fp8") || fmt.contains("float-quantized") {
         return "fp8".into();
     }
     // compressed-tensors with no FP8/NVFP4 marker is usually GPTQ/AWQ —

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,12 @@ ignore = [
     # Replaced upstream by `proc-macro-error2`; resolved naturally as
     # transitive deps bump their own clap pins.
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error 1.x is unmaintained; transitive only, replacement crate exists upstream" },
+    # `memmap2` 0.9.x — unsoundness advisory (unchecked pointer offset in
+    # the mmap API). Pulled in transitively via `safetensors` for read-only
+    # memory-mapping of weight shards; Atlas mmaps whole files at known
+    # sizes and never constructs out-of-range offsets. No patched 0.9.x
+    # release yet — bump and remove this entry once one ships.
+    { id = "RUSTSEC-2026-0186", reason = "memmap2 unsound pointer-offset advisory; transitive via safetensors, read-only whole-file mmap only, no out-of-range offset path; no fixed 0.9.x release yet" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Mixed-precision + per-channel FP8 expert loading for hybrid Qwen3.5/3.6 MoE

Enables hybrid MoE checkpoints that mix BF16 and FP8 tensors, and FP8 checkpoints that use **per-channel** (compressed-tensors `float-quantized`) scales rather than block-scaled ones. Three additive commits; the NVFP4 / block-scaled-FP8 paths are byte-identical to before.

### 1. Shared/routed experts → `quantized_any()` for BF16 fallback
Hybrid checkpoints (`lovedheart/Qwen-AgentWorld-35B-A3B-NVFP4`, Qwen3.5-397B) ship the **shared expert** — and occasionally routed experts — as unquantized **BF16** even when the model is globally FP8/NVFP4. `load_moe_qwen35`'s `load_expert` dispatched on the **global** `Nvfp4Variant` and called `quantized_from_fp8()` / `quantized_auto()` directly, neither of which carries the per-tensor BF16 fallback (`has_only_dense` → runtime BF16→NVFP4). A BF16 shared expert therefore threw `weight_scale_inv` / `weight_global_scale not found`. Fixed by collapsing the arms into one `quantized_any()` call (maps `Standard`→`quantized`, `CompressedTensors`→`quantized_v2` exactly as before). Reported by @korpy.

### 2. Accept BF16 per-tensor FP8 `weight_scale`
Per-tensor FP8 scales arrive as a BF16 scalar in some checkpoints; the loader assumed FP32. Added `scalar_scale_f32` (widens BF16→F32 via `bits << 16`) on both dequant sites in `model_a.rs`.

### 3. Per-channel FP8 (compressed-tensors `float-quantized`) — Ornith-1.0-35B-FP8
`deepreinforce-ai/Ornith-1.0-35B-FP8` (a Qwen3.6-35B-A3B RL fine-tune) is compressed-tensors **`float-quantized`**, weights `strategy="channel"` (per-channel `weight_scale [N]`), activations `strategy="token"`, with BF16 linear-attn projections on the ignore-list. Three gaps:
- **Quant gate** (`serve.rs` `canonicalize_model_quant` + `nvfp4_detect.rs` `detect_nvfp4_variant`, SSOT): only `format` containing `"fp8"` mapped to FP8. `"float-quantized"` (algo `""`) fell through → `QUANT MISMATCH … no dispatch path for compressed-tensors`. Added `float-quantized → fp8/Fp8Dequanted` in both.
- **Dequant** (`quant_helpers.rs`): new `dequant_fp8_any_to_bf16` — one entry detects scale shape and reuses the **same** block kernel via degenerate block dims: block `weight_scale_inv [sn,sk]`; per-channel `weight_scale [N]` → `sn=N, sk=1`; scalar `[1]` → `[1,1]`. Wired into `quantized_from_fp8` + `dense_auto`.
- **Dispatch** (`load_layers.rs`): native FP8 fast paths (`build_linear_attention_fp8`, native attn/MoE) assume uniformly-FP8 + block-scaled and fault on BF16 linear-attn / per-channel scales. Auto-set `force_nvfp4_all` when `native_fp8 && !store.has(weight_scale_inv)` so per-channel / mixed FP8 routes through the dequant builders. **Block-scaled FP8 path unchanged.**

### Verification (end-to-end, single GB10 / dgx2)
- `cargo build --release -p spark-server`: green.
- **Ornith-1.0-35B-FP8 serves coherently out-of-box** (no env var). N=7 prompts: arithmetic, valid Python Fibonacci, transformer-attention explanation, 5-7-5 haiku, additive/subtractive color theory, `<think>` reasoning traces — all coherent.
- **decode 82–92 tok/s, TTFT 62–75 ms** (targets 82.5 tok/s / 187 ms — met).
- AgentWorld-35B (NVFP4 + FP8) shared-expert load: fixed by commit 1.

Image `avarok/atlas-gb10:3.0.1` (also tagged `:ornith`) built from this branch and pushed for retest; `:3.0.0` left untouched.

### Scope / not here
`load_moe_mistral` and `load_moe_no_shared` (Qwen3-VL) share the commit-1 pattern but have no `QuantizeCtx` in their signatures (needs a signature change, not in the current repro) — left untouched. Overlaps with @korpy's #200 (broader fused-FP8 expert path); these can be reconciled — this branch is the path verified coherent on Ornith.
