### PR TITLE
fix(loader): native-FP8 SSM shadowed on modelopt-mixed-precision 35B

### DIFF
--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -787,7 +787,7 @@ pub(super) fn load_layers(
                     // fp4_proj_decode drops Holo's modelopt SSM out of the BF16-
                     // dense + FP8-overlay build so it falls through to the NVFP4
                     // builder below → in_proj_qkvz/out_proj decode on w4a16_gemv.
-                    _ if modelopt_mixed_precision && !fp4_proj_decode => {
+                    _ if modelopt_mixed_precision && !fp4_proj_decode && !ssm_native_fp8 => {
                         linear_attn_arms::build_linear_attention_dense_bf16(
                             i,
                             store,


### PR DESCRIPTION
## What

One-line match-guard fix so the **native-FP8 SSM** path actually engages on modelopt-mixed-precision Qwen3.5 (Holo-3.1-35B-A3B / Ornith) when `ATLAS_HOLO_NATIVE_FP8_SSM=1`.

## The bug (shadowed arm)

In `qwen35/load_layers.rs` the linear-attention builder match has, in order:

```rust
_ if modelopt_mixed_precision && !fp4_proj_decode => build_linear_attention_dense_bf16(...)  // BF16-dense SSM
...
_ if !(force_nvfp4_all || fp4_proj_decode) && ssm_native_fp8 => build_linear_attention_fp8(...)  // native-FP8 SSM
```

The BF16-dense arm sits **earlier** and matches first, so when `ssm_native_fp8` is set the modelopt 35B still builds a BF16-dense `in_proj_qkvz`/`out_proj` and the native-FP8 arm is **never reached**. The native-FP8-SSM machinery is present on `main` (folded in via #229) but unreachable on this path.

Fix: add `&& !ssm_native_fp8` to the BF16-dense guard so it yields to `build_linear_attention_fp8` when native FP8 SSM is requested.

```diff
- _ if modelopt_mixed_precision && !fp4_proj_decode =>
+ _ if modelopt_mixed_precision && !fp4_proj_decode && !ssm_native_fp8 =>
```

## Validation

`ssm_native_fp8` is already bound on `main` (same function), so this is a pure guard tightening — no new state. Cherry-picks onto current `main` with zero conflicts. The equivalent change has been running in our GB10 serving of Holo-3.1-35B-A3B-FP8 with `ATLAS_HOLO_NATIVE_FP8_SSM=1` (native-FP8 SSM engaged, coherent). Behavior is unchanged when `ssm_native_fp8` is false (byte-identical guard).


---
### Related PRs — independent, all target `main`

Now that #229 is merged, these three each **cherry-pick cleanly onto current main with zero conflicts** and are **independent (no stacking)** — review/merge in any order:

- #250 — native-BF16 dense loader (no-metadata Holo/Ornith dense)
- #251 — bench_isl_osl thinking toggles
- #252 — native-FP8-SSM shadowing fix (modelopt 35B)

Follow-ups (not yet opened): Tier-2 FlashInfer-prefill + decode-concurrency reconciliation vs #229 FI (needs a merge, not a clean pick); and closing older stacked PRs folded into #229 (e.g. #220 FlashInfer-GDN AOT) after a rebase-diff confirms no outstanding delta.
