### PR TITLE
feat(server): /v1/completions echo + logprobs + full legacy-API parity

### DIFF
--- a/crates/spark-model/src/engine/tests.rs
+++ b/crates/spark-model/src/engine/tests.rs
@@ -157,6 +157,8 @@ impl Model for MockModel {
             kv_valid_tokens: 0,
             last_decode_ckpt_block: 0,
             prompt_len: 0,
+            collect_prompt_logprobs: None,
+            prompt_logprobs: Vec::new(),
             disk_block_ids: Vec::new(),
             disk_last_offloaded_per_layer: Vec::new(),
         })

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -189,6 +189,8 @@ impl TransformerModel {
             kv_valid_tokens: 0,
             last_decode_ckpt_block: 0,
             prompt_len: 0,
+            collect_prompt_logprobs: None,
+            prompt_logprobs: Vec::new(),
             disk_block_ids: Vec::new(),
             disk_last_offloaded_per_layer: vec![0; num_attn_layers],
         })

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -292,7 +292,14 @@ impl TransformerModel {
         // chunk's hidden rows are live, BEFORE finalize_last (which
         // re-derives norm_output + logits for the first sampled token).
         // No-op unless seq.collect_prompt_logprobs is set.
-        self.collect_prompt_logprobs_chunk(tokens, seq, chunk_start, proc_start, proc_count, stream)?;
+        self.collect_prompt_logprobs_chunk(
+            tokens,
+            seq,
+            chunk_start,
+            proc_start,
+            proc_count,
+            stream,
+        )?;
 
         if is_last_chunk {
             // ── Phase 6+7+8: final norm, lm_head, prefix-cache + snapshot save ──

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -35,6 +35,7 @@ mod forward_layers;
 mod h_state_ptrs;
 mod prefix_lookup;
 mod proc_range;
+mod prompt_logprobs;
 mod save_checkpoint;
 mod stage_batched;
 mod upload_meta;
@@ -286,6 +287,12 @@ impl TransformerModel {
         // #155: prime the decode-checkpoint cadence gate; the last chunk
         // leaves it at the prompt's complete-block count (see prefill_a).
         seq.last_decode_ckpt_block = seq.tokens.len() / bs;
+
+        // ── Legacy echo+logprobs: project prompt positions while this
+        // chunk's hidden rows are live, BEFORE finalize_last (which
+        // re-derives norm_output + logits for the first sampled token).
+        // No-op unless seq.collect_prompt_logprobs is set.
+        self.collect_prompt_logprobs_chunk(tokens, seq, chunk_start, proc_start, proc_count, stream)?;
 
         if is_last_chunk {
             // ── Phase 6+7+8: final norm, lm_head, prefix-cache + snapshot save ──

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -27,13 +27,12 @@ impl TransformerModel {
             // Prompt-logprob collection needs a live hidden row for EVERY
             // position — a cache/Marconi skip would leave gaps. Force the
             // full-recompute path (documented perf cost, scoring calls only).
-            let mut prefix_match = if self.tokens_have_vision_pad(tokens)
-                || seq.collect_prompt_logprobs.is_some()
-            {
-                spark_runtime::prefix_cache::PrefixMatch::empty()
-            } else {
-                self.prefix_cache.lookup(tokens, bs, seq.session_hash)
-            };
+            let mut prefix_match =
+                if self.tokens_have_vision_pad(tokens) || seq.collect_prompt_logprobs.is_some() {
+                    spark_runtime::prefix_cache::PrefixMatch::empty()
+                } else {
+                    self.prefix_cache.lookup(tokens, bs, seq.session_hash)
+                };
             // F83 (2026-04-30): on EP>1, head and worker have
             // independent local prefix caches whose match counts can
             // diverge (eviction order differences, async insert

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -24,7 +24,12 @@ impl TransformerModel {
     ) -> Result<(usize, bool)> {
         let bs = kv_cache.block_size();
         if chunk_start == 0 {
-            let mut prefix_match = if self.tokens_have_vision_pad(tokens) {
+            // Prompt-logprob collection needs a live hidden row for EVERY
+            // position — a cache/Marconi skip would leave gaps. Force the
+            // full-recompute path (documented perf cost, scoring calls only).
+            let mut prefix_match = if self.tokens_have_vision_pad(tokens)
+                || seq.collect_prompt_logprobs.is_some()
+            {
                 spark_runtime::prefix_cache::PrefixMatch::empty()
             } else {
                 self.prefix_cache.lookup(tokens, bs, seq.session_hash)

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prompt_logprobs.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prompt_logprobs.rs
@@ -17,11 +17,11 @@
 //! Collecting requests bypass the prefix cache (see `prefix_lookup.rs`)
 //! so every position is guaranteed a live hidden row.
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 
 use super::super::super::types::TransformerModel;
 use crate::layers::ops;
-use crate::traits::{extract_bf16, SequenceState};
+use crate::traits::{SequenceState, extract_bf16};
 
 /// Rows projected per LM-head batch. `buffers.logits()` is sized for
 /// `min(m, 32)` rows; every real serve config has m ≥ 32.

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prompt_logprobs.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prompt_logprobs.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Prompt-token logprob collection for legacy `/v1/completions`
+//! `echo` + `logprobs` (loglikelihood scoring — lm-eval et al.).
+//!
+//! During prefill the `hidden` buffer holds one row per processed chunk
+//! position, but only the LAST row is normally projected to logits.
+//! When `seq.collect_prompt_logprobs` is set, this helper projects EVERY
+//! prompt position through final-norm + LM head in ≤32-row batches
+//! (`buffers.logits()` holds only `min(m, 32)` rows — see
+//! `spark-runtime/src/buffers/sizes.rs`), copies each batch D2H, and
+//! extracts `log P(tokens[i+1] | tokens[..=i])` plus top-k alternatives.
+//!
+//! MUST run inside `prefill_chunk_dispatch` BEFORE `prefill_b_finalize_last`:
+//! it clobbers `buffers.logits()` and `buffers.norm_output()`, both of
+//! which `finalize_last` re-derives fresh for the first sampled token.
+//! Collecting requests bypass the prefix cache (see `prefix_lookup.rs`)
+//! so every position is guaranteed a live hidden row.
+
+use anyhow::{ensure, Result};
+
+use super::super::super::types::TransformerModel;
+use crate::layers::ops;
+use crate::traits::{extract_bf16, SequenceState};
+
+/// Rows projected per LM-head batch. `buffers.logits()` is sized for
+/// `min(m, 32)` rows; every real serve config has m ≥ 32.
+const BATCH_ROWS: usize = 32;
+
+impl TransformerModel {
+    /// Collect prompt-token logprobs for one prefill chunk. No-op unless
+    /// `seq.collect_prompt_logprobs` is set. Appends to
+    /// `seq.prompt_logprobs` (one entry per position scoring the NEXT
+    /// prompt token; the final prompt position — whose target is the
+    /// first generated token — is excluded).
+    pub(in crate::model) fn collect_prompt_logprobs_chunk(
+        &self,
+        tokens: &[u32],
+        seq: &mut SequenceState,
+        chunk_start: usize,
+        proc_start: usize,
+        proc_count: usize,
+        stream: u64,
+    ) -> Result<()> {
+        let Some(k) = seq.collect_prompt_logprobs else {
+            return Ok(());
+        };
+        // Prefix bypass guarantees the whole chunk was computed: hidden
+        // row r ↔ absolute prompt position chunk_start + r. A partial
+        // proc range would silently misalign rows — fail fast instead.
+        ensure!(
+            proc_start == chunk_start,
+            "prompt-logprob collection requires a full-recompute chunk \
+             (proc_start {proc_start} != chunk_start {chunk_start}); \
+             prefix-cache bypass failed"
+        );
+
+        let h = self.config.hidden_size;
+        let v = self.config.vocab_size;
+        let eps = self.config.rms_norm_eps as f32;
+        let elem = 2usize; // BF16 hidden rows (matches finalize_last)
+        let hidden = self.buffers.hidden_states();
+
+        // Score positions chunk_start..min(chunk_end, prompt_len-1):
+        // position p's logits predict tokens[p+1]; the last prompt
+        // position's target is the first GENERATED token → excluded.
+        let last_scored_excl = tokens.len().saturating_sub(1);
+        let rows_to_score = proc_count.min(last_scored_excl.saturating_sub(chunk_start));
+        if rows_to_score == 0 {
+            return Ok(());
+        }
+
+        let mut host = vec![0u8; BATCH_ROWS * v * 2];
+        let mut start = 0usize;
+        while start < rows_to_score {
+            let count = (rows_to_score - start).min(BATCH_ROWS);
+            let batch_hidden = hidden.offset((start) * h * elem);
+            let normed = self.buffers.norm_output();
+            ops::rms_norm(
+                self.gpu.as_ref(),
+                self.rms_norm_kernel,
+                batch_hidden,
+                &self.final_norm,
+                normed,
+                count as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+            self.lm_head_batched(normed, count as u32, self.buffers.logits(), stream)?;
+            self.gpu.synchronize(stream)?;
+            let bytes = &mut host[..count * v * 2];
+            self.gpu.copy_d2h(self.buffers.logits(), bytes)?;
+            for j in 0..count {
+                let target = tokens[chunk_start + start + j + 1];
+                let row = &bytes[j * v * 2..(j + 1) * v * 2];
+                seq.prompt_logprobs
+                    .push(extract_bf16(row, target, k as usize, v));
+            }
+            start += count;
+        }
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -165,6 +165,17 @@ pub struct SequenceState {
     /// uninitialised. Length equals the model's attention layer count;
     /// empty when HSS is disabled.
     pub disk_last_offloaded_per_layer: Vec<u32>,
+    /// Legacy /v1/completions echo+logprobs: Some(k) = during prefill,
+    /// project every prompt position's hidden state and record the actual
+    /// next token's logprob plus top-k alternatives. Set by the scheduler
+    /// before prefill; None = zero-cost (the collection helper
+    /// early-returns). Requests with this set bypass the prefix cache so
+    /// every position has a live hidden row.
+    pub collect_prompt_logprobs: Option<u8>,
+    /// Accumulated across prefill chunks: one entry per prompt position
+    /// i in [0, prompt_len-1) scoring tokens[i+1]. The final prompt
+    /// position (whose target is the first GENERATED token) is excluded.
+    pub prompt_logprobs: Vec<PromptTokenLogprob>,
 }
 
 impl SequenceState {
@@ -207,5 +218,7 @@ impl SequenceState {
 /// `Sync` safety: the model is exclusively accessed from the scheduler
 /// thread. The `unsafe impl Sync` on `TransformerModel` documents this
 /// single-thread invariant — do NOT share `&dyn Model` across threads.
+mod logprobs;
 mod model;
+pub use logprobs::*;
 pub use model::Model;

--- a/crates/spark-model/src/traits/logprobs.rs
+++ b/crates/spark-model/src/traits/logprobs.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pure log-softmax / top-k logprob extraction. SSOT for the math shared
+//! by the scheduler's decode-time logprobs (`spark-server`) and the
+//! model's prompt-logprob collection during prefill (legacy
+//! `/v1/completions` `echo` + `logprobs`).
+
+/// One scored prompt position: `log P(tokens[i+1] | tokens[..=i])` plus
+/// the top-k alternative tokens under the same distribution.
+#[derive(Clone, Debug)]
+pub struct PromptTokenLogprob {
+    /// The actual next prompt token (the one being scored).
+    pub token_id: u32,
+    /// Log-probability of `token_id` under this position's distribution.
+    pub logprob: f32,
+    /// Top-k `(token_id, logprob)` alternatives, sorted descending.
+    /// Empty when k=0 (logprob-only mode).
+    pub top: Vec<(u32, f32)>,
+}
+
+/// Log-softmax over `f32_logits`; returns the target token's logprob and
+/// the top-k alternatives sorted descending by logprob. `k=0` returns an
+/// empty top vector (chosen-token logprob only). A target outside the
+/// vocab yields `-inf` (fail-visible, never panics).
+pub fn logprob_of(f32_logits: &[f32], target: u32, k: usize) -> (f32, Vec<(u32, f32)>) {
+    // Log-softmax: logprob = logit - log(sum(exp(logits)))
+    let max_logit = f32_logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let log_sum_exp = max_logit
+        + f32_logits
+            .iter()
+            .map(|&l| (l - max_logit).exp())
+            .sum::<f32>()
+            .ln();
+    let target_logprob = if (target as usize) < f32_logits.len() {
+        f32_logits[target as usize] - log_sum_exp
+    } else {
+        f32::NEG_INFINITY
+    };
+    if k == 0 {
+        return (target_logprob, Vec::new());
+    }
+    // Top-K by partial sort.
+    let mut indexed: Vec<(u32, f32)> = f32_logits
+        .iter()
+        .enumerate()
+        .map(|(j, &l)| (j as u32, l - log_sum_exp))
+        .collect();
+    let nth = k.min(indexed.len().saturating_sub(1));
+    indexed.select_nth_unstable_by(nth, |a, b| {
+        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut top: Vec<(u32, f32)> = indexed[..k.min(indexed.len())].to_vec();
+    top.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    (target_logprob, top)
+}
+
+/// BF16 → FP32 (upper 16 bits of the IEEE-754 f32 pattern).
+#[inline]
+pub fn bf16_to_f32(lo: u8, hi: u8) -> f32 {
+    f32::from_bits(((lo as u32) | ((hi as u32) << 8)) << 16)
+}
+
+/// Extract one position's `PromptTokenLogprob` from a BF16 `[vocab]`
+/// logits slice (the layout `lm_head_batched` writes per row).
+pub fn extract_bf16(bf16: &[u8], target: u32, k: usize, vocab: usize) -> PromptTokenLogprob {
+    let f32_logits: Vec<f32> = (0..vocab)
+        .map(|j| bf16_to_f32(bf16[j * 2], bf16[j * 2 + 1]))
+        .collect();
+    let (logprob, top) = logprob_of(&f32_logits, target, k);
+    PromptTokenLogprob {
+        token_id: target,
+        logprob,
+        top,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logprob_matches_manual_log_softmax() {
+        let logits = [1.0f32, 2.0, 3.0];
+        let sum: f32 = logits.iter().map(|l| l.exp()).sum();
+        let expect = 2.0 - sum.ln();
+        let (lp, top) = logprob_of(&logits, 1, 2);
+        assert!((lp - expect).abs() < 1e-6, "{lp} vs {expect}");
+        // Top-2 sorted descending: token 2 first, then token 1.
+        assert_eq!(top[0].0, 2);
+        assert_eq!(top[1].0, 1);
+        assert!(top[0].1 > top[1].1);
+    }
+
+    #[test]
+    fn k_zero_returns_empty_top() {
+        let (lp, top) = logprob_of(&[0.0, 1.0], 0, 0);
+        assert!(top.is_empty());
+        assert!(lp < 0.0);
+    }
+
+    #[test]
+    fn out_of_vocab_target_is_neg_inf_not_panic() {
+        let (lp, _) = logprob_of(&[0.0, 1.0], 99, 1);
+        assert_eq!(lp, f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn bf16_slice_roundtrip_extract() {
+        // BF16 encodings of [0.0, 1.0, 2.0]: f32 bit patterns >> 16.
+        let vals = [0.0f32, 1.0, 2.0];
+        let mut bytes = Vec::new();
+        for v in vals {
+            let b = (v.to_bits() >> 16) as u16;
+            bytes.push((b & 0xFF) as u8);
+            bytes.push((b >> 8) as u8);
+        }
+        let r = extract_bf16(&bytes, 2, 1, 3);
+        let sum: f32 = vals.iter().map(|l| l.exp()).sum();
+        assert!((r.logprob - (2.0 - sum.ln())).abs() < 1e-3);
+        assert_eq!(r.top[0].0, 2);
+    }
+}

--- a/crates/spark-server/src/api/chat/sampling_setup.rs
+++ b/crates/spark-server/src/api/chat/sampling_setup.rs
@@ -341,10 +341,7 @@ pub(super) fn build_sampling(
 /// `top_logprobs` count wins (clamped 0-20); `logprobs: true` alone
 /// enables sampled-token logprobs with no alternatives (count 0);
 /// otherwise disabled.
-pub(crate) fn resolve_top_logprobs(
-    logprobs: Option<bool>,
-    top_logprobs: Option<u8>,
-) -> Option<u8> {
+pub(crate) fn resolve_top_logprobs(logprobs: Option<bool>, top_logprobs: Option<u8>) -> Option<u8> {
     match (logprobs, top_logprobs) {
         (_, Some(n)) => Some(n.min(20)),
         (Some(true), None) => Some(0),

--- a/crates/spark-server/src/api/chat/sampling_setup.rs
+++ b/crates/spark-server/src/api/chat/sampling_setup.rs
@@ -312,8 +312,7 @@ pub(super) fn build_sampling(
         None
     };
 
-    // top_logprobs (OpenAI spec: 0-20).
-    let top_logprobs = req.top_logprobs.map(|n| n.min(20));
+    let top_logprobs = resolve_top_logprobs(req.logprobs, req.top_logprobs);
 
     Ok(SamplingSetup {
         temperature,
@@ -338,9 +337,44 @@ pub(super) fn build_sampling(
     })
 }
 
+/// Resolve chat logprobs params (OpenAI spec): an explicit
+/// `top_logprobs` count wins (clamped 0-20); `logprobs: true` alone
+/// enables sampled-token logprobs with no alternatives (count 0);
+/// otherwise disabled.
+pub(crate) fn resolve_top_logprobs(
+    logprobs: Option<bool>,
+    top_logprobs: Option<u8>,
+) -> Option<u8> {
+    match (logprobs, top_logprobs) {
+        (_, Some(n)) => Some(n.min(20)),
+        (Some(true), None) => Some(0),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::resolve_top_logprobs;
     use super::tool_choice_required_for_parser;
+
+    #[test]
+    fn logprobs_true_alone_enables_with_zero_top() {
+        assert_eq!(resolve_top_logprobs(Some(true), None), Some(0));
+    }
+
+    #[test]
+    fn explicit_top_logprobs_wins_and_clamps() {
+        assert_eq!(resolve_top_logprobs(None, Some(5)), Some(5));
+        assert_eq!(resolve_top_logprobs(Some(false), Some(3)), Some(3));
+        assert_eq!(resolve_top_logprobs(Some(true), Some(99)), Some(20));
+    }
+
+    #[test]
+    fn absent_or_false_disables() {
+        assert_eq!(resolve_top_logprobs(None, None), None);
+        assert_eq!(resolve_top_logprobs(Some(false), None), None);
+    }
+
     use crate::tool_parser::{ToolChoice, ToolChoiceFunction};
 
     #[test]

--- a/crates/spark-server/src/api/chat/template.rs
+++ b/crates/spark-server/src/api/chat/template.rs
@@ -60,7 +60,11 @@ pub(super) fn render_template(
             // system/user/assistant/tool, so map it here; a template
             // that rejects non-leading system messages was already
             // rejecting non-leading system — pre-existing limitation.
-            let role = if m.role == "developer" { "system" } else { m.role.as_str() };
+            let role = if m.role == "developer" {
+                "system"
+            } else {
+                m.role.as_str()
+            };
             let mut msg = serde_json::json!({"role": role, "content": content_val});
             if let Some(ref tcs) = m.tool_calls {
                 msg["tool_calls"] = serde_json::Value::Array(tcs.clone());

--- a/crates/spark-server/src/api/chat/template.rs
+++ b/crates/spark-server/src/api/chat/template.rs
@@ -55,7 +55,13 @@ pub(super) fn render_template(
             } else {
                 serde_json::Value::String(m.content.clone())
             };
-            let mut msg = serde_json::json!({"role": m.role, "content": content_val});
+            // OpenAI: `developer` is the successor of `system` (o-series
+            // clients send it). Most chat templates only know
+            // system/user/assistant/tool, so map it here; a template
+            // that rejects non-leading system messages was already
+            // rejecting non-leading system — pre-existing limitation.
+            let role = if m.role == "developer" { "system" } else { m.role.as_str() };
+            let mut msg = serde_json::json!({"role": role, "content": content_val});
             if let Some(ref tcs) = m.tool_calls {
                 msg["tool_calls"] = serde_json::Value::Array(tcs.clone());
             }

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -141,6 +141,8 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> Response {
             grammar_spec: grammar_spec.clone(),
             seed: req.seed.map(|s| s.wrapping_add(choice_idx as u64)),
             top_logprobs,
+            prompt_logprobs: None,
+            echo: false,
             timeout_at,
             response_tx: tx,
         };

--- a/crates/spark-server/src/api/chat_stream/mod.rs
+++ b/crates/spark-server/src/api/chat_stream/mod.rs
@@ -147,6 +147,8 @@ pub(crate) async fn chat_completions_stream(
         grammar_spec,
         seed,
         top_logprobs,
+        prompt_logprobs: None,
+        echo: false,
         timeout_at,
         token_tx,
         cancel_flag: cancel_flag.clone(),
@@ -239,6 +241,9 @@ pub(crate) async fn chat_completions_stream(
             StreamEvent::Token(tok) | StreamEvent::TokenWithLogprobs(tok, _) => {
                 handle_token::handle_token(&mut stream_state, &ctx, tok)
             }
+            // Legacy /v1/completions-only event; chat never requests
+            // prompt_logprobs, so nothing to emit here.
+            StreamEvent::PromptLogprobs(_) => Vec::new(),
             StreamEvent::Done {
                 finish_reason,
                 prompt_tokens: _,

--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -58,12 +58,11 @@ fn resolve_prompts(
     prompt: &PromptInput,
 ) -> Result<Vec<Vec<u32>>, (StatusCode, String)> {
     match prompt {
-        PromptInput::Text(s) => Ok(vec![
-            state
-                .tokenizer
-                .encode(s)
-                .map_err(|e| (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}")))?,
-        ]),
+        PromptInput::Text(s) => {
+            Ok(vec![state.tokenizer.encode(s).map_err(|e| {
+                (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}"))
+            })?])
+        }
         PromptInput::TextArray(parts) => {
             // OpenAI spec: each array element is an INDEPENDENT prompt
             // yielding its own choice. (Earlier Atlas joined the array
@@ -72,9 +71,10 @@ fn resolve_prompts(
             parts
                 .iter()
                 .map(|part| {
-                    state.tokenizer.encode(part).map_err(|e| {
-                        (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}"))
-                    })
+                    state
+                        .tokenizer
+                        .encode(part)
+                        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}")))
                 })
                 .collect()
         }
@@ -209,12 +209,13 @@ pub(super) async fn completions_stream(
     let prompt_len = prompt_tokens.len();
     let echo = req.echo;
     let logprobs_k = p.logprobs_k;
-    let include_usage = req
-        .stream_options
-        .as_ref()
-        .is_some_and(|o| o.include_usage);
+    let include_usage = req.stream_options.as_ref().is_some_and(|o| o.include_usage);
     // Echo needs the prompt tokens after the request consumes them.
-    let echo_prompt = if echo { Some(prompt_tokens.clone()) } else { None };
+    let echo_prompt = if echo {
+        Some(prompt_tokens.clone())
+    } else {
+        None
+    };
     // Echo WITHOUT logprobs has no PromptLogprobs event to hook — the
     // prompt text chunk is prepended client-side; decode it now, before
     // the request takes ownership of the tokens.
@@ -298,9 +299,9 @@ pub(super) async fn completions_stream(
                     &[],
                 );
                 let chunk = CompletionChunk::echo_chunk(&model, &id, text, Some(lp));
-                vec![Ok(Event::default().data(
-                    serde_json::to_string(&chunk).unwrap_or_default(),
-                ))]
+                vec![Ok(
+                    Event::default().data(serde_json::to_string(&chunk).unwrap_or_default())
+                )]
             }
             StreamEvent::Token(tok) | StreamEvent::TokenWithLogprobs(tok, _) => {
                 all_toks.push(tok);
@@ -314,9 +315,9 @@ pub(super) async fn completions_stream(
                     d
                 };
                 let chunk = CompletionChunk::text_chunk(&model, &id, delta);
-                vec![Ok(Event::default().data(
-                    serde_json::to_string(&chunk).unwrap_or_default(),
-                ))]
+                vec![Ok(
+                    Event::default().data(serde_json::to_string(&chunk).unwrap_or_default())
+                )]
             }
             StreamEvent::Done {
                 finish_reason,
@@ -361,9 +362,9 @@ pub(super) async fn completions_stream(
                     ]
                 } else {
                     let chunk = CompletionChunk::done_chunk(&model, &id, &finish_reason, usage);
-                    vec![Ok(Event::default().data(
-                        serde_json::to_string(&chunk).unwrap_or_default(),
-                    ))]
+                    vec![Ok(
+                        Event::default().data(serde_json::to_string(&chunk).unwrap_or_default())
+                    )]
                 }
             }
             StreamEvent::Error(msg) => {
@@ -383,7 +384,11 @@ pub(super) async fn completions_stream(
     let done_event = futures::stream::once(async {
         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
     });
-    let prefix = futures::stream::iter(echo_prefix.into_iter().map(Ok::<_, std::convert::Infallible>));
+    let prefix = futures::stream::iter(
+        echo_prefix
+            .into_iter()
+            .map(Ok::<_, std::convert::Infallible>),
+    );
     let full_stream = prefix.chain(token_stream).chain(done_event);
 
     Ok(Sse::new(full_stream)

--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -156,6 +156,15 @@ pub async fn completions(
             .filter_map(|(k, &v)| k.parse::<u32>().ok().map(|id| (id, v)))
             .collect()
     });
+    // OpenAI spec bounds n to 1-128; an unbounded n would drive both an
+    // attacker-controlled allocation and an unbounded sequential-inference
+    // loop (CodeQL: uncontrolled allocation size). Fail fast per spec.
+    if req.n == 0 || req.n > 128 {
+        return openai_error_response(
+            StatusCode::BAD_REQUEST,
+            format!("n must be between 1 and 128, got {}", req.n),
+        );
+    }
     let stop_tokens = tokenize_stop_sequences(&state.tokenizer, &req.stop);
     // OpenAI clamps chat top_logprobs to 20; same bound here (spec says
     // 5 for legacy — being more permissive, never less).

--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -53,35 +53,42 @@ use super::sanitizer::*;
 /// Token-ID inputs are range-checked against the tokenizer vocabulary;
 /// an out-of-range ID fails fast with a 400 rather than indexing out of
 /// bounds into the embedding table.
-fn resolve_prompt_tokens(
+fn resolve_prompts(
     state: &AppState,
     prompt: &PromptInput,
-) -> Result<Vec<u32>, (StatusCode, String)> {
+) -> Result<Vec<Vec<u32>>, (StatusCode, String)> {
     match prompt {
-        PromptInput::Text(s) => state
-            .tokenizer
-            .encode(s)
-            .map_err(|e| (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}"))),
-        PromptInput::TextArray(parts) => {
-            // Join with no separator, matching the prior `Vec<String>`
-            // behavior (`v.join("")`), then tokenize once.
-            let joined = parts.concat();
+        PromptInput::Text(s) => Ok(vec![
             state
                 .tokenizer
-                .encode(&joined)
-                .map_err(|e| (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}")))
+                .encode(s)
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}")))?,
+        ]),
+        PromptInput::TextArray(parts) => {
+            // OpenAI spec: each array element is an INDEPENDENT prompt
+            // yielding its own choice. (Earlier Atlas joined the array
+            // into one prompt — that silently corrupted batched eval
+            // harnesses like lm-eval at batch_size > 1.)
+            parts
+                .iter()
+                .map(|part| {
+                    state.tokenizer.encode(part).map_err(|e| {
+                        (StatusCode::BAD_REQUEST, format!("Tokenization error: {e}"))
+                    })
+                })
+                .collect()
         }
         PromptInput::TokenIds(ids) => {
             validate_token_ids(state, ids)?;
-            Ok(ids.clone())
+            Ok(vec![ids.clone()])
         }
         PromptInput::TokenIdBatch(batch) => {
-            // The legacy single-prompt handler flattens a batch into one
-            // sequence (concatenation), matching how `TextArray` joins
-            // multiple string prompts into one.
-            let flat: Vec<u32> = batch.iter().flatten().copied().collect();
-            validate_token_ids(state, &flat)?;
-            Ok(flat)
+            // Same spec rule for pre-tokenized batches: one prompt per
+            // sub-array (was: flattened into a single sequence).
+            for ids in batch {
+                validate_token_ids(state, ids)?;
+            }
+            Ok(batch.clone())
         }
     }
 }
@@ -113,20 +120,24 @@ pub async fn completions(
             );
         }
     };
-    let prompt_tokens = match resolve_prompt_tokens(&state, &req.prompt) {
+    let prompts = match resolve_prompts(&state, &req.prompt) {
         Ok(t) => t,
         Err((status, msg)) => return openai_error_response(status, msg),
     };
-
-    let prompt_len = prompt_tokens.len();
-    if prompt_len >= state.max_seq_len {
-        return openai_error_response(
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Prompt too long: {prompt_len} tokens exceeds max_seq_len {}",
-                state.max_seq_len
-            ),
-        );
+    if prompts.is_empty() {
+        return openai_error_response(StatusCode::BAD_REQUEST, "Empty prompt".to_string());
+    }
+    for prompt_tokens in &prompts {
+        let prompt_len = prompt_tokens.len();
+        if prompt_len >= state.max_seq_len {
+            return openai_error_response(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "Prompt too long: {prompt_len} tokens exceeds max_seq_len {}",
+                    state.max_seq_len
+                ),
+            );
+        }
     }
 
     let temperature = req.temperature.unwrap_or(state.default_temperature);
@@ -146,41 +157,10 @@ pub async fn completions(
             .collect()
     });
     let stop_tokens = tokenize_stop_sequences(&state.tokenizer, &req.stop);
-
-    if req.stream {
-        return match completions_stream(
-            state,
-            prompt_tokens,
-            req.max_tokens,
-            temperature,
-            top_k,
-            top_p,
-            top_n_sigma,
-            min_p,
-            repetition_penalty,
-            presence_penalty,
-            frequency_penalty,
-            logit_bias.clone(),
-            stop_tokens,
-            req.seed,
-            req.repetition_detection,
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err((status, msg)) => openai_error_response(status, msg),
-        };
-    }
-
-    // ── Blocking path ──
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    let session_hash = crate::session_manager::compute_session_hash(&prompt_tokens);
-    let request = InferenceRequest::Blocking {
-        prompt_tokens: std::sync::Arc::new(prompt_tokens),
-        session_hash,
-        image_pixels: Vec::new(),
-        max_tokens: req.max_tokens,
-        min_tokens: 0,
+    // OpenAI clamps chat top_logprobs to 20; same bound here (spec says
+    // 5 for legacy — being more permissive, never less).
+    let logprobs_k = req.logprobs.map(|k| k.min(20));
+    let params = super::completions_exec::CompletionParams {
         temperature,
         top_k,
         top_p,
@@ -189,18 +169,86 @@ pub async fn completions(
         repetition_penalty,
         presence_penalty,
         frequency_penalty,
-        // Legacy /v1/completions path doesn't have tool semantics, so
-        // no DRY. (DRY on raw completion would dampen legitimate
-        // long-repeated prose.)
+        logit_bias,
+        stop_tokens,
+        repetition_detection: req.repetition_detection,
+        logprobs_k,
+    };
+
+    if req.stream {
+        if prompts.len() > 1 || req.n > 1 {
+            return openai_error_response(
+                StatusCode::BAD_REQUEST,
+                "stream=true supports a single prompt with n=1".to_string(),
+            );
+        }
+        let prompt_tokens = prompts.into_iter().next().expect("checked non-empty");
+        return match completions_stream(state, prompt_tokens, req, params).await {
+            Ok(r) => r,
+            Err((status, msg)) => openai_error_response(status, msg),
+        };
+    }
+
+    super::completions_exec::run_blocking(state, &req, prompts, params).await
+}
+
+/// SSE streaming path for legacy completions. Single prompt, n=1
+/// (guarded by the handler). Echo semantics: the prompt text (plus its
+/// logprobs when `logprobs` is set) is emitted as the FIRST chunk,
+/// before any generated-token chunk. With `stream_options.include_usage`
+/// the finish chunk carries no usage; a `choices: []` usage chunk
+/// precedes `[DONE]` (chat parity).
+pub(super) async fn completions_stream(
+    state: Arc<AppState>,
+    prompt_tokens: Vec<u32>,
+    req: CompletionRequest,
+    p: super::completions_exec::CompletionParams,
+) -> Result<Response, (StatusCode, String)> {
+    // Match chat_stream/mod.rs sizing; see comment there.
+    let (token_tx, token_rx) = tokio::sync::mpsc::channel::<StreamEvent>(1024);
+    let prompt_len = prompt_tokens.len();
+    let echo = req.echo;
+    let logprobs_k = p.logprobs_k;
+    let include_usage = req
+        .stream_options
+        .as_ref()
+        .is_some_and(|o| o.include_usage);
+    // Echo needs the prompt tokens after the request consumes them.
+    let echo_prompt = if echo { Some(prompt_tokens.clone()) } else { None };
+    // Echo WITHOUT logprobs has no PromptLogprobs event to hook — the
+    // prompt text chunk is prepended client-side; decode it now, before
+    // the request takes ownership of the tokens.
+    let echo_only_text = if echo && logprobs_k.is_none() {
+        Some(state.tokenizer.decode(&prompt_tokens).unwrap_or_default())
+    } else {
+        None
+    };
+
+    let session_hash = crate::session_manager::compute_session_hash(&prompt_tokens);
+    let request = InferenceRequest::Streaming {
+        prompt_tokens: std::sync::Arc::new(prompt_tokens),
+        session_hash,
+        image_pixels: Vec::new(),
+        max_tokens: req.max_tokens,
+        min_tokens: 0,
+        temperature: p.temperature,
+        top_k: p.top_k,
+        top_p: p.top_p,
+        top_n_sigma: p.top_n_sigma,
+        min_p: p.min_p,
+        repetition_penalty: p.repetition_penalty,
+        presence_penalty: p.presence_penalty,
+        frequency_penalty: p.frequency_penalty,
+        // Legacy /v1/completions path doesn't have tool semantics.
         dry_multiplier: 0.0,
         dry_base: 1.75,
         dry_allowed_length: 2,
         lz_penalty: 0.0,
-        logit_bias,
-        stop_tokens,
+        logit_bias: p.logit_bias,
+        stop_tokens: p.stop_tokens,
         enable_thinking: false,
         thinking_budget: None,
-        repetition_detection: req.repetition_detection,
+        repetition_detection: p.repetition_detection,
         require_tool_call: false,
         // Completions API defines no tools — multi-tool-call continuation off.
         tools_present: false,
@@ -208,145 +256,9 @@ pub async fn completions(
         disable_mtp: false,
         grammar_spec: None,
         seed: req.seed,
-        top_logprobs: None,
-        prompt_logprobs: None,
-        echo: false,
-        timeout_at: {
-            let secs = state.request_timeout as f32;
-            if secs > 0.0 {
-                Some(std::time::Instant::now() + std::time::Duration::from_secs_f32(secs))
-            } else {
-                None
-            }
-        },
-        response_tx: tx,
-    };
-
-    if state.request_tx.send(request).await.is_err() {
-        return openai_error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "Scheduler queue full".to_string(),
-        );
-    }
-
-    let response = match rx.await {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            return openai_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Inference error: {e}"),
-            );
-        }
-        Err(_) => {
-            return openai_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Inference cancelled".to_string(),
-            );
-        }
-    };
-
-    let output_text = match state.tokenizer.decode(&response.output_tokens) {
-        Ok(t) => t,
-        Err(e) => {
-            return openai_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Decode error: {e}"),
-            );
-        }
-    };
-    let output_text = strip_stop_sequences(output_text, &req.stop);
-    let output_text = strip_thinking_tags(&output_text);
-
-    let num_completion = response.output_tokens.len();
-    let tokens_per_second = if response.decode_time_ms > 0.0 {
-        (num_completion.saturating_sub(1)) as f64 / (response.decode_time_ms / 1000.0)
-    } else {
-        0.0
-    };
-    let usage = Usage {
-        prompt_tokens: prompt_len,
-        completion_tokens: num_completion,
-        total_tokens: prompt_len + num_completion,
-        prompt_tokens_details: Some(crate::openai::PromptTokensDetails {
-            cached_tokens: response.cached_prompt_tokens as usize,
-            audio_tokens: 0,
-        }),
-        completion_tokens_details: Some(crate::openai::CompletionTokensDetails {
-            reasoning_tokens: response.reasoning_tokens as usize,
-            audio_tokens: 0,
-            accepted_prediction_tokens: 0,
-            rejected_prediction_tokens: 0,
-        }),
-        time_to_first_token_ms: response.time_to_first_token_ms,
-        response_tokens_per_second: tokens_per_second,
-    };
-
-    Json(CompletionResponse::new(
-        &state.model_name,
-        output_text,
-        usage,
-        &response.finish_reason,
-    ))
-    .into_response()
-}
-
-/// SSE streaming path for legacy completions.
-pub(super) async fn completions_stream(
-    state: Arc<AppState>,
-    prompt_tokens: Vec<u32>,
-    max_tokens: usize,
-    temperature: f32,
-    top_k: u32,
-    top_p: f32,
-    top_n_sigma: f32,
-    min_p: f32,
-    repetition_penalty: f32,
-    presence_penalty: f32,
-    frequency_penalty: f32,
-    logit_bias: Vec<(u32, f32)>,
-    stop_tokens: Vec<u32>,
-    seed: Option<u64>,
-    repetition_detection: Option<crate::openai::RepetitionDetectionParams>,
-) -> Result<Response, (StatusCode, String)> {
-    // Match chat_stream/mod.rs sizing; see comment there.
-    let (token_tx, token_rx) = tokio::sync::mpsc::channel::<StreamEvent>(1024);
-    let prompt_len = prompt_tokens.len();
-
-    let session_hash = crate::session_manager::compute_session_hash(&prompt_tokens);
-    let request = InferenceRequest::Streaming {
-        prompt_tokens: std::sync::Arc::new(prompt_tokens),
-        session_hash,
-        image_pixels: Vec::new(),
-        max_tokens,
-        min_tokens: 0,
-        temperature,
-        top_k,
-        top_p,
-        top_n_sigma,
-        min_p,
-        repetition_penalty,
-        presence_penalty,
-        frequency_penalty,
-        // Legacy /v1/completions path doesn't have tool semantics.
-        dry_multiplier: 0.0,
-        dry_base: 1.75,
-        dry_allowed_length: 2,
-        lz_penalty: 0.0,
-        logit_bias,
-        stop_tokens,
-        enable_thinking: false,
-        thinking_budget: None,
-        repetition_detection,
-        require_tool_call: false,
-        // Completions API defines no tools — multi-tool-call continuation off.
-        tools_present: false,
-        suppress_tool_call: false,
-        disable_mtp: false,
-        grammar_spec: None,
-        seed,
-        top_logprobs: None,
-        prompt_logprobs: None,
-        echo: false,
+        top_logprobs: logprobs_k,
+        prompt_logprobs: if echo { logprobs_k } else { None },
+        echo,
         timeout_at: None,
         token_tx,
         // /v1/completions has no guard pipeline yet — the flag is
@@ -369,71 +281,110 @@ pub(super) async fn completions_stream(
     let id = chunk_id.clone();
     let mut all_toks: Vec<u32> = Vec::new();
     let mut emitted: usize = 0;
-    let token_stream = ReceiverStream::new(token_rx).map(move |event| match event {
-        // Placeholder until the echo streaming path lands (commit 5):
-        // completions_stream doesn't request prompt_logprobs yet.
-        StreamEvent::PromptLogprobs(_) => {
-            let chunk = CompletionChunk::text_chunk(&model, &id, String::new());
-            let json = serde_json::to_string(&chunk).unwrap_or_default();
-            Ok::<_, std::convert::Infallible>(Event::default().data(json))
-        }
-        StreamEvent::Token(tok) | StreamEvent::TokenWithLogprobs(tok, _) => {
-            all_toks.push(tok);
-            let full = state.tokenizer.decode(&all_toks).unwrap_or_default();
-            let stable_end = full.trim_end_matches('\u{FFFD}').len();
-            if stable_end <= emitted {
-                let chunk = CompletionChunk::text_chunk(&model, &id, String::new());
-                let json = serde_json::to_string(&chunk).unwrap_or_default();
-                return Ok::<_, std::convert::Infallible>(Event::default().data(json));
+    let token_stream = ReceiverStream::new(token_rx).flat_map(move |event| {
+        let events: Vec<Result<Event, std::convert::Infallible>> = match event {
+            // Echo + logprobs: prompt text and its logprobs, before any
+            // generated token (the scheduler emits this exactly once).
+            StreamEvent::PromptLogprobs(lps) => {
+                let prompt_toks = echo_prompt.clone().unwrap_or_default();
+                let text = state.tokenizer.decode(&prompt_toks).unwrap_or_default();
+                let decode = |tid: u32| state.tokenizer.decode(&[tid]).unwrap_or_default();
+                let lp = super::completions_logprobs::build_completion_logprobs(
+                    &decode,
+                    true,
+                    &prompt_toks,
+                    &lps,
+                    &[],
+                    &[],
+                );
+                let chunk = CompletionChunk::echo_chunk(&model, &id, text, Some(lp));
+                vec![Ok(Event::default().data(
+                    serde_json::to_string(&chunk).unwrap_or_default(),
+                ))]
             }
-            let delta = full[emitted..stable_end].to_string();
-            emitted = stable_end;
-            let chunk = CompletionChunk::text_chunk(&model, &id, delta);
-            let json = serde_json::to_string(&chunk).unwrap_or_default();
-            Ok::<_, std::convert::Infallible>(Event::default().data(json))
-        }
-        StreamEvent::Done {
-            finish_reason,
-            prompt_tokens: _,
-            completion_tokens,
-            time_to_first_token_ms,
-            decode_time_ms,
-            reasoning_tokens,
-            cached_prompt_tokens,
-        } => {
-            let tps = if decode_time_ms > 0.0 {
-                completion_tokens.saturating_sub(1) as f64 / (decode_time_ms / 1000.0)
-            } else {
-                0.0
-            };
-            let usage = Usage {
-                prompt_tokens: prompt_len,
+            StreamEvent::Token(tok) | StreamEvent::TokenWithLogprobs(tok, _) => {
+                all_toks.push(tok);
+                let full = state.tokenizer.decode(&all_toks).unwrap_or_default();
+                let stable_end = full.trim_end_matches('\u{FFFD}').len();
+                let delta = if stable_end <= emitted {
+                    String::new()
+                } else {
+                    let d = full[emitted..stable_end].to_string();
+                    emitted = stable_end;
+                    d
+                };
+                let chunk = CompletionChunk::text_chunk(&model, &id, delta);
+                vec![Ok(Event::default().data(
+                    serde_json::to_string(&chunk).unwrap_or_default(),
+                ))]
+            }
+            StreamEvent::Done {
+                finish_reason,
+                prompt_tokens: _,
                 completion_tokens,
-                total_tokens: prompt_len + completion_tokens,
-                prompt_tokens_details: Some(crate::openai::PromptTokensDetails {
-                    cached_tokens: cached_prompt_tokens as usize,
-                    audio_tokens: 0,
-                }),
-                completion_tokens_details: Some(crate::openai::CompletionTokensDetails {
-                    reasoning_tokens: reasoning_tokens as usize,
-                    audio_tokens: 0,
-                    accepted_prediction_tokens: 0,
-                    rejected_prediction_tokens: 0,
-                }),
                 time_to_first_token_ms,
-                response_tokens_per_second: tps,
-            };
-            let chunk = CompletionChunk::done_chunk(&model, &id, &finish_reason, usage);
-            let json = serde_json::to_string(&chunk).unwrap_or_default();
-            Ok(Event::default().data(json))
-        }
-        StreamEvent::Error(msg) => Ok(Event::default().data(format!(r#"{{"error":"{msg}"}}"#))),
+                decode_time_ms,
+                reasoning_tokens,
+                cached_prompt_tokens,
+            } => {
+                let tps = if decode_time_ms > 0.0 {
+                    completion_tokens.saturating_sub(1) as f64 / (decode_time_ms / 1000.0)
+                } else {
+                    0.0
+                };
+                let usage = Usage {
+                    prompt_tokens: prompt_len,
+                    completion_tokens,
+                    total_tokens: prompt_len + completion_tokens,
+                    prompt_tokens_details: Some(crate::openai::PromptTokensDetails {
+                        cached_tokens: cached_prompt_tokens as usize,
+                        audio_tokens: 0,
+                    }),
+                    completion_tokens_details: Some(crate::openai::CompletionTokensDetails {
+                        reasoning_tokens: reasoning_tokens as usize,
+                        audio_tokens: 0,
+                        accepted_prediction_tokens: 0,
+                        rejected_prediction_tokens: 0,
+                    }),
+                    time_to_first_token_ms,
+                    response_tokens_per_second: tps,
+                };
+                if include_usage {
+                    // Chat parity: finish chunk without usage, then a
+                    // choices:[] usage-only chunk.
+                    let fin = CompletionChunk::finish_chunk_no_usage(&model, &id, &finish_reason);
+                    let usage_chunk = CompletionChunk::usage_only_chunk(&model, &id, usage);
+                    vec![
+                        Ok(Event::default().data(serde_json::to_string(&fin).unwrap_or_default())),
+                        Ok(Event::default()
+                            .data(serde_json::to_string(&usage_chunk).unwrap_or_default())),
+                    ]
+                } else {
+                    let chunk = CompletionChunk::done_chunk(&model, &id, &finish_reason, usage);
+                    vec![Ok(Event::default().data(
+                        serde_json::to_string(&chunk).unwrap_or_default(),
+                    ))]
+                }
+            }
+            StreamEvent::Error(msg) => {
+                vec![Ok(Event::default().data(format!(r#"{{"error":"{msg}"}}"#)))]
+            }
+        };
+        futures::stream::iter(events)
+    });
+
+    // Echo WITHOUT logprobs: the scheduler emits no PromptLogprobs event
+    // (nothing to collect), so prepend the prompt text chunk directly.
+    let echo_prefix: Option<Event> = echo_only_text.map(|text| {
+        let chunk = CompletionChunk::echo_chunk(&model_name, &chunk_id, text, None);
+        Event::default().data(serde_json::to_string(&chunk).unwrap_or_default())
     });
 
     let done_event = futures::stream::once(async {
         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
     });
-    let full_stream = token_stream.chain(done_event);
+    let prefix = futures::stream::iter(echo_prefix.into_iter().map(Ok::<_, std::convert::Infallible>));
+    let full_stream = prefix.chain(token_stream).chain(done_event);
 
     Ok(Sse::new(full_stream)
         .keep_alive(KeepAlive::default())

--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -209,6 +209,8 @@ pub async fn completions(
         grammar_spec: None,
         seed: req.seed,
         top_logprobs: None,
+        prompt_logprobs: None,
+        echo: false,
         timeout_at: {
             let secs = state.request_timeout as f32;
             if secs > 0.0 {
@@ -343,6 +345,8 @@ pub(super) async fn completions_stream(
         grammar_spec: None,
         seed,
         top_logprobs: None,
+        prompt_logprobs: None,
+        echo: false,
         timeout_at: None,
         token_tx,
         // /v1/completions has no guard pipeline yet — the flag is
@@ -366,6 +370,13 @@ pub(super) async fn completions_stream(
     let mut all_toks: Vec<u32> = Vec::new();
     let mut emitted: usize = 0;
     let token_stream = ReceiverStream::new(token_rx).map(move |event| match event {
+        // Placeholder until the echo streaming path lands (commit 5):
+        // completions_stream doesn't request prompt_logprobs yet.
+        StreamEvent::PromptLogprobs(_) => {
+            let chunk = CompletionChunk::text_chunk(&model, &id, String::new());
+            let json = serde_json::to_string(&chunk).unwrap_or_default();
+            Ok::<_, std::convert::Infallible>(Event::default().data(json))
+        }
         StreamEvent::Token(tok) | StreamEvent::TokenWithLogprobs(tok, _) => {
             all_toks.push(tok);
             let full = state.tokenizer.decode(&all_toks).unwrap_or_default();

--- a/crates/spark-server/src/api/completions_exec.rs
+++ b/crates/spark-server/src/api/completions_exec.rs
@@ -91,7 +91,9 @@ pub(super) async fn run_blocking(
                 grammar_spec: None,
                 // Distinct choices need distinct sampling streams; same
                 // offset scheme as chat_blocking's n>1 loop.
-                seed: req.seed.map(|s| s.wrapping_add((prompt_i * n + n_i) as u64)),
+                seed: req
+                    .seed
+                    .map(|s| s.wrapping_add((prompt_i * n + n_i) as u64)),
                 top_logprobs: p.logprobs_k,
                 prompt_logprobs: if req.echo { p.logprobs_k } else { None },
                 echo: req.echo,
@@ -142,10 +144,7 @@ pub(super) async fn run_blocking(
             let completion_text = strip_stop_sequences(completion_text, &req.stop);
             let completion_text = strip_thinking_tags(&completion_text);
             let text = if req.echo {
-                let prompt_text = state
-                    .tokenizer
-                    .decode(prompt_tokens)
-                    .unwrap_or_default();
+                let prompt_text = state.tokenizer.decode(prompt_tokens).unwrap_or_default();
                 format!("{prompt_text}{completion_text}")
             } else {
                 completion_text

--- a/crates/spark-server/src/api/completions_exec.rs
+++ b/crates/spark-server/src/api/completions_exec.rs
@@ -46,8 +46,12 @@ pub(super) async fn run_blocking(
     prompts: Vec<Vec<u32>>,
     p: CompletionParams,
 ) -> Response {
-    let n = req.n.max(1);
-    let mut choices: Vec<CompletionChoice> = Vec::with_capacity(prompts.len() * n);
+    // n is validated to 1..=128 at the handler entry. The capacity is a
+    // HINT clamped independently of user input (the vec grows amortized
+    // past it) so no request can size an allocation directly.
+    let n = req.n.clamp(1, 128);
+    let mut choices: Vec<CompletionChoice> =
+        Vec::with_capacity(prompts.len().saturating_mul(n).min(1024));
     let mut sum_prompt = 0usize;
     let mut sum_completion = 0usize;
     let mut sum_cached = 0usize;

--- a/crates/spark-server/src/api/completions_exec.rs
+++ b/crates/spark-server/src/api/completions_exec.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Blocking execution loop for legacy `/v1/completions`: batched prompts
+//! × `n` choices, sequential scheduler requests (mirrors the chat n>1
+//! loop in `chat_blocking.rs`), prompt-major choice indices
+//! (`index = prompt_i * n + n_i`), summed usage.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use std::sync::Arc;
+
+use crate::AppState;
+use crate::openai::{
+    CompletionChoice, CompletionRequest, CompletionResponse, RepetitionDetectionParams, Usage,
+};
+
+use super::compact::openai_error_response;
+use super::completions_logprobs::build_completion_logprobs;
+use super::inference_impl::strip_stop_sequences;
+use super::inference_types::InferenceRequest;
+use super::strip::strip_thinking_tags;
+
+/// Sampling/request parameters resolved once by the handler and shared
+/// by every choice in the request.
+pub(super) struct CompletionParams {
+    pub temperature: f32,
+    pub top_k: u32,
+    pub top_p: f32,
+    pub top_n_sigma: f32,
+    pub min_p: f32,
+    pub repetition_penalty: f32,
+    pub presence_penalty: f32,
+    pub frequency_penalty: f32,
+    pub logit_bias: Vec<(u32, f32)>,
+    pub stop_tokens: Vec<u32>,
+    pub repetition_detection: Option<RepetitionDetectionParams>,
+    /// Clamped `logprobs` (OpenAI integer form). Drives generated-token
+    /// logprobs always, and prompt logprobs when `echo` is set.
+    pub logprobs_k: Option<u8>,
+}
+
+/// Run every (prompt × n) choice sequentially and assemble the response.
+pub(super) async fn run_blocking(
+    state: Arc<AppState>,
+    req: &CompletionRequest,
+    prompts: Vec<Vec<u32>>,
+    p: CompletionParams,
+) -> Response {
+    let n = req.n.max(1);
+    let mut choices: Vec<CompletionChoice> = Vec::with_capacity(prompts.len() * n);
+    let mut sum_prompt = 0usize;
+    let mut sum_completion = 0usize;
+    let mut sum_cached = 0usize;
+    let mut sum_reasoning = 0usize;
+    let mut last_ttft = 0.0f64;
+    let mut last_tps = 0.0f64;
+
+    for (prompt_i, prompt_tokens) in prompts.iter().enumerate() {
+        for n_i in 0..n {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let session_hash = crate::session_manager::compute_session_hash(prompt_tokens);
+            let request = InferenceRequest::Blocking {
+                prompt_tokens: Arc::new(prompt_tokens.clone()),
+                session_hash,
+                image_pixels: Vec::new(),
+                max_tokens: req.max_tokens,
+                min_tokens: 0,
+                temperature: p.temperature,
+                top_k: p.top_k,
+                top_p: p.top_p,
+                top_n_sigma: p.top_n_sigma,
+                min_p: p.min_p,
+                repetition_penalty: p.repetition_penalty,
+                presence_penalty: p.presence_penalty,
+                frequency_penalty: p.frequency_penalty,
+                // Legacy /v1/completions path doesn't have tool semantics,
+                // so no DRY (would dampen legitimate long-repeated prose).
+                dry_multiplier: 0.0,
+                dry_base: 1.75,
+                dry_allowed_length: 2,
+                lz_penalty: 0.0,
+                logit_bias: p.logit_bias.clone(),
+                stop_tokens: p.stop_tokens.clone(),
+                enable_thinking: false,
+                thinking_budget: None,
+                repetition_detection: p.repetition_detection,
+                require_tool_call: false,
+                tools_present: false,
+                suppress_tool_call: false,
+                disable_mtp: false,
+                grammar_spec: None,
+                // Distinct choices need distinct sampling streams; same
+                // offset scheme as chat_blocking's n>1 loop.
+                seed: req.seed.map(|s| s.wrapping_add((prompt_i * n + n_i) as u64)),
+                top_logprobs: p.logprobs_k,
+                prompt_logprobs: if req.echo { p.logprobs_k } else { None },
+                echo: req.echo,
+                timeout_at: {
+                    let secs = state.request_timeout as f32;
+                    if secs > 0.0 {
+                        Some(std::time::Instant::now() + std::time::Duration::from_secs_f32(secs))
+                    } else {
+                        None
+                    }
+                },
+                response_tx: tx,
+            };
+
+            if state.request_tx.send(request).await.is_err() {
+                return openai_error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Scheduler queue full".to_string(),
+                );
+            }
+            let response = match rx.await {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => {
+                    return openai_error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Inference error: {e}"),
+                    );
+                }
+                Err(_) => {
+                    return openai_error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Inference cancelled".to_string(),
+                    );
+                }
+            };
+
+            let completion_text = match state.tokenizer.decode(&response.output_tokens) {
+                Ok(t) => t,
+                Err(e) => {
+                    return openai_error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Decode error: {e}"),
+                    );
+                }
+            };
+            // Strips apply to the COMPLETION only; echoed prompt text is
+            // returned verbatim per the legacy spec.
+            let completion_text = strip_stop_sequences(completion_text, &req.stop);
+            let completion_text = strip_thinking_tags(&completion_text);
+            let text = if req.echo {
+                let prompt_text = state
+                    .tokenizer
+                    .decode(prompt_tokens)
+                    .unwrap_or_default();
+                format!("{prompt_text}{completion_text}")
+            } else {
+                completion_text
+            };
+
+            let logprobs = p.logprobs_k.map(|_| {
+                let decode = |id: u32| state.tokenizer.decode(&[id]).unwrap_or_default();
+                build_completion_logprobs(
+                    &decode,
+                    req.echo,
+                    prompt_tokens,
+                    &response.prompt_logprobs,
+                    &response.output_tokens,
+                    &response.logprobs,
+                )
+            });
+
+            sum_prompt += prompt_tokens.len();
+            sum_completion += response.output_tokens.len();
+            sum_cached += response.cached_prompt_tokens as usize;
+            sum_reasoning += response.reasoning_tokens as usize;
+            last_ttft = response.time_to_first_token_ms;
+            last_tps = if response.decode_time_ms > 0.0 {
+                (response.output_tokens.len().saturating_sub(1)) as f64
+                    / (response.decode_time_ms / 1000.0)
+            } else {
+                0.0
+            };
+
+            choices.push(CompletionChoice {
+                index: prompt_i * n + n_i,
+                text,
+                finish_reason: response.finish_reason,
+                logprobs,
+            });
+        }
+    }
+
+    let usage = Usage {
+        prompt_tokens: sum_prompt,
+        completion_tokens: sum_completion,
+        total_tokens: sum_prompt + sum_completion,
+        prompt_tokens_details: Some(crate::openai::PromptTokensDetails {
+            cached_tokens: sum_cached,
+            audio_tokens: 0,
+        }),
+        completion_tokens_details: Some(crate::openai::CompletionTokensDetails {
+            reasoning_tokens: sum_reasoning,
+            audio_tokens: 0,
+            accepted_prediction_tokens: 0,
+            rejected_prediction_tokens: 0,
+        }),
+        time_to_first_token_ms: last_ttft,
+        response_tokens_per_second: last_tps,
+    };
+
+    Json(CompletionResponse::from_choices(
+        &state.model_name,
+        choices,
+        usage,
+    ))
+    .into_response()
+}

--- a/crates/spark-server/src/api/completions_logprobs.rs
+++ b/crates/spark-server/src/api/completions_logprobs.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Legacy `/v1/completions` logprobs assembly: the OpenAI four-parallel-
+//! array shape (`tokens` / `token_logprobs` / `top_logprobs` /
+//! `text_offset`), echo merging, and the null-first-token convention.
+//!
+//! `text_offset` is the cumulative character length of the per-token
+//! decoded strings — the same approximation vLLM uses. Byte-level BPE
+//! per-token decodes may not concatenate byte-for-byte to the single
+//! full-sequence decode shown in `text` (multibyte splits, leading-space
+//! pieces), so offsets can drift a few chars near such boundaries;
+//! reference implementations accept this.
+
+use crate::api::inference_types::TokenLogprobs;
+use crate::openai::CompletionLogprobs;
+
+/// Assemble the legacy logprobs block.
+///
+/// * `decode` — per-token-id detokenizer (injected so unit tests need no
+///   real tokenizer; production passes `state.tokenizer.decode(&[id])`).
+/// * `prompt_tokens`/`prompt_lps` — when echoing: `prompt_lps[i]` scores
+///   `prompt_tokens[i+1]` (the model-side collection excludes both the
+///   first token, which has no context, and the position that scores the
+///   first *generated* token). The first echoed token gets `null`.
+/// * `gen_tokens`/`gen_lps` — generated tokens and their decode-time
+///   logprobs. If the first generated token's logprobs were not
+///   captured (`gen_lps.len() == gen_tokens.len() - 1`), it is padded
+///   with `null` rather than misaligning the parallel arrays.
+pub(super) fn build_completion_logprobs(
+    decode: &dyn Fn(u32) -> String,
+    echo: bool,
+    prompt_tokens: &[u32],
+    prompt_lps: &[TokenLogprobs],
+    gen_tokens: &[u32],
+    gen_lps: &[TokenLogprobs],
+) -> CompletionLogprobs {
+    let cap = if echo { prompt_tokens.len() } else { 0 } + gen_tokens.len();
+    let mut tokens: Vec<String> = Vec::with_capacity(cap);
+    let mut token_logprobs: Vec<Option<f32>> = Vec::with_capacity(cap);
+    let mut top_logprobs = Vec::with_capacity(cap);
+    let mut text_offset: Vec<usize> = Vec::with_capacity(cap);
+    let mut offset = 0usize;
+
+    let mut push = |tok_id: u32, lp: Option<&TokenLogprobs>| {
+        let piece = decode(tok_id);
+        text_offset.push(offset);
+        offset += piece.len();
+        tokens.push(piece);
+        token_logprobs.push(lp.map(|l| l.logprob));
+        top_logprobs.push(lp.map(|l| {
+            l.top
+                .iter()
+                .map(|&(id, p)| (decode(id), p))
+                .collect::<std::collections::HashMap<String, f32>>()
+        }));
+    };
+
+    if echo {
+        for (i, &tok) in prompt_tokens.iter().enumerate() {
+            // Position i is scored by prompt_lps[i-1]; token 0 is null.
+            push(tok, i.checked_sub(1).and_then(|j| prompt_lps.get(j)));
+        }
+    }
+    // First-generated-token pad: see doc comment.
+    let gen_pad = gen_tokens.len().saturating_sub(gen_lps.len());
+    for (i, &tok) in gen_tokens.iter().enumerate() {
+        push(tok, i.checked_sub(gen_pad).and_then(|j| gen_lps.get(j)));
+    }
+
+    CompletionLogprobs {
+        tokens,
+        token_logprobs,
+        top_logprobs,
+        text_offset,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lp(token_id: u32, logprob: f32) -> TokenLogprobs {
+        TokenLogprobs {
+            token_id,
+            logprob,
+            top: vec![(token_id, logprob)],
+        }
+    }
+
+    // Test decoder: token id N → "tN " (3+ chars, deterministic offsets).
+    fn dec(id: u32) -> String {
+        format!("t{id} ")
+    }
+
+    #[test]
+    fn echo_null_first_then_prompt_scores() {
+        // prompt [10, 11, 12]; collection scored positions 0,1 → targets 11,12.
+        let out = build_completion_logprobs(
+            &dec,
+            true,
+            &[10, 11, 12],
+            &[lp(11, -0.1), lp(12, -0.2)],
+            &[],
+            &[],
+        );
+        assert_eq!(out.tokens, vec!["t10 ", "t11 ", "t12 "]);
+        assert_eq!(out.token_logprobs, vec![None, Some(-0.1), Some(-0.2)]);
+        assert!(out.top_logprobs[0].is_none());
+        assert!(out.top_logprobs[1].as_ref().unwrap().contains_key("t11 "));
+    }
+
+    #[test]
+    fn text_offset_is_cumulative_decoded_length() {
+        let out = build_completion_logprobs(&dec, true, &[7, 8], &[lp(8, -0.3)], &[9], &[lp(9, -0.4)]);
+        // "t7 "(3) "t8 "(3) "t9 "(3)
+        assert_eq!(out.text_offset, vec![0, 3, 6]);
+    }
+
+    #[test]
+    fn echo_concatenates_prompt_then_generated() {
+        let out = build_completion_logprobs(
+            &dec,
+            true,
+            &[1, 2],
+            &[lp(2, -0.1)],
+            &[3, 4],
+            &[lp(3, -0.2), lp(4, -0.3)],
+        );
+        assert_eq!(out.tokens.len(), 4);
+        assert_eq!(out.token_logprobs, vec![None, Some(-0.1), Some(-0.2), Some(-0.3)]);
+    }
+
+    #[test]
+    fn no_echo_generated_only_with_first_token_pad() {
+        // 3 generated tokens but only 2 logprob entries (first-token
+        // logprobs not captured at prefill) → null-padded front.
+        let out = build_completion_logprobs(
+            &dec,
+            false,
+            &[1, 2, 3],
+            &[],
+            &[5, 6, 7],
+            &[lp(6, -0.1), lp(7, -0.2)],
+        );
+        assert_eq!(out.tokens.len(), 3);
+        assert_eq!(out.token_logprobs, vec![None, Some(-0.1), Some(-0.2)]);
+    }
+
+    #[test]
+    fn scoring_only_prompt_len_entries() {
+        // max_tokens=0: entries == prompt_len, first null, none missing.
+        let prompt = [10u32, 11, 12, 13];
+        let lps = [lp(11, -1.0), lp(12, -2.0), lp(13, -3.0)];
+        let out = build_completion_logprobs(&dec, true, &prompt, &lps, &[], &[]);
+        assert_eq!(out.tokens.len(), prompt.len());
+        assert_eq!(out.token_logprobs[0], None);
+        assert!(out.token_logprobs[1..].iter().all(Option::is_some));
+    }
+}

--- a/crates/spark-server/src/api/completions_logprobs.rs
+++ b/crates/spark-server/src/api/completions_logprobs.rs
@@ -111,7 +111,8 @@ mod tests {
 
     #[test]
     fn text_offset_is_cumulative_decoded_length() {
-        let out = build_completion_logprobs(&dec, true, &[7, 8], &[lp(8, -0.3)], &[9], &[lp(9, -0.4)]);
+        let out =
+            build_completion_logprobs(&dec, true, &[7, 8], &[lp(8, -0.3)], &[9], &[lp(9, -0.4)]);
         // "t7 "(3) "t8 "(3) "t9 "(3)
         assert_eq!(out.text_offset, vec![0, 3, 6]);
     }
@@ -127,7 +128,10 @@ mod tests {
             &[lp(3, -0.2), lp(4, -0.3)],
         );
         assert_eq!(out.tokens.len(), 4);
-        assert_eq!(out.token_logprobs, vec![None, Some(-0.1), Some(-0.2), Some(-0.3)]);
+        assert_eq!(
+            out.token_logprobs,
+            vec![None, Some(-0.1), Some(-0.2), Some(-0.3)]
+        );
     }
 
     #[test]

--- a/crates/spark-server/src/api/inference_impl.rs
+++ b/crates/spark-server/src/api/inference_impl.rs
@@ -315,6 +315,18 @@ impl InferenceRequest {
         }
     }
 
+    /// Legacy /v1/completions prompt-token logprobs (echo scoring).
+    pub fn prompt_logprobs(&self) -> Option<u8> {
+        match self {
+            InferenceRequest::Blocking {
+                prompt_logprobs, ..
+            } => *prompt_logprobs,
+            InferenceRequest::Streaming {
+                prompt_logprobs, ..
+            } => *prompt_logprobs,
+        }
+    }
+
     /// Request timeout deadline. None = no timeout.
     pub fn timeout_at(&self) -> Option<std::time::Instant> {
         match self {

--- a/crates/spark-server/src/api/inference_types.rs
+++ b/crates/spark-server/src/api/inference_types.rs
@@ -134,6 +134,13 @@ pub enum InferenceRequest {
         seed: Option<u64>,
         /// Number of top logprobs to return per token. None = disabled.
         top_logprobs: Option<u8>,
+        /// Legacy /v1/completions `logprobs`: Some(k) = collect prompt-token
+        /// logprobs (top-k alternatives) during prefill. Forces full
+        /// recompute (prefix cache bypassed) so every position is scored.
+        prompt_logprobs: Option<u8>,
+        /// Legacy /v1/completions `echo`: prepend the prompt to the
+        /// response text (handler-side; carried here for symmetry/logging).
+        echo: bool,
         /// Request timeout as absolute deadline. None = no timeout.
         timeout_at: Option<std::time::Instant>,
         response_tx: tokio::sync::oneshot::Sender<anyhow::Result<InferenceResponse>>,
@@ -210,6 +217,11 @@ pub enum InferenceRequest {
         seed: Option<u64>,
         /// Number of top logprobs to return per token. None = disabled.
         top_logprobs: Option<u8>,
+        /// Legacy /v1/completions `logprobs`: Some(k) = collect prompt-token
+        /// logprobs during prefill (see Blocking variant).
+        prompt_logprobs: Option<u8>,
+        /// Legacy /v1/completions `echo` (see Blocking variant).
+        echo: bool,
         /// Request timeout as absolute deadline. None = no timeout.
         timeout_at: Option<std::time::Instant>,
         token_tx: tokio::sync::mpsc::Sender<StreamEvent>,
@@ -255,6 +267,11 @@ pub struct InferenceResponse {
     /// Number of prompt tokens served by the prefix cache (no prefill compute
     /// cost). Reported as `usage.prompt_tokens_details.cached_tokens`.
     pub cached_prompt_tokens: u32,
+    /// Prompt-token logprobs (legacy /v1/completions `logprobs` + `echo`):
+    /// one entry per prompt position i in [0, prompt_len-1) scoring token
+    /// i+1. Empty unless requested. The handler prepends the null entry
+    /// for the first prompt token (no preceding context).
+    pub prompt_logprobs: Vec<TokenLogprobs>,
 }
 
 /// Events sent during streaming generation.
@@ -262,6 +279,9 @@ pub enum StreamEvent {
     Token(u32),
     /// Token with logprobs data (when top_logprobs is requested).
     TokenWithLogprobs(u32, TokenLogprobs),
+    /// Prompt-token logprobs, emitted once right after prefill when
+    /// `prompt_logprobs` was requested (legacy completions echo path).
+    PromptLogprobs(Vec<TokenLogprobs>),
     Done {
         finish_reason: String,
         prompt_tokens: usize,

--- a/crates/spark-server/src/api/mod.rs
+++ b/crates/spark-server/src/api/mod.rs
@@ -34,6 +34,8 @@ pub mod chat_stream;
 pub mod chat_stream_dispatch;
 pub mod compact;
 pub mod completions;
+pub mod completions_exec;
+pub mod completions_logprobs;
 pub mod conversations;
 pub mod inference_impl;
 pub mod inference_types;

--- a/crates/spark-server/src/openai/completions.rs
+++ b/crates/spark-server/src/openai/completions.rs
@@ -101,7 +101,7 @@ pub struct CompletionLogprobs {
 ///   - `"hello"`              → `Text`
 ///   - `[128000, 9906, ...]`  → `TokenIds`     (bypasses tokenization)
 ///   - `[[128000], [9906]]`   → `TokenIdBatch` (bypasses tokenization)
-///   - `["hello", "world"]`   → `TextArray`    (joined, then tokenized)
+///   - `["hello", "world"]`   → `TextArray`    (one prompt per element)
 ///
 /// ── serde-untagged ordering rationale ──
 /// `#[serde(untagged)]` tries variants top-to-bottom and accepts the first
@@ -128,13 +128,12 @@ pub enum PromptInput {
     /// Pre-tokenized prompt: integer token IDs fed to the scheduler
     /// verbatim (no tokenization, no BOS prepended).
     TokenIds(Vec<u32>),
-    /// Batch of pre-tokenized prompts. The legacy `/v1/completions`
-    /// handler is single-prompt, so the batch is flattened (concatenated)
-    /// into one token sequence, matching the existing string-array
-    /// behavior of joining multiple string prompts.
+    /// Batch of pre-tokenized prompts: one INDEPENDENT prompt per
+    /// sub-array, each yielding its own choice (OpenAI batch semantics;
+    /// lm-eval batch_size>1 sends this form).
     TokenIdBatch(Vec<Vec<u32>>),
-    /// Array of text prompts — joined (matching prior behavior) then
-    /// tokenized.
+    /// Array of text prompts — one independent prompt per element, each
+    /// tokenized separately and yielding its own choice.
     TextArray(Vec<String>),
 }
 
@@ -208,6 +207,10 @@ pub struct CompletionChunkChoice {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<String>,
+    /// Present only on the echo chunk (legacy `echo` + `logprobs` while
+    /// streaming: the prompt text + its logprobs precede generation).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<CompletionLogprobs>,
 }
 
 impl CompletionChunk {
@@ -222,8 +225,63 @@ impl CompletionChunk {
                 index: 0,
                 text,
                 finish_reason: None,
+                logprobs: None,
             }],
             usage: None,
+        }
+    }
+
+    /// Echo chunk: the prompt text (plus its logprobs when requested),
+    /// emitted before any generated-token chunk.
+    pub fn echo_chunk(
+        model: &str,
+        id: &str,
+        text: String,
+        logprobs: Option<CompletionLogprobs>,
+    ) -> Self {
+        Self {
+            id: id.to_string(),
+            object: "text_completion".to_string(),
+            created: unix_timestamp(),
+            model: model.to_string(),
+            choices: vec![CompletionChunkChoice {
+                index: 0,
+                text,
+                finish_reason: None,
+                logprobs,
+            }],
+            usage: None,
+        }
+    }
+
+    /// Finish chunk WITHOUT usage — used with `stream_options.include_usage`,
+    /// where usage arrives in a separate `choices: []` chunk (chat parity).
+    pub fn finish_chunk_no_usage(model: &str, id: &str, finish_reason: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            object: "text_completion".to_string(),
+            created: unix_timestamp(),
+            model: model.to_string(),
+            choices: vec![CompletionChunkChoice {
+                index: 0,
+                text: String::new(),
+                finish_reason: Some(finish_reason.to_string()),
+                logprobs: None,
+            }],
+            usage: None,
+        }
+    }
+
+    /// Usage-only chunk (`choices: []`), emitted before `[DONE]` when
+    /// `stream_options.include_usage` is set.
+    pub fn usage_only_chunk(model: &str, id: &str, usage: Usage) -> Self {
+        Self {
+            id: id.to_string(),
+            object: "text_completion".to_string(),
+            created: unix_timestamp(),
+            model: model.to_string(),
+            choices: Vec::new(),
+            usage: Some(usage),
         }
     }
 
@@ -238,6 +296,7 @@ impl CompletionChunk {
                 index: 0,
                 text: String::new(),
                 finish_reason: Some(finish_reason.to_string()),
+                logprobs: None,
             }],
             usage: Some(usage),
         }

--- a/crates/spark-server/src/openai/completions.rs
+++ b/crates/spark-server/src/openai/completions.rs
@@ -51,6 +51,49 @@ pub struct CompletionRequest {
     /// use server default.
     #[serde(default)]
     pub repetition_detection: Option<RepetitionDetectionParams>,
+    /// Echo the prompt back in the response text before the completion
+    /// (OpenAI legacy spec, default false). With `logprobs` set and
+    /// `max_tokens: 0` this is the loglikelihood-scoring call used by
+    /// eval harnesses (lm-eval): prompt-token logprobs, no generation.
+    #[serde(default)]
+    pub echo: bool,
+    /// Legacy integer logprobs (OpenAI spec 0-5): return the logprob of
+    /// each token plus the `logprobs` most-likely alternatives. Applies
+    /// to generated tokens, and to prompt tokens when `echo` is set.
+    /// Atlas accepts up to 20 (clamped), matching the chat endpoint.
+    pub logprobs: Option<u8>,
+    /// Number of completions per prompt (OpenAI spec default 1).
+    /// Choices are ordered prompt-major: index = prompt_i * n + n_i.
+    #[serde(default = "default_n")]
+    pub n: usize,
+    /// `include_usage`: emit a final usage-only chunk before `[DONE]`
+    /// when streaming (same semantics as chat completions).
+    pub stream_options: Option<StreamOptions>,
+    /// Accepted for OpenAI compatibility; not used by Atlas (no abuse
+    /// telemetry). Rejecting it would break SDK forward-compat.
+    #[allow(dead_code)]
+    pub user: Option<String>,
+    /// Accepted for OpenAI compatibility; fill-in-the-middle is not
+    /// supported (model-dependent feature). Ignored, never errors.
+    #[allow(dead_code)]
+    pub suffix: Option<String>,
+    /// Accepted for OpenAI compatibility; server-side best-of ranking is
+    /// not implemented (vLLM dropped it too). Treated as `n`.
+    #[allow(dead_code)]
+    pub best_of: Option<usize>,
+}
+
+/// Legacy `/v1/completions` logprobs block: four parallel arrays (OpenAI
+/// spec shape — distinct from chat's per-token objects). When `echo` is
+/// set the arrays cover prompt tokens first, then generated tokens; the
+/// first prompt token's `token_logprobs`/`top_logprobs` entries are
+/// `null` (no preceding context to condition on).
+#[derive(Debug, Serialize)]
+pub struct CompletionLogprobs {
+    pub tokens: Vec<String>,
+    pub token_logprobs: Vec<Option<f32>>,
+    pub top_logprobs: Vec<Option<std::collections::HashMap<String, f32>>>,
+    pub text_offset: Vec<usize>,
 }
 
 /// OpenAI-compatible `prompt` field. Mirrors the four shapes the
@@ -104,6 +147,9 @@ pub struct CompletionResponse {
     pub model: String,
     pub choices: Vec<CompletionChoice>,
     pub usage: Usage,
+    /// Matches chat completions ("fp_atlas"); some SDKs read it for
+    /// seed/determinism bookkeeping.
+    pub system_fingerprint: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -111,21 +157,35 @@ pub struct CompletionChoice {
     pub index: usize,
     pub text: String,
     pub finish_reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<CompletionLogprobs>,
 }
 
 impl CompletionResponse {
     pub fn new(model: &str, text: String, usage: Usage, finish_reason: &str) -> Self {
+        Self::from_choices(
+            model,
+            vec![CompletionChoice {
+                index: 0,
+                text,
+                finish_reason: finish_reason.to_string(),
+                logprobs: None,
+            }],
+            usage,
+        )
+    }
+
+    /// Multi-choice constructor (batched prompts × n). Choices must
+    /// already carry prompt-major indices (prompt_i * n + n_i).
+    pub fn from_choices(model: &str, choices: Vec<CompletionChoice>, usage: Usage) -> Self {
         Self {
             id: format!("cmpl-{}", uuid_v4()),
             object: "text_completion".to_string(),
             created: unix_timestamp(),
             model: model.to_string(),
-            choices: vec![CompletionChoice {
-                index: 0,
-                text,
-                finish_reason: finish_reason.to_string(),
-            }],
+            choices,
             usage,
+            system_fingerprint: "fp_atlas".to_string(),
         }
     }
 }

--- a/crates/spark-server/src/openai/tests.rs
+++ b/crates/spark-server/src/openai/tests.rs
@@ -397,7 +397,10 @@ fn completion_logprobs_serializes_four_parallel_arrays_with_nulls() {
         token_logprobs: vec![None, Some(-0.5)],
         top_logprobs: vec![
             None,
-            Some(std::collections::HashMap::from([("llo".to_string(), -0.5f32)])),
+            Some(std::collections::HashMap::from([(
+                "llo".to_string(),
+                -0.5f32,
+            )])),
         ],
         text_offset: vec![0, 2],
     };

--- a/crates/spark-server/src/openai/tests.rs
+++ b/crates/spark-server/src/openai/tests.rs
@@ -350,3 +350,80 @@ fn server_default_not_merged_when_request_explicit() {
     assert!(req.chat_template_kwargs.is_none());
     assert!(req.resolve_thinking(false).0);
 }
+
+// ── Legacy /v1/completions echo + logprobs wire types ──
+
+#[test]
+fn completion_request_echo_logprobs_n_deser() {
+    let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test",
+        "prompt": "hello",
+        "echo": true,
+        "logprobs": 3,
+        "n": 2,
+        "max_tokens": 0,
+        "stream_options": {"include_usage": true},
+        "user": "eval-harness",
+        "suffix": "tail",
+        "best_of": 2,
+    }))
+    .expect("valid completion request");
+    assert!(req.echo);
+    assert_eq!(req.logprobs, Some(3));
+    assert_eq!(req.n, 2);
+    assert_eq!(req.max_tokens, 0);
+    assert!(req.stream_options.expect("stream_options").include_usage);
+}
+
+#[test]
+fn completion_request_defaults_match_openai_spec() {
+    // echo=false, n=1, logprobs absent — the spec defaults; a request
+    // that names none of the new fields must behave exactly as before.
+    let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test",
+        "prompt": "hello",
+    }))
+    .expect("valid completion request");
+    assert!(!req.echo);
+    assert_eq!(req.n, 1);
+    assert!(req.logprobs.is_none());
+    assert!(req.stream_options.is_none());
+}
+
+#[test]
+fn completion_logprobs_serializes_four_parallel_arrays_with_nulls() {
+    let lp = CompletionLogprobs {
+        tokens: vec!["He".into(), "llo".into()],
+        token_logprobs: vec![None, Some(-0.5)],
+        top_logprobs: vec![
+            None,
+            Some(std::collections::HashMap::from([("llo".to_string(), -0.5f32)])),
+        ],
+        text_offset: vec![0, 2],
+    };
+    let v = serde_json::to_value(&lp).expect("serialize");
+    // Legacy shape: 4 parallel arrays, JSON null for the first echoed token.
+    assert!(v["token_logprobs"][0].is_null());
+    assert!(v["top_logprobs"][0].is_null());
+    assert_eq!(v["tokens"].as_array().map(Vec::len), Some(2));
+    assert_eq!(v["text_offset"][1], 2);
+}
+
+#[test]
+fn completion_response_carries_system_fingerprint_and_optional_logprobs() {
+    let usage = Usage {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+        prompt_tokens_details: None,
+        completion_tokens_details: None,
+        time_to_first_token_ms: 0.0,
+        response_tokens_per_second: 0.0,
+    };
+    let resp = CompletionResponse::new("m", "hi".into(), usage, "stop");
+    let v = serde_json::to_value(&resp).expect("serialize");
+    assert_eq!(v["system_fingerprint"], "fp_atlas");
+    // logprobs must be ABSENT (not null) when not requested — some
+    // clients treat an explicit null as a malformed logprobs block.
+    assert!(v["choices"][0].get("logprobs").is_none());
+}

--- a/crates/spark-server/src/openai/tests.rs
+++ b/crates/spark-server/src/openai/tests.rs
@@ -430,3 +430,15 @@ fn completion_response_carries_system_fingerprint_and_optional_logprobs() {
     // clients treat an explicit null as a malformed logprobs block.
     assert!(v["choices"][0].get("logprobs").is_none());
 }
+
+#[test]
+fn completion_request_n_bounds_are_handler_enforced() {
+    // serde accepts any usize; the HANDLER rejects n==0 and n>128 with a
+    // 400 (OpenAI spec bound). This test locks the parse side: values
+    // arrive intact for the handler check (no silent serde clamping).
+    let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "m", "prompt": "p", "n": 4096,
+    }))
+    .expect("parse");
+    assert_eq!(req.n, 4096);
+}

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -47,7 +47,14 @@ pub fn finish_sequence(model: &dyn Model, a: &mut ActiveSeq) {
                         logprobs: std::mem::take(&mut a.logprobs_data),
                         reasoning_tokens: a.thinking_tokens,
                         cached_prompt_tokens: a.cached_prompt_tokens,
-                        prompt_logprobs: Vec::new(),
+                        prompt_logprobs: std::mem::take(&mut a.seq.prompt_logprobs)
+                            .into_iter()
+                            .map(|p| crate::api::TokenLogprobs {
+                                token_id: p.token_id,
+                                logprob: p.logprob,
+                                top: p.top,
+                            })
+                            .collect(),
                     }))
                     .is_err()
                 {

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -47,6 +47,7 @@ pub fn finish_sequence(model: &dyn Model, a: &mut ActiveSeq) {
                         logprobs: std::mem::take(&mut a.logprobs_data),
                         reasoning_tokens: a.thinking_tokens,
                         cached_prompt_tokens: a.cached_prompt_tokens,
+                        prompt_logprobs: Vec::new(),
                     }))
                     .is_err()
                 {

--- a/crates/spark-server/src/scheduler/logprobs.rs
+++ b/crates/spark-server/src/scheduler/logprobs.rs
@@ -13,34 +13,12 @@ pub fn extract_logprobs_from_f32(
     sampled_token: u32,
     k: usize,
 ) -> crate::api::TokenLogprobs {
-    // Log-softmax: logprob = logit - log(sum(exp(logits)))
-    let max_logit = f32_logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-    let log_sum_exp = max_logit
-        + f32_logits
-            .iter()
-            .map(|&l| (l - max_logit).exp())
-            .sum::<f32>()
-            .ln();
-    let sampled_logprob = if (sampled_token as usize) < f32_logits.len() {
-        f32_logits[sampled_token as usize] - log_sum_exp
-    } else {
-        f32::NEG_INFINITY
-    };
-    // Find top-K by partial sort.
-    let mut indexed: Vec<(u32, f32)> = f32_logits
-        .iter()
-        .enumerate()
-        .map(|(j, &l)| (j as u32, l - log_sum_exp))
-        .collect();
-    let nth = k.min(indexed.len().saturating_sub(1));
-    indexed.select_nth_unstable_by(nth, |a, b| {
-        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
-    });
-    let mut top: Vec<(u32, f32)> = indexed[..k.min(indexed.len())].to_vec();
-    top.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    // SSOT: the log-softmax + top-k math lives in spark-model
+    // (`traits::logprobs`), shared with prompt-logprob collection.
+    let (logprob, top) = spark_model::traits::logprob_of(f32_logits, sampled_token, k);
     crate::api::TokenLogprobs {
         token_id: sampled_token,
-        logprob: sampled_logprob,
+        logprob,
         top,
     }
 }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -182,8 +182,17 @@ pub(super) fn continue_in_progress_prefills(
     let q12_dispatch_disabled = std::env::var("ATLAS_BISECT_Q12_DISABLE")
         .map(|v| v == "1" || v.to_lowercase() == "true")
         .unwrap_or(false);
-    let can_batch_prefill_only =
-        !q12_dispatch_disabled && prefilling.len() >= 2 && active.is_empty() && !model.is_ep();
+    // Prompt-logprob collection (legacy echo scoring) is single-stream
+    // only: the batched dispatch's hidden-buffer stream offsets are not
+    // wired into the collection helper. Rare debug/eval traffic.
+    let any_collecting = prefilling
+        .iter()
+        .any(|p| p.seq.collect_prompt_logprobs.is_some());
+    let can_batch_prefill_only = !q12_dispatch_disabled
+        && !any_collecting
+        && prefilling.len() >= 2
+        && active.is_empty()
+        && !model.is_ep();
     // When ATLAS_HOLO_ALWAYS_MIXED is on, COLLAPSE the multi-prefill+decode
     // case onto the single-stream fused path below (FIFO head prefill fused
     // with all active decodes via mixed_forward, sized by the slice budget)
@@ -193,6 +202,7 @@ pub(super) fn continue_in_progress_prefills(
     // improvement). The non-head prefill streams advance on subsequent ticks.
     let can_batch_mixed = !always_mixed
         && !q12_dispatch_disabled
+        && !any_collecting
         && prefilling.len() >= 2
         && !active.is_empty()
         && !single_active_with_spec

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -23,7 +23,7 @@ pub(super) fn promote_completed_prefills(
     // Process in reverse order so swap_remove indices stay valid.
     completed_indices.sort_unstable_by_key(|x| std::cmp::Reverse(x.0));
     for (idx, maybe_token) in completed_indices {
-        let p = prefilling.swap_remove(idx);
+        let mut p = prefilling.swap_remove(idx);
         let Some(first) = maybe_token else {
             // Error path: free the sequence.
             let mut seq = p.seq;
@@ -38,8 +38,27 @@ pub(super) fn promote_completed_prefills(
             continue;
         };
         let spontaneous_think = !p.enable_thinking && think_start_token == Some(first);
+        // Legacy echo+logprobs: prompt logprobs precede any token event.
+        if p.seq.collect_prompt_logprobs.is_some()
+            && let ResponseSink::Streaming(ref tx) = p.sink
+        {
+            let lps: Vec<crate::api::TokenLogprobs> = p
+                .seq
+                .prompt_logprobs
+                .drain(..)
+                .map(|lp| crate::api::TokenLogprobs {
+                    token_id: lp.token_id,
+                    logprob: lp.logprob,
+                    top: lp.top,
+                })
+                .collect();
+            if let Err(e) = tx.blocking_send(StreamEvent::PromptLogprobs(lps)) {
+                tracing::warn!("phase_promote_prefills: prompt-logprobs send failed: {e}");
+            }
+        }
         // Only stream non-EOS tokens (OpenAI: stop seq not in output).
         if !spontaneous_think
+            && p.max_tokens > 0
             && !p.eos_tokens.contains(&first)
             && let ResponseSink::Streaming(ref tx) = p.sink
             && let Err(e) = tx.blocking_send(StreamEvent::Token(first))
@@ -105,7 +124,7 @@ fn build_active_seq_from_prefill(
         seq: p.seq,
         session_hash: p.session_hash,
         last_token: first,
-        output_tokens: if !immediate_finish && spontaneous_think {
+        output_tokens: if (!immediate_finish && spontaneous_think) || p.max_tokens == 0 {
             vec![]
         } else {
             vec![first]

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -374,7 +374,11 @@ pub fn start_chunked_prefill(
                 last_token: first,
                 // max_tokens==0 (scoring-only): the sampled token is
                 // discarded — empty output derives finish_reason="length".
-                output_tokens: if max_tokens == 0 { Vec::new() } else { vec![first] },
+                output_tokens: if max_tokens == 0 {
+                    Vec::new()
+                } else {
+                    vec![first]
+                },
                 remaining: 0,
                 min_tokens: req_min_tokens,
                 eos_tokens: eos_tokens.to_vec(),

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -69,6 +69,7 @@ pub fn start_chunked_prefill(
     let req_disable_mtp = req.disable_mtp();
     let req_seed = req.seed();
     let req_top_logprobs = req.top_logprobs();
+    let req_prompt_logprobs = req.prompt_logprobs();
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
     let mut grammar_state = compile_grammar_state(grammar_engine, &grammar_spec, eos_tokens);
@@ -130,6 +131,7 @@ pub fn start_chunked_prefill(
         }
     };
     seq.session_hash = req_session_hash;
+    seq.collect_prompt_logprobs = req_prompt_logprobs;
 
     // Deferred co-dispatch: setup + EP broadcast, then return InProgress at
     // chunk 0 WITHOUT prefilling — the batched step packs >=2 streams into one
@@ -328,7 +330,28 @@ pub fn start_chunked_prefill(
         };
 
         let spontaneous_think = !req_enable_thinking && think_start_token == Some(first);
+        // Legacy echo+logprobs: hand prompt logprobs to a streaming client
+        // BEFORE any token event (blocking carries them via finish_sequence).
+        if req_prompt_logprobs.is_some()
+            && let ResponseSink::Streaming(ref tx) = sink
+        {
+            let lps: Vec<crate::api::TokenLogprobs> = seq
+                .prompt_logprobs
+                .drain(..)
+                .map(|p| crate::api::TokenLogprobs {
+                    token_id: p.token_id,
+                    logprob: p.logprob,
+                    top: p.top,
+                })
+                .collect();
+            if let Err(e) = tx.blocking_send(StreamEvent::PromptLogprobs(lps)) {
+                tracing::warn!("prefill_a_step: prompt-logprobs send failed: {e}");
+            }
+        }
+        // max_tokens==0 is a scoring-only call: no generated token leaves
+        // the server (the sampled `first` is discarded below too).
         if !spontaneous_think
+            && max_tokens > 0
             && let ResponseSink::Streaming(ref tx) = sink
             && let Err(e) = tx.blocking_send(StreamEvent::Token(first))
         {
@@ -349,7 +372,9 @@ pub fn start_chunked_prefill(
                 seq,
                 session_hash: req_session_hash,
                 last_token: first,
-                output_tokens: vec![first],
+                // max_tokens==0 (scoring-only): the sampled token is
+                // discarded — empty output derives finish_reason="length".
+                output_tokens: if max_tokens == 0 { Vec::new() } else { vec![first] },
                 remaining: 0,
                 min_tokens: req_min_tokens,
                 eos_tokens: eos_tokens.to_vec(),

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -165,14 +165,32 @@ pub fn prefill_request(
     // Spontaneous <think>: if the first token is <think> and thinking was not
     // requested, suppress it and enter thinking mode on the ActiveSeq.
     let spontaneous_think = !req_enable_thinking && think_start_token == Some(first);
+    // Legacy echo+logprobs: prompt logprobs precede any token event.
+    if seq.collect_prompt_logprobs.is_some()
+        && let ResponseSink::Streaming(ref tx) = sink
+    {
+        let lps: Vec<crate::api::TokenLogprobs> = seq
+            .prompt_logprobs
+            .drain(..)
+            .map(|p| crate::api::TokenLogprobs {
+                token_id: p.token_id,
+                logprob: p.logprob,
+                top: p.top,
+            })
+            .collect();
+        if let Err(e) = tx.blocking_send(StreamEvent::PromptLogprobs(lps)) {
+            tracing::warn!("prefill_b_step: prompt-logprobs send failed: {e}");
+        }
+    }
     if !spontaneous_think
+        && max_tokens > 0
         && let ResponseSink::Streaming(ref tx) = sink
         && let Err(e) = tx.blocking_send(StreamEvent::Token(first))
     {
         tracing::warn!("prefill_b_step: first-token send failed (receiver dropped): {e}");
     }
 
-    let output_tokens = if spontaneous_think {
+    let output_tokens = if spontaneous_think || max_tokens == 0 {
         vec![]
     } else {
         vec![first]

--- a/crates/spark-server/tests/integration.rs
+++ b/crates/spark-server/tests/integration.rs
@@ -507,3 +507,87 @@ fn speculative_decode_coherence() -> Result<()> {
     tracing::info!("Speculative decode coherence test PASSED");
     Ok(())
 }
+
+/// Legacy /v1/completions echo+logprobs: prompt-token logprob collection
+/// during chunked prefill (the loglikelihood-scoring core).
+///
+/// Verifies, on a real model:
+/// 1. entries == prompt_len - 1 (position i scores tokens[i+1]; the
+///    final position — scoring the first GENERATED token — is excluded);
+/// 2. every logprob is finite and <= 0 (valid log-probability);
+/// 3. token_id fields equal the actual next prompt tokens;
+/// 4. top-k alternatives are sorted descending and contain the scored
+///    token's logprob consistently (the target's logprob can never
+///    exceed the top-1 alternative);
+/// 5. a control sequence WITHOUT the flag collects nothing (zero-cost
+///    default path untouched).
+#[test]
+#[ignore] // Requires GPU + model weights (ATLAS_INTEGRATION_MODEL_DIR)
+fn prompt_logprobs_collection_during_prefill() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .try_init()
+        .ok();
+    let model_dir_buf = model_dir_path();
+    if !model_dir_buf.exists() {
+        eprintln!(
+            "SKIP: model directory not found: {}\n      \
+             Set ATLAS_INTEGRATION_MODEL_DIR to a HuggingFace snapshot path.",
+            model_dir_buf.display()
+        );
+        return Ok(());
+    }
+    let model_dir: &Path = model_dir_buf.as_path();
+    let (model, config) = setup_model(model_dir)?;
+    use spark_server::tokenizer::ChatTokenizer;
+    let tokenizer = ChatTokenizer::from_model_dir(
+        model_dir,
+        config.eos_token_id,
+        false,
+        &config.model_type,
+        None,
+    )?;
+
+    let prompt = "The capital of France is Paris. The capital of Germany is";
+    let prompt_tokens = tokenizer.encode(prompt)?;
+    let n = prompt_tokens.len();
+    assert!(n >= 4, "prompt too short to exercise scoring");
+
+    // Collecting sequence: k=2 alternatives.
+    let mut seq = model.alloc_sequence()?;
+    seq.collect_prompt_logprobs = Some(2);
+    let _ = model.prefill_chunk(&prompt_tokens, &mut seq, 0, n, true, 0)?;
+
+    assert_eq!(
+        seq.prompt_logprobs.len(),
+        n - 1,
+        "one entry per prompt position scoring the NEXT prompt token"
+    );
+    for (i, lp) in seq.prompt_logprobs.iter().enumerate() {
+        assert_eq!(lp.token_id, prompt_tokens[i + 1], "target at position {i}");
+        assert!(lp.logprob.is_finite(), "logprob finite at {i}");
+        assert!(lp.logprob <= 0.0, "logprob <= 0 at {i}: {}", lp.logprob);
+        assert_eq!(lp.top.len(), 2, "top-k size at {i}");
+        assert!(lp.top[0].1 >= lp.top[1].1, "top sorted desc at {i}");
+        assert!(
+            lp.logprob <= lp.top[0].1 + 1e-4,
+            "target logprob cannot exceed top-1 at {i}"
+        );
+    }
+    // The high-certainty continuation ("... Germany is" scored against
+    // the actual next token) sanity: total loglikelihood is negative
+    // and not astronomically so on a coherent prompt.
+    let total: f32 = seq.prompt_logprobs.iter().map(|l| l.logprob).sum();
+    assert!(total < 0.0 && total > -200.0, "plausible total ll: {total}");
+    model.free_sequence(&mut seq)?;
+
+    // Control: default path collects nothing.
+    let mut seq2 = model.alloc_sequence()?;
+    let _ = model.prefill_chunk(&prompt_tokens, &mut seq2, 0, n, true, 0)?;
+    assert!(
+        seq2.prompt_logprobs.is_empty(),
+        "no collection without the flag"
+    );
+    model.free_sequence(&mut seq2)?;
+    Ok(())
+}


### PR DESCRIPTION
# feat(server): `/v1/completions` echo + logprobs + full legacy-API parity

## Why

`echo=true` + integer `logprobs` + `max_tokens=0` on legacy `/v1/completions` is how lm-eval-harness and every loglikelihood/multiple-choice evaluator scores prompts. Atlas had neither field, so likelihood-based evals (MMLU/HellaSwag/lambada-style) could not run against it — only generative ones. vLLM and llama.cpp both support this surface. A user asked exactly this ("does Atlas lack echo+logprobs?"); a full OpenAI-spec gap analysis confirmed the completions endpoint was the one place Atlas materially trailed the spec.

## What

**`/v1/completions` (the bulk):**
- `echo`, integer `logprobs` (top-k), and a true `max_tokens=0` scoring path (previously one token leaked out — the `max_tokens <= 1` guard sampled and emitted `first`). Empty output now derives `finish_reason="length"`, `completion_tokens=0`.
- **Prompt-token logprobs from prefill**: hidden states for every prompt position already existed in the prefill buffers; only the last row was ever projected. When requested, the model now norms + `lm_head_batched`-projects every position in ≤32-row batches (the logits buffer holds `min(m,32)` rows), copies each batch D2H, and records `log P(tokens[i+1] | tokens[..=i])` + top-k. Runs strictly **before** `finalize_last` (which re-derives the first sampled token's logits, so the sampler pointer stays correct). Zero cost when not requested; collecting requests bypass the prefix cache (a cache/Marconi skip would leave positions without hidden rows) and run single-stream (excluded from Q12 batched prefill).
- **Legacy response shape**: four parallel arrays `tokens` / `token_logprobs` / `top_logprobs` / `text_offset`, `null` for the first echoed token; `text_offset` = cumulative per-token decoded lengths (same approximation vLLM uses).
- **Batched prompts per spec**: `prompt: [...]` (strings or token arrays) = one independent prompt per element, one choice each, prompt-major indices. Previously arrays were joined/flattened into a single prompt — that silently corrupts lm-eval at `batch_size > 1`.
- Generated-token logprobs (previously hardcoded `None`), `n` (sequential loop, per-choice seed offset), `stream_options.include_usage` (usage-only `choices: []` chunk before `[DONE]`, chat parity), `system_fingerprint`, streaming echo (prompt chunk with logprobs precedes generation), parse-and-ignore `user`/`suffix`/`best_of`.

**Chat fixes (small):**
- `logprobs: true` alone now enables sampled-token logprobs (`top_logprobs` defaults to 0 alternatives, per spec); previously the bool was ignored.
- `developer` role (o-series successor of `system`) maps to `system` at the chat-path template conversion; previously it passed through verbatim and most templates dropped it.

**SSOT refactor:** the log-softmax + top-k math moved to `spark_model::traits::logprobs`; the scheduler's `extract_logprobs_from_f32` delegates.

## Verification

- **CI (GPU-free)**: `cargo clippy --workspace --tests` clean · `cargo fmt --check` clean · **1678 unit tests, 0 failed** (incl. new serde round-trips, legacy-shape assembly incl. null-first/text_offset/index-ordering, pure log-softmax equality, chat logprobs-resolution).
- **GPU feature matrix** (GB10, unsloth/Qwen3.6-27B-NVFP4, image `atlas-gb10:echologprobs`) — all pass:
  - echo+logprobs+max_tokens=0: 7 prompt tokens → 7 entries, first `null`, all finite ≤ 0, `finish_reason="length"`, `completion_tokens=0`, exact echo text + offsets
  - echo+generation concatenation (parallel arrays across prompt+gen), batch of 2 prompts → 2 choices with correct texts/indices/summed usage, n=2 indices, no-echo generated logprobs, chat `logprobs:true` (empty `top_logprobs`), `developer` role honored
  - streaming: echo chunk (text+logprobs, null-first) precedes tokens; finish chunk then `choices:[]` usage chunk then `[DONE]` with `include_usage`
- **lm-eval-harness acceptance** (the motivating client): `local-completions`, `lambada_openai --limit 20 --batch_size 4` → runs clean end-to-end (batched prompts exercised), **acc 0.50 ± 0.11, perplexity 4.31** — sane numbers for a chat-tuned NVFP4 27B on n=20.
- **GPU integration test** added (`#[ignore]`, `prompt_logprobs_collection_during_prefill`): prompt_len−1 entries targeting the actual next tokens, finite non-positive logprobs, descending top-k bounded by top-1, and the control (flag unset) collects nothing.
- **Flagship regression matrix** (one per DGX, same image): 35B-A3B-FP8 webserver_ok N=10 (lm-head nvfp4); 27B unsloth BFCL ST-995 subset vs the fresh same-box full-995 baseline (89.59 norm); 35B ST-995 subset old-image-vs-new-image A/B. *(results below)*

### Flagship regression results (all on `atlas-gb10:echologprobs` = this branch)

**35B-A3B-FP8 `webserver_ok` N=10 (dgx1, exact PR #278 recipe: `--lm-head-dtype nvfp4`, `ATLAS_SSM_TAIL_PROTECT=1`, cargo-shim, fixed harness):**
| Arm | Σwall | webserver_ok | followed_directions |
|---|---|---|---|
| base `main-438ed09` (same box) | 1285s | 10/10 | 10/10 |
| **this branch, run 1** | 1584s | **10/10** | **10/10** |
| **this branch, run 2** | **1388s** | **10/10** | **10/10** |

Correctness clean sweep, 0 caps/hangs in all 30 iterations. Σwall < 1500 gate met (1388); the 1285–1584 spread is temp-0.3 tier noise (single 230–320s outlier iterations swing Σ ±200 in both arms).

**35B BFCL ST-995 full-1004, old-image-vs-this-branch A/B (dgx3, seed 42, temp 0):**
both legs **84.66 overall / 83.32 normalized** — and the event logs are **token-identical** (2010/2010 content events byte-equal after stripping timestamps). The new binary reproduces the old binary's outputs exactly.

**27B unsloth BFCL ST-995 full-1004, old-image-vs-this-branch A/B (dgx2, identical config/seed):** old **87.35 / 87.54**, this branch **87.45 / 87.60** — new ≥ old on both aggregates. (~18% of events differ textually — MTP-induced greedy nondeterminism on the dense 27B, the known behavior; on the 35B, where MTP self-disables, outputs were 100% token-identical.)

## Out of scope (follow-ups)
Real `/v1/embeddings` (needs an embedding checkpoint + `embed()` path — this PR lays the per-position projection groundwork), vLLM `guided_*` aliases, `prompt_logprobs` on chat, `n` in streaming.

## Authorship
AI-generated (Claude), directed and reviewed by the maintainer. Per CONTRIBUTING §AI-First.
