### PR TITLE
chore(git): merge=union for CHANGELOG/README to stop recurring fork-PR conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
 *.webm filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.mov filter=lfs diff=lfs merge=lfs -text
+
+# Append-style files that every feature PR touches (changelog entry, model-support
+# row). Without this, each merge to main conflicts the other open PRs on these files.
+# `merge=union` keeps both sides' added lines instead of emitting a conflict.
+# (Union may duplicate a line if two PRs edit the exact same one — harmless, de-dup at release.)
+CHANGELOG.md merge=union
+README.md merge=union


### PR DESCRIPTION
## Problem
Every GB10/model-enablement PR appends to the **same two files** — a `CHANGELOG.md` entry and a `README.md` model-support row. With no merge driver, the moment one such PR lands on `main`, the other open PRs immediately report conflicts on these files; resolving one re-conflicts the rest. Right now **#203, #210, #212** all touch both files and all sit in this loop.

## Fix
Add to `.gitattributes`:
```
CHANGELOG.md merge=union
README.md    merge=union
```
`merge=union` keeps **both** sides' added lines instead of emitting a conflict marker — the correct semantics for append-only lists. (Union can duplicate a line only when two PRs edit the exact same one — harmless, de-dup at release.)

## Scope / follow-up
This does **not** cover the semantic conflicts in `crates/atlas-core/src/config/dispatch.rs` and `crates/spark-model/src/layers/mod.rs` (the model registry + module list) — `merge=union` would break compilation there. Those need a structural fix (one-file-per-model registration + an inventory macro), proposed as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)