### PR TITLE
feat(rdma): add crates/atlas-rdma — CUDA-free RDMA verbs primitive + RailSet (fresh from main)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ crates/spark-server/                         @tbraun96 @azeezish @rsafier @SeedS
 
 # Multi-rank communication (NCCL / RDMA).
 crates/spark-comm/                           @tbraun96 @azeezish @rsafier @SeedSource
+crates/atlas-rdma/                           @tbraun96 @azeezish @rsafier @SeedSource
 
 # Storage / NVMe-backed swap.
 crates/spark-storage/                        @tbraun96 @azeezish @rsafier @SeedSource

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlas-rdma"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cc",
+]
+
+[[package]]
 name = "atlas-reduce"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/atlas-embed",
     "crates/atlas-reduce",
     "crates/atlas-kernels",
+    "crates/atlas-rdma",
     "crates/spark-runtime",
     "crates/spark-comm",
     "crates/spark-model",

--- a/crates/atlas-rdma/Cargo.toml
+++ b/crates/atlas-rdma/Cargo.toml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+[package]
+name = "atlas-rdma"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Atlas: one-sided RDMA verbs primitive (C shim + safe Rust wrapper) — CUDA-free"
+# `links` makes this the one crate that may compile rdma_shim.c (cargo hard-fails
+# a second `links = "atlas_rdma_shim"`), and — the load-bearing part — lets our
+# build script publish `cargo:has_verbs=1`, which direct dependents' build
+# scripts read as `DEP_ATLAS_RDMA_SHIM_HAS_VERBS` to re-emit
+# `cfg(atlas_rdma_verbs)` for THEIR own gated code (rustc-cfg never crosses
+# crate boundaries). See spark-storage/build.rs.
+links = "atlas_rdma_shim"
+
+# HARD CONSTRAINT (tiered-cache consolidation, atlas-rdma chunk): this crate is
+# the CUDA-free verbs transport the peer daemons AND the cuda client tiers both
+# build on. Its dependency budget is `anyhow` (+ `cc` at build time) — adding a
+# GPU dependency or any workspace crate here destroys the `atlas-expert-pack`
+# default-features = false property that keeps the peers CUDA-free (the same
+# rule crates/atlas-tier documents), and depending on spark-storage would be a
+# cycle.
+[dependencies]
+anyhow = { workspace = true }
+
+[build-dependencies]
+# Compiles the one-sided RDMA C-shim (src/rdma_shim.c) — ibv_post_send /
+# ibv_poll_cq are static inlines that must be called from C. Linux only.
+cc = "1"
+
+[lints]
+workspace = true

--- a/crates/atlas-rdma/Cargo.toml
+++ b/crates/atlas-rdma/Cargo.toml
@@ -11,16 +11,15 @@ description = "Atlas: one-sided RDMA verbs primitive (C shim + safe Rust wrapper
 # build script publish `cargo:has_verbs=1`, which direct dependents' build
 # scripts read as `DEP_ATLAS_RDMA_SHIM_HAS_VERBS` to re-emit
 # `cfg(atlas_rdma_verbs)` for THEIR own gated code (rustc-cfg never crosses
-# crate boundaries). See spark-storage/build.rs.
+# crate boundaries).
 links = "atlas_rdma_shim"
 
-# HARD CONSTRAINT (tiered-cache consolidation, atlas-rdma chunk): this crate is
-# the CUDA-free verbs transport the peer daemons AND the cuda client tiers both
-# build on. Its dependency budget is `anyhow` (+ `cc` at build time) — adding a
-# GPU dependency or any workspace crate here destroys the `atlas-expert-pack`
-# default-features = false property that keeps the peers CUDA-free (the same
-# rule crates/atlas-tier documents), and depending on spark-storage would be a
-# cycle.
+# HARD CONSTRAINT: this crate is the CUDA-free verbs transport the peer daemons
+# AND the CUDA client tiers both build on. Its dependency budget is `anyhow`
+# (+ `cc` at build time) — adding a GPU dependency or any workspace crate here
+# breaks the property that keeps the peer daemons CUDA-free (the same rule
+# crates/atlas-tier documents), and depending on a consumer crate would be a
+# dependency cycle.
 [dependencies]
 anyhow = { workspace = true }
 

--- a/crates/atlas-rdma/build.rs
+++ b/crates/atlas-rdma/build.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Build script for atlas-rdma — moved wholesale from spark-storage/build.rs
+// (`compile_rdma_shim`) in the tiered-cache consolidation. It compiles the
+// one-sided RDMA verbs C shim and decides `cfg(atlas_rdma_verbs)` for the
+// whole workspace:
+//
+//   * cfg ON  ⇔ target_os != macos AND !skip_build()   (unchanged semantics)
+//   * skip_build() honours ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD ∈ {1,true,TRUE}
+//     — the CPU/CI convention for hosts without rdma-core dev headers. There
+//     is deliberately NO header probing: on Linux with the skip unset and
+//     headers missing, cc fails the build loudly.
+//
+// Cross-crate propagation: `cargo:rustc-cfg` does NOT cross crate boundaries,
+// so when the shim builds we also publish `cargo:has_verbs=1`. Thanks to the
+// `links = "atlas_rdma_shim"` key, cargo exposes that to the build scripts of
+// DIRECT dependents as `DEP_ATLAS_RDMA_SHIM_HAS_VERBS`. A direct dependent's
+// build.rs (e.g. spark-storage, in a follow-up PR) reads it and re-emits
+// `cargo:rustc-cfg=atlas_rdma_verbs` for its own gated modules. Any crate that
+// grows a real `#[cfg(atlas_rdma_verbs)]` gate needs its own DIRECT dep on
+// atlas-rdma plus the same re-emit (DEP_ vars are invisible to transitive
+// dependents).
+
+fn main() {
+    // Unconditional and FIRST (before any early return): the lint config must
+    // know the cfg name even when the cfg is off — `unexpected_cfgs` is a hard
+    // error under `[workspace.lints.rust] warnings = "deny"`. (This also fixes
+    // the latent macOS ordering landmine the old spark-storage build.rs had,
+    // where the macOS arm returned before the check-cfg line.)
+    println!("cargo:rustc-check-cfg=cfg(atlas_rdma_verbs)");
+    println!("cargo:rerun-if-env-changed=ATLAS_SKIP_BUILD");
+    println!("cargo:rerun-if-env-changed=SKIP_ATLAS_BUILD");
+    println!("cargo:rerun-if-changed=src/rdma_shim.c");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Apple Silicon hosts have no rdma-core; the verbs module compiles out.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        return;
+    }
+    if skip_build() {
+        return;
+    }
+
+    // Compile `src/rdma_shim.c` and link libibverbs. `cc` emits the
+    // static-lib link directives (rustc-link-lib=static=atlas_rdma_shim +
+    // link-search into OUR OUT_DIR); static/dylib link flags propagate to
+    // final binaries transitively, so downstream crates need nothing.
+    cc::Build::new()
+        .file("src/rdma_shim.c")
+        .opt_level(2)
+        .warnings(true)
+        .compile("atlas_rdma_shim");
+    println!("cargo:rustc-link-lib=dylib=ibverbs");
+    // Gates our own `verbs` module.
+    println!("cargo:rustc-cfg=atlas_rdma_verbs");
+    // The cross-crate signal: DEP_ATLAS_RDMA_SHIM_HAS_VERBS in direct
+    // dependents' build scripts. Emitted only when ON (presence test
+    // downstream — matches the boolean semantics the cfg always had).
+    println!("cargo:has_verbs=1");
+}
+
+/// Verbatim spark-storage semantics: ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD in
+/// {"1","true","TRUE"} suppresses the shim compile and the cfg.
+fn skip_build() -> bool {
+    let truthy = |key: &str| {
+        matches!(
+            std::env::var(key).ok().as_deref(),
+            Some("1") | Some("true") | Some("TRUE")
+        )
+    };
+    truthy("ATLAS_SKIP_BUILD") || truthy("SKIP_ATLAS_BUILD")
+}

--- a/crates/atlas-rdma/build.rs
+++ b/crates/atlas-rdma/build.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Build script for atlas-rdma — moved wholesale from spark-storage/build.rs
-// (`compile_rdma_shim`) in the tiered-cache consolidation. It compiles the
-// one-sided RDMA verbs C shim and decides `cfg(atlas_rdma_verbs)` for the
-// whole workspace:
+// Build script for atlas-rdma. It compiles the one-sided RDMA verbs C shim
+// and decides `cfg(atlas_rdma_verbs)` for the whole workspace:
 //
 //   * cfg ON  ⇔ target_os != macos AND !skip_build()   (unchanged semantics)
 //   * skip_build() honours ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD ∈ {1,true,TRUE}

--- a/crates/atlas-rdma/src/env.rs
+++ b/crates/atlas-rdma/src/env.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Rail-env resolution helpers. The five RDMA clients share the SHAPE of this
+// logic but not the semantics: two distinct empty-string behaviors exist in
+// the deployed configs and BOTH must be preserved exactly —
+//
+//   * `first_set`      — an exported-but-EMPTY var counts as set (the
+//     `Result::or_else` / `unwrap_or_else` chains: KV / expert / snapshot
+//     single-key reads and the LoRA DEV chain).
+//   * `first_nonempty` — an empty var is SKIPPED (weight tier's `env_str`,
+//     which lets `ATLAS_WEIGHT_RDMA_DEV=""` fall through to the EXPERT name).
+//
+// Each client passes its EXACT key list; the fallback chains are per-tier
+// deployment surface (e.g. LoRA's GID reads ONLY `ATLAS_LORA_RDMA_GID` — no
+// WEIGHT/EXPERT fallback), so no chain is hardcoded here.
+
+/// First key whose var is present in the environment — even if empty.
+pub fn first_set(keys: &[&str], default: &str) -> String {
+    for k in keys {
+        if let Ok(v) = std::env::var(k) {
+            return v;
+        }
+    }
+    default.to_string()
+}
+
+/// First key whose var is present AND non-empty (weight-tier semantics).
+pub fn first_nonempty(keys: &[&str], default: &str) -> String {
+    for k in keys {
+        if let Ok(v) = std::env::var(k)
+            && !v.is_empty()
+        {
+            return v;
+        }
+    }
+    default.to_string()
+}
+
+/// First key whose var is present AND parses as `u32`; otherwise `default`.
+/// (A set-but-unparseable var falls through — the behavior of every existing
+/// per-client `env_u32`, single- and multi-key alike.)
+pub fn first_set_u32(keys: &[&str], default: u32) -> u32 {
+    for k in keys {
+        if let Some(v) = std::env::var(k).ok().and_then(|s| s.parse().ok()) {
+            return v;
+        }
+    }
+    default
+}

