### PR TITLE
fix(weights): unsloth mixed-precision NVFP4 — FP8 lm_head + per-row scales

### DIFF
--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -99,7 +99,7 @@ pub fn build_model(
     let mut layers = loader.load_layers(store, &config, gpu.as_ref(), &attn_layer_dtypes)?;
     let embed = loader.load_embedding(store, &config, gpu.as_ref())?;
     let final_norm = loader.load_final_norm(store, &config, gpu.as_ref())?;
-    let lm_head = loader.load_lm_head(store, &config)?;
+    let lm_head = loader.load_lm_head(store, &config, gpu.as_ref())?;
     let mtp_weights = loader.load_mtp_weights_multi(store, &config, gpu.as_ref())?;
 
     // DeepSeek-V4 ships an architecturally distinct MTP module (MLA + mHC), not

--- a/crates/spark-model/src/mistral_loader/loader_impl/mod.rs
+++ b/crates/spark-model/src/mistral_loader/loader_impl/mod.rs
@@ -79,7 +79,12 @@ impl ModelWeightLoader for MistralWeightLoader {
             .context("Mistral: final norm not found")
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         if store.contains("output.weight") {
             dense(store, "output.weight")
         } else if store.contains("lm_head.weight") {

--- a/crates/spark-model/src/weight_loader/deepseek_v4.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4.rs
@@ -78,7 +78,12 @@ impl ModelWeightLoader for DeepSeekV4WeightLoader {
             .context("DeepSeek-V4: no final norm tensor found (tried norm.weight, model.norm.weight, final_norm.weight)")
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         // Try standard HF name first
         if store.contains("lm_head.weight") {
             return dense(store, "lm_head.weight");

--- a/crates/spark-model/src/weight_loader/gemma4.rs
+++ b/crates/spark-model/src/weight_loader/gemma4.rs
@@ -75,7 +75,12 @@ impl ModelWeightLoader for Gemma4WeightLoader {
         loader_b::load_final_norm_impl(store, config)
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         loader_b::load_lm_head_impl(store, config)
     }
 

--- a/crates/spark-model/src/weight_loader/minimax.rs
+++ b/crates/spark-model/src/weight_loader/minimax.rs
@@ -316,7 +316,12 @@ impl ModelWeightLoader for MinimaxM2WeightLoader {
         dense(store, "model.norm.weight")
     }
 
-    fn load_lm_head(&self, store: &WeightStore, _config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        _config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         dense(store, "lm_head.weight")
     }
 

--- a/crates/spark-model/src/weight_loader/mod.rs
+++ b/crates/spark-model/src/weight_loader/mod.rs
@@ -189,7 +189,12 @@ pub trait ModelWeightLoader {
         config: &ModelConfig,
         gpu: &dyn GpuBackend,
     ) -> Result<DenseWeight>;
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight>;
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight>;
 
     /// Load MTP head weights (returns None if no MTP weights in store).
     fn load_mtp_weights(

--- a/crates/spark-model/src/weight_loader/nemotron.rs
+++ b/crates/spark-model/src/weight_loader/nemotron.rs
@@ -375,7 +375,12 @@ impl ModelWeightLoader for NemotronHWeightLoader {
         dense(store, &format!("{}.norm_f.weight", config.weight_prefix))
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         if store.contains("lm_head.weight") {
             dense(store, "lm_head.weight")
         } else {

--- a/crates/spark-model/src/weight_loader/qwen3.rs
+++ b/crates/spark-model/src/weight_loader/qwen3.rs
@@ -440,7 +440,12 @@ impl ModelWeightLoader for Qwen3WeightLoader {
         dense(store, "model.norm.weight")
     }
 
-    fn load_lm_head(&self, store: &WeightStore, _config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        _config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         if store.contains("lm_head.weight") {
             dense(store, "lm_head.weight")
         } else {

--- a/crates/spark-model/src/weight_loader/qwen35.rs
+++ b/crates/spark-model/src/weight_loader/qwen35.rs
@@ -10,9 +10,7 @@ use spark_runtime::weights::{WeightDtype, WeightStore};
 
 use super::ModelWeightLoader;
 use crate::layer::TransformerLayer;
-use crate::weight_map::{
-    DenseWeight, MtpWeights, dense, dense_auto, detect_nvfp4_variant, load_mtp,
-};
+use crate::weight_map::{DenseWeight, MtpWeights, dense_auto, detect_nvfp4_variant, load_mtp};
 
 pub struct Qwen35WeightLoader;
 
@@ -89,21 +87,44 @@ impl ModelWeightLoader for Qwen35WeightLoader {
         dense_auto(store, &format!("{prefix}.norm.weight"), gpu)
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         // lm_head location varies by quantizer:
         //   Sehyo: "lm_head.weight"
         //   Kbenkhaled: "language_model.lm_head.weight"
-        for pattern in &[
-            "lm_head.weight",
-            "language_model.lm_head.weight",
-            "model.lm_head.weight",
-        ] {
-            if store.contains(pattern) {
-                return dense(store, pattern);
+        //
+        // Dequant FP8 ONLY; hand every other dtype through untouched.
+        // `dense` does no dtype check, which is correct for a BF16 head and for
+        // a Standard-NVFP4 head (`weight` U8-packed + weight_scale_2, e.g.
+        // nvidia/Qwen3.6-*-NVFP4) that the consumer unpacks itself — routing
+        // those through `dense_auto_fp8_or_bf16` hard-errors on `unsupported
+        // dtype UInt8`. But it is WRONG for FP8: mixed-precision checkpoints
+        // (unsloth Qwen3.6-*-NVFP4, 2026-07-10) keep lm_head as FP8 E4M3 +
+        // per-row `weight_scale`, and feeding those bytes to a BF16 GEMM reads
+        // 2x the allocation on the largest tensor in the model →
+        // CUDA_ERROR_ILLEGAL_ADDRESS at the first sync after build.
+        for prefix in ["lm_head", "language_model.lm_head", "model.lm_head"] {
+            let key = format!("{prefix}.weight");
+            if !store.contains(&key) {
+                continue;
             }
+            let is_fp8 = store
+                .get(&key)
+                .map(|w| w.dtype == WeightDtype::FP8E4M3)
+                .unwrap_or(false);
+            return if is_fp8 {
+                crate::weight_map::dense_auto_fp8_or_bf16(store, prefix, gpu)
+            } else {
+                crate::weight_map::dense(store, &key)
+            };
         }
+        // Tied embeddings: the head IS the embedding table.
         let prefix = &config.weight_prefix;
-        dense(store, &format!("{prefix}.embed_tokens.weight"))
+        crate::weight_map::dense(store, &format!("{prefix}.embed_tokens.weight"))
     }
 
     fn load_mtp_weights(

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -34,20 +34,50 @@ fn proj_is_native_fp8(store: &WeightStore, prefix: &str) -> bool {
     is_fp8_weight && has_block_scale
 }
 
-/// True when `{prefix}.weight` is on-disk FP8 with ANY dequant scale — block
-/// (`weight_scale_inv` / 2D `weight_scale`) OR the ModelOpt per-tensor SCALAR
-/// `weight_scale` (shape `[]`). `load_fp8_block_scaled_as_fp8weight` broadcasts
-/// the scalar into a uniform block grid, so all three are loadable as FP8. The
-/// nvidia Qwen3.6-27B-NVFP4 GDN projections use the scalar form, which
-/// `proj_is_native_fp8` (2D-only) misses.
+/// True when `{prefix}.weight` is on-disk FP8 with a scale the native-FP8
+/// `w8a16` path can actually consume — i.e. one that is (or broadcasts to) the
+/// `[ceil(N/128), ceil(K/128)]` FP32 block grid the kernel indexes as
+/// `block_scale[n/128, k/128]`:
+///
+///   * `weight_scale_inv` / 2-D `weight_scale` shaped as that block grid
+///     (DeepSeek-V3 / Qwen-native convention), or
+///   * a per-tensor SCALAR `weight_scale` (ModelOpt; e.g. the nvidia
+///     Qwen3.6-27B-NVFP4 GDN projections) — `load_fp8_block_scaled_as_fp8weight`
+///     broadcasts it into a uniform grid, which is exact.
+///
+/// A **per-row** `weight_scale` (`[N,1]`, e.g. unsloth's re-quantized
+/// Qwen3.6-*-NVFP4, 2026-07-10) is deliberately REJECTED. It is not a block
+/// grid: the kernel would read row `n`'s multiplier from grid cell `n/128`, so
+/// 127 of every 128 rows get some other row's scale. That is in-bounds — the
+/// widened `[N]` buffer is *larger* than the `[N/128, K/128]` grid — so it does
+/// not fault; it silently produces garbage logits. Returning false here drops
+/// the projection to the default `dequant_fp8_blockscaled_to_bf16` →
+/// `quantize_to_nvfp4` path, which reads a `[N,1]` scale correctly
+/// (`block_n = N/N = 1`, i.e. one multiplier per row).
 fn proj_is_fp8_any_scale(store: &WeightStore, prefix: &str) -> bool {
-    let is_fp8 = store
-        .get(&format!("{prefix}.weight"))
-        .map(|w| w.dtype == WeightDtype::FP8E4M3)
-        .unwrap_or(false);
-    is_fp8
-        && (store.contains(&format!("{prefix}.weight_scale_inv"))
-            || store.contains(&format!("{prefix}.weight_scale")))
+    let Ok(w) = store.get(&format!("{prefix}.weight")) else {
+        return false;
+    };
+    if w.dtype != WeightDtype::FP8E4M3 || w.shape.len() != 2 {
+        return false;
+    }
+    let (n, k) = (w.shape[0], w.shape[1]);
+
+    for key in [
+        format!("{prefix}.weight_scale_inv"),
+        format!("{prefix}.weight_scale"),
+    ] {
+        let Ok(s) = store.get(&key) else { continue };
+        // Per-tensor scalar → broadcast to a uniform grid: exact.
+        if s.num_elements() == 1 {
+            return true;
+        }
+        // 2-D scale: only a genuine 128×128 block grid is consumable.
+        if s.shape.len() == 2 && s.shape[0] == n.div_ceil(128) && s.shape[1] == k.div_ceil(128) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Concatenate two block-scaled FP8 weights along rows (dim 0):
@@ -891,8 +921,13 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
         loaders_b::load_final_norm(store, config)
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
-        loaders_b::load_lm_head(store, config)
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
+        loaders_b::load_lm_head(store, config, gpu)
     }
 
     fn load_mtp_weights(

--- a/crates/spark-model/src/weight_loader/qwen35_dense/loaders_b.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/loaders_b.rs
@@ -5,9 +5,10 @@
 
 use anyhow::Result;
 use atlas_core::config::ModelConfig;
-use spark_runtime::weights::WeightStore;
+use spark_runtime::gpu::GpuBackend;
+use spark_runtime::weights::{WeightDtype, WeightStore};
 
-use crate::weight_map::{DenseWeight, dense};
+use crate::weight_map::{DenseWeight, dense, dense_auto_fp8_or_bf16};
 
 pub(super) fn load_embedding(store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
     let prefix = &config.weight_prefix;
@@ -19,16 +20,48 @@ pub(super) fn load_final_norm(store: &WeightStore, config: &ModelConfig) -> Resu
     dense(store, &format!("{prefix}.norm.weight"))
 }
 
-pub(super) fn load_lm_head(store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
-    for pattern in &[
-        "lm_head.weight",
-        "language_model.lm_head.weight",
-        "model.lm_head.weight",
-    ] {
-        if store.contains(pattern) {
-            return dense(store, pattern);
+/// Load the LM head, dequanting an **FP8** head to BF16 and otherwise handing
+/// the tensor through untouched.
+///
+/// `dense()` performs no dtype check — it hands the raw device pointer to the
+/// consumer. That is correct for the two layouts Atlas already supported:
+/// a BF16 head, and a Standard-NVFP4 head (`weight` U8-packed +
+/// `weight_scale`/`weight_scale_2`, e.g. nvidia/Qwen3.6-27B-NVFP4), which the
+/// LM-head consumer unpacks itself. Both MUST keep the passthrough.
+///
+/// It is NOT correct for FP8. Mixed-precision NVFP4 checkpoints (unsloth
+/// Qwen3.6-*-NVFP4, re-quantized 2026-07-10) keep `lm_head` as FP8 E4M3 + a
+/// per-row `weight_scale` while the body of the net is NVFP4. `lm_head` is the
+/// largest tensor in the model ([248320, 5120] = 1.27 GB of 1-byte elements on
+/// the 27B); handed to a BF16 GEMM it is a 2.54 GB read off a 1.27 GB
+/// allocation, surfacing as `CUDA_ERROR_ILLEGAL_ADDRESS` at the first sync
+/// after model build.
+///
+/// So: intercept FP8 only. Dispatching every dtype through
+/// `dense_auto_fp8_or_bf16` would hard-error on the U8 packed head
+/// (`unsupported dtype UInt8`) and break every Standard-NVFP4 checkpoint.
+pub(super) fn load_lm_head(
+    store: &WeightStore,
+    config: &ModelConfig,
+    gpu: &dyn GpuBackend,
+) -> Result<DenseWeight> {
+    for prefix in ["lm_head", "language_model.lm_head", "model.lm_head"] {
+        let key = format!("{prefix}.weight");
+        if !store.contains(&key) {
+            continue;
         }
+        let is_fp8 = store
+            .get(&key)
+            .map(|w| w.dtype == WeightDtype::FP8E4M3)
+            .unwrap_or(false);
+        return if is_fp8 {
+            dense_auto_fp8_or_bf16(store, prefix, gpu)
+        } else {
+            dense(store, &key)
+        };
     }
+    // Tied embeddings: the head IS the embedding table (BF16 in every
+    // checkpoint Atlas supports — no FP8 embed_tokens has been seen).
     let prefix = &config.weight_prefix;
     dense(store, &format!("{prefix}.embed_tokens.weight"))
 }

--- a/crates/spark-model/src/weight_loader/qwen3_vl.rs
+++ b/crates/spark-model/src/weight_loader/qwen3_vl.rs
@@ -167,7 +167,12 @@ impl ModelWeightLoader for Qwen3VLWeightLoader {
         dense(store, &format!("{prefix}.norm.weight"))
     }
 
-    fn load_lm_head(&self, store: &WeightStore, config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         for pattern in &[
             "lm_head.weight",
             "language_model.lm_head.weight",

--- a/crates/spark-model/src/weight_loader/step3p7.rs
+++ b/crates/spark-model/src/weight_loader/step3p7.rs
@@ -181,7 +181,12 @@ impl ModelWeightLoader for Step3p7WeightLoader {
         Ok(w)
     }
 
-    fn load_lm_head(&self, store: &WeightStore, _config: &ModelConfig) -> Result<DenseWeight> {
+    fn load_lm_head(
+        &self,
+        store: &WeightStore,
+        _config: &ModelConfig,
+        _gpu: &dyn GpuBackend,
+    ) -> Result<DenseWeight> {
         dense(store, "lm_head.weight")
     }
 

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -262,10 +262,7 @@ pub(crate) fn quantized_any(
         tracing::debug!("{prefix}: no quantization metadata; falling back to runtime BF16→NVFP4");
         Nvfp4Variant::Bf16Raw
     } else if has_fp8_dense
-        && !matches!(
-            variant,
-            Nvfp4Variant::Fp8Dequanted | Nvfp4Variant::Bf16Raw
-        )
+        && !matches!(variant, Nvfp4Variant::Fp8Dequanted | Nvfp4Variant::Bf16Raw)
     {
         tracing::debug!("{prefix}: FP8 key in an NVFP4 checkpoint; dequant FP8→BF16→NVFP4");
         Nvfp4Variant::Fp8Dequanted


### PR DESCRIPTION
Follow-up to #300. That PR made the re-quantized unsloth checkpoints *resolve* all their layers, but the model then died at the first sync after build with `CUDA_ERROR_ILLEGAL_ADDRESS`. Two further defects, both **outside** the layer loaders #300 touched.

## 1. FP8 `lm_head` handed to a BF16 GEMM — the crash

`load_lm_head` called `dense()`, which performs no dtype check; it passes the raw device pointer straight to the consumer. unsloth's `Qwen3.6-*-NVFP4` keep `lm_head` as **FP8 E4M3 + a per-row `weight_scale`** even though the body of the net is NVFP4. On the 27B that tensor is `[248320, 5120]` — 1.27 GB of 1-byte elements, the largest in the model. Read as BF16 it is a 2.54 GB read off a 1.27 GB allocation.

There are **three** `lm_head` layouts in play, and this intercepts exactly one:

| layout | handling |
|---|---|
| BF16 | passthrough (unchanged) |
| Standard NVFP4 — `weight` U8-packed + `weight_scale_2` (`nvidia/Qwen3.6-*`) | passthrough (unchanged); the LM-head consumer unpacks it itself |
| **FP8 E4M3 + per-row scale (unsloth)** | **dequant to BF16 — new** |

The naive version of this fix routes *every* dtype through `dense_auto_fp8_or_bf16`, which hard-errors `unsupported dtype UInt8 for lm_head.weight` on every Standard-NVFP4 checkpoint — i.e. it breaks the shipping nvidia recipes in order to fix unsloth. I hit exactly that and the regression gate caught it; hence the dtype guard.

This threads `gpu` into the trait's `load_lm_head`, matching its siblings `load_embedding` / `load_final_norm`, which already take it. Preferred over special-casing at the call site, which would duplicate the lm_head name-pattern list.

## 2. Per-row scales fed to a block-scaled kernel — silent corruption

`proj_is_fp8_any_scale` admitted **any** FP8 scale into the native-FP8 `w8a16` path. That kernel hardcodes the block grid:

```c
// out[n] = sum_k A[0,k] * E4M3_LUT[B[n,k]] * block_scale[n/BS, k/BS]
#define FP8_BLOCK 128
```

That path was built for the nvidia checkpoint's per-**tensor** scalar scale, which broadcasts to a uniform grid exactly. unsloth ships a per-**row** `[N,1]` scale — not a block grid at all — so row `n` reads its multiplier from grid cell `n/128`: **127 of every 128 rows get some other row's scale**, across all 48 GDN and 16 attention projections.

Critically, this is **in-bounds** — the widened `[N]` buffer is *larger* than the `[N/128, K/128]` grid — so it never faults. It just produces garbage logits. Fixing only (1) yields a model that boots and serves **fluent nonsense**, which is strictly worse than the crash.

Gate tightened to admit only scales the kernel can actually consume (per-tensor scalar, or a genuine 128×128 grid). Per-row now falls through to the existing `dequant_fp8_blockscaled_to_bf16` → `quantize_to_nvfp4` path, which reads `[N,1]` correctly (`block_n = N/N = 1`, one multiplier per row).

## Verification (dgx1, GB10, via `sparkrun` on `:dev` + this binary, N=10)

| checkpoint | throughput | correctness |
|---|---|---|
| `unsloth/Qwen3.6-27B-NVFP4` | 14.0 tok/s | Paris / 391 / dog — **PASS** (was: crash) |
| `nvidia/Qwen3.6-27B-NVFP4` | 19.9 tok/s | Paris / 391 / dog — **PASS** (baseline 19.8) |

The gate is **correctness, not "does it boot"** — bug 2 is invisible to a boot check. The arithmetic probe (`17 * 23 → 391`) is what catches wrong-scale garbage: it survives fluency, but not multiplication.

nvidia's 48 GDN layers still take the native-FP8 path, confirming the scalar-scale branch of (2) is intact and the shipping recipes are unregressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)