### PR TITLE
fix(qwen35): mixed-precision + fused-FP8 expert support for hybrid checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use atlas_core::config::{LayerType, ModelConfig};
 use spark_runtime::gpu::GpuBackend;
 use spark_runtime::kv_cache::KvCacheDtype;
-use spark_runtime::weights::WeightStore;
+use spark_runtime::weights::{WeightDtype, WeightStore};
 
 use super::super::{ModelWeightLoader, QuantFormat, WeightFormat};
 use crate::layer::TransformerLayer;
@@ -19,6 +19,20 @@ use crate::weight_map::{
     load_fp8_block_scaled_as_fp8weight, load_kv_scales, load_moe_qwen35,
     load_moe_qwen35_fp8_experts, quantize_to_nvfp4,
 };
+
+/// True when a projection ships as native block-scaled FP8 on disk
+/// (`FP8E4M3 .weight` + `.weight_scale_inv`). Hybrid mixed-precision
+/// checkpoints (lovedheart AgentWorld-35B) keep attention/SSM projections in
+/// BF16 — or in block-FP8 under a `.weight_scale` key — even when the model is
+/// globally FP8/NVFP4. Those return false so the loader routes them through
+/// the per-tensor dense/NVFP4 path instead of the native-FP8 fast arm.
+fn proj_is_native_fp8(store: &WeightStore, prefix: &str) -> bool {
+    store
+        .get(&format!("{prefix}.weight"))
+        .map(|w| w.dtype == WeightDtype::FP8E4M3)
+        .unwrap_or(false)
+        && store.contains(&format!("{prefix}.weight_scale_inv"))
+}
 
 pub(super) fn load_layers(
     loader: &dyn ModelWeightLoader,
@@ -136,10 +150,22 @@ pub(super) fn load_layers(
         let force_nvfp4_all = std::env::var("ATLAS_FORCE_NVFP4_ALL").ok().as_deref() == Some("1");
         let force_nvfp4_moe =
             force_nvfp4_all || std::env::var("ATLAS_FORCE_NVFP4_MOE").ok().as_deref() == Some("1");
-        let skip_nvfp4_experts = native_fp8 && !force_nvfp4_moe;
+        // Hybrid FP8 checkpoints (lovedheart AgentWorld-35B-FP8) ship routed
+        // experts in a FUSED layout (`experts.gate_up_proj`/`down_proj`), which
+        // the native-FP8 per-expert loader can't address — it Errs and the MoE
+        // is left with NULL routed experts (gibberish output). `load_moe_qwen35`
+        // handles the fused layout (BF16 and FP8) by dequant→NVFP4, so route
+        // fused checkpoints through the NVFP4 expert path (as ATLAS_FORCE_NVFP4_MOE
+        // does) rather than the native-FP8 per-expert path.
+        let fused_experts = store.contains(&format!("{lp}.mlp.experts.gate_up_proj"));
+        let skip_nvfp4_experts = native_fp8 && !force_nvfp4_moe && !fused_experts;
         if skip_nvfp4_experts {
             tracing::info!(
                 "FP8: skipping NVFP4 routed experts (FP8 fused MoE batch1/2/3 handles all dispatch)"
+            );
+        } else if native_fp8 && fused_experts {
+            tracing::info!(
+                "FP8: routed experts use FUSED layout — loading via NVFP4 expert path (dequant→NVFP4)"
             );
         } else if native_fp8 && force_nvfp4_moe {
             tracing::warn!(
@@ -329,58 +355,77 @@ pub(super) fn load_layers(
             }
         }
 
-        // Native FP8 MoE: load FP8 expert weights for decode
-        if native_fp8
-            && !force_nvfp4_moe
-            && !dequant_moe_to_bf16
-            && let Ok(fp8_experts) =
-                load_moe_qwen35_fp8_experts(store, &lp, config.num_experts, gpu, config)
-        {
-            let sp = format!("{lp}.mlp.shared_expert");
-            use crate::weight_map::{Fp8ExpertWeight as FEW, Fp8Weight as FW};
-            use spark_runtime::gpu::DevicePtr;
-            let null_fw = FW {
-                weight: DevicePtr::NULL,
-                row_scale: DevicePtr::NULL,
-                n: 0,
-                k: 0,
-                // Placeholder for absent shared-expert tensor: the
-                // calling site checks `weight == NULL` before
-                // launching any kernel, so the tag is conventional.
-                // Match the block-scaled FP8 loader the other arms
-                // use so the format is consistent.
-                scale_format: crate::weight_map::WeightQuantFormat::Fp8BlockScaled,
-            };
-            let sh_gate =
-                load_fp8_block_scaled_as_fp8weight(store, &format!("{sp}.gate_proj"), gpu);
-            let sh_up = load_fp8_block_scaled_as_fp8weight(store, &format!("{sp}.up_proj"), gpu);
-            let sh_down =
-                load_fp8_block_scaled_as_fp8weight(store, &format!("{sp}.down_proj"), gpu);
-            if sh_gate.is_err() || sh_up.is_err() || sh_down.is_err() {
-                tracing::warn!(
-                    "Layer {i}: shared expert FP8 load failed (gate={}, up={}, down={})",
-                    sh_gate.is_ok(),
-                    sh_up.is_ok(),
-                    sh_down.is_ok(),
-                );
-            }
-            let shared_fp8 = FEW {
-                gate_proj: sh_gate.unwrap_or(null_fw),
-                up_proj: sh_up.unwrap_or(null_fw),
-                down_proj: sh_down.unwrap_or(null_fw),
-            };
-            if let Err(e) = moe_layer.set_fp8_experts(&fp8_experts, shared_fp8, gpu) {
-                tracing::error!("Layer {i}: failed to build FP8 expert pointer tables: {e:#}");
-                tracing::warn!("Layer {i}: falling back to NVFP4-only decode for MoE experts");
-            } else {
-                tracing::info!("Layer {i}: MoE experts loaded as native FP8");
+        // Native FP8 MoE: load FP8 expert weights for decode. Skipped for fused
+        // layouts (handled above via the NVFP4 expert path). NOTE: a failure
+        // here is logged loudly — previously the load Err was swallowed by an
+        // `if let Ok(...)` guard, leaving routed experts NULL and the model
+        // emitting gibberish with no error (root cause of the AgentWorld-FP8
+        // incoherence before the fused-layout fix).
+        if native_fp8 && !force_nvfp4_moe && !dequant_moe_to_bf16 && !fused_experts {
+            let fp8_experts =
+                match load_moe_qwen35_fp8_experts(store, &lp, config.num_experts, gpu, config) {
+                    Ok(e) => Some(e),
+                    Err(e) => {
+                        tracing::error!(
+                            "Layer {i}: native-FP8 expert load failed: {e:#} — routed experts \
+                             would be NULL (incoherent output). MoE left on its fallback path."
+                        );
+                        None
+                    }
+                };
+            if let Some(fp8_experts) = fp8_experts {
+                let sp = format!("{lp}.mlp.shared_expert");
+                use crate::weight_map::{Fp8ExpertWeight as FEW, Fp8Weight as FW};
+                use spark_runtime::gpu::DevicePtr;
+                let null_fw = FW {
+                    weight: DevicePtr::NULL,
+                    row_scale: DevicePtr::NULL,
+                    n: 0,
+                    k: 0,
+                    // Placeholder for absent shared-expert tensor: the
+                    // calling site checks `weight == NULL` before
+                    // launching any kernel, so the tag is conventional.
+                    // Match the block-scaled FP8 loader the other arms
+                    // use so the format is consistent.
+                    scale_format: crate::weight_map::WeightQuantFormat::Fp8BlockScaled,
+                };
+                let sh_gate =
+                    load_fp8_block_scaled_as_fp8weight(store, &format!("{sp}.gate_proj"), gpu);
+                let sh_up =
+                    load_fp8_block_scaled_as_fp8weight(store, &format!("{sp}.up_proj"), gpu);
+                let sh_down =
+                    load_fp8_block_scaled_as_fp8weight(store, &format!("{sp}.down_proj"), gpu);
+                if sh_gate.is_err() || sh_up.is_err() || sh_down.is_err() {
+                    tracing::warn!(
+                        "Layer {i}: shared expert FP8 load failed (gate={}, up={}, down={})",
+                        sh_gate.is_ok(),
+                        sh_up.is_ok(),
+                        sh_down.is_ok(),
+                    );
+                }
+                let shared_fp8 = FEW {
+                    gate_proj: sh_gate.unwrap_or(null_fw),
+                    up_proj: sh_up.unwrap_or(null_fw),
+                    down_proj: sh_down.unwrap_or(null_fw),
+                };
+                if let Err(e) = moe_layer.set_fp8_experts(&fp8_experts, shared_fp8, gpu) {
+                    tracing::error!("Layer {i}: failed to build FP8 expert pointer tables: {e:#}");
+                    tracing::warn!("Layer {i}: falling back to NVFP4-only decode for MoE experts");
+                } else {
+                    tracing::info!("Layer {i}: MoE experts loaded as native FP8");
+                }
             }
         }
 
         let ffn = FfnComponent::Moe(moe_layer);
 
         match lt {
-            LayerType::FullAttention if native_fp8 && dequant_attn_to_bf16 && !force_nvfp4_all => {
+            LayerType::FullAttention
+                if native_fp8
+                    && dequant_attn_to_bf16
+                    && !force_nvfp4_all
+                    && proj_is_native_fp8(store, &format!("{lp}.self_attn.q_proj")) =>
+            {
                 // ── BF16-dequant attention (diagnostic, TP=1) ──
                 // Dequant FP8 Q/K/V/O → BF16 on GPU, store as dense weights,
                 // and leave q/k/v/o quant-weights None so both prefill and
@@ -434,7 +479,11 @@ pub(super) fn load_layers(
                 layers.push(Box::new(layer));
                 attn_idx += 1;
             }
-            LayerType::FullAttention if native_fp8 && !force_nvfp4_all => {
+            LayerType::FullAttention
+                if native_fp8
+                    && !force_nvfp4_all
+                    && proj_is_native_fp8(store, &format!("{lp}.self_attn.q_proj")) =>
+            {
                 // ── Native FP8 path: FP8 for both decode AND prefill ──
                 // NO NVFP4 dequant — saves ~30 GB peak memory on 122B EP=2.
                 // Decode uses w8a16_gemv, prefill uses w8a16_gemm (both with
@@ -572,10 +621,31 @@ pub(super) fn load_layers(
             // All non-FP8 variants (NVFP4 native, BF16, etc.) take the
             // existing NVFP4-quantized decode path.
             LayerType::LinearAttention => {
+                // Native-FP8 SSM decode is valid only when in_proj_qkv actually
+                // ships as block-scaled FP8 (FP8E4M3 + `weight_scale_inv`).
+                // Hybrid checkpoints (lovedheart AgentWorld-35B-FP8) keep the SSM
+                // in BF16 even when globally FP8 → route those to the NVFP4
+                // builder, which dequants per-tensor via `dense_auto` then
+                // runtime-quantizes. True-FP8 checkpoints (397B, Qwen3.6-FP8)
+                // keep the fast native-FP8 arm unchanged.
+                let ssm_native_fp8 =
+                    proj_is_native_fp8(store, &format!("{lp}.linear_attn.in_proj_qkv"));
+                // A BF16 SSM inside a globally-FP8 checkpoint must NOT take the
+                // Fp8Dequanted single-scale FP8 *prefill* bypass (it assumes the
+                // SSM shipped as native FP8) — that corrupts prefill on a
+                // BF16-sourced SSM. Hand the NVFP4 builder `Bf16Raw` so it uses
+                // the plain BF16→NVFP4 path (identical to how the NVFP4 checkpoint
+                // loads its SSM). Genuine FP8 SSMs keep `variant` unchanged.
+                let ssm_variant =
+                    if matches!(variant, Nvfp4Variant::Fp8Dequanted) && !ssm_native_fp8 {
+                        Nvfp4Variant::Bf16Raw
+                    } else {
+                        variant
+                    };
                 let layer = match variant {
                     // force_nvfp4_all routes the FP8 SSM through the NVFP4 builder
                     // (Fp8Dequanted requant) instead of the native-FP8 build.
-                    Nvfp4Variant::Fp8Dequanted if !force_nvfp4_all => {
+                    Nvfp4Variant::Fp8Dequanted if !force_nvfp4_all && ssm_native_fp8 => {
                         linear_attn_arms::build_linear_attention_fp8(
                             i,
                             store,
@@ -594,7 +664,7 @@ pub(super) fn load_layers(
                         store,
                         &lp,
                         gpu,
-                        variant,
+                        ssm_variant,
                         config,
                         h,
                         absmax_k,

--- a/crates/spark-model/src/weight_loader/qwen35/load_layers/attention_arms.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers/attention_arms.rs
@@ -50,7 +50,28 @@ pub(super) fn build_full_attention_nvfp4(
                               full_k: usize,
                               kind: TpShardKind|
              -> Result<crate::weight_map::QuantizedWeight> {
-                let src = quantized_auto(store, &format!("{p}.{name}"), gpu, variant)?;
+                let prefix = format!("{p}.{name}");
+                // Mixed-precision compressed-tensors checkpoints (lovedheart
+                // AgentWorld-35B-NVFP4) NVFP4-pack the MoE experts but keep
+                // attention q/k/v/o as block-scaled FP8 (`.weight` FP8E4M3 + 2D
+                // `.weight_scale`, no `.weight_packed`). When the pack metadata
+                // is absent, dequant per-tensor and runtime-quantize to NVFP4
+                // (mirrors the Standard arm) instead of failing on the missing
+                // `weight_packed`.
+                let src = if store.contains(&format!("{prefix}.weight_packed")) {
+                    quantized_auto(store, &prefix, gpu, variant)?
+                } else {
+                    let dense_bf16 = dense_auto(store, &format!("{prefix}.weight"), gpu)?;
+                    quantize_to_nvfp4(
+                        &dense_bf16,
+                        full_n,
+                        full_k,
+                        gpu,
+                        absmax_k,
+                        quantize_k,
+                        stream,
+                    )?
+                };
                 if tp_size == 1 {
                     return Ok(src);
                 }

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -63,10 +63,20 @@ pub(crate) fn dequant_fp8_blockscaled_to_bf16(
         "FP8 size mismatch: total={total} byte_size={byte_size}"
     );
 
-    let s = store.get(&format!("{prefix}.weight_scale_inv"))?;
+    // Block scale key: DeepSeek/Qwen native FP8 ships `weight_scale_inv`;
+    // ModelOpt / compressed-tensors mixed-precision checkpoints (e.g.
+    // lovedheart AgentWorld-35B attention + SSM kept block-FP8 while the MoE
+    // is NVFP4) ship a 2D `weight_scale`. Both are the per-block dequant
+    // multiplier consumed identically by `dequant_fp8_blockscaled_bf16`.
+    let scale_key = if store.contains(&format!("{prefix}.weight_scale_inv")) {
+        format!("{prefix}.weight_scale_inv")
+    } else {
+        format!("{prefix}.weight_scale")
+    };
+    let s = store.get(&scale_key)?;
     ensure!(
         s.dtype == WeightDtype::BF16 || s.dtype == WeightDtype::FP32,
-        "Expected BF16 or FP32 for {prefix}.weight_scale_inv, got {:?}",
+        "Expected BF16 or FP32 for {scale_key}, got {:?}",
         s.dtype,
     );
     let sn = s.shape[0];
@@ -139,7 +149,17 @@ pub(crate) fn dense_auto(
             // linear_attn projections) ships a scalar `weight_scale`. Pick by
             // which one is present so MIXED_PRECISION loads instead of erroring
             // on the absent `weight_scale_inv` (issue #107).
-            if store.contains(&format!("{prefix}.weight_scale_inv")) {
+            // Block-scaled FP8 ships a 2D scale (Qwen/DeepSeek native:
+            // `weight_scale_inv`; ModelOpt mixed-precision: `weight_scale`).
+            // Per-tensor FP8 (nvidia MIXED_PRECISION) ships a *scalar*
+            // `weight_scale`. Take the block dequant whenever a 2D scale is
+            // present under either key, else fall to the scalar path.
+            let has_scale_inv = store.contains(&format!("{prefix}.weight_scale_inv"));
+            let scale_is_2d = store
+                .get(&format!("{prefix}.weight_scale"))
+                .map(|s| s.shape.len() == 2)
+                .unwrap_or(false);
+            if has_scale_inv || scale_is_2d {
                 dequant_fp8_blockscaled_to_bf16(store, prefix, gpu)
             } else {
                 dequant_fp8_to_bf16(store, prefix, gpu)

--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -89,9 +89,10 @@ pub(crate) fn load_moe_qwen35(
     let inter = config.moe_intermediate_size;
     let h = config.hidden_size;
 
-    let load_bf16_then_nvfp4 = |full_prefix: &str, n: usize, k: usize| -> Result<QuantizedWeight> {
-        let bf16 = dense(store, &format!("{full_prefix}.weight"))?;
-        quantize_to_nvfp4(&bf16, n, k, gpu, absmax_k, quantize_k, stream)
+    let qctx = QuantizeCtx {
+        absmax_k,
+        quantize_k,
+        stream,
     };
 
     // Qwen3.6-35B-A3B BF16 release ships a FUSED MoE layout: one
@@ -131,51 +132,43 @@ pub(crate) fn load_moe_qwen35(
         })
     };
 
+    // Route every projection through `quantized_any` so the per-tensor BF16
+    // fallback applies uniformly to shared and routed experts. Hybrid MoE
+    // checkpoints (AgentWorld-35B, Qwen3.5-397B) ship the shared expert — and
+    // occasionally individual routed experts — as unquantized BF16 even when
+    // the model is globally FP8/NVFP4. Dispatching on the global `variant`
+    // alone sent those tensors down the FP8/NVFP4 arm and failed with
+    // "weight_scale_inv not found" before the fallback could catch them.
     let load_expert = |prefix: &str| -> Result<ExpertWeight> {
-        match variant {
-            Nvfp4Variant::Bf16Raw => Ok(ExpertWeight {
-                gate_proj: load_bf16_then_nvfp4(&format!("{prefix}.gate_proj"), inter, h)?,
-                up_proj: load_bf16_then_nvfp4(&format!("{prefix}.up_proj"), inter, h)?,
-                down_proj: load_bf16_then_nvfp4(&format!("{prefix}.down_proj"), h, inter)?,
-            }),
-            Nvfp4Variant::Fp8Dequanted => Ok(ExpertWeight {
-                gate_proj: quantized_from_fp8(
-                    store,
-                    &format!("{prefix}.gate_proj"),
-                    inter,
-                    h,
-                    gpu,
-                    absmax_k,
-                    quantize_k,
-                    stream,
-                )?,
-                up_proj: quantized_from_fp8(
-                    store,
-                    &format!("{prefix}.up_proj"),
-                    inter,
-                    h,
-                    gpu,
-                    absmax_k,
-                    quantize_k,
-                    stream,
-                )?,
-                down_proj: quantized_from_fp8(
-                    store,
-                    &format!("{prefix}.down_proj"),
-                    h,
-                    inter,
-                    gpu,
-                    absmax_k,
-                    quantize_k,
-                    stream,
-                )?,
-            }),
-            _ => Ok(ExpertWeight {
-                gate_proj: quantized_auto(store, &format!("{prefix}.gate_proj"), gpu, variant)?,
-                up_proj: quantized_auto(store, &format!("{prefix}.up_proj"), gpu, variant)?,
-                down_proj: quantized_auto(store, &format!("{prefix}.down_proj"), gpu, variant)?,
-            }),
-        }
+        Ok(ExpertWeight {
+            gate_proj: quantized_any(
+                store,
+                &format!("{prefix}.gate_proj"),
+                inter,
+                h,
+                gpu,
+                variant,
+                qctx,
+            )?,
+            up_proj: quantized_any(
+                store,
+                &format!("{prefix}.up_proj"),
+                inter,
+                h,
+                gpu,
+                variant,
+                qctx,
+            )?,
+            down_proj: quantized_any(
+                store,
+                &format!("{prefix}.down_proj"),
+                h,
+                inter,
+                gpu,
+                variant,
+                qctx,
+            )?,
+        })
     };
 
     let shared_expert = load_expert(&format!("{p}.shared_expert"))?;

--- a/crates/spark-model/src/weight_map/ssm_qwen35.rs
+++ b/crates/spark-model/src/weight_map/ssm_qwen35.rs
@@ -63,6 +63,48 @@ pub(crate) fn load_ssm_qwen35(
     })
 }
 
+/// Dequant a block-scaled FP8 weight to a fresh BF16 device buffer, given
+/// device pointers (not store keys). Mirrors `dequant_fp8_blockscaled_to_bf16`
+/// but operates on an aliased slice of a *fused* expert tensor
+/// (`experts.gate_up_proj` / `experts.down_proj`), where per-expert weights
+/// cannot be addressed by name. Caller owns and frees the returned buffer.
+#[allow(clippy::too_many_arguments)]
+fn dequant_fp8_block_slice_bf16(
+    gpu: &dyn GpuBackend,
+    weight_ptr: DevicePtr,
+    scale_ptr: DevicePtr,
+    n: usize,
+    k: usize,
+    sn: usize,
+    sk: usize,
+    scale_is_f32: bool,
+) -> Result<DevicePtr> {
+    use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+    let out = gpu.alloc(n * k * 2)?; // BF16 = 2 bytes/element
+    let block_n = (n / sn) as u32;
+    let block_k = (k / sk) as u32;
+    let stream = gpu.default_stream();
+    let kernel = gpu.kernel(
+        "dequant_fp8_blockscaled_bf16",
+        "dequant_fp8_blockscaled_bf16",
+    )?;
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(k as u32, 64), div_ceil(n as u32, 4), 1])
+        .block([64, 4, 1])
+        .arg_ptr(weight_ptr)
+        .arg_ptr(scale_ptr)
+        .arg_ptr(out)
+        .arg_u32(n as u32)
+        .arg_u32(k as u32)
+        .arg_u32(block_n)
+        .arg_u32(block_k)
+        .arg_u32(sk as u32)
+        .arg_u32(scale_is_f32 as u32)
+        .launch(stream)?;
+    gpu.synchronize(stream)?;
+    Ok(out)
+}
+
 /// Load MoE weights for Qwen3.5, auto-selecting NVFP4 naming convention.
 ///
 /// Under EP (ep_world_size > 1), only local experts are loaded from the store.
@@ -101,35 +143,108 @@ pub(crate) fn load_moe_qwen35(
     // each expert at load time and runtime-quantize to NVFP4.
     let fused_gate_up_key = format!("{p}.experts.gate_up_proj");
     let fused_down_key = format!("{p}.experts.down_proj");
-    let is_fused_bf16 = variant == Nvfp4Variant::Bf16Raw
-        && store.contains(&fused_gate_up_key)
-        && store.contains(&fused_down_key);
+    // FUSED expert layout: one `experts.gate_up_proj [E, 2*inter, h]` + one
+    // `experts.down_proj [E, h, inter]` per layer, sliced per expert at load and
+    // runtime-quantized to NVFP4. Two on-disk dtypes occur in the wild:
+    //   - BF16 (Qwen3.6-35B-A3B BF16 release) → slice and quantize directly.
+    //   - FP8E4M3 block-scaled (lovedheart AgentWorld-35B FP8: routed experts
+    //     fused-FP8 with `*_scale_inv`, while attention/SSM/shared are BF16) →
+    //     dequant each slice FP8→BF16 (reusing dequant_fp8_blockscaled_bf16)
+    //     then quantize to NVFP4. Equivalent to the proven NVFP4 expert decode
+    //     path (cf. ATLAS_FORCE_NVFP4_MOE), so no native-FP8 fused-shared kernel
+    //     contract is involved. Detection is dtype-based, not variant-based, so
+    //     it also covers a fused-BF16 layer inside a globally-FP8 checkpoint.
+    let is_fused = store.contains(&fused_gate_up_key) && store.contains(&fused_down_key);
+    let fused_is_fp8 = is_fused
+        && store
+            .get(&fused_gate_up_key)
+            .map(|w| w.dtype == WeightDtype::FP8E4M3)
+            .unwrap_or(false);
 
     let load_expert_fused = |expert_idx: usize| -> Result<ExpertWeight> {
-        // gate_up: [num_experts, 2*inter, hidden] BF16
         let fused_gu = store.get(&fused_gate_up_key)?;
-        // down: [num_experts, hidden, inter] BF16
         let fused_d = store.get(&fused_down_key)?;
-        let bf16 = 2usize;
-        let gu_per_expert_bytes = 2 * inter * h * bf16;
-        let d_per_expert_bytes = h * inter * bf16;
-        let gate_off = expert_idx * gu_per_expert_bytes;
-        let up_off = gate_off + inter * h * bf16;
-        let down_off = expert_idx * d_per_expert_bytes;
-        let gate_dw = DenseWeight {
-            weight: fused_gu.ptr.offset(gate_off),
-        };
-        let up_dw = DenseWeight {
-            weight: fused_gu.ptr.offset(up_off),
-        };
-        let down_dw = DenseWeight {
-            weight: fused_d.ptr.offset(down_off),
-        };
-        Ok(ExpertWeight {
-            gate_proj: quantize_to_nvfp4(&gate_dw, inter, h, gpu, absmax_k, quantize_k, stream)?,
-            up_proj: quantize_to_nvfp4(&up_dw, inter, h, gpu, absmax_k, quantize_k, stream)?,
-            down_proj: quantize_to_nvfp4(&down_dw, h, inter, gpu, absmax_k, quantize_k, stream)?,
-        })
+        if fused_is_fp8 {
+            // gate_up: [E, 2*inter, h] FP8 + gate_up_proj_scale_inv [E, sn, sk]
+            // down:    [E, h, inter] FP8   + down_proj_scale_inv    [E, sn, sk]
+            let gu_s = store.get(&format!("{fused_gate_up_key}_scale_inv"))?;
+            let d_s = store.get(&format!("{fused_down_key}_scale_inv"))?;
+            let (gu_sn, gu_sk) = (gu_s.shape[1], gu_s.shape[2]);
+            let (d_sn, d_sk) = (d_s.shape[1], d_s.shape[2]);
+            let gu_s_f32 = gu_s.dtype == WeightDtype::FP32;
+            let d_s_f32 = d_s.dtype == WeightDtype::FP32;
+            let gu_w_stride = 2 * inter * h; // FP8 = 1 byte/element
+            let d_w_stride = h * inter;
+            let gu_s_elem = if gu_s_f32 { 4 } else { 2 };
+            let d_s_elem = if d_s_f32 { 4 } else { 2 };
+            let gu_s_stride = gu_sn * gu_sk * gu_s_elem;
+            let d_s_stride = d_sn * d_sk * d_s_elem;
+            // Dequant the whole gate_up[e] [2*inter, h] FP8 → BF16, then slice
+            // gate (rows 0..inter) and up (rows inter..2*inter).
+            let gu_bf16 = dequant_fp8_block_slice_bf16(
+                gpu,
+                fused_gu.ptr.offset(expert_idx * gu_w_stride),
+                gu_s.ptr.offset(expert_idx * gu_s_stride),
+                2 * inter,
+                h,
+                gu_sn,
+                gu_sk,
+                gu_s_f32,
+            )?;
+            let down_bf16 = dequant_fp8_block_slice_bf16(
+                gpu,
+                fused_d.ptr.offset(expert_idx * d_w_stride),
+                d_s.ptr.offset(expert_idx * d_s_stride),
+                h,
+                inter,
+                d_sn,
+                d_sk,
+                d_s_f32,
+            )?;
+            let gate_dw = DenseWeight { weight: gu_bf16 };
+            let up_dw = DenseWeight {
+                weight: gu_bf16.offset(inter * h * 2), // BF16 = 2 bytes
+            };
+            let down_dw = DenseWeight { weight: down_bf16 };
+            let out = ExpertWeight {
+                gate_proj: quantize_to_nvfp4(
+                    &gate_dw, inter, h, gpu, absmax_k, quantize_k, stream,
+                )?,
+                up_proj: quantize_to_nvfp4(&up_dw, inter, h, gpu, absmax_k, quantize_k, stream)?,
+                down_proj: quantize_to_nvfp4(
+                    &down_dw, h, inter, gpu, absmax_k, quantize_k, stream,
+                )?,
+            };
+            gpu.free(gu_bf16)?;
+            gpu.free(down_bf16)?;
+            Ok(out)
+        } else {
+            // BF16 fused: slice and quantize directly.
+            let bf16 = 2usize;
+            let gu_per_expert_bytes = 2 * inter * h * bf16;
+            let d_per_expert_bytes = h * inter * bf16;
+            let gate_off = expert_idx * gu_per_expert_bytes;
+            let up_off = gate_off + inter * h * bf16;
+            let down_off = expert_idx * d_per_expert_bytes;
+            let gate_dw = DenseWeight {
+                weight: fused_gu.ptr.offset(gate_off),
+            };
+            let up_dw = DenseWeight {
+                weight: fused_gu.ptr.offset(up_off),
+            };
+            let down_dw = DenseWeight {
+                weight: fused_d.ptr.offset(down_off),
+            };
+            Ok(ExpertWeight {
+                gate_proj: quantize_to_nvfp4(
+                    &gate_dw, inter, h, gpu, absmax_k, quantize_k, stream,
+                )?,
+                up_proj: quantize_to_nvfp4(&up_dw, inter, h, gpu, absmax_k, quantize_k, stream)?,
+                down_proj: quantize_to_nvfp4(
+                    &down_dw, h, inter, gpu, absmax_k, quantize_k, stream,
+                )?,
+            })
+        }
     };
 
     // Route every projection through `quantized_any` so the per-tensor BF16
@@ -177,7 +292,7 @@ pub(crate) fn load_moe_qwen35(
     for e in 0..num_experts {
         if skip_routed_experts || !config.is_local_expert(e) {
             experts.push(ExpertWeight::null());
-        } else if is_fused_bf16 {
+        } else if is_fused {
             experts.push(load_expert_fused(e)?);
         } else {
             experts.push(load_expert(&format!("{p}.experts.{e}"))?);


### PR DESCRIPTION
## What
Make the Qwen3.5/3.6 weight loader tolerate the **per-tensor mixed precision** and **fused expert** layouts that real hybrid checkpoints ship, so `Qwen-AgentWorld-35B-A3B` loads and serves coherently in **both FP8 and NVFP4** on GB10 (SM121).

Supersedes #199 — this PR covers both gaps there (shared-expert `quantized_any` routing; a scalar `weight_scale` reader accepting BF16/FP32) plus three more. The first commit is the shared-expert `quantized_any` fallback (authored by @AzeezIsh, preserved); the second is the remaining five-gap fix.

## Why
`lovedheart/Qwen-AgentWorld-35B-A3B-{FP8,NVFP4}` quantize only the MoE **routed experts** and keep attention q/k/v/o, the SSM `linear_attn` projections, and the **shared expert** in BF16 (FP8 ckpt) or block-FP8 under a `.weight_scale` key (NVFP4 ckpt). The FP8 ckpt additionally ships routed experts in a **fused** layout (`experts.gate_up_proj`/`down_proj`). The loader assumed uniform quant + a per-expert layout, so these checkpoints either threw at load or — worse — loaded and emitted gibberish (routed experts left NULL by a silently-swallowed load `Err`).

## The fix (5 gaps, all reuse existing kernels — no new CUDA)
1. `dense_auto`: FP8E4M3 + a 2D `.weight_scale` (no `_inv`) → block dequant, not the scalar path.
2. `dequant_fp8_blockscaled_to_bf16`: accept `.weight_scale` as well as `.weight_scale_inv`.
3. Dispatch (LinearAttention + FullAttention): take the native-FP8 fast arm only when the projection is genuinely native block-FP8 (`FP8E4M3 .weight` + `.weight_scale_inv`); BF16 / block-FP8-`.weight_scale` fall to the per-tensor dense/NVFP4 builder. CompressedTensors attention arm gains a per-projection fallback to `dense_auto`+quantize when `.weight_packed` is absent.
4. **Fused FP8 routed experts**: `load_moe_qwen35` detects the fused layout by tensor+dtype (not the global variant) and handles BF16 **and** FP8 — FP8 slices are dequanted per expert then quantized to NVFP4 (the proven `ATLAS_FORCE_NVFP4_MOE` decode path). Also fixes a fused-BF16 layer inside a globally-FP8 checkpoint (the old `is_fused_bf16` was variant-gated).
5. **Un-silence** the native-FP8 expert-load `Err` (was an `if let Ok(...)` swallow → NULL routed experts → silent gibberish). Now logged loudly.

True-FP8 checkpoints (397B, Qwen3.6-35B-A3B-FP8) keep the native-FP8 fast path unchanged (detection gated on genuine block-FP8), so **no regression**.

## Benchmarks (single GB10, `avarok/atlas-gb10:3.0.0` runtime + this binary)
| ckpt | before | after |
|---|---|---|
| AgentWorld-35B **FP8** | load wall, then gibberish | loads, serves, smoke 2+2=4, finance core-8 **40/40**, **~82.5 tok/s** decode / ~187 ms TTFT |
| AgentWorld-35B **NVFP4** | load wall | loads, serves, smoke 2+2=4, finance core-8 **40/40**, **~94.6 tok/s** decode / ~70 ms TTFT |

(c=1, 200-tok fixed, temp 0, N=5 steady-state. NVFP4 eval is engine-equivalent to a prior vLLM-NVFP4 run.)

## Verification
`cargo fmt --all --check` ✓ · `cargo clippy --workspace -- -D warnings` ✓ · `cargo test -p spark-model` 76/76 ✓. Built in `nvidia/cuda:13.0.0-devel-ubuntu24.04` with `ATLAS_TARGET_MODEL='*'`.

## Authorship
AI-generated using Claude Code (Opus 4.8). CLA: acknowledged — happy to reply on the CLA bot thread.