### PR TITLE
fix(stream): don't strip the `tool` BPE fragment of tool_* names mid tool-call (#222)

### DIFF
--- a/crates/spark-server/src/api/chat_stream/handle_token.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_token.rs
@@ -42,6 +42,31 @@ type SseVec = Vec<Result<Event, std::convert::Infallible>>;
 /// wasted decode at ~10s @ 30 tok/s.
 const MAX_SUPPRESS_STREAK_TOKENS: u32 = 256;
 
+/// Drop a delta that is nothing but a bare role literal (`user` /
+/// `assistant` / `tool`) — a Qwen3.5/3.6 hallucination leak, companion to
+/// the scheduler-side `<|im_start|>` hard-stop.
+///
+/// `inside_tool_call` MUST be true whenever the streaming tool-call
+/// detector is mid-body (between `<tool_call>` and its close). Issue #222:
+/// for a `tool_*`-prefixed tool name (`tool_search`, `tool_call`,
+/// `tool_describe`) the byte-level BPE tokenizer emits a standalone `tool`
+/// token as the leading fragment of the NAME. Without the guard this strip
+/// clears that fragment, and the detector reassembles the name from the
+/// remainder (`_search`), truncating the streamed tool-call name by exactly
+/// `len("tool") == 4` chars. Non-streaming was unaffected because it parses
+/// the whole buffer at once. The guard confines the strip to genuine
+/// content leaks (no tool call in flight).
+pub(super) fn strip_bare_role_literal(delta: &mut String, inside_tool_call: bool) {
+    if inside_tool_call {
+        return;
+    }
+    let trimmed = delta.trim();
+    if delta.len() < 20 && matches!(trimmed, "user" | "assistant" | "tool") {
+        tracing::debug!("role-literal strip: dropped bare '{trimmed}' delta");
+        delta.clear();
+    }
+}
+
 /// Process one token. Returns the SSE events to forward to the
 /// client (empty `Vec` is valid).
 ///
@@ -368,13 +393,15 @@ fn handle_token_inner(state: &mut StreamState, ctx: &StreamCtx, tok: u32) -> Sse
     }
 
     // Bare role-literal leak (Qwen3.5/3.6) — companion to the
