### PR TITLE
fix(weights): load mixed-precision NVFP4 checkpoints (FP8 keys inside an NVFP4 net)

### DIFF
--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -246,7 +246,32 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                                               full_k: usize,
                                               kind: TpShardKind|
                              -> Result<crate::weight_map::QuantizedWeight> {
-                                let src = quantized_auto(store, &format!("{p}.{name}"), gpu, variant)?;
+                                let prefix = format!("{p}.{name}");
+                                // Mixed-precision compressed-tensors checkpoints
+                                // (unsloth Qwen3.6-*-NVFP4, re-quantized 2026-07-10)
+                                // NVFP4-pack most of the net but keep attention
+                                // q/k/v/o as FP8 (`.weight` FP8E4M3 + a per-row
+                                // `.weight_scale`, no `.weight_packed`). Without the
+                                // pack metadata, dequant and runtime-quantize to NVFP4
+                                // instead of failing on the absent
+                                // `weight_global_scale`. Mirrors the MoE loader's
+                                // attention arm (weight_loader/qwen35/load_layers/
+                                // attention_arms.rs).
+                                let src = if store.contains(&format!("{prefix}.weight_packed")) {
+                                    quantized_auto(store, &prefix, gpu, variant)?
+                                } else {
+                                    let dense_bf16 =
+                                        dense_auto(store, &format!("{prefix}.weight"), gpu)?;
+                                    quantize_to_nvfp4(
+                                        &dense_bf16,
+                                        full_n,
+                                        full_k,
+                                        gpu,
+                                        absmax_k,
+                                        quantize_k,
+                                        stream,
+                                    )?
+                                };
                                 if tp_size == 1 {
                                     return Ok(src);
                                 }

--- a/crates/spark-model/src/weight_map/fp8_lut.rs
+++ b/crates/spark-model/src/weight_map/fp8_lut.rs
@@ -378,9 +378,52 @@ pub(crate) fn load_dense_ffn(
             })
         }
         _ => {
-            let gate = quantized_auto(store, &format!("{prefix}.mlp.gate_proj"), gpu, variant)?;
-            let up = quantized_auto(store, &format!("{prefix}.mlp.up_proj"), gpu, variant)?;
-            let down = quantized_auto(store, &format!("{prefix}.mlp.down_proj"), gpu, variant)?;
+            // `quantized_any`, not `quantized_auto`: mixed-precision
+            // compressed-tensors checkpoints (unsloth Qwen3.6-*-NVFP4,
+            // re-quantized 2026-07-10) leave a tail of dense-FFN layers as FP8
+            // E4M3 + per-row `weight_scale` inside an otherwise-NVFP4 net.
+            // `quantized_auto` would take the declared variant at face value and
+            // die on the absent `weight_global_scale`; `quantized_any` detects
+            // the per-key layout and dequant→requantizes those keys. It
+            // dispatches identically for genuinely-NVFP4 keys.
+            let inter_ = if config.intermediate_size > 0 {
+                config.intermediate_size
+            } else {
+                config.moe_intermediate_size
+            };
+            let h_ = config.hidden_size;
+            let qctx = QuantizeCtx {
+                absmax_k,
+                quantize_k,
+                stream,
+            };
+            let gate = quantized_any(
+                store,
+                &format!("{prefix}.mlp.gate_proj"),
+                inter_,
+                h_,
+                gpu,
+                variant,
+                qctx,
+            )?;
+            let up = quantized_any(
+                store,
+                &format!("{prefix}.mlp.up_proj"),
+                inter_,
+                h_,
+                gpu,
+                variant,
+                qctx,
+            )?;
+            let down = quantized_any(
+                store,
+                &format!("{prefix}.mlp.down_proj"),
+                h_,
+                inter_,
+                gpu,
+                variant,
+                qctx,
+            )?;
             let inter = if config.intermediate_size > 0 {
                 config.intermediate_size
             } else {

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -234,9 +234,41 @@ pub(crate) fn quantized_any(
     let has_scale_inv = store.contains(&format!("{prefix}.weight_scale_inv"));
     let has_only_dense =
         !has_packed && !has_scale && !has_scale_inv && store.contains(&format!("{prefix}.weight"));
+
+    // Per-key fallback #2 (unsloth/Qwen3.6-{27B,35B-A3B}-NVFP4, re-quantized
+    // 2026-07-10): mixed-precision checkpoints that are NVFP4 for most of the
+    // net but leave a tail of layers — and, in the MoE, the shared experts —
+    // as FP8 E4M3 with a per-row `weight_scale` ([N,1] BF16). Those keys carry
+    // no NVFP4 metadata at all (no `weight_packed`, no `weight_global_scale`,
+    // no `weight_scale_2`), so the declared NVFP4 variant cannot load them and
+    // the whole model dies on `weight_global_scale not found in store`.
+    // Detect the FP8 layout per key and dequant→runtime-quantize instead.
+    //
+    // The three NVFP4 layouts are all excluded by construction, so this can
+    // never steal a key that IS NVFP4:
+    //   Standard (ModelOpt/nvidia) -> has `weight_scale_2`
+    //   CompressedTensors (Sehyo)  -> has `weight_packed` + `weight_global_scale`
+    //   this FP8 case              -> has neither, and `.weight` is FP8E4M3
+    let has_fp8_dense = !has_packed
+        && !store.contains(&format!("{prefix}.weight_global_scale"))
+        && !store.contains(&format!("{prefix}.weight_scale_2"))
+        && (has_scale || has_scale_inv)
+        && store
+            .get(&format!("{prefix}.weight"))
+            .map(|w| w.dtype == WeightDtype::FP8E4M3)
+            .unwrap_or(false);
+
     let effective_variant = if has_only_dense && !matches!(variant, Nvfp4Variant::Bf16Raw) {
         tracing::debug!("{prefix}: no quantization metadata; falling back to runtime BF16→NVFP4");
         Nvfp4Variant::Bf16Raw
+    } else if has_fp8_dense
+        && !matches!(
+            variant,
+            Nvfp4Variant::Fp8Dequanted | Nvfp4Variant::Bf16Raw
+        )
+    {
+        tracing::debug!("{prefix}: FP8 key in an NVFP4 checkpoint; dequant FP8→BF16→NVFP4");
+        Nvfp4Variant::Fp8Dequanted
     } else {
         variant
     };


### PR DESCRIPTION
## Problem

Community reports on Discord: every user who freshly downloaded `unsloth/Qwen3.6-27B-NVFP4` or `unsloth/Qwen3.6-35B-A3B-NVFP4` hit

```
Error: Failed to build model
Caused by: Weight 'model.language_model.layers.32.mlp.shared_expert.gate_proj.weight_global_scale' not found in store
```

while it kept working for us. Root cause: **unsloth re-quantized and re-uploaded both repos in place on 2026-07-10** as *mixed-precision* checkpoints — most of the net is NVFP4, but a tail of layers (dense FFN, shared experts, and attention q/k/v/o) is FP8 E4M3 with a **per-row `weight_scale` (`[N,1]`, BF16)** and no `weight_global_scale`. Our gate had run against the older snapshot, which is still in our local HF cache — so it worked on our boxes and failed for everyone else. The recipes pin no `revision:`, so the checkpoint moved under us.

Atlas had no path for an FP8 key sitting inside a checkpoint that declares itself NVFP4. Three call sites took the checkpoint-declared variant at face value and died on the absent key.

## Fix

Route all three through the existing per-key detection (`quantized_any`) instead of the variant-trusting `quantized_auto`:

| file | site |
|---|---|
| `weight_map/nvfp4_detect.rs` | teach `quantized_any` to recognize an FP8 key (FP8E4M3 `.weight` + `weight_scale`/`weight_scale_inv`, no `weight_packed`/`weight_global_scale`/`weight_scale_2`) and dequant FP8→BF16→NVFP4 |
| `weight_loader/qwen35_dense.rs` | dense attention arm — mirrors the fallback the MoE loader already had |
| `weight_map/fp8_lut.rs` | dense-FFN arm |

The three existing NVFP4 layouts are excluded by construction, so dispatch for genuinely-NVFP4 keys is unchanged: Standard has `weight_scale_2`, CompressedTensors has `weight_packed` + `weight_global_scale`, and this FP8 case has neither. The existing `dequant_fp8_blockscaled_to_bf16` kernel already generalizes to a per-row scale (`block_n = n/sn` collapses to 1).

## Verification (dgx1, GB10)

Both **nvidia** checkpoints serve end-to-end through `sparkrun` on an image built from this branch — coherent output and 3/3 parallel tool calls:

- `nvidia/Qwen3.6-27B-NVFP4` — 17.2 tok/s, 3/3 tool calls
- `nvidia/Qwen3.6-35B-A3B-NVFP4` — 3/3 tool calls

**Perf-neutral, controlled against stock `:dev`** (N=10, single-seq, 400-tok greedy, same recipe):

| build | median |
|---|---|
| stock `avarok/atlas-gb10:dev` | 82.5 tok/s |
| this branch | 81.7 tok/s |

Within run-to-run noise — the change is additive and only fires on keys that previously hard-errored.

## Scope / what this does not claim

The unsloth mixed-precision checkpoints now **load all 64 layers** (the missing-weight errors are gone), but the 27B then fails later in build with `CUDA_ERROR_ILLEGAL_ADDRESS` — a separate, pre-existing defect in the mixed-precision compute path, tracked independently. This PR is scoped to the loader; it unblocks the nvidia checkpoints, which are what the default recipes now track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)