### PR TITLE
fix(tool-parser): stop tool-call markup leaking into content on runaway/guard-end

### DIFF
--- a/crates/spark-server/src/api/chat_stream/handle_token.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_token.rs
@@ -404,11 +404,33 @@ fn handle_token_inner(state: &mut StreamState, ctx: &StreamCtx, tok: u32) -> Sse
     }
 
     if state.stop_string_triggered {
+        // The tool guards (F11 within-response dedup, hard-validation
+        // reject, loop cap) reuse `stop_string_triggered` as a generic
+        // "end this response" flag. But the scheduler keeps generating for
+        // a few tokens after the flag is set (cancel latency), and on a
+        // tool-call *runaway* those tokens are raw markup —
+        // `<tool_call><function=…><parameter=…>…</tool_call></_call>` —
+        // re-emitted here. A raw passthrough (the old behaviour) leaked
+        // that markup into `content` because this branch returns BEFORE the
+        // detector/sanitizer fork below. Route the delta through the
+        // buffered `sanitize_content_chunk` so multi-token markers that
+        // straddle deltas (`</_call>` = `</` `_` `call` `>`) are reassembled
+        // and scrubbed. For a genuine stop string, legitimate trailing
+        // content is untouched — the sanitizer only removes tool markup.
         if !delta.is_empty() {
-            let chunk = ChatCompletionChunk::content_chunk(&ctx.model, &ctx.id, delta)
-                .with_token_ids(state.take_ids_if(ctx.req_return_token_ids));
-            let json = serde_json::to_string(&chunk).unwrap_or_default();
-            sse_events.push(Ok(Event::default().data(json)));
+            let cleaned = sanitize_content_chunk(
+                &delta,
+                &mut state.tag_scan_buf,
+                &mut state.suppressing_param_leak,
+                &mut state.inside_envelope,
+                &ctx.leak_markers,
+            );
+            if !cleaned.is_empty() {
+                let chunk = ChatCompletionChunk::content_chunk(&ctx.model, &ctx.id, cleaned)
+                    .with_token_ids(state.take_ids_if(ctx.req_return_token_ids));
+                let json = serde_json::to_string(&chunk).unwrap_or_default();
+                sse_events.push(Ok(Event::default().data(json)));
+            }
         }
         return sse_events;
     }

--- a/crates/spark-server/src/api/sanitizer.rs
+++ b/crates/spark-server/src/api/sanitizer.rs
@@ -205,6 +205,63 @@ pub fn sanitize_content_chunk(
             }
         }
     }
+    // Defense-in-depth final scrub. The state machine above suppresses
+    // well-formed orphan blocks, but a streaming-detector desync at a
+    // tool-call *runaway* / truncation boundary (model re-opens 8+ blocks
+    // and emits spurious `</_call>` separators, then a guard force-ends)
+    // can dump raw markup — e.g. `<tool_call><function=alarms>
+    // <parameter=category>grid</parameter></function></tool_call></_call>`
+    // — straight into Content. Real tool calls never reach here (the
+    // detector routes them to ToolCall outputs first), so any complete
+    // marker tag still present is leaked markup and safe to remove.
+    scrub_tool_tags(&out, markers)
+}
+
+/// Remove any COMPLETE tool-call markup tags from a content string that is
+/// about to be emitted to the client. Derived from `markers` so it stays
+/// correct for every parser. Handles both exact full tags (`</tool_call>`,
+/// `<tool_call>`, `</_call>`) and attribute-prefix opens (`<function=…>`,
+/// `<parameter=…>`) by removing through their closing `>`. A partial tag
+/// with no closing `>` ends the scan (its remainder is a tag still being
+/// formed — the caller's hold-back buffer retains real partials, so the
+/// only way one reaches here is a desync dump, where dropping it is correct).
+pub(crate) fn scrub_tool_tags(text: &str, markers: &tool_parser::LeakMarkers) -> String {
+    if text.is_empty() || (markers.orphan_open.is_empty() && markers.close.is_empty()) {
+        return text.to_string();
+    }
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    'outer: while i < text.len() {
+        if bytes[i] == b'<' {
+            // Exact full-tag markers (close tags + full-tag opens that
+            // already carry their own `>`).
+            for m in markers.close.iter().chain(markers.orphan_open.iter()) {
+                if m.ends_with('>') && text[i..].starts_with(m) {
+                    i += m.len();
+                    continue 'outer;
+                }
+            }
+            // Attribute-prefix opens (e.g. `<function=`, `<parameter=`,
+            // `<param=`): remove from the prefix through the next `>`.
+            for m in markers.orphan_open.iter() {
+                if !m.ends_with('>') && text[i..].starts_with(m) {
+                    match text[i..].find('>') {
+                        Some(gt) => {
+                            i += gt + 1;
+                            continue 'outer;
+                        }
+                        // Partial open tag still forming at end-of-text —
+                        // drop the remainder (a desync fragment).
+                        None => return out,
+                    }
+                }
+            }
+        }
+        let ch_len = text[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+        out.push_str(&text[i..i + ch_len]);
+        i += ch_len;
+    }
     out
 }
 