--- a/crates/atlas-rdma/src/handshake.rs
+++ b/crates/atlas-rdma/src/handshake.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The client side of the rail handshake as PURE byte functions, generic over
+// `Read`/`Write` and taking QP identities as plain `(qpn, psn, gid)` tuples —
+// no `Verbs` (and thus no ibverbs) required. `railset::RailSet` delegates to
+// these in production; tests drive them against a scripted fake stream to pin
+// the client's complete emitted byte sequence (`tests/transcript_golden.rs`),
+// which is the only test class that catches a write REORDER.
+//
+// Wire order per dialect (all little-endian, frozen vs the live gx10 peer):
+//   client: [u8 n_rails]                                   (`write_n_rails`)
+//   server: RO  → [u8 n]{VerbsServerParams}×n              (`wire::read_server_rails`)
+//           RW  → [u8 n echo]{CacheServerParams}×n         (`read_rw_server_params`)
+//   client: [u8 n_rails] {VerbsClientParams}×n             (`write_client_params`)
+//   server: [u8 ack] == STATUS_OK                          (`read_ack`)
+// The n_rails byte is deliberately sent TWICE by the client — that is the wire
+// format, not a redundancy to deduplicate.
+
+use anyhow::{Context, Result, bail};
+use std::io::{Read, Write};
+
+use crate::wire::{CacheServerParams, STATUS_OK, VerbsClientParams};
+
+/// Step 1: tell the peer how many rails we want to stripe across.
+pub fn write_n_rails<W: Write>(w: &mut W, n: usize) -> Result<()> {
+    w.write_all(&[n as u8]).context("send n_rails")?;
+    Ok(())
+}
+
+/// RW-blade dialect (KV overflow / snapshots): read the peer's `[u8 n]` echo
+/// (must equal the negotiated `want`; deliberately NOT bounded to 8 — the RO
+/// dialect's 1..=8 bound is its own, and unifying validation would change
+/// accepted wire inputs) followed by `n` `CacheServerParams`.
+pub fn read_rw_server_params<R: Read>(
+    r: &mut R,
+    want: usize,
+    peer: &str,
+) -> Result<Vec<CacheServerParams>> {
+    let mut b1 = [0u8; 1];
+    r.read_exact(&mut b1).context("read peer n_rails")?;
+    if b1[0] as usize != want {
+        bail!("{peer} granted {} rails, wanted {want}", b1[0]);
+    }
+    let mut server = Vec::with_capacity(want);
+    for _ in 0..want {
+        server
+            .push(CacheServerParams::read_from(r).with_context(|| format!("read {peer} params"))?);
+    }
+    Ok(server)
+}
+
+/// Reply with our rail count (again — wire format) + each rail's QP identity.
+pub fn write_client_params<W: Write>(w: &mut W, ids: &[(u32, u32, [u8; 16])]) -> Result<()> {
+    w.write_all(&[ids.len() as u8])
+        .context("send client n_rails")?;
+    for &(qpn, psn, gid) in ids {
+        VerbsClientParams { qpn, psn, gid }
+            .write_to(w)
+            .context("send verbs client params")?;
+    }
+    Ok(())
+}
+
+/// Final step: the peer's one-byte ready ack, which must be `STATUS_OK`.
+pub fn read_ack<R: Read>(r: &mut R, peer: &str) -> Result<()> {
+    let mut ack = [0u8; 1];
+    r.read_exact(&mut ack).context("read verbs ready ack")?;
+    if ack[0] != STATUS_OK {
+        bail!("{peer} refused connection (ack {})", ack[0]);
+    }
+    Ok(())
+}

--- a/crates/atlas-rdma/src/handshake.rs
+++ b/crates/atlas-rdma/src/handshake.rs
@@ -37,7 +37,23 @@ pub fn read_rw_server_params<R: Read>(
     peer: &str,
 ) -> Result<Vec<CacheServerParams>> {
     let mut b1 = [0u8; 1];
-    r.read_exact(&mut b1).context("read peer n_rails")?;
+    if let Err(e) = r.read_exact(&mut b1) {
+        // A clean EOF here is the peer REJECTING us, not a transport fault: it
+        // hangs up after logging its own reason (e.g. "paging blade cap") and
+        // the v2 wire has no error frame to carry that reason back. Bare
+        // `read_exact` context yields "failed to fill whole buffer", which
+        // sends operators hunting a network problem that does not exist.
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            bail!(
+                "{peer} closed the connection during the rail handshake without sending rail \
+                 params. The peer REJECTED this client — read ITS log for the reason. Most \
+                 common: the arena this client requested exceeds the peer's --max-blade-gb \
+                 cap (peer logs \"paging blade cap\"); also possible: a blob_bytes/kind \
+                 mismatch against an arena a prior client already fixed."
+            );
+        }
+        return Err(e).context("read peer n_rails");
+    }
     if b1[0] as usize != want {
         bail!("{peer} granted {} rails, wanted {want}", b1[0]);
     }

--- a/crates/atlas-rdma/src/handshake.rs
+++ b/crates/atlas-rdma/src/handshake.rs
@@ -7,7 +7,7 @@
 // the client's complete emitted byte sequence (`tests/transcript_golden.rs`),
 // which is the only test class that catches a write REORDER.
 //
-// Wire order per dialect (all little-endian, frozen vs the live gx10 peer):
+// Wire order per dialect (all little-endian, a frozen external contract):
 //   client: [u8 n_rails]                                   (`write_n_rails`)
 //   server: RO  → [u8 n]{VerbsServerParams}×n              (`wire::read_server_rails`)
 //           RW  → [u8 n echo]{CacheServerParams}×n         (`read_rw_server_params`)

--- a/crates/atlas-rdma/src/lib.rs
+++ b/crates/atlas-rdma/src/lib.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#![deny(warnings)]
+#![deny(clippy::all)]
+
+//! atlas-rdma: the one-sided RDMA verbs primitive shared by every Atlas RDMA
+//! tier (experts / KV overflow / weight staging / LoRA / SSM snapshots).
+//!
+//! Step A of the RailSet extraction (tiered-cache consolidation, chunk 2):
+//! this crate OWNS what used to be `spark-storage/src/rdma_verbs.rs` and
+//! `spark-storage/src/rdma_shim.c`, moved verbatim — the shim's QP/RTR/RTS
+//! attribute constants are interop-visible to the live gx10 peer running an
+//! older binary, so the .c file is byte-identical. No client refactor here.
+//!
+//! CUDA-free by hard constraint (see Cargo.toml): both the non-cuda peer
+//! daemons (`atlas-expert-pack`) and the cuda client tiers link this.
+//!
+//! `cfg(atlas_rdma_verbs)` is decided by build.rs — ON when `target_os` is not
+//! macOS and `ATLAS_SKIP_BUILD`/`SKIP_ATLAS_BUILD` is unset (there is no
+//! rdma-core probe; if the headers are missing there, `cc` fails the build
+//! loudly) — and published to direct dependents via the `links` metadata
+//! `DEP_ATLAS_RDMA_SHIM_HAS_VERBS`. See build.rs for the full story.
+
+/// Rail-env resolution helpers (`first_set` / `first_nonempty` /
+/// `first_set_u32`) — un-gated, pure `std::env`.
+pub mod env;
+/// Client handshake steps as pure `Read`/`Write` byte functions (identity
+/// tuples, no `Verbs`) — un-gated so the transcript goldens run everywhere.
+pub mod handshake;
+/// The golden handshake wire codecs (both server-param dialects, rails
+/// framing, mode/status bytes) — un-gated, frozen vs the live gx10 peer.
+pub mod wire;
+
+/// Safe-ish wrapper over the C shim: one [`verbs::Verbs`] == one RC QP.
+/// Compiled only where the shim is (`cfg(atlas_rdma_verbs)`).
+#[cfg(atlas_rdma_verbs)]
+pub mod verbs;
+
+/// RailSet — the one client-side rail bring-up (Step B of the extraction).
+/// Gated with the shim: it creates and connects real QPs.
+#[cfg(atlas_rdma_verbs)]
+pub mod railset;
+
+#[cfg(atlas_rdma_verbs)]
+pub use railset::{Rail, RailSet, RailSpec};
+#[cfg(atlas_rdma_verbs)]
+pub use verbs::{Gid, MrKeys, Verbs};
+pub use wire::{
+    CacheServerParams, MODE_TCP, MODE_VERBS, RemoteQp, STATUS_ERR, STATUS_OK, VerbsClientParams,
+    VerbsServerParams,
+};
+
+/// `true` iff this build of atlas-rdma compiled the verbs shim (i.e. the
+/// `atlas_rdma_verbs` cfg was emitted by build.rs). A permanent, always-
+/// compiled witness: tests assert it so a silent cfg evaporation fails
+/// `cargo test` on verbs hosts instead of green-building an empty crate.
+pub const fn verbs_enabled() -> bool {
+    cfg!(atlas_rdma_verbs)
+}

--- a/crates/atlas-rdma/src/lib.rs
+++ b/crates/atlas-rdma/src/lib.rs
@@ -6,14 +6,12 @@
 //! atlas-rdma: the one-sided RDMA verbs primitive shared by every Atlas RDMA
 //! tier (experts / KV overflow / weight staging / LoRA / SSM snapshots).
 //!
-//! Step A of the RailSet extraction (tiered-cache consolidation, chunk 2):
-//! this crate OWNS what used to be `spark-storage/src/rdma_verbs.rs` and
-//! `spark-storage/src/rdma_shim.c`, moved verbatim — the shim's QP/RTR/RTS
-//! attribute constants are interop-visible to the live gx10 peer running an
-//! older binary, so the .c file is byte-identical. No client refactor here.
+//! The C shim's QP/RTR/RTS attribute constants and the handshake wire codecs
+//! are a frozen external contract: they must stay byte-compatible with already
+//! deployed peers, so the shim is treated as byte-stable.
 //!
-//! CUDA-free by hard constraint (see Cargo.toml): both the non-cuda peer
-//! daemons (`atlas-expert-pack`) and the cuda client tiers link this.
+//! CUDA-free by hard constraint (see Cargo.toml): both the non-CUDA peer
+//! daemons and the CUDA client tiers link this.
 //!
 //! `cfg(atlas_rdma_verbs)` is decided by build.rs — ON when `target_os` is not
 //! macOS and `ATLAS_SKIP_BUILD`/`SKIP_ATLAS_BUILD` is unset (there is no
@@ -28,7 +26,7 @@ pub mod env;
 /// tuples, no `Verbs`) — un-gated so the transcript goldens run everywhere.
 pub mod handshake;
 /// The golden handshake wire codecs (both server-param dialects, rails
-/// framing, mode/status bytes) — un-gated, frozen vs the live gx10 peer.
+/// framing, mode/status bytes) — un-gated, a frozen external wire contract.
 pub mod wire;
 
 /// Safe-ish wrapper over the C shim: one [`verbs::Verbs`] == one RC QP.
@@ -36,8 +34,8 @@ pub mod wire;
 #[cfg(atlas_rdma_verbs)]
 pub mod verbs;
 
-/// RailSet — the one client-side rail bring-up (Step B of the extraction).
-/// Gated with the shim: it creates and connects real QPs.
+/// RailSet — the one client-side rail bring-up. Gated with the shim: it
+/// creates and connects real QPs.
 #[cfg(atlas_rdma_verbs)]
 pub mod railset;
 

