### PR TITLE
SBR M1: opt-in tail-pin SSM-snapshot eviction (8× warm-resume on deep agentic convs)

### DIFF
--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -10,25 +10,44 @@ use std::sync::OnceLock;
 
 use super::hash_token_prefix;
 
-/// SBR M1 two-tier eviction policy. When enabled, [`SsmSnapshotIndex::evict_lru`]
-/// evicts NON-resumable (one-shot / untracked) snapshots before any resumable
-/// multi-turn conversation's snapshot — protecting live conversations' SSM
-/// checkpoints from transient one-shot churn (the cause of the "replay grows as
-/// slots fill" TTFT blowup, 1s→21s). When every entry is resumable it degrades
-/// identically to the baseline recency·hit forecast (Marconi §4) — provably
-/// do-no-harm.
+/// SBR M1 tail-pin eviction policy — OPT-IN, OFF by default. When enabled,
+/// [`SsmSnapshotIndex::evict_lru`] pins the top-`tail_pin_k` DEEPEST snapshots of
+/// each RESUMABLE session (one resumed at least once), so a resuming deep
+/// conversation finds a near-tail SSM anchor instead of replaying from a far
+/// shallow survivor (the "replay grows as slots fill" blowup, 1s→21s). Measured
+/// 8× warm-resume speedup on the deep-conversation agentic regime.
 ///
-/// Enabled by default; set `ATLAS_SBR_TAIL_PIN=0` to restore the pure
-/// forecast-LRU baseline (for A/B benchmarking against the fix).
+/// DEFAULT OFF: it wins the single/few-deep-conversation regime but REGRESSES
+/// balanced many-conversation serving ~30% (the recency·hit forecast is already
+/// near-optimal there). Set `ATLAS_SBR_TAIL_PIN=1` for deep-agentic workloads.
 fn tail_pin_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        let on = std::env::var("ATLAS_SBR_TAIL_PIN").map(|v| v != "0").unwrap_or(true);
+        let on = std::env::var("ATLAS_SBR_TAIL_PIN")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
         tracing::info!(
-            "SBR snapshot two-tier eviction (protect resumable convs): {}",
-            if on { "ENABLED" } else { "disabled (baseline)" },
+            "SBR snapshot tail-pin eviction: {} (opt-in, top-K={})",
+            if on { "ENABLED" } else { "off (baseline forecast)" },
+            tail_pin_k()
         );
         on
+    })
+}
+
+/// Number of a resumable session's DEEPEST snapshots to pin. The single deepest
+/// overshoots the next match point (the leaf includes generated tokens, so the
+/// block-aligned match lands just below it), so K≥2 is needed; K=8 spans the
+/// overshoot and flattened warm-resume TTFT in measurement (mean 1.18s vs K=4
+/// 3.37s vs baseline 9.53s). Override with `ATLAS_SBR_TAIL_PIN_K`.
+fn tail_pin_k() -> usize {
+    static K: OnceLock<usize> = OnceLock::new();
+    *K.get_or_init(|| {
+        std::env::var("ATLAS_SBR_TAIL_PIN_K")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&k| k >= 1)
+            .unwrap_or(8)
     })
 }
 
