### PR TITLE
fix(qwen3.6): FP8 block-scaled prefill default-on + agentic fixes, rebased + hardened (carries #177)

### DIFF
--- a/bench/tool_format_eval/GROUND_TRUTH_RESULT.md
+++ b/bench/tool_format_eval/GROUND_TRUTH_RESULT.md
@@ -1,0 +1,41 @@
+# BF16 ground-truth result: the forward pass is NOT the bug
+
+Method: downloaded the original BF16 base `Qwen/Qwen3.6-35B-A3B` (full precision,
+same weights the FP8 checkpoint quantizes), ran a forward (layer-truncated to 16
+layers to fit unified memory — layer N depends only on 0..N, so L0..15 are
+bit-exact), op-hooked the last-token hidden states, and compared BOTH Atlas-FP8
+and vLLM-FP8 against this ground truth (same 149 tokens). `threeway_vs_bf16_truth.py`.
+
+## Result — Atlas is CLOSER to truth than vLLM at every layer and op
+
+Per-layer residual rel_l2 vs BF16 truth (lower = more accurate):
+  L3  Atlas 0.046  vLLM 0.065      L7  Atlas 0.041  vLLM 0.052
+  L11 Atlas 0.049  vLLM 0.059      L15 Atlas 0.052  vLLM 0.062
+  -> ATLAS closer at ALL 16 layers.
+o_proj (attention output) rel_l2 vs truth:
+  L3 Atlas 0.059 / vLLM 0.071 ; L11 Atlas 0.083 / vLLM 0.102 -> ATLAS closer.
+Atlas q/k/v proj + k-norm vs truth: 0.014 / 0.034 / 0.039 / 0.036 (all tight).
+
+## Conclusion
+
+Atlas's forward pass — attention, RoPE, q/k-norm ((1+w), matches HF
+Qwen3_5MoeRMSNorm), projections (W8A16), MoE, SSM — is FAITHFUL and MORE accurate
+than vLLM's W8A8. The Atlas-vs-vLLM divergence measured earlier (and localized to
+the attention path) was vLLM's lower precision, NOT an Atlas bug. There is no
+kernel/numerical bug.
+
+The tool-calling failure is therefore POST-logits: the thinking->tool-call
+transition is a knife-edge decision where ~0.05-level differences (inherent to any
+FP8 engine; present in both Atlas and vLLM) flip a low-margin token. Atlas lands in
+the narrate-then-malformed basin more often than vLLM, despite being more accurate.
+
+## Fix
+
+Not a kernel change. Constrain the output structure so a flipped low-margin token
+cannot malform: force the qwen3_coder tool grammar to engage right after `</think>`
+on tool-armed turns (non-triggered grammar). Keeps thinking on. thinking_in_tools=
+false works for the same reason (skips the brittle transition) but is the blunt version.
+
+Earlier KERNEL_LOCALIZATION.md conclusion ("full-attention kernel is the divergent
+op") is SUPERSEDED by this: that divergence was vLLM-relative; vs ground truth Atlas
+is the more accurate engine.

--- a/bench/tool_format_eval/KERNEL_LOCALIZATION.md
+++ b/bench/tool_format_eval/KERNEL_LOCALIZATION.md
@@ -1,0 +1,35 @@
+# Kernel-level localization: Atlas-FP8 vs vLLM-FP8 forward-pass divergence
+
+Goal: name the Atlas kernel responsible for the tool-calling forward-pass
+divergence (engine half of the defect; see README.md). Method: dump per-layer
+residual + per-op hidden states from Atlas (`ATLAS_OP_DUMP`/`ATLAS_GDN_DUMP`/
+`ATLAS_NEMO_DUMP`, local `spark` binary) and from vLLM-FP8 (in-process hooks,
+`bench/fp8_dgx2_drift/vllm_layer_dump.py` adapted), SAME tokens, last-token
+slice, f32. Compare with `cosine_atlas_vllm.py`.
+
+## Result (149-token probe, current single-GPU build, Qwen3.6-35B-A3B-FP8)
+
+- Per-LAYER residual cosine: all 40 layers cos > 0.997, |vllm|≈|atlas| (magnitudes
+  match → directional drift). Mild at this short prompt; SSM/GDN layers track vLLM.
+- Per-OP `o_proj` (attention output) cosine — divergence concentrated and DEPTH-GROWING:
+    L3 0.9983 / L15 0.9993 / L19 0.9968 / L23 0.9960 / **L27 0.9907 (rel_l2 .139)** /
+    **L31 0.9925 (rel_l2 .124)** / L35 0.9968 / L39 0.9992.
+  The attention OUTPUT carries 2-3x the relative error of the residual stream.
+- Prior 10382-token study (bench/fp8_dgx2_drift/FP8_COSINE_RESULTS_2026_05_29.txt):
+  clean per-layer onset at **L3 (first full-attention layer)**, monotonic collapse
+  to L38 (cos 0.9865). The amplified long-context version of the same pattern.
+
+## Conclusion
+
+The divergent kernel is Atlas's **full-attention path** (attention compute +
+`o_proj` FP8 GEMM at sm_121) — NOT the SSM/GatedDeltaNet, MoE, or norm kernels,
+which track vLLM. Error concentrates in the attention output and accumulates with
+depth AND context length, explaining why tool-calling degrades with more tools /
+longer context / thinking (more tokens through the attention).
+
+## Next refinement (not yet run)
+- Longer prompt (~2-8K tok) to reproduce the dramatic late-layer collapse on this build.
+- Finer per-op: Atlas dumps q_proj/q_post_rope/k_proj/k_post_norm/k_post_rope/
+  v_proj/attn_out_pre_gate/attn_out_post_gate. vLLM fuses qkv, so use the HF
+  reference (needs the transformers finegrained-fp8 `kernels` pkg pinned to a
+  compatible version, or a manual fused-MoE dequant) to split q vs k vs attn-compute.