--- a/crates/spark-server/src/api/stream_guards.rs
+++ b/crates/spark-server/src/api/stream_guards.rs
@@ -148,7 +148,7 @@ pub fn flush_content_sanitizer(
         .max()
         .unwrap_or(0);
     let mut final_text = std::mem::take(tag_scan_buf);
-    // Drop any COMPLETE standalone close markers still sitting in the
+    // Drop any COMPLETE tool-call markup tags still sitting in the
     // held-back tail. The streaming `sanitize_content_chunk` loop drops a
     // close via its `OrphanClose` arm, but a close that only finishes
     // assembling at end-of-stream (or one preceded by whitespace, e.g.
@@ -157,21 +157,11 @@ pub fn flush_content_sanitizer(
     // the spurious redundant close some models emit right after the real
     // `</tool_call>` (Ornith-1.0: `</_call>` — BPE-split into `</` `_`
     // `call` `>` — or a doubled `</tool_call>`) leaks into streamed
-    // `content`. This generalises to every marker in `markers.close`,
-    // including multi-token ones, since we match the assembled buffer.
-    loop {
-        let earliest = markers
-            .close
-            .iter()
-            .filter_map(|t| final_text.find(t).map(|p| (p, t.len())))
-            .min_by_key(|(p, _)| *p);
-        match earliest {
-            Some((pos, len)) => {
-                final_text.replace_range(pos..pos + len, "");
-            }
-            None => break,
-        }
-    }
+    // `content`. `scrub_tool_tags` removes every complete marker —
+    // close tags, full-tag opens, and `<function=…>` / `<parameter=…>`
+    // attribute tags — so a runaway/desync tail dumped here is cleaned
+    // the same way as the per-chunk path.
+    final_text = super::sanitizer::scrub_tool_tags(&final_text, markers);
     // Drop a TRAILING INCOMPLETE close marker (e.g. the stream ended after
     // `</_call` before its closing `>` arrived). The original
     // `looks_like_partial_tag` guard below only fires when the WHOLE tail

--- a/crates/spark-server/src/api/stream_guards.rs
+++ b/crates/spark-server/src/api/stream_guards.rs
@@ -147,7 +147,50 @@ pub fn flush_content_sanitizer(
         .map(|t| t.len())
         .max()
         .unwrap_or(0);
-    let final_text = std::mem::take(tag_scan_buf);
+    let mut final_text = std::mem::take(tag_scan_buf);
+    // Drop any COMPLETE standalone close markers still sitting in the
+    // held-back tail. The streaming `sanitize_content_chunk` loop drops a
+    // close via its `OrphanClose` arm, but a close that only finishes
+    // assembling at end-of-stream (or one preceded by whitespace, e.g.
+    // `\n\n</_call>`, so the tail's `looks_like_partial_tag` check below
+    // never fires) survives into this flush. Without stripping it here,
+    // the spurious redundant close some models emit right after the real
+    // `</tool_call>` (Ornith-1.0: `</_call>` — BPE-split into `</` `_`
+    // `call` `>` — or a doubled `</tool_call>`) leaks into streamed
+    // `content`. This generalises to every marker in `markers.close`,
+    // including multi-token ones, since we match the assembled buffer.
+    loop {
+        let earliest = markers
+            .close
+            .iter()
+            .filter_map(|t| final_text.find(t).map(|p| (p, t.len())))
+            .min_by_key(|(p, _)| *p);
+        match earliest {
+            Some((pos, len)) => {
+                final_text.replace_range(pos..pos + len, "");
+            }
+            None => break,
+        }
+    }
+    // Drop a TRAILING INCOMPLETE close marker (e.g. the stream ended after
+    // `</_call` before its closing `>` arrived). The original
+    // `looks_like_partial_tag` guard below only fires when the WHOLE tail
+    // is a partial opener (`t.starts_with('<')`); a partial close preceded
+    // by emittable content/whitespace — `\n\n</_call` — slips past it and
+    // leaks. Find the last `<` and, if everything from it to end-of-buffer
+    // is a strict prefix of some close marker (and not a complete marker —
+    // those were already removed above), trim it off. The preceding bytes
+    // are real content and still flush.
+    if let Some(lt) = final_text.rfind('<') {
+        let suffix = &final_text[lt..];
+        let is_partial_close = markers
+            .close
+            .iter()
+            .any(|t| t.len() > suffix.len() && t.starts_with(suffix));
+        if is_partial_close {
+            final_text.truncate(lt);
+        }
+    }
     let looks_like_partial_tag = {
         let t = final_text.trim_end();
         tag_max > 0 && t.starts_with('<') && !t.contains(char::is_whitespace) && t.len() < tag_max

--- a/crates/spark-server/src/tool_parser/tests/streaming_frag.rs
+++ b/crates/spark-server/src/tool_parser/tests/streaming_frag.rs
@@ -385,6 +385,237 @@ fn kill_switch_buffers_full_args_no_fragments() {
     assert_eq!(args["content"], "hello");
 }
 
+/// End-to-end streaming harness: feed each chunk through the detector
+/// exactly as `handle_token` does, routing every `Content` payload
+/// through the production `sanitize_content_chunk` with the qwen3_coder
+/// leak markers. Returns `(tool_calls, content)` where `tool_calls` is
+/// the list of `(name, args_json)` reassembled from the incremental
+/// Start/Fragment/Delta/End (or bulk `ToolCall`) events, and `content`
+/// is the concatenation of every post-sanitizer content chunk — i.e.
+/// exactly what the client would see in `choices[].delta.content`.
+fn stream_through_pipeline(chunks: &[&str]) -> (Vec<(String, String)>, String) {
+    use crate::tool_parser::LeakMarkers;
+    let markers: LeakMarkers = Qwen3CoderParser.leak_markers();
+    let mut det = StreamingToolDetector::new_with_tools(write_and_bash_tools());
+
+    // Sanitizer state (mirrors the per-request fields on `StreamState`).
+    let mut tag_scan_buf = String::new();
+    let mut suppressing = false;
+    let mut inside_env = false;
+
+    // Tool-call accumulators keyed by idx (mirrors streaming_tool_args).
+    let mut tc_acc: std::collections::BTreeMap<usize, (String, String)> =
+        std::collections::BTreeMap::new();
+    let mut content = String::new();
+
+    let run = |out: &[DetectorOutput],
+               tc_acc: &mut std::collections::BTreeMap<usize, (String, String)>,
+               content: &mut String,
+               tag_scan_buf: &mut String,
+               suppressing: &mut bool,
+               inside_env: &mut bool| {
+        for o in out {
+            match o {
+                DetectorOutput::Content(text) => {
+                    // Content → Tool boundary handling in production runs a
+                    // `flush_content_sanitizer` on tool events; here the
+                    // content arm just sanitizes (the leak we test is pure
+                    // content, never a tool event).
+                    let s = crate::api::sanitizer::sanitize_content_chunk(
+                        text,
+                        tag_scan_buf,
+                        suppressing,
+                        inside_env,
+                        &markers,
+                    );
+                    content.push_str(&s);
+                }
+                DetectorOutput::ToolCallStart { name, idx, .. } => {
+                    tc_acc.insert(*idx, (name.clone(), String::new()));
+                }
+                DetectorOutput::ToolCallArgsFragment { fragment, idx } => {
+                    tc_acc.entry(*idx).or_default().1.push_str(fragment);
+                }
+                DetectorOutput::ToolCallDelta { args, idx } => {
+                    tc_acc.entry(*idx).or_default().1.push_str(args);
+                }
+                DetectorOutput::ToolCall(tc, idx) => {
+                    tc_acc.insert(
+                        *idx,
+                        (tc.function.name.clone(), tc.function.arguments.clone()),
+                    );
+                }
+                DetectorOutput::ToolCallEnd { .. } => {}
+            }
+        }
+    };
+
+    for c in chunks {
+        let out = det.process(c);
+        run(
+            &out,
+            &mut tc_acc,
+            &mut content,
+            &mut tag_scan_buf,
+            &mut suppressing,
+            &mut inside_env,
+        );
+    }
+    let out = det.flush();
+    run(
+        &out,
+        &mut tc_acc,
+        &mut content,
+        &mut tag_scan_buf,
+        &mut suppressing,
+        &mut inside_env,
+    );
+    // Final sanitizer-tail flush (handle_done).
+    content.push_str(&crate::api::stream_guards::flush_content_sanitizer(
+        &mut tag_scan_buf,
+        &mut suppressing,
+        &markers,
+    ));
+
+    (tc_acc.into_values().collect(), content)
+}
+
+/// Regression: a model that appends a SPURIOUS redundant close marker
+/// right after the real `</tool_call>` (Ornith-1.0 emits `</_call>` —
+/// which BPE-tokenizes as `</` `_` `call` `>` — or a doubled
+/// `</tool_call>`) must not leak that close into streamed `content`.
+/// The real tool call must still parse with the correct name + args.
+///
+/// Live repro (2026-06-26): after 3 correct tool-call deltas the client
+/// received a content delta of exactly `"\n\n</_call>"`. The trailing
+/// close has no active orphan suppression (the detector already consumed
+/// the real `</tool_call>`), so it must be dropped by the standalone
+/// OrphanClose path in `sanitize_content_chunk`, including when split
+/// across single-token chunks.
+#[test]
+fn qwen3_coder_spurious_trailing_close_underscore_call_not_leaked() {
+    // One token per chunk for the 4-token `</_call>` tail, mirroring the
+    // real BPE split (id-248059 `</tool_call>` is whole; `</_call>` is
+    // `</` `_` `call` `>`).
+    let chunks = [
+        "<tool_call>",
+        "<function=Bash>",
+        "<parameter=command>",
+        "ls -la",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+        "\n\n", // whitespace the model emits before the spurious close
+        "</",
+        "_",
+        "call",
+        ">",
+    ];
+    let (calls, content) = stream_through_pipeline(&chunks);
+    assert_eq!(calls.len(), 1, "exactly one tool call: {calls:?}");
+    assert_eq!(calls[0].0, "Bash", "tool name preserved");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1)
+        .unwrap_or_else(|e| panic!("args not valid JSON: {e}; raw={:?}", calls[0].1));
+    assert_eq!(args["command"], "ls -la", "args preserved");
+    assert!(
+        !content.contains("</_call>") && !content.contains("</tool_call>"),
+        "spurious trailing close leaked into content: {content:?}"
+    );
+}
+
+/// Companion case: a doubled real close `</tool_call></tool_call>`. The
+/// second `</tool_call>` is a single vocab token, so it arrives as one
+/// chunk — still must be dropped, not streamed as content.
+#[test]
+fn qwen3_coder_doubled_tool_call_close_not_leaked() {
+    let chunks = [
+        "<tool_call>",
+        "<function=Bash>",
+        "<parameter=command>",
+        "echo hi",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+        "</tool_call>", // spurious doubled close (whole token)
+    ];
+    let (calls, content) = stream_through_pipeline(&chunks);
+    assert_eq!(calls.len(), 1, "exactly one tool call: {calls:?}");
+    assert_eq!(calls[0].0, "Bash", "tool name preserved");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1)
+        .unwrap_or_else(|e| panic!("args not valid JSON: {e}; raw={:?}", calls[0].1));
+    assert_eq!(args["command"], "echo hi", "args preserved");
+    assert!(
+        !content.contains("</tool_call>"),
+        "spurious doubled close leaked into content: {content:?}"
+    );
+}
+
+/// Direct guard on the buggy spot (`flush_content_sanitizer`). The live
+/// leak (`content: '\n\n</_call>'`) reaches the client when the spurious
+/// close is still sitting in the held-back tail buffer at stream end —
+/// either fully assembled (`\n\n</_call>` / `\n\n</tool_call>`) or cut off
+/// before its final `>` (`\n\n</_call`, when the closing token fused with
+/// EOS). The pre-fix flush returned the tail VERBATIM because the leading
+/// whitespace made `looks_like_partial_tag` (which requires the whole tail
+/// to start with `<`) miss it. Assert every such tail flushes to just its
+/// real-content prefix, with no close leak.
+#[test]
+fn flush_content_sanitizer_drops_held_back_trailing_close() {
+    use crate::tool_parser::LeakMarkers;
+    let markers: LeakMarkers = Qwen3CoderParser.leak_markers();
+    let cases = [
+        ("\n\n</_call>", "\n\n"),        // complete spurious close
+        ("\n\n</tool_call>", "\n\n"),    // complete doubled real close
+        ("\n\n</_call", "\n\n"),         // incomplete: `>` never arrived
+        ("ok</tool_call>", "ok"),        // close right after real content
+        ("plain text", "plain text"),    // no close → untouched
+    ];
+    for (tail, want) in cases {
+        let mut buf = String::from(tail);
+        let mut suppress = false;
+        let out =
+            crate::api::stream_guards::flush_content_sanitizer(&mut buf, &mut suppress, &markers);
+        assert_eq!(out, want, "flush of {tail:?} should yield {want:?}, got {out:?}");
+        assert!(
+            !out.contains("</_call") && !out.contains("</tool_call"),
+            "close leaked from flush of {tail:?}: {out:?}"
+        );
+    }
+}
+
+/// End-to-end variant where the spurious `</_call>` reaches the FLUSH
+/// (not the per-chunk sanitizer): the stream ends after `call` before the
+/// closing `>` token arrives, so the streaming `sanitize_content_chunk`
+/// holds the partial close in its tail and `flush_content_sanitizer` must
+/// drop it. Without the fix this leaks `\n\n</_call` as a final content
+/// chunk. The tool call still parses.
+#[test]
+fn qwen3_coder_spurious_trailing_close_reaches_flush_not_leaked() {
+    let chunks = [
+        "<tool_call>",
+        "<function=Bash>",
+        "<parameter=command>",
+        "ls -la",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+        "\n\n",
+        "</",
+        "_",
+        "call", // stream ends here — the `>` token never came (fused w/ EOS)
+    ];
+    let (calls, content) = stream_through_pipeline(&chunks);
+    assert_eq!(calls.len(), 1, "exactly one tool call: {calls:?}");
+    assert_eq!(calls[0].0, "Bash", "tool name preserved");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1)
+        .unwrap_or_else(|e| panic!("args not valid JSON: {e}; raw={:?}", calls[0].1));
+    assert_eq!(args["command"], "ls -la", "args preserved");
+    assert!(
+        !content.contains("</_call") && !content.contains("</tool_call"),
+        "spurious trailing close leaked into content: {content:?}"
+    );
+}
+
 /// Minimal serial env-var guard for the kill-switch test. Sets a var for the
 /// duration of a guard, restoring the prior value on drop. A process-wide
 /// mutex serialises env mutation so the env test cannot race a parallel test

--- a/crates/spark-server/src/tool_parser/tests/streaming_frag.rs
+++ b/crates/spark-server/src/tool_parser/tests/streaming_frag.rs
@@ -616,6 +616,70 @@ fn qwen3_coder_spurious_trailing_close_reaches_flush_not_leaked() {
     );
 }
 
