### PR TITLE
feat(dflash): unified context commit (commit_ctx), env-gated (re-land of #305 onto current main)

### DIFF
--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -388,6 +388,95 @@ impl Model for TransformerModel {
         Ok(())
     }
 
+    fn commit_ctx(
+        &self,
+        seq: &mut SequenceState,
+        num_committed: usize,
+        base_pos: usize,
+    ) -> Result<()> {
+        if num_committed == 0 {
+            return Ok(());
+        }
+        let base = match self.dflash_hidden_save {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+        let prop = match seq.proposer_state.as_mut() {
+            Some(p) => p.as_mut(),
+            None => return Ok(()),
+        };
+        // Graceful no-op for non-DFlash proposers (shared bootstrap path).
+        let d = match prop
+            .as_any_mut()
+            .downcast_mut::<crate::layers::DflashProposerState>()
+        {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+        let n_layers = self.dflash_capture_layers.len();
+        if n_layers == 0 {
+            return Ok(());
+        }
+        let ctx_slot_bytes = n_layers * self.config.hidden_size * 2;
+        let stream = self.gpu.default_stream();
+
+        // Watermark slide FIRST, on the ctx_len (row-index) axis. If the
+        // incoming rows would exceed capacity, keep the NEWEST rows and drop
+        // the oldest (mirrors dflash_serial_ctx_append). keep is clamped so
+        // drop_n >= keep — the single D2D copy's src/dst can never overlap.
+        // ctx_committed resets to 0 (next propose re-precomputes the slid
+        // rows chunk-wise); ctx_positions values (absolute RoPE positions)
+        // are preserved by the drain, so stamps stay exact across the slide.
+        if d.ctx_len + num_committed > d.max_ctx_len {
+            let keep = (d.max_ctx_len / 2).min(d.max_ctx_len.saturating_sub(num_committed));
+            let drop_n = d.ctx_len.saturating_sub(keep);
+            if drop_n > 0 {
+                let src = d.ctx_hidden_acc.offset(drop_n * ctx_slot_bytes);
+                let dst0 = d.ctx_hidden_acc.offset(0);
+                self.gpu
+                    .copy_d2d_async(src, dst0, keep * ctx_slot_bytes, stream)?;
+                d.ctx_positions.drain(..drop_n);
+                d.ctx_len = keep;
+                d.ctx_committed = 0;
+                tracing::info!(
+                    "DFlash UNIFIED_CTX watermark: slid ctx window (dropped {} oldest, keep {})",
+                    drop_n,
+                    keep,
+                );
+            }
+        }
+
+        // Append num_committed rows at the TAIL (ctx_len axis). dst uses
+        // ctx_len (acc row index); base_pos stamps ctx_positions (RoPE axis).
+        // Conflating the two axes is the DDD §4.1 landmine: they coincide
+        // only until the first slide — and the sliding prompts ARE the reds.
+        debug_assert_eq!(d.ctx_positions.len(), d.ctx_len);
+        for t in 0..num_committed {
+            let row = base.offset(t * ctx_slot_bytes);
+            let dst = d.ctx_hidden_acc.offset(d.ctx_len * ctx_slot_bytes);
+            self.gpu.copy_d2d_async(row, dst, ctx_slot_bytes, stream)?;
+            d.ctx_positions.push((base_pos + t) as i32);
+            d.ctx_len += 1;
+        }
+        // Freshest ctx slot = row (num_committed-1) = the bonus generator
+        // (EAGLE order, matches kgamma_append). Block the next propose()'s
+        // internal decode-append so this capture is never double-appended.
+        d.skip_next_decode_append = true;
+
+        // One-shot activation log so A/B runs can confirm the path is live.
+        static UNIFIED_CTX_LOGGED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        if !UNIFIED_CTX_LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            tracing::info!(
+                "DFlash UNIFIED_CTX ACTIVE: first commit_ctx rows={} base_pos={} ctx_len={}",
+                num_committed,
+                base_pos,
+                d.ctx_len,
+            );
+        }
+        Ok(())
+    }
+
     fn dflash_serial_ctx_append(&self, seq: &mut SequenceState) -> Result<()> {
         // Ctx-holes fix: append the serial-decoded token's captured hidden.
         // The decode layer loop (decode_a.rs try_dflash_capture) already

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -251,12 +251,19 @@ impl TransformerModel {
                 // this layer's activation — mirrors verify_b.rs for K=2.
                 // Must be inside the graph capture region so the per-layer
                 // intermediate (not the final-layer-only post-loop value) is
-                // recorded. Under ATLAS_DFLASH_EAGLE_FIX=1, capture ALL k
-                // verify rows so the scheduler can append rows
-                // 0..=num_accepted to ctx after the accept walk (EAGLE).
-                let eagle_fix =
-                    std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() == Some("1");
-                if eagle_fix {
+                // recorded. Under ATLAS_DFLASH_EAGLE_FIX=1 OR
+                // ATLAS_DFLASH_UNIFIED_CTX=1, capture ALL k verify rows so
+                // the scheduler can append rows 0..=num_accepted to ctx
+                // after the accept walk (EAGLE order). UNIFIED_CTX requires
+                // the same full capture: commit_ctx copies scratch rows
+                // 0..=num_accepted — with only the k-1 capture, row 0 holds
+                // the WRONG token's hidden and rows 1.. are stale garbage
+                // (2026-07-09 accept-collapse root cause: EAGLE_FIX=0 under
+                // UNIFIED=1 starved this capture and poisoned drafter ctx).
+                let capture_all = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref()
+                    == Some("1")
+                    || std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() == Some("1");
+                if capture_all {
                     self.try_dflash_capture_all(layer_idx, k, stream)?;
                 } else {
                     self.try_dflash_capture(layer_idx, k - 1, stream)?;

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -505,6 +505,23 @@ pub trait Model: Send + Sync {
         Ok(())
     }
 
+    /// Unified DFlash ctx commit (ATLAS_DFLASH_UNIFIED_CTX=1). Copies
+    /// `num_committed` scratch rows (`dflash_hidden_save` rows
+    /// `0..num_committed`) into `ctx_hidden_acc` at the CURRENT TAIL
+    /// (`ctx_len`), stamping RoPE positions `base_pos..base_pos+num_committed`,
+    /// folding the watermark slide in first. `base_pos` is the RoPE position,
+    /// NOT the acc row index (they diverge after a watermark slide — DDD §4.1
+    /// landmine). The single structural replacement for the ~5 fragmented
+    /// appends. Default no-op for models without a DFlash drafter.
+    fn commit_ctx(
+        &self,
+        _seq: &mut SequenceState,
+        _num_committed: usize,
+        _base_pos: usize,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Run the MTP proposer for one draft token off the saved hidden state.
     /// `None` when no proposer is wired.
     fn run_mtp_propose(

--- a/crates/spark-server/src/scheduler/adaptive_spec.rs
+++ b/crates/spark-server/src/scheduler/adaptive_spec.rs
@@ -128,6 +128,17 @@ pub(crate) fn serial_append_enabled() -> bool {
     *CACHED.get_or_init(|| std::env::var("ATLAS_DFLASH_SERIAL_APPEND").ok().as_deref() == Some("1"))
 }
 
+/// ATLAS_DFLASH_UNIFIED_CTX=1 → route the two commit points through the
+/// single `commit_ctx` (hole-immune by construction, DDD §4.1) instead of
+/// the ~5 fragmented appends. Default OFF = the 24.1 path, so both paths
+/// A/B on ONE binary.
+pub(crate) fn unified_ctx_enabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() == Some("1")
+    })
+}
+
 /// Count a serially-decoded token toward the re-probe interval.
 pub(crate) fn tick_serial(a: &mut ActiveSeq) {
     if enabled() && a.spec_adapt.suspended {

--- a/crates/spark-server/src/scheduler/adaptive_spec.rs
+++ b/crates/spark-server/src/scheduler/adaptive_spec.rs
@@ -134,9 +134,7 @@ pub(crate) fn serial_append_enabled() -> bool {
 /// A/B on ONE binary.
 pub(crate) fn unified_ctx_enabled() -> bool {
     static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() == Some("1")
-    })
+    *CACHED.get_or_init(|| std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() == Some("1"))
 }
 
 /// Count a serially-decoded token toward the re-probe interval.

--- a/crates/spark-server/src/scheduler/decode_step.rs
+++ b/crates/spark-server/src/scheduler/decode_step.rs
@@ -88,11 +88,19 @@ pub fn step_decode_only(
     // token's capture. n==1 only: `try_dflash_capture` stores row 0, which
     // is ambiguous in a multi-seq batch (fine here — DFlash runs
     // --max-batch-size 1).
-    if n == 1
-        && crate::scheduler::adaptive_spec::serial_append_enabled()
-        && let Err(e) = model.dflash_serial_ctx_append(&mut active[0].seq)
-    {
-        tracing::error!("dflash_serial_ctx_append (decode_only): {e:#}");
+    if n == 1 {
+        if crate::scheduler::adaptive_spec::unified_ctx_enabled() {
+            // Unified ctx commit: serial token at RoPE position seq_len-1
+            // (decode() advanced seq_len past the token just processed).
+            let base_pos = active[0].seq.seq_len.saturating_sub(1);
+            if let Err(e) = model.commit_ctx(&mut active[0].seq, 1, base_pos) {
+                tracing::error!("commit_ctx (decode_only serial): {e:#}");
+            }
+        } else if crate::scheduler::adaptive_spec::serial_append_enabled()
+            && let Err(e) = model.dflash_serial_ctx_append(&mut active[0].seq)
+        {
+            tracing::error!("dflash_serial_ctx_append (decode_only): {e:#}");
+        }
     }
 
     process_decode_logits(

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -201,7 +201,17 @@ pub fn step_mtp(
         let was_suspended = crate::scheduler::adaptive_spec::is_suspended(a);
         let will_propose = crate::scheduler::adaptive_spec::spec_allowed(a);
         let reprobe_resume = was_suspended && will_propose;
-        if crate::scheduler::adaptive_spec::serial_append_enabled()
+        if crate::scheduler::adaptive_spec::unified_ctx_enabled() {
+            // Unified ctx commit: same complement-gate as the old serial
+            // append — fire iff propose() will NOT run (or re-probe resume),
+            // so commit and propose decode-append never both cover a token.
+            if !will_propose || reprobe_resume {
+                let base_pos = a.seq.seq_len.saturating_sub(1);
+                if let Err(e) = model.commit_ctx(&mut a.seq, 1, base_pos) {
+                    tracing::error!("commit_ctx (mtp serial): {e:#}");
+                }
+            }
+        } else if crate::scheduler::adaptive_spec::serial_append_enabled()
             && (!will_propose || reprobe_resume)
             && let Err(e) = model.dflash_serial_ctx_append(&mut a.seq)
         {

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -134,11 +134,21 @@ pub fn step_verify_dflash(
     // generator (row num_accepted) freshest. Fixes the ctx-undercount (was 1
     // slot/step regardless of num_accepted) and the EAGLE conditioning shift.
     // Sets skip_next_decode_append so the propose below does NOT re-append row 0.
-    let eagle_fix = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() == Some("1");
-    if eagle_fix
-        && let Err(e) = model.dflash_eagle_kgamma_append(&mut a.seq, num_accepted, pre_verify_len)
-    {
-        tracing::error!("dflash_eagle_kgamma_append: {e:#}");
+    // Unified ctx commit (ATLAS_DFLASH_UNIFIED_CTX=1): ONE unconditional
+    // commit at the K=gamma point — rows 0..=num_accepted at RoPE base
+    // pre_verify_len. Structural replacement for dflash_eagle_kgamma_append.
+    if crate::scheduler::adaptive_spec::unified_ctx_enabled() {
+        if let Err(e) = model.commit_ctx(&mut a.seq, num_accepted + 1, pre_verify_len) {
+            tracing::error!("commit_ctx (kgamma): {e:#}");
+        }
+    } else {
+        let eagle_fix = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() == Some("1");
+        if eagle_fix
+            && let Err(e) =
+                model.dflash_eagle_kgamma_append(&mut a.seq, num_accepted, pre_verify_len)
+        {
+            tracing::error!("dflash_eagle_kgamma_append: {e:#}");
+        }
     }
 
     // Emit accepted drafts.


### PR DESCRIPTION
Re-lands the unified context commit (`commit_ctx`) from #305 onto current `main`, on top of the policy layer (#313 / originally #304). Same two commits by @rrstesiak, authorship preserved — only the base changed.

## Why a new PR

#305 was merged on 2026-07-12 (`f1098db7`) and then reverted in #312, because the stack landed out of order: its squash carried the whole K=γ engine (#303 + #304 + #305) in one commit, ahead of #303 and #304 themselves. With #302, #303 and now the policy layer merged in the right order, this PR re-lands only #305's own delta.

The original branch (`rrstesiak:feat/dflash-unified-ctx`) was deleted on merge and the PR shows `MERGED`, so it can't be reopened — hence a fresh branch here.

## What's in it

The replayed delta is content-identical to #305's original patch (the only textual difference is a hunk line-number offset in `decode_step.rs`, since the policy layer added lines above it):

```
crates/spark-model/src/model/trait_impl/mod.rs      | 89 ++++++++++++++++
crates/spark-model/src/model/trait_impl/verify_d.rs | 19 +++--
crates/spark-model/src/traits/model.rs              | 17 +++++
crates/spark-server/src/scheduler/adaptive_spec.rs  |  9 +++
crates/spark-server/src/scheduler/decode_step.rs    | 18 +++--
crates/spark-server/src/scheduler/mtp_step.rs       | 12 ++-
crates/spark-server/src/scheduler/verify_dflash_step.rs | 20 +++--
7 files changed, 167 insertions(+), 17 deletions(-)
```

Env-gated `ATLAS_DFLASH_UNIFIED_CTX=1`, **default OFF** — default behavior is byte-identical to `main`.

## Verification

Local, on the combined stack (policy layer + this):

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --tests` (CI-exact env) clean
- `cargo test --workspace` — all pass, 0 failures

The GB10 benchmark receipts from the original #305 run still apply — this is a content-exact replay of code that passed all three gates (Gate A webserver_ok 10/10 + 10/10, Σwall 1048.2s; Gate B ST-995 84.66/83.32 = same-box `main` control; Gate C warm-TTFT median +0.08% / p90 −0.02%). Full receipts: https://github.com/Avarok-Cybersecurity/atlas/pull/305#issuecomment-4953294116

As noted there: those gates confirm the default-OFF path is byte-identical to `main`; they do **not** exercise `commit_ctx` itself. The extended runbook still needs to land before the flag flips ON by default, and it stays OFF until then.

Re-lands #305 (reverted in #312).
