### PR TITLE
ci(security): make cargo-deny green — pin toolchain to 1.93.1, fix RUSTSEC-2026-0190, drop stale ignores

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,4 +35,7 @@ jobs:
       # with. (deny is metadata-only — it does not compile the workspace.)
       - run: rustup show
       - uses: taiki-e/install-action@cargo-deny
-      - run: cargo deny check advisories licenses sources bans --all-features
+      # Feature selection comes from deny.toml's `[graph] all-features = true`,
+      # so no --all-features flag is needed (and newer cargo-deny rejects it on
+      # the `check` subcommand).
+      - run: cargo deny check advisories licenses sources bans

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check advisories licenses sources bans
+      # Run cargo-deny under the repo's pinned toolchain (rust-toolchain.toml,
+      # currently 1.93.1) instead of the EmbarkStudios cargo-deny-action's
+      # Docker image, whose bundled Rust (1.85) cannot honor the pin and
+      # errored out ("override toolchain '1.93.1' is not installed") before
+      # deny ever ran. `rustup show` installs + selects the pinned channel;
+      # cargo-deny then resolves the graph with the same toolchain we build
+      # with. (deny is metadata-only — it does not compile the workspace.)
+      - run: rustup show
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check advisories licenses sources bans --all-features

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,16 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Run cargo-deny under the repo's pinned toolchain (rust-toolchain.toml,
-      # currently 1.93.1) instead of the EmbarkStudios cargo-deny-action's
-      # Docker image, whose bundled Rust (1.85) cannot honor the pin and
-      # errored out ("override toolchain '1.93.1' is not installed") before
-      # deny ever ran. `rustup show` installs + selects the pinned channel;
-      # cargo-deny then resolves the graph with the same toolchain we build
-      # with. (deny is metadata-only — it does not compile the workspace.)
-      - run: rustup show
-      - uses: taiki-e/install-action@cargo-deny
-      # Feature selection comes from deny.toml's `[graph] all-features = true`,
-      # so no --all-features flag is needed (and newer cargo-deny rejects it on
-      # the `check` subcommand).
-      - run: cargo deny check advisories licenses sources bans
+      # `rust-version` pins the action's in-container toolchain to our
+      # rust-toolchain.toml channel. Without it, the action's bundled Rust
+      # can't honor the repo pin and rustup errors ("override toolchain
+      # '1.93.1' is not installed") before cargo-deny runs. Keep this in sync
+      # with rust-toolchain.toml. (cargo-deny is metadata-only — it audits the
+      # pinned Cargo.lock and does not compile the workspace — so the toolchain
+      # is about consistency with the repo pin, not the audit result.)
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.93.1"
+          command: check advisories licenses sources bans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atlas-activation"

--- a/deny.toml
+++ b/deny.toml
@@ -16,17 +16,15 @@ yanked = "warn"
 # real vulnerabilities (the entry should be removed and the upstream
 # bumped).
 ignore = [
-    # `atty` — replaced by `is-terminal` in modern crates. Pulled in
-    # by older diagnostic / CLI helper crates as a transitive dep.
-    { id = "RUSTSEC-2024-0375", reason = "atty is unmaintained but only used for TTY detection in transitive deps; no vulnerability path" },
     # `paste` — proc-macro for token pasting. The crate works fine
     # but its maintainer stepped away; replacements (e.g. `pastey`)
     # exist but the deps that use it haven't migrated yet.
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; proc-macro is feature-complete and pulled in by transitive deps we don't control" },
-    # `proc-macro-error` 1.x — pulled in by older clap derive macros.
-    # Replaced upstream by `proc-macro-error2`; resolved naturally as
-    # transitive deps bump their own clap pins.
-    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error 1.x is unmaintained; transitive only, replacement crate exists upstream" },
+    # NOTE: RUSTSEC-2024-0375 (`atty`) and RUSTSEC-2024-0370
+    # (`proc-macro-error` 1.x) were removed once those crates dropped out
+    # of the tree — keeping them produced cargo-deny `advisory-not-detected`
+    # warnings ("no crate matched advisory criteria"). Re-add only if a dep
+    # pulls them back in.
 ]
 
 [licenses]


### PR DESCRIPTION
Makes the `cargo deny` required check pass cleanly. Three changes — and notably, fixing the toolchain is what *surfaced* the real advisory that had been hidden.

### 1. Run cargo-deny under our pinned toolchain (the root failure)
`EmbarkStudios/cargo-deny-action@v2` runs in a container whose bundled Rust cannot honor `rust-toolchain.toml`'s pin (**1.93.1**), so rustup hard-errors (`override toolchain '1.93.1' is not installed`) **before deny even runs**. Path-filtered to `Cargo.*`/`deny.toml`, so it bites any dependency change.

**Fix:** use the action's `rust-version: "1.93.1"` input so it installs + selects our pinned channel in-container before running. deny now audits with the **same toolchain we build with**. cargo-deny is metadata-only (it audits the pinned `Cargo.lock`, doesn't compile the workspace), so keep `rust-version` in sync with `rust-toolchain.toml`.

> Tried a runner-based `taiki-e/install-action` + `cargo deny` first (intermediate commits), but its *latest* cargo-deny hit an `unresolved-workspace-dependency` resolver bug on this workspace. The action's pinned cargo-deny is unaffected, so `rust-version` is the cleaner lever.

### 2. Fix RUSTSEC-2026-0190 — `anyhow` unsoundness (surfaced by #1)
Once deny actually ran, it flagged a real advisory: `anyhow` 1.0.102 has unsoundness in `Error::downcast_mut()` (UB when `downcast_mut` is called on an error that had context added via `Error::context`). **Bumped `anyhow` 1.0.102 → 1.0.103** (the patched release; no API change). Fixed, not ignored. https://rustsec.org/advisories/RUSTSEC-2026-0190

### 3. Drop two stale advisory ignores
`atty` (RUSTSEC-2024-0375) and `proc-macro-error` 1.x (RUSTSEC-2024-0370) dropped out of the tree, so their `ignore` entries matched nothing -> `advisory-not-detected` warnings. Removed both; kept `paste` (RUSTSEC-2024-0436), still present.

All 11 checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