--- a/crates/atlas-rdma/src/railset.rs
+++ b/crates/atlas-rdma/src/railset.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RailSet — the ONE client-side rail bring-up, extracted from the five
+// hand-rolled copies (rdma_kv_backend / expert_tier_rdma / weight_tier_rdma /
+// weight_lora_rdma / rdma_snapshot). Compositional by design, byte-identical
+// by construction:
+//
+//   * The stream must be ALREADY PREAMBLED — the five preambles (expert
+//     manifest + MODE_VERBS, weight/LoRA model request + manifest +
+//     MODE_VERBS, KV `[u64 total_bytes]`, snapshot paging magic) differ and
+//     stay in the clients. RailSet never owns the `TcpStream` (the snapshot
+//     tier keeps it as a live paging control channel after connect).
+//   * MR registration stays AT THE CALL SITE: there is no registration method
+//     here, so the access flag (`reg_mr(.., false)` for every client landing
+//     buffer, `true` / `reg_mr_rw` on the untouched server side) can never be
+//     defaulted or homogenized. Callers do `rail.verbs.reg_mr(..)` directly —
+//     `verbs` is deliberately `pub` (the KV zero-copy hot path and the
+//     snapshot staged path also post/poll on it raw).
+//   * PSN is CALLER-SUPPLIED via `RailSpec` (clients keep their
+//     `rand::random::<u32>() & 0xff_ffff` per rail; `rand` stays out of this
+//     crate and fixed PSNs make the handshake transcript-testable).
+//
+// Handshake order (the wire steps are frozen; local steps are free):
+//   begin: write [u8 n_rails] → Verbs::create per rail
+//   caller: reg_mr its landing buffers on each rail.verbs
+//   read_server_ro / read_server_rw: the dialect's server params
+//   caller (RO tiers): validate the table against its manifest — a failed
+//     validation must bail BEFORE client params are written, exactly as today
+//   complete: write [u8 n_rails] + client params → connect each rail
+//     INIT→RTR→RTS → read [u8 ack] == STATUS_OK
+//   into_verbs: decompose — clients re-own each `Verbs` in their own rail
+//     structs, so drop order (MR dereg before buffer free) is unchanged.
+
+use anyhow::{Context, Result, bail};
+use std::io::{Read, Write};
+
+use crate::handshake;
+use crate::verbs::Verbs;
+use crate::wire::{CacheServerParams, RemoteQp, VerbsServerParams, read_server_rails};
+
+/// Guard for `complete`'s rail/param pairing. A bare `zip` would SILENTLY
+/// truncate: a server slice shorter than the rail count leaves the trailing
+/// rails stuck in INIT (never RTS) while `complete` still returns `Ok`, so the
+/// caller believes it is connected and fails later, obscurely, on its first
+/// RDMA op. Pure so it is unit-testable without a NIC.
+pub(crate) fn check_rail_count(server_len: usize, rails_len: usize, peer: &str) -> Result<()> {
+    if server_len != rails_len {
+        bail!(
+            "{peer}: server returned {server_len} rail params for {rails_len} client rails — \
+             refusing to leave rails unconnected (a zip would silently truncate)"
+        );
+    }
+    Ok(())
+}
+
+/// One rail's bring-up parameters: device name, RoCEv2 GID index, and the
+/// caller-chosen 24-bit send PSN.
+#[derive(Clone, Debug)]
+pub struct RailSpec {
+    pub dev: String,
+    pub gid_idx: u32,
+    pub psn: u32,
+}
+
+impl RailSpec {
+    /// A spec with a fresh random 24-bit PSN — what every client tier does.
+    pub fn new(dev: String, gid_idx: u32, psn: u32) -> Self {
+        Self { dev, gid_idx, psn }
+    }
+}
+
+/// One connected (or connecting) rail. `verbs` is public: registration and
+/// the data plane (post_read/post_write/poll) belong to the caller.
+pub struct Rail {
+    pub verbs: Verbs,
+}
+
+/// All rails of one client connection, mid-handshake.
+pub struct RailSet {
+    pub rails: Vec<Rail>,
+}
+
+impl RailSet {
+    /// Wire step 1 + local QP creation: write `[u8 n_rails]` to the
+    /// already-preambled stream, then `Verbs::create` one RC QP per spec.
+    pub fn begin<W: Write>(stream: &mut W, specs: &[RailSpec]) -> Result<Self> {
+        handshake::write_n_rails(stream, specs.len())?;
+        let rails = specs
+            .iter()
+            .map(|s| Verbs::create(&s.dev, s.gid_idx, s.psn).map(|verbs| Rail { verbs }))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { rails })
+    }
+
+    pub fn n_rails(&self) -> usize {
+        self.rails.len()
+    }
+
+    /// RO dialect (expert/weight/LoRA): `[u8 n]{VerbsServerParams}×n`, with
+    /// the framed count validated == ours and 1..=8. Returned un-consumed so
+    /// the caller can validate the per-layer/per-shard tables against its
+    /// manifest BEFORE `complete` writes anything back.
+    pub fn read_server_ro<R: Read>(&self, stream: &mut R) -> Result<Vec<VerbsServerParams>> {
+        read_server_rails(stream, self.rails.len())
+    }
+
+    /// RW-blade dialect (KV/snapshot): `[u8 n echo]{CacheServerParams}×n`.
+    pub fn read_server_rw<R: Read>(
+        &self,
+        stream: &mut R,
+        peer: &str,
+    ) -> Result<Vec<CacheServerParams>> {
+        handshake::read_rw_server_params(stream, self.rails.len(), peer)
+    }
+
+    /// The common handshake tail: write `[u8 n_rails]` (again — wire format)
+    /// plus each rail's client QP params, connect each rail to its peer rail
+    /// (INIT→RTR→RTS), then read the one-byte ready ack.
+    pub fn complete<S: Read + Write, P: RemoteQp>(
+        &mut self,
+        stream: &mut S,
+        server: &[P],
+        peer: &str,
+    ) -> Result<()> {
+        check_rail_count(server.len(), self.rails.len(), peer)?;
+        let ids: Vec<(u32, u32, [u8; 16])> = self
+            .rails
+            .iter()
+            .map(|r| (r.verbs.qpn(), r.verbs.psn(), r.verbs.gid()))
+            .collect();
+        handshake::write_client_params(stream, &ids)?;
+        for (rail, sp) in self.rails.iter_mut().zip(server) {
+            let (qpn, psn, gid) = sp.qp_identity();
+            rail.verbs
+                .connect(qpn, psn, &gid)
+                .with_context(|| format!("connect {peer} rail"))?;
+        }
+        handshake::read_ack(stream, peer)
+    }
+
+    /// `read_server_rw` + `complete` in one call — the RW clients have no
+    /// mid-handshake validation. Returns the params for rkey/base capture
+    /// (each caller keeps its own policy; KV/snapshot use the LAST base).
+    pub fn finish_rw<S: Read + Write>(
+        &mut self,
+        stream: &mut S,
+        peer: &str,
+    ) -> Result<Vec<CacheServerParams>> {
+        let server = self.read_server_rw(stream, peer)?;
+        self.complete(stream, &server, peer)?;
+        Ok(server)
+    }
+
+    /// Decompose after `complete`: hand each `Verbs` back to the caller's own
+    /// rail struct so ownership (and thus drop order vs the registered
+    /// buffers) is exactly what it was before the extraction.
+    pub fn into_verbs(self) -> Vec<Verbs> {
+        self.rails.into_iter().map(|r| r.verbs).collect()
+    }
+}
+
+#[cfg(test)]
+#[path = "railset_tests.rs"]
+mod tests;

