### PR TITLE
docs(releases): record :dev @ 288c17c GB10 validation

### DIFF
--- a/docs/releases/288c17c.md
+++ b/docs/releases/288c17c.md
@@ -1,0 +1,42 @@
+# Release record — `avarok/atlas-gb10:dev` @ `288c17c`
+
+- **Git**: `main` @ `288c17c1` (`fix(openai): emit only reasoning_content, drop redundant reasoning mirror`, #271)
+- **Image**: `avarok/atlas-gb10:dev` (also tagged `:288c17c`), image config `sha256:e238efaf…`
+- **Date**: 2026-07-06
+- **Hardware**: DGX Spark GB10 (sm_121, 119.7 GB unified memory)
+- **Model validated**: `nvidia/Qwen3.6-27B-NVFP4` (GDN FP8 + MLP NVFP4 + MTP BF16; lm_head ships pre-packed NVFP4)
+
+## Serve configuration
+
+```
+spark serve nvidia/Qwen3.6-27B-NVFP4 --model-name Qwen3.6-27B-Q4_K_M \
+  --port 8085 --max-seq-len 32768 --max-batch-size 2 --gpu-memory-utilization 0.90 \
+  --kv-cache-dtype bf16 --scheduling-policy slai \
+  --enable-prefix-caching --ssm-cache-slots 256 --ssm-checkpoint-interval 16 \
+  --tool-call-parser qwen3_coder --disable-tool-grammar true \
+  --speculative --num-drafts 1 --mtp-quantization bf16
+```
+
+32k context · prefix caching · SSM snapshot cache (256 slots) + tail/intermediate
+SSM checkpoints (interval 16) · MTP K=1. BFCL/agentic runs use reasoning OFF
+(`--disable-thinking`), matching the edge reference methodology.
+
+## Results (measured on this image)
+
+| Signal | Harness | Result |
+|--------|---------|--------|
+| **BFCL v4 single-turn accuracy** (subset: 107 samples, seed 42, temp 0) | `inference-endpoint` `perf_probe.yaml` | **85.05** overall · 86.67 normalized ST · non_live 94.27 / live 77.50 / hallucination 88.24 · parallel subsets 100.0 (no grammar collapse) |
+| **Agentic-coding inline IoU** (3 trajectories from `agentic_coding_2.5h.jsonl`, reasoning off) | `inference-endpoint` `agentic_inference` | **0.6398** (llama.cpp Q4_K_M / Jetson Thor reference: 0.6335) · 0 dropped turns · 1087 s |
+| **Reasoning wire format** (thinking ON, blocking + streaming) | curl + `scripts/dev/coherence_test.py` | single `reasoning_content` field, no `reasoning` mirror (fix #271) · dev coherence suite 10/10 |
+
+Notes:
+- The BFCL number is a **subset gate**, not full ST-995; use it for config A/Bs and
+  release smoke, not milestone claims.
+- Agentic IoU run-to-run varies ~1% on 3 trajectories (greedy-decode noise floor);
+  0.6398 here vs 0.6456 on the pre-fix image is within that band, both above the
+  reference. The #271 fix touches only response serialization and is a no-op for
+  these reasoning-off runs.
+
+**Verdict**: shippable — serves the flagship 27B NVFP4 checkpoint coherently,
+tool-calls correctly, meets the accuracy + agentic gates, and emits a spec-compliant
+reasoning field.


### PR DESCRIPTION
Documents the e2e validation of `avarok/atlas-gb10:dev` (= main `288c17c`, incl. the #271 reasoning fix) on GB10 with `nvidia/Qwen3.6-27B-NVFP4`: BFCL v4 ST subset 85.05, agentic-coding inline IoU 0.6398 (> llama.cpp ref 0.6335), reasoning wire format spec-compliant, dev coherence suite 10/10. Numbers measured on the shipped image with 32k/prefix-cache/ssm-cache+tail-ckpt/MTP-K1.

Authored by the maintainer with AI assistance (Claude), per CONTRIBUTING.md §Authorship.