### PR TITLE
fix(tool-parser): strip spurious trailing close markers leaking into streamed content

### DIFF
--- a/crates/spark-server/src/api/stream_guards.rs
+++ b/crates/spark-server/src/api/stream_guards.rs
@@ -147,7 +147,50 @@ pub fn flush_content_sanitizer(
         .map(|t| t.len())
         .max()
         .unwrap_or(0);
-    let final_text = std::mem::take(tag_scan_buf);
+    let mut final_text = std::mem::take(tag_scan_buf);
+    // Drop any COMPLETE standalone close markers still sitting in the
+    // held-back tail. The streaming `sanitize_content_chunk` loop drops a
+    // close via its `OrphanClose` arm, but a close that only finishes
+    // assembling at end-of-stream (or one preceded by whitespace, e.g.
+    // `\n\n</_call>`, so the tail's `looks_like_partial_tag` check below
+    // never fires) survives into this flush. Without stripping it here,
+    // the spurious redundant close some models emit right after the real
+    // `</tool_call>` (Ornith-1.0: `</_call>` — BPE-split into `</` `_`
+    // `call` `>` — or a doubled `</tool_call>`) leaks into streamed
+    // `content`. This generalises to every marker in `markers.close`,
+    // including multi-token ones, since we match the assembled buffer.
+    loop {
+        let earliest = markers
+            .close
+            .iter()
+            .filter_map(|t| final_text.find(t).map(|p| (p, t.len())))
+            .min_by_key(|(p, _)| *p);
+        match earliest {
+            Some((pos, len)) => {
+                final_text.replace_range(pos..pos + len, "");
+            }
+            None => break,
+        }
+    }
+    // Drop a TRAILING INCOMPLETE close marker (e.g. the stream ended after
+    // `</_call` before its closing `>` arrived). The original
+    // `looks_like_partial_tag` guard below only fires when the WHOLE tail
+    // is a partial opener (`t.starts_with('<')`); a partial close preceded
+    // by emittable content/whitespace — `\n\n</_call` — slips past it and
+    // leaks. Find the last `<` and, if everything from it to end-of-buffer
+    // is a strict prefix of some close marker (and not a complete marker —
+    // those were already removed above), trim it off. The preceding bytes
+    // are real content and still flush.
+    if let Some(lt) = final_text.rfind('<') {
+        let suffix = &final_text[lt..];
+        let is_partial_close = markers
+            .close
+            .iter()
+            .any(|t| t.len() > suffix.len() && t.starts_with(suffix));
+        if is_partial_close {
+            final_text.truncate(lt);
+        }
+    }
     let looks_like_partial_tag = {
         let t = final_text.trim_end();
         tag_max > 0 && t.starts_with('<') && !t.contains(char::is_whitespace) && t.len() < tag_max

--- a/crates/spark-server/src/tool_parser/tests/streaming_frag.rs
+++ b/crates/spark-server/src/tool_parser/tests/streaming_frag.rs
@@ -385,6 +385,237 @@ fn kill_switch_buffers_full_args_no_fragments() {
     assert_eq!(args["content"], "hello");
 }
 
+/// End-to-end streaming harness: feed each chunk through the detector
+/// exactly as `handle_token` does, routing every `Content` payload
+/// through the production `sanitize_content_chunk` with the qwen3_coder
+/// leak markers. Returns `(tool_calls, content)` where `tool_calls` is
+/// the list of `(name, args_json)` reassembled from the incremental
+/// Start/Fragment/Delta/End (or bulk `ToolCall`) events, and `content`
+/// is the concatenation of every post-sanitizer content chunk — i.e.
+/// exactly what the client would see in `choices[].delta.content`.
+fn stream_through_pipeline(chunks: &[&str]) -> (Vec<(String, String)>, String) {
+    use crate::tool_parser::LeakMarkers;
+    let markers: LeakMarkers = Qwen3CoderParser.leak_markers();
+    let mut det = StreamingToolDetector::new_with_tools(write_and_bash_tools());
+
+    // Sanitizer state (mirrors the per-request fields on `StreamState`).
+    let mut tag_scan_buf = String::new();
+    let mut suppressing = false;
+    let mut inside_env = false;
+
+    // Tool-call accumulators keyed by idx (mirrors streaming_tool_args).
+    let mut tc_acc: std::collections::BTreeMap<usize, (String, String)> =
+        std::collections::BTreeMap::new();
+    let mut content = String::new();
+
+    let run = |out: &[DetectorOutput],
+               tc_acc: &mut std::collections::BTreeMap<usize, (String, String)>,
+               content: &mut String,
+               tag_scan_buf: &mut String,
+               suppressing: &mut bool,
+               inside_env: &mut bool| {
+        for o in out {
+            match o {
+                DetectorOutput::Content(text) => {
+                    // Content → Tool boundary handling in production runs a
+                    // `flush_content_sanitizer` on tool events; here the
+                    // content arm just sanitizes (the leak we test is pure
+                    // content, never a tool event).
+                    let s = crate::api::sanitizer::sanitize_content_chunk(
+                        text,
+                        tag_scan_buf,
+                        suppressing,
+                        inside_env,
+                        &markers,
+                    );
+                    content.push_str(&s);
+                }
+                DetectorOutput::ToolCallStart { name, idx, .. } => {
+                    tc_acc.insert(*idx, (name.clone(), String::new()));
+                }
+                DetectorOutput::ToolCallArgsFragment { fragment, idx } => {
+                    tc_acc.entry(*idx).or_default().1.push_str(fragment);
+                }
+                DetectorOutput::ToolCallDelta { args, idx } => {
+                    tc_acc.entry(*idx).or_default().1.push_str(args);
+                }
+                DetectorOutput::ToolCall(tc, idx) => {
+                    tc_acc.insert(
+                        *idx,
+                        (tc.function.name.clone(), tc.function.arguments.clone()),
+                    );
+                }
+                DetectorOutput::ToolCallEnd { .. } => {}
+            }
+        }
+    };
+
+    for c in chunks {
+        let out = det.process(c);
+        run(
+            &out,
+            &mut tc_acc,
+            &mut content,
+            &mut tag_scan_buf,
+            &mut suppressing,
+            &mut inside_env,
+        );
+    }
+    let out = det.flush();
+    run(
+        &out,
+        &mut tc_acc,
+        &mut content,
+        &mut tag_scan_buf,
+        &mut suppressing,
+        &mut inside_env,
+    );
+    // Final sanitizer-tail flush (handle_done).
+    content.push_str(&crate::api::stream_guards::flush_content_sanitizer(
+        &mut tag_scan_buf,
+        &mut suppressing,
+        &markers,
+    ));
+
+    (tc_acc.into_values().collect(), content)
+}
+
+/// Regression: a model that appends a SPURIOUS redundant close marker
+/// right after the real `</tool_call>` (Ornith-1.0 emits `</_call>` —
+/// which BPE-tokenizes as `</` `_` `call` `>` — or a doubled
+/// `</tool_call>`) must not leak that close into streamed `content`.
+/// The real tool call must still parse with the correct name + args.
+///
+/// Live repro (2026-06-26): after 3 correct tool-call deltas the client
+/// received a content delta of exactly `"\n\n</_call>"`. The trailing
+/// close has no active orphan suppression (the detector already consumed
+/// the real `</tool_call>`), so it must be dropped by the standalone
+/// OrphanClose path in `sanitize_content_chunk`, including when split
+/// across single-token chunks.
+#[test]
+fn qwen3_coder_spurious_trailing_close_underscore_call_not_leaked() {
+    // One token per chunk for the 4-token `</_call>` tail, mirroring the
+    // real BPE split (id-248059 `</tool_call>` is whole; `</_call>` is
+    // `</` `_` `call` `>`).
+    let chunks = [
+        "<tool_call>",
+        "<function=Bash>",
+        "<parameter=command>",
+        "ls -la",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+        "\n\n", // whitespace the model emits before the spurious close
+        "</",
+        "_",
+        "call",
+        ">",
+    ];
+    let (calls, content) = stream_through_pipeline(&chunks);
+    assert_eq!(calls.len(), 1, "exactly one tool call: {calls:?}");
+    assert_eq!(calls[0].0, "Bash", "tool name preserved");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1)
+        .unwrap_or_else(|e| panic!("args not valid JSON: {e}; raw={:?}", calls[0].1));
+    assert_eq!(args["command"], "ls -la", "args preserved");
+    assert!(
+        !content.contains("</_call>") && !content.contains("</tool_call>"),
+        "spurious trailing close leaked into content: {content:?}"
+    );
+}
+
+/// Companion case: a doubled real close `</tool_call></tool_call>`. The
+/// second `</tool_call>` is a single vocab token, so it arrives as one
+/// chunk — still must be dropped, not streamed as content.
+#[test]
+fn qwen3_coder_doubled_tool_call_close_not_leaked() {
+    let chunks = [
+        "<tool_call>",
+        "<function=Bash>",
+        "<parameter=command>",
+        "echo hi",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+        "</tool_call>", // spurious doubled close (whole token)
+    ];
+    let (calls, content) = stream_through_pipeline(&chunks);
+    assert_eq!(calls.len(), 1, "exactly one tool call: {calls:?}");
+    assert_eq!(calls[0].0, "Bash", "tool name preserved");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1)
+        .unwrap_or_else(|e| panic!("args not valid JSON: {e}; raw={:?}", calls[0].1));
+    assert_eq!(args["command"], "echo hi", "args preserved");
+    assert!(
+        !content.contains("</tool_call>"),
+        "spurious doubled close leaked into content: {content:?}"
+    );
+}
+
+/// Direct guard on the buggy spot (`flush_content_sanitizer`). The live
+/// leak (`content: '\n\n</_call>'`) reaches the client when the spurious
+/// close is still sitting in the held-back tail buffer at stream end —
+/// either fully assembled (`\n\n</_call>` / `\n\n</tool_call>`) or cut off
+/// before its final `>` (`\n\n</_call`, when the closing token fused with
+/// EOS). The pre-fix flush returned the tail VERBATIM because the leading
+/// whitespace made `looks_like_partial_tag` (which requires the whole tail
+/// to start with `<`) miss it. Assert every such tail flushes to just its
+/// real-content prefix, with no close leak.
+#[test]
+fn flush_content_sanitizer_drops_held_back_trailing_close() {
+    use crate::tool_parser::LeakMarkers;
+    let markers: LeakMarkers = Qwen3CoderParser.leak_markers();
+    let cases = [
+        ("\n\n</_call>", "\n\n"),        // complete spurious close
+        ("\n\n</tool_call>", "\n\n"),    // complete doubled real close
+        ("\n\n</_call", "\n\n"),         // incomplete: `>` never arrived
+        ("ok</tool_call>", "ok"),        // close right after real content
+        ("plain text", "plain text"),    // no close → untouched
+    ];
+    for (tail, want) in cases {
+        let mut buf = String::from(tail);
+        let mut suppress = false;
+        let out =
+            crate::api::stream_guards::flush_content_sanitizer(&mut buf, &mut suppress, &markers);
+        assert_eq!(out, want, "flush of {tail:?} should yield {want:?}, got {out:?}");
+        assert!(
+            !out.contains("</_call") && !out.contains("</tool_call"),
+            "close leaked from flush of {tail:?}: {out:?}"
+        );
+    }
+}
+
+/// End-to-end variant where the spurious `</_call>` reaches the FLUSH
+/// (not the per-chunk sanitizer): the stream ends after `call` before the
+/// closing `>` token arrives, so the streaming `sanitize_content_chunk`
+/// holds the partial close in its tail and `flush_content_sanitizer` must
+/// drop it. Without the fix this leaks `\n\n</_call` as a final content
+/// chunk. The tool call still parses.
+#[test]
+fn qwen3_coder_spurious_trailing_close_reaches_flush_not_leaked() {
+    let chunks = [
+        "<tool_call>",
+        "<function=Bash>",
+        "<parameter=command>",
+        "ls -la",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+        "\n\n",
+        "</",
+        "_",
+        "call", // stream ends here — the `>` token never came (fused w/ EOS)
+    ];
+    let (calls, content) = stream_through_pipeline(&chunks);
+    assert_eq!(calls.len(), 1, "exactly one tool call: {calls:?}");
+    assert_eq!(calls[0].0, "Bash", "tool name preserved");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1)
+        .unwrap_or_else(|e| panic!("args not valid JSON: {e}; raw={:?}", calls[0].1));
+    assert_eq!(args["command"], "ls -la", "args preserved");
+    assert!(
+        !content.contains("</_call") && !content.contains("</tool_call"),
+        "spurious trailing close leaked into content: {content:?}"
+    );
+}
+
 /// Minimal serial env-var guard for the kill-switch test. Sets a var for the
 /// duration of a guard, restoring the prior value on drop. A process-wide
 /// mutex serialises env mutation so the env test cannot race a parallel test


