### PR TITLE
feat(qwen35): native FP8 for Holo-3.1 (compressed-tensors float-quantized)

### DIFF
--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -804,7 +804,7 @@ pub(super) fn load_layers(
                     // fp4_proj_decode drops Holo's modelopt SSM out of the BF16-
                     // dense + FP8-overlay build so it falls through to the NVFP4
                     // builder below → in_proj_qkvz/out_proj decode on w4a16_gemv.
-                    _ if modelopt_mixed_precision && !fp4_proj_decode => {
+                    _ if modelopt_mixed_precision && !fp4_proj_decode && !ssm_native_fp8 => {
                         linear_attn_arms::build_linear_attention_dense_bf16(
                             i,
                             store,

--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -20,18 +20,25 @@ use crate::weight_map::{
     load_moe_qwen35_fp8_experts, quantize_to_nvfp4,
 };
 
-/// True when a projection ships as native block-scaled FP8 on disk
-/// (`FP8E4M3 .weight` + `.weight_scale_inv`). Hybrid mixed-precision
-/// checkpoints (lovedheart AgentWorld-35B) keep attention/SSM projections in
-/// BF16 — or in block-FP8 under a `.weight_scale` key — even when the model is
-/// globally FP8/NVFP4. Those return false so the loader routes them through
-/// the per-tensor dense/NVFP4 path instead of the native-FP8 fast arm.
+/// True when a projection ships as native block-scaled FP8 on disk: an
+/// `FP8E4M3 .weight` plus a 2D block scale. The scale tensor name varies by
+/// producer — DeepSeek/Qwen-native FP8 uses `.weight_scale_inv`, while
+/// compressed-tensors `float-quantized` (e.g. Hcompany/Holo-3.1-*-FP8) uses a
+/// 2D `.weight_scale`; both are accepted (`load_fp8_block_scaled_as_fp8weight`
+/// resolves either). A *scalar* `.weight_scale` (ModelOpt per-tensor FP8) is
+/// NOT native-block here → returns false so those route through the
+/// per-tensor dense/NVFP4 path instead of the native-FP8 fast arm.
 fn proj_is_native_fp8(store: &WeightStore, prefix: &str) -> bool {
-    store
+    let is_fp8_weight = store
         .get(&format!("{prefix}.weight"))
         .map(|w| w.dtype == WeightDtype::FP8E4M3)
-        .unwrap_or(false)
-        && store.contains(&format!("{prefix}.weight_scale_inv"))
+        .unwrap_or(false);
+    let has_block_scale = store.contains(&format!("{prefix}.weight_scale_inv"))
+        || store
+            .get(&format!("{prefix}.weight_scale"))
+            .map(|s| s.shape.len() == 2)
+            .unwrap_or(false);
+    is_fp8_weight && has_block_scale
 }
 
 pub(super) fn load_layers(

--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -29,16 +29,34 @@ use crate::weight_map::{
 /// NOT native-block here → returns false so those route through the
 /// per-tensor dense/NVFP4 path instead of the native-FP8 fast arm.
 fn proj_is_native_fp8(store: &WeightStore, prefix: &str) -> bool {
-    let is_fp8_weight = store
-        .get(&format!("{prefix}.weight"))
-        .map(|w| w.dtype == WeightDtype::FP8E4M3)
-        .unwrap_or(false);
-    let has_block_scale = store.contains(&format!("{prefix}.weight_scale_inv"))
-        || store
-            .get(&format!("{prefix}.weight_scale"))
-            .map(|s| s.shape.len() == 2)
-            .unwrap_or(false);
-    is_fp8_weight && has_block_scale
+    let Ok(w) = store.get(&format!("{prefix}.weight")) else {
+        return false;
+    };
+    if w.dtype != WeightDtype::FP8E4M3 || w.shape.len() != 2 {
+        return false;
+    }
+    let (n, k) = (w.shape[0], w.shape[1]);
+    // Detection MUST agree with `load_fp8_block_scaled_as_fp8weight`: the native
+    // arm feeds the 2D scale straight into `w8a16_gemv`, which hardcodes
+    // FP8_BLOCK=128 and indexes `scale[(n/128)*ceil(K/128) + (k/128)]`. A
+    // per-channel `[N,1]` scale (compressed-tensors float-quantized,
+    // llm-compressor keepdim — most RedHatAI FP8-dynamic checkpoints) is 2D but
+    // NOT a block grid, so it must return false here and fall through to the
+    // requant path (which handles arbitrary geometry). NOTE: this gates the
+    // ATTENTION / linear-attn native-FP8 fast arm only; the MoE expert loader
+    // (`load_moe_qwen35_fp8_experts`) does not consult this and keeps its own
+    // proven per-row path.
+    let scale_key = if store.contains(&format!("{prefix}.weight_scale_inv")) {
+        format!("{prefix}.weight_scale_inv")
+    } else {
+        format!("{prefix}.weight_scale")
+    };
+    store
+        .get(&scale_key)
+        .map(|s| {
+            s.shape.len() == 2 && s.shape[0] == n.div_ceil(128) && s.shape[1] == k.div_ceil(128)
+        })
+        .unwrap_or(false)
 }
 
 pub(super) fn load_layers(

--- a/crates/spark-model/src/weight_map/loaders_fp8.rs
+++ b/crates/spark-model/src/weight_map/loaders_fp8.rs
@@ -49,22 +49,33 @@ pub fn load_fp8_block_scaled_as_fp8weight(
     let k = w.shape[1];
     let weight_ptr = w.ptr;
 
-    // Load block scale [N/BS, K/BS] — already on GPU from safetensors. Names:
-    //   * `weight_scale_inv` — DeepSeek-V3 / Qwen native-FP8 (2D block scale)
-    //   * `weight_scale` (2D)  — compressed-tensors re-quants (RedHatAI, e.g.
-    //                            DeepSeek-V4-Flash): SAME per-block dequant mult.
-    //   * `weight_scale` (scalar) — ModelOpt MIXED_PRECISION: one scalar to
-    //                            expand to a [N/BS, K/BS] block matrix.
-    // Accept all three: prefer `weight_scale_inv`, else `weight_scale`; branch on
-    // 2D-block (widen to FP32) vs scalar (expand) by the loaded tensor's shape.
-    let scale_key = if store.contains(&format!("{prefix}.weight_scale_inv")) {
-        format!("{prefix}.weight_scale_inv")
+    // Load block scale [N/BS, K/BS] — already on GPU from safetensors. The
+    // tensor name varies by producer: DeepSeek/Qwen-native FP8 ships
+    // `weight_scale_inv` (2D); compressed-tensors `float-quantized` (e.g.
+    // Hcompany/Holo-3.1-*-FP8) ships a 2D `weight_scale`; ModelOpt
+    // MIXED_PRECISION ships a *scalar* `weight_scale` (expanded to the block
+    // matrix shape below). All three are the per-block FP8 dequant multiplier
+    // the W8A16 kernels apply in FP32. Prefer whichever 2D block scale exists.
+    let scale_inv_key = format!("{prefix}.weight_scale_inv");
+    let plain_scale_key = format!("{prefix}.weight_scale");
+    let block_scale_key = if store.contains(&scale_inv_key) {
+        Some(scale_inv_key.clone())
+    } else if store
+        .get(&plain_scale_key)
+        .map(|s| s.shape.len() == 2)
+        .unwrap_or(false)
+    {
+        Some(plain_scale_key.clone())
     } else {
-        format!("{prefix}.weight_scale")
+        None
     };
-    let is_2d_block = store.contains(&scale_key) && store.get(&scale_key)?.shape.len() == 2;
-    let row_scale = if is_2d_block {
+    let row_scale = if let Some(scale_key) = block_scale_key {
         let s = store.get(&scale_key)?;
+        ensure!(
+            s.shape.len() == 2,
+            "Expected 2D shape for {scale_key}, got {:?}",
+            s.shape,
+        );
         ensure!(
             s.dtype == WeightDtype::BF16 || s.dtype == WeightDtype::FP32,
             "Expected BF16 or FP32 for {scale_key}, got {:?}",
@@ -98,9 +109,9 @@ pub fn load_fp8_block_scaled_as_fp8weight(
         gpu.synchronize(stream)?;
         row_scale
     } else {
-        let scalar_key = format!("{prefix}.weight_scale");
+        let scalar_key = plain_scale_key;
         let scale = scalar_f32(store, &scalar_key, gpu)
-            .with_context(|| format!("Missing {scale_key} or scalar {scalar_key}"))?;
+            .with_context(|| format!("Missing {scale_inv_key} or scalar {scalar_key}"))?;
         let n_blocks = n.div_ceil(128);
         let k_blocks = k.div_ceil(128);
         let scale_total = n_blocks * k_blocks;

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -115,6 +115,28 @@ pub fn detect_nvfp4_variant(
         if store.contains(&fp8_attn_key) {
             return Nvfp4Variant::Fp8Dequanted;
         }
+        // compressed-tensors `float-quantized` FP8 (e.g. Hcompany/Holo-3.1-*-FP8)
+        // ships block-FP8 as an FP8E4M3 `.weight` + 2D `.weight_scale` — NO
+        // `.weight_packed` (that's NVFP4) and NO `.weight_scale_inv` (that's
+        // DeepSeek/Qwen-native FP8). The `.weight_scale` name alias-collides
+        // with compressed-tensors NVFP4, so the `.weight_scale` checks below
+        // would misroute it to an NVFP4 variant. Disambiguate by the
+        // unambiguous FP8E4M3 weight dtype: an FP8E4M3 projection weight is
+        // always block-FP8 (Fp8Dequanted; the FP8→BF16→NVFP4 requant path in
+        // `quantized_from_fp8` reads the 2D `.weight_scale`).
+        for key in [
+            format!("{pfx}.mlp.experts.{local_expert}.gate_proj.weight"),
+            format!("{pfx}.mlp.gate_proj.weight"),
+            format!("{pfx}.self_attn.q_proj.weight"),
+        ] {
+            if store
+                .get(&key)
+                .map(|w| w.dtype == WeightDtype::FP8E4M3)
+                .unwrap_or(false)
+            {
+                return Nvfp4Variant::Fp8Dequanted;
+            }
+        }
     }
     // Fallback: scan any tensor name for `.weight_scale_inv` suffix.
     // Catches FP8 checkpoints where the layer prefix hasn't been resolved yet.

--- a/crates/spark-server/src/api/chat/sampling_setup.rs
+++ b/crates/spark-server/src/api/chat/sampling_setup.rs
@@ -85,29 +85,20 @@ pub(super) fn build_sampling(
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
-    // Core sampling (temp/top_k/top_p) defaults to the model's shipped
-    // generation_config.json (state.default_*) — matching vLLM and the model
-    // author's recommended config — instead of the hand-curated MODEL.toml
-    // [sampling] presets. The lower preset temps (e.g. Holo thinking/tools =
-    // 0.6 vs generation_config 1.0) made the model over-commit to tool calls
-    // vs vLLM: lower temperature is more deterministic, so it picks "call the
-    // tool" far more consistently. The selected preset still drives the
-    // penalties below (generation_config doesn't define those); min_p and
-    // top_n_sigma already default to generation_config.
     let temperature = if force_temp_zero {
         0.0
     } else {
-        req.temperature.unwrap_or(state.default_temperature)
+        req.temperature.unwrap_or(preset.temperature)
     };
     let top_k = if force_temp_zero {
         0
     } else {
-        req.top_k.unwrap_or(state.default_top_k)
+        req.top_k.unwrap_or(preset.top_k)
     };
     let top_p = if force_temp_zero {
         1.0
     } else {
-        req.top_p.unwrap_or(state.default_top_p)
+        req.top_p.unwrap_or(preset.top_p)
     };
     let top_n_sigma = if force_temp_zero {
         0.0

--- a/crates/spark-server/src/api/chat/sampling_setup.rs
+++ b/crates/spark-server/src/api/chat/sampling_setup.rs
@@ -85,20 +85,29 @@ pub(super) fn build_sampling(
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
+    // Core sampling (temp/top_k/top_p) defaults to the model's shipped
+    // generation_config.json (state.default_*) — matching vLLM and the model
+    // author's recommended config — instead of the hand-curated MODEL.toml
+    // [sampling] presets. The lower preset temps (e.g. Holo thinking/tools =
+    // 0.6 vs generation_config 1.0) made the model over-commit to tool calls
+    // vs vLLM: lower temperature is more deterministic, so it picks "call the
+    // tool" far more consistently. The selected preset still drives the
+    // penalties below (generation_config doesn't define those); min_p and
+    // top_n_sigma already default to generation_config.
     let temperature = if force_temp_zero {
         0.0
     } else {
-        req.temperature.unwrap_or(preset.temperature)
+        req.temperature.unwrap_or(state.default_temperature)
     };
     let top_k = if force_temp_zero {
         0
     } else {
-        req.top_k.unwrap_or(preset.top_k)
+        req.top_k.unwrap_or(state.default_top_k)
     };
     let top_p = if force_temp_zero {
         1.0
     } else {
-        req.top_p.unwrap_or(preset.top_p)
+        req.top_p.unwrap_or(state.default_top_p)
     };
     let top_n_sigma = if force_temp_zero {
         0.0

--- a/kernels/gb10/holo-3.1-0.8b/MODEL.toml
+++ b/kernels/gb10/holo-3.1-0.8b/MODEL.toml
@@ -85,6 +85,9 @@ max_inter_tool_prose = 384
 max_post_think_content_tokens = 8192
 default_num_drafts = 0
 tool_call_parser = "qwen3_coder"
+# Tool-call grammar OFF: XGrammar tool-constrained decoding degenerates the
+# Holo family (see holo-3.1-35b-a3b/MODEL.toml). Matches vLLM.
+disable_tool_grammar = true
 
 # Dense Qwen3.5/Holo: model_type stays "qwen3_5" (num_experts == 0). MRoPE is
 # present but the qwen3_5 -> qwen3_6_moe rewrite is gated on is_moe, so dense

--- a/kernels/gb10/holo-3.1-35b-a3b/MODEL.toml
+++ b/kernels/gb10/holo-3.1-35b-a3b/MODEL.toml
@@ -86,6 +86,12 @@ max_inter_tool_prose = 384
 max_post_think_content_tokens = 8192
 default_num_drafts = 0
 tool_call_parser = "qwen3_coder"
+# Tool-call grammar OFF: XGrammar-constrained decoding for tool requests makes
+# Holo-3.1 degenerate (runaway reasoning, hallucinated `Human:` turns, fin=length)
+# — verified against vLLM, which does free-generate + parse-after and stays
+# coherent. Disabling it makes Atlas match vLLM (concise, correct tools, clean
+# stops). The qwen3_coder parser still reads the model's tool calls.
+disable_tool_grammar = true
 
 [[model_types]]
 model_type = "holo3_1_moe"

--- a/kernels/gb10/holo-3.1-4b/MODEL.toml
+++ b/kernels/gb10/holo-3.1-4b/MODEL.toml
@@ -86,6 +86,9 @@ max_inter_tool_prose = 384
 max_post_think_content_tokens = 8192
 default_num_drafts = 0
 tool_call_parser = "qwen3_coder"
+# Tool-call grammar OFF: XGrammar tool-constrained decoding degenerates the
+# Holo family (see holo-3.1-35b-a3b/MODEL.toml). Matches vLLM.
+disable_tool_grammar = true
 
 # Dense Qwen3.5/Holo: model_type stays "qwen3_5" (num_experts == 0). MRoPE is
 # present but the qwen3_5 -> qwen3_6_moe rewrite is gated on is_moe, so dense

--- a/kernels/gb10/ornith-1.0-9b/MODEL.toml
+++ b/kernels/gb10/ornith-1.0-9b/MODEL.toml
@@ -82,6 +82,11 @@ max_inter_tool_prose = 384
 max_post_think_content_tokens = 8192
 default_num_drafts = 0
 tool_call_parser = "qwen3_coder"
+# Tool-call grammar OFF: same XGrammar degeneration as Holo-3.1 (runaway
+# reasoning / hallucinated `Human:` turns under tool-constrained decoding).
+# Matches vLLM, which free-generates + parses tool calls after. See
+# holo-3.1-35b-a3b/MODEL.toml for the full root-cause writeup.
+disable_tool_grammar = true
 
 # Dense Qwen3.5/Ornith: model_type stays "qwen3_5" (num_experts == 0). MRoPE
 # present but the qwen3_5 -> qwen3_6_moe rewrite is gated on is_moe, so dense


### PR DESCRIPTION
**Stacked on #203** (holo-gb10), which is stacked on #202 (vision ViT perf). Review/merge **after** #203 — the diff below includes the #202+#203 commits until those land; the FP8-specific change is the single top commit (`feat(qwen35): load compressed-tensors float-quantized FP8`, 4 files).

## What
Loads & runs `Hcompany/Holo-3.1-35B-A3B-FP8` (and dense siblings) as **native FP8** on GB10.

The checkpoint is block-FP8 via compressed-tensors `format="float-quantized"`: an `FP8E4M3 .weight` + a 2D `.weight_scale` per `[128,128]` block (no `.weight_packed`, no `.weight_scale_inv`). The block math is identical to DeepSeek/Qwen block-FP8 — **only the scale tensor name differs** (`weight_scale` vs `weight_scale_inv`). Atlas only recognised the `weight_scale_inv` spelling, so these checkpoints misrouted to the NVFP4 path and failed with `...weight_global_scale not found`.

## How (4 sites taught the compressed-tensors spelling — no kernel/math change)
- `nvfp4_detect.rs` — compressed-tensors config dispatch + heuristic recognise `float-quantized` (and, defensively, the `FP8E4M3` weight dtype) → `Fp8Dequanted` instead of an NVFP4 variant.
- `serve.rs canonicalize_model_quant` — `float-quantized` → `"fp8"` so the kernel/model quant guard accepts it on the nvfp4 bundle (`quant_pair_compatible: nvfp4↔fp8`).
- `loaders_fp8.rs load_fp8_block_scaled_as_fp8weight` — resolve the 2D block scale from `weight_scale_inv` **or** a 2D `weight_scale`; expand a scalar only when genuinely scalar (ModelOpt per-tensor FP8).
- `load_layers.rs proj_is_native_fp8` — accept a 2D `weight_scale` so attention takes the native-FP8 arm.

## Validation (GB10, `Hcompany/Holo-3.1-35B-A3B-FP8`)
- Loads native FP8: logs `quant_format: Fp8`, `Weight format: Fp8BlockScaled`, `MoE experts loaded as native FP8`, `attention FP8 native`.
- Coherent text (Rayleigh scattering / Python / arithmetic), vision all sizes pass, **0 faults**.
- Decode ~77 tok/s @ C=1 (vs ~92 for the 0.5-byte NVFP4 Holo — expected; FP8 is 1 byte/weight and decode is weight-bandwidth-bound).
- SSM (`linear_attn`) stays BF16 per the checkpoint ignore list.

Serves on the standard `ATLAS_TARGET_QUANT=nvfp4` holo build (its bundle carries the FP8 kernels: `w8a16_gemv` decode, FP8 fused MoE, FP8 prefill). No `FORCE_NVFP4_ALL` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)