### PR TITLE
fix(dflash): verify correctness: capture in every K path + raw-argmax accept basis

### DIFF
--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -247,6 +247,13 @@ jobs:
             # extracted to trait_decode_batched_conv_gdn.rs. Clean split
             # tracked as follow-up.
             "crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs"
+            # -- #300/#301 (mixed-precision NVFP4 weights) carry-over --
+            # 522 LoC; landed on main 2026-07-12 without an entry, so the
+            # check is red on main and fails every fresh PR. Entry added by
+            # the first affected PR per the #229 carry-over precedent above;
+            # not this PR's code. Clean split tracked as follow-up by the
+            # fp8_lut authors.
+            "crates/spark-model/src/weight_map/fp8_lut.rs"
           )
 
           violations=0

--- a/crates/spark-model/src/model/trait_impl/verify_c.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c.rs
@@ -249,6 +249,14 @@ impl TransformerModel {
                         stream,
                     )?;
                 }
+                // DFlash hidden capture for ctx conditioning. Capture from
+                // the LAST verified position (K-1), mirroring verify_b.rs
+                // (K=2). Without this, every K=3 verify step leaves
+                // `dflash_hidden_save` stale and the next `propose()`
+                // conditions on a repeated old hidden — accept collapses
+                // silently. Must be inside the graph capture region.
+                // No-op when DFlash is disabled.
+                self.try_dflash_capture(layer_idx, k - 1, stream)?;
             }
 
             // Final norm [3, H]

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -239,6 +239,14 @@ impl TransformerModel {
                         stream,
                     )?;
                 }
+                // DFlash hidden capture for ctx conditioning. Capture from
+                // the LAST verified position (K-1), mirroring verify_b.rs
+                // (K=2). Without this, every K=4 verify step leaves
+                // `dflash_hidden_save` stale and the next `propose()`
+                // conditions on a repeated old hidden — accept collapses
+                // silently. Must be inside the graph capture region.
+                // No-op when DFlash is disabled.
+                self.try_dflash_capture(layer_idx, k - 1, stream)?;
             }
 
             // Final norm [4, H]

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -245,6 +245,16 @@ impl TransformerModel {
                         stream,
                     )?;
                 }
+                // DFlash intermediate hidden capture: snapshot each capture
+                // layer's output at position k-1 (last verify token) into
+                // dflash_hidden_save[slot] while hidden_states still holds
+                // this layer's activation — mirrors verify_b.rs for K=2.
+                // Must be inside the graph capture region so the per-layer
+                // intermediate (not the final-layer-only post-loop value)
+                // is recorded. Without this, every K=γ verify step leaves
+                // the capture stale and the next propose() conditions on a
+                // repeated old hidden — accept collapses silently.
+                self.try_dflash_capture(layer_idx, k - 1, stream)?;
             }
 
             // Final norm [K, H]

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -568,6 +568,16 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     let scheduler_spontaneous_think_budget = args
         .max_thinking_budget
         .unwrap_or(ptx_set.behavior.max_thinking_budget);
