### PR TITLE
feat(tier): add crates/atlas-tier — CUDA-free tiered-cache core (fresh from main)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@ crates/spark-comm/                           @tbraun96 @azeezish @rsafier @SeedS
 
 # Storage / NVMe-backed swap.
 crates/spark-storage/                        @tbraun96 @azeezish @rsafier @SeedSource
+crates/atlas-tier/                           @tbraun96 @azeezish @rsafier @SeedSource
 
 # Build, CI, governance. Belt-and-suspenders: the broad `.github/`
 # pattern catches everything in the tree, and the more specific entries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlas-tier"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/atlas-embed",
     "crates/atlas-reduce",
     "crates/atlas-kernels",
+    "crates/atlas-tier",
     "crates/spark-runtime",
     "crates/spark-comm",
     "crates/spark-model",

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -18,5 +18,10 @@ anyhow = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+# Tests implement SlotArena/SwapStore fault-injecting fakes, which return
+# `anyhow::Result` — same budget as the runtime dep, nothing new.
+anyhow = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+[package]
+name = "atlas-tier"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Atlas: generic tiered-cache core (SlotArena / SwapStore / Residency) — CUDA- and verbs-free"
+
+# HARD CONSTRAINT (tiered-cache consolidation step 2): this crate is the
+# CUDA-free, verbs-free paging core the peer daemons build on. Its dependency
+# budget is anyhow (+ libc for the O_DIRECT swap file on unix) — adding a GPU
+# or RDMA dependency here destroys the `atlas-expert-pack`
+# default-features = false property that keeps the peers CUDA-free.
+[dependencies]
+anyhow = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -7,11 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "Atlas: generic tiered-cache core (SlotArena / SwapStore / Residency) — CUDA- and verbs-free"
 
-# HARD CONSTRAINT (tiered-cache consolidation step 2): this crate is the
-# CUDA-free, verbs-free paging core the peer daemons build on. Its dependency
-# budget is anyhow (+ libc for the O_DIRECT swap file on unix) — adding a GPU
-# or RDMA dependency here destroys the `atlas-expert-pack`
-# default-features = false property that keeps the peers CUDA-free.
+# HARD CONSTRAINT: this crate is the CUDA-free, verbs-free paging core the peer
+# daemons build on. Its dependency budget is anyhow (+ libc for the O_DIRECT
+# swap file on unix) — adding a GPU or RDMA dependency here breaks the property
+# that keeps the peer daemons CUDA-free.
 [dependencies]
 anyhow = { workspace = true }
 

--- a/crates/atlas-tier/src/direct_swap.rs
+++ b/crates/atlas-tier/src/direct_swap.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! [`DirectSwapFile`] — the real O_DIRECT NVMe cold tier, plus its
+//! page-aligned bounce-buffer plumbing.
+
+use std::fs::OpenOptions;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use crate::traits::SwapStore;
+
+/// `O_DIRECT` is a Linux-only open flag (macOS has no equivalent — `F_NOCACHE`
+/// is an `fcntl`, not an open flag). The type itself must still compile on every
+/// unix because `spark_storage::snapshot_swap` re-exports it unconditionally and
+/// the workspace has a macOS/metal CI job; off Linux it simply opens buffered.
+/// That is harmless: the NVMe cold tier only ever runs on the Linux fleet.
+#[cfg(target_os = "linux")]
+const DIRECT_FLAGS: i32 = libc::O_DIRECT;
+#[cfg(not(target_os = "linux"))]
+const DIRECT_FLAGS: i32 = 0;
+
+/// O_DIRECT fixed-stride swap file on NVMe (the peer's cold tier). `record_bytes`
+/// MUST be a 4 KiB multiple (O_DIRECT) — the SSM snapshot blob (66,846,720 B =
+/// 16,320 × 4 KiB) already is. Records are addressed by `disk_slot` at
+/// `disk_slot * record_bytes`; the file grows sparsely as slots are allocated.
+///
+/// Buffers passed to read/write must be page-aligned for O_DIRECT. The peer's
+/// callers pass the mmap'd arena scratch (page-aligned); the residency scratch
+/// is a plain Vec — see `read/write_record` which stage through an aligned
+/// bounce only when the caller's buffer isn't aligned.
+pub struct DirectSwapFile {
+    fd: OwnedFd,
+    record_bytes: usize,
+    /// Page-aligned bounce for callers whose buffer isn't O_DIRECT-aligned.
+    bounce: AlignedBuf,
+}
+
+impl DirectSwapFile {
+    pub fn create(path: &Path, record_bytes: usize) -> Result<Self> {
+        if record_bytes == 0 || !record_bytes.is_multiple_of(4096) {
+            bail!(
+                "DirectSwapFile: record_bytes ({record_bytes}) must be a non-zero 4 KiB multiple"
+            );
+        }
+        let f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(DIRECT_FLAGS)
+            .open(path)
+            .map_err(|e| anyhow::anyhow!("open O_DIRECT {}: {e}", path.display()))?;
+        Ok(Self {
+            fd: OwnedFd::from(f),
+            record_bytes,
+            bounce: AlignedBuf::new(record_bytes),
+        })
+    }
+
+    fn offset(&self, disk_slot: usize) -> libc::off_t {
+        (disk_slot as u64 * self.record_bytes as u64) as libc::off_t
+    }
+}
+
+impl SwapStore for DirectSwapFile {
+    fn record_bytes(&self) -> usize {
+        self.record_bytes
+    }
+
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.record_bytes {
+            bail!(
+                "write_record: {} bytes, expected {}",
+                bytes.len(),
+                self.record_bytes
+            );
+        }
+        let off = self.offset(disk_slot);
+        let src = if is_aligned(bytes.as_ptr()) {
+            bytes.as_ptr()
+        } else {
+            self.bounce.as_mut_slice().copy_from_slice(bytes);
+            self.bounce.ptr()
+        };
+        let n = unsafe {
+            libc::pwrite(
+                self.fd.as_raw_fd(),
+                src as *const libc::c_void,
+                self.record_bytes,
+                off,
+            )
+        };
+        if n != self.record_bytes as isize {
+            bail!("pwrite record {disk_slot} returned {n}, errno {}", errno());
+        }
+        Ok(())
+    }
+
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        if out.len() != self.record_bytes {
+            bail!(
+                "read_record: {} bytes, expected {}",
+                out.len(),
+                self.record_bytes
+            );
+        }
+        let off = self.offset(disk_slot);
+        if is_aligned(out.as_ptr()) {
+            let n = unsafe {
+                libc::pread(
+                    self.fd.as_raw_fd(),
+                    out.as_mut_ptr() as *mut libc::c_void,
+                    self.record_bytes,
+                    off,
+                )
+            };
+            if n != self.record_bytes as isize {
+                bail!("pread record {disk_slot} returned {n}, errno {}", errno());
+            }
+        } else {
+            // Stage through the aligned bounce, then copy out. `&self` — the
+            // bounce is interior; take a raw ptr (single-threaded peer loop).
+            let bp = self.bounce.ptr();
+            let n = unsafe {
+                libc::pread(
+                    self.fd.as_raw_fd(),
+                    bp as *mut libc::c_void,
+                    self.record_bytes,
+                    off,
+                )
+            };
+            if n != self.record_bytes as isize {
+                bail!(
+                    "pread(bounce) record {disk_slot} returned {n}, errno {}",
+                    errno()
+                );
+            }
+            unsafe {
+                std::ptr::copy_nonoverlapping(bp, out.as_mut_ptr(), self.record_bytes);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn errno() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+fn is_aligned(p: *const u8) -> bool {
+    (p as usize) & 0xfff == 0
+}
+
+/// A page-aligned heap buffer (posix_memalign) for O_DIRECT staging.
+struct AlignedBuf {
+    ptr: *mut u8,
+    len: usize,
+}
+unsafe impl Send for AlignedBuf {}
+impl AlignedBuf {
+    fn new(len: usize) -> Self {
+        let mut p: *mut libc::c_void = std::ptr::null_mut();
+        let rc = unsafe { libc::posix_memalign(&mut p, 4096, len) };
+        assert!(
+            rc == 0 && !p.is_null(),
+            "posix_memalign({len}) failed rc={rc}"
+        );
+        Self {
+            ptr: p as *mut u8,
+            len,
+        }
+    }
+    fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.ptr as *mut libc::c_void) }
+    }
+}

--- a/crates/atlas-tier/src/direct_swap.rs
+++ b/crates/atlas-tier/src/direct_swap.rs
@@ -13,9 +13,8 @@ use anyhow::{Result, bail};
 use crate::traits::SwapStore;
 
 /// `O_DIRECT` is a Linux-only open flag (macOS has no equivalent — `F_NOCACHE`
-/// is an `fcntl`, not an open flag). The type itself must still compile on every
-/// unix because `spark_storage::snapshot_swap` re-exports it unconditionally and
-/// the workspace has a macOS/metal CI job; off Linux it simply opens buffered.
+/// is an `fcntl`, not an open flag). The type must still compile on every unix
+/// (the workspace has a macOS/metal CI job); off Linux it simply opens buffered.
 /// That is harmless: the NVMe cold tier only ever runs on the Linux fleet.
 #[cfg(target_os = "linux")]
 const DIRECT_FLAGS: i32 = libc::O_DIRECT;

