### PR TITLE
chore(deps): bump crossbeam-epoch 0.9.18→0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Freshly published **RUSTSEC-2026-0204** (invalid pointer dereference in `crossbeam-epoch` `fmt::Pointer` for `Atomic`/`Shared`) is failing `cargo deny` on **every open PR** (#279/#278/#273/#272 confirmed).

`crossbeam-epoch` is a transitive **dev-dependency** (criterion → rayon → crossbeam-deque), not in any shipped binary. This is a lockfile-only bump to the patched **0.9.20** to restore a green `cargo deny` repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)