--- a/crates/atlas-rdma/src/railset_tests.rs
+++ b/crates/atlas-rdma/src/railset_tests.rs
@@ -15,9 +15,11 @@ fn equal_counts_are_ok() {
 #[test]
 fn short_server_slice_is_refused_not_truncated() {
     // The regression this guards: a bare `zip` would connect 1 of 2 rails and
-    // return Ok, leaving rail 1 stuck in INIT.
-    let e = check_rail_count(1, 2, "gx10:9916").unwrap_err().to_string();
-    assert!(e.contains("gx10:9916"), "peer named: {e}");
+    // return Ok, leaving rail 1 stuck in INIT. The `peer` arg is just the label
+    // the error interpolates (real endpoints are env-resolved upstream); a
+    // distinctive fixture value lets us assert it is echoed.
+    let e = check_rail_count(1, 2, "test-peer").unwrap_err().to_string();
+    assert!(e.contains("test-peer"), "peer named: {e}");
     assert!(
         e.contains("1 rail params for 2 client rails"),
         "counts reported: {e}"

--- a/crates/atlas-rdma/src/railset_tests.rs
+++ b/crates/atlas-rdma/src/railset_tests.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Guard tests for `RailSet::complete`'s rail/param pairing. `complete` itself
+// needs a live NIC (`Verbs::create`), so the check is factored into the pure
+// `check_rail_count` and exercised here without hardware.
+
+use super::check_rail_count;
+
+#[test]
+fn equal_counts_are_ok() {
+    assert!(check_rail_count(2, 2, "peer").is_ok());
+    assert!(check_rail_count(0, 0, "peer").is_ok());
+}
+
+#[test]
+fn short_server_slice_is_refused_not_truncated() {
+    // The regression this guards: a bare `zip` would connect 1 of 2 rails and
+    // return Ok, leaving rail 1 stuck in INIT.
+    let e = check_rail_count(1, 2, "gx10:9916").unwrap_err().to_string();
+    assert!(e.contains("gx10:9916"), "peer named: {e}");
+    assert!(
+        e.contains("1 rail params for 2 client rails"),
+        "counts reported: {e}"
+    );
+}
+
+#[test]
+fn long_server_slice_is_also_refused() {
+    assert!(check_rail_count(3, 2, "peer").is_err());
+}

--- a/crates/atlas-rdma/src/rdma_shim.c
+++ b/crates/atlas-rdma/src/rdma_shim.c
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // Minimal one-sided RDMA READ shim over libibverbs (RoCEv2), for the expert
-// weight tier (streaming-experts WS2, Phase B).
+// weight tier.
 //
 // `ibv_post_send` / `ibv_poll_cq` are `static inline` in <infiniband/verbs.h>,
 // so they cannot be FFI'd directly from Rust — they must be called from a C
 // translation unit. This shim is that unit: it wraps the whole RC-QP lifecycle
 // (create -> INIT -> RTR -> RTS), MR registration, one-sided READ posting, and
-// completion polling behind a tiny C ABI the Rust side (`rdma_verbs.rs`) binds.
+// completion polling behind a tiny C ABI the Rust side (`verbs.rs`) binds.
 //
 // Design: one `rs_conn` == one device context + PD + CQ + RC QP, plus a small
 // fixed table of registered MRs. Both peer (server, registers its store with
@@ -15,7 +15,7 @@
 // one. QP identity (qpn/psn/gid) is exchanged out-of-band over the existing TCP
 // control channel; `rs_connect` drives the state machine with the remote params.
 // One-sided: the client is the requester (posts READs); the server QP only has
-// to reach RTS to respond, its CPU stays idle — the intended Phase B win.
+// to reach RTS to respond, its CPU stays idle (the point of one-sided reads).
 
 #include <infiniband/verbs.h>
 #include <stdint.h>

--- a/crates/atlas-rdma/src/rdma_shim.c
+++ b/crates/atlas-rdma/src/rdma_shim.c
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Minimal one-sided RDMA READ shim over libibverbs (RoCEv2), for the expert
+// weight tier (streaming-experts WS2, Phase B).
+//
+// `ibv_post_send` / `ibv_poll_cq` are `static inline` in <infiniband/verbs.h>,
+// so they cannot be FFI'd directly from Rust — they must be called from a C
+// translation unit. This shim is that unit: it wraps the whole RC-QP lifecycle
+// (create -> INIT -> RTR -> RTS), MR registration, one-sided READ posting, and
+// completion polling behind a tiny C ABI the Rust side (`rdma_verbs.rs`) binds.
+//
+// Design: one `rs_conn` == one device context + PD + CQ + RC QP, plus a small
+// fixed table of registered MRs. Both peer (server, registers its store with
+// REMOTE_READ) and client (registers its pinned arena with LOCAL_WRITE) create
+// one. QP identity (qpn/psn/gid) is exchanged out-of-band over the existing TCP
+// control channel; `rs_connect` drives the state machine with the remote params.
+// One-sided: the client is the requester (posts READs); the server QP only has
+// to reach RTS to respond, its CPU stays idle — the intended Phase B win.
+
+#include <infiniband/verbs.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define RS_MAX_MR 512
+
+struct rs_conn {
+    struct ibv_context *ctx;
+    struct ibv_pd *pd;
+    struct ibv_cq *cq;
+    struct ibv_qp *qp;
+    union ibv_gid gid;
+    struct ibv_mr *mrs[RS_MAX_MR];
+    int n_mr;
+    uint8_t port;
+    int gid_idx;
+};
+
+void rs_destroy(struct rs_conn *c);
+
+// Open device `dev_name` (port 1), read the GID at `gid_idx`, allocate PD + CQ,
+// create an RC QP and move it to INIT. Returns NULL on any failure.
+struct rs_conn *rs_create(const char *dev_name, int gid_idx) {
+    struct ibv_device **list = ibv_get_device_list(NULL);
+    if (!list) {
+        return NULL;
+    }
+    struct ibv_device *dev = NULL;
+    for (int i = 0; list[i]; i++) {
+        if (strcmp(ibv_get_device_name(list[i]), dev_name) == 0) {
+            dev = list[i];
+            break;
+        }
+    }
+    if (!dev) {
+        ibv_free_device_list(list);
+        return NULL;
+    }
+    struct rs_conn *c = calloc(1, sizeof(*c));
+    if (!c) {
+        ibv_free_device_list(list);
+        return NULL;
+    }
+    c->port = 1;
+    c->gid_idx = gid_idx;
+    c->ctx = ibv_open_device(dev);
+    ibv_free_device_list(list);
+    if (!c->ctx) {
+        goto err;
+    }
+    if (ibv_query_gid(c->ctx, c->port, gid_idx, &c->gid)) {
+        goto err;
+    }
+    c->pd = ibv_alloc_pd(c->ctx);
+    if (!c->pd) {
+        goto err;
+    }
+    c->cq = ibv_create_cq(c->ctx, 256, NULL, NULL, 0);
+    if (!c->cq) {
+        goto err;
+    }
+    struct ibv_qp_init_attr qa;
+    memset(&qa, 0, sizeof(qa));
+    qa.send_cq = c->cq;
+    qa.recv_cq = c->cq;
+    qa.qp_type = IBV_QPT_RC;
+    qa.cap.max_send_wr = 256;
+    qa.cap.max_recv_wr = 16;
+    qa.cap.max_send_sge = 1;
+    qa.cap.max_recv_sge = 1;
+    c->qp = ibv_create_qp(c->pd, &qa);
+    if (!c->qp) {
+        goto err;
+    }
+    struct ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = c->port;
+    // Grant REMOTE_READ + REMOTE_WRITE on the QP. The expert tier only issues
+    // READs, and its MRs are REMOTE_READ-only, so a stray write is still refused
+    // at the MR level — but the KV overflow blade's QP must accept incoming
+    // RDMA WRITEs. QP-level flags are a ceiling; per-MR flags do the enforcing.
+    attr.qp_access_flags =
+        IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+    if (ibv_modify_qp(c->qp, &attr,
+                      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                          IBV_QP_ACCESS_FLAGS)) {
+        goto err;
+    }
+    return c;
+err:
+    rs_destroy(c);
+    return NULL;
+}
+
+uint32_t rs_qpn(struct rs_conn *c) { return c->qp->qp_num; }
+
+// Copy this QP's 16-byte GID (the one at gid_idx) out for the wire handshake.
+void rs_gid(struct rs_conn *c, uint8_t out[16]) { memcpy(out, c->gid.raw, 16); }
+
+// Register `[addr, addr+len)` as an MR. `flags` is a bitmask giving each side
+// exactly the access it needs and no more:
+//   bit 0 (1) -> REMOTE_READ   (expert store; also the KV blade's read-back)
+//   bit 1 (2) -> REMOTE_WRITE  (KV overflow blade; implies LOCAL_WRITE per the
+//                               verbs rule that REMOTE_WRITE requires LOCAL_WRITE)
+//   flags == 0 -> LOCAL_WRITE  (the client's landing/bounce buffer)
+// REMOTE_READ alone deliberately omits LOCAL_WRITE (requesting it on a PROT_READ
+// mmap makes ibv_reg_mr fail — the expert store is registered read-only this way).
+// So: expert store = 1, client bounce = 0, KV blade = 3 (RR|RW|LW).
+int rs_reg_mr(struct rs_conn *c, void *addr, size_t len, int flags,
+              uint32_t *lkey, uint32_t *rkey) {
+    if (c->n_mr >= RS_MAX_MR) {
+        return -1;
+    }
+    int access = 0;
+    if (flags & 1) {
+        access |= IBV_ACCESS_REMOTE_READ;
+    }
+    if (flags & 2) {
+        access |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+    }
+    if (access == 0) {
+        access = IBV_ACCESS_LOCAL_WRITE;
+    }
+    struct ibv_mr *mr = ibv_reg_mr(c->pd, addr, len, access);
+    if (!mr) {
+        return -1;
+    }
+    c->mrs[c->n_mr++] = mr;
+    *lkey = mr->lkey;
+    *rkey = mr->rkey;
+    return 0;
+}
+
+// Drive INIT -> RTR -> RTS with the remote QP's params. `remote_psn` is the
+// remote's send PSN (our rq_psn); `local_psn` is our send PSN (our sq_psn). The
+// path MTU is taken from the port's active MTU. Returns 0, or a negative code
+// identifying the failed transition.
+int rs_connect(struct rs_conn *c, uint32_t remote_qpn, uint32_t remote_psn,
+               uint32_t local_psn, const uint8_t remote_gid[16]) {
+    struct ibv_port_attr pa;
+    if (ibv_query_port(c->ctx, c->port, &pa)) {
+        return -1;
+    }
+    struct ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = pa.active_mtu;
+    attr.dest_qp_num = remote_qpn;
+    attr.rq_psn = remote_psn;
+    attr.max_dest_rd_atomic = 16;
+    attr.min_rnr_timer = 12;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.port_num = c->port;
+    attr.ah_attr.grh.hop_limit = 64;
+    attr.ah_attr.grh.sgid_index = c->gid_idx;
+    attr.ah_attr.grh.traffic_class = 0;
+    memcpy(attr.ah_attr.grh.dgid.raw, remote_gid, 16);
+    if (ibv_modify_qp(c->qp, &attr,
+                      IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+                          IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                          IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER)) {
+        return -2;
+    }
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.timeout = 14;
+    attr.retry_cnt = 7;
+    attr.rnr_retry = 7;
+    attr.sq_psn = local_psn;
+    attr.max_rd_atomic = 16;
+    if (ibv_modify_qp(c->qp, &attr,
+                      IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+                          IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                          IBV_QP_MAX_QP_RD_ATOMIC)) {
+        return -3;
+    }
+    return 0;
+}
+
+// Post a single one-sided RDMA READ: pull `len` bytes from the remote
+// `remote_addr` (protected by `rkey`) into local `local_addr` (registered under
+// `lkey`). Signaled, so it generates a completion tagged with `wr_id`.
+int rs_post_read(struct rs_conn *c, void *local_addr, uint32_t lkey,
+                 uint64_t remote_addr, uint32_t rkey, uint32_t len,
+                 uint64_t wr_id) {
+    struct ibv_sge sge;
+    memset(&sge, 0, sizeof(sge));
+    sge.addr = (uintptr_t)local_addr;
+    sge.length = len;
+    sge.lkey = lkey;
+    struct ibv_send_wr wr;
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = wr_id;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_READ;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = remote_addr;
+    wr.wr.rdma.rkey = rkey;
+    struct ibv_send_wr *bad = NULL;
+    return ibv_post_send(c->qp, &wr, &bad);
+}
+
+// Post a single one-sided RDMA WRITE: push `len` bytes from local `local_addr`
+// (registered under `lkey`) to the remote `remote_addr` (protected by `rkey`).
+// Signaled, so it generates a completion tagged with `wr_id`. Used by the KV
+// overflow tier to offload a K/V group into the peer's registered RAM blade.
+int rs_post_write(struct rs_conn *c, void *local_addr, uint32_t lkey,
+                  uint64_t remote_addr, uint32_t rkey, uint32_t len,
+                  uint64_t wr_id) {
+    struct ibv_sge sge;
+    memset(&sge, 0, sizeof(sge));
+    sge.addr = (uintptr_t)local_addr;
+    sge.length = len;
+    sge.lkey = lkey;
+    struct ibv_send_wr wr;
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = wr_id;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_WRITE;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = remote_addr;
+    wr.wr.rdma.rkey = rkey;
+    struct ibv_send_wr *bad = NULL;
+    return ibv_post_send(c->qp, &wr, &bad);
+}
+
+// Blocking busy-poll for exactly one completion. On success returns 0 and writes
+// the completed work-request's id to *out_wr_id; on a completion error returns
+// the positive `ibv_wc_status`; on a poll error returns -1.
+int rs_poll(struct rs_conn *c, uint64_t *out_wr_id) {
+    struct ibv_wc wc;
+    for (;;) {
+        int n = ibv_poll_cq(c->cq, 1, &wc);
+        if (n < 0) {
+            return -1;
+        }
+        if (n == 0) {
+            continue;
+        }
+        *out_wr_id = wc.wr_id;
+        if (wc.status != IBV_WC_SUCCESS) {
+            return (int)wc.status;
+        }
+        return 0;
+    }
+}
+
+void rs_destroy(struct rs_conn *c) {
+    if (!c) {
+        return;
+    }
+    if (c->qp) {
+        ibv_destroy_qp(c->qp);
+    }
+    for (int i = 0; i < c->n_mr; i++) {
+        if (c->mrs[i]) {
+            ibv_dereg_mr(c->mrs[i]);
+        }
+    }
+    if (c->cq) {
+        ibv_destroy_cq(c->cq);
+    }
+    if (c->pd) {
+        ibv_dealloc_pd(c->pd);
+    }
+    if (c->ctx) {
+        ibv_close_device(c->ctx);
+    }
+    free(c);
+}

--- a/crates/atlas-rdma/src/verbs.rs
+++ b/crates/atlas-rdma/src/verbs.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Safe-ish Rust wrapper over the one-sided RDMA READ C-shim (`rdma_shim.c`).
+// Compiled only where the shim is (`cfg(atlas_rdma_verbs)`, emitted by build.rs
+// on Linux with rdma-core). Deliberately CUDA-free: the peer server (non-cuda)
+// registers its store here, the client tier (cuda) registers its pinned arena.
+//
+// One `Verbs` == one RC QP + its device context. The QP-identity exchange
+// (qpn/psn/gid) rides the existing TCP control channel in `expert_peer.rs`;
+// `connect` drives INIT->RTR->RTS. The client posts `IBV_WR_RDMA_READ`s with
+// `post_read` and reaps them with `poll` (blocking busy-poll); the server QP
+// only reaches RTS to respond, its CPU idle — the Phase B win.
+
+use anyhow::{Result, bail};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
+
+/// A 16-byte RoCEv2 GID, exchanged verbatim over the control channel.
+pub type Gid = [u8; 16];
+
+#[repr(C)]
+struct RsConn {
+    _private: [u8; 0],
+}
+
+unsafe extern "C" {
+    fn rs_create(dev_name: *const c_char, gid_idx: c_int) -> *mut RsConn;
+    fn rs_destroy(c: *mut RsConn);
+    fn rs_qpn(c: *mut RsConn) -> u32;
+    fn rs_gid(c: *mut RsConn, out: *mut u8);
+    fn rs_reg_mr(
+        c: *mut RsConn,
+        addr: *mut c_void,
+        len: usize,
+        flags: c_int,
+        lkey: *mut u32,
+        rkey: *mut u32,
+    ) -> c_int;
+    fn rs_connect(
+        c: *mut RsConn,
+        remote_qpn: u32,
+        remote_psn: u32,
+        local_psn: u32,
+        remote_gid: *const u8,
+    ) -> c_int;
+    fn rs_post_read(
+        c: *mut RsConn,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> c_int;
+    fn rs_post_write(
+        c: *mut RsConn,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> c_int;
+    fn rs_poll(c: *mut RsConn, out_wr_id: *mut u64) -> c_int;
+}
+
+/// Registration keys returned when a memory region is pinned to the QP's PD.
+#[derive(Clone, Copy, Debug)]
+pub struct MrKeys {
+    pub lkey: u32,
+    pub rkey: u32,
+}
+
+/// One RC QP over a RoCEv2 device. Not `Clone`; owns the C connection.
+pub struct Verbs {
+    conn: *mut RsConn,
+    /// This QP's send PSN — sent to the peer as its rq_psn.
+    local_psn: u32,
+}
+
+// The C connection is used single-threaded (owned by the prefetch worker on the
+// client, by one accept thread on the server). We move it across the thread that
+// owns it; never share it. Marking Send lets the client's tier (which the worker
+// thread owns) satisfy `ExpertTier: Send`.
+unsafe impl Send for Verbs {}
+
+impl Verbs {
+    /// Open `dev_name` (e.g. `roceP2p1s0f1`) at RoCEv2 `gid_idx`, create the RC
+    /// QP (INIT). `local_psn` seeds our send sequence — any 24-bit value the two
+    /// ends agree on; we exchange it so a fixed constant is unnecessary.
+    pub fn create(dev_name: &str, gid_idx: u32, local_psn: u32) -> Result<Self> {
+        let dev = CString::new(dev_name).unwrap_or_default();
+        // SAFETY: dev is a valid NUL-terminated string for the call's duration.
+        let conn = unsafe { rs_create(dev.as_ptr(), gid_idx as c_int) };
+        if conn.is_null() {
+            bail!(
+                "rs_create failed for device '{dev_name}' gid_idx {gid_idx} \
+                 (check `ibv_devinfo -d {dev_name}` link state / GID)"
+            );
+        }
+        Ok(Self { conn, local_psn })
+    }
+
+    pub fn qpn(&self) -> u32 {
+        // SAFETY: conn is a live rs_conn for self's lifetime.
+        unsafe { rs_qpn(self.conn) }
+    }
+
+    pub fn psn(&self) -> u32 {
+        self.local_psn
+    }
+
+    pub fn gid(&self) -> Gid {
+        let mut g = [0u8; 16];
+        // SAFETY: conn live; out buffer is 16 bytes as the shim expects.
+        unsafe { rs_gid(self.conn, g.as_mut_ptr()) };
+        g
+    }
+
+    /// Register `[addr, addr+len)`. `remote_read` = REMOTE_READ only (the
+    /// server's read-only store MR); otherwise LOCAL_WRITE (the client's arena,
+    /// the HCA's READ landing buffer).
+    ///
+    /// # Safety
+    /// `addr` must point at `len` bytes that outlive this `Verbs` (the MR is
+    /// dereg'd on drop, but the NIC may DMA into/out of it until then).
+    pub unsafe fn reg_mr(
+        &mut self,
+        addr: *mut c_void,
+        len: usize,
+        remote_read: bool,
+    ) -> Result<MrKeys> {
+        let mut lkey = 0u32;
+        let mut rkey = 0u32;
+        // SAFETY: conn live; lkey/rkey out params valid; caller upholds addr/len.
+        let rc = unsafe {
+            rs_reg_mr(
+                self.conn,
+                addr,
+                len,
+                remote_read as c_int,
+                &mut lkey,
+                &mut rkey,
+            )
+        };
+        if rc != 0 {
+            bail!("ibv_reg_mr failed (addr {addr:p} len {len} remote_read {remote_read})");
+        }
+        Ok(MrKeys { lkey, rkey })
+    }
+
+    /// Register `[addr, addr+len)` as a READ+WRITE remote region (REMOTE_READ |
+    /// REMOTE_WRITE | LOCAL_WRITE) — the KV overflow blade's arena, which peers
+    /// both write groups into (offload) and read back (restore).
+    ///
+    /// # Safety
+    /// Same as [`Verbs::reg_mr`]: `addr` must back `len` live bytes outliving self.
+    pub unsafe fn reg_mr_rw(&mut self, addr: *mut c_void, len: usize) -> Result<MrKeys> {
+        let mut lkey = 0u32;
+        let mut rkey = 0u32;
+        // flags=3 → REMOTE_READ|REMOTE_WRITE|LOCAL_WRITE (see rdma_shim.c).
+        // SAFETY: conn live; out params valid; caller upholds addr/len.
+        let rc = unsafe { rs_reg_mr(self.conn, addr, len, 3, &mut lkey, &mut rkey) };
+        if rc != 0 {
+            bail!("ibv_reg_mr(RW) failed (addr {addr:p} len {len})");
+        }
+        Ok(MrKeys { lkey, rkey })
+    }
+
+    /// Drive INIT->RTR->RTS with the remote QP's identity.
+    pub fn connect(&mut self, remote_qpn: u32, remote_psn: u32, remote_gid: &Gid) -> Result<()> {
+        // SAFETY: conn live; remote_gid is 16 bytes.
+        let rc = unsafe {
+            rs_connect(
+                self.conn,
+                remote_qpn,
+                remote_psn,
+                self.local_psn,
+                remote_gid.as_ptr(),
+            )
+        };
+        match rc {
+            0 => Ok(()),
+            -1 => bail!("rs_connect: ibv_query_port failed"),
+            -2 => bail!("rs_connect: modify_qp -> RTR failed (check MTU/GID/dest_qpn)"),
+            -3 => bail!("rs_connect: modify_qp -> RTS failed"),
+            other => bail!("rs_connect: unexpected code {other}"),
+        }
+    }
+
+    /// Post a one-sided READ of `len` bytes from `remote_addr` (`rkey`) into the
+    /// local `local_addr` (`lkey`), tagged `wr_id`. Non-blocking; reap with
+    /// `poll`.
+    ///
+    /// # Safety
+    /// `local_addr..+len` must lie inside a live MR registered under `lkey`.
+    /// The op is asynchronous: that buffer and its MR must stay live and
+    /// untouched by the CPU until the matching `wr_id` is reaped by `poll`
+    /// (dropping the QP or freeing the buffer before then risks a NIC DMA into
+    /// freed memory).
+    pub unsafe fn post_read(
+        &mut self,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> Result<()> {
+        // SAFETY: conn live; caller upholds local_addr/lkey validity.
+        let rc =
+            unsafe { rs_post_read(self.conn, local_addr, lkey, remote_addr, rkey, len, wr_id) };
+        if rc != 0 {
+            bail!("ibv_post_send(RDMA_READ) failed: {rc}");
+        }
+        Ok(())
+    }
+
+    /// Post a one-sided WRITE of `len` bytes from local `local_addr` (`lkey`) to
+    /// the remote `remote_addr` (`rkey`), tagged `wr_id`. Non-blocking; reap with
+    /// `poll`. Used to offload a K/V group into the peer's RW blade.
+    ///
+    /// # Safety
+    /// `local_addr..+len` must lie inside a live MR registered under `lkey`.
+    /// The op is asynchronous: that buffer and its MR must stay live and
+    /// unmodified until the matching `wr_id` is reaped by `poll` (the NIC DMAs
+    /// from it after this returns).
+    pub unsafe fn post_write(
+        &mut self,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> Result<()> {
+        // SAFETY: conn live; caller upholds local_addr/lkey validity.
+        let rc =
+            unsafe { rs_post_write(self.conn, local_addr, lkey, remote_addr, rkey, len, wr_id) };
+        if rc != 0 {
+            bail!("ibv_post_send(RDMA_WRITE) failed: {rc}");
+        }
+        Ok(())
+    }
+
+    /// Block until one completion arrives; return its `wr_id`. Errors on a
+    /// non-success completion status (the NIC's `ibv_wc_status`).
+    pub fn poll(&mut self) -> Result<u64> {
+        let mut wr_id = 0u64;
+        // SAFETY: conn live; wr_id out param valid.
+        let rc = unsafe { rs_poll(self.conn, &mut wr_id) };
+        if rc == 0 {
+            Ok(wr_id)
+        } else if rc < 0 {
+            bail!("ibv_poll_cq error");
+        } else {
+            bail!("RDMA completion error: ibv_wc_status {rc}");
+        }
+    }
+}
+
+impl Drop for Verbs {
+    fn drop(&mut self) {
+        // SAFETY: conn was created by rs_create and not yet destroyed.
+        unsafe { rs_destroy(self.conn) };
+    }
+}

--- a/crates/atlas-rdma/src/verbs.rs
+++ b/crates/atlas-rdma/src/verbs.rs
@@ -6,10 +6,10 @@
 // registers its store here, the client tier (cuda) registers its pinned arena.
 //
 // One `Verbs` == one RC QP + its device context. The QP-identity exchange
-// (qpn/psn/gid) rides the existing TCP control channel in `expert_peer.rs`;
-// `connect` drives INIT->RTR->RTS. The client posts `IBV_WR_RDMA_READ`s with
-// `post_read` and reaps them with `poll` (blocking busy-poll); the server QP
-// only reaches RTS to respond, its CPU idle — the Phase B win.
+// (qpn/psn/gid) rides the TCP control channel; `connect` drives INIT->RTR->RTS.
+// The client posts `IBV_WR_RDMA_READ`s with `post_read` and reaps them with
+// `poll` (blocking busy-poll); the server QP only reaches RTS to respond, its
+// CPU idle (the point of one-sided reads).
 
 use anyhow::{Result, bail};
 use std::ffi::CString;

--- a/crates/atlas-rdma/src/wire.rs
+++ b/crates/atlas-rdma/src/wire.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The RDMA handshake wire codecs, shared by every Atlas RDMA client AND the
+// peer daemons. Extracted from the RDMA peer codecs; the peer daemons
+// re-export these at their old paths (a follow-up PR) so the servers stay
+// zero-diff.
+//
+// ** GOLDEN WIRE FORMAT ** — the live gx10 peer runs an OLDER binary, so
+// every byte layout here is frozen. All integers little-endian. The byte
+// vectors are pinned by `tests/wire_roundtrip.rs` and `tests/transcript_golden.rs`,
+// and the frozen constant values by `frozen_wire_constants` (wire_roundtrip.rs).
+//
+// Un-gated on purpose: pure `std::io` + anyhow, so it compiles and unit-tests
+// on the metal/ATLAS_SKIP_BUILD build with no rdma-core.
+
+use anyhow::{Context, Result, bail};
+
+// ── Shared status / transport-mode bytes ──
+pub const STATUS_OK: u8 = 0;
+pub const STATUS_ERR: u8 = 1;
+/// Two-sided TCP record streaming (the Stage-4 Phase-A expert path).
+pub const MODE_TCP: u8 = 0;
+/// One-sided RDMA READ over verbs (WS2 Phase B): the server publishes its
+/// store's MRs and the client READs records directly into its arena.
+pub const MODE_VERBS: u8 = 1;
+
+/// The server's half of the verbs handshake (RO dialect: expert / weight /
+/// LoRA tiers): its QP identity plus, per MoE layer (or per shard), the base
+/// virtual address + rkey of that entry's registered MR.
+/// `remote_addr(layer, expert) = layers[layer].0 + expert * record_stride`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerbsServerParams {
+    pub qpn: u32,
+    pub psn: u32,
+    pub gid: [u8; 16],
+    /// `(mr_base_addr, rkey)` for each MoE layer (expert tier) or shard
+    /// (weight/LoRA tiers), index-addressed.
+    pub layers: Vec<(u64, u32)>,
+}
+
+/// The client's half: just its QP identity (its arena MR is local-only).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerbsClientParams {
+    pub qpn: u32,
+    pub psn: u32,
+    pub gid: [u8; 16],
+}
+
+/// The peer's half of the RW-blade handshake (KV overflow / SSM snapshots):
+/// its QP identity + the single RW MR.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CacheServerParams {
+    pub qpn: u32,
+    pub psn: u32,
+    pub gid: [u8; 16],
+    pub base_addr: u64,
+    pub rkey: u32,
+}
+
+/// Anything that carries a remote QP identity a client rail can `connect` to.
+/// Implemented by both server-param dialects so the RailSet handshake tail is
+/// shared without homogenizing the two wire layouts.
+pub trait RemoteQp {
+    fn qp_identity(&self) -> (u32, u32, [u8; 16]);
+}
+
+impl RemoteQp for VerbsServerParams {
+    fn qp_identity(&self) -> (u32, u32, [u8; 16]) {
+        (self.qpn, self.psn, self.gid)
+    }
+}
+
+impl RemoteQp for CacheServerParams {
+    fn qp_identity(&self) -> (u32, u32, [u8; 16]) {
+        (self.qpn, self.psn, self.gid)
+    }
+}
+
+impl VerbsServerParams {
+    /// Wire form: `[u32 qpn][u32 psn][16 gid][u32 n_layers]{[u64 base][u32 rkey]}*`.
+    pub fn write_to<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.qpn.to_le_bytes())?;
+        w.write_all(&self.psn.to_le_bytes())?;
+        w.write_all(&self.gid)?;
+        w.write_all(&(self.layers.len() as u32).to_le_bytes())?;
+        for (base, rkey) in &self.layers {
+            w.write_all(&base.to_le_bytes())?;
+            w.write_all(&rkey.to_le_bytes())?;
+        }
+        Ok(())
+    }
+
+    pub fn read_from<R: std::io::Read>(r: &mut R) -> Result<Self> {
+        let qpn = read_u32(r)?;
+        let psn = read_u32(r)?;
+        let mut gid = [0u8; 16];
+        r.read_exact(&mut gid).context("read server gid")?;
+        let n = read_u32(r)? as usize;
+        if n == 0 || n > 4096 {
+            bail!("implausible verbs layer count: {n}");
+        }
+        let mut layers = Vec::with_capacity(n);
+        for _ in 0..n {
+            let mut b8 = [0u8; 8];
+            r.read_exact(&mut b8).context("read mr base")?;
+            let base = u64::from_le_bytes(b8);
+            let rkey = read_u32(r)?;
+            layers.push((base, rkey));
+        }
+        Ok(Self {
+            qpn,
+            psn,
+            gid,
+            layers,
+        })
+    }
+}
+
+impl VerbsClientParams {
+    /// Wire form: `[u32 qpn][u32 psn][16 gid]`.
+    pub fn write_to<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.qpn.to_le_bytes())?;
+        w.write_all(&self.psn.to_le_bytes())?;
+        w.write_all(&self.gid)?;
+        Ok(())
+    }
+
+    pub fn read_from<R: std::io::Read>(r: &mut R) -> Result<Self> {
+        let qpn = read_u32(r)?;
+        let psn = read_u32(r)?;
+        let mut gid = [0u8; 16];
+        r.read_exact(&mut gid).context("read client gid")?;
+        Ok(Self { qpn, psn, gid })
+    }
+}
+
+impl CacheServerParams {
+    /// Wire form: `[u32 qpn][u32 psn][16 gid][u64 base_addr][u32 rkey]`.
+    pub fn write_to<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.qpn.to_le_bytes())?;
+        w.write_all(&self.psn.to_le_bytes())?;
+        w.write_all(&self.gid)?;
+        w.write_all(&self.base_addr.to_le_bytes())?;
+        w.write_all(&self.rkey.to_le_bytes())?;
+        Ok(())
+    }
+
+    pub fn read_from<R: std::io::Read>(r: &mut R) -> Result<Self> {
+        let mut b4 = [0u8; 4];
+        let mut b8 = [0u8; 8];
+        let mut gid = [0u8; 16];
+        r.read_exact(&mut b4).context("kv qpn")?;
+        let qpn = u32::from_le_bytes(b4);
+        r.read_exact(&mut b4).context("kv psn")?;
+        let psn = u32::from_le_bytes(b4);
+        r.read_exact(&mut gid).context("kv gid")?;
+        r.read_exact(&mut b8).context("kv base")?;
+        let base_addr = u64::from_le_bytes(b8);
+        r.read_exact(&mut b4).context("kv rkey")?;
+        let rkey = u32::from_le_bytes(b4);
+        Ok(Self {
+            qpn,
+            psn,
+            gid,
+            base_addr,
+            rkey,
+        })
+    }
+}
+
+fn read_u32<R: std::io::Read>(r: &mut R) -> Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).context("read u32")?;
+    Ok(u32::from_le_bytes(b))
+}
+
+/// Frame N per-rail `VerbsServerParams` for the dual-rail RO tiers: a leading
+/// `[u8 n_rails]` count followed by each rail's params — exactly how the RW
+/// blade frames its per-rail `CacheServerParams`. Single-rail (`n == 1`) is the
+/// default, byte-for-byte the pre-dual-rail path plus the one-byte count prefix.
+pub fn write_server_rails<W: std::io::Write>(w: &mut W, rails: &[VerbsServerParams]) -> Result<()> {
+    if rails.is_empty() || rails.len() > 8 {
+        bail!("implausible server rail count: {}", rails.len());
+    }
+    w.write_all(&[rails.len() as u8])?;
+    for sp in rails {
+        sp.write_to(w)?;
+    }
+    Ok(())
+}
+
+/// Read `want` per-rail `VerbsServerParams` framed by a leading `[u8 n_rails]`.
+/// Bails if the framed count is zero, absurd (> 8), or != `want` — the client
+/// already negotiated `want` rails, so any other count is a protocol error.
+pub fn read_server_rails<R: std::io::Read>(
+    r: &mut R,
+    want: usize,
+) -> Result<Vec<VerbsServerParams>> {
+    let mut b1 = [0u8; 1];
+    r.read_exact(&mut b1).context("read server rail count")?;
+    let n = b1[0] as usize;
+    if n == 0 || n > 8 {
+        bail!("implausible server rail count: {n}");
+    }
+    if n != want {
+        bail!("server framed {n} rails but client negotiated {want}");
+    }
+    let mut rails = Vec::with_capacity(n);
+    for _ in 0..n {
+        rails.push(VerbsServerParams::read_from(r)?);
+    }
+    Ok(rails)
+}

