### PR TITLE
fix(openai): emit only reasoning_content, drop redundant reasoning mirror

### DIFF
--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -291,8 +291,7 @@ async fn build_choice_message(
     let _ = response; // currently only used for finish_reason.clone() below
     let mut message = crate::openai::ChatMessage {
         role: "assistant".to_string(),
-        reasoning_content: reasoning_content_i.clone(),
-        reasoning: reasoning_content_i,
+        reasoning_content: reasoning_content_i,
         annotations: crate::citation::merged_annotations(&output_text_i),
         refusal: None,
         content: Some(output_text_i.clone()),
@@ -328,8 +327,7 @@ async fn build_choice_message(
                 "F7: hoisted {} tool-call(s) from inside <think> block (would have been silently dropped)",
                 hoisted_tool_calls.len()
             );
-            message.reasoning_content = hoisted_reasoning.clone();
-            message.reasoning = hoisted_reasoning;
+            message.reasoning_content = hoisted_reasoning;
         }
         let (content, parsed_tool_calls) = tool_parser::parse_tool_calls(&output_text_i);
         let mut tool_calls_i = hoisted_tool_calls;

--- a/crates/spark-server/src/openai/annotations.rs
+++ b/crates/spark-server/src/openai/annotations.rs
@@ -8,12 +8,13 @@ pub struct ChatMessage {
     /// Model reasoning trace (from <think>...</think> tags).
     /// Only populated when enable_thinking=true. Both Cline and Roo Code
     /// check for this field. DeepSeek-originated, vLLM/LiteLLM standard.
+    /// This is the single canonical reasoning field on the response wire —
+    /// Atlas deliberately does NOT also emit a `reasoning` mirror, because
+    /// strict OpenAI-compatible clients reject a message that carries both
+    /// (they expect exactly one). Requests may still send either name; see
+    /// the `alias = "reasoning"` on the input-side message type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
-    /// Forward-compatible alias: mirrors `reasoning_content` for clients that
-    /// use the shorter `reasoning` field name (e.g. some OpenAI SDK versions).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reasoning: Option<String>,
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<crate::tool_parser::ToolCall>>,

--- a/crates/spark-server/src/openai/chat_response.rs
+++ b/crates/spark-server/src/openai/chat_response.rs
@@ -136,7 +136,6 @@ impl ChatCompletionResponse {
                 message: ChatMessage {
                     role: "assistant".to_string(),
                     reasoning_content: None,
-                    reasoning: None,
                     annotations: extract_url_annotations(&content),
                     refusal: None,
                     content: Some(content),
@@ -168,7 +167,6 @@ impl ChatCompletionResponse {
                 message: ChatMessage {
                     role: "assistant".to_string(),
                     reasoning_content: None,
-                    reasoning: None,
                     annotations: content.as_deref().and_then(extract_url_annotations),
                     refusal: None,
                     content,

--- a/crates/spark-server/src/openai/stream_chunk.rs
+++ b/crates/spark-server/src/openai/stream_chunk.rs
@@ -45,12 +45,10 @@ pub struct ChunkDelta {
     /// Reasoning trace chunk (from <think>...</think>). Streamed during
     /// the thinking phase when enable_thinking=true. Cline and Roo Code
     /// both check for this field via `"reasoning_content" in delta`.
+    /// Single canonical field — no `reasoning` mirror is emitted (a delta
+    /// carrying both is rejected by strict OpenAI-compatible clients).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
-    /// Forward-compatible alias: mirrors `reasoning_content` for clients that
-    /// use the shorter `reasoning` field name.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reasoning: Option<String>,
     /// Omitted when absent — Cline, Roo Code, and most OpenAI-compatible clients
     /// expect content to be missing (not `null`) in role and done chunks.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,7 +79,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: Some("assistant".to_string()),
                     reasoning_content: None,
-                    reasoning: None,
                     content: None,
                     tool_calls: None,
                     refusal: None,
@@ -107,8 +104,7 @@ impl ChatCompletionChunk {
                 index: 0,
                 delta: ChunkDelta {
                     role: None,
-                    reasoning_content: Some(text.clone()),
-                    reasoning: Some(text),
+                    reasoning_content: Some(text),
                     content: None,
                     tool_calls: None,
                     refusal: None,
@@ -134,7 +130,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: None,
                     reasoning_content: None,
-                    reasoning: None,
                     content: Some(text),
                     tool_calls: None,
                     refusal: None,
@@ -167,7 +162,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: Some("assistant".to_string()),
                     reasoning_content: None,
-                    reasoning: None,
                     content: None,
                     tool_calls: Some(vec![crate::tool_parser::ChunkToolCall {
                         index: tc_index,
@@ -204,7 +198,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: None,
                     reasoning_content: None,
-                    reasoning: None,
                     content: None,
                     tool_calls: Some(vec![crate::tool_parser::ChunkToolCall {
                         index: tc_index,
@@ -238,7 +231,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: None,
                     reasoning_content: None,
-                    reasoning: None,
                     content: None,
                     tool_calls: None,
                     refusal: None,
@@ -285,7 +277,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: None,
                     reasoning_content: None,
-                    reasoning: None,
                     content: None,
                     tool_calls: None,
                     refusal: Some(refusal),
@@ -313,7 +304,6 @@ impl ChatCompletionChunk {
                 delta: ChunkDelta {
                     role: None,
                     reasoning_content: None,
-                    reasoning: None,
                     content: None,
                     tool_calls: None,
                     refusal: None,

--- a/crates/spark-server/src/openai/tests.rs
+++ b/crates/spark-server/src/openai/tests.rs
@@ -247,6 +247,46 @@ fn with_token_ids_stamps_first_choice() {
     assert!(chunk.choices.is_empty());
 }
 
+// ── reasoning wire format: exactly one field ────────────────────────
+// A response carrying BOTH `reasoning_content` and a `reasoning` mirror is
+// rejected by strict OpenAI-compatible clients (they assert exactly one).
+// Atlas emits only `reasoning_content` — these lock that contract in.
+
+#[test]
+fn reasoning_delta_emits_only_reasoning_content() {
+    let chunk = ChatCompletionChunk::reasoning_chunk("m", "id", "thinking".into());
+    let json = serde_json::to_string(&chunk).unwrap();
+    assert!(
+        json.contains("\"reasoning_content\":\"thinking\""),
+        "reasoning_content missing: {json}"
+    );
+    assert!(
+        !json.contains("\"reasoning\":"),
+        "mirror `reasoning` field leaked into stream delta: {json}"
+    );
+}
+
+#[test]
+fn blocking_message_emits_only_reasoning_content() {
+    let msg = ChatMessage {
+        role: "assistant".into(),
+        reasoning_content: Some("thinking".into()),
+        content: Some("hi".into()),
+        tool_calls: None,
+        annotations: None,
+        refusal: None,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    assert!(
+        json.contains("\"reasoning_content\":\"thinking\""),
+        "reasoning_content missing: {json}"
+    );
+    assert!(
+        !json.contains("\"reasoning\":"),
+        "mirror `reasoning` field leaked into message: {json}"
+    );
+}
+
 // ── ChatTemplateKwargs ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Problem

The chat-completions response carried **both** `reasoning_content` and a `reasoning` mirror field set to the same value — on the blocking `ChatMessage` and on the streaming `ChunkDelta`. Strict OpenAI-compatible clients assert a message carries *exactly one* of the two, so a response with both is rejected.

Caught while validating `avarok/atlas-gb10:dev` with `nvidia/Qwen3.6-27B-NVFP4` on GB10: the BFCL v4 harness (inference-endpoint) failed **100%** of requests with `Response contains both 'reasoning_content' and 'reasoning'; expected exactly one` whenever reasoning was enabled. It only passed once thinking was disabled server-side, which masks the bug rather than fixing it.

## Fix

`reasoning_content` is the DeepSeek/vLLM/LiteLLM standard that Cline, Roo Code, and the rest read, so it stays as the single canonical field. The `reasoning` mirror was a forward-compat alias, but emitting both is objectively wrong (SSOT — one datum, one field, matching vLLM exactly). Removed the mirror field and its populate sites on both response paths.

The **input** side is unchanged: requests may still send either name (`alias = "reasoning"` on the request message; `.get("reasoning")` fallbacks in the stored/tokenizer paths).

## Validation

- **Unit** (`openai::tests`): two new wire-format tests assert exactly `reasoning_content` serializes for the blocking message and the stream delta; all 25 `openai` tests pass, no regressions.
- **Before/after on GB10** (`nvidia/Qwen3.6-27B-NVFP4`, thinking ON):
  - before: keys `[role, reasoning_content, reasoning, content]` (both present)
  - after: keys `[role, reasoning_content, content]`; streaming emits `reasoning_content` deltas with **zero** `reasoning` mirror
- **Dev coherence suite** (`scripts/dev/coherence_test.py`): 10/10 pass on the fixed image, including the `enable_thinking=True` case.
- Same image also clears a BFCL v4 single-turn subset (85.05 overall, no parallel collapse) and the agentic-coding inline-IoU perf replay (0.6456, above the llama.cpp reference).

---
Authored by the maintainer with AI assistance (Claude), per CONTRIBUTING.md §Authorship.