### PR TITLE
feat(sampling): default temp/top_k/top_p from generation_config.json (split from #210)

### DIFF
--- a/crates/spark-server/src/api/chat/sampling_setup.rs
+++ b/crates/spark-server/src/api/chat/sampling_setup.rs
@@ -85,20 +85,29 @@ pub(super) fn build_sampling(
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
+    // Core sampling (temp/top_k/top_p) defaults to the model's shipped
+    // generation_config.json (state.default_*) — matching vLLM and the model
+    // author's recommended config — instead of the hand-curated MODEL.toml
+    // [sampling] presets. The lower preset temps (e.g. Holo thinking/tools =
+    // 0.6 vs generation_config 1.0) made the model over-commit to tool calls
+    // vs vLLM: lower temperature is more deterministic, so it picks "call the
+    // tool" far more consistently. The selected preset still drives the
+    // penalties below (generation_config doesn't define those); min_p and
+    // top_n_sigma already default to generation_config.
     let temperature = if force_temp_zero {
         0.0
     } else {
-        req.temperature.unwrap_or(preset.temperature)
+        req.temperature.unwrap_or(state.default_temperature)
     };
     let top_k = if force_temp_zero {
         0
     } else {
-        req.top_k.unwrap_or(preset.top_k)
+        req.top_k.unwrap_or(state.default_top_k)
     };
     let top_p = if force_temp_zero {
         1.0
     } else {
-        req.top_p.unwrap_or(preset.top_p)
+        req.top_p.unwrap_or(state.default_top_p)
     };
     let top_n_sigma = if force_temp_zero {
         0.0


### PR DESCRIPTION
Split out of #210 (native FP8) per review. Core chat sampling (temp/top_k/top_p) now defaults to the model's shipped `generation_config.json` (`state.default_*`) instead of the hand-curated `MODEL.toml [sampling]` presets — matching vLLM and the model author's config, and mirroring what `completions.rs` already does.

Carved into its own PR because it is a **global behavior change** for every served model, including the 27B flagship whose BFCL numbers were measured under the presets, and it overlaps #162's vLLM-parity generation-control work. It should get its own **BFCL A/B** before landing — decided here rather than smuggled into an FP8-loader PR.

(The selected MODEL.toml preset still drives the penalties, which `generation_config.json` doesn't define.)