--- a/crates/atlas-rdma/src/wire.rs
+++ b/crates/atlas-rdma/src/wire.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
-// The RDMA handshake wire codecs, shared by every Atlas RDMA client AND the
-// peer daemons. Extracted from the RDMA peer codecs; the peer daemons
-// re-export these at their old paths (a follow-up PR) so the servers stay
-// zero-diff.
+// The RDMA handshake wire codecs, shared by every Atlas RDMA client and the
+// peer daemons (the daemons re-export these, so client and server speak one
+// codec).
 //
-// ** GOLDEN WIRE FORMAT ** — the live gx10 peer runs an OLDER binary, so
-// every byte layout here is frozen. All integers little-endian. The byte
+// ** GOLDEN WIRE FORMAT ** — every byte layout here is a frozen external
+// contract (already-deployed peers depend on it). All integers little-endian. The byte
 // vectors are pinned by `tests/wire_roundtrip.rs` and `tests/transcript_golden.rs`,
 // and the frozen constant values by `frozen_wire_constants` (wire_roundtrip.rs).
 //
@@ -18,10 +17,10 @@ use anyhow::{Context, Result, bail};
 // ── Shared status / transport-mode bytes ──
 pub const STATUS_OK: u8 = 0;
 pub const STATUS_ERR: u8 = 1;