-    // scheduler-side <|im_start|> hard-stop.
+    // scheduler-side <|im_start|> hard-stop. Suppressed mid tool-call
+    // body: there a standalone `tool` token is the leading BPE fragment
+    // of a `tool_*` NAME (issue #222) being reassembled, not a role leak.
     {
-        let trimmed = delta.trim();
-        if delta.len() < 20 && matches!(trimmed, "user" | "assistant" | "tool") {
-            tracing::debug!("role-literal strip: dropped bare '{trimmed}' delta");
-            delta.clear();
-        }
+        let inside_tool_call = state
+            .detector
+            .as_ref()
+            .is_some_and(|d| d.inside_tool_call());
+        strip_bare_role_literal(&mut delta, inside_tool_call);
     }
 
     if delta.is_empty() {
@@ -775,5 +802,126 @@ mod stop_string_holdback_tests {
         assert_eq!(out, "a");
         assert!(out.is_char_boundary(out.len()));
         assert!(!triggered);
+    }
+}
+
+#[cfg(test)]
+mod role_literal_strip_tests {
+    use super::strip_bare_role_literal;
+    use crate::tool_parser::{DetectorOutput, StreamingToolDetector};
+
+    /// Faithfully mirror the `handle_token` content-phase pipeline for the
+    /// two steps under test: the bare role-literal strip (guarded by the
+    /// detector's `inside_tool_call()`) feeding the surviving delta into the
+    /// streaming tool-call detector. Returns every `ToolCallStart` name.
+    fn stream_names(chunks: &[&str]) -> Vec<String> {
+        let mut det = StreamingToolDetector::new();
+        let mut names = Vec::new();
+        for &c in chunks {
+            let mut delta = c.to_string();
+            // Same call the real content phase makes, in the same order:
+            // read the detector's in-body flag BEFORE feeding this delta.
+            let inside_tool_call = det.inside_tool_call();
+            strip_bare_role_literal(&mut delta, inside_tool_call);
+            if delta.is_empty() {
+                continue;
+            }
+            for o in det.process(&delta) {
+                if let DetectorOutput::ToolCallStart { name, .. } = o {
+                    names.push(name);
+                }
+            }
+        }
+        for o in det.flush() {
+            if let DetectorOutput::ToolCallStart { name, .. } = o {
+                names.push(name);
+            }
+        }
+        names
+    }
+
+    /// Issue #222: a `tool_search` NAME whose leading `tool` arrives as a
+    /// standalone BPE fragment must stream intact, not truncate to `_search`.
+    #[test]
+    fn tool_search_name_split_after_tool_streams_intact() {
+        let names = stream_names(&[
+            "<tool_call>\n{\"name\": \"",
+            "tool", // standalone BPE fragment of the NAME
+            "_search\", \"arguments\": {\"query\": \"CRM\"}}",
+            "\n</tool_call>",
+        ]);
+        assert_eq!(names, vec!["tool_search".to_string()]);
+    }
+
+    /// `tool_call` — the name that collides most directly with the markup.
+    #[test]
+    fn tool_call_name_split_after_tool_streams_intact() {
+        let names = stream_names(&[
+            "<tool_call>\n{\"name\": \"",
+            "tool",
+            "_call\", \"arguments\": {}}",
+            "\n</tool_call>",
+        ]);
+        assert_eq!(names, vec!["tool_call".to_string()]);
+    }
+
+    /// `tool_describe` — same class, different suffix.
+    #[test]
+    fn tool_describe_name_split_after_tool_streams_intact() {
+        let names = stream_names(&[
+            "<tool_call>\n{\"name\": \"",
+            "tool",
+            "_describe\", \"arguments\": {\"id\": 7}}",
+            "\n</tool_call>",
+        ]);
+        assert_eq!(names, vec!["tool_describe".to_string()]);
+    }
+
+    /// Non-`tool_*` name fed in fragments must remain intact (control).
+    #[test]
+    fn ordinary_name_streams_intact() {
+        let names = stream_names(&[
+            "<tool_call>\n{\"name\": \"get",
+            "_weather\", \"arguments\": {\"city\": \"NYC\"}}",
+            "\n</tool_call>",
+        ]);
+        assert_eq!(names, vec!["get_weather".to_string()]);
+    }
+
+    /// The #204/#205/#206 leak suppression the guard must NOT regress: a bare
+    /// role literal in genuine content (no tool call in flight) is still
+    /// cleared. Verified for all three literals and for a `tool` fragment
+    /// that is only a real leak when `inside_tool_call == false`.
+    #[test]
+    fn bare_role_literal_still_stripped_outside_tool_call() {
+        for lit in ["user", "assistant", "tool", "  tool  "] {
+            let mut d = lit.to_string();
+            strip_bare_role_literal(&mut d, false);
+            assert!(
+                d.is_empty(),
+                "bare role literal {lit:?} must be stripped in content"
+            );
+        }
+    }
+
+    /// Inside a tool-call body the same fragments must survive untouched.
+    #[test]
+    fn bare_role_literal_preserved_inside_tool_call() {
+        for lit in ["user", "assistant", "tool"] {
+            let mut d = lit.to_string();
+            strip_bare_role_literal(&mut d, true);
+            assert_eq!(d, lit, "fragment {lit:?} must survive inside a tool call");
+        }
+    }
+
+    /// Ordinary content (not a bare role literal) is never touched, in or out
+    /// of a tool call.
+    #[test]
+    fn ordinary_content_untouched() {
+        for inside in [false, true] {
+            let mut d = "the tool ran".to_string();
+            strip_bare_role_literal(&mut d, inside);
+            assert_eq!(d, "the tool ran");
+        }
     }
 }