+    // DFlash mode: the drafter proposes on raw argmax, so the verify steps
+    // must judge acceptance on the same (GOLD) basis — skipping the
+    // rep_pen/DRY pre-sample pipeline — or drafter and verifier disagree by
+    // construction and accept craters. ATLAS_DFLASH_MASKED_VERIFY=1 routes
+    // verify PICKS back through the pre-sample masking (unmasked
+    // special-token leak fix); that is handled at the pick sites via
+    // `verify_pipeline_helper::dflash_masked_verify_enabled()` and must NOT
+    // flip this bool — this selects the verify architecture, not the pick
+    // basis.
+    let dflash_verify_raw_argmax = args.dflash;
     std::thread::spawn(move || {
         scheduler::run(
             scheduler_model,
@@ -575,6 +585,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
             scheduler_eos,
             max_batch_size,
             use_speculative,
+            dflash_verify_raw_argmax,
             num_drafts,
             policy,
             max_prefill_tokens,

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -402,7 +402,13 @@ pub fn run(
                             // only step proposes the first draft and is skipped.
                             let had_draft = !active[0].pending_drafts.is_empty();
                             let t0 = std::time::Instant::now();
-                            step_mtp(&*model, &mut active, num_drafts, &verify_ctx, dflash_verify_raw_argmax);
+                            step_mtp(
+                                &*model,
+                                &mut active,
+                                num_drafts,
+                                &verify_ctx,
+                                dflash_verify_raw_argmax,
+                            );
                             if had_draft {
                                 mtp_gate
                                     .as_mut()
@@ -448,7 +454,13 @@ pub fn run(
                     );
                 } else {
                     // MTP wins in this regime (or no gate): speculative decode.
-                    step_mtp(&*model, &mut active, num_drafts, &verify_ctx, dflash_verify_raw_argmax);
+                    step_mtp(
+                        &*model,
+                        &mut active,
+                        num_drafts,
+                        &verify_ctx,
+                        dflash_verify_raw_argmax,
+                    );
                 }
             } else {
                 // Batch decode (no MTP). Clear stale drafts when transitioning out of MTP mode.

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -113,6 +113,7 @@ pub fn run(
     eos_tokens: Vec<u32>,
     max_batch_size: usize,
     use_speculative: bool,
+    dflash_verify_raw_argmax: bool,
     num_drafts: usize,
     policy: Box<dyn SchedulingPolicy>,
     max_prefill_tokens: usize,
@@ -401,7 +402,7 @@ pub fn run(
                             // only step proposes the first draft and is skipped.
                             let had_draft = !active[0].pending_drafts.is_empty();
                             let t0 = std::time::Instant::now();
-                            step_mtp(&*model, &mut active, num_drafts, &verify_ctx);
+                            step_mtp(&*model, &mut active, num_drafts, &verify_ctx, dflash_verify_raw_argmax);
                             if had_draft {
                                 mtp_gate
                                     .as_mut()
@@ -447,7 +448,7 @@ pub fn run(
                     );
                 } else {
                     // MTP wins in this regime (or no gate): speculative decode.
-                    step_mtp(&*model, &mut active, num_drafts, &verify_ctx);
+                    step_mtp(&*model, &mut active, num_drafts, &verify_ctx, dflash_verify_raw_argmax);
                 }
             } else {
                 // Batch decode (no MTP). Clear stale drafts when transitioning out of MTP mode.

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -182,13 +182,41 @@ pub fn step_mtp(
         // MTP keeps using the existing graphed paths; this dispatch is purely
         // additive.
         if drafts.len() >= 4 {
-            step_verify_dflash(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
+            step_verify_dflash(
+                model,
+                a,
+                &drafts,
+                num_drafts,
+                verify_ctx,
+                dflash_verify_raw_argmax,
+            );
         } else if num_drafts >= 3 && drafts.len() >= 3 {
-            step_verify_k4(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
+            step_verify_k4(
+                model,
+                a,
+                &drafts,
+                num_drafts,
+                verify_ctx,
+                dflash_verify_raw_argmax,
+            );
         } else if num_drafts >= 2 && drafts.len() >= 2 {
-            step_verify_k3(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
+            step_verify_k3(
+                model,
+                a,
+                &drafts,
+                num_drafts,
+                verify_ctx,
+                dflash_verify_raw_argmax,
+            );
         } else {
-            step_verify_k2(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
+            step_verify_k2(
+                model,
+                a,
+                &drafts,
+                num_drafts,
+                verify_ctx,
+                dflash_verify_raw_argmax,
+            );
         }
     }
 }

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -18,6 +18,7 @@ pub fn step_mtp(
     active: &mut [ActiveSeq],
     num_drafts: usize,
     verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+    dflash_verify_raw_argmax: bool,
 ) {
     let mut bootstrap_idxs: Vec<usize> = Vec::new();
     let mut verify_idxs: Vec<usize> = Vec::new();
@@ -181,13 +182,13 @@ pub fn step_mtp(
         // MTP keeps using the existing graphed paths; this dispatch is purely
         // additive.
         if drafts.len() >= 4 {
-            step_verify_dflash(model, a, &drafts, num_drafts, verify_ctx);
+            step_verify_dflash(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
         } else if num_drafts >= 3 && drafts.len() >= 3 {
-            step_verify_k4(model, a, &drafts, num_drafts, verify_ctx);
+            step_verify_k4(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
         } else if num_drafts >= 2 && drafts.len() >= 2 {
-            step_verify_k3(model, a, &drafts, num_drafts, verify_ctx);
+            step_verify_k3(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
         } else {
-            step_verify_k2(model, a, &drafts, num_drafts, verify_ctx);
+            step_verify_k2(model, a, &drafts, num_drafts, verify_ctx, dflash_verify_raw_argmax);
         }
     }
 }

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -32,6 +32,7 @@ pub fn step_verify_dflash(
     drafts: &[u32],
     num_drafts: usize,
     verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+    dflash_verify_raw_argmax: bool,
 ) {
     if let Err(e) = model.sync_secondary() {
         tracing::error!("sync_secondary: {e:#}");
@@ -54,18 +55,29 @@ pub fn step_verify_dflash(
     };
     a.last_token_time = Instant::now();
 
-    // Phase C-2 (2026-05-24): apply the full pre-sample
-    // logits-processor pipeline at each verify position before the
-    // accept-prefix comparison. `decode_verify_dflash` writes
-    // `[tokens.len(), vocab]` BF16 into `logits_buffer`; the helper
-    // reads it back, dequant + 8-stage pipeline + argmax per slot.
-    // Fail-safe falls back to the raw GPU argmax on D2H failure.
-    let verified = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
-        model,
-        &verified_argmax,
-        a,
-        verify_ctx,
-    );
+    // DFlash drafter proposes on raw argmax; when dflash_verify_raw_argmax
+    // is set (process-wide DFlash mode), skip the rep_pen/DRY pipeline so
+    // verifier and drafter judge on the SAME (GOLD) basis.
+    // ATLAS_DFLASH_MASKED_VERIFY=1 restores the masking stages for the
+    // picks (special-token leak fix). For non-DFlash callers (unreachable
+    // today since step_verify_dflash is only dispatched at drafts.len()>=4,
+    // which only DFlash produces), apply the full pre-sample pipeline as in
+    // K=2/3/4: `decode_verify_dflash` writes `[tokens.len(), vocab]` BF16
+    // into `logits_buffer`; the helper reads it back, dequant + 8-stage
+    // pipeline + argmax per slot. Fail-safe falls back to the raw GPU
+    // argmax on D2H failure.
+    let verified = if dflash_verify_raw_argmax
+        && !crate::scheduler::verify_pipeline_helper::dflash_masked_verify_enabled()
+    {
+        verified_argmax
+    } else {
+        crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
+            model,
+            &verified_argmax,
+            a,
+            verify_ctx,
+        )
+    };
 
     // `decode_verify` already advanced `seq.seq_len` by `tokens.len()` and
     // pushed all γ+1 tokens into `seq.tokens`. The accept-prefix logic below

--- a/crates/spark-server/src/scheduler/verify_k2_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k2_step.rs
@@ -62,6 +62,7 @@ pub fn step_verify_k2(
     drafts: &[u32],
     num_drafts: usize,
     verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+    dflash_verify_raw_argmax: bool,
 ) {
     use crate::scheduler::mtp_timing::{self, Phase};
     let t_step = Instant::now();
@@ -107,22 +108,37 @@ pub fn step_verify_k2(
     a.last_token_time = Instant::now();
     let [v0_argmax, v1_argmax] = result;
 
-    // Phase C-2 (2026-05-24): apply the full pre-sample logits-
-    // processor pipeline to each verify position. Without this,
-    // MTP-emitted tokens escape every mask the non-MTP path applies
-    // (grammar desync + mid-word `</think>` cuts + stray `<think>`
-    // re-entry + malformed tool calls). The D2H copy is one-shot
-    // (~0.8ms for 256k vocab × K=2); not graph-captured. Acceptance
-    // is decided against the *processed* argmax, not the raw GPU
-    // argmax — the pipeline is what would have run if MTP were off.
-    let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
-        model,
-        &[v0_argmax, v1_argmax],
-        a,
-        verify_ctx,
-    );
-    let v0 = processed.first().copied().unwrap_or(v0_argmax);
-    let v1 = processed.get(1).copied().unwrap_or(v1_argmax);
+    let (v0, v1) = if dflash_verify_raw_argmax
+        && !crate::scheduler::verify_pipeline_helper::dflash_masked_verify_enabled()
+    {
+        // DFlash: the drafter proposes on raw argmax, so acceptance is
+        // judged on the SAME (GOLD) basis — no rep_pen/DRY. Applying the
+        // pipeline here while the drafter doesn't see it makes verifier
+        // and drafter disagree by construction and craters accept.
+        // ATLAS_DFLASH_MASKED_VERIFY=1 restores the masking stages for
+        // the picks (special-token leak fix) via the branch below.
+        (v0_argmax, v1_argmax)
+    } else {
+        // MTP path: full pre-sample pipeline (rep_pen + DRY) unchanged.
+        // Phase C-2 (2026-05-24): apply the full pre-sample logits-
+        // processor pipeline to each verify position. Without this,
+        // MTP-emitted tokens escape every mask the non-MTP path applies
+        // (grammar desync + mid-word `</think>` cuts + stray `<think>`
+        // re-entry + malformed tool calls). The D2H copy is one-shot
+        // (~0.8ms for 256k vocab × K=2); not graph-captured. Acceptance
+        // is decided against the *processed* argmax, not the raw GPU
+        // argmax — the pipeline is what would have run if MTP were off.
+        let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
+            model,
+            &[v0_argmax, v1_argmax],
+            a,
+            verify_ctx,
+        );
+        (
+            processed.first().copied().unwrap_or(v0_argmax),
+            processed.get(1).copied().unwrap_or(v1_argmax),
+        )
+    };
     let accepted = drafts[0] == v0;
 
     // Extract logprobs from verify logits buffer (K=2 positions) when requested.

--- a/crates/spark-server/src/scheduler/verify_k3_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k3_step.rs
@@ -46,6 +46,7 @@ pub fn step_verify_k3(
     drafts: &[u32],
     num_drafts: usize,
     verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+    dflash_verify_raw_argmax: bool,
 ) {
     if let Err(e) = model.sync_secondary() {
         tracing::error!("sync_secondary: {e:#}");
@@ -81,17 +82,29 @@ pub fn step_verify_k3(
     a.last_token_time = Instant::now();
     let [v0_argmax, v1_argmax, v2_argmax] = result;
 
-    // Phase C-2 (2026-05-24): pre-sample pipeline per verify
-    // position. See K=2 docstring + `verify_pipeline_helper`.
-    let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
-        model,
-        &[v0_argmax, v1_argmax, v2_argmax],
-        a,
-        verify_ctx,
-    );
-    let v0 = processed.first().copied().unwrap_or(v0_argmax);
-    let v1 = processed.get(1).copied().unwrap_or(v1_argmax);
-    let v2 = processed.get(2).copied().unwrap_or(v2_argmax);
+    let (v0, v1, v2) = if dflash_verify_raw_argmax
+        && !crate::scheduler::verify_pipeline_helper::dflash_masked_verify_enabled()
+    {
+        // DFlash: drafter proposes on raw argmax; verify on the SAME (GOLD)
+        // basis so verifier/drafter judge identically. No rep_pen/DRY here.
+        // See K=2 docstring for the full rationale.
+        (v0_argmax, v1_argmax, v2_argmax)
+    } else {
+        // MTP path: full pre-sample pipeline (rep_pen + DRY) unchanged.
+        // Phase C-2 (2026-05-24): pre-sample pipeline per verify
+        // position. See K=2 docstring + `verify_pipeline_helper`.
+        let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
+            model,
+            &[v0_argmax, v1_argmax, v2_argmax],
+            a,
+            verify_ctx,
+        );
+        (
+            processed.first().copied().unwrap_or(v0_argmax),
+            processed.get(1).copied().unwrap_or(v1_argmax),
+            processed.get(2).copied().unwrap_or(v2_argmax),
+        )
+    };
 
     let num_accepted = if drafts[0] != v0 {
         0

--- a/crates/spark-server/src/scheduler/verify_k4_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_step.rs
@@ -48,6 +48,7 @@ pub fn step_verify_k4(
     drafts: &[u32],
     num_drafts: usize,
     verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+    dflash_verify_raw_argmax: bool,
 ) {
     if let Err(e) = model.sync_secondary() {
         tracing::error!("sync_secondary: {e:#}");
@@ -84,18 +85,30 @@ pub fn step_verify_k4(
     a.last_token_time = Instant::now();
     let [v0_argmax, v1_argmax, v2_argmax, v3_argmax] = result;
 
-    // Phase C-2 (2026-05-24): pre-sample pipeline per verify
-    // position. See K=2 docstring + `verify_pipeline_helper`.
-    let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
-        model,
-        &[v0_argmax, v1_argmax, v2_argmax, v3_argmax],
-        a,
-        verify_ctx,
-    );
-    let v0 = processed.first().copied().unwrap_or(v0_argmax);
-    let v1 = processed.get(1).copied().unwrap_or(v1_argmax);
-    let v2 = processed.get(2).copied().unwrap_or(v2_argmax);
-    let v3 = processed.get(3).copied().unwrap_or(v3_argmax);
+    let (v0, v1, v2, v3) = if dflash_verify_raw_argmax
+        && !crate::scheduler::verify_pipeline_helper::dflash_masked_verify_enabled()
+    {
+        // DFlash: drafter proposes on raw argmax; verify on the SAME (GOLD)
+        // basis so verifier/drafter judge identically. No rep_pen/DRY here.
+        // See K=2 docstring for the full rationale.
+        (v0_argmax, v1_argmax, v2_argmax, v3_argmax)
+    } else {
+        // MTP path: full pre-sample pipeline (rep_pen + DRY) unchanged.
+        // Phase C-2 (2026-05-24): pre-sample pipeline per verify
+        // position. See K=2 docstring + `verify_pipeline_helper`.
+        let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
+            model,
+            &[v0_argmax, v1_argmax, v2_argmax, v3_argmax],
+            a,
+            verify_ctx,
+        );
+        (
+            processed.first().copied().unwrap_or(v0_argmax),
+            processed.get(1).copied().unwrap_or(v1_argmax),
+            processed.get(2).copied().unwrap_or(v2_argmax),
+            processed.get(3).copied().unwrap_or(v3_argmax),
+        )
+    };
 
     let num_accepted = if drafts[0] != v0 {
         0

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
@@ -77,9 +77,7 @@ pub(crate) fn fast_greedy_grammar_enabled() -> bool {
 /// is cheap (the chat fast path in this file makes it ≈ free).
 pub(crate) fn dflash_masked_verify_enabled() -> bool {
     static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        std::env::var("ATLAS_DFLASH_MASKED_VERIFY").ok().as_deref() == Some("1")
-    })
+    *CACHED.get_or_init(|| std::env::var("ATLAS_DFLASH_MASKED_VERIFY").ok().as_deref() == Some("1"))
 }
 
 /// Per-position verify logits, dequantised + processed through the full

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
@@ -50,6 +50,8 @@
 //! still see slightly stale `output_tokens` for positions ≥ 1 —
 //! best-effort, mirrors greedy unroll.
 
+mod fast_masked;
+
 use crate::scheduler::ActiveSeq;
 use crate::scheduler::decode_logits_seq::force_temp_zero_enabled;
 use crate::scheduler::helpers::bf16_to_f32;
@@ -62,6 +64,22 @@ use spark_model::traits::Model;
 pub(crate) fn fast_greedy_grammar_enabled() -> bool {
     static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| std::env::var("ATLAS_DISABLE_FAST_GREEDY").ok().as_deref() != Some("1"))
+}
+
+/// ATLAS_DFLASH_MASKED_VERIFY=1: route DFlash verify PICKS through the
+/// pre-sample pipeline so structural specials (`</think>`, `<think>`,
+/// `<tool_call>`) can never leak unmasked into the output — the T=0
+/// spec-entry derails, root cause 2026-07-08.
+///
+/// ⚠️ PICK-BASIS ONLY. This must never gate `dflash_verify_raw_argmax`
+/// itself: that bool selects the verify architecture at the step level,
+/// this env only chooses the pick basis at the pick sites. Masking picks
+/// is cheap (the chat fast path in this file makes it ≈ free).
+pub(crate) fn dflash_masked_verify_enabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("ATLAS_DFLASH_MASKED_VERIFY").ok().as_deref() == Some("1")
+    })
 }
 
 /// Per-position verify logits, dequantised + processed through the full
@@ -184,6 +202,16 @@ pub fn verify_pick_all_with_pipeline(
     let k = argmax_ids.len();
     if k == 0 {
         return Vec::new();
+    }
+
+    // ── CHAT FAST PATH (2026-07-08): masked-greedy == raw-argmax guard ──
+    // See `fast_masked` module docs: for a grammarless request with no
+    // forced/stateful stage armed and argmax-preserving penalties, the
+    // pipeline provably cannot change any pick, so the raw argmax IS the
+    // masked pick and the [K, vocab] D2H is skipped entirely. Any
+    // ineligible position falls through to the slow path for the call.
+    if let Some(picks) = fast_masked::try_chat_fast_path(model, argmax_ids, a, ctx) {
+        return picks;
     }
 
     // ── FAST PATH (#3, 2026-06-02): on-GPU greedy pick under grammar ──

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Chat fast path for masked verify picks (2026-07-08):
+//! masked-greedy == raw-argmax guard.
+//!
+//! The DFlash MASKED_VERIFY fix routes verify picks through
+//! `verify_pick_all_with_pipeline` so structural specials can never leak
+//! unmasked (the T=0 wrong-universe derails). But the grammar fast path
+//! there requires an active grammar AND `!inside_thinking`, so a plain
+//! chat request — no tools, no grammar — paid the slow path on EVERY
+//! position: `[K, vocab]` D2H + 248k BF16→F32 dequant + 8-stage pipeline
+//! + host argmax, ×K rows/step (measured 2026-07-08: 11.5 tok/s vs 15.8
+//! NOSPEC on the prose probe at γ17 — the masking was correct but the
+//! detour ate the spec win).
+//!
+//! For a grammarless request the pipeline can change the emitted pick
+//! ONLY when one of these holds:
+//!  (a) the raw argmax IS a maskable structural id: think_end
+//!      (MidWordThinkEndMask / PostCloseThinkMask), think_start
+//!      (PostCloseThinkMask), or tool_call_start
+//!      (ToolCallDuringThinkingMask — both branches: its -12.0 bias only
+//!      LOWERS tool_call_start, which cannot promote another token above
+//!      the raw max);
+//!  (b) a forced/stateful stage is armed on the seq: F2 confidence
+//!      early-stop (reads the row's softmax + mutates
+//!      consecutive_confident), ForcedThinkEndInjector (blanket-mask
+//!      injection — or its armed-deferring branch, which must tick
+//!      sentence_defer_count), PinToToolCallStart;
+//!  (c) penalties are not provably argmax-preserving (same SSOT gate as
+//!      the grammar fast path: Neutral, or ReduceOnly + per-pick immune;
+//!      the A4-floor/logit-bias case classifies as Blocked);
+//!  (d) the AdaDec diagnostic is recording (must observe the post-mask
+//!      distribution).
+//! (b)-(d) are step-level flag/env checks with no logits access; (a) is
+//! three integer compares per position. When none hold, masking only
+//! removes non-argmax candidates, so masked-greedy == `argmax_ids[i]` by
+//! definition and the call does no D2H at all.
+//!
+//! State-staleness parity: the slow path evaluates `a.*` flags and
+//! `a.output_tokens` FIXED across the K loop (they only advance in
+//! `emit_token`, after the helper), and the gates here read exactly that
+//! same fixed state — eligibility is uniform across positions and the
+//! equivalence is per-call exact. Any ineligible position falls through
+//! to the unmodified slow path for the whole call.
+//! Kill-switch: `ATLAS_DISABLE_FAST_MASKED=1`.
+
+use crate::scheduler::ActiveSeq;
+use crate::scheduler::logit_processors::LogitsContext;
+use crate::scheduler::mtp_timing::{self, Phase};
+use spark_model::traits::Model;
+
+/// Returns `Some(picks)` when the fast path proves masked-greedy ==
+/// raw-argmax for every position (picks are the raw `argmax_ids`);
+/// `None` when any gate fails and the caller must run the slow path.
+pub(super) fn try_chat_fast_path(
+    model: &dyn Model,
+    argmax_ids: &[u32],
+    a: &ActiveSeq,
+    ctx: &LogitsContext,
+) -> Option<Vec<u32>> {
+    let fast_masked_enabled = {
+        static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *CACHED.get_or_init(|| {
+            std::env::var("ATLAS_DISABLE_FAST_MASKED").ok().as_deref() != Some("1")
+        })
+    };
+    let adadec_recording = {
+        static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *CACHED.get_or_init(|| std::env::var("ATLAS_ADADEC_DIAGNOSTIC").is_ok())
+    };
+    if !fast_masked_enabled || a.grammar_state.is_some() || adadec_recording {
+        return None;
+    }
+    use crate::scheduler::confidence::{
+        MAX_SENTENCE_DEFER_TOKENS, THINK_DEFER_ABS_CEILING, THINK_DEFER_BUDGET_FACTOR,
+    };
+    // (b) forced/stateful stage preconditions — mirrored exactly from
+    // f2_confidence.rs / forced_think_end.rs / pin_tool_call.rs.
+    let f2_active = !crate::scheduler::helpers::disable_watchdogs()
+        && a.inside_thinking
+        && !a.force_end_thinking
+        && a.thinking_tokens >= 400
+        && crate::scheduler::helpers::watchdog_params().confidence_early_stop;
+    let defer_hard_override = match a.thinking_budget {
+        Some(b) => a.thinking_tokens >= b.saturating_mul(THINK_DEFER_BUDGET_FACTOR),
+        None => a.thinking_tokens >= THINK_DEFER_ABS_CEILING,
+    } || a.sentence_defer_count >= MAX_SENTENCE_DEFER_TOKENS;
+    let think_end_inject_armed =
+        a.inside_thinking && (a.force_end_thinking || defer_hard_override);
+    let pin_tool_armed = a.think_just_ended
+        && a.require_tool_call
+        && !a.tool_call_opened
+        && !a.inside_thinking;
+    // (c) penalty gate — same construction the slow path uses per
+    // position (penalty_params_for is position-independent here).
+    let penalty_gate = crate::scheduler::fast_greedy::classify_penalties(
+        &crate::scheduler::sample_step::penalty_params_for(
+            a,
+            crate::scheduler::sample_step::PositionKind::Verify,
+            0.0,
+            None,
+            Vec::new(),
+        ),
+    );
+    if f2_active
+        || think_end_inject_armed
+        || pin_tool_armed
+        || penalty_gate == crate::scheduler::fast_greedy::PenaltyGate::Blocked
+    {
+        return None;
+    }
+    let t_fast = std::time::Instant::now();
+    let scoped_history: Vec<u32> =
+        if penalty_gate == crate::scheduler::fast_greedy::PenaltyGate::ReduceOnly {
+            crate::scheduler::sample_step::penalty_history_scope(
+                &a.output_tokens,
+                ctx.tool_call_end_token,
+            )
+            .to_vec()
+        } else {
+            Vec::new()
+        };
+    let vocab = model.vocab_size();
+    let logits_base = model.logits_buffer_ptr();
+    let mut all_clear = true;
+    for (i, &tok) in argmax_ids.iter().enumerate() {
+        // (a) maskable structural ids → slow path for the call.
+        if Some(tok) == ctx.think_end_token
+            || Some(tok) == a.think_start_token
+            || Some(tok) == ctx.tool_call_start_token
+        {
+            all_clear = false;
+            break;
+        }
+        if penalty_gate == crate::scheduler::fast_greedy::PenaltyGate::ReduceOnly
+            && !crate::scheduler::fast_greedy::argmax_immune(tok, &scoped_history, || {
+                crate::scheduler::fast_greedy::logit_is_positive(
+                    model,
+                    logits_base,
+                    i,
+                    vocab,
+                    tok,
+                )
+            })
+        {
+            all_clear = false;
+            break;
+        }
+    }
+    mtp_timing::record(Phase::FastGreedy, t_fast);
+    if all_clear {
+        static LOGGED: std::sync::Once = std::sync::Once::new();
+        LOGGED.call_once(|| {
+            tracing::info!(
+                "verify chat fast path ACTIVE: masked-greedy == raw argmax, no D2H \
+                 (kill-switch: ATLAS_DISABLE_FAST_MASKED=1)"
+            );
+        });
+        return Some(argmax_ids.to_vec());
+    }
+    // Fall through — grammar fast path can't fire (grammar_state is
+    // None), so the slow path handles the call.
+    None
+}

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
@@ -58,6 +58,17 @@ pub(super) fn try_chat_fast_path(
     a: &ActiveSeq,
     ctx: &LogitsContext,
 ) -> Option<Vec<u32>> {
+    // DFlash masked-verify mode ONLY. The fast path exists to make
+    // ATLAS_DFLASH_MASKED_VERIFY affordable; it must never run for MTP:
+    // returning the GPU argmax where the slow path computes a host-side
+    // argmax over dequantized F32 logits changes tie-breaking on
+    // near-tie tokens — measured 2026-07-11 as temp-0 MTP output drift
+    // vs an unpatched binary (think block identical, answer flips at
+    // low-margin tokens). MTP keeps the slow path unconditionally so
+    // its behavior is byte-invariant by construction.
+    if !super::dflash_masked_verify_enabled() {
+        return None;
+    }
     let fast_masked_enabled = {
         static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         *CACHED

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
@@ -60,9 +60,8 @@ pub(super) fn try_chat_fast_path(
 ) -> Option<Vec<u32>> {
     let fast_masked_enabled = {
         static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        *CACHED.get_or_init(|| {
-            std::env::var("ATLAS_DISABLE_FAST_MASKED").ok().as_deref() != Some("1")
-        })
+        *CACHED
+            .get_or_init(|| std::env::var("ATLAS_DISABLE_FAST_MASKED").ok().as_deref() != Some("1"))
     };
     let adadec_recording = {
         static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -85,12 +84,9 @@ pub(super) fn try_chat_fast_path(
         Some(b) => a.thinking_tokens >= b.saturating_mul(THINK_DEFER_BUDGET_FACTOR),
         None => a.thinking_tokens >= THINK_DEFER_ABS_CEILING,
     } || a.sentence_defer_count >= MAX_SENTENCE_DEFER_TOKENS;
-    let think_end_inject_armed =
-        a.inside_thinking && (a.force_end_thinking || defer_hard_override);
-    let pin_tool_armed = a.think_just_ended
-        && a.require_tool_call
-        && !a.tool_call_opened
-        && !a.inside_thinking;
+    let think_end_inject_armed = a.inside_thinking && (a.force_end_thinking || defer_hard_override);
+    let pin_tool_armed =
+        a.think_just_ended && a.require_tool_call && !a.tool_call_opened && !a.inside_thinking;
     // (c) penalty gate — same construction the slow path uses per
     // position (penalty_params_for is position-independent here).
     let penalty_gate = crate::scheduler::fast_greedy::classify_penalties(
@@ -134,13 +130,7 @@ pub(super) fn try_chat_fast_path(
         }
         if penalty_gate == crate::scheduler::fast_greedy::PenaltyGate::ReduceOnly
             && !crate::scheduler::fast_greedy::argmax_immune(tok, &scoped_history, || {
-                crate::scheduler::fast_greedy::logit_is_positive(
-                    model,
-                    logits_base,
-                    i,
-                    vocab,
-                    tok,
-                )
+                crate::scheduler::fast_greedy::logit_is_positive(model, logits_base, i, vocab, tok)
             })
         {
             all_clear = false;


### PR DESCRIPTION
## Summary

Fixes two silent accept-rate defects in the DFlash verify path: (1) K=3/K=4/K=γ
verify never captured hiddens for the drafter, so `propose()` conditions on a
stale hidden and accept collapses silently (50%→3% measured); (2) verify judged
acceptance through the rep_pen/DRY pipeline while the drafter proposes on raw
argmax, deflating accept by construction. Also adds an opt-in
`ATLAS_DFLASH_MASKED_VERIFY=1` that restores structural-token masking for the
picks at near-zero cost via a proven fast path. Non-DFlash behavior is unchanged
(byte-verified). First of five PRs upstreaming my DFlash work; this one is the
measuring instrument that makes later accept-rate claims trustworthy.

## What changed

- **`416311e5`**: capture one-liners in `verify_c.rs` (K=3), `verify_c2.rs`
  (K=4), `verify_d.rs` (K=γ), mirroring `verify_b.rs:315`, inside the graph
  capture region. Unreachable under `--dflash` today (proposer caps at one
  draft, so K=2 only); becomes load-bearing when the γ engine lands (next PR).
  Reviewer rule: any new K-verify path must wire `try_dflash_capture` before
  its accept numbers mean anything.
- **`5f29ace4`**: thread `dflash_verify_raw_argmax` (= `--dflash`) from
  serve to scheduler to all four verify steps; DFlash accepts against the raw
  GPU argmax (GOLD basis), MTP keeps the pipelined verify unchanged. Adds the
  masked-verify opt-in plus a chat fast path
  (`verify_pipeline_helper/fast_masked.rs`, split as a submodule to respect
  the 500-LoC cap; kill-switch `ATLAS_DISABLE_FAST_MASKED=1`).
- **`11d9795f`**: found by this PR's own A/B validation. The fast path
  originally fired for MTP too, and GPU-vs-host argmax tie-breaking flipped
  near-tie tokens at temp 0. Now gated to masked-verify mode; MTP takes the
  slow path unconditionally, byte-invariant by construction.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --tests` (CI-exact invocation, clean)
- [x] SPDX headers verified on all 12 touched files incl. the new one
  (license-eye image is amd64-only and won't exec on GB10/ARM; CI runs the
  authoritative check)
- [x] `typos`, `cargo test -p spark-server -p spark-model --locked`
  (GPU-free CI variant), file-size cap; `cargo deny` n/a (no `Cargo.*` changes)
- [x] Tested against real hardware (GB10/sm_121f, Qwen3.6-27B-NVFP4, temp 0):
  - **MTP byte-invariance A/B** vs a main-built (`f26f392f`) binary: MinHeap
    code prompt content byte-identical ×2; Volvo prose byte-identical at
    steady state ×2; think blocks byte-identical in every run.
  - **`--dflash` stub parity:** reproduces main's pre-existing stub state
    exactly (K=2-capped, 0% accept per main's own drift-gauge warning); no
    crash, clean output.
  - **Masked-verify probe:** fast-path `ACTIVE` log line fires, zero leaked
    structural specials, pace unchanged vs unmasked.
- [ ] Agentic-harness distributions accompany PR 3 of this train (where perf
  is claimed); this PR makes no perf claims.

## Notes for reviewers

- The raw-argmax basis is gated on `--dflash`, which no MTP configuration
  sets. MTP semantics (Phase C-2 pipelined verify) are intact and
  byte-verified.
- One engine observation from the A/B protocol, relevant to anyone benching:
  prose prompts at temp 0 sit on near-tie tokens and are boot-sensitive on
  unmodified main (reproduced across cold boots on a clean `f26f392f`
  build; pre-existing, not from this PR). Code prompts are fully
  deterministic and serve as the invariance witnesses here.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
