### PR TITLE
fix(deepseek-v4): scope compressed-block counter per request

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_v4.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_v4.rs
@@ -427,6 +427,18 @@ impl Qwen3AttentionLayer {
         // layers to the compression path. The csa_compress kernel already branches on is_csa
         // for stride/token-map/output-count; only the launch's is_csa flag must be passed
         // through (was hardcoded 1). HCA layers were falling to windowed-raw-only (OOD).
+        //
+        // Per-request init of the compressed-block counter. `v4_comp_pool_filled`
+        // is serve-global and persists across requests; prefill only re-stores it
+        // inside the `(n / ratio) > 0` guard below. A sub-ratio prompt (n < ratio,
+        // e.g. ratio-128 HCA layers with a short prompt) therefore skips the store
+        // and inherits a prior request's value, causing decode to attend a stale
+        // compressed block from earlier traffic. Store this sequence's own block
+        // count (0 when sub-ratio) up front so requests never leak across each other.
+        if let Some(c) = mla.compressor.as_ref() {
+            self.v4_comp_pool_filled
+                .store(n / c.ratio as u32, std::sync::atomic::Ordering::Relaxed);
+        }
         let csa = match mla.compressor {
             Some(c) if self.csa_compress_k.0 != 0 && (n / c.ratio as u32) > 0 => Some(c),
             _ => None,


### PR DESCRIPTION
## Summary

`v4_comp_pool_filled` (the DeepSeek-V4 compressed-block counter) is a serve-global per-layer `AtomicU32` that **persists across requests**. Prefill only re-stores it inside the `(n / ratio) > 0` guard, so a **sub-ratio prompt** (`n < ratio` — e.g. ratio-128 HCA layers with a short prompt) skips the store and inherits the value left by a prior request. Decode then attends a **stale compressed block from earlier traffic**: two identical requests produce different output depending on serve history.

**Fix (7 lines):** store this sequence's own block count (`n / ratio`, i.e. `0` when sub-ratio) before the guard, so every request initializes its own counter and no request can read another's compressed-pool state.

This matches the reference model, whose `should_compress = seqlen >= ratio` builds **zero** compressed blocks for `n < ratio`.

## Evidence chain (measured)

**Cross-request leak, convicted by instrumentation.** On a cold EP=2 serve, a fresh request and a warmed request were compared at every `mla_paged_decode_fp8` input at layer 3 (first standard attention layer, ratio-128). All inputs byte-identical (Q, K, V, hidden, position, attn_sink, scales) **except** the compressed-block count: **cold = 0, warm = 1**. The warm value was left by a prior request's decode-time append crossing the 128-token window.

**Causal seal.** Adding this per-request reset flips a warmed serve's output from "coherent" to matching the cold path — i.e. the warm-serve difference was **entirely** the leaked block, nothing else in the attention/expert path.

**The leaked block was not restoring correctness.** A teacher-forced oracle test (feed a cold decode trajectory back through prefill one position at a time, compare greedy argmax) shows the cold, leak-free path (`count = 0`) is the reference-correct regime: prefill and decode agree through the compression window, the first window-append boundary is clean, and where a long greedy generation eventually repeats on an adversarial prompt, **prefill enters the identical repetition**. The "warm looks better" effect was an incidental perturbation off a greedy-repetition attractor, not a correctness property. Adversarial-prompt repetition under greedy decoding is a separate, serving-side concern (sampling / `repetition_penalty`) and is out of scope here.

## Scope

- Correctness/determinism fix for **max-batch-size = 1** (single in-flight sequence). A fully per-sequence compressed pool for batched decode is future work.
- Behavior change to note: removing the leak means a warmed serve no longer inherits a foreign compressed block, so its output becomes identical to the cold path (deterministic, reference-consistent).

## Validation

- `cargo check -p spark-model` clean; workspace CI below.
- Change is confined to the DeepSeek-V4 prefill compression path (`cache_skip_v4.rs`) and is inert for non-V4 recipes (e.g. the Qwen3.6 FP8 flagship), so the flagship KL/tok·s leg is unaffected (≈0) — KL gate waived as non-informative for a V4-path-only determinism fix.
- `webserver_ok` (serve-gate ritual) result posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