--- a/crates/spark-server/src/tool_parser/streaming_impl.rs
+++ b/crates/spark-server/src/tool_parser/streaming_impl.rs
@@ -438,6 +438,18 @@ impl StreamingToolDetector {
         self.call_counter > 0
     }
 
+    /// True while the detector is between a `<tool_call>` opener and its
+    /// matching close — i.e. accumulating a tool-call body. Callers use this
+    /// to suppress content-level scrubbing (e.g. the bare role-literal strip
+    /// in `handle_token`) that would otherwise eat a legitimate name/argument
+    /// fragment. A standalone `tool` BPE token inside the body is the leading
+    /// fragment of a `tool_*`-prefixed NAME (`tool_search`, `tool_call`,
+    /// `tool_describe`) being reassembled across token boundaries — dropping
+    /// it truncates the streamed name by exactly `len("tool")` == 4 chars.
+    pub fn inside_tool_call(&self) -> bool {
+        self.inside_tag
+    }
+
     /// Returns safe byte length to emit without splitting a partial tag.
     /// Holds back content that could be the start of `<tool_call>` or bare `<function`.
     fn safe_emit_len(&self) -> usize {


### PR DESCRIPTION
Fixes #222.

## Problem
When **streaming** with tool_choice auto, the streamed tool-call **name** drops its leading `tool` (exactly 4 chars) for any name that collides with the `<tool_call>` markup:

| requested | streamed (before) |
|---|---|
| `tool_search` | `_search` |
| `tool_describe` | `_describe` |
| `tool_call` | `_call` |

Non-streaming returns the correct full name. Parser-independent (repro'd with both `qwen3_coder` and `hermes`), name-specific (`findManyCompanies`/`create_document`/`get_weather` stream fine), streaming-only.

## Root cause
The bare role-literal strip in `handle_token_inner` (`crates/spark-server/src/api/chat_stream/handle_token.rs`), added for the #204/#205/#206 streaming leak-marker suppression, clears any content delta that trims to exactly `"user"` / `"assistant"` / `"tool"` (to drop hallucinated bare role words). Qwen's byte-level BPE tokenizer emits a **standalone `tool` token** as the leading fragment of any `tool_*`-prefixed name. That delta is cleared **before** it reaches the streaming tool-call detector, which then reassembles the name from the remaining `_search` fragment — so `ToolCallStart` carries the truncated name. Exactly `len("tool") == 4` chars, hence the symptom. Confirmed empirically: replaying the pipeline with the old logic emits `_search` for input `tool_search`; with the fix it emits `tool_search`.

## Fix
Surgical, 2 files:
- `tool_parser/streaming_impl.rs`: add `StreamingToolDetector::inside_tool_call()` accessor (is the detector mid `<tool_call>` body).
- `api/chat_stream/handle_token.rs`: extract the strip into `strip_bare_role_literal(delta, inside_tool_call)` that **early-returns when `inside_tool_call` is true**; the call site passes `state.detector.as_ref().is_some_and(|d| d.inside_tool_call())`. Outside a tool call the leak strip is unchanged; tool **arguments** and non-`tool_*` names are never touched.

## Tests
7 new tests (`role_literal_strip_tests` in `handle_token.rs`):
- `tool_search` / `tool_call` / `tool_describe` split right after `tool` stream intact (through the real detector + real strip in `handle_token` order).
- `get_weather` control still streams intact.
- Bare role words (`user`/`assistant`/`tool`) still stripped in genuine content — protects the #204/#205/#206 leak suppression.
- Boundary cases (preserved inside a tool call, ordinary content untouched).

`cargo test -p spark-server`: **530 passed, 0 failed**, no regressions in the sanitizer/leak-marker suite (`api/tests/sanitizer.rs`).

## Repro (from the issue)
```python
tools = [{"type":"function","function":{"name":"tool_search","description":"Search for tools",
    "parameters":{"type":"object","properties":{"query":{"type":"string"}}}}}]
# stream=True + tool_choice auto → before: '_search' ; after: 'tool_search'
```