-/// Two-sided TCP record streaming (the Stage-4 Phase-A expert path).
+/// Two-sided TCP record streaming (the expert record path).
 pub const MODE_TCP: u8 = 0;
-/// One-sided RDMA READ over verbs (WS2 Phase B): the server publishes its
-/// store's MRs and the client READs records directly into its arena.
+/// One-sided RDMA READ over verbs: the server publishes its store's MRs and
+/// the client READs records directly into its arena.
 pub const MODE_VERBS: u8 = 1;
 
 /// The server's half of the verbs handshake (RO dialect: expert / weight /

--- a/crates/atlas-rdma/tests/env_chains.rs
+++ b/crates/atlas-rdma/tests/env_chains.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Pins the TWO distinct env-fallback semantics the RDMA tiers deploy with
+// (RailSet extraction, Step B): `first_set` (an exported-but-EMPTY var counts
+// as set — KV/expert/snapshot reads and the LoRA DEV chain) vs
+// `first_nonempty` (empty is SKIPPED — the weight tier), plus the
+// parse-or-fall-through `first_set_u32`. A unified helper that flipped either
+// behavior would silently change deployed configs (e.g. make
+// ATLAS_WEIGHT_RDMA_GID start affecting LoRA).
+
+use atlas_rdma::env::{first_nonempty, first_set, first_set_u32};
+
+/// All env mutation lives in this ONE test: `set_var` is process-global and
+/// test threads run concurrently, so a single serialized test avoids races.
+/// Var names are unique to this file.
+#[test]
+fn env_helper_semantics() {
+    // SAFETY: single-threaded within this test; the vars are test-unique, and
+    // no other test in this binary mutates the environment.
+    unsafe {
+        std::env::set_var("ATLAS_RDMATEST_EMPTY", "");
+        std::env::set_var("ATLAS_RDMATEST_DEV2", "rocep1s0f1");
+        std::env::set_var("ATLAS_RDMATEST_BADNUM", "not-a-number");
+        std::env::set_var("ATLAS_RDMATEST_NUM", "7");
+    }
+
+    // first_set: an exported-but-empty var COUNTS AS SET (Result::or_else /
+    // unwrap_or_else chain semantics) — it wins over later keys AND defaults.
+    assert_eq!(
+        first_set(&["ATLAS_RDMATEST_EMPTY", "ATLAS_RDMATEST_DEV2"], "dflt"),
+        "",
+        "first_set must treat an exported-but-empty var as set"
+    );
+    assert_eq!(
+        first_set(&["ATLAS_RDMATEST_UNSET", "ATLAS_RDMATEST_DEV2"], "dflt"),
+        "rocep1s0f1",
+        "first_set must chain past unset keys"
+    );
+
+    // first_nonempty: the same empty var is SKIPPED (weight-tier env_str).
+    assert_eq!(
+        first_nonempty(&["ATLAS_RDMATEST_EMPTY", "ATLAS_RDMATEST_DEV2"], "dflt"),
+        "rocep1s0f1",
+        "first_nonempty must skip an exported-but-empty var"
+    );
+
+    // first_set_u32: a set-but-unparseable var falls through to the next key
+    // (and to the default when it is the only key) — every pre-extraction
+    // per-client env_u32 behaved this way.
+    assert_eq!(
+        first_set_u32(&["ATLAS_RDMATEST_BADNUM", "ATLAS_RDMATEST_NUM"], 3),
+        7
+    );
+    assert_eq!(first_set_u32(&["ATLAS_RDMATEST_BADNUM"], 3), 3);
+    assert_eq!(first_set_u32(&["ATLAS_RDMATEST_NUM"], 3), 7);
+}
+
+/// Read-only (no env mutation): unset chains land on the tier defaults —
+/// the deployed single-rail path with a clean environment.
+#[test]
+fn unset_chains_yield_defaults() {
+    assert_eq!(
+        first_set(
+            &["ATLAS_RDMATEST_NOPE1", "ATLAS_RDMATEST_NOPE2"],
+            "roceP2p1s0f1"
+        ),
+        "roceP2p1s0f1"
+    );
+    assert_eq!(
+        first_nonempty(&["ATLAS_RDMATEST_NOPE1"], "roceP2p1s0f1"),
+        "roceP2p1s0f1"
+    );
+    assert_eq!(first_set_u32(&["ATLAS_RDMATEST_NOPE1"], 3), 3);
+}

--- a/crates/atlas-rdma/tests/env_chains.rs
+++ b/crates/atlas-rdma/tests/env_chains.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Pins the TWO distinct env-fallback semantics the RDMA tiers deploy with
-// (RailSet extraction, Step B): `first_set` (an exported-but-EMPTY var counts
-// as set — KV/expert/snapshot reads and the LoRA DEV chain) vs
+// Pins the TWO distinct env-fallback semantics the RDMA tiers deploy with:
+// `first_set` (an exported-but-EMPTY var counts as set — KV/expert/snapshot
+// reads and the LoRA DEV chain) vs
 // `first_nonempty` (empty is SKIPPED — the weight tier), plus the
 // parse-or-fall-through `first_set_u32`. A unified helper that flipped either
 // behavior would silently change deployed configs (e.g. make

