### PR TITLE
fix(deepseek-v4): sliding-layer rope in chunk-1+ prefill (paged_v4)

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_v4.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_v4.rs
@@ -184,8 +184,19 @@ impl Qwen3AttentionLayer {
             nkv,
             rope,
             rope,
-            mla.yarn_inv_freq,
-            super::super::helpers::yarn_rope_mscale(ctx.config),
+            // Sliding layers (compressor==None) = main θ=10000, mscale=1; CSA/HCA
+            // = θ=160000 yarn. Matches the eq.26 de-rotation below. (V4-exclusive
+            // file, so compressor==None is a V4 sliding layer, never a non-V4 model.)
+            if mla.compressor.is_none() {
+                mla.main_inv_freq
+            } else {
+                mla.yarn_inv_freq
+            },
+            if mla.compressor.is_none() {
+                1.0f32
+            } else {
+                super::super::helpers::yarn_rope_mscale(ctx.config)
+            },
             stream,
         )?;
         ops::mla_q_rope_writeback_batched(
@@ -291,8 +302,17 @@ impl Qwen3AttentionLayer {
                 0,
                 rope,
                 rope,
-                mla.yarn_inv_freq,
-                super::super::helpers::yarn_rope_mscale(ctx.config),
+                // De-rotation must match the rope-in inv_freq above (else salad).
+                if mla.compressor.is_none() {
+                    mla.main_inv_freq
+                } else {
+                    mla.yarn_inv_freq
+                },
+                if mla.compressor.is_none() {
+                    1.0f32
+                } else {
+                    super::super::helpers::yarn_rope_mscale(ctx.config)
+                },
                 stream,
             )?;
             ops::mla_q_rope_writeback_batched(


### PR DESCRIPTION
# fix(deepseek-v4): sliding-layer rope in chunk-1+ prefill (paged_v4)

Follow-up to **#276**. That PR fixed the sliding-layer rope-θ (main θ=10000 vs compress θ=160000) on the **chunk-0
prefill** (`cache_skip_v4`) and **single-token decode** (`attention_forward_v4`). This closes the remaining
V4-Flash-reachable site: **chunk-1+ prefill** (`paged_v4.rs`), which still applied `yarn_inv_freq` (θ=160000) to
sliding layers on both its rope-in and its eq.26 de-rotation. Only reached for prompts spanning >1 prefill chunk
(>`max_prefill_tokens`, 8192 by default) — which is why #276's q3 (~210 tok, single chunk) passed with it unfixed.

## Completeness audit — every `yarn_inv_freq` use in a rope call

Classified so no site is fixed by sampling. `main_inv_freq` (θ=10000) is selected **only** in V4-exclusive files where
`compressor.is_none()` provably means a V4 sliding layer — never in generic MLA paths shared with V2/V3, where
`compressor` is always `None` but yarn is correct.

| site | path | V4-reachable | class | action |
|---|---|---|---|---|
| `cache_skip_v4.rs` :338/340, :701/703 | V4 chunk-0 prefill (rope-in + de-rotate) | yes | V4 sliding | **fixed in #276** |
| `attention_forward_v4.rs` :517/519, :694/696 | V4 single-token decode (rope-in + de-rotate) | yes | V4 sliding | **fixed in #276** |
| `paged_v4.rs` :~188, :~294 | V4 **chunk-1+ prefill** (rope-in + de-rotate) | yes | V4 sliding | **THIS PR** |
| `cache_skip_v4.rs` :524, `attention_forward_v4.rs` :223 | V4 CSA/HCA compressor rope | yes | compress (θ=160000 correct) | leave |
| `multi_seq/mla.rs` :392/403 | absorbed batched decode | **no** — V4 (`o_lora_rank>0`) calls `attention_forward_v4` per seq (:160), not this absorbed path | non-V4 MLA (V2/V3) | leave |
| `paged_mla.rs`, `cache_skip_mla.rs`, `attention_forward_mla.rs`, `paged.rs` | generic MLA prefill/decode | no | non-V4 MLA (V2/V3) | leave — selecting here would **regress V2/V3** |
| `dflash_head/forward_block_layer.rs` :212/223 | MTP draft head | n/a — uses dflash_head's **own** `yarn_inv_freq`, not `mla` | separate struct; `mtp=false` in serve | **scoped out** (tracked separately; needs its own `main_inv_freq` if MTP has sliding layers) |

**Net:** V4-Flash decode (single-token, batched, MTP-verify) + chunk-0 prefill were covered by #276; this adds chunk-1+
prefill. The remaining un-split V4 surface is the MTP **draft** head only, which is a separate structure and currently
disabled.

## The fix

Same pattern as #276: at both `paged_v4` rope sites (rope-in + eq.26 de-rotation), select `mla.main_inv_freq`
(θ=10000, mscale=1) when `mla.compressor.is_none()`, else `mla.yarn_inv_freq`. De-rotation matches rope-in (mismatch =
salad, per #276). `paged_v4` is V4-exclusive (`o_lora_rank>0`; header: "no other models reach this code"). 1 file, +24/−4.

## Validation

- V4 **decode** (single-token / batched / MTP-verify) is unchanged — it reuses the #276-verified `attention_forward_v4`,
  whose q3 flip (wrong→correct) is the end-to-end evidence.
- `paged_v4` (chunk-1+ prefill) is exercised only by prompts >1 prefill chunk (>8192 tok). **Not directly validated
  end-to-end here** — the change is a line-for-line mirror of the `cache_skip_v4` split that #276 verified on a live
  serve. A >8192-token V4 prompt would exercise it directly; stating untested rather than implying coverage.

`cargo check` + `clippy` (deny-all) + `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
