### PR TITLE
feat(spark-runtime): CUTLASS Sm120 + FlashInfer prefill wrappers (opt-in, split from #203)

### DIFF
--- a/crates/spark-model/examples/fp4_mma_microproof.rs
+++ b/crates/spark-model/examples/fp4_mma_microproof.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! PHASE-1 MMA PROOF: hand-rolled Sm120 block-scaled FP4 MMA vs the CUTLASS
+//! collective.
+//!
+//! The simplest possible single-tile-looped [M,N,K] GEMM built on a hand-written
+//!   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3
+//! (kernel module `fp4_mma_microtest`, kernels `fp4_microtest_pack` +
+//! `fp4_microtest_mma`). NO cp.async, NO grouping, NO gate+up fusion.
+//!
+//! Oracle: spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t — the SAME Sm120
+//! block-scaled FP4 math. MUST agree cos >= 0.999 at M=64, N=1024, K=2048.
+//!
+//! Build (remote GB10):
+//!   cargo build --release -p spark-model --example fp4_mma_microproof \
+//!     --no-default-features --features "cuda gpu-examples"
+//! Run: target/release/examples/fp4_mma_microproof
+
+use anyhow::{Result, bail};
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+// ───────────────────────── deterministic PRNG ─────────────────────────
+struct Rng(u64);
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn unit(&mut self) -> f32 {
+        ((self.next_u64() >> 40) as f32) / ((1u64 << 24) as f32)
+    }
+    fn uniform(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.unit()
+    }
+}
+
+fn f32_to_bf16_bits(f: f32) -> u16 {
+    let bits = f.to_bits();
+    if (bits & 0x7FFF_FFFF) > 0x7F80_0000 {
+        return ((bits >> 16) | 0x0040) as u16;
+    }
+    let rounding_bias = 0x7FFF + ((bits >> 16) & 1);
+    (bits.wrapping_add(rounding_bias) >> 16) as u16
+}
+fn bf16_bits_to_f32(b: u16) -> f32 {
+    f32::from_bits((b as u32) << 16)
+}
+
+fn u16s_to_le(v: &[u16]) -> Vec<u8> {
+    v.iter().flat_map(|x| x.to_le_bytes()).collect()
+}
+fn upload_bytes(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len())?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+fn read_bf16(gpu: &dyn GpuBackend, ptr: DevicePtr, m: usize, n: usize) -> Result<Vec<u16>> {
+    let mut raw = vec![0u8; m * n * 2];
+    gpu.copy_d2h(ptr, &mut raw)?;
+    Ok(raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect())
+}
+
+fn cosine_u16(a: &[u16], b: &[u16]) -> f64 {
+    let (mut dot, mut na, mut nb) = (0f64, 0f64, 0f64);
+    for i in 0..a.len() {
+        let x = bf16_bits_to_f32(a[i]) as f64;
+        let y = bf16_bits_to_f32(b[i]) as f64;
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na > 0.0 && nb > 0.0 {
+        dot / (na.sqrt() * nb.sqrt())
+    } else {
+        0.0
+    }
+}
+
+fn main() -> Result<()> {
+    let (m, n, k) = (64usize, 1024usize, 2048usize);
+    let seed = 0x_5151_A7A7u64;
+    println!("=== Phase-1 hand-rolled Sm120 FP4 MMA microproof ===");
+    println!("M={m} N={n} K={k}; oracle = nvfp4_gemm_bf16_act_weight_t (same Sm120 FP4 math)");
+
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let gpu: &dyn GpuBackend = &backend;
+    let stream = gpu.create_stream()?;
+
+    let mut rng = Rng(seed);
+    let a_bf16: Vec<u16> = (0..m * k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-1.0, 1.0)))
+        .collect();
+    let b_bf16: Vec<u16> = (0..n * k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-0.5, 0.5)))
+        .collect();
+
+    let a_ptr = upload_bytes(gpu, &u16s_to_le(&a_bf16))?;
+    let b_ptr = upload_bytes(gpu, &u16s_to_le(&b_bf16))?;
+
+    // ── Oracle: CUTLASS collective. Pack B once into [K/2,N]/[K/16,N]. ──
+    let packed_len = (k / 2) * n;
+    let scale_len = (k / 16) * n;
+    let packed_ptr = gpu.alloc(packed_len)?;
+    let scale_ptr = gpu.alloc(scale_len)?;
+    spark_runtime::cutlass::pack_bf16_weight_to_nvfp4_t(
+        b_ptr.0,
+        packed_ptr.0,
+        scale_ptr.0,
+        n as u32,
+        k as u32,
+        stream,
+    )?;
+    gpu.synchronize(stream)?;
+
+    let out_oracle = gpu.alloc(m * n * 2)?;
+    spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t(
+        a_ptr.0,
+        packed_ptr.0,
+        scale_ptr.0,
+        1.0,
+        out_oracle.0,
+        m as u32,
+        n as u32,
+        k as u32,
+        stream,
+    )?;
+    gpu.synchronize(stream)?;
+    let c_oracle = read_bf16(gpu, out_oracle, m, n)?;
+
+    // ── Hand-rolled MMA path ──
+    // Pre-pass pack A[M][K] and B[N][K] into natural-layout packed+scales.
+    let pack_handle = gpu.kernel("fp4_mma_microtest", "fp4_microtest_pack")?;
+    let mma_handle = gpu.kernel("fp4_mma_microtest", "fp4_microtest_mma")?;
+
+    let a_packed = gpu.alloc((k / 2) * m)?;
+    let a_scales = gpu.alloc((k / 16) * m)?;
+    let b_packed = gpu.alloc((k / 2) * n)?;
+    let b_scales = gpu.alloc((k / 16) * n)?;
+
+    // pack A: grid (rows, groups/threads), block 128 over groups
+    let groups = (k / 16) as u32;
+    let pack_a = || -> Result<()> {
+        KernelLaunch::new(gpu, pack_handle)
+            .grid([m as u32, div_ceil(groups, 128), 1])
+            .block([128, 1, 1])
+            .arg_ptr(a_ptr)
+            .arg_ptr(a_packed)
+            .arg_ptr(a_scales)
+            .arg_u32(m as u32)
+            .arg_u32(k as u32)
+            .launch(stream)?;
+        Ok(())
+    };
+    let pack_b = || -> Result<()> {
+        KernelLaunch::new(gpu, pack_handle)
+            .grid([n as u32, div_ceil(groups, 128), 1])
+            .block([128, 1, 1])
+            .arg_ptr(b_ptr)
+            .arg_ptr(b_packed)
+            .arg_ptr(b_scales)
+            .arg_u32(n as u32)
+            .arg_u32(k as u32)
+            .launch(stream)?;
+        Ok(())
+    };
+    pack_a()?;
+    pack_b()?;
+    gpu.synchronize(stream)?;
+
+    let out_mma = gpu.alloc(m * n * 2)?;
+    let mma_launch = || -> Result<()> {
+        KernelLaunch::new(gpu, mma_handle)
+            .grid([div_ceil(n as u32, 8), div_ceil(m as u32, 16), 1])
+            .block([32, 1, 1])
+            .arg_ptr(a_packed)
+            .arg_ptr(a_scales)
+            .arg_ptr(b_packed)
+            .arg_ptr(b_scales)
+            .arg_ptr(out_mma)
+            .arg_u32(m as u32)
+            .arg_u32(n as u32)
+            .arg_u32(k as u32)
+            .launch(stream)?;
+        Ok(())
+    };
+    mma_launch()?;
+    gpu.synchronize(stream)?;
+    let c_mma = read_bf16(gpu, out_mma, m, n)?;
+
+    let cos = cosine_u16(&c_mma, &c_oracle);
+    println!();
+    println!("hand-rolled MMA  vs  CUTLASS collective  cosine = {cos:.6}");
+    // sample a few values
+    println!(
+        "sample [0][0..4]: mma={:?} oracle={:?}",
+        &c_mma[0..4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>(),
+        &c_oracle[0..4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>()
+    );
+    println!(
+        "sample [1][0..4]: mma={:?} oracle={:?}",
+        &c_mma[n..n + 4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>(),
+        &c_oracle[n..n + 4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>()
+    );
+
+    for p in [
+        a_ptr, b_ptr, packed_ptr, scale_ptr, out_oracle, a_packed, a_scales, b_packed, b_scales,
+        out_mma,
+    ] {
+        gpu.free(p).ok();
+    }
+
+    if cos >= 0.999 {
+        println!("\nPASS: cos {cos:.6} >= 0.999");
+        Ok(())
+    } else {
+        bail!("FAIL: cos {cos:.6} < 0.999");
+    }
+}

--- a/crates/spark-model/src/layers/moe/forward_prefill_routed.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_routed.rs
@@ -10,6 +10,16 @@
 
 use super::*;
 
+/// Whether the single-launch CUTLASS grouped NVFP4 gate_up path is enabled
+/// (`ATLAS_HOLO_MOE_GROUPED_CUTLASS=1`). Off by default; falls back to the
+/// hand-rolled fused FP4/FP8 grouped kernels when unset.
+fn grouped_cutlass_gate_up_enabled() -> bool {
+    std::env::var("ATLAS_HOLO_MOE_GROUPED_CUTLASS")
+        .ok()
+        .as_deref()
+        == Some("1")
+}
+
 impl MoeLayer {
     /// Routed-expert grouped-GEMM path: upper-bound grid sizing → grouped
     /// gate+up GEMM → SiLU+mul → grouped down GEMM.
@@ -116,7 +126,40 @@ impl MoeLayer {
         }
         if max_m_tiles > 0 {
             if let (Some(gp), Some(up)) = (&self.gate_ptrs_t, &self.up_ptrs_t) {
-                if self.gateup_fp4 && self.moe_fused_gate_up_t_k64_fp4.0 != 0 {
+                if grouped_cutlass_gate_up_enabled()
+                    && self.gate_sfb_cutlass.is_some()
+                    && self.up_sfb_cutlass.is_some()
+                {
+                    // ── SINGLE-LAUNCH CUTLASS grouped NVFP4 gate_up
+                    // (ATLAS_HOLO_MOE_GROUPED_CUTLASS=1) ── one
+                    // GemmUniversalMode::kGrouped launch over all active experts in
+                    // place of the per-expert collective loop. Weights: the decode
+                    // `gate_ptrs`/`up_ptrs` packed `[N,K/2]` (CUTLASS ColumnMajor B) +
+                    // the load-built swizzled SFB tables (`gate_sfb_cutlass`) + the real
+                    // per-expert scale2 (epilogue alpha). The token gather is FUSED into
+                    // the kernel's per-group A-pack (lever 2): pass token-major
+                    // expert_input + sorted_token_ids directly, no separate permute pass.
+                    // Writes C_gate/C_up in the sorted layout so silu+down+unpermute are
+                    // unchanged.
+                    ops::moe_grouped_gate_up_cutlass(
+                        ctx.gpu,
+                        expert_input,
+                        sorted_token_ids,
+                        self.gate_ptrs.packed_ptrs,
+                        self.gate_sfb_cutlass.expect("gate sfb checked above"),
+                        self.gate_ptrs.scale2_vals,
+                        self.up_ptrs.packed_ptrs,
+                        self.up_sfb_cutlass.expect("up sfb checked above"),
+                        self.up_ptrs.scale2_vals,
+                        expert_gate_out,
+                        expert_up_out,
+                        expert_offsets,
+                        num_experts as usize,
+                        inter,
+                        h,
+                        stream,
+                    )?;
+                } else if self.gateup_fp4 && self.moe_fused_gate_up_t_k64_fp4.0 != 0 {
                     // ── FUSED FP4 gate_up (ATLAS_HOLO_MOE_GATEUP_FP4) ──
                     // Block-scaled FP4 over the SHARED FAST_MOE=full [K/2,N] tables
                     // (gate_ptrs_t/up_ptrs_t — the SAME bytes the FP8 fused path
@@ -256,7 +299,30 @@ impl MoeLayer {
             // FP8/w4a16 down kernels, so unpermute downstream is unchanged.
             // Compounds with the FP4 gate_up path to run the whole FFN at FP4.
             if let Some(dp) = &self.down_ptrs_t {
-                if self.down_fp4 && self.moe_down_t_k64_fp4.0 != 0 {
+                if grouped_cutlass_gate_up_enabled()
+                    && self.down_sfb_cutlass.is_some()
+                    && std::env::var("ATLAS_HOLO_MOE_GROUPED_DOWN").ok().as_deref() == Some("1")
+                {
+                    // ── CUTLASS grouped NVFP4 down (ATLAS_HOLO_MOE_GROUPED_CUTLASS
+                    //    + ATLAS_HOLO_MOE_GROUPED_DOWN) ──
+                    // A = post-SiLU expert_gate_out, already expert-contiguous (the grouped
+                    // gate_up wrote it sorted), so NO gather. Weights = decode down_ptrs
+                    // packed [N=hidden,K/2] + load-built swizzled SFB + real scale2. Writes
+                    // expert_down_out in the sorted layout (unpermute downstream unchanged).
+                    ops::moe_grouped_down_cutlass(
+                        ctx.gpu,
+                        expert_gate_out,
+                        self.down_ptrs.packed_ptrs,
+                        self.down_sfb_cutlass.expect("down sfb checked above"),
+                        self.down_ptrs.scale2_vals,
+                        expert_down_out,
+                        expert_offsets,
+                        num_experts as usize,
+                        h,
+                        inter,
+                        stream,
+                    )?;
+                } else if self.down_fp4 && self.moe_down_t_k64_fp4.0 != 0 {
                     // ── FP4 down (ATLAS_HOLO_MOE_DOWN_FP4) over the SHARED down_ptrs_t
                     // [K/2,N] table (real per-expert scale2; coalesced K-major load +
                     // on-chip DN4_TRANSPOSE). Same sorted layout + null

--- a/crates/spark-model/src/layers/moe/helpers_a.rs
+++ b/crates/spark-model/src/layers/moe/helpers_a.rs
@@ -269,4 +269,67 @@ impl MoeLayer {
 
         Ok(())
     }
+
+    /// Build per-expert swizzled SFB weight-scale tables for the CUTLASS grouped
+    /// NVFP4 path (`ATLAS_HOLO_MOE_GROUPED_CUTLASS`). For each expert, swizzle the
+    /// `[K/16,N]` `gate_ptrs_t`/`up_ptrs_t` scale into the CUTLASS SFB atom via
+    /// `pack_weight_sfb`, then upload the per-expert pointer arrays. The grouped
+    /// kernel pairs these with `gate_ptrs.packed` (`[N,K/2]`) + the real per-expert
+    /// `scale2`. Requires FAST_MOE=full (gate_ptrs_t/up_ptrs_t present); no-op else.
+    pub fn build_cutlass_grouped_sfb(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        config: &atlas_core::config::ModelConfig,
+        stream: u64,
+    ) -> Result<()> {
+        let h = config.hidden_size;
+        let inter = config.moe_intermediate_size;
+        let num = self.weights.experts.len();
+        // Swizzled SFB atom size (bytes): round_up(N,128) * round_up(K/16,4).
+        let sfb_len = |n: usize, k: usize| n.div_ceil(128) * 128 * (k / 16).div_ceil(4) * 4;
+        let (gate_scale_dev, up_scale_dev) =
+            match (self.gate_ptrs_t.as_ref(), self.up_ptrs_t.as_ref()) {
+                (Some(g), Some(u)) => (g.scale_ptrs, u.scale_ptrs),
+                _ => return Ok(()),
+            };
+        let down_scale_dev = self.down_ptrs_t.as_ref().map(|d| d.scale_ptrs);
+        let mut owned: Vec<DevicePtr> = Vec::new();
+        // Swizzle each expert's [K/16,N] scale into the CUTLASS SFB atom. `n`/`k`
+        // are the projection's GEMM dims: gate/up = (inter, hidden); down = (hidden, inter).
+        let mut build_one = |scale_ptrs_dev: DevicePtr, n: usize, k: usize| -> Result<DevicePtr> {
+            let len = sfb_len(n, k);
+            let mut sp = vec![0u8; num * 8];
+            gpu.copy_d2h(scale_ptrs_dev, &mut sp)?;
+            let scale_ptrs: Vec<u64> = sp
+                .chunks_exact(8)
+                .map(|c| u64::from_le_bytes(c.try_into().expect("8 bytes")))
+                .collect();
+            let mut sfb_ptrs = vec![0u64; num];
+            for (e, &sptr) in scale_ptrs.iter().enumerate() {
+                if sptr == 0 {
+                    continue; // remote/placeholder expert
+                }
+                let sfb = gpu.alloc(len)?;
+                spark_runtime::cutlass::pack_weight_sfb(sptr, sfb.0, n as u32, k as u32, stream)?;
+                sfb_ptrs[e] = sfb.0;
+                owned.push(sfb);
+            }
+            gpu.synchronize(stream)?;
+            let bytes: Vec<u8> = sfb_ptrs.iter().flat_map(|p| p.to_le_bytes()).collect();
+            let arr = gpu.alloc(bytes.len().max(8))?;
+            gpu.copy_h2d(&bytes, arr)?;
+            owned.push(arr);
+            Ok(arr)
+        };
+        self.gate_sfb_cutlass = Some(build_one(gate_scale_dev, inter, h)?);
+        self.up_sfb_cutlass = Some(build_one(up_scale_dev, inter, h)?);
+        if let Some(ds) = down_scale_dev {
+            self.down_sfb_cutlass = Some(build_one(ds, h, inter)?);
+        }
+        self._cutlass_sfb_owned = owned;
+        tracing::info!(
+            "CUTLASS grouped SFB: built {num} experts gate/up (N={inter} K={h}) + down (N={h} K={inter})"
+        );
+        Ok(())
+    }
 }

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -197,6 +197,10 @@ impl MoeLayer {
             gate_ptrs_t: None,
             up_ptrs_t: None,
             down_ptrs_t: None,
+            gate_sfb_cutlass: None,
+            up_sfb_cutlass: None,
+            down_sfb_cutlass: None,
+            _cutlass_sfb_owned: Vec::new(),
             down_t_scratch_packed: None,
             down_t_scratch_scale: None,
             moe_transpose_u8_batched_k: gpu

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -128,6 +128,17 @@ pub struct MoeLayer {
     gate_ptrs_t: Option<ExpertPtrTable>,
     up_ptrs_t: Option<ExpertPtrTable>,
     down_ptrs_t: Option<ExpertPtrTable>,
+    /// CUTLASS grouped-NVFP4 swizzled SFB weight-scale tables
+    /// (`ATLAS_HOLO_MOE_GROUPED_CUTLASS`). Device `[num_experts]` u64 arrays of
+    /// per-expert SFB pointers, built at load by `build_cutlass_grouped_sfb` from
+    /// the `gate_ptrs_t`/`up_ptrs_t` `[K/16,N]` scales (`pack_weight_sfb` swizzle).
+    /// The grouped kernel reads `gate_ptrs.packed` (`[N,K/2]`) + these SFB + the
+    /// real per-expert `scale2`. `None` => the CUTLASS grouped path is unavailable.
+    gate_sfb_cutlass: Option<DevicePtr>,
+    up_sfb_cutlass: Option<DevicePtr>,
+    down_sfb_cutlass: Option<DevicePtr>,
+    /// Keeps the per-expert SFB buffers + the two pointer arrays alive.
+    _cutlass_sfb_owned: Vec<DevicePtr>,
     /// Lazy down_proj transpose scratch — populated at the start of each
     /// prefill call when the persistent transpose pass couldn't fit
     /// down_proj. Decode keeps using `down_ptrs` (untransposed); prefill

--- a/crates/spark-model/src/layers/ops/dispatch_helpers.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_helpers.rs
@@ -42,6 +42,66 @@ pub fn cublas_fp8_enabled() -> bool {
     *EN.get_or_init(|| std::env::var("ATLAS_CUBLAS_FP8").ok().as_deref() == Some("1"))
 }
 
+/// CUTLASS GEMM path enabled? (`ATLAS_CUTLASS_GEMM=1`), cached. M0 is scoped to
+/// dense BF16 projections using the same FP8→BF16 cached dequant as cuBLASLt.
+pub fn cutlass_gemm_enabled() -> bool {
+    use std::sync::OnceLock;
+    static EN: OnceLock<bool> = OnceLock::new();
+    *EN.get_or_init(|| std::env::var("ATLAS_CUTLASS_GEMM").ok().as_deref() == Some("1"))
+}
+
+/// Native CUTLASS NVFP4 GEMM path enabled? (`ATLAS_CUTLASS_NVFP4_GEMM=1`).
+/// This path quantizes activations to CUTLASS NVFP4 and consumes transposed
+/// Atlas NVFP4 weights after repacking scales into CUTLASS SM120 layout.
+pub fn cutlass_nvfp4_gemm_enabled() -> bool {
+    use std::sync::OnceLock;
+    static EN: OnceLock<bool> = OnceLock::new();
+    *EN.get_or_init(|| std::env::var("ATLAS_CUTLASS_NVFP4_GEMM").ok().as_deref() == Some("1"))
+}
+
+fn cutlass_nvfp4_flag_enabled(name: &str) -> bool {
+    std::env::var(name).ok().as_deref() == Some("1")
+}
+
+/// Native CUTLASS NVFP4 SSM QKVZ path enabled.
+pub fn cutlass_nvfp4_qkvz_enabled() -> bool {
+    cutlass_nvfp4_gemm_enabled() || cutlass_nvfp4_flag_enabled("ATLAS_CUTLASS_NVFP4_QKVZ")
+}
+
+/// Native CUTLASS NVFP4 attention Q/K/V path enabled for the named projection.
+pub fn cutlass_nvfp4_attn_qkv_enabled(label: &str) -> bool {
+    cutlass_nvfp4_gemm_enabled()
+        || match label {
+            "q_proj" => cutlass_nvfp4_flag_enabled("ATLAS_CUTLASS_NVFP4_ATTN_Q"),
+            "k_proj" | "v_proj" => cutlass_nvfp4_flag_enabled("ATLAS_CUTLASS_NVFP4_ATTN_KV"),
+            _ => false,
+        }
+}
+
+/// Native CUTLASS NVFP4 attention O path enabled.
+pub fn cutlass_nvfp4_attn_o_enabled() -> bool {
+    cutlass_nvfp4_gemm_enabled() || cutlass_nvfp4_flag_enabled("ATLAS_CUTLASS_NVFP4_ATTN_O")
+}
+
+/// Native CUTLASS NVFP4 SSM out-projection path enabled.
+pub fn cutlass_nvfp4_ssm_out_enabled() -> bool {
+    cutlass_nvfp4_flag_enabled("ATLAS_CUTLASS_NVFP4_SSM_OUT")
+}
+
+pub fn log_cutlass_nvfp4_route(name: &str, m: u32, n: u32, k: u32) {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static SEEN: OnceLock<Mutex<HashSet<(u64, u32, u32, u32)>>> = OnceLock::new();
+    let mut h: u64 = 1469598103934665603;
+    for b in name.bytes() {
+        h = (h ^ b as u64).wrapping_mul(1099511628211);
+    }
+    let seen = SEEN.get_or_init(|| Mutex::new(HashSet::new()));
+    if seen.lock().unwrap().insert((h, m, n, k)) {
+        tracing::warn!("CUTLASS_NVFP4_ROUTE {name} M={m} N={n} K={k}");
+    }
+}
+
 /// Roofline instrumentation: log each unique (kernel, M, N, K) GEMM shape once,
 /// gated by `ATLAS_GEMM_SHAPE_LOG=1`. Used to cross-reference nsys per-call
 /// durations → achieved TFLOPS/bandwidth vs GB10 peak.

--- a/crates/spark-model/src/layers/ops/dispatch_proj.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_proj.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! cuBLAS projection routers + their cached weight-prep helpers.
+//! cuBLAS / CUTLASS projection routers + their cached weight-prep helpers.
 //! Extracted from `dispatch_helpers.rs` during the ≤500-line split. Re-exported
 //! at `crate::layers::ops::*` via `ops.rs`.
 
@@ -211,6 +211,36 @@ fn dequant_fp8_bf16_cached(
     Ok(out.0)
 }
 
+fn dequant_fp8_bf16_uncached(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    fp8w: &crate::weight_map::Fp8Weight,
+    stream: u64,
+) -> anyhow::Result<spark_runtime::gpu::DevicePtr> {
+    use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+    let (n, kk) = (fp8w.n, fp8w.k);
+    let out = gpu.alloc(n as usize * kk as usize * 2)?;
+    let block = 128u32;
+    let sk = kk / block;
+    let kernel = gpu.kernel(
+        "dequant_fp8_blockscaled_bf16",
+        "dequant_fp8_blockscaled_bf16",
+    )?;
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(kk, 64), div_ceil(n, 4), 1])
+        .block([64, 4, 1])
+        .arg_ptr(fp8w.weight)
+        .arg_ptr(fp8w.row_scale)
+        .arg_ptr(out)
+        .arg_u32(n)
+        .arg_u32(kk)
+        .arg_u32(block)
+        .arg_u32(block)
+        .arg_u32(sk)
+        .arg_u32(1)
+        .launch(stream)?;
+    Ok(out)
+}
+
 /// Route a projection `out[M,N] = act[M,K] @ weightᵀ` through cuBLASLt BF16.
 /// The FP8 weight is dequantized to BF16 once (cached); W16A16 here is strictly
 /// more accurate than the blockscaled W8A8 path it replaces.
@@ -227,4 +257,127 @@ pub fn cublas_bf16_proj(
 ) -> anyhow::Result<()> {
     let w_bf16 = dequant_fp8_bf16_cached(gpu, fp8w, stream)?;
     spark_runtime::cublaslt::bf16_gemm_act_weight_t(act.0, w_bf16, out.0, m, n, k, stream)
+}
+
+/// Route a projection `out[M,N] = act[M,K] @ weightᵀ` through CUTLASS BF16.
+/// This is the M0 de-risk path for replacing Atlas/cuBLAS GEMMs with
+/// CUTLASS-backed kernels on GB10; keep it behind `ATLAS_CUTLASS_GEMM=1`.
+#[allow(clippy::too_many_arguments)]
+pub fn cutlass_bf16_proj(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    act: spark_runtime::gpu::DevicePtr,
+    fp8w: &crate::weight_map::Fp8Weight,
+    out: spark_runtime::gpu::DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> anyhow::Result<()> {
+    let w_bf16 = dequant_fp8_bf16_cached(gpu, fp8w, stream)?;
+    spark_runtime::cutlass::bf16_gemm_act_weight_t(act.0, w_bf16, out.0, m, n, k, stream)
+}
+
+/// Route a projection `out[M,N] = act[M,K] @ weightᵀ` through native CUTLASS
+/// NVFP4. The activation is packed to CUTLASS NVFP4 inside the runtime wrapper.
+/// `weight_t` must be Atlas's transposed NVFP4 layout `[K/2,N]` plus
+/// `[K/16,N]` scales, as produced by `QuantizedWeight::transpose_for_gemm`.
+#[allow(clippy::too_many_arguments)]
+/// Transpose a native NVFP4 checkpoint weight from Atlas `[K/2,N]` into the
+/// CUTLASS `[N,K/2]` byte layout the GEMM consumes, caching the result by
+/// source weight ptr. Without this the ColumnMajor B operand is read
+/// transposed and the GEMM produces garbage (cos≈0 vs reference).
+fn cutlass_nvfp4_weight_transposed_cached(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    weight_t: &crate::weight_map::QuantizedWeight,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> anyhow::Result<u64> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<HashMap<u64, u64>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(&p) = cache.lock().unwrap().get(&weight_t.weight.0) {
+        return Ok(p);
+    }
+    let dst = gpu.alloc((n as usize) * (k as usize) / 2)?;
+    spark_runtime::cutlass::transpose_nvfp4_packed_kton(weight_t.weight.0, dst.0, n, k, stream)?;
+    gpu.synchronize(stream)?;
+    cache.lock().unwrap().insert(weight_t.weight.0, dst.0);
+    Ok(dst.0)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn cutlass_nvfp4_proj(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    act: spark_runtime::gpu::DevicePtr,
+    weight_t: &crate::weight_map::QuantizedWeight,
+    out: spark_runtime::gpu::DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> anyhow::Result<()> {
+    let packed = cutlass_nvfp4_weight_transposed_cached(gpu, weight_t, n, k, stream)?;
+    spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t(
+        act.0,
+        packed,
+        weight_t.weight_scale.0,
+        weight_t.weight_scale_2,
+        out.0,
+        m,
+        n,
+        k,
+        stream,
+    )
+}
+
+fn cutlass_nvfp4_weight_from_fp8_cached(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    fp8w: &crate::weight_map::Fp8Weight,
+    stream: u64,
+) -> anyhow::Result<(u64, u64)> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<HashMap<u64, (u64, u64)>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(&p) = cache.lock().unwrap().get(&fp8w.weight.0) {
+        return Ok(p);
+    }
+
+    let n = fp8w.n as usize;
+    let k = fp8w.k as usize;
+    let w_bf16 = dequant_fp8_bf16_uncached(gpu, fp8w, stream)?;
+    let packed_t = gpu.alloc(n * k / 2)?;
+    let scale_t = gpu.alloc(n * k / 16)?;
+    spark_runtime::cutlass::pack_bf16_weight_to_nvfp4_t(
+        w_bf16.0, packed_t.0, scale_t.0, fp8w.n, fp8w.k, stream,
+    )?;
+    gpu.synchronize(stream)?;
+    gpu.free(w_bf16)?;
+    cache
+        .lock()
+        .unwrap()
+        .insert(fp8w.weight.0, (packed_t.0, scale_t.0));
+    Ok((packed_t.0, scale_t.0))
+}
+
+/// Native CUTLASS NVFP4 projection for FP8 checkpoint weights. The FP8 weight
+/// is dequantized to BF16 using the existing cache, then packed once into
+/// Atlas-transposed NVFP4 data/scales and reused for future calls.
+#[allow(clippy::too_many_arguments)]
+pub fn cutlass_nvfp4_proj_from_fp8(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    act: spark_runtime::gpu::DevicePtr,
+    fp8w: &crate::weight_map::Fp8Weight,
+    out: spark_runtime::gpu::DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> anyhow::Result<()> {
+    let (packed_t, scale_t) = cutlass_nvfp4_weight_from_fp8_cached(gpu, fp8w, stream)?;
+    spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t(
+        act.0, packed_t, scale_t, 1.0, out.0, m, n, k, stream,
+    )
 }

--- a/crates/spark-model/src/layers/ops/moe_grouped_a2.rs
+++ b/crates/spark-model/src/layers/ops/moe_grouped_a2.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! MoE token-routing reduce ops — extracted from `moe_grouped_a.rs` during the
-//! ≤500-line split. All public items remain available at
-//! `crate::layers::ops::*` via the re-export in `ops.rs`.
+//! MoE token-routing reduce + CUTLASS grouped ops — extracted from
+//! `moe_grouped_a.rs` during the ≤500-line split. All public items remain
+//! available at `crate::layers::ops::*` via the re-export in `ops.rs`.
 
 #![allow(unused_imports)]
 
@@ -101,4 +101,136 @@ pub fn moe_batched_blend(
         .arg_u32(hidden_size)
         .arg_u32(num_tokens)
         .launch(stream)
+}
+
+/// Single-launch CUTLASS grouped NVFP4 fused gate_up GEMM (Phase-2).
+///
+/// Bridges the device-resident per-expert pointer/scale tables to the host-side
+/// [`spark_runtime::cutlass::nvfp4_grouped_gate_up_fused`] entry. `a` is the
+/// expert-contiguous bf16 activation `[total_expanded, k]`. `gate_packed`/
+/// `gate_sfb`/`up_packed`/`up_sfb` are device `[num_experts]` u64 pointer arrays
+/// (into the CUTLASS-layout weight + swizzled-SFB tables); `gate_scale2`/
+/// `up_scale2` are device `[num_experts]` f32 arrays; `expert_offsets` is the
+/// device i32 `[num_experts+1]` prefix sum. This op copies all of those host-side
+/// (the C entry indexes offsets/scale2 on the host and needs the pointer values),
+/// syncs the stream so they are valid, then dispatches the single grouped launch.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_grouped_gate_up_cutlass(
+    gpu: &dyn GpuBackend,
+    a: DevicePtr,
+    sorted_token_ids: DevicePtr,
+    gate_packed: DevicePtr,
+    gate_sfb: DevicePtr,
+    gate_scale2: DevicePtr,
+    up_packed: DevicePtr,
+    up_sfb: DevicePtr,
+    up_scale2: DevicePtr,
+    c_gate: DevicePtr,
+    c_up: DevicePtr,
+    expert_offsets: DevicePtr,
+    num_experts: usize,
+    inter: u32,
+    hidden: u32,
+    stream: u64,
+) -> Result<()> {
+    let read_u64 = |p: DevicePtr| -> Result<Vec<u64>> {
+        let mut raw = vec![0u8; num_experts * 8];
+        gpu.copy_d2h_on_stream(p, &mut raw, stream)?;
+        Ok(raw
+            .chunks_exact(8)
+            .map(|c| u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+            .collect())
+    };
+    let read_f32 = |p: DevicePtr| -> Result<Vec<f32>> {
+        let mut raw = vec![0u8; num_experts * 4];
+        gpu.copy_d2h_on_stream(p, &mut raw, stream)?;
+        Ok(raw
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect())
+    };
+
+    let gate_packed_h = read_u64(gate_packed)?;
+    let gate_sfb_h = read_u64(gate_sfb)?;
+    let up_packed_h = read_u64(up_packed)?;
+    let up_sfb_h = read_u64(up_sfb)?;
+    let gate_scale2_h = read_f32(gate_scale2)?;
+    let up_scale2_h = read_f32(up_scale2)?;
+
+    let mut off_raw = vec![0u8; (num_experts + 1) * 4];
+    gpu.copy_d2h_on_stream(expert_offsets, &mut off_raw, stream)?;
+    // The pointer/scale/offset host snapshots above are needed by the C entry
+    // before it can launch — make sure the async D2H copies have landed.
+    gpu.synchronize(stream)?;
+    let eoff: Vec<i32> = off_raw
+        .chunks_exact(4)
+        .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+
+    spark_runtime::cutlass::nvfp4_grouped_gate_up_fused(
+        a.0,
+        sorted_token_ids.0,
+        &gate_packed_h,
+        &gate_sfb_h,
+        &gate_scale2_h,
+        &up_packed_h,
+        &up_sfb_h,
+        &up_scale2_h,
+        c_gate.0,
+        c_up.0,
+        &eoff,
+        inter,
+        hidden,
+        stream,
+    )
+}
+
+/// Single-launch CUTLASS grouped NVFP4 DOWN projection. `a` is the post-SiLU
+/// intermediate `[total_expanded, inter]` (already expert-contiguous — no gather).
+/// `packed`/`sfb` are device `[num_experts]` u64 pointer arrays into the
+/// `[N=hidden,K/2]` down packed + swizzled-SFB tables; `scale2` is the device
+/// `[num_experts]` f32 array; `expert_offsets` is the device i32 `[num_experts+1]`
+/// prefix sum. Snapshots the pointer/offset tables host-side, then dispatches.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_grouped_down_cutlass(
+    gpu: &dyn GpuBackend,
+    a: DevicePtr,
+    packed: DevicePtr,
+    sfb: DevicePtr,
+    scale2: DevicePtr,
+    c: DevicePtr,
+    expert_offsets: DevicePtr,
+    num_experts: usize,
+    hidden: u32,
+    inter: u32,
+    stream: u64,
+) -> Result<()> {
+    let mut praw = vec![0u8; num_experts * 8];
+    gpu.copy_d2h_on_stream(packed, &mut praw, stream)?;
+    let mut sraw = vec![0u8; num_experts * 8];
+    gpu.copy_d2h_on_stream(sfb, &mut sraw, stream)?;
+    let mut s2raw = vec![0u8; num_experts * 4];
+    gpu.copy_d2h_on_stream(scale2, &mut s2raw, stream)?;
+    let mut off_raw = vec![0u8; (num_experts + 1) * 4];
+    gpu.copy_d2h_on_stream(expert_offsets, &mut off_raw, stream)?;
+    gpu.synchronize(stream)?;
+    let packed_h: Vec<u64> = praw
+        .chunks_exact(8)
+        .map(|c| u64::from_le_bytes(c.try_into().expect("8")))
+        .collect();
+    let sfb_h: Vec<u64> = sraw
+        .chunks_exact(8)
+        .map(|c| u64::from_le_bytes(c.try_into().expect("8")))
+        .collect();
+    let scale2_h: Vec<f32> = s2raw
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes(c.try_into().expect("4")))
+        .collect();
+    let eoff: Vec<i32> = off_raw
+        .chunks_exact(4)
+        .map(|c| i32::from_le_bytes(c.try_into().expect("4")))
+        .collect();
+    spark_runtime::cutlass::nvfp4_grouped_down(
+        a.0, &packed_h, &sfb_h, &scale2_h, c.0, &eoff, hidden, inter, stream,
+    )
 }

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -169,7 +169,17 @@ impl Qwen3AttentionLayer {
 
         let use_t_pipelined =
             std::env::var("ATLAS_ATTN_PREFILL_T_PIPE").ok().as_deref() == Some("1");
-        if ops::cublas_gemm_enabled()
+        if ops::cutlass_nvfp4_attn_qkv_enabled(label)
+            && let Some(nvfp4_t) = nvfp4_t
+        {
+            ops::log_cutlass_nvfp4_route(label, n, out_dim, h);
+            ops::cutlass_nvfp4_proj(ctx.gpu, normed, nvfp4_t, out, n, out_dim, h, stream)?;
+        } else if ops::cutlass_nvfp4_attn_qkv_enabled(label)
+            && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8())
+        {
+            ops::log_cutlass_nvfp4_route(label, n, out_dim, h);
+            ops::cutlass_nvfp4_proj_from_fp8(ctx.gpu, normed, fp8w, out, n, out_dim, h, stream)?;
+        } else if ops::cublas_gemm_enabled()
             && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8())
         {
             // cuBLASLt BF16 (3x the hand-written mma.sync GEMM on GB10).

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged.rs
@@ -509,23 +509,77 @@ impl Qwen3AttentionLayer {
                 .launch(stream)?;
         }
         if let Some(bmeta) = batched_meta {
-            // Q12 Path B: batched paged-prefill attention. The kernel reads
-            // Q/O at per-batch offsets internally via blockIdx.z and uses
-            // block_table_ptrs[b] for each stream's paged KV pages.
-            let args = super::paged_attn_batched::PagedAttnBatchedArgs {
-                q_contiguous,
-                attn_out,
-                seq_len_start,
-                nq,
-                nkv,
-                hd,
-                bs,
-                inv_sqrt_d,
-                kv_len,
-                batched_meta: bmeta,
-                stream,
-            };
-            self.prefill_attention_paged_attn_batched(kv_cache, ctx, &args)?;
+            // Cross-request prefill via FlashInfer ragged/varlen attention
+            // (ATLAS_FLASHINFER_PREFILL=1): the fresh contiguous, post-RoPE
+            // Q/K/V already match FlashInfer's [rows, heads, 256] layout, so ONE
+            // varlen launch runs all N co-dispatched requests' causal
+            // self-attention — replacing the slow paged batched kernel (the
+            // reason co-dispatch flatlined). Chunk-0 only (seq_len_start==0):
+            // later chunks need the cached prefix, which isn't in the fresh
+            // buffers. BF16 / no-WHT only; head_dim 256.
+            let use_flashinfer = seq_len_start == 0
+                && hd == 256
+                && !k_is_turbo
+                && !v_is_turbo
+                && spark_runtime::flashinfer::available()
+                && std::env::var("ATLAS_FLASHINFER_PREFILL").ok().as_deref() == Some("1");
+            if use_flashinfer {
+                // VARLEN: real per-request cu_seqlens from the staged metadata
+                // (host + device copies) — works for both uniform and varied
+                // request lengths. For chunk-0 self-attention qo_indptr==kv_indptr.
+                let batch = bmeta.batch_size as usize;
+                let total = bmeta.total_tokens;
+                let indptr_h = &bmeta.cu_seqlens_host;
+                let indptr_d = bmeta.cu_seqlens.0;
+                {
+                    use std::sync::atomic::{AtomicBool, Ordering};
+                    static LOGGED: AtomicBool = AtomicBool::new(false);
+                    if !LOGGED.swap(true, Ordering::Relaxed) {
+                        tracing::warn!(
+                            "FLASHINFER_PREFILL(varlen) batch={batch} total={total} \
+                             num_tokens={num_tokens} cu_seqlens={indptr_h:?} \
+                             nq={nq} nkv={nkv} hd={hd} sm_scale={inv_sqrt_d}"
+                        );
+                    }
+                }
+                spark_runtime::flashinfer::ragged_prefill_bf16_hd256(
+                    q_contiguous.0,
+                    k_contiguous.0,
+                    v_contiguous.0,
+                    attn_out.0,
+                    indptr_h,
+                    indptr_h,
+                    indptr_d,
+                    indptr_d,
+                    batch as u32,
+                    total,
+                    total,
+                    nq,
+                    nkv,
+                    hd,
+                    inv_sqrt_d,
+                    true,
+                    stream,
+                )?;
+            } else {
+                // Q12 Path B: batched paged-prefill attention. The kernel reads
+                // Q/O at per-batch offsets internally via blockIdx.z and uses
+                // block_table_ptrs[b] for each stream's paged KV pages.
+                let args = super::paged_attn_batched::PagedAttnBatchedArgs {
+                    q_contiguous,
+                    attn_out,
+                    seq_len_start,
+                    nq,
+                    nkv,
+                    hd,
+                    bs,
+                    inv_sqrt_d,
+                    kv_len,
+                    batched_meta: bmeta,
+                    stream,
+                };
+                self.prefill_attention_paged_attn_batched(kv_cache, ctx, &args)?;
+            }
         } else {
             // Single-stream path requires meta_for_single (validated above).
             let meta = meta_for_single

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
@@ -26,7 +26,26 @@ impl Qwen3AttentionLayer {
     ) -> Result<DevicePtr> {
         let o_out = ctx.buffers.norm_output();
         let force_w8a8 = ops::fp8_blockscaled_prefill_enabled();
-        if ops::cublas_gemm_enabled()
+        if ops::cutlass_nvfp4_attn_o_enabled()
+            && let Some(ref nvfp4_t) = self.o_nvfp4_t
+        {
+            ops::log_cutlass_nvfp4_route("attn_o", n, h, nq * hd);
+            ops::cutlass_nvfp4_proj(ctx.gpu, attn_out, nvfp4_t, o_out, n, h, nq * hd, stream)?;
+        } else if ops::cutlass_nvfp4_attn_o_enabled()
+            && let Some(fp8w) = self.o_weight.as_ref().and_then(|w| w.as_fp8())
+        {
+            ops::log_cutlass_nvfp4_route("attn_o", n, h, nq * hd);
+            ops::cutlass_nvfp4_proj_from_fp8(
+                ctx.gpu,
+                attn_out,
+                fp8w,
+                o_out,
+                n,
+                h,
+                nq * hd,
+                stream,
+            )?;
+        } else if ops::cublas_gemm_enabled()
             && let Some(fp8w) = self.o_weight.as_ref().and_then(|w| w.as_fp8())
         {
             // cuBLASLt BF16 (3x the hand-written mma.sync GEMM on GB10).

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_qkv.rs
@@ -102,7 +102,7 @@ impl Qwen3AttentionLayer {
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
-        let (fp8w_t, weight_opt, fp8, nvfp4_t, dense, _label) = match proj {
+        let (fp8w_t, weight_opt, fp8, nvfp4_t, dense, label) = match proj {
             Proj::Q => (
                 self.q_fp8w_t.as_ref(),
                 self.q_weight.as_ref(),
@@ -133,7 +133,17 @@ impl Qwen3AttentionLayer {
         // W8A8 + FP32 epilogue: requires NON-transposed FP8 weights with
         // block scales (matches the kernel signature). The attn layer stores
         // those via set_fp8_weights — accessible via weight_opt.as_fp8().
-        if force_w8a8
+        if ops::cutlass_nvfp4_attn_qkv_enabled(label)
+            && let Some(nvfp4_t) = nvfp4_t
+        {
+            ops::log_cutlass_nvfp4_route(label, n, out_dim, h);
+            ops::cutlass_nvfp4_proj(ctx.gpu, normed, nvfp4_t, out, n, out_dim, h, stream)?;
+        } else if ops::cutlass_nvfp4_attn_qkv_enabled(label)
+            && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8())
+        {
+            ops::log_cutlass_nvfp4_route(label, n, out_dim, h);
+            ops::cutlass_nvfp4_proj_from_fp8(ctx.gpu, normed, fp8w, out, n, out_dim, h, stream)?;
+        } else if force_w8a8
             && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8())
             && self.per_token_group_quant_fp8_k.0 != 0
             && self.fp8_gemm_t_blockscaled_k.0 != 0

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
@@ -135,6 +135,12 @@ impl Qwen3AttentionLayer {
         gpu: &dyn GpuBackend,
         stream: u64,
     ) -> anyhow::Result<()> {
+        if crate::layers::ops::cutlass_nvfp4_gemm_enabled() {
+            tracing::info!(
+                "Skipping attention FP8 prefill transposes because ATLAS_CUTLASS_NVFP4_GEMM=1"
+            );
+            return Ok(());
+        }
         if self.w8a16_gemm_t_k.0 == 0 {
             return Ok(()); // kernel not available
         }
@@ -167,6 +173,18 @@ impl Qwen3AttentionLayer {
         config: &atlas_core::config::ModelConfig,
         stream: u64,
     ) -> Result<()> {
+        // Under native NVFP4 prefill (ATLAS_CUTLASS_NVFP4_GEMM=1) all of Q/K/V/O
+        // take the CUTLASS NVFP4 path; the FP8 predequant outputs (q_fp8..o_fp8)
+        // are read only by the legacy FP8 prefill path and decode never reads
+        // them (decode attention uses its own weights), so they'd be allocated
+        // at load and never used. Skip them — saves ~260MB and a wasted per-
+        // prefill BF16->FP8 activation conversion. Mirrors transpose_fp8_for_prefill.
+        if crate::layers::ops::cutlass_nvfp4_gemm_enabled() {
+            tracing::info!(
+                "Skipping attention FP8 prefill predequant because ATLAS_CUTLASS_NVFP4_GEMM=1"
+            );
+            return Ok(());
+        }
         let predequant_k = gpu.kernel("w4a16", "predequant_nvfp4_to_fp8")?;
         let h = config.hidden_size;
         let nq = config.num_attention_heads;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
@@ -27,7 +27,35 @@ impl Qwen3SsmLayer {
         stream: u64,
     ) -> Result<()> {
         let force_w8a8 = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"));
-        if let Some(ref dense_out) = self.out_proj_dense {
+        if ops::cutlass_nvfp4_ssm_out_enabled()
+            && let Some(ref nvfp4_t) = self.out_proj_nvfp4_t
+        {
+            ops::log_cutlass_nvfp4_route("ssm_out_nvfp4", k, h as u32, value_dim as u32);
+            ops::cutlass_nvfp4_proj(
+                ctx.gpu,
+                normed_out_buf,
+                nvfp4_t,
+                out_proj_buf,
+                k,
+                h as u32,
+                value_dim as u32,
+                stream,
+            )
+        } else if ops::cutlass_nvfp4_ssm_out_enabled()
+            && let Some(ref fp8w) = self.out_proj_fp8w
+        {
+            ops::log_cutlass_nvfp4_route("ssm_out_fp8pack", k, h as u32, value_dim as u32);
+            ops::cutlass_nvfp4_proj_from_fp8(
+                ctx.gpu,
+                normed_out_buf,
+                fp8w,
+                out_proj_buf,
+                k,
+                h as u32,
+                value_dim as u32,
+                stream,
+            )
+        } else if let Some(ref dense_out) = self.out_proj_dense {
             // SSM out_proj is kept BF16 dense for accuracy (decode uses FP8
             // block-scaled, prefill stays BF16). Always routed through the
             // tensor-core dense_gemm_bf16_pipelined kernel (~40× vs the old

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
@@ -50,7 +50,48 @@ impl Qwen3SsmLayer {
         // ceiling on GB10 (32 vs 85 TFLOPS bf16 on this shape). Dequant the FP8
         // weight to BF16 once (cached), then route the projection through
         // cuBLASLt. W16A16 here is strictly more accurate than the W8A8 path.
-        if ops::cublas_fp8_enabled()
+        if ops::cutlass_nvfp4_qkvz_enabled()
+            && let Some(ref nvfp4_t) = self.qkvz_nvfp4_t
+        {
+            ops::log_cutlass_nvfp4_route("ssm_qkvz_nvfp4", k, qkvz_size as u32, h as u32);
+            ops::cutlass_nvfp4_proj(
+                ctx.gpu,
+                normed,
+                nvfp4_t,
+                proj_dst,
+                k,
+                qkvz_size as u32,
+                h as u32,
+                stream,
+            )?;
+        } else if ops::cutlass_nvfp4_qkvz_enabled()
+            && let Some(ref fp8w) = self.qkvz_fp8w
+        {
+            ops::log_cutlass_nvfp4_route("ssm_qkvz_fp8pack", k, qkvz_size as u32, h as u32);
+            ops::cutlass_nvfp4_proj_from_fp8(
+                ctx.gpu,
+                normed,
+                fp8w,
+                proj_dst,
+                k,
+                qkvz_size as u32,
+                h as u32,
+                stream,
+            )?;
+        } else if ops::cutlass_gemm_enabled()
+            && let Some(ref fp8w) = self.qkvz_fp8w
+        {
+            ops::cutlass_bf16_proj(
+                ctx.gpu,
+                normed,
+                fp8w,
+                proj_dst,
+                k,
+                qkvz_size as u32,
+                h as u32,
+                stream,
+            )?;
+        } else if ops::cublas_fp8_enabled()
             && let Some(ref fp8w) = self.qkvz_fp8w
         {
             ops::cublas_fp8_rowwise_proj(

--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -340,6 +340,18 @@ pub(super) fn load_layers(
         if (!native_fp8 || force_nvfp4_moe) && !skip_moe_prefill_copies {
             moe_layer.predequant_for_prefill(gpu, config, stream)?;
         }
+        // CUTLASS grouped NVFP4 gate_up (ATLAS_HOLO_MOE_GROUPED_CUTLASS): swizzle
+        // the per-expert [K/16,N] weight scales into the CUTLASS SFB atom once at
+        // load (the grouped kernel pairs them with gate_ptrs [N,K/2] + real scale2).
+        // Needs the shared gate_ptrs_t/up_ptrs_t scales (FAST_MOE=full).
+        if fast_holo_moe_layer
+            && std::env::var("ATLAS_HOLO_MOE_GROUPED_CUTLASS")
+                .ok()
+                .as_deref()
+                == Some("1")
+        {
+            moe_layer.build_cutlass_grouped_sfb(gpu, config, stream)?;
+        }
 
         // ATLAS_FP8_DEQUANT_MOE_TO_BF16: dequant FP8 experts to BF16 at load,
         // route MoE through the BF16 grouped GEMM + fused-decode kernels.

--- a/crates/spark-runtime/build.rs
+++ b/crates/spark-runtime/build.rs
@@ -3,6 +3,8 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=ATLAS_SKIP_BUILD");
     println!("cargo:rerun-if-env-changed=ATLAS_TARGET_HW");
+    println!("cargo:rerun-if-env-changed=CUTLASS_HOME");
+    println!("cargo:rerun-if-env-changed=FLASHINFER_HOME");
     println!("cargo:rerun-if-env-changed=ATLAS_CUDA_ARCH");
     // Register the `atlas_scale` cfg so `#[cfg(atlas_scale)]` does not trip
     // the `unexpected_cfgs` lint. `atlas_scale` selects SCALE/AMD (gfx1151)
@@ -12,6 +14,8 @@ fn main() {
     // signal the atlas-kernels build uses; covers both the SCALE (`strix`)
     // and native-HIP (`strix-hip`) AMD targets.
     println!("cargo:rustc-check-cfg=cfg(atlas_scale)");
+    println!("cargo:rustc-check-cfg=cfg(atlas_cutlass)");
+    println!("cargo:rustc-check-cfg=cfg(atlas_flashinfer)");
     if std::env::var("ATLAS_TARGET_HW")
         .as_deref()
         .map(|hw| hw.starts_with("strix"))
@@ -61,10 +65,11 @@ fn main() {
     // ceiling on GB10; cuBLASLt is a measured 2.7-4.8x lever on those shapes.
     println!("cargo:rustc-link-lib=dylib=cublasLt");
     // cudart: copy_d2d_2d_async uses cudaMemcpy2DAsync (a runtime, not driver,
-    // symbol). Previously only emitted in the ATLAS_SKIP_BUILD stub path, so a
-    // real GPU build fails to link with "undefined reference to
-    // cudaMemcpy2DAsync" even though CI (which builds under ATLAS_SKIP_BUILD)
-    // is green.
+    // symbol). Previously only emitted in the ATLAS_SKIP_BUILD stub path and
+    // the optional CUTLASS/FlashInfer object paths below, so a real GPU build
+    // without CUTLASS_HOME/FLASHINFER_HOME set fails to link with "undefined
+    // reference to cudaMemcpy2DAsync" even though CI (which builds under
+    // ATLAS_SKIP_BUILD) is green.
     println!("cargo:rustc-link-lib=dylib=cudart");
 
     if let Ok(cuda_path) = std::env::var("CUDA_HOME") {
@@ -75,4 +80,146 @@ fn main() {
     println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
     println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64/stubs");
     println!("cargo:rustc-link-search=native=/usr/lib/aarch64-linux-gnu");
+
+    if let Some(cutlass_home) = std::env::var_os("CUTLASS_HOME") {
+        build_cutlass_object(std::path::PathBuf::from(cutlass_home));
+    }
+
+    if let Some(fi_home) = std::env::var_os("FLASHINFER_HOME") {
+        build_flashinfer_object(std::path::PathBuf::from(fi_home));
+    }
+}
+
+/// Compile the FlashInfer ragged-prefill wrapper to a static lib (host-callable,
+/// like the CUTLASS object). FlashInfer's FA2 (SM80-class) ragged-prefill kernel
+/// codegens for sm_121f on GB10. Gated on `FLASHINFER_HOME`. Needs FlashInfer's
+/// PINNED CCCL via `-isystem` ahead of the CUDA-13 toolkit CCCL (which lacks
+/// `cuda::fast_mod_div`).
+fn build_flashinfer_object(fi_home: std::path::PathBuf) {
+    use std::process::Command;
+
+    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR set"));
+    let lib = out_dir.join("libatlas_flashinfer.a");
+    let arch = std::env::var("ATLAS_CUDA_ARCH").unwrap_or_else(|_| "sm_121f".to_string());
+    let cuda_home = std::env::var("CUDA_HOME").unwrap_or_else(|_| "/usr/local/cuda".to_string());
+    let nvcc = std::path::Path::new(&cuda_home).join("bin/nvcc");
+
+    let src = std::path::PathBuf::from("cuda/flashinfer_ragged_prefill.cu");
+    println!("cargo:rerun-if-changed={}", src.display());
+    println!("cargo:rustc-cfg=atlas_flashinfer");
+
+    let cccl = fi_home.join("3rdparty/cccl");
+    let obj = out_dir.join("flashinfer_ragged_prefill.o");
+    let status = Command::new(&nvcc)
+        .arg("-c")
+        .arg("-O3")
+        .arg("-std=c++17")
+        .arg("--expt-relaxed-constexpr")
+        .arg("-Xcompiler")
+        .arg("-fPIC")
+        .arg(format!("-arch={arch}"))
+        // FlashInfer's pinned CCCL MUST precede the toolkit CCCL.
+        .arg("-isystem")
+        .arg(cccl.join("libcudacxx/include"))
+        .arg("-isystem")
+        .arg(cccl.join("cub"))
+        .arg("-isystem")
+        .arg(cccl.join("thrust"))
+        .arg(format!("-I{}", fi_home.join("include").display()))
+        .arg(&src)
+        .arg("-o")
+        .arg(&obj)
+        .status()
+        .expect("failed to spawn nvcc for FlashInfer wrapper");
+    assert!(
+        status.success(),
+        "nvcc failed while building FlashInfer wrapper"
+    );
+
+    let status = Command::new("ar")
+        .arg("crus")
+        .arg(&lib)
+        .arg(&obj)
+        .status()
+        .expect("failed to spawn ar for FlashInfer wrapper");
+    assert!(
+        status.success(),
+        "ar failed while archiving FlashInfer wrapper"
+    );
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=atlas_flashinfer");
+    println!("cargo:rustc-link-lib=dylib=cudart");
+    println!("cargo:rustc-link-lib=dylib=stdc++");
+}
+
+fn build_cutlass_object(cutlass_home: std::path::PathBuf) {
+    use std::process::Command;
+
+    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR set"));
+    let lib = out_dir.join("libatlas_cutlass.a");
+    let arch = std::env::var("ATLAS_CUDA_ARCH").unwrap_or_else(|_| "sm_121f".to_string());
+    let cuda_home = std::env::var("CUDA_HOME").unwrap_or_else(|_| "/usr/local/cuda".to_string());
+    let nvcc = std::path::Path::new(&cuda_home).join("bin/nvcc");
+
+    let sources = [
+        std::path::PathBuf::from("cuda/cutlass_bf16_gemm.cu"),
+        std::path::PathBuf::from("cuda/cutlass_nvfp4_gemm.cu"),
+        std::path::PathBuf::from("cuda/cutlass_nvfp4_grouped_gemm.cu"),
+    ];
+    for src in &sources {
+        println!("cargo:rerun-if-changed={}", src.display());
+    }
+    println!("cargo:rustc-cfg=atlas_cutlass");
+
+    let mut objects = Vec::new();
+    for src in &sources {
+        let obj = out_dir.join(
+            src.file_stem()
+                .expect("CUTLASS wrapper source has a file stem")
+                .to_string_lossy()
+                .to_string()
+                + ".o",
+        );
+        let status = Command::new(&nvcc)
+            .arg("-c")
+            .arg("-O3")
+            .arg("-std=c++17")
+            .arg("--expt-relaxed-constexpr")
+            .arg("-Xcompiler")
+            .arg("-fPIC")
+            .arg(format!("-arch={arch}"))
+            .arg(format!("-I{}", cutlass_home.join("include").display()))
+            .arg(format!(
+                "-I{}",
+                cutlass_home.join("tools/util/include").display()
+            ))
+            .arg(src)
+            .arg("-o")
+            .arg(&obj)
+            .status()
+            .expect("failed to spawn nvcc for CUTLASS wrapper");
+        assert!(
+            status.success(),
+            "nvcc failed while building CUTLASS wrapper {}",
+            src.display()
+        );
+        objects.push(obj);
+    }
+
+    let mut ar = Command::new("ar");
+    ar.arg("crus").arg(&lib);
+    for obj in &objects {
+        ar.arg(obj);
+    }
+    let status = ar.status().expect("failed to spawn ar for CUTLASS wrapper");
+    assert!(
+        status.success(),
+        "ar failed while archiving CUTLASS wrapper"
+    );
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=atlas_cutlass");
+    println!("cargo:rustc-link-lib=dylib=cudart");
+    println!("cargo:rustc-link-lib=dylib=stdc++");
 }

--- a/crates/spark-runtime/cuda/cutlass_bf16_gemm.cu
+++ b/crates/spark-runtime/cuda/cutlass_bf16_gemm.cu
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include <cuda_runtime_api.h>
+
+#include <cublasLt.h>
+
+#include "cutlass/bfloat16.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/layout/matrix.h"
+
+template <int TB_M, int TB_N, int TB_K, int W_M, int W_N, int W_K>
+int atlas_cutlass_bf16_gemm_act_weight_t_impl(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  using Element = cutlass::bfloat16_t;
+  using Gemm = cutlass::gemm::device::Gemm<
+      Element,
+      cutlass::layout::RowMajor,
+      Element,
+      cutlass::layout::ColumnMajor,
+      Element,
+      cutlass::layout::RowMajor,
+      float,
+      cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm80,
+      cutlass::gemm::GemmShape<TB_M, TB_N, TB_K>,
+      cutlass::gemm::GemmShape<W_M, W_N, W_K>,
+      cutlass::gemm::GemmShape<16, 8, 16>,
+      cutlass::epilogue::thread::LinearCombination<Element, 8, float, float>>;
+
+  Gemm gemm;
+  typename Gemm::Arguments args(
+      {m, n, k},
+      {static_cast<Element const*>(act), k},
+      {static_cast<Element const*>(weight), k},
+      {static_cast<Element const*>(out), n},
+      {static_cast<Element*>(out), n},
+      {1.0f, 0.0f});
+
+  size_t needed = Gemm::get_workspace_size(args);
+  if (needed > workspace_size) {
+    return -2;
+  }
+  cutlass::Status status = gemm.can_implement(args);
+  if (status != cutlass::Status::kSuccess) {
+    return static_cast<int>(status);
+  }
+  status = gemm.initialize(args, workspace, stream);
+  if (status != cutlass::Status::kSuccess) {
+    return static_cast<int>(status);
+  }
+  status = gemm(stream);
+  return static_cast<int>(status);
+}
+
+extern "C" int atlas_cutlass_bf16_gemm_act_weight_t(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  return atlas_cutlass_bf16_gemm_act_weight_t_impl<128, 128, 32, 64, 64, 32>(
+      act, weight, out, m, n, k, workspace, workspace_size, stream);
+}
+
+extern "C" int atlas_cutlass_bf16_gemm_act_weight_t_128x256(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  return atlas_cutlass_bf16_gemm_act_weight_t_impl<128, 256, 32, 64, 64, 32>(
+      act, weight, out, m, n, k, workspace, workspace_size, stream);
+}
+
+extern "C" int atlas_cutlass_bf16_gemm_act_weight_t_256x128(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  return atlas_cutlass_bf16_gemm_act_weight_t_impl<256, 128, 32, 64, 64, 32>(
+      act, weight, out, m, n, k, workspace, workspace_size, stream);
+}
+
+extern "C" int atlas_cutlass_bf16_gemm_act_weight_t_64x128(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  return atlas_cutlass_bf16_gemm_act_weight_t_impl<64, 128, 32, 32, 64, 32>(
+      act, weight, out, m, n, k, workspace, workspace_size, stream);
+}
+
+extern "C" int atlas_cutlass_bf16_gemm_act_weight_t_128x64(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  return atlas_cutlass_bf16_gemm_act_weight_t_impl<128, 64, 32, 64, 32, 32>(
+      act, weight, out, m, n, k, workspace, workspace_size, stream);
+}
+
+extern "C" int atlas_cutlass_bf16_gemm_act_weight_t_64x64(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  return atlas_cutlass_bf16_gemm_act_weight_t_impl<64, 64, 32, 32, 32, 32>(
+      act, weight, out, m, n, k, workspace, workspace_size, stream);
+}
+
+extern "C" int atlas_cublaslt_bf16_gemm_act_weight_t_algo(
+    const void* act,
+    const void* weight,
+    void* out,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream,
+    int algo_index,
+    int* returned_count) {
+  static cublasLtHandle_t handle = nullptr;
+  if (handle == nullptr) {
+    cublasStatus_t st = cublasLtCreate(&handle);
+    if (st != CUBLAS_STATUS_SUCCESS) {
+      return static_cast<int>(st);
+    }
+  }
+
+  cublasLtMatmulDesc_t desc = nullptr;
+  cublasLtMatrixLayout_t layout_a = nullptr;
+  cublasLtMatrixLayout_t layout_b = nullptr;
+  cublasLtMatrixLayout_t layout_d = nullptr;
+  cublasLtMatmulPreference_t pref = nullptr;
+
+  auto cleanup = [&]() {
+    if (pref) cublasLtMatmulPreferenceDestroy(pref);
+    if (layout_a) cublasLtMatrixLayoutDestroy(layout_a);
+    if (layout_b) cublasLtMatrixLayoutDestroy(layout_b);
+    if (layout_d) cublasLtMatrixLayoutDestroy(layout_d);
+    if (desc) cublasLtMatmulDescDestroy(desc);
+  };
+
+  cublasStatus_t st =
+      cublasLtMatmulDescCreate(&desc, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  cublasOperation_t trans_a = CUBLAS_OP_T;
+  cublasOperation_t trans_b = CUBLAS_OP_N;
+  st = cublasLtMatmulDescSetAttribute(
+      desc, CUBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(trans_a));
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  st = cublasLtMatmulDescSetAttribute(
+      desc, CUBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(trans_b));
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+
+  st = cublasLtMatrixLayoutCreate(&layout_a, CUDA_R_16BF, k, n, k);
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  st = cublasLtMatrixLayoutCreate(&layout_b, CUDA_R_16BF, k, m, k);
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  st = cublasLtMatrixLayoutCreate(&layout_d, CUDA_R_16BF, n, m, n);
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  st = cublasLtMatmulPreferenceCreate(&pref);
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  st = cublasLtMatmulPreferenceSetAttribute(
+      pref,
+      CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+      &workspace_size,
+      sizeof(workspace_size));
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+
+  constexpr int kMaxAlgos = 16;
+  cublasLtMatmulHeuristicResult_t results[kMaxAlgos];
+  int returned = 0;
+  st = cublasLtMatmulAlgoGetHeuristic(
+      handle,
+      desc,
+      layout_a,
+      layout_b,
+      layout_d,
+      layout_d,
+      pref,
+      kMaxAlgos,
+      results,
+      &returned);
+  if (returned_count) {
+    *returned_count = returned;
+  }
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    cleanup();
+    return static_cast<int>(st);
+  }
+  if (algo_index < 0 || algo_index >= returned) {
+    cleanup();
+    return -3;
+  }
+  if (results[algo_index].state != CUBLAS_STATUS_SUCCESS ||
+      results[algo_index].workspaceSize > workspace_size) {
+    cleanup();
+    return -4;
+  }
+
+  float alpha = 1.0f;
+  float beta = 0.0f;
+  st = cublasLtMatmul(
+      handle,
+      desc,
+      &alpha,
+      weight,
+      layout_a,
+      act,
+      layout_b,
+      &beta,
+      out,
+      layout_d,
+      out,
+      layout_d,
+      &results[algo_index].algo,
+      workspace,
+      workspace_size,
+      stream);
+  cleanup();
+  return static_cast<int>(st);
+}

--- a/crates/spark-runtime/cuda/cutlass_nvfp4_gemm.cu
+++ b/crates/spark-runtime/cuda/cutlass_nvfp4_gemm.cu
@@ -1,0 +1,543 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime_api.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/bfloat16.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/util/packed_stride.hpp"
+
+using namespace cute;
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+
+using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+using LayoutATag = cutlass::layout::RowMajor;
+constexpr int AlignmentA = 32;
+
+using ElementB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+using LayoutBTag = cutlass::layout::ColumnMajor;
+constexpr int AlignmentB = 32;
+
+using ElementD = cutlass::bfloat16_t;
+using ElementC = cutlass::bfloat16_t;
+using LayoutCTag = cutlass::layout::RowMajor;
+using LayoutDTag = cutlass::layout::RowMajor;
+constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+using ElementAccumulator = float;
+using ArchTag = cutlass::arch::Sm120;
+using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+using ThreadBlockShape = Shape<_128, _128, _128>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+    ArchTag,
+    OperatorClass,
+    ThreadBlockShape,
+    ClusterShape,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    ElementAccumulator,
+    ElementAccumulator,
+    ElementC,
+    LayoutCTag,
+    AlignmentC,
+    ElementD,
+    LayoutDTag,
+    AlignmentD,
+    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+    ArchTag,
+    OperatorClass,
+    ElementA,
+    LayoutATag,
+    AlignmentA,
+    ElementB,
+    LayoutBTag,
+    AlignmentB,
+    ElementAccumulator,
+    ThreadBlockShape,
+    ClusterShape,
+    cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+    Shape<int, int, int, int>,
+    CollectiveMainloop,
+    CollectiveEpilogue,
+    void>;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+using StrideA = typename Gemm::GemmKernel::StrideA;
+using LayoutA = decltype(cute::make_layout(make_shape(0, 0, 0), StrideA{}));
+using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFA;
+using StrideB = typename Gemm::GemmKernel::StrideB;
+using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFB;
+using StrideC = typename Gemm::GemmKernel::StrideC;
+using StrideD = typename Gemm::GemmKernel::StrideD;
+
+template <typename T>
+__device__ __forceinline__ unsigned char byte_of(T v) {
+  return *reinterpret_cast<unsigned char*>(&v);
+}
+
+__device__ __forceinline__ unsigned char float_to_e2m1(float x) {
+  unsigned char sign = (x < 0.0f) ? 8u : 0u;
+  float ax = fabsf(x);
+  unsigned char mag;
+  if (ax <= 0.25f) {
+    mag = 0;
+  } else if (ax <= 0.75f) {
+    mag = 1;
+  } else if (ax <= 1.25f) {
+    mag = 2;
+  } else if (ax <= 1.75f) {
+    mag = 3;
+  } else if (ax <= 2.5f) {
+    mag = 4;
+  } else if (ax <= 3.5f) {
+    mag = 5;
+  } else if (ax <= 5.0f) {
+    mag = 6;
+  } else {
+    mag = 7;
+  }
+  return sign | mag;
+}
+
+__device__ __forceinline__ float fp8_e4m3_to_float(unsigned char byte) {
+  __nv_fp8_e4m3 v;
+  *reinterpret_cast<unsigned char*>(&v) = byte;
+  return static_cast<float>(v);
+}
+
+template <class Layout>
+__global__ void atlas_cutlass_pack_bf16_act_nvfp4(
+    const __nv_bfloat16* __restrict__ act,
+    unsigned char* __restrict__ packed,
+    unsigned char* __restrict__ scales,
+    int m,
+    int k,
+    Layout layout_sfa) {
+  int row = blockIdx.x;
+  int group = blockIdx.y * blockDim.x + threadIdx.x;
+  int groups = k / 16;
+  if (row >= m || group >= groups) {
+    return;
+  }
+
+  int base = group * 16;
+  float max_abs = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float v = __bfloat162float(act[(unsigned long long)row * k + base + i]);
+    max_abs = fmaxf(max_abs, fabsf(v));
+  }
+
+  float scale = max_abs > 0.0f ? max_abs / 6.0f : 1.0f;
+  cutlass::float_ue4m3_t sf(scale);
+  scales[layout_sfa(row, base, 0)] = byte_of(sf);
+  float decoded_scale = static_cast<float>(sf);
+  float inv_scale = decoded_scale > 0.0f ? 1.0f / decoded_scale : 0.0f;
+
+#pragma unroll
+  for (int i = 0; i < 16; i += 2) {
+    float v0 = __bfloat162float(act[(unsigned long long)row * k + base + i]) * inv_scale;
+    float v1 = __bfloat162float(act[(unsigned long long)row * k + base + i + 1]) * inv_scale;
+    packed[(unsigned long long)row * (k / 2) + base / 2 + i / 2] =
+        static_cast<unsigned char>(float_to_e2m1(v0) | (float_to_e2m1(v1) << 4));
+  }
+}
+
+template <class Layout>
+__global__ void atlas_cutlass_pack_nvfp4_weight_scales_t(
+    const unsigned char* __restrict__ atlas_scales_t,
+    unsigned char* __restrict__ cutlass_scales,
+    float scale2,
+    int n,
+    int k,
+    Layout layout_sfb) {
+  int col = blockIdx.x;
+  int group = blockIdx.y * blockDim.x + threadIdx.x;
+  int groups = k / 16;
+  if (col >= n || group >= groups) {
+    return;
+  }
+  unsigned char atlas_scale = atlas_scales_t[(unsigned long long)group * n + col];
+  float scale = fp8_e4m3_to_float(atlas_scale);
+  cutlass::float_ue4m3_t sf(scale);
+  cutlass_scales[layout_sfb(col, group * 16, 0)] = byte_of(sf);
+}
+
+__global__ void atlas_cutlass_pack_bf16_weight_nvfp4_t(
+    const __nv_bfloat16* __restrict__ weight,
+    unsigned char* __restrict__ packed_t,
+    unsigned char* __restrict__ scale_t,
+    int n,
+    int k) {
+  int col = blockIdx.x;
+  int group = blockIdx.y * blockDim.x + threadIdx.x;
+  int groups = k / 16;
+  if (col >= n || group >= groups) {
+    return;
+  }
+
+  int base = group * 16;
+  float max_abs = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float v = __bfloat162float(weight[(unsigned long long)col * k + base + i]);
+    max_abs = fmaxf(max_abs, fabsf(v));
+  }
+
+  float scale = max_abs > 0.0f ? max_abs / 6.0f : 1.0f;
+  __nv_fp8_e4m3 fp8_scale(scale);
+  scale_t[(unsigned long long)group * n + col] = byte_of(fp8_scale);
+  float decoded_scale = static_cast<float>(fp8_scale);
+  float inv_scale = decoded_scale > 0.0f ? 1.0f / decoded_scale : 0.0f;
+
+#pragma unroll
+  for (int i = 0; i < 16; i += 2) {
+    float v0 = __bfloat162float(weight[(unsigned long long)col * k + base + i]) * inv_scale;
+    float v1 = __bfloat162float(weight[(unsigned long long)col * k + base + i + 1]) * inv_scale;
+    // CUTLASS ColumnMajor B(N,K) wants element (n,k) at offset n*K+k -> byte
+    // n*(K/2)+k/2 (K-contiguous, [N,K/2]). NOT Atlas's transposed [K/2,N].
+    packed_t[(unsigned long long)col * (k / 2) + base / 2 + i / 2] =
+        static_cast<unsigned char>(float_to_e2m1(v0) | (float_to_e2m1(v1) << 4));
+  }
+}
+
+size_t align_up(size_t x, size_t a) {
+  return (x + a - 1) & ~(a - 1);
+}
+
+#endif
+
+// Single-tile NVFP4 GEMM (M bounded so the packed-act + scale reservations fit the
+// shared workspace). The public entry point below tiles M into calls of this.
+static int nvfp4_gemm_single_tile(
+    const void* act_bf16,
+    const void* weight_packed_t,
+    const void* weight_scale_t,
+    float weight_scale_2,
+    void* out_bf16,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  if (m <= 0 || n <= 0 || k <= 0 || (k % 16) != 0) {
+    return -1;
+  }
+
+  StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, {m, k, 1});
+  StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, {n, k, 1});
+  StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, {m, n, 1});
+  StrideD stride_d = cutlass::make_cute_packed_stride(StrideD{}, {m, n, 1});
+  LayoutA layout_a = make_layout(make_shape(m, k, 1), stride_a);
+  auto layout_sfa = CollectiveMainloop::Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(m, n, k, 1));
+  auto layout_sfb = CollectiveMainloop::Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(m, n, k, 1));
+
+  size_t a_bytes = align_up(static_cast<size_t>(size(layout_a)), 256);
+  size_t sfa_bytes = align_up(static_cast<size_t>(size(filter_zeros(layout_sfa))), 256);
+  size_t sfb_bytes = align_up(static_cast<size_t>(size(filter_zeros(layout_sfb))), 256);
+
+  Gemm gemm;
+  typename Gemm::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {m, n, k, 1},
+      {
+          reinterpret_cast<ElementA::DataType const*>(workspace),
+          stride_a,
+          reinterpret_cast<ElementB::DataType const*>(weight_packed_t),
+          stride_b,
+          reinterpret_cast<ElementA::ScaleFactorType const*>(
+              static_cast<unsigned char*>(workspace) + a_bytes),
+          layout_sfa,
+          reinterpret_cast<ElementB::ScaleFactorType const*>(
+              static_cast<unsigned char*>(workspace) + a_bytes + sfa_bytes),
+          layout_sfb,
+      },
+      {
+          {weight_scale_2, 0.0f},
+          reinterpret_cast<ElementC const*>(out_bf16),
+          stride_c,
+          reinterpret_cast<ElementD*>(out_bf16),
+          stride_d,
+      }};
+
+  size_t gemm_workspace_size = Gemm::get_workspace_size(args);
+  size_t gemm_workspace_off = align_up(a_bytes + sfa_bytes + sfb_bytes, 256);
+  if (gemm_workspace_off + gemm_workspace_size > workspace_size) {
+    return -2;
+  }
+
+  dim3 block(256);
+  dim3 grid_act(m, (k / 16 + block.x - 1) / block.x);
+  atlas_cutlass_pack_bf16_act_nvfp4<<<grid_act, block, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(act_bf16),
+      static_cast<unsigned char*>(workspace),
+      static_cast<unsigned char*>(workspace) + a_bytes,
+      m,
+      k,
+      layout_sfa);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    return -10 - static_cast<int>(err);
+  }
+
+  dim3 grid_sfb(n, (k / 16 + block.x - 1) / block.x);
+  atlas_cutlass_pack_nvfp4_weight_scales_t<<<grid_sfb, block, 0, stream>>>(
+      static_cast<const unsigned char*>(weight_scale_t),
+      static_cast<unsigned char*>(workspace) + a_bytes + sfa_bytes,
+      weight_scale_2,
+      n,
+      k,
+      layout_sfb);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    return -1000 - static_cast<int>(err);
+  }
+
+  cutlass::Status status = gemm.can_implement(args);
+  if (status != cutlass::Status::kSuccess) {
+    return static_cast<int>(status);
+  }
+  status = gemm.initialize(
+      args,
+      static_cast<unsigned char*>(workspace) + gemm_workspace_off,
+      stream);
+  if (status != cutlass::Status::kSuccess) {
+    return static_cast<int>(status);
+  }
+  status = gemm(stream);
+  return static_cast<int>(status);
+#else
+  (void)act_bf16;
+  (void)weight_packed_t;
+  (void)weight_scale_t;
+  (void)weight_scale_2;
+  (void)out_bf16;
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)workspace;
+  (void)workspace_size;
+  (void)stream;
+  return -120;
+#endif
+}
+
+// Public NVFP4 GEMM: C[m,n] = quant(act[m,k]) @ weight_t[n,k]. The single-tile path
+// reserves packed-act + scale-factor workspace ∝ M, which overflows the shared 64MB
+// CUTLASS workspace at large M (status -2, e.g. M>~12K at K=4096 — was the cause of
+// the "max-prefill 4096 cap"). Tile M into ≤4096-row sub-GEMMs: each fits the
+// workspace and is a known-valid problem size; the weight (and its scales) are shared
+// across tiles, only the activation rows and output rows are sliced. Bit-identical to
+// a single call for m≤4096; for larger m the partials are independent rows (no cross-
+// tile reduction), so the result is exact.
+extern "C" int atlas_cutlass_nvfp4_gemm_bf16_act_weight_t(
+    const void* act_bf16,
+    const void* weight_packed_t,
+    const void* weight_scale_t,
+    float weight_scale_2,
+    void* out_bf16,
+    int m,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+  const int M_TILE = 4096;
+  if (m <= M_TILE) {
+    return nvfp4_gemm_single_tile(act_bf16, weight_packed_t, weight_scale_t,
+        weight_scale_2, out_bf16, m, n, k, workspace, workspace_size, stream);
+  }
+  for (int m0 = 0; m0 < m; m0 += M_TILE) {
+    int sub_m = (m - m0 < M_TILE) ? (m - m0) : M_TILE;
+    const void* a_off = static_cast<const void*>(
+        static_cast<const __nv_bfloat16*>(act_bf16) + static_cast<size_t>(m0) * k);
+    void* c_off = static_cast<void*>(
+        static_cast<__nv_bfloat16*>(out_bf16) + static_cast<size_t>(m0) * n);
+    int rc = nvfp4_gemm_single_tile(a_off, weight_packed_t, weight_scale_t,
+        weight_scale_2, c_off, sub_m, n, k, workspace, workspace_size, stream);
+    if (rc != 0) {
+      return rc;
+    }
+  }
+  return 0;
+}
+
+// Transpose an Atlas-packed NVFP4 weight from `[K/2, N]` (N-contiguous, the
+// checkpoint/hand-kernel layout) into CUTLASS's `[N, K/2]` (K-contiguous) byte
+// layout. Each byte holds the FP4 pair (k, k+1) in (low, high) nibbles in BOTH
+// layouts, so this is a pure byte transpose that preserves nibble pairing.
+__global__ void atlas_cutlass_transpose_nvfp4_packed(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__ dst,
+    int n,
+    int k) {
+  int half = k / 2;
+  int c = blockIdx.x * blockDim.x + threadIdx.x; // N index
+  int h = blockIdx.y * blockDim.y + threadIdx.y; // K/2 index
+  if (c >= n || h >= half) {
+    return;
+  }
+  // src [K/2, N]: row h, col c -> h*N + c. dst [N, K/2]: row c, col h.
+  dst[(unsigned long long)c * half + h] = src[(unsigned long long)h * n + c];
+}
+
+extern "C" int atlas_cutlass_transpose_nvfp4_packed_kton(
+    const void* src_packed_t,
+    void* dst_packed,
+    int n,
+    int k,
+    cudaStream_t stream) {
+  if (n <= 0 || k <= 0 || (k % 16) != 0) {
+    return -1;
+  }
+  dim3 block(32, 8);
+  dim3 grid((n + block.x - 1) / block.x, (k / 2 + block.y - 1) / block.y);
+  atlas_cutlass_transpose_nvfp4_packed<<<grid, block, 0, stream>>>(
+      static_cast<const unsigned char*>(src_packed_t),
+      static_cast<unsigned char*>(dst_packed),
+      n,
+      k);
+  cudaError_t err = cudaGetLastError();
+  return err == cudaSuccess ? 0 : -static_cast<int>(err);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// GROUPED NVFP4 gate_up (Holo MoE Phase-1 ESCAPE-HATCH path).
+//
+// Proves the FP4 MATH integrates correctly in a grouped (per-expert) form by
+// dispatching the proven Sm120 NVFP4 collective once per expert over its token
+// slice. This is the documented fallback in the Phase-1 plan: it is bit-faithful
+// to nvfp4_gemm_bf16_act_weight_t (it IS that collective), at the cost of one
+// kernel launch per active expert (perf caveat — a hand-rolled grouped
+// block-scaled mma is the Phase-2 follow-up; the exact Sm120 instruction is
+//   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64
+//     .row.col.f32.e2m1.e2m1.f32.ue4m3
+// from $CUTLASS_HOME/include/cute/arch/mma_sm120.hpp:3216, SFA/SFB e4m3 scale
+// operands per cute/atom/mma_traits_sm120.hpp SFALayout/SFBLayout).
+//
+// Layout (matches the per-expert single-GEMM exactly):
+//   A          : bf16 [M_total, K] activations, row-major; expert e owns rows
+//                [expert_offsets[e], expert_offsets[e+1]).
+//   gate/up    : per-expert weight pointers; packed_t [N,K/2] + scale_t [K/16,N]
+//                (the pack_bf16_weight_to_nvfp4_t layout), scale2 = 1.0.
+//   C_gate/C_up: bf16 [M_total, N] each (gate and up written separately).
+// The CUTLASS collective requires M-tile alignment that it carves internally; we
+// pass the exact per-expert M (it handles M not a multiple of the CTA tile).
+extern "C" int atlas_cutlass_nvfp4_grouped_gate_up(
+    const void* A_bf16,                         // [M_total, K]
+    const unsigned long long* gate_packed_ptrs, // [num_experts] device ptrs -> [N,K/2]
+    const unsigned long long* gate_scale_ptrs,  // [num_experts] device ptrs -> [K/16,N]
+    const float* gate_scale2_vals,              // host or device? -> HOST array
+    const unsigned long long* up_packed_ptrs,
+    const unsigned long long* up_scale_ptrs,
+    const float* up_scale2_vals,
+    void* C_gate_bf16,                          // [M_total, N]
+    void* C_up_bf16,                            // [M_total, N]
+    const int* expert_offsets_host,             // [num_experts+1] HOST
+    int num_experts,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  if (n <= 0 || k <= 0 || (k % 16) != 0 || num_experts <= 0) {
+    return -1;
+  }
+  const __nv_bfloat16* A = static_cast<const __nv_bfloat16*>(A_bf16);
+  __nv_bfloat16* Cg = static_cast<__nv_bfloat16*>(C_gate_bf16);
+  __nv_bfloat16* Cu = static_cast<__nv_bfloat16*>(C_up_bf16);
+
+  for (int e = 0; e < num_experts; ++e) {
+    int m_start = expert_offsets_host[e];
+    int m_end = expert_offsets_host[e + 1];
+    int m_e = m_end - m_start;
+    if (m_e <= 0) {
+      continue;
+    }
+    const __nv_bfloat16* A_e = A + (size_t)m_start * k;
+    // gate
+    int rc = atlas_cutlass_nvfp4_gemm_bf16_act_weight_t(
+        A_e,
+        reinterpret_cast<const void*>(gate_packed_ptrs[e]),
+        reinterpret_cast<const void*>(gate_scale_ptrs[e]),
+        gate_scale2_vals[e],
+        Cg + (size_t)m_start * n,
+        m_e, n, k, workspace, workspace_size, stream);
+    if (rc != 0) {
+      return 100000 + rc;
+    }
+    // up
+    rc = atlas_cutlass_nvfp4_gemm_bf16_act_weight_t(
+        A_e,
+        reinterpret_cast<const void*>(up_packed_ptrs[e]),
+        reinterpret_cast<const void*>(up_scale_ptrs[e]),
+        up_scale2_vals[e],
+        Cu + (size_t)m_start * n,
+        m_e, n, k, workspace, workspace_size, stream);
+    if (rc != 0) {
+      return 200000 + rc;
+    }
+  }
+  return 0;
+#else
+  (void)A_bf16; (void)gate_packed_ptrs; (void)gate_scale_ptrs; (void)gate_scale2_vals;
+  (void)up_packed_ptrs; (void)up_scale_ptrs; (void)up_scale2_vals;
+  (void)C_gate_bf16; (void)C_up_bf16; (void)expert_offsets_host;
+  (void)num_experts; (void)n; (void)k; (void)workspace; (void)workspace_size; (void)stream;
+  return -120;
+#endif
+}
+
+extern "C" int atlas_cutlass_pack_bf16_weight_to_nvfp4_t(
+    const void* weight_bf16,
+    void* packed_t,
+    void* scale_t,
+    int n,
+    int k,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  if (n <= 0 || k <= 0 || (k % 16) != 0) {
+    return -1;
+  }
+  dim3 block(256);
+  dim3 grid(n, (k / 16 + block.x - 1) / block.x);
+  atlas_cutlass_pack_bf16_weight_nvfp4_t<<<grid, block, 0, stream>>>(
+      static_cast<const __nv_bfloat16*>(weight_bf16),
+      static_cast<unsigned char*>(packed_t),
+      static_cast<unsigned char*>(scale_t),
+      n,
+      k);
+  cudaError_t err = cudaGetLastError();
+  return err == cudaSuccess ? 0 : -static_cast<int>(err);
+#else
+  (void)weight_bf16;
+  (void)packed_t;
+  (void)scale_t;
+  (void)n;
+  (void)k;
+  (void)stream;
+  return -120;
+#endif
+}

--- a/crates/spark-runtime/cuda/cutlass_nvfp4_grouped_gemm.cu
+++ b/crates/spark-runtime/cuda/cutlass_nvfp4_grouped_gemm.cu
@@ -1,0 +1,593 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Single-launch Sm120 NVFP4 grouped GEMM for Holo MoE Phase-2.
+// Replaces the per-expert dense-collective loop (atlas_cutlass_nvfp4_grouped_gate_up)
+// with one GemmUniversalMode::kGrouped launch over all active experts.
+//
+// Style/types mirror the dense binding cutlass_nvfp4_gemm.cu: same Sm120 /
+// OpClassBlockScaledTensorOp / nv_float4_t<e2m1> / float_ue4m3_t SF collective,
+// same #ifdef arch guard, same extern "C" status-code convention. The only new
+// machinery here is the single-launch grouped host assembly (per-group problem
+// shapes / pointers / strides / SF-layouts) plus a per-group activation pack into
+// the grouped SFA atom.
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime_api.h>
+#include <vector>
+
+#include "cute/tensor.hpp"
+#include "cutlass/bfloat16.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/util/packed_stride.hpp"
+
+using namespace cute;
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+
+// ─── element + layout aliases (IDENTICAL to dense cutlass_nvfp4_gemm.cu:23-42) ───
+using ElementInput = cutlass::float_e2m1_t;
+using ElementA = cutlass::nv_float4_t<ElementInput>;
+using ElementB = cutlass::nv_float4_t<ElementInput>;
+using ElementC = cutlass::bfloat16_t;
+using ElementD = cutlass::bfloat16_t;
+using ElementSF = cutlass::float_ue4m3_t;
+using ElementAccumulator = float;
+using ElementCompute = float;
+
+// pointer-to-layout  ⇒  selects GROUPED (IsGroupedGemmKernel)
+using GmemLayoutA = cutlass::layout::RowMajor;
+using GmemLayoutB = cutlass::layout::ColumnMajor;
+using GmemLayoutC = cutlass::layout::RowMajor;  // dense path uses RowMajor C/D; keep it
+using GmemLayoutD = cutlass::layout::RowMajor;
+
+constexpr int AlignmentA = 32;  // = 128 / 4   (FP4 elems)
+constexpr int AlignmentB = 32;
+constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;  // = 8
+constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;  // = 8
+
+using ArchTag = cutlass::arch::Sm120;
+using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+using TileShape = Shape<_128, _128, _128>;  // matches dense ThreadBlockShape
+using ClusterShape = Shape<_1, _1, _1>;
+
+// ─── EPILOGUE (plain LinearCombination; beta=0; per-expert scale2 via alpha_ptr) ───
+using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+    ArchTag,
+    OperatorClass,
+    TileShape,
+    ClusterShape,
+    cutlass::epilogue::collective::EpilogueTileAuto,
+    ElementAccumulator,
+    ElementCompute,
+    ElementC,
+    GmemLayoutC*,  // trailing '*' ⇒ grouped
+    AlignmentC,
+    ElementD,
+    GmemLayoutD*,
+    AlignmentD,
+    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+
+// ─── MAINLOOP (pointer-to-layout ⇒ grouped; all-TMA pingpong) ───
+using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+    ArchTag,
+    OperatorClass,
+    ElementA,
+    GmemLayoutA*,
+    AlignmentA,
+    ElementB,
+    GmemLayoutB*,
+    AlignmentB,
+    ElementAccumulator,
+    TileShape,
+    ClusterShape,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+    cutlass::gemm::KernelPtrArrayTmaWarpSpecializedPingpong>::CollectiveOp;
+// Fallback if can_implement rejects pingpong on sm_121f:
+//   cutlass::gemm::collective::KernelScheduleAuto   (cooperative)
+
+using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+    cutlass::gemm::GroupProblemShape<cute::Shape<int, int, int>>,
+    CollectiveMainloop,
+    CollectiveEpilogue>;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+// per-group internal types (pointer types at the Arguments boundary)
+using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+using StrideC = typename Gemm::GemmKernel::InternalStrideC;
+using StrideD = typename Gemm::GemmKernel::InternalStrideD;
+using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFA;
+using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::InternalLayoutSFB;
+using Sm1xxBlkScaledConfig =
+    typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+using ProblemShape = cute::Shape<int, int, int>;
+
+static inline size_t align_up_(size_t x, size_t a) {
+  return (x + a - 1) & ~(a - 1);
+}
+
+// FP4 (e2m1) quantization helper — identical to dense float_to_e2m1 (cu:95-117).
+__device__ __forceinline__ unsigned char float_to_e2m1_g(float x) {
+  unsigned char sign = (x < 0.0f) ? 8u : 0u;
+  float ax = fabsf(x);
+  unsigned char mag;
+  if (ax <= 0.25f) {
+    mag = 0;
+  } else if (ax <= 0.75f) {
+    mag = 1;
+  } else if (ax <= 1.25f) {
+    mag = 2;
+  } else if (ax <= 1.75f) {
+    mag = 3;
+  } else if (ax <= 2.5f) {
+    mag = 4;
+  } else if (ax <= 3.5f) {
+    mag = 5;
+  } else if (ax <= 5.0f) {
+    mag = 6;
+  } else {
+    mag = 7;
+  }
+  return sign | mag;
+}
+
+// ─── per-group activation pack into the GROUPED SFA atom ───
+// Identical body to dense atlas_cutlass_pack_bf16_act_nvfp4 (cu:125-161) but the
+// kernel receives the per-group layout_sfa built from THAT group's {m,n,k}.
+template <class LayoutSFA_t>
+__global__ void pack_act_group(
+    const __nv_bfloat16* __restrict__ act_global,  // TOKEN-MAJOR base [*, k]
+    const int* __restrict__ sorted_token_ids,      // null => identity (expert-contig)
+    int ms,                                         // group's first sorted row
+    unsigned char* __restrict__ packed,            // group packed-A region [m_e, k/2]
+    unsigned char* __restrict__ scales,            // group SFA region
+    int m,
+    int k,
+    LayoutSFA_t layout_sfa) {
+  int row = blockIdx.x;
+  int group = blockIdx.y * blockDim.x + threadIdx.x;
+  int groups = k / 16;
+  if (row >= m || group >= groups) {
+    return;
+  }
+  // Fused gather (lever 2): the activation row for this group's local `row` is the
+  // sorted token id — read token-major A directly, no separate permute pass.
+  int gid = ms + row;
+  int tok = sorted_token_ids ? sorted_token_ids[gid] : gid;
+  const __nv_bfloat16* arow = act_global + (unsigned long long)tok * k;
+  int base = group * 16;
+  float max_abs = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float v = __bfloat162float(arow[base + i]);
+    max_abs = fmaxf(max_abs, fabsf(v));
+  }
+  float scale = max_abs > 0.0f ? max_abs / 6.0f : 1.0f;
+  cutlass::float_ue4m3_t sf(scale);
+  scales[layout_sfa(row, base, 0)] = *reinterpret_cast<unsigned char*>(&sf);
+  float dec = static_cast<float>(sf);
+  float inv = dec > 0.0f ? 1.0f / dec : 0.0f;
+#pragma unroll
+  for (int i = 0; i < 16; i += 2) {
+    float v0 = __bfloat162float(arow[base + i]) * inv;
+    float v1 = __bfloat162float(arow[base + i + 1]) * inv;
+    packed[(unsigned long long)row * (k / 2) + base / 2 + i / 2] =
+        static_cast<unsigned char>(float_to_e2m1_g(v0) | (float_to_e2m1_g(v1) << 4));
+  }
+}
+
+// ─── per-{n,k} SFB swizzle pack (load-time helper) ───
+// Reads Atlas-transposed E4M3 weight scale [K/16, N] (the pack_bf16_weight_to_nvfp4_t
+// layout) and writes it into the grouped/dense SFB atom for one expert. SFB depends
+// ONLY on N,K (not M), so a single load-time call is valid for all per-group M.
+template <class LayoutSFB_t>
+__global__ void pack_weight_sfb_group(
+    const unsigned char* __restrict__ atlas_scales_t,  // [K/16, N] E4M3
+    unsigned char* __restrict__ cutlass_scales,        // swizzled SFB out
+    int n,
+    int k,
+    LayoutSFB_t layout_sfb) {
+  int col = blockIdx.x;
+  int group = blockIdx.y * blockDim.x + threadIdx.x;
+  int groups = k / 16;
+  if (col >= n || group >= groups) {
+    return;
+  }
+  unsigned char atlas_scale = atlas_scales_t[(unsigned long long)group * n + col];
+  __nv_fp8_e4m3 in;
+  *reinterpret_cast<unsigned char*>(&in) = atlas_scale;
+  float scale = static_cast<float>(in);
+  cutlass::float_ue4m3_t sf(scale);
+  cutlass_scales[layout_sfb(col, group * 16, 0)] = *reinterpret_cast<unsigned char*>(&sf);
+}
+
+#endif  // arch guard for device code
+
+// ════════════════════════════════════════════════════════════════════════════
+// Load-time SFB swizzle pack — produces the grouped/dense SFB atom for one expert
+// from the Atlas-transposed [K/16,N] E4M3 weight scale. SFB is M-independent, so
+// this is a one-time-per-expert call (gated by FAST_MOE_MODE at the Rust layer).
+// ════════════════════════════════════════════════════════════════════════════
+extern "C" int atlas_cutlass_pack_weight_sfb(
+    const void* scale_in,  // [K/16, N] E4M3 (Atlas transposed)
+    void* scale_out,       // swizzled SFB (ue4m3)
+    int n,
+    int k,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  if (n <= 0 || k <= 0 || (k % 16) != 0) {
+    return -1;
+  }
+  // SFB layout depends only on N,K — M is a placeholder (use 1).
+  auto layout_sfb =
+      Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(cute::make_shape(1, n, k, 1));
+  dim3 block(256);
+  dim3 grid(n, (k / 16 + block.x - 1) / block.x);
+  pack_weight_sfb_group<<<grid, block, 0, stream>>>(
+      static_cast<const unsigned char*>(scale_in),
+      static_cast<unsigned char*>(scale_out),
+      n,
+      k,
+      layout_sfb);
+  cudaError_t err = cudaGetLastError();
+  return err == cudaSuccess ? 0 : -static_cast<int>(err);
+#else
+  (void)scale_in;
+  (void)scale_out;
+  (void)n;
+  (void)k;
+  (void)stream;
+  return -120;
+#endif
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Grouped NVFP4 MoE: A-pack (shared across projections) + per-projection GEMM.
+// A_global is TOKEN-MAJOR; sorted_token_ids (null=identity) selects each group's
+// rows — the gather is FUSED into the per-group A-pack (lever 2: no permute pass).
+// gate_up packs A ONCE and runs gate+up against it (lever: pack-A-once); down packs
+// its own (different) A. Workspace carve: [ packed-A | SFA | A-arrays | B-arrays+gemm_ws ].
+// ════════════════════════════════════════════════════════════════════════════
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+
+// Shared per-forward A-pack result: packed-A + SFA staged in ws, A-side argument
+// arrays uploaded. Reused by every projection that shares this A.
+struct GroupedAPrep {
+  int status = 0;                          // non-zero on failure
+  int G = 0;                               // active groups
+  std::vector<ProblemShape> host_shapes;   // {m_e, n, k} per group
+  std::vector<int> ms;                     // sorted-row start per group (C offset)
+  std::vector<int> me;                     // m_e per group
+  std::vector<int> eidx;                   // expert index per group (B/scale2 lookup)
+  ProblemShape* dShapes = nullptr;
+  const ElementA::DataType** dA = nullptr;
+  const ElementSF** dSFA = nullptr;
+  StrideA* dsA = nullptr;
+  LayoutSFA* dlSFA = nullptr;
+  size_t cursor = 0;                       // free ws offset after the A-side arrays
+};
+
+// Gather+pack A once (per active group), upload the A-side argument arrays.
+static GroupedAPrep prep_grouped_a(
+    const __nv_bfloat16* A_global,
+    const int* sorted_token_ids,
+    const int* expert_offsets_host,
+    int num_experts,
+    int n,
+    int k,
+    unsigned char* ws,
+    cudaStream_t stream) {
+  GroupedAPrep p;
+  std::vector<const ElementA::DataType*> hA;
+  std::vector<const ElementSF*> hSFA;
+  std::vector<StrideA> sA;
+
+  // First pass: per-group padded sizes for the packed-A / SFA staging carve.
+  std::vector<size_t> a_grp_off;
+  std::vector<size_t> sfa_grp_off;
+  size_t a_acc = 0;
+  size_t sfa_acc = 0;
+  for (int e = 0; e < num_experts; ++e) {
+    int m_e = expert_offsets_host[e + 1] - expert_offsets_host[e];
+    if (m_e <= 0) {
+      continue;
+    }
+    auto lsa =
+        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(cute::make_shape(m_e, n, k, 1));
+    a_grp_off.push_back(a_acc);
+    sfa_grp_off.push_back(sfa_acc);
+    a_acc += align_up_((size_t)m_e * (k / 2), 256);
+    sfa_acc += align_up_((size_t)size(filter_zeros(lsa)), 256);
+  }
+  size_t a_off = 0;
+  size_t sfa_off = align_up_(a_acc, 256);
+  size_t cursor = align_up_(sfa_off + sfa_acc, 256);
+
+  // Second pass: pack A per active group + build A-side host arrays.
+  int gi = 0;
+  for (int e = 0; e < num_experts; ++e) {
+    int ms = expert_offsets_host[e];
+    int m_e = expert_offsets_host[e + 1] - ms;
+    if (m_e <= 0) {
+      continue;
+    }
+    auto lsa =
+        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(cute::make_shape(m_e, n, k, 1));
+    unsigned char* a_e = ws + a_off + a_grp_off[gi];
+    unsigned char* sfa_e = ws + sfa_off + sfa_grp_off[gi];
+
+    dim3 blk(256);
+    dim3 grd(m_e, (k / 16 + blk.x - 1) / blk.x);
+    pack_act_group<<<grd, blk, 0, stream>>>(
+        A_global, sorted_token_ids, ms, a_e, sfa_e, m_e, k, lsa);
+
+    p.host_shapes.push_back(ProblemShape{m_e, n, k});
+    p.ms.push_back(ms);
+    p.me.push_back(m_e);
+    p.eidx.push_back(e);
+    hA.push_back(reinterpret_cast<const ElementA::DataType*>(a_e));
+    hSFA.push_back(reinterpret_cast<const ElementSF*>(sfa_e));
+    sA.push_back(cutlass::make_cute_packed_stride(StrideA{}, {m_e, k, 1}));
+    ++gi;
+  }
+  p.G = (int)p.host_shapes.size();
+  if (p.G == 0) {
+    p.cursor = cursor;
+    return p;
+  }
+
+  auto put = [&](const void* src, size_t bytes) -> void* {
+    void* dst = ws + cursor;
+    cursor = align_up_(cursor + bytes, 256);
+    cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, stream);
+    return dst;
+  };
+  p.dShapes = (ProblemShape*)put(p.host_shapes.data(), p.G * sizeof(ProblemShape));
+  p.dA = (const ElementA::DataType**)put(hA.data(), p.G * sizeof(void*));
+  p.dSFA = (const ElementSF**)put(hSFA.data(), p.G * sizeof(void*));
+  p.dsA = (StrideA*)put(sA.data(), p.G * sizeof(StrideA));
+  {
+    std::vector<LayoutSFA> lSFA(p.G);
+    for (int g = 0; g < p.G; ++g) {
+      lSFA[g] =
+          Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(cute::make_shape(p.me[g], n, k, 1));
+    }
+    p.dlSFA = (LayoutSFA*)put(lSFA.data(), p.G * sizeof(LayoutSFA));
+  }
+  p.cursor = cursor;
+  return p;
+}
+
+// One grouped projection GEMM reusing a shared A-prep. B-side arrays + gemm_ws are
+// carved starting at `cursor_start` (reused across the projections sharing `a`).
+static int launch_projection(
+    const GroupedAPrep& a,
+    const unsigned long long* packed_ptrs,
+    const unsigned long long* sfb_ptrs,
+    const float* scale2_vals,
+    __nv_bfloat16* C_bf16,
+    int n,
+    int k,
+    unsigned char* ws,
+    size_t cursor_start,
+    size_t workspace_size,
+    cudaStream_t stream,
+    int tag) {
+  int G = a.G;
+  if (G == 0) {
+    return 0;
+  }
+  std::vector<const ElementB::DataType*> hB(G);
+  std::vector<const ElementSF*> hSFB(G);
+  std::vector<const ElementC*> hC(G);
+  std::vector<ElementD*> hD(G);
+  std::vector<StrideB> sB(G);
+  std::vector<StrideC> sC(G);
+  std::vector<StrideD> sD(G);
+  std::vector<LayoutSFB> lSFB(G);
+  std::vector<float> alpha_host(G);
+  for (int g = 0; g < G; ++g) {
+    int e = a.eidx[g];
+    int m_e = a.me[g];
+    size_t ms = (size_t)a.ms[g];
+    hB[g] = reinterpret_cast<const ElementB::DataType*>(packed_ptrs[e]);
+    hSFB[g] = reinterpret_cast<const ElementSF*>(sfb_ptrs[e]);
+    hC[g] = reinterpret_cast<const ElementC*>(C_bf16 + ms * n);
+    hD[g] = reinterpret_cast<ElementD*>(C_bf16 + ms * n);
+    sB[g] = cutlass::make_cute_packed_stride(StrideB{}, {n, k, 1});
+    sC[g] = cutlass::make_cute_packed_stride(StrideC{}, {m_e, n, 1});
+    sD[g] = cutlass::make_cute_packed_stride(StrideD{}, {m_e, n, 1});
+    lSFB[g] =
+        Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(cute::make_shape(m_e, n, k, 1));
+    alpha_host[g] = scale2_vals[e];
+  }
+
+  size_t cursor = cursor_start;
+  auto put = [&](const void* src, size_t bytes) -> void* {
+    void* dst = ws + cursor;
+    cursor = align_up_(cursor + bytes, 256);
+    cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, stream);
+    return dst;
+  };
+  auto* dB = (const ElementB::DataType**)put(hB.data(), G * sizeof(void*));
+  auto* dSFB = (const ElementSF**)put(hSFB.data(), G * sizeof(void*));
+  auto* dC = (const ElementC**)put(hC.data(), G * sizeof(void*));
+  auto* dD = (ElementD**)put(hD.data(), G * sizeof(void*));
+  auto* dsB = (StrideB*)put(sB.data(), G * sizeof(StrideB));
+  auto* dsC = (StrideC*)put(sC.data(), G * sizeof(StrideC));
+  auto* dsD = (StrideD*)put(sD.data(), G * sizeof(StrideD));
+  auto* dlSFB = (LayoutSFB*)put(lSFB.data(), G * sizeof(LayoutSFB));
+  auto* dAlpha = (float*)put(alpha_host.data(), G * sizeof(float));
+  // Per-group alpha (scale2) needs alpha_ptr_array (G POINTERS, one per group →
+  // &dAlpha[g]); the scalar alpha_ptr would apply dAlpha[0] to every group.
+  std::vector<const float*> hAlphaPtr(G);
+  for (int g = 0; g < G; ++g) {
+    hAlphaPtr[g] = dAlpha + g;
+  }
+  auto* dAlphaPtr = (const float**)put(hAlphaPtr.data(), G * sizeof(const float*));
+
+  cutlass::KernelHardwareInfo hw{};
+  hw.device_id = 0;
+  hw.sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(0);
+
+  typename Gemm::GemmKernel::CollectiveMainloop::Arguments mainloop_args{
+      a.dA, a.dsA, dB, dsB, a.dSFA, a.dlSFA, dSFB, dlSFB};
+
+  typename Gemm::GemmKernel::CollectiveEpilogue::Arguments epi_args{};
+  epi_args.thread.alpha = 1.0f;
+  epi_args.thread.beta = 0.0f;
+  epi_args.thread.alpha_ptr_array = dAlphaPtr;
+  epi_args.ptr_C = dC;
+  epi_args.dC = dsC;
+  epi_args.ptr_D = dD;
+  epi_args.dD = dsD;
+
+  typename Gemm::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {G, a.dShapes, const_cast<ProblemShape*>(a.host_shapes.data())},
+      mainloop_args,
+      epi_args,
+      hw};
+
+  Gemm gemm;
+  size_t need = Gemm::get_workspace_size(args);
+  if (cursor + need > workspace_size) {
+    return -2;
+  }
+  if (gemm.can_implement(args) != cutlass::Status::kSuccess) {
+    return tag + (-50);
+  }
+  cutlass::Status st = gemm.initialize(args, ws + cursor, stream);
+  if (st != cutlass::Status::kSuccess) {
+    return tag + static_cast<int>(st);
+  }
+  st = gemm.run(stream);
+  return st == cutlass::Status::kSuccess ? 0 : tag + static_cast<int>(st);
+}
+#endif  // arch guard
+
+// ════════════════════════════════════════════════════════════════════════════
+// PUBLIC ENTRY — grouped gate_up. A_bf16 [num_tokens,K] TOKEN-MAJOR; the gather is
+// fused into the A-pack via sorted_token_ids. A is packed ONCE and shared by the
+// gate and up kGrouped launches. *_packed_ptrs[e]=[N,K/2] e2m1, *_sfb_ptrs[e]=
+// swizzled SFB, *_scale2_vals=HOST f32[num_experts]. C_*=[M_total,N] sorted output.
+// ════════════════════════════════════════════════════════════════════════════
+extern "C" int atlas_cutlass_nvfp4_grouped_gate_up_fused(
+    const void* A_bf16,
+    const int* sorted_token_ids,
+    const unsigned long long* gate_packed_ptrs,
+    const unsigned long long* gate_sfb_ptrs,
+    const float* gate_scale2_vals,
+    const unsigned long long* up_packed_ptrs,
+    const unsigned long long* up_sfb_ptrs,
+    const float* up_scale2_vals,
+    void* C_gate_bf16,
+    void* C_up_bf16,
+    const int* expert_offsets_host,
+    int num_experts,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  if (n <= 0 || k <= 0 || (k % 16) != 0 || num_experts <= 0) {
+    return -1;
+  }
+  unsigned char* ws = static_cast<unsigned char*>(workspace);
+  // Pack A ONCE (gate + up share the same activation).
+  GroupedAPrep a = prep_grouped_a(static_cast<const __nv_bfloat16*>(A_bf16),
+                                  sorted_token_ids, expert_offsets_host, num_experts,
+                                  n, k, ws, stream);
+  if (a.G == 0) {
+    return 0;
+  }
+  // Both projections carve their B-arrays + gemm_ws from a.cursor (gate's launch
+  // completes on the stream before up's overwrites the region — serialized).
+  int rc = launch_projection(a, gate_packed_ptrs, gate_sfb_ptrs, gate_scale2_vals,
+                             static_cast<__nv_bfloat16*>(C_gate_bf16), n, k, ws,
+                             a.cursor, workspace_size, stream, 100000);
+  if (rc) {
+    return rc;
+  }
+  rc = launch_projection(a, up_packed_ptrs, up_sfb_ptrs, up_scale2_vals,
+                         static_cast<__nv_bfloat16*>(C_up_bf16), n, k, ws, a.cursor,
+                         workspace_size, stream, 200000);
+  return rc;
+#else
+  (void)A_bf16;
+  (void)sorted_token_ids;
+  (void)gate_packed_ptrs;
+  (void)gate_sfb_ptrs;
+  (void)gate_scale2_vals;
+  (void)up_packed_ptrs;
+  (void)up_sfb_ptrs;
+  (void)up_scale2_vals;
+  (void)C_gate_bf16;
+  (void)C_up_bf16;
+  (void)expert_offsets_host;
+  (void)num_experts;
+  (void)n;
+  (void)k;
+  (void)workspace;
+  (void)workspace_size;
+  (void)stream;
+  return -120;
+#endif
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PUBLIC ENTRY — grouped DOWN. A = post-SiLU intermediate [M_total, K=inter],
+// ALREADY expert-contiguous (sorted_token_ids=null). B = down_proj [N=hidden,K/2].
+// ════════════════════════════════════════════════════════════════════════════
+extern "C" int atlas_cutlass_nvfp4_grouped_down(
+    const void* A_bf16,
+    const unsigned long long* packed_ptrs,
+    const unsigned long long* sfb_ptrs,
+    const float* scale2_vals,
+    void* C_bf16,
+    const int* expert_offsets_host,
+    int num_experts,
+    int n,
+    int k,
+    void* workspace,
+    size_t workspace_size,
+    cudaStream_t stream) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED)
+  if (n <= 0 || k <= 0 || (k % 16) != 0 || num_experts <= 0) {
+    return -1;
+  }
+  unsigned char* ws = static_cast<unsigned char*>(workspace);
+  GroupedAPrep a = prep_grouped_a(static_cast<const __nv_bfloat16*>(A_bf16), nullptr,
+                                  expert_offsets_host, num_experts, n, k, ws, stream);
+  if (a.G == 0) {
+    return 0;
+  }
+  return launch_projection(a, packed_ptrs, sfb_ptrs, scale2_vals,
+                           static_cast<__nv_bfloat16*>(C_bf16), n, k, ws, a.cursor,
+                           workspace_size, stream, 300000);
+#else
+  (void)A_bf16;
+  (void)packed_ptrs;
+  (void)sfb_ptrs;
+  (void)scale2_vals;
+  (void)C_bf16;
+  (void)expert_offsets_host;
+  (void)num_experts;
+  (void)n;
+  (void)k;
+  (void)workspace;
+  (void)workspace_size;
+  (void)stream;
+  return -120;
+#endif
+}

--- a/crates/spark-runtime/cuda/flashinfer_ragged_prefill.cu
+++ b/crates/spark-runtime/cuda/flashinfer_ragged_prefill.cu
@@ -1,0 +1,307 @@
+// flashinfer_ragged_prefill.cu
+//
+// Host-callable C-ABI wrapper around FlashInfer's FA2 ragged batched-prefill
+// attention kernel, specialized for BF16 Q/K/V/O, head_dim = 256, GQA, causal
+// (or non-causal). Built for GB10 / sm_121f, CUDA 13.
+//
+// This file mirrors the canonical caller `csrc/batch_prefill.cu`
+// (`BatchPrefillWithRaggedKVCacheRun`), stripped of the torch / TensorView
+// wrapping. It uses:
+//   - flashinfer::PrefillPlan        (scheduler.cuh)      -> scheduler metadata
+//   - flashinfer::PrefillPlanInfo    (scheduler.cuh)      -> plan offsets
+//   - flashinfer::BatchPrefillRaggedParams (default_prefill_params.cuh)
+//   - flashinfer::BatchPrefillWithRaggedKVCacheDispatched (prefill.cuh)
+//   - flashinfer::DefaultAttention<false,false,false,false> (variants.cuh)
+//
+// The wrapper owns NO persistent state; all scratch buffers are passed in.
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+#include <flashinfer/allocator.h>
+#include <flashinfer/fastdiv.cuh>
+#include <flashinfer/pos_enc.cuh>
+#include <flashinfer/attention/mask.cuh>
+#include <flashinfer/attention/scheduler.cuh>
+#include <flashinfer/attention/variants.cuh>
+#include <flashinfer/attention/default_prefill_params.cuh>
+#include <flashinfer/attention/prefill.cuh>
+
+namespace flashinfer {
+// Forward declaration of the dispatched ragged-prefill entry point. It is also
+// defined (as a template) in prefill.cuh which we include above; declaring it
+// here keeps parity with csrc/batch_prefill.cu.
+template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
+          typename AttentionVariant, typename Params>
+cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
+                                                    float* tmp_s, bool enable_pdl,
+                                                    cudaStream_t stream);
+}  // namespace flashinfer
+
+using flashinfer::BatchPrefillRaggedParams;
+using flashinfer::DefaultAttention;
+using flashinfer::GetPtrFromBaseOffset;
+using flashinfer::MaskMode;
+using flashinfer::PosEncodingMode;
+using flashinfer::PrefillPlan;
+using flashinfer::PrefillPlanInfo;
+
+// Compile-time configuration. head_dim is always 256 here.
+namespace {
+constexpr uint32_t kHeadDim = 256;
+constexpr PosEncodingMode kPosEnc = PosEncodingMode::kNone;
+constexpr bool kUseFp16QkReduction = false;
+
+// Standard (composable default) attention variant: no custom mask, no sliding
+// window, no logits soft-cap, no alibi. This is exactly what the JIT codegen
+// emits for plain causal attention:
+//   DefaultAttention<false, false, false, false>
+// (see flashinfer/jit/attention/modules.py and
+//  csrc/batch_decode_mla_config.jinja).
+using StandardAttention = DefaultAttention</*use_custom_mask=*/false,
+                                           /*use_sliding_window=*/false,
+                                           /*use_logits_soft_cap=*/false,
+                                           /*use_alibi=*/false>;
+
+using Params = BatchPrefillRaggedParams<__nv_bfloat16, __nv_bfloat16, __nv_bfloat16, int32_t>;
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Workspace sizing.
+//
+// PrefillPlan carves its scheduler metadata out of caller-provided int/float
+// workspaces using an AlignedAllocator. The exact byte counts depend on
+// `padded_batch_size`, which is computed at plan time from the indptr arrays
+// and the device's SM count. We therefore return generous upper bounds.
+//
+// int_ws layout (per PrefillPlan):
+//   request_indices : padded_batch_size * 4
+//   qo_tile_indices : padded_batch_size * 4
+//   kv_tile_indices : padded_batch_size * 4
+//   o_indptr        : (batch+1) * 4
+//   kv_chunk_size   : 4
+//   [cuda_graph]    : total_num_rows (uint32) * 4  (we never enable cuda graph)
+//   [split_kv]      : merge_indptr (total_rows+1)*4 + block_valid_mask (padded_batch)*1
+//   + 16B alignment slack per allocation.
+//
+// padded_batch_size is bounded by the kernel grid: <= 2 * num_sm rounded up.
+// We use a safe ceiling of 4096 CTAs.
+//
+// float_ws layout (only used when split_kv): tmp_v + tmp_s, sized
+//   num_qo_heads * padded_batch_size * cta_tile_q * (head_dim_vo + 1) * 4 bytes.
+// ---------------------------------------------------------------------------
+extern "C" int atlas_fi_ragged_prefill_workspace_sizes(
+    uint32_t max_batch, uint32_t max_total_qo_rows, uint32_t num_qo_heads,
+    uint32_t num_kv_heads, uint32_t head_dim,
+    size_t* float_ws_bytes_out, size_t* int_ws_bytes_out, size_t* pinned_int_ws_bytes_out) {
+  if (float_ws_bytes_out == nullptr || int_ws_bytes_out == nullptr ||
+      pinned_int_ws_bytes_out == nullptr) {
+    return -1;
+  }
+  if (head_dim != kHeadDim) {
+    return -2;
+  }
+
+  // Upper bound on the scheduler's padded batch size. PrefillPlan uses
+  // 2 * num_sm CTAs as the grid ceiling; query the device but clamp to a
+  // safe minimum so callers can size buffers before any device is selected.
+  int num_sm = 0;
+  int dev_id = 0;
+  if (cudaGetDevice(&dev_id) == cudaSuccess) {
+    cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id);
+  }
+  const uint32_t grid_ceiling = (num_sm > 0) ? static_cast<uint32_t>(2 * num_sm) : 512u;
+  // padded_batch_size can be at most the grid ceiling, but also at least the
+  // number of qo tiles which is bounded by total_qo_rows. Take a safe max.
+  uint32_t padded_batch = grid_ceiling;
+  if (max_batch > padded_batch) padded_batch = max_batch;
+  if (max_total_qo_rows > padded_batch) padded_batch = max_total_qo_rows;
+  // Add headroom.
+  padded_batch += 256;
+
+  const size_t align_slack = 16;
+
+  // int workspace (device) and pinned int workspace (host) have the SAME
+  // layout (PrefillPlan fills the pinned buffer then memcpys to device).
+  size_t int_bytes = 0;
+  int_bytes += static_cast<size_t>(padded_batch) * sizeof(int32_t) + align_slack;  // request_indices
+  int_bytes += static_cast<size_t>(padded_batch) * sizeof(int32_t) + align_slack;  // qo_tile_indices
+  int_bytes += static_cast<size_t>(padded_batch) * sizeof(int32_t) + align_slack;  // kv_tile_indices
+  int_bytes += (static_cast<size_t>(max_batch) + 1) * sizeof(int32_t) + align_slack;  // o_indptr
+  int_bytes += sizeof(int32_t) + align_slack;                                       // kv_chunk_size
+  int_bytes += sizeof(uint32_t) + align_slack;                                      // total_num_rows (cuda graph; unused but cheap)
+  // split_kv extras:
+  int_bytes += (static_cast<size_t>(max_total_qo_rows) + 1) * sizeof(int32_t) + align_slack;  // merge_indptr
+  int_bytes += static_cast<size_t>(padded_batch) * sizeof(bool) + align_slack;                // block_valid_mask
+
+  // float workspace (device), only used when split_kv. Size for the largest
+  // cta_tile_q (128).
+  const uint32_t cta_tile_q_max = 128;
+  size_t float_bytes = 0;
+  float_bytes += static_cast<size_t>(num_qo_heads) * padded_batch * cta_tile_q_max *
+                     head_dim * sizeof(float) + align_slack;  // tmp_v
+  float_bytes += static_cast<size_t>(num_qo_heads) * padded_batch * cta_tile_q_max *
+                     sizeof(float) + align_slack;             // tmp_s
+
+  *int_ws_bytes_out = int_bytes;
+  *pinned_int_ws_bytes_out = int_bytes;
+  *float_ws_bytes_out = float_bytes;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// One-shot ragged batched prefill attention.
+// ---------------------------------------------------------------------------
+namespace {
+
+// Populate the scheduler-derived params fields from a decoded plan_info, and
+// resolve split-KV scratch pointers (tmp_v/tmp_s). Mirrors the
+// post-ADDITIONAL_PARAMS_SETTER block of csrc/batch_prefill.cu.
+inline void apply_plan_info(Params& params, const PrefillPlanInfo& plan_info,
+                            void* int_buffer_ptr, void* float_buffer_ptr,
+                            __nv_bfloat16** tmp_v_out, float** tmp_s_out) {
+  params.request_indices =
+      GetPtrFromBaseOffset<int32_t>(int_buffer_ptr, plan_info.request_indices_offset);
+  params.qo_tile_indices =
+      GetPtrFromBaseOffset<int32_t>(int_buffer_ptr, plan_info.qo_tile_indices_offset);
+  params.kv_tile_indices =
+      GetPtrFromBaseOffset<int32_t>(int_buffer_ptr, plan_info.kv_tile_indices_offset);
+  params.o_indptr = GetPtrFromBaseOffset<int32_t>(int_buffer_ptr, plan_info.o_indptr_offset);
+  params.kv_chunk_size_ptr =
+      GetPtrFromBaseOffset<int32_t>(int_buffer_ptr, plan_info.kv_chunk_size_ptr_offset);
+
+  __nv_bfloat16* tmp_v = nullptr;
+  float* tmp_s = nullptr;
+  if (plan_info.split_kv) {
+    params.merge_indptr =
+        GetPtrFromBaseOffset<int32_t>(int_buffer_ptr, plan_info.merge_indptr_offset);
+    tmp_v = GetPtrFromBaseOffset<__nv_bfloat16>(float_buffer_ptr, plan_info.v_offset);
+    tmp_s = GetPtrFromBaseOffset<float>(float_buffer_ptr, plan_info.s_offset);
+    if (plan_info.enable_cuda_graph) {
+      params.block_valid_mask =
+          GetPtrFromBaseOffset<bool>(int_buffer_ptr, plan_info.block_valid_mask_offset);
+    }
+  }
+  params.padded_batch_size = plan_info.padded_batch_size;
+  params.max_total_num_rows = plan_info.total_num_rows;
+  if (plan_info.enable_cuda_graph) {
+    params.total_num_rows =
+        GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
+  }
+  *tmp_v_out = tmp_v;
+  *tmp_s_out = tmp_s;
+}
+
+// Run the dispatched kernel for a fixed MaskMode, dispatching on cta_tile_q.
+template <MaskMode MASK_MODE>
+inline cudaError_t run_dispatched(Params& params, __nv_bfloat16* tmp_v, float* tmp_s,
+                                  int64_t cta_tile_q, cudaStream_t stream) {
+  cudaError_t status = cudaSuccess;
+  DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
+    status = flashinfer::BatchPrefillWithRaggedKVCacheDispatched<
+        CTA_TILE_Q, kHeadDim, kHeadDim, kPosEnc, kUseFp16QkReduction, MASK_MODE,
+        StandardAttention, Params>(params, tmp_v, tmp_s, /*enable_pdl=*/false, stream);
+  });
+  return status;
+}
+
+}  // namespace
+
+extern "C" int atlas_fi_ragged_prefill_bf16_hd256(
+    const void* q, const void* k, const void* v, void* o,
+    const int32_t* qo_indptr_h, const int32_t* kv_indptr_h,
+    const int32_t* qo_indptr_d, const int32_t* kv_indptr_d,
+    uint32_t batch, uint32_t total_qo_rows, uint32_t total_kv_rows,
+    uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
+    float sm_scale, int causal,
+    void* float_ws, size_t float_ws_bytes,
+    void* int_ws, size_t int_ws_bytes,
+    void* pinned_int_ws, size_t pinned_int_ws_bytes,
+    void* stream_raw) {
+  if (head_dim != kHeadDim) return -2;
+  if (num_kv_heads == 0 || num_qo_heads % num_kv_heads != 0) return -3;
+
+  cudaStream_t stream = static_cast<cudaStream_t>(stream_raw);
+
+  // ------------------------------------------------------------------
+  // Stage 1: plan. Fill scheduler metadata into int_ws / pinned_int_ws and
+  // produce a PrefillPlanInfo. PrefillPlan reads the HOST indptr arrays.
+  // ------------------------------------------------------------------
+  PrefillPlanInfo plan_info;
+  cudaError_t status = PrefillPlan<int32_t>(
+      float_ws, float_ws_bytes,
+      int_ws, pinned_int_ws, int_ws_bytes,
+      plan_info,
+      const_cast<int32_t*>(qo_indptr_h), const_cast<int32_t*>(kv_indptr_h),
+      /*total_num_rows=*/total_qo_rows,
+      /*batch_size=*/batch,
+      num_qo_heads, num_kv_heads,
+      /*head_dim_qk=*/head_dim, /*head_dim_vo=*/head_dim,
+      /*page_size=*/1,
+      /*enable_cuda_graph=*/false,
+      /*sizeof_dtype_o=*/sizeof(__nv_bfloat16),
+      /*window_left=*/-1,
+      /*fixed_split_size=*/-1,
+      /*disable_split_kv=*/false,
+      /*num_colocated_ctas=*/0,
+      stream);
+  if (status != cudaSuccess) {
+    return static_cast<int>(status);
+  }
+
+  // ------------------------------------------------------------------
+  // Stage 2: build params. Contiguous row-major [rows, heads, head_dim] so
+  //   stride_n = num_*_heads * head_dim, stride_h = head_dim.
+  // ------------------------------------------------------------------
+  Params params;  // zero/default-initialized by the host ctor
+
+  params.q = static_cast<__nv_bfloat16*>(const_cast<void*>(q));
+  params.k = static_cast<__nv_bfloat16*>(const_cast<void*>(k));
+  params.v = static_cast<__nv_bfloat16*>(const_cast<void*>(v));
+  params.o = static_cast<__nv_bfloat16*>(o);
+  params.lse = nullptr;
+
+  // The kernel reads the DEVICE indptr copies.
+  params.q_indptr = const_cast<int32_t*>(qo_indptr_d);
+  params.kv_indptr = const_cast<int32_t*>(kv_indptr_d);
+
+  params.num_qo_heads = num_qo_heads;
+  params.num_kv_heads = num_kv_heads;
+  params.group_size = flashinfer::uint_fastdiv(num_qo_heads / num_kv_heads);
+
+  params.q_stride_n = num_qo_heads * head_dim;
+  params.q_stride_h = head_dim;
+  params.k_stride_n = num_kv_heads * head_dim;
+  params.k_stride_h = head_dim;
+  params.v_stride_n = num_kv_heads * head_dim;
+  params.v_stride_h = head_dim;
+
+  params.window_left = -1;
+  params.logits_soft_cap = 0.0f;
+  params.sm_scale = sm_scale;
+  // rope_* unused (PosEncodingMode::kNone); leave at ctor defaults (0).
+
+  // Scheduler-derived pointers + split-KV scratch.
+  __nv_bfloat16* tmp_v = nullptr;
+  float* tmp_s = nullptr;
+  apply_plan_info(params, plan_info, int_ws, float_ws, &tmp_v, &tmp_s);
+
+  // ------------------------------------------------------------------
+  // Stage 3: dispatch the kernel. MaskMode is a compile-time template param,
+  // selected at runtime from `causal`.
+  // ------------------------------------------------------------------
+  if (causal) {
+    status = run_dispatched<MaskMode::kCausal>(params, tmp_v, tmp_s, plan_info.cta_tile_q, stream);
+  } else {
+    status = run_dispatched<MaskMode::kNone>(params, tmp_v, tmp_s, plan_info.cta_tile_q, stream);
+  }
+  if (status != cudaSuccess) {
+    return static_cast<int>(status);
+  }
+  return 0;
+}

--- a/crates/spark-runtime/src/cutlass.rs
+++ b/crates/spark-runtime/src/cutlass.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Optional CUTLASS host-wrapper FFI for de-risking GB10 GEMM replacements.
+//!
+//! Split for the ≤500 LoC cap: this root holds the shared FFI `extern` block,
+//! the workspace `Ctx`, and module wiring; the public wrappers live in the
+//! `gemm` (dense BF16 + NVFP4), `grouped` (per-expert MoE), and `pack`
+//! (weight pack / SFB swizzle / transpose) siblings. The public API
+//! (`spark_runtime::cutlass::<fn>`) is preserved via the re-exports below.
+
+#[cfg(atlas_cutlass)]
+use anyhow::{Result, bail};
+
+#[cfg(atlas_cutlass)]
+use std::ffi::c_void;
+#[cfg(atlas_cutlass)]
+use std::sync::OnceLock;
+
+mod gemm;
+mod grouped;
+mod pack;
+
+pub use gemm::{bf16_gemm_act_weight_t, nvfp4_gemm_bf16_act_weight_t};
+pub use grouped::{nvfp4_grouped_down, nvfp4_grouped_gate_up, nvfp4_grouped_gate_up_fused};
+pub use pack::{pack_bf16_weight_to_nvfp4_t, pack_weight_sfb, transpose_nvfp4_packed_kton};
+
+#[cfg(all(test, atlas_cutlass))]
+mod tests;
+
+#[cfg(atlas_cutlass)]
+unsafe extern "C" {
+    pub(crate) fn atlas_cutlass_bf16_gemm_act_weight_t(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_nvfp4_gemm_bf16_act_weight_t(
+        act: *const c_void,
+        weight_packed_t: *const c_void,
+        weight_scale_t: *const c_void,
+        weight_scale_2: f32,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_pack_bf16_weight_to_nvfp4_t(
+        weight_bf16: *const c_void,
+        packed_t: *mut c_void,
+        scale_t: *mut c_void,
+        n: i32,
+        k: i32,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_nvfp4_grouped_gate_up(
+        a_bf16: *const c_void,
+        gate_packed_ptrs: *const u64,
+        gate_scale_ptrs: *const u64,
+        gate_scale2_vals: *const f32,
+        up_packed_ptrs: *const u64,
+        up_scale_ptrs: *const u64,
+        up_scale2_vals: *const f32,
+        c_gate_bf16: *mut c_void,
+        c_up_bf16: *mut c_void,
+        expert_offsets_host: *const i32,
+        num_experts: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_nvfp4_grouped_gate_up_fused(
+        a_bf16: *const c_void,
+        sorted_token_ids: *const i32,
+        gate_packed_ptrs: *const u64,
+        gate_sfb_ptrs: *const u64,
+        gate_scale2_vals: *const f32,
+        up_packed_ptrs: *const u64,
+        up_sfb_ptrs: *const u64,
+        up_scale2_vals: *const f32,
+        c_gate_bf16: *mut c_void,
+        c_up_bf16: *mut c_void,
+        expert_offsets_host: *const i32,
+        num_experts: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_nvfp4_grouped_down(
+        a_bf16: *const c_void,
+        packed_ptrs: *const u64,
+        sfb_ptrs: *const u64,
+        scale2_vals: *const f32,
+        c_bf16: *mut c_void,
+        expert_offsets_host: *const i32,
+        num_experts: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_pack_weight_sfb(
+        scale_in: *const c_void,
+        scale_out: *mut c_void,
+        n: i32,
+        k: i32,
+        stream: *mut c_void,
+    ) -> i32;
+    pub(crate) fn atlas_cutlass_transpose_nvfp4_packed_kton(
+        src_packed_t: *const c_void,
+        dst_packed: *mut c_void,
+        n: i32,
+        k: i32,
+        stream: *mut c_void,
+    ) -> i32;
+    #[cfg(test)]
+    pub(crate) fn atlas_cutlass_bf16_gemm_act_weight_t_128x256(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    #[cfg(test)]
+    pub(crate) fn atlas_cutlass_bf16_gemm_act_weight_t_256x128(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    #[cfg(test)]
+    pub(crate) fn atlas_cutlass_bf16_gemm_act_weight_t_64x128(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    #[cfg(test)]
+    pub(crate) fn atlas_cutlass_bf16_gemm_act_weight_t_128x64(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    #[cfg(test)]
+    pub(crate) fn atlas_cutlass_bf16_gemm_act_weight_t_64x64(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+    ) -> i32;
+    #[cfg(test)]
+    pub(crate) fn atlas_cublaslt_bf16_gemm_act_weight_t_algo(
+        act: *const c_void,
+        weight: *const c_void,
+        out: *mut c_void,
+        m: i32,
+        n: i32,
+        k: i32,
+        workspace: *mut c_void,
+        workspace_size: usize,
+        stream: *mut c_void,
+        algo_index: i32,
+        returned_count: *mut i32,
+    ) -> i32;
+    pub(crate) fn cuMemAlloc_v2(dptr: *mut u64, bytesize: usize) -> i32;
+}
+
+#[cfg(atlas_cutlass)]
+pub(crate) struct Ctx {
+    pub(crate) workspace: u64,
+    pub(crate) ws_size: usize,
+}
+
+#[cfg(atlas_cutlass)]
+unsafe impl Send for Ctx {}
+#[cfg(atlas_cutlass)]
+unsafe impl Sync for Ctx {}
+
+#[cfg(atlas_cutlass)]
+static CTX: OnceLock<Ctx> = OnceLock::new();
+
+#[cfg(atlas_cutlass)]
+pub(crate) fn ctx() -> Result<&'static Ctx> {
+    if let Some(c) = CTX.get() {
+        return Ok(c);
+    }
+    // Shared scratch for all CUTLASS host wrappers. The grouped NVFP4 MoE path
+    // (single-launch kGrouped over up to 256 experts) stages packed-A + SFA +
+    // per-group arrays + the gemm workspace here; at large prefill M the 256-group
+    // gemm workspace alone exceeds the old 64 MB (-> status -2 + an OOB context
+    // corruption). 512 MB by default; override with ATLAS_CUTLASS_WORKSPACE_MB.
+    let ws_size = std::env::var("ATLAS_CUTLASS_WORKSPACE_MB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(512)
+        * 1024
+        * 1024;
+    let mut workspace = 0u64;
+    let status = unsafe { cuMemAlloc_v2(&mut workspace, ws_size) };
+    if status != 0 {
+        bail!("cuMemAlloc CUTLASS workspace failed: {status}");
+    }
+    let _ = CTX.set(Ctx { workspace, ws_size });
+    Ok(CTX.get().unwrap())
+}

--- a/crates/spark-runtime/src/cutlass/gemm.rs
+++ b/crates/spark-runtime/src/cutlass/gemm.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Dense CUTLASS GEMM host wrappers (BF16 + native NVFP4 projection).
+
+use anyhow::{Result, bail};
+
+#[cfg(atlas_cutlass)]
+use std::ffi::c_void;
+
+#[cfg(atlas_cutlass)]
+use super::*;
+
+/// Row-major `out[M,N] = act[M,K] @ weight[N,K]^T`, all BF16.
+#[allow(clippy::too_many_arguments)]
+pub fn bf16_gemm_act_weight_t(
+    act: u64,
+    weight: u64,
+    out: u64,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let ctx = ctx()?;
+        let status = unsafe {
+            atlas_cutlass_bf16_gemm_act_weight_t(
+                act as *const c_void,
+                weight as *const c_void,
+                out as *mut c_void,
+                m as i32,
+                n as i32,
+                k as i32,
+                ctx.workspace as *mut c_void,
+                ctx.ws_size,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS bf16 GEMM failed: status {status} for {m}x{n}x{k}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (act, weight, out, m, n, k, stream);
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}
+
+/// Native CUTLASS NVFP4 dense projection:
+/// `out[M,N] = quant_nvfp4(act[M,K]) @ weight_t[N,K]^T -> BF16`.
+///
+/// `weight_packed_t` and `weight_scale_t` are Atlas's transposed NVFP4
+/// prefill layout: packed data `[K/2,N]`, scales `[K/16,N]`. The wrapper
+/// repacks activation and scale tensors into CUTLASS's SM120 blockscaled
+/// layouts in the shared CUTLASS workspace before dispatch.
+#[allow(clippy::too_many_arguments)]
+pub fn nvfp4_gemm_bf16_act_weight_t(
+    act: u64,
+    weight_packed_t: u64,
+    weight_scale_t: u64,
+    weight_scale_2: f32,
+    out: u64,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let ctx = ctx()?;
+        let status = unsafe {
+            atlas_cutlass_nvfp4_gemm_bf16_act_weight_t(
+                act as *const c_void,
+                weight_packed_t as *const c_void,
+                weight_scale_t as *const c_void,
+                weight_scale_2,
+                out as *mut c_void,
+                m as i32,
+                n as i32,
+                k as i32,
+                ctx.workspace as *mut c_void,
+                ctx.ws_size,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS nvfp4 GEMM failed: status {status} for {m}x{n}x{k}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (
+            act,
+            weight_packed_t,
+            weight_scale_t,
+            weight_scale_2,
+            out,
+            m,
+            n,
+            k,
+            stream,
+        );
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}

--- a/crates/spark-runtime/src/cutlass/grouped.rs
+++ b/crates/spark-runtime/src/cutlass/grouped.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Grouped (per-expert) CUTLASS NVFP4 MoE GEMM host wrappers.
+
+use anyhow::{Result, bail};
+
+#[cfg(atlas_cutlass)]
+use std::ffi::c_void;
+
+#[cfg(atlas_cutlass)]
+use super::*;
+
+/// Grouped (per-expert) NVFP4 fused gate_up GEMM — Holo MoE Phase-1
+/// escape-hatch path. Dispatches the proven Sm120 NVFP4 collective once per
+/// active expert over its token slice; bit-faithful to
+/// `nvfp4_gemm_bf16_act_weight_t` (it IS that collective), at one launch per
+/// expert. Used to validate that the FP4 math integrates correctly in grouped
+/// form before the hand-rolled block-scaled mma (Phase 2).
+///
+/// `a` is bf16 `[M_total, K]`; expert `e` owns rows
+/// `[expert_offsets[e], expert_offsets[e+1])`. `*_packed_ptrs`/`*_scale_ptrs`
+/// are device-pointer arrays (one per expert) in the
+/// `pack_bf16_weight_to_nvfp4_t` layout (`[N,K/2]` + `[K/16,N]`); the
+/// `*_scale2_vals` and `expert_offsets` slices are HOST arrays.
+#[allow(clippy::too_many_arguments)]
+pub fn nvfp4_grouped_gate_up(
+    a: u64,
+    gate_packed_ptrs: &[u64],
+    gate_scale_ptrs: &[u64],
+    gate_scale2_vals: &[f32],
+    up_packed_ptrs: &[u64],
+    up_scale_ptrs: &[u64],
+    up_scale2_vals: &[f32],
+    c_gate: u64,
+    c_up: u64,
+    expert_offsets: &[i32],
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let num_experts = gate_packed_ptrs.len();
+        if expert_offsets.len() != num_experts + 1 {
+            bail!(
+                "nvfp4_grouped_gate_up: expert_offsets len {} != num_experts+1 {}",
+                expert_offsets.len(),
+                num_experts + 1
+            );
+        }
+        let ctx = ctx()?;
+        let status = unsafe {
+            atlas_cutlass_nvfp4_grouped_gate_up(
+                a as *const c_void,
+                gate_packed_ptrs.as_ptr(),
+                gate_scale_ptrs.as_ptr(),
+                gate_scale2_vals.as_ptr(),
+                up_packed_ptrs.as_ptr(),
+                up_scale_ptrs.as_ptr(),
+                up_scale2_vals.as_ptr(),
+                c_gate as *mut c_void,
+                c_up as *mut c_void,
+                expert_offsets.as_ptr(),
+                num_experts as i32,
+                n as i32,
+                k as i32,
+                ctx.workspace as *mut c_void,
+                ctx.ws_size,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS nvfp4 grouped gate_up failed: status {status}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (
+            a,
+            gate_packed_ptrs,
+            gate_scale_ptrs,
+            gate_scale2_vals,
+            up_packed_ptrs,
+            up_scale_ptrs,
+            up_scale2_vals,
+            c_gate,
+            c_up,
+            expert_offsets,
+            n,
+            k,
+            stream,
+        );
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}
+
+/// Single-launch grouped (`GemmUniversalMode::kGrouped`) NVFP4 fused gate_up
+/// GEMM — the Phase-2 successor to [`nvfp4_grouped_gate_up`]. Replaces the
+/// per-expert collective loop with ONE grouped launch over all active experts,
+/// eliminating the N-launch overhead.
+///
+/// `a` is bf16 `[M_total, K]`, expert-contiguous (caller permuted so expert `e`
+/// owns rows `[expert_offsets_host[e], expert_offsets_host[e+1])`).
+/// `*_packed_ptrs` are device-pointer arrays (one per expert) into the CUTLASS
+/// `[N,K/2]` packed weight tables; `*_sfb_ptrs` are device-pointer arrays into
+/// the swizzled SFB (ue4m3) scale tables (see `pack_weight_sfb`).
+/// `*_scale2_vals` and `expert_offsets_host` are HOST arrays.
+#[allow(clippy::too_many_arguments)]
+pub fn nvfp4_grouped_gate_up_fused(
+    a: u64,
+    sorted_token_ids: u64,
+    gate_packed_ptrs: &[u64],
+    gate_sfb_ptrs: &[u64],
+    gate_scale2_vals: &[f32],
+    up_packed_ptrs: &[u64],
+    up_sfb_ptrs: &[u64],
+    up_scale2_vals: &[f32],
+    c_gate: u64,
+    c_up: u64,
+    expert_offsets_host: &[i32],
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let num_experts = gate_packed_ptrs.len();
+        if expert_offsets_host.len() != num_experts + 1 {
+            bail!(
+                "nvfp4_grouped_gate_up_fused: expert_offsets len {} != num_experts+1 {}",
+                expert_offsets_host.len(),
+                num_experts + 1
+            );
+        }
+        let ctx = ctx()?;
+        let status = unsafe {
+            atlas_cutlass_nvfp4_grouped_gate_up_fused(
+                a as *const c_void,
+                sorted_token_ids as *const i32,
+                gate_packed_ptrs.as_ptr(),
+                gate_sfb_ptrs.as_ptr(),
+                gate_scale2_vals.as_ptr(),
+                up_packed_ptrs.as_ptr(),
+                up_sfb_ptrs.as_ptr(),
+                up_scale2_vals.as_ptr(),
+                c_gate as *mut c_void,
+                c_up as *mut c_void,
+                expert_offsets_host.as_ptr(),
+                num_experts as i32,
+                n as i32,
+                k as i32,
+                ctx.workspace as *mut c_void,
+                ctx.ws_size,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS nvfp4 grouped(fused) gate_up failed: status {status}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (
+            a,
+            sorted_token_ids,
+            gate_packed_ptrs,
+            gate_sfb_ptrs,
+            gate_scale2_vals,
+            up_packed_ptrs,
+            up_sfb_ptrs,
+            up_scale2_vals,
+            c_gate,
+            c_up,
+            expert_offsets_host,
+            n,
+            k,
+            stream,
+        );
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}
+
+/// Single-launch grouped NVFP4 DOWN projection (`atlas_cutlass_nvfp4_grouped_down`).
+/// `a` is the post-SiLU bf16 intermediate `[M_total, K=inter]`, ALREADY
+/// expert-contiguous (no gather). `packed_ptrs`/`sfb_ptrs` are device-pointer
+/// arrays into the `[N=hidden,K/2]` packed + swizzled-SFB down tables; `scale2_vals`
+/// and `expert_offsets_host` are HOST arrays. Writes `c` `[M_total, N=hidden]`.
+#[allow(clippy::too_many_arguments)]
+pub fn nvfp4_grouped_down(
+    a: u64,
+    packed_ptrs: &[u64],
+    sfb_ptrs: &[u64],
+    scale2_vals: &[f32],
+    c: u64,
+    expert_offsets_host: &[i32],
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let num_experts = packed_ptrs.len();
+        if expert_offsets_host.len() != num_experts + 1 {
+            bail!(
+                "nvfp4_grouped_down: expert_offsets len {} != num_experts+1 {}",
+                expert_offsets_host.len(),
+                num_experts + 1
+            );
+        }
+        let ctx = ctx()?;
+        let status = unsafe {
+            atlas_cutlass_nvfp4_grouped_down(
+                a as *const c_void,
+                packed_ptrs.as_ptr(),
+                sfb_ptrs.as_ptr(),
+                scale2_vals.as_ptr(),
+                c as *mut c_void,
+                expert_offsets_host.as_ptr(),
+                num_experts as i32,
+                n as i32,
+                k as i32,
+                ctx.workspace as *mut c_void,
+                ctx.ws_size,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS nvfp4 grouped down failed: status {status}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (
+            a,
+            packed_ptrs,
+            sfb_ptrs,
+            scale2_vals,
+            c,
+            expert_offsets_host,
+            n,
+            k,
+            stream,
+        );
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}

--- a/crates/spark-runtime/src/cutlass/pack.rs
+++ b/crates/spark-runtime/src/cutlass/pack.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! CUTLASS NVFP4 weight pack / scale-swizzle / transpose host wrappers.
+
+use anyhow::{Result, bail};
+
+#[cfg(atlas_cutlass)]
+use std::ffi::c_void;
+
+#[cfg(atlas_cutlass)]
+use super::*;
+
+/// Repack an Atlas E4M3 weight scale `[K/16,N]` (or `[N,K/16]`) into the CUTLASS
+/// SM120 blockscaled SFB swizzle atom (`tile_atom_to_shape_SFB`, ue4m3) that the
+/// grouped collective reads. M-independent (the SFB atom depends only on N,K) so
+/// this runs once per expert at load. `scale_out` must hold the swizzled SFB
+/// region the grouped kernel consumes.
+pub fn pack_weight_sfb(scale_in: u64, scale_out: u64, n: u32, k: u32, stream: u64) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let status = unsafe {
+            atlas_cutlass_pack_weight_sfb(
+                scale_in as *const c_void,
+                scale_out as *mut c_void,
+                n as i32,
+                k as i32,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS weight SFB pack failed: status {status} for {n}x{k}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (scale_in, scale_out, n, k, stream);
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}
+
+/// Pack BF16 row-major weight `[N,K]` into the native CUTLASS NVFP4 layout:
+/// packed `[N,K/2]` (N-major, K-contiguous — NOT the Atlas transposed `[K/2,N]`)
+/// and E4M3 scales `[K/16,N]`. `weight_scale_2` is assumed to be 1.0 by the
+/// caller when feeding this into the native CUTLASS wrapper.
+pub fn pack_bf16_weight_to_nvfp4_t(
+    weight_bf16: u64,
+    packed_t: u64,
+    scale_t: u64,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let status = unsafe {
+            atlas_cutlass_pack_bf16_weight_to_nvfp4_t(
+                weight_bf16 as *const c_void,
+                packed_t as *mut c_void,
+                scale_t as *mut c_void,
+                n as i32,
+                k as i32,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS BF16->NVFP4 weight pack failed: status {status} for {n}x{k}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (weight_bf16, packed_t, scale_t, n, k, stream);
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}
+
+/// Transpose an Atlas-packed NVFP4 weight from the checkpoint/hand-kernel
+/// `[K/2, N]` layout into CUTLASS's `[N, K/2]` layout (the byte order the
+/// native NVFP4 GEMM consumes for the ColumnMajor B operand). Pure byte
+/// transpose; nibble pairing within each byte is preserved. `dst_packed` must
+/// have `N * K/2` bytes.
+pub fn transpose_nvfp4_packed_kton(
+    src_packed_t: u64,
+    dst_packed: u64,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_cutlass)]
+    {
+        let status = unsafe {
+            atlas_cutlass_transpose_nvfp4_packed_kton(
+                src_packed_t as *const c_void,
+                dst_packed as *mut c_void,
+                n as i32,
+                k as i32,
+                stream as *mut c_void,
+            )
+        };
+        if status != 0 {
+            bail!("CUTLASS NVFP4 weight transpose failed: status {status} for {n}x{k}");
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_cutlass))]
+    {
+        let _ = (src_packed_t, dst_packed, n, k, stream);
+        bail!("CUTLASS support was not built; set CUTLASS_HOME when building")
+    }
+}

--- a/crates/spark-runtime/src/cutlass/tests/bf16.rs
+++ b/crates/spark-runtime/src/cutlass/tests/bf16.rs
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Dense BF16 CUTLASS smoke/correctness + tile-variant & cuBLASLt algo benches.
+
+use super::super::*;
+use super::*;
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cutlass_bf16_ffi_smoke_computes_row_major_act_by_weight_t() {
+    const M: usize = 128;
+    const N: usize = 128;
+    const K: usize = 32;
+
+    let act_f32: Vec<f32> = (0..M * K)
+        .map(|i| ((i % 11) as f32 - 5.0) * 0.125)
+        .collect();
+    let weight_f32: Vec<f32> = (0..N * K).map(|i| ((i % 7) as f32 - 3.0) * 0.25).collect();
+    let act: Vec<u16> = act_f32.iter().copied().map(f32_to_bf16).collect();
+    let weight: Vec<u16> = weight_f32.iter().copied().map(f32_to_bf16).collect();
+    let mut out = vec![0u16; M * N];
+
+    let act_dev;
+    let weight_dev;
+    let out_dev;
+    unsafe {
+        act_dev = device_alloc(act.len() * 2);
+        weight_dev = device_alloc(weight.len() * 2);
+        out_dev = device_alloc(out.len() * 2);
+        copy_h2d(act_dev, &act);
+        copy_h2d(weight_dev, &weight);
+    }
+
+    let result = bf16_gemm_act_weight_t(
+        act_dev as u64,
+        weight_dev as u64,
+        out_dev as u64,
+        M as u32,
+        N as u32,
+        K as u32,
+        0,
+    );
+    assert!(result.is_ok(), "{result:?}");
+
+    unsafe {
+        cuda_check(cudaDeviceSynchronize(), "device synchronize");
+        copy_d2h(&mut out, out_dev);
+        cuda_check(cudaFree(act_dev), "free act");
+        cuda_check(cudaFree(weight_dev), "free weight");
+        cuda_check(cudaFree(out_dev), "free out");
+    }
+
+    for m in 0..M {
+        for n in 0..N {
+            let mut expected = 0.0f32;
+            for k in 0..K {
+                expected += bf16_to_f32(act[m * K + k]) * bf16_to_f32(weight[n * K + k]);
+            }
+            let actual = bf16_to_f32(out[m * N + n]);
+            assert!(
+                (actual - expected).abs() < 0.025,
+                "m={m} n={n} actual={actual} expected={expected}"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cutlass_bf16_ffi_computes_holo_ssm_qkvz_shape() {
+    const M: usize = 3537;
+    const N: usize = 12288;
+    const K: usize = 2048;
+
+    let mut act = vec![0u16; M * K];
+    for m in 0..M {
+        act[m * K + (m % K)] = f32_to_bf16(1.0);
+    }
+    let weight: Vec<u16> = (0..N * K)
+        .map(|i| f32_to_bf16(((i % 17) as f32 - 8.0) * 0.0625))
+        .collect();
+    let mut out = vec![0u16; M * N];
+
+    let act_dev;
+    let weight_dev;
+    let out_dev;
+    unsafe {
+        act_dev = device_alloc(act.len() * 2);
+        weight_dev = device_alloc(weight.len() * 2);
+        out_dev = device_alloc(out.len() * 2);
+        copy_h2d(act_dev, &act);
+        copy_h2d(weight_dev, &weight);
+    }
+
+    let result = bf16_gemm_act_weight_t(
+        act_dev as u64,
+        weight_dev as u64,
+        out_dev as u64,
+        M as u32,
+        N as u32,
+        K as u32,
+        0,
+    );
+    assert!(result.is_ok(), "{result:?}");
+
+    unsafe {
+        cuda_check(cudaDeviceSynchronize(), "device synchronize");
+        copy_d2h(&mut out, out_dev);
+        cuda_check(cudaFree(act_dev), "free act");
+        cuda_check(cudaFree(weight_dev), "free weight");
+        cuda_check(cudaFree(out_dev), "free out");
+    }
+
+    for m in 0..M {
+        let selected_k = m % K;
+        for n in 0..N {
+            let actual = bf16_to_f32(out[m * N + n]);
+            let expected = bf16_to_f32(weight[n * K + selected_k]);
+            assert_eq!(
+                actual, expected,
+                "m={m} n={n} selected_k={selected_k} actual={actual} expected={expected}"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cutlass_bf16_holo_qkvz_bench_against_cublaslt() {
+    const ITERS: usize = 100;
+
+    let shapes = [
+        ("ssm_qkvz", 3537usize, 12288usize, 2048usize),
+        ("ssm_out", 3537, 2048, 4096),
+        ("attn_q", 3537, 8192, 2048),
+        ("attn_k", 3537, 512, 2048),
+        ("attn_v", 3537, 512, 2048),
+        ("attn_o", 3537, 2048, 4096),
+        ("moe_gate_up_dense", 28296, 1024, 2048),
+        ("moe_down_dense", 28296, 2048, 512),
+    ];
+
+    let variants: [(&str, CutlassVariant); 6] = [
+        ("128x128", atlas_cutlass_bf16_gemm_act_weight_t),
+        ("128x256", atlas_cutlass_bf16_gemm_act_weight_t_128x256),
+        ("256x128", atlas_cutlass_bf16_gemm_act_weight_t_256x128),
+        ("64x128", atlas_cutlass_bf16_gemm_act_weight_t_64x128),
+        ("128x64", atlas_cutlass_bf16_gemm_act_weight_t_128x64),
+        ("64x64", atlas_cutlass_bf16_gemm_act_weight_t_64x64),
+    ];
+
+    for (name, m, n, k) in shapes {
+        let act: Vec<u16> = (0..m * k)
+            .map(|i| f32_to_bf16(((i % 13) as f32 - 6.0) * 0.03125))
+            .collect();
+        let weight: Vec<u16> = (0..n * k)
+            .map(|i| f32_to_bf16(((i % 17) as f32 - 8.0) * 0.0625))
+            .collect();
+
+        let act_dev;
+        let weight_dev;
+        let cutlass_out;
+        let cublas_out;
+        unsafe {
+            act_dev = device_alloc(act.len() * 2);
+            weight_dev = device_alloc(weight.len() * 2);
+            cutlass_out = device_alloc(m * n * 2);
+            cublas_out = device_alloc(m * n * 2);
+            copy_h2d(act_dev, &act);
+            copy_h2d(weight_dev, &weight);
+        }
+
+        crate::cublaslt::bf16_gemm_act_weight_t(
+            act_dev as u64,
+            weight_dev as u64,
+            cublas_out as u64,
+            m as u32,
+            n as u32,
+            k as u32,
+            0,
+        )
+        .unwrap();
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "warmup synchronize");
+        }
+
+        let mut best_variant = "";
+        let mut best_cutlass_ms = f64::INFINITY;
+        for (variant, f) in variants {
+            run_cutlass_variant(variant, f, act_dev, weight_dev, cutlass_out, m, n, k).unwrap();
+            unsafe {
+                cuda_check(cudaDeviceSynchronize(), "cutlass warmup synchronize");
+            }
+            let t0 = std::time::Instant::now();
+            for _ in 0..ITERS {
+                run_cutlass_variant(variant, f, act_dev, weight_dev, cutlass_out, m, n, k).unwrap();
+            }
+            unsafe {
+                cuda_check(cudaDeviceSynchronize(), "cutlass synchronize");
+            }
+            let cutlass_ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+            if cutlass_ms < best_cutlass_ms {
+                best_cutlass_ms = cutlass_ms;
+                best_variant = variant;
+            }
+        }
+
+        let t0 = std::time::Instant::now();
+        for _ in 0..ITERS {
+            crate::cublaslt::bf16_gemm_act_weight_t(
+                act_dev as u64,
+                weight_dev as u64,
+                cublas_out as u64,
+                m as u32,
+                n as u32,
+                k as u32,
+                0,
+            )
+            .unwrap();
+        }
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "cublas synchronize");
+        }
+        let cublas_ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+
+        let flop = 2.0 * m as f64 * n as f64 * k as f64;
+        eprintln!(
+            "HOLO_DENSE_BENCH {name} M={m} N={n} K={k} iters={ITERS} best_cutlass={best_variant} cutlass_ms={best_cutlass_ms:.3} cutlass_tflops={:.1} cublaslt_ms={cublas_ms:.3} cublaslt_tflops={:.1} speedup_vs_cublas={:.3}",
+            flop / (best_cutlass_ms / 1000.0) / 1.0e12,
+            flop / (cublas_ms / 1000.0) / 1.0e12,
+            cublas_ms / best_cutlass_ms
+        );
+
+        unsafe {
+            cuda_check(cudaFree(act_dev), "free act");
+            cuda_check(cudaFree(weight_dev), "free weight");
+            cuda_check(cudaFree(cutlass_out), "free cutlass out");
+            cuda_check(cudaFree(cublas_out), "free cublas out");
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cutlass_bf16_holo_decode_route_batch_shapes() {
+    const ITERS: usize = 2000;
+    let shapes = [
+        ("moe_gate_up_routes_c1", 8usize, 1024usize, 2048usize),
+        ("moe_gate_up_routes_c2", 16, 1024, 2048),
+        ("moe_gate_up_routes_c4", 32, 1024, 2048),
+        ("moe_gate_up_routes_c8", 64, 1024, 2048),
+        ("moe_gate_up_routes_c16", 128, 1024, 2048),
+        ("moe_down_routes_c1", 8, 2048, 512),
+        ("moe_down_routes_c2", 16, 2048, 512),
+        ("moe_down_routes_c4", 32, 2048, 512),
+        ("moe_down_routes_c8", 64, 2048, 512),
+        ("moe_down_routes_c16", 128, 2048, 512),
+    ];
+    let variants: [(&str, CutlassVariant); 6] = [
+        ("128x128", atlas_cutlass_bf16_gemm_act_weight_t),
+        ("128x256", atlas_cutlass_bf16_gemm_act_weight_t_128x256),
+        ("256x128", atlas_cutlass_bf16_gemm_act_weight_t_256x128),
+        ("64x128", atlas_cutlass_bf16_gemm_act_weight_t_64x128),
+        ("128x64", atlas_cutlass_bf16_gemm_act_weight_t_128x64),
+        ("64x64", atlas_cutlass_bf16_gemm_act_weight_t_64x64),
+    ];
+
+    for (name, m, n, k) in shapes {
+        let act: Vec<u16> = (0..m * k)
+            .map(|i| f32_to_bf16(((i % 13) as f32 - 6.0) * 0.03125))
+            .collect();
+        let weight: Vec<u16> = (0..n * k)
+            .map(|i| f32_to_bf16(((i % 17) as f32 - 8.0) * 0.0625))
+            .collect();
+
+        let act_dev;
+        let weight_dev;
+        let cutlass_out;
+        let cublas_out;
+        unsafe {
+            act_dev = device_alloc(act.len() * 2);
+            weight_dev = device_alloc(weight.len() * 2);
+            cutlass_out = device_alloc(m * n * 2);
+            cublas_out = device_alloc(m * n * 2);
+            copy_h2d(act_dev, &act);
+            copy_h2d(weight_dev, &weight);
+        }
+
+        crate::cublaslt::bf16_gemm_act_weight_t(
+            act_dev as u64,
+            weight_dev as u64,
+            cublas_out as u64,
+            m as u32,
+            n as u32,
+            k as u32,
+            0,
+        )
+        .unwrap();
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "warmup synchronize");
+        }
+
+        let mut best_variant = "";
+        let mut best_cutlass_ms = f64::INFINITY;
+        for (variant, f) in variants {
+            run_cutlass_variant(variant, f, act_dev, weight_dev, cutlass_out, m, n, k).unwrap();
+            unsafe {
+                cuda_check(cudaDeviceSynchronize(), "cutlass warmup synchronize");
+            }
+            let t0 = std::time::Instant::now();
+            for _ in 0..ITERS {
+                run_cutlass_variant(variant, f, act_dev, weight_dev, cutlass_out, m, n, k).unwrap();
+            }
+            unsafe {
+                cuda_check(cudaDeviceSynchronize(), "cutlass synchronize");
+            }
+            let cutlass_ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+            if cutlass_ms < best_cutlass_ms {
+                best_cutlass_ms = cutlass_ms;
+                best_variant = variant;
+            }
+        }
+
+        let t0 = std::time::Instant::now();
+        for _ in 0..ITERS {
+            crate::cublaslt::bf16_gemm_act_weight_t(
+                act_dev as u64,
+                weight_dev as u64,
+                cublas_out as u64,
+                m as u32,
+                n as u32,
+                k as u32,
+                0,
+            )
+            .unwrap();
+        }
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "cublas synchronize");
+        }
+        let cublas_ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+
+        let flop = 2.0 * m as f64 * n as f64 * k as f64;
+        eprintln!(
+            "HOLO_ROUTE_BATCH_BENCH {name} M={m} N={n} K={k} iters={ITERS} best_cutlass={best_variant} cutlass_us={:.3} cutlass_tflops={:.1} cublaslt_us={:.3} cublaslt_tflops={:.1} speedup_vs_cublas={:.3}",
+            best_cutlass_ms * 1000.0,
+            flop / (best_cutlass_ms / 1000.0) / 1.0e12,
+            cublas_ms * 1000.0,
+            flop / (cublas_ms / 1000.0) / 1.0e12,
+            cublas_ms / best_cutlass_ms
+        );
+
+        unsafe {
+            cuda_check(cudaFree(act_dev), "free act");
+            cuda_check(cudaFree(weight_dev), "free weight");
+            cuda_check(cudaFree(cutlass_out), "free cutlass out");
+            cuda_check(cudaFree(cublas_out), "free cublas out");
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cublaslt_bf16_holo_route_batch_algo_sweep() {
+    const ITERS: usize = 2000;
+    let shapes = [
+        ("gate_up_c1", 8usize, 1024usize, 2048usize),
+        ("gate_up_c2", 16, 1024, 2048),
+        ("gate_up_c4", 32, 1024, 2048),
+        ("gate_up_c8", 64, 1024, 2048),
+        ("gate_up_c16", 128, 1024, 2048),
+        ("down_c1", 8, 2048, 512),
+        ("down_c2", 16, 2048, 512),
+        ("down_c4", 32, 2048, 512),
+        ("down_c8", 64, 2048, 512),
+        ("down_c16", 128, 2048, 512),
+    ];
+
+    for (name, m, n, k) in shapes {
+        let act: Vec<u16> = (0..m * k)
+            .map(|i| f32_to_bf16(((i % 13) as f32 - 6.0) * 0.03125))
+            .collect();
+        let weight: Vec<u16> = (0..n * k)
+            .map(|i| f32_to_bf16(((i % 17) as f32 - 8.0) * 0.0625))
+            .collect();
+        let act_dev;
+        let weight_dev;
+        let out_dev;
+        unsafe {
+            act_dev = device_alloc(act.len() * 2);
+            weight_dev = device_alloc(weight.len() * 2);
+            out_dev = device_alloc(m * n * 2);
+            copy_h2d(act_dev, &act);
+            copy_h2d(weight_dev, &weight);
+        }
+
+        let returned = run_cublaslt_algo(0, act_dev, weight_dev, out_dev, m, n, k).unwrap();
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "algo warmup synchronize");
+        }
+        let mut best_algo = 0;
+        let mut best_ms = f64::INFINITY;
+        for algo in 0..returned.min(16) {
+            if run_cublaslt_algo(algo, act_dev, weight_dev, out_dev, m, n, k).is_err() {
+                continue;
+            }
+            unsafe {
+                cuda_check(cudaDeviceSynchronize(), "algo warmup synchronize");
+            }
+            let t0 = std::time::Instant::now();
+            let mut ok = true;
+            for _ in 0..ITERS {
+                if run_cublaslt_algo(algo, act_dev, weight_dev, out_dev, m, n, k).is_err() {
+                    ok = false;
+                    break;
+                }
+            }
+            unsafe {
+                cuda_check(cudaDeviceSynchronize(), "algo synchronize");
+            }
+            if ok {
+                let ms = t0.elapsed().as_secs_f64() * 1000.0 / ITERS as f64;
+                if ms < best_ms {
+                    best_ms = ms;
+                    best_algo = algo;
+                }
+            }
+        }
+        let flop = 2.0 * m as f64 * n as f64 * k as f64;
+        eprintln!(
+            "HOLO_CUBLASLT_ALGO_BENCH {name} M={m} N={n} K={k} returned={returned} best_algo={best_algo} best_us={:.3} best_tflops={:.1}",
+            best_ms * 1000.0,
+            flop / (best_ms / 1000.0) / 1.0e12
+        );
+        unsafe {
+            cuda_check(cudaFree(act_dev), "free act");
+            cuda_check(cudaFree(weight_dev), "free weight");
+            cuda_check(cudaFree(out_dev), "free out");
+        }
+    }
+}

--- a/crates/spark-runtime/src/cutlass/tests/mod.rs
+++ b/crates/spark-runtime/src/cutlass/tests/mod.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! CUTLASS host-wrapper test suite (split for ≤500 LoC).
+//!
+//! Shared CUDA/test helpers live here; the actual `#[test]` functions live in
+//! the `bf16` (dense BF16 + bench/algo sweeps) and `nvfp4` (NVFP4 numeric
+//! comparator + transpose) sibling modules.
+
+use super::*;
+use std::ffi::c_void;
+
+mod bf16;
+mod nvfp4;
+
+pub(super) const CUDA_MEMCPY_HOST_TO_DEVICE: i32 = 1;
+pub(super) const CUDA_MEMCPY_DEVICE_TO_HOST: i32 = 2;
+
+unsafe extern "C" {
+    pub(super) fn cudaMalloc(ptr: *mut *mut c_void, size: usize) -> i32;
+    pub(super) fn cudaFree(ptr: *mut c_void) -> i32;
+    pub(super) fn cudaMemcpy(dst: *mut c_void, src: *const c_void, count: usize, kind: i32) -> i32;
+    pub(super) fn cudaDeviceSynchronize() -> i32;
+}
+
+pub(super) fn f32_to_bf16(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let lsb = (bits >> 16) & 1;
+    ((bits + 0x7fff + lsb) >> 16) as u16
+}
+
+pub(super) fn bf16_to_f32(x: u16) -> f32 {
+    f32::from_bits((x as u32) << 16)
+}
+
+pub(super) fn cuda_check(status: i32, what: &str) {
+    assert_eq!(status, 0, "CUDA {what} failed: {status}");
+}
+
+pub(super) unsafe fn device_alloc(bytes: usize) -> *mut c_void {
+    let mut ptr = std::ptr::null_mut();
+    cuda_check(unsafe { cudaMalloc(&mut ptr, bytes) }, "malloc");
+    ptr
+}
+
+pub(super) unsafe fn copy_h2d<T>(dst: *mut c_void, src: &[T]) {
+    cuda_check(
+        unsafe {
+            cudaMemcpy(
+                dst,
+                src.as_ptr() as *const c_void,
+                std::mem::size_of_val(src),
+                CUDA_MEMCPY_HOST_TO_DEVICE,
+            )
+        },
+        "copy h2d",
+    );
+}
+
+pub(super) unsafe fn copy_d2h<T>(dst: &mut [T], src: *const c_void) {
+    cuda_check(
+        unsafe {
+            cudaMemcpy(
+                dst.as_mut_ptr() as *mut c_void,
+                src,
+                std::mem::size_of_val(dst),
+                CUDA_MEMCPY_DEVICE_TO_HOST,
+            )
+        },
+        "copy d2h",
+    );
+}
+
+pub(super) type CutlassVariant = unsafe extern "C" fn(
+    *const c_void,
+    *const c_void,
+    *mut c_void,
+    i32,
+    i32,
+    i32,
+    *mut c_void,
+    usize,
+    *mut c_void,
+) -> i32;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_cutlass_variant(
+    name: &str,
+    f: CutlassVariant,
+    act: *mut c_void,
+    weight: *mut c_void,
+    out: *mut c_void,
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<()> {
+    let ctx = ctx()?;
+    let status = unsafe {
+        f(
+            act,
+            weight,
+            out,
+            m as i32,
+            n as i32,
+            k as i32,
+            ctx.workspace as *mut c_void,
+            ctx.ws_size,
+            std::ptr::null_mut(),
+        )
+    };
+    if status != 0 {
+        bail!("CUTLASS variant {name} failed: status {status} for {m}x{n}x{k}");
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_cublaslt_algo(
+    algo_index: i32,
+    act: *mut c_void,
+    weight: *mut c_void,
+    out: *mut c_void,
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<i32> {
+    let ctx = ctx()?;
+    let mut returned = 0i32;
+    let status = unsafe {
+        atlas_cublaslt_bf16_gemm_act_weight_t_algo(
+            act,
+            weight,
+            out,
+            m as i32,
+            n as i32,
+            k as i32,
+            ctx.workspace as *mut c_void,
+            ctx.ws_size,
+            std::ptr::null_mut(),
+            algo_index,
+            &mut returned,
+        )
+    };
+    if status != 0 {
+        bail!(
+            "cuBLASLt algo {algo_index} failed: status {status} returned={returned} for {m}x{n}x{k}"
+        );
+    }
+    Ok(returned)
+}
+
+// ---- NVFP4 op-level numeric helpers ------------------------------------
+//
+// Shared by the NVFP4 comparator/transpose tests. See `nvfp4.rs` for the
+// full op-level comparator rationale.
+
+/// E2M1 (FP4) level magnitudes, indexed by the low 3 bits; bit 3 is sign.
+pub(super) const E2M1_LEVELS: [f32; 8] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0];
+
+pub(super) fn decode_e2m1(nib: u8) -> f32 {
+    let mag = E2M1_LEVELS[(nib & 0x7) as usize];
+    if nib & 0x8 != 0 { -mag } else { mag }
+}
+
+/// Matches the device `float_to_e2m1` round-to-nearest-bin in the wrapper.
+pub(super) fn f32_to_e2m1(x: f32) -> u8 {
+    let sign = if x < 0.0 { 0x8u8 } else { 0 };
+    let ax = x.abs();
+    let mag = if ax <= 0.25 {
+        0
+    } else if ax <= 0.75 {
+        1
+    } else if ax <= 1.25 {
+        2
+    } else if ax <= 1.75 {
+        3
+    } else if ax <= 2.5 {
+        4
+    } else if ax <= 3.5 {
+        5
+    } else if ax <= 5.0 {
+        6
+    } else {
+        7
+    };
+    sign | mag
+}
+
+/// Decode an OCP E4M3 byte (the format `__nv_fp8_e4m3` stores the weight
+/// per-group scale in) to f32. Scales are always positive here.
+pub(super) fn e4m3_to_f32(byte: u8) -> f32 {
+    let sign = if byte & 0x80 != 0 { -1.0 } else { 1.0 };
+    let e = ((byte >> 3) & 0x0f) as i32;
+    let m = (byte & 0x07) as i32;
+    let val = if e == 0 {
+        // subnormal: m/8 * 2^(1-7)
+        (m as f32 / 8.0) * 2f32.powi(1 - 7)
+    } else {
+        // normal: (1 + m/8) * 2^(e-7)
+        (1.0 + m as f32 / 8.0) * 2f32.powi(e - 7)
+    };
+    sign * val
+}
+
+/// Deterministic, full-rank-ish pseudo-random value in roughly [-0.5, 0.5].
+pub(super) fn gen_val(seed: u64) -> f32 {
+    let mut x = seed
+        .wrapping_mul(0x9E3779B97F4A7C15)
+        .wrapping_add(0x1234_5678_9ABC_DEF0);
+    x ^= x >> 30;
+    x = x.wrapping_mul(0xBF58476D1CE4E5B9);
+    x ^= x >> 27;
+    x = x.wrapping_mul(0x94D049BB133111EB);
+    x ^= x >> 31;
+    ((x >> 40) as f32) / ((1u64 << 24) as f32) - 0.5
+}
+
+pub(super) fn cosine(a: &[f32], b: &[f32]) -> f64 {
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot += x as f64 * y as f64;
+        na += x as f64 * x as f64;
+        nb += y as f64 * y as f64;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}

--- a/crates/spark-runtime/src/cutlass/tests/nvfp4.rs
+++ b/crates/spark-runtime/src/cutlass/tests/nvfp4.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! NVFP4 op-level numeric comparator + packed-weight transpose bit-exactness.
+//
+// Goal: decide whether the corrupt-output native-NVFP4 prefill path is a
+// wrapper layout/scale BUG (fixable) or inherent W4A4 quantization LOSS
+// (abandon on the sensitive projections). For each Holo projection shape we
+// compare three GEMM results over the SAME inputs:
+//   - out_cutlass: the native CUTLASS NVFP4 kernel (act packed in-wrapper,
+//     weight = our packed_t/scale_t).
+//   - out_ref:     a host W4A4 dequant reference. The weight side reads the
+//     EXACT packed_t nibbles + scale_t (e4m3) bytes the kernel consumes, so
+//     it is bit-faithful to the kernel's weight operand; the activation side
+//     replicates the wrapper's per-16-group max/6 -> e2m1 quantizer.
+//   - out_true:    the full unquantized BF16 GEMM.
+// Interpretation:
+//   cos(cutlass,ref) ~ 1  -> kernel + layouts are CORRECT; any divergence
+//       from out_true is inherent W4A4 loss (see cos(ref,true)).
+//   cos(cutlass,ref) low  -> wrapper layout/scale BUG; the kernel is not
+//       computing what its packed operands imply.
+
+use super::super::*;
+use super::*;
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cutlass_nvfp4_projection_numeric_comparator() {
+    // Small M faithfully exercises the N/K-dependent weight scale-factor
+    // layout (the suspected bug correlates with large N) while keeping the
+    // host reference GEMM cheap.
+    const M: usize = 128;
+    let shapes = [
+        ("ssm_qkvz", 12288usize, 2048usize),
+        ("attn_q", 8192, 2048),
+        ("attn_kv", 512, 2048),
+        ("attn_o", 2048, 4096),
+    ];
+
+    for (name, n, k) in shapes {
+        assert_eq!(k % 16, 0, "{name}: K must be a multiple of 16");
+
+        // Host inputs (bf16, as the device sees them).
+        let weight_bf16: Vec<u16> = (0..n * k)
+            .map(|i| f32_to_bf16(gen_val(i as u64) * 0.2))
+            .collect();
+        let act_bf16: Vec<u16> = (0..M * k)
+            .map(|i| f32_to_bf16(gen_val((i as u64) ^ 0xA5A5_0000_0000) * 2.0))
+            .collect();
+
+        let packed_len = (k / 2) * n; // [K/2, N] u8
+        let scale_len = (k / 16) * n; // [K/16, N] u8
+
+        let weight_dev;
+        let act_dev;
+        let packed_dev;
+        let scale_dev;
+        let out_dev;
+        unsafe {
+            weight_dev = device_alloc(weight_bf16.len() * 2);
+            act_dev = device_alloc(act_bf16.len() * 2);
+            packed_dev = device_alloc(packed_len);
+            scale_dev = device_alloc(scale_len);
+            out_dev = device_alloc(M * n * 2);
+            copy_h2d(weight_dev, &weight_bf16);
+            copy_h2d(act_dev, &act_bf16);
+        }
+
+        // Pack the weight to Atlas transposed NVFP4 exactly as the runtime does.
+        pack_bf16_weight_to_nvfp4_t(
+            weight_dev as u64,
+            packed_dev as u64,
+            scale_dev as u64,
+            n as u32,
+            k as u32,
+            0,
+        )
+        .unwrap();
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "pack synchronize");
+        }
+
+        // Native CUTLASS NVFP4 GEMM (weight_scale_2 = 1.0 for this pack).
+        nvfp4_gemm_bf16_act_weight_t(
+            act_dev as u64,
+            packed_dev as u64,
+            scale_dev as u64,
+            1.0,
+            out_dev as u64,
+            M as u32,
+            n as u32,
+            k as u32,
+            0,
+        )
+        .unwrap();
+        unsafe {
+            cuda_check(cudaDeviceSynchronize(), "cutlass gemm synchronize");
+        }
+
+        let mut out_cutlass_bf16 = vec![0u16; M * n];
+        let mut packed = vec![0u8; packed_len];
+        let mut scale = vec![0u8; scale_len];
+        unsafe {
+            copy_d2h(&mut out_cutlass_bf16, out_dev);
+            copy_d2h(&mut packed, packed_dev);
+            copy_d2h(&mut scale, scale_dev);
+            cuda_check(cudaFree(weight_dev), "free weight");
+            cuda_check(cudaFree(act_dev), "free act");
+            cuda_check(cudaFree(packed_dev), "free packed");
+            cuda_check(cudaFree(scale_dev), "free scale");
+            cuda_check(cudaFree(out_dev), "free out");
+        }
+
+        // Weight dequant, bit-faithful to the kernel's operand: read the same
+        // packed nibbles + e4m3 group scales the kernel consumes. The pack
+        // kernel emits CUTLASS [N,K/2] layout (K-contiguous): byte for
+        // (n=col,k) is col*(K/2) + k/2, nibble = k&1. Scales stay [K/16,N].
+        let mut w_q = vec![0f32; n * k];
+        let mut w_true = vec![0f32; n * k];
+        for col in 0..n {
+            for kk in 0..k {
+                let g = kk / 16;
+                let byte = packed[col * (k / 2) + kk / 2];
+                let nib = if kk % 2 == 0 { byte & 0x0f } else { byte >> 4 };
+                let s = e4m3_to_f32(scale[g * n + col]);
+                w_q[col * k + kk] = decode_e2m1(nib) * s;
+                w_true[col * k + kk] = bf16_to_f32(weight_bf16[col * k + kk]);
+            }
+        }
+
+        // Activation dequant, replicating the wrapper's per-16-group quantizer.
+        let mut a_q = vec![0f32; M * k];
+        let mut a_true = vec![0f32; M * k];
+        for m in 0..M {
+            for g in 0..(k / 16) {
+                let base = g * 16;
+                let mut max_abs = 0.0f32;
+                for i in 0..16 {
+                    let v = bf16_to_f32(act_bf16[m * k + base + i]);
+                    max_abs = max_abs.max(v.abs());
+                }
+                let s = if max_abs > 0.0 { max_abs / 6.0 } else { 1.0 };
+                let inv = if s > 0.0 { 1.0 / s } else { 0.0 };
+                for i in 0..16 {
+                    let v = bf16_to_f32(act_bf16[m * k + base + i]);
+                    let nib = f32_to_e2m1(v * inv);
+                    a_q[m * k + base + i] = decode_e2m1(nib) * s;
+                    a_true[m * k + base + i] = v;
+                }
+            }
+        }
+
+        // Reference GEMMs: out[m,n] = sum_k a[m,k] * w[n,k].
+        let mut out_ref = vec![0f32; M * n];
+        let mut out_true = vec![0f32; M * n];
+        let mut out_cutlass = vec![0f32; M * n];
+        for m in 0..M {
+            for col in 0..n {
+                let mut acc_ref = 0.0f32;
+                let mut acc_true = 0.0f32;
+                for kk in 0..k {
+                    acc_ref += a_q[m * k + kk] * w_q[col * k + kk];
+                    acc_true += a_true[m * k + kk] * w_true[col * k + kk];
+                }
+                out_ref[m * n + col] = acc_ref;
+                out_true[m * n + col] = acc_true;
+                out_cutlass[m * n + col] = bf16_to_f32(out_cutlass_bf16[m * n + col]);
+            }
+        }
+
+        let cos_cr = cosine(&out_cutlass, &out_ref);
+        let cos_ct = cosine(&out_cutlass, &out_true);
+        let cos_rt = cosine(&out_ref, &out_true);
+        let max_abs_cr = out_cutlass
+            .iter()
+            .zip(&out_ref)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        let ref_rms =
+            (out_ref.iter().map(|x| (x * x) as f64).sum::<f64>() / out_ref.len() as f64).sqrt();
+
+        let verdict = if cos_cr > 0.999 {
+            "KERNEL OK (cutlass matches W4A4 ref) -> divergence from true is inherent W4A4 loss"
+        } else if cos_cr > 0.95 {
+            "SUSPECT (minor cutlass<->ref drift; check scale rounding)"
+        } else {
+            "BUG (cutlass does NOT match its own packed operands -> layout/scale wrong)"
+        };
+
+        eprintln!(
+            "NVFP4_COMPARATOR {name} M={M} N={n} K={k} \
+             cos(cutlass,ref)={cos_cr:.6} cos(cutlass,true)={cos_ct:.6} \
+             cos(ref,true)={cos_rt:.6} max_abs(cutlass-ref)={max_abs_cr:.5} \
+             ref_rms={ref_rms:.5} => {verdict}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires a free CUDA device and CUTLASS_HOME build"]
+fn cutlass_nvfp4_transpose_is_bit_exact() {
+    // Validate the [K/2,N] -> [N,K/2] packed-weight transpose used by the
+    // native-checkpoint path (cutlass_nvfp4_proj). Build a golden [N,K/2]
+    // pack from a bf16 weight, derive the [K/2,N] "checkpoint" form by
+    // transposing on host, run the device transpose, and require it to
+    // reproduce the golden pack byte-for-byte.
+    const N: usize = 512;
+    const K: usize = 256;
+    let half = K / 2;
+
+    let weight_bf16: Vec<u16> = (0..N * K)
+        .map(|i| f32_to_bf16(gen_val(i as u64) * 0.2))
+        .collect();
+
+    // Golden [N,K/2] pack via the (fixed) pack kernel.
+    let weight_dev;
+    let golden_dev;
+    let scale_dev;
+    unsafe {
+        weight_dev = device_alloc(weight_bf16.len() * 2);
+        golden_dev = device_alloc(N * half);
+        scale_dev = device_alloc((K / 16) * N);
+        copy_h2d(weight_dev, &weight_bf16);
+    }
+    pack_bf16_weight_to_nvfp4_t(
+        weight_dev as u64,
+        golden_dev as u64,
+        scale_dev as u64,
+        N as u32,
+        K as u32,
+        0,
+    )
+    .unwrap();
+    unsafe {
+        cuda_check(cudaDeviceSynchronize(), "pack synchronize");
+    }
+    let mut golden = vec![0u8; N * half];
+    unsafe {
+        copy_d2h(&mut golden, golden_dev);
+    }
+
+    // Host-derived [K/2,N] checkpoint form: src[h*N + c] = golden[c*half + h].
+    let mut checkpoint = vec![0u8; half * N];
+    for c in 0..N {
+        for h in 0..half {
+            checkpoint[h * N + c] = golden[c * half + h];
+        }
+    }
+
+    let src_dev;
+    let dst_dev;
+    unsafe {
+        src_dev = device_alloc(checkpoint.len());
+        dst_dev = device_alloc(N * half);
+        copy_h2d(src_dev, &checkpoint);
+    }
+    transpose_nvfp4_packed_kton(src_dev as u64, dst_dev as u64, N as u32, K as u32, 0).unwrap();
+    unsafe {
+        cuda_check(cudaDeviceSynchronize(), "transpose synchronize");
+    }
+    let mut got = vec![0u8; N * half];
+    unsafe {
+        copy_d2h(&mut got, dst_dev);
+        cuda_check(cudaFree(weight_dev), "free weight");
+        cuda_check(cudaFree(golden_dev), "free golden");
+        cuda_check(cudaFree(scale_dev), "free scale");
+        cuda_check(cudaFree(src_dev), "free src");
+        cuda_check(cudaFree(dst_dev), "free dst");
+    }
+
+    assert_eq!(
+        got, golden,
+        "device transpose must reproduce the golden [N,K/2] pack"
+    );
+    eprintln!(
+        "NVFP4_TRANSPOSE bit-exact over N={N} K={K} ({} bytes) OK",
+        N * half
+    );
+}

--- a/crates/spark-runtime/src/cutlass_metal_stub.rs
+++ b/crates/spark-runtime/src/cutlass_metal_stub.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Metal-build stub of the cuda-only `cutlass` module.
+//!
+//! The real [`crate::cutlass`] module (CUTLASS NVFP4/BF16 GEMMs + weight
+//! packing) is gated behind `feature = "cuda"` because it `#include`s CUTLASS
+//! C++ headers that do not exist on macOS. spark-model names these entry
+//! points unconditionally, so the metal build (`cargo check --features metal`,
+//! cuda off) needs the symbols to resolve even though FP4/FP8 inference never
+//! runs there. The bodies are `unreachable!` — reaching one on metal is a bug.
+
+use anyhow::Result;
+
+pub fn bf16_gemm_act_weight_t(
+    _act: u64,
+    _weight: u64,
+    _out: u64,
+    _m: u32,
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::bf16_gemm_act_weight_t is cuda-only (not built for metal)")
+}
+
+pub fn nvfp4_gemm_bf16_act_weight_t(
+    _act: u64,
+    _weight_packed_t: u64,
+    _weight_scale_t: u64,
+    _weight_scale_2: f32,
+    _out: u64,
+    _m: u32,
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::nvfp4_gemm_bf16_act_weight_t is cuda-only (not built for metal)")
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn nvfp4_grouped_gate_up_fused(
+    _a: u64,
+    _sorted_token_ids: u64,
+    _gate_packed_ptrs: &[u64],
+    _gate_sfb_ptrs: &[u64],
+    _gate_scale2_vals: &[f32],
+    _up_packed_ptrs: &[u64],
+    _up_sfb_ptrs: &[u64],
+    _up_scale2_vals: &[f32],
+    _c_gate: u64,
+    _c_up: u64,
+    _expert_offsets_host: &[i32],
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::nvfp4_grouped_gate_up_fused is cuda-only (not built for metal)")
+}
+
+pub fn nvfp4_grouped_down(
+    _a: u64,
+    _packed_ptrs: &[u64],
+    _sfb_ptrs: &[u64],
+    _scale2_vals: &[f32],
+    _c: u64,
+    _expert_offsets_host: &[i32],
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::nvfp4_grouped_down is cuda-only (not built for metal)")
+}
+
+pub fn pack_bf16_weight_to_nvfp4_t(
+    _weight_bf16: u64,
+    _packed_t: u64,
+    _scale_t: u64,
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::pack_bf16_weight_to_nvfp4_t is cuda-only (not built for metal)")
+}
+
+pub fn pack_weight_sfb(
+    _scale_in: u64,
+    _scale_out: u64,
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::pack_weight_sfb is cuda-only (not built for metal)")
+}
+
+pub fn transpose_nvfp4_packed_kton(
+    _src_packed_t: u64,
+    _dst_packed: u64,
+    _n: u32,
+    _k: u32,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("cutlass::transpose_nvfp4_packed_kton is cuda-only (not built for metal)")
+}

--- a/crates/spark-runtime/src/flashinfer.rs
+++ b/crates/spark-runtime/src/flashinfer.rs
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Host-callable FlashInfer ragged/varlen prefill attention FFI (GB10/sm_121).
+//!
+//! FlashInfer's `BatchPrefillWithRaggedKVCacheDispatched` is a FlashAttention-2
+//! SM80-class kernel (mma.sync/ldmatrix/cp.async) that codegens for sm_121f. We
+//! wrap it host-side exactly like the CUTLASS object: nvcc compiles
+//! `cuda/flashinfer_ragged_prefill.cu` to a static lib in `build.rs` (gated on
+//! `FLASHINFER_HOME`), this module declares the `extern "C"` ABI, and callers
+//! pass `u64` device pointers + a `cudaStream_t` as `u64`.
+//!
+//! Purpose: batch N requests' attention into ONE varlen launch (q_indptr/
+//! kv_indptr ragged offsets) so cross-request prefill scales — the missing
+//! piece behind Atlas's flat ~3880 tok/s prefill at any concurrency.
+
+use anyhow::{Result, bail};
+
+#[cfg(atlas_flashinfer)]
+use std::ffi::c_void;
+#[cfg(atlas_flashinfer)]
+use std::sync::OnceLock;
+
+#[cfg(atlas_flashinfer)]
+unsafe extern "C" {
+    // Available for diagnostics; the wrapper uses fixed workspace budgets instead.
+    #[allow(dead_code)]
+    fn atlas_fi_ragged_prefill_workspace_sizes(
+        max_batch: u32,
+        max_total_qo_rows: u32,
+        num_qo_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+        float_ws_bytes_out: *mut usize,
+        int_ws_bytes_out: *mut usize,
+        pinned_int_ws_bytes_out: *mut usize,
+    ) -> i32;
+
+    #[allow(clippy::too_many_arguments)]
+    fn atlas_fi_ragged_prefill_bf16_hd256(
+        q: *const c_void,
+        k: *const c_void,
+        v: *const c_void,
+        o: *mut c_void,
+        qo_indptr_h: *const i32,
+        kv_indptr_h: *const i32,
+        qo_indptr_d: *const i32,
+        kv_indptr_d: *const i32,
+        batch: u32,
+        total_qo_rows: u32,
+        total_kv_rows: u32,
+        num_qo_heads: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+        sm_scale: f32,
+        causal: i32,
+        float_ws: *mut c_void,
+        float_ws_bytes: usize,
+        int_ws: *mut c_void,
+        int_ws_bytes: usize,
+        pinned_int_ws: *mut c_void,
+        pinned_int_ws_bytes: usize,
+        stream: *mut c_void,
+    ) -> i32;
+
+    #[cfg(atlas_flashinfer)]
+    fn cuMemAlloc_v2(dptr: *mut u64, bytesize: usize) -> i32;
+    #[cfg(atlas_flashinfer)]
+    fn cudaHostAlloc(ptr: *mut *mut c_void, size: usize, flags: u32) -> i32;
+}
+
+/// Whether the FlashInfer wrapper was compiled in (FLASHINFER_HOME was set at build).
+pub fn available() -> bool {
+    cfg!(atlas_flashinfer)
+}
+
+// Persistent workspaces, sized for a generous max config and reused across calls
+// (FlashInfer plans into these each call; they don't carry state between calls).
+#[cfg(atlas_flashinfer)]
+struct Workspaces {
+    float_ws: u64,
+    int_ws: u64,
+    pinned_int_ws: u64,
+    float_sz: usize,
+    int_sz: usize,
+    pinned_sz: usize,
+}
+#[cfg(atlas_flashinfer)]
+unsafe impl Send for Workspaces {}
+#[cfg(atlas_flashinfer)]
+unsafe impl Sync for Workspaces {}
+#[cfg(atlas_flashinfer)]
+static WS: OnceLock<Workspaces> = OnceLock::new();
+
+// Max config the persistent workspaces are sized for. Generous upper bounds for
+// Holo serving (>= any realistic concurrent-prefill batch). num heads/head_dim
+// are fixed by the model.
+#[cfg(atlas_flashinfer)]
+const MAX_BATCH: u32 = 16;
+#[cfg(atlas_flashinfer)]
+const MAX_TOTAL_QO_ROWS: u32 = 16 * 16384;
+#[cfg(atlas_flashinfer)]
+const N_QO_HEADS: u32 = 16;
+#[cfg(atlas_flashinfer)]
+const N_KV_HEADS: u32 = 2;
+#[cfg(atlas_flashinfer)]
+const HEAD_DIM: u32 = 256;
+
+// FlashInfer's float workspace is a BUDGET PrefillPlan splits KV within (it
+// plans to fit, not a hard requirement) — vLLM uses ~128MB. The int/pinned
+// workspaces hold the scheduler metadata arrays (request/tile indices), bounded
+// by tile count. Fixed generous budgets; PrefillPlan adapts within them.
+#[cfg(atlas_flashinfer)]
+const FLOAT_WS_BYTES: usize = 256 << 20; // 256 MB
+#[cfg(atlas_flashinfer)]
+const INT_WS_BYTES: usize = 64 << 20; // 64 MB
+#[cfg(atlas_flashinfer)]
+const PINNED_WS_BYTES: usize = 64 << 20; // 64 MB
+
+#[cfg(atlas_flashinfer)]
+fn workspaces() -> Result<&'static Workspaces> {
+    if let Some(w) = WS.get() {
+        return Ok(w);
+    }
+    let _ = (
+        MAX_BATCH,
+        MAX_TOTAL_QO_ROWS,
+        N_QO_HEADS,
+        N_KV_HEADS,
+        HEAD_DIM,
+    );
+    let (fsz, isz, psz) = (FLOAT_WS_BYTES, INT_WS_BYTES, PINNED_WS_BYTES);
+    let mut float_ws = 0u64;
+    let mut int_ws = 0u64;
+    let mut pinned = std::ptr::null_mut::<c_void>();
+    unsafe {
+        let s1 = cuMemAlloc_v2(&mut float_ws, fsz.max(1));
+        if s1 != 0 {
+            bail!("cuMemAlloc FlashInfer float ws ({fsz}B) failed: {s1}");
+        }
+        let s2 = cuMemAlloc_v2(&mut int_ws, isz.max(1));
+        if s2 != 0 {
+            bail!("cuMemAlloc FlashInfer int ws ({isz}B) failed: {s2}");
+        }
+        let s3 = cudaHostAlloc(&mut pinned, psz.max(1), 0);
+        if s3 != 0 {
+            bail!("cudaHostAlloc FlashInfer pinned int ws ({psz}B) failed: {s3}");
+        }
+    }
+    let _ = WS.set(Workspaces {
+        float_ws,
+        int_ws,
+        pinned_int_ws: pinned as u64,
+        float_sz: fsz,
+        int_sz: isz,
+        pinned_sz: psz,
+    });
+    Ok(WS.get().unwrap())
+}
+
+/// Ragged batched prefill attention (BF16, head_dim=256, GQA, causal selectable).
+///
+/// `q`/`o`: `[total_qo_rows, num_qo_heads, 256]` BF16 device; `k`/`v`:
+/// `[total_kv_rows, num_kv_heads, 256]` BF16 device. `qo_indptr`/`kv_indptr` are
+/// `[batch+1]` int32 prefix-sum offsets — provided both on host (`*_h`, for the
+/// scheduler plan) and as device copies (`*_d`, read by the kernel).
+#[allow(clippy::too_many_arguments)]
+pub fn ragged_prefill_bf16_hd256(
+    q: u64,
+    k: u64,
+    v: u64,
+    o: u64,
+    qo_indptr_h: &[i32],
+    kv_indptr_h: &[i32],
+    qo_indptr_d: u64,
+    kv_indptr_d: u64,
+    batch: u32,
+    total_qo_rows: u32,
+    total_kv_rows: u32,
+    num_qo_heads: u32,
+    num_kv_heads: u32,
+    head_dim: u32,
+    sm_scale: f32,
+    causal: bool,
+    stream: u64,
+) -> Result<()> {
+    #[cfg(atlas_flashinfer)]
+    {
+        if head_dim != HEAD_DIM {
+            bail!("FlashInfer wrapper is head_dim=256 only (got {head_dim})");
+        }
+        if qo_indptr_h.len() != (batch + 1) as usize || kv_indptr_h.len() != (batch + 1) as usize {
+            bail!("indptr host slices must be batch+1 long");
+        }
+        let ws = workspaces()?;
+        let st = unsafe {
+            atlas_fi_ragged_prefill_bf16_hd256(
+                q as *const c_void,
+                k as *const c_void,
+                v as *const c_void,
+                o as *mut c_void,
+                qo_indptr_h.as_ptr(),
+                kv_indptr_h.as_ptr(),
+                qo_indptr_d as *const i32,
+                kv_indptr_d as *const i32,
+                batch,
+                total_qo_rows,
+                total_kv_rows,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                sm_scale,
+                if causal { 1 } else { 0 },
+                ws.float_ws as *mut c_void,
+                ws.float_sz,
+                ws.int_ws as *mut c_void,
+                ws.int_sz,
+                ws.pinned_int_ws as *mut c_void,
+                ws.pinned_sz,
+                stream as *mut c_void,
+            )
+        };
+        if st != 0 {
+            bail!(
+                "FlashInfer ragged prefill failed: status {st} (batch={batch}, qo={total_qo_rows})"
+            );
+        }
+        Ok(())
+    }
+    #[cfg(not(atlas_flashinfer))]
+    {
+        let _ = (
+            q,
+            k,
+            v,
+            o,
+            qo_indptr_h,
+            kv_indptr_h,
+            qo_indptr_d,
+            kv_indptr_d,
+            batch,
+            total_qo_rows,
+            total_kv_rows,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            sm_scale,
+            causal,
+            stream,
+        );
+        bail!("FlashInfer support was not built; set FLASHINFER_HOME when building")
+    }
+}
+
+#[cfg(all(test, atlas_flashinfer))]
+mod tests {
+    use super::*;
+    use std::ffi::c_void;
+
+    const H2D: i32 = 1;
+    const D2H: i32 = 2;
+    unsafe extern "C" {
+        fn cudaMalloc(p: *mut *mut c_void, n: usize) -> i32;
+        fn cudaFree(p: *mut c_void) -> i32;
+        fn cudaMemcpy(d: *mut c_void, s: *const c_void, n: usize, k: i32) -> i32;
+        fn cudaDeviceSynchronize() -> i32;
+    }
+    fn f32_to_bf16(x: f32) -> u16 {
+        let b = x.to_bits();
+        ((b + 0x7fff + ((b >> 16) & 1)) >> 16) as u16
+    }
+    fn bf16_to_f32(x: u16) -> f32 {
+        f32::from_bits((x as u32) << 16)
+    }
+    unsafe fn dev<T>(data: &[T]) -> u64 {
+        let bytes = std::mem::size_of_val(data);
+        let mut p = std::ptr::null_mut();
+        assert_eq!(unsafe { cudaMalloc(&mut p, bytes.max(1)) }, 0);
+        assert_eq!(
+            unsafe { cudaMemcpy(p, data.as_ptr() as *const c_void, bytes, H2D) },
+            0
+        );
+        p as u64
+    }
+
+    #[test]
+    #[ignore = "requires a free CUDA device + FLASHINFER_HOME build"]
+    #[allow(clippy::needless_range_loop)] // numerical reference: index-parallel loops read clearest
+    fn flashinfer_ragged_prefill_matches_cpu_reference() {
+        // 2 ragged requests (6 + 10 tokens), GQA 4 qo / 2 kv heads, hd=256, causal.
+        const HD: usize = 256;
+        const NQO: usize = 4;
+        const NKV: usize = 2;
+        let lens = [6usize, 10usize];
+        let qo_indptr: Vec<i32> = {
+            let mut v = vec![0i32];
+            for &l in &lens {
+                v.push(v.last().unwrap() + l as i32);
+            }
+            v
+        };
+        let kv_indptr = qo_indptr.clone();
+        let total: usize = lens.iter().sum();
+        let sm_scale = 1.0f32 / (HD as f32).sqrt();
+
+        // Deterministic pseudo-random bf16 inputs.
+        let rnd = |seed: u64| -> f32 {
+            let mut x = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(1);
+            x ^= x >> 31;
+            x = x.wrapping_mul(0xBF58476D1CE4E5B9);
+            ((x >> 40) as f32 / (1u64 << 24) as f32 - 0.5) * 0.5
+        };
+        let q: Vec<u16> = (0..total * NQO * HD)
+            .map(|i| f32_to_bf16(rnd(i as u64)))
+            .collect();
+        let k: Vec<u16> = (0..total * NKV * HD)
+            .map(|i| f32_to_bf16(rnd(i as u64 ^ 0x1111)))
+            .collect();
+        let v: Vec<u16> = (0..total * NKV * HD)
+            .map(|i| f32_to_bf16(rnd(i as u64 ^ 0x2222)))
+            .collect();
+        let mut o = vec![0u16; total * NQO * HD];
+
+        let (q_d, k_d, v_d, o_d, qo_d, kv_d);
+        unsafe {
+            q_d = dev(&q);
+            k_d = dev(&k);
+            v_d = dev(&v);
+            o_d = dev(&o);
+            qo_d = dev(&qo_indptr);
+            kv_d = dev(&kv_indptr);
+        }
+
+        ragged_prefill_bf16_hd256(
+            q_d,
+            k_d,
+            v_d,
+            o_d,
+            &qo_indptr,
+            &kv_indptr,
+            qo_d,
+            kv_d,
+            lens.len() as u32,
+            total as u32,
+            total as u32,
+            NQO as u32,
+            NKV as u32,
+            HD as u32,
+            sm_scale,
+            true,
+            0,
+        )
+        .unwrap();
+        unsafe {
+            assert_eq!(cudaDeviceSynchronize(), 0);
+            assert_eq!(
+                cudaMemcpy(
+                    o.as_mut_ptr() as *mut c_void,
+                    o_d as *const c_void,
+                    o.len() * 2,
+                    D2H
+                ),
+                0
+            );
+        }
+
+        // CPU reference: per-request causal GQA attention.
+        let group = NQO / NKV;
+        let qf = |r: usize, h: usize, d: usize| bf16_to_f32(q[(r * NQO + h) * HD + d]);
+        let kf = |r: usize, kh: usize, d: usize| bf16_to_f32(k[(r * NKV + kh) * HD + d]);
+        let vf = |r: usize, kh: usize, d: usize| bf16_to_f32(v[(r * NKV + kh) * HD + d]);
+        let mut max_rel = 0.0f64;
+        let mut worst_cos = 1.0f64;
+        for (b, &len) in lens.iter().enumerate() {
+            let start = qo_indptr[b] as usize;
+            for qi in 0..len {
+                for h in 0..NQO {
+                    let kh = h / group;
+                    let mut scores = vec![0f32; qi + 1];
+                    for j in 0..=qi {
+                        let mut s = 0.0f32;
+                        for d in 0..HD {
+                            s += qf(start + qi, h, d) * kf(start + j, kh, d);
+                        }
+                        scores[j] = s * sm_scale;
+                    }
+                    let mx = scores.iter().cloned().fold(f32::MIN, f32::max);
+                    let mut den = 0.0f32;
+                    for s in &mut scores {
+                        *s = (*s - mx).exp();
+                        den += *s;
+                    }
+                    let mut out_ref = vec![0f32; HD];
+                    for (j, &p) in scores.iter().enumerate() {
+                        let w = p / den;
+                        for d in 0..HD {
+                            out_ref[d] += w * vf(start + j, kh, d);
+                        }
+                    }
+                    let mut dot = 0.0f64;
+                    let mut na = 0.0f64;
+                    let mut nb = 0.0f64;
+                    for d in 0..HD {
+                        let g = bf16_to_f32(o[(start + qi) * NQO * HD + h * HD + d]) as f64;
+                        let r = out_ref[d] as f64;
+                        dot += g * r;
+                        na += g * g;
+                        nb += r * r;
+                        max_rel = max_rel.max((g - r).abs() / (r.abs() + 1e-3));
+                    }
+                    let cos = dot / (na.sqrt() * nb.sqrt() + 1e-12);
+                    worst_cos = worst_cos.min(cos);
+                }
+            }
+        }
+        unsafe {
+            for p in [q_d, k_d, v_d, o_d, qo_d, kv_d] {
+                cudaFree(p as *mut c_void);
+            }
+        }
+        eprintln!("FLASHINFER_RAGGED worst_cos={worst_cos:.6} max_rel={max_rel:.4}");
+        assert!(
+            worst_cos > 0.99,
+            "FlashInfer ragged prefill diverges from CPU ref: cos {worst_cos}"
+        );
+    }
+}

--- a/crates/spark-runtime/src/flashinfer_metal_stub.rs
+++ b/crates/spark-runtime/src/flashinfer_metal_stub.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Metal-build stub of the cuda-only `flashinfer` module.
+//!
+//! The real [`crate::flashinfer`] module (FlashInfer ragged BF16 prefill) is
+//! gated behind `feature = "cuda"`; it links the FlashInfer AOT artifacts that
+//! do not exist on macOS. spark-model names these entry points unconditionally,
+//! so the metal build (`cargo check --features metal`, cuda off) needs them to
+//! resolve. `available()` reports `false`, so the (guarded) prefill call is
+//! never reached — its body is `unreachable!`.
+
+use anyhow::Result;
+
+/// FlashInfer is never available in a non-cuda build.
+pub fn available() -> bool {
+    false
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn ragged_prefill_bf16_hd256(
+    _q: u64,
+    _k: u64,
+    _v: u64,
+    _o: u64,
+    _qo_indptr_h: &[i32],
+    _kv_indptr_h: &[i32],
+    _qo_indptr_d: u64,
+    _kv_indptr_d: u64,
+    _batch: u32,
+    _total_qo_rows: u32,
+    _total_kv_rows: u32,
+    _num_qo_heads: u32,
+    _num_kv_heads: u32,
+    _head_dim: u32,
+    _sm_scale: f32,
+    _causal: bool,
+    _stream: u64,
+) -> Result<()> {
+    unreachable!("flashinfer::ragged_prefill_bf16_hd256 is cuda-only (not built for metal)")
+}

--- a/crates/spark-runtime/src/lib.rs
+++ b/crates/spark-runtime/src/lib.rs
@@ -13,8 +13,18 @@ pub mod cublaslt;
 pub mod cublaslt;
 #[cfg(feature = "cuda")]
 pub mod cuda_backend;
+#[cfg(feature = "cuda")]
+pub mod cutlass;
+#[cfg(not(feature = "cuda"))]
+#[path = "cutlass_metal_stub.rs"]
+pub mod cutlass;
 #[cfg(unix)]
 pub mod fast_weights;
+#[cfg(feature = "cuda")]
+pub mod flashinfer;
+#[cfg(not(feature = "cuda"))]
+#[path = "flashinfer_metal_stub.rs"]
+pub mod flashinfer;
 pub mod gpu;
 pub mod kernel_args;
 pub mod kernel_audit;


### PR DESCRIPTION
Extracted from #203 per review: the CUTLASS (cute/cutlass headers) + FlashInfer wrappers that #203 deliberately no longer carries, so #203 stays a clean pure-Rust bring-up. This PR is the **exact inverse** of #203's removal commit — it re-adds the whole layer as an **opt-in, default-off** feature.

## What's here
- `spark-runtime/cuda/{cutlass_bf16,cutlass_nvfp4,cutlass_nvfp4_grouped}_gemm.cu`, `flashinfer_ragged_prefill.cu`
- `spark-runtime/src/{cutlass/,flashinfer.rs}` wrappers + metal stubs
- `build.rs` `CUTLASS_HOME`/`FLASHINFER_HOME` nvcc wiring + `atlas_cutlass`/`atlas_flashinfer` cfgs
- `spark-model` dispatch flags (`ATLAS_CUTLASS_*`, `ATLAS_FLASHINFER_PREFILL`, `ATLAS_HOLO_MOE_GROUPED_CUTLASS`) + the CUTLASS/FI dispatch branches (MoE-grouped, attention qkv/o prefill, SSM prefill)

## Default-off by construction
Wrappers `bail!` unless `CUTLASS_HOME`/`FLASHINFER_HOME` is set at build (`atlas_cutlass`/`atlas_flashinfer` cfg); every call site is `if <ATLAS_CUTLASS_* env> { cutlass } else { <pure-Rust path> }`, flags off unless exported. **Proven neutral:** with the split applied, `unsloth`/`nvidia` **Qwen3.6-27B-NVFP4 greedy output is bit-identical to `main`** (229/229 tokens, mean/max KL = 0.000000) — removing/re-adding this layer does not change default behavior.

Split so the pure-Rust-vs-CUTLASS policy call can be made on its own.