### PR TITLE
fix(ssm): recency-only snapshot eviction — hit-weighted score pinned fossil anchors (warm TTFT 6.1s→1.6s avg, llama parity)

### DIFF
--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -14,12 +14,6 @@ pub(super) struct SnapshotEntry {
     token_count: usize,
     prefix_hash: u64,
     last_access: u64,
-    /// Cumulative hits over the entry's lifetime — combined with
-    /// `last_access` in eviction to approximate the forecast-based
-    /// policy from the Marconi paper §4 (B.4, 2026-04-25). Hot
-    /// prefixes (high hit count) survive longer than cold ones at
-    /// the same age.
-    hit_count: u32,
 }
 
 pub(super) struct SsmSnapshotIndex {
@@ -66,7 +60,6 @@ impl SsmSnapshotIndex {
             token_count,
             prefix_hash,
             last_access: self.access_counter,
-            hit_count: 0,
         });
         None
     }
@@ -82,8 +75,15 @@ impl SsmSnapshotIndex {
         if session_hash != 0 {
             self.last_lookup_session = session_hash;
         }
+        // Side-effect-free scan: only the WINNER gets its recency bumped,
+        // below. Bumping every improving candidate kept shallow early-prefix
+        // entries eternally fresh (each deep lookup walks the improving chain
+        // through them), pinning them in the pool while the tail checkpoints
+        // the next warm turn actually needs were evicted — the measured
+        // frozen-anchor / 18.6k-token SSM replay pathology (2026-07-10).
         let mut best: Option<(usize, usize)> = None; // (snapshot_id, token_count)
-        for entry in &mut self.entries {
+        let mut best_idx: Option<usize> = None;
+        for (i, entry) in self.entries.iter().enumerate() {
             if entry.token_count > matched_tokens {
                 continue;
             }
@@ -95,11 +95,13 @@ impl SsmSnapshotIndex {
                 continue;
             }
             if best.is_none() || entry.token_count > best.unwrap().1 {
-                self.access_counter += 1;
-                entry.last_access = self.access_counter;
-                entry.hit_count = entry.hit_count.saturating_add(1);
                 best = Some((entry.snapshot_id, entry.token_count));
+                best_idx = Some(i);
             }
+        }
+        if let Some(i) = best_idx {
+            self.access_counter += 1;
+            self.entries[i].last_access = self.access_counter;
         }
         if std::env::var("ATLAS_SNAP_LOOKUP_DBG").is_ok() {
             let mut cands: Vec<usize> = self.entries.iter().map(|e| e.token_count).collect();
@@ -118,10 +120,17 @@ impl SsmSnapshotIndex {
         if self.entries.is_empty() {
             return None;
         }
-        // Per-entry forecast score (B.4, Marconi paper §4): old AND cold first.
-        // last_access * (1 + hit_count) — recent/hot survive. #155 fixed the
-        // inverted (÷) form that evicted just-selected snapshots.
-        let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
+        // Pure recency (LRU). The former forecast score
+        // `last_access * (1 + hit_count)` multiplied a monotonic timestamp by
+        // hit count, so any once-hit old entry outscored every fresh save;
+        // once the cold entries drained, each new save's evict victim was the
+        // PREVIOUS fresh save — the live turn's tail checkpoint died ms before
+        // the next turn's lookup needed it, freezing the restore anchor
+        // (measured: anchor pinned at token 9056 for 29 turns, 12.7k-token SSM
+        // replay, 40s TTFT tail). With winner-only recency bumps in `lookup`,
+        // plain LRU keeps the selected anchor and recent tail checkpoints
+        // resident and lets unhit fossils age out.
+        let escore = |e: &SnapshotEntry| e.last_access;
 
         // SESSION-AWARE eviction (default ON; ATLAS_SNAP_EVICT_LEGACY=1 → old
         // per-entry policy). The agentic workload interleaves ~20 multi-turn

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -350,6 +350,47 @@ fn test_snapshot_index_overwrite_existing() {
 }
 
 #[test]
+fn test_snapshot_index_hit_pinned_fossil_does_not_starve_fresh_tail() {
+    // Regression: agentic warm-restore anchor freeze (2026-07-10). A shallow
+    // early-conversation snapshot that lookups repeatedly walked through must
+    // NOT outlive the strictly fresher tail checkpoint the next warm turn
+    // needs. Under the old `last_access * (1 + hit_count)` eviction score the
+    // fossil was unbeatable and every eviction killed the newest save.
+    let mut idx = SsmSnapshotIndex::new();
+    let tokens: Vec<u32> = (0..256).collect();
+    let session = 7;
+
+    // Fossil at token 16, selected as anchor by many deep lookups.
+    idx.insert(hash_token_prefix(&tokens, 16), 1, session, 16);
+    for _ in 0..30 {
+        assert_eq!(idx.lookup(&tokens, 24, session), Some((1, 16)));
+    }
+
+    // The live turn then saves a deeper tail checkpoint.
+    idx.insert(hash_token_prefix(&tokens, 112), 2, session, 112);
+
+    // Pool pressure: the fossil must be the victim, not the fresh tail.
+    assert_eq!(idx.evict_lru(), Some(1));
+    assert_eq!(idx.lookup(&tokens, 112, session), Some((2, 112)));
+}
+
+#[test]
+fn test_snapshot_index_lookup_bumps_winner_only() {
+    // The improving-chain scan must be side-effect-free for losers: after a
+    // deep lookup selects the deepest entry, the shallow entries it walked
+    // through must still be older than the winner (evictable first).
+    let mut idx = SsmSnapshotIndex::new();
+    let tokens: Vec<u32> = (0..256).collect();
+
+    idx.insert(hash_token_prefix(&tokens, 16), 1, 0, 16); // shallow, inserted first
+    idx.insert(hash_token_prefix(&tokens, 32), 2, 0, 32); // deep
+    assert_eq!(idx.lookup(&tokens, 48, 0), Some((2, 32)));
+
+    // Shallow loser must be evicted before the bumped winner.
+    assert_eq!(idx.evict_lru(), Some(1));
+}
+
+#[test]
 fn test_snapshot_index_deepest_match() {
     let mut idx = SsmSnapshotIndex::new();
     let tokens: Vec<u32> = (0..64).collect();


### PR DESCRIPTION
# fix(ssm): recency-only snapshot eviction — hit-weighted score pinned fossil anchors

## Problem

On multi-turn agentic workloads, warm-restore TTFT degrades catastrophically with conversation depth: the SSM restore anchor freezes on an early-conversation snapshot while the tip grows, replaying up to **18.6k tokens through all GDN layers per turn** (≈40 s TTFT tail). Measured on unsloth/Qwen3.6-27B-NVFP4, GB10, 174-turn deep agentic bench, seed 42:

| build / config | TTFT med | avg | p90 | max | max SSM replay |
|---|---|---|---|---|---|
| llama.cpp reference | 1373 | 1592 | 2223 | 9775 | ~0 |
| main-438ed09, int32/sl128 | 1661 | 6292 | 24769 | 40967 | 18640 |
| main-438ed09, int0/sl128 | 1616 | 6123 | 24545 | 40528 | 18640 |

Identical `max_recompute` across checkpoint-interval configs ruled out snapshot *placement*; instrumented probes (`ATLAS_SNAP_LOOKUP_DBG=1`) showed `matched_tokens` lands within 16 tokens of the previous prompt tip on **every** warm turn — the anchor exists, the index just evicts it.

## Root cause

Two compounding defects in `SsmSnapshotIndex` (`radix_tree/snapshot.rs`):

1. **`lookup()` bumped every improving candidate** in its scan (recency + hit count), not just the winner. Deep lookups walk the improving chain through shallow early-prefix entries, keeping them eternally fresh.
2. **`evict_lru()` scored entries `last_access × (1 + hit_count)`** — a monotonic timestamp multiplied by hit count. Any once-hit old entry outscores every fresh save, so once cold entries drain, each new save's eviction victim is the *previous fresh save*: the tail checkpoint written during this turn's prefill is evicted by the same turn's finish-leaf save, ~25 ms before the next turn's lookup needs it. The stale anchor keeps getting selected → keeps getting hit-bumped → **absorbing frozen-anchor state** (observed: anchor pinned at token 9056 for 29 consecutive turns, replay growing 16 → 12672 tokens).

## Fix

- `lookup()`: side-effect-free scan; bump recency **once, on the winner only**.
- `evict_lru()`: pure LRU on `last_access`; drop the now write-only `hit_count` field.

Winner-only bumps + pure LRU make the eviction victim always the oldest fossil/dead-session entry, never the live turn's tail checkpoint — the absorbing state is unreachable. Steady state retains ≈128/3.5 ≈ 36 turns of anchors; every warm lookup selects the previous turn's tail checkpoint (16-token replay, the measured healthy behavior).

## Verification

- Regression test `test_snapshot_index_hit_pinned_fossil_does_not_starve_fresh_tail` fails on the old policy, passes with the fix; full radix_tree suite green.
- A/B (same box, same flags, same seed, only the fix differs — GB10/dgx2, 174-turn deep agentic):

| TTFT (ms) | old | **fixed** | llama.cpp ref |
|---|---|---|---|
| median | 1616 | **1469** | 1373 |
| avg | 6123 | **1642** | 1592 |
| p90 | 24545 | **2283** | 2223 |
| max | 40528 | **5123** | 9775 |

  All 146 warm restores replayed exactly **16 tokens** (one block — the floor), vs 18640 max before. Agentic IoU identical (0.6264). SM utilization stays 95% median through the run.
- Isolated-box replication (dgx1, same flags/seed): median 1478 / avg 1656 / p90 2307 / max 5142 — within 1% of dgx2. 174/174 completed, 0 failed; coherence and parallel-tool-call smokes pass.
- Same-box head-to-head vs llama.cpp (pinned cfff1fc, identical harness/workload/seed): TTFT median **1478 vs 1487** (parity), max **5142 vs 5832** (better), TPOT **57.4 vs 87.7 ms** (1.53× decode win retained).
- Full golden e2e with the fix (1007-turn agentic + BFCL ST-995, int32/sl128, GB10): TTFT median **1403** / avg 1724 / p90 2702 (old code: median 11979 golden, 2347 best-tuned); **857/862 warm restores replayed exactly 16 tokens**; 1007/1007 completed, 0 failed; TPOT 58.2 ms.
- **BFCL ST-995: 87.44 overall / 89.59 normalized** — reference golden run was 87.44 / 89.39 (no regression, +0.2 normalized; java/js unchanged at model cap). Agentic IoU 0.6202 vs 0.6232-0.6264 historical — within documented ±1-2% trajectory noise; warm-path outputs proven byte-identical to old code (14/14 turns, identical-prefix greedy probe).
- Warm-vs-cold FP divergence investigated: pre-existing property of the restore path (old and new images produce byte-identical warm outputs and identical divergence vs monolithic recompute); not introduced by this change.