### PR DESCRIPTION
## Problem

Some models emit a **redundant tool-call close right after the real `</tool_call>`**. Ornith-1.0-35B, for example, emits `</_call>` (BPE-split into the four tokens `</` `_` `call` `>`) or a doubled `</tool_call>`. The real tool call parses correctly, but the spurious trailing close **leaked into the streamed `content`** field — observed delta: `"\n\n</_call>"`. Non-streaming output was unaffected.

## Root cause

The streaming `sanitize_content_chunk` loop drops standalone close markers via its `OrphanClose` arm, but a close that only finishes assembling at end-of-stream — or one preceded by emittable whitespace, so the tail's `looks_like_partial_tag` guard never fires — survives into `flush_content_sanitizer`, which previously dumped the held-back tail **verbatim**.

## Fix

In `flush_content_sanitizer` (`crates/spark-server/src/api/stream_guards.rs`), before flushing the held-back tail:
1. Strip every **complete** close marker from `markers.close` (matched against the reassembled buffer, so multi-token closes split across chunks are covered).
2. Trim a **trailing incomplete** close-marker prefix that the whitespace-blind `looks_like_partial_tag` check misses.

Only close markers are removed — legitimate content (including `<...>` prose, which never matches a `</...>` close-marker prefix) is untouched, and detector-based tool-call parsing is unchanged.

## Tests

Regression tests in `tool_parser/tests/streaming_frag.rs`:
- `</_call>` delivered as four single-token chunks
- doubled `</tool_call>`
- partial close reaching the flush boundary
- direct `flush_content_sanitizer` unit test (complete / incomplete / content-prefixed / no-close)

Each asserts the tool call still parses with correct name+args and that no markup leaks into content.

`cargo test -p spark-server tool_parser` → **90 passed**; `stream_guards` → **7 passed**. Stashing the fix reproduces the exact leak (`"\n\n</_call>"`).

## End-to-end verification

Validated against Ornith-1.0-35B streaming on GB10: streamed content is now empty with two correctly-parsed `history(...)` tool calls (previously leaked `</_call>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)