--- a/bench/tool_format_eval/README.md
+++ b/bench/tool_format_eval/README.md
@@ -1,0 +1,121 @@
+# Tool-format eval harness
+
+Quantifies and root-causes the multi-turn tool-call **format** failure on
+Qwen3.6-35B (the "narrate-then-malformed-`<parameter>`" degradation that breaks
+agentic tool calling under `thinking_in_tools=true`). Built to answer one
+question with statistics instead of N=10 guesswork:
+
+> Is the failure in **parsing**, or in **model inference/decoding**?
+
+## The three layers
+
+| Layer | Script | Needs | Answers |
+|-------|--------|-------|---------|
+| 1 — behavioral rate | `harness.py` | Atlas only | failure **rate** + Wilson 95% CI across configs |
+| 2 — failure classifier | `harness.py` | Atlas only | per-turn **parsing vs generation** bin (from raw text) |
+| 3a — logit decision probe | `logit_probe.py` | Atlas only | does Atlas's own next-token dist **rank** `<tool_call>` at the decision point? |
+| 3b — dump localization | `dump_analyze.py` | `ATLAS_LOGIT_DUMP` | **model** vs **Atlas-processor** vs **sampler** (within Atlas) |
+| 4 — Atlas↔vLLM diff | `compare_endpoints.py` | a running vLLM endpoint | **Atlas inference faithful** vs **forward-pass/quant divergence** |
+
+Layers 1–3a run on this box with no extra deps (stdlib `urllib`). Layer 4 needs a
+vLLM reference dump (this box has no torch/transformers).
+
+## Run
+
+```bash
+# Layer 1+2 — rate + classifier (N per cell; 50 gives ~±14% CI, 200 ~±7%)
+python3 bench/tool_format_eval/harness.py --n 50
+
+# Layer 3a — is the forward pass favoring the wrong token? (parser-free)
+python3 bench/tool_format_eval/logit_probe.py --runs 12 --top 10 --thinking on
+
+# Layer 3b — localize within ONE Atlas dump (model vs bias vs sampler)
+ATLAS_LOGIT_DUMP=/tmp/atlas.jsonl ./target/release/spark serve <model> --tool-call-parser qwen3_coder ...
+#   then send exactly ONE failing tool-turn request, stop the server, then:
+python3 bench/tool_format_eval/dump_analyze.py single /tmp/atlas.jsonl
+
+# Layer 4 — definitive: Atlas vs vLLM forward-pass divergence (just needs a vLLM
+#   OpenAI endpoint; greedy top_logprobs diff, no dumps / no token-id alignment)
+python3 bench/tool_format_eval/compare_endpoints.py \
+    --atlas-url http://localhost:8888 --atlas-model nvidia/Qwen3.6-35B-A3B-NVFP4 \
+    --vllm-url http://<host>:8000 --vllm-model Qwen/Qwen3.6-35B-A3B-FP8 \
+    --thinking on --top 8
+```
+
+## How to read it
+
+- **Layer 2**: failures dominated by `malformed_opener` ⇒ the model emitted the
+  wrong dialect itself ⇒ **generation/decode**, not parsing. `parser_miss`
+  dominated ⇒ **parsing** (model was fine, Atlas dropped it).
+- **Layer 3a**: if `<tool_call>` is rarely top-1 at the first post-`</think>`
+  token, Atlas's forward pass disfavors the structural opener ⇒ decode/inference.
+- **Layer 3b**: `bias`-flips ⇒ Atlas's additive processor stack (think-suppression,
+  attractor, WS mask) is steering — vLLM has none of these. Otherwise the wrong
+  token is the model's own argmax ⇒ forward-pass/quant ⇒ run Layer 4.
+- **Layer 4**: `raw_topk` top-1 **diverges early** from vLLM ⇒ Atlas's forward
+  pass (quant kernels / KV) is numerically off. `raw_topk` **matches** vLLM but
+  Atlas still picks differently ⇒ the divergence is Atlas's `bias`/sampler, not
+  the model.
+
+## Findings to date (2026-06-16, NVFP4 Qwen3.6-35B)
+
+- **Layer 1 (N=50/cell):** thinking ON = 43/50 (tools=2), 29/50 (tools=4); thinking
+  OFF = 50/50, 50/50. Degrades with tool count ⇒ context-load effect.
+- **Layer 2:** ZERO `parser_miss` in 200 turns ⇒ **parsing exonerated**. Failures
+  are `malformed_opener` + `runaway`. Captured failure dialects: `<parameter
+  name=…>` (attribute-XML) AND `` ```json {"command":…} `` `` (hermes JSON) — the
+  model emits the wrong tool *dialect*, not the qwen3_coder `<tool_call>` XML.
+- **Layer 3a:** `<tool_call>` opener TOP-1 at the decision point in **0/12** runs;
+  model deterministically narrates first.
+- **Layer 3b (ATLAS_LOGIT_DUMP, 229 steps incl. a failing run):** **bias-flips = 0**
+  in every block (bias applied on every step but never flipped the argmax) ⇒
+  **Atlas additive-processor stack exonerated**. 215/229 picks are the model's own
+  raw argmax; 14 are sampler (min_p/penalty, ~15% noisy 2nd-order effect).
+
+- **Parser swap (hermes vs qwen3_coder, N=30/50):** thinking-ON validity is
+  comparable and still flaky (hermes 21/30, 24/30; qwen3_coder 43/50, 29/50;
+  CIs overlap), thinking-OFF 100% for both. Parser choice does NOT fix it ⇒
+  further confirms the defect is not parsing.
+
+- **Chat template (vs the vLLM `fix-qwen3.6-chat-template` mod):** Atlas uses the
+  stock tokenizer_config template (model_type rewritten to `qwen3_6_moe`, no
+  `qwen3_6_moe.jinja` override exists). Rendering the stock vs vLLM-fixed template
+  on realistic 2- and 3-turn agentic contexts (prior assistant thinking + tool
+  calls) is **byte-identical**; the patch only changes edge cases (unclosed
+  `<think>` in content, `<|think_off|>` markers, developer role, no-user-query),
+  and Atlas already normalizes string→dict tool args. ⇒ **template eliminated**.
+
+- **Layer 4 — Atlas-NVFP4 vs vLLM-FP8, same harness (vLLM via the user's
+  spark-vllm-docker recipe, single-GPU `-tp 1`, qwen3_xml + fixed template +
+  DFlash):** thinking ON — Atlas 43/50 (t=2), 29/50 (t=4); **vLLM 30/30, 30/30**.
+  vLLM is 120/120 across all cells. SAME model, SAME contexts, thinking on ⇒
+  vLLM has NO degradation, Atlas does. Proves the model can do thinking+tools at
+  100%; the defect is **Atlas's forward pass**. (vLLM reasoning is in the
+  `reasoning` field, not `reasoning_content` — it IS thinking, and still 100%.)
+
+- **Engine vs quant decomposition (4 tools, thinking ON):** Atlas-NVFP4 58%;
+  Atlas-FP8 45/60 = **75% [63,84]** (N=60); vLLM-FP8 **100% [89,100]**. Atlas-FP8
+  serves the SAME checkpoint vLLM uses (`quant compat: kernel=nvfp4 model=fp8 OK`,
+  FP8 prefill kernels). Two independent, separable contributions:
+    * **NVFP4 quant** — 58%→75% switching NVFP4→FP8 weights on the same engine.
+    * **Atlas engine forward pass** — 75%→100% on IDENTICAL FP8 weights, CIs
+      non-overlapping ⇒ a real engine numerical divergence independent of weights.
+
+**VERDICT:** not parsing / processors / parser / template. It is **Atlas
+inference forward-pass**, with two parts: NVFP4 weight quant AND an engine-level
+numerical divergence present even at FP8 (the same weights vLLM runs at 100%).
+Durable fix: `thinking_in_tools=false` (both Atlas precisions → ~100%). FP8
+weights are also notably more thinking-robust than NVFP4 on Atlas (75% vs 58%).
+
+**Next — localize the divergent kernel (layer-diff):** Atlas dumps per-layer
+residual hidden states via `ATLAS_OP_DUMP=<dir> ATLAS_OP_DUMP_LAYERS=… OPS=…`;
+compare against a same-weights reference (vLLM-FP8 hidden states from inside the
+container, or an HF/BF16 oracle) with the `bench/nemotron_layer_diff.py` cosine/L2
+comparator to flag the first divergent layer → names the kernel (attn / MoE gate /
+norm / KV). Cleanest target is Atlas-FP8 vs vLLM-FP8 (no quant confound); the
+risky part is extracting matching per-layer hidden states from vLLM internals.
+The malformed tokens are the model's OWN raw-logit argmax under Atlas's forward
+pass (it prefers narration + JSON/attr-XML over qwen3_coder XML when thinking).
+The single OPEN question is whether that distribution is faithful to the true
+model or a forward-pass/quant divergence — **Layer 4 (`compare_endpoints.py`)**,
+which needs a running vLLM endpoint.

--- a/bench/tool_format_eval/compare_endpoints.py
+++ b/bench/tool_format_eval/compare_endpoints.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tool-format eval harness — Layer 4: Atlas vs vLLM forward-pass divergence.
+
+The decisive "inference numerics vs model behavior" test, run over two
+OpenAI-compatible endpoints (Atlas + your vLLM) — no dump files, no token-id
+alignment. Both decode the SAME prompt GREEDILY (temperature 0) with
+`top_logprobs`; we diff their per-position top-1 token (string) and top-K overlap
+until the first divergence (the metal_kv_kld_compare.py convention: greedy paths
+share context only while their argmax agrees).
+
+Interpretation at the post-`</think>` decision region:
+  - top-1 tokens AGREE between Atlas and vLLM, both narrate/drift
+        => the bad distribution is the MODEL's genuine behavior; Atlas inference
+           is faithful. vLLM "works" for a different reason (parser/format/post-
+           processing), NOT because its forward pass is better.
+  - top-1 DIVERGES EARLY (Atlas ranks the wrong token where vLLM ranks
+    `<tool_call>` / the right token)
+        => Atlas's forward pass (NVFP4 quant kernels / KV) is numerically off
+           => a real Atlas INFERENCE bug.
+
+Caveat: if Atlas serves NVFP4 and vLLM serves FP8, some divergence is precision,
+not a bug — prefer matched precision when possible; otherwise read the *pattern*
+(does Atlas uniquely disfavor the structural opener?) not tiny logprob deltas.
+
+Usage:
+  python3 bench/tool_format_eval/compare_endpoints.py \
+      --atlas-url http://localhost:8888 --atlas-model nvidia/Qwen3.6-35B-A3B-NVFP4 \
+      --vllm-url  http://OTHER:8000   --vllm-model  Qwen/Qwen3.6-35B-A3B-FP8 \
+      --top 8 --thinking on --max-tokens 40
+"""
+import argparse
+import json
+import urllib.request
+
+
+def context(ntools):
+    defs = [
+        ("list_files", "List files", {"path": {"type": "string"}}, ["path"]),
+        ("read_file", "Read a file", {"path": {"type": "string"}}, ["path"]),
+        ("write_file", "Write a file",
+         {"path": {"type": "string"}, "content": {"type": "string"}}, ["path", "content"]),
+        ("run_command", "Run a shell command", {"command": {"type": "string"}}, ["command"]),
+    ][:ntools]
+    tools = [{"type": "function", "function": {
+        "name": a, "description": b,
+        "parameters": {"type": "object", "properties": c, "required": d}}}
+        for a, b, c, d in defs]
+    msgs = [
+        {"role": "system", "content": "You are a coding agent. Use tools. One action at a time."},
+        {"role": "user", "content": "Read src/main.rs and tell me what it does."},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "list_files", "arguments": '{"path":"src"}'}}]},
+        {"role": "tool", "tool_call_id": "c1", "name": "list_files",
+         "content": '["src/main.rs","src/lib.rs"]'},
+    ]
+    return msgs, tools
+
+
+def trace(url, model, ntools, top, thinking, max_tokens):
+    """Greedy decode with top_logprobs; return list of (chosen, [(tok,logprob)...])."""
+    msgs, tools = context(ntools)
+    body = {"model": model, "messages": msgs, "tools": tools,
+            "max_tokens": max_tokens, "temperature": 0.0,
+            "logprobs": True, "top_logprobs": top,
+            "chat_template_kwargs": {"enable_thinking": thinking}}
+    req = urllib.request.Request(url + "/v1/chat/completions",
+                                 data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=180) as r:
+        d = json.load(r)
+    lp = (d["choices"][0].get("logprobs") or {}).get("content") or []
+    return [(t["token"], [(x["token"], round(x["logprob"], 2))
+                          for x in t.get("top_logprobs", [])]) for t in lp]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--atlas-url", default="http://localhost:8888")
+    ap.add_argument("--atlas-model", default="nvidia/Qwen3.6-35B-A3B-NVFP4")
+    ap.add_argument("--vllm-url", required=True)
+    ap.add_argument("--vllm-model", required=True)
+    ap.add_argument("--ntools", type=int, default=4)
+    ap.add_argument("--top", type=int, default=8)
+    ap.add_argument("--thinking", default="on")
+    ap.add_argument("--max-tokens", type=int, default=40)
+    a = ap.parse_args()
+    think = a.thinking.lower() in ("on", "true", "1")
+
+    A = trace(a.atlas_url, a.atlas_model, a.ntools, a.top, think, a.max_tokens)
+    V = trace(a.vllm_url, a.vllm_model, a.ntools, a.top, think, a.max_tokens)
+    n = min(len(A), len(V))
+    print(f"# Layer-4 Atlas↔vLLM top_logprobs diff (greedy)  thinking={'ON' if think else 'OFF'}")
+    print(f"# atlas={a.atlas_model}  vllm={a.vllm_model}  comparing {n} positions\n")
+    print(f"{'pos':>3} {'atlas_top1':>14} {'vllm_top1':>14} {'=':>2} {'topK_jaccard':>12}")
+    agree = 0
+    diverged = None
+    for i in range(n):
+        at, av = A[i][0], V[i][0]
+        sa = {t for t, _ in A[i][1]}
+        sv = {t for t, _ in V[i][1]}
+        jac = len(sa & sv) / max(1, len(sa | sv))
+        same = at == av
+        agree += int(same)
+        print(f"{i:>3} {at!r:>14} {av!r:>14} {'=' if same else 'X':>2} {jac:>12.2f}")
+        if not same and diverged is None:
+            diverged = i
+            # show where the wrong/right structural token ranks on each side
+            ar = next((r for r, (t, _) in enumerate(A[i][1]) if t.strip().startswith("<")), None)
+            vr = next((r for r, (t, _) in enumerate(V[i][1]) if t.strip().startswith("<")), None)
+            print(f"    -> FIRST top-1 divergence at pos {i}. "
+                  f"'<'-tag rank: atlas={ar} vllm={vr}")
+    print(f"\ntop-1 agreement: {agree}/{n}"
+          + (f"  (first divergence at pos {diverged})" if diverged is not None else "  (full agreement)"))
+    print("high agreement / both drift => model behavior, Atlas inference faithful "
+          "(vLLM wins on parser/format).")
+    print("early divergence, atlas uniquely disfavors '<' => Atlas forward-pass/quant bug.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/tool_format_eval/cosine_atlas_vllm.py
+++ b/bench/tool_format_eval/cosine_atlas_vllm.py
@@ -1,0 +1,27 @@
+import numpy as np, pathlib
+A=pathlib.Path("/tmp/atlas_fp8_dump"); V=pathlib.Path("/tmp/vllm_ref")
+def rd(p):
+    p=pathlib.Path(p); return np.fromfile(p,dtype="<f4") if p.exists() else None
+def cos(a,b):
+    a=a.astype(np.float64);b=b.astype(np.float64);n=min(a.size,b.size);a,b=a[:n],b[:n]
+    na,nb=np.linalg.norm(a),np.linalg.norm(b)
+    return float(np.dot(a,b)/(na*nb)) if na and nb else float('nan')
+def rl2(a,b):
+    n=min(a.size,b.size);a,b=a[:n].astype(np.float64),b[:n].astype(np.float64)
+    return float(np.linalg.norm(a-b)/(np.linalg.norm(b)+1e-9))
+FULL=[3,7,11,15,19,23,27,31,35,39]
+print("=== PER-LAYER residual cosine: Atlas-FP8 vs vLLM-FP8 (149-tok probe, current build) ===")
+print(f"{'L':>3} {'type':>5} {'cos':>9} {'rel_l2':>8} {'|vllm|':>8} {'|atlas|':>8}")
+onset=None
+for i in range(40):
+    a=rd(A/f"atlas_L{i}.bin"); v=rd(V/f"vllm_L{i}.bin")
+    if a is None or v is None: print(f"{i:>3}  missing"); continue
+    c=cos(a,v); typ="attn" if i in FULL else "ssm"; flag=""
+    if c<0.999 and onset is None: onset=i; flag="  <-- ONSET"
+    print(f"{i:>3} {typ:>5} {c:>9.5f} {rl2(a,v):>8.4f} {np.linalg.norm(v):>8.2f} {np.linalg.norm(a):>8.2f}{flag}")
+print(f"\nDIVERGENCE ONSET: L{onset}")
+print("\n=== PER-OP o_proj cosine (attn layers): Atlas vs vLLM ===")
+for rel,abs_i in enumerate(FULL):
+    a=rd(A/f"atlas_op_L{rel}_o_proj.bin"); v=rd(V/f"vllm_op_L{abs_i}_o_proj.bin")
+    if a is None or v is None: print(f"  L{abs_i}: missing (a={a is not None} v={v is not None})"); continue
+    print(f"  L{abs_i:>2}  o_proj  cos={cos(a,v):.5f}  rel_l2={rl2(a,v):.4f}")

--- a/bench/tool_format_eval/dump_analyze.py
+++ b/bench/tool_format_eval/dump_analyze.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tool-format eval harness — Layer 3b/4: ATLAS_LOGIT_DUMP analysis + Atlas↔vLLM diff.
+
+Consumes the JSONL written by `ATLAS_LOGIT_DUMP=<file>` (see
+crates/spark-server/src/scheduler/logit_dump.rs). Each record has:
+    step, in_body, chars, raw_topk:[[id,logit]...], bias:[[id,delta]...],
+    post_argmax, sampled
+`raw_topk` is the model's OWN distribution before Atlas's additive bias stack;
+`bias` is the Atlas-only processor delta (vLLM applies none).
+
+Two modes:
+
+  single  — localize each step within ONE Atlas dump:
+              * does Atlas's `bias` flip the argmax vs raw?  => PROCESSOR divergence
+              * is the sampled token NOT the raw argmax?      => sampler (min_p/penalty)
+              * otherwise the pick == model's own argmax       => MODEL distribution
+            Tells you whether the wrong token is the model's own top pick or an
+            Atlas post-processor artifact — without an external reference.
+
+  diff    — compare an Atlas dump vs a vLLM dump (same teacher-forced tokens):
+              per-step top-1 agreement on `raw_topk` + symmetric divergence of
+              the shared top-K. raw_topk DIFFERS => model/inference (forward pass)
+              divergence; raw_topk MATCHES but argmax flips => Atlas bias. Mirrors
+              tests/metal_kv_kld_compare.py's stop-at-first-divergence logic.
+
+Produce the vLLM reference with vLLM's patched sampler (same raw_topk+sampled
+shape, per logit_dump.rs) or `prompt_logprobs` over the identical forced prefix.
+
+Usage:
+  ATLAS_LOGIT_DUMP=/tmp/atlas.jsonl ./target/release/spark serve ...   # then 1 request
+  python3 bench/tool_format_eval/dump_analyze.py single /tmp/atlas.jsonl
+  python3 bench/tool_format_eval/dump_analyze.py diff /tmp/atlas.jsonl /tmp/vllm.jsonl
+"""
+import argparse
+import json
+import math
+
+
+def load(path):
+    # The dump formats f32 ±inf as bare `inf`/`-inf` (Rust Display), which is not
+    # valid JSON. These are Atlas's hard-mask bias deltas (WS mask / think
+    # suppression). Map to large finite sentinels so argmax math still reflects
+    # "hard-masked" / "force".
+    recs = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            line = line.replace("-inf", "-1e30").replace("inf", "1e30").replace("nan", "0")
+            recs.append(json.loads(line))
+    return recs
+
+
+def raw_argmax(rec):
+    tk = rec["raw_topk"]
+    return max(tk, key=lambda p: p[1])[0]
+
+
+def post_bias_argmax(rec):
+    bias = {b[0]: b[1] for b in rec.get("bias", [])}
+    best, bid = -1e30, None
+    for tid, lg in rec["raw_topk"]:
+        v = lg + bias.get(tid, 0.0)
+        if v > best:
+            best, bid = v, tid
+    return bid
+
+
+def single(path):
+    recs = load(path)
+    n = len(recs)
+    model_pick = bias_flip = sampler_pick = 0
+    print(f"# single-dump localization — {n} steps from {path}\n")
+    print(f"{'step':>4} {'in_body':>7} {'raw_argmax':>10} {'post_bias':>9} "
+          f"{'sampled':>7}  verdict")
+    for r in recs:
+        ra = raw_argmax(r)
+        pb = post_bias_argmax(r)
+        sm = r["sampled"]
+        if pb != ra:
+            verdict = "BIAS flips argmax (Atlas processor)"
+            bias_flip += 1
+        elif sm != ra:
+            verdict = "sampler picked non-argmax (min_p/penalty/temp)"
+            sampler_pick += 1
+        else:
+            verdict = "model's own argmax"
+            model_pick += 1
+        if r["step"] < 24 or pb != ra or sm != ra:
+            print(f"{r['step']:>4} {str(r['in_body']):>7} {ra:>10} {pb:>9} {sm:>7}  {verdict}")
+    print(f"\nmodel-argmax picks: {model_pick}  | bias-flips: {bias_flip}  "
+          f"| sampler picks: {sampler_pick}  (of {n})")
+    print("bias-flips>0 => Atlas's additive processor stack is steering tokens (vLLM has none).")
+    print("else the wrong tokens are the MODEL's own argmax => forward-pass/quant; diff vs vLLM.")
+
+
+def topk_map(rec):
+    return {p[0]: p[1] for p in rec["raw_topk"]}
+
+
+def sym_div(a, b):
+    """Symmetric mean |logit| gap over shared top-K ids (proxy for divergence)."""
+    shared = set(a) & set(b)
+    if not shared:
+        return float("nan")
+    return sum(abs(a[i] - b[i]) for i in shared) / len(shared)
+
+
+def diff(atlas_path, vllm_path):
+    A, V = load(atlas_path), load(vllm_path)
+    n = min(len(A), len(V))
+    agree = 0
+    compared = 0
+    print(f"# Atlas↔vLLM raw_topk diff — comparing {n} aligned steps\n")
+    print(f"{'step':>4} {'atlas_argmax':>12} {'vllm_argmax':>11} {'top1':>5} {'sharedΔ':>8}")
+    for i in range(n):
+        aa, va = raw_argmax(A[i]), raw_argmax(V[i])
+        same = aa == va
+        agree += int(same)
+        compared += 1
+        d = sym_div(topk_map(A[i]), topk_map(V[i]))
+        print(f"{i:>4} {aa:>12} {va:>11} {'=' if same else 'X':>5} {d:>8.3f}")
+        if not same:
+            print(f"     -> FIRST top-1 divergence at step {i}: "
+                  f"raw_topk differs => MODEL/inference (forward-pass) divergence.")
+            break
+    print(f"\ntop-1 agreement: {agree}/{compared} up to first divergence.")
+    print("high agreement => Atlas inference matches vLLM (look at bias/sampler/parsing).")
+    print("early divergence => Atlas forward pass (quant kernels/KV) differs from vLLM.")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="mode", required=True)
+    s = sub.add_parser("single"); s.add_argument("dump")
+    df = sub.add_parser("diff"); df.add_argument("atlas"); df.add_argument("vllm")
+    a = ap.parse_args()
+    if a.mode == "single":
+        single(a.dump)
+    else:
+        diff(a.atlas, a.vllm)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/tool_format_eval/harness.py
+++ b/bench/tool_format_eval/harness.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tool-format eval harness — Layer 1 (behavioral) + Layer 2 (failure classifier).
+
+Quantifies the multi-turn tool-call FORMAT failure on Qwen3.6-35B (and any
+OpenAI-compatible Atlas endpoint) with confidence intervals, and classifies each
+failure as a PARSING problem vs a GENERATION (decode/inference) problem.
+
+Why two layers:
+  - Layer 1 gives a validity RATE with a Wilson 95% CI, so config A/Bs are
+    distinguishable above N=10 noise (the reason this harness exists).
+  - Layer 2 reads the RAW model text on every non-ok turn and bins it:
+      * parser_miss     -> model emitted well-formed <tool_call><function=…>,
+                           but Atlas parsed nothing  => PARSING bug
+      * malformed_opener-> model emitted <parameter…>/<arg…>/bare <function…>
+                           (wrong dialect)            => GENERATION/decode
+      * runaway         -> finish=length, no call
+      * text_answer     -> prose, no tool tags
+    If failures are overwhelmingly `malformed_opener`, parsing is exonerated and
+    the defect is upstream (decode/inference) — confirm with logit_probe.py /
+    dump_analyze.py.
+
+Usage:
+  python3 bench/tool_format_eval/harness.py --n 50
+  python3 bench/tool_format_eval/harness.py --n 50 --url http://localhost:8888 \
+      --model nvidia/Qwen3.6-35B-A3B-NVFP4
+"""
+import argparse
+import json
+import math
+import re
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+VALID_TOOLS = {"list_files", "read_file", "write_file", "run_command"}
+
+TOOLDEFS = [
+    ("list_files", "List files in a directory", {"path": {"type": "string"}}, ["path"]),
+    ("read_file", "Read a file's contents", {"path": {"type": "string"}}, ["path"]),
+    ("write_file", "Write content to a file",
+     {"path": {"type": "string"}, "content": {"type": "string"}}, ["path", "content"]),
+    ("run_command", "Run a shell command", {"command": {"type": "string"}}, ["command"]),
+]
+
+
+def tools(n):
+    return [{"type": "function", "function": {
+        "name": a, "description": b,
+        "parameters": {"type": "object", "properties": c, "required": d}}}
+        for a, b, c, d in TOOLDEFS[:n]]
+
+
+# A multi-turn agentic context: one completed tool call + its result, model must
+# now emit the NEXT tool call. This is the turn that degenerates under thinking.
+def context():
+    return [
+        {"role": "system", "content": "You are a coding agent. Use tools. One action at a time."},
+        {"role": "user", "content": "Read src/main.rs and tell me what it does."},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "list_files", "arguments": '{"path":"src"}'}}]},
+        {"role": "tool", "tool_call_id": "c1", "name": "list_files",
+         "content": '["src/main.rs","src/lib.rs"]'},
+    ]
+
+
+def post(url, body, timeout=180):
+    req = urllib.request.Request(url + "/v1/chat/completions",
+                                 data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.load(r)
+
+
+# Well-formed qwen3_coder call the parser SHOULD extract.
+WELLFORMED = re.compile(r"<tool_call>\s*<function=\w+>")
+BADOPENER = re.compile(r"<\s*(parameter|arg|param)\b|<function\s+name=|<function=\w+>(?!.*</tool_call>)", re.S)
+
+
+def classify(resp):
+    c = resp["choices"][0]
+    m = c["message"]
+    fr = c["finish_reason"]
+    content = m.get("content") or ""
+    tcs = m.get("tool_calls") or []
+    # ok: at least one known tool, valid JSON args, and not truncated.
+    if tcs and fr != "length":
+        good = True
+        for t in tcs:
+            if t["function"]["name"] not in VALID_TOOLS:
+                good = False
+            else:
+                try:
+                    json.loads(t["function"]["arguments"])
+                except Exception:
+                    good = False
+        if good:
+            return "ok"
+        return "wrong_tool"
+    # No usable tool call — inspect the raw text the model produced.
+    if WELLFORMED.search(content):
+        return "parser_miss"          # PARSING bug
+    if BADOPENER.search(content):
+        return "malformed_opener"     # GENERATION/decode
+    if fr == "length":
+        return "runaway"
+    if content.strip():
+        return "text_answer"
+    return "empty"
+
+
+def wilson(k, n, z=1.96):
+    if n == 0:
+        return (0.0, 0.0)
+    p = k / n
+    d = 1 + z * z / n
+    c = p + z * z / (2 * n)
+    h = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return ((c - h) / d, (c + h) / d)
+
+
+def trial(url, model, ntools, thinking):
+    body = {"model": model, "messages": context(), "tools": tools(ntools),
+            "max_tokens": 400, "temperature": 0.7}
+    body["chat_template_kwargs"] = {"enable_thinking": thinking}
+    try:
+        return classify(post(url, body))
+    except Exception as e:
+        return f"error:{type(e).__name__}"
+
+
+def run_cell(url, model, ntools, thinking, n, workers):
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        outs = list(ex.map(lambda _: trial(url, model, ntools, thinking), range(n)))
+    hist = {}
+    for o in outs:
+        hist[o] = hist.get(o, 0) + 1
+    ok = hist.get("ok", 0)
+    lo, hi = wilson(ok, n)
+    return ok, n, lo, hi, hist
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://localhost:8888")
+    ap.add_argument("--model", default="nvidia/Qwen3.6-35B-A3B-NVFP4")
+    ap.add_argument("--n", type=int, default=50)
+    ap.add_argument("--workers", type=int, default=4)
+    ap.add_argument("--tool-counts", default="2,4")
+    a = ap.parse_args()
+    counts = [int(x) for x in a.tool_counts.split(",")]
+
+    print(f"# Tool-format eval — {a.model}  N={a.n}/cell  workers={a.workers}")
+    print(f"{'cell':<28}{'valid':>10}{'95% CI':>16}   failure-mode breakdown")
+    print("-" * 100)
+    for ntools in counts:
+        for thinking in (True, False):
+            ok, n, lo, hi, hist = run_cell(a.url, a.model, ntools, thinking, a.n, a.workers)
+            fails = {k: v for k, v in sorted(hist.items(), key=lambda x: -x[1]) if k != "ok"}
+            cell = f"tools={ntools} thinking={'ON' if thinking else 'OFF'}"
+            ci = f"[{lo*100:4.0f},{hi*100:4.0f}]%"
+            print(f"{cell:<28}{ok}/{n:<8}{ci:>16}   {fails}")
+    print("-" * 100)
+    print("Read: high `malformed_opener` share => GENERATION/decode (not parsing).")
+    print("      high `parser_miss` share      => PARSING bug.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/tool_format_eval/logit_probe.py
+++ b/bench/tool_format_eval/logit_probe.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Tool-format eval harness — Layer 3a: within-Atlas logit decision-point probe.
+
+Answers "parsing vs inference" WITHOUT an external reference, using the
+OpenAI `top_logprobs` field. For each generated token it asks: at the moment the
+model commits to narration / a malformed opener, how did Atlas's own next-token
+distribution RANK the correct structural token (`<tool_call>` / `<` / `function`)?
+
+  - If the correct structural token is TOP-1 / high-prob but a wrong token was
+    sampled => the forward pass favored the right answer; failure is sampling/
+    decode DYNAMICS, not the logits.
+  - If the correct structural token is BURIED (low rank/logprob) => Atlas's
+    forward pass is mis-ranking => INFERENCE/decode issue. Confirm the *cause*
+    (model vs Atlas bias) with dump_analyze.py (ATLAS_LOGIT_DUMP raw_topk vs bias).
+
+This is parser-free: it inspects the token stream the model actually produced,
+upstream of any tool-call parsing.
+
+Usage:
+  python3 bench/tool_format_eval/logit_probe.py --runs 8 --top 10
+"""
+import argparse
+import json
+import urllib.request
+
+# Tokens that (as a prefix) begin a CORRECT qwen3_coder tool call.
+STRUCT_PREFIXES = ("<tool_call", "<tool", "<", "tool_call", "function", "<function")
+
+
+def context(ntools):
+    defs = [
+        ("list_files", "List files", {"path": {"type": "string"}}, ["path"]),
+        ("read_file", "Read a file", {"path": {"type": "string"}}, ["path"]),
+        ("write_file", "Write a file",
+         {"path": {"type": "string"}, "content": {"type": "string"}}, ["path", "content"]),
+        ("run_command", "Run a shell command", {"command": {"type": "string"}}, ["command"]),
+    ][:ntools]
+    tools = [{"type": "function", "function": {
+        "name": a, "description": b,
+        "parameters": {"type": "object", "properties": c, "required": d}}}
+        for a, b, c, d in defs]
+    msgs = [
+        {"role": "system", "content": "You are a coding agent. Use tools. One action at a time."},
+        {"role": "user", "content": "Read src/main.rs and tell me what it does."},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "list_files", "arguments": '{"path":"src"}'}}]},
+        {"role": "tool", "tool_call_id": "c1", "name": "list_files",
+         "content": '["src/main.rs","src/lib.rs"]'},
+    ]
+    return msgs, tools
+
+
+def post(url, body, timeout=180):
+    req = urllib.request.Request(url + "/v1/chat/completions",
+                                 data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.load(r)
+
+
+def struct_rank(top_logprobs):
+    """Best (rank, logprob) among candidates whose token begins a tool-call opener."""
+    for rank, cand in enumerate(top_logprobs):
+        tok = cand["token"].strip()
+        if any(tok.startswith(p) or p.startswith(tok) and tok for p in ("<tool_call", "<", "<function")):
+            if tok in ("<", "<tool_call", "<tool", "<function", "<tool_call>", "<function="):
+                return rank, cand["logprob"], cand["token"]
+    return None
+
+
+def probe_run(url, model, ntools, top, thinking):
+    msgs, tools = context(ntools)
+    body = {"model": model, "messages": msgs, "tools": tools, "max_tokens": 24,
+            "temperature": 1.0, "logprobs": True, "top_logprobs": top,
+            "chat_template_kwargs": {"enable_thinking": thinking}}
+    d = post(url, body)
+    c = d["choices"][0]
+    lp = (c.get("logprobs") or {}).get("content") or []
+    chosen = [t["token"] for t in lp]
+    # Decision point = first content token after </think> (index 0 of the
+    # returned trace, since thinking is stripped from `content`). Also scan for
+    # the first '<'-tag the model opens.
+    rows = []
+    for i, t in enumerate(lp[:12]):
+        sr = struct_rank(t.get("top_logprobs", []))
+        rows.append((i, t["token"], round(t["logprob"], 2),
+                     None if sr is None else (sr[0], round(sr[1], 2))))
+    return chosen, rows, c["finish_reason"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://localhost:8888")
+    ap.add_argument("--model", default="nvidia/Qwen3.6-35B-A3B-NVFP4")
+    ap.add_argument("--runs", type=int, default=8)
+    ap.add_argument("--ntools", type=int, default=2)
+    ap.add_argument("--top", type=int, default=10)
+    ap.add_argument("--thinking", default="on")
+    a = ap.parse_args()
+    think = a.thinking.lower() in ("on", "true", "1")
+    print(f"# Layer-3a logit probe — {a.model}  thinking={'ON' if think else 'OFF'}  "
+          f"tools={a.ntools}  top_logprobs={a.top}")
+    print("At pos 0 (first post-</think> token): rank/logprob of the <tool_call> opener vs chosen.\n")
+    pos0_struct_top1 = 0
+    for r in range(a.runs):
+        chosen, rows, fr = probe_run(a.url, a.model, a.ntools, a.top, think)
+        p0 = rows[0] if rows else None
+        if p0 and p0[3] is not None and p0[3][0] == 0:
+            pos0_struct_top1 += 1
+        first = "".join(chosen[:10]).replace("\n", "\\n")
+        sr = "n/a" if not p0 or p0[3] is None else f"rank{p0[3][0]} lp{p0[3][1]}"
+        print(f"run {r+1}: chose0={p0[1]!r:>10} lp{p0[2]:<6} | <tool_call> opener: {sr:<16} "
+              f"| start={first!r} | finish={fr}")
+    print(f"\n<tool_call>-opener was TOP-1 at the decision point in "
+          f"{pos0_struct_top1}/{a.runs} runs.")
+    print("low share => forward pass disfavors the structural opener => inference/decode, "
+          "not parsing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/tool_format_eval/threeway_vs_bf16_truth.py
+++ b/bench/tool_format_eval/threeway_vs_bf16_truth.py
@@ -1,0 +1,35 @@
+import numpy as np, pathlib
+AT=pathlib.Path("/tmp/atlas_fp8_dump"); VL=pathlib.Path("/tmp/vllm_ref"); VL2=pathlib.Path("/tmp/vllm_ref2"); BF=pathlib.Path("/tmp/bf16_truth")
+def rd(p): p=pathlib.Path(p); return np.fromfile(p,dtype="<f4") if pathlib.Path(p).exists() else None
+def cd(a,b):
+    if a is None or b is None: return None
+    n=min(a.size,b.size);x,y=a[:n].astype(np.float64),b[:n].astype(np.float64)
+    nx,ny=np.linalg.norm(x),np.linalg.norm(y)
+    cos=float(np.dot(x,y)/(nx*ny)) if nx and ny else float('nan')
+    return (cos, float(np.linalg.norm(x-y)/(ny+1e-9)))
+def fmt(r): return f"{r[0]:.5f}/{r[1]:.4f}" if r else "  -  "
+FULL=[3,7,11,15]; ATTN_REL={3:0,7:1,11:2,15:3}
+print("cos/rel_l2 vs BF16 GROUND TRUTH   (lower rel_l2 = closer to correct)")
+print(f"{'op':>22} {'layer':>6} {'Atlas-FP8':>16} {'vLLM-FP8':>16}   winner")
+print('-'*82)
+# per-layer residual (all L0..15)
+for i in range(16):
+    a=cd(rd(AT/f"atlas_L{i}.bin"), rd(BF/f"hf_op_L{i}_layer_out.bin"))
+    v=cd(rd(VL/f"vllm_L{i}.bin"),  rd(BF/f"hf_op_L{i}_layer_out.bin"))
+    w = "" if (a is None or v is None) else ("ATLAS closer" if a[1]<v[1] else "vLLM closer")
+    print(f"{'residual':>22} {i:>6} {fmt(a):>16} {fmt(v):>16}   {w}")
+print('-'*82)
+# attention-layer ops: o_proj, q/k/v proj, k_after_norm
+for op,af,bf,vf in [("o_proj","atlas_op_L{r}_o_proj.bin","hf_op_L{a}_o_proj.bin","vllm_op_L{a}_o_proj.bin"),
+                    ("q_proj","atlas_op_L{r}_q_proj_full.bin","hf_op_L{a}_q_proj_full.bin",None),
+                    ("k_proj","atlas_op_L{r}_k_proj.bin","hf_op_L{a}_k_proj.bin",None),
+                    ("v_proj","atlas_op_L{r}_v_proj.bin","hf_op_L{a}_v_proj.bin",None),
+                    ("k_after_norm","atlas_op_L{r}_k_post_norm.bin","hf_op_L{a}_k_after_norm.bin",None),
+                    ("post_attn_norm","atlas_op_L{r}_post_attn_norm_out.bin","hf_op_L{a}_post_attn_norm_out.bin",None)]:
+    for L in FULL:
+        r=ATTN_REL[L]
+        a=cd(rd(AT/(af.format(r=r))), rd(BF/(bf.format(a=L))))
+        if vf: v=cd(rd(VL2/(vf.format(a=L))), rd(BF/(bf.format(a=L))))
+        else:  v=None
+        w = "" if a is None else ("" if v is None else ("ATLAS closer" if a[1]<v[1] else "vLLM closer"))
+        print(f"{op:>22} {L:>6} {fmt(a):>16} {fmt(v):>16}   {w}")

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -47,9 +47,15 @@ impl MoeLayer {
         // fp8_gemm_t_blockscaled with both scales in the FP32 epilogue.
         // The shared expert is dense (every token), so we reuse the same
         // dense W8A8 GEMM that attention QKV/O proj already use.
-        let force_w8a8_sh = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"))
+        // `is_block_scaled()` on all three projections: the kernel reads
+        // each `row_scale` as [N/128, K/128] blocks — a non-block-scaled
+        // shared expert must fall through to the w8a16 path below.
+        let force_w8a8_sh = ops::fp8_blockscaled_prefill_enabled()
             && self.fp8_gemm_t_blockscaled_k.0 != 0
-            && self.per_token_group_quant_fp8_k.0 != 0;
+            && self.per_token_group_quant_fp8_k.0 != 0
+            && sh.gate_proj.is_block_scaled()
+            && sh.up_proj.is_block_scaled()
+            && sh.down_proj.is_block_scaled();
         let has_shared = shared_inter > 0;
         if has_shared && force_w8a8_sh {
             let shared_gate_out = ctx.buffers.ssm_deinterleaved();
@@ -363,9 +369,14 @@ impl MoeLayer {
         }
         // ATLAS_FP8_W8A8: pre-quant input/intermediate to FP8 with per-token-
         // per-128 FP32 scale, use new W8A8 grouped GEMM (vLLM-equivalent).
-        let force_w8a8 = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"))
+        // `fp8_experts_block_scaled` (recorded by `set_fp8_experts`, the
+        // pointer tables erase the per-weight format tag) gates the grouped
+        // GEMM to actual [N/128, K/128] block scales — non-block-scaled
+        // experts fall through to the grouped FP8 path below.
+        let force_w8a8 = ops::fp8_blockscaled_prefill_enabled()
             && self.moe_w8a8_grouped_gemm_k.0 != 0
-            && self.per_token_group_quant_fp8_k.0 != 0;
+            && self.per_token_group_quant_fp8_k.0 != 0
+            && self.fp8_experts_block_scaled;
 
         if force_w8a8 && max_m_tiles > 0 {
             // Quant input [num_tokens, h] → input_fp8 + input_a_scale ONCE,

--- a/crates/spark-model/src/layers/moe/helpers_c.rs
+++ b/crates/spark-model/src/layers/moe/helpers_c.rs
@@ -68,6 +68,15 @@ impl MoeLayer {
         self.fp8_gate_weight_ptrs = Some(build_fp8_ptr_table(experts, |e| &e.gate_proj, gpu)?);
         self.fp8_up_weight_ptrs = Some(build_fp8_ptr_table(experts, |e| &e.up_proj, gpu)?);
         self.fp8_down_weight_ptrs = Some(build_fp8_ptr_table(experts, |e| &e.down_proj, gpu)?);
+        // Record whether every projection behind the tables carries
+        // [N/128, K/128] block scales — the pointer tables erase the
+        // format tag, and `moe_w8a8_grouped_gemm` (block-scaled prefill)
+        // must not consume per-row / single-scale FP8.
+        self.fp8_experts_block_scaled = experts.iter().all(|e| {
+            e.gate_proj.is_block_scaled()
+                && e.up_proj.is_block_scaled()
+                && e.down_proj.is_block_scaled()
+        });
         self.fp8_shared_expert = Some(shared_expert);
         Ok(())
     }

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -300,6 +300,8 @@ impl MoeLayer {
             fp8_gate_weight_ptrs: None,
             fp8_up_weight_ptrs: None,
             fp8_down_weight_ptrs: None,
+            // No FP8 experts installed yet — set by `set_fp8_experts`.
+            fp8_experts_block_scaled: false,
             bf16_gate_weight_ptrs: None,
             bf16_up_weight_ptrs: None,
             bf16_down_weight_ptrs: None,

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -269,6 +269,11 @@ pub struct MoeLayer {
     fp8_gate_weight_ptrs: Option<Fp8ExpertPtrTable>,
     fp8_up_weight_ptrs: Option<Fp8ExpertPtrTable>,
     fp8_down_weight_ptrs: Option<Fp8ExpertPtrTable>,
+    // True when EVERY routed expert projection behind the pointer tables is
+    // `WeightQuantFormat::Fp8BlockScaled` ([N/128, K/128] scales). Recorded
+    // by `set_fp8_experts` because the raw pointer tables erase the format
+    // tag; gates the `moe_w8a8_grouped_gemm` block-scaled prefill dispatch.
+    fp8_experts_block_scaled: bool,
     // BF16 expert pointer tables — populated by the FP8-dequant-on-load
     // path. When Some, the routed-expert dispatch in `forward_prefill_fp8`
     // routes through `moe_bf16_grouped_gemm` instead of the FP8 grouped

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -112,3 +112,31 @@ pub use ssm_gdn_b::*;
 pub use ssm_gdn_batched::*;
 pub use ssm_mamba::*;
 pub use ssm_preproc::*;
+
+/// Whether block-scaled FP8 prefill (per-128-block weight scales + per-token
+/// activation scales via `fp8_gemm_t_blockscaled` / `moe_w8a8_grouped_gemm`)
+/// is enabled. This is the DEFAULT for block-scaled FP8 checkpoints as of
+/// 2026-06-17: it matches vLLM's per-block precision and avoids the
+/// single-scale `fp8_gemm_n128` path, whose collapse of per-block dynamic
+/// range pushed long-context tool-arg decode into the FP8 argmax-flip regime
+/// (B1 drift gauge ~1400 → ~100 once block-scaled prefill is on).
+///
+/// Opt out with `ATLAS_FP8_SINGLE_SCALE=1` to restore the old single-scale
+/// prefill (diagnostic / fallback only). Call sites still guard on the
+/// presence of block-scaled weights + kernel handles, so builds/models
+/// without those fall back automatically regardless of this flag.
+///
+/// The env var is read ONCE and cached: this helper is consulted on every
+/// projection dispatch of every layer of every prefill, and a per-call
+/// `std::env::var` shows up in profiles (plus `set_var` after startup is
+/// UB-adjacent in multithreaded programs — snapshotting at first use gives
+/// one consistent answer for the process lifetime).
+pub fn fp8_blockscaled_prefill_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !matches!(
+            std::env::var("ATLAS_FP8_SINGLE_SCALE").ok().as_deref(),
+            Some("1")
+        )
+    })
+}

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
@@ -25,9 +25,13 @@ impl Qwen3AttentionLayer {
         stream: u64,
     ) -> Result<DevicePtr> {
         let o_out = ctx.buffers.norm_output();
-        let force_w8a8 = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"));
+        let force_w8a8 = ops::fp8_blockscaled_prefill_enabled();
+        // `is_block_scaled()`: fp8_gemm_t_blockscaled reads `row_scale` as
+        // `[N/128, K/128]` blocks — per-row / single-scale FP8 must fall
+        // through to the w8a16 paths below.
         if force_w8a8
             && let Some(fp8w) = self.o_weight.as_ref().and_then(|w| w.as_fp8())
+            && fp8w.is_block_scaled()
             && self.per_token_group_quant_fp8_k.0 != 0
             && self.fp8_gemm_t_blockscaled_k.0 != 0
         {

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_qkv.rs
@@ -126,12 +126,15 @@ impl Qwen3AttentionLayer {
             ),
         };
 
-        let force_w8a8 = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"));
+        let force_w8a8 = ops::fp8_blockscaled_prefill_enabled();
         // W8A8 + FP32 epilogue: requires NON-transposed FP8 weights with
         // block scales (matches the kernel signature). The attn layer stores
         // those via set_fp8_weights — accessible via weight_opt.as_fp8().
+        // `is_block_scaled()` gates on the actual scale layout: per-row /
+        // single-scale FP8 must fall through to the w8a16 paths below.
         if force_w8a8
             && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8())
+            && fp8w.is_block_scaled()
             && self.per_token_group_quant_fp8_k.0 != 0
             && self.fp8_gemm_t_blockscaled_k.0 != 0
         {

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
@@ -94,13 +94,16 @@ impl Qwen3AttentionLayer {
         self.o_nvfp4_t = o_nvfp4_t;
     }
 
-    /// Set native FP8 checkpoint weights for `w8a16_gemv` decode path.
+    /// Set native FP8 checkpoint weights for the `w8a16_gemv` decode path.
     ///
-    /// NOTE: Does NOT set `q_fp8`/`k_fp8`/`v_fp8`/`o_fp8` (raw FP8
-    /// prefill pointers) because `fp8_gemm_t` doesn't apply block scales.
-    /// Native FP8 block-scaled weights need per-block scale during GEMM,
-    /// which `fp8_gemm_t` doesn't do. Prefill falls through to the
-    /// NVFP4/BF16 dequant path instead.
+    /// The block-scaled FP8 weights stored here (weight + per-128 `row_scale`)
+    /// are ALSO consumed by block-scaled prefill: `fp8_gemm_t_blockscaled`
+    /// folds both the per-token activation scale and the per-block weight
+    /// scale in an FP32 epilogue. (Historical note: the older single-scale
+    /// `fp8_gemm_t`/`fp8_gemm_n128` prefill could not apply block scales, so
+    /// prefill used to fall through to the NVFP4/BF16 dequant path — that is
+    /// no longer the case; block-scaled prefill is the default, see
+    /// `ops::fp8_blockscaled_prefill_enabled`.)
     pub fn set_fp8_weights(
         &mut self,
         q: Option<Fp8Weight>,
@@ -108,6 +111,21 @@ impl Qwen3AttentionLayer {
         v: Option<Fp8Weight>,
         o: Option<Fp8Weight>,
     ) {
+        // Both consumers of these weights (`w8a16_gemv` decode and the
+        // block-scaled `fp8_gemm_t_blockscaled` prefill) read the scale
+        // buffer as [N/BS, K/BS] blocks — fail fast on any other layout
+        // (mirrors the SSM `set_fp8_decode_weights` setter).
+        for (w, name) in [(&q, "q"), (&k, "k"), (&v, "v"), (&o, "o")] {
+            if let Some(w) = w {
+                w.scale_format.expect(
+                    crate::weight_map::WeightQuantFormat::Fp8BlockScaled,
+                    &format!(
+                        "set_fp8_weights::{name} (w8a16_gemv / fp8_gemm_t_blockscaled expect \
+                         [N/BS,K/BS] block scales)"
+                    ),
+                );
+            }
+        }
         // Overwrite decode weights with FP8 variant. Replaces any NVFP4
         // weights set during construction.
         if let Some(qw) = q {

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_phase3.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_phase3.rs
@@ -50,7 +50,7 @@ impl Qwen3SsmLayer {
 
         // ── 10. Output projection GEMM: [N, 4096] × [4096, 2048] → [N, 2048] ──
         let out_proj_buf = ctx.buffers.moe_output();
-        let force_w8a8_op = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"));
+        let force_w8a8_op = ops::fp8_blockscaled_prefill_enabled();
         if let Some(ref dense_out) = self.out_proj_dense {
             ops::dense_gemm(
                 ctx.gpu,
@@ -65,11 +65,24 @@ impl Qwen3SsmLayer {
             )
         } else if force_w8a8_op
             && let Some(ref fp8w) = self.out_proj_fp8w
+            // fp8_gemm_t_blockscaled reads row_scale as [N/128, K/128]
+            // blocks — non-block-scaled FP8 falls through to the
+            // single-scale / NVFP4 paths below.
+            && fp8w.is_block_scaled()
             && self.per_token_group_quant_fp8_k.0 != 0
             && self.fp8_gemm_t_blockscaled_k.0 != 0
         {
+            // out_proj GEMM: C[M, N] = A[M, K] @ B[N, K]
+            //   A = normed_out : [num_tokens, value_dim]  (K = value_dim)
+            //   B = out_proj   : [h, value_dim]           (N = h)
+            // Derive N/K from the weight itself (SSOT) — the checkpoint
+            // stores out_proj as [h, value_dim], so fp8w.n = h and
+            // fp8w.k = value_dim. (The original cut quantized the
+            // activation at width h and swapped N/K in the GEMM call —
+            // latent, since `out_proj_dense` above currently shadows
+            // this branch in the native-FP8 loader arm.)
             let m = k as usize;
-            let k_dim = h;
+            let k_dim = fp8w.k as usize;
             let a_fp8_bytes = m * k_dim;
             let a_scale_bytes = m * (k_dim / 128) * 4;
             let a_fp8_buf = ctx.gpu.alloc(a_fp8_bytes)?;
@@ -81,7 +94,7 @@ impl Qwen3SsmLayer {
                 a_fp8_buf,
                 a_scale_buf,
                 k,
-                k_dim as u32,
+                fp8w.k,
                 stream,
             )?;
             ops::fp8_gemm_t_blockscaled(
@@ -93,8 +106,8 @@ impl Qwen3SsmLayer {
                 fp8w.row_scale,
                 out_proj_buf,
                 k,
-                value_dim as u32,
-                h as u32,
+                fp8w.n,
+                fp8w.k,
                 stream,
             )?;
             ctx.gpu.synchronize(stream)?;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
@@ -44,7 +44,7 @@ impl Qwen3SsmLayer {
             std::env::var("ATLAS_GDN_BF16_WEIGHTS").ok().as_deref(),
             Some("1")
         );
-        let force_w8a8 = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"));
+        let force_w8a8 = ops::fp8_blockscaled_prefill_enabled();
         if force_bf16 {
             ops::dense_gemm(
                 ctx.gpu,
@@ -64,11 +64,14 @@ impl Qwen3SsmLayer {
             })?;
         } else if force_w8a8
             && let Some(ref fp8w) = self.qkvz_fp8w
+            // fp8_gemm_t_blockscaled reads row_scale as [N/128, K/128]
+            // blocks — non-block-scaled FP8 falls through to w8a16 below.
+            && fp8w.is_block_scaled()
             && self.per_token_group_quant_fp8_k.0 != 0
             && self.fp8_gemm_t_blockscaled_k.0 != 0
         {
-            tracing::info!(
-                "ssm prefill: QKVZ via W8A8+FP32-epilogue (vLLM-equivalent, M={k} K={h} N={qkvz_size})"
+            tracing::debug!(
+                "ssm prefill: QKVZ via block-scaled FP8 (W8A8+FP32-epilogue, M={k} K={h} N={qkvz_size})"
             );
             let m = k as usize;
             let k_dim = h;
@@ -76,10 +79,8 @@ impl Qwen3SsmLayer {
             let a_scale_bytes = m * (k_dim / 128) * 4;
             let a_fp8_buf = ctx.gpu.alloc(a_fp8_bytes)?;
             let a_scale_buf = ctx.gpu.alloc(a_scale_bytes)?;
-            // BISECT TEST 1: quant kernel only — call it then fall through
-            // to w8a16_gemm (which we know works) for the actual GEMM.
-            // If this still crashes, the bug is in per_token_group_quant_fp8.
-            // If it works, the bug is in fp8_gemm_t_blockscaled.
+            // Per-token block FP8 quant of the activation, then block-scaled
+            // FP8×FP8 GEMM folding both per-128 scales in an FP32 epilogue.
             ops::per_token_group_quant_fp8(
                 ctx.gpu,
                 self.per_token_group_quant_fp8_k,
@@ -90,9 +91,6 @@ impl Qwen3SsmLayer {
                 k_dim as u32,
                 stream,
             )?;
-            // BISECT TEST 2: now call the GEMM with no-fold variant. If
-            // this crashes, the bug is in the MMA loop itself.
-            tracing::info!("ssm prefill: calling fp8_gemm_t_blockscaled (no-fold bisect)");
             ops::fp8_gemm_t_blockscaled(
                 ctx.gpu,
                 self.fp8_gemm_t_blockscaled_k,

--- a/crates/spark-model/src/weight_map/quantized.rs
+++ b/crates/spark-model/src/weight_map/quantized.rs
@@ -241,6 +241,17 @@ pub struct Fp8WeightTransposed {
 }
 
 impl Fp8Weight {
+    /// True when `row_scale` holds `[N/128, K/128]` per-block scales
+    /// ([`WeightQuantFormat::Fp8BlockScaled`]) — the only layout the
+    /// block-scaled prefill kernels (`fp8_gemm_t_blockscaled`,
+    /// `moe_w8a8_grouped_gemm`) may consume. Dispatch sites MUST check
+    /// this before routing through those kernels: feeding per-row or
+    /// single-scale FP8 would silently read the scale buffer at the
+    /// wrong shape.
+    pub fn is_block_scaled(&self) -> bool {
+        self.scale_format == WeightQuantFormat::Fp8BlockScaled
+    }
+
     /// Transpose this FP8 weight for coalesced prefill GEMM.
     /// Allocates new GPU buffers for `B_t[K,N]` (FP8 bytes) and
     /// `scale_t[K/128, N/128]` (FP32; `row_scale` is already FP32).

--- a/crates/spark-server/src/openai/chat_request.rs
+++ b/crates/spark-server/src/openai/chat_request.rs
@@ -367,8 +367,13 @@ impl ChatCompletionRequest {
             if let Some(budget) = tc.budget_tokens {
                 return (true, Some(budget));
             }
-            // thinking object present with no budget → enable with default
-            return (true, Some(DEFAULT_THINKING_BUDGET));
+            // Anthropic "adaptive" / thinking object with no explicit budget
+            // means "think as long as needed" — defer to the per-model
+            // `max_thinking_budget` (None), NOT the conservative 256-token
+            // DEFAULT_THINKING_BUDGET. A hard 256 cut force-injects </think>
+            // mid-reasoning on agentic turns and wrecks tool selection.
+            // Mirrors the step-5 enable_thinking path below.
+            return (true, None);
         }
 
         // 2. vLLM PR: thinking_token_budget

--- a/crates/spark-server/src/tool_parser/tests/group_e.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_e.rs
@@ -368,3 +368,33 @@ fn repair_empty_key_skips_when_multiple_required_missing() {
         "must NOT repair when >1 required prop is missing (ambiguous)"
     );
 }
+
+#[test]
+fn repair_empty_key_in_stringified_nested_array() {
+    // The qwen3_coder XML format serializes a nested-array parameter as JSON
+    // *text* inside <parameter=…>, so `allowedPrompts` arrives as a STRING, not
+    // an array. The first empty-key repair pass runs before string→array
+    // coercion and can't descend into the opaque string; the second pass (after
+    // coercion materializes the array) must catch it. Regression for the
+    // ordering fix (2026-06-17).
+    let tools = vec![exitplanmode_tool()];
+    let stringified = serde_json::json!({
+        "plan": "build",
+        "allowedPrompts": r#"[{"":"Bash","prompt":"run cargo"}]"#
+    })
+    .to_string();
+    let mut calls = vec![make_call("ExitPlanMode", &stringified)];
+    coerce_all(&mut calls, &tools);
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert!(
+        args["allowedPrompts"].is_array(),
+        "stringified array must be coerced to a real array"
+    );
+    let item = &args["allowedPrompts"][0];
+    assert_eq!(
+        item["tool"], "Bash",
+        "empty key repaired to `tool` post-coercion"
+    );
+    assert_eq!(item["prompt"], "run cargo");
+    assert!(item.get("").is_none(), "empty key must be removed");
+}

--- a/crates/spark-server/src/tool_parser/type_coerce.rs
+++ b/crates/spark-server/src/tool_parser/type_coerce.rs
@@ -109,6 +109,17 @@ fn coerce_call_args(call: &mut ToolCall, tool_def: Option<&ToolDefinition>) {
         }
     }
 
+    // Second empty-key repair pass (2026-06-17). The first pass above runs
+    // BEFORE the string→array/object coercion, so a nested param that arrived
+    // stringified (the qwen3_coder XML format serializes nested arrays as JSON
+    // text inside `<parameter=…>`) was still an opaque String when repair_empty_keys
+    // first walked it — it could not descend, and degenerate `{"": "Bash", …}`
+    // items survived. Now that the coercion loop has materialized those strings
+    // into real arrays/objects, re-run the repair so the empty keys inside them
+    // get relabelled to their unique missing required property (e.g. ExitPlanMode
+    // `allowedPrompts` items → `tool`). Idempotent: no-op once no `""` keys remain.
+    changed |= repair_empty_keys(&mut args, schema);
+
     if changed && let Ok(s) = serde_json::to_string(&args) {
         call.function.arguments = s;
     }


### PR DESCRIPTION
carries @mission-deny-the-mission's #177 rebuilt as a clean series on current main: (1) block-scaled FP8 W8A8 prefill DEFAULT-ON across the six dispatch sites (opt-out ATLAS_FP8_SINGLE_SCALE=1) — their B1-drift root-cause; (2) anthropic thinking-object-without-budget deferral; (3) tool-coerce second pass. the EOS-guard hunk was dropped (landed via #183 with identical semantics). hardening from review: is_block_scaled() guard on all six force_w8a8 sites + scale_format assert in attention set_fp8_weights (a per-row FP8 weight can no longer be misread as [N/128,K/128] blocks), and the env flag is cached in a OnceLock instead of re-read per dispatch.

gates pending on a spark: KL + coherence on Qwen3.6-27B-FP8 (the default-flip surface) A/B vs main, NVFP4 flagship no-regression KL, then merge.