### PR TITLE
  fix(dflash): implement free_state — free ctx_hidden_acc (~241 MiB/req measured) and reclaim drafter KV blocks

### DIFF
--- a/crates/spark-model/src/layers/deepseek_v4_mtp.rs
+++ b/crates/spark-model/src/layers/deepseek_v4_mtp.rs
@@ -553,7 +553,7 @@ impl DraftProposer for DeepseekV4MtpHead {
         Ok(())
     }
 
-    fn free_state(&self, state: &mut dyn ProposerState) -> Result<()> {
+    fn free_state(&self, _gpu: &dyn GpuBackend, state: &mut dyn ProposerState) -> Result<()> {
         let v4_state = state
             .as_any_mut()
             .downcast_mut::<DeepseekV4MtpProposerState>()

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -264,7 +264,7 @@ mod propose;
 impl DraftProposer for BlockDiffusionDraftHead {
     fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn ProposerState>> {
         // Per-seq ctx accumulator: `[max_seq_len, 5 * target_hidden] BF16`.
-        // Sized once, re-used across the seq's lifetime; reset on
+        // Sized once, re-used across the seq's lifetime; freed in
         // `free_state`. At max_seq_len=16384 and 5×2048 BF16: 320 MB per
         // seq — tolerable on a single Spark with max_batch_size=1; for
         // higher batch we may want to reduce to a smaller working window.
@@ -331,9 +331,31 @@ impl DraftProposer for BlockDiffusionDraftHead {
         Ok(())
     }
 
-    fn free_state(&self, _state: &mut dyn ProposerState) -> Result<()> {
-        // Phase 1: nothing to free (no allocated KV blocks yet). Phase 2
-        // reclaims paged blocks across all drafter layers.
+    fn free_state(&self, gpu: &dyn GpuBackend, state: &mut dyn ProposerState) -> Result<()> {
+        let dstate = state
+            .as_any_mut()
+            .downcast_mut::<DflashProposerState>()
+            .ok_or_else(|| anyhow::anyhow!("Invalid DFlash proposer state"))?;
+        // Reclaim drafter KV blocks (mirrors MtpHead::free_state). The table
+        // is empty today — propose() does not yet allocate paged blocks — but
+        // this closes the leak class for the paged drafter path.
+        if !dstate.block_table.is_empty() {
+            self.kv_cache.lock().free_blocks(&dstate.block_table);
+            dstate.block_table.clear();
+        }
+        // Free the per-seq ctx accumulator — the dominant per-request
+        // allocation (`max_seq_len × 5 × target_hidden` BF16; ~320 MB at
+        // max_seq_len=16384). `DevicePtr` has no Drop, so without this every
+        // finished sequence leaks it for the server's lifetime. Guarded on a
+        // non-null pointer so a double free_state is a no-op.
+        if dstate.ctx_hidden_acc.0 != 0 {
+            gpu.free(dstate.ctx_hidden_acc)?;
+            dstate.ctx_hidden_acc = DevicePtr(0);
+        }
+        dstate.seq_len = 0;
+        dstate.ctx_len = 0;
+        dstate.prefill_done = false;
+        dstate.last_num_drafted = 0;
         Ok(())
     }
 }

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -353,7 +353,7 @@ impl DraftProposer for MtpHead {
         Ok(())
     }
 
-    fn free_state(&self, state: &mut dyn ProposerState) -> Result<()> {
+    fn free_state(&self, _gpu: &dyn GpuBackend, state: &mut dyn ProposerState) -> Result<()> {
         let mtp_state = state
             .as_any_mut()
             .downcast_mut::<MtpProposerState>()

--- a/crates/spark-model/src/layers/mtp_multi.rs
+++ b/crates/spark-model/src/layers/mtp_multi.rs
@@ -213,7 +213,7 @@ impl DraftProposer for MultiModuleMtpHead {
         Ok(())
     }
 
-    fn free_state(&self, state: &mut dyn ProposerState) -> Result<()> {
+    fn free_state(&self, _gpu: &dyn GpuBackend, state: &mut dyn ProposerState) -> Result<()> {
         let mm_state = state
             .as_any_mut()
             .downcast_mut::<MultiModuleMtpState>()

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -213,11 +213,11 @@ impl TransformerModel {
             }
         }
 
-        // Free MTP proposer state (KV cache blocks).
+        // Free proposer state (KV cache blocks + per-seq device buffers).
         if let Some(ref proposer) = self.proposer
             && let Some(ref mut pstate) = seq.proposer_state
         {
-            proposer.free_state(pstate.as_mut())?;
+            proposer.free_state(self.gpu.as_ref(), pstate.as_mut())?;
         }
 
         self.free_chunked_prefill_meta(seq)?;

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -82,11 +82,15 @@ pub trait DraftProposer: Send + Sync {
         stream: u64,
     ) -> Result<()>;
 
-    /// Free per-sequence proposer state (KV cache blocks, etc.).
+    /// Free per-sequence proposer state (KV cache blocks, device buffers, etc.).
     ///
     /// Must be called when a sequence is finished to avoid resource leaks.
-    fn free_state(&self, state: &mut dyn ProposerState) -> Result<()> {
-        let _ = state;
+    /// `gpu` is threaded in (symmetric with `alloc_state`) so implementations
+    /// can release raw device allocations stored on the state — `DevicePtr`
+    /// has no `Drop`, so anything `alloc_state` allocated leaks unless it is
+    /// explicitly freed here.
+    fn free_state(&self, gpu: &dyn GpuBackend, state: &mut dyn ProposerState) -> Result<()> {
+        let _ = (gpu, state);
         Ok(())
     }
 }


### PR DESCRIPTION
`BlockDiffusionDraftHead::free_state` was still the Phase-1 no-op stub, while `alloc_state` allocates a per-sequence ctx accumulator of `max_seq_len × 5 × target_hidden` BF16. `DevicePtr` has no `Drop`, so every finished request under `--dflash` leaked that buffer for the server's lifetime:

- at the in-code comment's example `--max-seq-len 16384`: ~320 MB / request
- at the current CLI default `--max-seq-len 32768`: ~640 MB / request

A long-lived `--dflash` server OOMs after a handful of requests.

## Changes

- Thread `gpu: &dyn GpuBackend` through `DraftProposer::free_state` (symmetric with `alloc_state`); the only call site (`free_sequence`, `trait_impl/sequence.rs`) already has `self.gpu` in scope. `MtpHead`, `MultiModuleMtpHead`, and `DeepseekV4MtpHead` take the parameter unused.
- `BlockDiffusionDraftHead::free_state` now:
  - frees `ctx_hidden_acc` (null-guarded, so a double call is a no-op),
  - reclaims `block_table` blocks via `kv_cache.free_blocks` — the table is empty on current main (`propose()` doesn't yet allocate paged drafter blocks), but this closes the leak class for the paged drafter path when it lands, mirroring `MtpHead::free_state`,
  - resets `seq_len` / `ctx_len` / `prefill_done` / `last_num_drafted`.

## Verification

Measured via system `free -m` — `nvidia-smi` memory queries return `[N/A]` on GB10 unified memory, and CUDA allocations don't appear in process RSS there, so system-wide used memory is the reproducible signal on this hardware.

Setup: Qwen3.6-27B-NVFP4 target + z-lab/Qwen3.6-27B-DFlash drafter, `--dflash --dflash-gamma 3 --max-seq-len 4096 --gpu-memory-utilization 0.55 --max-batch-size 1`, 5 sequential identical chat completions (300 tokens, temperature 0), identical launch for both builds.

Raw readings (fix branch tested first, then `main` baseline on the same box):

```
AFTER FIX
free -m | awk 'NR==2{print strftime("%H:%M:%S"), $3" MiB used, "$7" MiB available"}'
09:50:47 74204 MiB used, 50405 MiB available
AFTER 5 VOLVO TEST PROMPT RUNS:
09:54:14 74174 MiB used, 50435 MiB available


BEFORE FIX
09:59:23 74348 MiB used, 50262 MiB available
AFTER 5 VOLVO TEST PROMPT RUNS:
10:03:18 75554 MiB used, 49055 MiB available
```

Summary:

| Build | Before | After 5 requests | Retained |
|---|---|---|---|
| `main` @ 355c6e4 (stub) | 74,348 MiB | 75,554 MiB | **+1,206 MiB (~241 MiB/request), never freed** |
| this branch | 74,204 MiB | 74,174 MiB | **flat** (−30 MiB idle jitter) |

At the default `--max-seq-len 32768` the per-request retention is ~8× larger.

Root cause was identified during the June 10 review of `fix/dflash-verify-argmax-gate` (the argmax-gate half of that branch now lands via #218); this is the leak fix re-cut against current main as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)