--- a/crates/atlas-rdma/tests/handshake_reject.rs
+++ b/crates/atlas-rdma/tests/handshake_reject.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// A peer that REJECTS a client hangs up mid-handshake: the v2 wire carries no
+// error frame, so the reason lives only in the peer's log. Bare `read_exact`
+// context then surfaces "failed to fill whole buffer", which reads like a
+// transport fault and sends operators hunting a network problem that does not
+// exist.
+//
+// This was found by running a real serve against a capped `atlas-cache-peer`
+// (client asked for a 31.9 GiB arena against a 4 GiB `--max-blade-gb`; the peer
+// logged "paging blade cap" and closed). No unit test caught it, because every
+// existing handshake test scripts a COOPERATIVE peer.
+
+use std::io::{Read, Result as IoResult};
+
+use atlas_rdma::handshake::read_rw_server_params;
+
+/// A stream that yields `n` bytes then EOFs — the peer hanging up.
+struct TruncatedPeer {
+    remaining: Vec<u8>,
+}
+
+impl Read for TruncatedPeer {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        if self.remaining.is_empty() {
+            return Ok(0); // clean EOF -> read_exact yields UnexpectedEof
+        }
+        let n = buf.len().min(self.remaining.len());
+        buf[..n].copy_from_slice(&self.remaining[..n]);
+        self.remaining.drain(..n);
+        Ok(n)
+    }
+}
+
+#[test]
+fn peer_hangup_before_rail_params_names_the_rejection_not_a_buffer_error() {
+    let mut s = TruncatedPeer { remaining: vec![] };
+    let err = read_rw_server_params(&mut s, 1, "test-peer").unwrap_err();
+    let msg = format!("{err:#}");
+
+    assert!(
+        msg.contains("closed the connection during the rail handshake"),
+        "must say the peer hung up: {msg}"
+    );
+    assert!(
+        msg.contains("REJECTED"),
+        "must name this as a rejection, not a transport fault: {msg}"
+    );
+    assert!(
+        msg.contains("--max-blade-gb"),
+        "must point at the most common cause (arena exceeds the peer cap): {msg}"
+    );
+    assert!(
+        msg.contains("test-peer"),
+        "must name WHICH peer rejected us: {msg}"
+    );
+    // The regression we are pinning: the old message was exactly this.
+    assert!(
+        !msg.contains("failed to fill whole buffer"),
+        "must not surface the raw io error as the headline: {msg}"
+    );
+}
+
+#[test]
+fn a_truncated_params_body_is_still_a_read_error_not_a_rejection() {
+    // The peer DID send its n_rails echo, then died partway through the params
+    // body. That is a genuine transport/protocol fault, not a clean rejection,
+    // and must not be mislabelled as "the peer rejected you".
+    let mut s = TruncatedPeer {
+        remaining: vec![1u8, 0xde, 0xad],
+    };
+    let err = read_rw_server_params(&mut s, 1, "test-peer").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("REJECTED"),
+        "a mid-body truncation is not a rejection: {msg}"
+    );
+    assert!(
+        msg.contains("params"),
+        "should blame the params read: {msg}"
+    );
+}
+
+#[test]
+fn a_rail_count_mismatch_is_reported_as_a_grant_mismatch() {
+    // Peer answers with a DIFFERENT rail count. Distinct failure, distinct
+    // message — this path must not be swallowed by the new EOF branch.
+    let mut s = TruncatedPeer {
+        remaining: vec![3u8],
+    };
+    let err = read_rw_server_params(&mut s, 1, "test-peer").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("granted 3 rails, wanted 1"), "{msg}");
+}

--- a/crates/atlas-rdma/tests/transcript_golden.rs
+++ b/crates/atlas-rdma/tests/transcript_golden.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// TRANSCRIPT goldens — the only test class that pins the client's write ORDER
+// (struct goldens pin field layout; round-trips are blind to symmetric
+// reorders). Drives the exact handshake step sequence `railset::RailSet`
+// performs, via the un-gated `handshake` byte functions with FIXED QP
+// identities (no ibverbs — runs on the ATLAS_SKIP_BUILD/CI path), against a
+// scripted fake peer, and asserts:
+//   * the client's COMPLETE emitted byte stream, hand-written, per dialect
+//     (RO = expert/weight/LoRA, RW = KV/snapshot) at 1 and 2 rails;
+//   * every read happens at the right point of the written stream (the
+//     [n_rails] → server params → [n_rails]+client params → ack interleaving);
+//   * the parsed server params, against hand-written reply bytes (pins the
+//     reader field order independent of the writer).
+// The live gx10 peer runs an older binary: these transcripts are frozen.
+
+use std::io::{Read, Write};
+
+use atlas_rdma::handshake::{read_ack, read_rw_server_params, write_client_params, write_n_rails};
+use atlas_rdma::wire::{CacheServerParams, VerbsServerParams, read_server_rails};
+
+/// Fake bidirectional stream: scripted input, captured output, plus a log of
+/// `out.len()` at every read call — pinning WHEN the client reads relative to
+/// what it has written.
+struct Duplex {
+    inp: std::io::Cursor<Vec<u8>>,
+    out: Vec<u8>,
+    reads_at: Vec<usize>,
+}
+
+impl Duplex {
+    fn scripted(reply: Vec<u8>) -> Self {
+        Self {
+            inp: std::io::Cursor::new(reply),
+            out: Vec::new(),
+            reads_at: Vec::new(),
+        }
+    }
+}
+
+impl Read for Duplex {
+    fn read(&mut self, b: &mut [u8]) -> std::io::Result<usize> {
+        self.reads_at.push(self.out.len());
+        self.inp.read(b)
+    }
+}
+
+impl Write for Duplex {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.out.extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn gid(start: u8) -> [u8; 16] {
+    core::array::from_fn(|i| start + i as u8)
+}
+
+/// Fixed client QP identities with per-field-distinct bytes.
+const CLIENT_IDS: [(u32, u32, [u8; 16]); 2] = [
+    (
+        0x1122_3344,
+        0x00AA_BBCC,
+        [
+            0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D,
+            0x6E, 0x6F,
+        ],
+    ),
+    (
+        0x5566_7788,
+        0x00DD_EEFF,
+        [
+            0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D,
+            0x7E, 0x7F,
+        ],
+    ),
+];
+
+/// The client params block: `[u8 n]` + n × `[qpn][psn][gid]` (24 B each).
+fn expected_client_params(n: usize) -> Vec<u8> {
+    let mut v = vec![n as u8];
+    #[rustfmt::skip]
+    v.extend_from_slice(&[
+        0x44, 0x33, 0x22, 0x11, // qpn 0x1122_3344 LE
+        0xCC, 0xBB, 0xAA, 0x00, // psn 0x00AA_BBCC LE
+        0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, // gid verbatim
+        0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F,
+    ]);
+    if n == 2 {
+        #[rustfmt::skip]
+        v.extend_from_slice(&[
+            0x88, 0x77, 0x66, 0x55, // qpn 0x5566_7788 LE
+            0xFF, 0xEE, 0xDD, 0x00, // psn 0x00DD_EEFF LE
+            0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, // gid verbatim
+            0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F,
+        ]);
+    }
+    v
+}
+
+/// Hand-written server-side QP identity block `[qpn][psn][gid]` for rail `i`.
+fn server_qp_bytes(i: usize) -> Vec<u8> {
+    match i {
+        0 => {
+            let mut v = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+            v.extend_from_slice(&gid(0x20));
+            v
+        }
+        _ => {
+            let mut v = vec![0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10];
+            v.extend_from_slice(&gid(0x30));
+            v
+        }
+    }
+}
+
+const BASE0: [u8; 8] = [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11]; // 0x1122_3344_5566_7788
+const RKEY0: [u8; 4] = [0xCC, 0xBB, 0xAA, 0x99]; // 0x99AA_BBCC
+const BASE1: [u8; 8] = [0x0D, 0xF0, 0xAD, 0x0B, 0xEF, 0xBE, 0xAD, 0xDE]; // 0xDEAD_BEEF_0BAD_F00D
+const RKEY1: [u8; 4] = [0x04, 0x03, 0x02, 0x01]; // 0x0102_0304
+
+fn expected_server_param(i: usize) -> VerbsServerParams {
+    let (qpn, psn) = if i == 0 {
+        (0x0403_0201, 0x0807_0605)
+    } else {
+        (0x0C0B_0A09, 0x100F_0E0D)
+    };
+    VerbsServerParams {
+        qpn,
+        psn,
+        gid: gid(if i == 0 { 0x20 } else { 0x30 }),
+        layers: vec![if i == 0 {
+            (0x1122_3344_5566_7788, 0x99AA_BBCC)
+        } else {
+            (0xDEAD_BEEF_0BAD_F00D, 0x0102_0304)
+        }],
+    }
+}
+
+/// RO dialect (expert / weight / LoRA), post-preamble: the client writes
+/// `[u8 n]`, reads `[u8 n]{VerbsServerParams}×n`, writes `[u8 n]` + client
+/// params, reads `[ack]`.
+fn drive_ro(n: usize) {
+    // Scripted peer reply: [u8 n] + n × (qp identity + [u32 1][base][rkey]),
+    // then the STATUS_OK ack byte. Hand-written.
+    let mut reply = vec![n as u8];
+    for i in 0..n {
+        reply.extend_from_slice(&server_qp_bytes(i));
+        reply.extend_from_slice(&1u32.to_le_bytes()); // n_layers = 1
+        reply.extend_from_slice(if i == 0 { &BASE0 } else { &BASE1 });
+        reply.extend_from_slice(if i == 0 { &RKEY0 } else { &RKEY1 });
+    }
+    reply.push(0x00); // ack = STATUS_OK
+
+    let mut fake = Duplex::scripted(reply);
+    // The exact RailSet step sequence (begin → read_server_ro → complete).
+    write_n_rails(&mut fake, n).unwrap();
+    let server = read_server_rails(&mut fake, n).unwrap();
+    write_client_params(&mut fake, &CLIENT_IDS[..n]).unwrap();
+    read_ack(&mut fake, "test peer").unwrap();
+
+    // 1. The parsed server params, against the hand bytes (reader order pin).
+    let want: Vec<VerbsServerParams> = (0..n).map(expected_server_param).collect();
+    assert_eq!(server, want);
+
+    // 2. The complete emitted client stream, hand-written (writer order pin).
+    let mut expect = vec![n as u8];
+    expect.extend_from_slice(&expected_client_params(n));
+    assert_eq!(fake.out, expect, "RO client transcript changed ({n} rails)");
+
+    // 3. Interleaving: every server-params read happened after exactly the
+    // 1-byte n_rails write; the ack read after the full client stream.
+    let total = expect.len();
+    assert_eq!(fake.reads_at.first(), Some(&1));
+    assert_eq!(fake.reads_at.last(), Some(&total));
+    assert!(fake.reads_at.iter().all(|&a| a == 1 || a == total));
+}
+
+/// RW dialect (KV / snapshot), post-preamble: `[u8 n]` out, `[u8 n echo]` +
+/// n × CacheServerParams in, `[u8 n]` + client params out, `[ack]` in.
+fn drive_rw(n: usize) {
+    let mut reply = vec![n as u8];
+    for i in 0..n {
+        reply.extend_from_slice(&server_qp_bytes(i));
+        reply.extend_from_slice(if i == 0 { &BASE0 } else { &BASE1 });
+        reply.extend_from_slice(if i == 0 { &RKEY0 } else { &RKEY1 });
+    }
+    reply.push(0x00); // ack
+
+    let mut fake = Duplex::scripted(reply);
+    write_n_rails(&mut fake, n).unwrap();
+    let server = read_rw_server_params(&mut fake, n, "test peer").unwrap();
+    write_client_params(&mut fake, &CLIENT_IDS[..n]).unwrap();
+    read_ack(&mut fake, "test peer").unwrap();
+
+    let want: Vec<CacheServerParams> = (0..n)
+        .map(|i| {
+            let ro = expected_server_param(i);
+            CacheServerParams {
+                qpn: ro.qpn,
+                psn: ro.psn,
+                gid: ro.gid,
+                base_addr: ro.layers[0].0,
+                rkey: ro.layers[0].1,
+            }
+        })
+        .collect();
+    assert_eq!(server, want);
+
+    let mut expect = vec![n as u8];
+    expect.extend_from_slice(&expected_client_params(n));
+    assert_eq!(fake.out, expect, "RW client transcript changed ({n} rails)");
+
+    let total = expect.len();
+    assert_eq!(fake.reads_at.first(), Some(&1));
+    assert_eq!(fake.reads_at.last(), Some(&total));
+    assert!(fake.reads_at.iter().all(|&a| a == 1 || a == total));
+}
+
+#[test]
+fn ro_transcript_single_rail() {
+    drive_ro(1);
+}
+
+#[test]
+fn ro_transcript_dual_rail() {
+    drive_ro(2);
+}
+
+#[test]
+fn rw_transcript_single_rail() {
+    drive_rw(1);
+}
+
+#[test]
+fn rw_transcript_dual_rail() {
+    drive_rw(2);
+}
+
+#[test]
+fn rw_echo_mismatch_bails() {
+    // Peer echoes 3 rails when the client negotiated 2 → protocol error
+    // BEFORE any params are consumed. (Deliberately unbounded otherwise —
+    // the RO dialect's 1..=8 bound is its own.)
+    let mut fake = Duplex::scripted(vec![3u8]);
+    assert!(read_rw_server_params(&mut fake, 2, "test peer").is_err());
+}
+
+#[test]
+fn non_ok_ack_bails() {
+    let mut fake = Duplex::scripted(vec![1u8]); // STATUS_ERR
+    let err = read_ack(&mut fake, "test peer").unwrap_err();
+    assert!(err.to_string().contains("refused connection (ack 1)"));
+}

--- a/crates/atlas-rdma/tests/transcript_golden.rs
+++ b/crates/atlas-rdma/tests/transcript_golden.rs
@@ -12,7 +12,7 @@
 //     [n_rails] → server params → [n_rails]+client params → ack interleaving);
 //   * the parsed server params, against hand-written reply bytes (pins the
 //     reader field order independent of the writer).
-// The live gx10 peer runs an older binary: these transcripts are frozen.
+// These transcripts are frozen: a stable external wire contract.
 
 use std::io::{Read, Write};
 

--- a/crates/atlas-rdma/tests/verbs_probe.rs
+++ b/crates/atlas-rdma/tests/verbs_probe.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Public-API tests for atlas-rdma that need NO RDMA hardware and NO network:
+// the cfg witness, and `Verbs::create` failing cleanly for a device name that
+// cannot exist (`ibv_get_device_list` lookup miss — purely local).
+
+/// The always-compiled witness must agree with the cfg as seen by this test
+/// target (build-script cfgs apply to a crate's tests too). Runs in BOTH cfg
+/// states: verbs hosts assert `true`, ATLAS_SKIP_BUILD/macOS assert `false`.
+#[test]
+fn verbs_enabled_matches_cfg() {
+    assert_eq!(atlas_rdma::verbs_enabled(), cfg!(atlas_rdma_verbs));
+}
+
+#[cfg(atlas_rdma_verbs)]
+mod with_shim {
+    use atlas_rdma::{Gid, MrKeys, Verbs};
+
+    /// A nonexistent device must fail `rs_create` (NULL) and surface the
+    /// device name + gid index in the error. Exercises the real C shim and
+    /// libibverbs linkage without touching any NIC state.
+    #[test]
+    fn create_unknown_device_errors() {
+        let err = match Verbs::create("atlas-rdma-no-such-dev", 3, 0x0012_3456) {
+            Ok(_) => panic!("create() succeeded for a device that cannot exist"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("rs_create failed"), "unexpected error: {msg}");
+        assert!(
+            msg.contains("atlas-rdma-no-such-dev"),
+            "device name missing: {msg}"
+        );
+    }
+
+    /// `MrKeys` stays `Copy` (clients stash lkey/rkey by value everywhere) and
+    /// `Gid` stays exactly 16 bytes — it is exchanged verbatim on the wire.
+    #[test]
+    fn mr_keys_copy_and_gid_layout() {
+        let k = MrKeys { lkey: 1, rkey: 2 };
+        let k2 = k; // Copy, not move
+        assert_eq!((k.lkey, k.rkey), (k2.lkey, k2.rkey));
+        assert_eq!(std::mem::size_of::<Gid>(), 16);
+    }
+}

--- a/crates/atlas-rdma/tests/wire_roundtrip.rs
+++ b/crates/atlas-rdma/tests/wire_roundtrip.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Codec round-trip / validation tests, extracted WITH the codecs from the
+// RDMA peer daemons (RailSet extraction). These cover reader/writer agreement,
+// the exact byte layouts (see also `tests/transcript_golden.rs`), the frozen
+// interop constant values (`frozen_wire_constants`), and the validation bails.
+// Un-gated: pure `std::io`, runs on the ATLAS_SKIP_BUILD path.
+
+use atlas_rdma::wire::{
+    CacheServerParams, MODE_TCP, MODE_VERBS, STATUS_ERR, STATUS_OK, VerbsClientParams,
+    VerbsServerParams, read_server_rails, write_server_rails,
+};
+
+/// The interop bytes the live gx10 peer speaks are frozen — a value flip here
+/// is a silent wire break, so pin them explicitly (the goldens only exercise
+/// STATUS_OK/MODE bytes indirectly).
+#[test]
+fn frozen_wire_constants() {
+    assert_eq!(STATUS_OK, 0, "STATUS_OK is frozen vs the live peer");
+    assert_eq!(STATUS_ERR, 1, "STATUS_ERR is frozen vs the live peer");
+    assert_eq!(MODE_TCP, 0, "MODE_TCP is frozen vs the live peer");
+    assert_eq!(MODE_VERBS, 1, "MODE_VERBS is frozen vs the live peer");
+}
+
+#[test]
+fn verbs_server_params_round_trip() {
+    let sp = VerbsServerParams {
+        qpn: 0x1234,
+        psn: 0x00ab_cdef & 0xff_ffff,
+        gid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 178, 12],
+        layers: vec![(0x7f00_0000_0000, 1001), (0x7f00_0100_0000, 1002)],
+    };
+    let mut buf = Vec::new();
+    sp.write_to(&mut buf).unwrap();
+    let back = VerbsServerParams::read_from(&mut &buf[..]).unwrap();
+    assert_eq!(sp, back);
+}
+
+#[test]
+fn verbs_client_params_round_trip() {
+    let cp = VerbsClientParams {
+        qpn: 0x9999,
+        psn: 0x0055_5555,
+        gid: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    };
+    let mut buf = Vec::new();
+    cp.write_to(&mut buf).unwrap();
+    let back = VerbsClientParams::read_from(&mut &buf[..]).unwrap();
+    assert_eq!(cp, back);
+}
+
+#[test]
+fn server_rails_round_trip() {
+    // The dual-rail framing: N `VerbsServerParams` with a leading count.
+    let mk = |qpn| VerbsServerParams {
+        qpn,
+        psn: 0x0012_3456 & 0xff_ffff,
+        gid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 178, 12],
+        // Same base VA across rails (shared pages), distinct rkeys per rail.
+        layers: vec![
+            (0x7f00_0000_0000, 1001 + qpn),
+            (0x7f00_0100_0000, 1002 + qpn),
+        ],
+    };
+    let rails = vec![mk(0x1111), mk(0x2222)];
+    let mut buf = Vec::new();
+    write_server_rails(&mut buf, &rails).unwrap();
+    let back = read_server_rails(&mut &buf[..], 2).unwrap();
+    assert_eq!(rails, back);
+}
+
+#[test]
+fn single_rail_framing_round_trips() {
+    // n == 1 is the default path; must round-trip through the framing.
+    let sp = VerbsServerParams {
+        qpn: 7,
+        psn: 9,
+        gid: [1u8; 16],
+        layers: vec![(0x1000, 42)],
+    };
+    let mut buf = Vec::new();
+    write_server_rails(&mut buf, std::slice::from_ref(&sp)).unwrap();
+    // Leading count byte then the single params struct.
+    assert_eq!(buf[0], 1);
+    let back = read_server_rails(&mut &buf[..], 1).unwrap();
+    assert_eq!(back, vec![sp]);
+}
+
+#[test]
+fn read_server_rails_rejects_mismatch() {
+    // Framed count (1) != what the caller negotiated (2) -> protocol error.
+    let sp = VerbsServerParams {
+        qpn: 1,
+        psn: 2,
+        gid: [0u8; 16],
+        layers: vec![(0x1000, 7)],
+    };
+    let mut buf = Vec::new();
+    write_server_rails(&mut buf, std::slice::from_ref(&sp)).unwrap();
+    assert!(read_server_rails(&mut &buf[..], 2).is_err());
+}
+
+#[test]
+fn read_server_rails_rejects_zero_count() {
+    // A zero rail count is a corrupt/hostile frame.
+    let buf = [0u8; 1];
+    assert!(read_server_rails(&mut &buf[..], 1).is_err());
+}
+
+#[test]
+fn write_server_rails_rejects_empty() {
+    let mut buf = Vec::new();
+    assert!(write_server_rails(&mut buf, &[]).is_err());
+}
+
+#[test]
+fn verbs_server_params_reject_absurd_layer_count() {
+    // A corrupt/hostile count must Err, not attempt a huge allocation.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&1u32.to_le_bytes()); // qpn
+    buf.extend_from_slice(&2u32.to_le_bytes()); // psn
+    buf.extend_from_slice(&[0u8; 16]); // gid
+    buf.extend_from_slice(&99_999u32.to_le_bytes()); // n_layers (absurd)
+    assert!(VerbsServerParams::read_from(&mut &buf[..]).is_err());
+}
+
+#[test]
+fn kv_server_params_round_trip() {
+    let sp = CacheServerParams {
+        qpn: 0x4242,
+        psn: 0x0012_3456 & 0xff_ffff,
+        gid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 178, 12],
+        base_addr: 0x7f00_1234_0000,
+        rkey: 0xdead_beef,
+    };
+    let mut buf = Vec::new();
+    sp.write_to(&mut buf).unwrap();
+    assert_eq!(CacheServerParams::read_from(&mut &buf[..]).unwrap(), sp);
+}