+/// Defense-in-depth: `scrub_tool_tags` must remove EVERY complete tool-call
+/// markup tag from a content string, including the full raw block a desync'd
+/// detector can dump on a runaway/truncation boundary. Uses the exact shape
+/// reported live against Ornith-1.0-35B (leading spurious `</_call>`, multiple
+/// `<tool_call><function=…><parameter=…>…</tool_call></_call>` blocks). Only
+/// markup is removed; the inner argument *values* and surrounding whitespace
+/// survive (they are not tool tags).
+#[test]
+fn scrub_tool_tags_strips_runaway_markup_dump() {
+    use crate::tool_parser::LeakMarkers;
+    let markers: LeakMarkers = Qwen3CoderParser.leak_markers();
+    let dump = "</_call>\n<tool_call>\n<function=alarms>\n<parameter=category>\ngrid_power\n\
+                </parameter>\n<parameter=window>\n24h\n</parameter>\n</function>\n</tool_call></_call>\n\
+                <tool_call>\n<function=fleet>\n<parameter=limit>\n200\n</parameter>\n</function>\n\
+                </tool_call></_call>";
+    let scrubbed = crate::api::sanitizer::scrub_tool_tags(dump, &markers);
+    for tag in [
+        "<tool_call>", "</tool_call>", "</_call>", "<function=", "</function>",
+        "<parameter=", "</parameter>",
+    ] {
+        assert!(
+            !scrubbed.contains(tag),
+            "tag {tag:?} survived scrub: {scrubbed:?}"
+        );
+    }
+    // Argument values are not tags and must remain.
+    assert!(scrubbed.contains("grid_power"), "value dropped: {scrubbed:?}");
+    assert!(scrubbed.contains("200"), "value dropped: {scrubbed:?}");
+}
+
+/// `scrub_tool_tags` must leave legitimate prose untouched — a bare `<`
+/// (math/comparison) and a non-tool `<...>` tag are not tool markup.
+#[test]
+fn scrub_tool_tags_preserves_non_tool_content() {
+    use crate::tool_parser::LeakMarkers;
+    let markers: LeakMarkers = Qwen3CoderParser.leak_markers();
+    let prose = "if a < b and c > d, use <div> in the template";
+    let scrubbed = crate::api::sanitizer::scrub_tool_tags(prose, &markers);
+    assert_eq!(scrubbed, prose, "non-tool content altered");
+}
+
+/// End-to-end through the streaming pipeline: when the detector hands a full
+/// raw tool-call block to the Content arm (the desync/runaway case — here
+/// forced by a leading spurious `</_call>` that desyncs envelope detection),
+/// no `<tool_call>`/`<function=`/`<parameter=`/`</_call>` markup may reach
+/// the client's content stream.
+#[test]
+fn qwen3_coder_runaway_content_dump_not_leaked() {
+    // Whole-string chunks (the detector classifies the leading stray close
+    // and any unrecognised markup as Content, which routes through the
+    // sanitizer + final scrub).
+    let chunks = [
+        "</_call>",
+        "<tool_call><function=alarms><parameter=category>grid_power</parameter></function></tool_call></_call>",
+    ];
+    let (_calls, content) = stream_through_pipeline(&chunks);
+    for tag in ["<tool_call>", "</tool_call>", "</_call>", "<function=", "<parameter="] {
+        assert!(
+            !content.contains(tag),
+            "runaway markup {tag:?} leaked into content: {content:?}"
+        );
+    }
+}
+
 /// Minimal serial env-var guard for the kill-switch test. Sets a var for the
 /// duration of a guard, restoring the prior value on drop. A process-wide
 /// mutex serialises env mutation so the env test cannot race a parallel test