@@ -129,76 +148,70 @@ impl SsmSnapshotIndex {
     }
 
     pub(super) fn evict_lru(&mut self) -> Option<usize> {
+        self.evict_lru_inner(tail_pin_enabled(), tail_pin_k())
+    }
+
+    /// Eviction victim selection (split out so the policy is unit-testable
+    /// without the env-gated `OnceLock`).
+    ///
+    /// Baseline forecast (B.4, 2026-04-25, Marconi paper §4): evict the entry
+    /// with the lowest `last_access * (1 + hit_count)` — old AND cold first.
+    /// hit_count weighting keeps recurrent prefixes (system prompts, tool
+    /// descriptions) resident (#155 fixed the inverted divide-by form).
+    ///
+    /// SBR M1 tail-pin (`pin == true`, OPT-IN — see [`tail_pin_enabled`]): the
+    /// forecast is orthogonal to REPLAY DISTANCE — a conversation's deep
+    /// per-turn checkpoints have hit_count≈0 (never the resume anchor) and get
+    /// evicted before the hot shallow prefix, stranding the next resume far from
+    /// its tail (replay = depth − shallow_prefix → the 1s→21s blowup). When
+    /// enabled we PIN the top-`pin_k` DEEPEST snapshots of each RESUMABLE session
+    /// (one with any hit_count>0) so a near-tail anchor survives, evicting only
+    /// NON-pinned entries (falling back to the global forecast only if every
+    /// entry is pinned). Measured (deep conv idle under one-shot pressure):
+    /// baseline 9.53s → 1.18s (8×, replay 11–984 tok).
+    ///
+    /// SCOPE / honesty: this wins the single/few-deep-conversation agentic
+    /// regime but REGRESSES balanced many-conversation round-robin ~30% (the
+    /// recency·hit forecast is already near-optimal there and pinning fights it),
+    /// so it is OFF by default. `pin == false` is exactly the baseline forecast.
+    pub(super) fn evict_lru_inner(&mut self, pin: bool, pin_k: usize) -> Option<usize> {
         if self.entries.is_empty() {
             return None;
         }
-        // Forecast-based policy (B.4, 2026-04-25, Marconi paper §4):
-        // evict the entry with the lowest last_access * (1 + hit_count)
-        // — old AND cold first. Pure LRU (`last_access` only) discarded
-        // hot prefixes that just happened to be re-accessed less
-        // recently than a one-shot entry; weighting by hit_count keeps
-        // recurrent prefixes (system prompts, tool descriptions in
-        // agentic sessions) resident longer.
-        //
-        // #155: the original formula DIVIDED by (1 + hit_count), which
-        // inverts the intent — frequently-hit snapshots scored LOWEST
-        // and were evicted first at pool saturation (measured: a
-        // just-selected snapshot evicted 7s later while ~50
-        // never-accessed entries survived → selected=None mid-session
-        // → full-conversation SSM recompute on the next warm hit).
-        //
-        // SBR M1 tail-pin: forecast score keeps HOT (shared-prefix) snapshots
-        // resident, but that is orthogonal to REPLAY DISTANCE — a conversation's
-        // deep per-turn checkpoint has hit_count≈0 and gets evicted before the
-        // hot system-prompt prefix, stranding a resuming turn far from its tail
-        // (replay = depth − shallow_prefix → 21s). We therefore exclude each
-        // session's DEEPEST snapshot (its "tail" = the global section we keep
-        // resident) from eviction, falling back to evicting the lowest-score
-        // tail only if every entry is a tail (pool too small for the live set).
-        // Pin only RESUMABLE sessions' deepest. A session is resumable if any
-        // of its entries has been hit (hit_count>0) — i.e. a real multi-turn
-        // conversation that has actually been resumed. One-shot sessions
-        // (e.g. distractor traffic that never returns) are NOT pinned, so they
-        // age out under the forecast score instead of wastefully holding slots
-        // and evicting a live conversation's useful intermediate checkpoints.
-        // (Measured 2026-06-27: naive "pin every session's deepest" REGRESSED
-        // a main conversation 4.0s→8.8s by pinning ~96 dead one-shot tails.)
-        // SBR M1 — TWO-TIER eviction (protect resumable conversations from
-        // transient one-shot churn). A session is RESUMABLE iff some entry has
-        // hit_count>0 (a real multi-turn conversation that was actually resumed
-        // at least once). The stranding pathology is the forecast evicting a live
-        // conversation's deep SSM checkpoint to make room for transient one-shot
-        // traffic, leaving the next resume to replay from a far-shallow survivor
-        // (1s→21s). Fix: evict NON-resumable (one-shot / untracked) entries BEFORE
-        // any resumable conversation's entry; only when no non-resumable entry
-        // exists do we fall through to the pure recency·hit forecast over all
-        // entries.
-        //
-        // This is the right discriminator (NOT count/budget heuristics, which are
-        // unreliable from the index's local view): it protects exactly what a
-        // resuming conversation needs (its own checkpoints) and is PROVABLY
-        // do-no-harm when every entry is resumable (balanced multi-conversation
-        // round-robin) — the non-resumable pool is empty, so it is identical to
-        // the baseline forecast. Earlier "pin the top-K deepest" variants
-        // regressed that regime 5.9s→7.7s by displacing live convs' working sets.
-        let pin = tail_pin_enabled();
-        let mut resumable: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        // Pin the top-`pin_k` deepest snapshots of each RESUMABLE session.
+        let mut pinned = std::collections::HashSet::new();
         if pin {
-            for e in &self.entries {
-                if e.session_hash != 0 && e.hit_count > 0 {
+            let mut by_session: std::collections::HashMap<u64, Vec<(usize, usize)>> =
+                std::collections::HashMap::new();
+            let mut resumable: std::collections::HashSet<u64> = std::collections::HashSet::new();
+            for (i, e) in self.entries.iter().enumerate() {
+                if e.session_hash == 0 {
+                    continue;
+                }
+                if e.hit_count > 0 {
                     resumable.insert(e.session_hash);
+                }
+                by_session
+                    .entry(e.session_hash)
+                    .or_default()
+                    .push((e.token_count, i));
+            }
+            for (s, mut v) in by_session {
+                if !resumable.contains(&s) {
+                    continue;
+                }
+                v.sort_unstable_by(|a, b| b.0.cmp(&a.0)); // deepest first
+                for &(_, idx) in v.iter().take(pin_k) {
+                    pinned.insert(idx);
                 }
             }
         }
-        let protected = |e: &SnapshotEntry| -> bool {
-            pin && e.session_hash != 0 && resumable.contains(&e.session_hash)
-        };
 
-        // Tier 1: lowest-score among NON-protected (one-shot / untracked).
-        // Tier 2 fallback: lowest-score among ALL (pure forecast) when every
-        // entry belongs to a resumable conversation.
-        let mut tier1_idx: Option<usize> = None;
-        let mut tier1_score = u64::MAX;
+        // Evict the lowest-forecast NON-pinned entry; fall back to the global
+        // lowest (pure forecast) only when every entry is pinned.
+        let mut victim_idx: Option<usize> = None;
+        let mut victim_score = u64::MAX;
         let mut all_idx = 0;
         let mut all_score = u64::MAX;
         for (i, entry) in self.entries.iter().enumerate() {
@@ -209,12 +222,12 @@ impl SsmSnapshotIndex {
                 all_score = score;
                 all_idx = i;
             }
-            if !protected(entry) && score < tier1_score {
-                tier1_score = score;
-                tier1_idx = Some(i);
+            if !pinned.contains(&i) && score < victim_score {
+                victim_score = score;
+                victim_idx = Some(i);
             }
         }
-        let idx = tier1_idx.unwrap_or(all_idx);
+        let idx = victim_idx.unwrap_or(all_idx);
         let entry = self.entries.swap_remove(idx);
         Some(entry.snapshot_id)
     }

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -6,7 +6,31 @@
 //! same prompt across requests can hit a cached SSM state without going
 //! through the radix tree.
 
+use std::sync::OnceLock;
+
 use super::hash_token_prefix;
+
+/// SBR M1 two-tier eviction policy. When enabled, [`SsmSnapshotIndex::evict_lru`]
+/// evicts NON-resumable (one-shot / untracked) snapshots before any resumable
+/// multi-turn conversation's snapshot — protecting live conversations' SSM
+/// checkpoints from transient one-shot churn (the cause of the "replay grows as
+/// slots fill" TTFT blowup, 1s→21s). When every entry is resumable it degrades
+/// identically to the baseline recency·hit forecast (Marconi §4) — provably
+/// do-no-harm.
+///
+/// Enabled by default; set `ATLAS_SBR_TAIL_PIN=0` to restore the pure
+/// forecast-LRU baseline (for A/B benchmarking against the fix).
+fn tail_pin_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        let on = std::env::var("ATLAS_SBR_TAIL_PIN").map(|v| v != "0").unwrap_or(true);
+        tracing::info!(
+            "SBR snapshot two-tier eviction (protect resumable convs): {}",
+            if on { "ENABLED" } else { "disabled (baseline)" },
+        );
+        on
+    })
+}
 
 pub(super) struct SnapshotEntry {
     snapshot_id: usize,
@@ -122,18 +146,76 @@ impl SsmSnapshotIndex {
         // just-selected snapshot evicted 7s later while ~50
         // never-accessed entries survived → selected=None mid-session
         // → full-conversation SSM recompute on the next warm hit).
-        let mut victim_idx = 0;
-        let mut victim_score = u64::MAX;
+        //
+        // SBR M1 tail-pin: forecast score keeps HOT (shared-prefix) snapshots
+        // resident, but that is orthogonal to REPLAY DISTANCE — a conversation's
+        // deep per-turn checkpoint has hit_count≈0 and gets evicted before the
+        // hot system-prompt prefix, stranding a resuming turn far from its tail
+        // (replay = depth − shallow_prefix → 21s). We therefore exclude each
+        // session's DEEPEST snapshot (its "tail" = the global section we keep
+        // resident) from eviction, falling back to evicting the lowest-score
+        // tail only if every entry is a tail (pool too small for the live set).
+        // Pin only RESUMABLE sessions' deepest. A session is resumable if any
+        // of its entries has been hit (hit_count>0) — i.e. a real multi-turn
+        // conversation that has actually been resumed. One-shot sessions
+        // (e.g. distractor traffic that never returns) are NOT pinned, so they
+        // age out under the forecast score instead of wastefully holding slots
+        // and evicting a live conversation's useful intermediate checkpoints.
+        // (Measured 2026-06-27: naive "pin every session's deepest" REGRESSED
+        // a main conversation 4.0s→8.8s by pinning ~96 dead one-shot tails.)
+        // SBR M1 — TWO-TIER eviction (protect resumable conversations from
+        // transient one-shot churn). A session is RESUMABLE iff some entry has
+        // hit_count>0 (a real multi-turn conversation that was actually resumed
+        // at least once). The stranding pathology is the forecast evicting a live
+        // conversation's deep SSM checkpoint to make room for transient one-shot
+        // traffic, leaving the next resume to replay from a far-shallow survivor
+        // (1s→21s). Fix: evict NON-resumable (one-shot / untracked) entries BEFORE
+        // any resumable conversation's entry; only when no non-resumable entry
+        // exists do we fall through to the pure recency·hit forecast over all
+        // entries.
+        //
+        // This is the right discriminator (NOT count/budget heuristics, which are
+        // unreliable from the index's local view): it protects exactly what a
+        // resuming conversation needs (its own checkpoints) and is PROVABLY
+        // do-no-harm when every entry is resumable (balanced multi-conversation
+        // round-robin) — the non-resumable pool is empty, so it is identical to
+        // the baseline forecast. Earlier "pin the top-K deepest" variants
+        // regressed that regime 5.9s→7.7s by displacing live convs' working sets.
+        let pin = tail_pin_enabled();
+        let mut resumable: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        if pin {
+            for e in &self.entries {
+                if e.session_hash != 0 && e.hit_count > 0 {
+                    resumable.insert(e.session_hash);
+                }
+            }
+        }
+        let protected = |e: &SnapshotEntry| -> bool {
+            pin && e.session_hash != 0 && resumable.contains(&e.session_hash)
+        };
+
+        // Tier 1: lowest-score among NON-protected (one-shot / untracked).
+        // Tier 2 fallback: lowest-score among ALL (pure forecast) when every
+        // entry belongs to a resumable conversation.
+        let mut tier1_idx: Option<usize> = None;
+        let mut tier1_score = u64::MAX;
+        let mut all_idx = 0;
+        let mut all_score = u64::MAX;
         for (i, entry) in self.entries.iter().enumerate() {
             // Saturating math: both factors fit u64 comfortably
             // (access_counter is monotonic per-process, hit_count u32).
             let score = entry.last_access.saturating_mul(1 + entry.hit_count as u64);
-            if score < victim_score {
-                victim_score = score;
-                victim_idx = i;
+            if score < all_score {
+                all_score = score;
+                all_idx = i;
+            }
+            if !protected(entry) && score < tier1_score {
+                tier1_score = score;
+                tier1_idx = Some(i);
             }
         }
-        let entry = self.entries.swap_remove(victim_idx);
+        let idx = tier1_idx.unwrap_or(all_idx);
+        let entry = self.entries.swap_remove(idx);
         Some(entry.snapshot_id)
     }
 

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -28,7 +28,11 @@ fn tail_pin_enabled() -> bool {
             .unwrap_or(false);
         tracing::info!(
             "SBR snapshot tail-pin eviction: {} (opt-in, top-K={})",
-            if on { "ENABLED" } else { "off (baseline forecast)" },
+            if on {
+                "ENABLED"
+            } else {
+                "off (baseline forecast)"
+            },
             tail_pin_k()
         );
         on

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -308,6 +308,54 @@ fn test_snapshot_index_lru_eviction() {
 }
 
 #[test]
+fn test_two_tier_protects_resumable_intermediate_over_oneshot() {
+    // SBR M1 two-tier: the stranding cause is that a live conversation's DEEP
+    // intermediate checkpoints have hit_count==0 (they were never the resume
+    // anchor), so the forecast treats them like one-shots and evicts them by age
+    // — even though their SESSION has been resumed. Two-tier protects ALL entries
+    // of a resumable SESSION, evicting genuine one-shots (whose session was never
+    // resumed) first instead.
+    let mut idx = SsmSnapshotIndex::new();
+    let tok: Vec<u32> = (0..128).collect();
+    let other: Vec<u32> = (200..264).collect();
+    // conv 100: deep anchor (id1, tok128) + an OLDER intermediate (id3, tok64,
+    // never individually hit).
+    idx.insert(hash_token_prefix(&tok, 128), 1, 100, 128);
+    idx.insert(hash_token_prefix(&tok, 64), 3, 100, 64); // intermediate, hit=0, oldest
+    // Resume conv 100 (hit the deep anchor) → session 100 is resumable.
+    assert_eq!(idx.lookup(&tok, 128, 100), Some((1, 128)));
+    // A genuine one-shot conv arrives NEWEST (distinct prefix hash).
+    idx.insert(hash_token_prefix(&other, 64), 2, 200, 64);
+
+    // Forecast would evict id3 (resumable conv's old intermediate = lowest score),
+    // stranding conv 100. Two-tier evicts the one-shot (id2) instead.
+    assert_eq!(
+        idx.evict_lru(),
+        Some(2),
+        "two-tier must evict the one-shot (id2), not the resumable conv's intermediate (id3)"
+    );
+}
+
+#[test]
+fn test_two_tier_all_resumable_is_pure_forecast() {
+    // Do-no-harm: when EVERY entry belongs to a resumable conversation (balanced
+    // multi-conv), there are no non-resumable victims, so two-tier degrades to
+    // the baseline recency·hit forecast — evicting the lowest-score (oldest,
+    // unhit) entry. This is the regime where "pin the deepest" variants regressed.
+    let mut idx = SsmSnapshotIndex::new();
+    let ta: Vec<u32> = (0..32).collect();
+    let tb: Vec<u32> = (100..132).collect();
+    idx.insert(hash_token_prefix(&ta, 32), 1, 100, 32); // conv A (oldest)
+    idx.insert(hash_token_prefix(&tb, 32), 2, 200, 32); // conv B (newer)
+    // Make BOTH sessions resumable.
+    assert_eq!(idx.lookup(&ta, 32, 100), Some((1, 32)));
+    assert_eq!(idx.lookup(&tb, 32, 200), Some((2, 32)));
+    // Both resumable → no one-shot victim → pure forecast evicts lowest score.
+    // After the lookups, A was hit before B (A older last_access) → A evicted.
+    assert_eq!(idx.evict_lru(), Some(1));
+}
+
+#[test]
 fn test_snapshot_index_session_isolation() {
     let mut idx = SsmSnapshotIndex::new();
     let tokens: Vec<u32> = (0..16).collect();

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -308,51 +308,43 @@ fn test_snapshot_index_lru_eviction() {
 }
 
 #[test]
-fn test_two_tier_protects_resumable_intermediate_over_oneshot() {
-    // SBR M1 two-tier: the stranding cause is that a live conversation's DEEP
-    // intermediate checkpoints have hit_count==0 (they were never the resume
-    // anchor), so the forecast treats them like one-shots and evicts them by age
-    // — even though their SESSION has been resumed. Two-tier protects ALL entries
-    // of a resumable SESSION, evicting genuine one-shots (whose session was never
-    // resumed) first instead.
+fn test_tail_pin_protects_top_k_deepest() {
+    // SBR M1 tail-pin (opt-in): when enabled, the top-K DEEPEST snapshots of a
+    // RESUMABLE session are pinned, so the shallowest (which a resume past them
+    // does not need) are evicted first and the near-tail anchors survive cache
+    // pressure. (Called via evict_lru_inner so the test is independent of the
+    // env-gated default, which is OFF.)
     let mut idx = SsmSnapshotIndex::new();
-    let tok: Vec<u32> = (0..128).collect();
-    let other: Vec<u32> = (200..264).collect();
-    // conv 100: deep anchor (id1, tok128) + an OLDER intermediate (id3, tok64,
-    // never individually hit).
-    idx.insert(hash_token_prefix(&tok, 128), 1, 100, 128);
-    idx.insert(hash_token_prefix(&tok, 64), 3, 100, 64); // intermediate, hit=0, oldest
-    // Resume conv 100 (hit the deep anchor) → session 100 is resumable.
-    assert_eq!(idx.lookup(&tok, 128, 100), Some((1, 128)));
-    // A genuine one-shot conv arrives NEWEST (distinct prefix hash).
-    idx.insert(hash_token_prefix(&other, 64), 2, 200, 64);
+    let tok: Vec<u32> = (0..256).collect();
+    // 10 checkpoints for session 100 at increasing depths (ids 1..=10).
+    let depths = [16usize, 32, 48, 64, 80, 96, 112, 128, 144, 160];
+    for (i, tc) in depths.iter().enumerate() {
+        idx.insert(hash_token_prefix(&tok, *tc), i + 1, 100, *tc);
+    }
+    // Resume conv 100 (hit the deepest) → session 100 resumable.
+    assert_eq!(idx.lookup(&tok, 160, 100), Some((10, 160)));
 
-    // Forecast would evict id3 (resumable conv's old intermediate = lowest score),
-    // stranding conv 100. Two-tier evicts the one-shot (id2) instead.
-    assert_eq!(
-        idx.evict_lru(),
-        Some(2),
-        "two-tier must evict the one-shot (id2), not the resumable conv's intermediate (id3)"
+    // pin_k=8 → pin the 8 deepest (ids 3..=10); evict the 2 shallowest (ids 1,2).
+    let e1 = idx.evict_lru_inner(true, 8).unwrap();
+    let e2 = idx.evict_lru_inner(true, 8).unwrap();
+    assert!(
+        [1, 2].contains(&e1) && [1, 2].contains(&e2) && e1 != e2,
+        "tail-pin must evict the two shallowest (ids 1,2), got {e1},{e2}"
     );
+    assert_eq!(idx.len(), 8, "the top-8 deepest must survive");
 }
 
 #[test]
-fn test_two_tier_all_resumable_is_pure_forecast() {
-    // Do-no-harm: when EVERY entry belongs to a resumable conversation (balanced
-    // multi-conv), there are no non-resumable victims, so two-tier degrades to
-    // the baseline recency·hit forecast — evicting the lowest-score (oldest,
-    // unhit) entry. This is the regime where "pin the deepest" variants regressed.
+fn test_tail_pin_off_is_pure_forecast() {
+    // Default-off / pin=false must be exactly the baseline forecast: evict the
+    // lowest-score (oldest, unhit) entry regardless of depth.
     let mut idx = SsmSnapshotIndex::new();
-    let ta: Vec<u32> = (0..32).collect();
-    let tb: Vec<u32> = (100..132).collect();
-    idx.insert(hash_token_prefix(&ta, 32), 1, 100, 32); // conv A (oldest)
-    idx.insert(hash_token_prefix(&tb, 32), 2, 200, 32); // conv B (newer)
-    // Make BOTH sessions resumable.
-    assert_eq!(idx.lookup(&ta, 32, 100), Some((1, 32)));
-    assert_eq!(idx.lookup(&tb, 32, 200), Some((2, 32)));
-    // Both resumable → no one-shot victim → pure forecast evicts lowest score.
-    // After the lookups, A was hit before B (A older last_access) → A evicted.
-    assert_eq!(idx.evict_lru(), Some(1));
+    let tok: Vec<u32> = (0..256).collect();
+    idx.insert(hash_token_prefix(&tok, 128), 1, 100, 128); // deep, oldest
+    idx.insert(hash_token_prefix(&tok, 16), 2, 100, 16); // shallow, newer
+    // pin OFF → forecast evicts the older (lower last_access) entry = id1,
+    // even though it is the deepest (no protection).
+    assert_eq!(idx.evict_lru_inner(false, 8), Some(1));
 }
 
 #[test]

--- a/research/sbr/M1_RESULTS.md
+++ b/research/sbr/M1_RESULTS.md
@@ -45,10 +45,35 @@ WITHOUT keeping the sequence live (slots still evicted/shared). Default set to K
 non-flat point — the ideal anchor wasn't yet in top-K when the first burst hit;
 still 2.8× better than baseline.
 
-## Status: M1 DECISIVE WIN. Open follow-ups (lower priority)
-- Multi-real-conversation regime (K·N vs slots) robustness sweep.
+## Final shipping form (2026-06-27): top-K=8, DEFAULT OFF
+
+Multi-conversation robustness sweep settled the policy honestly:
+
+| regime | baseline | tail-pin ON | verdict |
+|---|---|---|---|
+| single deep conv (strand) | 9.53s | **1.18s (8×)** | decisive win |
+| balanced 8-conv / 24-slot round-robin | 5.89s | 7.68–7.86s | **~30% REGRESSION** |
+
+Across all four policy variants tried (single-deepest, top-K, budget-aware,
+session-count gate, two-tier), enabling tail-pin reliably **regresses balanced
+many-conversation round-robin ~30%** — the recency·hit forecast is already
+near-optimal there and pinning fights it. Attempts to detect the regime from the
+index's local view (budget/n, in-index session count, two-tier resumable-set)
+all failed because that view doesn't reflect the true active-conversation count.
+The two-tier variant was also empirically *worse* on strand (cyc0 9.04s) and is
+reverted.
+
+**Decision: ship the top-K=8 policy OFF by default** (`ATLAS_SBR_TAIL_PIN` unset
+= pure baseline forecast = provably do-no-harm everywhere), enabled via
+`ATLAS_SBR_TAIL_PIN=1` for deep single/few-conversation agentic workloads (the
+user's 1s→21s symptom), where it delivers the 8× win. Exact in both modes.
+Policy selection split into `evict_lru_inner(pin, k)` for unit-testability.
+
+## Open follow-ups (lower priority)
+- Regime auto-detection from a TRUE active-conversation signal (scheduler-side,
+  not index-local) to enable safe default-on — the 4 index-local attempts failed.
 - Formal argmax/KL parity table for the paper (exactness is structural; measure it).
-- Optional: range-based pin `[tail−W, tail]` as a principled alternative to top-K.
+- M3 2-D sheaf reconciliation: prototyped → honest negative (see M3_FINDINGS.md).
 
 ## Config / reproduction
 Binary: SBR `feat/sheaf-based-replaying` built on dgx1, bind-mounted into

--- a/research/sbr/M1_RESULTS.md
+++ b/research/sbr/M1_RESULTS.md
@@ -1,0 +1,57 @@
+# SBR M1 (tail-pin eviction) — e2e results on dgx2 (Qwen3-Next-80B-NVFP4)
+
+## Win (stranding scenario: deep ~24k conv, warmed, idle under 30-conv pressure bursts, resumed)
+
+`--enable-prefix-caching --ssm-cache-slots 16`, `ATLAS_SBR_TAIL_PIN` 0 vs 1, top-K=4.
+
+| resume cycle | Baseline TTFT / replay-tok | Tail-pin TTFT / replay-tok |
+|---|---|---|
+| cyc0 | 9.31s / 7456 | 3.32s / 2417 |
+| cyc1 | 9.48s / —    | 0.44s / 984  |
+| cyc2 | 9.58s / 7568 | 9.29s / 7633 (gap) |
+| cyc3 | 9.74s / 7760 | 0.45s / 11   |
+| **mean** | **9.53s** | **3.37s** |
+
+- **2.8× mean TTFT, up to 21× (0.45s vs 9.74s) on the best cycle.**
+- Replay distance collapses from ~7600 tokens → **11–984** when the anchor survives.
+- **Exact by construction**: tail-pin changes only WHICH checkpoint is restored; the
+  replay from it is the unchanged bit-exact WY4 path (`gdn_exact_replay`), so reconstructed
+  state at the match point is identical regardless of anchor depth. (Formal argmax/KL
+  parity check pending for the paper.)
+- Baseline is steadily stranded (~9.5s, replay ~7600) — the 1s→21s pathology, here at
+  ~24k depth manifesting as ~9.5s.
+
+## Root cause confirmed (snap-lookup token_counts)
+Baseline at match 23968 keeps `[…,16512]` (deep region evicted) → replay 7456. The fix
+keeps the resumable session's **top-K deepest**; pinning the single deepest alone failed
+because the leaf **overshoots** the match point (`24061 > 23968`, lookup excludes it). K≥2
+keeps a usable ≤-match anchor.
+
+## Robustness FIXED with top-K=8 (now the default)
+
+| resume cycle | Baseline | K=4 | **K=8 (default)** |
+|---|---|---|---|
+| cyc0 | 9.31s | 3.32s | 3.35s |
+| cyc1 | 9.48s | 0.44s | 0.45s |
+| cyc2 | 9.58s | 9.29s | **0.46s** |
+| cyc3 | 9.74s | 0.45s | 0.45s |
+| **mean** | **9.53s** | 3.37s | **1.18s** |
+
+K=8 eliminates the cyc2 spike (replay now 11–19 tok on warm cycles). **8× mean
+speedup, up to 21×, FLAT and exact.** The warm-cycle 0.45s **matches llama.cpp's
+continuous-sequence resume** — i.e. SBR attains the "never recompute" latency
+WITHOUT keeping the sequence live (slots still evicted/shared). Default set to K=8
+(`ATLAS_SBR_TAIL_PIN_K`). cyc0 (first post-pressure resume, 3.35s) is the only
+non-flat point — the ideal anchor wasn't yet in top-K when the first burst hit;
+still 2.8× better than baseline.
+
+## Status: M1 DECISIVE WIN. Open follow-ups (lower priority)
+- Multi-real-conversation regime (K·N vs slots) robustness sweep.
+- Formal argmax/KL parity table for the paper (exactness is structural; measure it).
+- Optional: range-based pin `[tail−W, tail]` as a principled alternative to top-K.
+
+## Config / reproduction
+Binary: SBR `feat/sheaf-based-replaying` built on dgx1, bind-mounted into
+`atlas-gb10:ornith-perf` on dgx2. Scripts: `research/sbr/sbr_strand.py`,
+`run_strand_ab.sh`. See [[project_atlas_marconi_warmhit_bench_gotchas]] for the
+must-pass gates (esp. `--enable-prefix-caching`).

--- a/research/sbr/M3_FINDINGS.md
+++ b/research/sbr/M3_FINDINGS.md
@@ -1,0 +1,152 @@
+# M3 — 2-D (position × layer) sheaf L₀ reconciliation: findings
+
+Synthetic CPU prototype (`M3_sheaf_prototype.py`, fp32 sim / fp64 solve). Tests
+the one regime where sheaf cohomology is non-vacuous for SBR: a 2-D cell complex
+`(token-position × layer)`, where the four restriction maps around a plaquette
+need not commute (H¹≠0 / nonzero curvature). The load-bearing object is the **L₀
+sheaf-Laplacian least-squares reconciliation**: cross-layer × cross-position
+redundancy over-determines the multi-layer SSM state, so it *might* denoise cheap
+lossy per-layer (contractive-window) reconstructions.
+
+## Setup
+- L=48 layers, H=4 heads, KD=VD=16 → stalk dim **D=1024** per cell.
+- Affine-GDN per-token update reused from Phase-1: `h_t = (exp(g_t)I − β_t k_t k_tᵀ)h_{t−1} + β_t k_t v_tᵀ`.
+- Heavy-tailed decay: 76% fast heads ∈[0.95,0.999], **24% slow** ∈[0.9999,1.0]
+  (measured 50/192 = 26% slow; 36/48 layers carry ≥1 slow head).
+- Layers coupled: layer ℓ+1's streams are driven by a projection of layer ℓ's
+  per-token state (low noise) → consecutive-layer states are genuinely related,
+  so the **vertical restriction maps are meaningful** (not noise).
+- **Horizontal edges** = EXACT per-chunk GDN affine operators `Γ` with the exact
+  (materialized-input) drive `c`. **Vertical edges** = ridge-fit linear map
+  `V_ℓ: stateℓ → stateℓ+1` (+ bias).
+- **Lossy input** = per-layer contractive-window replay from a zero state over the
+  last τ tokens. Small τ → exact-ish for fast heads, degraded for slow heads.
+- Solve: `min_x [ w_d·‖x−lossy‖² + w_h·‖x_v−Γx_u−c‖²(horiz) + w_v·‖x_v−Vx_u−b‖²(vert) ]`
+  with a subset of **layers pinned exact**; CG over the free cells.
+- Metric: cosine vs the exact reference, over **free (unpinned) cells**, reported
+  full-cell and split into **slow-head** vs **fast-head** sub-blocks.
+
+Diagnostics: vertical ridge fit cosine **0.978** (min 0.971); **mean plaquette
+curvature (relative H/V non-commutation) = 0.479** — the fitted 2-D sheaf is
+strongly non-flat.
+
+## Main table — τ=48, pin 12/48 layers exact (every 4th), free cells
+| method | min | mean | median | ≥0.999 | slow-sub | fast-sub |
+|---|---|---|---|---|---|---|
+| lossy input | 0.547 | 0.964 | 0.973 | 0.000 | 0.916 | 0.994 |
+| **horiz-only** (no cross-layer) | 0.613 | **0.995** | 0.9998 | **0.861** | 0.989 | 0.999 |
+| FULL 2-D sheaf (w_v=3) | 0.954 | 0.992 | 0.997 | 0.022 | 0.994 | 0.991 |
+
+Reading: horizontal-only (exact GDN recurrence + lossy data + exact pins) already
+does the heavy lifting — lossy 0.964 → 0.995, and 86% of free cells clear the
+0.999 gate. The FULL sheaf with a fitted map at w_v=3 **raises the floor** (min
+0.61→0.95, slow-sub 0.989→0.994) but **drags the bulk down** (fast-sub 0.999→0.991,
+≥0.999 collapses 0.861→0.022). The vertical term behaves as a regularizer toward
+the vertical map's own ~0.99 accuracy ceiling: it helps the worst slow cells and
+hurts the many cells horizontal already fixed.
+
+## (a) τ sweep — mean cell cosine / slow-subspace cosine (pin 12/48)
+| τ | lossy | horiz-only | FULL (w_v=3) |
+|---|---|---|---|
+| 24 | 0.894 / 0.791 | 0.987 / 0.974 | **0.992 / 0.993** |
+| 48 | 0.964 / 0.916 | **0.995** / 0.989 | 0.992 / 0.994 |
+| 96 | 0.989 / 0.978 | **0.998** / 0.996 | 0.993 / 0.995 |
+
+A clean **crossover**: FULL beats horiz-only only at τ=24 (lossy so bad that
+horizontal+pins cannot recover it and the vertical prediction is more accurate).
+At τ≥48 horiz-only wins on mean; the vertical map's ~0.99 ceiling caps FULL.
+
+## (b) pin-set size sweep (τ=48) — mean cell cosine over free
+| pinned | lossy | horiz | full | full−horiz |
+|---|---|---|---|---|
+| 24/48 | 0.958 | 0.994 | 0.991 | −0.0028 |
+| 16/48 | 0.963 | 0.995 | 0.992 | −0.0025 |
+| 12/48 | 0.964 | 0.995 | 0.992 | −0.0027 |
+| 6/48 | 0.964 | 0.995 | 0.993 | −0.0025 |
+| 3/48 | 0.965 | 0.995 | 0.992 | −0.0029 |
+
+The cross-layer term is **uniformly slightly negative** vs horizontal-only at this
+τ regardless of anchor density. The win in horiz-only comes from the exact
+horizontal recurrence + anchors, **not** from cross-layer structure.
+
+## (c) vertical weight w_v sweep (τ=48, pin 12/48); w_v=0 == horiz-only
+| w_v | cell-mean | slow-sub | ≥0.999 |
+|---|---|---|---|
+| 0.0 | 0.9951 | 0.9887 | 0.861 |
+| **0.3** | **0.9966** | 0.9933 | 0.861 |
+| 1.0 | 0.9964 | 0.9957 | 0.725 |
+| 3.0 | 0.9924 | 0.9944 | 0.022 |
+| 10.0 | 0.9786 | 0.9856 | 0.003 |
+
+There **is** a tuned sweet spot (w_v≈0.3) where the fitted-map sheaf beats
+horiz-only on both mean (+0.0015) and slow-subspace (+0.0046) **without** losing
+gate fraction. But it does not *raise* the gate fraction (0.861 either way): it
+improves slow-cell fidelity, not the count of cells clearing 0.999.
+
+## (d) vertical-map fit quality + ORACLE ceiling (τ=48, pin 12/48, w_v=3)
+| fit | fit-cos | full-mean | full-slow | vs horiz |
+|---|---|---|---|---|
+| ridge λ=1e−3 (overfit) | 1.000 | 0.990 | 0.993 | −0.0048 |
+| ridge λ=1e−1 | 0.978 | 0.992 | 0.994 | −0.0027 |
+| ridge λ=1e+1 | 0.820 | 0.993 | 0.993 | −0.0021 |
+| ridge λ=1e+3 | 0.775 | 0.990 | 0.984 | −0.0054 |
+| **ORACLE-V w_v=1** | 1.000 | 0.9988 | 0.9974 | **+0.0037** |
+| **ORACLE-V w_v=3** | 1.000 | 0.9996 | 0.9992 | **+0.0045** |
+| **ORACLE-V w_v=10** | 1.000 | **0.9999** | **0.9998** | **+0.0048** |
+
+ORACLE-V = best linear ℓ→ℓ+1 map fit directly on the **exact** grid states
+(curvature driven to **0.0001**, a nearly flat sheaf). This is the decisive
+ablation: with an accurate vertical map the FULL 2-D sheaf **beats horiz-only by
++0.0048**, lifts the slow-subspace to **0.9998**, and reaches **mean 0.9999** —
+clearing the coherence gate that horizontal-only (0.995, 86%) cannot.
+
+## Cost
+At τ=48, pin 12/48: solve is 331,776 free DOF (CG ~30 matvecs). Lossy windows cost
+~15.5k token-updates vs ~147k for exact full replay of the unpinned layers (~9×
+cheaper) — but only horiz-only converts that cheap lossy input into gate-passing
+states; the cross-layer sheaf does not improve on it with a fitted map.
+
+## VERDICT (brutally honest)
+
+**The 2-D sheaf does genuine, non-trivial work in principle — but the realistic
+version is dominated by the cheaper non-sheaf baseline, so it is NOT a usable SBR
+lever as-is.**
+
+1. **The concept is real, not vacuous.** With an accurate vertical map (ORACLE,
+   curvature→0), the cross-layer L₀ solve reaches mean **0.9999** / slow-sub
+   **0.9998** and beats the no-cross-layer baseline by **+0.0048**, clearing the
+   gate that horizontal-only plateaus below (0.995 / 86%). The extra fidelity is
+   exactly the cross-layer information — this is **not** something a per-layer
+   (horizontal-only) least-squares can match. So the "H¹≠0 / 2-D redundancy"
+   premise is validated at the ceiling.
+
+2. **But with a fittable vertical map it adds nothing exploitable.** A ridge map
+   on activations tops out at cosine ~0.978 / plaquette curvature ~0.48. That
+   accuracy caps the reconciled state at ~0.99, so at practical τ (≥48) the FULL
+   sheaf is **net-negative vs horizontal-only** (−0.002 to −0.003 mean) and
+   destroys the gate fraction (0.861→0.022 at w_v=3). It only helps (a) at extreme
+   lossiness τ=24, or (b) at a hand-tuned tiny w_v≈0.3 where the gain is +0.0015
+   mean / +0.005 slow and **does not raise the gate fraction**.
+
+3. **The win that exists is horizontal + anchors, which is exactly M1.** The
+   honesty check from the plan is answered: horizontal-only (exact GDN recurrence
+   + exact pinned layers) — a plain per-layer least-squares with **no sheaf
+   cross-layer coupling** — already lifts the lossy input from 0.964 to 0.995 and
+   86% gate-passing. That is the M1 lever (exact recurrence from near anchors), not
+   sheaf topology.
+
+4. **The bottleneck is precisely measured: vertical-map quality (plaquette
+   curvature), not the sheaf math.** Closing the gap requires an inter-layer
+   restriction map far more accurate than ridge-on-activations — but a static
+   linear ℓ→ℓ+1 map is fundamentally limited by each layer's own recurrence memory
+   (the source of curvature 0.48), and the only map that reaches curvature ≈0 is
+   fit on the exact states you are trying to recover (circular — if you had them
+   you would not need reconciliation).
+
+**Practical conclusion for Atlas/SBR:** ship the exact horizontal lever (M1:
+eviction/tail-pin + checkpoint replay over known inputs). The 2-D sheaf L₀
+reconciliation is a real but currently *un-actionable* idea: it would only pay off
+given a high-accuracy learned inter-layer state map (curvature ≪ 0.1), which we do
+not have and cannot get cheaply for GDN. Recommend **not** pursuing real-model
+(dgx2) validation unless/until such a map is demonstrated — the synthetic ceiling
+already bounds the upside and the fitted-map regime is a negative.

--- a/research/sbr/M3_SHEAF_PLAN.md
+++ b/research/sbr/M3_SHEAF_PLAN.md
@@ -1,0 +1,61 @@
+# M3 — 2-D (position × layer) sheaf reconciliation (research, background)
+
+## Why this and not the 1-D sheaf
+On a causal 1-D path (a conversation) a cellular sheaf has H¹=0, so "gluing"
+collapses to the exact associative prefix-product — vacuous (M1 already exploits
+it without topology). The **only** place sheaf cohomology does real work here is a
+**2-D cell complex** `(token-position × layer)`: on a 2-D complex H¹ can be ≠0, and
+the four restriction maps around each plaquette need not commute → genuine
+curvature. The honest framing (per the topology scan): the load-bearing object is
+the **L₀ sheaf-Laplacian least-squares reconciliation** (the "H¹≠0" label is
+decorative); its value is that cross-layer × cross-position **redundancy
+over-determines** the state, denoising cheap *lossy* per-layer reconstructions.
+
+## Hypothesis
+A cheap APPROXIMATE per-layer SSM-state reconstruction (e.g. contractive-window
+replay with small τ — exact for the ~76% fast heads, lossy for the ~24% slow/
+weak-forget heads) can be **reconciled** by an L₀ harmonic solve over the
+position×layer sheaf into a globally-consistent multi-layer state with
+**materially higher fidelity than the lossy input** — ideally enough to clear the
+coherence gate (cosine ≥ 0.999) at a fraction of exact-replay cost.
+
+If true → an approximate fast-reconstruction mode (window + sheaf glue) and a
+genuine novel contribution. If false → an honest negative result; M1 (exact)
+stands as the win.
+
+## Construction
+- Base complex: rectangle, cells `(p, ℓ)`, p ∈ chunk boundaries, ℓ ∈ 0..L (48).
+- Vertex stalk `F(p,ℓ)` = layer ℓ's SSM state at position p (full, or low-rank embed).
+- **Horizontal** edge `(p,ℓ)→(p+1,ℓ)`: restriction = layer ℓ's per-chunk GDN affine
+  operator `(Γ,C)` (position recurrence — already materialized by the FLA kernel).
+- **Vertical** edge `(p,ℓ)→(p,ℓ+1)`: restriction = inter-layer map (how layer ℓ's
+  output conditions layer ℓ+1's SSM-state evolution). Approximate as a linear map
+  fit from activations (ridge regression) or use the actual input projections.
+- Plaquette curvature = non-commutation of the 4 maps (nonzero under approximation).
+- L₀ = δ⁰ᵀ δ⁰ (sheaf Laplacian). Reconcile by Dirichlet harmonic extension: fix
+  TRUSTED cells (exact anchors — e.g. attention layers' KV-derived state, or a few
+  exact layers), solve `min_x xᵀ L₀ x` for the rest (sparse SPD solve / CG).
+
+## Prototype (numpy/torch, CPU — no dgx GPU contention)
+`research/sbr/M3_sheaf_prototype.py`:
+1. Synthetic 48-layer GDN states at a match point M; exact reference via full
+   recurrence (reuse sbr_phase1 machinery + a fitted vertical map).
+2. Lossy input: contractive-window reconstruction per layer (small τ) → degrades
+   slow heads (per real heavy-tailed A_log: ~24% need long memory).
+3. Build δ⁰ (horizontal GDN ops + vertical fitted maps), L₀.
+4. Harmonic solve with a subset of layers/positions pinned exact.
+5. Metric: per-layer cosine(reconciled, ref) vs cosine(lossy, ref) — does
+   reconciliation lift the slow-head layers toward ≥0.999? Cost vs exact replay.
+6. Ablations: pin set size, vertical-map fit quality, low-rank stalk dim.
+
+## Gate / honesty
+- Compare against the trivial baseline: does the L₀ solve beat just using the
+  lossy states (and beat plain per-layer smoothing without the sheaf structure)?
+- If the win comes only from pinning exact anchors (not the cross-layer coupling),
+  say so — that would mean the sheaf adds nothing beyond denser anchoring.
+- Real-model validation (dgx2) only after the synthetic prototype shows a clear,
+  non-trivial lift; otherwise stop and report the negative result.
+
+## Status
+Background research thread (started 2026-06-27). Independent of M1 (shipped,
+exact). Does NOT touch dgx2 GPU (CPU prototype first). See [[project_sheaf_based_replaying_2026_06_27]].

--- a/research/sbr/M3_sheaf_prototype.py
+++ b/research/sbr/M3_sheaf_prototype.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""M3 - 2-D (position x layer) cellular-sheaf L0 reconciliation (CPU, fp32/fp64).
+
+Tests the ONLY regime where sheaf cohomology is non-vacuous for SBR: a 2-D cell
+complex (token-position x layer). On a 2-D complex H^1 can be != 0 -> the four
+restriction maps around a plaquette need not commute (genuine curvature). The
+load-bearing object is the L0 sheaf-Laplacian *least-squares reconciliation*:
+cross-layer x cross-position redundancy over-determines the multi-layer SSM
+state, so in principle it can denoise CHEAP LOSSY per-layer (contractive-window)
+reconstructions.
+
+HYPOTHESIS: a sheaf L0 harmonic solve (lossy data term + exact horizontal GDN
+recurrence edges + fitted vertical inter-layer edges + a few pinned exact layers)
+recovers free (unpinned) layers with materially higher cosine than the lossy
+input AND beats the no-vertical-coupling baseline. If the win comes only from
+horizontal structure / exact anchors, the cross-layer sheaf adds nothing beyond
+per-layer smoothing that a non-sheaf least-squares matches -> honest negative.
+
+Synthetic, self-contained. Reuses the affine-GDN per-token update
+  h_t = A_t h_{t-1} + B_t,   A_t = exp(g_t) I - beta_t k_t k_t^T,  B_t = beta_t k_t v_t^T
+from sbr_phase1_glocal_window.py, with a heavy-tailed decay mix
+(~76% fast heads in [0.95,0.999], ~24% slow heads in [0.9999,1.0]).
+
+CPU ONLY. Run: python3 M3_sheaf_prototype.py
+"""
+import os
+
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+import numpy as np
+import torch
+
+torch.manual_seed(7)
+np.random.seed(7)
+torch.set_num_threads(min(8, os.cpu_count() or 1))
+DEV = torch.device("cpu")
+F32 = torch.float32
+
+# ---- geometry -------------------------------------------------------------
+L = 48           # layers
+H = 4            # heads per layer
+KD = 16          # key dim per head
+VD = 16          # value dim per head
+D = H * KD * VD  # stalk dim (flattened multi-head SSM state) = 1024
+N_TOK = 4096     # sequence length; match point M = end
+P_GRID = 9       # grid positions (chunk boundaries) over the tail
+DELTA = 256      # token spacing between grid positions
+M_LATENT = 96    # cross-layer coupling signal dim
+SLOW_FRAC = 0.24
+SUB = 8          # subsample stride for vertical-map fit data
+TAU_MAIN = 48    # representative degraded contractive window
+TAUS = [24, 48, 96]
+
+
+def make_decay():
+    lo = torch.empty(L, H, dtype=F32)
+    hi = torch.empty(L, H, dtype=F32)
+    slow = torch.rand(L, H) < SLOW_FRAC
+    lo[slow], hi[slow] = 0.9999, 1.0
+    lo[~slow], hi[~slow] = 0.95, 0.999
+    return lo, hi, slow
+
+
+def per_token_decay(lo_h, hi_h):
+    u = torch.rand(N_TOK, H, dtype=F32)
+    return lo_h.unsqueeze(0) + u * (hi_h - lo_h).unsqueeze(0)
+
+
+def head_scan(h0, g, beta, k, v, lo, hi, keep=False):
+    """Affine-GDN recurrence over tokens [lo,hi). g,beta:(T,H) k,v:(T,H,*)."""
+    h = h0.clone()
+    states = [] if keep else None
+    for t in range(lo, hi):
+        a = torch.einsum("hkv,hk->hv", h, k[t])
+        vp = (v[t] - a) * beta[t].unsqueeze(-1)
+        h = torch.exp(g[t]).view(-1, 1, 1) * h + torch.einsum("hk,hv->hkv", k[t], vp)
+        if keep:
+            states.append(h.reshape(-1).clone())
+    if keep:
+        return h, torch.stack(states)
+    return h
+
+
+def gen_layer0():
+    k = torch.randn(N_TOK, H, KD, dtype=F32)
+    k = k / k.norm(dim=2, keepdim=True).clamp_min(1e-6)
+    v = torch.randn(N_TOK, H, VD, dtype=F32)
+    beta = torch.sigmoid(torch.randn(N_TOK, H, dtype=F32))
+    return k, v, beta
+
+
+def gen_coupled(prev_s, Wk, Wv, Wb):
+    """Layer l+1 streams driven by layer l output signal prev_s (T,M_LATENT).
+    Low coupling noise -> the inter-layer relation is mostly linear; residual
+    error comes from layer l+1's OWN recurrence memory (genuine curvature)."""
+    k = (prev_s @ Wk).reshape(N_TOK, H, KD) + 0.05 * torch.randn(N_TOK, H, KD)
+    k = k / k.norm(dim=2, keepdim=True).clamp_min(1e-6)
+    v = (prev_s @ Wv).reshape(N_TOK, H, VD) + 0.05 * torch.randn(N_TOK, H, VD)
+    beta = torch.sigmoid((prev_s @ Wb).reshape(N_TOK, H) + 0.1 * torch.randn(N_TOK, H))
+    return k, v, beta
+
+
+def build_forward():
+    lo_h, hi_h, slow = make_decay()
+    g_idx = [N_TOK - 1 - (P_GRID - 1 - i) * DELTA for i in range(P_GRID)]
+    P_o = torch.randn(D, M_LATENT, dtype=F32) / np.sqrt(D)
+    streams, grid_states, sub_states = [], [], []
+    prev_s = None
+    for l in range(L):
+        g = torch.log(per_token_decay(lo_h[l], hi_h[l]))
+        if l == 0:
+            k, v, beta = gen_layer0()
+        else:
+            Wk = torch.randn(M_LATENT, H * KD, dtype=F32) / np.sqrt(M_LATENT)
+            Wv = torch.randn(M_LATENT, H * VD, dtype=F32) / np.sqrt(M_LATENT)
+            Wb = torch.randn(M_LATENT, H, dtype=F32) / np.sqrt(M_LATENT)
+            k, v, beta = gen_coupled(prev_s, Wk, Wv, Wb)
+        h0 = torch.zeros(H, KD, VD, dtype=F32)
+        _, states_t = head_scan(h0, g, beta, k, v, 0, N_TOK, keep=True)
+        grid_states.append(states_t[g_idx])
+        sub_states.append(states_t[::SUB])
+        prev_s = states_t @ P_o
+        streams.append((g, beta, k, v))
+    return streams, torch.stack(grid_states), torch.stack(sub_states), slow, g_idx
+
+
+# ---- horizontal (position) GDN chunk operators ----------------------------
+def chunk_gamma(g, beta, k, lo, hi):
+    G = torch.eye(KD, dtype=F32).unsqueeze(0).repeat(H, 1, 1)
+    eyeH = torch.eye(KD).unsqueeze(0)
+    for t in range(lo + 1, hi + 1):
+        A = torch.exp(g[t]).view(-1, 1, 1) * eyeH \
+            - beta[t].view(-1, 1, 1) * torch.einsum("hi,hj->hij", k[t], k[t])
+        G = torch.einsum("hij,hjk->hik", A, G)
+    return G
+
+
+def gamma_apply(G, x):
+    return torch.einsum("hij,hjv->hiv", G, x.reshape(H, KD, VD)).reshape(-1)
+
+
+def gamma_apply_T(G, x):
+    return torch.einsum("hji,hjv->hiv", G, x.reshape(H, KD, VD)).reshape(-1)
+
+
+# ---- vertical inter-layer maps (ridge regression) -------------------------
+def fit_vertical(states_per_layer, lam):
+    """Fit W_l (D,D), b_l (D): state_{l+1} ~ W_l^T state_l + b_l. Returns
+    (W,b) list and per-layer fit cosine. states_per_layer: (L, n, D)."""
+    S = states_per_layer.double()
+    Ws, qual = [], []
+    I = torch.eye(D, dtype=torch.float64)
+    for l in range(L - 1):
+        X, Y = S[l], S[l + 1]
+        mx, my = X.mean(0), Y.mean(0)
+        Xc, Yc = X - mx, Y - my
+        W = torch.linalg.solve(Xc.T @ Xc + lam * I, Xc.T @ Yc)
+        b = my - W.T @ mx
+        Yhat = X @ W + b
+        q = torch.nn.functional.cosine_similarity(
+            (Y - my).flatten(), (Yhat - my).flatten(), dim=0).item()
+        Ws.append((W.float(), b.float()))
+        qual.append(q)
+    return Ws, qual
+
+
+# ---- lossy contractive-window reconstruction ------------------------------
+def lossy_states(streams, g_idx, tau):
+    out = torch.zeros(L, P_GRID, D, dtype=F32)
+    z = torch.zeros(H, KD, VD, dtype=F32)
+    for l in range(L):
+        g, beta, k, v = streams[l]
+        for i, gp in enumerate(g_idx):
+            lo = max(0, gp + 1 - tau)
+            out[l, i] = head_scan(z, g, beta, k, v, lo, gp + 1).reshape(-1)
+    return out
+
+
+# ---- sheaf assembly --------------------------------------------------------
+def cid(i, l):
+    return i * L + l
+
+
+def build_h_edges(streams, grid_states, g_idx):
+    """Exact horizontal GDN edges: (u, v, Gamma, drive). Drive is EXACT (the
+    materialized inter-position input is known in the SBR setting)."""
+    edges = []
+    for l in range(L):
+        g, beta, k, _ = streams[l]
+        for i in range(P_GRID - 1):
+            G = chunk_gamma(g, beta, k, g_idx[i], g_idx[i + 1])
+            c = grid_states[l, i + 1] - gamma_apply(G, grid_states[l, i])
+            edges.append((cid(i, l), cid(i + 1, l), G, c))
+    return edges
+
+
+def build_v_edges(Ws):
+    edges = []
+    for i in range(P_GRID):
+        for l in range(L - 1):
+            W, b = Ws[l]
+            edges.append((cid(i, l), cid(i, l + 1), W, b))
+    return edges
+
+
+def grad_full(x, h_edges, v_edges, lossy, free, wd, wh, wv, use_offset):
+    gr = torch.zeros_like(x)
+    if use_offset:
+        gr[free] += wd * (x[free] - lossy[free])
+    else:
+        gr[free] += wd * x[free]
+    for (u, vtx, G, c) in h_edges:
+        r = x[vtx] - gamma_apply(G, x[u])
+        if use_offset:
+            r = r - c
+        gr[vtx] += wh * r
+        gr[u] -= wh * gamma_apply_T(G, r)
+    for (u, vtx, W, b) in v_edges:
+        r = x[vtx] - (W.T @ x[u])
+        if use_offset:
+            r = r - b
+        gr[vtx] += wv * r
+        gr[u] -= wv * (W @ r)
+    return gr
+
+
+def cg_solve(applyH, rhs, free, max_iter=300, tol=1e-7):
+    x = torch.zeros_like(rhs)
+    r = rhs.clone()
+    r[~free] = 0.0
+    p = r.clone()
+    rs = (r * r).sum()
+    rs0 = rs.clone()
+    it = 0
+    for it in range(1, max_iter + 1):
+        Ap = applyH(p)
+        Ap[~free] = 0.0
+        alpha = rs / (p * Ap).sum().clamp_min(1e-30)
+        x = x + alpha * p
+        r = r - alpha * Ap
+        r[~free] = 0.0
+        rs_new = (r * r).sum()
+        if rs_new <= tol * tol * rs0:
+            break
+        p = r + (rs_new / rs) * p
+        rs = rs_new
+    return x, it
+
+
+def solve_sheaf(h_edges, v_edges, lossy, exact, pinned, wd, wh, wv):
+    free = ~pinned
+    he = [(u, v, G.double(), c.double()) for (u, v, G, c) in h_edges]
+    ve = [(u, v, W.double(), b.double()) for (u, v, W, b) in v_edges]
+    lossy_d = lossy.double()
+    x0 = torch.zeros_like(lossy_d)
+    x0[pinned] = exact.double()[pinned]
+    rhs = -grad_full(x0, he, ve, lossy_d, free, wd, wh, wv, True)
+    rhs[~free] = 0.0
+
+    def applyH(x):
+        xx = x.clone()
+        xx[~free] = 0.0
+        out = grad_full(xx, he, ve, lossy_d, free, wd, wh, wv, False)
+        out[~free] = 0.0
+        return out
+
+    dx, it = cg_solve(applyH, rhs, free)
+    x = x0.clone()
+    x[free] = x0[free] + dx[free]
+    return x.float(), it
+
+
+# ---- metrics --------------------------------------------------------------
+def cell_cos(states, exact):
+    return torch.nn.functional.cosine_similarity(states, exact, dim=1)
+
+
+def slow_dim_mask(slow):
+    """(L, D) bool: dims belonging to slow heads of each layer."""
+    m = torch.zeros(L, D, dtype=torch.bool)
+    blk = KD * VD
+    for l in range(L):
+        for hh in range(H):
+            if slow[l, hh]:
+                m[l, hh * blk:(hh + 1) * blk] = True
+    return m
+
+
+def subspace_cos(states, exact, layer_of, sdmask, want_slow):
+    """Mean cosine over slow- (or fast-) head dims, per cell, averaged."""
+    vals = []
+    for c in range(states.shape[0]):
+        l = layer_of[c].item()
+        mask = sdmask[l] if want_slow else ~sdmask[l]
+        if mask.sum() == 0:
+            continue
+        a, b = states[c][mask], exact[c][mask]
+        vals.append(torch.nn.functional.cosine_similarity(a, b, dim=0).item())
+    return float(np.mean(vals)) if vals else float("nan")
+
+
+def pin_mask(pin_layers):
+    m = torch.zeros(P_GRID * L, dtype=torch.bool)
+    for i in range(P_GRID):
+        for l in pin_layers:
+            m[cid(i, l)] = True
+    return m
+
+
+def plaquette_curvature(h_edges, v_edges, exact):
+    hmap = {(u, v): (G, c) for (u, v, G, c) in h_edges}
+    vmap = {(u, v): (W, b) for (u, v, W, b) in v_edges}
+    rel = []
+    for i in range(P_GRID - 1):
+        for l in range(L - 1):
+            x = exact[cid(i, l)]
+            G1, c1 = hmap[(cid(i, l), cid(i + 1, l))]
+            W1, b1 = vmap[(cid(i, l), cid(i, l + 1))]
+            G2, c2 = hmap[(cid(i, l + 1), cid(i + 1, l + 1))]
+            W2, b2 = vmap[(cid(i + 1, l), cid(i + 1, l + 1))]
+            a = W2.T @ (gamma_apply(G1, x) + c1) + b2        # H then V
+            bb = gamma_apply(G2, (W1.T @ x + b1)) + c2       # V then H
+            rel.append(((a - bb).norm() / a.norm().clamp_min(1e-6)).item())
+    return float(np.mean(rel))
+
+
+def report(name, c, free, layer_of, sdmask, states, exact):
+    cf = c[free]
+    sl = subspace_cos(states[free], exact[free], layer_of[free], sdmask, True)
+    fa = subspace_cos(states[free], exact[free], layer_of[free], sdmask, False)
+    print(f"{name:<26}{cf.min():>9.4f}{cf.mean():>9.4f}{cf.median():>9.4f}"
+          f"{(cf >= 0.999).float().mean():>9.3f}{sl:>11.4f}{fa:>11.4f}")
+    return cf.mean().item(), sl
+
+
+def main():
+    print("=== M3 2-D sheaf L0 reconciliation prototype (CPU) ===")
+    print(f"L={L} H={H} KD=VD={KD} D={D} N_TOK={N_TOK} P_GRID={P_GRID} "
+          f"DELTA={DELTA} slow_frac={SLOW_FRAC}")
+    streams, grid_states, sub_states, slow, g_idx = build_forward()
+    exact = grid_states.permute(1, 0, 2).reshape(-1, D)
+    layer_of = torch.tensor([l for i in range(P_GRID) for l in range(L)])
+    sdmask = slow_dim_mask(slow)
+    print(f"slow heads total: {int(slow.sum())}/{L * H} "
+          f"({100 * slow.float().mean():.0f}%); layers with >=1 slow head: "
+          f"{int(slow.any(1).sum())}/{L}")
+
+    Ws, qual = fit_vertical(sub_states, lam=1e-1)
+    print(f"vertical ridge fit cosine: mean={np.mean(qual):.4f} "
+          f"min={np.min(qual):.4f} max={np.max(qual):.4f}")
+    h_edges = build_h_edges(streams, grid_states, g_idx)
+    v_edges = build_v_edges(Ws)
+    print(f"mean plaquette curvature (rel. H/V non-commutation): "
+          f"{plaquette_curvature(h_edges, v_edges, exact):.4f}")
+
+    pin_layers = list(range(0, L, 4))
+    pinned = pin_mask(pin_layers)
+    free = ~pinned
+    hdr = (f"{'method':<26}{'min':>9}{'mean':>9}{'median':>9}{'>=.999':>9}"
+           f"{'slow-sub':>11}{'fast-sub':>11}")
+    print(f"\n### MAIN: tau={TAU_MAIN}, pin {len(pin_layers)}/{L} layers exact "
+          f"(every 4th). Metrics over FREE (unpinned) cells.")
+    print(hdr)
+    lossy = lossy_states(streams, g_idx, TAU_MAIN)
+    lossy_f = lossy.permute(1, 0, 2).reshape(-1, D)
+    report("lossy input", cell_cos(lossy_f, exact), free, layer_of, sdmask, lossy_f, exact)
+    xh, ih = solve_sheaf(h_edges, v_edges, lossy_f, exact, pinned, 1.0, 10.0, 0.0)
+    report("horiz-only (no x-layer)", cell_cos(xh, exact), free, layer_of, sdmask, xh, exact)
+    xf, iff = solve_sheaf(h_edges, v_edges, lossy_f, exact, pinned, 1.0, 10.0, 3.0)
+    report("FULL 2-D sheaf", cell_cos(xf, exact), free, layer_of, sdmask, xf, exact)
+    print(f"CG iters: horiz={ih} full={iff}")
+    nfl = L - len(pin_layers)
+    print(f"cost: free DOF={int(free.sum()) * D}  | exact full-replay of unpinned "
+          f"layers={nfl * N_TOK} tok-updates  (lossy window={nfl * P_GRID * TAU_MAIN})")
+
+    print("\n=== ABLATIONS ===")
+    print(f"(a) tau sweep (mean cell cosine / slow-subspace cosine over free), pin 12/48")
+    print(f"{'tau':<8}{'lossy':>18}{'horiz':>18}{'full':>18}")
+    for tau in TAUS:
+        lz = lossy_states(streams, g_idx, tau).permute(1, 0, 2).reshape(-1, D)
+        cl = cell_cos(lz, exact)[free].mean().item()
+        sl_l = subspace_cos(lz[free], exact[free], layer_of[free], sdmask, True)
+        xhh, _ = solve_sheaf(h_edges, v_edges, lz, exact, pinned, 1.0, 10.0, 0.0)
+        xff, _ = solve_sheaf(h_edges, v_edges, lz, exact, pinned, 1.0, 10.0, 3.0)
+        ch = cell_cos(xhh, exact)[free].mean().item()
+        sh = subspace_cos(xhh[free], exact[free], layer_of[free], sdmask, True)
+        cf = cell_cos(xff, exact)[free].mean().item()
+        sf = subspace_cos(xff[free], exact[free], layer_of[free], sdmask, True)
+        print(f"{tau:<8}{cl:>9.4f}/{sl_l:<8.4f}{ch:>9.4f}/{sh:<8.4f}{cf:>9.4f}/{sf:<8.4f}")
+
+    print(f"\n(b) pin-set size sweep (tau={TAU_MAIN}); mean cell cosine over free")
+    print(f"{'pinned':<12}{'lossy':>9}{'horiz':>9}{'full':>9}{'full-horiz':>12}")
+    lz = lossy_states(streams, g_idx, TAU_MAIN).permute(1, 0, 2).reshape(-1, D)
+    for step in [2, 3, 4, 8, 16]:
+        pl = list(range(0, L, step))
+        pm = pin_mask(pl)
+        fr = ~pm
+        cl = cell_cos(lz, exact)[fr].mean().item()
+        xhh, _ = solve_sheaf(h_edges, v_edges, lz, exact, pm, 1.0, 10.0, 0.0)
+        xff, _ = solve_sheaf(h_edges, v_edges, lz, exact, pm, 1.0, 10.0, 3.0)
+        ch = cell_cos(xhh, exact)[fr].mean().item()
+        cf = cell_cos(xff, exact)[fr].mean().item()
+        print(f"{len(pl):>3}/{L:<8}{cl:>9.4f}{ch:>9.4f}{cf:>9.4f}{cf - ch:>12.4f}")
+
+    print(f"\n(c) vertical weight w_v sweep (tau={TAU_MAIN}, pin 12/48); w_v=0 == horiz-only")
+    print(f"{'w_v':<8}{'cell-mean':>11}{'slow-sub':>11}{'>=.999':>9}")
+    for wv in [0.0, 0.3, 1.0, 3.0, 10.0]:
+        xff, _ = solve_sheaf(h_edges, v_edges, lz, exact, pinned, 1.0, 10.0, wv)
+        cc = cell_cos(xff, exact)
+        ss = subspace_cos(xff[free], exact[free], layer_of[free], sdmask, True)
+        print(f"{wv:<8.1f}{cc[free].mean():>11.4f}{ss:>11.4f}"
+              f"{(cc[free] >= 0.999).float().mean():>9.3f}")
+
+    print(f"\n(d) vertical-map fit quality sweep (ridge lambda; tau={TAU_MAIN}, pin 12/48, w_v=3)")
+    print(f"   incl. ORACLE-V = best linear l->l+1 map fit on EXACT grid states (ceiling)")
+    print(f"{'fit':<14}{'fitcos':>9}{'full-mean':>11}{'full-slow':>11}{'vs horiz':>11}")
+    base_h = cell_cos(xh, exact)[free].mean().item()
+    for lam in [1e-3, 1e-1, 1e1, 1e3]:
+        Ws2, q2 = fit_vertical(sub_states, lam=lam)
+        ve2 = build_v_edges(Ws2)
+        xff, _ = solve_sheaf(h_edges, ve2, lz, exact, pinned, 1.0, 10.0, 3.0)
+        cc = cell_cos(xff, exact)[free].mean().item()
+        ss = subspace_cos(xff[free], exact[free], layer_of[free], sdmask, True)
+        print(f"ridge {lam:<8.0e}{np.mean(q2):>9.4f}{cc:>11.4f}{ss:>11.4f}{cc - base_h:>11.4f}")
+    # oracle: fit on the exact grid states themselves (upper bound)
+    grid_layer_first = exact.reshape(P_GRID, L, D).permute(1, 0, 2)  # (L,P_GRID,D)
+    Wso, qo = fit_vertical(grid_layer_first, lam=1e-4)
+    veo = build_v_edges(Wso)
+    print(f"oracle plaquette curvature: {plaquette_curvature(h_edges, veo, exact):.4f}")
+    for wv in [1.0, 3.0, 10.0]:
+        xff, _ = solve_sheaf(h_edges, veo, lz, exact, pinned, 1.0, 10.0, wv)
+        cc = cell_cos(xff, exact)[free].mean().item()
+        ss = subspace_cos(xff[free], exact[free], layer_of[free], sdmask, True)
+        print(f"oracle w_v={wv:<5.1f}{np.mean(qo):>9.4f}{cc:>11.4f}{ss:>11.4f}{cc - base_h:>11.4f}")
+
+    print("\nVERDICT logic: FULL must beat BOTH 'lossy' and 'horiz-only' by a real "
+          "margin (esp. slow-subspace) for the 2-D sheaf to do non-trivial work. "
+          "If full<=horiz, the cross-layer sheaf adds nothing beyond per-layer "
+          "smoothing a non-sheaf LS already gives. ORACLE-V isolates whether the "
+          "blocker is vertical-map quality vs the sheaf concept itself.")
+    print("DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/sbr/M3_sheaf_prototype.py
+++ b/research/sbr/M3_sheaf_prototype.py
@@ -155,9 +155,9 @@ def fit_vertical(states_per_layer, lam):
         Xc, Yc = X - mx, Y - my
         W = torch.linalg.solve(Xc.T @ Xc + lam * I, Xc.T @ Yc)
         b = my - W.T @ mx
-        Yhat = X @ W + b
+        Y_hat = X @ W + b
         q = torch.nn.functional.cosine_similarity(
-            (Y - my).flatten(), (Yhat - my).flatten(), dim=0).item()
+            (Y - my).flatten(), (Y_hat - my).flatten(), dim=0).item()
         Ws.append((W.float(), b.float()))
         qual.append(q)
     return Ws, qual

--- a/research/sbr/PHASE0_RESULTS.md
+++ b/research/sbr/PHASE0_RESULTS.md
@@ -1,0 +1,38 @@
+# SBR Phase-0 — Validation kill-gate results
+
+## (A) Exactness of operator-transport — PASS (synthetic, decisive)
+
+Per-token GDN update is affine in the state: `h_t = A_t h_{t-1} + B_t`, with
+`A_t = exp(g_t) I − β_t k_t k_tᵀ` (diagonal-plus-rank-1) and `B_t = β_t k_t v_tᵀ`,
+derived directly from the kernel recurrence in `gated_delta_rule.cu`. Per-chunk
+affine operators therefore compose associatively.
+
+`research/sbr/sbr_phase0_synthetic.py` (CPU, fp32, realistic decay∈[0.95,0.9999],
+β=sigmoid(N), L2-normalized keys) compares balanced **segment-tree reassociated**
+chunk-operator compose against **sequential per-token replay**:
+
+| depth (tokens) | chunks | transport cosine | max-abs-err | rel-L2 |
+|---|---|---|---|---|
+| 512   | 8   | 1.00000024 | 1.97e-6 | 8.9e-7 |
+| 2048  | 32  | 1.00000000 | 1.43e-6 | 8.5e-7 |
+| 8192  | 128 | 0.99999994 | 1.61e-6 | 8.7e-7 |
+| 16384 | 256 | 1.00000000 | 1.61e-6 | 8.8e-7 |
+
+Worst transport cosine across depths = **0.99999994** ≫ 0.999 gate. Reassociation
+error sits at the fp32 rounding floor; depth does not degrade it. **Transport is
+numerically sound — proceed to implementation.**
+
+## (B) Invertibility / group-subtraction eligibility — PASS under nominal dist.
+
+`A_t` eigenvalues: `exp(g)` (mult K−1) and `exp(g) − β‖k‖²` (along k). Under nominal
+distribution: **100% eligible** (|λ_min|>1e-3), median condition number 2.04, p99 16,
+max 436. Group-subtraction (Phase 3) is broadly applicable; FiBA backbone covers the
+ill-conditioned tail.
+
+> **Caveat / TODO before Phase 3:** confirm against REAL Qwen3-Next-NVFP4 weights on
+> dgx2 that no head cluster sits at β≈1 / `exp(g)≈β‖k‖²` (near-singular). This gates
+> the eviction design only — transport (Phase 2) is invertibility-independent.
+
+## Sequencing
+Phase 0(A) green → Phase 1 (persist chunk operators + path-product) → Phase 2
+(transport) → real-weight 0(B) audit on dgx2 → Phase 3 (group-subtraction eviction).

--- a/research/sbr/PHASE1_FINDINGS.md
+++ b/research/sbr/PHASE1_FINDINGS.md
@@ -1,0 +1,98 @@
+# SBR Phase-1 — architectural findings (synthetic, fp32) → refines the method
+
+## What the measurements decided
+
+### 1. Dense operator-transport: DEAD for GDN (FLOP-negative)
+Composing dense per-chunk affine operators `(A 128×128, B 128×128)` costs
+`O(n_chunks · d³)`; sequential replay costs `O(n_chunks · 64 · d²)`. Since `d=128 > 64`,
+**compose ≈ 2× the cost of replay**, and the operator is not more compact than the
+state (`A` is diagonal + rank-≤64 correction ⇒ effectively full at chunk=64). The
+O(log n) segment-tree story does not pay off for GDN. (Exact for Mamba2 scalar gates,
+but Qwen3-Next is GDN/DPLR.)
+
+### 2. Contractive-window reconstruction: WORKS — the real glocal lever
+GDN is contractive (decay<1), so `h_M` depends only on the last ~τ tokens before M;
+older tokens' contributions decay away. Local replay from a **zero** state over the
+last τ tokens (mixed decay: 75% heads ∈[0.95,0.999], 25% weak-forget ∈[0.9995,1.0]):
+
+| τ (tokens) | min cosine | mean | median |
+|---|---|---|---|
+| 256  | 0.8818 | 0.9724 | 1.0000 |
+| 512  | 0.9759 | 0.9944 | 1.0000 |
+| 1024 | 0.9989 | 0.9997 | 1.0000 |
+| **2048** | **0.999997** | 1.000000 | 1.000000 |
+
+**τ ≈ 2048 reconstructs ALL heads to cosine ≥ 0.999 from zero state, independent of
+(M−C).** This bounds warm-hit replay regardless of depth/eviction — flat TTFT.
+
+### 3. Low-rank "slow-mode global summary": DEAD
+Weak-forget head far-field state is near-full-rank: **86/128 modes for 90% energy,
+115/128 for 99%**. You cannot summarize the long-range part in few modes. The glocal
+split is therefore: **local-τ window (approx, gated) + exact checkpoint** (NOT low-rank
+compression of the global part).
+
+## Refined SBR method (honest, for GDN / Qwen3-Next)
+
+- **EXACT default = eviction + checkpoint-density fix** (the dominant lever, matches the
+  adversarial critique's #1). Marconi already checkpoints every 64 tokens but LRU
+  **evicts the active conversation's recent checkpoints**, stranding it far from an
+  anchor (the user's sibling-session symptom). Fix: **per-conversation tail-pin** +
+  decouple KV-leaf vs SSM-any-node LRU so M−C stays ~one turn. Exact, cheap.
+- **GLOCAL "transport" = contractive-window cap.** When no usable near checkpoint
+  exists (cold / heavy eviction), reconstruct `h_M` by replaying only the last
+  τ≈2048 tokens — bounded cost, cosine-gated. This is the local section staying
+  connected to the whole via the decaying restriction maps. **Approximate ⇒ behind a
+  coherence gate, not the exact default.**
+- **fp32 operator application** for the replay window (not bf16 FLA) — fixes the
+  documented warm-hit corruption (`trait_prefill_recur.rs:80-90`, "token-stutter
+  corruption 2026-06-10") that currently forces full O(M−C) WY4 replay.
+
+## REAL-MODEL decay envelope (dgx2, A_log + dt_bias, 36 GDN layers × 32 heads = 1152)
+
+Extracted `decay0 = exp(-exp(A_log)·softplus(dt_bias))` (baseline dt; real dt is
+input-modulated, so this is an envelope):
+
+| metric | value |
+|---|---|
+| per-head decay0 | min 0.0, median **0.958**, max 1.0 |
+| weak-forget heads (decay>0.9995) | **5.9%** (68/1152) |
+| horizon τ (tokens to ε=1e-3) | median **163**, p90 9164, p99 53798 |
+| τ≤512 / τ≤2048 / τ≤8192 | **64% / 76% / 88%** |
+
+**Heavy-tailed.** Most heads forget within a few hundred tokens (window-friendly), but
+**~12% have τ>8192** — long-range heads, the ones that matter most for instruction
+following.
+
+### Decisive consequence: contractive window cannot cover slow heads
+A slow head does not forget old tokens but **still integrates new ones**, so its state at
+M depends on the *entire* [C,M] span — a last-τ window drops the contributions of
+[C, M−τ] that it has NOT forgotten. Therefore:
+
+- **Fast heads (~76%, τ≤2048):** local-τ window replay — cheap, flat in (M−C). ✓
+- **Slow heads (~24%):** require exact replay over the full [C,M]; the ONLY way to make
+  that cheap is a **near checkpoint** ⇒ the **eviction/tail-pin fix is mandatory and
+  primary** (matches the adversarial critique's #1). Low-rank compression of these
+  heads is dead (near-full-rank).
+
+### Reordered priorities (data-driven)
+1. **EVICTION / tail-pin (exact, primary)** — bounds (M−C) so the un-truncatable slow
+   heads replay cheaply. This is the real cure for 1s→21s.
+2. **Contractive-window (glocal, secondary)** — cuts the fast-head (76%) cost and gives a
+   bounded approximate fallback when no near checkpoint exists; coherence-gated.
+3. Optionally replay only the slow-head subset over long spans when cold (0.24× cost).
+
+The sheaf/glocality framing now maps cleanly and *honestly*: the "global section" is the
+slow-head exact state (kept via tail-pinned checkpoints); the "local sections" are the
+fast-head windows; they glue because the fast heads' dependence on the far past has
+decayed to zero (the restriction maps are contractive).
+
+## Authoritative gate still required (dgx2, real Qwen3-Next-NVFP4)
+- Real **per-head horizon under actual inference dt** (not just baseline) — needs an
+  instrumented prefill on dgx2; sets the true fast/slow partition and τ.
+1. **Real τ**: synthetic τ≈2048 assumes a decay mix; the real per-head decay sets the
+   actual safe window. Measure per-head decay during a real prefill.
+2. **Coherence safety**: confirm window reconstruction at the real τ holds
+   cosine/argmax/KL under the coherence-parity gate (the model already sits near an
+   FP8 content floor — 0.999 may need headroom).
+3. **Baseline curve**: reproduce the warm-hit TTFT-vs-(M−C) 1s→21s curve to define the
+   number we must beat.

--- a/research/sbr/run_sbr_ab.sh
+++ b/research/sbr/run_sbr_ab.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SBR M1 A/B benchmark orchestration — run ON dgx2.
+# For each config (baseline tail-pin OFF, fix tail-pin ON) start Atlas with the
+# SBR binary bind-mounted into the runtime image, run the warm-hit TTFT harness,
+# capture server logs (replay distances), and stop.
+set -uo pipefail
+
+IMAGE="${IMAGE:-atlas-gb10:ornith-perf}"
+BIN="${BIN:-$HOME/sbr_bench/spark}"
+MODEL="${MODEL:-nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4}"
+OUT="$HOME/sbr_bench"
+TURNS="${TURNS:-16}"
+DISTRACTORS="${DISTRACTORS:-24}"
+BASE_TOKENS="${BASE_TOKENS:-8000}"
+MAXLEN="${MAXLEN:-24576}"
+SLOTS="${SLOTS:-16}"
+
+run_one() {
+  local label="$1" pin="$2"
+  echo "=== [$label] ATLAS_SBR_TAIL_PIN=$pin ==="
+  sudo docker rm -f sbr-srv >/dev/null 2>&1
+  sudo docker run -d --name sbr-srv --gpus all --ipc=host --network host \
+    -e ATLAS_SBR_TAIL_PIN="$pin" -e ATLAS_SNAP_LOOKUP_DBG=1 -e RUST_LOG=info \
+    -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
+    -v "$BIN:/usr/local/bin/spark:ro" \
+    "$IMAGE" serve "$MODEL" \
+      --port 8888 --host 0.0.0.0 --max-seq-len "$MAXLEN" --ssm-cache-slots "$SLOTS" \
+      >/dev/null 2>&1
+
+  echo "[$label] waiting for server ready (model load ~6min)..."
+  local ready=0
+  for i in $(seq 1 180); do
+    if curl -sf http://localhost:8888/v1/models >/dev/null 2>&1; then ready=1; break; fi
+    if ! sudo docker ps --format '{{.Names}}' | grep -q sbr-srv; then
+      echo "[$label] container died during load"; sudo docker logs sbr-srv 2>&1 | tail -30; return 1
+    fi
+    sleep 5
+  done
+  if [ "$ready" -ne 1 ]; then echo "[$label] server never ready"; sudo docker logs sbr-srv 2>&1 | tail -30; sudo docker rm -f sbr-srv >/dev/null 2>&1; return 1; fi
+  echo "[$label] server ready."
+
+  python3 "$OUT/sbr_bench.py" --label "$label" --out "$OUT/$label.json" \
+    --model "$MODEL" --turns "$TURNS" --distractors "$DISTRACTORS" \
+    --base-tokens "$BASE_TOKENS" --distractor-tokens 400 --resp-tokens 200
+
+  sudo docker logs sbr-srv > "$OUT/$label.serverlog" 2>&1
+  grep -E "Marconi intermediate hit|snap-lookup" "$OUT/$label.serverlog" | tail -40 > "$OUT/$label.replaylog" 2>/dev/null
+  sudo docker rm -f sbr-srv >/dev/null 2>&1
+  echo "[$label] done -> $OUT/$label.json"
+}
+
+run_one baseline_tailpin_off 0
+run_one sbr_tailpin_on 1
+
+echo "=== A/B SUMMARY ==="
+python3 - "$OUT/baseline_tailpin_off.json" "$OUT/sbr_tailpin_on.json" <<'PY'
+import json, sys
+for p in sys.argv[1:]:
+    try:
+        d = json.load(open(p))
+    except Exception as e:
+        print(f"{p}: MISSING ({e})"); continue
+    t = [r["ttft_s"] for r in d["rows"] if r.get("ttft_s")]
+    if not t: print(f"{d['label']}: no ttft"); continue
+    print(f"{d['label']:24s} turns={d['turns']} TTFT first={t[0]:.3f}s last={t[-1]:.3f}s "
+          f"max={max(t):.3f}s mean={sum(t)/len(t):.3f}s")
+PY

--- a/research/sbr/sbr_bench.py
+++ b/research/sbr/sbr_bench.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""SBR M1 benchmark — warm-hit TTFT vs conversation depth under cache pressure.
+
+Reproduces the "replay grows as slots fill" symptom and measures whether the
+tail-pin eviction (ATLAS_SBR_TAIL_PIN, set on the SERVER) flattens it.
+
+Workload:
+  * ONE "main" multi-turn conversation whose shared prefix grows each turn
+    (system document + accumulated turns). Each turn re-sends the full history
+    -> prefix-cache + SSM-snapshot warm hit; replay = matched - nearest_snapshot.
+  * Between main turns, fire DISTRACTORS distinct one-shot conversations to churn
+    the snapshot LRU (pool default 16 slots). Baseline LRU evicts the main
+    conversation's deep tail; tail-pin protects it.
+
+Metric: TTFT (time-to-first-token, streaming) of each MAIN turn vs depth.
+Also records the assistant's first-token id per turn for A/B exactness check.
+
+Run (on dgx2, server already up on :8888):
+  python3 sbr_bench.py --label tailpin_on --out tailpin_on.json --turns 16 --distractors 24
+"""
+import argparse, json, time, sys
+import urllib.request
+
+WORDS = ("the model integrates state across tokens while attention reads the "
+         "key value cache and the recurrent layer accumulates a hidden matrix "
+         "that decays per step according to a learned gate and beta factor "
+         "producing an output that the next layer consumes in sequence").split()
+
+
+def filler(n_tokens):
+    # ~0.75 tokens/word -> words ~= tokens / 0.75; deterministic, varied by seed
+    n_words = int(n_tokens / 0.75)
+    return " ".join(WORDS[i % len(WORDS)] for i in range(n_words))
+
+
+def chat_stream(base_url, model, messages, max_tokens):
+    """POST streaming chat; return (ttft_s, total_s, text, first_tok)."""
+    body = json.dumps({
+        "model": model, "messages": messages, "max_tokens": max_tokens,
+        "temperature": 0.0, "stream": True,
+    }).encode()
+    req = urllib.request.Request(base_url + "/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.perf_counter()
+    ttft = None
+    first_tok = None
+    text = []
+    with urllib.request.urlopen(req, timeout=600) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "ignore").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                ev = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            delta = ev.get("choices", [{}])[0].get("delta", {})
+            chunk = delta.get("content")
+            if chunk:
+                if ttft is None:
+                    ttft = time.perf_counter() - t0
+                    first_tok = chunk
+                text.append(chunk)
+    total = time.perf_counter() - t0
+    return ttft, total, "".join(text), first_tok
+
+
+def run_distractors(base_url, model, n, base_tokens, idx):
+    for d in range(n):
+        doc = f"distractor {idx}_{d} " + filler(base_tokens) + f" unique salt {idx}-{d}-xyz"
+        msgs = [{"role": "system", "content": doc},
+                {"role": "user", "content": f"Summarize point {d} in one sentence."}]
+        try:
+            chat_stream(base_url, model, msgs, 32)
+        except Exception as e:
+            print(f"  distractor {idx}_{d} err: {e}", file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--base-url", default="http://localhost:8888/v1")
+    ap.add_argument("--model", default="nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
+    ap.add_argument("--turns", type=int, default=16)
+    ap.add_argument("--distractors", type=int, default=24)
+    ap.add_argument("--base-tokens", type=int, default=6000)
+    ap.add_argument("--distractor-tokens", type=int, default=400,
+                    help="size of each distractor conv (just needs to occupy a snapshot slot)")
+    ap.add_argument("--resp-tokens", type=int, default=200)
+    args = ap.parse_args()
+
+    system_doc = ("You are a careful assistant. Reference document follows.\n" +
+                  filler(args.base_tokens))
+    history = [{"role": "system", "content": system_doc}]
+    rows = []
+    questions = [
+        "What does the recurrent layer accumulate?", "How does the gate affect state?",
+        "Summarize the document in one line.", "What consumes the output?",
+        "Explain the beta factor.", "What decays per step?",
+        "Relate attention to the kv cache.", "Why is sequence order important?",
+        "What is the hidden matrix?", "Describe state integration.",
+        "What does the next layer read?", "How is the output produced?",
+    ]
+
+    # warm up the main prefix once (cold), then churn + measure resumes
+    for turn in range(args.turns):
+        q = questions[turn % len(questions)]
+        history.append({"role": "user", "content": f"Turn {turn}: {q}"})
+        # churn the snapshot LRU between resumes (skip before first turn)
+        if turn > 0:
+            run_distractors(args.base_url, args.model, args.distractors, args.distractor_tokens, turn)
+        approx_depth = sum(len(m["content"].split()) for m in history) * 4 // 3
+        ttft, total, text, first_tok = chat_stream(
+            args.base_url, args.model, history, args.resp_tokens)
+        history.append({"role": "assistant", "content": text})
+        rows.append({"turn": turn, "approx_depth_tokens": approx_depth,
+                     "ttft_s": ttft, "total_s": total, "first_tok": first_tok})
+        print(f"[{args.label}] turn {turn:2d} depth~{approx_depth:6d} "
+              f"TTFT={ttft:.3f}s total={total:.3f}s", flush=True)
+
+    out = {"label": args.label, "turns": args.turns, "distractors": args.distractors,
+           "base_tokens": args.base_tokens, "rows": rows}
+    with open(args.out, "w") as f:
+        json.dump(out, f, indent=2)
+    ttfts = [r["ttft_s"] for r in rows if r["ttft_s"]]
+    if ttfts:
+        print(f"\n[{args.label}] TTFT first={ttfts[0]:.3f}s last={ttfts[-1]:.3f}s "
+              f"max={max(ttfts):.3f}s mean={sum(ttfts)/len(ttfts):.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/sbr/sbr_evict_ab.py
+++ b/research/sbr/sbr_evict_ab.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""SBR M1 eviction-isolation A/B — does tail-pin keep warm-hit TTFT flat?
+
+Uses FEW long-lived sessions (distinct prefixes -> distinct session_hash),
+interleaved round-robin so each session's deep tail competes for snapshot slots
+with the others. Avoids the many-short-session slot leak. With the snapshot pool
+sized below the sum of all sessions' checkpoint chains, the eviction policy must
+choose victims: baseline evicts the least-recently-used session's deep tail (so
+its next resume replays far); tail-pin protects each session's deepest snapshot
+(so every resume replays only ~one interval).
+
+Run on dgx2 against a server already up:
+  python3 sbr_evict_ab.py --label sbr_on --out sbr_on.json --sessions 4 --rounds 6
+"""
+import argparse, json, time, urllib.request
+
+WORDS = ("the recurrent layer accumulates a decaying hidden state while attention "
+         "reads the key value cache and each token updates the matrix in sequence "
+         "according to a learned gate beta and delta rule producing the next output").split()
+
+
+def filler(n_tokens, salt):
+    n = int(n_tokens / 0.75)
+    base = " ".join(WORDS[(i + salt) % len(WORDS)] for i in range(n))
+    return f"[session {salt}] " + base + f" [unique-marker-{salt}]"
+
+
+def chat_ttft(base_url, model, messages, max_tokens):
+    body = json.dumps({"model": model, "messages": messages, "max_tokens": max_tokens,
+                       "temperature": 0.0, "stream": True}).encode()
+    req = urllib.request.Request(base_url + "/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.perf_counter()
+    ttft, first, text = None, None, []
+    with urllib.request.urlopen(req, timeout=900) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "ignore").strip()
+            if line.startswith("data:") and line[5:].strip() not in ("", "[DONE]"):
+                try:
+                    d = json.loads(line[5:].strip())
+                except json.JSONDecodeError:
+                    continue
+                c = d.get("choices", [{}])[0].get("delta", {}).get("content")
+                if c:
+                    if ttft is None:
+                        ttft, first = time.perf_counter() - t0, c
+                    text.append(c)
+    return ttft, "".join(text), first
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--base-url", default="http://localhost:8888/v1")
+    ap.add_argument("--model", default="nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
+    ap.add_argument("--sessions", type=int, default=4)
+    ap.add_argument("--rounds", type=int, default=6)
+    ap.add_argument("--base-tokens", type=int, default=3000)
+    ap.add_argument("--resp-tokens", type=int, default=300)
+    a = ap.parse_args()
+
+    histories = [[{"role": "system", "content": filler(a.base_tokens, s)}]
+                 for s in range(a.sessions)]
+    rows = []
+    for rnd in range(a.rounds):
+        for s in range(a.sessions):
+            histories[s].append({"role": "user", "content": f"R{rnd} S{s}: continue the analysis."})
+            depth = sum(len(m["content"].split()) for m in histories[s])  # ~words≈tokens*0.75
+            depth_tok = int(depth / 0.75)
+            ttft, text, first = chat_ttft(a.base_url, a.model, histories[s], a.resp_tokens)
+            histories[s].append({"role": "assistant", "content": text})
+            rows.append({"round": rnd, "session": s, "depth_tok": depth_tok,
+                         "ttft_s": ttft, "first_tok": first})
+            print(f"[{a.label}] r{rnd} s{s} depth~{depth_tok:6d} TTFT={ttft:.3f}s", flush=True)
+
+    json.dump({"label": a.label, "sessions": a.sessions, "rounds": a.rounds, "rows": rows},
+              open(a.out, "w"), indent=2)
+    # per-round resume TTFT (rounds>0 are warm resumes)
+    warm = [r["ttft_s"] for r in rows if r["round"] > 0 and r["ttft_s"]]
+    if warm:
+        print(f"\n[{a.label}] warm-resume TTFT: mean={sum(warm)/len(warm):.3f}s "
+              f"max={max(warm):.3f}s min={min(warm):.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/sbr/sbr_multiconv.py
+++ b/research/sbr/sbr_multiconv.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""SBR M1 multi-conversation robustness — many REAL conversations competing.
+
+Phase A (WARM): build M conversations sequentially to moderate depth, resuming
+  each turn so every conversation becomes resumable (hit_count>0).
+Phase B (COMPETE): round-robin resume all M conversations for R rounds; between
+  a conversation's turns the other M-1 churn the snapshot pool. With K*M > slots
+  the tail-pin fallback is exercised. Measures per-conversation resume TTFT.
+
+Reports per-round resume TTFT distribution. Compare baseline vs tail-pin: tail-pin
+should keep every resumable conversation's deep tail anchored (low, flat TTFT)
+while baseline strands the least-recently-used ones (high-variance TTFT).
+"""
+import argparse, json, time, urllib.request
+
+WORDS = ("the recurrent state integrates tokens through a gated delta rule while "
+         "attention reads cached keys and values producing activations for the next "
+         "transformer block across the growing context window of the conversation").split()
+
+
+def filler(n_tokens, salt):
+    n = int(n_tokens / 0.75)
+    return f"[conv {salt}] " + " ".join(WORDS[(i + salt) % len(WORDS)] for i in range(n)) + f" #{salt}"
+
+
+def chat(base_url, model, messages, max_tokens):
+    body = json.dumps({"model": model, "messages": messages, "max_tokens": max_tokens,
+                       "temperature": 0.0, "stream": True}).encode()
+    req = urllib.request.Request(base_url + "/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.perf_counter(); ttft=None; out=[]
+    with urllib.request.urlopen(req, timeout=900) as resp:
+        for raw in resp:
+            ln = raw.decode("utf-8","ignore").strip()
+            if ln.startswith("data:") and ln[5:].strip() not in ("","[DONE]"):
+                try: d=json.loads(ln[5:].strip())
+                except json.JSONDecodeError: continue
+                c=d.get("choices",[{}])[0].get("delta",{}).get("content")
+                if c:
+                    if ttft is None: ttft=time.perf_counter()-t0
+                    out.append(c)
+    return ttft, "".join(out)
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--label", required=True); ap.add_argument("--out", required=True)
+    ap.add_argument("--base-url", default="http://localhost:8888/v1")
+    ap.add_argument("--model", default="nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
+    ap.add_argument("--convs", type=int, default=8)
+    ap.add_argument("--build-turns", type=int, default=4)
+    ap.add_argument("--rounds", type=int, default=4)
+    ap.add_argument("--base-tokens", type=int, default=2000)
+    ap.add_argument("--chunk-tokens", type=int, default=1500)
+    a=ap.parse_args()
+
+    H=[[{"role":"system","content":"You analyze a document.\n"+filler(a.base_tokens, s)}]
+       for s in range(a.convs)]
+    rows=[]
+    # Phase A: warm each conversation (sequential build, resumed -> resumable)
+    for s in range(a.convs):
+        for t in range(a.build_turns):
+            H[s].append({"role":"user","content":f"Sec {t}: {filler(a.chunk_tokens, s*10+t)} Summarize."})
+            ttft,text=chat(a.base_url,a.model,H[s],60)
+            H[s].append({"role":"assistant","content":text})
+        print(f"[{a.label}] warmed conv {s} depth~{int(sum(len(m['content'].split()) for m in H[s])/0.75)}",flush=True)
+
+    # Phase B: round-robin resume under mutual pressure
+    for rnd in range(a.rounds):
+        for s in range(a.convs):
+            H[s].append({"role":"user","content":f"R{rnd}: conclude given all sections."})
+            depth=int(sum(len(m['content'].split()) for m in H[s])/0.75)
+            ttft,text=chat(a.base_url,a.model,H[s],60)
+            H[s].append({"role":"assistant","content":text})
+            rows.append({"round":rnd,"conv":s,"depth":depth,"ttft_s":ttft})
+            print(f"[{a.label}] r{rnd} conv{s} depth~{depth:6d} TTFT={ttft:.3f}s",flush=True)
+
+    json.dump({"label":a.label,"convs":a.convs,"rounds":a.rounds,"rows":rows},open(a.out,"w"),indent=2)
+    t=[r["ttft_s"] for r in rows if r.get("ttft_s")]
+    import statistics
+    print(f"\n[{a.label}] resume TTFT mean={statistics.mean(t):.3f}s p50={statistics.median(t):.3f}s "
+          f"p90={sorted(t)[int(0.9*len(t))-1]:.3f}s max={max(t):.3f}s")
+
+
+if __name__=="__main__":
+    main()

--- a/research/sbr/sbr_parity.py
+++ b/research/sbr/sbr_parity.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""SBR M1 exactness parity — tail-pin vs baseline (full-replay reference).
+
+Tail-pin changes only WHICH checkpoint is restored; replay from it is the same
+bit-exact WY4 path, so greedy (temp=0) generations MUST be token-identical to the
+baseline that replays from a deeper/closer checkpoint. This harness runs an
+identical set of N warm-resume prompts on whatever server is up, recording the
+greedy continuation + per-token top-logprob. Run once per config (baseline,
+tail-pin), then `--compare a.json b.json` for argmax-agreement + KL.
+
+  python3 sbr_parity.py --label baseline --out p_base.json --n 10
+  python3 sbr_parity.py --label tailpin  --out p_pin.json  --n 10
+  python3 sbr_parity.py --compare p_base.json p_pin.json
+"""
+import argparse, json, math, time, urllib.request
+
+WORDS=("the recurrent state integrates each token through a gated delta update while "
+       "attention reads cached keys and values across the long context window").split()
+def filler(n,s):
+    m=int(n/0.75); return f"[doc {s}] "+" ".join(WORDS[(i+s)%len(WORDS)] for i in range(m))
+
+def gen(base_url, model, messages, max_tokens=64):
+    body=json.dumps({"model":model,"messages":messages,"max_tokens":max_tokens,
+                     "temperature":0.0,"logprobs":True,"top_logprobs":1,"stream":False}).encode()
+    req=urllib.request.Request(base_url+"/chat/completions",data=body,headers={"Content-Type":"application/json"})
+    with urllib.request.urlopen(req,timeout=900) as r: d=json.loads(r.read())
+    ch=d["choices"][0]; text=ch["message"]["content"]
+    toks=[]
+    lp=ch.get("logprobs") or {}
+    for c in lp.get("content",[]):
+        toks.append({"tok":c.get("token"),"lp":c.get("logprob")})
+    return text, toks
+
+def run(a):
+    # N deep multi-turn prompts (distinct), each a warm-resume-shaped prompt
+    res=[]
+    for i in range(a.n):
+        msgs=[{"role":"system","content":"Analyze.\n"+filler(3000,i)},
+              {"role":"user","content":f"Q{i}: {filler(1500,i+50)} Summarize in one paragraph."},
+              {"role":"assistant","content":filler(400,i+100)},
+              {"role":"user","content":"Given all the above, state the single key conclusion."}]
+        text,toks=gen(a.base_url,a.model,msgs,64)
+        res.append({"i":i,"text":text,"toks":toks})
+        print(f"[{a.label}] prompt {i}: {text[:60]!r}",flush=True)
+    json.dump({"label":a.label,"res":res},open(a.out,"w"),indent=2)
+
+def compare(pa,pb):
+    A=json.load(open(pa))["res"]; B=json.load(open(pb))["res"]
+    assert len(A)==len(B)
+    n_text_eq=0; tot_tok=0; agree=0; kl_sum=0.0; kl_n=0
+    for a,b in zip(A,B):
+        if a["text"]==b["text"]: n_text_eq+=1
+        for ta,tb in zip(a["toks"],b["toks"]):
+            tot_tok+=1
+            if ta["tok"]==tb["tok"]: agree+=1
+            if ta["lp"] is not None and tb["lp"] is not None:
+                pa_=math.exp(ta["lp"]); pb_=math.exp(tb["lp"])
+                if pa_>0 and pb_>0: kl_sum+=pa_*math.log(pa_/pb_); kl_n+=1
+    print(f"text-identical: {n_text_eq}/{len(A)}")
+    print(f"argmax agreement: {agree}/{tot_tok} = {100*agree/max(tot_tok,1):.2f}%")
+    print(f"mean top-token KL: {kl_sum/max(kl_n,1):.3e} (n={kl_n})")
+    print("VERDICT:", "EXACT (parity)" if n_text_eq==len(A) and agree==tot_tok else "DIVERGENCE")
+
+if __name__=="__main__":
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--label"); ap.add_argument("--out"); ap.add_argument("--n",type=int,default=10)
+    ap.add_argument("--base-url",default="http://localhost:8888/v1")
+    ap.add_argument("--model",default="nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
+    ap.add_argument("--compare",nargs=2)
+    a=ap.parse_args()
+    if a.compare: compare(*a.compare)
+    else: run(a)

--- a/research/sbr/sbr_phase0_synthetic.py
+++ b/research/sbr/sbr_phase0_synthetic.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""SBR Phase-0 synthetic kill-test (CPU, fp32).
+
+Validates the core Sheaf-Based-Replaying claim BEFORE any kernel work:
+  the GDN per-token update is affine in the state h,
+      h_t = A_t h_{t-1} + B_t,   A_t = exp(g_t) I - beta_t k_t k_t^T,  B_t = beta_t k_t v_t^T
+  so per-chunk affine operators (A_chunk, B_chunk) compose associatively and an
+  operator-transport reconstruction of h_M (segment-tree compose of chunk ops,
+  applied once to the anchor state h_C) must equal sequential token replay.
+
+Decisive questions:
+  (1) Does the segment-tree (balanced, reassociated) compose hold cosine >= 0.999
+      and small max-abs-err vs the sequential per-token scan, at realistic depth?
+  (2) Sanity: does the affine operator form reproduce the reference recurrence bit-closely?
+  (3) Invertibility audit: fraction of per-token A_t that are well-conditioned
+      (eligible for O(1) group-subtraction on evict) under realistic gate/beta.
+
+Run: python3 sbr_phase0_synthetic.py
+"""
+import torch
+
+torch.manual_seed(0)
+DEV = "cpu"  # never touch dgx1 GPU
+DT = torch.float32
+
+# Qwen3-Next GDN per-head dims
+K_DIM = 128
+V_DIM = 128
+CHUNK = 64
+
+
+def make_token_stream(n_tok, decay_lo=0.95, decay_hi=0.9999, beta_mode="sigmoid"):
+    """Realistic per-token GDN inputs for one head."""
+    # decay a_t = exp(g_t) in [decay_lo, decay_hi] (close to 1, per GDN behaviour)
+    a = torch.empty(n_tok, dtype=DT).uniform_(decay_lo, decay_hi)
+    g = torch.log(a)
+    # beta_t in (0,1): sigmoid of a normal logit (matches BA projection -> sigmoid)
+    if beta_mode == "sigmoid":
+        beta = torch.sigmoid(torch.randn(n_tok, dtype=DT))
+    else:
+        beta = torch.empty(n_tok, dtype=DT).uniform_(0.0, 1.0)
+    # keys L2-normalized (GDN normalizes k); values ~ N(0,1)
+    k = torch.randn(n_tok, K_DIM, dtype=DT)
+    k = k / k.norm(dim=1, keepdim=True).clamp_min(1e-6)
+    v = torch.randn(n_tok, V_DIM, dtype=DT)
+    return g, beta, k, v
+
+
+def reference_scan(h0, g, beta, k, v):
+    """Exact per-token recurrence straight from the kernel comment."""
+    h = h0.clone()
+    for t in range(g.shape[0]):
+        a_t = (h.transpose(0, 1) @ k[t])          # [V_DIM]  = h^T k
+        vp = (v[t] - a_t) * beta[t]               # v'_t     [V_DIM]
+        h = torch.exp(g[t]) * h + torch.outer(k[t], vp)  # k ⊗ v'
+    return h
+
+
+def token_affine(g_t, beta_t, k_t, v_t):
+    """Per-token affine operator (A_t, B_t) with h_t = A_t h_{t-1} + B_t."""
+    A = torch.exp(g_t) * torch.eye(K_DIM, dtype=DT) - beta_t * torch.outer(k_t, k_t)
+    B = beta_t * torch.outer(k_t, v_t)            # [K_DIM, V_DIM]
+    return A, B
+
+
+def compose(op2, op1):
+    """(A2,B2) ∘ (A1,B1) = (A2 A1, A2 B1 + B2). Applies op1 first, then op2."""
+    A1, B1 = op1
+    A2, B2 = op2
+    return (A2 @ A1, A2 @ B1 + B2)
+
+
+def chunk_operator(g, beta, k, v, lo, hi):
+    """Compose per-token ops over [lo, hi) sequentially -> one chunk affine op."""
+    A = torch.eye(K_DIM, dtype=DT)
+    B = torch.zeros(K_DIM, V_DIM, dtype=DT)
+    for t in range(lo, hi):
+        At, Bt = token_affine(g[t], beta[t], k[t], v[t])
+        A, B = compose((At, Bt), (A, B))
+    return (A, B)
+
+
+def segtree_compose(ops):
+    """Balanced (reassociated) reduction of a list of affine ops, left-to-right order."""
+    # pairwise balanced tree to maximize reassociation difference vs linear fold
+    cur = ops
+    while len(cur) > 1:
+        nxt = []
+        for i in range(0, len(cur) - 1, 2):
+            nxt.append(compose(cur[i + 1], cur[i]))  # op[i] first, then op[i+1]
+        if len(cur) % 2 == 1:
+            nxt.append(cur[-1])
+        cur = nxt
+    return cur[0]
+
+
+def cos(a, b):
+    return torch.nn.functional.cosine_similarity(a.flatten(), b.flatten(), dim=0).item()
+
+
+def run_case(n_tok, label):
+    g, beta, k, v = make_token_stream(n_tok)
+    h0 = torch.randn(K_DIM, V_DIM, dtype=DT) * 0.1  # anchor state h_C
+
+    h_ref = reference_scan(h0, g, beta, k, v)
+
+    # sanity: per-token affine fold reproduces reference
+    A = torch.eye(K_DIM, dtype=DT); B = torch.zeros(K_DIM, V_DIM, dtype=DT)
+    for t in range(n_tok):
+        At, Bt = token_affine(g[t], beta[t], k[t], v[t])
+        A, B = compose((At, Bt), (A, B))
+    h_affine = A @ h0 + B
+    cos_affine = cos(h_ref, h_affine)
+    mae_affine = (h_ref - h_affine).abs().max().item()
+
+    # transport: chunk ops -> balanced segment-tree compose -> apply to anchor
+    n_chunks = (n_tok + CHUNK - 1) // CHUNK
+    ops = [chunk_operator(g, beta, k, v, c * CHUNK, min((c + 1) * CHUNK, n_tok))
+           for c in range(n_chunks)]
+    A_tot, B_tot = segtree_compose(ops)
+    h_transport = A_tot @ h0 + B_tot
+    cos_tr = cos(h_ref, h_transport)
+    mae_tr = (h_ref - h_transport).abs().max().item()
+    rel_tr = ((h_ref - h_transport).norm() / h_ref.norm().clamp_min(1e-9)).item()
+
+    print(f"[{label}] n_tok={n_tok} chunks={n_chunks} |h_ref|={h_ref.norm():.2f}")
+    print(f"    affine-fold   : cos={cos_affine:.8f}  maxabs={mae_affine:.3e}")
+    print(f"    segtree-transp: cos={cos_tr:.8f}  maxabs={mae_tr:.3e}  rel_l2={rel_tr:.3e}")
+    return cos_tr
+
+
+def invertibility_audit(n_tok=20000):
+    """Fraction of per-token A_t eligible for O(1) group-subtraction.
+    A_t = exp(g) I - beta k k^T has eigenvalues {exp(g) (mult K-1), exp(g)-beta|k|^2}.
+    Well-conditioned iff exp(g)-beta|k|^2 bounded away from 0 (|k|=1 here)."""
+    g, beta, k, v = make_token_stream(n_tok)
+    a = torch.exp(g)                       # exp(g)
+    lam_min = a - beta                     # |k|^2 = 1
+    cond = a / lam_min.abs().clamp_min(1e-12)
+    eligible = (lam_min.abs() > 1e-3).float().mean().item()
+    near_sing = (lam_min.abs() <= 1e-3).float().mean().item()
+    print("\n[invertibility audit]  (per-token A_t = exp(g)I - beta kk^T)")
+    print(f"    decay exp(g): min={a.min():.4f} max={a.max():.4f}")
+    print(f"    beta        : min={beta.min():.4f} max={beta.max():.4f}")
+    print(f"    eligible (|lam_min|>1e-3): {eligible*100:.1f}%   near-singular: {near_sing*100:.2f}%")
+    print(f"    condition number: median={cond.median():.2f} p99={cond.quantile(0.99):.2f} max={cond.max():.2f}")
+
+
+if __name__ == "__main__":
+    print("=== SBR Phase-0 synthetic kill-test (CPU fp32) ===")
+    worst = 1.0
+    for n in (512, 2048, 8192, 16384):
+        worst = min(worst, run_case(n, f"depth"))
+    invertibility_audit()
+    print(f"\nGATE: worst transport cosine across depths = {worst:.8f}  "
+          f"({'PASS' if worst >= 0.999 else 'FAIL'} @ 0.999)")

--- a/research/sbr/sbr_phase1_glocal_window.py
+++ b/research/sbr/sbr_phase1_glocal_window.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""SBR Phase-1 — contractive-window / glocal-split measurement (CPU, fp32).
+
+Decides the implementation primitive for GDN. Dense operator-transport loses to
+replay for GDN (compose is O(chunks·d^3) vs replay O(chunks·64·d^2)), and GDN
+operators are not more compact than the state. The real lever is GLOCALITY via
+CONTRACTIVITY:
+
+  h_M = A_{C->M} h_C + sum_j A_{j+1->M} (contribution_j)
+
+Each token j's contribution is weighted by the decay product A_{j+1->M} ~ exp(sum g).
+For contractive heads (decay<1) tokens far before M contribute ~0, so:
+
+  * LOCAL: reconstruct h_M by replaying only the last tau tokens before M from a
+    ZERO state — error = dropped far-field, bounded by cumulative decay. NO anchor
+    near M needed -> warm-hit cost O(tau), FLAT in (M-C).
+  * GLOBAL (slow modes): weak-forget heads (decay~1) keep long memory; they need a
+    cheap always-maintained coarse summary (few slow modes) = the "global section".
+
+This script measures, on a realistic MIXED decay population:
+  (1) per-head reconstruction cosine vs window tau (local replay from zero),
+  (2) what fraction of heads are "fast" (tau<=512 reaches 0.999) vs "slow"
+      (need the global summary),
+  (3) the slow-mode count: how few modes carry the long-range info.
+
+Run: python3 sbr_phase1_glocal_window.py
+"""
+import torch
+
+torch.manual_seed(1)
+DT = torch.float32
+K_DIM = 128
+V_DIM = 128
+N_HEADS = 32
+N_TOK = 16384  # deep conversation; "match point" M = end
+
+
+def mixed_decay(n_tok, n_heads, weak_frac=0.25):
+    """Per-head, per-token decay a_t=exp(g_t). Most heads forget; a weak_frac
+    minority are near-1 (long-range)."""
+    a = torch.empty(n_heads, n_tok, dtype=DT)
+    n_weak = int(round(weak_frac * n_heads))
+    # fast-forgetting heads: decay in [0.95, 0.999]
+    a[: n_heads - n_weak] = torch.empty(n_heads - n_weak, n_tok, dtype=DT).uniform_(0.95, 0.999)
+    # weak-forget (long-range) heads: decay in [0.9995, 1.0]
+    a[n_heads - n_weak :] = torch.empty(n_weak, n_tok, dtype=DT).uniform_(0.9995, 1.0)
+    return a, n_weak
+
+
+def head_stream(n_tok, decay_row):
+    g = torch.log(decay_row)
+    beta = torch.sigmoid(torch.randn(n_tok, dtype=DT))
+    k = torch.randn(n_tok, K_DIM, dtype=DT)
+    k = k / k.norm(dim=1, keepdim=True).clamp_min(1e-6)
+    v = torch.randn(n_tok, V_DIM, dtype=DT)
+    return g, beta, k, v
+
+
+def scan(h0, g, beta, k, v, lo, hi):
+    h = h0.clone()
+    for t in range(lo, hi):
+        a_t = h.transpose(0, 1) @ k[t]
+        vp = (v[t] - a_t) * beta[t]
+        h = torch.exp(g[t]) * h + torch.outer(k[t], vp)
+    return h
+
+
+def cos(a, b):
+    return torch.nn.functional.cosine_similarity(a.flatten(), b.flatten(), dim=0).item()
+
+
+def main():
+    print("=== SBR Phase-1 contractive-window / glocal-split (CPU fp32) ===")
+    decay, n_weak = mixed_decay(N_TOK, N_HEADS)
+    taus = [64, 128, 256, 512, 1024, 2048, 4096]
+    fast_heads = 0
+    slow_heads = []
+    # aggregate cosine per tau across heads
+    agg = {t: [] for t in taus}
+    h_full_norm_slow = []
+
+    for hd in range(N_HEADS):
+        g, beta, k, v = head_stream(N_TOK, decay[hd])
+        h0 = torch.zeros(K_DIM, V_DIM, dtype=DT)
+        h_full = scan(h0, g, beta, k, v, 0, N_TOK)  # exact, from true start
+        per_tau_cos = {}
+        for tau in taus:
+            lo = max(0, N_TOK - tau)
+            h_loc = scan(torch.zeros(K_DIM, V_DIM, dtype=DT), g, beta, k, v, lo, N_TOK)
+            c = cos(h_full, h_loc)
+            agg[tau].append(c)
+            per_tau_cos[tau] = c
+        # classify: fast if tau<=512 reaches 0.999
+        if per_tau_cos[512] >= 0.999:
+            fast_heads += 1
+        else:
+            slow_heads.append((hd, per_tau_cos[512], per_tau_cos[4096]))
+
+    print(f"\nHeads: {N_HEADS} ({n_weak} seeded weak-forget). "
+          f"FAST (tau<=512 -> cos>=0.999): {fast_heads}/{N_HEADS} "
+          f"({100*fast_heads/N_HEADS:.0f}%)")
+    print("\nAggregate reconstruction cosine (local replay from zero, last-tau):")
+    print("  tau   |  min      mean     median")
+    for t in taus:
+        col = torch.tensor(agg[t])
+        print(f"  {t:5d} | {col.min():.6f}  {col.mean():.6f}  {col.median():.6f}")
+
+    if slow_heads:
+        print(f"\nSLOW heads needing global summary ({len(slow_heads)}): "
+              f"[head, cos@512, cos@4096]")
+        for hd, c5, c4 in slow_heads[:12]:
+            print(f"    head {hd:2d}: {c5:.5f} -> {c4:.5f}")
+
+    # slow-mode rank: for one weak-forget head, how many SVD modes of the
+    # far-field state carry the long-range info?
+    hd = N_HEADS - 1  # a weak-forget head
+    g, beta, k, v = head_stream(N_TOK, decay[hd])
+    h_far = scan(torch.zeros(K_DIM, V_DIM, dtype=DT), g, beta, k, v, 0, N_TOK - 512)
+    sv = torch.linalg.svdvals(h_far)
+    energy = (sv.cumsum(0) / sv.sum())
+    r90 = int((energy < 0.90).sum()) + 1
+    r99 = int((energy < 0.99).sum()) + 1
+    print(f"\nSlow-mode rank (weak-forget head {hd}, far-field h before last-512):")
+    print(f"    rank for 90% energy: {r90}/{K_DIM}   99% energy: {r99}/{K_DIM}")
+    print(f"    -> global summary needs ~{r90}-{r99} modes, not full {K_DIM}x{V_DIM}")
+
+    print("\nINTERPRETATION: if FAST% is high and slow-mode rank is low, the glocal "
+          "split (local-tau replay + small slow-mode global summary) gives FLAT-in-(M-C) "
+          "warm-hit cost. This is the SBR primitive to implement, not dense segment-tree.")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/sbr/sbr_probe.py
+++ b/research/sbr/sbr_probe.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Minimal serial Marconi warm-hit probe — does the warm-hit SSM path fire at all?
+
+Serial (no concurrency), ample slots, no distractors. Sends:
+  1. P            (cold prefill)
+  2. P            (exact repeat -> exact leaf-snapshot hit, should be fast)
+  3. P + s200     (intermediate hit + ~200-tok replay)
+  4. P + s2000    (deeper resume + ~2000-tok replay)
+Reports TTFT for each; pair with server log greps for 'Marconi intermediate hit'.
+"""
+import argparse, json, time, urllib.request
+
+WORDS = ("the model integrates state across tokens while the recurrent layer "
+         "accumulates a decaying hidden matrix and attention reads the cache").split()
+
+
+def filler(n_tokens):
+    n = int(n_tokens / 0.75)
+    return " ".join(WORDS[i % len(WORDS)] for i in range(n))
+
+
+def ttft(base_url, model, messages, max_tokens=16):
+    body = json.dumps({"model": model, "messages": messages, "max_tokens": max_tokens,
+                       "temperature": 0.0, "stream": True}).encode()
+    req = urllib.request.Request(base_url + "/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.perf_counter()
+    first = None
+    with urllib.request.urlopen(req, timeout=600) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "ignore").strip()
+            if line.startswith("data:") and line[5:].strip() not in ("", "[DONE]"):
+                try:
+                    d = json.loads(line[5:].strip())
+                except json.JSONDecodeError:
+                    continue
+                if d.get("choices", [{}])[0].get("delta", {}).get("content"):
+                    first = time.perf_counter() - t0
+                    break
+    return first
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", default="http://localhost:8888/v1")
+    ap.add_argument("--model", default="nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
+    ap.add_argument("--base-tokens", type=int, default=2000)
+    a = ap.parse_args()
+    sysdoc = "Reference:\n" + filler(a.base_tokens)
+    P = [{"role": "system", "content": sysdoc}, {"role": "user", "content": "Q0: summarize."}]
+
+    print(f"1. cold P        TTFT={ttft(a.base_url, a.model, P):.3f}s", flush=True)
+    print(f"2. repeat P      TTFT={ttft(a.base_url, a.model, P):.3f}s", flush=True)
+    P2 = P + [{"role": "assistant", "content": filler(200)}, {"role": "user", "content": "Q1?"}]
+    print(f"3. P+~200 replay TTFT={ttft(a.base_url, a.model, P2):.3f}s", flush=True)
+    P3 = P + [{"role": "assistant", "content": filler(2000)}, {"role": "user", "content": "Q2?"}]
+    print(f"4. P+~2000 reply TTFT={ttft(a.base_url, a.model, P3):.3f}s", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/sbr/sbr_strand.py
+++ b/research/sbr/sbr_strand.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""SBR M1 stranding reproduction — the user's actual scenario.
+
+Phase 1 (BUILD+WARM): grow ONE deep conversation A to ~target depth over several
+  turns, resuming each turn -> A becomes "resumable" (snapshot hits register).
+Phase 2 (PRESSURE): bursts of one-shot distractor conversations churn the
+  snapshot pool while A is idle.
+Phase 3 (RESUME): resume A after each pressure burst; measure TTFT + (from logs)
+  replay distance. Baseline: A's deep checkpoint evicted -> far replay (slow).
+  Tail-pin: A is resumable -> its deepest pinned -> survives -> fast.
+
+Each A turn appends ~chunk_tokens of new context (fast depth growth) + short gen.
+"""
+import argparse, json, time, urllib.request
+
+WORDS = ("the recurrent state integrates each token through a gated delta update "
+         "while attention layers read the cached keys and values across the context "
+         "window producing hidden activations consumed by the next transformer block").split()
+
+
+def filler(n_tokens, salt=0):
+    n = int(n_tokens / 0.75)
+    return f"[ctx {salt}] " + " ".join(WORDS[(i + salt) % len(WORDS)] for i in range(n))
+
+
+def chat(base_url, model, messages, max_tokens):
+    body = json.dumps({"model": model, "messages": messages, "max_tokens": max_tokens,
+                       "temperature": 0.0, "stream": True}).encode()
+    req = urllib.request.Request(base_url + "/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.perf_counter(); ttft=None; first=None; out=[]
+    with urllib.request.urlopen(req, timeout=900) as resp:
+        for raw in resp:
+            ln = raw.decode("utf-8","ignore").strip()
+            if ln.startswith("data:") and ln[5:].strip() not in ("","[DONE]"):
+                try: d=json.loads(ln[5:].strip())
+                except json.JSONDecodeError: continue
+                c=d.get("choices",[{}])[0].get("delta",{}).get("content")
+                if c:
+                    if ttft is None: ttft,first=time.perf_counter()-t0,c
+                    out.append(c)
+    return ttft, "".join(out), first
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--label", required=True); ap.add_argument("--out", required=True)
+    ap.add_argument("--base-url", default="http://localhost:8888/v1")
+    ap.add_argument("--model", default="nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
+    ap.add_argument("--build-turns", type=int, default=8)
+    ap.add_argument("--chunk-tokens", type=int, default=1800)
+    ap.add_argument("--pressure", type=int, default=30, help="one-shot convs per burst")
+    ap.add_argument("--pressure-tokens", type=int, default=2000)
+    ap.add_argument("--resume-cycles", type=int, default=4)
+    a=ap.parse_args()
+
+    A=[{"role":"system","content":"You analyze a growing document.\n"+filler(3000)}]
+    rows=[]
+    # Phase 1: build + warm (A resumed each turn -> becomes resumable)
+    for t in range(a.build_turns):
+        A.append({"role":"user","content":f"Section {t}: {filler(a.chunk_tokens, t+1)}\nSummarize so far."})
+        depth=int(sum(len(m['content'].split()) for m in A)/0.75)
+        ttft,text,_=chat(a.base_url,a.model,A,80)
+        A.append({"role":"assistant","content":text})
+        rows.append({"phase":"build","t":t,"depth":depth,"ttft_s":ttft})
+        print(f"[{a.label}] build t{t} depth~{depth:6d} TTFT={ttft:.3f}s",flush=True)
+
+    # Phase 2+3: pressure burst then resume A
+    for cyc in range(a.resume_cycles):
+        for d in range(a.pressure):
+            sysd=filler(a.pressure_tokens, 1000+cyc*100+d)+f" salt-{cyc}-{d}"
+            try: chat(a.base_url,a.model,[{"role":"system","content":sysd},
+                                          {"role":"user","content":"One-line summary."}],24)
+            except Exception as e: print(f"  pressure err {e}")
+        A.append({"role":"user","content":f"Resume {cyc}: given all sections, conclude."})
+        depth=int(sum(len(m['content'].split()) for m in A)/0.75)
+        ttft,text,_=chat(a.base_url,a.model,A,80)
+        A.append({"role":"assistant","content":text})
+        rows.append({"phase":"resume","cyc":cyc,"depth":depth,"ttft_s":ttft})
+        print(f"[{a.label}] RESUME cyc{cyc} (after {a.pressure} pressure) depth~{depth:6d} TTFT={ttft:.3f}s",flush=True)
+
+    json.dump({"label":a.label,"rows":rows},open(a.out,"w"),indent=2)
+    res=[r["ttft_s"] for r in rows if r["phase"]=="resume" and r.get("ttft_s")]
+    if res: print(f"\n[{a.label}] post-pressure RESUME TTFT: mean={sum(res)/len(res):.3f}s max={max(res):.3f}s")
+
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
## Problem

On a warm multi-turn hit, KV is reused but the GDN/Mamba SSM layers must replay
their recurrent state from the nearest deeper Marconi checkpoint to the match
point. As the snapshot pool fills, the forecast eviction (`last_access·(1+hit_count)`)
drops a live conversation's **deep** per-turn checkpoints first — their
`hit_count≈0` (they were never the resume *anchor*), so they look like one-shot
traffic — leaving the next resume to replay from a far-shallow survivor. Replay
distance grows with depth → warm-hit TTFT climbs (measured ~9.5s at ~24k depth;
the 1s→21s pathology).

## Fix (M1) — opt-in, OFF by default

`SsmSnapshotIndex::evict_lru` gains a tail-pin mode: pin the **top-K (=8) deepest
snapshots of each *resumable* session** (a conversation resumed at least once),
evicting only non-pinned entries. A resuming deep conversation then finds a
near-tail SSM anchor instead of a far one.

Measured on dgx2 (Qwen3-Next-80B-NVFP4, deep conv idle under one-shot pressure,
then resumed):

| | baseline (forecast) | tail-pin ON |
|---|---|---|
| warm-resume TTFT (mean) | 9.53 s | **1.18 s (8×)** |
| best cycle | 9.74 s | **0.45 s (21×)** |
| replay distance | ~7,600 tok | **11–984 tok** |

The 0.45 s warm-cycle latency matches llama.cpp's continuous-sequence resume —
without keeping the sequence live. **Exact by construction**: only *which*
checkpoint is restored changes; replay is the unchanged bit-exact WY4 path.

## Honest scope — why OFF by default

Enabling tail-pin **regresses balanced many-conversation round-robin ~30%**
(5.9s→7.7s): there the recency·hit forecast is already near-optimal and pinning
fights it, and the regime cannot be reliably detected from the snapshot index's
local view (four gating variants tried, all failed). So it is **OFF by default**
— `ATLAS_SBR_TAIL_PIN` unset is exactly the baseline forecast (do-no-harm
everywhere). Set `ATLAS_SBR_TAIL_PIN=1` (optionally `ATLAS_SBR_TAIL_PIN_K`) for
deep single/few-conversation agentic workloads, where it delivers the 8×.

## Research artifacts (`research/sbr/`)

Full forensics, benchmark harnesses, and findings, including the negative
results that bound the approach:
- Dense operator-transport is FLOP-negative for GDN; real GDN decay is
  heavy-tailed (median horizon ~163 tok, but ~12% of heads > 8192).
- **M3 2-D (position × layer) sheaf reconciliation** prototyped → honest
  negative: non-vacuous with an oracle inter-layer map but circular/net-negative
  with a fittable one (an accurate inter-layer restriction map *is* the layer's
  forward pass → no shortcut). M1 is the real win, not the sheaf framing.

## Tests
`cargo test -p spark-runtime radix_tree::tests::snapshot` — 20 pass, incl.
`test_tail_pin_protects_top_k_deepest` and `test_tail_pin_off_is_pure_forecast`.