--- a/crates/atlas-rdma/tests/wire_roundtrip.rs
+++ b/crates/atlas-rdma/tests/wire_roundtrip.rs
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Codec round-trip / validation tests, extracted WITH the codecs from the
-// RDMA peer daemons (RailSet extraction). These cover reader/writer agreement,
-// the exact byte layouts (see also `tests/transcript_golden.rs`), the frozen
-// interop constant values (`frozen_wire_constants`), and the validation bails.
-// Un-gated: pure `std::io`, runs on the ATLAS_SKIP_BUILD path.
+// Codec round-trip / validation tests for the RDMA peer daemons' shared wire
+// codecs. These cover reader/writer agreement, the exact byte layouts (see
+// also `tests/transcript_golden.rs`), the frozen interop constant values
+// (`frozen_wire_constants`), and the validation bails. Un-gated: pure
+// `std::io`, runs on the ATLAS_SKIP_BUILD path.
 
 use atlas_rdma::wire::{
     CacheServerParams, MODE_TCP, MODE_VERBS, STATUS_ERR, STATUS_OK, VerbsClientParams,
     VerbsServerParams, read_server_rails, write_server_rails,
 };
 
-/// The interop bytes the live gx10 peer speaks are frozen — a value flip here
-/// is a silent wire break, so pin them explicitly (the goldens only exercise
+/// These interop bytes are a frozen external contract — a value flip here is a
+/// silent wire break, so pin them explicitly (the goldens only exercise
 /// STATUS_OK/MODE bytes indirectly).
 #[test]
 fn frozen_wire_constants() {
-    assert_eq!(STATUS_OK, 0, "STATUS_OK is frozen vs the live peer");
-    assert_eq!(STATUS_ERR, 1, "STATUS_ERR is frozen vs the live peer");
-    assert_eq!(MODE_TCP, 0, "MODE_TCP is frozen vs the live peer");
-    assert_eq!(MODE_VERBS, 1, "MODE_VERBS is frozen vs the live peer");
+    assert_eq!(STATUS_OK, 0, "STATUS_OK is a frozen wire constant");
+    assert_eq!(STATUS_ERR, 1, "STATUS_ERR is a frozen wire constant");
+    assert_eq!(MODE_TCP, 0, "MODE_TCP is a frozen wire constant");
+    assert_eq!(MODE_VERBS, 1, "MODE_VERBS is a frozen wire constant");
 }
 
 #[test]


### PR DESCRIPTION
Adds the **`crates/atlas-rdma`** leaf crate — a CUDA-free RDMA verbs primitive + `RailSet`. Self-contained: new crate dir + workspace member; no changes to existing crates. Rebased fresh onto current `main` (clean add-only diff, +1884 LoC under `crates/atlas-rdma/`).

Independent of #atlas-tier and mergeable on its own.

Mirrors MonumentalSystems/atlas#25.