### PR DESCRIPTION
> **Stacked on #204** — shares `flush_content_sanitizer`. Until #204 merges, this PR's diff also shows #204's commit; review the second commit (`stop tool-call markup leaking into content on runaway/guard-end`) or merge #204 first.

## Problem

When a tool guard ends a response early — F11 within-response dedup, hard validation reject, or the loop cap — it sets `stop_string_triggered` as a generic "stop emitting" flag. But the scheduler keeps generating for a short tail (cancel latency), and on a tool-call **runaway** (the model re-opens 8+ `<tool_call>` blocks and emits spurious `</_call>` separators) those tail tokens are raw markup.

The `stop_string_triggered` arm in `handle_token` **returns before the detector/sanitizer fork** and emitted the delta verbatim, so the runaway markup — `<tool_call><function=…><parameter=…>…</tool_call></_call>` — leaked into the streamed `content` field. It only surfaced on `finish=length` runaways (high temperature + many tools + multi-turn), so a clean single-call turn never showed it.

## Root cause (traced from server logs)

```
Tool call: power({"range":"24h"})
F11 within-response dedup tripped: 2+ identical streaming tool calls; ending response  ← sets stop_string_triggered
… ~200 more tokens generated (cancel latency) → raw-emit path → LEAK …
tool-call repetition runaway … opens=8
Done: 265 tokens (length)
```

