### PR TITLE
fix(deepseek-v4): main θ=10000 rope on sliding_attention layers (was θ=160000)

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/decode/attention_forward_v4.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/decode/attention_forward_v4.rs
@@ -511,8 +511,18 @@ impl Qwen3AttentionLayer {
                 1,
                 mla_rope,
                 mla_rope,
-                mla.yarn_inv_freq,
-                super::super::helpers::yarn_rope_mscale(ctx.config),
+                // Sliding layers (compressor==None) = reference "main" rope:
+                // plain θ=10000, mscale=1 (no yarn). CSA/HCA keep θ=160000 yarn.
+                if mla.compressor.is_none() {
+                    mla.main_inv_freq
+                } else {
+                    mla.yarn_inv_freq
+                },
+                if mla.compressor.is_none() {
+                    1.0f32
+                } else {
+                    super::super::helpers::yarn_rope_mscale(ctx.config)
+                },
                 stream,
             )
         })?;
@@ -677,8 +687,19 @@ impl Qwen3AttentionLayer {
                 0, // no KV heads — de-rotate the query/output heads only
                 mla_rope,
                 mla_rope,
-                mla.yarn_inv_freq,
-                super::super::helpers::yarn_rope_mscale(ctx.config),
+                // MUST match the Q/K rope inv_freq for this layer type (rope-in
+                // == de-rotate-out), else the output is scrambled. Sliding =
+                // main θ=10000; CSA/HCA = θ=160000 yarn.
+                if mla.compressor.is_none() {
+                    mla.main_inv_freq
+                } else {
+                    mla.yarn_inv_freq
+                },
+                if mla.compressor.is_none() {
+                    1.0f32
+                } else {
+                    super::super::helpers::yarn_rope_mscale(ctx.config)
+                },
                 stream,
             )?;
             ops::mla_q_rope_writeback_batched(

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_v4.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_v4.rs
@@ -332,8 +332,18 @@ impl Qwen3AttentionLayer {
             nkv,
             rope,
             rope,
-            mla.yarn_inv_freq,
-            super::super::helpers::yarn_rope_mscale(ctx.config),
+            // Sliding layers (compressor==None) = reference "main" rope: plain
+            // θ=10000, mscale=1 (no yarn). CSA/HCA keep the θ=160000 yarn table.
+            if mla.compressor.is_none() {
+                mla.main_inv_freq
+            } else {
+                mla.yarn_inv_freq
+            },
+            if mla.compressor.is_none() {
+                1.0f32
+            } else {
+                super::super::helpers::yarn_rope_mscale(ctx.config)
+            },
             stream,
         )?;
         ops::mla_q_rope_writeback_batched(
@@ -685,8 +695,18 @@ impl Qwen3AttentionLayer {
                 0,
                 rope,
                 rope,
-                mla.yarn_inv_freq,
-                super::super::helpers::yarn_rope_mscale(ctx.config),
+                // De-rotation must match this layer's Q/K rope (rope-in ==
+                // de-rotate-out): sliding = main θ=10000; CSA/HCA = θ=160000.
+                if mla.compressor.is_none() {
+                    mla.main_inv_freq
+                } else {
+                    mla.yarn_inv_freq
+                },
+                if mla.compressor.is_none() {
+                    1.0f32
+                } else {
+                    super::super::helpers::yarn_rope_mscale(ctx.config)
+                },
                 stream,
             )?;
             ops::mla_q_rope_writeback_batched(

--- a/crates/spark-model/src/layers/qwen3_attention/types.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types.rs
@@ -68,6 +68,12 @@ pub struct MlaWeights {
     /// Precomputed YaRN inv_freq table [rotary_dim/2] FP32 on GPU.
     /// NULL = use standard theta computation in the RoPE kernel.
     pub yarn_inv_freq: spark_runtime::gpu::DevicePtr,
+    /// Plain θ=10000 inv_freq [rotary_dim/2] FP32 on GPU, NO YaRN. Used for the
+    /// raw-arm Q/K rope on `sliding_attention` layers (compressor==None): the
+    /// reference gives sliding layers the "main" rope (θ=rope_theta=10000, no
+    /// yarn) while CSA/HCA layers use "compress" (θ=compress_rope_theta=160000
+    /// + yarn). Atlas previously applied the single yarn table to every layer.
+    pub main_inv_freq: spark_runtime::gpu::DevicePtr,
     pub q_lora_rank: usize,
     pub kv_lora_rank: usize,
     pub o_lora_rank: usize,

--- a/crates/spark-model/src/mistral_loader/loader_impl/phase_assemble.rs
+++ b/crates/spark-model/src/mistral_loader/loader_impl/phase_assemble.rs
@@ -116,6 +116,7 @@ pub(super) fn assemble_layer(
         w_uk_block_diag: require(ctx.w_uk_block_diag, "w_uk_block_diag")?,
         w_uv_block_diag: require(ctx.w_uv_block_diag, "w_uv_block_diag")?,
         yarn_inv_freq,
+        main_inv_freq: yarn_inv_freq, // non-V4: no sliding/compress rope split
         q_lora_rank: q_lora,
         kv_lora_rank: kv_lora,
         o_lora_rank: 0,

--- a/crates/spark-model/src/weight_loader/deepseek_v4/assemble.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/assemble.rs
@@ -393,6 +393,7 @@ pub fn assemble_layer(
         w_uk_block_diag,
         w_uv_block_diag,
         yarn_inv_freq,
+        main_inv_freq: super::compute::main_inv_freq(config, gpu)?,
         q_lora_rank: config.q_lora_rank,
         kv_lora_rank: config.kv_lora_rank,
         o_lora_rank: config.o_lora_rank,

--- a/crates/spark-model/src/weight_loader/deepseek_v4/compute.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/compute.rs
@@ -311,3 +311,23 @@ pub fn ensure_yarn_inv_freq(
     *shared = ptr;
     Ok(ptr)
 }
+
+/// Plain θ=10000 inv_freq (NO YaRN) for the raw-arm rope on `sliding_attention`
+/// layers. The reference's "main" rope: θ=10000 (config `rope_theta`, which
+/// Atlas's dispatch overrides to compress_rope_theta=160000 for the shared yarn
+/// table — so the 10000 base is hardcoded here to match the reference). Cheap
+/// (~32 floats); computed per compressor-less layer, no shared cache needed.
+pub fn main_inv_freq(config: &ModelConfig, gpu: &dyn GpuBackend) -> Result<DevicePtr> {
+    const MAIN_ROPE_THETA: f32 = 10000.0; // reference rope_theta for sliding layers
+    let rope = config.qk_rope_head_dim;
+    let n_pairs = rope / 2;
+    let dim_f = rope as f32;
+    let mut inv_freq = vec![0.0f32; n_pairs];
+    for (j, f) in inv_freq.iter_mut().enumerate() {
+        *f = 1.0 / MAIN_ROPE_THETA.powf((2 * j) as f32 / dim_f);
+    }
+    let bytes: Vec<u8> = inv_freq.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let ptr = alloc_or_managed(gpu, bytes.len())?;
+    gpu.copy_h2d(&bytes, ptr)?;
+    Ok(ptr)
+}


### PR DESCRIPTION
# fix(deepseek-v4): main θ=10000 rope on sliding_attention layers (was θ=160000)

Follow-up to **#275** (the V4-Flash compressed-KV port, now merged) — the separate rope fix promised there.
This is the root cause of the V4-Flash numeric-reasoning corruption; the compressed-KV port was empirically clear of it.

## The bug

DeepSeek-V4 uses **two** RoPE bases, per layer type:
- `sliding_attention` layers (`compress_ratios[L]==0`) → **main** rope, `rope_theta=10000`, **no YaRN**;
- `compressed_sparse_attention` / `heavily_compressed_attention` → **compress** rope, `compress_rope_theta=160000` + YaRN.

Reference `modular_deepseek_v4.py` config: *"yarn is applied ONLY to layers with a compressor (CSA/HCA); … main = pure."*
Attention selects `rope_layer_type = "main" if layer_type=="sliding_attention" else "compress"`.

Atlas builds a **single** shared `yarn_inv_freq` (θ=160000 + YaRN, `ensure_yarn_inv_freq`) and applies it to the Q/K
rope **and** the eq.26 output de-rotation on **every** layer. So the ratio-0 sliding layers (indices 0, 1, 42 in this
checkpoint) rotate with θ=160000 where they must use plain θ=10000.

The error is **layer-type-dependent and position-growing** (a base-θ difference, not YaRN interpolation) — which is why
it was invisible to short-context probes:

| decode position | max per-dim angle error (θ=160000 vs θ=10000) | \|Δcos\| |
|---|---|---|
| 150 | 14.5 rad | — |
| 240 | 23.2 rad | — |
| 330 | 31.9 rad | up to 1.85 (of 2.0 max) |

## The fix

Add `main_inv_freq` (plain θ=10000, mscale=1) to `MlaWeights`; select it over `yarn_inv_freq` when
`mla.compressor.is_none()` (== sliding layer) at all four raw-arm rope sites — **rope-in and the eq.26 de-rotation, in
both prefill (`cache_skip_v4.rs`) and single-token decode (`attention_forward_v4.rs`)**. The de-rotation must match the
rope-in inv_freq or the output is scrambled. CSA/HCA layers are unchanged (still θ=160000 + YaRN). Non-V4 (mistral)
loader sets `main_inv_freq = yarn_inv_freq`. 6 files, +77/−8.

## Measured (fp8-KV EP=2, greedy, RoCE-verified; futures risk-sizing gates vs NVIDIA NIM reference)

| gate | before (θ=160000 all layers) | after (this fix) |
|---|---|---|
| q3 (max size) | "10 points / $10,000" — **wrong** | **"1 contract … take the trade"** — correct (matches NIM) |
| q8 (revenge) | fabricates a "$5,000 margin" not in the scenario | recalls the real $1,600 / $2,000; **verdict still "valid" (should be not-valid)** |
| coherence onset (280-tok non-arithmetic probe) | ~150 tok | **~150 tok (unchanged)** |

**Scope of the claim:** this fixes the sliding-layer **rope** fault — q3 flips to the correct answer, q8 stops
fabricating numbers. It is **not** a full task fix: q8's multi-step breach reasoning still errs, and the ~150-token
coherence ceiling is **unmoved** by this change (measured above) — a separate, still-open issue, not the rope.

## Coverage gap (batched / MTP)

This PR splits the rope only on the **single-token decode + prefill** paths. The **batched decode**
(`trait_impl/multi_seq/mla.rs`) and **MTP verify** paths still apply `yarn_inv_freq` (θ=160000) to sliding layers.

**Observable consequence:** single-token (`--max-batch-size 1`) output on layers 0/1/42 is now correct; **batched
decode and MTP-verify output will differ on those layers until they get the same `compressor.is_none()` split.** A
follow-up will cover them; flagged so the partial coverage is explicit, not silent.

`cargo check` + `clippy` (deny-all) + `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