--- a/crates/atlas-tier/src/entropy.rs
+++ b/crates/atlas-tier/src/entropy.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! OS entropy for **per-process key salts** (the SSM decode-tier client salt).
+//!
+//! Deliberately NOT in [`crate::hash`]: that module is the durable-determinism
+//! seam (same input ⇒ same `u64` forever, a fleet-wide on-disk contract); this
+//! one is its exact opposite — a value that must be FRESH per process so two
+//! same-model clients sharing one paging peer can never derive the same
+//! slot-coordinate wire keys.
+//!
+//! Failure is a HARD error, never a silent zero/degraded salt: a degraded
+//! shared salt would quietly reintroduce the exact cross-client key sharing
+//! the salt exists to prevent (PCND — no silent fallthrough).
+
+use anyhow::Result;
+
+/// 8 bytes of OS entropy as a `u64`.
+///
+/// Linux: `libc::getrandom` (flags = 0: the `/dev/urandom` pool, blocking only
+/// pre-seed at early boot), looping on `EINTR` and partial reads. Other unix
+/// (macOS): `/dev/urandom` via `read_exact`.
+pub fn random_u64() -> Result<u64> {
+    let mut buf = [0u8; 8];
+    fill(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+#[cfg(target_os = "linux")]
+fn fill(buf: &mut [u8]) -> Result<()> {
+    let mut got = 0usize;
+    while got < buf.len() {
+        let r = unsafe { libc::getrandom(buf[got..].as_mut_ptr().cast(), buf.len() - got, 0) };
+        if r < 0 {
+            let e = std::io::Error::last_os_error();
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            anyhow::bail!("getrandom failed (refusing a degraded zero-entropy salt): {e}");
+        }
+        got += r as usize;
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn fill(buf: &mut [u8]) -> Result<()> {
+    use std::io::Read;
+    let mut f = std::fs::File::open("/dev/urandom")
+        .map_err(|e| anyhow::anyhow!("open /dev/urandom failed (refusing a degraded salt): {e}"))?;
+    f.read_exact(buf)
+        .map_err(|e| anyhow::anyhow!("read /dev/urandom failed (refusing a degraded salt): {e}"))
+}
+
+#[cfg(test)]
+#[path = "entropy_tests.rs"]
+mod tests;

--- a/crates/atlas-tier/src/entropy_tests.rs
+++ b/crates/atlas-tier/src/entropy_tests.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `random_u64` sanity: it must succeed and actually vary — a constant (or
+//! erroring) source would silently give every process the SAME decode client
+//! salt, which is exactly the cross-client sharing the salt exists to prevent.
+
+use super::random_u64;
+
+#[test]
+fn random_u64_succeeds_and_varies() {
+    // 8 draws all identical has probability 2^-448 from a real entropy
+    // source — this fails only if the source is broken (constant/zero).
+    let draws: Vec<u64> = (0..8).map(|_| random_u64().expect("OS entropy")).collect();
+    assert!(
+        draws.iter().any(|&d| d != draws[0]),
+        "8 identical draws — entropy source is degraded/constant: {draws:?}"
+    );
+}

--- a/crates/atlas-tier/src/hash.rs
+++ b/crates/atlas-tier/src/hash.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Stable hash primitives for **durable, cross-process cache keys**.
+//!
+//! These values are written into the paging peer's NVMe swap file, which
+//! outlives the client that wrote them. So the same input must produce the same
+//! `u64` forever — across toolchains, platforms, target architectures and
+//! rebuilds. That is a *durable on-disk contract*, not a hashmap.
+//!
+//! `std::hash::DefaultHasher` is unusable here: std documents its algorithm as
+//! unspecified and "not to be relied upon over releases", so a toolchain bump
+//! silently rotates every persisted key (total cache miss) or collides with a
+//! stale namespace (silent wrong-state corruption). `ahash` is worse still — it
+//! varies by CPU feature (AES-NI). A crate dependency is also a hazard: a
+//! version bump could rotate the fleet's keys. Hence: vendored, ~20 lines, here.
+//!
+//! They live in `atlas-tier` because it is pure (`anyhow` + `libc`, no CUDA, no
+//! verbs) and a common ancestor of its consumers — the SSM tier fingerprint and
+//! the KV paging namespace — so both derive keys from ONE definition of these
+//! constants rather than separate copies free to drift.
+//!
+//! ## Threat model (read before reusing these)
+//!
+//! FNV-1a is **not collision-resistant against an adversary**: it is
+//! multiplicative and trivially invertible, so collisions are *constructible*,
+//! not merely improbable. That is fine for the current use — a trusted fleet
+//! whose model configs are not attacker-chosen, where safety comes from the
+//! *injective encoding* of the input plus determinism, and where the birthday
+//! bound over a few dozen configs is nil.
+//!
+//! It would **not** be fine if a shared paging peer ever served untrusted or
+//! multi-tenant configs: an attacker able to choose a config could craft one
+//! whose namespace collides with another tenant's and read that tenant's
+//! recurrent state off the shared peer — defeating the exact property the
+//! namespace exists to provide. If that day comes, switch to a keyed hash
+//! (keyed BLAKE3, or a vendored SipHash-2-4 with a fixed key) behind a
+//! namespace-version bump, which is a deliberate fleet-wide cache flush.
+
+/// FNV-1a/64 offset basis (published constant).
+pub const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+/// FNV-1a/64 prime (published constant).
+pub const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+const GOLDEN: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// FNV-1a/64 over a byte stream. Fully specified, endianness-free (it consumes
+/// bytes, not words), and deterministic across every toolchain and platform.
+pub const fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut h = FNV_OFFSET;
+    let mut i = 0;
+    while i < bytes.len() {
+        h = (h ^ bytes[i] as u64).wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    h
+}
+
+/// splitmix64 finalizer over `a ^ b·GOLDEN` — domain-separated mixing.
+///
+/// This is the single definition of the fold used for **every persisted wire
+/// key**: `PagingSnapshotStore::wire(key) == mix64(key, namespace)` and the
+/// decode namespace is `mix64(fingerprint, DECODE_DOMAIN)`. Changing it rotates
+/// every key on every peer.
+pub const fn mix64(a: u64, b: u64) -> u64 {
+    let mut h = a ^ b.wrapping_mul(GOLDEN);
+    h ^= h >> 30;
+    h = h.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    h ^= h >> 27;
+    h = h.wrapping_mul(0x94D0_49BB_1331_11EB);
+    h ^ (h >> 31)
+}
+
+#[cfg(test)]
+#[path = "hash_tests.rs"]
+mod tests;

--- a/crates/atlas-tier/src/hash_tests.rs
+++ b/crates/atlas-tier/src/hash_tests.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! These pins are the whole safety story for durable cache keys: they catch a
+//! "helpful" reimplementation that changes the value, which would silently
+//! rotate (or collide) every key persisted in a peer's NVMe swap file.
+
+use super::{fnv1a_64, mix64};
+
+/// Pin the primitive to the PUBLISHED FNV-1a/64 reference vectors — someone
+/// else's constants, so a swapped or "optimized" implementation cannot pass.
+#[test]
+fn fnv1a_64_matches_published_reference_vectors() {
+    assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+    assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+}
+
+#[test]
+fn fnv1a_64_is_order_sensitive_and_length_sensitive() {
+    assert_ne!(fnv1a_64(b"ab"), fnv1a_64(b"ba"));
+    assert_ne!(fnv1a_64(b"a"), fnv1a_64(b"aa"));
+}
+
+/// mix64 is the fold behind EVERY persisted wire key. Pin it to literals: this
+/// is the value that lands on disk, so it is arguably a more important pin than
+/// the fingerprint itself.
+#[test]
+fn mix64_golden_pins() {
+    assert_eq!(mix64(1, 0), 0x5692_161d_100b_05e5);
+    assert_eq!(mix64(0, 1), 0xe220_a839_7b1d_cdaf);
+    assert_eq!(mix64(0xdead_beef, 0xcafe_f00d), 0x5f3e_915c_5c36_4c56);
+}
+
+/// splitmix64 has a ZERO FIXED POINT: `mix64(0, 0) == 0`. Pinned because it is
+/// load-bearing, not a curiosity — it is precisely why every caller that turns a
+/// mix into a namespace needs zero-avoidance (`NonZeroU64`), and why the decode
+/// namespace must not fall back to the fingerprint when the mix lands on zero.
+#[test]
+fn mix64_has_a_zero_fixed_point() {
+    assert_eq!(mix64(0, 0), 0);
+}
+
+/// Namespace separation: the same logical key under two namespaces must not
+/// collide. This is the property that stops two models cross-serving on one peer.
+#[test]
+fn mix64_separates_namespaces() {
+    let key = 0x1234_5678_9abc_def0;
+    assert_ne!(mix64(key, 1), mix64(key, 2));
+    assert_ne!(mix64(key, 0), mix64(key, u64::MAX));
+}
+
+/// Deterministic + const-evaluable (both are load-bearing: the values are
+/// durable, and callers use them in const contexts).
+#[test]
+fn mix64_and_fnv_are_const_and_deterministic() {
+    const H: u64 = fnv1a_64(b"atlas");
+    const M: u64 = mix64(H, 7);
+    assert_eq!(H, fnv1a_64(b"atlas"));
+    assert_eq!(M, mix64(H, 7));
+}

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::all)]
 
 //! The generic tiered-cache core: the CUDA-free, verbs-free paging foundation
-//! that the streaming-weights peer daemons build on.
+//! that the peer daemons build on.
 //!
 //! One mechanism, three seams:
 //!   * [`SlotArena`]  — the bounded HOT tier: `num_slots` fixed-size byte slots
@@ -21,8 +21,7 @@
 //! fully unit-testable without RDMA or a GPU and lets the downstream peer
 //! daemons build CUDA-free. The peer wire protocol (paging loops, client
 //! codec) and the concrete RDMA/HBM tier implementations deliberately do NOT
-//! live here — they arrive in the consumer crates (cache-peer, the
-//! `spark-storage` re-export) in follow-up PRs of the streaming-weights work.
+//! live here — they belong to the consumer crates that build on this core.
 
 mod direct_swap;
 mod mem;

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+#![deny(warnings)]
+#![deny(clippy::all)]
+
+//! The generic tiered-cache core: the CUDA-free, verbs-free paging foundation
+//! that the streaming-weights peer daemons build on.
+//!
+//! One mechanism, three seams:
+//!   * [`SlotArena`]  — the bounded HOT tier: `num_slots` fixed-size byte slots
+//!     (a peer's mmap'd RDMA MR, a host-RAM `Vec`, …). No CUDA/HBM impl may
+//!     live in this crate — that belongs to consumer crates.
+//!   * [`SwapStore`]  — the unbounded COLD tier: a fixed-stride record store
+//!     ([`DirectSwapFile`] on NVMe, [`MemSwapStore`] in RAM, …).
+//!   * [`Residency`]  — the page table over both: opaque `u64` key →
+//!     byte-agnostic fixed-size blob, two-level LRU (RAM `lru` above
+//!     `disk_lru`), read-pins so a slot is never reused mid-read, and
+//!     NEVER-reject puts (a full arena spills the coldest resident to disk; a
+//!     capped disk drops its coldest key → clean later miss).
+//!
+//! This crate is CPU/disk-only: deps are `anyhow` + `libc` (unix), so it is
+//! fully unit-testable without RDMA or a GPU and lets the downstream peer
+//! daemons build CUDA-free. The peer wire protocol (paging loops, client
+//! codec) and the concrete RDMA/HBM tier implementations deliberately do NOT
+//! live here — they arrive in the consumer crates (cache-peer, the
+//! `spark-storage` re-export) in follow-up PRs of the streaming-weights work.
+
+mod direct_swap;
+mod mem;
+mod residency;
+mod traits;
+
+pub use direct_swap::DirectSwapFile;
+pub use mem::{MemSwapStore, VecSlotArena};
+pub use residency::Residency;
+pub use traits::{SlotArena, SwapStats, SwapStore};

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -28,6 +28,9 @@ mod mem;
 mod residency;
 mod traits;
 
+pub mod entropy;
+pub mod hash;
+
 pub use direct_swap::DirectSwapFile;
 pub use mem::{MemSwapStore, VecSlotArena};
 pub use residency::Residency;

--- a/crates/atlas-tier/src/mem.rs
+++ b/crates/atlas-tier/src/mem.rs
@@ -9,9 +9,9 @@ use anyhow::{Result, bail};
 
 use crate::traits::{SlotArena, SwapStore};
 
-/// Host-RAM [`SlotArena`] over one flat `Vec<u8>` (promoted from the original
-/// test fake). The hot tier for in-process consumers — e.g. the unified SSM
-/// spill store's RAM cache. Allocates `slot_bytes * num_slots` up front.
+/// Host-RAM [`SlotArena`] over one flat `Vec<u8>`. The hot tier for in-process
+/// consumers — e.g. the unified SSM spill store's RAM cache. Allocates
+/// `slot_bytes * num_slots` up front.
 pub struct VecSlotArena {
     buf: Vec<u8>,
     slot_bytes: usize,
@@ -53,9 +53,9 @@ impl SlotArena for VecSlotArena {
     }
 }
 
-/// Host-RAM [`SwapStore`] over a `HashMap` (promoted from the original test
-/// fake). Records live in ordinary heap memory — the "swap" tier when no NVMe
-/// directory is configured (unbounded, still LRU-ordered by the residency).
+/// Host-RAM [`SwapStore`] over a `HashMap`. Records live in ordinary heap
+/// memory — the "swap" tier when no NVMe directory is configured (unbounded,
+/// still LRU-ordered by the residency).
 pub struct MemSwapStore {
     recs: HashMap<usize, Vec<u8>>,
     record_bytes: usize,

--- a/crates/atlas-tier/src/mem.rs
+++ b/crates/atlas-tier/src/mem.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Host-RAM reference impls: [`VecSlotArena`] (hot tier) and [`MemSwapStore`]
+//! (cold tier).
+
+use std::collections::HashMap;
+
+use anyhow::{Result, bail};
+
+use crate::traits::{SlotArena, SwapStore};
+
+/// Host-RAM [`SlotArena`] over one flat `Vec<u8>` (promoted from the original
+/// test fake). The hot tier for in-process consumers — e.g. the unified SSM
+/// spill store's RAM cache. Allocates `slot_bytes * num_slots` up front.
+pub struct VecSlotArena {
+    buf: Vec<u8>,
+    slot_bytes: usize,
+    n: usize,
+}
+
+impl VecSlotArena {
+    pub fn new(slot_bytes: usize, num_slots: usize) -> Self {
+        Self {
+            buf: vec![0u8; slot_bytes * num_slots],
+            slot_bytes,
+            n: num_slots,
+        }
+    }
+}
+
+impl SlotArena for VecSlotArena {
+    fn slot_bytes(&self) -> usize {
+        self.slot_bytes
+    }
+    fn num_slots(&self) -> usize {
+        self.n
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        if slot >= self.n || out.len() != self.slot_bytes {
+            bail!("VecSlotArena::read_slot({slot}) out of range / size mismatch");
+        }
+        let o = slot * self.slot_bytes;
+        out.copy_from_slice(&self.buf[o..o + self.slot_bytes]);
+        Ok(())
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        if slot >= self.n || bytes.len() != self.slot_bytes {
+            bail!("VecSlotArena::write_slot({slot}) out of range / size mismatch");
+        }
+        let o = slot * self.slot_bytes;
+        self.buf[o..o + self.slot_bytes].copy_from_slice(bytes);
+        Ok(())
+    }
+}
+
+/// Host-RAM [`SwapStore`] over a `HashMap` (promoted from the original test
+/// fake). Records live in ordinary heap memory — the "swap" tier when no NVMe
+/// directory is configured (unbounded, still LRU-ordered by the residency).
+pub struct MemSwapStore {
+    recs: HashMap<usize, Vec<u8>>,
+    record_bytes: usize,
+}
+
+impl MemSwapStore {
+    pub fn new(record_bytes: usize) -> Self {
+        Self {
+            recs: HashMap::new(),
+            record_bytes,
+        }
+    }
+}
+
+impl SwapStore for MemSwapStore {
+    fn record_bytes(&self) -> usize {
+        self.record_bytes
+    }
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.record_bytes {
+            bail!(
+                "MemSwapStore::write_record: {} bytes, expected {}",
+                bytes.len(),
+                self.record_bytes
+            );
+        }
+        self.recs.insert(disk_slot, bytes.to_vec());
+        Ok(())
+    }
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        match self.recs.get(&disk_slot) {
+            Some(v) => {
+                out.copy_from_slice(v);
+                Ok(())
+            }
+            None => bail!("MemSwapStore: no record {disk_slot}"),
+        }
+    }
+    fn discard_record(&mut self, disk_slot: usize) {
+        self.recs.remove(&disk_slot);
+    }
+}

--- a/crates/atlas-tier/src/residency.rs
+++ b/crates/atlas-tier/src/residency.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! [`Residency`] — the policy core: the page table over a bounded hot
+//! [`SlotArena`] and an unbounded cold [`SwapStore`].
+
+use std::collections::{HashMap, VecDeque};
+
+use anyhow::{Result, bail};
+
+use crate::traits::{SlotArena, SwapStats, SwapStore};
+
+/// Where a key's blob currently lives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Loc {
+    /// Arena slot handed out for an in-flight PUT; pinned (not evictable) until
+    /// `commit`. Holds the caller's about-to-be-written bytes.
+    Reserved(usize),
+    /// Live in an arena slot (RDMA-readable now).
+    Resident(usize),
+    /// Spilled to a disk record; a GET faults it back into a slot.
+    OnDisk(usize),
+}
+
+/// The page table: `key → Loc` over a bounded [`SlotArena`] (hot) backed by an
+/// unbounded [`SwapStore`] (cold), with LRU eviction of resident slots to disk.
+/// (Historically `SnapshotResidency` — `spark-storage::snapshot_swap` re-exports
+/// it under that name for the peer.)
+pub struct Residency<A: SlotArena, S: SwapStore> {
+    arena: A,
+    swap: S,
+    blob_bytes: usize,
+    map: HashMap<u64, Loc>,
+    /// Free arena slot indices (LIFO reuse).
+    free_slots: Vec<usize>,
+    /// Resident keys, front = coldest (LRU eviction victim). Reserved keys are
+    /// NOT in here (pinned).
+    lru: VecDeque<u64>,
+    /// On-disk keys, front = coldest — the disk-cap eviction victim. Every
+    /// `OnDisk` entry is exactly once in here (a bounded two-level LRU:
+    /// RAM `lru` above disk `disk_lru`).
+    disk_lru: VecDeque<u64>,
+    /// Max simultaneous on-disk records (the disk cap / blob_bytes). 0 =
+    /// unbounded. When full, the coldest on-disk snapshot is dropped to make
+    /// room — a later GET for it misses and the model recomputes (correct
+    /// degradation, keeps the swap file bounded).
+    max_disk_slots: usize,
+    /// Free disk record indices (reused before growing the high-water mark).
+    free_disk: Vec<usize>,
+    next_disk: usize,
+    /// Reusable scratch for a single blob move (spill/fault), sized once.
+    scratch: Vec<u8>,
+    /// Read-pins: `key → active reader count`. A GET hands the client an arena
+    /// offset it then one-sided-RDMA-READs; the peer drops the residency lock
+    /// before that read, so a concurrent ALLOC on another connection could pick
+    /// the slot as an eviction victim and reuse it mid-read (torn restore). A
+    /// pinned key is held OUT of `lru` (like a `Reserved` slot) so
+    /// `evict_coldest_to_disk` can never choose it. Ref-counted for concurrent
+    /// readers of the same key. Invariant: `key ∈ lru ⟺ Resident AND unpinned`.
+    read_pins: HashMap<u64, u32>,
+    stats: SwapStats,
+}
+
+impl<A: SlotArena, S: SwapStore> Residency<A, S> {
+    /// Unbounded disk tier (no cap). Prefer [`Residency::new_capped`] in
+    /// production.
+    pub fn new(arena: A, swap: S) -> Result<Self> {
+        Self::new_capped(arena, swap, 0)
+    }
+
+    /// `max_disk_slots` bounds the on-disk record count (0 = unbounded). When
+    /// full, spilling evicts the coldest on-disk snapshot (dropped → later GET
+    /// misses → recompute), keeping the swap file at ≤ `max_disk_slots` records.
+    pub fn new_capped(arena: A, swap: S, max_disk_slots: usize) -> Result<Self> {
+        let blob_bytes = arena.slot_bytes();
+        if blob_bytes == 0 {
+            bail!("Residency: slot_bytes must be > 0");
+        }
+        if swap.record_bytes() != blob_bytes {
+            bail!(
+                "Residency: arena slot ({}) and swap record ({}) sizes differ",
+                blob_bytes,
+                swap.record_bytes()
+            );
+        }
+        let n = arena.num_slots();
+        if n == 0 {
+            bail!("Residency: arena must have >= 1 slot");
+        }
+        Ok(Self {
+            arena,
+            swap,
+            blob_bytes,
+            map: HashMap::new(),
+            free_slots: (0..n).rev().collect(),
+            lru: VecDeque::new(),
+            disk_lru: VecDeque::new(),
+            max_disk_slots,
+            free_disk: Vec::new(),
+            next_disk: 0,
+            scratch: vec![0u8; blob_bytes],
+            read_pins: HashMap::new(),
+            stats: SwapStats::default(),
+        })
+    }
+
+    pub fn blob_bytes(&self) -> usize {
+        self.blob_bytes
+    }
+    pub fn stats(&self) -> &SwapStats {
+        &self.stats
+    }
+    pub fn resident_count(&self) -> usize {
+        self.lru.len()
+    }
+    pub fn total_keys(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Direct arena access for the data plane. The peer writes the slots its
+    /// clients one-sided-RDMA into/out of; in-process consumers should prefer
+    /// [`Residency::put_blob`] / [`Residency::get_blob`].
+    pub fn arena(&self) -> &A {
+        &self.arena
+    }
+    pub fn arena_mut(&mut self) -> &mut A {
+        &mut self.arena
+    }
+
+    /// Byte offset of an arena slot (what the client RDMA-reads/writes).
+    pub fn slot_offset(&self, slot: usize) -> u64 {
+        (slot as u64) * (self.blob_bytes as u64)
+    }
+
+    // ─────────────────────────── control-plane ops ───────────────────────────
+
+    /// PUT step 1 — reserve an arena slot for `key`. Evicts the coldest resident
+    /// slot to disk if the arena is full (never rejects). The caller then
+    /// RDMA-WRITEs the blob into `slot_offset(slot)` and calls `commit(key)`.
+    /// Re-PUT of a live key reuses its current slot (idempotent overwrite).
+    pub fn alloc(&mut self, key: u64) -> Result<usize> {
+        self.stats.puts += 1;
+        // Overwrite-in-place: a key already resident/reserved keeps its slot.
+        match self.map.get(&key).copied() {
+            Some(Loc::Resident(slot)) => {
+                self.lru_remove(key); // pin during the rewrite
+                self.map.insert(key, Loc::Reserved(slot));
+                return Ok(slot);
+            }
+            Some(Loc::Reserved(slot)) => return Ok(slot),
+            Some(Loc::OnDisk(disk_slot)) => {
+                // Rewriting a spilled key: reclaim its disk record, give a slot.
+                self.disk_lru_remove(key);
+                self.free_disk.push(disk_slot);
+                self.swap.discard_record(disk_slot);
+            }
+            None => {}
+        }
+        let slot = self.acquire_slot()?;
+        self.map.insert(key, Loc::Reserved(slot));
+        Ok(slot)
+    }
+
+    /// PUT step 2 — the client's RDMA-WRITE into the reserved slot has landed;
+    /// mark `key` resident (and hottest in the LRU).
+    pub fn commit(&mut self, key: u64) -> Result<()> {
+        match self.map.get(&key).copied() {
+            Some(Loc::Reserved(slot)) => {
+                self.map.insert(key, Loc::Resident(slot));
+                // Maintain the `in-lru ⟺ Resident AND unpinned` invariant: if a
+                // reader pinned this key while the re-PUT was in flight, leave it
+                // out of the LRU — `unpin_read` re-adds it when the last reader
+                // releases.
+                if !self.read_pins.contains_key(&key) {
+                    self.lru.push_back(key); // hottest
+                }
+                Ok(())
+            }
+            Some(Loc::Resident(_)) => Ok(()), // already committed — idempotent
+            _ => bail!("commit({key:#x}): no reserved slot (alloc not called / evicted)"),
+        }
+    }
+
+    /// GET — ensure `key` is resident and return its arena slot (offset via
+    /// `slot_offset`). Faults from disk into a slot if it was spilled (evicting
+    /// a victim to make room). `Ok(None)` = unknown key (caller recomputes).
+    pub fn locate(&mut self, key: u64) -> Result<Option<usize>> {
+        self.stats.gets += 1;
+        match self.map.get(&key).copied() {
+            Some(Loc::Resident(slot)) => {
+                self.stats.resident_hits += 1;
+                // A concurrently-pinned key is held out of `lru`; touching it
+                // would re-insert it (breaking the invariant + making it an
+                // eviction victim while still being read). The caller pins right
+                // after this returns, so unpinned hits get refreshed here and
+                // pinned ones stay out.
+                if !self.read_pins.contains_key(&key) {
+                    self.lru_touch(key);
+                }
+                Ok(Some(slot))
+            }
+            Some(Loc::Reserved(slot)) => {
+                // A GET racing an uncommitted PUT: the bytes are (being) written
+                // by the same caller; hand back the slot.
+                Ok(Some(slot))
+            }
+            Some(Loc::OnDisk(disk_slot)) => {
+                // Pin against `acquire_slot`'s spill+make_disk_room evicting THIS
+                // key (it is still OnDisk until the fault below completes).
+                self.disk_lru_remove(key);
+                let slot = match self.acquire_slot() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        self.disk_lru.push_front(key); // un-pin (still on disk)
+                        return Err(e);
+                    }
+                };
+                // scratch is exclusive to one move at a time (control loop is
+                // single-threaded per connection); read disk → arena slot.
+                let mut buf = std::mem::take(&mut self.scratch);
+                let r = self.swap.read_record(disk_slot, &mut buf);
+                if r.is_ok() {
+                    r.and_then(|_| self.arena.write_slot(slot, &buf))?;
+                } else {
+                    self.scratch = buf;
+                    self.free_slots.push(slot);
+                    self.disk_lru.push_front(key); // still on disk; re-pin (cold)
+                    return r.map(|_| None);
+                }
+                self.scratch = buf;
+                self.free_disk.push(disk_slot);
+                self.swap.discard_record(disk_slot);
+                self.map.insert(key, Loc::Resident(slot));
+                self.lru.push_back(key);
+                self.stats.faults_from_disk += 1;
+                Ok(Some(slot))
+            }
+            None => {
+                self.stats.get_miss += 1;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Drop `key` entirely, reclaiming its arena slot or disk record.
+    pub fn remove(&mut self, key: u64) {
+        match self.map.remove(&key) {
+            Some(Loc::Resident(slot)) | Some(Loc::Reserved(slot)) => {
+                self.lru_remove(key);
+                self.free_slots.push(slot);
+            }
+            Some(Loc::OnDisk(disk_slot)) => {
+                self.disk_lru_remove(key);
+                self.free_disk.push(disk_slot);
+                self.swap.discard_record(disk_slot);
+            }
+            None => {}
+        }
+    }
+
+    /// Read-pin `key` so its resident slot cannot be chosen as an eviction
+    /// victim while a client's one-sided RDMA READ of it is in flight (the
+    /// GET→RDMA-read race: the peer replies with the offset and drops the lock
+    /// before the client reads, so a concurrent ALLOC could otherwise
+    /// spill+reuse the slot). Ref-counted for concurrent readers; the first pin
+    /// removes the key from `lru` (like a `Reserved` slot). No-op unless the key
+    /// is currently `Resident`.
+    pub fn pin_read(&mut self, key: u64) {
+        if !matches!(self.map.get(&key), Some(Loc::Resident(_))) {
+            return;
+        }
+        let n = self.read_pins.get(&key).copied().unwrap_or(0);
+        if n == 0 {
+            self.lru_remove(key); // exclude from eviction victims while read
+        }
+        self.read_pins.insert(key, n + 1);
+    }
+
+    /// Release one read-pin taken by [`Residency::pin_read`]. When the last
+    /// reader releases, the key rejoins `lru` as hottest (it was just read).
+    /// No-op if the key holds no pin. Robust to the key having been removed
+    /// while pinned: only re-adds to `lru` if still `Resident` and not already
+    /// present.
+    pub fn unpin_read(&mut self, key: u64) {
+        let Some(n) = self.read_pins.get_mut(&key) else {
+            return;
+        };
+        *n -= 1;
+        if *n == 0 {
+            self.read_pins.remove(&key);
+            if matches!(self.map.get(&key), Some(Loc::Resident(_))) && !self.lru.contains(&key) {
+                self.lru.push_back(key); // hottest — just accessed
+            }
+        }
+    }
+
+    /// Active read-pin count (test/introspection).
+    pub fn read_pin_count(&self, key: u64) -> u32 {
+        self.read_pins.get(&key).copied().unwrap_or(0)
+    }
+
+    // ───────────────────── in-process one-shot helpers ─────────────────────
+
+    /// One-shot in-process PUT: reserve a slot, copy `bytes` into it, commit.
+    /// Same NEVER-reject chain as the two-phase peer path (alloc → spill the
+    /// coldest resident → drop the coldest on-disk key when capped). For
+    /// consumers whose data plane is a memcpy rather than a client RDMA-WRITE.
+    pub fn put_blob(&mut self, key: u64, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.blob_bytes {
+            bail!(
+                "put_blob({key:#x}): {} bytes, expected {}",
+                bytes.len(),
+                self.blob_bytes
+            );
+        }
+        let slot = self.alloc(key)?;
+        if let Err(e) = self.arena.write_slot(slot, bytes) {
+            // Roll back the reservation so the slot is not stranded Reserved
+            // (a later GET must miss cleanly, never read a torn slot).
+            self.remove(key);
+            return Err(e);
+        }
+        self.commit(key)
+    }
+
+    /// One-shot in-process GET: fault `key` in (if spilled) and copy its blob
+    /// into `out`. `Ok(false)` = unknown key (caller recomputes).
+    pub fn get_blob(&mut self, key: u64, out: &mut [u8]) -> Result<bool> {
+        if out.len() != self.blob_bytes {
+            bail!(
+                "get_blob({key:#x}): {} bytes, expected {}",
+                out.len(),
+                self.blob_bytes
+            );
+        }
+        match self.locate(key)? {
+            Some(slot) => {
+                self.arena.read_slot(slot, out)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    // ─────────────────────────── internals ───────────────────────────
+
+    /// A free arena slot, spilling the coldest resident slot to disk if none.
+    fn acquire_slot(&mut self) -> Result<usize> {
+        if let Some(s) = self.free_slots.pop() {
+            return Ok(s);
+        }
+        self.evict_coldest_to_disk()
+    }
+
+    /// Spill the LRU-coldest RESIDENT key to a disk record and return its freed
+    /// arena slot. Reserved (pinned) keys are never victims.
+    fn evict_coldest_to_disk(&mut self) -> Result<usize> {
+        let Some(victim) = self.lru.pop_front() else {
+            bail!(
+                "Residency: arena exhausted — all {} slots reserved (uncommitted \
+                 PUTs) or read-pinned (in-flight RDMA READs)",
+                self.arena.num_slots()
+            );
+        };
+        let slot = match self.map.get(&victim).copied() {
+            Some(Loc::Resident(slot)) => slot,
+            other => bail!("LRU/map desync: victim {victim:#x} is {other:?}, expected Resident"),
+        };
+        // Bound the disk tier: drop the coldest on-disk snapshot(s) if at cap
+        // BEFORE claiming a disk slot for this spill.
+        self.make_disk_room();
+        let disk_slot = self.alloc_disk_slot();
+        let mut buf = std::mem::take(&mut self.scratch);
+        let res = self
+            .arena
+            .read_slot(slot, &mut buf)
+            .and_then(|_| self.swap.write_record(disk_slot, &buf));
+        self.scratch = buf;
+        if let Err(e) = res {
+            // Roll back: victim stays resident, disk slot returns to the pool.
+            self.free_disk.push(disk_slot);
+            self.lru.push_front(victim);
+            return Err(e);
+        }
+        self.map.insert(victim, Loc::OnDisk(disk_slot));
+        self.disk_lru.push_back(victim); // warmest on-disk entry
+        self.stats.spills_to_disk += 1;
+        Ok(slot)
+    }
+
+    /// Evict the coldest on-disk snapshot(s) until there is room for one more
+    /// under `max_disk_slots` (no-op when unbounded). A dropped snapshot's key
+    /// leaves the map entirely → a later GET misses → the model recomputes.
+    fn make_disk_room(&mut self) {
+        if self.max_disk_slots == 0 {
+            return;
+        }
+        while self.disk_lru.len() >= self.max_disk_slots {
+            let Some(cold) = self.disk_lru.pop_front() else {
+                break;
+            };
+            if let Some(Loc::OnDisk(ds)) = self.map.remove(&cold) {
+                self.free_disk.push(ds);
+                self.swap.discard_record(ds);
+                self.stats.disk_evictions += 1;
+            }
+        }
+    }
+
+    fn alloc_disk_slot(&mut self) -> usize {
+        if let Some(d) = self.free_disk.pop() {
+            d
+        } else {
+            let d = self.next_disk;
+            self.next_disk += 1;
+            d
+        }
+    }
+
+    fn disk_lru_remove(&mut self, key: u64) {
+        if let Some(pos) = self.disk_lru.iter().position(|&k| k == key) {
+            self.disk_lru.remove(pos);
+        }
+    }
+
+    fn lru_touch(&mut self, key: u64) {
+        self.lru_remove(key);
+        self.lru.push_back(key);
+    }
+
+    fn lru_remove(&mut self, key: u64) {
+        if let Some(pos) = self.lru.iter().position(|&k| k == key) {
+            self.lru.remove(pos);
+        }
+    }
+}

--- a/crates/atlas-tier/src/residency.rs
+++ b/crates/atlas-tier/src/residency.rs
@@ -51,7 +51,7 @@ pub struct Residency<A: SlotArena, S: SwapStore> {
     scratch: Vec<u8>,
     /// Read-pins: `key → active reader count`. A GET hands the client an arena
     /// offset it then one-sided-RDMA-READs; the peer drops the residency lock
-    /// before that read, so a concurrent ALLOC on another connection could pick
+    /// before that read, so a concurrent allocation on another connection could pick
     /// the slot as an eviction victim and reuse it mid-read (torn restore). A
     /// pinned key is held OUT of `lru` (like a `Reserved` slot) so
     /// `evict_coldest_to_disk` can never choose it. Ref-counted for concurrent
@@ -260,7 +260,7 @@ impl<A: SlotArena, S: SwapStore> Residency<A, S> {
     /// Read-pin `key` so its resident slot cannot be chosen as an eviction
     /// victim while a client's one-sided RDMA READ of it is in flight (the
     /// GET→RDMA-read race: the peer replies with the offset and drops the lock
-    /// before the client reads, so a concurrent ALLOC could otherwise
+    /// before the client reads, so a concurrent allocation could otherwise
     /// spill+reuse the slot). Ref-counted for concurrent readers; the first pin
     /// removes the key from `lru` (like a `Reserved` slot). No-op unless the key
     /// is currently `Resident`.

--- a/crates/atlas-tier/src/residency.rs
+++ b/crates/atlas-tier/src/residency.rs
@@ -23,8 +23,6 @@ enum Loc {
 
 /// The page table: `key → Loc` over a bounded [`SlotArena`] (hot) backed by an
 /// unbounded [`SwapStore`] (cold), with LRU eviction of resident slots to disk.
-/// (Historically `SnapshotResidency` — `spark-storage::snapshot_swap` re-exports
-/// it under that name for the peer.)
 pub struct Residency<A: SlotArena, S: SwapStore> {
     arena: A,
     swap: S,

--- a/crates/atlas-tier/src/traits.rs
+++ b/crates/atlas-tier/src/traits.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The two tier seams — [`SlotArena`] (hot) and [`SwapStore`] (cold) — plus
+//! [`SwapStats`], the counters [`crate::Residency`] keeps over them.
+
+use anyhow::Result;
+
+/// The hot tier: a RAM arena as a set of `num_slots` fixed-size slots. The
+/// cache peer implements this over its `mmap`'d MR (page-aligned →
+/// O_DIRECT-safe); in-process consumers use [`crate::VecSlotArena`].
+pub trait SlotArena: Send {
+    fn slot_bytes(&self) -> usize;
+    fn num_slots(&self) -> usize;
+    /// Copy arena slot → `out` (for spilling a victim to disk). `out.len()`
+    /// MUST equal `slot_bytes()`.
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()>;
+    /// Copy `bytes` → arena slot (for faulting a record back in). `bytes.len()`
+    /// MUST equal `slot_bytes()`.
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()>;
+}
+
+/// The cold tier: an unbounded fixed-stride record store addressed by a
+/// monotonic `disk_slot` index. The peer implements this over an O_DIRECT NVMe
+/// file ([`crate::DirectSwapFile`]); [`crate::MemSwapStore`] is the host-RAM
+/// variant.
+pub trait SwapStore: Send {
+    fn record_bytes(&self) -> usize;
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()>;
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()>;
+    /// Optional: reclaim disk space for a freed slot (default no-op; a hole in
+    /// a preallocated file is fine — the free-list reuses the index).
+    fn discard_record(&mut self, _disk_slot: usize) {}
+}
+
+// Boxed trait objects compose (lets a consumer pick arena/swap impls at
+// runtime: `Residency<Box<dyn SlotArena>, Box<dyn SwapStore>>`).
+impl<T: SlotArena + ?Sized> SlotArena for Box<T> {
+    fn slot_bytes(&self) -> usize {
+        (**self).slot_bytes()
+    }
+    fn num_slots(&self) -> usize {
+        (**self).num_slots()
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        (**self).read_slot(slot, out)
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        (**self).write_slot(slot, bytes)
+    }
+}
+
+impl<T: SwapStore + ?Sized> SwapStore for Box<T> {
+    fn record_bytes(&self) -> usize {
+        (**self).record_bytes()
+    }
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        (**self).write_record(disk_slot, bytes)
+    }
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        (**self).read_record(disk_slot, out)
+    }
+    fn discard_record(&mut self, disk_slot: usize) {
+        (**self).discard_record(disk_slot)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct SwapStats {
+    pub puts: u64,
+    pub gets: u64,
+    pub get_miss: u64,
+    pub spills_to_disk: u64,
+    pub faults_from_disk: u64,
+    pub resident_hits: u64,
+    /// Cold on-disk snapshots dropped because the disk cap was hit (a later GET
+    /// for one cleanly misses → recompute).
+    pub disk_evictions: u64,
+}

--- a/crates/atlas-tier/tests/direct_swap.rs
+++ b/crates/atlas-tier/tests/direct_swap.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Public-API integration tests for [`DirectSwapFile`] — real O_DIRECT I/O
+//! under `target/atlas-tier-tests`, with an EINVAL-skip when the filesystem
+//! (tmpfs/overlay) refuses O_DIRECT so containerized CI doesn't break.
+
+use std::path::Path;
+
+use atlas_tier::{DirectSwapFile, Residency, SwapStore, VecSlotArena};
+
+/// A real-filesystem dir for O_DIRECT (tmpfs/overlay EINVALs on O_DIRECT —
+/// tolerated as a skip so containerized CI doesn't break).
+fn o_direct_file(record_bytes: usize, tag: &str) -> Option<(DirectSwapFile, std::path::PathBuf)> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/atlas-tier-tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("dsf-{tag}-{}.swap", std::process::id()));
+    match DirectSwapFile::create(&path, record_bytes) {
+        Ok(f) => Some((f, path)),
+        Err(e) => {
+            eprintln!("skipping O_DIRECT test (filesystem refused O_DIRECT): {e:#}");
+            None
+        }
+    }
+}
+
+#[test]
+fn direct_swap_file_rejects_bad_record_bytes() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/atlas-tier-tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("dsf-bad.swap");
+    assert!(
+        DirectSwapFile::create(&path, 0).is_err(),
+        "zero record_bytes rejected"
+    );
+    assert!(
+        DirectSwapFile::create(&path, 1000).is_err(),
+        "non-4KiB multiple rejected"
+    );
+}
+
+/// O_DIRECT write/read round-trips through the page-aligned bounce (a plain
+/// `Vec` caller buffer is usually unaligned, exercising both bounce paths).
+#[test]
+fn direct_swap_file_roundtrips_records() {
+    let rb = 4096usize;
+    let Some((mut f, path)) = o_direct_file(rb, "rt") else {
+        return;
+    };
+    assert_eq!(f.record_bytes(), rb);
+    let mut pat = vec![0u8; rb];
+    for (i, b) in pat.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+    f.write_record(3, &pat).unwrap(); // sparse: slot 3 before slot 0
+    f.write_record(0, &vec![0xEE; rb]).unwrap();
+    let mut out = vec![0u8; rb];
+    f.read_record(3, &mut out).unwrap();
+    assert_eq!(out, pat, "record 3 byte-identical");
+    f.read_record(0, &mut out).unwrap();
+    assert_eq!(out, vec![0xEE; rb], "record 0 byte-identical");
+    // Size validation is a hard error, not a short IO.
+    assert!(f.write_record(1, &pat[..100]).is_err());
+    let mut short = vec![0u8; 100];
+    assert!(f.read_record(0, &mut short).is_err());
+    let _ = std::fs::remove_file(path);
+}
+
+/// End-to-end: the residency spills to a REAL O_DIRECT file and faults back
+/// byte-identical (the exact peer configuration, minus RDMA).
+#[test]
+fn residency_over_o_direct_swap_byte_identical() {
+    let rb = 4096usize;
+    let Some((f, path)) = o_direct_file(rb, "resid") else {
+        return;
+    };
+    let mut r = Residency::new(VecSlotArena::new(rb, 2), f).unwrap();
+    for k in 0..8u64 {
+        r.put_blob(k, &vec![k as u8; rb]).unwrap();
+    }
+    assert_eq!(r.total_keys(), 8);
+    assert!(
+        r.stats().spills_to_disk >= 6,
+        "cold keys spilled to the O_DIRECT file"
+    );
+    let mut out = vec![0u8; rb];
+    for k in 0..8u64 {
+        assert!(r.get_blob(k, &mut out).unwrap(), "key {k}");
+        assert_eq!(
+            out,
+            vec![k as u8; rb],
+            "key {k} byte-identical through O_DIRECT"
+        );
+    }
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/atlas-tier/tests/direct_swap.rs
+++ b/crates/atlas-tier/tests/direct_swap.rs
@@ -17,10 +17,23 @@ fn o_direct_file(record_bytes: usize, tag: &str) -> Option<(DirectSwapFile, std:
     match DirectSwapFile::create(&path, record_bytes) {
         Ok(f) => Some((f, path)),
         Err(e) => {
+            // Opt-in enforcement: CI on a real disk sets this so a silent skip
+            // can't green-light a run that never touched the O_DIRECT path.
+            if std::env::var_os("ATLAS_TIER_REQUIRE_O_DIRECT").is_some() {
+                panic!("ATLAS_TIER_REQUIRE_O_DIRECT set but O_DIRECT unavailable: {e:#}");
+            }
             eprintln!("skipping O_DIRECT test (filesystem refused O_DIRECT): {e:#}");
             None
         }
     }
+}
+
+/// A page-aligned (4 KiB) mutable sub-slice of `storage`, which must be
+/// over-allocated by at least 4096 bytes past `len`. Lets a test deterministically
+/// hit the O_DIRECT *aligned fast-path* (plain `Vec`s almost never are).
+fn page_aligned(storage: &mut [u8], len: usize) -> &mut [u8] {
+    let pad = (4096 - (storage.as_ptr() as usize & 0xfff)) & 0xfff;
+    &mut storage[pad..pad + len]
 }
 
 #[test]
@@ -90,6 +103,43 @@ fn residency_over_o_direct_swap_byte_identical() {
             vec![k as u8; rb],
             "key {k} byte-identical through O_DIRECT"
         );
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+/// Deterministically exercise the O_DIRECT *aligned fast-path* (the direct
+/// pwrite/pread, not the bounce staging): pass page-aligned buffers so
+/// `write_record`/`read_record` take the `is_aligned()` branch. The existing
+/// `Vec`-based tests almost always hit the bounce instead, so this is the only
+/// coverage of the zero-copy path the peer's mmap'd arena actually uses.
+#[test]
+fn direct_swap_aligned_fast_path_roundtrips() {
+    let rb = 4096usize;
+    let Some((mut f, path)) = o_direct_file(rb, "aligned") else {
+        return;
+    };
+    let mut wstore = vec![0u8; rb + 4096];
+    let w = page_aligned(&mut wstore, rb);
+    assert_eq!(
+        w.as_ptr() as usize & 0xfff,
+        0,
+        "write buffer is page-aligned → fast-path"
+    );
+    for (i, b) in w.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+    f.write_record(7, w).unwrap(); // aligned src → direct pwrite
+
+    let mut rstore = vec![0u8; rb + 4096];
+    let rbuf = page_aligned(&mut rstore, rb);
+    assert_eq!(
+        rbuf.as_ptr() as usize & 0xfff,
+        0,
+        "read buffer is page-aligned → fast-path"
+    );
+    f.read_record(7, rbuf).unwrap(); // aligned dst → direct pread
+    for (i, b) in rbuf.iter().enumerate() {
+        assert_eq!(*b, (i % 251) as u8, "aligned fast-path byte {i}");
     }
     let _ = std::fs::remove_file(path);
 }

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -302,3 +302,178 @@ fn boxed_trait_objects_compose() {
         assert_eq!(out, blob(k as u8));
     }
 }
+
+// ───────────────────── fault-injection: mid-op I/O failure rollbacks ─────────
+//
+// The reference impls never fail, so the trickiest invariant in the policy core
+// — that a blob-move (spill/fault/put) that errors HALFWAY leaves the page table
+// consistent — is otherwise untested. These fakes fail one operation on demand.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use anyhow::{Result, bail};
+
+/// `VecSlotArena` that fails the next `write_slot` when armed (via `arena_mut`).
+struct FaultyArena {
+    inner: VecSlotArena,
+    fail_next_write: bool,
+}
+impl FaultyArena {
+    fn new(slots: usize) -> Self {
+        Self {
+            inner: VecSlotArena::new(B, slots),
+            fail_next_write: false,
+        }
+    }
+}
+impl SlotArena for FaultyArena {
+    fn slot_bytes(&self) -> usize {
+        self.inner.slot_bytes()
+    }
+    fn num_slots(&self) -> usize {
+        self.inner.num_slots()
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        self.inner.read_slot(slot, out)
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        if self.fail_next_write {
+            self.fail_next_write = false;
+            bail!("injected write_slot failure");
+        }
+        self.inner.write_slot(slot, bytes)
+    }
+}
+
+/// Shared arm-once toggles for [`FaultySwap`] (the store is moved into the
+/// `Residency`, so the test keeps a clone to arm faults after construction).
+#[derive(Default)]
+struct SwapFaults {
+    fail_write: AtomicBool,
+    fail_read: AtomicBool,
+}
+struct FaultySwap {
+    inner: MemSwapStore,
+    faults: Arc<SwapFaults>,
+}
+impl FaultySwap {
+    fn new() -> (Self, Arc<SwapFaults>) {
+        let faults = Arc::new(SwapFaults::default());
+        (
+            Self {
+                inner: MemSwapStore::new(B),
+                faults: Arc::clone(&faults),
+            },
+            faults,
+        )
+    }
+}
+impl SwapStore for FaultySwap {
+    fn record_bytes(&self) -> usize {
+        self.inner.record_bytes()
+    }
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if self.faults.fail_write.swap(false, Ordering::SeqCst) {
+            bail!("injected write_record failure");
+        }
+        self.inner.write_record(disk_slot, bytes)
+    }
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        if self.faults.fail_read.swap(false, Ordering::SeqCst) {
+            bail!("injected read_record failure");
+        }
+        self.inner.read_record(disk_slot, out)
+    }
+    fn discard_record(&mut self, disk_slot: usize) {
+        self.inner.discard_record(disk_slot);
+    }
+}
+
+/// `put_blob` whose arena WRITE fails must roll the reservation back — the slot
+/// is reclaimed (not stranded `Reserved`), the key is absent (a GET misses
+/// cleanly), and prior keys survive.
+#[test]
+fn put_blob_rolls_back_reservation_on_arena_write_failure() {
+    let (swap, _f) = FaultySwap::new();
+    let mut r = Residency::new(FaultyArena::new(2), swap).unwrap();
+    r.put_blob(1, &blob(1)).unwrap();
+
+    r.arena_mut().fail_next_write = true;
+    assert!(r.put_blob(2, &blob(2)).is_err(), "write failure propagates");
+
+    let mut out = vec![0u8; B];
+    assert!(
+        !r.get_blob(2, &mut out).unwrap(),
+        "rolled-back key 2 misses cleanly (not a torn Reserved slot)"
+    );
+    assert_eq!(r.total_keys(), 1, "no stranded key-2 entry");
+    // The freed slot is reusable and key 1 is intact.
+    r.put_blob(3, &blob(3)).unwrap();
+    assert!(r.get_blob(1, &mut out).unwrap() && out == blob(1), "key 1 intact");
+    assert!(
+        r.get_blob(3, &mut out).unwrap() && out == blob(3),
+        "key 3 reuses the reclaimed slot"
+    );
+}
+
+/// A spill whose swap WRITE fails must roll back: the victim stays resident and
+/// intact, no spill is counted, and the disk-slot pool isn't leaked (a later
+/// successful spill reuses it).
+#[test]
+fn spill_rolls_back_on_swap_write_failure_victim_stays_resident() {
+    let (swap, faults) = FaultySwap::new();
+    let mut r = Residency::new(FaultyArena::new(1), swap).unwrap(); // 1 slot → new key evicts
+    r.put_blob(10, &blob(10)).unwrap();
+
+    faults.fail_write.store(true, Ordering::SeqCst);
+    assert!(
+        r.put_blob(11, &blob(11)).is_err(),
+        "spill write failure propagates"
+    );
+    assert_eq!(r.stats().spills_to_disk, 0, "failed spill is not counted");
+    assert_eq!(r.total_keys(), 1, "failed put left no key 11");
+
+    let mut out = vec![0u8; B];
+    assert!(
+        r.get_blob(10, &mut out).unwrap() && out == blob(10),
+        "victim 10 stayed resident and intact"
+    );
+    assert!(!r.get_blob(11, &mut out).unwrap(), "key 11 never landed");
+    // A subsequent spill succeeds — the disk-slot pool wasn't corrupted.
+    r.put_blob(12, &blob(12)).unwrap();
+    assert_eq!(r.stats().spills_to_disk, 1);
+    assert!(
+        r.get_blob(10, &mut out).unwrap() && out == blob(10),
+        "10 faults back from disk byte-identical"
+    );
+}
+
+/// A fault-in whose swap READ fails must leave the key `OnDisk` (re-pinned) and
+/// return its scratched slot — the error propagates but a retry succeeds, and a
+/// bystander key spilled during the failed fault's `acquire_slot` is intact.
+#[test]
+fn fault_in_read_failure_keeps_key_on_disk_and_frees_slot() {
+    let (swap, faults) = FaultySwap::new();
+    let mut r = Residency::new(FaultyArena::new(1), swap).unwrap();
+    r.put_blob(20, &blob(20)).unwrap();
+    r.put_blob(21, &blob(21)).unwrap(); // evicts 20 to disk
+    assert_eq!(r.stats().spills_to_disk, 1);
+
+    faults.fail_read.store(true, Ordering::SeqCst);
+    let mut out = vec![0u8; B];
+    assert!(
+        r.get_blob(20, &mut out).is_err(),
+        "fault-in read failure propagates"
+    );
+
+    // 20 is still OnDisk; a retry (fault auto-cleared) faults it in cleanly.
+    assert!(
+        r.get_blob(20, &mut out).unwrap() && out == blob(20),
+        "20 faults back on retry"
+    );
+    assert!(
+        r.get_blob(21, &mut out).unwrap() && out == blob(21),
+        "bystander 21 (spilled during the failed fault) is intact"
+    );
+}

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Public-API integration tests for the [`Residency`] policy core over the
+//! host-RAM reference impls ([`VecSlotArena`] + [`MemSwapStore`]), moved out
+//! of `src/lib.rs` per the repo's tests-in-their-own-file convention. Living
+//! here also pins the crate's public surface.
+
+use atlas_tier::{MemSwapStore, Residency, SlotArena, SwapStore, VecSlotArena};
+
+const B: usize = 8; // tiny blob for tests
+
+fn blob(tag: u8) -> Vec<u8> {
+    vec![tag; B]
+}
+
+/// Client-side helper: alloc → write bytes into the arena slot → commit.
+fn put(r: &mut Residency<VecSlotArena, MemSwapStore>, key: u64, tag: u8) {
+    let slot = r.alloc(key).unwrap();
+    r.arena_mut().write_slot(slot, &blob(tag)).unwrap();
+    r.commit(key).unwrap();
+}
+fn get(r: &mut Residency<VecSlotArena, MemSwapStore>, key: u64) -> Option<Vec<u8>> {
+    r.locate(key).unwrap().map(|slot| {
+        let mut out = vec![0u8; B];
+        r.arena().read_slot(slot, &mut out).unwrap();
+        out
+    })
+}
+
+fn residency(slots: usize) -> Residency<VecSlotArena, MemSwapStore> {
+    Residency::new(VecSlotArena::new(B, slots), MemSwapStore::new(B)).unwrap()
+}
+
+fn residency_capped(slots: usize, max_disk: usize) -> Residency<VecSlotArena, MemSwapStore> {
+    Residency::new_capped(VecSlotArena::new(B, slots), MemSwapStore::new(B), max_disk).unwrap()
+}
+
+/// Disk cap: the swap tier is BOUNDED — beyond RAM slots + `max_disk`, the
+/// COLDEST on-disk snapshot is dropped (a later GET misses → recompute), so
+/// the swap file never grows past the cap. This is the operator's 50 GB
+/// sanity limit at the paging layer.
+#[test]
+fn disk_cap_bounds_swap_and_drops_coldest() {
+    let mut r = residency_capped(2, 3); // 2 RAM + 3 disk = 5 total capacity
+    for k in 0..10u64 {
+        put(&mut r, k, k as u8);
+    }
+    assert!(
+        r.stats().disk_evictions >= 5,
+        "coldest disk snaps must be dropped at cap"
+    );
+    assert!(
+        r.total_keys() <= 2 + 3,
+        "total tracked keys bounded by RAM + disk cap"
+    );
+    // Coldest keys were dropped → clean miss (checked first: a miss doesn't
+    // perturb residency).
+    assert_eq!(
+        get(&mut r, 0),
+        None,
+        "oldest key evicted from the capped disk"
+    );
+    assert_eq!(get(&mut r, 1), None);
+    // The hottest keys survive (resident) and are byte-identical.
+    assert_eq!(get(&mut r, 9).as_deref(), Some(&blob(9)[..]));
+    assert_eq!(get(&mut r, 8).as_deref(), Some(&blob(8)[..]));
+}
+
+/// THE headline invariant: put far more keys than the arena holds; the
+/// coldest spill to the disk tier and fault back BYTE-IDENTICAL. "Infinite
+/// depth, never dropped" proven at the paging layer.
+#[test]
+fn infinite_depth_spill_and_fault_byte_identical() {
+    let mut r = residency(4); // 4 slots
+    for k in 0..64u64 {
+        put(&mut r, k, k as u8);
+    }
+    assert!(
+        r.stats().spills_to_disk >= 60,
+        "most keys must have spilled to disk"
+    );
+    assert_eq!(r.resident_count(), 4, "only 4 slots resident at once");
+    assert_eq!(r.total_keys(), 64, "all 64 keys tracked — nothing dropped");
+    // Every key faults back to its exact bytes.
+    for k in 0..64u64 {
+        assert_eq!(
+            get(&mut r, k).as_deref(),
+            Some(&blob(k as u8)[..]),
+            "key {k}"
+        );
+    }
+    assert!(r.stats().faults_from_disk > 0);
+}
+
+/// THE eviction-pin guarantee (WS-A GET→RDMA-read race): a read-pinned key
+/// is never chosen as an eviction victim, even when it is the LRU-coldest —
+/// a concurrent ALLOC spills the next-coldest UNPINNED key instead, so the
+/// client's in-flight one-sided RDMA READ is never torn by slot reuse.
+#[test]
+fn read_pin_survives_concurrent_eviction() {
+    let mut r = residency(2);
+    put(&mut r, 0, 0); // resident: [0] (coldest)
+    put(&mut r, 1, 1); // resident: [0,1]
+    // Client A GETs key 0 (the coldest) and begins its RDMA read → pin it.
+    assert!(r.locate(0).unwrap().is_some());
+    r.pin_read(0);
+    assert_eq!(r.read_pin_count(0), 1);
+    let faults_before = r.stats().faults_from_disk;
+
+    // Client B ALLOCs a new key → arena full → must evict. Key 0 is coldest
+    // but pinned, so key 1 is spilled instead.
+    put(&mut r, 2, 2);
+    assert_eq!(r.stats().spills_to_disk, 1, "exactly one eviction");
+    assert_eq!(
+        get(&mut r, 1),
+        Some(blob(1)),
+        "the UNPINNED key 1 was the victim"
+    );
+    // Key 0 is still resident (byte-intact) and never touched disk.
+    assert_eq!(
+        get(&mut r, 0),
+        Some(blob(0)),
+        "pinned key 0 survived intact"
+    );
+    assert_eq!(
+        r.stats().faults_from_disk,
+        faults_before + 1,
+        "only key 1 faulted back; key 0 never spilled"
+    );
+}
+
+/// Ref-counted: concurrent readers each add a pin; the key stays protected
+/// until the LAST reader releases, then rejoins the LRU (no double-insert).
+#[test]
+fn refcounted_read_pins_release_to_evictable() {
+    let mut r = residency(2);
+    put(&mut r, 0, 0);
+    put(&mut r, 1, 1);
+    r.pin_read(0);
+    r.pin_read(0); // second concurrent reader of key 0
+    assert_eq!(r.read_pin_count(0), 2);
+    r.unpin_read(0);
+    assert_eq!(r.read_pin_count(0), 1, "still one reader → still pinned");
+    // Force an eviction: key 0 is still protected → key 1 spills.
+    put(&mut r, 2, 2);
+    assert_eq!(
+        get(&mut r, 1),
+        Some(blob(1)),
+        "key 1 evicted while key 0 still pinned"
+    );
+    // Last reader releases → key 0 rejoins the LRU exactly once and is now
+    // an eligible victim again.
+    r.unpin_read(0);
+    assert_eq!(r.read_pin_count(0), 0);
+    assert_eq!(
+        r.resident_count(),
+        2,
+        "keys 0 and 2 resident; no LRU double-insert"
+    );
+    put(&mut r, 3, 3); // evicts the now-unpinned coldest (key 0)
+    put(&mut r, 4, 4);
+    assert_eq!(
+        get(&mut r, 0),
+        Some(blob(0)),
+        "unpinned key 0 spilled+faulted byte-identical"
+    );
+}
+
+#[test]
+fn resident_hit_does_not_touch_disk() {
+    let mut r = residency(4);
+    for k in 0..3u64 {
+        put(&mut r, k, k as u8);
+    }
+    let spills_before = r.stats().spills_to_disk;
+    assert_eq!(get(&mut r, 1), Some(blob(1)));
+    assert_eq!(
+        r.stats().spills_to_disk,
+        spills_before,
+        "resident hit spills nothing"
+    );
+    assert!(r.stats().resident_hits >= 1);
+}
+
+#[test]
+fn lru_evicts_coldest_first() {
+    let mut r = residency(2);
+    put(&mut r, 10, 10); // resident: [10]
+    put(&mut r, 11, 11); // resident: [10,11]
+    get(&mut r, 10); // touch 10 → [11,10]; 11 now coldest
+    put(&mut r, 12, 12); // arena full → evict coldest (11) to disk
+    // 11 must be on disk, 10 & 12 resident.
+    assert_eq!(get(&mut r, 11), Some(blob(11))); // faults back correctly
+    assert!(r.stats().faults_from_disk >= 1);
+}
+
+#[test]
+fn overwrite_in_place_reuses_slot_no_leak() {
+    let mut r = residency(2);
+    put(&mut r, 5, 100);
+    put(&mut r, 5, 200); // rewrite same key
+    assert_eq!(get(&mut r, 5), Some(blob(200)));
+    assert_eq!(r.total_keys(), 1, "no phantom duplicate");
+    assert_eq!(r.resident_count(), 1);
+}
+
+#[test]
+fn overwrite_spilled_key_reclaims_disk() {
+    let mut r = residency(1); // force spilling
+    put(&mut r, 1, 1);
+    put(&mut r, 2, 2); // spills key 1 to disk
+    put(&mut r, 1, 99); // rewrite the SPILLED key 1
+    assert_eq!(get(&mut r, 1), Some(blob(99)));
+    assert_eq!(get(&mut r, 2), Some(blob(2)));
+}
+
+#[test]
+fn remove_frees_resources() {
+    let mut r = residency(2);
+    put(&mut r, 1, 1);
+    put(&mut r, 2, 2);
+    put(&mut r, 3, 3); // 1 spills to disk
+    r.remove(1); // remove a spilled key
+    r.remove(2); // remove a resident key
+    assert_eq!(get(&mut r, 1), None, "removed key is a clean miss");
+    assert_eq!(get(&mut r, 2), None);
+    assert_eq!(get(&mut r, 3), Some(blob(3)));
+    assert_eq!(r.total_keys(), 1);
+}
+
+#[test]
+fn unknown_key_is_clean_miss() {
+    let mut r = residency(2);
+    assert_eq!(r.locate(0xdead).unwrap(), None);
+    assert_eq!(r.stats().get_miss, 1);
+}
+
+#[test]
+fn reserved_slot_pinned_during_put() {
+    // A slot handed out by alloc must not be evictable before commit.
+    let mut r = residency(1);
+    let slot = r.alloc(1).unwrap();
+    // Second alloc with the only slot reserved-and-uncommitted must error,
+    // not silently evict the in-flight PUT.
+    let err = r.alloc(2);
+    assert!(err.is_err(), "must not evict an uncommitted reserved slot");
+    // Finish the first PUT and it all works.
+    r.arena_mut().write_slot(slot, &blob(1)).unwrap();
+    r.commit(1).unwrap();
+    assert_eq!(get(&mut r, 1), Some(blob(1)));
+}
+
+#[test]
+fn size_mismatch_rejected() {
+    let bad = Residency::new(VecSlotArena::new(8, 2), MemSwapStore::new(16));
+    assert!(
+        bad.is_err(),
+        "arena/swap size mismatch must be rejected at construction"
+    );
+}
+
+// ───────────── one-shot helpers + boxed composition ─────────────
+
+/// `put_blob`/`get_blob` never reject and round-trip bytes exactly like the
+/// two-phase alloc/commit path (the in-process consumer contract).
+#[test]
+fn put_get_blob_helpers_never_reject_and_roundtrip() {
+    let mut r = residency(2);
+    for k in 0..32u64 {
+        r.put_blob(k, &blob(k as u8)).unwrap();
+    }
+    assert_eq!(r.total_keys(), 32, "never-reject: every key tracked");
+    assert_eq!(r.resident_count(), 2);
+    let mut out = vec![0u8; B];
+    for k in 0..32u64 {
+        assert!(r.get_blob(k, &mut out).unwrap(), "key {k} present");
+        assert_eq!(out, blob(k as u8), "key {k} byte-identical");
+    }
+    assert!(
+        !r.get_blob(999, &mut out).unwrap(),
+        "unknown key is a clean miss"
+    );
+    // Size mismatches are hard errors, never silent corruption.
+    assert!(r.put_blob(1, &[0u8; B + 1]).is_err());
+    let mut short = vec![0u8; B - 1];
+    assert!(r.get_blob(1, &mut short).is_err());
+}
+
+/// `Residency<Box<dyn SlotArena>, Box<dyn SwapStore>>` composes (runtime
+/// arena/swap selection — what the unified SSM store uses).
+#[test]
+fn boxed_trait_objects_compose() {
+    let arena: Box<dyn SlotArena> = Box::new(VecSlotArena::new(B, 2));
+    let swap: Box<dyn SwapStore> = Box::new(MemSwapStore::new(B));
+    let mut r = Residency::new(arena, swap).unwrap();
+    for k in 0..16u64 {
+        r.put_blob(k, &blob(k as u8)).unwrap();
+    }
+    let mut out = vec![0u8; B];
+    for k in 0..16u64 {
+        assert!(r.get_blob(k, &mut out).unwrap());
+        assert_eq!(out, blob(k as u8));
+    }
+}

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -94,7 +94,7 @@ fn infinite_depth_spill_and_fault_byte_identical() {
 
 /// THE eviction-pin guarantee (WS-A GET→RDMA-read race): a read-pinned key
 /// is never chosen as an eviction victim, even when it is the LRU-coldest —
-/// a concurrent ALLOC spills the next-coldest UNPINNED key instead, so the
+/// a concurrent allocation spills the next-coldest unpinned key instead, so the
 /// client's in-flight one-sided RDMA READ is never torn by slot reuse.
 #[test]
 fn read_pin_survives_concurrent_eviction() {
@@ -107,7 +107,7 @@ fn read_pin_survives_concurrent_eviction() {
     assert_eq!(r.read_pin_count(0), 1);
     let faults_before = r.stats().faults_from_disk;
 
-    // Client B ALLOCs a new key → arena full → must evict. Key 0 is coldest
+    // Client B allocates a new key → arena full → must evict. Key 0 is coldest
     // but pinned, so key 1 is spilled instead.
     put(&mut r, 2, 2);
     assert_eq!(r.stats().spills_to_disk, 1, "exactly one eviction");

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -410,7 +410,10 @@ fn put_blob_rolls_back_reservation_on_arena_write_failure() {
     assert_eq!(r.total_keys(), 1, "no stranded key-2 entry");
     // The freed slot is reusable and key 1 is intact.
     r.put_blob(3, &blob(3)).unwrap();
-    assert!(r.get_blob(1, &mut out).unwrap() && out == blob(1), "key 1 intact");
+    assert!(
+        r.get_blob(1, &mut out).unwrap() && out == blob(1),
+        "key 1 intact"
+    );
     assert!(
         r.get_blob(3, &mut out).unwrap() && out == blob(3),
         "key 3 reuses the reclaimed slot"


### PR DESCRIPTION
Adds the **`crates/atlas-tier`** leaf crate — a CUDA-free, `anyhow`-only tiered-cache core. Self-contained: new crate dir + workspace member; no changes to existing crates. Rebased fresh onto current `main` (clean add-only diff, +1706 LoC under `crates/atlas-tier/`).

Foundation for the streaming-storage / cache-peer stack. Independent of #atlas-rdma and mergeable on its own.

Mirrors MonumentalSystems/atlas#24.