## Fixes (qwen3_coder, but parser-agnostic)

1. **`handle_token` (root cause):** route the post-trigger delta through the buffered `sanitize_content_chunk` instead of a raw passthrough, so multi-token markers that straddle deltas (`</_call>` = `</` `_` `call` `>`) are reassembled and stripped. A genuine stop-string's trailing content is unaffected — the sanitizer only removes tool-call markup.
2. **`scrub_tool_tags` (sanitizer.rs):** defense-in-depth final pass removing every complete tool-call markup tag from a content chunk — close tags, full-tag opens, and `<function=…>` / `<parameter=…>` attribute tags — derived from `LeakMarkers` so it holds for any parser.
3. **`flush_content_sanitizer`** now calls `scrub_tool_tags` (a superset of the close-only scrub from #204).

## Tests

3 new regression tests in `streaming_frag.rs` (direct `scrub_tool_tags` runaway-dump, non-tool-content preservation, end-to-end pipeline desync dump). **All 537 spark-server tests pass.**

## End-to-end validation

Ornith-1.0-35B on GB10. A runaway repro that leaked raw markup in **13/24** streams (`temp=0.6`, 20 tools, multi-turn) now leaks in **0/36**, including at `max_tokens=8192` / `temp=0.7`. Tool calls still parse correctly; the truncated-runaway content is now just `\n` separators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)