### PR TITLE
feat(loader): HSS — tiered storage + atlas-rdma / atlas-tier (re-cut of #316 onto main, +build fixes)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ crates/spark-server/                         @tbraun96 @azeezish @rsafier @SeedS
 
 # Multi-rank communication (NCCL / RDMA).
 crates/spark-comm/                           @tbraun96 @azeezish @rsafier @SeedSource
+crates/atlas-rdma/                           @tbraun96 @azeezish @rsafier @SeedSource
 
 # Storage / NVMe-backed swap.
 crates/spark-storage/                        @tbraun96 @azeezish @rsafier @SeedSource

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@ crates/spark-comm/                           @tbraun96 @azeezish @rsafier @SeedS
 
 # Storage / NVMe-backed swap.
 crates/spark-storage/                        @tbraun96 @azeezish @rsafier @SeedSource
+crates/atlas-tier/                           @tbraun96 @azeezish @rsafier @SeedSource
 
 # Build, CI, governance. Belt-and-suspenders: the broad `.github/`
 # pattern catches everything in the tree, and the more specific entries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
           int cuMemAllocHost(void **a, unsigned long b) { (void)a; (void)b; return 100; }
           int cuMemAllocHost_v2(void **a, unsigned long b) { (void)a; (void)b; return 100; }
           int cuMemFreeHost(void *a) { (void)a; return 100; }
+          int cuMemHostGetDevicePointer_v2(unsigned long long *a, void *b, unsigned int c) { (void)a; (void)b; (void)c; return 100; }
           /* Memcpy / memset */
           int cuMemcpyHtoD(unsigned long long a, const void *b, unsigned long c) {
               (void)a; (void)b; (void)c; return 100;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,6 +2189,8 @@ name = "spark-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atlas-rdma",
+ "atlas-tier",
  "cufile-sys",
  "half",
  "io-uring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "spark-runtime",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlas-tier"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
  "anyhow",
  "atlas-core",
  "atlas-kernels",
+ "atlas-tier",
  "base64 0.22.1",
  "half",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlas-rdma"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cc",
+]
+
+[[package]]
 name = "atlas-reduce"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/atlas-embed",
     "crates/atlas-reduce",
     "crates/atlas-kernels",
+    "crates/atlas-rdma",
     "crates/spark-runtime",
     "crates/spark-comm",
     "crates/spark-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ atlas-activation = { path = "crates/atlas-activation" }
 atlas-embed = { path = "crates/atlas-embed" }
 atlas-reduce = { path = "crates/atlas-reduce" }
 atlas-kernels = { path = "crates/atlas-kernels" }
+atlas-tier = { path = "crates/atlas-tier" }
 
 # W7: the `[patch.crates-io] xgrammar-rs` entry was removed — Atlas now
 # depends on the pure-Rust `crates/xgrammar` crate directly (no FFI,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/atlas-embed",
     "crates/atlas-reduce",
     "crates/atlas-kernels",
+    "crates/atlas-tier",
     "crates/spark-runtime",
     "crates/spark-comm",
     "crates/spark-model",

--- a/crates/atlas-core/src/config/methods.rs
+++ b/crates/atlas-core/src/config/methods.rs
@@ -59,6 +59,23 @@ impl ModelConfig {
         }
     }
 
+    /// Whether this model carries recurrent (SSM / linear-attention) state —
+    /// the honest capability signal for the SSM snapshot tiers. Derived from
+    /// [`Self::num_ssm_layers`] so the config-level predicate and the runtime
+    /// pool predicate (`ssm_pool.num_ssm_layers > 0`) agree by construction
+    /// (SSOT). A pure-attention model (dense or MoE) returns `false`:
+    /// requesting an SSM tier for it must fail fast, never silently no-op.
+    pub fn has_recurrent_state(&self) -> bool {
+        self.num_ssm_layers() > 0
+    }
+
+    /// Whether this model has MoE routed experts — the capability signal for
+    /// the expert-streaming tier. Keyed on config, never on observed expert
+    /// tensors (EP ranks legitimately own zero local expert tensors).
+    pub fn has_experts(&self) -> bool {
+        self.num_experts > 0
+    }
+
     /// Rotary embedding dimension.
     ///
     /// Priority:

--- a/crates/atlas-kernels/src/lib.rs
+++ b/crates/atlas-kernels/src/lib.rs
@@ -276,6 +276,10 @@ pub const ROLLBACK_RESTEER_CAP: u32 = 2;
 /// models ignore this (their ring is 0; they roll back to any boundary).
 pub const DECODE_ROLLBACK_RING_SLOTS: usize = 8;
 
+/// Domain salt folded into every decode cold-tier key so a decode-ring blob can
+/// never collide with a Marconi prefix-hash key on a shared store/peer.
+pub const DECODE_DOMAIN: u64 = 0xD3C0_DE12_A5B6_C7D8;
+
 impl Default for ModelBehavior {
     fn default() -> Self {
         Self {

--- a/crates/atlas-rdma/Cargo.toml
+++ b/crates/atlas-rdma/Cargo.toml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+[package]
+name = "atlas-rdma"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Atlas: one-sided RDMA verbs primitive (C shim + safe Rust wrapper) — CUDA-free"
+# `links` makes this the one crate that may compile rdma_shim.c (cargo hard-fails
+# a second `links = "atlas_rdma_shim"`), and — the load-bearing part — lets our
+# build script publish `cargo:has_verbs=1`, which direct dependents' build
+# scripts read as `DEP_ATLAS_RDMA_SHIM_HAS_VERBS` to re-emit
+# `cfg(atlas_rdma_verbs)` for THEIR own gated code (rustc-cfg never crosses
+# crate boundaries). See spark-storage/build.rs.
+links = "atlas_rdma_shim"
+
+# HARD CONSTRAINT (tiered-cache consolidation, atlas-rdma chunk): this crate is
+# the CUDA-free verbs transport the peer daemons AND the cuda client tiers both
+# build on. Its dependency budget is `anyhow` (+ `cc` at build time) — adding a
+# GPU dependency or any workspace crate here destroys the `atlas-expert-pack`
+# default-features = false property that keeps the peers CUDA-free (the same
+# rule crates/atlas-tier documents), and depending on spark-storage would be a
+# cycle.
+[dependencies]
+anyhow = { workspace = true }
+
+[build-dependencies]
+# Compiles the one-sided RDMA C-shim (src/rdma_shim.c) — ibv_post_send /
+# ibv_poll_cq are static inlines that must be called from C. Linux only.
+cc = "1"
+
+[lints]
+workspace = true

--- a/crates/atlas-rdma/Cargo.toml
+++ b/crates/atlas-rdma/Cargo.toml
@@ -11,16 +11,15 @@ description = "Atlas: one-sided RDMA verbs primitive (C shim + safe Rust wrapper
 # build script publish `cargo:has_verbs=1`, which direct dependents' build
 # scripts read as `DEP_ATLAS_RDMA_SHIM_HAS_VERBS` to re-emit
 # `cfg(atlas_rdma_verbs)` for THEIR own gated code (rustc-cfg never crosses
-# crate boundaries). See spark-storage/build.rs.
+# crate boundaries).
 links = "atlas_rdma_shim"
 
-# HARD CONSTRAINT (tiered-cache consolidation, atlas-rdma chunk): this crate is
-# the CUDA-free verbs transport the peer daemons AND the cuda client tiers both
-# build on. Its dependency budget is `anyhow` (+ `cc` at build time) — adding a
-# GPU dependency or any workspace crate here destroys the `atlas-expert-pack`
-# default-features = false property that keeps the peers CUDA-free (the same
-# rule crates/atlas-tier documents), and depending on spark-storage would be a
-# cycle.
+# HARD CONSTRAINT: this crate is the CUDA-free verbs transport the peer daemons
+# AND the CUDA client tiers both build on. Its dependency budget is `anyhow`
+# (+ `cc` at build time) — adding a GPU dependency or any workspace crate here
+# breaks the property that keeps the peer daemons CUDA-free (the same rule
+# crates/atlas-tier documents), and depending on a consumer crate would be a
+# dependency cycle.
 [dependencies]
 anyhow = { workspace = true }
 

--- a/crates/atlas-rdma/build.rs
+++ b/crates/atlas-rdma/build.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Build script for atlas-rdma — moved wholesale from spark-storage/build.rs
+// (`compile_rdma_shim`) in the tiered-cache consolidation. It compiles the
+// one-sided RDMA verbs C shim and decides `cfg(atlas_rdma_verbs)` for the
+// whole workspace:
+//
+//   * cfg ON  ⇔ target_os != macos AND !skip_build()   (unchanged semantics)
+//   * skip_build() honours ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD ∈ {1,true,TRUE}
+//     — the CPU/CI convention for hosts without rdma-core dev headers. There
+//     is deliberately NO header probing: on Linux with the skip unset and
+//     headers missing, cc fails the build loudly.
+//
+// Cross-crate propagation: `cargo:rustc-cfg` does NOT cross crate boundaries,
+// so when the shim builds we also publish `cargo:has_verbs=1`. Thanks to the
+// `links = "atlas_rdma_shim"` key, cargo exposes that to the build scripts of
+// DIRECT dependents as `DEP_ATLAS_RDMA_SHIM_HAS_VERBS`. A direct dependent's
+// build.rs (e.g. spark-storage, in a follow-up PR) reads it and re-emits
+// `cargo:rustc-cfg=atlas_rdma_verbs` for its own gated modules. Any crate that
+// grows a real `#[cfg(atlas_rdma_verbs)]` gate needs its own DIRECT dep on
+// atlas-rdma plus the same re-emit (DEP_ vars are invisible to transitive
+// dependents).
+
+fn main() {
+    // Unconditional and FIRST (before any early return): the lint config must
+    // know the cfg name even when the cfg is off — `unexpected_cfgs` is a hard
+    // error under `[workspace.lints.rust] warnings = "deny"`. (This also fixes
+    // the latent macOS ordering landmine the old spark-storage build.rs had,
+    // where the macOS arm returned before the check-cfg line.)
+    println!("cargo:rustc-check-cfg=cfg(atlas_rdma_verbs)");
+    println!("cargo:rerun-if-env-changed=ATLAS_SKIP_BUILD");
+    println!("cargo:rerun-if-env-changed=SKIP_ATLAS_BUILD");
+    println!("cargo:rerun-if-changed=src/rdma_shim.c");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Apple Silicon hosts have no rdma-core; the verbs module compiles out.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        return;
+    }
+    if skip_build() {
+        return;
+    }
+
+    // Compile `src/rdma_shim.c` and link libibverbs. `cc` emits the
+    // static-lib link directives (rustc-link-lib=static=atlas_rdma_shim +
+    // link-search into OUR OUT_DIR); static/dylib link flags propagate to
+    // final binaries transitively, so downstream crates need nothing.
+    cc::Build::new()
+        .file("src/rdma_shim.c")
+        .opt_level(2)
+        .warnings(true)
+        .compile("atlas_rdma_shim");
+    println!("cargo:rustc-link-lib=dylib=ibverbs");
+    // Gates our own `verbs` module.
+    println!("cargo:rustc-cfg=atlas_rdma_verbs");
+    // The cross-crate signal: DEP_ATLAS_RDMA_SHIM_HAS_VERBS in direct
+    // dependents' build scripts. Emitted only when ON (presence test
+    // downstream — matches the boolean semantics the cfg always had).
+    println!("cargo:has_verbs=1");
+}
+
+/// Verbatim spark-storage semantics: ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD in
+/// {"1","true","TRUE"} suppresses the shim compile and the cfg.
+fn skip_build() -> bool {
+    let truthy = |key: &str| {
+        matches!(
+            std::env::var(key).ok().as_deref(),
+            Some("1") | Some("true") | Some("TRUE")
+        )
+    };
+    truthy("ATLAS_SKIP_BUILD") || truthy("SKIP_ATLAS_BUILD")
+}

--- a/crates/atlas-rdma/build.rs
+++ b/crates/atlas-rdma/build.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Build script for atlas-rdma — moved wholesale from spark-storage/build.rs
-// (`compile_rdma_shim`) in the tiered-cache consolidation. It compiles the
-// one-sided RDMA verbs C shim and decides `cfg(atlas_rdma_verbs)` for the
-// whole workspace:
+// Build script for atlas-rdma. It compiles the one-sided RDMA verbs C shim
+// and decides `cfg(atlas_rdma_verbs)` for the whole workspace:
 //
 //   * cfg ON  ⇔ target_os != macos AND !skip_build()   (unchanged semantics)
 //   * skip_build() honours ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD ∈ {1,true,TRUE}

--- a/crates/atlas-rdma/src/env.rs
+++ b/crates/atlas-rdma/src/env.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Rail-env resolution helpers. The five RDMA clients share the SHAPE of this
+// logic but not the semantics: two distinct empty-string behaviors exist in
+// the deployed configs and BOTH must be preserved exactly —
+//
+//   * `first_set`      — an exported-but-EMPTY var counts as set (the
+//     `Result::or_else` / `unwrap_or_else` chains: KV / expert / snapshot
+//     single-key reads and the LoRA DEV chain).
+//   * `first_nonempty` — an empty var is SKIPPED (weight tier's `env_str`,
+//     which lets `ATLAS_WEIGHT_RDMA_DEV=""` fall through to the EXPERT name).
+//
+// Each client passes its EXACT key list; the fallback chains are per-tier
+// deployment surface (e.g. LoRA's GID reads ONLY `ATLAS_LORA_RDMA_GID` — no
+// WEIGHT/EXPERT fallback), so no chain is hardcoded here.
+
+/// First key whose var is present in the environment — even if empty.
+pub fn first_set(keys: &[&str], default: &str) -> String {
+    for k in keys {
+        if let Ok(v) = std::env::var(k) {
+            return v;
+        }
+    }
+    default.to_string()
+}
+
+/// First key whose var is present AND non-empty (weight-tier semantics).
+pub fn first_nonempty(keys: &[&str], default: &str) -> String {
+    for k in keys {
+        if let Ok(v) = std::env::var(k)
+            && !v.is_empty()
+        {
+            return v;
+        }
+    }
+    default.to_string()
+}
+
+/// First key whose var is present AND parses as `u32`; otherwise `default`.
+/// (A set-but-unparseable var falls through — the behavior of every existing
+/// per-client `env_u32`, single- and multi-key alike.)
+pub fn first_set_u32(keys: &[&str], default: u32) -> u32 {
+    for k in keys {
+        if let Some(v) = std::env::var(k).ok().and_then(|s| s.parse().ok()) {
+            return v;
+        }
+    }
+    default
+}

--- a/crates/atlas-rdma/src/handshake.rs
+++ b/crates/atlas-rdma/src/handshake.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The client side of the rail handshake as PURE byte functions, generic over
+// `Read`/`Write` and taking QP identities as plain `(qpn, psn, gid)` tuples —
+// no `Verbs` (and thus no ibverbs) required. `railset::RailSet` delegates to
+// these in production; tests drive them against a scripted fake stream to pin
+// the client's complete emitted byte sequence (`tests/transcript_golden.rs`),
+// which is the only test class that catches a write REORDER.
+//
+// Wire order per dialect (all little-endian, frozen vs the live gx10 peer):
+//   client: [u8 n_rails]                                   (`write_n_rails`)
+//   server: RO  → [u8 n]{VerbsServerParams}×n              (`wire::read_server_rails`)
+//           RW  → [u8 n echo]{CacheServerParams}×n         (`read_rw_server_params`)
+//   client: [u8 n_rails] {VerbsClientParams}×n             (`write_client_params`)
+//   server: [u8 ack] == STATUS_OK                          (`read_ack`)
+// The n_rails byte is deliberately sent TWICE by the client — that is the wire
+// format, not a redundancy to deduplicate.
+
+use anyhow::{Context, Result, bail};
+use std::io::{Read, Write};
+
+use crate::wire::{CacheServerParams, STATUS_OK, VerbsClientParams};
+
+/// Step 1: tell the peer how many rails we want to stripe across.
+pub fn write_n_rails<W: Write>(w: &mut W, n: usize) -> Result<()> {
+    w.write_all(&[n as u8]).context("send n_rails")?;
+    Ok(())
+}
+
+/// RW-blade dialect (KV overflow / snapshots): read the peer's `[u8 n]` echo
+/// (must equal the negotiated `want`; deliberately NOT bounded to 8 — the RO
+/// dialect's 1..=8 bound is its own, and unifying validation would change
+/// accepted wire inputs) followed by `n` `CacheServerParams`.
+pub fn read_rw_server_params<R: Read>(
+    r: &mut R,
+    want: usize,
+    peer: &str,
+) -> Result<Vec<CacheServerParams>> {
+    let mut b1 = [0u8; 1];
+    r.read_exact(&mut b1).context("read peer n_rails")?;
+    if b1[0] as usize != want {
+        bail!("{peer} granted {} rails, wanted {want}", b1[0]);
+    }
+    let mut server = Vec::with_capacity(want);
+    for _ in 0..want {
+        server
+            .push(CacheServerParams::read_from(r).with_context(|| format!("read {peer} params"))?);
+    }
+    Ok(server)
+}
+
+/// Reply with our rail count (again — wire format) + each rail's QP identity.
+pub fn write_client_params<W: Write>(w: &mut W, ids: &[(u32, u32, [u8; 16])]) -> Result<()> {
+    w.write_all(&[ids.len() as u8])
+        .context("send client n_rails")?;
+    for &(qpn, psn, gid) in ids {
+        VerbsClientParams { qpn, psn, gid }
+            .write_to(w)
+            .context("send verbs client params")?;
+    }
+    Ok(())
+}
+
+/// Final step: the peer's one-byte ready ack, which must be `STATUS_OK`.
+pub fn read_ack<R: Read>(r: &mut R, peer: &str) -> Result<()> {
+    let mut ack = [0u8; 1];
+    r.read_exact(&mut ack).context("read verbs ready ack")?;
+    if ack[0] != STATUS_OK {
+        bail!("{peer} refused connection (ack {})", ack[0]);
+    }
+    Ok(())
+}

--- a/crates/atlas-rdma/src/handshake.rs
+++ b/crates/atlas-rdma/src/handshake.rs
@@ -37,7 +37,23 @@ pub fn read_rw_server_params<R: Read>(
     peer: &str,
 ) -> Result<Vec<CacheServerParams>> {
     let mut b1 = [0u8; 1];
-    r.read_exact(&mut b1).context("read peer n_rails")?;
+    if let Err(e) = r.read_exact(&mut b1) {
+        // A clean EOF here is the peer REJECTING us, not a transport fault: it
+        // hangs up after logging its own reason (e.g. "paging blade cap") and
+        // the v2 wire has no error frame to carry that reason back. Bare
+        // `read_exact` context yields "failed to fill whole buffer", which
+        // sends operators hunting a network problem that does not exist.
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            bail!(
+                "{peer} closed the connection during the rail handshake without sending rail \
+                 params. The peer REJECTED this client — read ITS log for the reason. Most \
+                 common: the arena this client requested exceeds the peer's --max-blade-gb \
+                 cap (peer logs \"paging blade cap\"); also possible: a blob_bytes/kind \
+                 mismatch against an arena a prior client already fixed."
+            );
+        }
+        return Err(e).context("read peer n_rails");
+    }
     if b1[0] as usize != want {
         bail!("{peer} granted {} rails, wanted {want}", b1[0]);
     }

--- a/crates/atlas-rdma/src/handshake.rs
+++ b/crates/atlas-rdma/src/handshake.rs
@@ -7,7 +7,7 @@
 // the client's complete emitted byte sequence (`tests/transcript_golden.rs`),
 // which is the only test class that catches a write REORDER.
 //
-// Wire order per dialect (all little-endian, frozen vs the live gx10 peer):
+// Wire order per dialect (all little-endian, a frozen external contract):
 //   client: [u8 n_rails]                                   (`write_n_rails`)
 //   server: RO  → [u8 n]{VerbsServerParams}×n              (`wire::read_server_rails`)
 //           RW  → [u8 n echo]{CacheServerParams}×n         (`read_rw_server_params`)

--- a/crates/atlas-rdma/src/lib.rs
+++ b/crates/atlas-rdma/src/lib.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#![deny(warnings)]
+#![deny(clippy::all)]
+
+//! atlas-rdma: the one-sided RDMA verbs primitive shared by every Atlas RDMA
+//! tier (experts / KV overflow / weight staging / LoRA / SSM snapshots).
+//!
+//! Step A of the RailSet extraction (tiered-cache consolidation, chunk 2):
+//! this crate OWNS what used to be `spark-storage/src/rdma_verbs.rs` and
+//! `spark-storage/src/rdma_shim.c`, moved verbatim — the shim's QP/RTR/RTS
+//! attribute constants are interop-visible to the live gx10 peer running an
+//! older binary, so the .c file is byte-identical. No client refactor here.
+//!
+//! CUDA-free by hard constraint (see Cargo.toml): both the non-cuda peer
+//! daemons (`atlas-expert-pack`) and the cuda client tiers link this.
+//!
+//! `cfg(atlas_rdma_verbs)` is decided by build.rs — ON when `target_os` is not
+//! macOS and `ATLAS_SKIP_BUILD`/`SKIP_ATLAS_BUILD` is unset (there is no
+//! rdma-core probe; if the headers are missing there, `cc` fails the build
+//! loudly) — and published to direct dependents via the `links` metadata
+//! `DEP_ATLAS_RDMA_SHIM_HAS_VERBS`. See build.rs for the full story.
+
+/// Rail-env resolution helpers (`first_set` / `first_nonempty` /
+/// `first_set_u32`) — un-gated, pure `std::env`.
+pub mod env;
+/// Client handshake steps as pure `Read`/`Write` byte functions (identity
+/// tuples, no `Verbs`) — un-gated so the transcript goldens run everywhere.
+pub mod handshake;
+/// The golden handshake wire codecs (both server-param dialects, rails
+/// framing, mode/status bytes) — un-gated, frozen vs the live gx10 peer.
+pub mod wire;
+
+/// Safe-ish wrapper over the C shim: one [`verbs::Verbs`] == one RC QP.
+/// Compiled only where the shim is (`cfg(atlas_rdma_verbs)`).
+#[cfg(atlas_rdma_verbs)]
+pub mod verbs;
+
+/// RailSet — the one client-side rail bring-up (Step B of the extraction).
+/// Gated with the shim: it creates and connects real QPs.
+#[cfg(atlas_rdma_verbs)]
+pub mod railset;
+
+#[cfg(atlas_rdma_verbs)]
+pub use railset::{Rail, RailSet, RailSpec};
+#[cfg(atlas_rdma_verbs)]
+pub use verbs::{Gid, MrKeys, Verbs};
+pub use wire::{
+    CacheServerParams, MODE_TCP, MODE_VERBS, RemoteQp, STATUS_ERR, STATUS_OK, VerbsClientParams,
+    VerbsServerParams,
+};
+
+/// `true` iff this build of atlas-rdma compiled the verbs shim (i.e. the
+/// `atlas_rdma_verbs` cfg was emitted by build.rs). A permanent, always-
+/// compiled witness: tests assert it so a silent cfg evaporation fails
+/// `cargo test` on verbs hosts instead of green-building an empty crate.
+pub const fn verbs_enabled() -> bool {
+    cfg!(atlas_rdma_verbs)
+}

--- a/crates/atlas-rdma/src/lib.rs
+++ b/crates/atlas-rdma/src/lib.rs
@@ -6,14 +6,12 @@
 //! atlas-rdma: the one-sided RDMA verbs primitive shared by every Atlas RDMA
 //! tier (experts / KV overflow / weight staging / LoRA / SSM snapshots).
 //!
-//! Step A of the RailSet extraction (tiered-cache consolidation, chunk 2):
-//! this crate OWNS what used to be `spark-storage/src/rdma_verbs.rs` and
-//! `spark-storage/src/rdma_shim.c`, moved verbatim — the shim's QP/RTR/RTS
-//! attribute constants are interop-visible to the live gx10 peer running an
-//! older binary, so the .c file is byte-identical. No client refactor here.
+//! The C shim's QP/RTR/RTS attribute constants and the handshake wire codecs
+//! are a frozen external contract: they must stay byte-compatible with already
+//! deployed peers, so the shim is treated as byte-stable.
 //!
-//! CUDA-free by hard constraint (see Cargo.toml): both the non-cuda peer
-//! daemons (`atlas-expert-pack`) and the cuda client tiers link this.
+//! CUDA-free by hard constraint (see Cargo.toml): both the non-CUDA peer
+//! daemons and the CUDA client tiers link this.
 //!
 //! `cfg(atlas_rdma_verbs)` is decided by build.rs — ON when `target_os` is not
 //! macOS and `ATLAS_SKIP_BUILD`/`SKIP_ATLAS_BUILD` is unset (there is no
@@ -28,7 +26,7 @@ pub mod env;
 /// tuples, no `Verbs`) — un-gated so the transcript goldens run everywhere.
 pub mod handshake;
 /// The golden handshake wire codecs (both server-param dialects, rails
-/// framing, mode/status bytes) — un-gated, frozen vs the live gx10 peer.
+/// framing, mode/status bytes) — un-gated, a frozen external wire contract.
 pub mod wire;
 
 /// Safe-ish wrapper over the C shim: one [`verbs::Verbs`] == one RC QP.
@@ -36,8 +34,8 @@ pub mod wire;
 #[cfg(atlas_rdma_verbs)]
 pub mod verbs;
 
-/// RailSet — the one client-side rail bring-up (Step B of the extraction).
-/// Gated with the shim: it creates and connects real QPs.
+/// RailSet — the one client-side rail bring-up. Gated with the shim: it
+/// creates and connects real QPs.
 #[cfg(atlas_rdma_verbs)]
 pub mod railset;
 

--- a/crates/atlas-rdma/src/railset.rs
+++ b/crates/atlas-rdma/src/railset.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RailSet — the ONE client-side rail bring-up, extracted from the five
+// hand-rolled copies (rdma_kv_backend / expert_tier_rdma / weight_tier_rdma /
+// weight_lora_rdma / rdma_snapshot). Compositional by design, byte-identical
+// by construction:
+//
+//   * The stream must be ALREADY PREAMBLED — the five preambles (expert
+//     manifest + MODE_VERBS, weight/LoRA model request + manifest +
+//     MODE_VERBS, KV `[u64 total_bytes]`, snapshot paging magic) differ and
+//     stay in the clients. RailSet never owns the `TcpStream` (the snapshot
+//     tier keeps it as a live paging control channel after connect).
+//   * MR registration stays AT THE CALL SITE: there is no registration method
+//     here, so the access flag (`reg_mr(.., false)` for every client landing
+//     buffer, `true` / `reg_mr_rw` on the untouched server side) can never be
+//     defaulted or homogenized. Callers do `rail.verbs.reg_mr(..)` directly —
+//     `verbs` is deliberately `pub` (the KV zero-copy hot path and the
+//     snapshot staged path also post/poll on it raw).
+//   * PSN is CALLER-SUPPLIED via `RailSpec` (clients keep their
+//     `rand::random::<u32>() & 0xff_ffff` per rail; `rand` stays out of this
+//     crate and fixed PSNs make the handshake transcript-testable).
+//
+// Handshake order (the wire steps are frozen; local steps are free):
+//   begin: write [u8 n_rails] → Verbs::create per rail
+//   caller: reg_mr its landing buffers on each rail.verbs
+//   read_server_ro / read_server_rw: the dialect's server params
+//   caller (RO tiers): validate the table against its manifest — a failed
+//     validation must bail BEFORE client params are written, exactly as today
+//   complete: write [u8 n_rails] + client params → connect each rail
+//     INIT→RTR→RTS → read [u8 ack] == STATUS_OK
+//   into_verbs: decompose — clients re-own each `Verbs` in their own rail
+//     structs, so drop order (MR dereg before buffer free) is unchanged.
+
+use anyhow::{Context, Result, bail};
+use std::io::{Read, Write};
+
+use crate::handshake;
+use crate::verbs::Verbs;
+use crate::wire::{CacheServerParams, RemoteQp, VerbsServerParams, read_server_rails};
+
+/// Guard for `complete`'s rail/param pairing. A bare `zip` would SILENTLY
+/// truncate: a server slice shorter than the rail count leaves the trailing
+/// rails stuck in INIT (never RTS) while `complete` still returns `Ok`, so the
+/// caller believes it is connected and fails later, obscurely, on its first
+/// RDMA op. Pure so it is unit-testable without a NIC.
+pub(crate) fn check_rail_count(server_len: usize, rails_len: usize, peer: &str) -> Result<()> {
+    if server_len != rails_len {
+        bail!(
+            "{peer}: server returned {server_len} rail params for {rails_len} client rails — \
+             refusing to leave rails unconnected (a zip would silently truncate)"
+        );
+    }
+    Ok(())
+}
+
+/// One rail's bring-up parameters: device name, RoCEv2 GID index, and the
+/// caller-chosen 24-bit send PSN.
+#[derive(Clone, Debug)]
+pub struct RailSpec {
+    pub dev: String,
+    pub gid_idx: u32,
+    pub psn: u32,
+}
+
+impl RailSpec {
+    /// A spec with a fresh random 24-bit PSN — what every client tier does.
+    pub fn new(dev: String, gid_idx: u32, psn: u32) -> Self {
+        Self { dev, gid_idx, psn }
+    }
+}
+
+/// One connected (or connecting) rail. `verbs` is public: registration and
+/// the data plane (post_read/post_write/poll) belong to the caller.
+pub struct Rail {
+    pub verbs: Verbs,
+}
+
+/// All rails of one client connection, mid-handshake.
+pub struct RailSet {
+    pub rails: Vec<Rail>,
+}
+
+impl RailSet {
+    /// Wire step 1 + local QP creation: write `[u8 n_rails]` to the
+    /// already-preambled stream, then `Verbs::create` one RC QP per spec.
+    pub fn begin<W: Write>(stream: &mut W, specs: &[RailSpec]) -> Result<Self> {
+        handshake::write_n_rails(stream, specs.len())?;
+        let rails = specs
+            .iter()
+            .map(|s| Verbs::create(&s.dev, s.gid_idx, s.psn).map(|verbs| Rail { verbs }))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { rails })
+    }
+
+    pub fn n_rails(&self) -> usize {
+        self.rails.len()
+    }
+
+    /// RO dialect (expert/weight/LoRA): `[u8 n]{VerbsServerParams}×n`, with
+    /// the framed count validated == ours and 1..=8. Returned un-consumed so
+    /// the caller can validate the per-layer/per-shard tables against its
+    /// manifest BEFORE `complete` writes anything back.
+    pub fn read_server_ro<R: Read>(&self, stream: &mut R) -> Result<Vec<VerbsServerParams>> {
+        read_server_rails(stream, self.rails.len())
+    }
+
+    /// RW-blade dialect (KV/snapshot): `[u8 n echo]{CacheServerParams}×n`.
+    pub fn read_server_rw<R: Read>(
+        &self,
+        stream: &mut R,
+        peer: &str,
+    ) -> Result<Vec<CacheServerParams>> {
+        handshake::read_rw_server_params(stream, self.rails.len(), peer)
+    }
+
+    /// The common handshake tail: write `[u8 n_rails]` (again — wire format)
+    /// plus each rail's client QP params, connect each rail to its peer rail
+    /// (INIT→RTR→RTS), then read the one-byte ready ack.
+    pub fn complete<S: Read + Write, P: RemoteQp>(
+        &mut self,
+        stream: &mut S,
+        server: &[P],
+        peer: &str,
+    ) -> Result<()> {
+        check_rail_count(server.len(), self.rails.len(), peer)?;
+        let ids: Vec<(u32, u32, [u8; 16])> = self
+            .rails
+            .iter()
+            .map(|r| (r.verbs.qpn(), r.verbs.psn(), r.verbs.gid()))
+            .collect();
+        handshake::write_client_params(stream, &ids)?;
+        for (rail, sp) in self.rails.iter_mut().zip(server) {
+            let (qpn, psn, gid) = sp.qp_identity();
+            rail.verbs
+                .connect(qpn, psn, &gid)
+                .with_context(|| format!("connect {peer} rail"))?;
+        }
+        handshake::read_ack(stream, peer)
+    }
+
+    /// `read_server_rw` + `complete` in one call — the RW clients have no
+    /// mid-handshake validation. Returns the params for rkey/base capture
+    /// (each caller keeps its own policy; KV/snapshot use the LAST base).
+    pub fn finish_rw<S: Read + Write>(
+        &mut self,
+        stream: &mut S,
+        peer: &str,
+    ) -> Result<Vec<CacheServerParams>> {
+        let server = self.read_server_rw(stream, peer)?;
+        self.complete(stream, &server, peer)?;
+        Ok(server)
+    }
+
+    /// Decompose after `complete`: hand each `Verbs` back to the caller's own
+    /// rail struct so ownership (and thus drop order vs the registered
+    /// buffers) is exactly what it was before the extraction.
+    pub fn into_verbs(self) -> Vec<Verbs> {
+        self.rails.into_iter().map(|r| r.verbs).collect()
+    }
+}
+
+#[cfg(test)]
+#[path = "railset_tests.rs"]
+mod tests;

--- a/crates/atlas-rdma/src/railset_tests.rs
+++ b/crates/atlas-rdma/src/railset_tests.rs
@@ -15,9 +15,11 @@ fn equal_counts_are_ok() {
 #[test]
 fn short_server_slice_is_refused_not_truncated() {
     // The regression this guards: a bare `zip` would connect 1 of 2 rails and
-    // return Ok, leaving rail 1 stuck in INIT.
-    let e = check_rail_count(1, 2, "gx10:9916").unwrap_err().to_string();
-    assert!(e.contains("gx10:9916"), "peer named: {e}");
+    // return Ok, leaving rail 1 stuck in INIT. The `peer` arg is just the label
+    // the error interpolates (real endpoints are env-resolved upstream); a
+    // distinctive fixture value lets us assert it is echoed.
+    let e = check_rail_count(1, 2, "test-peer").unwrap_err().to_string();
+    assert!(e.contains("test-peer"), "peer named: {e}");
     assert!(
         e.contains("1 rail params for 2 client rails"),
         "counts reported: {e}"

--- a/crates/atlas-rdma/src/railset_tests.rs
+++ b/crates/atlas-rdma/src/railset_tests.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Guard tests for `RailSet::complete`'s rail/param pairing. `complete` itself
+// needs a live NIC (`Verbs::create`), so the check is factored into the pure
+// `check_rail_count` and exercised here without hardware.
+
+use super::check_rail_count;
+
+#[test]
+fn equal_counts_are_ok() {
+    assert!(check_rail_count(2, 2, "peer").is_ok());
+    assert!(check_rail_count(0, 0, "peer").is_ok());
+}
+
+#[test]
+fn short_server_slice_is_refused_not_truncated() {
+    // The regression this guards: a bare `zip` would connect 1 of 2 rails and
+    // return Ok, leaving rail 1 stuck in INIT.
+    let e = check_rail_count(1, 2, "gx10:9916").unwrap_err().to_string();
+    assert!(e.contains("gx10:9916"), "peer named: {e}");
+    assert!(
+        e.contains("1 rail params for 2 client rails"),
+        "counts reported: {e}"
+    );
+}
+
+#[test]
+fn long_server_slice_is_also_refused() {
+    assert!(check_rail_count(3, 2, "peer").is_err());
+}

--- a/crates/atlas-rdma/src/rdma_shim.c
+++ b/crates/atlas-rdma/src/rdma_shim.c
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // Minimal one-sided RDMA READ shim over libibverbs (RoCEv2), for the expert
-// weight tier (streaming-experts WS2, Phase B).
+// weight tier.
 //
 // `ibv_post_send` / `ibv_poll_cq` are `static inline` in <infiniband/verbs.h>,
 // so they cannot be FFI'd directly from Rust — they must be called from a C
 // translation unit. This shim is that unit: it wraps the whole RC-QP lifecycle
 // (create -> INIT -> RTR -> RTS), MR registration, one-sided READ posting, and
-// completion polling behind a tiny C ABI the Rust side (`rdma_verbs.rs`) binds.
+// completion polling behind a tiny C ABI the Rust side (`verbs.rs`) binds.
 //
 // Design: one `rs_conn` == one device context + PD + CQ + RC QP, plus a small
 // fixed table of registered MRs. Both peer (server, registers its store with
@@ -15,7 +15,7 @@
 // one. QP identity (qpn/psn/gid) is exchanged out-of-band over the existing TCP
 // control channel; `rs_connect` drives the state machine with the remote params.
 // One-sided: the client is the requester (posts READs); the server QP only has
-// to reach RTS to respond, its CPU stays idle — the intended Phase B win.
+// to reach RTS to respond, its CPU stays idle (the point of one-sided reads).
 
 #include <infiniband/verbs.h>
 #include <stdint.h>

--- a/crates/atlas-rdma/src/rdma_shim.c
+++ b/crates/atlas-rdma/src/rdma_shim.c
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Minimal one-sided RDMA READ shim over libibverbs (RoCEv2), for the expert
+// weight tier (streaming-experts WS2, Phase B).
+//
+// `ibv_post_send` / `ibv_poll_cq` are `static inline` in <infiniband/verbs.h>,
+// so they cannot be FFI'd directly from Rust — they must be called from a C
+// translation unit. This shim is that unit: it wraps the whole RC-QP lifecycle
+// (create -> INIT -> RTR -> RTS), MR registration, one-sided READ posting, and
+// completion polling behind a tiny C ABI the Rust side (`rdma_verbs.rs`) binds.
+//
+// Design: one `rs_conn` == one device context + PD + CQ + RC QP, plus a small
+// fixed table of registered MRs. Both peer (server, registers its store with
+// REMOTE_READ) and client (registers its pinned arena with LOCAL_WRITE) create
+// one. QP identity (qpn/psn/gid) is exchanged out-of-band over the existing TCP
+// control channel; `rs_connect` drives the state machine with the remote params.
+// One-sided: the client is the requester (posts READs); the server QP only has
+// to reach RTS to respond, its CPU stays idle — the intended Phase B win.
+
+#include <infiniband/verbs.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define RS_MAX_MR 512
+
+struct rs_conn {
+    struct ibv_context *ctx;
+    struct ibv_pd *pd;
+    struct ibv_cq *cq;
+    struct ibv_qp *qp;
+    union ibv_gid gid;
+    struct ibv_mr *mrs[RS_MAX_MR];
+    int n_mr;
+    uint8_t port;
+    int gid_idx;
+};
+
+void rs_destroy(struct rs_conn *c);
+
+// Open device `dev_name` (port 1), read the GID at `gid_idx`, allocate PD + CQ,
+// create an RC QP and move it to INIT. Returns NULL on any failure.
+struct rs_conn *rs_create(const char *dev_name, int gid_idx) {
+    struct ibv_device **list = ibv_get_device_list(NULL);
+    if (!list) {
+        return NULL;
+    }
+    struct ibv_device *dev = NULL;
+    for (int i = 0; list[i]; i++) {
+        if (strcmp(ibv_get_device_name(list[i]), dev_name) == 0) {
+            dev = list[i];
+            break;
+        }
+    }
+    if (!dev) {
+        ibv_free_device_list(list);
+        return NULL;
+    }
+    struct rs_conn *c = calloc(1, sizeof(*c));
+    if (!c) {
+        ibv_free_device_list(list);
+        return NULL;
+    }
+    c->port = 1;
+    c->gid_idx = gid_idx;
+    c->ctx = ibv_open_device(dev);
+    ibv_free_device_list(list);
+    if (!c->ctx) {
+        goto err;
+    }
+    if (ibv_query_gid(c->ctx, c->port, gid_idx, &c->gid)) {
+        goto err;
+    }
+    c->pd = ibv_alloc_pd(c->ctx);
+    if (!c->pd) {
+        goto err;
+    }
+    c->cq = ibv_create_cq(c->ctx, 256, NULL, NULL, 0);
+    if (!c->cq) {
+        goto err;
+    }
+    struct ibv_qp_init_attr qa;
+    memset(&qa, 0, sizeof(qa));
+    qa.send_cq = c->cq;
+    qa.recv_cq = c->cq;
+    qa.qp_type = IBV_QPT_RC;
+    qa.cap.max_send_wr = 256;
+    qa.cap.max_recv_wr = 16;
+    qa.cap.max_send_sge = 1;
+    qa.cap.max_recv_sge = 1;
+    c->qp = ibv_create_qp(c->pd, &qa);
+    if (!c->qp) {
+        goto err;
+    }
+    struct ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = c->port;
+    // Grant REMOTE_READ + REMOTE_WRITE on the QP. The expert tier only issues
+    // READs, and its MRs are REMOTE_READ-only, so a stray write is still refused
+    // at the MR level — but the KV overflow blade's QP must accept incoming
+    // RDMA WRITEs. QP-level flags are a ceiling; per-MR flags do the enforcing.
+    attr.qp_access_flags =
+        IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+    if (ibv_modify_qp(c->qp, &attr,
+                      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                          IBV_QP_ACCESS_FLAGS)) {
+        goto err;
+    }
+    return c;
+err:
+    rs_destroy(c);
+    return NULL;
+}
+
+uint32_t rs_qpn(struct rs_conn *c) { return c->qp->qp_num; }
+
+// Copy this QP's 16-byte GID (the one at gid_idx) out for the wire handshake.
+void rs_gid(struct rs_conn *c, uint8_t out[16]) { memcpy(out, c->gid.raw, 16); }
+
+// Register `[addr, addr+len)` as an MR. `flags` is a bitmask giving each side
+// exactly the access it needs and no more:
+//   bit 0 (1) -> REMOTE_READ   (expert store; also the KV blade's read-back)
+//   bit 1 (2) -> REMOTE_WRITE  (KV overflow blade; implies LOCAL_WRITE per the
+//                               verbs rule that REMOTE_WRITE requires LOCAL_WRITE)
+//   flags == 0 -> LOCAL_WRITE  (the client's landing/bounce buffer)
+// REMOTE_READ alone deliberately omits LOCAL_WRITE (requesting it on a PROT_READ
+// mmap makes ibv_reg_mr fail — the expert store is registered read-only this way).
+// So: expert store = 1, client bounce = 0, KV blade = 3 (RR|RW|LW).
+int rs_reg_mr(struct rs_conn *c, void *addr, size_t len, int flags,
+              uint32_t *lkey, uint32_t *rkey) {
+    if (c->n_mr >= RS_MAX_MR) {
+        return -1;
+    }
+    int access = 0;
+    if (flags & 1) {
+        access |= IBV_ACCESS_REMOTE_READ;
+    }
+    if (flags & 2) {
+        access |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
+    }
+    if (access == 0) {
+        access = IBV_ACCESS_LOCAL_WRITE;
+    }
+    struct ibv_mr *mr = ibv_reg_mr(c->pd, addr, len, access);
+    if (!mr) {
+        return -1;
+    }
+    c->mrs[c->n_mr++] = mr;
+    *lkey = mr->lkey;
+    *rkey = mr->rkey;
+    return 0;
+}
+
+// Drive INIT -> RTR -> RTS with the remote QP's params. `remote_psn` is the
+// remote's send PSN (our rq_psn); `local_psn` is our send PSN (our sq_psn). The
+// path MTU is taken from the port's active MTU. Returns 0, or a negative code
+// identifying the failed transition.
+int rs_connect(struct rs_conn *c, uint32_t remote_qpn, uint32_t remote_psn,
+               uint32_t local_psn, const uint8_t remote_gid[16]) {
+    struct ibv_port_attr pa;
+    if (ibv_query_port(c->ctx, c->port, &pa)) {
+        return -1;
+    }
+    struct ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = pa.active_mtu;
+    attr.dest_qp_num = remote_qpn;
+    attr.rq_psn = remote_psn;
+    attr.max_dest_rd_atomic = 16;
+    attr.min_rnr_timer = 12;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.port_num = c->port;
+    attr.ah_attr.grh.hop_limit = 64;
+    attr.ah_attr.grh.sgid_index = c->gid_idx;
+    attr.ah_attr.grh.traffic_class = 0;
+    memcpy(attr.ah_attr.grh.dgid.raw, remote_gid, 16);
+    if (ibv_modify_qp(c->qp, &attr,
+                      IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+                          IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                          IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER)) {
+        return -2;
+    }
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.timeout = 14;
+    attr.retry_cnt = 7;
+    attr.rnr_retry = 7;
+    attr.sq_psn = local_psn;
+    attr.max_rd_atomic = 16;
+    if (ibv_modify_qp(c->qp, &attr,
+                      IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+                          IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                          IBV_QP_MAX_QP_RD_ATOMIC)) {
+        return -3;
+    }
+    return 0;
+}
+
+// Post a single one-sided RDMA READ: pull `len` bytes from the remote
+// `remote_addr` (protected by `rkey`) into local `local_addr` (registered under
+// `lkey`). Signaled, so it generates a completion tagged with `wr_id`.
+int rs_post_read(struct rs_conn *c, void *local_addr, uint32_t lkey,
+                 uint64_t remote_addr, uint32_t rkey, uint32_t len,
+                 uint64_t wr_id) {
+    struct ibv_sge sge;
+    memset(&sge, 0, sizeof(sge));
+    sge.addr = (uintptr_t)local_addr;
+    sge.length = len;
+    sge.lkey = lkey;
+    struct ibv_send_wr wr;
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = wr_id;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_READ;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = remote_addr;
+    wr.wr.rdma.rkey = rkey;
+    struct ibv_send_wr *bad = NULL;
+    return ibv_post_send(c->qp, &wr, &bad);
+}
+
+// Post a single one-sided RDMA WRITE: push `len` bytes from local `local_addr`
+// (registered under `lkey`) to the remote `remote_addr` (protected by `rkey`).
+// Signaled, so it generates a completion tagged with `wr_id`. Used by the KV
+// overflow tier to offload a K/V group into the peer's registered RAM blade.
+int rs_post_write(struct rs_conn *c, void *local_addr, uint32_t lkey,
+                  uint64_t remote_addr, uint32_t rkey, uint32_t len,
+                  uint64_t wr_id) {
+    struct ibv_sge sge;
+    memset(&sge, 0, sizeof(sge));
+    sge.addr = (uintptr_t)local_addr;
+    sge.length = len;
+    sge.lkey = lkey;
+    struct ibv_send_wr wr;
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = wr_id;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_WRITE;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = remote_addr;
+    wr.wr.rdma.rkey = rkey;
+    struct ibv_send_wr *bad = NULL;
+    return ibv_post_send(c->qp, &wr, &bad);
+}
+
+// Blocking busy-poll for exactly one completion. On success returns 0 and writes
+// the completed work-request's id to *out_wr_id; on a completion error returns
+// the positive `ibv_wc_status`; on a poll error returns -1.
+int rs_poll(struct rs_conn *c, uint64_t *out_wr_id) {
+    struct ibv_wc wc;
+    for (;;) {
+        int n = ibv_poll_cq(c->cq, 1, &wc);
+        if (n < 0) {
+            return -1;
+        }
+        if (n == 0) {
+            continue;
+        }
+        *out_wr_id = wc.wr_id;
+        if (wc.status != IBV_WC_SUCCESS) {
+            return (int)wc.status;
+        }
+        return 0;
+    }
+}
+
+void rs_destroy(struct rs_conn *c) {
+    if (!c) {
+        return;
+    }
+    if (c->qp) {
+        ibv_destroy_qp(c->qp);
+    }
+    for (int i = 0; i < c->n_mr; i++) {
+        if (c->mrs[i]) {
+            ibv_dereg_mr(c->mrs[i]);
+        }
+    }
+    if (c->cq) {
+        ibv_destroy_cq(c->cq);
+    }
+    if (c->pd) {
+        ibv_dealloc_pd(c->pd);
+    }
+    if (c->ctx) {
+        ibv_close_device(c->ctx);
+    }
+    free(c);
+}

--- a/crates/atlas-rdma/src/verbs.rs
+++ b/crates/atlas-rdma/src/verbs.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Safe-ish Rust wrapper over the one-sided RDMA READ C-shim (`rdma_shim.c`).
+// Compiled only where the shim is (`cfg(atlas_rdma_verbs)`, emitted by build.rs
+// on Linux with rdma-core). Deliberately CUDA-free: the peer server (non-cuda)
+// registers its store here, the client tier (cuda) registers its pinned arena.
+//
+// One `Verbs` == one RC QP + its device context. The QP-identity exchange
+// (qpn/psn/gid) rides the existing TCP control channel in `expert_peer.rs`;
+// `connect` drives INIT->RTR->RTS. The client posts `IBV_WR_RDMA_READ`s with
+// `post_read` and reaps them with `poll` (blocking busy-poll); the server QP
+// only reaches RTS to respond, its CPU idle — the Phase B win.
+
+use anyhow::{Result, bail};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
+
+/// A 16-byte RoCEv2 GID, exchanged verbatim over the control channel.
+pub type Gid = [u8; 16];
+
+#[repr(C)]
+struct RsConn {
+    _private: [u8; 0],
+}
+
+unsafe extern "C" {
+    fn rs_create(dev_name: *const c_char, gid_idx: c_int) -> *mut RsConn;
+    fn rs_destroy(c: *mut RsConn);
+    fn rs_qpn(c: *mut RsConn) -> u32;
+    fn rs_gid(c: *mut RsConn, out: *mut u8);
+    fn rs_reg_mr(
+        c: *mut RsConn,
+        addr: *mut c_void,
+        len: usize,
+        flags: c_int,
+        lkey: *mut u32,
+        rkey: *mut u32,
+    ) -> c_int;
+    fn rs_connect(
+        c: *mut RsConn,
+        remote_qpn: u32,
+        remote_psn: u32,
+        local_psn: u32,
+        remote_gid: *const u8,
+    ) -> c_int;
+    fn rs_post_read(
+        c: *mut RsConn,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> c_int;
+    fn rs_post_write(
+        c: *mut RsConn,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> c_int;
+    fn rs_poll(c: *mut RsConn, out_wr_id: *mut u64) -> c_int;
+}
+
+/// Registration keys returned when a memory region is pinned to the QP's PD.
+#[derive(Clone, Copy, Debug)]
+pub struct MrKeys {
+    pub lkey: u32,
+    pub rkey: u32,
+}
+
+/// One RC QP over a RoCEv2 device. Not `Clone`; owns the C connection.
+pub struct Verbs {
+    conn: *mut RsConn,
+    /// This QP's send PSN — sent to the peer as its rq_psn.
+    local_psn: u32,
+}
+
+// The C connection is used single-threaded (owned by the prefetch worker on the
+// client, by one accept thread on the server). We move it across the thread that
+// owns it; never share it. Marking Send lets the client's tier (which the worker
+// thread owns) satisfy `ExpertTier: Send`.
+unsafe impl Send for Verbs {}
+
+impl Verbs {
+    /// Open `dev_name` (e.g. `roceP2p1s0f1`) at RoCEv2 `gid_idx`, create the RC
+    /// QP (INIT). `local_psn` seeds our send sequence — any 24-bit value the two
+    /// ends agree on; we exchange it so a fixed constant is unnecessary.
+    pub fn create(dev_name: &str, gid_idx: u32, local_psn: u32) -> Result<Self> {
+        let dev = CString::new(dev_name).unwrap_or_default();
+        // SAFETY: dev is a valid NUL-terminated string for the call's duration.
+        let conn = unsafe { rs_create(dev.as_ptr(), gid_idx as c_int) };
+        if conn.is_null() {
+            bail!(
+                "rs_create failed for device '{dev_name}' gid_idx {gid_idx} \
+                 (check `ibv_devinfo -d {dev_name}` link state / GID)"
+            );
+        }
+        Ok(Self { conn, local_psn })
+    }
+
+    pub fn qpn(&self) -> u32 {
+        // SAFETY: conn is a live rs_conn for self's lifetime.
+        unsafe { rs_qpn(self.conn) }
+    }
+
+    pub fn psn(&self) -> u32 {
+        self.local_psn
+    }
+
+    pub fn gid(&self) -> Gid {
+        let mut g = [0u8; 16];
+        // SAFETY: conn live; out buffer is 16 bytes as the shim expects.
+        unsafe { rs_gid(self.conn, g.as_mut_ptr()) };
+        g
+    }
+
+    /// Register `[addr, addr+len)`. `remote_read` = REMOTE_READ only (the
+    /// server's read-only store MR); otherwise LOCAL_WRITE (the client's arena,
+    /// the HCA's READ landing buffer).
+    ///
+    /// # Safety
+    /// `addr` must point at `len` bytes that outlive this `Verbs` (the MR is
+    /// dereg'd on drop, but the NIC may DMA into/out of it until then).
+    pub unsafe fn reg_mr(
+        &mut self,
+        addr: *mut c_void,
+        len: usize,
+        remote_read: bool,
+    ) -> Result<MrKeys> {
+        let mut lkey = 0u32;
+        let mut rkey = 0u32;
+        // SAFETY: conn live; lkey/rkey out params valid; caller upholds addr/len.
+        let rc = unsafe {
+            rs_reg_mr(
+                self.conn,
+                addr,
+                len,
+                remote_read as c_int,
+                &mut lkey,
+                &mut rkey,
+            )
+        };
+        if rc != 0 {
+            bail!("ibv_reg_mr failed (addr {addr:p} len {len} remote_read {remote_read})");
+        }
+        Ok(MrKeys { lkey, rkey })
+    }
+
+    /// Register `[addr, addr+len)` as a READ+WRITE remote region (REMOTE_READ |
+    /// REMOTE_WRITE | LOCAL_WRITE) — the KV overflow blade's arena, which peers
+    /// both write groups into (offload) and read back (restore).
+    ///
+    /// # Safety
+    /// Same as [`Verbs::reg_mr`]: `addr` must back `len` live bytes outliving self.
+    pub unsafe fn reg_mr_rw(&mut self, addr: *mut c_void, len: usize) -> Result<MrKeys> {
+        let mut lkey = 0u32;
+        let mut rkey = 0u32;
+        // flags=3 → REMOTE_READ|REMOTE_WRITE|LOCAL_WRITE (see rdma_shim.c).
+        // SAFETY: conn live; out params valid; caller upholds addr/len.
+        let rc = unsafe { rs_reg_mr(self.conn, addr, len, 3, &mut lkey, &mut rkey) };
+        if rc != 0 {
+            bail!("ibv_reg_mr(RW) failed (addr {addr:p} len {len})");
+        }
+        Ok(MrKeys { lkey, rkey })
+    }
+
+    /// Drive INIT->RTR->RTS with the remote QP's identity.
+    pub fn connect(&mut self, remote_qpn: u32, remote_psn: u32, remote_gid: &Gid) -> Result<()> {
+        // SAFETY: conn live; remote_gid is 16 bytes.
+        let rc = unsafe {
+            rs_connect(
+                self.conn,
+                remote_qpn,
+                remote_psn,
+                self.local_psn,
+                remote_gid.as_ptr(),
+            )
+        };
+        match rc {
+            0 => Ok(()),
+            -1 => bail!("rs_connect: ibv_query_port failed"),
+            -2 => bail!("rs_connect: modify_qp -> RTR failed (check MTU/GID/dest_qpn)"),
+            -3 => bail!("rs_connect: modify_qp -> RTS failed"),
+            other => bail!("rs_connect: unexpected code {other}"),
+        }
+    }
+
+    /// Post a one-sided READ of `len` bytes from `remote_addr` (`rkey`) into the
+    /// local `local_addr` (`lkey`), tagged `wr_id`. Non-blocking; reap with
+    /// `poll`.
+    ///
+    /// # Safety
+    /// `local_addr..+len` must lie inside a live MR registered under `lkey`.
+    /// The op is asynchronous: that buffer and its MR must stay live and
+    /// untouched by the CPU until the matching `wr_id` is reaped by `poll`
+    /// (dropping the QP or freeing the buffer before then risks a NIC DMA into
+    /// freed memory).
+    pub unsafe fn post_read(
+        &mut self,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> Result<()> {
+        // SAFETY: conn live; caller upholds local_addr/lkey validity.
+        let rc =
+            unsafe { rs_post_read(self.conn, local_addr, lkey, remote_addr, rkey, len, wr_id) };
+        if rc != 0 {
+            bail!("ibv_post_send(RDMA_READ) failed: {rc}");
+        }
+        Ok(())
+    }
+
+    /// Post a one-sided WRITE of `len` bytes from local `local_addr` (`lkey`) to
+    /// the remote `remote_addr` (`rkey`), tagged `wr_id`. Non-blocking; reap with
+    /// `poll`. Used to offload a K/V group into the peer's RW blade.
+    ///
+    /// # Safety
+    /// `local_addr..+len` must lie inside a live MR registered under `lkey`.
+    /// The op is asynchronous: that buffer and its MR must stay live and
+    /// unmodified until the matching `wr_id` is reaped by `poll` (the NIC DMAs
+    /// from it after this returns).
+    pub unsafe fn post_write(
+        &mut self,
+        local_addr: *mut c_void,
+        lkey: u32,
+        remote_addr: u64,
+        rkey: u32,
+        len: u32,
+        wr_id: u64,
+    ) -> Result<()> {
+        // SAFETY: conn live; caller upholds local_addr/lkey validity.
+        let rc =
+            unsafe { rs_post_write(self.conn, local_addr, lkey, remote_addr, rkey, len, wr_id) };
+        if rc != 0 {
+            bail!("ibv_post_send(RDMA_WRITE) failed: {rc}");
+        }
+        Ok(())
+    }
+
+    /// Block until one completion arrives; return its `wr_id`. Errors on a
+    /// non-success completion status (the NIC's `ibv_wc_status`).
+    pub fn poll(&mut self) -> Result<u64> {
+        let mut wr_id = 0u64;
+        // SAFETY: conn live; wr_id out param valid.
+        let rc = unsafe { rs_poll(self.conn, &mut wr_id) };
+        if rc == 0 {
+            Ok(wr_id)
+        } else if rc < 0 {
+            bail!("ibv_poll_cq error");
+        } else {
+            bail!("RDMA completion error: ibv_wc_status {rc}");
+        }
+    }
+}
+
+impl Drop for Verbs {
+    fn drop(&mut self) {
+        // SAFETY: conn was created by rs_create and not yet destroyed.
+        unsafe { rs_destroy(self.conn) };
+    }
+}

--- a/crates/atlas-rdma/src/verbs.rs
+++ b/crates/atlas-rdma/src/verbs.rs
@@ -6,10 +6,10 @@
 // registers its store here, the client tier (cuda) registers its pinned arena.
 //
 // One `Verbs` == one RC QP + its device context. The QP-identity exchange
-// (qpn/psn/gid) rides the existing TCP control channel in `expert_peer.rs`;
-// `connect` drives INIT->RTR->RTS. The client posts `IBV_WR_RDMA_READ`s with
-// `post_read` and reaps them with `poll` (blocking busy-poll); the server QP
-// only reaches RTS to respond, its CPU idle — the Phase B win.
+// (qpn/psn/gid) rides the TCP control channel; `connect` drives INIT->RTR->RTS.
+// The client posts `IBV_WR_RDMA_READ`s with `post_read` and reaps them with
+// `poll` (blocking busy-poll); the server QP only reaches RTS to respond, its
+// CPU idle (the point of one-sided reads).
 
 use anyhow::{Result, bail};
 use std::ffi::CString;

--- a/crates/atlas-rdma/src/wire.rs
+++ b/crates/atlas-rdma/src/wire.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The RDMA handshake wire codecs, shared by every Atlas RDMA client AND the
+// peer daemons. Extracted from the RDMA peer codecs; the peer daemons
+// re-export these at their old paths (a follow-up PR) so the servers stay
+// zero-diff.
+//
+// ** GOLDEN WIRE FORMAT ** — the live gx10 peer runs an OLDER binary, so
+// every byte layout here is frozen. All integers little-endian. The byte
+// vectors are pinned by `tests/wire_roundtrip.rs` and `tests/transcript_golden.rs`,
+// and the frozen constant values by `frozen_wire_constants` (wire_roundtrip.rs).
+//
+// Un-gated on purpose: pure `std::io` + anyhow, so it compiles and unit-tests
+// on the metal/ATLAS_SKIP_BUILD build with no rdma-core.
+
+use anyhow::{Context, Result, bail};
+
+// ── Shared status / transport-mode bytes ──
+pub const STATUS_OK: u8 = 0;
+pub const STATUS_ERR: u8 = 1;
+/// Two-sided TCP record streaming (the Stage-4 Phase-A expert path).
+pub const MODE_TCP: u8 = 0;
+/// One-sided RDMA READ over verbs (WS2 Phase B): the server publishes its
+/// store's MRs and the client READs records directly into its arena.
+pub const MODE_VERBS: u8 = 1;
+
+/// The server's half of the verbs handshake (RO dialect: expert / weight /
+/// LoRA tiers): its QP identity plus, per MoE layer (or per shard), the base
+/// virtual address + rkey of that entry's registered MR.
+/// `remote_addr(layer, expert) = layers[layer].0 + expert * record_stride`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerbsServerParams {
+    pub qpn: u32,
+    pub psn: u32,
+    pub gid: [u8; 16],
+    /// `(mr_base_addr, rkey)` for each MoE layer (expert tier) or shard
+    /// (weight/LoRA tiers), index-addressed.
+    pub layers: Vec<(u64, u32)>,
+}
+
+/// The client's half: just its QP identity (its arena MR is local-only).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerbsClientParams {
+    pub qpn: u32,
+    pub psn: u32,
+    pub gid: [u8; 16],
+}
+
+/// The peer's half of the RW-blade handshake (KV overflow / SSM snapshots):
+/// its QP identity + the single RW MR.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CacheServerParams {
+    pub qpn: u32,
+    pub psn: u32,
+    pub gid: [u8; 16],
+    pub base_addr: u64,
+    pub rkey: u32,
+}
+
+/// Anything that carries a remote QP identity a client rail can `connect` to.
+/// Implemented by both server-param dialects so the RailSet handshake tail is
+/// shared without homogenizing the two wire layouts.
+pub trait RemoteQp {
+    fn qp_identity(&self) -> (u32, u32, [u8; 16]);
+}
+
+impl RemoteQp for VerbsServerParams {
+    fn qp_identity(&self) -> (u32, u32, [u8; 16]) {
+        (self.qpn, self.psn, self.gid)
+    }
+}
+
+impl RemoteQp for CacheServerParams {
+    fn qp_identity(&self) -> (u32, u32, [u8; 16]) {
+        (self.qpn, self.psn, self.gid)
+    }
+}
+
+impl VerbsServerParams {
+    /// Wire form: `[u32 qpn][u32 psn][16 gid][u32 n_layers]{[u64 base][u32 rkey]}*`.
+    pub fn write_to<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.qpn.to_le_bytes())?;
+        w.write_all(&self.psn.to_le_bytes())?;
+        w.write_all(&self.gid)?;
+        w.write_all(&(self.layers.len() as u32).to_le_bytes())?;
+        for (base, rkey) in &self.layers {
+            w.write_all(&base.to_le_bytes())?;
+            w.write_all(&rkey.to_le_bytes())?;
+        }
+        Ok(())
+    }
+
+    pub fn read_from<R: std::io::Read>(r: &mut R) -> Result<Self> {
+        let qpn = read_u32(r)?;
+        let psn = read_u32(r)?;
+        let mut gid = [0u8; 16];
+        r.read_exact(&mut gid).context("read server gid")?;
+        let n = read_u32(r)? as usize;
+        if n == 0 || n > 4096 {
+            bail!("implausible verbs layer count: {n}");
+        }
+        let mut layers = Vec::with_capacity(n);
+        for _ in 0..n {
+            let mut b8 = [0u8; 8];
+            r.read_exact(&mut b8).context("read mr base")?;
+            let base = u64::from_le_bytes(b8);
+            let rkey = read_u32(r)?;
+            layers.push((base, rkey));
+        }
+        Ok(Self {
+            qpn,
+            psn,
+            gid,
+            layers,
+        })
+    }
+}
+
+impl VerbsClientParams {
+    /// Wire form: `[u32 qpn][u32 psn][16 gid]`.
+    pub fn write_to<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.qpn.to_le_bytes())?;
+        w.write_all(&self.psn.to_le_bytes())?;
+        w.write_all(&self.gid)?;
+        Ok(())
+    }
+
+    pub fn read_from<R: std::io::Read>(r: &mut R) -> Result<Self> {
+        let qpn = read_u32(r)?;
+        let psn = read_u32(r)?;
+        let mut gid = [0u8; 16];
+        r.read_exact(&mut gid).context("read client gid")?;
+        Ok(Self { qpn, psn, gid })
+    }
+}
+
+impl CacheServerParams {
+    /// Wire form: `[u32 qpn][u32 psn][16 gid][u64 base_addr][u32 rkey]`.
+    pub fn write_to<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        w.write_all(&self.qpn.to_le_bytes())?;
+        w.write_all(&self.psn.to_le_bytes())?;
+        w.write_all(&self.gid)?;
+        w.write_all(&self.base_addr.to_le_bytes())?;
+        w.write_all(&self.rkey.to_le_bytes())?;
+        Ok(())
+    }
+
+    pub fn read_from<R: std::io::Read>(r: &mut R) -> Result<Self> {
+        let mut b4 = [0u8; 4];
+        let mut b8 = [0u8; 8];
+        let mut gid = [0u8; 16];
+        r.read_exact(&mut b4).context("kv qpn")?;
+        let qpn = u32::from_le_bytes(b4);
+        r.read_exact(&mut b4).context("kv psn")?;
+        let psn = u32::from_le_bytes(b4);
+        r.read_exact(&mut gid).context("kv gid")?;
+        r.read_exact(&mut b8).context("kv base")?;
+        let base_addr = u64::from_le_bytes(b8);
+        r.read_exact(&mut b4).context("kv rkey")?;
+        let rkey = u32::from_le_bytes(b4);
+        Ok(Self {
+            qpn,
+            psn,
+            gid,
+            base_addr,
+            rkey,
+        })
+    }
+}
+
+fn read_u32<R: std::io::Read>(r: &mut R) -> Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).context("read u32")?;
+    Ok(u32::from_le_bytes(b))
+}
+
+/// Frame N per-rail `VerbsServerParams` for the dual-rail RO tiers: a leading
+/// `[u8 n_rails]` count followed by each rail's params — exactly how the RW
+/// blade frames its per-rail `CacheServerParams`. Single-rail (`n == 1`) is the
+/// default, byte-for-byte the pre-dual-rail path plus the one-byte count prefix.
+pub fn write_server_rails<W: std::io::Write>(w: &mut W, rails: &[VerbsServerParams]) -> Result<()> {
+    if rails.is_empty() || rails.len() > 8 {
+        bail!("implausible server rail count: {}", rails.len());
+    }
+    w.write_all(&[rails.len() as u8])?;
+    for sp in rails {
+        sp.write_to(w)?;
+    }
+    Ok(())
+}
+
+/// Read `want` per-rail `VerbsServerParams` framed by a leading `[u8 n_rails]`.
+/// Bails if the framed count is zero, absurd (> 8), or != `want` — the client
+/// already negotiated `want` rails, so any other count is a protocol error.
+pub fn read_server_rails<R: std::io::Read>(
+    r: &mut R,
+    want: usize,
+) -> Result<Vec<VerbsServerParams>> {
+    let mut b1 = [0u8; 1];
+    r.read_exact(&mut b1).context("read server rail count")?;
+    let n = b1[0] as usize;
+    if n == 0 || n > 8 {
+        bail!("implausible server rail count: {n}");
+    }
+    if n != want {
+        bail!("server framed {n} rails but client negotiated {want}");
+    }
+    let mut rails = Vec::with_capacity(n);
+    for _ in 0..n {
+        rails.push(VerbsServerParams::read_from(r)?);
+    }
+    Ok(rails)
+}

--- a/crates/atlas-rdma/src/wire.rs
+++ b/crates/atlas-rdma/src/wire.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
-// The RDMA handshake wire codecs, shared by every Atlas RDMA client AND the
-// peer daemons. Extracted from the RDMA peer codecs; the peer daemons
-// re-export these at their old paths (a follow-up PR) so the servers stay
-// zero-diff.
+// The RDMA handshake wire codecs, shared by every Atlas RDMA client and the
+// peer daemons (the daemons re-export these, so client and server speak one
+// codec).
 //
-// ** GOLDEN WIRE FORMAT ** — the live gx10 peer runs an OLDER binary, so
-// every byte layout here is frozen. All integers little-endian. The byte
+// ** GOLDEN WIRE FORMAT ** — every byte layout here is a frozen external
+// contract (already-deployed peers depend on it). All integers little-endian. The byte
 // vectors are pinned by `tests/wire_roundtrip.rs` and `tests/transcript_golden.rs`,
 // and the frozen constant values by `frozen_wire_constants` (wire_roundtrip.rs).
 //
@@ -18,10 +17,10 @@ use anyhow::{Context, Result, bail};
 // ── Shared status / transport-mode bytes ──
 pub const STATUS_OK: u8 = 0;
 pub const STATUS_ERR: u8 = 1;
-/// Two-sided TCP record streaming (the Stage-4 Phase-A expert path).
+/// Two-sided TCP record streaming (the expert record path).
 pub const MODE_TCP: u8 = 0;
-/// One-sided RDMA READ over verbs (WS2 Phase B): the server publishes its
-/// store's MRs and the client READs records directly into its arena.
+/// One-sided RDMA READ over verbs: the server publishes its store's MRs and
+/// the client READs records directly into its arena.
 pub const MODE_VERBS: u8 = 1;
 
 /// The server's half of the verbs handshake (RO dialect: expert / weight /

--- a/crates/atlas-rdma/tests/env_chains.rs
+++ b/crates/atlas-rdma/tests/env_chains.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Pins the TWO distinct env-fallback semantics the RDMA tiers deploy with
+// (RailSet extraction, Step B): `first_set` (an exported-but-EMPTY var counts
+// as set — KV/expert/snapshot reads and the LoRA DEV chain) vs
+// `first_nonempty` (empty is SKIPPED — the weight tier), plus the
+// parse-or-fall-through `first_set_u32`. A unified helper that flipped either
+// behavior would silently change deployed configs (e.g. make
+// ATLAS_WEIGHT_RDMA_GID start affecting LoRA).
+
+use atlas_rdma::env::{first_nonempty, first_set, first_set_u32};
+
+/// All env mutation lives in this ONE test: `set_var` is process-global and
+/// test threads run concurrently, so a single serialized test avoids races.
+/// Var names are unique to this file.
+#[test]
+fn env_helper_semantics() {
+    // SAFETY: single-threaded within this test; the vars are test-unique, and
+    // no other test in this binary mutates the environment.
+    unsafe {
+        std::env::set_var("ATLAS_RDMATEST_EMPTY", "");
+        std::env::set_var("ATLAS_RDMATEST_DEV2", "rocep1s0f1");
+        std::env::set_var("ATLAS_RDMATEST_BADNUM", "not-a-number");
+        std::env::set_var("ATLAS_RDMATEST_NUM", "7");
+    }
+
+    // first_set: an exported-but-empty var COUNTS AS SET (Result::or_else /
+    // unwrap_or_else chain semantics) — it wins over later keys AND defaults.
+    assert_eq!(
+        first_set(&["ATLAS_RDMATEST_EMPTY", "ATLAS_RDMATEST_DEV2"], "dflt"),
+        "",
+        "first_set must treat an exported-but-empty var as set"
+    );
+    assert_eq!(
+        first_set(&["ATLAS_RDMATEST_UNSET", "ATLAS_RDMATEST_DEV2"], "dflt"),
+        "rocep1s0f1",
+        "first_set must chain past unset keys"
+    );
+
+    // first_nonempty: the same empty var is SKIPPED (weight-tier env_str).
+    assert_eq!(
+        first_nonempty(&["ATLAS_RDMATEST_EMPTY", "ATLAS_RDMATEST_DEV2"], "dflt"),
+        "rocep1s0f1",
+        "first_nonempty must skip an exported-but-empty var"
+    );
+
+    // first_set_u32: a set-but-unparseable var falls through to the next key
+    // (and to the default when it is the only key) — every pre-extraction
+    // per-client env_u32 behaved this way.
+    assert_eq!(
+        first_set_u32(&["ATLAS_RDMATEST_BADNUM", "ATLAS_RDMATEST_NUM"], 3),
+        7
+    );
+    assert_eq!(first_set_u32(&["ATLAS_RDMATEST_BADNUM"], 3), 3);
+    assert_eq!(first_set_u32(&["ATLAS_RDMATEST_NUM"], 3), 7);
+}
+
+/// Read-only (no env mutation): unset chains land on the tier defaults —
+/// the deployed single-rail path with a clean environment.
+#[test]
+fn unset_chains_yield_defaults() {
+    assert_eq!(
+        first_set(
+            &["ATLAS_RDMATEST_NOPE1", "ATLAS_RDMATEST_NOPE2"],
+            "roceP2p1s0f1"
+        ),
+        "roceP2p1s0f1"
+    );
+    assert_eq!(
+        first_nonempty(&["ATLAS_RDMATEST_NOPE1"], "roceP2p1s0f1"),
+        "roceP2p1s0f1"
+    );
+    assert_eq!(first_set_u32(&["ATLAS_RDMATEST_NOPE1"], 3), 3);
+}

--- a/crates/atlas-rdma/tests/env_chains.rs
+++ b/crates/atlas-rdma/tests/env_chains.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Pins the TWO distinct env-fallback semantics the RDMA tiers deploy with
-// (RailSet extraction, Step B): `first_set` (an exported-but-EMPTY var counts
-// as set — KV/expert/snapshot reads and the LoRA DEV chain) vs
+// Pins the TWO distinct env-fallback semantics the RDMA tiers deploy with:
+// `first_set` (an exported-but-EMPTY var counts as set — KV/expert/snapshot
+// reads and the LoRA DEV chain) vs
 // `first_nonempty` (empty is SKIPPED — the weight tier), plus the
 // parse-or-fall-through `first_set_u32`. A unified helper that flipped either
 // behavior would silently change deployed configs (e.g. make

--- a/crates/atlas-rdma/tests/handshake_reject.rs
+++ b/crates/atlas-rdma/tests/handshake_reject.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// A peer that REJECTS a client hangs up mid-handshake: the v2 wire carries no
+// error frame, so the reason lives only in the peer's log. Bare `read_exact`
+// context then surfaces "failed to fill whole buffer", which reads like a
+// transport fault and sends operators hunting a network problem that does not
+// exist.
+//
+// This was found by running a real serve against a capped `atlas-cache-peer`
+// (client asked for a 31.9 GiB arena against a 4 GiB `--max-blade-gb`; the peer
+// logged "paging blade cap" and closed). No unit test caught it, because every
+// existing handshake test scripts a COOPERATIVE peer.
+
+use std::io::{Read, Result as IoResult};
+
+use atlas_rdma::handshake::read_rw_server_params;
+
+/// A stream that yields `n` bytes then EOFs — the peer hanging up.
+struct TruncatedPeer {
+    remaining: Vec<u8>,
+}
+
+impl Read for TruncatedPeer {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        if self.remaining.is_empty() {
+            return Ok(0); // clean EOF -> read_exact yields UnexpectedEof
+        }
+        let n = buf.len().min(self.remaining.len());
+        buf[..n].copy_from_slice(&self.remaining[..n]);
+        self.remaining.drain(..n);
+        Ok(n)
+    }
+}
+
+#[test]
+fn peer_hangup_before_rail_params_names_the_rejection_not_a_buffer_error() {
+    let mut s = TruncatedPeer { remaining: vec![] };
+    let err = read_rw_server_params(&mut s, 1, "test-peer").unwrap_err();
+    let msg = format!("{err:#}");
+
+    assert!(
+        msg.contains("closed the connection during the rail handshake"),
+        "must say the peer hung up: {msg}"
+    );
+    assert!(
+        msg.contains("REJECTED"),
+        "must name this as a rejection, not a transport fault: {msg}"
+    );
+    assert!(
+        msg.contains("--max-blade-gb"),
+        "must point at the most common cause (arena exceeds the peer cap): {msg}"
+    );
+    assert!(
+        msg.contains("test-peer"),
+        "must name WHICH peer rejected us: {msg}"
+    );
+    // The regression we are pinning: the old message was exactly this.
+    assert!(
+        !msg.contains("failed to fill whole buffer"),
+        "must not surface the raw io error as the headline: {msg}"
+    );
+}
+
+#[test]
+fn a_truncated_params_body_is_still_a_read_error_not_a_rejection() {
+    // The peer DID send its n_rails echo, then died partway through the params
+    // body. That is a genuine transport/protocol fault, not a clean rejection,
+    // and must not be mislabelled as "the peer rejected you".
+    let mut s = TruncatedPeer {
+        remaining: vec![1u8, 0xde, 0xad],
+    };
+    let err = read_rw_server_params(&mut s, 1, "test-peer").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("REJECTED"),
+        "a mid-body truncation is not a rejection: {msg}"
+    );
+    assert!(
+        msg.contains("params"),
+        "should blame the params read: {msg}"
+    );
+}
+
+#[test]
+fn a_rail_count_mismatch_is_reported_as_a_grant_mismatch() {
+    // Peer answers with a DIFFERENT rail count. Distinct failure, distinct
+    // message — this path must not be swallowed by the new EOF branch.
+    let mut s = TruncatedPeer {
+        remaining: vec![3u8],
+    };
+    let err = read_rw_server_params(&mut s, 1, "test-peer").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("granted 3 rails, wanted 1"), "{msg}");
+}

--- a/crates/atlas-rdma/tests/transcript_golden.rs
+++ b/crates/atlas-rdma/tests/transcript_golden.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// TRANSCRIPT goldens — the only test class that pins the client's write ORDER
+// (struct goldens pin field layout; round-trips are blind to symmetric
+// reorders). Drives the exact handshake step sequence `railset::RailSet`
+// performs, via the un-gated `handshake` byte functions with FIXED QP
+// identities (no ibverbs — runs on the ATLAS_SKIP_BUILD/CI path), against a
+// scripted fake peer, and asserts:
+//   * the client's COMPLETE emitted byte stream, hand-written, per dialect
+//     (RO = expert/weight/LoRA, RW = KV/snapshot) at 1 and 2 rails;
+//   * every read happens at the right point of the written stream (the
+//     [n_rails] → server params → [n_rails]+client params → ack interleaving);
+//   * the parsed server params, against hand-written reply bytes (pins the
+//     reader field order independent of the writer).
+// The live gx10 peer runs an older binary: these transcripts are frozen.
+
+use std::io::{Read, Write};
+
+use atlas_rdma::handshake::{read_ack, read_rw_server_params, write_client_params, write_n_rails};
+use atlas_rdma::wire::{CacheServerParams, VerbsServerParams, read_server_rails};
+
+/// Fake bidirectional stream: scripted input, captured output, plus a log of
+/// `out.len()` at every read call — pinning WHEN the client reads relative to
+/// what it has written.
+struct Duplex {
+    inp: std::io::Cursor<Vec<u8>>,
+    out: Vec<u8>,
+    reads_at: Vec<usize>,
+}
+
+impl Duplex {
+    fn scripted(reply: Vec<u8>) -> Self {
+        Self {
+            inp: std::io::Cursor::new(reply),
+            out: Vec::new(),
+            reads_at: Vec::new(),
+        }
+    }
+}
+
+impl Read for Duplex {
+    fn read(&mut self, b: &mut [u8]) -> std::io::Result<usize> {
+        self.reads_at.push(self.out.len());
+        self.inp.read(b)
+    }
+}
+
+impl Write for Duplex {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.out.extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn gid(start: u8) -> [u8; 16] {
+    core::array::from_fn(|i| start + i as u8)
+}
+
+/// Fixed client QP identities with per-field-distinct bytes.
+const CLIENT_IDS: [(u32, u32, [u8; 16]); 2] = [
+    (
+        0x1122_3344,
+        0x00AA_BBCC,
+        [
+            0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D,
+            0x6E, 0x6F,
+        ],
+    ),
+    (
+        0x5566_7788,
+        0x00DD_EEFF,
+        [
+            0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D,
+            0x7E, 0x7F,
+        ],
+    ),
+];
+
+/// The client params block: `[u8 n]` + n × `[qpn][psn][gid]` (24 B each).
+fn expected_client_params(n: usize) -> Vec<u8> {
+    let mut v = vec![n as u8];
+    #[rustfmt::skip]
+    v.extend_from_slice(&[
+        0x44, 0x33, 0x22, 0x11, // qpn 0x1122_3344 LE
+        0xCC, 0xBB, 0xAA, 0x00, // psn 0x00AA_BBCC LE
+        0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, // gid verbatim
+        0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F,
+    ]);
+    if n == 2 {
+        #[rustfmt::skip]
+        v.extend_from_slice(&[
+            0x88, 0x77, 0x66, 0x55, // qpn 0x5566_7788 LE
+            0xFF, 0xEE, 0xDD, 0x00, // psn 0x00DD_EEFF LE
+            0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, // gid verbatim
+            0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F,
+        ]);
+    }
+    v
+}
+
+/// Hand-written server-side QP identity block `[qpn][psn][gid]` for rail `i`.
+fn server_qp_bytes(i: usize) -> Vec<u8> {
+    match i {
+        0 => {
+            let mut v = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+            v.extend_from_slice(&gid(0x20));
+            v
+        }
+        _ => {
+            let mut v = vec![0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10];
+            v.extend_from_slice(&gid(0x30));
+            v
+        }
+    }
+}
+
+const BASE0: [u8; 8] = [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11]; // 0x1122_3344_5566_7788
+const RKEY0: [u8; 4] = [0xCC, 0xBB, 0xAA, 0x99]; // 0x99AA_BBCC
+const BASE1: [u8; 8] = [0x0D, 0xF0, 0xAD, 0x0B, 0xEF, 0xBE, 0xAD, 0xDE]; // 0xDEAD_BEEF_0BAD_F00D
+const RKEY1: [u8; 4] = [0x04, 0x03, 0x02, 0x01]; // 0x0102_0304
+
+fn expected_server_param(i: usize) -> VerbsServerParams {
+    let (qpn, psn) = if i == 0 {
+        (0x0403_0201, 0x0807_0605)
+    } else {
+        (0x0C0B_0A09, 0x100F_0E0D)
+    };
+    VerbsServerParams {
+        qpn,
+        psn,
+        gid: gid(if i == 0 { 0x20 } else { 0x30 }),
+        layers: vec![if i == 0 {
+            (0x1122_3344_5566_7788, 0x99AA_BBCC)
+        } else {
+            (0xDEAD_BEEF_0BAD_F00D, 0x0102_0304)
+        }],
+    }
+}
+
+/// RO dialect (expert / weight / LoRA), post-preamble: the client writes
+/// `[u8 n]`, reads `[u8 n]{VerbsServerParams}×n`, writes `[u8 n]` + client
+/// params, reads `[ack]`.
+fn drive_ro(n: usize) {
+    // Scripted peer reply: [u8 n] + n × (qp identity + [u32 1][base][rkey]),
+    // then the STATUS_OK ack byte. Hand-written.
+    let mut reply = vec![n as u8];
+    for i in 0..n {
+        reply.extend_from_slice(&server_qp_bytes(i));
+        reply.extend_from_slice(&1u32.to_le_bytes()); // n_layers = 1
+        reply.extend_from_slice(if i == 0 { &BASE0 } else { &BASE1 });
+        reply.extend_from_slice(if i == 0 { &RKEY0 } else { &RKEY1 });
+    }
+    reply.push(0x00); // ack = STATUS_OK
+
+    let mut fake = Duplex::scripted(reply);
+    // The exact RailSet step sequence (begin → read_server_ro → complete).
+    write_n_rails(&mut fake, n).unwrap();
+    let server = read_server_rails(&mut fake, n).unwrap();
+    write_client_params(&mut fake, &CLIENT_IDS[..n]).unwrap();
+    read_ack(&mut fake, "test peer").unwrap();
+
+    // 1. The parsed server params, against the hand bytes (reader order pin).
+    let want: Vec<VerbsServerParams> = (0..n).map(expected_server_param).collect();
+    assert_eq!(server, want);
+
+    // 2. The complete emitted client stream, hand-written (writer order pin).
+    let mut expect = vec![n as u8];
+    expect.extend_from_slice(&expected_client_params(n));
+    assert_eq!(fake.out, expect, "RO client transcript changed ({n} rails)");
+
+    // 3. Interleaving: every server-params read happened after exactly the
+    // 1-byte n_rails write; the ack read after the full client stream.
+    let total = expect.len();
+    assert_eq!(fake.reads_at.first(), Some(&1));
+    assert_eq!(fake.reads_at.last(), Some(&total));
+    assert!(fake.reads_at.iter().all(|&a| a == 1 || a == total));
+}
+
+/// RW dialect (KV / snapshot), post-preamble: `[u8 n]` out, `[u8 n echo]` +
+/// n × CacheServerParams in, `[u8 n]` + client params out, `[ack]` in.
+fn drive_rw(n: usize) {
+    let mut reply = vec![n as u8];
+    for i in 0..n {
+        reply.extend_from_slice(&server_qp_bytes(i));
+        reply.extend_from_slice(if i == 0 { &BASE0 } else { &BASE1 });
+        reply.extend_from_slice(if i == 0 { &RKEY0 } else { &RKEY1 });
+    }
+    reply.push(0x00); // ack
+
+    let mut fake = Duplex::scripted(reply);
+    write_n_rails(&mut fake, n).unwrap();
+    let server = read_rw_server_params(&mut fake, n, "test peer").unwrap();
+    write_client_params(&mut fake, &CLIENT_IDS[..n]).unwrap();
+    read_ack(&mut fake, "test peer").unwrap();
+
+    let want: Vec<CacheServerParams> = (0..n)
+        .map(|i| {
+            let ro = expected_server_param(i);
+            CacheServerParams {
+                qpn: ro.qpn,
+                psn: ro.psn,
+                gid: ro.gid,
+                base_addr: ro.layers[0].0,
+                rkey: ro.layers[0].1,
+            }
+        })
+        .collect();
+    assert_eq!(server, want);
+
+    let mut expect = vec![n as u8];
+    expect.extend_from_slice(&expected_client_params(n));
+    assert_eq!(fake.out, expect, "RW client transcript changed ({n} rails)");
+
+    let total = expect.len();
+    assert_eq!(fake.reads_at.first(), Some(&1));
+    assert_eq!(fake.reads_at.last(), Some(&total));
+    assert!(fake.reads_at.iter().all(|&a| a == 1 || a == total));
+}
+
+#[test]
+fn ro_transcript_single_rail() {
+    drive_ro(1);
+}
+
+#[test]
+fn ro_transcript_dual_rail() {
+    drive_ro(2);
+}
+
+#[test]
+fn rw_transcript_single_rail() {
+    drive_rw(1);
+}
+
+#[test]
+fn rw_transcript_dual_rail() {
+    drive_rw(2);
+}
+
+#[test]
+fn rw_echo_mismatch_bails() {
+    // Peer echoes 3 rails when the client negotiated 2 → protocol error
+    // BEFORE any params are consumed. (Deliberately unbounded otherwise —
+    // the RO dialect's 1..=8 bound is its own.)
+    let mut fake = Duplex::scripted(vec![3u8]);
+    assert!(read_rw_server_params(&mut fake, 2, "test peer").is_err());
+}
+
+#[test]
+fn non_ok_ack_bails() {
+    let mut fake = Duplex::scripted(vec![1u8]); // STATUS_ERR
+    let err = read_ack(&mut fake, "test peer").unwrap_err();
+    assert!(err.to_string().contains("refused connection (ack 1)"));
+}

--- a/crates/atlas-rdma/tests/transcript_golden.rs
+++ b/crates/atlas-rdma/tests/transcript_golden.rs
@@ -12,7 +12,7 @@
 //     [n_rails] → server params → [n_rails]+client params → ack interleaving);
 //   * the parsed server params, against hand-written reply bytes (pins the
 //     reader field order independent of the writer).
-// The live gx10 peer runs an older binary: these transcripts are frozen.
+// These transcripts are frozen: a stable external wire contract.
 
 use std::io::{Read, Write};
 

--- a/crates/atlas-rdma/tests/verbs_probe.rs
+++ b/crates/atlas-rdma/tests/verbs_probe.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Public-API tests for atlas-rdma that need NO RDMA hardware and NO network:
+// the cfg witness, and `Verbs::create` failing cleanly for a device name that
+// cannot exist (`ibv_get_device_list` lookup miss — purely local).
+
+/// The always-compiled witness must agree with the cfg as seen by this test
+/// target (build-script cfgs apply to a crate's tests too). Runs in BOTH cfg
+/// states: verbs hosts assert `true`, ATLAS_SKIP_BUILD/macOS assert `false`.
+#[test]
+fn verbs_enabled_matches_cfg() {
+    assert_eq!(atlas_rdma::verbs_enabled(), cfg!(atlas_rdma_verbs));
+}
+
+#[cfg(atlas_rdma_verbs)]
+mod with_shim {
+    use atlas_rdma::{Gid, MrKeys, Verbs};
+
+    /// A nonexistent device must fail `rs_create` (NULL) and surface the
+    /// device name + gid index in the error. Exercises the real C shim and
+    /// libibverbs linkage without touching any NIC state.
+    #[test]
+    fn create_unknown_device_errors() {
+        let err = match Verbs::create("atlas-rdma-no-such-dev", 3, 0x0012_3456) {
+            Ok(_) => panic!("create() succeeded for a device that cannot exist"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("rs_create failed"), "unexpected error: {msg}");
+        assert!(
+            msg.contains("atlas-rdma-no-such-dev"),
+            "device name missing: {msg}"
+        );
+    }
+
+    /// `MrKeys` stays `Copy` (clients stash lkey/rkey by value everywhere) and
+    /// `Gid` stays exactly 16 bytes — it is exchanged verbatim on the wire.
+    #[test]
+    fn mr_keys_copy_and_gid_layout() {
+        let k = MrKeys { lkey: 1, rkey: 2 };
+        let k2 = k; // Copy, not move
+        assert_eq!((k.lkey, k.rkey), (k2.lkey, k2.rkey));
+        assert_eq!(std::mem::size_of::<Gid>(), 16);
+    }
+}

--- a/crates/atlas-rdma/tests/wire_roundtrip.rs
+++ b/crates/atlas-rdma/tests/wire_roundtrip.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Codec round-trip / validation tests, extracted WITH the codecs from the
+// RDMA peer daemons (RailSet extraction). These cover reader/writer agreement,
+// the exact byte layouts (see also `tests/transcript_golden.rs`), the frozen
+// interop constant values (`frozen_wire_constants`), and the validation bails.
+// Un-gated: pure `std::io`, runs on the ATLAS_SKIP_BUILD path.
+
+use atlas_rdma::wire::{
+    CacheServerParams, MODE_TCP, MODE_VERBS, STATUS_ERR, STATUS_OK, VerbsClientParams,
+    VerbsServerParams, read_server_rails, write_server_rails,
+};
+
+/// The interop bytes the live gx10 peer speaks are frozen — a value flip here
+/// is a silent wire break, so pin them explicitly (the goldens only exercise
+/// STATUS_OK/MODE bytes indirectly).
+#[test]
+fn frozen_wire_constants() {
+    assert_eq!(STATUS_OK, 0, "STATUS_OK is frozen vs the live peer");
+    assert_eq!(STATUS_ERR, 1, "STATUS_ERR is frozen vs the live peer");
+    assert_eq!(MODE_TCP, 0, "MODE_TCP is frozen vs the live peer");
+    assert_eq!(MODE_VERBS, 1, "MODE_VERBS is frozen vs the live peer");
+}
+
+#[test]
+fn verbs_server_params_round_trip() {
+    let sp = VerbsServerParams {
+        qpn: 0x1234,
+        psn: 0x00ab_cdef & 0xff_ffff,
+        gid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 178, 12],
+        layers: vec![(0x7f00_0000_0000, 1001), (0x7f00_0100_0000, 1002)],
+    };
+    let mut buf = Vec::new();
+    sp.write_to(&mut buf).unwrap();
+    let back = VerbsServerParams::read_from(&mut &buf[..]).unwrap();
+    assert_eq!(sp, back);
+}
+
+#[test]
+fn verbs_client_params_round_trip() {
+    let cp = VerbsClientParams {
+        qpn: 0x9999,
+        psn: 0x0055_5555,
+        gid: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    };
+    let mut buf = Vec::new();
+    cp.write_to(&mut buf).unwrap();
+    let back = VerbsClientParams::read_from(&mut &buf[..]).unwrap();
+    assert_eq!(cp, back);
+}
+
+#[test]
+fn server_rails_round_trip() {
+    // The dual-rail framing: N `VerbsServerParams` with a leading count.
+    let mk = |qpn| VerbsServerParams {
+        qpn,
+        psn: 0x0012_3456 & 0xff_ffff,
+        gid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 178, 12],
+        // Same base VA across rails (shared pages), distinct rkeys per rail.
+        layers: vec![
+            (0x7f00_0000_0000, 1001 + qpn),
+            (0x7f00_0100_0000, 1002 + qpn),
+        ],
+    };
+    let rails = vec![mk(0x1111), mk(0x2222)];
+    let mut buf = Vec::new();
+    write_server_rails(&mut buf, &rails).unwrap();
+    let back = read_server_rails(&mut &buf[..], 2).unwrap();
+    assert_eq!(rails, back);
+}
+
+#[test]
+fn single_rail_framing_round_trips() {
+    // n == 1 is the default path; must round-trip through the framing.
+    let sp = VerbsServerParams {
+        qpn: 7,
+        psn: 9,
+        gid: [1u8; 16],
+        layers: vec![(0x1000, 42)],
+    };
+    let mut buf = Vec::new();
+    write_server_rails(&mut buf, std::slice::from_ref(&sp)).unwrap();
+    // Leading count byte then the single params struct.
+    assert_eq!(buf[0], 1);
+    let back = read_server_rails(&mut &buf[..], 1).unwrap();
+    assert_eq!(back, vec![sp]);
+}
+
+#[test]
+fn read_server_rails_rejects_mismatch() {
+    // Framed count (1) != what the caller negotiated (2) -> protocol error.
+    let sp = VerbsServerParams {
+        qpn: 1,
+        psn: 2,
+        gid: [0u8; 16],
+        layers: vec![(0x1000, 7)],
+    };
+    let mut buf = Vec::new();
+    write_server_rails(&mut buf, std::slice::from_ref(&sp)).unwrap();
+    assert!(read_server_rails(&mut &buf[..], 2).is_err());
+}
+
+#[test]
+fn read_server_rails_rejects_zero_count() {
+    // A zero rail count is a corrupt/hostile frame.
+    let buf = [0u8; 1];
+    assert!(read_server_rails(&mut &buf[..], 1).is_err());
+}
+
+#[test]
+fn write_server_rails_rejects_empty() {
+    let mut buf = Vec::new();
+    assert!(write_server_rails(&mut buf, &[]).is_err());
+}
+
+#[test]
+fn verbs_server_params_reject_absurd_layer_count() {
+    // A corrupt/hostile count must Err, not attempt a huge allocation.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&1u32.to_le_bytes()); // qpn
+    buf.extend_from_slice(&2u32.to_le_bytes()); // psn
+    buf.extend_from_slice(&[0u8; 16]); // gid
+    buf.extend_from_slice(&99_999u32.to_le_bytes()); // n_layers (absurd)
+    assert!(VerbsServerParams::read_from(&mut &buf[..]).is_err());
+}
+
+#[test]
+fn kv_server_params_round_trip() {
+    let sp = CacheServerParams {
+        qpn: 0x4242,
+        psn: 0x0012_3456 & 0xff_ffff,
+        gid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 178, 12],
+        base_addr: 0x7f00_1234_0000,
+        rkey: 0xdead_beef,
+    };
+    let mut buf = Vec::new();
+    sp.write_to(&mut buf).unwrap();
+    assert_eq!(CacheServerParams::read_from(&mut &buf[..]).unwrap(), sp);
+}

--- a/crates/atlas-rdma/tests/wire_roundtrip.rs
+++ b/crates/atlas-rdma/tests/wire_roundtrip.rs
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Codec round-trip / validation tests, extracted WITH the codecs from the
-// RDMA peer daemons (RailSet extraction). These cover reader/writer agreement,
-// the exact byte layouts (see also `tests/transcript_golden.rs`), the frozen
-// interop constant values (`frozen_wire_constants`), and the validation bails.
-// Un-gated: pure `std::io`, runs on the ATLAS_SKIP_BUILD path.
+// Codec round-trip / validation tests for the RDMA peer daemons' shared wire
+// codecs. These cover reader/writer agreement, the exact byte layouts (see
+// also `tests/transcript_golden.rs`), the frozen interop constant values
+// (`frozen_wire_constants`), and the validation bails. Un-gated: pure
+// `std::io`, runs on the ATLAS_SKIP_BUILD path.
 
 use atlas_rdma::wire::{
     CacheServerParams, MODE_TCP, MODE_VERBS, STATUS_ERR, STATUS_OK, VerbsClientParams,
     VerbsServerParams, read_server_rails, write_server_rails,
 };
 
-/// The interop bytes the live gx10 peer speaks are frozen — a value flip here
-/// is a silent wire break, so pin them explicitly (the goldens only exercise
+/// These interop bytes are a frozen external contract — a value flip here is a
+/// silent wire break, so pin them explicitly (the goldens only exercise
 /// STATUS_OK/MODE bytes indirectly).
 #[test]
 fn frozen_wire_constants() {
-    assert_eq!(STATUS_OK, 0, "STATUS_OK is frozen vs the live peer");
-    assert_eq!(STATUS_ERR, 1, "STATUS_ERR is frozen vs the live peer");
-    assert_eq!(MODE_TCP, 0, "MODE_TCP is frozen vs the live peer");
-    assert_eq!(MODE_VERBS, 1, "MODE_VERBS is frozen vs the live peer");
+    assert_eq!(STATUS_OK, 0, "STATUS_OK is a frozen wire constant");
+    assert_eq!(STATUS_ERR, 1, "STATUS_ERR is a frozen wire constant");
+    assert_eq!(MODE_TCP, 0, "MODE_TCP is a frozen wire constant");
+    assert_eq!(MODE_VERBS, 1, "MODE_VERBS is a frozen wire constant");
 }
 
 #[test]

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -18,5 +18,10 @@ anyhow = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+# Tests implement SlotArena/SwapStore fault-injecting fakes, which return
+# `anyhow::Result` — same budget as the runtime dep, nothing new.
+anyhow = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+[package]
+name = "atlas-tier"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Atlas: generic tiered-cache core (SlotArena / SwapStore / Residency) — CUDA- and verbs-free"
+
+# HARD CONSTRAINT (tiered-cache consolidation step 2): this crate is the
+# CUDA-free, verbs-free paging core the peer daemons build on. Its dependency
+# budget is anyhow (+ libc for the O_DIRECT swap file on unix) — adding a GPU
+# or RDMA dependency here destroys the `atlas-expert-pack`
+# default-features = false property that keeps the peers CUDA-free.
+[dependencies]
+anyhow = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -7,11 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "Atlas: generic tiered-cache core (SlotArena / SwapStore / Residency) — CUDA- and verbs-free"
 
-# HARD CONSTRAINT (tiered-cache consolidation step 2): this crate is the
-# CUDA-free, verbs-free paging core the peer daemons build on. Its dependency
-# budget is anyhow (+ libc for the O_DIRECT swap file on unix) — adding a GPU
-# or RDMA dependency here destroys the `atlas-expert-pack`
-# default-features = false property that keeps the peers CUDA-free.
+# HARD CONSTRAINT: this crate is the CUDA-free, verbs-free paging core the peer
+# daemons build on. Its dependency budget is anyhow (+ libc for the O_DIRECT
+# swap file on unix) — adding a GPU or RDMA dependency here breaks the property
+# that keeps the peer daemons CUDA-free.
 [dependencies]
 anyhow = { workspace = true }
 

--- a/crates/atlas-tier/src/direct_swap.rs
+++ b/crates/atlas-tier/src/direct_swap.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! [`DirectSwapFile`] — the real O_DIRECT NVMe cold tier, plus its
+//! page-aligned bounce-buffer plumbing.
+
+use std::fs::OpenOptions;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use crate::traits::SwapStore;
+
+/// `O_DIRECT` is a Linux-only open flag (macOS has no equivalent — `F_NOCACHE`
+/// is an `fcntl`, not an open flag). The type itself must still compile on every
+/// unix because `spark_storage::snapshot_swap` re-exports it unconditionally and
+/// the workspace has a macOS/metal CI job; off Linux it simply opens buffered.
+/// That is harmless: the NVMe cold tier only ever runs on the Linux fleet.
+#[cfg(target_os = "linux")]
+const DIRECT_FLAGS: i32 = libc::O_DIRECT;
+#[cfg(not(target_os = "linux"))]
+const DIRECT_FLAGS: i32 = 0;
+
+/// O_DIRECT fixed-stride swap file on NVMe (the peer's cold tier). `record_bytes`
+/// MUST be a 4 KiB multiple (O_DIRECT) — the SSM snapshot blob (66,846,720 B =
+/// 16,320 × 4 KiB) already is. Records are addressed by `disk_slot` at
+/// `disk_slot * record_bytes`; the file grows sparsely as slots are allocated.
+///
+/// Buffers passed to read/write must be page-aligned for O_DIRECT. The peer's
+/// callers pass the mmap'd arena scratch (page-aligned); the residency scratch
+/// is a plain Vec — see `read/write_record` which stage through an aligned
+/// bounce only when the caller's buffer isn't aligned.
+pub struct DirectSwapFile {
+    fd: OwnedFd,
+    record_bytes: usize,
+    /// Page-aligned bounce for callers whose buffer isn't O_DIRECT-aligned.
+    bounce: AlignedBuf,
+}
+
+impl DirectSwapFile {
+    pub fn create(path: &Path, record_bytes: usize) -> Result<Self> {
+        if record_bytes == 0 || !record_bytes.is_multiple_of(4096) {
+            bail!(
+                "DirectSwapFile: record_bytes ({record_bytes}) must be a non-zero 4 KiB multiple"
+            );
+        }
+        let f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(DIRECT_FLAGS)
+            .open(path)
+            .map_err(|e| anyhow::anyhow!("open O_DIRECT {}: {e}", path.display()))?;
+        Ok(Self {
+            fd: OwnedFd::from(f),
+            record_bytes,
+            bounce: AlignedBuf::new(record_bytes),
+        })
+    }
+
+    fn offset(&self, disk_slot: usize) -> libc::off_t {
+        (disk_slot as u64 * self.record_bytes as u64) as libc::off_t
+    }
+}
+
+impl SwapStore for DirectSwapFile {
+    fn record_bytes(&self) -> usize {
+        self.record_bytes
+    }
+
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.record_bytes {
+            bail!(
+                "write_record: {} bytes, expected {}",
+                bytes.len(),
+                self.record_bytes
+            );
+        }
+        let off = self.offset(disk_slot);
+        let src = if is_aligned(bytes.as_ptr()) {
+            bytes.as_ptr()
+        } else {
+            self.bounce.as_mut_slice().copy_from_slice(bytes);
+            self.bounce.ptr()
+        };
+        let n = unsafe {
+            libc::pwrite(
+                self.fd.as_raw_fd(),
+                src as *const libc::c_void,
+                self.record_bytes,
+                off,
+            )
+        };
+        if n != self.record_bytes as isize {
+            bail!("pwrite record {disk_slot} returned {n}, errno {}", errno());
+        }
+        Ok(())
+    }
+
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        if out.len() != self.record_bytes {
+            bail!(
+                "read_record: {} bytes, expected {}",
+                out.len(),
+                self.record_bytes
+            );
+        }
+        let off = self.offset(disk_slot);
+        if is_aligned(out.as_ptr()) {
+            let n = unsafe {
+                libc::pread(
+                    self.fd.as_raw_fd(),
+                    out.as_mut_ptr() as *mut libc::c_void,
+                    self.record_bytes,
+                    off,
+                )
+            };
+            if n != self.record_bytes as isize {
+                bail!("pread record {disk_slot} returned {n}, errno {}", errno());
+            }
+        } else {
+            // Stage through the aligned bounce, then copy out. `&self` — the
+            // bounce is interior; take a raw ptr (single-threaded peer loop).
+            let bp = self.bounce.ptr();
+            let n = unsafe {
+                libc::pread(
+                    self.fd.as_raw_fd(),
+                    bp as *mut libc::c_void,
+                    self.record_bytes,
+                    off,
+                )
+            };
+            if n != self.record_bytes as isize {
+                bail!(
+                    "pread(bounce) record {disk_slot} returned {n}, errno {}",
+                    errno()
+                );
+            }
+            unsafe {
+                std::ptr::copy_nonoverlapping(bp, out.as_mut_ptr(), self.record_bytes);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn errno() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+fn is_aligned(p: *const u8) -> bool {
+    (p as usize) & 0xfff == 0
+}
+
+/// A page-aligned heap buffer (posix_memalign) for O_DIRECT staging.
+struct AlignedBuf {
+    ptr: *mut u8,
+    len: usize,
+}
+unsafe impl Send for AlignedBuf {}
+impl AlignedBuf {
+    fn new(len: usize) -> Self {
+        let mut p: *mut libc::c_void = std::ptr::null_mut();
+        let rc = unsafe { libc::posix_memalign(&mut p, 4096, len) };
+        assert!(
+            rc == 0 && !p.is_null(),
+            "posix_memalign({len}) failed rc={rc}"
+        );
+        Self {
+            ptr: p as *mut u8,
+            len,
+        }
+    }
+    fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.ptr as *mut libc::c_void) }
+    }
+}

--- a/crates/atlas-tier/src/direct_swap.rs
+++ b/crates/atlas-tier/src/direct_swap.rs
@@ -13,9 +13,8 @@ use anyhow::{Result, bail};
 use crate::traits::SwapStore;
 
 /// `O_DIRECT` is a Linux-only open flag (macOS has no equivalent — `F_NOCACHE`
-/// is an `fcntl`, not an open flag). The type itself must still compile on every
-/// unix because `spark_storage::snapshot_swap` re-exports it unconditionally and
-/// the workspace has a macOS/metal CI job; off Linux it simply opens buffered.
+/// is an `fcntl`, not an open flag). The type must still compile on every unix
+/// (the workspace has a macOS/metal CI job); off Linux it simply opens buffered.
 /// That is harmless: the NVMe cold tier only ever runs on the Linux fleet.
 #[cfg(target_os = "linux")]
 const DIRECT_FLAGS: i32 = libc::O_DIRECT;

--- a/crates/atlas-tier/src/entropy.rs
+++ b/crates/atlas-tier/src/entropy.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! OS entropy for **per-process key salts** (the SSM decode-tier client salt).
+//!
+//! Deliberately NOT in [`crate::hash`]: that module is the durable-determinism
+//! seam (same input ⇒ same `u64` forever, a fleet-wide on-disk contract); this
+//! one is its exact opposite — a value that must be FRESH per process so two
+//! same-model clients sharing one paging peer can never derive the same
+//! slot-coordinate wire keys.
+//!
+//! Failure is a HARD error, never a silent zero/degraded salt: a degraded
+//! shared salt would quietly reintroduce the exact cross-client key sharing
+//! the salt exists to prevent (PCND — no silent fallthrough).
+
+use anyhow::Result;
+
+/// 8 bytes of OS entropy as a `u64`.
+///
+/// Linux: `libc::getrandom` (flags = 0: the `/dev/urandom` pool, blocking only
+/// pre-seed at early boot), looping on `EINTR` and partial reads. Other unix
+/// (macOS): `/dev/urandom` via `read_exact`.
+pub fn random_u64() -> Result<u64> {
+    let mut buf = [0u8; 8];
+    fill(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+#[cfg(target_os = "linux")]
+fn fill(buf: &mut [u8]) -> Result<()> {
+    let mut got = 0usize;
+    while got < buf.len() {
+        let r = unsafe { libc::getrandom(buf[got..].as_mut_ptr().cast(), buf.len() - got, 0) };
+        if r < 0 {
+            let e = std::io::Error::last_os_error();
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            anyhow::bail!("getrandom failed (refusing a degraded zero-entropy salt): {e}");
+        }
+        got += r as usize;
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn fill(buf: &mut [u8]) -> Result<()> {
+    use std::io::Read;
+    let mut f = std::fs::File::open("/dev/urandom")
+        .map_err(|e| anyhow::anyhow!("open /dev/urandom failed (refusing a degraded salt): {e}"))?;
+    f.read_exact(buf)
+        .map_err(|e| anyhow::anyhow!("read /dev/urandom failed (refusing a degraded salt): {e}"))
+}
+
+#[cfg(test)]
+#[path = "entropy_tests.rs"]
+mod tests;

--- a/crates/atlas-tier/src/entropy_tests.rs
+++ b/crates/atlas-tier/src/entropy_tests.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `random_u64` sanity: it must succeed and actually vary — a constant (or
+//! erroring) source would silently give every process the SAME decode client
+//! salt, which is exactly the cross-client sharing the salt exists to prevent.
+
+use super::random_u64;
+
+#[test]
+fn random_u64_succeeds_and_varies() {
+    // 8 draws all identical has probability 2^-448 from a real entropy
+    // source — this fails only if the source is broken (constant/zero).
+    let draws: Vec<u64> = (0..8).map(|_| random_u64().expect("OS entropy")).collect();
+    assert!(
+        draws.iter().any(|&d| d != draws[0]),
+        "8 identical draws — entropy source is degraded/constant: {draws:?}"
+    );
+}

--- a/crates/atlas-tier/src/hash.rs
+++ b/crates/atlas-tier/src/hash.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Stable hash primitives for **durable, cross-process cache keys**.
+//!
+//! These values are written into the paging peer's NVMe swap file, which
+//! outlives the client that wrote them. So the same input must produce the same
+//! `u64` forever — across toolchains, platforms, target architectures and
+//! rebuilds. That is a *durable on-disk contract*, not a hashmap.
+//!
+//! `std::hash::DefaultHasher` is unusable here: std documents its algorithm as
+//! unspecified and "not to be relied upon over releases", so a toolchain bump
+//! silently rotates every persisted key (total cache miss) or collides with a
+//! stale namespace (silent wrong-state corruption). `ahash` is worse still — it
+//! varies by CPU feature (AES-NI). A crate dependency is also a hazard: a
+//! version bump could rotate the fleet's keys. Hence: vendored, ~20 lines, here.
+//!
+//! They live in `atlas-tier` because it is pure (`anyhow` + `libc`, no CUDA, no
+//! verbs) and a common ancestor of its consumers — the SSM tier fingerprint and
+//! the KV paging namespace — so both derive keys from ONE definition of these
+//! constants rather than separate copies free to drift.
+//!
+//! ## Threat model (read before reusing these)
+//!
+//! FNV-1a is **not collision-resistant against an adversary**: it is
+//! multiplicative and trivially invertible, so collisions are *constructible*,
+//! not merely improbable. That is fine for the current use — a trusted fleet
+//! whose model configs are not attacker-chosen, where safety comes from the
+//! *injective encoding* of the input plus determinism, and where the birthday
+//! bound over a few dozen configs is nil.
+//!
+//! It would **not** be fine if a shared paging peer ever served untrusted or
+//! multi-tenant configs: an attacker able to choose a config could craft one
+//! whose namespace collides with another tenant's and read that tenant's
+//! recurrent state off the shared peer — defeating the exact property the
+//! namespace exists to provide. If that day comes, switch to a keyed hash
+//! (keyed BLAKE3, or a vendored SipHash-2-4 with a fixed key) behind a
+//! namespace-version bump, which is a deliberate fleet-wide cache flush.
+
+/// FNV-1a/64 offset basis (published constant).
+pub const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+/// FNV-1a/64 prime (published constant).
+pub const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+const GOLDEN: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// FNV-1a/64 over a byte stream. Fully specified, endianness-free (it consumes
+/// bytes, not words), and deterministic across every toolchain and platform.
+pub const fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut h = FNV_OFFSET;
+    let mut i = 0;
+    while i < bytes.len() {
+        h = (h ^ bytes[i] as u64).wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    h
+}
+
+/// splitmix64 finalizer over `a ^ b·GOLDEN` — domain-separated mixing.
+///
+/// This is the single definition of the fold used for **every persisted wire
+/// key**: `PagingSnapshotStore::wire(key) == mix64(key, namespace)` and the
+/// decode namespace is `mix64(fingerprint, DECODE_DOMAIN)`. Changing it rotates
+/// every key on every peer.
+pub const fn mix64(a: u64, b: u64) -> u64 {
+    let mut h = a ^ b.wrapping_mul(GOLDEN);
+    h ^= h >> 30;
+    h = h.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    h ^= h >> 27;
+    h = h.wrapping_mul(0x94D0_49BB_1331_11EB);
+    h ^ (h >> 31)
+}
+
+#[cfg(test)]
+#[path = "hash_tests.rs"]
+mod tests;

--- a/crates/atlas-tier/src/hash_tests.rs
+++ b/crates/atlas-tier/src/hash_tests.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! These pins are the whole safety story for durable cache keys: they catch a
+//! "helpful" reimplementation that changes the value, which would silently
+//! rotate (or collide) every key persisted in a peer's NVMe swap file.
+
+use super::{fnv1a_64, mix64};
+
+/// Pin the primitive to the PUBLISHED FNV-1a/64 reference vectors — someone
+/// else's constants, so a swapped or "optimized" implementation cannot pass.
+#[test]
+fn fnv1a_64_matches_published_reference_vectors() {
+    assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+    assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+}
+
+#[test]
+fn fnv1a_64_is_order_sensitive_and_length_sensitive() {
+    assert_ne!(fnv1a_64(b"ab"), fnv1a_64(b"ba"));
+    assert_ne!(fnv1a_64(b"a"), fnv1a_64(b"aa"));
+}
+
+/// mix64 is the fold behind EVERY persisted wire key. Pin it to literals: this
+/// is the value that lands on disk, so it is arguably a more important pin than
+/// the fingerprint itself.
+#[test]
+fn mix64_golden_pins() {
+    assert_eq!(mix64(1, 0), 0x5692_161d_100b_05e5);
+    assert_eq!(mix64(0, 1), 0xe220_a839_7b1d_cdaf);
+    assert_eq!(mix64(0xdead_beef, 0xcafe_f00d), 0x5f3e_915c_5c36_4c56);
+}
+
+/// splitmix64 has a ZERO FIXED POINT: `mix64(0, 0) == 0`. Pinned because it is
+/// load-bearing, not a curiosity — it is precisely why every caller that turns a
+/// mix into a namespace needs zero-avoidance (`NonZeroU64`), and why the decode
+/// namespace must not fall back to the fingerprint when the mix lands on zero.
+#[test]
+fn mix64_has_a_zero_fixed_point() {
+    assert_eq!(mix64(0, 0), 0);
+}
+
+/// Namespace separation: the same logical key under two namespaces must not
+/// collide. This is the property that stops two models cross-serving on one peer.
+#[test]
+fn mix64_separates_namespaces() {
+    let key = 0x1234_5678_9abc_def0;
+    assert_ne!(mix64(key, 1), mix64(key, 2));
+    assert_ne!(mix64(key, 0), mix64(key, u64::MAX));
+}
+
+/// Deterministic + const-evaluable (both are load-bearing: the values are
+/// durable, and callers use them in const contexts).
+#[test]
+fn mix64_and_fnv_are_const_and_deterministic() {
+    const H: u64 = fnv1a_64(b"atlas");
+    const M: u64 = mix64(H, 7);
+    assert_eq!(H, fnv1a_64(b"atlas"));
+    assert_eq!(M, mix64(H, 7));
+}

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::all)]
 
 //! The generic tiered-cache core: the CUDA-free, verbs-free paging foundation
-//! that the streaming-weights peer daemons build on.
+//! that the peer daemons build on.
 //!
 //! One mechanism, three seams:
 //!   * [`SlotArena`]  — the bounded HOT tier: `num_slots` fixed-size byte slots
@@ -21,8 +21,7 @@
 //! fully unit-testable without RDMA or a GPU and lets the downstream peer
 //! daemons build CUDA-free. The peer wire protocol (paging loops, client
 //! codec) and the concrete RDMA/HBM tier implementations deliberately do NOT
-//! live here — they arrive in the consumer crates (cache-peer, the
-//! `spark-storage` re-export) in follow-up PRs of the streaming-weights work.
+//! live here — they belong to the consumer crates that build on this core.
 
 mod direct_swap;
 mod mem;

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+#![deny(warnings)]
+#![deny(clippy::all)]
+
+//! The generic tiered-cache core: the CUDA-free, verbs-free paging foundation
+//! that the streaming-weights peer daemons build on.
+//!
+//! One mechanism, three seams:
+//!   * [`SlotArena`]  — the bounded HOT tier: `num_slots` fixed-size byte slots
+//!     (a peer's mmap'd RDMA MR, a host-RAM `Vec`, …). No CUDA/HBM impl may
+//!     live in this crate — that belongs to consumer crates.
+//!   * [`SwapStore`]  — the unbounded COLD tier: a fixed-stride record store
+//!     ([`DirectSwapFile`] on NVMe, [`MemSwapStore`] in RAM, …).
+//!   * [`Residency`]  — the page table over both: opaque `u64` key →
+//!     byte-agnostic fixed-size blob, two-level LRU (RAM `lru` above
+//!     `disk_lru`), read-pins so a slot is never reused mid-read, and
+//!     NEVER-reject puts (a full arena spills the coldest resident to disk; a
+//!     capped disk drops its coldest key → clean later miss).
+//!
+//! This crate is CPU/disk-only: deps are `anyhow` + `libc` (unix), so it is
+//! fully unit-testable without RDMA or a GPU and lets the downstream peer
+//! daemons build CUDA-free. The peer wire protocol (paging loops, client
+//! codec) and the concrete RDMA/HBM tier implementations deliberately do NOT
+//! live here — they arrive in the consumer crates (cache-peer, the
+//! `spark-storage` re-export) in follow-up PRs of the streaming-weights work.
+
+mod direct_swap;
+mod mem;
+mod residency;
+mod traits;
+
+pub use direct_swap::DirectSwapFile;
+pub use mem::{MemSwapStore, VecSlotArena};
+pub use residency::Residency;
+pub use traits::{SlotArena, SwapStats, SwapStore};

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -28,6 +28,9 @@ mod mem;
 mod residency;
 mod traits;
 
+pub mod entropy;
+pub mod hash;
+
 pub use direct_swap::DirectSwapFile;
 pub use mem::{MemSwapStore, VecSlotArena};
 pub use residency::Residency;

--- a/crates/atlas-tier/src/mem.rs
+++ b/crates/atlas-tier/src/mem.rs
@@ -9,9 +9,9 @@ use anyhow::{Result, bail};
 
 use crate::traits::{SlotArena, SwapStore};
 
-/// Host-RAM [`SlotArena`] over one flat `Vec<u8>` (promoted from the original
-/// test fake). The hot tier for in-process consumers — e.g. the unified SSM
-/// spill store's RAM cache. Allocates `slot_bytes * num_slots` up front.
+/// Host-RAM [`SlotArena`] over one flat `Vec<u8>`. The hot tier for in-process
+/// consumers — e.g. the unified SSM spill store's RAM cache. Allocates
+/// `slot_bytes * num_slots` up front.
 pub struct VecSlotArena {
     buf: Vec<u8>,
     slot_bytes: usize,
@@ -53,9 +53,9 @@ impl SlotArena for VecSlotArena {
     }
 }
 
-/// Host-RAM [`SwapStore`] over a `HashMap` (promoted from the original test
-/// fake). Records live in ordinary heap memory — the "swap" tier when no NVMe
-/// directory is configured (unbounded, still LRU-ordered by the residency).
+/// Host-RAM [`SwapStore`] over a `HashMap`. Records live in ordinary heap
+/// memory — the "swap" tier when no NVMe directory is configured (unbounded,
+/// still LRU-ordered by the residency).
 pub struct MemSwapStore {
     recs: HashMap<usize, Vec<u8>>,
     record_bytes: usize,

--- a/crates/atlas-tier/src/mem.rs
+++ b/crates/atlas-tier/src/mem.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Host-RAM reference impls: [`VecSlotArena`] (hot tier) and [`MemSwapStore`]
+//! (cold tier).
+
+use std::collections::HashMap;
+
+use anyhow::{Result, bail};
+
+use crate::traits::{SlotArena, SwapStore};
+
+/// Host-RAM [`SlotArena`] over one flat `Vec<u8>` (promoted from the original
+/// test fake). The hot tier for in-process consumers — e.g. the unified SSM
+/// spill store's RAM cache. Allocates `slot_bytes * num_slots` up front.
+pub struct VecSlotArena {
+    buf: Vec<u8>,
+    slot_bytes: usize,
+    n: usize,
+}
+
+impl VecSlotArena {
+    pub fn new(slot_bytes: usize, num_slots: usize) -> Self {
+        Self {
+            buf: vec![0u8; slot_bytes * num_slots],
+            slot_bytes,
+            n: num_slots,
+        }
+    }
+}
+
+impl SlotArena for VecSlotArena {
+    fn slot_bytes(&self) -> usize {
+        self.slot_bytes
+    }
+    fn num_slots(&self) -> usize {
+        self.n
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        if slot >= self.n || out.len() != self.slot_bytes {
+            bail!("VecSlotArena::read_slot({slot}) out of range / size mismatch");
+        }
+        let o = slot * self.slot_bytes;
+        out.copy_from_slice(&self.buf[o..o + self.slot_bytes]);
+        Ok(())
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        if slot >= self.n || bytes.len() != self.slot_bytes {
+            bail!("VecSlotArena::write_slot({slot}) out of range / size mismatch");
+        }
+        let o = slot * self.slot_bytes;
+        self.buf[o..o + self.slot_bytes].copy_from_slice(bytes);
+        Ok(())
+    }
+}
+
+/// Host-RAM [`SwapStore`] over a `HashMap` (promoted from the original test
+/// fake). Records live in ordinary heap memory — the "swap" tier when no NVMe
+/// directory is configured (unbounded, still LRU-ordered by the residency).
+pub struct MemSwapStore {
+    recs: HashMap<usize, Vec<u8>>,
+    record_bytes: usize,
+}
+
+impl MemSwapStore {
+    pub fn new(record_bytes: usize) -> Self {
+        Self {
+            recs: HashMap::new(),
+            record_bytes,
+        }
+    }
+}
+
+impl SwapStore for MemSwapStore {
+    fn record_bytes(&self) -> usize {
+        self.record_bytes
+    }
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.record_bytes {
+            bail!(
+                "MemSwapStore::write_record: {} bytes, expected {}",
+                bytes.len(),
+                self.record_bytes
+            );
+        }
+        self.recs.insert(disk_slot, bytes.to_vec());
+        Ok(())
+    }
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        match self.recs.get(&disk_slot) {
+            Some(v) => {
+                out.copy_from_slice(v);
+                Ok(())
+            }
+            None => bail!("MemSwapStore: no record {disk_slot}"),
+        }
+    }
+    fn discard_record(&mut self, disk_slot: usize) {
+        self.recs.remove(&disk_slot);
+    }
+}

--- a/crates/atlas-tier/src/residency.rs
+++ b/crates/atlas-tier/src/residency.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! [`Residency`] — the policy core: the page table over a bounded hot
+//! [`SlotArena`] and an unbounded cold [`SwapStore`].
+
+use std::collections::{HashMap, VecDeque};
+
+use anyhow::{Result, bail};
+
+use crate::traits::{SlotArena, SwapStats, SwapStore};
+
+/// Where a key's blob currently lives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Loc {
+    /// Arena slot handed out for an in-flight PUT; pinned (not evictable) until
+    /// `commit`. Holds the caller's about-to-be-written bytes.
+    Reserved(usize),
+    /// Live in an arena slot (RDMA-readable now).
+    Resident(usize),
+    /// Spilled to a disk record; a GET faults it back into a slot.
+    OnDisk(usize),
+}
+
+/// The page table: `key → Loc` over a bounded [`SlotArena`] (hot) backed by an
+/// unbounded [`SwapStore`] (cold), with LRU eviction of resident slots to disk.
+/// (Historically `SnapshotResidency` — `spark-storage::snapshot_swap` re-exports
+/// it under that name for the peer.)
+pub struct Residency<A: SlotArena, S: SwapStore> {
+    arena: A,
+    swap: S,
+    blob_bytes: usize,
+    map: HashMap<u64, Loc>,
+    /// Free arena slot indices (LIFO reuse).
+    free_slots: Vec<usize>,
+    /// Resident keys, front = coldest (LRU eviction victim). Reserved keys are
+    /// NOT in here (pinned).
+    lru: VecDeque<u64>,
+    /// On-disk keys, front = coldest — the disk-cap eviction victim. Every
+    /// `OnDisk` entry is exactly once in here (a bounded two-level LRU:
+    /// RAM `lru` above disk `disk_lru`).
+    disk_lru: VecDeque<u64>,
+    /// Max simultaneous on-disk records (the disk cap / blob_bytes). 0 =
+    /// unbounded. When full, the coldest on-disk snapshot is dropped to make
+    /// room — a later GET for it misses and the model recomputes (correct
+    /// degradation, keeps the swap file bounded).
+    max_disk_slots: usize,
+    /// Free disk record indices (reused before growing the high-water mark).
+    free_disk: Vec<usize>,
+    next_disk: usize,
+    /// Reusable scratch for a single blob move (spill/fault), sized once.
+    scratch: Vec<u8>,
+    /// Read-pins: `key → active reader count`. A GET hands the client an arena
+    /// offset it then one-sided-RDMA-READs; the peer drops the residency lock
+    /// before that read, so a concurrent ALLOC on another connection could pick
+    /// the slot as an eviction victim and reuse it mid-read (torn restore). A
+    /// pinned key is held OUT of `lru` (like a `Reserved` slot) so
+    /// `evict_coldest_to_disk` can never choose it. Ref-counted for concurrent
+    /// readers of the same key. Invariant: `key ∈ lru ⟺ Resident AND unpinned`.
+    read_pins: HashMap<u64, u32>,
+    stats: SwapStats,
+}
+
+impl<A: SlotArena, S: SwapStore> Residency<A, S> {
+    /// Unbounded disk tier (no cap). Prefer [`Residency::new_capped`] in
+    /// production.
+    pub fn new(arena: A, swap: S) -> Result<Self> {
+        Self::new_capped(arena, swap, 0)
+    }
+
+    /// `max_disk_slots` bounds the on-disk record count (0 = unbounded). When
+    /// full, spilling evicts the coldest on-disk snapshot (dropped → later GET
+    /// misses → recompute), keeping the swap file at ≤ `max_disk_slots` records.
+    pub fn new_capped(arena: A, swap: S, max_disk_slots: usize) -> Result<Self> {
+        let blob_bytes = arena.slot_bytes();
+        if blob_bytes == 0 {
+            bail!("Residency: slot_bytes must be > 0");
+        }
+        if swap.record_bytes() != blob_bytes {
+            bail!(
+                "Residency: arena slot ({}) and swap record ({}) sizes differ",
+                blob_bytes,
+                swap.record_bytes()
+            );
+        }
+        let n = arena.num_slots();
+        if n == 0 {
+            bail!("Residency: arena must have >= 1 slot");
+        }
+        Ok(Self {
+            arena,
+            swap,
+            blob_bytes,
+            map: HashMap::new(),
+            free_slots: (0..n).rev().collect(),
+            lru: VecDeque::new(),
+            disk_lru: VecDeque::new(),
+            max_disk_slots,
+            free_disk: Vec::new(),
+            next_disk: 0,
+            scratch: vec![0u8; blob_bytes],
+            read_pins: HashMap::new(),
+            stats: SwapStats::default(),
+        })
+    }
+
+    pub fn blob_bytes(&self) -> usize {
+        self.blob_bytes
+    }
+    pub fn stats(&self) -> &SwapStats {
+        &self.stats
+    }
+    pub fn resident_count(&self) -> usize {
+        self.lru.len()
+    }
+    pub fn total_keys(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Direct arena access for the data plane. The peer writes the slots its
+    /// clients one-sided-RDMA into/out of; in-process consumers should prefer
+    /// [`Residency::put_blob`] / [`Residency::get_blob`].
+    pub fn arena(&self) -> &A {
+        &self.arena
+    }
+    pub fn arena_mut(&mut self) -> &mut A {
+        &mut self.arena
+    }
+
+    /// Byte offset of an arena slot (what the client RDMA-reads/writes).
+    pub fn slot_offset(&self, slot: usize) -> u64 {
+        (slot as u64) * (self.blob_bytes as u64)
+    }
+
+    // ─────────────────────────── control-plane ops ───────────────────────────
+
+    /// PUT step 1 — reserve an arena slot for `key`. Evicts the coldest resident
+    /// slot to disk if the arena is full (never rejects). The caller then
+    /// RDMA-WRITEs the blob into `slot_offset(slot)` and calls `commit(key)`.
+    /// Re-PUT of a live key reuses its current slot (idempotent overwrite).
+    pub fn alloc(&mut self, key: u64) -> Result<usize> {
+        self.stats.puts += 1;
+        // Overwrite-in-place: a key already resident/reserved keeps its slot.
+        match self.map.get(&key).copied() {
+            Some(Loc::Resident(slot)) => {
+                self.lru_remove(key); // pin during the rewrite
+                self.map.insert(key, Loc::Reserved(slot));
+                return Ok(slot);
+            }
+            Some(Loc::Reserved(slot)) => return Ok(slot),
+            Some(Loc::OnDisk(disk_slot)) => {
+                // Rewriting a spilled key: reclaim its disk record, give a slot.
+                self.disk_lru_remove(key);
+                self.free_disk.push(disk_slot);
+                self.swap.discard_record(disk_slot);
+            }
+            None => {}
+        }
+        let slot = self.acquire_slot()?;
+        self.map.insert(key, Loc::Reserved(slot));
+        Ok(slot)
+    }
+
+    /// PUT step 2 — the client's RDMA-WRITE into the reserved slot has landed;
+    /// mark `key` resident (and hottest in the LRU).
+    pub fn commit(&mut self, key: u64) -> Result<()> {
+        match self.map.get(&key).copied() {
+            Some(Loc::Reserved(slot)) => {
+                self.map.insert(key, Loc::Resident(slot));
+                // Maintain the `in-lru ⟺ Resident AND unpinned` invariant: if a
+                // reader pinned this key while the re-PUT was in flight, leave it
+                // out of the LRU — `unpin_read` re-adds it when the last reader
+                // releases.
+                if !self.read_pins.contains_key(&key) {
+                    self.lru.push_back(key); // hottest
+                }
+                Ok(())
+            }
+            Some(Loc::Resident(_)) => Ok(()), // already committed — idempotent
+            _ => bail!("commit({key:#x}): no reserved slot (alloc not called / evicted)"),
+        }
+    }
+
+    /// GET — ensure `key` is resident and return its arena slot (offset via
+    /// `slot_offset`). Faults from disk into a slot if it was spilled (evicting
+    /// a victim to make room). `Ok(None)` = unknown key (caller recomputes).
+    pub fn locate(&mut self, key: u64) -> Result<Option<usize>> {
+        self.stats.gets += 1;
+        match self.map.get(&key).copied() {
+            Some(Loc::Resident(slot)) => {
+                self.stats.resident_hits += 1;
+                // A concurrently-pinned key is held out of `lru`; touching it
+                // would re-insert it (breaking the invariant + making it an
+                // eviction victim while still being read). The caller pins right
+                // after this returns, so unpinned hits get refreshed here and
+                // pinned ones stay out.
+                if !self.read_pins.contains_key(&key) {
+                    self.lru_touch(key);
+                }
+                Ok(Some(slot))
+            }
+            Some(Loc::Reserved(slot)) => {
+                // A GET racing an uncommitted PUT: the bytes are (being) written
+                // by the same caller; hand back the slot.
+                Ok(Some(slot))
+            }
+            Some(Loc::OnDisk(disk_slot)) => {
+                // Pin against `acquire_slot`'s spill+make_disk_room evicting THIS
+                // key (it is still OnDisk until the fault below completes).
+                self.disk_lru_remove(key);
+                let slot = match self.acquire_slot() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        self.disk_lru.push_front(key); // un-pin (still on disk)
+                        return Err(e);
+                    }
+                };
+                // scratch is exclusive to one move at a time (control loop is
+                // single-threaded per connection); read disk → arena slot.
+                let mut buf = std::mem::take(&mut self.scratch);
+                let r = self.swap.read_record(disk_slot, &mut buf);
+                if r.is_ok() {
+                    r.and_then(|_| self.arena.write_slot(slot, &buf))?;
+                } else {
+                    self.scratch = buf;
+                    self.free_slots.push(slot);
+                    self.disk_lru.push_front(key); // still on disk; re-pin (cold)
+                    return r.map(|_| None);
+                }
+                self.scratch = buf;
+                self.free_disk.push(disk_slot);
+                self.swap.discard_record(disk_slot);
+                self.map.insert(key, Loc::Resident(slot));
+                self.lru.push_back(key);
+                self.stats.faults_from_disk += 1;
+                Ok(Some(slot))
+            }
+            None => {
+                self.stats.get_miss += 1;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Drop `key` entirely, reclaiming its arena slot or disk record.
+    pub fn remove(&mut self, key: u64) {
+        match self.map.remove(&key) {
+            Some(Loc::Resident(slot)) | Some(Loc::Reserved(slot)) => {
+                self.lru_remove(key);
+                self.free_slots.push(slot);
+            }
+            Some(Loc::OnDisk(disk_slot)) => {
+                self.disk_lru_remove(key);
+                self.free_disk.push(disk_slot);
+                self.swap.discard_record(disk_slot);
+            }
+            None => {}
+        }
+    }
+
+    /// Read-pin `key` so its resident slot cannot be chosen as an eviction
+    /// victim while a client's one-sided RDMA READ of it is in flight (the
+    /// GET→RDMA-read race: the peer replies with the offset and drops the lock
+    /// before the client reads, so a concurrent ALLOC could otherwise
+    /// spill+reuse the slot). Ref-counted for concurrent readers; the first pin
+    /// removes the key from `lru` (like a `Reserved` slot). No-op unless the key
+    /// is currently `Resident`.
+    pub fn pin_read(&mut self, key: u64) {
+        if !matches!(self.map.get(&key), Some(Loc::Resident(_))) {
+            return;
+        }
+        let n = self.read_pins.get(&key).copied().unwrap_or(0);
+        if n == 0 {
+            self.lru_remove(key); // exclude from eviction victims while read
+        }
+        self.read_pins.insert(key, n + 1);
+    }
+
+    /// Release one read-pin taken by [`Residency::pin_read`]. When the last
+    /// reader releases, the key rejoins `lru` as hottest (it was just read).
+    /// No-op if the key holds no pin. Robust to the key having been removed
+    /// while pinned: only re-adds to `lru` if still `Resident` and not already
+    /// present.
+    pub fn unpin_read(&mut self, key: u64) {
+        let Some(n) = self.read_pins.get_mut(&key) else {
+            return;
+        };
+        *n -= 1;
+        if *n == 0 {
+            self.read_pins.remove(&key);
+            if matches!(self.map.get(&key), Some(Loc::Resident(_))) && !self.lru.contains(&key) {
+                self.lru.push_back(key); // hottest — just accessed
+            }
+        }
+    }
+
+    /// Active read-pin count (test/introspection).
+    pub fn read_pin_count(&self, key: u64) -> u32 {
+        self.read_pins.get(&key).copied().unwrap_or(0)
+    }
+
+    // ───────────────────── in-process one-shot helpers ─────────────────────
+
+    /// One-shot in-process PUT: reserve a slot, copy `bytes` into it, commit.
+    /// Same NEVER-reject chain as the two-phase peer path (alloc → spill the
+    /// coldest resident → drop the coldest on-disk key when capped). For
+    /// consumers whose data plane is a memcpy rather than a client RDMA-WRITE.
+    pub fn put_blob(&mut self, key: u64, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.blob_bytes {
+            bail!(
+                "put_blob({key:#x}): {} bytes, expected {}",
+                bytes.len(),
+                self.blob_bytes
+            );
+        }
+        let slot = self.alloc(key)?;
+        if let Err(e) = self.arena.write_slot(slot, bytes) {
+            // Roll back the reservation so the slot is not stranded Reserved
+            // (a later GET must miss cleanly, never read a torn slot).
+            self.remove(key);
+            return Err(e);
+        }
+        self.commit(key)
+    }
+
+    /// One-shot in-process GET: fault `key` in (if spilled) and copy its blob
+    /// into `out`. `Ok(false)` = unknown key (caller recomputes).
+    pub fn get_blob(&mut self, key: u64, out: &mut [u8]) -> Result<bool> {
+        if out.len() != self.blob_bytes {
+            bail!(
+                "get_blob({key:#x}): {} bytes, expected {}",
+                out.len(),
+                self.blob_bytes
+            );
+        }
+        match self.locate(key)? {
+            Some(slot) => {
+                self.arena.read_slot(slot, out)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    // ─────────────────────────── internals ───────────────────────────
+
+    /// A free arena slot, spilling the coldest resident slot to disk if none.
+    fn acquire_slot(&mut self) -> Result<usize> {
+        if let Some(s) = self.free_slots.pop() {
+            return Ok(s);
+        }
+        self.evict_coldest_to_disk()
+    }
+
+    /// Spill the LRU-coldest RESIDENT key to a disk record and return its freed
+    /// arena slot. Reserved (pinned) keys are never victims.
+    fn evict_coldest_to_disk(&mut self) -> Result<usize> {
+        let Some(victim) = self.lru.pop_front() else {
+            bail!(
+                "Residency: arena exhausted — all {} slots reserved (uncommitted \
+                 PUTs) or read-pinned (in-flight RDMA READs)",
+                self.arena.num_slots()
+            );
+        };
+        let slot = match self.map.get(&victim).copied() {
+            Some(Loc::Resident(slot)) => slot,
+            other => bail!("LRU/map desync: victim {victim:#x} is {other:?}, expected Resident"),
+        };
+        // Bound the disk tier: drop the coldest on-disk snapshot(s) if at cap
+        // BEFORE claiming a disk slot for this spill.
+        self.make_disk_room();
+        let disk_slot = self.alloc_disk_slot();
+        let mut buf = std::mem::take(&mut self.scratch);
+        let res = self
+            .arena
+            .read_slot(slot, &mut buf)
+            .and_then(|_| self.swap.write_record(disk_slot, &buf));
+        self.scratch = buf;
+        if let Err(e) = res {
+            // Roll back: victim stays resident, disk slot returns to the pool.
+            self.free_disk.push(disk_slot);
+            self.lru.push_front(victim);
+            return Err(e);
+        }
+        self.map.insert(victim, Loc::OnDisk(disk_slot));
+        self.disk_lru.push_back(victim); // warmest on-disk entry
+        self.stats.spills_to_disk += 1;
+        Ok(slot)
+    }
+
+    /// Evict the coldest on-disk snapshot(s) until there is room for one more
+    /// under `max_disk_slots` (no-op when unbounded). A dropped snapshot's key
+    /// leaves the map entirely → a later GET misses → the model recomputes.
+    fn make_disk_room(&mut self) {
+        if self.max_disk_slots == 0 {
+            return;
+        }
+        while self.disk_lru.len() >= self.max_disk_slots {
+            let Some(cold) = self.disk_lru.pop_front() else {
+                break;
+            };
+            if let Some(Loc::OnDisk(ds)) = self.map.remove(&cold) {
+                self.free_disk.push(ds);
+                self.swap.discard_record(ds);
+                self.stats.disk_evictions += 1;
+            }
+        }
+    }
+
+    fn alloc_disk_slot(&mut self) -> usize {
+        if let Some(d) = self.free_disk.pop() {
+            d
+        } else {
+            let d = self.next_disk;
+            self.next_disk += 1;
+            d
+        }
+    }
+
+    fn disk_lru_remove(&mut self, key: u64) {
+        if let Some(pos) = self.disk_lru.iter().position(|&k| k == key) {
+            self.disk_lru.remove(pos);
+        }
+    }
+
+    fn lru_touch(&mut self, key: u64) {
+        self.lru_remove(key);
+        self.lru.push_back(key);
+    }
+
+    fn lru_remove(&mut self, key: u64) {
+        if let Some(pos) = self.lru.iter().position(|&k| k == key) {
+            self.lru.remove(pos);
+        }
+    }
+}

--- a/crates/atlas-tier/src/residency.rs
+++ b/crates/atlas-tier/src/residency.rs
@@ -51,7 +51,7 @@ pub struct Residency<A: SlotArena, S: SwapStore> {
     scratch: Vec<u8>,
     /// Read-pins: `key → active reader count`. A GET hands the client an arena
     /// offset it then one-sided-RDMA-READs; the peer drops the residency lock
-    /// before that read, so a concurrent ALLOC on another connection could pick
+    /// before that read, so a concurrent allocation on another connection could pick
     /// the slot as an eviction victim and reuse it mid-read (torn restore). A
     /// pinned key is held OUT of `lru` (like a `Reserved` slot) so
     /// `evict_coldest_to_disk` can never choose it. Ref-counted for concurrent
@@ -260,7 +260,7 @@ impl<A: SlotArena, S: SwapStore> Residency<A, S> {
     /// Read-pin `key` so its resident slot cannot be chosen as an eviction
     /// victim while a client's one-sided RDMA READ of it is in flight (the
     /// GET→RDMA-read race: the peer replies with the offset and drops the lock
-    /// before the client reads, so a concurrent ALLOC could otherwise
+    /// before the client reads, so a concurrent allocation could otherwise
     /// spill+reuse the slot). Ref-counted for concurrent readers; the first pin
     /// removes the key from `lru` (like a `Reserved` slot). No-op unless the key
     /// is currently `Resident`.

--- a/crates/atlas-tier/src/residency.rs
+++ b/crates/atlas-tier/src/residency.rs
@@ -23,8 +23,6 @@ enum Loc {
 
 /// The page table: `key → Loc` over a bounded [`SlotArena`] (hot) backed by an
 /// unbounded [`SwapStore`] (cold), with LRU eviction of resident slots to disk.
-/// (Historically `SnapshotResidency` — `spark-storage::snapshot_swap` re-exports
-/// it under that name for the peer.)
 pub struct Residency<A: SlotArena, S: SwapStore> {
     arena: A,
     swap: S,

--- a/crates/atlas-tier/src/traits.rs
+++ b/crates/atlas-tier/src/traits.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The two tier seams — [`SlotArena`] (hot) and [`SwapStore`] (cold) — plus
+//! [`SwapStats`], the counters [`crate::Residency`] keeps over them.
+
+use anyhow::Result;
+
+/// The hot tier: a RAM arena as a set of `num_slots` fixed-size slots. The
+/// cache peer implements this over its `mmap`'d MR (page-aligned →
+/// O_DIRECT-safe); in-process consumers use [`crate::VecSlotArena`].
+pub trait SlotArena: Send {
+    fn slot_bytes(&self) -> usize;
+    fn num_slots(&self) -> usize;
+    /// Copy arena slot → `out` (for spilling a victim to disk). `out.len()`
+    /// MUST equal `slot_bytes()`.
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()>;
+    /// Copy `bytes` → arena slot (for faulting a record back in). `bytes.len()`
+    /// MUST equal `slot_bytes()`.
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()>;
+}
+
+/// The cold tier: an unbounded fixed-stride record store addressed by a
+/// monotonic `disk_slot` index. The peer implements this over an O_DIRECT NVMe
+/// file ([`crate::DirectSwapFile`]); [`crate::MemSwapStore`] is the host-RAM
+/// variant.
+pub trait SwapStore: Send {
+    fn record_bytes(&self) -> usize;
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()>;
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()>;
+    /// Optional: reclaim disk space for a freed slot (default no-op; a hole in
+    /// a preallocated file is fine — the free-list reuses the index).
+    fn discard_record(&mut self, _disk_slot: usize) {}
+}
+
+// Boxed trait objects compose (lets a consumer pick arena/swap impls at
+// runtime: `Residency<Box<dyn SlotArena>, Box<dyn SwapStore>>`).
+impl<T: SlotArena + ?Sized> SlotArena for Box<T> {
+    fn slot_bytes(&self) -> usize {
+        (**self).slot_bytes()
+    }
+    fn num_slots(&self) -> usize {
+        (**self).num_slots()
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        (**self).read_slot(slot, out)
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        (**self).write_slot(slot, bytes)
+    }
+}
+
+impl<T: SwapStore + ?Sized> SwapStore for Box<T> {
+    fn record_bytes(&self) -> usize {
+        (**self).record_bytes()
+    }
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        (**self).write_record(disk_slot, bytes)
+    }
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        (**self).read_record(disk_slot, out)
+    }
+    fn discard_record(&mut self, disk_slot: usize) {
+        (**self).discard_record(disk_slot)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct SwapStats {
+    pub puts: u64,
+    pub gets: u64,
+    pub get_miss: u64,
+    pub spills_to_disk: u64,
+    pub faults_from_disk: u64,
+    pub resident_hits: u64,
+    /// Cold on-disk snapshots dropped because the disk cap was hit (a later GET
+    /// for one cleanly misses → recompute).
+    pub disk_evictions: u64,
+}

--- a/crates/atlas-tier/tests/direct_swap.rs
+++ b/crates/atlas-tier/tests/direct_swap.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Public-API integration tests for [`DirectSwapFile`] — real O_DIRECT I/O
+//! under `target/atlas-tier-tests`, with an EINVAL-skip when the filesystem
+//! (tmpfs/overlay) refuses O_DIRECT so containerized CI doesn't break.
+
+use std::path::Path;
+
+use atlas_tier::{DirectSwapFile, Residency, SwapStore, VecSlotArena};
+
+/// A real-filesystem dir for O_DIRECT (tmpfs/overlay EINVALs on O_DIRECT —
+/// tolerated as a skip so containerized CI doesn't break).
+fn o_direct_file(record_bytes: usize, tag: &str) -> Option<(DirectSwapFile, std::path::PathBuf)> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/atlas-tier-tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("dsf-{tag}-{}.swap", std::process::id()));
+    match DirectSwapFile::create(&path, record_bytes) {
+        Ok(f) => Some((f, path)),
+        Err(e) => {
+            eprintln!("skipping O_DIRECT test (filesystem refused O_DIRECT): {e:#}");
+            None
+        }
+    }
+}
+
+#[test]
+fn direct_swap_file_rejects_bad_record_bytes() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/atlas-tier-tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("dsf-bad.swap");
+    assert!(
+        DirectSwapFile::create(&path, 0).is_err(),
+        "zero record_bytes rejected"
+    );
+    assert!(
+        DirectSwapFile::create(&path, 1000).is_err(),
+        "non-4KiB multiple rejected"
+    );
+}
+
+/// O_DIRECT write/read round-trips through the page-aligned bounce (a plain
+/// `Vec` caller buffer is usually unaligned, exercising both bounce paths).
+#[test]
+fn direct_swap_file_roundtrips_records() {
+    let rb = 4096usize;
+    let Some((mut f, path)) = o_direct_file(rb, "rt") else {
+        return;
+    };
+    assert_eq!(f.record_bytes(), rb);
+    let mut pat = vec![0u8; rb];
+    for (i, b) in pat.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+    f.write_record(3, &pat).unwrap(); // sparse: slot 3 before slot 0
+    f.write_record(0, &vec![0xEE; rb]).unwrap();
+    let mut out = vec![0u8; rb];
+    f.read_record(3, &mut out).unwrap();
+    assert_eq!(out, pat, "record 3 byte-identical");
+    f.read_record(0, &mut out).unwrap();
+    assert_eq!(out, vec![0xEE; rb], "record 0 byte-identical");
+    // Size validation is a hard error, not a short IO.
+    assert!(f.write_record(1, &pat[..100]).is_err());
+    let mut short = vec![0u8; 100];
+    assert!(f.read_record(0, &mut short).is_err());
+    let _ = std::fs::remove_file(path);
+}
+
+/// End-to-end: the residency spills to a REAL O_DIRECT file and faults back
+/// byte-identical (the exact peer configuration, minus RDMA).
+#[test]
+fn residency_over_o_direct_swap_byte_identical() {
+    let rb = 4096usize;
+    let Some((f, path)) = o_direct_file(rb, "resid") else {
+        return;
+    };
+    let mut r = Residency::new(VecSlotArena::new(rb, 2), f).unwrap();
+    for k in 0..8u64 {
+        r.put_blob(k, &vec![k as u8; rb]).unwrap();
+    }
+    assert_eq!(r.total_keys(), 8);
+    assert!(
+        r.stats().spills_to_disk >= 6,
+        "cold keys spilled to the O_DIRECT file"
+    );
+    let mut out = vec![0u8; rb];
+    for k in 0..8u64 {
+        assert!(r.get_blob(k, &mut out).unwrap(), "key {k}");
+        assert_eq!(
+            out,
+            vec![k as u8; rb],
+            "key {k} byte-identical through O_DIRECT"
+        );
+    }
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/atlas-tier/tests/direct_swap.rs
+++ b/crates/atlas-tier/tests/direct_swap.rs
@@ -17,10 +17,23 @@ fn o_direct_file(record_bytes: usize, tag: &str) -> Option<(DirectSwapFile, std:
     match DirectSwapFile::create(&path, record_bytes) {
         Ok(f) => Some((f, path)),
         Err(e) => {
+            // Opt-in enforcement: CI on a real disk sets this so a silent skip
+            // can't green-light a run that never touched the O_DIRECT path.
+            if std::env::var_os("ATLAS_TIER_REQUIRE_O_DIRECT").is_some() {
+                panic!("ATLAS_TIER_REQUIRE_O_DIRECT set but O_DIRECT unavailable: {e:#}");
+            }
             eprintln!("skipping O_DIRECT test (filesystem refused O_DIRECT): {e:#}");
             None
         }
     }
+}
+
+/// A page-aligned (4 KiB) mutable sub-slice of `storage`, which must be
+/// over-allocated by at least 4096 bytes past `len`. Lets a test deterministically
+/// hit the O_DIRECT *aligned fast-path* (plain `Vec`s almost never are).
+fn page_aligned(storage: &mut [u8], len: usize) -> &mut [u8] {
+    let pad = (4096 - (storage.as_ptr() as usize & 0xfff)) & 0xfff;
+    &mut storage[pad..pad + len]
 }
 
 #[test]
@@ -90,6 +103,43 @@ fn residency_over_o_direct_swap_byte_identical() {
             vec![k as u8; rb],
             "key {k} byte-identical through O_DIRECT"
         );
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+/// Deterministically exercise the O_DIRECT *aligned fast-path* (the direct
+/// pwrite/pread, not the bounce staging): pass page-aligned buffers so
+/// `write_record`/`read_record` take the `is_aligned()` branch. The existing
+/// `Vec`-based tests almost always hit the bounce instead, so this is the only
+/// coverage of the zero-copy path the peer's mmap'd arena actually uses.
+#[test]
+fn direct_swap_aligned_fast_path_roundtrips() {
+    let rb = 4096usize;
+    let Some((mut f, path)) = o_direct_file(rb, "aligned") else {
+        return;
+    };
+    let mut wstore = vec![0u8; rb + 4096];
+    let w = page_aligned(&mut wstore, rb);
+    assert_eq!(
+        w.as_ptr() as usize & 0xfff,
+        0,
+        "write buffer is page-aligned → fast-path"
+    );
+    for (i, b) in w.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+    f.write_record(7, w).unwrap(); // aligned src → direct pwrite
+
+    let mut rstore = vec![0u8; rb + 4096];
+    let rbuf = page_aligned(&mut rstore, rb);
+    assert_eq!(
+        rbuf.as_ptr() as usize & 0xfff,
+        0,
+        "read buffer is page-aligned → fast-path"
+    );
+    f.read_record(7, rbuf).unwrap(); // aligned dst → direct pread
+    for (i, b) in rbuf.iter().enumerate() {
+        assert_eq!(*b, (i % 251) as u8, "aligned fast-path byte {i}");
     }
     let _ = std::fs::remove_file(path);
 }

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -302,3 +302,178 @@ fn boxed_trait_objects_compose() {
         assert_eq!(out, blob(k as u8));
     }
 }
+
+// ───────────────────── fault-injection: mid-op I/O failure rollbacks ─────────
+//
+// The reference impls never fail, so the trickiest invariant in the policy core
+// — that a blob-move (spill/fault/put) that errors HALFWAY leaves the page table
+// consistent — is otherwise untested. These fakes fail one operation on demand.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use anyhow::{Result, bail};
+
+/// `VecSlotArena` that fails the next `write_slot` when armed (via `arena_mut`).
+struct FaultyArena {
+    inner: VecSlotArena,
+    fail_next_write: bool,
+}
+impl FaultyArena {
+    fn new(slots: usize) -> Self {
+        Self {
+            inner: VecSlotArena::new(B, slots),
+            fail_next_write: false,
+        }
+    }
+}
+impl SlotArena for FaultyArena {
+    fn slot_bytes(&self) -> usize {
+        self.inner.slot_bytes()
+    }
+    fn num_slots(&self) -> usize {
+        self.inner.num_slots()
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        self.inner.read_slot(slot, out)
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        if self.fail_next_write {
+            self.fail_next_write = false;
+            bail!("injected write_slot failure");
+        }
+        self.inner.write_slot(slot, bytes)
+    }
+}
+
+/// Shared arm-once toggles for [`FaultySwap`] (the store is moved into the
+/// `Residency`, so the test keeps a clone to arm faults after construction).
+#[derive(Default)]
+struct SwapFaults {
+    fail_write: AtomicBool,
+    fail_read: AtomicBool,
+}
+struct FaultySwap {
+    inner: MemSwapStore,
+    faults: Arc<SwapFaults>,
+}
+impl FaultySwap {
+    fn new() -> (Self, Arc<SwapFaults>) {
+        let faults = Arc::new(SwapFaults::default());
+        (
+            Self {
+                inner: MemSwapStore::new(B),
+                faults: Arc::clone(&faults),
+            },
+            faults,
+        )
+    }
+}
+impl SwapStore for FaultySwap {
+    fn record_bytes(&self) -> usize {
+        self.inner.record_bytes()
+    }
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if self.faults.fail_write.swap(false, Ordering::SeqCst) {
+            bail!("injected write_record failure");
+        }
+        self.inner.write_record(disk_slot, bytes)
+    }
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        if self.faults.fail_read.swap(false, Ordering::SeqCst) {
+            bail!("injected read_record failure");
+        }
+        self.inner.read_record(disk_slot, out)
+    }
+    fn discard_record(&mut self, disk_slot: usize) {
+        self.inner.discard_record(disk_slot);
+    }
+}
+
+/// `put_blob` whose arena WRITE fails must roll the reservation back — the slot
+/// is reclaimed (not stranded `Reserved`), the key is absent (a GET misses
+/// cleanly), and prior keys survive.
+#[test]
+fn put_blob_rolls_back_reservation_on_arena_write_failure() {
+    let (swap, _f) = FaultySwap::new();
+    let mut r = Residency::new(FaultyArena::new(2), swap).unwrap();
+    r.put_blob(1, &blob(1)).unwrap();
+
+    r.arena_mut().fail_next_write = true;
+    assert!(r.put_blob(2, &blob(2)).is_err(), "write failure propagates");
+
+    let mut out = vec![0u8; B];
+    assert!(
+        !r.get_blob(2, &mut out).unwrap(),
+        "rolled-back key 2 misses cleanly (not a torn Reserved slot)"
+    );
+    assert_eq!(r.total_keys(), 1, "no stranded key-2 entry");
+    // The freed slot is reusable and key 1 is intact.
+    r.put_blob(3, &blob(3)).unwrap();
+    assert!(r.get_blob(1, &mut out).unwrap() && out == blob(1), "key 1 intact");
+    assert!(
+        r.get_blob(3, &mut out).unwrap() && out == blob(3),
+        "key 3 reuses the reclaimed slot"
+    );
+}
+
+/// A spill whose swap WRITE fails must roll back: the victim stays resident and
+/// intact, no spill is counted, and the disk-slot pool isn't leaked (a later
+/// successful spill reuses it).
+#[test]
+fn spill_rolls_back_on_swap_write_failure_victim_stays_resident() {
+    let (swap, faults) = FaultySwap::new();
+    let mut r = Residency::new(FaultyArena::new(1), swap).unwrap(); // 1 slot → new key evicts
+    r.put_blob(10, &blob(10)).unwrap();
+
+    faults.fail_write.store(true, Ordering::SeqCst);
+    assert!(
+        r.put_blob(11, &blob(11)).is_err(),
+        "spill write failure propagates"
+    );
+    assert_eq!(r.stats().spills_to_disk, 0, "failed spill is not counted");
+    assert_eq!(r.total_keys(), 1, "failed put left no key 11");
+
+    let mut out = vec![0u8; B];
+    assert!(
+        r.get_blob(10, &mut out).unwrap() && out == blob(10),
+        "victim 10 stayed resident and intact"
+    );
+    assert!(!r.get_blob(11, &mut out).unwrap(), "key 11 never landed");
+    // A subsequent spill succeeds — the disk-slot pool wasn't corrupted.
+    r.put_blob(12, &blob(12)).unwrap();
+    assert_eq!(r.stats().spills_to_disk, 1);
+    assert!(
+        r.get_blob(10, &mut out).unwrap() && out == blob(10),
+        "10 faults back from disk byte-identical"
+    );
+}
+
+/// A fault-in whose swap READ fails must leave the key `OnDisk` (re-pinned) and
+/// return its scratched slot — the error propagates but a retry succeeds, and a
+/// bystander key spilled during the failed fault's `acquire_slot` is intact.
+#[test]
+fn fault_in_read_failure_keeps_key_on_disk_and_frees_slot() {
+    let (swap, faults) = FaultySwap::new();
+    let mut r = Residency::new(FaultyArena::new(1), swap).unwrap();
+    r.put_blob(20, &blob(20)).unwrap();
+    r.put_blob(21, &blob(21)).unwrap(); // evicts 20 to disk
+    assert_eq!(r.stats().spills_to_disk, 1);
+
+    faults.fail_read.store(true, Ordering::SeqCst);
+    let mut out = vec![0u8; B];
+    assert!(
+        r.get_blob(20, &mut out).is_err(),
+        "fault-in read failure propagates"
+    );
+
+    // 20 is still OnDisk; a retry (fault auto-cleared) faults it in cleanly.
+    assert!(
+        r.get_blob(20, &mut out).unwrap() && out == blob(20),
+        "20 faults back on retry"
+    );
+    assert!(
+        r.get_blob(21, &mut out).unwrap() && out == blob(21),
+        "bystander 21 (spilled during the failed fault) is intact"
+    );
+}

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Public-API integration tests for the [`Residency`] policy core over the
+//! host-RAM reference impls ([`VecSlotArena`] + [`MemSwapStore`]), moved out
+//! of `src/lib.rs` per the repo's tests-in-their-own-file convention. Living
+//! here also pins the crate's public surface.
+
+use atlas_tier::{MemSwapStore, Residency, SlotArena, SwapStore, VecSlotArena};
+
+const B: usize = 8; // tiny blob for tests
+
+fn blob(tag: u8) -> Vec<u8> {
+    vec![tag; B]
+}
+
+/// Client-side helper: alloc → write bytes into the arena slot → commit.
+fn put(r: &mut Residency<VecSlotArena, MemSwapStore>, key: u64, tag: u8) {
+    let slot = r.alloc(key).unwrap();
+    r.arena_mut().write_slot(slot, &blob(tag)).unwrap();
+    r.commit(key).unwrap();
+}
+fn get(r: &mut Residency<VecSlotArena, MemSwapStore>, key: u64) -> Option<Vec<u8>> {
+    r.locate(key).unwrap().map(|slot| {
+        let mut out = vec![0u8; B];
+        r.arena().read_slot(slot, &mut out).unwrap();
+        out
+    })
+}
+
+fn residency(slots: usize) -> Residency<VecSlotArena, MemSwapStore> {
+    Residency::new(VecSlotArena::new(B, slots), MemSwapStore::new(B)).unwrap()
+}
+
+fn residency_capped(slots: usize, max_disk: usize) -> Residency<VecSlotArena, MemSwapStore> {
+    Residency::new_capped(VecSlotArena::new(B, slots), MemSwapStore::new(B), max_disk).unwrap()
+}
+
+/// Disk cap: the swap tier is BOUNDED — beyond RAM slots + `max_disk`, the
+/// COLDEST on-disk snapshot is dropped (a later GET misses → recompute), so
+/// the swap file never grows past the cap. This is the operator's 50 GB
+/// sanity limit at the paging layer.
+#[test]
+fn disk_cap_bounds_swap_and_drops_coldest() {
+    let mut r = residency_capped(2, 3); // 2 RAM + 3 disk = 5 total capacity
+    for k in 0..10u64 {
+        put(&mut r, k, k as u8);
+    }
+    assert!(
+        r.stats().disk_evictions >= 5,
+        "coldest disk snaps must be dropped at cap"
+    );
+    assert!(
+        r.total_keys() <= 2 + 3,
+        "total tracked keys bounded by RAM + disk cap"
+    );
+    // Coldest keys were dropped → clean miss (checked first: a miss doesn't
+    // perturb residency).
+    assert_eq!(
+        get(&mut r, 0),
+        None,
+        "oldest key evicted from the capped disk"
+    );
+    assert_eq!(get(&mut r, 1), None);
+    // The hottest keys survive (resident) and are byte-identical.
+    assert_eq!(get(&mut r, 9).as_deref(), Some(&blob(9)[..]));
+    assert_eq!(get(&mut r, 8).as_deref(), Some(&blob(8)[..]));
+}
+
+/// THE headline invariant: put far more keys than the arena holds; the
+/// coldest spill to the disk tier and fault back BYTE-IDENTICAL. "Infinite
+/// depth, never dropped" proven at the paging layer.
+#[test]
+fn infinite_depth_spill_and_fault_byte_identical() {
+    let mut r = residency(4); // 4 slots
+    for k in 0..64u64 {
+        put(&mut r, k, k as u8);
+    }
+    assert!(
+        r.stats().spills_to_disk >= 60,
+        "most keys must have spilled to disk"
+    );
+    assert_eq!(r.resident_count(), 4, "only 4 slots resident at once");
+    assert_eq!(r.total_keys(), 64, "all 64 keys tracked — nothing dropped");
+    // Every key faults back to its exact bytes.
+    for k in 0..64u64 {
+        assert_eq!(
+            get(&mut r, k).as_deref(),
+            Some(&blob(k as u8)[..]),
+            "key {k}"
+        );
+    }
+    assert!(r.stats().faults_from_disk > 0);
+}
+
+/// THE eviction-pin guarantee (WS-A GET→RDMA-read race): a read-pinned key
+/// is never chosen as an eviction victim, even when it is the LRU-coldest —
+/// a concurrent ALLOC spills the next-coldest UNPINNED key instead, so the
+/// client's in-flight one-sided RDMA READ is never torn by slot reuse.
+#[test]
+fn read_pin_survives_concurrent_eviction() {
+    let mut r = residency(2);
+    put(&mut r, 0, 0); // resident: [0] (coldest)
+    put(&mut r, 1, 1); // resident: [0,1]
+    // Client A GETs key 0 (the coldest) and begins its RDMA read → pin it.
+    assert!(r.locate(0).unwrap().is_some());
+    r.pin_read(0);
+    assert_eq!(r.read_pin_count(0), 1);
+    let faults_before = r.stats().faults_from_disk;
+
+    // Client B ALLOCs a new key → arena full → must evict. Key 0 is coldest
+    // but pinned, so key 1 is spilled instead.
+    put(&mut r, 2, 2);
+    assert_eq!(r.stats().spills_to_disk, 1, "exactly one eviction");
+    assert_eq!(
+        get(&mut r, 1),
+        Some(blob(1)),
+        "the UNPINNED key 1 was the victim"
+    );
+    // Key 0 is still resident (byte-intact) and never touched disk.
+    assert_eq!(
+        get(&mut r, 0),
+        Some(blob(0)),
+        "pinned key 0 survived intact"
+    );
+    assert_eq!(
+        r.stats().faults_from_disk,
+        faults_before + 1,
+        "only key 1 faulted back; key 0 never spilled"
+    );
+}
+
+/// Ref-counted: concurrent readers each add a pin; the key stays protected
+/// until the LAST reader releases, then rejoins the LRU (no double-insert).
+#[test]
+fn refcounted_read_pins_release_to_evictable() {
+    let mut r = residency(2);
+    put(&mut r, 0, 0);
+    put(&mut r, 1, 1);
+    r.pin_read(0);
+    r.pin_read(0); // second concurrent reader of key 0
+    assert_eq!(r.read_pin_count(0), 2);
+    r.unpin_read(0);
+    assert_eq!(r.read_pin_count(0), 1, "still one reader → still pinned");
+    // Force an eviction: key 0 is still protected → key 1 spills.
+    put(&mut r, 2, 2);
+    assert_eq!(
+        get(&mut r, 1),
+        Some(blob(1)),
+        "key 1 evicted while key 0 still pinned"
+    );
+    // Last reader releases → key 0 rejoins the LRU exactly once and is now
+    // an eligible victim again.
+    r.unpin_read(0);
+    assert_eq!(r.read_pin_count(0), 0);
+    assert_eq!(
+        r.resident_count(),
+        2,
+        "keys 0 and 2 resident; no LRU double-insert"
+    );
+    put(&mut r, 3, 3); // evicts the now-unpinned coldest (key 0)
+    put(&mut r, 4, 4);
+    assert_eq!(
+        get(&mut r, 0),
+        Some(blob(0)),
+        "unpinned key 0 spilled+faulted byte-identical"
+    );
+}
+
+#[test]
+fn resident_hit_does_not_touch_disk() {
+    let mut r = residency(4);
+    for k in 0..3u64 {
+        put(&mut r, k, k as u8);
+    }
+    let spills_before = r.stats().spills_to_disk;
+    assert_eq!(get(&mut r, 1), Some(blob(1)));
+    assert_eq!(
+        r.stats().spills_to_disk,
+        spills_before,
+        "resident hit spills nothing"
+    );
+    assert!(r.stats().resident_hits >= 1);
+}
+
+#[test]
+fn lru_evicts_coldest_first() {
+    let mut r = residency(2);
+    put(&mut r, 10, 10); // resident: [10]
+    put(&mut r, 11, 11); // resident: [10,11]
+    get(&mut r, 10); // touch 10 → [11,10]; 11 now coldest
+    put(&mut r, 12, 12); // arena full → evict coldest (11) to disk
+    // 11 must be on disk, 10 & 12 resident.
+    assert_eq!(get(&mut r, 11), Some(blob(11))); // faults back correctly
+    assert!(r.stats().faults_from_disk >= 1);
+}
+
+#[test]
+fn overwrite_in_place_reuses_slot_no_leak() {
+    let mut r = residency(2);
+    put(&mut r, 5, 100);
+    put(&mut r, 5, 200); // rewrite same key
+    assert_eq!(get(&mut r, 5), Some(blob(200)));
+    assert_eq!(r.total_keys(), 1, "no phantom duplicate");
+    assert_eq!(r.resident_count(), 1);
+}
+
+#[test]
+fn overwrite_spilled_key_reclaims_disk() {
+    let mut r = residency(1); // force spilling
+    put(&mut r, 1, 1);
+    put(&mut r, 2, 2); // spills key 1 to disk
+    put(&mut r, 1, 99); // rewrite the SPILLED key 1
+    assert_eq!(get(&mut r, 1), Some(blob(99)));
+    assert_eq!(get(&mut r, 2), Some(blob(2)));
+}
+
+#[test]
+fn remove_frees_resources() {
+    let mut r = residency(2);
+    put(&mut r, 1, 1);
+    put(&mut r, 2, 2);
+    put(&mut r, 3, 3); // 1 spills to disk
+    r.remove(1); // remove a spilled key
+    r.remove(2); // remove a resident key
+    assert_eq!(get(&mut r, 1), None, "removed key is a clean miss");
+    assert_eq!(get(&mut r, 2), None);
+    assert_eq!(get(&mut r, 3), Some(blob(3)));
+    assert_eq!(r.total_keys(), 1);
+}
+
+#[test]
+fn unknown_key_is_clean_miss() {
+    let mut r = residency(2);
+    assert_eq!(r.locate(0xdead).unwrap(), None);
+    assert_eq!(r.stats().get_miss, 1);
+}
+
+#[test]
+fn reserved_slot_pinned_during_put() {
+    // A slot handed out by alloc must not be evictable before commit.
+    let mut r = residency(1);
+    let slot = r.alloc(1).unwrap();
+    // Second alloc with the only slot reserved-and-uncommitted must error,
+    // not silently evict the in-flight PUT.
+    let err = r.alloc(2);
+    assert!(err.is_err(), "must not evict an uncommitted reserved slot");
+    // Finish the first PUT and it all works.
+    r.arena_mut().write_slot(slot, &blob(1)).unwrap();
+    r.commit(1).unwrap();
+    assert_eq!(get(&mut r, 1), Some(blob(1)));
+}
+
+#[test]
+fn size_mismatch_rejected() {
+    let bad = Residency::new(VecSlotArena::new(8, 2), MemSwapStore::new(16));
+    assert!(
+        bad.is_err(),
+        "arena/swap size mismatch must be rejected at construction"
+    );
+}
+
+// ───────────── one-shot helpers + boxed composition ─────────────
+
+/// `put_blob`/`get_blob` never reject and round-trip bytes exactly like the
+/// two-phase alloc/commit path (the in-process consumer contract).
+#[test]
+fn put_get_blob_helpers_never_reject_and_roundtrip() {
+    let mut r = residency(2);
+    for k in 0..32u64 {
+        r.put_blob(k, &blob(k as u8)).unwrap();
+    }
+    assert_eq!(r.total_keys(), 32, "never-reject: every key tracked");
+    assert_eq!(r.resident_count(), 2);
+    let mut out = vec![0u8; B];
+    for k in 0..32u64 {
+        assert!(r.get_blob(k, &mut out).unwrap(), "key {k} present");
+        assert_eq!(out, blob(k as u8), "key {k} byte-identical");
+    }
+    assert!(
+        !r.get_blob(999, &mut out).unwrap(),
+        "unknown key is a clean miss"
+    );
+    // Size mismatches are hard errors, never silent corruption.
+    assert!(r.put_blob(1, &[0u8; B + 1]).is_err());
+    let mut short = vec![0u8; B - 1];
+    assert!(r.get_blob(1, &mut short).is_err());
+}
+
+/// `Residency<Box<dyn SlotArena>, Box<dyn SwapStore>>` composes (runtime
+/// arena/swap selection — what the unified SSM store uses).
+#[test]
+fn boxed_trait_objects_compose() {
+    let arena: Box<dyn SlotArena> = Box::new(VecSlotArena::new(B, 2));
+    let swap: Box<dyn SwapStore> = Box::new(MemSwapStore::new(B));
+    let mut r = Residency::new(arena, swap).unwrap();
+    for k in 0..16u64 {
+        r.put_blob(k, &blob(k as u8)).unwrap();
+    }
+    let mut out = vec![0u8; B];
+    for k in 0..16u64 {
+        assert!(r.get_blob(k, &mut out).unwrap());
+        assert_eq!(out, blob(k as u8));
+    }
+}

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -94,7 +94,7 @@ fn infinite_depth_spill_and_fault_byte_identical() {
 
 /// THE eviction-pin guarantee (WS-A GET→RDMA-read race): a read-pinned key
 /// is never chosen as an eviction victim, even when it is the LRU-coldest —
-/// a concurrent ALLOC spills the next-coldest UNPINNED key instead, so the
+/// a concurrent allocation spills the next-coldest unpinned key instead, so the
 /// client's in-flight one-sided RDMA READ is never torn by slot reuse.
 #[test]
 fn read_pin_survives_concurrent_eviction() {
@@ -107,7 +107,7 @@ fn read_pin_survives_concurrent_eviction() {
     assert_eq!(r.read_pin_count(0), 1);
     let faults_before = r.stats().faults_from_disk;
 
-    // Client B ALLOCs a new key → arena full → must evict. Key 0 is coldest
+    // Client B allocates a new key → arena full → must evict. Key 0 is coldest
     // but pinned, so key 1 is spilled instead.
     put(&mut r, 2, 2);
     assert_eq!(r.stats().spills_to_disk, 1, "exactly one eviction");

--- a/crates/atlas-tier/tests/residency.rs
+++ b/crates/atlas-tier/tests/residency.rs
@@ -410,7 +410,10 @@ fn put_blob_rolls_back_reservation_on_arena_write_failure() {
     assert_eq!(r.total_keys(), 1, "no stranded key-2 entry");
     // The freed slot is reusable and key 1 is intact.
     r.put_blob(3, &blob(3)).unwrap();
-    assert!(r.get_blob(1, &mut out).unwrap() && out == blob(1), "key 1 intact");
+    assert!(
+        r.get_blob(1, &mut out).unwrap() && out == blob(1),
+        "key 1 intact"
+    );
     assert!(
         r.get_blob(3, &mut out).unwrap() && out == blob(3),
         "key 3 reuses the reclaimed slot"

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -36,6 +36,7 @@ gpu-examples = []
 [dependencies]
 atlas-core = { workspace = true }
 atlas-kernels = { workspace = true }
+atlas-tier = { workspace = true }
 # `default-features = false` so the metal feature can opt out of
 # spark-runtime's `cuda` default — otherwise the dep line silently
 # re-enables cudarc on every build.

--- a/crates/spark-model/src/engine/tests.rs
+++ b/crates/spark-model/src/engine/tests.rs
@@ -142,6 +142,7 @@ impl Model for MockModel {
 
     fn alloc_sequence(&self) -> Result<SequenceState> {
         Ok(SequenceState {
+            adapter_id: 0,
             tokens: Vec::new(),
             block_table: Vec::new(),
             seq_len: 0,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -147,6 +147,11 @@ impl TransformerModel {
             gpu.as_ref(),
         )?);
 
+        // Fail fast if an SSM tier was requested (`ATLAS_SSM_TIER`) on a model
+        // with no recurrent state — a tier request there was previously a
+        // silent no-op. No-op when the tier is unset (default path).
+        super::ssm_tier::ensure_ssm_tier_capability(&config)?;
+
         // SSM snapshot pool: Marconi prefix-cache slots + Phase-C
         // decode-rollback ring. The decode-rollback region is only sized
         // for SSM models — `num_ssm_layers == 0` makes both regions
@@ -173,6 +178,13 @@ impl TransformerModel {
             // without re-running the last token through the SSM layers.
             config.hidden_size * 2,
             gpu.as_ref(),
+        )?;
+        // Optional SSM snapshot spill tier. `None` (default) keeps the reclaim
+        // drop path byte-identical; blob sizing tracks the pool's spill layout.
+        let ssm_tier_store = super::impl_a1_init::build_ssm_tier_store(
+            &config,
+            ssm_snapshots.spill_blob_bytes(),
+            ssm_pool.num_ssm_layers,
         )?;
         if ssm_checkpoint_interval > 0 && ssm_cache_slots > 0 {
             tracing::info!(
@@ -466,6 +478,7 @@ impl TransformerModel {
             ),
             ssm_pool,
             ssm_snapshots,
+            ssm_tier_store,
             max_blocks_per_seq,
             dummy_kv_block,
             profile,

--- a/crates/spark-model/src/model/impl_a1_init.rs
+++ b/crates/spark-model/src/model/impl_a1_init.rs
@@ -149,3 +149,24 @@ pub(super) fn build_mtp_proposer(
         }
     }
 }
+
+/// Build the optional SSM snapshot spill tier for `TransformerModel::new`,
+/// hoisted 1:1 to keep `impl_a1.rs` under the 500-LoC cap. Returns `None`
+/// (the byte-identical default) unless `ATLAS_SSM_TIER` is set on a recurrent
+/// model; otherwise selects the env-driven backend keyed by the model
+/// fingerprint (so different models sharing one peer can't collide).
+///
+/// `blob_bytes` MUST be `SsmSnapshotPool::spill_blob_bytes()` so the tier's
+/// fixed blob sizing matches the spill/fault-in gathers.
+pub(super) fn build_ssm_tier_store(
+    config: &ModelConfig,
+    blob_bytes: usize,
+    num_ssm_layers: usize,
+) -> Result<Option<Arc<dyn super::ssm_tier::SnapshotBlobStore>>> {
+    if super::ssm_tier::ssm_tier_enabled() && num_ssm_layers > 0 {
+        let fp = super::ssm_tier::ModelFingerprint::derive(config, blob_bytes)?;
+        Ok(Some(super::ssm_tier::build_tier_store(fp, blob_bytes)?))
+    } else {
+        Ok(None)
+    }
+}

--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod impl_b2;
 pub(crate) mod impl_b3;
 pub(crate) mod ssm_pool;
 pub(crate) mod ssm_snapshot;
+pub(crate) mod ssm_snapshot_spill;
 pub(crate) mod ssm_tier;
 pub(crate) mod trait_impl;
 pub(crate) mod types;

--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod impl_b2;
 pub(crate) mod impl_b3;
 pub(crate) mod ssm_pool;
 pub(crate) mod ssm_snapshot;
+pub(crate) mod ssm_tier;
 pub(crate) mod trait_impl;
 pub(crate) mod types;
 

--- a/crates/spark-model/src/model/ssm_snapshot.rs
+++ b/crates/spark-model/src/model/ssm_snapshot.rs
@@ -416,19 +416,8 @@ impl SsmSnapshotPool {
         Ok(())
     }
 
-    /// Try to reclaim a snapshot slot by evicting the LRU snapshot from the
-    /// prefix cache's snapshot index. Snapshots are decoupled from tree nodes,
-    /// so this directly frees a snapshot without needing to evict KV blocks.
-    pub(super) fn reclaim_from_cache(
-        &self,
-        prefix_cache: &dyn spark_runtime::prefix_cache::PrefixCache,
-        _kv_cache: &mut PagedKvCache,
-    ) -> bool {
-        if let Some(snap) = prefix_cache.evict_snapshot_lru() {
-            self.free(snap);
-            true
-        } else {
-            false
-        }
-    }
+    // `reclaim_from_cache` (spill-or-drop) and the Phase-1 spill/fault-in
+    // primitives live in the sibling `ssm_snapshot_spill` module to keep this
+    // file under the 500-LoC cap. They are a second `impl SsmSnapshotPool`
+    // block over the same fields.
 }

--- a/crates/spark-model/src/model/ssm_snapshot_spill.rs
+++ b/crates/spark-model/src/model/ssm_snapshot_spill.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// The `#![allow]` on `ssm_snapshot.rs` does not cross into this sibling module
+// file. `tag_session`/`try_pop_free_slot`/`acquire_or_spill_slot`/`fault_in_slot`
+// have no non-test caller until the Phase-1b fault-in serving wiring (a later
+// PR), so they are dead here — exercised only by `ssm_snapshot_spill_tests`.
+#![allow(unused_imports, dead_code)]
+
+use anyhow::Result;
+use spark_runtime::gpu::GpuBackend;
+use spark_runtime::kv_cache::PagedKvCache;
+
+use super::ssm_snapshot::SsmSnapshotPool;
+
+/// Phase-1 snapshot **spill** (spill-not-drop) and fault-in primitives, plus the
+/// tier-aware [`reclaim_from_cache`](SsmSnapshotPool::reclaim_from_cache). Split
+/// out of `ssm_snapshot.rs` (500-LoC cap) as a second impl block over the same
+/// fields; default-off (`tier == None`) keeps every path byte-identical.
+impl SsmSnapshotPool {
+    /// Tag Marconi slot `snap_slot` as owned by `session_hash` (0 ⇒ untagged).
+    pub(super) fn tag_session(&self, snap_slot: usize, session_hash: u64) {
+        if session_hash != 0 {
+            self.session_tags.lock().insert(snap_slot, session_hash);
+        }
+    }
+
+    /// Claim an immediately-free Marconi slot (no eviction). `None` when the
+    /// pool is full. The claimed slot must be `free`d if the caller doesn't use
+    /// it (e.g. a fault-in miss).
+    pub(super) fn try_pop_free_slot(&self) -> Option<usize> {
+        if !self.is_enabled() {
+            return None;
+        }
+        self.free_slots.lock().pop()
+    }
+
+    /// Acquire a Marconi slot for a **fault-in target** (Phase 1b), spilling a
+    /// resident victim to make room when the pool is full. Under a small pool +
+    /// heavy churn the free list is usually empty at warm-turn lookup time, so
+    /// without this the fault-in silently degrades to recompute (measured: only
+    /// 13 of 43 tiered hits completed a fault-in at `--ssm-cache-slots 4`).
+    ///
+    /// Order: pop a free slot; else spill the session-aware victim
+    /// (`evict_snapshot_to_tier` keeps its entry findable → still faultable
+    /// later) to free its slot, then pop that. The victim is always a RESIDENT
+    /// entry (`skip_tiered`), never the tiered entry we're about to fault in.
+    /// `None` only if nothing is resident to evict (every slot mid-flight).
+    pub(super) fn acquire_or_spill_slot(
+        &self,
+        prefix_cache: &dyn spark_runtime::prefix_cache::PrefixCache,
+        store: &dyn super::ssm_tier::SnapshotBlobStore,
+        gpu: &dyn GpuBackend,
+    ) -> Option<usize> {
+        if let Some(s) = self.try_pop_free_slot() {
+            return Some(s);
+        }
+        let (victim_slot, key) = prefix_cache.evict_snapshot_to_tier()?;
+        let stream = gpu.default_stream();
+        if let Err(e) = self.spill_slot(victim_slot, key, store, gpu, stream) {
+            tracing::warn!("SSM spill during fault-in acquire failed ({e:#}); freeing slot anyway");
+        }
+        self.free(victim_slot);
+        self.try_pop_free_slot()
+    }
+
+    /// Bytes in one slot's full spill blob: every SSM layer's `h` + `conv`
+    /// state, laid out `[h_0 conv_0 h_1 conv_1 … h_{L-1} conv_{L-1}]`.
+    pub(super) fn spill_blob_bytes(&self) -> usize {
+        self.num_ssm_layers * (self.h_bytes + self.conv_bytes)
+    }
+
+    /// **Spill** Marconi slot `snap_slot` to the byte tier (Phase 1,
+    /// spill-not-drop): gather the slot's scattered per-layer `(h,conv)` device
+    /// chunks D2H into one host blob and `put` it under `key` (the snapshot's
+    /// prefix hash). Returns whether the tier accepted the blob — `false` (tier
+    /// full / disabled pool) means the caller should fall back to a plain drop.
+    ///
+    /// Ordering: a single `synchronize(stream)` first drains any in-flight D2D
+    /// `save` into this slot (which the caller enqueued on `stream`) before the
+    /// D2H read, so we never spill a half-written snapshot — the read-direction
+    /// half of the cross-stream hazard the plan flags. (The caller still owns
+    /// ordering the *slot reuse* after this spill; see Phase 1b.)
+    pub(super) fn spill_slot(
+        &self,
+        snap_slot: usize,
+        key: u64,
+        store: &dyn super::ssm_tier::SnapshotBlobStore,
+        gpu: &dyn GpuBackend,
+        stream: u64,
+    ) -> Result<bool> {
+        if !self.is_enabled() {
+            return Ok(false);
+        }
+        let timing = std::env::var_os("ATLAS_SSM_TIER_TIMING").is_some();
+        let t0 = std::time::Instant::now();
+        gpu.synchronize(stream)?; // drain the pending save into this slot
+        let mut blob = vec![0u8; self.spill_blob_bytes()];
+        let per_layer = self.h_bytes + self.conv_bytes;
+        for i in 0..self.num_ssm_layers {
+            let off = i * per_layer;
+            gpu.copy_d2h(
+                self.h_snapshots[i].offset(snap_slot * self.h_bytes),
+                &mut blob[off..off + self.h_bytes],
+            )?;
+            gpu.copy_d2h(
+                self.conv_snapshots[i].offset(snap_slot * self.conv_bytes),
+                &mut blob[off + self.h_bytes..off + per_layer],
+            )?;
+        }
+        let t_put = std::time::Instant::now();
+        let r = store.put(key, &blob)?;
+        if timing {
+            tracing::info!(
+                "SSM spill: {} B  gather+sync={}us  store.put={}us  total={}us",
+                blob.len(),
+                t_put.duration_since(t0).as_micros(),
+                t_put.elapsed().as_micros(),
+                t0.elapsed().as_micros(),
+            );
+        }
+        Ok(r)
+    }
+
+    /// **Fault in** a spilled snapshot for `key` into Marconi slot `snap_slot`:
+    /// fetch the host blob and scatter it H2D back into the slot's per-layer
+    /// `(h,conv)` chunks. Returns `false` if the tier has no blob for `key`
+    /// (caller recomputes) — the correct miss degradation.
+    ///
+    /// A trailing `synchronize(stream)` guarantees the H2D scatter has
+    /// committed before the caller issues a `restore` (D2D slot→main pool) that
+    /// reads this slot — the write-direction half of the ordering hazard.
+    pub(super) fn fault_in_slot(
+        &self,
+        snap_slot: usize,
+        key: u64,
+        store: &dyn super::ssm_tier::SnapshotBlobStore,
+        gpu: &dyn GpuBackend,
+        stream: u64,
+    ) -> Result<bool> {
+        if !self.is_enabled() {
+            return Ok(false);
+        }
+        let timing = std::env::var_os("ATLAS_SSM_TIER_TIMING").is_some();
+        let t0 = std::time::Instant::now();
+        let mut blob = vec![0u8; self.spill_blob_bytes()];
+        let hit = store.get(key, &mut blob)?;
+        let get_us = t0.elapsed().as_micros();
+        if !hit {
+            return Ok(false);
+        }
+        let per_layer = self.h_bytes + self.conv_bytes;
+        for i in 0..self.num_ssm_layers {
+            let off = i * per_layer;
+            gpu.copy_h2d_async(
+                &blob[off..off + self.h_bytes],
+                self.h_snapshots[i].offset(snap_slot * self.h_bytes),
+                stream,
+            )?;
+            gpu.copy_h2d_async(
+                &blob[off + self.h_bytes..off + per_layer],
+                self.conv_snapshots[i].offset(snap_slot * self.conv_bytes),
+                stream,
+            )?;
+        }
+        gpu.synchronize(stream)?; // commit before caller's restore reads the slot
+        if timing {
+            tracing::info!(
+                "SSM fault-in: {} B  store.get(RDMA read)={}us  scatter+sync={}us  total={}us",
+                blob.len(),
+                get_us,
+                t0.elapsed().as_micros() - get_us,
+                t0.elapsed().as_micros(),
+            );
+        }
+        Ok(true)
+    }
+
+    /// Try to reclaim a snapshot slot by evicting a snapshot from the prefix
+    /// cache's snapshot index. Snapshots are decoupled from tree nodes, so this
+    /// directly frees a slot without evicting KV blocks.
+    ///
+    /// Phase 1b: when `tier` is `Some` (`ATLAS_SSM_TIER`), the victim is
+    /// **spilled** — its bytes moved to the tier and its index entry kept
+    /// (findable), so a warm turn faults it back instead of recomputing — before
+    /// the slot is freed for reuse. When `tier` is `None` the victim is dropped
+    /// exactly as before (byte-identical default path). Returns whether a slot
+    /// was reclaimed.
+    pub(super) fn reclaim_from_cache(
+        &self,
+        prefix_cache: &dyn spark_runtime::prefix_cache::PrefixCache,
+        _kv_cache: &mut PagedKvCache,
+        tier: Option<&dyn super::ssm_tier::SnapshotBlobStore>,
+        gpu: &dyn GpuBackend,
+    ) -> bool {
+        if let Some(store) = tier {
+            // Spill-not-drop. Marconi saves are enqueued on the default stream,
+            // so draining it inside `spill_slot` guarantees we never D2H a
+            // half-written victim slot (the read half of the ordering hazard).
+            if let Some((slot, key)) = prefix_cache.evict_snapshot_to_tier() {
+                let stream = gpu.default_stream();
+                match self.spill_slot(slot, key, store, gpu, stream) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        // Unbounded tier never rejects; a bounded one could. The
+                        // entry is now marked tiered but holds no bytes → a later
+                        // fault-in cleanly misses (recompute). Bounded-tier
+                        // drop-on-reject is a follow-up.
+                        tracing::warn!(
+                            "SSM spill tier refused a blob; entry will miss on fault-in"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("SSM spill failed ({e:#}); freeing slot, entry will miss");
+                    }
+                }
+                self.free(slot); // slot reusable regardless; bytes are (or aren't) in the tier
+                return true;
+            }
+            return false;
+        }
+        if let Some(snap) = prefix_cache.evict_snapshot_lru() {
+            self.free(snap);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "ssm_snapshot_spill_tests.rs"]
+mod tier_tests;

--- a/crates/spark-model/src/model/ssm_snapshot_spill_tests.rs
+++ b/crates/spark-model/src/model/ssm_snapshot_spill_tests.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Unit tests for the Phase-1 SSM snapshot spill/fault-in primitives. Exercise
+// spill_slot / fault_in_slot / spill_blob_bytes / acquire_or_spill_slot against
+// a `MockGpuBackend` + host-RAM `MemBlobStore`, so the otherwise-dead fault-in
+// primitives get coverage before the Phase-1b serving wiring lands.
+
+use super::*;
+use crate::model::ssm_tier::{MemBlobStore, SnapshotBlobStore};
+use spark_runtime::gpu::mock::MockGpuBackend;
+
+/// Build a small Marconi-only pool (no decode-rollback region).
+fn pool(gpu: &dyn GpuBackend, slots: usize, layers: usize) -> SsmSnapshotPool {
+    SsmSnapshotPool::new(
+        slots, /*h_bytes*/ 32, /*conv_bytes*/ 16, layers, /*decode_ring*/ 0,
+        /*decode_max_seqs*/ 0, /*hidden_bytes*/ 8, gpu,
+    )
+    .unwrap()
+}
+
+/// Fill slot `s`'s per-layer (h,conv) device chunks with a pattern unique
+/// per (layer, field) so a mis-scatter would be caught.
+fn write_pattern(p: &SsmSnapshotPool, gpu: &dyn GpuBackend, s: usize) {
+    for i in 0..p.num_ssm_layers {
+        let h = vec![(0x10 + i) as u8; p.h_bytes];
+        let c = vec![(0x80 + i) as u8; p.conv_bytes];
+        gpu.copy_h2d(&h, p.h_snapshots[i].offset(s * p.h_bytes))
+            .unwrap();
+        gpu.copy_h2d(&c, p.conv_snapshots[i].offset(s * p.conv_bytes))
+            .unwrap();
+    }
+}
+
+fn read_slot(p: &SsmSnapshotPool, gpu: &dyn GpuBackend, s: usize) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    let mut hs = Vec::new();
+    let mut cs = Vec::new();
+    for i in 0..p.num_ssm_layers {
+        let mut h = vec![0u8; p.h_bytes];
+        let mut c = vec![0u8; p.conv_bytes];
+        gpu.copy_d2h(p.h_snapshots[i].offset(s * p.h_bytes), &mut h)
+            .unwrap();
+        gpu.copy_d2h(p.conv_snapshots[i].offset(s * p.conv_bytes), &mut c)
+            .unwrap();
+        hs.push(h);
+        cs.push(c);
+    }
+    (hs, cs)
+}
+
+/// The headline invariant: spill a slot's scattered state to the tier, then
+/// fault it back into a DIFFERENT slot — the recurrent state is bit-for-bit
+/// preserved. This is "spill-not-drop" proven end-to-end at the pool layer.
+#[test]
+fn spill_then_fault_in_preserves_bytes() {
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu, /*slots*/ 4, /*layers*/ 3);
+    let store = MemBlobStore::new(0);
+    let key = 0xABCD_1234;
+
+    write_pattern(&p, &gpu, /*src*/ 1);
+    let want = read_slot(&p, &gpu, 1);
+
+    assert!(p.spill_slot(1, key, &store, &gpu, 0).unwrap());
+    assert_eq!(store.len(), 1);
+    assert_eq!(store.bytes_resident(), p.spill_blob_bytes());
+
+    // Fault into slot 2 (which is still zeroed) and compare to slot 1.
+    assert!(p.fault_in_slot(2, key, &store, &gpu, 0).unwrap());
+    let got = read_slot(&p, &gpu, 2);
+    assert_eq!(
+        got, want,
+        "faulted-in slot must equal the spilled slot bit-for-bit"
+    );
+}
+
+/// Faulting an absent key is a clean miss (caller recomputes), not an error.
+#[test]
+fn fault_in_absent_key_is_miss() {
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu, 4, 2);
+    let store = MemBlobStore::new(0);
+    assert!(!p.fault_in_slot(0, /*absent*/ 999, &store, &gpu, 0).unwrap());
+}
+
+/// Blob size accounts for every layer's h+conv.
+#[test]
+fn spill_blob_bytes_matches_layout() {
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu, 2, 5);
+    assert_eq!(p.spill_blob_bytes(), 5 * (32 + 16));
+}
+
+/// Full-pool fault-in: when no slot is free, `acquire_or_spill_slot` spills a
+/// resident victim (to the tier, keeping it faultable) and hands back its
+/// freed slot — so a warm tiered hit isn't lost to a busy pool.
+#[test]
+fn acquire_or_spill_frees_a_slot_under_full_pool() {
+    use spark_runtime::prefix_cache::PrefixCache;
+    use spark_runtime::radix_tree::RadixTree;
+
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu, /*slots*/ 2, /*layers*/ 2);
+    let store = MemBlobStore::new(0);
+    let tree = RadixTree::new();
+
+    // Register two resident snapshots (slots 0 and 1) for two prefixes, then
+    // drain the free list so the pool is full.
+    let toks_a: Vec<u32> = (0..16).collect();
+    let toks_b: Vec<u32> = (100..116).collect();
+    tree.insert_with_snapshot(
+        &toks_a,
+        &[10],
+        &[],
+        16,
+        /*slot*/ 0,
+        /*sess*/ 7,
+        0,
+        0,
+    );
+    tree.insert_with_snapshot(
+        &toks_b,
+        &[20],
+        &[],
+        16,
+        /*slot*/ 1,
+        /*sess*/ 9,
+        0,
+        0,
+    );
+    assert!(p.try_pop_free_slot().is_some());
+    assert!(p.try_pop_free_slot().is_some());
+    assert_eq!(p.try_pop_free_slot(), None, "pool is now full");
+
+    // Acquire must spill a victim and return its slot.
+    let slot = p
+        .acquire_or_spill_slot(&tree, &store, &gpu)
+        .expect("a resident victim exists to spill");
+    assert!(slot == 0 || slot == 1);
+    assert_eq!(
+        store.len(),
+        1,
+        "the evicted victim was spilled, not dropped"
+    );
+    // The other snapshot stays resident (drop path can still free it).
+    assert!(tree.evict_snapshot_lru().is_some());
+}
+
+/// The integration invariant: the tier is keyed by prefix, INDEPENDENT of
+/// HBM slot lifecycle. Spill snapshot A from slot 0, recycle slot 0 for a
+/// different snapshot B, spill B under its own key, then fault BOTH back —
+/// each must recover its own bytes. This is exactly what the Phase-1b
+/// serving wiring creates: `evict_to_tier` frees a slot that `save` then
+/// reuses, and a later warm turn faults the spilled key into a fresh slot.
+#[test]
+fn tier_survives_slot_recycling() {
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu, /*slots*/ 3, /*layers*/ 2);
+    let store = MemBlobStore::new(0);
+    let (key_a, key_b) = (0xAAAA, 0xBBBB);
+
+    // Snapshot A lives in slot 0; spill it.
+    write_pattern(&p, &gpu, 0);
+    let want_a = read_slot(&p, &gpu, 0);
+    assert!(p.spill_slot(0, key_a, &store, &gpu, 0).unwrap());
+
+    // Recycle slot 0 for a DIFFERENT snapshot B (distinct bytes), spill it.
+    for i in 0..p.num_ssm_layers {
+        let h = vec![0xEE; p.h_bytes];
+        let c = vec![0xDD; p.conv_bytes];
+        gpu.copy_h2d(&h, p.h_snapshots[i].offset(0)).unwrap();
+        gpu.copy_h2d(&c, p.conv_snapshots[i].offset(0)).unwrap();
+    }
+    let want_b = read_slot(&p, &gpu, 0);
+    assert_ne!(want_a, want_b, "B must differ from A for the test to bite");
+    assert!(p.spill_slot(0, key_b, &store, &gpu, 0).unwrap());
+    assert_eq!(store.len(), 2);
+
+    // Fault each key into fresh slots — bytes recovered independently.
+    assert!(p.fault_in_slot(1, key_a, &store, &gpu, 0).unwrap());
+    assert!(p.fault_in_slot(2, key_b, &store, &gpu, 0).unwrap());
+    assert_eq!(
+        read_slot(&p, &gpu, 1),
+        want_a,
+        "key A recovered after slot recycle"
+    );
+    assert_eq!(read_slot(&p, &gpu, 2), want_b, "key B recovered");
+}

--- a/crates/spark-model/src/model/ssm_tier.rs
+++ b/crates/spark-model/src/model/ssm_tier.rs
@@ -9,8 +9,10 @@
 //!   [`ArenaSnapshotStore`]/[`PagingSnapshotStore`] over a [`SnapshotTransport`]/
 //!   [`PagingTransport`], proven on [`MockSnapshotTransport`]/[`FileSnapshotArena`]).
 //!   The env-driven store selection ([`build_tier_store`] / [`build_decode_tier_store`],
-//!   gated by `ATLAS_SSM_TIER`) picks a local backend here; the RDMA transport
-//!   binding and its peer arms land in a follow-up PR.
+//!   gated by `ATLAS_SSM_TIER`) picks a backend. The RDMA/peer arms bind to
+//!   `spark_storage::RdmaSnapshotArena` — a `connect`-always-errors stub today
+//!   (so a requested RDMA tier degrades to host-RAM), whose real verbs data path
+//!   lands with the SSM-snapshot spill wiring in a follow-up PR.
 
 mod arena_store;
 mod capability;

--- a/crates/spark-model/src/model/ssm_tier.rs
+++ b/crates/spark-model/src/model/ssm_tier.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Model-safety contract for the SSM snapshot tiers: the stable, model-agnostic
+//! durable-key [`ModelFingerprint`] and the [`ensure_ssm_tier_capability`]
+//! gate. Both are pure `ModelConfig`-derived leaves — no HBM, RDMA, or paging
+//! machinery — so a caching tier can key entries so they never collide across
+//! models and can refuse a model that has no recurrent state. The paging/spill
+//! machinery that consumes these lands separately.
+
+mod capability;
+mod fingerprint;
+
+pub(crate) use capability::ensure_ssm_tier_capability;
+pub(crate) use fingerprint::ModelFingerprint;

--- a/crates/spark-model/src/model/ssm_tier.rs
+++ b/crates/spark-model/src/model/ssm_tier.rs
@@ -1,14 +1,31 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Model-safety contract for the SSM snapshot tiers: the stable, model-agnostic
+//! The SSM snapshot spill tier: the model-safety contract (the model-agnostic
 //! durable-key [`ModelFingerprint`] and the [`ensure_ssm_tier_capability`]
-//! gate. Both are pure `ModelConfig`-derived leaves — no HBM, RDMA, or paging
-//! machinery — so a caching tier can key entries so they never collide across
-//! models and can refuse a model that has no recurrent state. The paging/spill
-//! machinery that consumes these lands separately.
+//! gate) plus the byte-store substrate an evicted snapshot spills into.
+//!
+//! * [`SnapshotBlobStore`] — the seam: a keyed fixed-size blob store. Backends
+//!   are hardware-free and in-process here ([`MemBlobStore`] host-RAM;
+//!   [`ArenaSnapshotStore`]/[`PagingSnapshotStore`] over a [`SnapshotTransport`]/
+//!   [`PagingTransport`], proven on [`MockSnapshotTransport`]/[`FileSnapshotArena`]).
+//!   The env-driven store selection ([`build_tier_store`] / [`build_decode_tier_store`],
+//!   gated by `ATLAS_SSM_TIER`) picks a local backend here; the RDMA transport
+//!   binding and its peer arms land in a follow-up PR.
 
+mod arena_store;
 mod capability;
 mod fingerprint;
+mod selectors;
+mod store;
+mod transport;
+mod unified;
 
+pub(crate) use arena_store::{ArenaSnapshotStore, PagingSnapshotStore, RdmaSnapshotStore};
 pub(crate) use capability::ensure_ssm_tier_capability;
 pub(crate) use fingerprint::ModelFingerprint;
+pub(crate) use selectors::{build_decode_tier_store, build_tier_store, ssm_tier_enabled};
+pub(crate) use store::{BlobStoreStats, MemBlobStore, SnapshotBlobStore};
+pub(crate) use transport::{
+    FileSnapshotArena, MockSnapshotTransport, PagingTransport, SnapshotTransport,
+};
+pub(crate) use unified::{UnifiedSnapshotStore, ssm_tier_unified};

--- a/crates/spark-model/src/model/ssm_tier/arena_store.rs
+++ b/crates/spark-model/src/model/ssm_tier/arena_store.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The two remote stores: the peer-owned paging store and the client-side
+//! fixed-slot arena store (RDMA or local file, via [`SnapshotTransport`]).
+
+use std::collections::HashMap;
+use std::num::NonZeroU64;
+use std::sync::atomic::Ordering;
+
+use anyhow::Result;
+use parking_lot::Mutex;
+
+use super::{BlobStoreStats, PagingTransport, SnapshotBlobStore, SnapshotTransport};
+
+/// WS-A paging-mode store: the PEER owns residency + an NVMe swap file, so this
+/// store just forwards PUT/GET/REMOVE over the arena's control channel. Unlike
+/// [`RdmaSnapshotStore`] (client-side fixed-slot allocator, `Ok(false)` when the
+/// arena fills), a paging PUT **never rejects** — the peer spills the coldest
+/// slot to disk. This is the "infinite depth" tier + shared across clients (one
+/// peer-owned map) that the bounded RDMA/host-RAM stores can't give.
+pub(crate) struct PagingSnapshotStore {
+    /// Keyed paging seam: the RDMA arena in production, a shared in-process
+    /// mock peer in the cross-model isolation tests.
+    arena: Box<dyn PagingTransport>,
+    blob_bytes: usize,
+    /// Per-model namespace folded into every key so a SHARED peer never serves
+    /// one model's SSM state to another (the prefix_hash is model-independent —
+    /// same tokens collide across models, but their recurrent state differs).
+    /// `NonZeroU64`: the old ns=0 passthrough (which silently cross-served
+    /// state between models) is unrepresentable — the namespace is either an
+    /// explicit override or the config-derived model fingerprint.
+    namespace: NonZeroU64,
+}
+
+impl PagingSnapshotStore {
+    pub(crate) fn new(
+        arena: Box<dyn PagingTransport>,
+        blob_bytes: usize,
+        namespace: NonZeroU64,
+    ) -> Self {
+        Self {
+            arena,
+            blob_bytes,
+            namespace,
+        }
+    }
+
+    /// Fold the namespace into a key (splitmix64 on `key ^ ns`). Deterministic
+    /// (same model+key → same wire key → cache hit) with negligible cross-model
+    /// collision, same 64-bit contract as `prefix_hash` itself.
+    fn wire(&self, key: u64) -> u64 {
+        // SSOT: this WAS a third transcription of the splitmix64 constants. It is
+        // exactly `mix64(key, ns)` — same operands, same order — so routing it
+        // through the one definition in `atlas_tier::hash` is VALUE-PRESERVING:
+        // no key rotates, no FP_VERSION bump. Proven by the golden pin in
+        // `paging_isolation_tests::wire_key_is_mix64_of_key_and_ns`.
+        atlas_tier::hash::mix64(key, self.namespace.get())
+    }
+}
+
+impl SnapshotBlobStore for PagingSnapshotStore {
+    fn put(&self, key: u64, bytes: &[u8]) -> Result<bool> {
+        if bytes.len() != self.blob_bytes {
+            anyhow::bail!(
+                "paging put: {} != blob_bytes {}",
+                bytes.len(),
+                self.blob_bytes
+            );
+        }
+        self.arena.paging_put(self.wire(key), bytes)?;
+        Ok(true) // never full — the peer spills to NVMe
+    }
+    fn get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+        if out.len() != self.blob_bytes {
+            anyhow::bail!(
+                "paging get: {} != blob_bytes {}",
+                out.len(),
+                self.blob_bytes
+            );
+        }
+        self.arena.paging_get(self.wire(key), out)
+    }
+    fn remove(&self, key: u64) {
+        if let Err(e) = self.arena.paging_remove(self.wire(key)) {
+            tracing::debug!("paging remove {key:#x} failed: {e:#}");
+        }
+    }
+    // Residency lives on the peer (RAM cache + NVMe); the client doesn't track it.
+    fn len(&self) -> usize {
+        0
+    }
+    fn bytes_resident(&self) -> usize {
+        0
+    }
+}
+
+/// RDMA snapshot spill tier: a `SnapshotBlobStore` over a remote byte arena.
+/// Because every snapshot blob is the SAME fixed size (`spill_blob_bytes()`),
+/// the allocator is a trivial **fixed-slot arena**: slot `i` lives at offset
+/// `i * blob_bytes`; a free-list of slot indices + a `key → slot` map track
+/// residency. A full arena makes `put` return `Ok(false)` — the graceful-drop
+/// contract `reclaim_from_cache` already handles (free the pool slot; the entry
+/// misses into recompute). All map/free-list mutation is `Mutex`-guarded; the
+/// (blocking) transport op runs outside the lock and rolls the allocator back on
+/// failure so a half-written slot is never left mapped (never read as garbage).
+#[allow(dead_code)] // constructed by the Inc-3 gate wiring (impl_a1 selector)
+pub(crate) struct RdmaSnapshotStore {
+    transport: Box<dyn SnapshotTransport>,
+    blob_bytes: usize,
+    inner: Mutex<RdmaInner>,
+    pub stats: BlobStoreStats,
+}
+
+struct RdmaInner {
+    /// key → slot index (byte offset = slot × blob_bytes).
+    map: HashMap<u64, usize>,
+    /// Free slot indices (LIFO reuse).
+    free: Vec<usize>,
+}
+
+#[allow(dead_code)]
+impl RdmaSnapshotStore {
+    /// Build a store over `transport` with `arena_slots` fixed slots of
+    /// `blob_bytes` each. The transport's arena must cover
+    /// `arena_slots × blob_bytes` bytes.
+    pub(crate) fn new(
+        transport: Box<dyn SnapshotTransport>,
+        blob_bytes: usize,
+        arena_slots: usize,
+    ) -> Self {
+        let free: Vec<usize> = (0..arena_slots).rev().collect();
+        Self {
+            transport,
+            blob_bytes,
+            inner: Mutex::new(RdmaInner {
+                map: HashMap::new(),
+                free,
+            }),
+            stats: BlobStoreStats::default(),
+        }
+    }
+
+    #[inline]
+    fn offset_of(&self, slot: usize) -> u64 {
+        (slot * self.blob_bytes) as u64
+    }
+}
+
+impl SnapshotBlobStore for RdmaSnapshotStore {
+    fn put(&self, key: u64, bytes: &[u8]) -> Result<bool> {
+        // Fixed-slot arena: only the snapshot blob size fits. A size mismatch is
+        // a caller bug — refuse gracefully rather than corrupt a slot.
+        if bytes.len() != self.blob_bytes {
+            self.stats.put_rejects.fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        // Pick the slot under the lock, but DON'T commit a new mapping until the
+        // write succeeds (so a failed write never leaves a garbage slot mapped).
+        let (slot, was_new) = {
+            let mut g = self.inner.lock();
+            match g.map.get(&key) {
+                Some(&slot) => (slot, false), // overwrite in place
+                None => {
+                    let Some(slot) = g.free.pop() else {
+                        // Arena full → graceful drop (entry misses → recompute).
+                        self.stats.put_rejects.fetch_add(1, Ordering::Relaxed);
+                        return Ok(false);
+                    };
+                    (slot, true)
+                }
+            }
+        };
+        match self.transport.write_blob(self.offset_of(slot), bytes) {
+            Ok(()) => {
+                if was_new {
+                    self.inner.lock().map.insert(key, slot);
+                }
+                self.stats.puts.fetch_add(1, Ordering::Relaxed);
+                Ok(true)
+            }
+            Err(e) => {
+                // Roll back: a new slot returns to the free-list (nothing
+                // mapped); an overwrite drops the mapping AND frees the slot —
+                // its bytes may be half-overwritten, so a later `get` must miss
+                // (recompute), never read a corrupted slot.
+                let mut g = self.inner.lock();
+                if was_new {
+                    g.free.push(slot);
+                } else if let Some(s) = g.map.remove(&key) {
+                    g.free.push(s);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+        // Defensive: never scatter a wrong-sized blob into a slot.
+        if out.len() != self.blob_bytes {
+            self.stats.get_misses.fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        let slot = match self.inner.lock().map.get(&key) {
+            Some(&slot) => slot,
+            None => {
+                self.stats.get_misses.fetch_add(1, Ordering::Relaxed);
+                return Ok(false);
+            }
+        };
+        self.transport.read_blob(self.offset_of(slot), out)?;
+        self.stats.get_hits.fetch_add(1, Ordering::Relaxed);
+        Ok(true)
+    }
+
+    fn remove(&self, key: u64) {
+        let mut g = self.inner.lock();
+        if let Some(slot) = g.map.remove(&key) {
+            g.free.push(slot);
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.inner.lock().map.len()
+    }
+
+    fn bytes_resident(&self) -> usize {
+        self.inner.lock().map.len() * self.blob_bytes
+    }
+}
+
+/// The fixed-slot offset-addressed arena store ([`RdmaSnapshotStore`]) is
+/// transport-agnostic — it runs equally over the RDMA arena or a local file
+/// (see [`super::FileSnapshotArena`]). `ArenaSnapshotStore` is the
+/// transport-neutral name the decode rolling tier selects; `RdmaSnapshotStore`
+/// remains as an alias for the existing Marconi call sites.
+pub(crate) type ArenaSnapshotStore = RdmaSnapshotStore;
+
+#[cfg(test)]
+#[path = "arena_store_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "paging_isolation_tests.rs"]
+mod paging_isolation_tests;

--- a/crates/spark-model/src/model/ssm_tier/arena_store_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/arena_store_tests.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! RdmaSnapshotStore (over MockSnapshotTransport) + FileSnapshotArena tests
+//! (moved from the pre-split ssm_tier.rs).
+
+use super::super::{FileSnapshotArena, MockSnapshotTransport};
+use super::*;
+
+// ── Phase 4b: RdmaSnapshotStore (over MockSnapshotTransport) ──────────
+// Fixed blob size (BLOB) + finite arena (SLOTS) so full-arena / slot-reuse
+// paths are exercised. These mirror the MemBlobStore contract tests.
+const BLOB: usize = 4;
+fn rdma_store(slots: usize) -> RdmaSnapshotStore {
+    let t = Box::new(MockSnapshotTransport::new(slots * BLOB));
+    RdmaSnapshotStore::new(t, BLOB, slots)
+}
+
+#[test]
+fn rdma_put_get_round_trip_bit_identical() {
+    let s = rdma_store(4);
+    assert!(s.put(42, &[1, 2, 3, 4]).unwrap());
+    let mut out = [0u8; BLOB];
+    assert!(s.get(42, &mut out).unwrap());
+    assert_eq!(out, [1, 2, 3, 4], "spill->arena->fault is bit-identical");
+    assert_eq!(s.len(), 1);
+    assert_eq!(s.bytes_resident(), BLOB);
+}
+
+#[test]
+fn rdma_get_absent_is_miss_not_error() {
+    let s = rdma_store(4);
+    let mut out = [0u8; BLOB];
+    assert!(!s.get(7, &mut out).unwrap());
+    assert_eq!(s.stats.get_misses.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn rdma_wrong_size_get_refused_out_untouched() {
+    let s = rdma_store(4);
+    s.put(1, &[9; BLOB]).unwrap();
+    let mut out = [0u8; BLOB + 4]; // mismatched
+    assert!(
+        !s.get(1, &mut out).unwrap(),
+        "never scatter a wrong-sized blob"
+    );
+    assert_eq!(out, [0u8; BLOB + 4], "out left untouched on refusal");
+}
+
+#[test]
+fn rdma_wrong_size_put_refused() {
+    let s = rdma_store(4);
+    assert!(
+        !s.put(1, &[0; BLOB + 1]).unwrap(),
+        "off-size blob refused, not corrupt"
+    );
+    assert_eq!(s.len(), 0);
+}
+
+#[test]
+fn rdma_full_arena_put_returns_false_not_err() {
+    let s = rdma_store(2);
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    assert!(s.put(2, &[2; BLOB]).unwrap());
+    // Third key, no free slot → graceful Ok(false), NOT Err, NOT overwrite.
+    assert!(!s.put(3, &[3; BLOB]).unwrap());
+    assert_eq!(s.len(), 2);
+    assert_eq!(s.stats.put_rejects.load(Ordering::Relaxed), 1);
+    // The two resident keys are intact.
+    let mut o = [0u8; BLOB];
+    assert!(s.get(1, &mut o).unwrap() && o == [1; BLOB]);
+    assert!(s.get(2, &mut o).unwrap() && o == [2; BLOB]);
+}
+
+#[test]
+fn rdma_remove_frees_slot_for_reuse() {
+    let s = rdma_store(1); // single slot
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    assert!(!s.put(2, &[2; BLOB]).unwrap(), "arena full");
+    s.remove(1);
+    assert!(s.put(2, &[2; BLOB]).unwrap(), "freed slot reused");
+    let mut o = [0u8; BLOB];
+    assert!(s.get(2, &mut o).unwrap() && o == [2; BLOB]);
+    assert!(!s.get(1, &mut o).unwrap(), "removed key gone");
+    assert_eq!(s.len(), 1);
+}
+
+#[test]
+fn rdma_overwrite_in_place_no_slot_leak() {
+    let s = rdma_store(1); // single slot forces in-place overwrite
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    assert!(
+        s.put(1, &[2; BLOB]).unwrap(),
+        "overwrite reuses the same slot"
+    );
+    assert_eq!(s.len(), 1);
+    assert_eq!(s.bytes_resident(), BLOB);
+    let mut o = [0u8; BLOB];
+    assert!(s.get(1, &mut o).unwrap());
+    assert_eq!(o, [2; BLOB], "reads the overwritten value");
+}
+
+// ── Decode rolling tier: FileSnapshotArena (local NVMe) ───────────────
+#[test]
+fn file_arena_round_trip_bit_identical() {
+    let dir = std::env::temp_dir().join(format!("atlas-decode-test-{}", std::process::id()));
+    let dir = dir.to_str().unwrap();
+    let store = ArenaSnapshotStore::new(
+        Box::new(FileSnapshotArena::create(dir, 4 * BLOB as u64).unwrap()),
+        BLOB,
+        4,
+    );
+    assert!(store.put(0xDEAD, &[9, 8, 7, 6]).unwrap());
+    let mut out = [0u8; BLOB];
+    assert!(store.get(0xDEAD, &mut out).unwrap());
+    assert_eq!(
+        out,
+        [9, 8, 7, 6],
+        "file spill->arena->fault is bit-identical"
+    );
+    // Slot recycle: distinct key reuses a fresh slot, both recover.
+    assert!(store.put(0xBEEF, &[1, 2, 3, 4]).unwrap());
+    let mut o2 = [0u8; BLOB];
+    assert!(store.get(0xBEEF, &mut o2).unwrap() && o2 == [1, 2, 3, 4]);
+    assert!(store.get(0xDEAD, &mut out).unwrap() && out == [9, 8, 7, 6]);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn file_arena_write_past_capacity_errs_not_corrupts() {
+    let dir = std::env::temp_dir().join(format!("atlas-decode-cap-{}", std::process::id()));
+    let dir = dir.to_str().unwrap();
+    let arena = FileSnapshotArena::create(dir, BLOB as u64).unwrap();
+    assert!(arena.write_blob(0, &[1; BLOB]).is_ok());
+    assert!(
+        arena.write_blob(1, &[1; BLOB]).is_err(),
+        "over-capacity write refused"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/spark-model/src/model/ssm_tier/capability.rs
+++ b/crates/spark-model/src/model/ssm_tier/capability.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Capability gate: selecting a tier the model cannot populate is a STARTUP
+//! ERROR, never a silent no-op.
+//!
+//! "Model-agnostic" does NOT mean every model has every tier. The SSM
+//! snapshot tiers (Marconi spill, decode rollback ring) hold recurrent
+//! state that only exists on hybrid SSM+attention models
+//! ([`ModelConfig::has_recurrent_state`]); a pure-attention model — dense or
+//! MoE — can never populate them. Before this gate, an SSM tier env var on
+//! such a model was swallowed silently (the `num_ssm_layers > 0` arms in
+//! `impl_a1` just skipped construction WITHOUT reading the vars, hiding even
+//! hard misconfigurations like `ATLAS_SSM_DECODE_TIER=nvme` with no dir).
+//! "Works on Holo, mysteriously does nothing on X" is exactly the failure
+//! mode PCND forbids: require explicit config or fail fast.
+//!
+//! When the capability IS present — or when no tier var is set at all — this
+//! gate reads env *presence* only and changes nothing: the byte-identical
+//! default path is preserved.
+
+use anyhow::{Result, bail};
+use atlas_core::config::ModelConfig;
+
+/// Every env var that requests an SSM snapshot tier. Any of these set on a
+/// model with no recurrent state is a startup error. (`ATLAS_SSM_SWAP_NS` /
+/// `ATLAS_SSM_DECODE_NS` are namespace *overrides*, not tier selectors, and
+/// are deliberately absent.)
+const SSM_TIER_VARS: [&str; 5] = [
+    "ATLAS_SSM_TIER",
+    "ATLAS_SSM_RDMA_TIER",
+    "ATLAS_SSM_SWAP",
+    "ATLAS_SSM_DECODE_TIER",
+    "ATLAS_SSM_DECODE_RING_ROLL",
+];
+
+/// Fail fast when an SSM tier is requested on a model that cannot populate
+/// it. Called from `TransformerModel::new` BEFORE pool construction, weight
+/// residency, or any peer connect (a capability error is a config error, not
+/// a connectivity error).
+pub(crate) fn ensure_ssm_tier_capability(config: &ModelConfig) -> Result<()> {
+    let set: Vec<&str> = SSM_TIER_VARS
+        .iter()
+        .copied()
+        .filter(|v| std::env::var_os(v).is_some())
+        .collect();
+    ensure_ssm_tier_capability_from(config, &set)
+}
+
+/// Env-free core (unit-testable without process-global `set_var` races):
+/// `set_vars` is the list of SSM tier env vars found set.
+pub(crate) fn ensure_ssm_tier_capability_from(
+    config: &ModelConfig,
+    set_vars: &[&str],
+) -> Result<()> {
+    if set_vars.is_empty() || config.has_recurrent_state() {
+        return Ok(());
+    }
+    bail!(
+        "model '{}' has no recurrent state (num_ssm_layers=0) — the SSM snapshot \
+         tier cannot be populated by this model. Unset {} for this serve (fleet-wide \
+         env files now need per-model curation; a tier request on an incapable model \
+         was previously a SILENT no-op and is now a startup error).",
+        config.model_type,
+        set_vars.join(", "),
+    );
+}
+
+#[cfg(test)]
+#[path = "capability_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/ssm_tier/capability_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/capability_tests.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Capability-gate tests: a tier the model cannot populate is REJECTED at
+//! startup with an actionable message — never a silent no-op — while capable
+//! models and the no-env default path are untouched.
+
+use atlas_core::config::{LayerType, ModelConfig};
+
+use super::*;
+
+/// Hybrid SSM+attention MoE (the Holo/Qwen3-next family shape).
+fn hybrid() -> ModelConfig {
+    ModelConfig::qwen3_next_80b_nvfp4()
+}
+
+/// Pure-attention dense model: no recurrent state, no experts.
+fn dense() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.model_type = "qwen3".to_string();
+    c.num_hidden_layers = 28;
+    c.layer_types = vec![LayerType::FullAttention; 28];
+    c.num_experts = 0;
+    c.linear_num_key_heads = 0;
+    c.linear_key_head_dim = 0;
+    c.linear_num_value_heads = 0;
+    c.linear_value_head_dim = 0;
+    c
+}
+
+// ── The honest predicates (config-derived, SSOT) ───────────────────────
+
+#[test]
+fn capability_predicates_are_honest() {
+    assert!(hybrid().has_recurrent_state());
+    assert!(hybrid().has_experts());
+    assert!(!dense().has_recurrent_state());
+    assert!(!dense().has_experts());
+    // Pure-attention MoE (DeepSeek/Mixtral shape): experts yes, SSM no.
+    let mut moe = dense();
+    moe.num_experts = 512;
+    assert!(moe.has_experts());
+    assert!(!moe.has_recurrent_state());
+}
+
+// ── Startup rejection: dense model + any SSM tier var ──────────────────
+
+#[test]
+fn dense_model_with_ssm_tier_var_is_rejected() {
+    let err = ensure_ssm_tier_capability_from(&dense(), &["ATLAS_SSM_TIER"]).unwrap_err();
+    let msg = format!("{err:#}");
+    // Actionable: names the model and the exact var(s) to unset.
+    assert!(msg.contains("qwen3"), "names the model: {msg}");
+    assert!(msg.contains("ATLAS_SSM_TIER"), "names the var: {msg}");
+    assert!(msg.contains("no recurrent state"), "says why: {msg}");
+}
+
+#[test]
+fn dense_model_rejects_every_tier_selector_var() {
+    for var in [
+        "ATLAS_SSM_TIER",
+        "ATLAS_SSM_RDMA_TIER",
+        "ATLAS_SSM_SWAP",
+        "ATLAS_SSM_DECODE_TIER",
+        "ATLAS_SSM_DECODE_RING_ROLL",
+    ] {
+        let err = ensure_ssm_tier_capability_from(&dense(), &[var]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains(var),
+            "gate must reject and name {var}"
+        );
+    }
+}
+
+#[test]
+fn dense_model_error_lists_all_set_vars() {
+    let err =
+        ensure_ssm_tier_capability_from(&dense(), &["ATLAS_SSM_TIER", "ATLAS_SSM_DECODE_TIER"])
+            .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("ATLAS_SSM_TIER") && msg.contains("ATLAS_SSM_DECODE_TIER"));
+}
+
+// ── The unchanged paths: no-env default and capable models ─────────────
+
+#[test]
+fn dense_model_without_tier_vars_is_ok() {
+    // The byte-identical default path: env presence only, no error.
+    ensure_ssm_tier_capability_from(&dense(), &[]).unwrap();
+}
+
+#[test]
+fn hybrid_model_with_all_tier_vars_is_ok() {
+    ensure_ssm_tier_capability_from(
+        &hybrid(),
+        &[
+            "ATLAS_SSM_TIER",
+            "ATLAS_SSM_RDMA_TIER",
+            "ATLAS_SSM_SWAP",
+            "ATLAS_SSM_DECODE_TIER",
+            "ATLAS_SSM_DECODE_RING_ROLL",
+        ],
+    )
+    .unwrap();
+}

--- a/crates/spark-model/src/model/ssm_tier/fingerprint.rs
+++ b/crates/spark-model/src/model/ssm_tier/fingerprint.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Stable, config-derived model fingerprint for the SHARED paging peer.
+//!
+//! The paging peer (atlas-cache-peer) owns ONE residency map shared across
+//! every fleet client, keyed purely by the u64 the client sends — so the
+//! per-model namespace folded into each key is the ONLY thing preventing two
+//! models from silently serving each other's recurrent state. That makes the
+//! namespace a **durable on-disk contract**: the peer's NVMe swap file
+//! outlives client rebuilds and toolchains, so the same model config must
+//! derive the same u64 forever.
+//!
+//! ## Why FNV-1a/64, vendored
+//!
+//! `std::hash::DefaultHasher` documents its algorithm as unspecified and "not
+//! to be relied upon over releases" — a toolchain bump may silently rotate
+//! every persisted key (total cache miss) or collide with a stale namespace
+//! (silent wrong-state corruption). FNV-1a/64 is fully specified (offset
+//! basis `0xcbf29ce484222325`, prime `0x100000001b3`), consumes a byte stream
+//! (endianness-free), and is vendored here (~10 lines) so no crate version
+//! bump can ever change the value. The test file pins the primitive to the
+//! published FNV reference vectors and the full fingerprint of known configs
+//! to frozen literals. Collision quality is irrelevant at this input size (a
+//! handful of fleet model configs, not an adversarial keyspace).
+//!
+//! ## Encoding contract
+//!
+//! The hash input is an injective canonical encoding: tagged records, u64s as
+//! `[tag][8-byte LE]`, strings length-prefixed `[tag][4-byte LE len][bytes]`
+//! (so `("ab","c")` never collides with `("a","bc")`). Field set and order
+//! are FROZEN behind [`FP_VERSION`]; any change to either is a deliberate
+//! fleet-wide cache flush and must bump the version. `kv_layer_dims` is
+//! loader-populated and order-sensitive — derive() must run after loader
+//! post-processing (it does: the only call sites are in
+//! `TransformerModel::new`).
+//!
+//! The runtime KV-cache dtype (`--kv-cache-dtype`) is deliberately EXCLUDED:
+//! SSM h/conv state is FP32 by construction regardless of KV dtype, so two
+//! serves of one model with different KV dtypes produce byte-identical SSM
+//! blobs and SHOULD share the warm cache. A future KV paging tier must fold
+//! its own dtype/block_size mix-in at its own call site.
+//!
+//! Note: `wire()`'s splitmix fold is bijective per namespace, but two
+//! DIFFERENT namespaces can map two (key, ns) pairs to one wire key with
+//! ~2^-64 probability — acceptable, and NOT to be "strengthened" into a wire
+//! -format change.
+
+use std::num::NonZeroU64;
+
+use anyhow::{Result, anyhow, bail};
+use atlas_core::config::ModelConfig;
+
+// SSOT: the durable-key hash primitives live in atlas-tier (pure, dep-free, a
+// common ancestor of this crate and spark-storage's kv_paging). They were
+// transcribed in three places; the constants are now defined exactly once.
+pub(crate) use atlas_tier::hash::{FNV_OFFSET, fnv1a_64, mix64};
+
+/// Bump = deliberate fleet-wide cache-key rotation (document it).
+// v2 (2026-07-10): added hidden_size / num_attention_heads / intermediate_size /
+// moe_intermediate_size / num_experts_per_tok (tags 0x16-0x1a). v1 omitted them, so
+// two distinct models differing only in residual/FFN width collided. Bumping the
+// version is a DELIBERATE, one-time fleet cache-key rotation (greenfield: no shim).
+pub(crate) const FP_VERSION: u64 = 2;
+
+fn put_u64(buf: &mut Vec<u8>, tag: u8, v: u64) {
+    buf.push(tag);
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+fn put_str(buf: &mut Vec<u8>, tag: u8, s: &str) {
+    buf.push(tag);
+    buf.extend_from_slice(&(s.len() as u32).to_le_bytes());
+    buf.extend_from_slice(s.as_bytes());
+}
+
+/// Stable identity of "the bytes this model's SSM tier produces", derived
+/// from the loaded [`ModelConfig`] geometry + quantization identity +
+/// `blob_bytes`. Non-zero by construction (a 0 namespace — the old silent
+/// passthrough — is unrepresentable downstream).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct ModelFingerprint(NonZeroU64);
+
+impl ModelFingerprint {
+    /// Derive the fingerprint and log it at INFO so operators can see and pin
+    /// it. `ATLAS_MODEL_ID` (optional) is an extra salt for the one case
+    /// geometry cannot distinguish: a fine-tune with byte-identical config —
+    /// unset (the common case) it contributes an empty record and never
+    /// rotates keys.
+    pub(crate) fn derive(cfg: &ModelConfig, blob_bytes: usize) -> Result<Self> {
+        let model_id = std::env::var("ATLAS_MODEL_ID").unwrap_or_default();
+        let fp = Self::derive_with_id(cfg, blob_bytes, &model_id)?;
+        tracing::info!(
+            "SSM tier model fingerprint = {:#018x} (model_type={}, blob_bytes={blob_bytes}, \
+             ATLAS_MODEL_ID={model_id:?}); pin with ATLAS_SSM_SWAP_NS / ATLAS_SSM_DECODE_NS",
+            fp.get(),
+            cfg.model_type,
+        );
+        // The fingerprint is GEOMETRY-ONLY. It cannot distinguish two checkpoints
+        // with byte-identical config — a fine-tune, an RL variant, a continued
+        // pre-train of one base. Those derive the same namespace and would share
+        // one store's cache. We cannot fail fast (config carries no weight
+        // identity), so warn loudly exactly when it matters: a SHARED store backs
+        // the tier and the operator gave neither a salt nor an explicit ns.
+        //
+        // NOT just a peer: ATLAS_SSM_SWAP=1 is a LOCAL swap FILE, which two
+        // processes pointed at one swap dir share exactly as dangerously. Saying
+        // "peer" here sent an operator hunting for an RDMA peer that was never
+        // configured (found by running the serve path, not by any unit test).
+        let shared_store = std::env::var("ATLAS_SSM_SWAP").ok().as_deref() == Some("1")
+            || std::env::var("ATLAS_SSM_DECODE_TIER").ok().as_deref() == Some("peer");
+        let overridden = std::env::var_os("ATLAS_SSM_SWAP_NS").is_some()
+            || std::env::var_os("ATLAS_SSM_DECODE_NS").is_some();
+        if shared_store && model_id.is_empty() && !overridden {
+            tracing::warn!(
+                "a SHARED SSM cache store is selected (ATLAS_SSM_SWAP=1 local swap file, or \
+                 ATLAS_SSM_DECODE_TIER=peer) but ATLAS_MODEL_ID is unset: the fingerprint is \
+                 derived from config GEOMETRY ONLY, so two checkpoints with identical config \
+                 (fine-tunes, RL variants, continued pre-train of one base) will SHARE cache \
+                 keys and silently cross-serve recurrent state. Set ATLAS_MODEL_ID to a stable \
+                 per-checkpoint string (or set ATLAS_SSM_SWAP_NS / ATLAS_SSM_DECODE_NS \
+                 explicitly) when co-locating such models on one store."
+            );
+        }
+        Ok(fp)
+    }
+
+    /// KV-paging fingerprint (`ATLAS_KV_PAGING`): the SAME canonical
+    /// per-model encoding as the SSM tier, derived with the KV CONVENTION
+    /// `blob_bytes = 0` (tag 0x40 = 0 marks the KV instance; SSM instances
+    /// put their real, non-zero blob size there — so the two never share a
+    /// value, and attention-only models with no SSM tier still get an fp).
+    /// The KV tier folds its full block geometry + dtype + a per-client salt
+    /// DOWNSTREAM at its own call site (`spark_storage::kv_paging::ns`),
+    /// exactly as the module doc above prescribes — do NOT add KV fields
+    /// here (that would rotate SSM keys).
+    pub(crate) fn derive_kv(cfg: &ModelConfig) -> Result<Self> {
+        let model_id = std::env::var("ATLAS_MODEL_ID").unwrap_or_default();
+        let fp = Self::derive_with_id(cfg, 0, &model_id)?;
+        tracing::info!(
+            "KV paging model fingerprint = {:#018x} (model_type={}, \
+             ATLAS_MODEL_ID={model_id:?}); folded into the ATLAS_KV_PAGING namespace",
+            fp.get(),
+            cfg.model_type,
+        );
+        Ok(fp)
+    }
+
+    /// Pure derivation (no env, no logging) — the canonical encoding.
+    /// FROZEN: field set + order changes require an FP_VERSION bump.
+    pub(crate) fn derive_with_id(
+        cfg: &ModelConfig,
+        blob_bytes: usize,
+        model_id: &str,
+    ) -> Result<Self> {
+        // Defensive PCND bail: never legitimate after parse_config. Without a
+        // real fingerprint a shared peer would need an explicit override.
+        if cfg.model_type.is_empty() && cfg.num_hidden_layers == 0 {
+            bail!(
+                "cannot derive a model fingerprint: empty model_type and zero geometry; \
+                 fix the model config or set ATLAS_SSM_SWAP_NS / ATLAS_SSM_DECODE_NS \
+                 to explicit non-zero u64 namespaces"
+            );
+        }
+        let (qm, qa, qf) = cfg.quantization_config.as_ref().map_or(("", "", ""), |q| {
+            (
+                q.quant_method.as_str(),
+                q.quant_algo.as_str(),
+                q.format.as_str(),
+            )
+        });
+        let mut buf = Vec::with_capacity(256);
+        put_u64(&mut buf, 0x00, FP_VERSION);
+        put_str(&mut buf, 0x01, &cfg.model_type);
+        // Quant identity: an NVFP4 build and a bf16 build of one checkpoint
+        // share geometry but produce different recurrent state values.
+        put_str(&mut buf, 0x02, qm);
+        put_str(&mut buf, 0x03, qa);
+        put_str(&mut buf, 0x04, qf);
+        put_str(&mut buf, 0x05, model_id);
+        for (tag, v) in [
+            (0x10, cfg.num_hidden_layers),
+            (0x11, cfg.num_ssm_layers()),
+            (0x12, cfg.num_attention_layers()),
+            (0x13, cfg.head_dim),
+            (0x14, cfg.num_key_value_heads),
+            (0x15, cfg.num_experts),
+            // FP_VERSION 2: residual-stream and FFN widths. Omitting these was a
+            // BLOCKING defect — two distinct models differing ONLY in
+            // `hidden_size` / `num_attention_heads` hashed identically and would
+            // have silently cross-served recurrent state on a shared paging peer
+            // (the exact failure this fingerprint exists to prevent). `blob_bytes`
+            // does NOT capture them: it is `num_ssm_layers * (h + conv)` bytes,
+            // which is SSM-state-only and independent of the residual width.
+            (0x16, cfg.hidden_size),
+            (0x17, cfg.num_attention_heads),
+            (0x18, cfg.intermediate_size),
+            (0x19, cfg.moe_intermediate_size),
+            (0x1a, cfg.num_experts_per_tok),
+            // SSM state geometry — included alongside blob_bytes because the
+            // blob size is a lossy product of these.
+            (0x20, cfg.linear_num_key_heads),
+            (0x21, cfg.linear_key_head_dim),
+            (0x22, cfg.linear_num_value_heads),
+            (0x23, cfg.linear_value_head_dim),
+            (0x24, cfg.linear_conv_kernel_dim),
+            (0x25, cfg.mamba_num_heads),
+            (0x26, cfg.mamba_head_dim),
+            (0x27, cfg.ssm_state_size),
+            (0x28, cfg.n_groups),
+            // SSM h/conv state element size: FP32 today (the ×4 hardcoded in
+            // ssm_h_state_bytes/ssm_conv_state_bytes). Fingerprinted so a
+            // future non-FP32 SSM state rotates keys instead of colliding.
+            (0x30, 4),
+            (0x40, blob_bytes),
+        ] {
+            put_u64(&mut buf, tag, v as u64);
+        }
+        // Heterogeneous-attention per-layer (kv_heads, head_dim) overrides
+        // (Gemma-4). Loader-populated; canonical order = layer order.
+        put_u64(&mut buf, 0x50, cfg.kv_layer_dims.len() as u64);
+        for &(kvh, hd) in &cfg.kv_layer_dims {
+            put_u64(&mut buf, 0x51, kvh as u64);
+            put_u64(&mut buf, 0x52, hd as u64);
+        }
+        let h = fnv1a_64(&buf);
+        // Zero-avoidance (p = 2^-64): keep NonZeroU64 total + deterministic.
+        Ok(Self(
+            NonZeroU64::new(h).unwrap_or(NonZeroU64::new(FNV_OFFSET).unwrap()),
+        ))
+    }
+
+    pub(crate) fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    pub(crate) fn nonzero(self) -> NonZeroU64 {
+        self.0
+    }
+}
+
+/// Marconi swap namespace: `ATLAS_SSM_SWAP_NS` override (strict — junk or 0
+/// is a startup ERROR, never a silent fallthrough) else the fingerprint.
+pub(crate) fn resolve_swap_ns(fp: ModelFingerprint) -> Result<NonZeroU64> {
+    resolve_ns_from(
+        std::env::var("ATLAS_SSM_SWAP_NS").ok().as_deref(),
+        "ATLAS_SSM_SWAP_NS",
+        fp.nonzero(),
+    )
+}
+
+/// Per-process decode CLIENT salt — resolved ONCE (`OnceLock`) so every decode
+/// store built in this process folds the SAME salt: `cold_key` determinism
+/// within a process is an invariant the spill FIFO / epoch guard rest on.
+///
+/// `ATLAS_SSM_DECODE_CLIENT_ID` pins it (strict parse; 0 is PERMITTED — the
+/// salt is key material folded through `mix64`, not a sentinel); unset ⇒
+/// fresh OS entropy per process. Entropy failure is a hard startup error,
+/// never a silent zero-salt (a degraded shared salt would quietly reintroduce
+/// cross-client key sharing).
+fn decode_client_salt() -> Result<u64> {
+    use std::sync::OnceLock;
+    static SALT: OnceLock<u64> = OnceLock::new();
+    if let Some(&s) = SALT.get() {
+        return Ok(s);
+    }
+    let salt = match std::env::var("ATLAS_SSM_DECODE_CLIENT_ID").ok() {
+        Some(raw) => parse_u64_strict("ATLAS_SSM_DECODE_CLIENT_ID", &raw)?,
+        None => atlas_tier::entropy::random_u64()?,
+    };
+    // A racing thread may have won `get_or_init` meanwhile; both then return
+    // the ONE stored value — the process-wide salt is still unique.
+    Ok(*SALT.get_or_init(|| salt))
+}
+
+/// Env-free core of the decode namespace:
+/// `mix64(mix64(fingerprint, DECODE_DOMAIN), client_salt)`.
+///
+/// Every layer is load-bearing: the DOMAIN separator keeps decode keys off the
+/// same model's Marconi keys (both tiers share ONE peer residency whenever
+/// blob_bytes match); the fingerprint keeps them off OTHER models' decode
+/// spills; the CLIENT salt keeps them off other same-model PROCESSES' spills —
+/// decode keys are SLOT COORDINATES (`cold_key(seq, logical)`), byte-identical
+/// across same-model clients, so without the salt two clients on one peer
+/// cross-serve and cross-delete each other's rollback state.
+///
+/// Zero-avoidance (each layer p = 2^-64) falls back exactly ONE layer: never
+/// `fp` bare (that IS the Marconi swap namespace), never `DECODE_DOMAIN` alone
+/// (model-blind). Total over all inputs.
+pub(crate) fn derive_decode_ns_salted(fp: u64, salt: u64) -> NonZeroU64 {
+    let base = NonZeroU64::new(mix64(fp, atlas_kernels::DECODE_DOMAIN)).unwrap_or_else(|| {
+        NonZeroU64::new(atlas_kernels::DECODE_DOMAIN).expect("DECODE_DOMAIN is a non-zero constant")
+    });
+    NonZeroU64::new(mix64(base.get(), salt)).unwrap_or(base)
+}
+
+/// Decode namespace: `ATLAS_SSM_DECODE_NS` override (strict, wins UNSALTED —
+/// the escape hatch fully determines the ns) else the per-process salted
+/// derivation [`derive_decode_ns_salted`]. Decode blobs are process-ephemeral
+/// (pid-named local arenas, all-Absent manager init, no store enumeration —
+/// never recovered across runs), so the per-process rotation loses nothing;
+/// the generated salt is INFO-logged so an operator can pin/reproduce it.
+pub(crate) fn resolve_decode_ns(fp: ModelFingerprint) -> Result<NonZeroU64> {
+    if let Ok(raw) = std::env::var("ATLAS_SSM_DECODE_NS") {
+        // Mirror the ATLAS_MODEL_ID warn in `ModelFingerprint::derive`: the
+        // override is the documented escape hatch, and exactly as dangerous.
+        tracing::warn!(
+            "ATLAS_SSM_DECODE_NS={raw:?} bypasses the per-process decode client salt: decode \
+             keys are SLOT COORDINATES (not content hashes), so two processes sharing this \
+             value on one peer WILL cross-serve and cross-delete each other's rollback state \
+             (silent corruption + spurious 'cold MISS on live target'). Ensure a DISTINCT \
+             value per process, or unset it and pin ATLAS_SSM_DECODE_CLIENT_ID instead."
+        );
+        if std::env::var_os("ATLAS_SSM_DECODE_CLIENT_ID").is_some() {
+            tracing::warn!(
+                "ATLAS_SSM_DECODE_CLIENT_ID is IGNORED while ATLAS_SSM_DECODE_NS is set \
+                 (the explicit namespace fully determines the wire keys)"
+            );
+        }
+        return parse_ns("ATLAS_SSM_DECODE_NS", &raw);
+    }
+    let salt = decode_client_salt()?;
+    let ns = derive_decode_ns_salted(fp.get(), salt);
+    tracing::info!(
+        "SSM decode ns = {ns:#018x} (fp {:#018x} ⊕ DECODE_DOMAIN ⊕ client_salt \
+         {salt:#018x}); decode keys are CLIENT-PRIVATE on a shared peer; pin \
+         ATLAS_SSM_DECODE_CLIENT_ID={salt:#x} to reproduce this namespace",
+        fp.get(),
+    );
+    Ok(ns)
+}
+
+/// Env-free core (unit-testable without process-global setenv races).
+pub(crate) fn resolve_ns_from(
+    override_raw: Option<&str>,
+    var: &str,
+    derived: NonZeroU64,
+) -> Result<NonZeroU64> {
+    match override_raw {
+        Some(raw) => parse_ns(var, raw),
+        None => Ok(derived),
+    }
+}
+
+/// Strict u64 parser: decimal or `0x`-hex. Junk is a hard startup error, never
+/// a silent fallthrough (PCND). Unlike [`parse_ns`], 0 is PERMITTED — callers
+/// needing `NonZeroU64` layer that check on top.
+pub(crate) fn parse_u64_strict(var: &str, raw: &str) -> Result<u64> {
+    let s = raw.trim();
+    let parsed = match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        Some(hex) => u64::from_str_radix(hex, 16),
+        None => s.parse::<u64>(),
+    };
+    parsed.map_err(|e| anyhow!("{var}={raw:?} is not a valid u64 (decimal or 0x-hex): {e}"))
+}
+
+/// Strict override parser: decimal or `0x`-hex u64. Unparseable values are a
+/// hard error (PCND — the old code silently `.ok()`-swallowed a mistyped
+/// override into the model-blind default). 0 is a hard error: the ns=0
+/// passthrough is removed, a shared peer must always be namespaced.
+pub(crate) fn parse_ns(var: &str, raw: &str) -> Result<NonZeroU64> {
+    let v = parse_u64_strict(var, raw)?;
+    NonZeroU64::new(v).ok_or_else(|| {
+        anyhow!(
+            "{var}=0 is invalid: the ns=0 passthrough is removed (it silently \
+             cross-served state between models on a shared peer); unset {var} \
+             to use the derived model fingerprint (logged at INFO on startup)"
+        )
+    })
+}
+
+#[cfg(test)]
+#[path = "fingerprint_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/ssm_tier/fingerprint_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/fingerprint_tests.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Fingerprint golden pins + determinism + override precedence.
+//!
+//! L1 pins the hash primitive to external FNV reference vectors, L2 pins two
+//! full fingerprints to frozen literals, L3 proves per-field sensitivity (a
+//! refactor cannot silently drop a field), L4 proves encoding injectivity.
+
+use std::num::NonZeroU64;
+
+use atlas_core::config::{LayerType, ModelConfig, QuantizationConfig};
+
+use super::*;
+
+const BLOB: usize = 4096;
+
+fn hybrid() -> ModelConfig {
+    ModelConfig::qwen3_next_80b_nvfp4()
+}
+
+fn dense() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.model_type = "qwen3".to_string();
+    c.num_hidden_layers = 28;
+    c.layer_types = vec![LayerType::FullAttention; 28];
+    c.num_experts = 0;
+    c.linear_num_key_heads = 0;
+    c.linear_key_head_dim = 0;
+    c.linear_num_value_heads = 0;
+    c.linear_value_head_dim = 0;
+    c
+}
+
+fn fp(cfg: &ModelConfig) -> u64 {
+    ModelFingerprint::derive_with_id(cfg, BLOB, "")
+        .unwrap()
+        .get()
+}
+
+// ── L1: pin the primitive to published FNV-1a/64 reference vectors ────
+// A swapped or "optimized" implementation cannot pass someone else's
+// constants.
+#[test]
+fn fnv1a_64_matches_reference_vectors() {
+    assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+    assert_eq!(fnv1a_64(b"foobar"), 0x85944171f73967e8);
+}
+
+// ── L2: golden pins ────────────────────────────────────────────────────
+// DO NOT update these literals to make a test pass — changing them
+// invalidates every persisted cache key on every shared paging peer. An
+// encoding change is a deliberate fleet-wide cache flush and bumps
+// FP_VERSION (and gets a changelog entry).
+#[test]
+fn golden_fingerprint_hybrid_moe_is_pinned() {
+    // FP_VERSION 2 (2026-07-10): rotated by the addition of the width fields
+    // (hidden_size / num_attention_heads / intermediate_size /
+    // moe_intermediate_size / num_experts_per_tok). Deliberate cache flush.
+    assert_eq!(fp(&hybrid()), 0x5629_922c_51a1_6a10);
+}
+
+#[test]
+fn golden_fingerprint_dense_is_pinned() {
+    // FP_VERSION 2 — see the hybrid pin above.
+    assert_eq!(fp(&dense()), 0x971e_b3b4_bd13_22f1);
+}
+
+/// Frozen `mix64` output pins: these EXACT literals ARE the durable wire-key
+/// contract. The fold turns (key, ns) into the on-peer durable key on both the
+/// SSM and KV paging paths, so any consumer that mirrors this hash (the KV
+/// paging namespace) must assert the same literals — a drifted constant on
+/// either side rotates or collides deployed keys.
+#[test]
+fn mix64_frozen_literals() {
+    assert_eq!(mix64(0, 0), 0x0); // splitmix64's fixed point at zero
+    assert_eq!(mix64(1, 2), 0xbeeb_8da1_658e_ec67);
+    assert_eq!(
+        mix64(0x5EED_F00D_CAFE_D00D, 0xD3C0_DE12_A5B6_C7D8),
+        0xe567_5d86_f750_1640
+    );
+}
+
+/// The KV-paging fp convention: same encoding, blob_bytes = 0 — distinct
+/// from every SSM instance (whose blob is real and non-zero) and frozen like
+/// the other goldens.
+#[test]
+fn golden_kv_fingerprint_is_pinned_and_distinct() {
+    let kv = ModelFingerprint::derive_with_id(&hybrid(), 0, "")
+        .unwrap()
+        .get();
+    assert_eq!(kv, 0x8dea_f1c5_3d0f_3540);
+    assert_ne!(
+        kv,
+        fp(&hybrid()),
+        "KV instance must not equal the SSM instance"
+    );
+}
+
+// ── Determinism: same config → same u64, every time ───────────────────
+#[test]
+fn fingerprint_is_deterministic() {
+    assert_eq!(fp(&hybrid()), fp(&hybrid()));
+    assert_eq!(fp(&dense()), fp(&dense()));
+    assert_ne!(fp(&hybrid()), fp(&dense()));
+}
+
+// ── L3: per-field sensitivity ──────────────────────────────────────────
+// Mutating any single fingerprint field must change the value — this is
+// what prevents a refactor from silently DROPPING a field from the
+// encoding (the golden pin alone would still pass whenever the dropped
+// field is unchanged in the fixture).
+#[test]
+/// ⚠ This is a HAND-MAINTAINED list, so despite the name it CANNOT prove the
+/// fingerprint is exhaustive — it only proves the fields listed below are
+/// load-bearing. A `ModelConfig` field that is in neither `derive_with_id` nor
+/// this list is invisible to it. That is not hypothetical: `hidden_size`,
+/// `num_attention_heads`, `intermediate_size`, `moe_intermediate_size` and
+/// `num_experts_per_tok` were absent from BOTH, so this test was green while
+/// two distinct models silently shared a namespace on a paging peer.
+/// When you add a field to `ModelConfig` that changes the produced bytes, add it
+/// to `derive_with_id` AND here, and bump `FP_VERSION`.
+fn every_fingerprint_field_is_load_bearing() {
+    let base = fp(&hybrid());
+    let muts: Vec<(&str, Box<dyn Fn(&mut ModelConfig)>)> = vec![
+        ("model_type", Box::new(|c| c.model_type = "other".into())),
+        (
+            "num_hidden_layers",
+            Box::new(|c| {
+                c.num_hidden_layers += 1;
+                // keep layer_types-driven counts moving too
+                c.layer_types.push(LayerType::FullAttention);
+            }),
+        ),
+        (
+            "layer mix (ssm/attn split)",
+            Box::new(|c| {
+                c.layer_types[0] = LayerType::FullAttention;
+            }),
+        ),
+        ("head_dim", Box::new(|c| c.head_dim += 1)),
+        (
+            "num_key_value_heads",
+            Box::new(|c| c.num_key_value_heads += 1),
+        ),
+        ("num_experts", Box::new(|c| c.num_experts = 0)),
+        // FP_VERSION 2. These five were MISSING from the fingerprint and this
+        // list simultaneously — so this test passed green while two models
+        // differing only in `hidden_size` / `num_attention_heads` collided on a
+        // shared paging peer. Adding a field to `derive_with_id` without adding
+        // it here reproduces exactly that false confidence.
+        ("hidden_size", Box::new(|c| c.hidden_size += 1)),
+        (
+            "num_attention_heads",
+            Box::new(|c| c.num_attention_heads += 1),
+        ),
+        ("intermediate_size", Box::new(|c| c.intermediate_size += 1)),
+        (
+            "moe_intermediate_size",
+            Box::new(|c| c.moe_intermediate_size += 1),
+        ),
+        (
+            "num_experts_per_tok",
+            Box::new(|c| c.num_experts_per_tok += 1),
+        ),
+        (
+            "linear_num_key_heads",
+            Box::new(|c| c.linear_num_key_heads += 1),
+        ),
+        (
+            "linear_key_head_dim",
+            Box::new(|c| c.linear_key_head_dim += 1),
+        ),
+        (
+            "linear_num_value_heads",
+            Box::new(|c| c.linear_num_value_heads += 1),
+        ),
+        (
+            "linear_value_head_dim",
+            Box::new(|c| c.linear_value_head_dim += 1),
+        ),
+        (
+            "linear_conv_kernel_dim",
+            Box::new(|c| c.linear_conv_kernel_dim += 1),
+        ),
+        ("mamba_num_heads", Box::new(|c| c.mamba_num_heads = 8)),
+        ("mamba_head_dim", Box::new(|c| c.mamba_head_dim = 64)),
+        ("ssm_state_size", Box::new(|c| c.ssm_state_size = 128)),
+        ("n_groups", Box::new(|c| c.n_groups = 8)),
+        (
+            "quantization_config",
+            Box::new(|c| {
+                c.quantization_config = Some(QuantizationConfig {
+                    quant_method: "modelopt".into(),
+                    quant_algo: "NVFP4".into(),
+                    format: String::new(),
+                    ignore_modules: Vec::new(),
+                });
+            }),
+        ),
+        (
+            "kv_layer_dims",
+            Box::new(|c| c.kv_layer_dims = vec![(2, 256), (4, 128)]),
+        ),
+    ];
+    for (name, m) in muts {
+        let mut c = hybrid();
+        m(&mut c);
+        assert_ne!(fp(&c), base, "field {name} dropped from the fingerprint");
+    }
+    // blob_bytes is a fingerprint input too (task hard requirement).
+    let b2 = ModelFingerprint::derive_with_id(&hybrid(), BLOB + 1, "")
+        .unwrap()
+        .get();
+    assert_ne!(b2, base, "blob_bytes dropped from the fingerprint");
+    // Optional ATLAS_MODEL_ID salt (fine-tune with identical geometry).
+    let salted = ModelFingerprint::derive_with_id(&hybrid(), BLOB, "ft-v2")
+        .unwrap()
+        .get();
+    assert_ne!(salted, base, "model_id salt dropped from the fingerprint");
+}
+
+// kv_layer_dims order is canonical (layer order) — a reorder must rotate.
+#[test]
+fn kv_layer_dims_order_is_canonical() {
+    let mut a = hybrid();
+    a.kv_layer_dims = vec![(2, 256), (4, 128)];
+    let mut b = hybrid();
+    b.kv_layer_dims = vec![(4, 128), (2, 256)];
+    assert_ne!(fp(&a), fp(&b));
+}
+
+// ── L4: encoding injectivity (length-prefixed strings) ─────────────────
+// Under naive concatenation ("ab" + "c") == ("a" + "bc"); the tagged,
+// length-prefixed encoding must keep them distinct.
+#[test]
+fn string_encoding_is_injective() {
+    let mut a = hybrid();
+    a.model_type = "ab".into();
+    a.quantization_config = Some(QuantizationConfig {
+        quant_method: "c".into(),
+        quant_algo: String::new(),
+        format: String::new(),
+        ignore_modules: Vec::new(),
+    });
+    let mut b = hybrid();
+    b.model_type = "a".into();
+    b.quantization_config = Some(QuantizationConfig {
+        quant_method: "bc".into(),
+        quant_algo: String::new(),
+        format: String::new(),
+        ignore_modules: Vec::new(),
+    });
+    assert_ne!(fp(&a), fp(&b));
+}
+
+// ── Fail-fast: an underivable config is a hard error (PCND) ───────────
+#[test]
+fn underivable_config_fails_fast() {
+    let mut c = hybrid();
+    c.model_type = String::new();
+    c.num_hidden_layers = 0;
+    c.layer_types = Vec::new();
+    let err = ModelFingerprint::derive_with_id(&c, BLOB, "").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("ATLAS_SSM_SWAP_NS"),
+        "actionable message: {msg}"
+    );
+}
+
+// ── Decode namespace: domain-separated mix, never the bare constant ────
+#[test]
+fn decode_ns_mixes_fingerprint_and_domain() {
+    let fa = ModelFingerprint::derive_with_id(&hybrid(), BLOB, "").unwrap();
+    let fb = ModelFingerprint::derive_with_id(&dense(), BLOB, "").unwrap();
+    let da = mix64(fa.get(), atlas_kernels::DECODE_DOMAIN);
+    let db = mix64(fb.get(), atlas_kernels::DECODE_DOMAIN);
+    // Separated from the same model's Marconi keys (shared peer residency)…
+    assert_ne!(da, fa.get());
+    // …never the bare constant (the old cross-model decode collision)…
+    assert_ne!(da, atlas_kernels::DECODE_DOMAIN);
+    // …and distinct across models.
+    assert_ne!(da, db);
+}
+
+// ── Override precedence + strict parsing ───────────────────────────────
+#[test]
+fn override_precedence_and_strict_parse() {
+    let derived = NonZeroU64::new(0xFEED).unwrap();
+    // No override → derived fingerprint namespace.
+    assert_eq!(resolve_ns_from(None, "V", derived).unwrap(), derived);
+    // Explicit decimal and 0x-hex overrides win.
+    assert_eq!(resolve_ns_from(Some("42"), "V", derived).unwrap().get(), 42);
+    assert_eq!(
+        resolve_ns_from(Some("0xD3C0"), "V", derived).unwrap().get(),
+        0xD3C0
+    );
+    // Unparseable is a hard error, not a silent fallthrough (PCND).
+    assert!(resolve_ns_from(Some("banana"), "V", derived).is_err());
+    assert!(resolve_ns_from(Some("-1"), "V", derived).is_err());
+    assert!(resolve_ns_from(Some("18446744073709551616"), "V", derived).is_err());
+    // 0 is a hard error: the passthrough is removed.
+    let err = resolve_ns_from(Some("0"), "V", derived).unwrap_err();
+    assert!(format!("{err:#}").contains("passthrough"));
+}
+
+/// The decode namespace must never equal the Marconi (swap) namespace for the
+/// same model: the two tiers share a peer, and an alias would let a decode
+/// rollback blob be served as a Marconi snapshot. The zero-avoidance fallback in
+/// `resolve_decode_ns` previously collapsed onto `fp` itself, which IS the swap
+/// namespace — so the guard is on the fallback, not just the happy path.
+#[test]
+fn decode_ns_never_aliases_the_swap_ns() {
+    for cfg in [hybrid(), dense()] {
+        let f = ModelFingerprint::derive_with_id(&cfg, BLOB, "").unwrap();
+        let swap = resolve_swap_ns(f).unwrap();
+        let decode = resolve_decode_ns(f).unwrap();
+        assert_ne!(
+            swap, decode,
+            "decode namespace aliased the swap namespace for {}",
+            cfg.model_type
+        );
+        // And the swap ns is the fingerprint itself (no override set).
+        assert_eq!(swap.get(), f.get());
+    }
+}

--- a/crates/spark-model/src/model/ssm_tier/paging_isolation_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/paging_isolation_tests.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! THE cross-model shared-peer regression tests — hardware-free.
+//!
+//! The paging peer owns ONE residency map keyed purely by the u64 wire key
+//! the client sends, so the fingerprint-derived namespace folded by
+//! [`PagingSnapshotStore::wire`] is the ONLY thing preventing two models from
+//! silently serving each other's recurrent state for the same (model-
+//! independent) `prefix_hash`. Before the fingerprint work this failure was
+//! SILENT — a cross-model GET was a cache *hit* with the wrong bytes, the
+//! worst failure mode in this system. These tests drive two stores with
+//! different namespaces over ONE shared mock peer and pin both directions:
+//! distinct namespaces isolate; equal namespaces (the old ns=0-passthrough /
+//! shared-DECODE_DOMAIN defaults) collide.
+
+use std::collections::HashMap;
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
+use anyhow::Result;
+use atlas_core::config::{LayerType, ModelConfig};
+use parking_lot::Mutex;
+
+use super::super::fingerprint::{ModelFingerprint, mix64};
+use super::super::{MockSnapshotTransport, PagingTransport, SnapshotBlobStore, SnapshotTransport};
+use super::PagingSnapshotStore;
+
+const BLOB: usize = 64;
+/// A logical tier key. `prefix_hash` is computed over TOKENS only, so two
+/// models given the same prompt derive this SAME key — model identity must
+/// come from the namespace, nowhere else.
+const K: u64 = 0x5EED_F00D_CAFE_D00D;
+
+// ── Mock peer: byte-faithful to the shared paging peer's service ──
+// ONE residency map (wire-key → slot) + ONE flat arena shared by every
+// client store — exactly like production clients sharing one RAM blade.
+// Models residency + the arena only (no LRU eviction / NVMe spill /
+// read-pins: collision semantics don't depend on those).
+
+// `pub(super)` so a later cross-client decode-salt regression module can drive
+// the SAME byte-faithful mock peer instead of transcribing a second copy.
+pub(super) struct MockPagingPeer {
+    blob_bytes: usize,
+    inner: Mutex<MockPeerInner>,
+    arena: MockSnapshotTransport,
+}
+
+struct MockPeerInner {
+    /// wire-key → slot: the peer-side `Residency.map` (`HashMap<u64, Loc>`).
+    map: HashMap<u64, usize>,
+    free: Vec<usize>,
+}
+
+impl MockPagingPeer {
+    pub(super) fn new(blob_bytes: usize, slots: usize) -> Self {
+        Self {
+            blob_bytes,
+            inner: Mutex::new(MockPeerInner {
+                map: HashMap::new(),
+                free: (0..slots).rev().collect(),
+            }),
+            arena: MockSnapshotTransport::new(blob_bytes * slots),
+        }
+    }
+}
+
+impl PagingTransport for Arc<MockPagingPeer> {
+    fn paging_put(&self, key: u64, bytes: &[u8]) -> Result<()> {
+        let slot = {
+            let mut g = self.inner.lock();
+            match g.map.get(&key) {
+                Some(&s) => s,
+                None => {
+                    let s = g.free.pop().expect("mock peer full — size the test arena");
+                    g.map.insert(key, s);
+                    s
+                }
+            }
+        };
+        self.arena
+            .write_blob((slot * self.blob_bytes) as u64, bytes)
+    }
+    fn paging_get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+        let slot = match self.inner.lock().map.get(&key) {
+            Some(&s) => s,
+            None => return Ok(false),
+        };
+        self.arena.read_blob((slot * self.blob_bytes) as u64, out)?;
+        Ok(true)
+    }
+    fn paging_remove(&self, key: u64) -> Result<()> {
+        let mut g = self.inner.lock();
+        if let Some(s) = g.map.remove(&key) {
+            g.free.push(s);
+        }
+        Ok(())
+    }
+}
+
+// ── Fixtures: two DIFFERENT models, fingerprints derived the real way ────
+
+fn hybrid() -> ModelConfig {
+    ModelConfig::qwen3_next_80b_nvfp4()
+}
+
+fn dense() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.model_type = "qwen3".to_string();
+    c.num_hidden_layers = 28;
+    c.layer_types = vec![LayerType::FullAttention; 28];
+    c.num_experts = 0;
+    c.linear_num_key_heads = 0;
+    c.linear_key_head_dim = 0;
+    c.linear_num_value_heads = 0;
+    c.linear_value_head_dim = 0;
+    c
+}
+
+fn ns_of(cfg: &ModelConfig) -> NonZeroU64 {
+    ModelFingerprint::derive_with_id(cfg, BLOB, "")
+        .unwrap()
+        .nonzero()
+}
+
+fn store(peer: &Arc<MockPagingPeer>, ns: NonZeroU64) -> PagingSnapshotStore {
+    PagingSnapshotStore::new(Box::new(peer.clone()), BLOB, ns)
+}
+
+// ── T1 (the headline): distinct fingerprints do not cross-serve ──────────
+
+#[test]
+fn distinct_fingerprints_do_not_cross_serve() {
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    let a = store(&peer, ns_of(&hybrid()));
+    let b = store(&peer, ns_of(&dense()));
+    a.put(K, &[0xAA; BLOB]).unwrap();
+    let mut out = [0u8; BLOB];
+    assert!(
+        !b.get(K, &mut out).unwrap(),
+        "model B must MISS model A's state for the same logical key"
+    );
+    assert_eq!(out, [0u8; BLOB], "a miss must leave `out` untouched");
+    // …while model A still hits its own entry (isolation, not amnesia).
+    assert!(a.get(K, &mut out).unwrap());
+    assert_eq!(out, [0xAA; BLOB]);
+}
+
+// ── T2: pin the OLD bug so it cannot come back ────────────────────────────
+// OLD behavior: with ATLAS_TARGET_MODEL unset both models derived ns=0 and
+// wire() passed the key through unchanged — i.e. both folded ONE equal
+// effective namespace (the decode tier likewise shared the bare
+// DECODE_DOMAIN constant). ns=0 is now unrepresentable (NonZeroU64), so the
+// pin is written as "EQUAL namespaces collide" — semantically the same bug,
+// refactor-proof against the passthrough deletion.
+
+#[test]
+fn equal_namespaces_cross_serve_the_old_default_bug() {
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    // e.g. the old shared decode default: DECODE_DOMAIN for EVERY model.
+    let shared = NonZeroU64::new(atlas_kernels::DECODE_DOMAIN).unwrap();
+    let a = store(&peer, shared);
+    let b = store(&peer, shared);
+    a.put(K, &[0xAA; BLOB]).unwrap();
+    let mut out = [0u8; BLOB];
+    assert!(
+        b.get(K, &mut out).unwrap(),
+        "equal namespaces DO collide — this is the pinned bug"
+    );
+    assert_eq!(
+        out, [0xAA; BLOB],
+        "model B silently served model A's recurrent state as a cache HIT"
+    );
+}
+
+// ── T3: identical fingerprint round-trips (the whole point of sharing) ────
+
+#[test]
+fn same_fingerprint_round_trips_across_clients() {
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    let ns = ns_of(&hybrid());
+    let c1 = store(&peer, ns);
+    let c2 = store(&peer, ns);
+    let blob: Vec<u8> = (0..BLOB as u8).collect();
+    c1.put(K, &blob).unwrap();
+    let mut out = vec![0u8; BLOB];
+    assert!(
+        c2.get(K, &mut out).unwrap(),
+        "same model, second client: shared warm-cache HIT"
+    );
+    assert_eq!(out, blob, "bit-identical restore");
+}
+
+// ── Namespace scoping extends to REMOVE and to the decode domain ─────────
+
+#[test]
+fn remove_is_namespace_scoped() {
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    let a = store(&peer, ns_of(&hybrid()));
+    let b = store(&peer, ns_of(&dense()));
+    a.put(K, &[0xAA; BLOB]).unwrap();
+    b.remove(K); // must not evict A's entry
+    let mut out = [0u8; BLOB];
+    assert!(a.get(K, &mut out).unwrap(), "B's remove must not evict A");
+    a.remove(K);
+    assert!(!a.get(K, &mut out).unwrap(), "A's remove evicts A");
+}
+
+#[test]
+fn decode_and_marconi_tiers_do_not_cross_serve_on_one_peer() {
+    // Decode + Marconi share ONE peer residency whenever blob_bytes match;
+    // the decode namespace mix64(fp, DECODE_DOMAIN) must keep one model's
+    // decode spills off its own Marconi keys.
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    let fp = ModelFingerprint::derive_with_id(&hybrid(), BLOB, "").unwrap();
+    let marconi = store(&peer, fp.nonzero());
+    let decode = store(
+        &peer,
+        NonZeroU64::new(mix64(fp.get(), atlas_kernels::DECODE_DOMAIN)).unwrap(),
+    );
+    marconi.put(K, &[0xAA; BLOB]).unwrap();
+    let mut out = [0u8; BLOB];
+    assert!(
+        !decode.get(K, &mut out).unwrap(),
+        "decode namespace must not serve Marconi state"
+    );
+}
+
+// ── wire() determinism: what T3 (and every warm hit ever) depends on ──────
+
+#[test]
+fn wire_fold_is_deterministic_per_store_instance() {
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    let ns = ns_of(&hybrid());
+    let s1 = store(&peer, ns);
+    let s2 = store(&peer, ns);
+    for key in [0u64, 1, K, u64::MAX] {
+        assert_eq!(s1.wire(key), s2.wire(key), "same (ns, key) → same wire key");
+    }
+    // And distinct namespaces fold the same key differently (T1's mechanism).
+    let other = store(&peer, ns_of(&dense()));
+    assert_ne!(s1.wire(K), other.wire(K));
+}
+
+/// GOLDEN PIN on the PERSISTED key. `wire_fold_is_deterministic_per_store_instance`
+/// above proves self-consistency, so it would still pass if the entire fold
+/// rotated — while every key already written to a peer's NVMe swap file became
+/// unreachable. This pins the actual `u64` that goes on the wire and onto disk.
+///
+/// It also pins the SSOT identity `wire(key) == mix64(key, ns)`: `wire()` used to
+/// be a third hand-transcription of the splitmix64 constants and now delegates to
+/// `atlas_tier::hash::mix64`. If those ever diverge, this fails.
+///
+/// DO NOT update the literal to make this pass — a change here is a deliberate
+/// fleet-wide cache flush and must be versioned.
+#[test]
+fn wire_key_is_mix64_of_key_and_ns() {
+    let peer = Arc::new(MockPagingPeer::new(BLOB, 8));
+    // The pinned hybrid-MoE fingerprint (fingerprint_tests::golden_fingerprint_*).
+    let ns = NonZeroU64::new(0x5629_922c_51a1_6a10).unwrap();
+    let s = store(&peer, ns);
+    let key = 0x0123_4567_89ab_cdef_u64;
+
+    assert_eq!(
+        s.wire(key),
+        0x51f6_0258_9d95_1e89,
+        "persisted wire key rotated"
+    );
+    assert_eq!(
+        s.wire(key),
+        mix64(key, ns.get()),
+        "wire() must BE mix64(key, ns)"
+    );
+}

--- a/crates/spark-model/src/model/ssm_tier/selectors.rs
+++ b/crates/spark-model/src/model/ssm_tier/selectors.rs
@@ -5,11 +5,11 @@
 
 use anyhow::{Result, bail};
 
-use super::fingerprint::ModelFingerprint;
-use super::unified::{build_unified_swap, unified_hot_slots};
+use super::fingerprint::{ModelFingerprint, resolve_decode_ns, resolve_swap_ns};
+use super::unified::{TransportSlotArena, build_unified_swap, unified_hot_slots};
 use super::{
-    ArenaSnapshotStore, FileSnapshotArena, MemBlobStore, SnapshotBlobStore, UnifiedSnapshotStore,
-    ssm_tier_unified,
+    ArenaSnapshotStore, FileSnapshotArena, MemBlobStore, PagingSnapshotStore, RdmaSnapshotStore,
+    SnapshotBlobStore, UnifiedSnapshotStore, ssm_tier_unified,
 };
 
 /// Whether the SSM spill tier is engaged (`ATLAS_SSM_TIER`). Default off ⇒
@@ -19,16 +19,108 @@ pub(crate) fn ssm_tier_enabled() -> bool {
 }
 
 /// Build the SSM spill-tier store (called only when `ssm_tier_enabled()`).
-/// Local backends: the unified host-RAM [`UnifiedSnapshotStore`] when
-/// `ATLAS_SSM_TIER_UNIFIED` is set (logging and falling back to host-RAM on a
-/// build error — the tier is optional, never a hard model-init error),
-/// otherwise `MemBlobStore::new(0)` — the byte-identical default. The RDMA arena
-/// (`ATLAS_SSM_RDMA_TIER` / `ATLAS_SSM_SWAP`) binding lands in a follow-up PR.
+/// `ATLAS_SSM_RDMA_TIER=host:port` selects the RDMA arena
+/// ([`RdmaSnapshotStore`] over a peer blade, `ATLAS_SSM_RDMA_ARENA_SLOTS` slots,
+/// default 512); otherwise the host-RAM [`MemBlobStore`]. A connect failure (or
+/// a build without RDMA verbs) LOGS and falls back to host-RAM — the tier is
+/// optional, never a hard model-init error. With `ATLAS_SSM_RDMA_TIER` unset the
+/// result is exactly `MemBlobStore::new(0)` as before ⇒ byte-identical.
+///
+/// `Err` is reserved for CONFIG errors (a bad `ATLAS_SSM_SWAP_NS` override —
+/// PCND fail-fast, resolved BEFORE any connect attempt); connectivity failures
+/// keep the non-fatal fallback chain paging → bounded RDMA → host-RAM.
 pub(crate) fn build_tier_store(
-    _fp: ModelFingerprint,
+    fp: ModelFingerprint,
     blob_bytes: usize,
 ) -> Result<std::sync::Arc<dyn SnapshotBlobStore>> {
     use std::sync::Arc;
+    if let Some(peer) = std::env::var("ATLAS_SSM_RDMA_TIER")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        let slots: usize = std::env::var("ATLAS_SSM_RDMA_ARENA_SLOTS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(512);
+        let arena_bytes = slots as u64 * blob_bytes as u64;
+        // WS-A: ATLAS_SSM_SWAP=1 selects PAGING mode — the peer (started with
+        // --swap-dir) owns residency and backs the RAM arena with an NVMe swap
+        // file, giving infinite depth (never drops) shared across clients. Falls
+        // through to the bounded RDMA store / host-RAM on any connect failure.
+        if std::env::var("ATLAS_SSM_SWAP").ok().as_deref() == Some("1") {
+            // Namespace = ATLAS_SSM_SWAP_NS (explicit u64 override, strict) or
+            // the config-derived model fingerprint, so different models sharing
+            // one peer can never collide. Resolved BEFORE the connect attempt:
+            // a bad override is a config error, not a connectivity error.
+            let namespace = resolve_swap_ns(fp)?;
+            match spark_storage::RdmaSnapshotArena::connect_paging(&peer, arena_bytes, blob_bytes) {
+                Ok(arena) => {
+                    tracing::info!(
+                        "SSM spill tier = RDMA PAGING peer {peer} ({slots}-slot shared RAM cache × \
+                         {blob_bytes} B + NVMe swap = infinite depth; ns={namespace:#x}, model \
+                         fingerprint {:#018x})",
+                        fp.get(),
+                    );
+                    return Ok(Arc::new(PagingSnapshotStore::new(
+                        Box::new(arena),
+                        blob_bytes,
+                        namespace,
+                    )));
+                }
+                Err(e) => tracing::warn!(
+                    "SSM RDMA paging connect to {peer} failed ({e:#}); trying bounded RDMA"
+                ),
+            }
+        }
+        // `connect` errors (and we fall back) both on a real connect failure and
+        // in a build without the RDMA verbs (the stub arena always errors).
+        match spark_storage::RdmaSnapshotArena::connect(&peer, arena_bytes, blob_bytes) {
+            Ok(arena) => {
+                if ssm_tier_unified() {
+                    // §4 fix (the LIVE bug arm): replace the drop-on-full
+                    // fixed-slot allocator with the peer's LRU/never-reject
+                    // Residency, client-side, over the same remote arena — an
+                    // arena-full PUT now LRU-spills the coldest blob to the
+                    // local swap tier instead of silently discarding the spill.
+                    let hot = Box::new(TransportSlotArena {
+                        transport: Box::new(arena),
+                        slot_bytes: blob_bytes,
+                        num_slots: slots,
+                    });
+                    let swap = build_unified_swap(blob_bytes, "marconi-rdma");
+                    match UnifiedSnapshotStore::new(hot, swap, blob_bytes) {
+                        Ok(s) => {
+                            tracing::info!(
+                                "SSM spill tier = UNIFIED residency over RDMA peer {peer} \
+                                 ({slots} hot slots × {blob_bytes} B, LRU spill, never rejects)"
+                            );
+                            return Ok(Arc::new(s));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "SSM unified residency init failed ({e:#}); \
+                                 falling back to host-RAM"
+                            );
+                            return Ok(Arc::new(MemBlobStore::new(0)));
+                        }
+                    }
+                }
+                tracing::info!(
+                    "SSM spill tier = RDMA peer {peer} ({slots} slots × {blob_bytes} B = \
+                     {:.2} GiB arena)",
+                    arena_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+                );
+                return Ok(Arc::new(RdmaSnapshotStore::new(
+                    Box::new(arena),
+                    blob_bytes,
+                    slots,
+                )));
+            }
+            Err(e) => tracing::warn!(
+                "SSM RDMA tier connect to {peer} failed ({e:#}); falling back to host-RAM"
+            ),
+        }
+    }
     if ssm_tier_unified() {
         // §4 fix (host-RAM arm): one policy core instead of the FIFO
         // MemBlobStore — a bounded LRU hot arena that spills (never rejects)
@@ -64,11 +156,12 @@ pub(crate) fn build_tier_store(
 /// Selection (`ATLAS_SSM_DECODE_TIER`):
 ///   - `nvme` + `ATLAS_SSM_DECODE_NVME_DIR=<dir>` → [`FileSnapshotArena`] behind
 ///     [`ArenaSnapshotStore`], provably sized ≥ `min_slots`.
-///   - unset / anything else → unbounded host-RAM `MemBlobStore::new(0)`.
-///
-/// The `peer` (RDMA) decode tier binding lands in a follow-up PR.
+///   - `peer`  + `ATLAS_SSM_DECODE_RDMA_TIER=host:port` → the never-dropping
+///     [`PagingSnapshotStore`] (peer LRU-spills to its own NVMe), own
+///     `ATLAS_SSM_DECODE_NS` namespace fold.
+///   - unset / anything else → unbounded host-RAM [`MemBlobStore::new(0)`].
 pub(crate) fn build_decode_tier_store(
-    _fp: ModelFingerprint,
+    fp: ModelFingerprint,
     blob_bytes: usize,
     min_slots: usize,
 ) -> Result<std::sync::Arc<dyn SnapshotBlobStore>> {
@@ -124,6 +217,44 @@ pub(crate) fn build_decode_tier_store(
                 Box::new(arena),
                 blob_bytes,
                 slots,
+            )))
+        }
+        Some("peer") => {
+            let peer = std::env::var("ATLAS_SSM_DECODE_RDMA_TIER")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "ATLAS_SSM_DECODE_TIER=peer requires ATLAS_SSM_DECODE_RDMA_TIER=host:port"
+                    )
+                })?;
+            // Namespace = ATLAS_SSM_DECODE_NS (explicit u64 override, strict)
+            // or mix64(mix64(fingerprint, DECODE_DOMAIN), client_salt): the
+            // DOMAIN separator keeps decode spills off the same model's Marconi
+            // keys (both tiers share ONE peer residency whenever blob_bytes
+            // match), the fingerprint keeps them off OTHER models' decode
+            // spills, and the per-process client salt keeps them off other
+            // same-model CLIENTS' spills (cold keys are slot coordinates —
+            // identical across processes without it). NOTE the manager-side
+            // cold_key also folds DECODE_DOMAIN over (seq, logical) — that fold
+            // stays: removing it while this ns is overridden would re-collide
+            // decode with Marconi. Resolved BEFORE the (fatal) connect.
+            let namespace = resolve_decode_ns(fp)?;
+            // Arena RAM cache size is a hint; the peer pages to its own NVMe so
+            // the store never drops regardless of this slot count.
+            let slots = (min_slots + 1).max(512);
+            let arena_bytes = slots as u64 * blob_bytes as u64;
+            let arena =
+                spark_storage::RdmaSnapshotArena::connect_paging(&peer, arena_bytes, blob_bytes)?;
+            tracing::info!(
+                "SSM decode cold tier = RDMA PAGING peer {peer} (non-dropping, ns={namespace:#x}, \
+                 model fingerprint {:#018x})",
+                fp.get(),
+            );
+            Ok(Arc::new(PagingSnapshotStore::new(
+                Box::new(arena),
+                blob_bytes,
+                namespace,
             )))
         }
         // Unset = the documented default: unbounded, non-dropping host RAM.

--- a/crates/spark-model/src/model/ssm_tier/selectors.rs
+++ b/crates/spark-model/src/model/ssm_tier/selectors.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Env-driven selectors: which store backs the Marconi spill tier and the
+//! decode rolling tier.
+
+use anyhow::{Result, bail};
+
+use super::fingerprint::ModelFingerprint;
+use super::unified::{build_unified_swap, unified_hot_slots};
+use super::{
+    ArenaSnapshotStore, FileSnapshotArena, MemBlobStore, SnapshotBlobStore, UnifiedSnapshotStore,
+    ssm_tier_unified,
+};
+
+/// Whether the SSM spill tier is engaged (`ATLAS_SSM_TIER`). Default off ⇒
+/// eviction drops exactly as before ⇒ byte-identical to a pre-tier build.
+pub(crate) fn ssm_tier_enabled() -> bool {
+    std::env::var_os("ATLAS_SSM_TIER").is_some()
+}
+
+/// Build the SSM spill-tier store (called only when `ssm_tier_enabled()`).
+/// Local backends: the unified host-RAM [`UnifiedSnapshotStore`] when
+/// `ATLAS_SSM_TIER_UNIFIED` is set (logging and falling back to host-RAM on a
+/// build error — the tier is optional, never a hard model-init error),
+/// otherwise `MemBlobStore::new(0)` — the byte-identical default. The RDMA arena
+/// (`ATLAS_SSM_RDMA_TIER` / `ATLAS_SSM_SWAP`) binding lands in a follow-up PR.
+pub(crate) fn build_tier_store(
+    _fp: ModelFingerprint,
+    blob_bytes: usize,
+) -> Result<std::sync::Arc<dyn SnapshotBlobStore>> {
+    use std::sync::Arc;
+    if ssm_tier_unified() {
+        // §4 fix (host-RAM arm): one policy core instead of the FIFO
+        // MemBlobStore — a bounded LRU hot arena that spills (never rejects)
+        // into the swap tier. NOTE: unlike today's lazily-growing unbounded
+        // store, the hot arena is allocated up front (slots × blob_bytes).
+        let hot_slots = unified_hot_slots();
+        let hot = Box::new(atlas_tier::VecSlotArena::new(blob_bytes, hot_slots));
+        let swap = build_unified_swap(blob_bytes, "marconi-host");
+        match UnifiedSnapshotStore::new(hot, swap, blob_bytes) {
+            Ok(s) => {
+                tracing::info!(
+                    "SSM spill tier = UNIFIED residency in host RAM ({hot_slots} hot slots × \
+                     {blob_bytes} B, LRU spill, never rejects)"
+                );
+                return Ok(Arc::new(s));
+            }
+            Err(e) => tracing::warn!(
+                "SSM unified residency init failed ({e:#}); falling back to host-RAM store"
+            ),
+        }
+    }
+    Ok(Arc::new(MemBlobStore::new(0)))
+}
+
+/// Build the **decode rolling-tier** cold store (a SEPARATE instance from the
+/// Marconi `build_tier_store`, its own `ATLAS_SSM_DECODE_*` env namespace so keys
+/// and budgets never collide). Non-dropping is a HARD requirement: a dropped
+/// decode blob is a lost rollback target = corrupt restore (unlike Marconi's
+/// miss→recompute). `min_slots` = `(ring_slots − hot_lanes) × max_batch_size` is
+/// the worst-case cold residency; the local NVMe arena is sized ≥ that and its
+/// undersizing is a preflight ERROR, never a warn.
+///
+/// Selection (`ATLAS_SSM_DECODE_TIER`):
+///   - `nvme` + `ATLAS_SSM_DECODE_NVME_DIR=<dir>` → [`FileSnapshotArena`] behind
+///     [`ArenaSnapshotStore`], provably sized ≥ `min_slots`.
+///   - unset / anything else → unbounded host-RAM `MemBlobStore::new(0)`.
+///
+/// The `peer` (RDMA) decode tier binding lands in a follow-up PR.
+pub(crate) fn build_decode_tier_store(
+    _fp: ModelFingerprint,
+    blob_bytes: usize,
+    min_slots: usize,
+) -> Result<std::sync::Arc<dyn SnapshotBlobStore>> {
+    use std::sync::Arc;
+    match std::env::var("ATLAS_SSM_DECODE_TIER").ok().as_deref() {
+        Some("nvme") => {
+            let dir = std::env::var("ATLAS_SSM_DECODE_NVME_DIR")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "ATLAS_SSM_DECODE_TIER=nvme requires ATLAS_SSM_DECODE_NVME_DIR=<dir>"
+                    )
+                })?;
+            if ssm_tier_unified() && blob_bytes > 0 && blob_bytes.is_multiple_of(4096) {
+                // §4 unification: a RAM hot cache over the lifted O_DIRECT swap
+                // file. The uncapped disk tier (max_disk_slots = 0) makes
+                // NON-DROPPING hold BY CONSTRUCTION instead of by arena sizing
+                // — a decode rollback target can never be refused or dropped.
+                std::fs::create_dir_all(&dir)?;
+                let path = std::path::Path::new(&dir)
+                    .join(format!("atlas-decode-ring.{}.swap", std::process::id()));
+                let swap = atlas_tier::DirectSwapFile::create(&path, blob_bytes)?;
+                let hot_slots = unified_hot_slots().min(min_slots + 1);
+                let hot = Box::new(atlas_tier::VecSlotArena::new(blob_bytes, hot_slots));
+                let store = UnifiedSnapshotStore::new(hot, Box::new(swap), blob_bytes)?;
+                tracing::info!(
+                    "SSM decode cold tier = UNIFIED residency ({hot_slots} hot RAM slots + \
+                     O_DIRECT swap in {dir}; non-dropping by construction ≥ min_slots \
+                     {min_slots})"
+                );
+                return Ok(Arc::new(store));
+            }
+            if ssm_tier_unified() {
+                tracing::info!(
+                    "SSM decode cold tier: ATLAS_SSM_TIER_UNIFIED set but blob_bytes \
+                     {blob_bytes} is not a 4 KiB multiple (O_DIRECT stride); keeping the \
+                     sized arena store"
+                );
+            }
+            // Provision to the worst-case cold residency + headroom slot so the
+            // non-dropping invariant holds by construction (an undersized arena
+            // would return Ok(false) on a live target = corruption).
+            let slots = min_slots + 1;
+            let capacity = slots as u64 * blob_bytes as u64;
+            let arena = FileSnapshotArena::create(&dir, capacity)?;
+            tracing::info!(
+                "SSM decode cold tier = LOCAL NVMe {dir} ({slots} slots × {blob_bytes} B = \
+                 {:.2} GiB, non-dropping ≥ min_slots {min_slots})",
+                capacity as f64 / (1024.0 * 1024.0 * 1024.0),
+            );
+            Ok(Arc::new(ArenaSnapshotStore::new(
+                Box::new(arena),
+                blob_bytes,
+                slots,
+            )))
+        }
+        // Unset = the documented default: unbounded, non-dropping host RAM.
+        None => {
+            tracing::info!("SSM decode cold tier = host-RAM (unbounded, non-dropping)");
+            Ok(Arc::new(MemBlobStore::new(0)))
+        }
+        // PCND: a typo ("nmve", "peer ", "") must never silently defeat the
+        // tiering intent by falling through to unbounded host RAM, where decode
+        // spills accumulate until OOM on a long session. Fail fast, name the
+        // variable, the bad value, and the accepted values — mirroring the strict
+        // `parse_ns` this chunk introduced one match arm away.
+        Some(other) => bail!(
+            "ATLAS_SSM_DECODE_TIER={other:?} is not recognized (accepted: \"nvme\", \"peer\", or \
+             unset for unbounded host-RAM). Refusing to silently fall back to host-RAM."
+        ),
+    }
+}
+
+#[cfg(test)]
+#[path = "selectors_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/ssm_tier/selectors_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/selectors_tests.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Env-guarded selector default-path tests (moved from the pre-split
+//! ssm_tier.rs).
+
+use super::*;
+
+fn fp() -> ModelFingerprint {
+    let cfg = atlas_core::config::ModelConfig::qwen3_next_80b_nvfp4();
+    ModelFingerprint::derive_with_id(&cfg, 4, "").unwrap()
+}
+
+#[test]
+fn decode_tier_defaults_to_host_ram_non_dropping() {
+    // With ATLAS_SSM_DECODE_TIER unset the decode store is unbounded host-RAM
+    // and never drops (the correctness floor). Guard on the var being unset.
+    if std::env::var_os("ATLAS_SSM_DECODE_TIER").is_none() {
+        let s = build_decode_tier_store(fp(), 4, /*min_slots*/ 8).unwrap();
+        for k in 0..2000u64 {
+            assert!(s.put(k, &[0; 4]).unwrap(), "non-dropping: nothing refused");
+        }
+        assert_eq!(s.len(), 2000);
+    }
+}
+
+#[test]
+fn build_tier_store_defaults_to_host_ram_unbounded() {
+    // With ATLAS_SSM_RDMA_TIER absent (the byte-identical default), the
+    // selector yields the unbounded host-RAM store. Guarded on the var being
+    // unset so a concurrent env-setting test can't flake this.
+    if std::env::var_os("ATLAS_SSM_RDMA_TIER").is_none() {
+        let s = build_tier_store(fp(), 4).unwrap();
+        assert!(s.put(1, &[1, 2, 3, 4]).unwrap());
+        let mut o = [0u8; 4];
+        assert!(s.get(1, &mut o).unwrap());
+        assert_eq!(o, [1, 2, 3, 4]);
+        for k in 0..1000u64 {
+            assert!(s.put(k, &[0; 4]).unwrap(), "unbounded: nothing dropped");
+        }
+        assert_eq!(s.len(), 1000);
+    }
+}

--- a/crates/spark-model/src/model/ssm_tier/store.rs
+++ b/crates/spark-model/src/model/ssm_tier/store.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The [`SnapshotBlobStore`] seam and the host-RAM reference store.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use parking_lot::Mutex;
+
+/// A keyed byte-blob store backing the SSM spill tier. One blob == one
+/// snapshot's full `(h,conv)×layers` state, keyed by its prefix hash (the same
+/// stable identity the [`crate::traits`] snapshot index keys on).
+///
+/// Implementations must be cheap to share (`Send + Sync`) — the tier is
+/// consulted from the scheduler thread on eviction and on prefix lookup.
+pub(crate) trait SnapshotBlobStore: Send + Sync {
+    /// Store `bytes` under `key`, replacing any prior value. Returns `false`
+    /// when the tier is full and refused the write — the caller then falls back
+    /// to a plain drop (correct degradation, never a hard error).
+    fn put(&self, key: u64, bytes: &[u8]) -> Result<bool>;
+
+    /// Copy the blob for `key` into `out` (which must be sized to the blob).
+    /// Returns `false` if `key` is absent (caller recomputes) or the length
+    /// mismatches (defensive: never scatter a wrong-sized blob into a slot).
+    fn get(&self, key: u64, out: &mut [u8]) -> Result<bool>;
+
+    /// Drop the blob for `key` if present (e.g. when its prefix is invalidated).
+    fn remove(&self, key: u64);
+
+    /// Resident blob count.
+    fn len(&self) -> usize;
+
+    /// Total resident bytes — for budget enforcement and telemetry.
+    fn bytes_resident(&self) -> usize;
+}
+
+/// Aggregate spill-tier telemetry (mirrors the Phase-0 snapshot stats).
+#[derive(Default)]
+pub(crate) struct BlobStoreStats {
+    pub puts: AtomicUsize,
+    pub put_rejects: AtomicUsize,
+    pub get_hits: AtomicUsize,
+    pub get_misses: AtomicUsize,
+    pub evictions: AtomicUsize,
+}
+
+/// In-memory host-RAM spill tier. On GB10 (unified LPDDR) this is a real T1
+/// tier, not a test stand-in: spilling here frees a scarce pinned snapshot-pool
+/// slot while the bytes remain in abundant UMA. Bounded by `cap_bytes` with
+/// FIFO eviction so a runaway session can't exhaust host memory; `cap_bytes ==
+/// 0` means unbounded.
+pub(crate) struct MemBlobStore {
+    inner: Mutex<MemInner>,
+    bytes: AtomicUsize,
+    cap_bytes: usize,
+    pub stats: BlobStoreStats,
+}
+
+struct MemInner {
+    map: HashMap<u64, Vec<u8>>,
+    /// Insertion order for FIFO eviction when `cap_bytes` is exceeded. A key is
+    /// pushed on first insert; re-`put` of an existing key overwrites in place
+    /// without reordering (keeps eviction simple and allocation-free).
+    order: std::collections::VecDeque<u64>,
+}
+
+impl MemBlobStore {
+    /// `cap_bytes == 0` → unbounded.
+    pub(crate) fn new(cap_bytes: usize) -> Self {
+        Self {
+            inner: Mutex::new(MemInner {
+                map: HashMap::new(),
+                order: std::collections::VecDeque::new(),
+            }),
+            bytes: AtomicUsize::new(0),
+            cap_bytes,
+            stats: BlobStoreStats::default(),
+        }
+    }
+}
+
+impl SnapshotBlobStore for MemBlobStore {
+    fn put(&self, key: u64, bytes: &[u8]) -> Result<bool> {
+        // A single blob larger than the whole cap can never fit — refuse rather
+        // than evict everything and still fail.
+        if self.cap_bytes != 0 && bytes.len() > self.cap_bytes {
+            self.stats.put_rejects.fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        let mut g = self.inner.lock();
+        // Overwrite in place: reclaim the old blob's bytes first.
+        if let Some(old) = g.map.get(&key) {
+            self.bytes.fetch_sub(old.len(), Ordering::Relaxed);
+        } else {
+            g.order.push_back(key);
+        }
+        // Evict oldest until the new blob fits under the cap.
+        if self.cap_bytes != 0 {
+            while self.bytes.load(Ordering::Relaxed) + bytes.len() > self.cap_bytes {
+                let Some(victim) = g.order.pop_front() else {
+                    break;
+                };
+                if victim == key {
+                    // Don't evict the key we're inserting; requeue and stop.
+                    g.order.push_front(victim);
+                    break;
+                }
+                if let Some(v) = g.map.remove(&victim) {
+                    self.bytes.fetch_sub(v.len(), Ordering::Relaxed);
+                    self.stats.evictions.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        self.bytes.fetch_add(bytes.len(), Ordering::Relaxed);
+        g.map.insert(key, bytes.to_vec());
+        self.stats.puts.fetch_add(1, Ordering::Relaxed);
+        Ok(true)
+    }
+
+    fn get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+        let g = self.inner.lock();
+        match g.map.get(&key) {
+            Some(v) if v.len() == out.len() => {
+                out.copy_from_slice(v);
+                self.stats.get_hits.fetch_add(1, Ordering::Relaxed);
+                Ok(true)
+            }
+            _ => {
+                self.stats.get_misses.fetch_add(1, Ordering::Relaxed);
+                Ok(false)
+            }
+        }
+    }
+
+    fn remove(&self, key: u64) {
+        let mut g = self.inner.lock();
+        if let Some(v) = g.map.remove(&key) {
+            self.bytes.fetch_sub(v.len(), Ordering::Relaxed);
+            g.order.retain(|&k| k != key);
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.inner.lock().map.len()
+    }
+
+    fn bytes_resident(&self) -> usize {
+        self.bytes.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/ssm_tier/store_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/store_tests.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! MemBlobStore contract tests (moved from the pre-split ssm_tier.rs).
+
+use super::*;
+
+#[test]
+fn put_get_round_trip() {
+    let s = MemBlobStore::new(0);
+    assert!(s.put(42, &[1, 2, 3, 4]).unwrap());
+    let mut out = [0u8; 4];
+    assert!(s.get(42, &mut out).unwrap());
+    assert_eq!(out, [1, 2, 3, 4]);
+    assert_eq!(s.len(), 1);
+    assert_eq!(s.bytes_resident(), 4);
+}
+
+#[test]
+fn get_absent_is_miss_not_error() {
+    let s = MemBlobStore::new(0);
+    let mut out = [0u8; 4];
+    assert!(!s.get(7, &mut out).unwrap());
+    assert_eq!(s.stats.get_misses.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn wrong_size_get_refused() {
+    let s = MemBlobStore::new(0);
+    s.put(1, &[9; 8]).unwrap();
+    let mut out = [0u8; 4]; // mismatched
+    assert!(
+        !s.get(1, &mut out).unwrap(),
+        "never scatter a wrong-sized blob"
+    );
+}
+
+#[test]
+fn overwrite_reclaims_bytes() {
+    let s = MemBlobStore::new(0);
+    s.put(1, &[0; 10]).unwrap();
+    s.put(1, &[0; 3]).unwrap();
+    assert_eq!(s.len(), 1);
+    assert_eq!(
+        s.bytes_resident(),
+        3,
+        "old blob bytes reclaimed on overwrite"
+    );
+}
+
+#[test]
+fn cap_evicts_fifo() {
+    let s = MemBlobStore::new(10);
+    s.put(1, &[0; 4]).unwrap(); // 4
+    s.put(2, &[0; 4]).unwrap(); // 8
+    s.put(3, &[0; 4]).unwrap(); // would be 12 > 10 → evict key 1 (oldest)
+    assert!(s.bytes_resident() <= 10);
+    let mut o = [0u8; 4];
+    assert!(!s.get(1, &mut o).unwrap(), "oldest evicted");
+    assert!(s.get(3, &mut o).unwrap(), "newest resident");
+    assert!(s.stats.evictions.load(Ordering::Relaxed) >= 1);
+}
+
+#[test]
+fn blob_larger_than_cap_refused() {
+    let s = MemBlobStore::new(4);
+    assert!(
+        !s.put(1, &[0; 8]).unwrap(),
+        "over-cap blob refused, not partial"
+    );
+    assert_eq!(s.len(), 0);
+    assert_eq!(s.stats.put_rejects.load(Ordering::Relaxed), 1);
+}

--- a/crates/spark-model/src/model/ssm_tier/transport.rs
+++ b/crates/spark-model/src/model/ssm_tier/transport.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Byte-mover plumbing: the [`SnapshotTransport`] seam and its in-process,
+//! RDMA, and local-NVMe implementations.
+
+use anyhow::Result;
+use parking_lot::Mutex;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Phase 4b — RDMA snapshot spill tier (`RdmaSnapshotStore`)
+//
+// A second `SnapshotBlobStore` that ships the (already-contiguous) spill blob to
+// a remote RAM blade over RDMA instead of local host RAM. Scales warm-snapshot
+// capacity past local LPDDR and frees ~16-20 GB HBM; converts an SSM-prefix
+// *recompute* into a ~5-7 ms remote restore. Default-off ⇒ byte-identical.
+//
+// The blob gather/scatter and ALL device ordering (leading/trailing
+// `synchronize`) already happen in `SsmSnapshotPool::{spill_slot,fault_in_slot}`
+// before/after the store is called, so a transport only ever moves HOST bytes —
+// the "60 scattered device pointers" problem is solved at the trait boundary.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Transport seam for the RDMA snapshot tier: a flat remote byte arena addressed
+/// by absolute offset. The RDMA implementation (Phase 4b Inc 2, behind
+/// `atlas_rdma_verbs`) ships each contiguous spill blob to a peer RAM blade over
+/// CX7; `MockSnapshotTransport` is an in-process arena for unit tests. Snapshots
+/// must NOT reuse the KV `RdmaKvBackend` `GroupKey`/`group_stride` addressing
+/// (wrong layout — would corrupt live KV); this arena is offset-addressed only.
+#[allow(dead_code)] // real (RDMA) transport + gate wiring land in Inc 2/3
+pub(crate) trait SnapshotTransport: Send + Sync {
+    /// Write `bytes` to the arena at absolute `offset`. The caller
+    /// (`RdmaSnapshotStore`) guarantees `offset + bytes.len()` is within
+    /// capacity and drains the op's completion before returning.
+    fn write_blob(&self, offset: u64, bytes: &[u8]) -> Result<()>;
+    /// Read `out.len()` bytes from the arena at absolute `offset` into `out`.
+    fn read_blob(&self, offset: u64, out: &mut [u8]) -> Result<()>;
+}
+
+/// In-process arena transport — the unit-test / no-NIC backing for
+/// `RdmaSnapshotStore`. Byte-for-byte faithful to the RDMA transport contract (a
+/// flat offset-addressed arena) so store-level tests exercise the real store.
+#[allow(dead_code)] // used by tests now; by the RDMA transport swap in Inc 2
+pub(crate) struct MockSnapshotTransport {
+    arena: Mutex<Vec<u8>>,
+}
+
+#[allow(dead_code)]
+impl MockSnapshotTransport {
+    pub(crate) fn new(capacity_bytes: usize) -> Self {
+        Self {
+            arena: Mutex::new(vec![0u8; capacity_bytes]),
+        }
+    }
+}
+
+impl SnapshotTransport for MockSnapshotTransport {
+    fn write_blob(&self, offset: u64, bytes: &[u8]) -> Result<()> {
+        let mut a = self.arena.lock();
+        let off = offset as usize;
+        a[off..off + bytes.len()].copy_from_slice(bytes);
+        Ok(())
+    }
+    fn read_blob(&self, offset: u64, out: &mut [u8]) -> Result<()> {
+        let a = self.arena.lock();
+        let off = offset as usize;
+        out.copy_from_slice(&a[off..off + out.len()]);
+        Ok(())
+    }
+}
+
+/// Keyed paging seam for `PagingSnapshotStore`: the PEER owns residency, so
+/// the ops are key-addressed (opaque u64 → blob) — a different contract from
+/// the offset-addressed [`SnapshotTransport`] above (do not conflate the two).
+/// Production = the RDMA paging arena (one shared residency map per peer);
+/// tests = an in-process mock peer, which is what makes the cross-model
+/// isolation regression test hardware-free. The `Box<dyn>` indirection costs
+/// one vtable hop per op — irrelevant next to a multi-ms RDMA round trip; do
+/// NOT "optimize" it back to the concrete type (that kills testability).
+pub(crate) trait PagingTransport: Send + Sync {
+    /// Store `bytes` under `key` on the peer. Never rejects (the peer spills
+    /// its coldest slot to NVMe).
+    fn paging_put(&self, key: u64, bytes: &[u8]) -> Result<()>;
+    /// Fetch `key` into `out`. `Ok(false)` = not resident anywhere (a miss).
+    fn paging_get(&self, key: u64, out: &mut [u8]) -> Result<bool>;
+    /// Drop `key` from the peer's residency (RAM and swap).
+    fn paging_remove(&self, key: u64) -> Result<()>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Local-NVMe transport for the decode rolling tier (`FileSnapshotArena`)
+//
+// The decode cold tier needs a HOST-LOCAL NVMe destination as an alternative to
+// the RDMA paging peer. `spark-storage`'s `StorageBackend` lands bytes directly
+// at a *device* pointer and is KV-`Layout`-coupled — the wrong contract here,
+// where the pool has already gathered host bytes and wants a flat u64→bytes
+// arena. So we plug a `pwrite`/`pread`-at-offset file into the SAME fixed-slot
+// `ArenaSnapshotStore` the RDMA path uses. O_DIRECT is deferred (a pinned bounce
+// like `posix.rs` is a later optimization); a plain buffered file is correct.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// A flat offset-addressed NVMe arena backing the decode cold tier. One
+/// pre-sized file; slot `i`'s blob lives at `i * blob_bytes`. `pwrite`/`pread`
+/// via `FileExt::{write_at,read_at}` are offset-absolute (no shared cursor), so
+/// the store's `Mutex`-guarded allocator is the only serialization needed and
+/// the (blocking) I/O runs on the caller's thread — for the decode tier that is
+/// always the async spill worker, never the decode critical path.
+#[allow(dead_code)]
+pub(crate) struct FileSnapshotArena {
+    file: std::fs::File,
+    capacity: u64,
+}
+
+#[allow(dead_code)]
+impl FileSnapshotArena {
+    /// Create/truncate a backing file of exactly `capacity` bytes under `dir`.
+    /// The file name embeds the pid so two servers on one box never share a
+    /// backing store (decode blobs are ephemeral, never recovered across runs).
+    pub(crate) fn create(dir: &str, capacity: u64) -> Result<Self> {
+        std::fs::create_dir_all(dir)?;
+        let path = std::path::Path::new(dir)
+            .join(format!("atlas-decode-ring.{}.arena", std::process::id()));
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)?;
+        file.set_len(capacity)?;
+        Ok(Self { file, capacity })
+    }
+}
+
+impl SnapshotTransport for FileSnapshotArena {
+    fn write_blob(&self, offset: u64, bytes: &[u8]) -> Result<()> {
+        use std::os::unix::fs::FileExt;
+        if offset + bytes.len() as u64 > self.capacity {
+            anyhow::bail!(
+                "FileSnapshotArena write {offset}+{} exceeds capacity {}",
+                bytes.len(),
+                self.capacity
+            );
+        }
+        self.file.write_all_at(bytes, offset)?;
+        Ok(())
+    }
+    fn read_blob(&self, offset: u64, out: &mut [u8]) -> Result<()> {
+        use std::os::unix::fs::FileExt;
+        if offset + out.len() as u64 > self.capacity {
+            anyhow::bail!(
+                "FileSnapshotArena read {offset}+{} exceeds capacity {}",
+                out.len(),
+                self.capacity
+            );
+        }
+        self.file.read_exact_at(out, offset)?;
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/model/ssm_tier/transport.rs
+++ b/crates/spark-model/src/model/ssm_tier/transport.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use parking_lot::Mutex;
 
 // ─────────────────────────────────────────────────────────────────────────
-// Phase 4b — RDMA snapshot spill tier (`RdmaSnapshotStore`)
+// RDMA snapshot spill tier (`RdmaSnapshotStore`)
 //
 // A second `SnapshotBlobStore` that ships the (already-contiguous) spill blob to
 // a remote RAM blade over RDMA instead of local host RAM. Scales warm-snapshot
@@ -21,7 +21,7 @@ use parking_lot::Mutex;
 // ─────────────────────────────────────────────────────────────────────────
 
 /// Transport seam for the RDMA snapshot tier: a flat remote byte arena addressed
-/// by absolute offset. The RDMA implementation (Phase 4b Inc 2, behind
+/// by absolute offset. The RDMA implementation (behind
 /// `atlas_rdma_verbs`) ships each contiguous spill blob to a peer RAM blade over
 /// CX7; `MockSnapshotTransport` is an in-process arena for unit tests. Snapshots
 /// must NOT reuse the KV `RdmaKvBackend` `GroupKey`/`group_stride` addressing
@@ -84,6 +84,35 @@ pub(crate) trait PagingTransport: Send + Sync {
     fn paging_get(&self, key: u64, out: &mut [u8]) -> Result<bool>;
     /// Drop `key` from the peer's residency (RAM and swap).
     fn paging_remove(&self, key: u64) -> Result<()>;
+}
+
+// Pure delegation to the arena's inherent paging ops (fully-qualified so the
+// inherent method — not this trait method — is what's called).
+// REVIEW CAREFULLY: a put/get transposition here would corrupt production
+// while every mock-backed test still passes.
+impl PagingTransport for spark_storage::RdmaSnapshotArena {
+    fn paging_put(&self, key: u64, bytes: &[u8]) -> Result<()> {
+        spark_storage::RdmaSnapshotArena::paging_put(self, key, bytes)
+    }
+    fn paging_get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+        spark_storage::RdmaSnapshotArena::paging_get(self, key, out)
+    }
+    fn paging_remove(&self, key: u64) -> Result<()> {
+        spark_storage::RdmaSnapshotArena::paging_remove(self, key)
+    }
+}
+
+// The real transport is spark-storage's offset-addressed
+// `RdmaSnapshotArena` (CX7 verbs + kv-peer blade; a `connect`-errors stub when
+// verbs aren't built). We own `SnapshotTransport` here, so implementing it for
+// the foreign type is allowed (no orphan rule).
+impl SnapshotTransport for spark_storage::RdmaSnapshotArena {
+    fn write_blob(&self, offset: u64, bytes: &[u8]) -> Result<()> {
+        self.write(offset, bytes)
+    }
+    fn read_blob(&self, offset: u64, out: &mut [u8]) -> Result<()> {
+        self.read(offset, out)
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/spark-model/src/model/ssm_tier/unified.rs
+++ b/crates/spark-model/src/model/ssm_tier/unified.rs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! TIERED-CACHE-CONSOLIDATION §4 fix, step 3: the `ATLAS_SSM_TIER_UNIFIED`
+//! flag and the [`UnifiedSnapshotStore`] it routes the spill stores through.
+
+use std::sync::atomic::Ordering;
+
+use anyhow::Result;
+use parking_lot::Mutex;
+
+use super::{BlobStoreStats, SnapshotBlobStore, SnapshotTransport};
+
+/// Opt-in truthy parse for `ATLAS_SSM_TIER_UNIFIED` (style-matching
+/// `ATLAS_HSS_COALESCE_WRITE_RUNS` in spark-storage/high_speed_swap.rs).
+fn unified_flag_truthy(v: Option<&str>) -> bool {
+    matches!(
+        v.map(str::trim),
+        Some("1") | Some("true") | Some("on") | Some("yes")
+    )
+}
+
+/// TIERED-CACHE-CONSOLIDATION §4 fix, step 3: whether the client-side SSM
+/// spill stores route through the ONE lifted policy core
+/// ([`atlas_tier::Residency`] — two-level LRU, never rejects) instead of the
+/// per-store policies (MemBlobStore FIFO, RdmaSnapshotStore drop-on-full).
+/// DEFAULT OFF ⇒ the selectors construct exactly today's stores, byte- and
+/// behavior-identical.
+///
+/// ⚠ **BEFORE FLIPPING THIS DEFAULT ON**, three flag-ON-only defects found by the
+/// step-3 adversarial review must be fixed. None affect the default path; all three
+/// are latent the moment the flag is engaged in production:
+///
+/// 1. **Lock held across transport I/O.** The RDMA arm's `put` path holds the
+///    `UnifiedSnapshotStore` mutex across a victim evict (remote READ of a ~64 MB
+///    blob, ~5–7 ms) *plus* the new blob's remote WRITE. Today's `RdmaSnapshotStore`
+///    does not. Split the residency map ops from the byte moves — the core already
+///    exposes the two-phase `alloc`/`commit` API needed to run transport I/O outside
+///    the lock.
+/// 2. **Silent downgrade to unbounded host RAM.** If `UnifiedSnapshotStore::new`
+///    fails *after* a successful peer connect, the RDMA arm falls back to
+///    `MemBlobStore::new(0)` (unbounded host RAM) with only a warn, abandoning the
+///    connected arena. It should fall through to the legacy `RdmaSnapshotStore`
+///    instead — the arena is already connected.
+/// 3. **Swap files leak.** Flag-ON swap files (`atlas-ssm-{tag}.{pid}.swap`,
+///    `atlas-decode-ring.{pid}.swap`) are per-PID and never unlinked, and the disk
+///    tier grows unbounded by design. Unlink same-tag stale files on create, or open
+///    with `O_TMPFILE`.
+///
+/// Coverage gap to close alongside: the flag-ON **RDMA** and **decode-NVMe** selector
+/// arms are only component-tested, never exercised through `build_tier_store` /
+/// `build_decode_tier_store` with the env set (the host-RAM arm is).
+pub(crate) fn ssm_tier_unified() -> bool {
+    unified_flag_truthy(std::env::var("ATLAS_SSM_TIER_UNIFIED").ok().as_deref())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// §4 unification (TIERED-CACHE-CONSOLIDATION step 3) — ATLAS_SSM_TIER_UNIFIED
+//
+// The SAME logical tier historically got a DIFFERENT eviction policy per
+// backing store: MemBlobStore evicts FIFO by insertion order (latent — the
+// production cap is always 0), RdmaSnapshotStore drops-on-full with no recency
+// at all (live), while the peer's paging Residency does two-level LRU and
+// never rejects. FIFO/drop-on-full defeat the HBM pool's session-aware victim
+// selection: the carefully chosen victim spills into a tier that re-picks its
+// own victim by insertion order — or silently discards it.
+//
+// Flag ON routes the client-side spill stores through the ONE policy core
+// lifted from the peer (`atlas_tier::Residency`: LRU over a hot arena, spill
+// to a swap tier, NEVER reject, uncapped disk ⇒ nothing ever dropped). Flag
+// OFF (default) constructs exactly today's stores — byte/behavior-identical.
+// The gather/scatter of the ~60 per-layer device regions stays ABOVE this
+// boundary in SsmSnapshotPool::{spill_slot,fault_in_slot}; the store only ever
+// moves ONE contiguous host blob, so no scatter-capable SwapStore is needed
+// and the StorageBackend refusals above remain true.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Adapts a [`SnapshotTransport`] (flat offset-addressed remote/file arena) to
+/// the [`atlas_tier::SlotArena`] hot-tier seam: slot `i` lives at offset
+/// `i × slot_bytes` — the same fixed-slot geometry [`super::RdmaSnapshotStore`]
+/// uses, so the peer arena layout is unchanged under the flag.
+// Constructed only through the RDMA transport binding (a follow-up PR) and the
+// unit tests; the local-only selector arms in this PR don't build one yet.
+#[allow(dead_code)]
+pub(super) struct TransportSlotArena {
+    pub(super) transport: Box<dyn SnapshotTransport>,
+    pub(super) slot_bytes: usize,
+    pub(super) num_slots: usize,
+}
+
+impl atlas_tier::SlotArena for TransportSlotArena {
+    fn slot_bytes(&self) -> usize {
+        self.slot_bytes
+    }
+    fn num_slots(&self) -> usize {
+        self.num_slots
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        if slot >= self.num_slots || out.len() != self.slot_bytes {
+            anyhow::bail!("TransportSlotArena::read_slot({slot}) out of range / size mismatch");
+        }
+        self.transport
+            .read_blob((slot * self.slot_bytes) as u64, out)
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        if slot >= self.num_slots || bytes.len() != self.slot_bytes {
+            anyhow::bail!("TransportSlotArena::write_slot({slot}) out of range / size mismatch");
+        }
+        self.transport
+            .write_blob((slot * self.slot_bytes) as u64, bytes)
+    }
+}
+
+/// The flag-ON [`SnapshotBlobStore`]: a `Mutex`-shared [`atlas_tier::Residency`]
+/// (the peer's exact paging core, in-process). PUT never returns `Ok(false)`
+/// for a right-sized blob — a full hot arena LRU-spills its coldest resident
+/// into the swap tier, and the uncapped disk (`max_disk_slots = 0`) means
+/// nothing is ever dropped, which also satisfies the decode tier's HARD
+/// non-dropping requirement BY CONSTRUCTION rather than by sizing. The Mutex
+/// is held across the byte move — the same tradeoff the peer's
+/// `run_paging_loop_shared` documents (map op + one blob memcpy per call).
+pub(crate) struct UnifiedSnapshotStore {
+    inner: Mutex<
+        atlas_tier::Residency<Box<dyn atlas_tier::SlotArena>, Box<dyn atlas_tier::SwapStore>>,
+    >,
+    blob_bytes: usize,
+    pub stats: BlobStoreStats,
+}
+
+impl UnifiedSnapshotStore {
+    pub(super) fn new(
+        arena: Box<dyn atlas_tier::SlotArena>,
+        swap: Box<dyn atlas_tier::SwapStore>,
+        blob_bytes: usize,
+    ) -> Result<Self> {
+        // Uncapped disk tier: keys are NEVER dropped (a capped disk would let
+        // make_disk_room silently discard live decode rollback targets).
+        let residency = atlas_tier::Residency::new(arena, swap)?;
+        Ok(Self {
+            inner: Mutex::new(residency),
+            blob_bytes,
+            stats: BlobStoreStats::default(),
+        })
+    }
+}
+
+impl SnapshotBlobStore for UnifiedSnapshotStore {
+    fn put(&self, key: u64, bytes: &[u8]) -> Result<bool> {
+        // Fixed-size tier: an off-size blob is a caller bug — refuse gracefully
+        // (same contract as RdmaSnapshotStore), never corrupt a slot.
+        if bytes.len() != self.blob_bytes {
+            self.stats.put_rejects.fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        self.inner.lock().put_blob(key, bytes)?;
+        self.stats.puts.fetch_add(1, Ordering::Relaxed);
+        Ok(true) // never full — the residency spills, it doesn't reject
+    }
+
+    fn get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+        // Defensive: never scatter a wrong-sized blob into a slot.
+        if out.len() != self.blob_bytes {
+            self.stats.get_misses.fetch_add(1, Ordering::Relaxed);
+            return Ok(false);
+        }
+        let hit = self.inner.lock().get_blob(key, out)?;
+        if hit {
+            self.stats.get_hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.stats.get_misses.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(hit)
+    }
+
+    fn remove(&self, key: u64) {
+        self.inner.lock().remove(key);
+    }
+
+    fn len(&self) -> usize {
+        self.inner.lock().total_keys()
+    }
+
+    fn bytes_resident(&self) -> usize {
+        // Hot (RAM-arena) bytes; swapped records live in the swap tier.
+        self.inner.lock().resident_count() * self.blob_bytes
+    }
+}
+
+/// The unified stores' swap tier. `ATLAS_SSM_TIER_SWAP_DIR` selects the lifted
+/// O_DIRECT NVMe swap file (needs a 4 KiB-multiple blob — the O_DIRECT
+/// stride); otherwise (or on any setup failure) host-RAM records — still
+/// LRU-ordered and never-reject, just RAM-resident like today's stores.
+pub(super) fn build_unified_swap(blob_bytes: usize, tag: &str) -> Box<dyn atlas_tier::SwapStore> {
+    if let Some(dir) = std::env::var("ATLAS_SSM_TIER_SWAP_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        if blob_bytes > 0 && blob_bytes.is_multiple_of(4096) {
+            let make = || -> Result<atlas_tier::DirectSwapFile> {
+                std::fs::create_dir_all(&dir)?;
+                let path = std::path::Path::new(&dir)
+                    .join(format!("atlas-ssm-{tag}.{}.swap", std::process::id()));
+                atlas_tier::DirectSwapFile::create(&path, blob_bytes)
+            };
+            match make() {
+                Ok(f) => {
+                    tracing::info!("unified SSM tier ({tag}): O_DIRECT swap file in {dir}");
+                    return Box::new(f);
+                }
+                Err(e) => tracing::info!(
+                    "unified SSM tier ({tag}): swap dir {dir} unusable ({e:#}); \
+                     using host-RAM swap"
+                ),
+            }
+        } else {
+            tracing::info!(
+                "unified SSM tier ({tag}): blob_bytes {blob_bytes} is not a 4 KiB multiple \
+                 (O_DIRECT stride); using host-RAM swap"
+            );
+        }
+    }
+    Box::new(atlas_tier::MemSwapStore::new(blob_bytes))
+}
+
+/// Hot-arena slot count for the unified stores (`ATLAS_SSM_TIER_SLOTS`,
+/// default 64). The hot arena is allocated up front at `slots × blob_bytes`.
+pub(super) fn unified_hot_slots() -> usize {
+    std::env::var("ATLAS_SSM_TIER_SLOTS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(64)
+        .max(1)
+}
+
+#[cfg(test)]
+#[path = "unified_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/ssm_tier/unified.rs
+++ b/crates/spark-model/src/model/ssm_tier/unified.rs
@@ -78,9 +78,6 @@ pub(crate) fn ssm_tier_unified() -> bool {
 /// the [`atlas_tier::SlotArena`] hot-tier seam: slot `i` lives at offset
 /// `i × slot_bytes` — the same fixed-slot geometry [`super::RdmaSnapshotStore`]
 /// uses, so the peer arena layout is unchanged under the flag.
-// Constructed only through the RDMA transport binding (a follow-up PR) and the
-// unit tests; the local-only selector arms in this PR don't build one yet.
-#[allow(dead_code)]
 pub(super) struct TransportSlotArena {
     pub(super) transport: Box<dyn SnapshotTransport>,
     pub(super) slot_bytes: usize,

--- a/crates/spark-model/src/model/ssm_tier/unified_tests.rs
+++ b/crates/spark-model/src/model/ssm_tier/unified_tests.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! §4 unification (ATLAS_SSM_TIER_UNIFIED) tests, including the default-OFF
+//! regression guard (moved from the pre-split ssm_tier.rs).
+
+use super::super::{MockSnapshotTransport, RdmaSnapshotStore};
+use super::*;
+
+// Fixed blob size + a bounded-store helper, duplicated from arena_store_tests:
+// the default-OFF guard exercises the bounded store's drop-on-full policy.
+const BLOB: usize = 4;
+fn rdma_store(slots: usize) -> RdmaSnapshotStore {
+    let t = Box::new(MockSnapshotTransport::new(slots * BLOB));
+    RdmaSnapshotStore::new(t, BLOB, slots)
+}
+
+#[test]
+fn unified_flag_truthy_parse_matches_hss_style() {
+    for on in ["1", "true", "on", "yes", " 1 ", "yes "] {
+        assert!(unified_flag_truthy(Some(on)), "{on:?} must engage the flag");
+    }
+    for off in ["", "0", "false", "off", "no", "TRUE", "2"] {
+        assert!(!unified_flag_truthy(Some(off)), "{off:?} must stay off");
+    }
+    assert!(!unified_flag_truthy(None), "unset = default OFF");
+}
+
+fn unified_store(slots: usize) -> UnifiedSnapshotStore {
+    UnifiedSnapshotStore::new(
+        Box::new(atlas_tier::VecSlotArena::new(BLOB, slots)),
+        Box::new(atlas_tier::MemSwapStore::new(BLOB)),
+        BLOB,
+    )
+    .unwrap()
+}
+
+/// THE §4 fix: where the bounded stores FIFO-evict or drop-on-full, the
+/// unified store never rejects — overflow LRU-spills to the swap tier and
+/// every key faults back byte-identical.
+#[test]
+fn unified_store_never_rejects_and_faults_back() {
+    let s = unified_store(2);
+    for k in 0..32u64 {
+        assert!(
+            s.put(k, &[k as u8; BLOB]).unwrap(),
+            "put {k} must never be refused"
+        );
+    }
+    assert_eq!(s.len(), 32, "all keys tracked — nothing dropped");
+    let mut o = [0u8; BLOB];
+    for k in 0..32u64 {
+        assert!(s.get(k, &mut o).unwrap(), "key {k} present");
+        assert_eq!(o, [k as u8; BLOB], "key {k} byte-identical");
+    }
+    assert_eq!(s.stats.put_rejects.load(Ordering::Relaxed), 0);
+}
+
+/// LRU (not FIFO): touching the oldest-inserted key protects it — the
+/// spill victim is the least-recently-USED key. (A capped MemBlobStore
+/// would evict key 1 here; RdmaSnapshotStore would refuse key 3 outright.)
+#[test]
+fn unified_store_victim_is_lru_not_fifo_and_not_a_reject() {
+    let s = unified_store(2);
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    assert!(s.put(2, &[2; BLOB]).unwrap());
+    let mut o = [0u8; BLOB];
+    assert!(s.get(1, &mut o).unwrap()); // touch 1 → 2 is now coldest
+    assert!(s.put(3, &[3; BLOB]).unwrap(), "no drop-on-full");
+    assert_eq!(s.bytes_resident(), 2 * BLOB, "two hot slots resident");
+    // The hot-again key SURVIVED IN THE HOT TIER: getting key 1 is a
+    // resident hit (no disk fault), where FIFO would have evicted it as
+    // oldest-inserted; key 2 was the LRU spill victim and faults back.
+    let faults0 = s.inner.lock().stats().faults_from_disk;
+    assert!(s.get(1, &mut o).unwrap(), "hot-again key survives");
+    assert_eq!(o, [1u8; BLOB]);
+    assert_eq!(
+        s.inner.lock().stats().faults_from_disk,
+        faults0,
+        "key 1 was still RESIDENT — the LRU victim was key 2, not the FIFO-oldest"
+    );
+    assert!(
+        s.get(2, &mut o).unwrap(),
+        "spilled key faults back, never dropped"
+    );
+    assert_eq!(o, [2u8; BLOB]);
+    assert_eq!(
+        s.inner.lock().stats().faults_from_disk,
+        faults0 + 1,
+        "key 2 came back via a disk fault"
+    );
+    assert!(s.get(3, &mut o).unwrap());
+    assert_eq!(o, [3u8; BLOB]);
+}
+
+/// Read-pins are honored through the unified store: a read-pinned key can
+/// never be chosen as the LRU spill victim while pinned (the peer's
+/// mid-RDMA-READ guarantee survives the in-process adoption), and returns
+/// to normal LRU rotation after the last unpin.
+#[test]
+fn unified_store_honors_read_pins() {
+    let s = unified_store(2);
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    assert!(s.put(2, &[2; BLOB]).unwrap());
+    s.inner.lock().pin_read(1);
+    // Churn well past arena capacity: every spill victim must be a key
+    // OTHER than the pinned one.
+    for k in 10..20u64 {
+        assert!(
+            s.put(k, &[k as u8; BLOB]).unwrap(),
+            "puts never rejected while pinned"
+        );
+    }
+    let mut o = [0u8; BLOB];
+    {
+        let mut r = s.inner.lock();
+        assert_eq!(r.read_pin_count(1), 1);
+        let faults0 = r.stats().faults_from_disk;
+        assert!(r.get_blob(1, &mut o).unwrap(), "pinned key present");
+        assert_eq!(
+            r.stats().faults_from_disk,
+            faults0,
+            "pinned key stayed RESIDENT through the churn — never spilled"
+        );
+        r.unpin_read(1);
+        assert_eq!(r.read_pin_count(1), 0);
+    }
+    assert_eq!(o, [1u8; BLOB], "pinned key bytes intact");
+    // After the last unpin the key is evictable again: more churn spills
+    // it, and it faults back byte-identical (never dropped).
+    for k in 20..30u64 {
+        assert!(s.put(k, &[k as u8; BLOB]).unwrap());
+    }
+    let faults1 = s.inner.lock().stats().faults_from_disk;
+    assert!(
+        s.get(1, &mut o).unwrap(),
+        "unpinned key spilled but never dropped"
+    );
+    assert_eq!(o, [1u8; BLOB]);
+    assert_eq!(
+        s.inner.lock().stats().faults_from_disk,
+        faults1 + 1,
+        "unpinned key was evicted normally and faulted back from swap"
+    );
+}
+
+#[test]
+fn unified_store_wrong_size_refused_gracefully() {
+    let s = unified_store(2);
+    assert!(
+        !s.put(1, &[0; BLOB + 1]).unwrap(),
+        "off-size put refused, not corrupt"
+    );
+    assert!(s.put(1, &[7; BLOB]).unwrap());
+    let mut big = [0u8; BLOB + 4];
+    assert!(
+        !s.get(1, &mut big).unwrap(),
+        "never scatter a wrong-sized blob"
+    );
+    assert_eq!(big, [0u8; BLOB + 4], "out untouched on refusal");
+}
+
+#[test]
+fn unified_store_remove_is_clean_miss() {
+    let s = unified_store(2);
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    s.remove(1);
+    let mut o = [0u8; BLOB];
+    assert!(!s.get(1, &mut o).unwrap());
+    assert_eq!(s.len(), 0);
+}
+
+/// Unified over the SAME transport geometry the bounded RDMA store uses:
+/// where `RdmaSnapshotStore` returns Ok(false) at slot 5, the unified wrap
+/// keeps accepting (LRU spill to the swap tier) — the live §4 bug arm.
+#[test]
+fn unified_over_transport_never_drops_where_bounded_store_did() {
+    const SLOTS: usize = 4;
+    let hot = Box::new(TransportSlotArena {
+        transport: Box::new(MockSnapshotTransport::new(SLOTS * BLOB)),
+        slot_bytes: BLOB,
+        num_slots: SLOTS,
+    });
+    let s = UnifiedSnapshotStore::new(hot, Box::new(atlas_tier::MemSwapStore::new(BLOB)), BLOB)
+        .unwrap();
+    let mut o = [0u8; BLOB];
+    for k in 0..16u64 {
+        assert!(
+            s.put(k, &[k as u8; BLOB]).unwrap(),
+            "arena-full put {k} accepted"
+        );
+    }
+    for k in 0..16u64 {
+        assert!(s.get(k, &mut o).unwrap(), "key {k} recoverable");
+        assert_eq!(o, [k as u8; BLOB]);
+    }
+}
+
+/// DEFAULT-OFF byte/behavior identity: with the flag unset the selectors
+/// construct exactly today's stores with today's policies — the bounded
+/// arena still drop-on-fulls here, the FIFO MemBlobStore still evicts
+/// oldest-inserted (`cap_evicts_fifo` in store_tests), and `build_tier_store`
+/// still yields the unbounded host-RAM store
+/// (`build_tier_store_defaults_to_host_ram_unbounded` in selectors_tests).
+#[test]
+fn unified_flag_default_off_preserves_todays_policies() {
+    // Pure-logic half: holds regardless of the ambient environment.
+    assert!(!unified_flag_truthy(None), "absent env ⇒ flag OFF");
+    // Env-dependent half. This is the §4 default-OFF regression guard, so it
+    // must NEVER pass vacuously: fail loudly rather than skip when the flag is
+    // exported into the test environment.
+    assert!(
+        std::env::var_os("ATLAS_SSM_TIER_UNIFIED").is_none(),
+        "ATLAS_SSM_TIER_UNIFIED is set in the test environment — unset it. This test is \
+         the default-OFF regression guard for the TIERED-CACHE-CONSOLIDATION §4 fix; \
+         skipping it would green-light a change to the default path. To exercise the \
+         flag-ON arms, run the flag-ON tests selectively instead of exporting the var \
+         across the whole suite."
+    );
+    assert!(!ssm_tier_unified(), "flag must default OFF");
+    let s = rdma_store(1);
+    assert!(s.put(1, &[1; BLOB]).unwrap());
+    assert!(
+        !s.put(2, &[2; BLOB]).unwrap(),
+        "flag OFF: drop-on-full unchanged"
+    );
+}

--- a/crates/spark-model/src/model/trait_impl/decode_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_checkpoint.rs
@@ -96,10 +96,12 @@ impl TransformerModel {
         ) {
             Ok(Some(id)) => id,
             Ok(None) => {
-                if self
-                    .ssm_snapshots
-                    .reclaim_from_cache(self.prefix_cache.as_ref(), &mut kv)
-                {
+                if self.ssm_snapshots.reclaim_from_cache(
+                    self.prefix_cache.as_ref(),
+                    &mut kv,
+                    self.ssm_tier_store.as_deref(),
+                    self.gpu.as_ref(),
+                ) {
                     match self.ssm_snapshots.save(
                         seq.slot_idx,
                         seq.session_hash,
@@ -204,10 +206,12 @@ impl TransformerModel {
         ) {
             Ok(Some(id)) => Some(id),
             Ok(None) => {
-                if self
-                    .ssm_snapshots
-                    .reclaim_from_cache(self.prefix_cache.as_ref(), &mut self.kv_cache.lock())
-                {
+                if self.ssm_snapshots.reclaim_from_cache(
+                    self.prefix_cache.as_ref(),
+                    &mut self.kv_cache.lock(),
+                    self.ssm_tier_store.as_deref(),
+                    self.gpu.as_ref(),
+                ) {
                     let retry = self.ssm_snapshots.save(
                         seq.slot_idx,
                         seq.session_hash,

--- a/crates/spark-model/src/model/trait_impl/decode_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_checkpoint.rs
@@ -152,6 +152,7 @@ impl TransformerModel {
             snap_id,
             seq.session_hash,
             snap_tokens,
+            seq.adapter_id,
         );
         if let Some(old) = displaced {
             self.ssm_snapshots.free(old);

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -37,6 +37,23 @@ impl TransformerModel {
         // only models would need a different orchestrator. We expose dims
         // unconditionally and let the scheduler decide whether to install,
         // gated by the user's --high-speed-swap CLI choice.
+        //
+        // KV paging identity (ATLAS_KV_PAGING): the SAME config-derived
+        // fingerprint the SSM tier uses (quant identity + geometry + the
+        // ATLAS_MODEL_ID salt), via the KV convention (blob_bytes = 0).
+        // Underivable ⇒ None with a loud warn; the flag-ON connect then fails
+        // fast with an actionable error unless ATLAS_KV_PAGING_NS is set. Every
+        // other path ignores the field (default-off ⇒ unread).
+        let model_fp = match crate::model::ssm_tier::ModelFingerprint::derive_kv(&self.config) {
+            Ok(fp) => Some(fp.nonzero()),
+            Err(e) => {
+                tracing::warn!(
+                    "KV paging fingerprint underivable ({e:#}); ATLAS_KV_PAGING=1 \
+                     will fail fast unless ATLAS_KV_PAGING_NS is set"
+                );
+                None
+            }
+        };
         Some(spark_storage::ModelDims {
             num_layers: self.config.num_hidden_layers as u32,
             max_blocks_per_layer: self.max_blocks_per_seq,
@@ -44,6 +61,7 @@ impl TransformerModel {
             num_kv_heads: self.config.num_key_value_heads as u16,
             head_dim: self.config.head_dim as u16,
             block_size: self.kv_cache.lock().block_size() as u16,
+            model_fp,
         })
     }
 

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -174,6 +174,7 @@ impl TransformerModel {
         // every sequence's first decode step.
         let num_attn_layers = self.config.num_attention_layers();
         Ok(SequenceState {
+            adapter_id: 0,
             tokens: Vec::new(),
             block_table: Vec::new(),
             seq_len: 0,

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -31,6 +31,7 @@ mod prefill_c;
 mod prefill_d;
 mod sequence;
 mod speculative;
+mod ssm_fault_in;
 mod verify_a;
 mod verify_b;
 mod verify_c;

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -81,7 +81,8 @@ impl TransformerModel {
         let prefix_match = if self.tokens_have_vision_pad(tokens) {
             spark_runtime::prefix_cache::PrefixMatch::empty()
         } else {
-            self.prefix_cache.lookup(tokens, bs, seq.session_hash)
+            self.prefix_cache
+                .lookup(tokens, bs, seq.session_hash, seq.adapter_id)
         };
         let mut kv_write_start = prefix_match.matched_tokens;
         seq.cached_prefix_tokens = prefix_match.matched_tokens;

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -133,8 +133,12 @@ impl TransformerModel {
         // With intermediate checkpoints, ssm_snapshot_tokens may be less than
         // matched_tokens. Use ssm_snapshot_tokens as the skip point.
         // Session isolation: only restore snapshots belonging to this session.
-        let marconi_skip = if let Some(snap_id) = prefix_match.ssm_snapshot {
-            let snap_tok = prefix_match.ssm_snapshot_tokens;
+        // Phase 1b spill-tier fault-in (#6): fold a resident hit with a
+        // faulted-back spilled anchor; see `ssm_fault_in::eff_ssm_snapshot`.
+        let (eff_snapshot, eff_snapshot_tokens) =
+            self.eff_ssm_snapshot(&prefix_match, seq.session_hash, stream);
+        let marconi_skip = if let Some(snap_id) = eff_snapshot {
+            let snap_tok = eff_snapshot_tokens;
             if snap_tok > 0
                 && kv_write_start <= n
                 && self
@@ -165,9 +169,19 @@ impl TransformerModel {
                         snap_id,
                     );
                 }
-                // When all tokens matched (exact prompt), the snapshot covers
-                // everything — skip the entire prompt, process only the last token.
-                kv_write_start = if kv_write_start >= n { n } else { snap_tok };
+                // All tokens matched AND the snapshot covers the full match →
+                // skip the whole prompt (process only the last token). But an
+                // *intermediate* checkpoint at full match (snap_tok < n — e.g. a
+                // faulted-in anchor whose leaf was evicted) restored state at
+                // `snap_tok`, not `n`; skipping to `n` would desync SSM state
+                // from KV/positions → garbage. Then skip only to `snap_tok` so
+                // the suffix recomputes SSM over [snap_tok, n). (Mirrors the
+                // prefill_b/prefill_c warm-hit fix.)
+                kv_write_start = if kv_write_start >= n && snap_tok >= kv_write_start {
+                    n
+                } else {
+                    snap_tok
+                };
                 true
             } else {
                 if kv_write_start > 0 {

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -103,7 +103,11 @@ impl TransformerModel {
             let ep_active = self.comm.is_some() && self.config.ep_world_size > 1;
             if cut > chunk_start
                 && cut < total
-                && (ep_active || self.prefix_cache.peek_matched_tokens(tokens, bs) > 0)
+                && (ep_active
+                    || self
+                        .prefix_cache
+                        .peek_matched_tokens(tokens, bs, seq.adapter_id)
+                        > 0)
             {
                 self.prefill_chunk_dispatch(
                     tokens,

--- a/crates/spark-model/src/model/trait_impl/prefill_b/finalize_last.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/finalize_last.rs
@@ -351,10 +351,12 @@ impl TransformerModel {
                 Ok(Some(id)) => Some(id),
                 Ok(None) => {
                     tracing::debug!("Snapshot pool full, reclaiming...");
-                    if self
-                        .ssm_snapshots
-                        .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
-                    {
+                    if self.ssm_snapshots.reclaim_from_cache(
+                        self.prefix_cache.as_ref(),
+                        kv_cache,
+                        self.ssm_tier_store.as_deref(),
+                        self.gpu.as_ref(),
+                    ) {
                         self.ssm_snapshots
                             .save(
                                 seq.slot_idx,

--- a/crates/spark-model/src/model/trait_impl/prefill_b/finalize_last.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/finalize_last.rs
@@ -328,6 +328,7 @@ impl TransformerModel {
                     cache_disk_block_ids,
                     bs,
                     seq.cached_prefix_tokens.min(cache_tokens_len),
+                    seq.adapter_id,
                 );
                 super::super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
             }
@@ -399,6 +400,7 @@ impl TransformerModel {
                         snap_id,
                         seq.session_hash,
                         seq.cached_prefix_tokens,
+                        seq.adapter_id,
                     );
                     super::super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
                     if let Some(old) = displaced {
@@ -412,6 +414,7 @@ impl TransformerModel {
                     &seq.disk_block_ids,
                     bs,
                     seq.cached_prefix_tokens,
+                    seq.adapter_id,
                 );
                 super::super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
             }
@@ -422,6 +425,7 @@ impl TransformerModel {
                 &seq.disk_block_ids,
                 bs,
                 seq.cached_prefix_tokens,
+                seq.adapter_id,
             );
             super::super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
         }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -119,8 +119,13 @@ impl TransformerModel {
             // layer_kv_write_start floor (forward_layers.rs) skips writes below
             // cached_prefix_tokens, so the shared prefix-cache blocks keep the
             // original values (a non-bit-equal rewrite would poison them).
-            let mut skip = if let Some(snap_id) = prefix_match.ssm_snapshot {
-                let snap_tok = prefix_match.ssm_snapshot_tokens;
+            // Phase 1b spill-tier fault-in: fold a resident hit with a
+            // faulted-back spilled anchor; see `ssm_fault_in::eff_ssm_snapshot`.
+            let (eff_snapshot, eff_snapshot_tokens) =
+                self.eff_ssm_snapshot(&prefix_match, seq.session_hash, stream);
+
+            let mut skip = if let Some(snap_id) = eff_snapshot {
+                let snap_tok = eff_snapshot_tokens;
                 // Exact full-prompt hit on a hiddenless snapshot (finish
                 // leaves never stash a hidden): the exact-snap fixup cannot
                 // produce the first token's logits, so fall through to the
@@ -252,7 +257,18 @@ impl TransformerModel {
             // already-cached values).
             //
             // For pure attention (MLA/GQA): use matched tokens directly.
-            let snap_tok = prefix_match.ssm_snapshot_tokens;
+            //
+            // CRITICAL (tier fault-in skip fix): use the EFFECTIVE snapshot
+            // depth, not the resident-only `ssm_snapshot_tokens`. When the
+            // anchor was SPILLED and faulted back in above, the resident field
+            // is 0 and the real depth lives in `ssm_snapshot_tier_tokens` (both
+            // folded into `eff_snapshot_tokens`). Using the raw field here would
+            // make `snap_tok = 0 → skip_tokens = 0` for every tier restore, so
+            // the suffix prefill re-runs the SSM over the ENTIRE prefix — the
+            // restore completes but skips nothing, making a warm fault-in slower
+            // than a plain recompute. `eff_snapshot_tokens` makes the skip point
+            // equal the restored state depth.
+            let snap_tok = eff_snapshot_tokens;
             let skip_tokens = if skip && !has_ssm {
                 matched
             } else if skip && matched == total && snap_tok == matched {

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -31,7 +31,8 @@ impl TransformerModel {
                 if self.tokens_have_vision_pad(tokens) || seq.collect_prompt_logprobs.is_some() {
                     spark_runtime::prefix_cache::PrefixMatch::empty()
                 } else {
-                    self.prefix_cache.lookup(tokens, bs, seq.session_hash)
+                    self.prefix_cache
+                        .lookup(tokens, bs, seq.session_hash, seq.adapter_id)
                 };
             // F83 (2026-04-30): on EP>1, head and worker have
             // independent local prefix caches whose match counts can
@@ -60,11 +61,14 @@ impl TransformerModel {
                 let local = prefix_match.matched_tokens as u32;
                 let agreed = self.ep_min_u32(local)? as usize;
                 if agreed < prefix_match.matched_tokens {
-                    self.prefix_cache.release(tokens, bs);
+                    self.prefix_cache.release(tokens, bs, seq.adapter_id);
                     if agreed > 0 {
-                        prefix_match =
-                            self.prefix_cache
-                                .lookup(&tokens[..agreed], bs, seq.session_hash);
+                        prefix_match = self.prefix_cache.lookup(
+                            &tokens[..agreed],
+                            bs,
+                            seq.session_hash,
+                            seq.adapter_id,
+                        );
                     } else {
                         prefix_match = spark_runtime::prefix_cache::PrefixMatch::empty();
                     }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
@@ -78,10 +78,12 @@ impl TransformerModel {
             Ok(Some(id)) => Some(id),
             Ok(None) => {
                 // Pool exhausted — try to reclaim from cache
-                if self
-                    .ssm_snapshots
-                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
-                {
+                if self.ssm_snapshots.reclaim_from_cache(
+                    self.prefix_cache.as_ref(),
+                    kv_cache,
+                    self.ssm_tier_store.as_deref(),
+                    self.gpu.as_ref(),
+                ) {
                     self.ssm_snapshots
                         .save(
                             seq.slot_idx,

--- a/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
@@ -149,6 +149,7 @@ impl TransformerModel {
             boundary_disk,
             bs,
             end_token,
+            seq.adapter_id,
         );
         super::super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
         if let Some(old) = self.prefix_cache.insert_intermediate_snapshot(
@@ -159,6 +160,7 @@ impl TransformerModel {
             snap_id,
             seq.session_hash,
             end_token,
+            seq.adapter_id,
         ) {
             self.ssm_snapshots.free(old);
         }

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -159,7 +159,8 @@ impl TransformerModel {
         let prefix_match = if self.tokens_have_vision_pad(tokens) {
             spark_runtime::prefix_cache::PrefixMatch::empty()
         } else {
-            self.prefix_cache.lookup(tokens, bs, seq.session_hash)
+            self.prefix_cache
+                .lookup(tokens, bs, seq.session_hash, seq.adapter_id)
         };
         let matched = prefix_match.matched_tokens;
         seq.cached_prefix_tokens = matched;

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -176,8 +176,12 @@ impl TransformerModel {
         );
 
         // Marconi: restore SSM snapshot if available (session-gated).
-        let (kv_write_start, marconi_skip) = if let Some(snap_id) = prefix_match.ssm_snapshot {
-            let snap_tok = prefix_match.ssm_snapshot_tokens;
+        // Phase 1b spill-tier fault-in (#6): fold a resident hit with a
+        // faulted-back spilled anchor; see `ssm_fault_in::eff_ssm_snapshot`.
+        let (eff_snapshot, eff_snapshot_tokens) =
+            self.eff_ssm_snapshot(&prefix_match, seq.session_hash, stream);
+        let (kv_write_start, marconi_skip) = if let Some(snap_id) = eff_snapshot {
+            let snap_tok = eff_snapshot_tokens;
             if snap_tok > 0
                 && matched <= total_len
                 && self

--- a/crates/spark-model/src/model/trait_impl/prefill_d.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_d.rs
@@ -76,6 +76,7 @@ impl TransformerModel {
                 &seq.disk_block_ids,
                 bs,
                 seq.cached_prefix_tokens,
+                seq.adapter_id,
             );
             super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
         }
@@ -146,6 +147,7 @@ impl TransformerModel {
                         snap_id,
                         seq.session_hash,
                         seq.cached_prefix_tokens,
+                        seq.adapter_id,
                     );
                     super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
                     if let Some(old) = displaced {
@@ -159,6 +161,7 @@ impl TransformerModel {
                     &seq.disk_block_ids,
                     bs,
                     seq.cached_prefix_tokens,
+                    seq.adapter_id,
                 );
                 super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
             }
@@ -169,6 +172,7 @@ impl TransformerModel {
                 &seq.disk_block_ids,
                 bs,
                 seq.cached_prefix_tokens,
+                seq.adapter_id,
             );
             super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
         }
@@ -252,6 +256,7 @@ impl TransformerModel {
                         snap_id,
                         seq.session_hash,
                         seq.cached_prefix_tokens,
+                        seq.adapter_id,
                     );
                     super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
                     if let Some(old) = displaced {
@@ -265,6 +270,7 @@ impl TransformerModel {
                     &seq.disk_block_ids,
                     bs,
                     seq.cached_prefix_tokens,
+                    seq.adapter_id,
                 );
                 super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
             }
@@ -275,6 +281,7 @@ impl TransformerModel {
                 &seq.disk_block_ids,
                 bs,
                 seq.cached_prefix_tokens,
+                seq.adapter_id,
             );
             super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
         }

--- a/crates/spark-model/src/model/trait_impl/prefill_d.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_d.rs
@@ -107,10 +107,12 @@ impl TransformerModel {
                 Ok(Some(id)) => Some(id),
                 Ok(None) => {
                     // Pool exhausted — evict LRU entries to reclaim a slot
-                    if self
-                        .ssm_snapshots
-                        .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
-                    {
+                    if self.ssm_snapshots.reclaim_from_cache(
+                        self.prefix_cache.as_ref(),
+                        kv_cache,
+                        self.ssm_tier_store.as_deref(),
+                        self.gpu.as_ref(),
+                    ) {
                         self.ssm_snapshots
                             .save(
                                 seq.slot_idx,
@@ -201,10 +203,12 @@ impl TransformerModel {
                 Ok(Some(id)) => Some(id),
                 Ok(None) => {
                     tracing::debug!("Snapshot pool full, reclaiming...");
-                    if self
-                        .ssm_snapshots
-                        .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
-                    {
+                    if self.ssm_snapshots.reclaim_from_cache(
+                        self.prefix_cache.as_ref(),
+                        kv_cache,
+                        self.ssm_tier_store.as_deref(),
+                        self.gpu.as_ref(),
+                    ) {
                         self.ssm_snapshots
                             .save(
                                 seq.slot_idx,

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -69,6 +69,7 @@ impl TransformerModel {
                         snap_id,
                         seq.session_hash,
                         seq.prompt_len,
+                        seq.adapter_id,
                     );
                     if let Some(old) = displaced {
                         self.ssm_snapshots.free(old);
@@ -81,6 +82,7 @@ impl TransformerModel {
                         &seq.disk_block_ids,
                         bs,
                         seq.prompt_len,
+                        seq.adapter_id,
                     )
                 };
                 super::super::block_mgmt::cache_acquires_disk_refs(&acquired);
@@ -130,8 +132,11 @@ impl TransformerModel {
 
         // Release prefix cache refs before freeing blocks.
         // (i.e., blocks not shared with the prefix cache).
-        self.prefix_cache
-            .release(&seq.tokens, self.kv_cache.lock().block_size());
+        self.prefix_cache.release(
+            &seq.tokens,
+            self.kv_cache.lock().block_size(),
+            seq.adapter_id,
+        );
         if !seq.block_table.is_empty() {
             self.kv_cache.lock().free_blocks(&seq.block_table);
             seq.block_table.clear();

--- a/crates/spark-model/src/model/trait_impl/ssm_fault_in.rs
+++ b/crates/spark-model/src/model/trait_impl/ssm_fault_in.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared SSM-snapshot tier fault-in helper.
+//!
+//! When the radix prefix match finds a spilled anchor (`ssm_snapshot` is
+//! `None` but `ssm_snapshot_tier_key` is present), fault its bytes back into a
+//! resident Marconi slot and treat it as resident for the restore — converting
+//! a full-prefix SSM recompute into a tier restore.
+//!
+//! Extracted so all three prefill paths share one implementation
+//! (`prefill_b_prefix_lookup`, `prefill_a`/`prefill_dispatch`, and
+//! `prefill_c`/`prefill_twophase_dispatch`). Before this the logic lived inline
+//! in `prefill_b/prefix_lookup.rs` only, so `prefill_a`/`prefill_c` ignored the
+//! tier key and always recomputed (handoff task #6). The cost-aware depth gate
+//! (task #5) lives here too, so it applies uniformly across the three paths.
+
+#![allow(dead_code)]
+
+use spark_runtime::prefix_cache::PrefixMatch;
+
+use super::super::types::TransformerModel;
+
+/// Minimum tier-snapshot depth (in tokens) below which a fault-in is skipped in
+/// favour of recompute. Overridable via `ATLAS_SSM_FAULT_MIN_TOKENS`; `0`
+/// disables the gate (always fault when a tier key exists).
+///
+/// Cost model: a fault-in is a fixed ~28 ms — the full spill blob (every SSM
+/// layer's `h`+`conv`, ~66 MB on Holo-3.1-35B) is read back over RDMA/NVMe at
+/// ~2.5 GB/s (~26 ms) plus an H2D scatter + sync — and then the suffix prefill
+/// still replays SSM over `[snap_tok, matched)`. It only pays off when it
+/// elides MORE prefix SSM recompute than it costs. Below the threshold the
+/// matched prefix is so shallow that recomputing its SSM from scratch is
+/// cheaper than the fixed blob read, so we skip the fault and recompute.
+///
+/// Default `256` (16 blocks) is conservative: GDN prefill over a few hundred
+/// tokens is well under 28 ms, so below it recompute is unambiguously cheaper,
+/// while the tuned tail-clustered checkpoints (near the ~15 K prompt tail) sit
+/// far above it and always fault in. A low threshold minimises wrongly skipping
+/// a beneficial deep fault. Tune per template via the miss-depth histogram.
+const DEFAULT_FAULT_MIN_TOKENS: usize = 256;
+
+fn fault_in_min_tokens() -> usize {
+    parse_fault_min_tokens(std::env::var("ATLAS_SSM_FAULT_MIN_TOKENS").ok())
+}
+
+/// Pure parse of `ATLAS_SSM_FAULT_MIN_TOKENS`: an unset or unparseable value
+/// falls back to [`DEFAULT_FAULT_MIN_TOKENS`]; `0` disables the gate.
+fn parse_fault_min_tokens(raw: Option<String>) -> usize {
+    raw.and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_FAULT_MIN_TOKENS)
+}
+
+/// Whether a tier snapshot of `depth` tokens is too shallow to be worth a
+/// fixed-cost fault-in vs. recomputing the prefix (task #5). `min_depth == 0`
+/// disables the gate.
+fn should_skip_fault_for_depth(depth: usize, min_depth: usize) -> bool {
+    depth < min_depth
+}
+
+impl TransformerModel {
+    /// Resolve the **effective** SSM snapshot for a prefix match, folding a
+    /// resident hit with a spill-tier fault-in. Shared by all three prefill
+    /// paths (`prefill_a`/`prefill_b`/`prefill_c`).
+    ///
+    /// When the anchor was SPILLED (`ssm_snapshot` is `None` but a tier key is
+    /// present), [`try_fault_in_ssm_snapshot`](Self::try_fault_in_ssm_snapshot)
+    /// faults its bytes into a resident slot — converting a full-prefix SSM
+    /// recompute into a tier restore. Returns `(eff_snapshot, eff_depth)`:
+    /// - `eff_snapshot` = the resident slot, else the faulted-in slot, else
+    ///   `None` (nothing to restore → recompute the prefix).
+    /// - `eff_depth` = the restored state's token depth. A faulted anchor's
+    ///   resident `ssm_snapshot_tokens` field is `0`, so its real depth lives in
+    ///   `ssm_snapshot_tier_tokens`; callers MUST use this folded depth as the
+    ///   skip point or a tier restore skips nothing (warm hit slower than a
+    ///   plain recompute).
+    ///
+    /// A faulted slot is byte-identical to the snapshot it spilled from, so the
+    /// restore/skip logic at each call site is unchanged.
+    pub(in crate::model) fn eff_ssm_snapshot(
+        &self,
+        prefix_match: &PrefixMatch,
+        session_hash: u64,
+        stream: u64,
+    ) -> (Option<usize>, usize) {
+        let faulted_snap = self.try_fault_in_ssm_snapshot(prefix_match, session_hash, stream);
+        let eff_snapshot = prefix_match.ssm_snapshot.or(faulted_snap);
+        let eff_snapshot_tokens = if faulted_snap.is_some() {
+            prefix_match.ssm_snapshot_tier_tokens
+        } else {
+            prefix_match.ssm_snapshot_tokens
+        };
+        (eff_snapshot, eff_snapshot_tokens)
+    }
+
+    /// Attempt to fault a spilled SSM snapshot for `prefix_match` back into a
+    /// resident Marconi slot, re-homing it onto `session_hash`. Returns the
+    /// faulted-in slot on success, or `None` when there is nothing to fault
+    /// (resident snapshot already present, no tier store, no tier key), the
+    /// cost-aware depth gate rejects it (task #5), the pool is fully mid-flight,
+    /// or the blob is gone from the tier (miss → caller recomputes).
+    ///
+    /// On success the caller must treat the returned slot as the effective
+    /// snapshot with depth `prefix_match.ssm_snapshot_tier_tokens` (see
+    /// `eff_snapshot`/`eff_snapshot_tokens` at the call sites): the resident
+    /// `ssm_snapshot_tokens` field is `0` for a faulted-in anchor.
+    pub(in crate::model) fn try_fault_in_ssm_snapshot(
+        &self,
+        prefix_match: &PrefixMatch,
+        session_hash: u64,
+        stream: u64,
+    ) -> Option<usize> {
+        // Only relevant when the radix match had no RESIDENT snapshot but did
+        // carry a tier key — otherwise the resident path handles it.
+        if prefix_match.ssm_snapshot.is_some() {
+            return None;
+        }
+        let store = self.ssm_tier_store.as_deref()?;
+        let key = prefix_match.ssm_snapshot_tier_key?;
+
+        // #5 cost-aware gate: skip the fixed-cost fault when the matched prefix
+        // is shallow enough that recomputing its SSM is cheaper than the blob
+        // read + replay.
+        let depth = prefix_match.ssm_snapshot_tier_tokens;
+        let min_depth = fault_in_min_tokens();
+        if should_skip_fault_for_depth(depth, min_depth) {
+            tracing::info!(
+                "SSM tier fault-in SKIPPED (cost gate): tier snapshot depth {depth} < \
+                 ATLAS_SSM_FAULT_MIN_TOKENS={min_depth} — recomputing the shallow prefix \
+                 is cheaper than a ~28ms blob fault + replay"
+            );
+            return None;
+        }
+
+        // `acquire_or_spill_slot` spills a resident victim to make room when the
+        // pool is full, so a warm hit isn't lost to a busy pool; `None` only if
+        // every slot is mid-flight.
+        let slot = self.ssm_snapshots.acquire_or_spill_slot(
+            self.prefix_cache.as_ref(),
+            store,
+            self.gpu.as_ref(),
+        )?;
+        match self
+            .ssm_snapshots
+            .fault_in_slot(slot, key, store, self.gpu.as_ref(), stream)
+        {
+            Ok(true) => {
+                self.prefix_cache.promote_snapshot(key, slot);
+                // Re-home the session owner onto the fresh slot. Without this
+                // the slot is untagged (or carries a spill victim's stale tag)
+                // and the `session_matches` gate at the call site rejects the
+                // just-faulted state → full recompute. `lookup`/`lookup_tiered`
+                // already filtered by session, so `session_hash` is the
+                // rightful owner.
+                self.ssm_snapshots.tag_session(slot, session_hash);
+                tracing::info!(
+                    "SSM tier fault-in: restored spilled snapshot at token {depth} into slot {slot}"
+                );
+                Some(slot)
+            }
+            // Miss (blob gone) or error: return the slot, recompute.
+            _ => {
+                self.ssm_snapshots.free(slot);
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_FAULT_MIN_TOKENS, parse_fault_min_tokens, should_skip_fault_for_depth};
+
+    #[test]
+    fn min_tokens_defaults_when_unset_or_garbage() {
+        assert_eq!(parse_fault_min_tokens(None), DEFAULT_FAULT_MIN_TOKENS);
+        assert_eq!(
+            parse_fault_min_tokens(Some("not-a-number".into())),
+            DEFAULT_FAULT_MIN_TOKENS
+        );
+        assert_eq!(
+            parse_fault_min_tokens(Some("".into())),
+            DEFAULT_FAULT_MIN_TOKENS
+        );
+    }
+
+    #[test]
+    fn min_tokens_parses_explicit_values() {
+        assert_eq!(parse_fault_min_tokens(Some("0".into())), 0);
+        assert_eq!(parse_fault_min_tokens(Some("1024".into())), 1024);
+    }
+
+    #[test]
+    fn gate_skips_shallow_faults_only() {
+        let min = DEFAULT_FAULT_MIN_TOKENS;
+        // Shallow: recompute is cheaper → skip the fault.
+        assert!(should_skip_fault_for_depth(0, min));
+        assert!(should_skip_fault_for_depth(min - 1, min));
+        // At/above threshold: fault in.
+        assert!(!should_skip_fault_for_depth(min, min));
+        assert!(!should_skip_fault_for_depth(min + 1, min));
+        assert!(!should_skip_fault_for_depth(15_000, min));
+    }
+
+    #[test]
+    fn gate_disabled_never_skips() {
+        // min_depth == 0 disables the gate: even a depth-0 tier key faults in.
+        assert!(!should_skip_fault_for_depth(0, 0));
+        assert!(!should_skip_fault_for_depth(1, 0));
+    }
+}

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -89,6 +89,12 @@ pub struct TransformerModel {
     pub(super) ssm_pool: Arc<SsmStatePool>,
     /// SSM state snapshot pool for Marconi prefix caching.
     pub(super) ssm_snapshots: SsmSnapshotPool,
+    /// Optional SSM snapshot spill tier (`ATLAS_SSM_TIER`). `None` (default)
+    /// keeps the drop-only reclaim path byte-identical; `Some` moves an evicted
+    /// snapshot's bytes to the tier (keeping its index entry findable) so a warm
+    /// turn faults it back instead of recomputing. Threaded into
+    /// [`SsmSnapshotPool::reclaim_from_cache`] at every reclaim call site.
+    pub(super) ssm_tier_store: Option<Arc<dyn super::ssm_tier::SnapshotBlobStore>>,
     /// Fixed max blocks per sequence (max_seq_len / block_size + 1).
     /// Used as constant stride in attention metadata for CUDA graph compatibility.
     pub(super) max_blocks_per_seq: u32,

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -108,6 +108,11 @@ pub struct SequenceState {
     /// prefill. The model uses this to tag saved snapshots and verify ownership
     /// before restoring. 0 = no session tracking (legacy behavior).
     pub session_hash: u64,
+    /// Per-adapter prefix-cache namespace (adapter-correct KV). Folded into the
+    /// prefix hash so two adapters that share a token prefix never reuse each
+    /// other's blocks. `0` = base / no adapter (a strict no-op in the fold, so
+    /// behavior is byte-identical until a LoRA path stamps a non-zero id).
+    pub adapter_id: u64,
     /// Persistent paged metadata for chunked prefill, allocated lazily on the
     /// first chunk that needs paged attention.
     pub chunked_prefill_meta: Option<ChunkedPrefillPageMetadata>,

--- a/crates/spark-runtime/src/prefix_cache.rs
+++ b/crates/spark-runtime/src/prefix_cache.rs
@@ -79,6 +79,16 @@ pub struct PrefixMatch {
     /// checkpoints it may be less — the caller must recompute SSM state for
     /// tokens between `ssm_snapshot_tokens` and `matched_tokens`.
     pub ssm_snapshot_tokens: usize,
+    /// Phase 1b spill tier: when the deepest anchor for this prefix is SPILLED
+    /// (not resident in HBM), `ssm_snapshot` is `None` and this holds the tier
+    /// key (prefix hash). The caller faults the bytes into a fresh snapshot slot
+    /// (`SsmSnapshotPool::fault_in_slot`), `promote_snapshot`s the entry, then
+    /// restores. `None` whenever nothing is tiered (i.e. `ATLAS_SSM_TIER` off) —
+    /// so this field is inert on the default path.
+    pub ssm_snapshot_tier_key: Option<u64>,
+    /// Token depth covered by `ssm_snapshot_tier_key` (analogue of
+    /// `ssm_snapshot_tokens` for a tiered anchor).
+    pub ssm_snapshot_tier_tokens: usize,
 }
 
 impl PrefixMatch {
@@ -90,6 +100,8 @@ impl PrefixMatch {
             matched_tokens: 0,
             ssm_snapshot: None,
             ssm_snapshot_tokens: 0,
+            ssm_snapshot_tier_key: None,
+            ssm_snapshot_tier_tokens: 0,
         }
     }
 
@@ -122,13 +134,24 @@ pub trait PrefixCache: Send + Sync {
     /// Increments ref_count on matched nodes so they survive eviction
     /// while the sequence is active. `session_hash` is used for SSM
     /// snapshot isolation (0 = legacy/no session tracking).
-    fn lookup(&self, tokens: &[u32], block_size: usize, session_hash: u64) -> PrefixMatch;
+    ///
+    /// Task #24: `adapter_id` keys the KV/prefix + SSM-snapshot cache so a
+    /// request reuses ONLY blocks computed under the same adapter. `0` = base /
+    /// no adapter, which keys byte-identically to the pre-LoRA token-only cache.
+    fn lookup(
+        &self,
+        tokens: &[u32],
+        block_size: usize,
+        session_hash: u64,
+        adapter_id: u64,
+    ) -> PrefixMatch;
 
     /// Read-only longest-prefix probe: number of tokens (block-aligned)
     /// `lookup` would match, WITHOUT taking refs, touching LRU state, or
     /// counting a hit/miss. Used by the prefill tail-checkpoint split to
     /// detect conversation reuse before deciding to pay the extra pass.
-    fn peek_matched_tokens(&self, _tokens: &[u32], _block_size: usize) -> usize {
+    /// Task #24: keyed by `adapter_id` so a cross-adapter peek reports a miss.
+    fn peek_matched_tokens(&self, _tokens: &[u32], _block_size: usize, _adapter_id: u64) -> usize {
         0
     }
 
@@ -166,6 +189,7 @@ pub trait PrefixCache: Send + Sync {
         disk_block_ids: &[u32],
         block_size: usize,
         matched_tokens: usize,
+        adapter_id: u64,
     ) -> Vec<u32>;
 
     /// Insert blocks with an SSM state snapshot registered in the snapshot index.
@@ -188,6 +212,7 @@ pub trait PrefixCache: Send + Sync {
         snapshot_id: usize,
         session_hash: u64,
         matched_tokens: usize,
+        adapter_id: u64,
     ) -> (Option<usize>, Vec<u32>);
 
     /// Insert an SSM snapshot at an intermediate token boundary.
@@ -207,13 +232,15 @@ pub trait PrefixCache: Send + Sync {
         snapshot_id: usize,
         session_hash: u64,
         matched_tokens: usize,
+        adapter_id: u64,
     ) -> Option<usize>;
 
     /// Release ref_counts on blocks that were acquired via `lookup`.
     ///
     /// Called when a sequence finishes. Decrements ref_count on cache
     /// nodes matching the token prefix, making them eligible for eviction.
-    fn release(&self, tokens: &[u32], block_size: usize);
+    /// Task #24: `adapter_id` must match the one used at `lookup`/`insert`.
+    fn release(&self, tokens: &[u32], block_size: usize, adapter_id: u64);
 
     /// Evict up to `num_blocks` cached blocks, returning their physical
     /// indices and parallel disk-block IDs (Phase 6.1.e).
@@ -228,6 +255,23 @@ pub trait PrefixCache: Send + Sync {
     /// Evict the least-recently-used SSM snapshot from the snapshot index.
     /// Returns the snapshot ID so the caller can free it in `SsmSnapshotPool`.
     fn evict_snapshot_lru(&self) -> Option<usize>;
+
+    /// Phase 1b spill tier: pick a spill victim (same policy as
+    /// `evict_snapshot_lru`, HBM-resident only), **keep** its index entry
+    /// (findable so a warm turn faults it back), and return `(freed_slot, key)`
+    /// so the caller moves its bytes to the tier and reuses the slot. `None`
+    /// when nothing resident remains. Default: `None` (caches without a tier).
+    fn evict_snapshot_to_tier(&self) -> Option<(usize, u64)> {
+        None
+    }
+
+    /// Phase 1b spill tier: after the caller faulted a spilled snapshot's bytes
+    /// into `new_slot`, re-home its index entry to HBM. Returns `false` if the
+    /// key is unknown. Default: `false`.
+    fn promote_snapshot(&self, key: u64, new_slot: usize) -> bool {
+        let _ = (key, new_slot);
+        false
+    }
 
     /// Number of SSM snapshots currently stored in the snapshot index.
     fn snapshot_count(&self) -> usize;
@@ -244,7 +288,13 @@ impl PrefixCache for NoPrefixCaching {
         false
     }
 
-    fn lookup(&self, _tokens: &[u32], _block_size: usize, _session_hash: u64) -> PrefixMatch {
+    fn lookup(
+        &self,
+        _tokens: &[u32],
+        _block_size: usize,
+        _session_hash: u64,
+        _adapter_id: u64,
+    ) -> PrefixMatch {
         PrefixMatch::empty()
     }
 
@@ -255,6 +305,7 @@ impl PrefixCache for NoPrefixCaching {
         _disk_block_ids: &[u32],
         _block_size: usize,
         _matched_tokens: usize,
+        _adapter_id: u64,
     ) -> Vec<u32> {
         Vec::new()
     }
@@ -268,6 +319,7 @@ impl PrefixCache for NoPrefixCaching {
         _snapshot_id: usize,
         _session_hash: u64,
         _matched_tokens: usize,
+        _adapter_id: u64,
     ) -> (Option<usize>, Vec<u32>) {
         (None, Vec::new())
     }
@@ -281,11 +333,12 @@ impl PrefixCache for NoPrefixCaching {
         _snapshot_id: usize,
         _session_hash: u64,
         _matched_tokens: usize,
+        _adapter_id: u64,
     ) -> Option<usize> {
         None
     }
 
-    fn release(&self, _tokens: &[u32], _block_size: usize) {}
+    fn release(&self, _tokens: &[u32], _block_size: usize, _adapter_id: u64) {}
 
     fn evict(&self, _num_blocks: usize) -> EvictedBlocks {
         EvictedBlocks::default()
@@ -323,13 +376,13 @@ mod tests {
         let block_table = vec![0, 1];
         let disk_block_ids: Vec<u32> = vec![];
 
-        let m = cache.lookup(&tokens, 4, 0);
+        let m = cache.lookup(&tokens, 4, 0, 0);
         assert!(m.is_empty());
 
         // These should not panic
-        let new_acq = cache.insert(&tokens, &block_table, &disk_block_ids, 4, 0);
+        let new_acq = cache.insert(&tokens, &block_table, &disk_block_ids, 4, 0, 0);
         assert!(new_acq.is_empty());
-        cache.release(&tokens, 4);
+        cache.release(&tokens, 4, 0);
 
         let evicted = cache.evict(10);
         assert!(evicted.is_empty());

--- a/crates/spark-runtime/src/radix_tree.rs
+++ b/crates/spark-runtime/src/radix_tree.rs
@@ -21,11 +21,21 @@ mod tests;
 use inner::RadixTreeInner;
 use snapshot::SsmSnapshotIndex;
 
-/// FNV-1a-ish stable hash for the first `count` tokens — used to key
-/// snapshots independently of the radix tree (allows the same prefix
-/// hash to be reproduced across requests).
-pub(crate) fn hash_token_prefix(tokens: &[u32], count: usize) -> u64 {
+/// FNV-1a-ish stable hash for the first `count` tokens — used to key SSM
+/// snapshots independently of the radix tree (allows the same prefix hash to be
+/// reproduced across requests).
+///
+/// Task #24 (adapter-correct KV): `adapter_id` is folded in so two adapters that
+/// share a token prefix key to DIFFERENT snapshot hashes (no cross-adapter SSM
+/// restore). The fold is a strict no-op when `adapter_id == 0` (the base / no-
+/// adapter sentinel), so base keying is BYTE-IDENTICAL to the pre-LoRA hash and
+/// existing prefix-cache/snapshot hit rates are unchanged.
+pub(crate) fn hash_token_prefix(tokens: &[u32], count: usize, adapter_id: u64) -> u64 {
     let mut h: u64 = 0xcbf29ce484222325; // FNV-1a basis
+    if adapter_id != 0 {
+        h ^= adapter_id;
+        h = h.wrapping_mul(0x100000001b3);
+    }
     for &t in &tokens[..count] {
         h ^= t as u64;
         h = h.wrapping_mul(0x100000001b3);
@@ -59,29 +69,50 @@ impl RadixTree {
 }
 
 impl PrefixCache for RadixTree {
-    fn lookup(&self, tokens: &[u32], block_size: usize, session_hash: u64) -> PrefixMatch {
+    fn lookup(
+        &self,
+        tokens: &[u32],
+        block_size: usize,
+        session_hash: u64,
+        adapter_id: u64,
+    ) -> PrefixMatch {
         // Phase 1: walk tree (lock inner, then release)
         let (matched_blocks, matched_disk_block_ids, matched_tokens) = {
             let mut inner = self.inner.lock();
-            let (blocks, disk, matched) = inner.walk(tokens, block_size);
+            let (blocks, disk, matched) = inner.walk(tokens, block_size, adapter_id);
             if matched > 0 {
-                inner.inc_refs(tokens, block_size, matched);
+                inner.inc_refs(tokens, block_size, matched, adapter_id);
                 crate::prefix_cache::record_cache_hit(matched);
             } else {
                 crate::prefix_cache::record_cache_miss();
             }
             (blocks, disk, matched)
         };
-        // Phase 2: snapshot lookup (lock snapshot_index, inner NOT held)
-        let (ssm_snapshot, ssm_snapshot_tokens) = if matched_tokens > 0 {
+        // Phase 2: snapshot lookup (lock snapshot_index, inner NOT held).
+        // Tier-aware: `lookup_tiered` returns the deepest anchor across resident
+        // AND spilled entries. A resident hit populates `ssm_snapshot` (restore
+        // directly); a spilled hit populates `ssm_snapshot_tier_key` (caller
+        // faults it in). When nothing is spilled (ATLAS_SSM_TIER off) this is
+        // byte-identical to the old resident-only lookup.
+        let mut ssm_snapshot = None;
+        let mut ssm_snapshot_tokens = 0;
+        let mut ssm_snapshot_tier_key = None;
+        let mut ssm_snapshot_tier_tokens = 0;
+        if matched_tokens > 0 {
             let mut idx = self.snapshot_index.lock();
-            match idx.lookup(tokens, matched_tokens, session_hash) {
-                Some((snap_id, tok_count)) => (Some(snap_id), tok_count),
-                None => (None, 0),
+            if let Some(m) = idx.lookup_tiered(tokens, matched_tokens, session_hash, adapter_id) {
+                match m.loc {
+                    snapshot::SnapLoc::Hbm(slot) => {
+                        ssm_snapshot = Some(slot);
+                        ssm_snapshot_tokens = m.token_count;
+                    }
+                    snapshot::SnapLoc::Tier(key) => {
+                        ssm_snapshot_tier_key = Some(key);
+                        ssm_snapshot_tier_tokens = m.token_count;
+                    }
+                }
             }
-        } else {
-            (None, 0)
-        };
+        }
         // Filter disk_block_ids to MAX-free entries when HSS isn't in use, so
         // the caller can check `!matched_disk_block_ids.is_empty()` as the
         // HSS-engaged signal. When HSS *is* in use every entry should be a
@@ -97,11 +128,13 @@ impl PrefixCache for RadixTree {
             matched_tokens,
             ssm_snapshot,
             ssm_snapshot_tokens,
+            ssm_snapshot_tier_key,
+            ssm_snapshot_tier_tokens,
         }
     }
 
-    fn peek_matched_tokens(&self, tokens: &[u32], block_size: usize) -> usize {
-        self.inner.lock().walk(tokens, block_size).2
+    fn peek_matched_tokens(&self, tokens: &[u32], block_size: usize, adapter_id: u64) -> usize {
+        self.inner.lock().walk(tokens, block_size, adapter_id).2
     }
 
     fn insert(
@@ -111,6 +144,7 @@ impl PrefixCache for RadixTree {
         disk_block_ids: &[u32],
         block_size: usize,
         matched_tokens: usize,
+        adapter_id: u64,
     ) -> Vec<u32> {
         self.inner.lock().insert(
             tokens,
@@ -118,6 +152,7 @@ impl PrefixCache for RadixTree {
             disk_block_ids,
             block_size,
             matched_tokens,
+            adapter_id,
         )
     }
 
@@ -130,6 +165,7 @@ impl PrefixCache for RadixTree {
         snapshot_id: usize,
         session_hash: u64,
         matched_tokens: usize,
+        adapter_id: u64,
     ) -> (Option<usize>, Vec<u32>) {
         // Phase 1: insert tree nodes (lock inner, then release)
         let newly_acquired = self.inner.lock().insert(
@@ -138,9 +174,10 @@ impl PrefixCache for RadixTree {
             disk_block_ids,
             block_size,
             matched_tokens,
+            adapter_id,
         );
         // Phase 2: register snapshot in index (lock snapshot_index, inner NOT held)
-        let prefix_hash = hash_token_prefix(tokens, tokens.len());
+        let prefix_hash = hash_token_prefix(tokens, tokens.len(), adapter_id);
         let mut idx = self.snapshot_index.lock();
         let displaced = idx.insert(prefix_hash, snapshot_id, session_hash, tokens.len());
         (displaced, newly_acquired)
@@ -155,17 +192,18 @@ impl PrefixCache for RadixTree {
         snapshot_id: usize,
         session_hash: u64,
         _matched_tokens: usize,
+        adapter_id: u64,
     ) -> Option<usize> {
         // Intermediate snapshots go directly into the index with the correct
         // token boundary (tokens.len()). Tree nodes are already inserted by
         // a prior `insert()` call, which handled the ref_count bookkeeping.
-        let prefix_hash = hash_token_prefix(tokens, tokens.len());
+        let prefix_hash = hash_token_prefix(tokens, tokens.len(), adapter_id);
         let mut idx = self.snapshot_index.lock();
         idx.insert(prefix_hash, snapshot_id, session_hash, tokens.len())
     }
 
-    fn release(&self, tokens: &[u32], block_size: usize) {
-        self.inner.lock().dec_refs(tokens, block_size);
+    fn release(&self, tokens: &[u32], block_size: usize, adapter_id: u64) {
+        self.inner.lock().dec_refs(tokens, block_size, adapter_id);
     }
 
     fn evict(&self, num_blocks: usize) -> EvictedBlocks {
@@ -181,6 +219,14 @@ impl PrefixCache for RadixTree {
 
     fn evict_snapshot_lru(&self) -> Option<usize> {
         self.snapshot_index.lock().evict_lru()
+    }
+
+    fn evict_snapshot_to_tier(&self) -> Option<(usize, u64)> {
+        self.snapshot_index.lock().evict_to_tier()
+    }
+
+    fn promote_snapshot(&self, key: u64, new_slot: usize) -> bool {
+        self.snapshot_index.lock().promote(key, new_slot)
     }
 
     fn snapshot_count(&self) -> usize {

--- a/crates/spark-runtime/src/radix_tree/inner.rs
+++ b/crates/spark-runtime/src/radix_tree/inner.rs
@@ -55,7 +55,16 @@ pub(super) struct RadixTreeInner {
     nodes: Vec<RadixNode>,
     /// Indices of deleted nodes available for reuse.
     free_nodes: Vec<NodeId>,
-    root: NodeId,
+    /// Task #24 (adapter-correct KV): one radix ROOT per stable `adapter_id`.
+    /// Adapter A's and adapter B's node chains live in physically disjoint
+    /// subtrees, so a cross-adapter walk can never reach the wrong adapter's
+    /// blocks (correct MISS) and an insert under one root can never clobber
+    /// another adapter's node (the children map is keyed by token chunk, so
+    /// seeding the context-hash alone would NOT prevent that cross-adapter
+    /// insert-collision — disjoint roots do). `adapter_id == 0` is the base /
+    /// no-adapter root created in `new()`, so base keying is byte-identical to
+    /// the pre-LoRA single-root tree.
+    roots: HashMap<u64, NodeId>,
     access_counter: u64,
 }
 
@@ -72,10 +81,12 @@ impl RadixTreeInner {
             parent_key: None,
             partial_suffix: None,
         };
+        let mut roots = HashMap::new();
+        roots.insert(0u64, 0usize); // base / no-adapter root
         Self {
             nodes: vec![root],
             free_nodes: Vec::new(),
-            root: 0,
+            roots,
             access_counter: 0,
         }
     }
@@ -83,6 +94,34 @@ impl RadixTreeInner {
     pub(super) fn next_access(&mut self) -> u64 {
         self.access_counter += 1;
         self.access_counter
+    }
+
+    /// Read-side root for `adapter_id`: `None` when this adapter has no cached
+    /// blocks yet (walk/inc_refs/dec_refs then no-op → clean MISS).
+    fn root_for_read(&self, adapter_id: u64) -> Option<NodeId> {
+        self.roots.get(&adapter_id).copied()
+    }
+
+    /// Insert-side root for `adapter_id`: creates a fresh disjoint root the first
+    /// time an adapter caches anything. Roots carry `block_idx == u32::MAX` and
+    /// `parent == None`, so they are excluded from eviction and `num_entries`.
+    fn root_for_insert(&mut self, adapter_id: u64) -> NodeId {
+        if let Some(&id) = self.roots.get(&adapter_id) {
+            return id;
+        }
+        let id = self.alloc_node(RadixNode {
+            children: HashMap::new(),
+            block_idx: u32::MAX,
+            disk_block_id: u32::MAX,
+            context_hash: 0,
+            ref_count: 0,
+            last_access: 0,
+            parent: None,
+            parent_key: None,
+            partial_suffix: None,
+        });
+        self.roots.insert(adapter_id, id);
+        id
     }
 
     pub(super) fn alloc_node(&mut self, node: RadixNode) -> NodeId {
@@ -102,8 +141,16 @@ impl RadixTreeInner {
     /// that were inserted before HSS engaged (caller's responsibility to
     /// filter / treat MAX as "no disk-side ref to bump"). Snapshot lookup is
     /// now handled by the separate SsmSnapshotIndex after the walk completes.
-    pub(super) fn walk(&self, tokens: &[u32], block_size: usize) -> (Vec<u32>, Vec<u32>, usize) {
-        let mut current = self.root;
+    pub(super) fn walk(
+        &self,
+        tokens: &[u32],
+        block_size: usize,
+        adapter_id: u64,
+    ) -> (Vec<u32>, Vec<u32>, usize) {
+        let mut current = match self.root_for_read(adapter_id) {
+            Some(r) => r,
+            None => return (Vec::new(), Vec::new(), 0), // adapter has nothing cached
+        };
         let mut matched_blocks = Vec::new();
         let mut matched_disk = Vec::new();
         let mut matched_tokens = 0;
@@ -173,9 +220,18 @@ impl RadixTreeInner {
     }
 
     /// Increment ref_count on all nodes along the matched path.
-    pub(super) fn inc_refs(&mut self, tokens: &[u32], block_size: usize, num_matched: usize) {
+    pub(super) fn inc_refs(
+        &mut self,
+        tokens: &[u32],
+        block_size: usize,
+        num_matched: usize,
+        adapter_id: u64,
+    ) {
         let access = self.next_access();
-        let mut current = self.root;
+        let mut current = match self.root_for_read(adapter_id) {
+            Some(r) => r,
+            None => return,
+        };
         let num_blocks = num_matched / block_size;
 
         for i in 0..num_blocks {
@@ -191,8 +247,11 @@ impl RadixTreeInner {
     }
 
     /// Decrement ref_count on all nodes along the matched path.
-    pub(super) fn dec_refs(&mut self, tokens: &[u32], block_size: usize) {
-        let mut current = self.root;
+    pub(super) fn dec_refs(&mut self, tokens: &[u32], block_size: usize, adapter_id: u64) {
+        let mut current = match self.root_for_read(adapter_id) {
+            Some(r) => r,
+            None => return,
+        };
         let num_full_blocks = tokens.len() / block_size;
 
         for i in 0..num_full_blocks {
@@ -226,9 +285,11 @@ impl RadixTreeInner {
         disk_block_ids: &[u32],
         block_size: usize,
         matched_tokens: usize,
+        adapter_id: u64,
     ) -> Vec<u32> {
         let access = self.next_access();
-        let mut current = self.root;
+        let root_id = self.root_for_insert(adapter_id);
+        let mut current = root_id;
         let mut parent_ctx_hash: u64 = 0; // root context hash
         let num_full_blocks = tokens.len() / block_size;
         let num_blocks = num_full_blocks.min(block_table.len());
@@ -311,7 +372,7 @@ impl RadixTreeInner {
         }
 
         let remainder = tokens.len() % block_size;
-        if remainder > 0 && block_table.len() > num_full_blocks && current != self.root {
+        if remainder > 0 && block_table.len() > num_full_blocks && current != root_id {
             let partial_toks = tokens[num_full_blocks * block_size..].to_vec();
             let partial_block = block_table[num_full_blocks];
             let partial_disk = if hss_active && disk_block_ids.len() > num_full_blocks {
@@ -356,7 +417,10 @@ impl RadixTreeInner {
 
             let mut best: Option<(NodeId, u64)> = None;
             for (id, node) in self.nodes.iter().enumerate() {
-                if id == self.root {
+                // Roots (one per adapter_id) carry `parent == None` and
+                // `block_idx == u32::MAX`; the block_idx guard below already
+                // excludes them, but skip explicitly for clarity.
+                if node.parent.is_none() {
                     continue;
                 }
                 if node.ref_count <= 1 && node.children.is_empty() && node.block_idx != u32::MAX {
@@ -406,11 +470,11 @@ impl RadixTreeInner {
     }
 
     pub(super) fn num_entries(&self) -> usize {
-        // Count non-root, non-deleted nodes.
+        // Count non-root, non-deleted nodes. Roots (per adapter_id) and freed
+        // nodes both carry `block_idx == u32::MAX`, so this filter excludes them.
         self.nodes
             .iter()
-            .enumerate()
-            .filter(|(id, n)| *id != self.root && n.block_idx != u32::MAX)
+            .filter(|n| n.block_idx != u32::MAX)
             .count()
     }
 }

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -14,6 +14,35 @@ pub(super) struct SnapshotEntry {
     token_count: usize,
     prefix_hash: u64,
     last_access: u64,
+    /// Cumulative hits over the entry's lifetime — combined with
+    /// `last_access` in eviction to approximate the forecast-based
+    /// policy from the Marconi paper §4 (B.4, 2026-04-25). Hot
+    /// prefixes (high hit count) survive longer than cold ones at
+    /// the same age.
+    hit_count: u32,
+    /// Phase 1b — spill-not-drop location. `false` = resident in HBM at
+    /// `snapshot_id`. `true` = spilled to the byte tier; `snapshot_id` is stale
+    /// and the state is addressed by `prefix_hash` (the tier key). Always
+    /// `false` when `ATLAS_SSM_TIER` is off, so the default path is unchanged.
+    tiered: bool,
+}
+
+/// Where a matched snapshot's state currently lives (Phase 1b).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SnapLoc {
+    /// Resident in the HBM snapshot pool at this slot — restore directly.
+    Hbm(usize),
+    /// Spilled to the byte tier — fault in by this key (the prefix hash) into a
+    /// fresh HBM slot, then `promote`.
+    Tier(u64),
+}
+
+/// A tier-aware snapshot match (Phase 1b): the deepest anchor for a prefix plus
+/// where its state currently lives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SnapMatch {
+    pub token_count: usize,
+    pub loc: SnapLoc,
 }
 
 pub(super) struct SsmSnapshotIndex {
@@ -21,9 +50,48 @@ pub(super) struct SsmSnapshotIndex {
     pub(super) access_counter: u64,
     /// Session of the most recent `lookup` — the live conversation. Its
     /// DEEPEST snapshot is the one its next warm turn will restore from, so
-    /// `evict_lru` protects it (ATLAS_SSM_TAIL_PROTECT). Tracks the running
-    /// tip: recomputed each eviction from `token_count`, never a pinned slot.
+    /// `evict_lru` protects it (ATLAS_SSM_TAIL_PROTECT, ported from #278).
+    /// Tracks the running tip: recomputed each eviction from `token_count`,
+    /// never a pinned slot. Complements the session-aware victim ranking
+    /// below — session-aware protects the live session vs *dormant* ones;
+    /// tail-protect protects the deep tail *within* the live session (the
+    /// single/dominant-conversation case session-freshness can't see).
     last_lookup_session: u64,
+    /// Phase-0 measurement counters (ATLAS_SSM_SNAP_STATS). All aggregate,
+    /// off the hot path's critical decisions — they only observe. The residual
+    /// `recompute_tokens_on_hit` after tail-protect + a large pool is exactly
+    /// what Phase 1 (spill-not-drop) converts from recompute → fault-in.
+    stats: SnapshotStats,
+}
+
+/// Aggregate SSM-snapshot cache telemetry (Phase 0). Summarised via
+/// `log_stats_if_due` when `ATLAS_SSM_SNAP_STATS` is set.
+#[derive(Default, Clone, Copy)]
+pub(super) struct SnapshotStats {
+    /// Snapshots registered (new prefix inserted, not an overwrite).
+    pub saves: u64,
+    /// Prefix lookups attempted.
+    pub lookups: u64,
+    /// Lookups that restored *some* anchor (deep or shallow).
+    pub hits: u64,
+    /// Σ restored-anchor depth over hits — mean anchor = this / hits.
+    pub anchor_depth_sum: u64,
+    /// Σ (matched_tokens − anchor_depth) over hits: the SSM tokens that still
+    /// had to be recomputed because the deep tail was not resident. This is the
+    /// #278 metric ("mean recompute 4438→262 tok") and Phase 1's target.
+    pub recompute_tokens_on_hit: u64,
+    /// Σ matched_tokens over *misses* (no anchor at all → full recompute).
+    pub recompute_tokens_on_miss: u64,
+    /// Snapshot slots freed by `evict_lru` — a DROP (state discarded) on the
+    /// default path; Phase 1 spills instead via `evict_to_tier`.
+    pub evictions: u64,
+    /// Phase 1b: entries moved HBM→Tier by `evict_to_tier` (spills, not drops).
+    pub tier_spills: u64,
+    /// Phase 1b: lookups whose deepest anchor was found in the tier (would have
+    /// been a recompute pre-spill) — the converted loss.
+    pub tier_hits: u64,
+    /// Phase 1b: tier entries faulted back into HBM via `promote`.
+    pub tier_fault_ins: u64,
 }
 
 impl SsmSnapshotIndex {
@@ -32,6 +100,7 @@ impl SsmSnapshotIndex {
             entries: Vec::new(),
             access_counter: 0,
             last_lookup_session: 0,
+            stats: SnapshotStats::default(),
         }
     }
 
@@ -48,60 +117,85 @@ impl SsmSnapshotIndex {
                 entry.snapshot_id = snapshot_id;
                 entry.session_hash = session_hash;
                 entry.token_count = token_count;
+                // A fresh HBM save re-homes the prefix: it is resident again.
+                entry.tiered = false;
                 self.access_counter += 1;
                 entry.last_access = self.access_counter;
                 return Some(old);
             }
         }
         self.access_counter += 1;
+        self.stats.saves += 1;
         self.entries.push(SnapshotEntry {
             snapshot_id,
             session_hash,
             token_count,
             prefix_hash,
             last_access: self.access_counter,
+            hit_count: 0,
+            tiered: false,
         });
         None
     }
 
     /// Find deepest snapshot matching session within matched_tokens range.
+    /// Task #24: `adapter_id` is folded into the recomputed prefix hash so a
+    /// snapshot registered under one adapter never matches another's lookup.
+    ///
+    /// Resident-only (skips tiered entries). The serving path uses the
+    /// tier-aware `lookup_tiered`; this is retained as the reference for the
+    /// pre-tier contract and exercised by focused unit tests.
+    #[allow(dead_code)]
     pub(super) fn lookup(
         &mut self,
         tokens: &[u32],
         matched_tokens: usize,
         session_hash: u64,
+        adapter_id: u64,
     ) -> Option<(usize, usize)> {
-        // Track the live conversation so eviction can protect its deep tail.
+        // Track the live conversation so eviction can protect its deep tail
+        // (ATLAS_SSM_TAIL_PROTECT).
         if session_hash != 0 {
             self.last_lookup_session = session_hash;
         }
-        // Side-effect-free scan: only the WINNER gets its recency bumped,
-        // below. Bumping every improving candidate kept shallow early-prefix
-        // entries eternally fresh (each deep lookup walks the improving chain
-        // through them), pinning them in the pool while the tail checkpoints
-        // the next warm turn actually needs were evicted — the measured
-        // frozen-anchor / 18.6k-token SSM replay pathology (2026-07-10).
         let mut best: Option<(usize, usize)> = None; // (snapshot_id, token_count)
-        let mut best_idx: Option<usize> = None;
-        for (i, entry) in self.entries.iter().enumerate() {
+        for entry in &mut self.entries {
+            // Tiered entries hold no HBM slot — the non-tier `lookup` must never
+            // hand back a spilled entry's stale slot. Tier-aware callers use
+            // `lookup_tiered`. (No entry is ever tiered when ATLAS_SSM_TIER off.)
+            if entry.tiered {
+                continue;
+            }
             if entry.token_count > matched_tokens {
                 continue;
             }
             if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
                 continue;
             }
-            let h = hash_token_prefix(tokens, entry.token_count);
+            let h = hash_token_prefix(tokens, entry.token_count, adapter_id);
             if h != entry.prefix_hash {
                 continue;
             }
             if best.is_none() || entry.token_count > best.unwrap().1 {
+                self.access_counter += 1;
+                entry.last_access = self.access_counter;
+                entry.hit_count = entry.hit_count.saturating_add(1);
                 best = Some((entry.snapshot_id, entry.token_count));
-                best_idx = Some(i);
             }
         }
-        if let Some(i) = best_idx {
-            self.access_counter += 1;
-            self.entries[i].last_access = self.access_counter;
+        // Phase-0 telemetry: hit-rate + recompute distance. `recompute` is the
+        // SSM prefix that still had to be re-run because no deeper anchor was
+        // resident — the exact loss tail-protect shrinks and Phase 1 removes.
+        self.stats.lookups += 1;
+        match best {
+            Some((_, anchor)) => {
+                self.stats.hits += 1;
+                self.stats.anchor_depth_sum += anchor as u64;
+                self.stats.recompute_tokens_on_hit += matched_tokens.saturating_sub(anchor) as u64;
+            }
+            None => {
+                self.stats.recompute_tokens_on_miss += matched_tokens as u64;
+            }
         }
         if std::env::var("ATLAS_SNAP_LOOKUP_DBG").is_ok() {
             let mut cands: Vec<usize> = self.entries.iter().map(|e| e.token_count).collect();
@@ -113,24 +207,53 @@ impl SsmSnapshotIndex {
                 cands,
             );
         }
+        self.log_stats_if_due();
         best
+    }
+
+    /// Emit an aggregate SSM-snapshot cache summary every 64 lookups when
+    /// `ATLAS_SSM_SNAP_STATS` is set. Off-by-default and read-only, so it never
+    /// perturbs serving; the line is the Phase-0 measurement surface (hit-rate,
+    /// mean restore anchor, mean recompute tok/turn — the #278 metrics).
+    fn log_stats_if_due(&self) {
+        if !self.stats.lookups.is_multiple_of(64)
+            || std::env::var_os("ATLAS_SSM_SNAP_STATS").is_none()
+        {
+            return;
+        }
+        let s = &self.stats;
+        let hit_rate = s.hits as f64 / s.lookups.max(1) as f64;
+        let mean_anchor = s.anchor_depth_sum as f64 / s.hits.max(1) as f64;
+        let mean_recompute_hit = s.recompute_tokens_on_hit as f64 / s.hits.max(1) as f64;
+        let tiered = self.entries.iter().filter(|e| e.tiered).count();
+        tracing::info!(
+            "ssm-snap-stats: lookups={} hits={} hit_rate={:.2} saves={} evictions(drops)={} \
+             mean_anchor={:.0}tok mean_recompute_on_hit={:.0}tok recompute_on_miss={}tok \
+             resident={} tiered={} tier_spills={} tier_hits={} tier_fault_ins={}",
+            s.lookups,
+            s.hits,
+            hit_rate,
+            s.saves,
+            s.evictions,
+            mean_anchor,
+            mean_recompute_hit,
+            s.recompute_tokens_on_miss,
+            self.entries.len() - tiered,
+            tiered,
+            s.tier_spills,
+            s.tier_hits,
+            s.tier_fault_ins,
+        );
     }
 
     pub(super) fn evict_lru(&mut self) -> Option<usize> {
         if self.entries.is_empty() {
             return None;
         }
-        // Pure recency (LRU). The former forecast score
-        // `last_access * (1 + hit_count)` multiplied a monotonic timestamp by
-        // hit count, so any once-hit old entry outscored every fresh save;
-        // once the cold entries drained, each new save's evict victim was the
-        // PREVIOUS fresh save — the live turn's tail checkpoint died ms before
-        // the next turn's lookup needed it, freezing the restore anchor
-        // (measured: anchor pinned at token 9056 for 29 turns, 12.7k-token SSM
-        // replay, 40s TTFT tail). With winner-only recency bumps in `lookup`,
-        // plain LRU keeps the selected anchor and recent tail checkpoints
-        // resident and lets unhit fossils age out.
-        let escore = |e: &SnapshotEntry| e.last_access;
+        // Per-entry forecast score (B.4, Marconi paper §4): old AND cold first.
+        // last_access * (1 + hit_count) — recent/hot survive. #155 fixed the
+        // inverted (÷) form that evicted just-selected snapshots.
+        let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
 
         // SESSION-AWARE eviction (default ON; ATLAS_SNAP_EVICT_LEGACY=1 → old
         // per-entry policy). The agentic workload interleaves ~20 multi-turn
@@ -148,70 +271,215 @@ impl SsmSnapshotIndex {
         // (session_hash + prefix_hash) before using any snapshot; eviction only
         // frees a slot.
         if std::env::var_os("ATLAS_SNAP_EVICT_LEGACY").is_none() {
-            // session freshness = max last_access among that session's entries.
-            let mut session_fresh: std::collections::HashMap<u64, u64> =
-                std::collections::HashMap::with_capacity(self.entries.len());
-            for e in &self.entries {
-                let f = session_fresh.entry(e.session_hash).or_insert(0);
-                if e.last_access > *f {
-                    *f = e.last_access;
-                }
-            }
-            // ATLAS_SSM_TAIL_PROTECT: exempt the live conversation's DEEPEST
-            // snapshot from eviction — its next warm turn restores from it.
-            // Without this the just-saved deep tail (hit_count=0, low escore) is
-            // evicted before the hot token-8192 anchor (self-reinforced hit_count),
-            // so warm restore falls back to 8192 and recomputes thousands of SSM
-            // tokens (measured 50-75% of restores, mean ~4400 tok, ~7.6s TTFT/turn).
-            // Recomputed each call (follows the deepening tip, never a pinned slot);
-            // exactly ONE entry, scoped to the active session, so any pool >=2 has a
-            // victim and never deadlocks. Correctness-safe: restore re-validates
-            // session_hash+prefix_hash+depth, so changing the victim cannot drift.
-            let protected_idx: Option<usize> = if self.last_lookup_session != 0
-                && std::env::var_os("ATLAS_SSM_TAIL_PROTECT").is_some()
-            {
-                self.entries
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, e)| e.session_hash == self.last_lookup_session)
-                    .max_by_key(|(_, e)| e.token_count)
-                    .map(|(i, _)| i)
-            } else {
-                None
-            };
-            let n = self.entries.len();
-            let mut victim_idx = protected_idx.map_or(0, |p| if p == 0 && n > 1 { 1 } else { 0 });
-            // (stalest session first, then lowest entry score within it)
-            let mut victim_key = (u64::MAX, u64::MAX);
-            for (i, e) in self.entries.iter().enumerate() {
-                if Some(i) == protected_idx && n > 1 {
-                    continue; // never evict the live session's deepest tail
-                }
-                let sf = *session_fresh.get(&e.session_hash).unwrap_or(&0);
-                let key = (sf, escore(e));
-                if key < victim_key {
-                    victim_key = key;
-                    victim_idx = i;
-                }
-            }
+            let tail_protect = self.last_lookup_session != 0
+                && std::env::var_os("ATLAS_SSM_TAIL_PROTECT").is_some();
+            // Skip tiered entries — they hold no HBM slot to free.
+            let victim_idx = self.session_aware_victim(tail_protect, true)?;
             let entry = self.entries.swap_remove(victim_idx);
+            self.stats.evictions += 1;
             return Some(entry.snapshot_id);
         }
 
-        let mut victim_idx = 0;
+        let mut victim_idx = None;
         let mut victim_score = u64::MAX;
         for (i, entry) in self.entries.iter().enumerate() {
+            if entry.tiered {
+                continue; // no HBM slot to free
+            }
             let score = escore(entry);
             if score < victim_score {
                 victim_score = score;
-                victim_idx = i;
+                victim_idx = Some(i);
             }
         }
-        let entry = self.entries.swap_remove(victim_idx);
+        let entry = self.entries.swap_remove(victim_idx?);
+        self.stats.evictions += 1;
         Some(entry.snapshot_id)
+    }
+
+    /// Pure victim selection for the session-aware eviction policy (default
+    /// path). Returns the index into `self.entries` to drop. Split out so it
+    /// is unit-testable without mutating process env.
+    ///
+    /// Ranking: evict the STALEST conversation first (by session freshness =
+    /// max `last_access` over its entries), then the lowest per-entry forecast
+    /// score within it — the live conversation's whole deep chain stays
+    /// resident until every dormant conversation is gone.
+    ///
+    /// `tail_protect` (ATLAS_SSM_TAIL_PROTECT, ported from #278): additionally
+    /// exempt the live conversation's DEEPEST snapshot — its next warm turn
+    /// restores from it. Session-aware ranking alone only protects the live
+    /// session vs *dormant* ones; within a single/dominant session it falls
+    /// through to lowest-escore = the just-aged deep tail (hit_count=0), which
+    /// the hot token-8192 anchor out-scores, so warm restore falls back to 8192
+    /// and recomputes thousands of SSM tokens (~4400 tok, ~7.6s TTFT/turn).
+    /// Exactly ONE entry is exempted, scoped to the active session, so any pool
+    /// \>=2 always has a victim and never deadlocks. Correctness-safe: restore
+    /// re-validates session_hash+prefix_hash+depth, so changing the victim
+    /// cannot cause a wrong-position restore.
+    ///
+    /// `skip_tiered` (Phase 1b): ignore entries already spilled to the byte tier
+    /// — they hold no HBM slot, so they are neither a valid drop victim (freeing
+    /// their stale `snapshot_id` would double-free) nor a spill candidate.
+    /// Returns `None` when no eligible entry exists (all spilled / empty).
+    fn session_aware_victim(&self, tail_protect: bool, skip_tiered: bool) -> Option<usize> {
+        let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
+        let eligible = |e: &SnapshotEntry| !(skip_tiered && e.tiered);
+
+        // session freshness = max last_access among that session's eligible entries.
+        let mut session_fresh: std::collections::HashMap<u64, u64> =
+            std::collections::HashMap::with_capacity(self.entries.len());
+        for e in self.entries.iter().filter(|e| eligible(e)) {
+            let f = session_fresh.entry(e.session_hash).or_insert(0);
+            if e.last_access > *f {
+                *f = e.last_access;
+            }
+        }
+        let n_eligible = self.entries.iter().filter(|e| eligible(e)).count();
+        let protected_idx: Option<usize> = if tail_protect {
+            self.entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| eligible(e) && e.session_hash == self.last_lookup_session)
+                .max_by_key(|(_, e)| e.token_count)
+                .map(|(i, _)| i)
+        } else {
+            None
+        };
+        // (stalest session first, then lowest entry score within it). Protected
+        // bites only when >1 eligible entry remains, so a single-entry pool
+        // (even if it is the protected tail) still yields a victim → no deadlock.
+        let mut victim: Option<(usize, (u64, u64))> = None;
+        for (i, e) in self.entries.iter().enumerate() {
+            if !eligible(e) {
+                continue;
+            }
+            if Some(i) == protected_idx && n_eligible > 1 {
+                continue; // never evict the live session's deepest tail
+            }
+            let sf = *session_fresh.get(&e.session_hash).unwrap_or(&0);
+            let key = (sf, escore(e));
+            if victim.is_none_or(|(_, vk)| key < vk) {
+                victim = Some((i, key));
+            }
+        }
+        victim.map(|(i, _)| i)
+    }
+
+    // ─────────────────────────── Phase 1b: spill tier ───────────────────────
+    // Location state machine over the same `entries`: an entry is either
+    // resident (`tiered == false`, state at `snapshot_id`) or spilled
+    // (`tiered == true`, state at `prefix_hash` in the byte tier). Only reached
+    // when the caller has ATLAS_SSM_TIER on; the default path never tiers.
+    // Consumed via the `PrefixCache` trait (`evict_snapshot_to_tier`,
+    // `promote_snapshot`) and `RadixTree::lookup`'s tier-aware sub-lookup.
+
+    /// **Spill victim selection** (replaces `evict_lru`'s drop when the tier is
+    /// engaged). Pick the same session-aware/tail-protected victim as the drop
+    /// path but among HBM-resident entries only, mark it spilled, and return
+    /// `(freed_slot, key)` so the caller moves its bytes to the tier and reuses
+    /// the slot. The entry STAYS in the index (findable by `lookup_tiered`), so
+    /// a later warm turn faults it back in instead of recomputing.
+    /// `None` ⇒ nothing HBM-resident to free (all already spilled / empty).
+    pub(super) fn evict_to_tier(&mut self) -> Option<(usize, u64)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let tail_protect =
+            self.last_lookup_session != 0 && std::env::var_os("ATLAS_SSM_TAIL_PROTECT").is_some();
+        let idx = self.session_aware_victim(tail_protect, /*skip_tiered*/ true)?;
+        let e = &mut self.entries[idx];
+        e.tiered = true;
+        let freed_slot = e.snapshot_id;
+        let key = e.prefix_hash;
+        self.stats.tier_spills += 1;
+        Some((freed_slot, key))
+    }
+
+    /// **Tier-aware lookup** (used in place of `lookup` when the tier is on).
+    /// Returns the deepest matching anchor and where its state lives, so the
+    /// caller either restores from HBM or faults in from the tier. Feeds the
+    /// same Phase-0 telemetry as `lookup`, plus `tier_hits`.
+    pub(super) fn lookup_tiered(
+        &mut self,
+        tokens: &[u32],
+        matched_tokens: usize,
+        session_hash: u64,
+        adapter_id: u64,
+    ) -> Option<SnapMatch> {
+        if session_hash != 0 {
+            self.last_lookup_session = session_hash;
+        }
+        // Deepest matching prefix across BOTH resident and spilled entries.
+        let mut best: Option<usize> = None;
+        let mut best_depth = 0usize;
+        for (i, entry) in self.entries.iter().enumerate() {
+            if entry.token_count > matched_tokens {
+                continue;
+            }
+            if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
+                continue;
+            }
+            if hash_token_prefix(tokens, entry.token_count, adapter_id) != entry.prefix_hash {
+                continue;
+            }
+            if best.is_none() || entry.token_count > best_depth {
+                best = Some(i);
+                best_depth = entry.token_count;
+            }
+        }
+        self.stats.lookups += 1;
+        let result = if let Some(i) = best {
+            self.access_counter += 1;
+            let ac = self.access_counter;
+            let e = &mut self.entries[i];
+            e.last_access = ac;
+            e.hit_count = e.hit_count.saturating_add(1);
+            let tiered = e.tiered;
+            let depth = e.token_count;
+            let loc = if tiered {
+                SnapLoc::Tier(e.prefix_hash)
+            } else {
+                SnapLoc::Hbm(e.snapshot_id)
+            };
+            self.stats.hits += 1;
+            self.stats.anchor_depth_sum += depth as u64;
+            self.stats.recompute_tokens_on_hit += matched_tokens.saturating_sub(depth) as u64;
+            if tiered {
+                self.stats.tier_hits += 1;
+            }
+            Some(SnapMatch {
+                token_count: depth,
+                loc,
+            })
+        } else {
+            self.stats.recompute_tokens_on_miss += matched_tokens as u64;
+            None
+        };
+        self.log_stats_if_due();
+        result
+    }
+
+    /// **Promote** a spilled entry back to HBM after the caller faulted its
+    /// bytes into `new_slot`. Flips `tiered → false` and re-homes `snapshot_id`.
+    /// Returns `false` if `prefix_hash` is unknown (entry evicted meanwhile).
+    pub(super) fn promote(&mut self, prefix_hash: u64, new_slot: usize) -> bool {
+        for e in &mut self.entries {
+            if e.prefix_hash == prefix_hash {
+                e.tiered = false;
+                e.snapshot_id = new_slot;
+                self.stats.tier_fault_ins += 1;
+                return true;
+            }
+        }
+        false
     }
 
     pub(super) fn len(&self) -> usize {
         self.entries.len()
     }
 }
+
+#[cfg(test)]
+#[path = "tests/snapshot_index.rs"]
+mod tests;

--- a/crates/spark-runtime/src/radix_tree/tests/adapter.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/adapter.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::prefix_cache::PrefixCache;
+use crate::radix_tree::RadixTree;
+
+// ── Task #24: adapter-correct KV / prefix cache ──
+
+/// A prefix cached under adapter A must NOT be reused by an adapter-B request
+/// (or a base request), because the cached K/V carry adapter A's delta. A
+/// cross-adapter lookup is a MISS → recompute under the right adapter. The
+/// SAME adapter still reuses its own prefix (the cache still helps).
+#[test]
+fn test_kv_cache_adapter_isolation() {
+    let tree = RadixTree::new();
+    let tokens: Vec<u32> = (0..32).collect();
+    const A: u64 = 0x1111_2222_3333_4444;
+    const B: u64 = 0x5555_6666_7777_8888;
+
+    // Adapter A caches a prefix (cache-miss insert, then the inserting seq exits).
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, A);
+    tree.release(&tokens, 16, A);
+
+    // Adapter B: same tokens, different adapter → cross-adapter MISS.
+    let m_b = tree.lookup(&tokens, 16, 0, B);
+    assert!(
+        m_b.is_empty(),
+        "adapter B must NOT reuse adapter A's KV blocks"
+    );
+
+    // Base (id 0): also must not reuse an adapter's blocks.
+    let m_base = tree.lookup(&tokens, 16, 0, 0);
+    assert!(
+        m_base.is_empty(),
+        "base must NOT reuse an adapter's KV blocks"
+    );
+
+    // Same adapter A: full reuse still works.
+    let m_a = tree.lookup(&tokens, 16, 0, A);
+    assert_eq!(m_a.matched_tokens, 32);
+    assert_eq!(m_a.matched_blocks, vec![10, 20]);
+    tree.release(&tokens, 16, A);
+}
+
+/// The reverse direction: base-computed blocks are keyed under the base
+/// sentinel (id 0) and must not be reused by any adapter, while base requests
+/// still hit them (byte-identical to pre-#24 behavior).
+#[test]
+fn test_base_blocks_not_reused_by_adapter() {
+    let tree = RadixTree::new();
+    let tokens: Vec<u32> = (0..32).collect();
+
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0); // base
+    tree.release(&tokens, 16, 0);
+
+    // An adapter request misses base blocks.
+    let m_adapter = tree.lookup(&tokens, 16, 0, 0xABCD);
+    assert!(m_adapter.is_empty());
+
+    // Base still hits (unchanged cache behavior).
+    let m_base = tree.lookup(&tokens, 16, 0, 0);
+    assert_eq!(m_base.matched_tokens, 32);
+    assert_eq!(m_base.matched_blocks, vec![10, 20]);
+    tree.release(&tokens, 16, 0);
+}
+
+/// The reviewer's insert-collision hazard: after adapter B misses on the same
+/// tokens, its own insert must create a DISJOINT node (not clobber adapter A's
+/// node and steal its physical block). Both adapters must then reuse their OWN
+/// blocks independently.
+#[test]
+fn test_adapter_insert_does_not_clobber_other_adapter() {
+    let tree = RadixTree::new();
+    let tokens: Vec<u32> = (0..32).collect();
+    const A: u64 = 0xAAAA;
+    const B: u64 = 0xBBBB;
+
+    // A caches blocks [10,20]; B caches DIFFERENT physical blocks [30,40] for
+    // the identical token stream.
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, A);
+    tree.release(&tokens, 16, A);
+    tree.insert(&tokens, &[30, 40], &[], 16, 0, B);
+    tree.release(&tokens, 16, B);
+
+    // Each adapter reuses its OWN blocks — no cross-contamination.
+    let m_a = tree.lookup(&tokens, 16, 0, A);
+    assert_eq!(
+        m_a.matched_blocks,
+        vec![10, 20],
+        "adapter A kept its blocks"
+    );
+    tree.release(&tokens, 16, A);
+
+    let m_b = tree.lookup(&tokens, 16, 0, B);
+    assert_eq!(
+        m_b.matched_blocks,
+        vec![30, 40],
+        "adapter B kept its blocks"
+    );
+    tree.release(&tokens, 16, B);
+}

--- a/crates/spark-runtime/src/radix_tree/tests/basic.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/basic.rs
@@ -13,8 +13,8 @@ fn test_insert_and_lookup_exact() {
     let tokens: Vec<u32> = (0..16).collect(); // 1 block of 16 tokens
     let block_table = vec![42];
 
-    tree.insert(&tokens, &block_table, &[], 16, 0);
-    let m = tree.lookup(&tokens, 16, 0);
+    tree.insert(&tokens, &block_table, &[], 16, 0, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
 
     assert_eq!(m.matched_tokens, 16);
     assert_eq!(m.matched_blocks, vec![42]);
@@ -26,8 +26,8 @@ fn test_insert_and_lookup_multi_block() {
     let tokens: Vec<u32> = (0..48).collect(); // 3 blocks of 16
     let block_table = vec![10, 20, 30];
 
-    tree.insert(&tokens, &block_table, &[], 16, 0);
-    let m = tree.lookup(&tokens, 16, 0);
+    tree.insert(&tokens, &block_table, &[], 16, 0, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
 
     assert_eq!(m.matched_tokens, 48);
     assert_eq!(m.matched_blocks, vec![10, 20, 30]);
@@ -38,11 +38,11 @@ fn test_partial_match() {
     let tree = RadixTree::new();
     // Insert 32 tokens (2 blocks)
     let tokens_a: Vec<u32> = (0..32).collect();
-    tree.insert(&tokens_a, &[10, 20], &[], 16, 0);
+    tree.insert(&tokens_a, &[10, 20], &[], 16, 0, 0);
 
     // Lookup 48 tokens (3 blocks) — only first 2 match
     let tokens_b: Vec<u32> = (0..48).collect();
-    let m = tree.lookup(&tokens_b, 16, 0);
+    let m = tree.lookup(&tokens_b, 16, 0, 0);
 
     assert_eq!(m.matched_tokens, 32);
     assert_eq!(m.matched_blocks, vec![10, 20]);
@@ -52,11 +52,11 @@ fn test_partial_match() {
 fn test_no_match() {
     let tree = RadixTree::new();
     let tokens_a: Vec<u32> = (0..16).collect();
-    tree.insert(&tokens_a, &[10], &[], 16, 0);
+    tree.insert(&tokens_a, &[10], &[], 16, 0, 0);
 
     // Different tokens — no match
     let tokens_b: Vec<u32> = (100..116).collect();
-    let m = tree.lookup(&tokens_b, 16, 0);
+    let m = tree.lookup(&tokens_b, 16, 0, 0);
 
     assert!(m.is_empty());
 }
@@ -68,12 +68,12 @@ fn test_release_decrements_refcount() {
     // Simulate the real cache-miss flow: insert from a seq that did NOT
     // match on walk (matched_tokens=0), then that seq exits (release).
     // After release the cache holds exactly one ref (its baseline).
-    tree.insert(&tokens, &[42], &[], 16, 0);
-    tree.release(&tokens, 16);
+    tree.insert(&tokens, &[42], &[], 16, 0, 0);
+    tree.release(&tokens, 16, 0);
 
     // A second seq comes in, walks (hits), then exits.
-    let _ = tree.lookup(&tokens, 16, 0);
-    tree.release(&tokens, 16);
+    let _ = tree.lookup(&tokens, 16, 0, 0);
+    tree.release(&tokens, 16, 0);
 
     // After both seqs exit, ref_count == cache baseline (1) → evictable.
     let evicted = tree.evict(1);
@@ -90,14 +90,14 @@ fn test_insert_release_lookup_survives() {
     // inserting seq's pending release doesn't drop the cache's baseline.
     let tree = RadixTree::new();
     let tokens: Vec<u32> = (0..32).collect();
-    tree.insert(&tokens, &[10, 20], &[], 16, 0); // cache-miss insert
-    tree.release(&tokens, 16); // inserting seq exits
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0); // cache-miss insert
+    tree.release(&tokens, 16, 0); // inserting seq exits
 
     // Second request with identical prompt — must find the cached entry.
-    let m = tree.lookup(&tokens, 16, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.matched_tokens, 32, "stale cache entry after seq exit");
     assert_eq!(m.matched_blocks, vec![10, 20]);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -106,13 +106,13 @@ fn test_evict_lru_order() {
 
     // Insert block A (older) + release inserting seq
     let tokens_a: Vec<u32> = (0..16).collect();
-    tree.insert(&tokens_a, &[10], &[], 16, 0);
-    tree.release(&tokens_a, 16);
+    tree.insert(&tokens_a, &[10], &[], 16, 0, 0);
+    tree.release(&tokens_a, 16, 0);
 
     // Insert block B (newer) + release inserting seq
     let tokens_b: Vec<u32> = (100..116).collect();
-    tree.insert(&tokens_b, &[20], &[], 16, 0);
-    tree.release(&tokens_b, 16);
+    tree.insert(&tokens_b, &[20], &[], 16, 0, 0);
+    tree.release(&tokens_b, 16, 0);
 
     // Evict 1 — should be A (older LRU)
     let evicted = tree.evict(1);
@@ -128,18 +128,18 @@ fn test_evict_skips_referenced_nodes() {
     let tree = RadixTree::new();
     let tokens: Vec<u32> = (0..16).collect();
     // Cache-miss insert + release: node settles at ref_count=1 (cache baseline).
-    tree.insert(&tokens, &[42], &[], 16, 0);
-    tree.release(&tokens, 16);
+    tree.insert(&tokens, &[42], &[], 16, 0, 0);
+    tree.release(&tokens, 16, 0);
 
     // An active seq walks (matches) → ref_count bumps above the baseline.
-    let _ = tree.lookup(&tokens, 16, 0);
+    let _ = tree.lookup(&tokens, 16, 0, 0);
 
     // Evict should skip while the seq is active (ref_count > 1).
     let evicted = tree.evict(1);
     assert!(evicted.is_empty());
 
     // Seq exits → ref_count returns to the cache baseline → evictable.
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
     let evicted = tree.evict(1);
     assert_eq!(evicted.physical, vec![42]);
 }
@@ -149,8 +149,8 @@ fn test_evict_chain_from_leaf() {
     let tree = RadixTree::new();
     // Insert 3-block chain + release inserting seq so the chain is evictable.
     let tokens: Vec<u32> = (0..48).collect();
-    tree.insert(&tokens, &[10, 20, 30], &[], 16, 0);
-    tree.release(&tokens, 16);
+    tree.insert(&tokens, &[10, 20, 30], &[], 16, 0, 0);
+    tree.release(&tokens, 16, 0);
 
     // Evict 1 — should remove leaf (block 30)
     let evicted = tree.evict(1);
@@ -174,8 +174,8 @@ fn test_insert_idempotent() {
     let tokens: Vec<u32> = (0..16).collect();
 
     // Insert same sequence twice — should not create duplicate nodes
-    tree.insert(&tokens, &[42], &[], 16, 0);
-    tree.insert(&tokens, &[42], &[], 16, 0);
+    tree.insert(&tokens, &[42], &[], 16, 0, 0);
+    tree.insert(&tokens, &[42], &[], 16, 0, 0);
 
     assert_eq!(tree.stats(), (1, 1));
 }
@@ -186,25 +186,25 @@ fn test_branching_tree() {
 
     // Insert A: [0..32] → blocks [10, 20]
     let tokens_a: Vec<u32> = (0..32).collect();
-    tree.insert(&tokens_a, &[10, 20], &[], 16, 0);
+    tree.insert(&tokens_a, &[10, 20], &[], 16, 0, 0);
 
     // Insert B: [0..16, 100..116] → blocks [10, 30]
     // Same first block, different second block
     let mut tokens_b: Vec<u32> = (0..16).collect();
     tokens_b.extend(100..116);
-    tree.insert(&tokens_b, &[10, 30], &[], 16, 0);
+    tree.insert(&tokens_b, &[10, 30], &[], 16, 0, 0);
 
     // Lookup A — full match
-    let m = tree.lookup(&tokens_a, 16, 0);
+    let m = tree.lookup(&tokens_a, 16, 0, 0);
     assert_eq!(m.matched_tokens, 32);
     assert_eq!(m.matched_blocks, vec![10, 20]);
-    tree.release(&tokens_a, 16);
+    tree.release(&tokens_a, 16, 0);
 
     // Lookup B — full match
-    let m = tree.lookup(&tokens_b, 16, 0);
+    let m = tree.lookup(&tokens_b, 16, 0, 0);
     assert_eq!(m.matched_tokens, 32);
     assert_eq!(m.matched_blocks, vec![10, 30]);
-    tree.release(&tokens_b, 16);
+    tree.release(&tokens_b, 16, 0);
 
     // 3 nodes total: block 10 (shared prefix), block 20 (A), block 30 (B)
     assert_eq!(tree.stats(), (3, 3));
@@ -215,7 +215,7 @@ fn test_sub_block_tokens_ignored() {
     let tree = RadixTree::new();
     // Only 10 tokens — less than one block of 16, not inserted
     let tokens: Vec<u32> = (0..10).collect();
-    tree.insert(&tokens, &[42], &[], 16, 0);
+    tree.insert(&tokens, &[42], &[], 16, 0, 0);
 
     // No full blocks → nothing cached
     assert_eq!(tree.stats(), (0, 0));
@@ -234,7 +234,7 @@ fn test_hss_disk_ref_acquisition_cold_insert() {
     let disk_ids = vec![100u32, 101u32];
 
     // Cold insert with HSS active: cache takes ownership of both disk_ids.
-    let acquired = tree.insert(&tokens, &block_table, &disk_ids, 16, 0);
+    let acquired = tree.insert(&tokens, &block_table, &disk_ids, 16, 0, 0);
     assert_eq!(acquired, vec![100, 101]);
 }
 
@@ -246,13 +246,13 @@ fn test_hss_disk_ref_acquisition_re_insert_no_double() {
     let disk_ids = vec![100u32, 101u32];
 
     // First insert acquires both.
-    let acquired1 = tree.insert(&tokens, &block_table, &disk_ids, 16, 0);
+    let acquired1 = tree.insert(&tokens, &block_table, &disk_ids, 16, 0, 0);
     assert_eq!(acquired1, vec![100, 101]);
 
     // Second insert of the same prefix: nothing newly acquired (the cache
     // already owns these). Re-acquiring would over-inc and leak the disk
     // refcount.
-    let acquired2 = tree.insert(&tokens, &block_table, &disk_ids, 16, 0);
+    let acquired2 = tree.insert(&tokens, &block_table, &disk_ids, 16, 0, 0);
     assert!(
         acquired2.is_empty(),
         "re-insert should not re-acquire disk_ids; got {acquired2:?}"
@@ -266,7 +266,7 @@ fn test_hss_disk_ref_acquisition_extension() {
     let tokens_long: Vec<u32> = (0..48).collect();
 
     // Insert 2 blocks first.
-    let acquired1 = tree.insert(&tokens_short, &[10, 20], &[100u32, 101u32], 16, 0);
+    let acquired1 = tree.insert(&tokens_short, &[10, 20], &[100u32, 101u32], 16, 0, 0);
     assert_eq!(acquired1, vec![100, 101]);
 
     // Extension: same first 2 blocks (already cached) + 1 new block.
@@ -276,6 +276,7 @@ fn test_hss_disk_ref_acquisition_extension() {
         &[10, 20, 30],
         &[100u32, 101u32, 102u32],
         16,
+        0,
         0,
     );
     assert_eq!(acquired2, vec![102]);
@@ -288,7 +289,7 @@ fn test_hss_disk_ref_acquisition_no_op_when_hss_inactive() {
 
     // Empty disk_ids slice ⇒ HSS not active ⇒ nothing acquired regardless
     // of whether nodes are new or pre-existing.
-    let acquired = tree.insert(&tokens, &[10, 20], &[], 16, 0);
+    let acquired = tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
     assert!(acquired.is_empty());
 }
 
@@ -298,14 +299,14 @@ fn test_ssm_snapshot_insert_and_lookup() {
     let tokens: Vec<u32> = (0..32).collect();
 
     // Insert with snapshot on deepest node
-    tree.insert_with_snapshot(&tokens, &[10, 20], &[], 16, 42, 0, 0);
+    tree.insert_with_snapshot(&tokens, &[10, 20], &[], 16, 42, 0, 0, 0);
 
     // Lookup should return the snapshot at 32 tokens (leaf)
-    let m = tree.lookup(&tokens, 16, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.matched_tokens, 32);
     assert_eq!(m.ssm_snapshot, Some(42));
     assert_eq!(m.ssm_snapshot_tokens, 32);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -314,15 +315,15 @@ fn test_ssm_snapshot_partial_match_returns_deepest() {
 
     // Insert 3-block sequence with snapshot on leaf
     let tokens: Vec<u32> = (0..48).collect();
-    tree.insert_with_snapshot(&tokens, &[10, 20, 30], &[], 16, 99, 0, 0);
+    tree.insert_with_snapshot(&tokens, &[10, 20, 30], &[], 16, 99, 0, 0, 0);
 
     // Lookup only 2 blocks — snapshot is on block 3 (not matched)
     let tokens_short: Vec<u32> = (0..32).collect();
-    let m = tree.lookup(&tokens_short, 16, 0);
+    let m = tree.lookup(&tokens_short, 16, 0, 0);
     assert_eq!(m.matched_tokens, 32);
     assert_eq!(m.ssm_snapshot, None);
     assert_eq!(m.ssm_snapshot_tokens, 0);
-    tree.release(&tokens_short, 16);
+    tree.release(&tokens_short, 16, 0);
 }
 
 #[test]
@@ -332,8 +333,8 @@ fn test_ssm_snapshot_survives_tree_eviction() {
     let tree = RadixTree::new();
     let tokens: Vec<u32> = (0..16).collect();
 
-    tree.insert_with_snapshot(&tokens, &[10], &[], 16, 7, 0, 0);
-    tree.release(&tokens, 16); // inserting seq exits → node evictable
+    tree.insert_with_snapshot(&tokens, &[10], &[], 16, 7, 0, 0, 0);
+    tree.release(&tokens, 16, 0); // inserting seq exits → node evictable
 
     // Evict the tree node
     let evicted_blocks = tree.evict(1);
@@ -357,21 +358,21 @@ fn test_ssm_snapshot_overwrite_returns_displaced() {
     let tokens: Vec<u32> = (0..16).collect();
 
     // First insert — no displaced snapshot
-    let (displaced, _acquired) = tree.insert_with_snapshot(&tokens, &[10], &[], 16, 5, 0, 0);
+    let (displaced, _acquired) = tree.insert_with_snapshot(&tokens, &[10], &[], 16, 5, 0, 0, 0);
     assert_eq!(displaced, None);
 
     // Re-insert same path with new snapshot — returns displaced ID 5
-    let (displaced, _acquired) = tree.insert_with_snapshot(&tokens, &[10], &[], 16, 8, 0, 0);
+    let (displaced, _acquired) = tree.insert_with_snapshot(&tokens, &[10], &[], 16, 8, 0, 0, 0);
     assert_eq!(displaced, Some(5));
 
     // Only 1 entry in the index (overwrite, not append)
     assert_eq!(tree.snapshot_count(), 1);
 
     // Lookup should return new snapshot
-    let m = tree.lookup(&tokens, 16, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.ssm_snapshot, Some(8));
     assert_eq!(m.ssm_snapshot_tokens, 16);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 /// Issue #58: the prefix-cache key is derived from token IDs only, so two
@@ -397,8 +398,8 @@ fn test_vision_pad_tokens_are_image_blind_collision() {
     let page_b = page_a.clone();
 
     // Admitting page A's blocks would let page B match them in full.
-    tree.insert(&page_a, &[10, 20], &[], 16, 0);
-    let m = tree.lookup(&page_b, 16, 0);
+    tree.insert(&page_a, &[10, 20], &[], 16, 0, 0);
+    let m = tree.lookup(&page_b, 16, 0, 0);
 
     assert_eq!(
         m.matched_tokens, 32,

--- a/crates/spark-runtime/src/radix_tree/tests/mod.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/mod.rs
@@ -3,5 +3,6 @@
 //! Test split for radix tree — moved out of `radix_tree.rs` because
 //! the combined test file exceeded the workspace 500-LoC budget.
 
+mod adapter;
 mod basic;
 mod snapshot;

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -14,11 +14,11 @@ fn test_insert_without_snapshot() {
     let tree = RadixTree::new();
     let tokens: Vec<u32> = (0..16).collect();
 
-    tree.insert(&tokens, &[10], &[], 16, 0);
-    let m = tree.lookup(&tokens, 16, 0);
+    tree.insert(&tokens, &[10], &[], 16, 0, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.ssm_snapshot, None);
     assert_eq!(m.ssm_snapshot_tokens, 0);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -27,18 +27,18 @@ fn test_intermediate_snapshot_on_partial_match() {
 
     // Insert 4-block sequence
     let tokens: Vec<u32> = (0..64).collect();
-    tree.insert(&tokens, &[10, 20, 30, 40], &[], 16, 0);
+    tree.insert(&tokens, &[10, 20, 30, 40], &[], 16, 0, 0);
 
     // Attach intermediate snapshot at block 2 (token 32)
     let tokens_at_2: Vec<u32> = (0..32).collect();
-    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0);
+    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0, 0);
 
     // Lookup all 4 blocks — should return intermediate snapshot at block 2
-    let m = tree.lookup(&tokens, 16, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.matched_tokens, 64);
     assert_eq!(m.ssm_snapshot, Some(50));
     assert_eq!(m.ssm_snapshot_tokens, 32);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -47,18 +47,18 @@ fn test_intermediate_snapshot_deepest_wins() {
 
     // Insert 4-block sequence with leaf snapshot
     let tokens: Vec<u32> = (0..64).collect();
-    tree.insert_with_snapshot(&tokens, &[10, 20, 30, 40], &[], 16, 99, 0, 0);
+    tree.insert_with_snapshot(&tokens, &[10, 20, 30, 40], &[], 16, 99, 0, 0, 0);
 
     // Attach intermediate snapshot at block 2 (token 32)
     let tokens_at_2: Vec<u32> = (0..32).collect();
-    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0);
+    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0, 0);
 
     // Lookup all 4 blocks — leaf snapshot (deeper) wins
-    let m = tree.lookup(&tokens, 16, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.matched_tokens, 64);
     assert_eq!(m.ssm_snapshot, Some(99));
     assert_eq!(m.ssm_snapshot_tokens, 64);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -67,21 +67,21 @@ fn test_intermediate_snapshot_partial_prefix_hit() {
 
     // Insert 4-block sequence
     let tokens: Vec<u32> = (0..64).collect();
-    tree.insert(&tokens, &[10, 20, 30, 40], &[], 16, 0);
+    tree.insert(&tokens, &[10, 20, 30, 40], &[], 16, 0, 0);
 
     // Attach intermediate snapshot at block 2 (token 32)
     let tokens_at_2: Vec<u32> = (0..32).collect();
-    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0);
+    tree.insert_intermediate_snapshot(&tokens_at_2, &[10, 20], &[], 16, 50, 0, 0, 0);
 
     // New request shares first 48 tokens, diverges at block 4
     let mut tokens_new: Vec<u32> = (0..48).collect();
     tokens_new.extend(200..216);
-    let m = tree.lookup(&tokens_new, 16, 0);
+    let m = tree.lookup(&tokens_new, 16, 0, 0);
     // Matches 3 blocks (48 tokens), intermediate snapshot at block 2
     assert_eq!(m.matched_tokens, 48);
     assert_eq!(m.ssm_snapshot, Some(50));
     assert_eq!(m.ssm_snapshot_tokens, 32);
-    tree.release(&tokens_new, 16);
+    tree.release(&tokens_new, 16, 0);
 }
 
 #[test]
@@ -90,11 +90,11 @@ fn test_intermediate_snapshot_survives_tree_eviction() {
 
     // Insert 2-block sequence with intermediate snapshot on block 1
     let tokens: Vec<u32> = (0..32).collect();
-    tree.insert(&tokens, &[10, 20], &[], 16, 0);
-    tree.release(&tokens, 16); // inserting seq exits → nodes evictable
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
+    tree.release(&tokens, 16, 0); // inserting seq exits → nodes evictable
 
     let tokens_at_1: Vec<u32> = (0..16).collect();
-    tree.insert_intermediate_snapshot(&tokens_at_1, &[10], &[], 16, 50, 0, 0);
+    tree.insert_intermediate_snapshot(&tokens_at_1, &[10], &[], 16, 50, 0, 0, 0);
 
     // Evict both tree nodes — snapshot survives in index
     let evicted = tree.evict(1);
@@ -117,13 +117,13 @@ fn test_partial_suffix_insert_and_lookup() {
     let tokens: Vec<u32> = (0..20).collect();
     let block_table = vec![10, 20]; // block for full + block for partial
 
-    tree.insert(&tokens, &block_table, &[], 16, 0);
-    let m = tree.lookup(&tokens, 16, 0);
+    tree.insert(&tokens, &block_table, &[], 16, 0, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
 
     // Should match all 20 tokens (16 full + 4 partial)
     assert_eq!(m.matched_tokens, 20);
     assert_eq!(m.matched_blocks, vec![10, 20]);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -131,17 +131,17 @@ fn test_partial_suffix_no_match_different_suffix() {
     let tree = RadixTree::new();
     // Insert 20 tokens
     let tokens_a: Vec<u32> = (0..20).collect();
-    tree.insert(&tokens_a, &[10, 20], &[], 16, 0);
+    tree.insert(&tokens_a, &[10, 20], &[], 16, 0, 0);
 
     // Lookup 20 tokens with different suffix (same first 16, different last 4)
     let mut tokens_b: Vec<u32> = (0..16).collect();
     tokens_b.extend(100..104);
-    let m = tree.lookup(&tokens_b, 16, 0);
+    let m = tree.lookup(&tokens_b, 16, 0, 0);
 
     // Should match only 16 full-block tokens (partial suffix doesn't match)
     assert_eq!(m.matched_tokens, 16);
     assert_eq!(m.matched_blocks, vec![10]);
-    tree.release(&tokens_b, 16);
+    tree.release(&tokens_b, 16, 0);
 }
 
 #[test]
@@ -149,17 +149,17 @@ fn test_partial_suffix_not_matched_for_full_block_request() {
     let tree = RadixTree::new();
     // Insert 20 tokens (1 full + 4 partial)
     let tokens: Vec<u32> = (0..20).collect();
-    tree.insert(&tokens, &[10, 20], &[], 16, 0);
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
 
     // Lookup 32 tokens — 2 full blocks in request. Partial suffix is 4 tokens
     // but remainder is 0 (32 % 16 == 0), so partial check is skipped.
     let tokens_32: Vec<u32> = (0..32).collect();
-    let m = tree.lookup(&tokens_32, 16, 0);
+    let m = tree.lookup(&tokens_32, 16, 0, 0);
 
     // Only first full block matches (second block [16..32] has no matching tree node)
     assert_eq!(m.matched_tokens, 16);
     assert_eq!(m.matched_blocks, vec![10]);
-    tree.release(&tokens_32, 16);
+    tree.release(&tokens_32, 16, 0);
 }
 
 #[test]
@@ -167,8 +167,8 @@ fn test_partial_suffix_eviction_frees_both_blocks() {
     let tree = RadixTree::new();
     // Insert 20 tokens (1 full block + 4 partial) + release inserting seq
     let tokens: Vec<u32> = (0..20).collect();
-    tree.insert(&tokens, &[10, 20], &[], 16, 0);
-    tree.release(&tokens, 16);
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
+    tree.release(&tokens, 16, 0);
 
     // Evict 1 — should free block 10 (full) AND block 20 (partial suffix)
     let evicted = tree.evict(1);
@@ -185,23 +185,23 @@ fn test_partial_suffix_cleared_when_extended() {
     let tree = RadixTree::new();
     // Insert 20 tokens (1 full + 4 partial)
     let tokens_20: Vec<u32> = (0..20).collect();
-    tree.insert(&tokens_20, &[10, 20], &[], 16, 0);
+    tree.insert(&tokens_20, &[10, 20], &[], 16, 0, 0);
 
     // Insert 32 tokens (2 full blocks, extends past partial)
     let tokens_32: Vec<u32> = (0..32).collect();
-    tree.insert(&tokens_32, &[10, 30], &[], 16, 0);
+    tree.insert(&tokens_32, &[10, 30], &[], 16, 0, 0);
 
     // Lookup 20 tokens — partial suffix was cleared by the 32-token insert
-    let m = tree.lookup(&tokens_20, 16, 0);
+    let m = tree.lookup(&tokens_20, 16, 0, 0);
     assert_eq!(m.matched_tokens, 16);
     assert_eq!(m.matched_blocks, vec![10]);
-    tree.release(&tokens_20, 16);
+    tree.release(&tokens_20, 16, 0);
 
     // Lookup 32 tokens — full match
-    let m = tree.lookup(&tokens_32, 16, 0);
+    let m = tree.lookup(&tokens_32, 16, 0, 0);
     assert_eq!(m.matched_tokens, 32);
     assert_eq!(m.matched_blocks, vec![10, 30]);
-    tree.release(&tokens_32, 16);
+    tree.release(&tokens_32, 16, 0);
 }
 
 #[test]
@@ -212,12 +212,12 @@ fn test_partial_suffix_multi_block_prefix() {
     let block_table: Vec<u32> = (0..25).collect();
     // block_table[24] = partial block
 
-    tree.insert(&tokens, &block_table, &[], 16, 0);
-    let m = tree.lookup(&tokens, 16, 0);
+    tree.insert(&tokens, &block_table, &[], 16, 0, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
 
     assert_eq!(m.matched_tokens, 396);
     assert_eq!(m.matched_blocks.len(), 25);
-    tree.release(&tokens, 16);
+    tree.release(&tokens, 16, 0);
 }
 
 #[test]
@@ -225,16 +225,16 @@ fn test_partial_suffix_prefix_match_shorter_lookup() {
     let tree = RadixTree::new();
     // Insert 31 tokens (1 full block + 15 partial) — simulates prompt+generation
     let tokens_31: Vec<u32> = (0..31).collect();
-    tree.insert(&tokens_31, &[10, 20], &[], 16, 0);
+    tree.insert(&tokens_31, &[10, 20], &[], 16, 0, 0);
 
     // Lookup 22 tokens (1 full block + 6 partial) — simulates repeat of prompt only
     let tokens_22: Vec<u32> = (0..22).collect();
-    let m = tree.lookup(&tokens_22, 16, 0);
+    let m = tree.lookup(&tokens_22, 16, 0, 0);
 
     // Partial suffix [16..31] starts with [16..22], so prefix match succeeds
     assert_eq!(m.matched_tokens, 22);
     assert_eq!(m.matched_blocks, vec![10, 20]);
-    tree.release(&tokens_22, 16);
+    tree.release(&tokens_22, 16, 0);
 }
 
 #[test]
@@ -242,18 +242,18 @@ fn test_sub_block_match_via_child_key_prefix() {
     let tree = RadixTree::new();
     // Insert 35 tokens (2 full blocks + 3 partial) — prompt + generation
     let tokens_35: Vec<u32> = (0..35).collect();
-    tree.insert(&tokens_35, &[10, 20, 30], &[], 16, 0);
+    tree.insert(&tokens_35, &[10, 20, 30], &[], 16, 0, 0);
 
     // Lookup 22 tokens (1 full block + 6 remaining) — same prompt
     let tokens_22: Vec<u32> = (0..22).collect();
-    let m = tree.lookup(&tokens_22, 16, 0);
+    let m = tree.lookup(&tokens_22, 16, 0, 0);
 
     // Block 0 (0-15) matched as full block.
     // Remaining 6 tokens (16-21) are a prefix of block 1's key (16-31).
     // Sub-block matching should include block 1.
     assert_eq!(m.matched_tokens, 22);
     assert_eq!(m.matched_blocks, vec![10, 20]);
-    tree.release(&tokens_22, 16);
+    tree.release(&tokens_22, 16, 0);
 }
 
 #[test]
@@ -261,11 +261,11 @@ fn test_partial_suffix_sub_block_only() {
     let tree = RadixTree::new();
     // Only 10 tokens — no full blocks, partial suffix not stored (no parent)
     let tokens: Vec<u32> = (0..10).collect();
-    tree.insert(&tokens, &[42], &[], 16, 0);
+    tree.insert(&tokens, &[42], &[], 16, 0, 0);
 
     // No full blocks → nothing cached or matched
     assert_eq!(tree.stats(), (0, 0));
-    let m = tree.lookup(&tokens, 16, 0);
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.matched_tokens, 0);
 }
 
@@ -275,10 +275,10 @@ fn test_partial_suffix_sub_block_only() {
 fn test_snapshot_index_insert_lookup_roundtrip() {
     let mut idx = SsmSnapshotIndex::new();
     let tokens: Vec<u32> = (0..32).collect();
-    let prefix_hash = hash_token_prefix(&tokens, 32);
+    let prefix_hash = hash_token_prefix(&tokens, 32, 0);
 
     assert!(idx.insert(prefix_hash, 42, 100, 32).is_none());
-    let result = idx.lookup(&tokens, 32, 100);
+    let result = idx.lookup(&tokens, 32, 100, 0);
     assert_eq!(result, Some((42, 32)));
 }
 
@@ -287,8 +287,8 @@ fn test_snapshot_index_lru_eviction() {
     let mut idx = SsmSnapshotIndex::new();
     let tokens_a: Vec<u32> = (0..16).collect();
     let tokens_b: Vec<u32> = (100..116).collect();
-    let ha = hash_token_prefix(&tokens_a, 16);
-    let hb = hash_token_prefix(&tokens_b, 16);
+    let ha = hash_token_prefix(&tokens_a, 16, 0);
+    let hb = hash_token_prefix(&tokens_b, 16, 0);
 
     idx.insert(ha, 1, 0, 16); // older
     idx.insert(hb, 2, 0, 16); // newer
@@ -311,21 +311,21 @@ fn test_snapshot_index_lru_eviction() {
 fn test_snapshot_index_session_isolation() {
     let mut idx = SsmSnapshotIndex::new();
     let tokens: Vec<u32> = (0..16).collect();
-    let prefix_hash = hash_token_prefix(&tokens, 16);
+    let prefix_hash = hash_token_prefix(&tokens, 16, 0);
 
     // Insert snapshot for session 100
     idx.insert(prefix_hash, 42, 100, 16);
 
     // Lookup from session 200 — should NOT match (different session)
-    let result = idx.lookup(&tokens, 16, 200);
+    let result = idx.lookup(&tokens, 16, 200, 0);
     assert_eq!(result, None);
 
     // Lookup from session 100 — should match
-    let result = idx.lookup(&tokens, 16, 100);
+    let result = idx.lookup(&tokens, 16, 100, 0);
     assert_eq!(result, Some((42, 16)));
 
     // Lookup with session_hash=0 (legacy) — matches any session
-    let result = idx.lookup(&tokens, 16, 0);
+    let result = idx.lookup(&tokens, 16, 0, 0);
     assert_eq!(result, Some((42, 16)));
 }
 
@@ -333,7 +333,7 @@ fn test_snapshot_index_session_isolation() {
 fn test_snapshot_index_overwrite_existing() {
     let mut idx = SsmSnapshotIndex::new();
     let tokens: Vec<u32> = (0..16).collect();
-    let prefix_hash = hash_token_prefix(&tokens, 16);
+    let prefix_hash = hash_token_prefix(&tokens, 16, 0);
 
     // Insert first
     assert!(idx.insert(prefix_hash, 5, 0, 16).is_none());
@@ -345,49 +345,8 @@ fn test_snapshot_index_overwrite_existing() {
     assert_eq!(idx.len(), 1); // still 1 entry, not 2
 
     // Lookup returns new value
-    let result = idx.lookup(&tokens, 16, 0);
+    let result = idx.lookup(&tokens, 16, 0, 0);
     assert_eq!(result, Some((8, 16)));
-}
-
-#[test]
-fn test_snapshot_index_hit_pinned_fossil_does_not_starve_fresh_tail() {
-    // Regression: agentic warm-restore anchor freeze (2026-07-10). A shallow
-    // early-conversation snapshot that lookups repeatedly walked through must
-    // NOT outlive the strictly fresher tail checkpoint the next warm turn
-    // needs. Under the old `last_access * (1 + hit_count)` eviction score the
-    // fossil was unbeatable and every eviction killed the newest save.
-    let mut idx = SsmSnapshotIndex::new();
-    let tokens: Vec<u32> = (0..256).collect();
-    let session = 7;
-
-    // Fossil at token 16, selected as anchor by many deep lookups.
-    idx.insert(hash_token_prefix(&tokens, 16), 1, session, 16);
-    for _ in 0..30 {
-        assert_eq!(idx.lookup(&tokens, 24, session), Some((1, 16)));
-    }
-
-    // The live turn then saves a deeper tail checkpoint.
-    idx.insert(hash_token_prefix(&tokens, 112), 2, session, 112);
-
-    // Pool pressure: the fossil must be the victim, not the fresh tail.
-    assert_eq!(idx.evict_lru(), Some(1));
-    assert_eq!(idx.lookup(&tokens, 112, session), Some((2, 112)));
-}
-
-#[test]
-fn test_snapshot_index_lookup_bumps_winner_only() {
-    // The improving-chain scan must be side-effect-free for losers: after a
-    // deep lookup selects the deepest entry, the shallow entries it walked
-    // through must still be older than the winner (evictable first).
-    let mut idx = SsmSnapshotIndex::new();
-    let tokens: Vec<u32> = (0..256).collect();
-
-    idx.insert(hash_token_prefix(&tokens, 16), 1, 0, 16); // shallow, inserted first
-    idx.insert(hash_token_prefix(&tokens, 32), 2, 0, 32); // deep
-    assert_eq!(idx.lookup(&tokens, 48, 0), Some((2, 32)));
-
-    // Shallow loser must be evicted before the bumped winner.
-    assert_eq!(idx.evict_lru(), Some(1));
 }
 
 #[test]
@@ -396,18 +355,141 @@ fn test_snapshot_index_deepest_match() {
     let tokens: Vec<u32> = (0..64).collect();
 
     // Snapshot at token 16
-    let h16 = hash_token_prefix(&tokens, 16);
+    let h16 = hash_token_prefix(&tokens, 16, 0);
     idx.insert(h16, 10, 0, 16);
 
     // Snapshot at token 32
-    let h32 = hash_token_prefix(&tokens, 32);
+    let h32 = hash_token_prefix(&tokens, 32, 0);
     idx.insert(h32, 20, 0, 32);
 
     // Lookup with 48 matched tokens — deepest snapshot at 32 wins
-    let result = idx.lookup(&tokens, 48, 0);
+    let result = idx.lookup(&tokens, 48, 0, 0);
     assert_eq!(result, Some((20, 32)));
 
     // Lookup with 20 matched tokens — only snapshot at 16 qualifies
-    let result = idx.lookup(&tokens, 20, 0);
+    let result = idx.lookup(&tokens, 20, 0, 0);
     assert_eq!(result, Some((10, 16)));
+}
+
+// ── Task #24: adapter-correct SSM snapshots + base hash byte-identity ──
+
+/// `hash_token_prefix(_, _, 0)` (base sentinel) must reduce EXACTLY to the
+/// pre-#24 token-only FNV-1a value, so base prefix-cache/snapshot hit rates are
+/// unchanged. A non-zero adapter_id must change the hash.
+#[test]
+fn test_hash_token_prefix_base_byte_identical() {
+    let tokens: Vec<u32> = vec![7, 42, 1000, 65535, 3, 0, 128];
+    // Recompute the exact pre-#24 formula inline.
+    let mut expected: u64 = 0xcbf29ce484222325;
+    for &t in &tokens {
+        expected ^= t as u64;
+        expected = expected.wrapping_mul(0x100000001b3);
+    }
+    assert_eq!(
+        hash_token_prefix(&tokens, tokens.len(), 0),
+        expected,
+        "base (adapter_id=0) hash must be byte-identical to the pre-#24 value"
+    );
+    // Any non-zero adapter partitions the key.
+    assert_ne!(
+        hash_token_prefix(&tokens, tokens.len(), 0),
+        hash_token_prefix(&tokens, tokens.len(), 99),
+    );
+    assert_ne!(
+        hash_token_prefix(&tokens, tokens.len(), 7),
+        hash_token_prefix(&tokens, tokens.len(), 9),
+    );
+}
+
+/// The SSM snapshot index must isolate by adapter: a snapshot registered under
+/// adapter A's prefix hash is not found by an adapter-B lookup, but is by an
+/// adapter-A lookup.
+#[test]
+fn test_snapshot_index_adapter_isolation() {
+    let mut idx = SsmSnapshotIndex::new();
+    let tokens: Vec<u32> = (0..16).collect();
+    const A: u64 = 0xAA;
+    const B: u64 = 0xBB;
+
+    // Register under adapter A (the tree computes prefix_hash with A folded in).
+    let ph_a = hash_token_prefix(&tokens, 16, A);
+    idx.insert(ph_a, 42, 0, 16);
+
+    // Adapter B lookup recomputes with B → different hash → miss.
+    assert_eq!(idx.lookup(&tokens, 16, 0, B), None);
+    // Adapter A lookup → hit.
+    assert_eq!(idx.lookup(&tokens, 16, 0, A), Some((42, 16)));
+    // Base lookup → miss (base hash != A hash).
+    assert_eq!(idx.lookup(&tokens, 16, 0, 0), None);
+}
+
+/// End-to-end through the tree API: an SSM snapshot saved under adapter A is
+/// not restored for an adapter-B request, but is for an adapter-A request.
+#[test]
+fn test_ssm_snapshot_adapter_isolation_via_tree() {
+    let tree = RadixTree::new();
+    let tokens: Vec<u32> = (0..32).collect();
+    const A: u64 = 0x55;
+    const B: u64 = 0x66;
+
+    tree.insert_with_snapshot(&tokens, &[10, 20], &[], 16, 42, 0, 0, A);
+    tree.release(&tokens, 16, A);
+
+    // Adapter B: KV misses AND no snapshot restore.
+    let m_b = tree.lookup(&tokens, 16, 0, B);
+    assert!(m_b.is_empty());
+    assert_eq!(m_b.ssm_snapshot, None);
+
+    // Adapter A: KV hit + snapshot restored.
+    let m_a = tree.lookup(&tokens, 16, 0, A);
+    assert_eq!(m_a.matched_tokens, 32);
+    assert_eq!(m_a.ssm_snapshot, Some(42));
+    tree.release(&tokens, 16, A);
+}
+
+/// Phase 1b end-to-end trait surface: a snapshot's location transitions
+/// resident → spilled → resident through the `PrefixCache` API, and
+/// `lookup` reports each state correctly (the serving path's contract).
+#[test]
+fn test_spill_tier_lookup_transitions() {
+    let tree = RadixTree::new();
+    let tokens: Vec<u32> = (0..64).collect();
+    // Register a leaf snapshot (slot 99) for this prefix, session 7.
+    tree.insert_with_snapshot(&tokens, &[10, 20, 30, 40], &[], 16, 99, 7, 0, 0);
+
+    // Resident: lookup returns the HBM slot, no tier key.
+    let m = tree.lookup(&tokens, 16, 7, 0);
+    assert_eq!(m.ssm_snapshot, Some(99));
+    assert_eq!(m.ssm_snapshot_tokens, 64);
+    assert_eq!(m.ssm_snapshot_tier_key, None);
+
+    // Spill: evict_to_tier KEEPS the entry and returns (freed_slot, key).
+    let (freed, key) = tree.evict_snapshot_to_tier().expect("resident victim");
+    assert_eq!(freed, 99, "the resident slot is freed for reuse");
+
+    // Spilled: lookup now reports the anchor as tiered — ssm_snapshot is None
+    // (no HBM slot) and the tier key is present, so the caller faults it in.
+    let m = tree.lookup(&tokens, 16, 7, 0);
+    assert_eq!(m.ssm_snapshot, None, "no resident slot while spilled");
+    assert_eq!(m.ssm_snapshot_tier_key, Some(key));
+    assert_eq!(m.ssm_snapshot_tier_tokens, 64);
+
+    // Fault-in completes into slot 123; promote re-homes the entry to HBM.
+    assert!(tree.promote_snapshot(key, 123));
+
+    // Resident again at the new slot.
+    let m = tree.lookup(&tokens, 16, 7, 0);
+    assert_eq!(m.ssm_snapshot, Some(123));
+    assert_eq!(m.ssm_snapshot_tier_key, None);
+    tree.release(&tokens, 16, 0);
+}
+
+/// A caches-without-a-tier default: `evict_snapshot_to_tier` / `promote_snapshot`
+/// no-op on the trait default (NoPrefixCaching), so a non-radix cache is safe.
+#[test]
+fn test_no_tier_default_impl() {
+    use crate::prefix_cache::NoPrefixCaching;
+    let c = NoPrefixCaching;
+    assert_eq!(c.evict_snapshot_to_tier(), None);
+    assert!(!c.promote_snapshot(123, 0));
 }

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+
+/// Build an entry with an explicit forecast profile. `snapshot_id` doubles
+/// as a stable identity we assert on (independent of Vec index).
+fn entry(
+    snapshot_id: usize,
+    session_hash: u64,
+    token_count: usize,
+    last_access: u64,
+    hit_count: u32,
+) -> SnapshotEntry {
+    SnapshotEntry {
+        snapshot_id,
+        session_hash,
+        token_count,
+        prefix_hash: snapshot_id as u64, // unique, irrelevant to victim choice
+        last_access,
+        hit_count,
+        tiered: false,
+    }
+}
+
+fn index(entries: Vec<SnapshotEntry>, live: u64) -> SsmSnapshotIndex {
+    SsmSnapshotIndex {
+        entries,
+        access_counter: 1000,
+        last_lookup_session: live,
+        stats: SnapshotStats::default(),
+    }
+}
+
+/// The deep-tail eviction inversion (#278 root cause), reproduced against
+/// the session-aware policy: within a SINGLE live session the hot 8192
+/// anchor (self-reinforced hit_count) out-scores the just-aged deep tail
+/// (hit_count=0), so without tail-protect the tail is the victim.
+#[test]
+fn deep_tail_evicted_without_tail_protect() {
+    let idx = index(
+        vec![
+            entry(
+                /*id*/ 7, /*sess*/ 1, /*tok*/ 8192, /*last*/ 100,
+                /*hits*/ 10,
+            ),
+            entry(
+                /*id*/ 9, /*sess*/ 1, /*tok*/ 16000, /*last*/ 50,
+                /*hits*/ 0,
+            ),
+        ],
+        1,
+    );
+    // Victim is the deep tail (id 9) — the pathology.
+    let v = idx.session_aware_victim(false, false).unwrap();
+    assert_eq!(idx.entries[v].snapshot_id, 9);
+}
+
+/// With tail-protect the live session's DEEPEST snapshot is exempt, so the
+/// hot anchor is evicted instead and the warm-turn restore anchor survives.
+#[test]
+fn deep_tail_survives_with_tail_protect() {
+    let idx = index(
+        vec![entry(7, 1, 8192, 100, 10), entry(9, 1, 16000, 50, 0)],
+        1,
+    );
+    let v = idx.session_aware_victim(true, false).unwrap();
+    // Victim must NOT be the protected deep tail (id 9); it is the anchor.
+    assert_eq!(idx.entries[v].snapshot_id, 7);
+}
+
+/// Tail-protect only shields the LIVE conversation's tail; a dormant
+/// session's deep tail is still evictable (correct — session-aware ranking
+/// evicts the stalest conversation first).
+#[test]
+fn dormant_session_tail_not_protected() {
+    // session 2 is live; session 1 is dormant (older last_access).
+    let idx = index(
+        vec![
+            entry(1, 1, 20000, 10, 0), // dormant deep tail — should die first
+            entry(2, 2, 4000, 90, 0),  // live shallow
+            entry(3, 2, 12000, 95, 0), // live deep tail — protected
+        ],
+        2,
+    );
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(
+        idx.entries[v].snapshot_id, 1,
+        "stalest (dormant) session evicted first"
+    );
+}
+
+/// A pool of exactly one entry must still yield that entry as victim even
+/// when it is the protected tail — otherwise `save` can never reclaim and
+/// the cache deadlocks.
+#[test]
+fn single_protected_entry_still_evictable() {
+    let idx = index(vec![entry(5, 1, 16000, 50, 0)], 1);
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(idx.entries[v].snapshot_id, 5);
+}
+
+/// `lookup` records the live session so a later eviction protects the right
+/// conversation's tail.
+#[test]
+fn lookup_tracks_live_session() {
+    let mut idx = SsmSnapshotIndex::new();
+    assert_eq!(idx.last_lookup_session, 0);
+    // No matching entries — lookup returns None but must still latch the session.
+    let _ = idx.lookup(&[1, 2, 3], 3, /*session*/ 42, /*adapter*/ 0);
+    assert_eq!(idx.last_lookup_session, 42);
+}
+
+/// Telemetry: a miss records full-recompute; a hit records the residual
+/// distance between the match point and the restored anchor.
+#[test]
+fn stats_track_hits_and_recompute() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..100).collect();
+
+    // Cold miss over 100 matched tokens → full recompute counted.
+    assert!(
+        idx.lookup(&toks, 100, /*session*/ 7, /*adapter*/ 0)
+            .is_none()
+    );
+    // Register an anchor at depth 40 (hash must line up with lookup's recompute).
+    let ph = super::hash_token_prefix(&toks, 40, 0);
+    assert!(
+        idx.insert(
+            ph, /*snap*/ 3, /*session*/ 7, /*token_count*/ 40
+        )
+        .is_none()
+    );
+    // Warm turn: match 100 tokens, restore the depth-40 anchor → 60 recompute.
+    let hit = idx.lookup(&toks, 100, 7, 0);
+    assert_eq!(hit, Some((3, 40)));
+
+    let s = idx.stats; // child module: private field is in scope
+    assert_eq!(s.lookups, 2);
+    assert_eq!(s.hits, 1);
+    assert_eq!(s.saves, 1);
+    assert_eq!(s.anchor_depth_sum, 40);
+    assert_eq!(s.recompute_tokens_on_hit, 60, "matched(100) - anchor(40)");
+    assert_eq!(
+        s.recompute_tokens_on_miss, 100,
+        "cold miss = full recompute"
+    );
+}
+
+// ───────────────────────── Phase 1b state machine ───────────────────────
+
+/// `evict_to_tier` keeps the entry (findable) but flips it to spilled and
+/// frees its HBM slot — the core spill-not-drop transition.
+#[test]
+fn evict_to_tier_spills_not_removes() {
+    // id 3 = hot 8192 anchor (escore 1100); id 9 = cold deep tail (escore 50).
+    let mut idx = index(
+        vec![entry(3, 1, 8192, 100, 10), entry(9, 1, 16000, 50, 0)],
+        1,
+    );
+    let before = idx.len();
+    let (freed_slot, key) = idx.evict_to_tier().expect("a resident victim exists");
+    // No tail-protect (env off) → the coldest entry (deep tail id 9) is the
+    // victim — the #278 pathology, but harmless here because we SPILL it
+    // (faultable back in) rather than drop it.
+    assert_eq!(freed_slot, 9);
+    assert_eq!(key, 9, "key is the victim's prefix_hash");
+    assert_eq!(idx.len(), before, "entry kept, not removed");
+    assert_eq!(idx.stats.tier_spills, 1);
+    // The spilled entry holds no HBM slot: the drop path must skip it and
+    // free only the still-resident entry (id 3).
+    assert_eq!(idx.evict_lru(), Some(3));
+}
+
+/// A spilled entry is invisible to the non-tier `lookup` (never hands back a
+/// stale slot) but is found by `lookup_tiered` as `Tier(key)`.
+#[test]
+fn spilled_entry_lookup_semantics() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..50).collect();
+    let ph = super::hash_token_prefix(&toks, 50, 0);
+    idx.insert(ph, /*slot*/ 4, /*session*/ 7, /*tok*/ 50);
+    // Spill it.
+    let (freed, key) = idx.evict_to_tier().unwrap();
+    assert_eq!((freed, key), (4, ph));
+
+    // Non-tier lookup ignores the spilled entry → miss (safe recompute).
+    assert!(idx.lookup(&toks, 50, 7, 0).is_none());
+    // Tier-aware lookup finds it as Tier(key).
+    let m = idx.lookup_tiered(&toks, 50, 7, 0).expect("tiered hit");
+    assert_eq!(m.token_count, 50);
+    assert_eq!(m.loc, SnapLoc::Tier(ph));
+    assert_eq!(idx.stats.tier_hits, 1);
+}
+
+/// After fault-in, `promote` re-homes the entry to a fresh HBM slot and it
+/// is resident again (visible to both lookups as `Hbm`).
+#[test]
+fn promote_rehomes_to_hbm() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..30).collect();
+    let ph = super::hash_token_prefix(&toks, 30, 0);
+    idx.insert(ph, 1, 7, 30);
+    idx.evict_to_tier().unwrap();
+
+    assert!(idx.promote(ph, /*new_slot*/ 12));
+    assert_eq!(idx.stats.tier_fault_ins, 1);
+    // Resident again: non-tier lookup now returns the new slot.
+    assert_eq!(idx.lookup(&toks, 30, 7, 0), Some((12, 30)));
+    let m = idx.lookup_tiered(&toks, 30, 7, 0).unwrap();
+    assert_eq!(m.loc, SnapLoc::Hbm(12));
+}
+
+/// `evict_to_tier` returns None when every entry is already spilled — the
+/// caller must not spin (there is no HBM slot left to free).
+#[test]
+fn evict_to_tier_none_when_all_spilled() {
+    let mut idx = SsmSnapshotIndex::new();
+    idx.insert(10, 0, 7, 5);
+    idx.insert(20, 1, 7, 6);
+    assert!(idx.evict_to_tier().is_some());
+    assert!(idx.evict_to_tier().is_some());
+    assert_eq!(idx.evict_to_tier(), None, "nothing resident left to spill");
+    assert_eq!(idx.evict_lru(), None, "nothing resident left to drop");
+}
+
+/// Re-`insert` of a spilled prefix (a fresh HBM save) re-homes it to
+/// resident — it must not stay marked tiered.
+#[test]
+fn reinsert_unspills() {
+    let mut idx = SsmSnapshotIndex::new();
+    idx.insert(0xAA, 1, 7, 40);
+    idx.evict_to_tier().unwrap();
+    // Fresh save of the same prefix into slot 5 re-homes it to resident.
+    idx.insert(0xAA, 5, 7, 40);
+    // The entry is resident again at slot 5; the drop path can free it.
+    assert_eq!(idx.evict_lru(), Some(5));
+}

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -67,6 +67,26 @@ impl WeightDtype {
             other => bail!("Unsupported safetensors dtype: {other:?}"),
         }
     }
+
+    /// Map a raw safetensors header dtype STRING (as it appears in the JSON
+    /// header, e.g. `"BF16"`, `"F8_E4M3"`) to a [`WeightDtype`], factored out
+    /// so the RDMA weight loader (which receives dtype as a wire string in the
+    /// peer manifest, not a `safetensors::Dtype`) resolves it identically to
+    /// the disk loaders — byte-identity depends on the two ends agreeing.
+    pub fn from_safetensors_str(s: &str) -> Result<Self> {
+        Ok(match s {
+            "F32" => Self::FP32,
+            "BF16" => Self::BF16,
+            "U8" => Self::UInt8,
+            // I8 is a 1-byte raw container (packed NVFP4); signedness is
+            // irrelevant, treat as raw bytes exactly like the disk path.
+            "I8" => Self::UInt8,
+            "F8_E4M3" => Self::FP8E4M3,
+            "F8_E8M0" => Self::FP8E8M0,
+            "I64" => Self::Int64,
+            other => bail!("Unsupported safetensors dtype '{other}'"),
+        })
+    }
 }
 
 /// A weight tensor on the GPU.
@@ -99,9 +119,10 @@ impl WeightStore {
         }
     }
 
-    /// Crate-internal: wrap a pre-built map. Used by alternate loaders
-    /// (e.g. `fast_weights::FastSafetensorsLoader`).
-    pub(crate) fn from_map(weights: HashMap<String, WeightTensor>) -> Self {
+    /// Wrap a pre-built map. Used by alternate loaders (e.g.
+    /// `fast_weights::FastSafetensorsLoader`, and the RDMA weight loader in
+    /// `spark-storage`, which lives in a different crate and so needs this pub).
+    pub fn from_map(weights: HashMap<String, WeightTensor>) -> Self {
         Self { weights }
     }
 
@@ -224,7 +245,7 @@ impl SafetensorsLoader {
 }
 
 /// Parse expert index from tensor name (e.g. "model.layers.3.mlp.experts.42.gate_proj.weight" → 42).
-pub(crate) fn parse_expert_index(name: &str) -> Option<usize> {
+pub fn parse_expert_index(name: &str) -> Option<usize> {
     let parts: Vec<&str> = name.split('.').collect();
     for (i, part) in parts.iter().enumerate() {
         if *part == "experts" && i + 1 < parts.len() {
@@ -237,3 +258,33 @@ pub(crate) fn parse_expert_index(name: &str) -> Option<usize> {
 mod loader;
 pub mod mlx_int8;
 pub(crate) use loader::{check_oom_guard, estimate_has_fp8, estimate_load_bytes};
+
+#[cfg(test)]
+mod from_str_tests {
+    use super::WeightDtype;
+
+    #[test]
+    fn from_safetensors_str_matches_disk_mapping() {
+        // The RDMA weight peer publishes these raw header strings; the client
+        // must resolve them to the exact WeightDtype the disk loaders use, else
+        // byte_size/shape diverge and logits break. Locks the closed mapping.
+        use WeightDtype::*;
+        for (s, want) in [
+            ("F32", FP32),
+            ("BF16", BF16),
+            ("U8", UInt8),
+            ("I8", UInt8), // packed NVFP4 raw container
+            ("F8_E4M3", FP8E4M3),
+            ("F8_E8M0", FP8E8M0),
+            ("I64", Int64),
+        ] {
+            assert_eq!(
+                WeightDtype::from_safetensors_str(s).unwrap(),
+                want,
+                "dtype {s}"
+            );
+        }
+        assert!(WeightDtype::from_safetensors_str("F16").is_err());
+        assert!(WeightDtype::from_safetensors_str("bogus").is_err());
+    }
+}

--- a/crates/spark-storage/Cargo.toml
+++ b/crates/spark-storage/Cargo.toml
@@ -7,17 +7,24 @@ description = "Atlas: high-speed NVMe-backed KV cache offload (cuFile/GDS + io_u
 
 [features]
 default = ["cuda"]
-# `cuda` gates the cuda_min/module/graph + high-speed-swap stack. The
-# `metal` arm is empty: spark-storage's job (NVMe → HBM via cuFile/GDS)
-# isn't reachable on Apple Silicon UMA, so under metal the crate
-# compiles down to the pure-config / type modules only.
-cuda = []
+# `cuda` gates the cuda_min/module/graph + high-speed-swap stack. It also pulls
+# in spark-runtime for the RDMA weight loader (`weight_tier_rdma`), which builds
+# a `spark_runtime::weights::WeightStore` — the only reason spark-storage touches
+# spark-runtime (acyclic: spark-runtime does not depend on spark-storage). The
+# `metal` arm stays empty: spark-storage's job (NVMe → HBM via cuFile/GDS) isn't
+# reachable on Apple Silicon UMA, so under metal the crate compiles down to the
+# pure-config / type modules only (the weight_peer WIRE types included).
+cuda = ["dep:spark-runtime", "spark-runtime/cuda"]
 metal = []
 
 [dependencies]
 cufile-sys = { path = "../cufile-sys" }
 atlas-tier = { workspace = true }
 atlas-rdma = { workspace = true }
+# Only for the cuda-gated RDMA weight loader (see the `cuda` feature note). The
+# non-cuda peer server + wire types never touch it, so it stays optional and a
+# lean peer build (default-features = false) doesn't pull it.
+spark-runtime = { path = "../spark-runtime", optional = true, default-features = false }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/spark-storage/Cargo.toml
+++ b/crates/spark-storage/Cargo.toml
@@ -16,6 +16,8 @@ metal = []
 
 [dependencies]
 cufile-sys = { path = "../cufile-sys" }
+atlas-tier = { workspace = true }
+atlas-rdma = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/spark-storage/build.rs
+++ b/crates/spark-storage/build.rs
@@ -27,6 +27,10 @@ const KERNELS: &[&str] = &[
 fn main() {
     println!("cargo:rerun-if-env-changed=ATLAS_SKIP_BUILD");
     println!("cargo:rerun-if-env-changed=SKIP_ATLAS_BUILD");
+    // FIRST, before any early return: `rustc-check-cfg` does not cross crates,
+    // so this crate must declare the cfg name or every `#[cfg(atlas_rdma_verbs)]`
+    // below trips `unexpected_cfgs` (a hard error under `warnings = "deny"`).
+    println!("cargo:rustc-check-cfg=cfg(atlas_rdma_verbs)");
 
     // Apple Silicon hosts have no libcuda and no nvcc. Emit the stub and
     // skip the linker hint so `cargo check` works under
@@ -45,6 +49,15 @@ fn main() {
     // symbols resolved at link time even when the kernel registry is
     // an empty stub.
     link_libcuda();
+    // The one-sided RDMA verbs shim is built by the CUDA-free `atlas-rdma`
+    // crate; `rustc-cfg` does not cross crate boundaries, so re-emit
+    // `atlas_rdma_verbs` here for this crate's own gated code, keyed off
+    // atlas-rdma's `links` metadata (`cargo:has_verbs=1` → the DEP_ var below,
+    // visible because we depend on atlas-rdma DIRECTLY). The ON condition
+    // (Linux AND !ATLAS_SKIP_BUILD) is decided in one place — atlas-rdma/build.rs.
+    if std::env::var("DEP_ATLAS_RDMA_SHIM_HAS_VERBS").is_ok() {
+        println!("cargo:rustc-cfg=atlas_rdma_verbs");
+    }
     if skip_build() {
         emit_stub();
         println!("cargo:rerun-if-changed=build.rs");

--- a/crates/spark-storage/examples/long_context_bench.rs
+++ b/crates/spark-storage/examples/long_context_bench.rs
@@ -132,6 +132,7 @@ fn main() -> Result<()> {
         num_kv_heads: NUM_KV_HEADS,
         head_dim: HEAD_DIM,
         block_size: BLOCK_SIZE,
+        model_fp: None,
     };
     let mut hss = HighSpeedSwap::new(&ctx, cfg, model)?;
 

--- a/crates/spark-storage/examples/snapshot_paging_smoke.rs
+++ b/crates/spark-storage/examples/snapshot_paging_smoke.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// WS-A live smoke: drive the paging tier end-to-end over real RDMA against an
+// atlas-cache-peer started with --swap-dir. PUTs far more blobs than the RAM
+// arena holds → forces the peer to spill the coldest to its NVMe swap file →
+// GETs them all back and asserts byte-identical (a fault-from-disk on each key
+// the peer evicted). Proves: connect_paging handshake, control channel
+// (alloc/commit/get), one-sided RDMA data plane, and peer-side NVMe swap +
+// rehydrate — the whole stack minus the model.
+//
+//   ATLAS_SNAP_PEER=host:port \
+//   ATLAS_EXPERT_RDMA_DEV=roceP2p1s0f1 ATLAS_EXPERT_RDMA_GID=3 \
+//   cargo run -p spark-storage --features cuda --example snapshot_paging_smoke
+//
+// Requires a GPU (pinned bounce) + rdma-core. Defaults to 127.0.0.1:9918 (start
+// the peer: `atlas-cache-peer --listen 0.0.0.0:9918 --swap-dir /some/nvme/dir`).
+
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+fn main() -> anyhow::Result<()> {
+    use spark_storage::RdmaSnapshotArena;
+
+    // The pinned RDMA bounce (cuMemAllocHost) needs a current CUDA context; the
+    // model serve creates one, so a standalone client must too.
+    let _cuda = spark_storage::cuda_min::CudaCtx::new(0)?;
+
+    let addr = std::env::var("ATLAS_SNAP_PEER").unwrap_or_else(|_| "127.0.0.1:9918".into());
+    let blob: usize = std::env::var("SMOKE_BLOB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(65536); // 16 × 4 KiB → O_DIRECT-aligned
+    let slots: usize = std::env::var("SMOKE_SLOTS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4);
+    let n: u64 = std::env::var("SMOKE_KEYS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(32); // >> slots → guarantees disk spill
+
+    // put | get | putget (default) — the SSM paging modes (v2, kind=0); or
+    // kv | kv-isolation — the KV paging kind (PAGING_MAGIC_V2, kind=1)
+    // driven through the real KvPagingBackend StorageBackend client; or
+    // decode-isolation — two SSM decode clients (same model, different
+    // per-process client salts) on one shared arena (v2, kind=0).
+    let mode = std::env::var("SMOKE_MODE").unwrap_or_else(|_| "putget".into());
+    if mode == "kv" || mode == "kv-isolation" {
+        return kv_main(&addr, blob, slots, n, &mode);
+    }
+    if mode == "decode-isolation" {
+        return decode_isolation_main(&addr, blob, slots, n);
+    }
+
+    let arena_bytes = (slots * blob) as u64;
+    println!(
+        "connecting paging tier @ {addr} [{mode}]: {slots}-slot RAM arena × {blob} B, {n} keys \
+         (forces {} disk spills)",
+        n.saturating_sub(slots as u64)
+    );
+    let arena = RdmaSnapshotArena::connect_paging(&addr, arena_bytes, blob)?;
+
+    // Distinct, verifiable pattern per key.
+    let pat = |k: u64| -> Vec<u8> {
+        let mut v = vec![0u8; blob];
+        for (i, b) in v.iter_mut().enumerate() {
+            *b = (k as u8) ^ (i as u8).wrapping_mul(31);
+        }
+        v
+    };
+
+    let mut put_ms: Option<f64> = None;
+    if mode != "get" {
+        let t0 = std::time::Instant::now();
+        for k in 0..n {
+            arena.paging_put(k, &pat(k))?;
+        }
+        put_ms = Some(t0.elapsed().as_secs_f64() * 1e3);
+    }
+    if mode == "put" {
+        println!("PUT-only done: {n} keys left resident+spilled in the shared peer arena");
+        return Ok(());
+    }
+
+    let mut out = vec![0u8; blob];
+    let t1 = std::time::Instant::now();
+    for k in 0..n {
+        let hit = arena.paging_get(k, &mut out)?;
+        anyhow::ensure!(
+            hit,
+            "key {k} MISSING — peer dropped it, or (mode=get) not shared across connections"
+        );
+        anyhow::ensure!(
+            out == pat(k),
+            "key {k} CORRUPTED — spill/fault not byte-identical"
+        );
+    }
+    let get_ms = t1.elapsed().as_secs_f64() * 1e3;
+    if mode == "get" {
+        println!(
+            "CROSS-CONNECTION SHARING OK ✅  a SEPARATE client GET all {n} keys a prior `put` \
+             run left in the shared peer — {:.1}ms/blob",
+            get_ms / n as f64
+        );
+        return Ok(());
+    }
+    let put_ms = put_ms.unwrap_or(0.0);
+
+    // Re-GET a definitely-evicted early key to time a cold fault-from-disk.
+    let t2 = std::time::Instant::now();
+    let _ = arena.paging_get(0, &mut out)?;
+    let one_get_us = t2.elapsed().as_micros();
+
+    println!(
+        "PAGING SMOKE OK ✅  {n} blobs through {slots}-slot arena, ALL byte-identical after NVMe \
+         spill+fault.  put {put_ms:.0}ms ({:.1}/blob)  get {get_ms:.0}ms ({:.1}/blob)  \
+         single fault-from-disk {one_get_us}us",
+        put_ms / n as f64,
+        get_ms / n as f64,
+    );
+    Ok(())
+}
+
+/// SMOKE_MODE=decode-isolation — two SSM DECODE clients (same model
+/// fingerprint, DIFFERENT per-process client salts) against ONE shared peer
+/// paging arena (v2 handshake, kind=0). Decode cold keys are SLOT COORDINATES
+/// (client-local `(seq, logical)` indices), so both clients derive
+/// byte-identical pre-namespace keys — only the per-process client salt folded
+/// into the decode namespace (`ATLAS_SSM_DECODE_CLIENT_ID` in the model serve)
+/// keeps client B from faulting or deleting client A's rollback blobs.
+///
+/// Phase 1: client A PUTs `n` keys (n ≫ slots forces peer NVMe spills).
+/// Phase 2: client B (salt 2) must MISS every key; its removes must not leak.
+/// Phase 3: a THIRD connection with A's salt HITs all byte-identically — the
+/// control proving phase 2's misses are isolation, not a dead connection.
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+fn decode_isolation_main(addr: &str, blob: usize, slots: usize, n: u64) -> anyhow::Result<()> {
+    use atlas_tier::hash::mix64;
+    use spark_storage::RdmaSnapshotArena;
+
+    // Mirrors the SHAPE of spark-model's shipped derivation:
+    //   ns(salt)  = mix64(mix64(fp, DECODE_DOMAIN), client_salt)
+    //   wire(key) = mix64(cold_key, ns)
+    // DECODE_DOMAIN_LIT is an illustrative transcription of
+    // `atlas_kernels::DECODE_DOMAIN` (spark-storage has no atlas-kernels dep);
+    // the property under test is salt isolation on one shared arena, not the
+    // production constant's value.
+    const DECODE_DOMAIN_LIT: u64 = 0xD3C0_DE12_A5B6_C7D8;
+    const FP: u64 = 0xFEED_FACE_CAFE_BEEF; // fixed test "model" (as in kv_main)
+    let ns = |salt: u64| mix64(mix64(FP, DECODE_DOMAIN_LIT), salt);
+    let (ns_a, ns_b) = (ns(1), ns(2));
+
+    let arena_bytes = (slots * blob) as u64;
+    let pat = |k: u64| -> Vec<u8> {
+        let mut v = vec![0u8; blob];
+        for (i, x) in v.iter_mut().enumerate() {
+            *x = (k as u8) ^ (i as u8).wrapping_mul(37) ^ 0x5A;
+        }
+        v
+    };
+    println!(
+        "connecting SSM decode-isolation @ {addr}: {slots}-slot arena × {blob} B, {n} keys \
+         (forces {} disk spills)",
+        n.saturating_sub(slots as u64)
+    );
+    // Client A: PUT everything under its salted namespace.
+    let a = RdmaSnapshotArena::connect_paging(addr, arena_bytes, blob)?;
+    for k in 0..n {
+        a.paging_put(mix64(k, ns_a), &pat(k))?;
+    }
+    // Client B (same model, different salt): every GET must MISS, and its
+    // removes must not touch A's blobs (the cross-client delete hazard).
+    let b = RdmaSnapshotArena::connect_paging(addr, arena_bytes, blob)?;
+    let mut out = vec![0u8; blob];
+    for k in 0..n {
+        let hit = b.paging_get(mix64(k, ns_b), &mut out)?;
+        anyhow::ensure!(
+            !hit,
+            "DECODE ISOLATION BROKEN: client B was served client A's rollback blob (key {k})"
+        );
+        b.paging_remove(mix64(k, ns_b))?;
+    }
+    // Control: a third connection with A's salt HITs all byte-identically.
+    let a2 = RdmaSnapshotArena::connect_paging(addr, arena_bytes, blob)?;
+    for k in 0..n {
+        let hit = a2.paging_get(mix64(k, ns_a), &mut out)?;
+        anyhow::ensure!(
+            hit,
+            "control MISS on key {k}: blob lost — dead connection, or B's removes \
+             leaked across namespaces"
+        );
+        anyhow::ensure!(
+            out == pat(k),
+            "control CORRUPTED: key {k} not byte-identical"
+        );
+    }
+    println!(
+        "DECODE ISOLATION OK ✅  two client salts on one shared peer arena: B missed all \
+         {n} of A's slot-coordinate keys (and B's removes did not leak); a same-salt \
+         control connection restored all {n} byte-identical after peer NVMe spills"
+    );
+    Ok(())
+}
+
+/// SMOKE_MODE=kv — drive the KV paging kind end-to-end over real RDMA:
+/// v2 handshake (kind=1), block-granular ALLOC/WRITE/COMMIT offloads of far
+/// more blocks than the peer RAM arena holds (forcing NVMe spills), then
+/// block-granular GET/READ restores into a DEVICE buffer, asserting
+/// byte-identity (a fault-from-disk on every evicted block).
+///
+/// SMOKE_MODE=kv-isolation — two KV clients (same model fp, DIFFERENT client
+/// salts) against ONE peer arena: client B must MISS client A's blocks (the
+/// KV miss is a hard error naming --swap-cap-gb-kv), both round-trip their
+/// own — the client-local-block-id cross-serve hazard, proven on hardware.
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+fn kv_main(addr: &str, blob: usize, slots: usize, n: u64, mode: &str) -> anyhow::Result<()> {
+    use spark_storage::backend::BlockReadRequest;
+    use spark_storage::backend::StorageBackend;
+    use spark_storage::cuda_min::{DeviceBuffer, copy_d_to_h_async, stream_sync};
+    use spark_storage::group::{GroupKey, GroupLayout, KvKind};
+    use spark_storage::kv_paging::ns::derive_kv_ns;
+    use spark_storage::kv_paging::{KvPagingBackend, KvPagingConnect};
+
+    const NKV: u16 = 8;
+    anyhow::ensure!(
+        blob.is_multiple_of(2 * NKV as usize),
+        "SMOKE_BLOB must be a multiple of {} (2·num_kv_heads)",
+        2 * NKV
+    );
+    // A layout whose block_bytes == SMOKE_BLOB exactly (fields are pub; the
+    // backend only derives block_bytes/group_id from them).
+    let layout = GroupLayout {
+        num_layers: 1,
+        num_blocks: n as u32,
+        num_kv_heads: NKV,
+        group_stride: (blob / (2 * NKV as usize)) as u64,
+        fs_block_size: 4096,
+    };
+    assert_eq!(layout.block_bytes() as usize, blob);
+    let arena_bytes = (slots * blob) as u64;
+    let fp: u64 = 0xFEED_FACE_CAFE_BEEF; // fixed test "model"
+    let connect = |salt: u64| -> anyhow::Result<KvPagingBackend> {
+        KvPagingBackend::connect(
+            addr,
+            layout,
+            KvPagingConnect {
+                arena_bytes,
+                ns: derive_kv_ns(fp, &layout, 2, 16, 128, salt),
+            },
+        )
+    };
+    let pat = |b: u32, tag: u8| -> Vec<u8> {
+        let mut v = vec![0u8; blob];
+        for (i, x) in v.iter_mut().enumerate() {
+            *x = (b as u8) ^ (i as u8).wrapping_mul(29) ^ tag;
+        }
+        v
+    };
+    let key = |b: u32| GroupKey::new(0, b, 0, KvKind::K);
+    let dev = DeviceBuffer::new(blob)?;
+    let mut host = vec![0u8; blob];
+    let read_block = |be: &mut KvPagingBackend, b: u32, host: &mut [u8]| -> anyhow::Result<()> {
+        be.read_blocks(
+            &[BlockReadRequest {
+                base_key: key(b),
+                dst_dev_ptr: dev.ptr,
+            }],
+            0,
+        )?;
+        copy_d_to_h_async(host.as_mut_ptr() as *mut _, dev.ptr, blob, 0)?;
+        stream_sync(0)
+    };
+
+    println!(
+        "connecting KV paging tier @ {addr} [{mode}]: {slots}-slot arena × {blob} B blocks, \
+         {n} blocks (forces {} disk spills)",
+        n.saturating_sub(slots as u64)
+    );
+    if mode == "kv-isolation" {
+        let mut a = connect(0x0000_0000_0000_0001)?;
+        let mut b = connect(0x0000_0000_0000_0002)?;
+        for blk in 0..n as u32 {
+            a.write_block_from_host(key(blk), &pat(blk, 0xA0))?;
+        }
+        // Client B must MISS client A's blocks — the hard error, not bytes.
+        let miss = read_block(&mut b, 0, &mut host);
+        anyhow::ensure!(
+            miss.is_err(),
+            "ISOLATION BROKEN: client B was served client A's KV block"
+        );
+        let msg = format!("{:#}", miss.unwrap_err());
+        anyhow::ensure!(
+            msg.contains("unrecoverable"),
+            "unexpected miss error: {msg}"
+        );
+        // Both clients round-trip their OWN block 0 on the shared arena.
+        b.write_block_from_host(key(0), &pat(0, 0xB0))?;
+        read_block(&mut b, 0, &mut host)?;
+        anyhow::ensure!(host == pat(0, 0xB0), "client B corrupted");
+        read_block(&mut a, 0, &mut host)?;
+        anyhow::ensure!(host == pat(0, 0xA0), "client A corrupted by B's write");
+        println!(
+            "KV ISOLATION OK ✅  two salts on one shared peer arena: B missed A's blocks \
+             (hard error), both round-tripped their own byte-identical"
+        );
+        return Ok(());
+    }
+    // mode == "kv": spill + rehydrate byte-identity through the real backend.
+    let mut be = connect(0x5EED)?;
+    let t0 = std::time::Instant::now();
+    for blk in 0..n as u32 {
+        be.write_block_from_host(key(blk), &pat(blk, 0))?;
+    }
+    let put_ms = t0.elapsed().as_secs_f64() * 1e3;
+    let t1 = std::time::Instant::now();
+    for blk in 0..n as u32 {
+        read_block(&mut be, blk, &mut host)?;
+        anyhow::ensure!(
+            host == pat(blk, 0),
+            "block {blk} CORRUPTED — spill/fault not byte-identical"
+        );
+    }
+    let get_ms = t1.elapsed().as_secs_f64() * 1e3;
+    // Overwrite-in-place (disk-id reuse) survives the peer round-trip.
+    be.write_block_from_host(key(0), &pat(0, 0x77))?;
+    read_block(&mut be, 0, &mut host)?;
+    anyhow::ensure!(host == pat(0, 0x77), "overwrite-in-place corrupted");
+    println!(
+        "KV PAGING SMOKE OK ✅  {n} blocks through {slots}-slot arena, ALL byte-identical \
+         after NVMe spill+fault (+ overwrite-in-place).  put {put_ms:.0}ms ({:.1}/blk)  \
+         get {get_ms:.0}ms ({:.1}/blk)",
+        put_ms / n as f64,
+        get_ms / n as f64,
+    );
+    Ok(())
+}
+
+#[cfg(not(all(feature = "cuda", atlas_rdma_verbs)))]
+fn main() {
+    eprintln!("snapshot_paging_smoke needs --features cuda + rdma-core (atlas_rdma_verbs)");
+    std::process::exit(1);
+}

--- a/crates/spark-storage/src/backend/io_uring.rs
+++ b/crates/spark-storage/src/backend/io_uring.rs
@@ -12,7 +12,7 @@ use std::os::fd::RawFd;
 
 use super::{ReadRequest, StorageBackend};
 use crate::cuda_min::{CudaEvent, PinnedBuffer, copy_h_to_d_async, stream_sync};
-use crate::group::GroupKey;
+use crate::group::{GroupKey, GroupLayout};
 use crate::layout::Layout;
 
 pub struct IoUringBackend {
@@ -204,6 +204,10 @@ impl StorageBackend for IoUringBackend {
             );
         }
         Ok(())
+    }
+
+    fn group_layout(&self) -> GroupLayout {
+        self.layout.spec
     }
 }
 

--- a/crates/spark-storage/src/backend/mod.rs
+++ b/crates/spark-storage/src/backend/mod.rs
@@ -10,7 +10,7 @@
 
 use anyhow::Result;
 
-use crate::group::GroupKey;
+use crate::group::{GroupKey, GroupLayout, KvKind};
 
 pub mod io_uring;
 pub mod posix;
@@ -25,6 +25,46 @@ pub struct ReadRequest {
     pub dst_dev_ptr: u64,
 }
 
+/// One block-granular read: land the whole block (all kv-heads' K then V,
+/// `block_bytes`) into the device slot based at `dst_dev_ptr`
+/// (== `ScratchPool::slot_dev_ptr(slot)`). `base_key` carries `kv_head = 0,
+/// kind = K` by convention; only its `layer` and `block` are load-bearing.
+#[derive(Clone, Copy, Debug)]
+pub struct BlockReadRequest {
+    pub base_key: GroupKey,
+    pub dst_dev_ptr: u64,
+}
+
+/// Expand each `BlockReadRequest` into the exact `2·nkv` per-head `ReadRequest`s
+/// the un-coalesced path issues, in the SAME order the caller loops emit
+/// (interleaved `K(kh), V(kh)` for `kh` in `0..nkv`) with device destinations
+/// at `dst + kh·gs` (K) and `dst + (nkv+kh)·gs` (V).
+///
+/// This is the SINGLE source of the per-head fan-out: the default `read_blocks`
+/// / `write_block_from_host` trait impls AND the unit tests consume it, so the
+/// RDMA/Cascade backends (which inherit the default) can never drift from the
+/// caller-side per-head layout, and byte-identity is pinned host-side.
+pub fn expand_blocks_to_groups(spec: &GroupLayout, reqs: &[BlockReadRequest]) -> Vec<ReadRequest> {
+    let nkv = spec.num_kv_heads;
+    let gs = spec.group_stride;
+    let mut out = Vec::with_capacity(reqs.len() * 2 * nkv as usize);
+    for r in reqs {
+        let layer = r.base_key.layer;
+        let block = r.base_key.block;
+        for kh in 0..nkv {
+            out.push(ReadRequest {
+                group: GroupKey::new(layer, block, kh, KvKind::K),
+                dst_dev_ptr: r.dst_dev_ptr + (kh as u64) * gs,
+            });
+            out.push(ReadRequest {
+                group: GroupKey::new(layer, block, kh, KvKind::V),
+                dst_dev_ptr: r.dst_dev_ptr + (nkv as u64 + kh as u64) * gs,
+            });
+        }
+    }
+    out
+}
+
 pub trait StorageBackend: Send + Sync {
     /// Synchronously fulfil all `requests`, returning when the corresponding
     /// HBM destinations are populated and visible on `stream`. The backend
@@ -33,7 +73,113 @@ pub trait StorageBackend: Send + Sync {
     /// can issue subsequent kernels that depend on the data.
     fn read(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()>;
 
+    /// Async variant of `read`: enqueue the tier read + H2D on `stream` and
+    /// return WITHOUT a terminal host `stream_sync`. Default = the synchronous
+    /// `read`, so file backends need no change and the on-demand path stays
+    /// byte-identical.
+    fn read_async(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()> {
+        self.read(requests, stream)
+    }
+
     /// One-shot sequential write — used at offload time to populate disk
     /// from a host-side K/V buffer.
     fn write_from_host(&mut self, key: GroupKey, src: &[u8]) -> Result<()>;
+
+    /// Immutable disk/device geometry. The default block methods below use it to
+    /// fan a block op back out to the per-head path; io_uring/posix return their
+    /// layout spec, Cascade delegates to its backing, RDMA returns its layout.
+    fn group_layout(&self) -> GroupLayout;
+
+    /// Block-granular read: fulfil each request with ONE contiguous
+    /// `block_bytes` op instead of `2·nkv` per-head reads. Same stream contract
+    /// as `read`. The DEFAULT fans out to `read` via `expand_blocks_to_groups`,
+    /// so posix/RDMA/Cascade stay correct (just un-coalesced) with no change.
+    fn read_blocks(&mut self, requests: &[BlockReadRequest], stream: u64) -> Result<()> {
+        let groups = expand_blocks_to_groups(&self.group_layout(), requests);
+        self.read(&groups, stream)
+    }
+
+    /// Async block-granular read — the coalesced twin of `read_async` for the
+    /// prefetch path. DEFAULT fans out to `read_async`.
+    fn read_blocks_async(&mut self, requests: &[BlockReadRequest], stream: u64) -> Result<()> {
+        let groups = expand_blocks_to_groups(&self.group_layout(), requests);
+        self.read_async(&groups, stream)
+    }
+
+    /// Block-granular write: ONE contiguous `block_bytes` op. `src` is exactly
+    /// `block_bytes` laid out `[K0,K1,…,K(nkv-1),V0,…,V(nkv-1)]` at `group_stride`
+    /// pitch. `base_key` carries the block identity (kv_head/kind ignored).
+    /// DEFAULT splits `src` back into the `2·nkv` per-head `group_stride` stripes
+    /// and calls `write_from_host` per head — byte-identical on-disk image.
+    fn write_block_from_host(&mut self, base_key: GroupKey, src: &[u8]) -> Result<()> {
+        let spec = self.group_layout();
+        let nkv = spec.num_kv_heads as usize;
+        let gs = spec.group_stride as usize;
+        let expect = 2 * nkv * gs;
+        if src.len() != expect {
+            anyhow::bail!(
+                "write_block_from_host: src len {} != block bytes {expect}",
+                src.len()
+            );
+        }
+        let layer = base_key.layer;
+        let block = base_key.block;
+        for kh in 0..nkv {
+            let k_off = kh * gs;
+            let v_off = (nkv + kh) * gs;
+            self.write_from_host(
+                GroupKey::new(layer, block, kh as u16, KvKind::K),
+                &src[k_off..k_off + gs],
+            )?;
+            self.write_from_host(
+                GroupKey::new(layer, block, kh as u16, KvKind::V),
+                &src[v_off..v_off + gs],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Write a run of `run_len` strictly-consecutive same-layer blocks in ONE
+    /// contiguous op. `base_key` carries the run's FIRST block; `src` is exactly
+    /// `run_len · block_bytes`. DEFAULT fans out to `run_len`
+    /// `write_block_from_host` calls — byte- AND op-identical to the
+    /// un-coalesced path (and `run_len == 1` is exactly one call).
+    fn write_blocks_run(&mut self, base_key: GroupKey, run_len: usize, src: &[u8]) -> Result<()> {
+        let spec = self.group_layout();
+        let block_bytes = spec.block_bytes() as usize;
+        let expect = run_len * block_bytes;
+        if src.len() != expect {
+            anyhow::bail!(
+                "write_blocks_run: src len {} != run bytes {expect} ({run_len} × {block_bytes})",
+                src.len()
+            );
+        }
+        for i in 0..run_len {
+            let off = i * block_bytes;
+            self.write_block_from_host(
+                GroupKey::new(base_key.layer, base_key.block + i as u32, 0, KvKind::K),
+                &src[off..off + block_bytes],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Whether this backend can service `write_blocks_run` as a single wide op.
+    /// DEFAULT `false`: RDMA/Cascade keep the per-block fan-out, and the caller
+    /// stays on the per-block write path.
+    fn supports_write_run_coalescing(&self) -> bool {
+        false
+    }
+
+    /// Optionally pre-register `[base, base+len)` as the read-landing region.
+    /// The RDMA backend registers it as ONE MR (per rail) so zero-copy restore
+    /// reuses that lkey for every slot within it. No-op for the file backends.
+    fn register_landing_region(&mut self, base: u64, len: usize) -> Result<()> {
+        let _ = (base, len);
+        Ok(())
+    }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod coalesce_tests;

--- a/crates/spark-storage/src/backend/mod_tests.rs
+++ b/crates/spark-storage/src/backend/mod_tests.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! GPU-free tests for the block↔group mapping. These exercise only host-side
+//! pointer/offset arithmetic (no CUDA allocation, no I/O), so they run under
+//! the default cuda feature: the `expand_blocks_to_groups` fan-out and the
+//! default `read_blocks`/`write_block_from_host` trait impls that inherit it.
+
+use super::*;
+use crate::group::{GroupLayout, KvKind};
+
+fn spec() -> GroupLayout {
+    // Holo-like: 8 kv_heads, block_size 16, head_dim 128, BF16 → gs 4096.
+    GroupLayout::new(80, 4096, 8, 16, 128, 2, 4096)
+}
+
+/// expand_blocks_to_groups yields exactly the interleaved per-head requests
+/// the caller loops would push, in order, with the right disk keys + device
+/// destinations relative to the slot base. This pins the default fan-out
+/// (and thus RDMA/Cascade correctness) byte-for-byte without a GPU.
+#[test]
+fn expand_matches_the_per_head_loop() {
+    let s = spec();
+    let nkv = s.num_kv_heads;
+    let gs = s.group_stride;
+    let base = 0xDEAD_0000u64;
+    let (layer, block) = (7u32, 12u32);
+    let br = BlockReadRequest {
+        base_key: GroupKey::new(layer, block, 0, KvKind::K),
+        dst_dev_ptr: base,
+    };
+    let got = expand_blocks_to_groups(&s, &[br]);
+    assert_eq!(got.len(), 2 * nkv as usize);
+    for kh in 0..nkv {
+        let k = got[(2 * kh) as usize];
+        let v = got[(2 * kh + 1) as usize];
+        assert_eq!(k.group, GroupKey::new(layer, block, kh, KvKind::K));
+        assert_eq!(k.dst_dev_ptr, base + (kh as u64) * gs);
+        assert_eq!(v.group, GroupKey::new(layer, block, kh, KvKind::V));
+        assert_eq!(v.dst_dev_ptr, base + (nkv as u64 + kh as u64) * gs);
+    }
+}
+
+/// Multiple blocks in one call expand to concatenated per-block groups with
+/// independent bases (robustness / batching).
+#[test]
+fn expand_handles_multiple_blocks() {
+    let s = spec();
+    let nkv = s.num_kv_heads as usize;
+    let reqs = [
+        BlockReadRequest {
+            base_key: GroupKey::new(1, 2, 0, KvKind::K),
+            dst_dev_ptr: 0x1000,
+        },
+        BlockReadRequest {
+            base_key: GroupKey::new(1, 9, 0, KvKind::K),
+            dst_dev_ptr: 0x9000,
+        },
+    ];
+    let got = expand_blocks_to_groups(&s, &reqs);
+    assert_eq!(got.len(), 2 * (2 * nkv));
+    assert_eq!(got[0].group, GroupKey::new(1, 2, 0, KvKind::K));
+    assert_eq!(got[0].dst_dev_ptr, 0x1000);
+    assert_eq!(got[2 * nkv].group, GroupKey::new(1, 9, 0, KvKind::K));
+    assert_eq!(got[2 * nkv].dst_dev_ptr, 0x9000);
+}
+
+/// A recording StorageBackend: the default `read_blocks` /
+/// `write_block_from_host` must emit the IDENTICAL ordered (layer, offset,
+/// bytes, dst) op stream as the hand-written per-head path. Confirms the
+/// default fan-out inherited by RDMA/Cascade is op-equivalent.
+struct Recorder {
+    spec: GroupLayout,
+    reads: Vec<(u32, u64, usize, u64)>,
+    writes: Vec<(u32, u64, usize)>,
+}
+impl StorageBackend for Recorder {
+    fn read(&mut self, requests: &[ReadRequest], _stream: u64) -> Result<()> {
+        let gb = self.spec.group_bytes() as usize;
+        for r in requests {
+            self.reads.push((
+                r.group.layer,
+                self.spec.file_offset(r.group),
+                gb,
+                r.dst_dev_ptr,
+            ));
+        }
+        Ok(())
+    }
+    fn write_from_host(&mut self, key: GroupKey, src: &[u8]) -> Result<()> {
+        self.writes
+            .push((key.layer, self.spec.file_offset(key), src.len()));
+        Ok(())
+    }
+    fn group_layout(&self) -> GroupLayout {
+        self.spec
+    }
+}
+
+#[test]
+fn default_read_blocks_op_equivalent_to_per_head() {
+    let s = spec();
+    let base = 0x4000u64;
+    let br = BlockReadRequest {
+        base_key: GroupKey::new(4, 6, 0, KvKind::K),
+        dst_dev_ptr: base,
+    };
+    // Oracle: what the per-head loop expansion records.
+    let mut oracle = Recorder {
+        spec: s,
+        reads: vec![],
+        writes: vec![],
+    };
+    let groups = expand_blocks_to_groups(&s, &[br]);
+    oracle.read(&groups, 0).unwrap();
+    // Subject: the default read_blocks.
+    let mut subject = Recorder {
+        spec: s,
+        reads: vec![],
+        writes: vec![],
+    };
+    subject.read_blocks(&[br], 0).unwrap();
+    assert_eq!(subject.reads, oracle.reads);
+}
+
+#[test]
+fn default_write_block_op_equivalent_to_per_head() {
+    let s = spec();
+    let nkv = s.num_kv_heads as usize;
+    let gs = s.group_stride as usize;
+    let mut rec = Recorder {
+        spec: s,
+        reads: vec![],
+        writes: vec![],
+    };
+    let buf = vec![0u8; 2 * nkv * gs];
+    rec.write_block_from_host(GroupKey::new(2, 5, 0, KvKind::K), &buf)
+        .unwrap();
+    // 2*nkv per-head writes, each group_bytes, at the per-head offsets.
+    assert_eq!(rec.writes.len(), 2 * nkv);
+    let mut expected: Vec<(u32, u64, usize)> = Vec::new();
+    for kh in 0..s.num_kv_heads {
+        expected.push((2, s.file_offset(GroupKey::new(2, 5, kh, KvKind::K)), gs));
+        expected.push((2, s.file_offset(GroupKey::new(2, 5, kh, KvKind::V)), gs));
+    }
+    assert_eq!(rec.writes, expected);
+    // Length guard.
+    let bad = vec![0u8; 2 * nkv * gs - 1];
+    assert!(
+        rec.write_block_from_host(GroupKey::new(2, 5, 0, KvKind::K), &bad)
+            .is_err()
+    );
+}

--- a/crates/spark-storage/src/backend/posix.rs
+++ b/crates/spark-storage/src/backend/posix.rs
@@ -10,7 +10,7 @@ use std::ffi::c_void;
 
 use super::{ReadRequest, StorageBackend};
 use crate::cuda_min::{PinnedBuffer, copy_h_to_d_async, stream_sync};
-use crate::group::GroupKey;
+use crate::group::{GroupKey, GroupLayout};
 use crate::layout::Layout;
 
 pub struct PosixBackend {
@@ -80,6 +80,10 @@ impl StorageBackend for PosixBackend {
         // path where the file is single-process / single-run.
         let _ = fd;
         Ok(())
+    }
+
+    fn group_layout(&self) -> GroupLayout {
+        self.layout.spec
     }
 }
 

--- a/crates/spark-storage/src/blade_cap.rs
+++ b/crates/spark-storage/src/blade_cap.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// A process-global commit ledger for the RDMA memory blades (`cache_peer`,
+// `expert_peer`). Each peer server owns one `CommitLedger` (an `Arc`, cloned
+// into every per-connection thread) and, at the RDMA handshake — AFTER the
+// requested commit size is known but BEFORE any `mmap`/`reg_mr` pins RAM — a
+// connection calls `try_reserve(bytes)`. That either succeeds (returning an
+// RAII `Reservation` that releases the bytes on drop) or bails, so a client is
+// rejected before any memory is registered when it would push the running
+// total past the configured ceiling.
+//
+// This lives entirely OUTSIDE `cfg(atlas_rdma_verbs)` so the arithmetic is
+// unit-testable on the metal/skip build with no RDMA hardware — the verbs
+// handshake body that consumes it is gated, but the ledger is not.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result, bail};
+
+/// A process-global running total of committed (registered) bytes against a
+/// fixed ceiling. `cap == 0` means unlimited (the default — every existing
+/// invocation with no `--max-blade-gb` flag behaves exactly as before).
+#[derive(Debug)]
+pub struct CommitLedger {
+    cap: u64,
+    committed: AtomicU64,
+}
+
+/// An RAII claim on `bytes` of the ledger. Constructed only after a successful
+/// reservation; its `Drop` decrements the running total exactly once, so early
+/// bail, `reg_mr` failure, and normal hangup all release uniformly.
+#[derive(Debug)]
+pub struct Reservation {
+    ledger: Arc<CommitLedger>,
+    bytes: u64,
+}
+
+impl CommitLedger {
+    /// `cap_bytes == 0` = unlimited.
+    pub fn new(cap_bytes: u64) -> Self {
+        Self {
+            cap: cap_bytes,
+            committed: AtomicU64::new(0),
+        }
+    }
+
+    /// The configured ceiling in bytes (0 = unlimited).
+    pub fn cap(&self) -> u64 {
+        self.cap
+    }
+
+    /// Current committed total in bytes.
+    pub fn committed(&self) -> u64 {
+        self.committed.load(Ordering::Acquire)
+    }
+
+    /// Atomically test-against-cap-and-add `bytes`. A `compare_exchange` loop
+    /// keeps the test and the add indivisible, so two concurrent handshakes
+    /// cannot both slip past a nearly-full ledger. Returns an RAII `Reservation`
+    /// on success; bails (pinning nothing) when the request would cross the cap.
+    pub fn try_reserve(self: &Arc<Self>, bytes: u64) -> Result<Reservation> {
+        let mut cur = self.committed.load(Ordering::Acquire);
+        loop {
+            let new = cur
+                .checked_add(bytes)
+                .context("blade commit total overflow")?;
+            if self.cap != 0 && new > self.cap {
+                bail!(
+                    "blade cap exceeded: request {bytes} B + {cur} B committed > cap {} B",
+                    self.cap,
+                );
+            }
+            match self.committed.compare_exchange_weak(
+                cur,
+                new,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(Reservation {
+                        ledger: self.clone(),
+                        bytes,
+                    });
+                }
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+}
+
+impl Reservation {
+    /// The number of bytes this reservation holds.
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        self.ledger
+            .committed
+            .fetch_sub(self.bytes, Ordering::AcqRel);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserve_within_cap_raises_committed() {
+        let l = Arc::new(CommitLedger::new(1000));
+        let r = l.try_reserve(400).expect("within cap");
+        assert_eq!(l.committed(), 400);
+        assert_eq!(r.bytes(), 400);
+    }
+
+    #[test]
+    fn reserve_over_cap_bails_and_leaves_committed_unchanged() {
+        let l = Arc::new(CommitLedger::new(1000));
+        let _r = l.try_reserve(600).expect("within cap");
+        assert_eq!(l.committed(), 600);
+        let err = l.try_reserve(500);
+        assert!(err.is_err(), "600 + 500 > 1000 must be rejected");
+        // The rejected request pinned nothing: the total is unchanged.
+        assert_eq!(l.committed(), 600);
+    }
+
+    #[test]
+    fn dropping_a_reservation_restores_committed() {
+        let l = Arc::new(CommitLedger::new(1000));
+        {
+            let _r = l.try_reserve(700).expect("within cap");
+            assert_eq!(l.committed(), 700);
+        }
+        assert_eq!(l.committed(), 0);
+        // And a subsequent full-cap request now fits.
+        let _r2 = l.try_reserve(1000).expect("fits after release");
+        assert_eq!(l.committed(), 1000);
+    }
+
+    #[test]
+    fn two_reservations_aggregate_reject_then_accept_after_drop() {
+        let l = Arc::new(CommitLedger::new(1000));
+        let r1 = l.try_reserve(700).expect("first fits");
+        // Second crosses the cap while the first is held.
+        assert!(l.try_reserve(400).is_err(), "700 + 400 > 1000");
+        assert_eq!(l.committed(), 700);
+        drop(r1);
+        // Now it fits.
+        let _r2 = l.try_reserve(400).expect("fits after first drops");
+        assert_eq!(l.committed(), 400);
+    }
+
+    #[test]
+    fn cap_zero_accepts_arbitrarily_large() {
+        let l = Arc::new(CommitLedger::new(0));
+        let _r = l.try_reserve(u64::MAX / 2).expect("unlimited");
+        let _r2 = l.try_reserve(1 << 40).expect("still unlimited");
+        assert_eq!(l.committed(), (u64::MAX / 2) + (1 << 40));
+    }
+
+    #[test]
+    fn exact_fit_is_accepted() {
+        let l = Arc::new(CommitLedger::new(1000));
+        let _r = l.try_reserve(1000).expect("new == cap is allowed");
+        assert_eq!(l.committed(), 1000);
+        // But one more byte is not.
+        assert!(l.try_reserve(1).is_err());
+    }
+
+    #[test]
+    fn overflow_is_rejected_not_wrapped() {
+        // cap == 0 (unlimited) but the running total must not wrap around.
+        let l = Arc::new(CommitLedger::new(0));
+        let _r = l.try_reserve(u64::MAX - 10).expect("fits");
+        assert!(
+            l.try_reserve(100).is_err(),
+            "checked_add must reject wraparound"
+        );
+    }
+}

--- a/crates/spark-storage/src/cache_peer/mod.rs
+++ b/crates/spark-storage/src/cache_peer/mod.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// KV overflow blade — a dumb remote-RAM tier for the high-speed-swap KV cache.
+//
+// Where `expert_peer` serves READ-ONLY expert weights over one-sided RDMA READ,
+// this serves a READ-WRITE slab of RAM: a streaming client OFFLOADS cold K/V
+// groups into it with `IBV_WR_RDMA_WRITE` and RESTORES them with
+// `IBV_WR_RDMA_READ`, both one-sided, peer CPU idle. It is the "faster than the
+// SSD" overflow tier: local pinned RAM → **peer RAM (~12 GB/s over CX7)** →
+// local NVMe/USB SSD (~2 GB/s). The peer owns nothing — each group belongs to
+// exactly one client sequence; this process is a passive memory blade.
+//
+// Addressing is the flat group-id space of `GroupLayout`: a group lands at
+// `base + group_id * group_stride`, so no per-group bookkeeping on the peer.
+//
+// Wire protocol (little-endian), connection-oriented:
+//   1. client -> [u64 total_bytes]  (num_groups * group_stride it will address)
+//   2. peer allocates + registers a RW MR of that size, replies with
+//      CacheServerParams [u32 qpn][u32 psn][16 gid][u64 base_addr][u32 rkey]
+//   3. client -> VerbsClientParams [u32 qpn][u32 psn][16 gid]
+//   4. peer connects its QP, replies [u8 STATUS_OK]
+//   5. client does one-sided WRITE/READ; peer idles until the client hangs up,
+//      then unregisters + unmaps the blade.
+//
+// This module is split per the Atlas SDD file-size idiom:
+//   `server_impl.rs` — accept loop, first-u64 dispatch, server-side rail
+//                      handshake holding the crate's SINGLE `reg_mr_rw` call
+//                      site (the access flag stays AT the call site — census-
+//                      pinned by `tests/reg_mr_flag_audit.rs`), both data
+//                      planes;
+//   `registry.rs`    — peer POLICY: the process-global (kind, blob_bytes)
+//                      paging-arena registry, the disk-cap carve, and the anon
+//                      `Mmap` RAII the RDMA-registered arenas live in.
+// The peer's residency IS `atlas_tier::Residency` and its verbs ARE
+// `atlas_rdma::verbs`, imported directly — nothing tier- or verbs-shaped is
+// hand-rolled here.
+
+// The RW-blade handshake codec lives verbatim in the CUDA-free `atlas-rdma`
+// crate; re-exported at its old path so the server below and both RW clients
+// are zero-diff. Byte layout golden-pinned in `tests/rdma_wire_golden.rs` —
+// it is what the fleet cache-peer binary speaks.
+pub use atlas_rdma::wire::CacheServerParams;
+
+// Peer paging policy — verbs-only, like the paging handshake it backs.
+#[cfg(atlas_rdma_verbs)]
+mod registry;
+#[cfg(unix)]
+mod server_impl;
+
+#[cfg(unix)]
+pub use server_impl::{RdmaConfig, serve};
+
+// `kv_server_params_round_trip` lives WITH the codec in
+// `crates/atlas-rdma/tests/wire_roundtrip.rs`; the exact byte layout stays
+// pinned by `tests/rdma_wire_golden.rs` here. The `carve_disk_slots`
+// precedence pins live in `registry_tests.rs`.

--- a/crates/spark-storage/src/cache_peer/registry.rs
+++ b/crates/spark-storage/src/cache_peer/registry.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Process-global SHARED paging arenas (the cross-connection warm cache).
+// This is peer POLICY with no home in `atlas-tier`/`atlas-rdma`: the
+// (kind, blob_bytes) arena registry, the shared-vs-per-kind disk-cap carve,
+// and the anonymous `Mmap` RAII the RDMA-registered arenas live in
+// (deliberately NOT lifted to `atlas-tier`, whose charter excludes unsafe
+// raw-pointer arena types — see `snapshot_swap/mmap_arena.rs`).
+//
+// All paging connections of one (kind, shape) reg_mr the SAME arena and drive
+// ONE residency, so a snapshot PUT by one client is GET-able by another (same
+// namespace — the client folds a per-model id into the key). Arena + blob
+// geometry are fixed by the FIRST paging client of a shape; later clients must
+// match blob_bytes. The arena, swap file and blade reservation live for the
+// daemon's lifetime.
+
+use anyhow::{Context, Result, bail};
+use atlas_tier::{DirectSwapFile, Residency};
+
+use super::server_impl::RdmaConfig;
+use crate::snapshot_swap::MmapSlotArena;
+
+/// A page-aligned anonymous mapping, unmapped on drop.
+pub(super) struct Mmap {
+    pub(super) addr: *mut libc::c_void,
+    pub(super) len: usize,
+}
+
+impl Mmap {
+    pub(super) fn anon(len: usize) -> Result<Self> {
+        // SAFETY: standard anonymous private mapping of `len` bytes.
+        let addr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        if addr == libc::MAP_FAILED {
+            bail!(
+                "mmap anon {len} failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        Ok(Self { addr, len })
+    }
+}
+
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        // SAFETY: addr/len from a successful mmap, unmapped once.
+        unsafe { libc::munmap(self.addr, self.len) };
+    }
+}
+
+/// One (kind, shape) shared arena: the anon mapping every same-shape paging
+/// connection registers, plus the ONE residency that owns its slots.
+pub(super) struct SharedPaging {
+    pub(super) arena: Mmap,
+    pub(super) residency: std::sync::Mutex<Residency<MmapSlotArena, DirectSwapFile>>,
+    _reservation: crate::blade_cap::Reservation,
+}
+// SAFETY: `arena.addr` is a stable mapping; every mutable access to the
+// residency (and thus the arena bytes) is serialized through its Mutex.
+unsafe impl Send for SharedPaging {}
+unsafe impl Sync for SharedPaging {}
+
+/// Item 8: a REGISTRY of paging arenas keyed by (kind, blob_bytes) so ONE
+/// peer serves per-(kind, shape) arenas. Distinct shapes coexist (different
+/// fixed-slot geometries); same-shape clients share one arena (namespaced
+/// keys). The disk cap is a single hard-ceiling budget carved across entries.
+#[derive(Default)]
+struct PagingRegistry {
+    arenas: std::collections::HashMap<(u8, usize), std::sync::Arc<SharedPaging>>,
+    /// Remaining disk-cap budget (bytes); the first (SSM) entry claims the
+    /// remainder, honoring the hard `swap_cap_bytes` ceiling across arenas.
+    remaining_cap: u64,
+    cap_init: bool,
+    legacy_cleaned: bool,
+}
+
+static SHARED_PAGING: std::sync::LazyLock<std::sync::Mutex<PagingRegistry>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(PagingRegistry::default()));
+
+/// Decide a paging arena's disk-cap slot count and the updated shared-cap
+/// remainder. Precedence: (1) per-kind override → this kind's OWN fixed
+/// budget (0 = unbounded for it), leaving the shared remainder untouched so
+/// it can't starve other kinds; (2) shared `swap_cap` ceiling → claim the
+/// current remainder (≥1-record floor); (3) both unset (0) → unbounded.
+/// Pure so the precedence is unit-tested without RDMA/mmap.
+fn carve_disk_slots(
+    per_kind_cap: Option<u64>,
+    shared_cap: u64,
+    shared_remaining: u64,
+    blob_bytes: u64,
+) -> (usize, u64) {
+    let bb = blob_bytes.max(1);
+    match per_kind_cap {
+        Some(0) => (0, shared_remaining), // this kind explicitly unbounded
+        Some(cap) => (((cap / bb) as usize).max(1), shared_remaining),
+        None if shared_cap == 0 => (0, shared_remaining), // unbounded
+        None => {
+            let recs = (shared_remaining / bb) as usize;
+            (
+                recs.max(1),
+                shared_remaining.saturating_sub(recs as u64 * bb),
+            )
+        }
+    }
+}
+
+/// Get (first client of a (kind, blob) creates) that shape's shared arena.
+/// Charges the blade ledger per arena; carves the disk cap from a shared
+/// ceiling. The registry lock guards only the map + budget — residency ops
+/// run under each entry's own Mutex, never this lock.
+pub(super) fn get_or_init_shared_paging(
+    rdma: &RdmaConfig,
+    kind: u8,
+    arena_bytes: usize,
+    blob_bytes: usize,
+    ledger: &std::sync::Arc<crate::blade_cap::CommitLedger>,
+) -> Result<std::sync::Arc<SharedPaging>> {
+    let mut reg = SHARED_PAGING.lock().expect("paging registry poisoned");
+    let key = (kind, blob_bytes);
+    if let Some(sh) = reg.arenas.get(&key) {
+        return Ok(sh.clone()); // same (kind, shape) → share
+    }
+    let swap_dir = rdma
+        .swap_dir
+        .as_ref()
+        .context("paging client but peer has no --swap-dir configured")?;
+    std::fs::create_dir_all(swap_dir).ok();
+    // One-time: init the shared disk budget + remove the pre-registry fixed
+    // swap file (verify gap: orphaned atlas-snap-shared.swap on upgrade).
+    if !reg.cap_init {
+        reg.remaining_cap = rdma.swap_cap_bytes;
+        reg.cap_init = true;
+    }
+    if !reg.legacy_cleaned {
+        let _ = std::fs::remove_file(swap_dir.join("atlas-snap-shared.swap"));
+        reg.legacy_cleaned = true;
+    }
+    let reservation = ledger
+        .try_reserve(arena_bytes as u64)
+        .context("paging blade cap")?;
+    let arena = Mmap::anon(arena_bytes)?;
+    let num_slots = arena_bytes / blob_bytes;
+    // Disk-cap sizing (per-kind override → shared-ceiling carve → unbounded).
+    let (max_disk_slots, new_remaining) = carve_disk_slots(
+        rdma.per_kind_swap_cap_bytes.get(&kind).copied(),
+        rdma.swap_cap_bytes,
+        reg.remaining_cap,
+        blob_bytes as u64,
+    );
+    reg.remaining_cap = new_remaining;
+    let swap_path = swap_dir.join(format!("atlas-snap-{kind}-{blob_bytes}.swap"));
+    let swap = DirectSwapFile::create(&swap_path, blob_bytes)?;
+    // SAFETY: the Mmap is owned by SharedPaging (held by the registry Arc), so
+    // its base VA outlives every MmapSlotArena view of it.
+    let slot_arena = unsafe { MmapSlotArena::new(arena.addr as *mut u8, blob_bytes, num_slots) };
+    let residency = Residency::new_capped(slot_arena, swap, max_disk_slots)?;
+    tracing::info!(
+        "cache-peer paging arena kind={kind} shape={blob_bytes}B: {num_slots} slots RAM \
+         ({:.1} GiB) + NVMe swap {} (disk cap {} records; budget {:.0} GiB left)",
+        arena_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+        swap_path.display(),
+        if max_disk_slots == 0 {
+            "unbounded".to_string()
+        } else {
+            max_disk_slots.to_string()
+        },
+        reg.remaining_cap as f64 / (1024.0 * 1024.0 * 1024.0),
+    );
+    let sh = std::sync::Arc::new(SharedPaging {
+        arena,
+        residency: std::sync::Mutex::new(residency),
+        _reservation: reservation,
+    });
+    reg.arenas.insert(key, sh.clone());
+    Ok(sh)
+}
+
+#[cfg(test)]
+#[path = "registry_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/cache_peer/registry_tests.rs
+++ b/crates/spark-storage/src/cache_peer/registry_tests.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// `carve_disk_slots` precedence pins — moved to their own file (SDD test
+// convention) when `cache_peer.rs` split into `cache_peer/`; body unchanged.
+
+use super::carve_disk_slots;
+
+/// cross-KIND pin against the REAL registry (no RDMA needed — anon
+/// mmap + O_DIRECT swap file only): `(kind, blob_bytes)` keying gives SSM
+/// (kind 0) and KV (kind 1) arenas their OWN residency map and their OWN
+/// swap file even with IDENTICAL blob_bytes — so a numerically equal wire
+/// key can never be looked up across kinds. This is the structural guarantee
+/// the KV client's `KV_DOMAIN` namespace fold is defense-in-depth on top of;
+/// a refactor that collapses the registry keying fails here. Same-kind
+/// re-connects share the ONE arena (capacity pooling).
+#[test]
+fn cross_kind_arenas_are_disjoint_in_the_real_registry() {
+    // Real-filesystem dir (tmpfs/overlay EINVALs on O_DIRECT — skip like
+    // atlas-tier's direct_swap tests so containerized CI doesn't break).
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/atlas-kv-paging-registry-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let rdma = super::RdmaConfig {
+        swap_dir: Some(dir.clone()),
+        ..Default::default()
+    };
+    let ledger = std::sync::Arc::new(crate::blade_cap::CommitLedger::new(0));
+    // blob_bytes unique to this test (the registry is process-global) and a
+    // 4 KiB multiple (O_DIRECT record contract).
+    let blob = 8192usize;
+    let ssm = match super::get_or_init_shared_paging(&rdma, 0, 4 * blob, blob, &ledger) {
+        Ok(sh) => sh,
+        Err(e) => {
+            eprintln!("skipping registry test (filesystem refused O_DIRECT): {e:#}");
+            return;
+        }
+    };
+    let kv = super::get_or_init_shared_paging(&rdma, 1, 4 * blob, blob, &ledger).unwrap();
+    assert!(
+        !std::sync::Arc::ptr_eq(&ssm, &kv),
+        "same blob_bytes, different kind ⇒ different arenas"
+    );
+    // Same (kind, blob) ⇒ the ONE shared arena.
+    let kv2 = super::get_or_init_shared_paging(&rdma, 1, 4 * blob, blob, &ledger).unwrap();
+    assert!(std::sync::Arc::ptr_eq(&kv, &kv2));
+    // Per-kind swap files exist, named atlas-snap-{kind}-{blob}.swap.
+    assert!(dir.join(format!("atlas-snap-0-{blob}.swap")).exists());
+    assert!(dir.join(format!("atlas-snap-1-{blob}.swap")).exists());
+    // A key resident in the KV arena is INVISIBLE to the SSM arena.
+    let key = 0x4B56_4B56_4B56_4B56u64;
+    kv.residency
+        .lock()
+        .unwrap()
+        .put_blob(key, &vec![0x4B; blob])
+        .unwrap();
+    assert_eq!(ssm.residency.lock().unwrap().locate(key).unwrap(), None);
+    assert!(kv.residency.lock().unwrap().locate(key).unwrap().is_some());
+}
+
+#[test]
+fn carve_disk_slots_precedence() {
+    let bb = 4u64; // tiny blob
+    // Per-kind override: fixed budget, shared remainder UNTOUCHED (no starve).
+    let (slots, rem) = carve_disk_slots(Some(40), 100, 100, bb);
+    assert_eq!(slots, 10);
+    assert_eq!(
+        rem, 100,
+        "per-kind override must not consume the shared remainder"
+    );
+    // Per-kind 0 = unbounded for that kind, remainder untouched.
+    assert_eq!(carve_disk_slots(Some(0), 100, 100, bb), (0, 100));
+    // No override, shared cap set: claim the remainder (and it drops).
+    let (slots, rem) = carve_disk_slots(None, 100, 100, bb);
+    assert_eq!(slots, 25);
+    assert_eq!(rem, 0, "shared carve consumes the remainder");
+    // No override, shared cap 0 = unbounded.
+    assert_eq!(carve_disk_slots(None, 0, 0, bb), (0, 0));
+    // Starved shared remainder still floors at 1 record (never 0=unbounded).
+    assert_eq!(carve_disk_slots(None, 100, 0, bb), (1, 0));
+}

--- a/crates/spark-storage/src/cache_peer/server_impl.rs
+++ b/crates/spark-storage/src/cache_peer/server_impl.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Accept loop + per-connection lifecycle for the RW blade: the v2-only
+// handshake parse (paging vs RAW one-sided mode, selected by `blob_bytes`),
+// the server-side rail handshake holding the crate's SINGLE `reg_mr_rw` call
+// site (the access flag is a security invariant and stays AT the call site —
+// census-pinned by `tests/reg_mr_flag_audit.rs`), and the two data planes:
+// the shared paging control loop vs the RAW idle-until-hangup blade.
+
+use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+
+use anyhow::{Context, Result, bail};
+
+/// RDMA rail selection for the blade. One `(dev, gid_idx)` per CX7 adapter;
+/// a client requests N rails and the peer registers its arena on each so the
+/// client can stripe traffic across both adapters (~1.75x aggregate on GB10).
+#[derive(Clone, Debug)]
+pub struct RdmaConfig {
+    /// `(device, gid_idx)` per rail, in link order (rail 0 = .178, 1 = .177).
+    pub rails: Vec<(String, u32)>,
+    /// Ceiling on total committed (registered) blade RAM across all
+    /// concurrent connections, in bytes. `0` = unlimited (the default).
+    pub max_blade_bytes: u64,
+    /// Directory for NVMe swap files backing paging-mode connections
+    ///. `None` = paging clients are refused (RAM-only). When set, a
+    /// paging connection's RDMA arena becomes a page-cache over an O_DIRECT
+    /// swap file here, bounded by `swap_cap_bytes`.
+    pub swap_dir: Option<std::path::PathBuf>,
+    /// Disk cap for the paging swap file, in bytes: bounds the on-disk
+    /// snapshot count (coldest dropped when full → later GET misses →
+    /// recompute). 0 = unbounded. Default 50 GiB (operator sanity limit).
+    /// In the multi-arena registry this is the SHARED ceiling carved across
+    /// kinds unless a kind has a `per_kind_swap_cap_bytes` override.
+    pub swap_cap_bytes: u64,
+    /// Per-`PagingKind` disk-cap overrides (`kind.0 → bytes`). When a kind
+    /// is present here, its arena gets this FIXED disk budget instead of
+    /// carving from the shared `swap_cap_bytes` remainder — so one kind
+    /// (e.g. KV) can't starve another (e.g. SSM snapshots). 0 = unbounded
+    /// for that kind. Set via `--swap-cap-gb-<kind>`.
+    pub per_kind_swap_cap_bytes: std::collections::HashMap<u8, u64>,
+}
+
+impl Default for RdmaConfig {
+    fn default() -> Self {
+        Self {
+            rails: vec![("roceP2p1s0f1".into(), 3), ("rocep1s0f1".into(), 3)],
+            max_blade_bytes: 0,
+            swap_dir: None,
+            swap_cap_bytes: 50 * 1024 * 1024 * 1024,
+            per_kind_swap_cap_bytes: std::collections::HashMap::new(),
+        }
+    }
+}
+
+/// Serve a KV overflow blade on `addr` until interrupted. One thread per
+/// connection; each connection gets its own RW arena sized by the client.
+pub fn serve<A: ToSocketAddrs>(addr: A, rdma: RdmaConfig) -> Result<()> {
+    let listener = TcpListener::bind(addr).context("bind cache-peer listener")?;
+    let local = listener.local_addr().ok();
+    // One process-global ledger, shared by every connection thread; a
+    // connection reserves its arena size before it maps/registers any RAM.
+    let ledger = std::sync::Arc::new(crate::blade_cap::CommitLedger::new(rdma.max_blade_bytes));
+    tracing::info!(
+        "cache-peer (RW RDMA overflow blade) listening on {:?} (rails {:?}, cap {})",
+        local,
+        rdma.rails,
+        if rdma.max_blade_bytes == 0 {
+            "unlimited".to_string()
+        } else {
+            format!(
+                "{:.1} GiB",
+                rdma.max_blade_bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+            )
+        },
+    );
+    // Explicit memlock ceiling: paging arenas are anon-mmap'd AND
+    // RDMA-registered (pinned = memlocked). With no `--max-blade-gb` the
+    // registry can pin unbounded RAM across (kind, shape) arenas as clients
+    // of new shapes connect — on a shared box that can exhaust host RAM /
+    // hit the memlock rlimit. Warn so the operator sets an explicit cap.
+    if rdma.max_blade_bytes == 0 && rdma.swap_dir.is_some() {
+        tracing::warn!(
+            "cache-peer paging registry active with NO blade ceiling (--max-blade-gb 0 = \
+             unlimited): each new (kind, shape) arena pins RDMA-registered RAM without bound. \
+             Set --max-blade-gb <G> to cap total memlocked blade RAM."
+        );
+    }
+    for conn in listener.incoming() {
+        let stream = match conn {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("cache-peer accept error: {e}");
+                continue;
+            }
+        };
+        let rdma = rdma.clone();
+        let ledger = ledger.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = handle_conn(stream, &rdma, &ledger) {
+                tracing::warn!("cache-peer connection ended: {e}");
+            }
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(atlas_rdma_verbs))]
+fn handle_conn(
+    _stream: TcpStream,
+    _rdma: &RdmaConfig,
+    _ledger: &std::sync::Arc<crate::blade_cap::CommitLedger>,
+) -> Result<()> {
+    bail!("cache-peer needs a build with rdma-core (atlas_rdma_verbs)");
+}
+
+#[cfg(atlas_rdma_verbs)]
+fn handle_conn(
+    mut stream: TcpStream,
+    rdma: &RdmaConfig,
+    ledger: &std::sync::Arc<crate::blade_cap::CommitLedger>,
+) -> Result<()> {
+    use super::registry::{self, Mmap, SharedPaging};
+    use atlas_rdma::verbs::Verbs;
+    use atlas_rdma::wire::{CacheServerParams, STATUS_OK, VerbsClientParams};
+    use std::io::{Read, Write};
+    stream.set_nodelay(true).ok();
+
+    // 1. Client handshake (v2-only): EVERY client sends
+    //    `[u64 PAGING_MAGIC_V2][u8 kind][u64 arena_bytes][u64 blob_bytes]`.
+    //    blob_bytes > 0 → paging mode (peer-owned residency over the shared
+    //    per-(kind, blob) registry arena). blob_bytes == 0 → RAW one-sided
+    //    mode: a per-connection anonymous arena with a client-owned allocator
+    //    (the legacy data plane, selected explicitly).
+    //    `parse_paging_header` rejects the retired v1 magic and any bare
+    //    legacy total_bytes with a legible diagnostic.
+    let mut b8 = [0u8; 8];
+    stream.read_exact(&mut b8).context("read paging magic")?;
+    let first = u64::from_le_bytes(b8);
+    let (kind, arena_bytes, blob) = crate::snapshot_swap::parse_paging_header(first, &mut stream)?;
+    let total = arena_bytes as usize;
+    let blob = blob as usize;
+    // Explicit arena sanity bound. Pre-Step-C the `1<<42` check did double
+    // duty (legacy-vs-magic dispatch AND size sanity); the dispatch role is
+    // gone but the bound stays — arena size must never be limited only by
+    // the (default-unlimited, warn-only) blade ledger.
+    if total == 0 || total > (1usize << 42) {
+        bail!("implausible blade arena size: {total}");
+    }
+    let paging: Option<(u8, usize)> = if blob == 0 {
+        None // RAW one-sided mode
+    } else {
+        if !total.is_multiple_of(blob) {
+            bail!("paging: arena_bytes {total} not a multiple of blob_bytes {blob}");
+        }
+        // Reject BEFORE the rail handshake when this peer has no swap
+        // dir — the client's connect_paging then errors cleanly and
+        // falls back to the bounded/host-RAM tier.
+        if rdma.swap_dir.is_none() {
+            bail!("paging client but peer started without --swap-dir; refusing");
+        }
+        Some((kind.0, blob))
+    };
+    let mut b1 = [0u8; 1];
+    stream.read_exact(&mut b1).context("read n_rails")?;
+    let n_rails = b1[0] as usize;
+    if n_rails == 0 || n_rails > rdma.rails.len() {
+        bail!(
+            "client asked for {n_rails} rails; peer has {}",
+            rdma.rails.len()
+        );
+    }
+
+    // Acquire the arena to register. RAW mode: a per-connection anonymous
+    // mapping, charged per-conn. Paging: the process-global SHARED
+    // arena (charged ONCE at init) so every client's QPs point at the SAME
+    // physical slots → a snapshot PUT by one client is GET-able by another.
+    let pid = std::process::id();
+    let shared: Option<std::sync::Arc<SharedPaging>> = match paging {
+        Some((kind, blob)) => Some(registry::get_or_init_shared_paging(
+            rdma, kind, total, blob, ledger,
+        )?),
+        None => None,
+    };
+    // Per-connection arena + blade reservation (RAW mode only), kept alive
+    // until teardown; the shared arena's reservation lives in the static.
+    let local: Option<(crate::blade_cap::Reservation, Mmap)> = if shared.is_none() {
+        let reservation = ledger.try_reserve(total as u64).context("kv blade cap")?;
+        let arena = Mmap::anon(total).context("mmap kv blade arena")?;
+        Some((reservation, arena))
+    } else {
+        None
+    };
+    let (arena_base, arena_len): (*mut libc::c_void, usize) = match (&shared, &local) {
+        (Some(sh), _) => (sh.arena.addr, sh.arena.len),
+        (None, Some((_, arena))) => (arena.addr, arena.len),
+        _ => unreachable!("exactly one of shared/local is set"),
+    };
+    // Register the arena ONCE per rail (each device its own PD/rkey; shared
+    // refcounted pages, so N rails cost N MR handles + rkeys, not N× RAM).
+    let mut rails: Vec<Verbs> = Vec::with_capacity(n_rails);
+    let mut rkeys: Vec<u32> = Vec::with_capacity(n_rails);
+    for (i, (dev, gid)) in rdma.rails.iter().take(n_rails).enumerate() {
+        let psn = (0x5a5a5a ^ pid ^ ((i as u32) << 20)) & 0xff_ffff;
+        let mut v = Verbs::create(dev, *gid, psn)?;
+        // SAFETY: the arena (shared or local) outlives every rail below.
+        let keys = unsafe { v.reg_mr_rw(arena_base as *mut _, arena_len)? };
+        rkeys.push(keys.rkey);
+        rails.push(v);
+    }
+
+    // 2. Publish rail count + each rail's QP + rkey (shared base).
+    stream.write_all(&[n_rails as u8]).context("send n_rails")?;
+    for (v, rkey) in rails.iter().zip(&rkeys) {
+        CacheServerParams {
+            qpn: v.qpn(),
+            psn: v.psn(),
+            gid: v.gid(),
+            base_addr: arena_base as u64,
+            rkey: *rkey,
+        }
+        .write_to(&mut stream)
+        .context("send kv server params")?;
+    }
+
+    // 3-4. Learn each client rail's QP, connect, ack.
+    stream.read_exact(&mut b1).context("read client n_rails")?;
+    if b1[0] as usize != n_rails {
+        bail!("client rail count mismatch");
+    }
+    for v in rails.iter_mut() {
+        let cp = VerbsClientParams::read_from(&mut stream).context("read kv client params")?;
+        v.connect(cp.qpn, cp.psn, &cp.gid)?;
+    }
+    stream
+        .write_all(&[STATUS_OK])
+        .context("send kv ready ack")?;
+    let mode = if paging.is_some() {
+        "paging"
+    } else {
+        "raw one-sided"
+    };
+    tracing::info!(
+        "cache-peer client connected: kind {}, {n_rails} rail(s), {:.1} GiB RW blade ({mode})",
+        kind.0,
+        total as f64 / (1024.0 * 1024.0 * 1024.0),
+    );
+
+    // 5. Data plane.
+    if let Some(sh) = shared {
+        // Paging mode: drive the SHARED residency — a snapshot PUT by
+        // one client is GET-able by another (cross-connection warm cache).
+        // Bytes move one-sided over RDMA into/out of the shared arena slots;
+        // only tiny [op][key] control messages cross this TCP stream. The MR
+        // is never re-registered — swap happens under the stable rkey.
+        tracing::info!("cache-peer PAGING client joined shared arena ({n_rails} rail(s))");
+        let r = crate::snapshot_swap::run_paging_loop_shared(&mut stream, &sh.residency);
+        drop(rails); // dereg this conn's MRs; the shared arena stays mapped
+        return r;
+    }
+
+    // RAW one-sided blade (v2, blob_bytes == 0): the client owns allocation
+    // against the fixed arena; the peer just idles until hangup.
+    let mut sink = [0u8; 8];
+    loop {
+        match stream.read(&mut sink) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+    // Dereg (rails) before unmap (arena): drop rails first.
+    drop(rails);
+    drop(local);
+    Ok(())
+}

--- a/crates/spark-storage/src/cascade_backend.rs
+++ b/crates/spark-storage/src/cascade_backend.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// CascadeBackend — a T1 local pinned-LPDDR write-back cache in front of any
+// `StorageBackend` backing tier (the RDMA peer, or the SSD io_uring backend).
+//
+// The KV cache overflow already spills to `backing`; this inserts the handoff's
+// missing middle tier: hot groups live in a bounded pinned-host cache (fast,
+// GPU-addressable, no RDMA), and only evicted groups flush DOWN to `backing`.
+// A restore hits T1 (a local copy_h2d) or falls through to `backing`. Purely a
+// placement layer — no tier transforms bytes, so the composite is bit-identical
+// to the backing alone (the group-id -> address bijection is the same on every
+// tier). Enabled by $ATLAS_KV_LOCAL_GB; 0 (default) leaves the path untouched.
+
+use std::ffi::c_void;
+
+use anyhow::{Context, Result};
+
+use crate::backend::{ReadRequest, StorageBackend};
+use crate::cascade_policy::SlotCache;
+use crate::cuda_min::{CudaEvent, PinnedBuffer, copy_h_to_d_async, stream_sync};
+use crate::group::{GroupKey, GroupLayout};
+
+/// The T1 byte store: one pinned buffer of `cap_slots * group_bytes`, slot `i`
+/// at `ptr + i*group_bytes`. Pinned so the flush-read is a plain host slice and
+/// the restore copy_h2d is fast (same LPDDR is GPU-addressable on GB10).
+struct PinnedStore {
+    buf: PinnedBuffer,
+    group_bytes: usize,
+}
+
+impl PinnedStore {
+    fn new(cap_slots: u32, group_bytes: usize) -> Result<Self> {
+        let bytes = (cap_slots as usize)
+            .checked_mul(group_bytes)
+            .context("CascadeBackend T1 size overflow")?;
+        Ok(Self {
+            buf: PinnedBuffer::new(bytes).context("alloc T1 pinned store")?,
+            group_bytes,
+        })
+    }
+    #[inline]
+    fn slot_host_ptr(&self, slot: u32) -> *const c_void {
+        // SAFETY: slot < cap_slots (SlotCache invariant); offset within the buf.
+        unsafe {
+            (self.buf.ptr as *const u8).add(slot as usize * self.group_bytes) as *const c_void
+        }
+    }
+    /// Copy the group bytes for `slot` out into a fresh Vec (releases the borrow
+    /// so the flush can call `&mut backing`).
+    fn slot_bytes(&self, slot: u32) -> Vec<u8> {
+        // SAFETY: as above; the slot holds `group_bytes` valid bytes.
+        unsafe {
+            std::slice::from_raw_parts(
+                (self.buf.ptr as *const u8).add(slot as usize * self.group_bytes),
+                self.group_bytes,
+            )
+            .to_vec()
+        }
+    }
+    fn write_slot(&mut self, slot: u32, src: &[u8]) {
+        debug_assert_eq!(src.len(), self.group_bytes);
+        // SAFETY: slot in range; src is exactly group_bytes.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                src.as_ptr(),
+                (self.buf.ptr as *mut u8).add(slot as usize * self.group_bytes),
+                self.group_bytes,
+            );
+        }
+    }
+}
+
+pub struct CascadeBackend {
+    hot: SlotCache,
+    store: PinnedStore,
+    backing: Box<dyn StorageBackend>,
+    group_bytes: usize,
+    /// #11-refinement: last async T1 hit-copy event. `read_async` records it
+    /// after its hit `copy_h2d`s (which read the pinned slots); a subsequent
+    /// eviction `write_slot` over one of those slots `sync`s it first, so the
+    /// host cannot overwrite a slot a still-in-flight hit-copy is reading.
+    /// `None` on the sync path → byte-identical for prefetch-OFF.
+    last_read_event: Option<CudaEvent>,
+}
+
+// Single-owner rationale identical to RdmaKvBackend: both trait methods take
+// `&mut self`, no `&self` method touches shared state, and HighSpeedSwap owns it
+// single-threaded. The pinned store's raw ptr is only used under `&mut self`.
+unsafe impl Sync for CascadeBackend {}
+
+impl CascadeBackend {
+    pub fn new(
+        backing: Box<dyn StorageBackend>,
+        layout: GroupLayout,
+        cap_slots: u32,
+    ) -> Result<Self> {
+        let group_bytes = layout.group_bytes() as usize;
+        tracing::info!(
+            "high-speed-swap: T1 cascade cache = {cap_slots} slots × {group_bytes} B = {:.1} GiB local pinned RAM, backing below",
+            (cap_slots as f64 * group_bytes as f64) / (1024.0 * 1024.0 * 1024.0),
+        );
+        Ok(Self {
+            hot: SlotCache::new(cap_slots),
+            store: PinnedStore::new(cap_slots, group_bytes)?,
+            backing,
+            group_bytes,
+            last_read_event: None,
+        })
+    }
+
+    /// Flush every resident T1 group down to backing (durability on teardown).
+    fn flush_all(&mut self) -> Result<()> {
+        for (key, slot) in self.hot.residents() {
+            let bytes = self.store.slot_bytes(slot);
+            self.backing.write_from_host(key, &bytes)?;
+        }
+        Ok(())
+    }
+
+    /// Body shared by `read` (sync) and `read_async` (#11-refinement). The T1
+    /// hit copies pipeline identically; only the tail differs:
+    ///   * sync  (`false`): forward misses via `backing.read`, terminal
+    ///     `stream_sync`. Byte-identical to the pre-refinement `read`.
+    ///   * async (`true`): forward misses via `backing.read_async` (no terminal
+    ///     host sync there either), record `last_read_event` after the hit
+    ///     copies so a later eviction `write_slot` can guard against them, and
+    ///     OMIT the terminal `stream_sync`. Mirror-RAW for the hits is closed by
+    ///     the HSS `kv_prefetch_done` (the hit `copy_h2d`s are enqueued on
+    ///     `prefetch_stream` before HSS records that event).
+    fn read_common(&mut self, requests: &[ReadRequest], stream: u64, is_async: bool) -> Result<()> {
+        let keys: Vec<GroupKey> = requests.iter().map(|r| r.group).collect();
+        let (hits, misses) = self.hot.plan_read(&keys);
+        // T1 hits: local copy_h2d straight from the pinned slot into HBM.
+        for (i, slot) in &hits {
+            let src = self.store.slot_host_ptr(*slot);
+            copy_h_to_d_async(requests[*i].dst_dev_ptr, src, self.group_bytes, stream)?;
+            self.hot.touch(*slot);
+        }
+        // Async: record an event AFTER the hit copies read the pinned slots, so a
+        // subsequent eviction write_slot over one of those slots waits it out.
+        if is_async && !hits.is_empty() {
+            let ev = CudaEvent::new()?;
+            ev.record(stream)?;
+            self.last_read_event = Some(ev);
+        }
+        // Misses fall through to backing (peer RDMA or SSD). Non-promoting: a
+        // miss is NOT pulled up into T1 (smaller correctness surface; write-back
+        // populates T1). backing.read syncs the stream for its own dsts; the
+        // trailing stream_sync also covers the hit copy_h2d above.
+        if !misses.is_empty() {
+            let miss_reqs: Vec<ReadRequest> = misses.iter().map(|&i| requests[i]).collect();
+            if is_async {
+                self.backing.read_async(&miss_reqs, stream)?;
+            } else {
+                self.backing.read(&miss_reqs, stream)?;
+            }
+        }
+        if !is_async {
+            stream_sync(stream)?;
+        }
+        Ok(())
+    }
+}
+
+impl StorageBackend for CascadeBackend {
+    fn write_from_host(&mut self, key: GroupKey, src: &[u8]) -> Result<()> {
+        let plan = self.hot.plan_write(key);
+        // Evicted a resident group → flush its (still-in-slot) bytes DOWN first.
+        if let Some((victim_key, victim_slot)) = plan.flush_victim {
+            let victim_bytes = self.store.slot_bytes(victim_slot);
+            self.backing
+                .write_from_host(victim_key, &victim_bytes)
+                .context("cascade: flush T1 victim to backing")?;
+        }
+        // #11-refinement: an eviction is about to overwrite this slot in place.
+        // If a prior async hit-copy is still reading it (recorded in read_async),
+        // wait it out first — else the host `write_slot` below corrupts the bytes
+        // the copy engine is mid-read. No-op on the sync path (`None`) →
+        // byte-identical; when it fires it is on the offload/eviction path, never
+        // the decode run-ahead loop, so it never stalls decode.
+        if let Some(ev) = self.last_read_event.take() {
+            ev.sync()?;
+        }
+        // Then cache the new group in T1 (write-back — lives here until evicted).
+        self.store.write_slot(plan.slot, src);
+        Ok(())
+    }
+
+    fn read(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()> {
+        self.read_common(requests, stream, false)
+    }
+
+    fn read_async(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()> {
+        self.read_common(requests, stream, true)
+    }
+
+    fn register_landing_region(&mut self, base: u64, len: usize) -> Result<()> {
+        // Forward to backing so RDMA zero-copy restore of MISSES still lands
+        // directly into the UMA pool. (T1 hits copy_h2d locally regardless.)
+        self.backing.register_landing_region(base, len)
+    }
+
+    fn group_layout(&self) -> GroupLayout {
+        // Geometry is the backing's (the group-id ↔ address bijection is the
+        // same on every tier). Cascade inherits the DEFAULT block read/write
+        // (per-head fan-out through its own read/write_from_host = T1 caching) —
+        // correct, just un-coalesced. Native T1 block coalescing is a follow-up.
+        self.backing.group_layout()
+    }
+}
+
+impl Drop for CascadeBackend {
+    fn drop(&mut self) {
+        // Durability: push any T1-resident groups down to backing before the
+        // pinned store frees. Best-effort on teardown.
+        let _ = self.flush_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::PosixBackend;
+    use crate::cuda_min::{CudaCtx, DeviceBuffer, copy_d_to_h_async, stream_sync};
+    use crate::group::KvKind;
+    use crate::layout::Layout;
+
+    fn tempdir(name: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("atlas-cascade-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// #11-refinement staging-reuse gate for the cascade T1 tier: an eviction
+    /// `write_slot` must not overwrite a pinned slot that a still-in-flight async
+    /// hit-copy (`read_async`) is reading — `last_read_event.sync` guards it.
+    /// We size T1 to 2 slots over a 4-group set (forcing eviction), do a
+    /// `read_async` that hits both resident slots, then `write_from_host` a new
+    /// group whose eviction victim is one of those just-read slots, and finally
+    /// verify EVERY group reads back correctly (through T1 hits, evicted-then-
+    /// flushed backing reads, and a sync/async parity leg). A missing guard
+    /// would corrupt the victim's flushed-to-backing bytes silently.
+    #[test]
+    #[ignore = "requires GPU"]
+    fn read_async_eviction_no_corruption() {
+        let _ctx = CudaCtx::new(0).expect("cuda init");
+        let dir = tempdir("evict");
+        // 4 blocks, T1 caps at 2 slots → writing block 2/3 evicts 0/1.
+        let spec = GroupLayout::new(1, 4, 1, 16, 128, 2, 4096);
+        let layout = Layout::create(&dir, spec).unwrap();
+        let bytes = spec.group_bytes() as usize;
+        let backing = Box::new(PosixBackend::new(layout).unwrap());
+        let mut cascade = CascadeBackend::new(backing, spec, 2).unwrap();
+
+        let keys: Vec<GroupKey> = (0..4u32)
+            .map(|b| GroupKey::new(0, b, 0, KvKind::K))
+            .collect();
+        let pat = |b: usize| -> Vec<u8> {
+            (0..bytes)
+                .map(|i| ((i * 7 + b * 11) & 0xFF) as u8)
+                .collect()
+        };
+
+        // Cache g0,g1 in T1 (fits in the 2 slots).
+        cascade.write_from_host(keys[0], &pat(0)).unwrap();
+        cascade.write_from_host(keys[1], &pat(1)).unwrap();
+
+        // Async restore g0,g1 → both T1 hits; records last_read_event over the
+        // slots holding g0,g1.
+        let d0 = DeviceBuffer::new(bytes).unwrap();
+        let d1 = DeviceBuffer::new(bytes).unwrap();
+        cascade
+            .read_async(
+                &[
+                    ReadRequest {
+                        group: keys[0],
+                        dst_dev_ptr: d0.ptr,
+                    },
+                    ReadRequest {
+                        group: keys[1],
+                        dst_dev_ptr: d1.ptr,
+                    },
+                ],
+                _ctx.stream,
+            )
+            .unwrap();
+        // Evict: caching g2,g3 flushes g0,g1's slots DOWN to backing. Each
+        // write_from_host must sync the in-flight hit-copy before write_slot.
+        cascade.write_from_host(keys[2], &pat(2)).unwrap();
+        cascade.write_from_host(keys[3], &pat(3)).unwrap();
+        // The async reads' consumer would device-wait kv_prefetch_done; here we
+        // host-sync to read device memory back.
+        stream_sync(_ctx.stream).unwrap();
+        let readback = |d: &DeviceBuffer, want: &[u8]| {
+            let mut got = vec![0u8; bytes];
+            copy_d_to_h_async(got.as_mut_ptr() as *mut c_void, d.ptr, bytes, _ctx.stream).unwrap();
+            stream_sync(_ctx.stream).unwrap();
+            assert_eq!(&got, want, "cascade async restore corrupted");
+        };
+        readback(&d0, &pat(0));
+        readback(&d1, &pat(1));
+
+        // Now g0,g1 live in backing (evicted); g2,g3 in T1. A mixed sync read
+        // (hits g2/g3, misses g0/g1 → backing) must return every original byte.
+        let devs: Vec<DeviceBuffer> = (0..4).map(|_| DeviceBuffer::new(bytes).unwrap()).collect();
+        let reqs: Vec<ReadRequest> = keys
+            .iter()
+            .zip(&devs)
+            .map(|(k, d)| ReadRequest {
+                group: *k,
+                dst_dev_ptr: d.ptr,
+            })
+            .collect();
+        cascade.read(&reqs, _ctx.stream).unwrap();
+        for (b, d) in devs.iter().enumerate() {
+            readback(d, &pat(b));
+        }
+        drop(cascade);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/spark-storage/src/cascade_policy.rs
+++ b/crates/spark-storage/src/cascade_policy.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Placement + eviction bookkeeping for the KV cache tier cascade (T1 = local
+// pinned LPDDR write-back cache in front of the peer/SSD backing). Pure logic,
+// no I/O and no CUDA, so it unit-tests on the metal/skip build with no hardware.
+//
+// LRU by default: the `StorageBackend` trait passes no predictor score to the
+// backend, so a predictor-scored T1 eviction would need an out-of-trait side
+// channel (deferred). Groups are keyed by `GroupKey` — write_from_host / read
+// are per-group and each group is independently addressed.
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::group::GroupKey;
+
+/// Result of planning a T1 write: the slot to write `key` into, and — if a
+/// resident group had to be evicted to make room — the victim to flush DOWN to
+/// the backing tier first (its bytes still occupy `slot` until overwritten).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WritePlan {
+    pub slot: u32,
+    pub flush_victim: Option<(GroupKey, u32)>,
+}
+
+/// A fixed-capacity LRU set of resident groups over `cap_slots` byte slots.
+pub struct SlotCache {
+    cap_slots: u32,
+    lookup: HashMap<GroupKey, u32>,
+    slot_key: Vec<Option<GroupKey>>,
+    free: VecDeque<u32>,
+    /// LRU order: front = least-recently-used (eviction target), back = MRU.
+    lru: VecDeque<u32>,
+}
+
+impl SlotCache {
+    pub fn new(cap_slots: u32) -> Self {
+        assert!(cap_slots > 0, "SlotCache needs at least one slot");
+        Self {
+            cap_slots,
+            lookup: HashMap::new(),
+            slot_key: vec![None; cap_slots as usize],
+            free: (0..cap_slots).collect(),
+            lru: VecDeque::with_capacity(cap_slots as usize),
+        }
+    }
+
+    pub fn capacity(&self) -> u32 {
+        self.cap_slots
+    }
+
+    fn move_to_back(&mut self, slot: u32) {
+        if let Some(pos) = self.lru.iter().position(|&s| s == slot) {
+            self.lru.remove(pos);
+        }
+        self.lru.push_back(slot);
+    }
+
+    /// Bump `slot` to most-recently-used (call on every hit).
+    pub fn touch(&mut self, slot: u32) {
+        self.move_to_back(slot);
+    }
+
+    /// Plan a write of `key`. Overwrite-in-place if resident (no victim); else a
+    /// free slot; else evict the LRU slot and report its group to flush down.
+    pub fn plan_write(&mut self, key: GroupKey) -> WritePlan {
+        if let Some(&slot) = self.lookup.get(&key) {
+            self.move_to_back(slot);
+            return WritePlan {
+                slot,
+                flush_victim: None,
+            };
+        }
+        if let Some(slot) = self.free.pop_front() {
+            self.install(key, slot);
+            return WritePlan {
+                slot,
+                flush_victim: None,
+            };
+        }
+        // Full → evict the LRU tail's group (front of the deque).
+        let victim_slot = self.lru.pop_front().expect("full cache has an LRU entry");
+        let victim_key = self.slot_key[victim_slot as usize]
+            .take()
+            .expect("occupied slot has a key");
+        self.lookup.remove(&victim_key);
+        self.install(key, victim_slot);
+        WritePlan {
+            slot: victim_slot,
+            flush_victim: Some((victim_key, victim_slot)),
+        }
+    }
+
+    fn install(&mut self, key: GroupKey, slot: u32) {
+        self.lookup.insert(key, slot);
+        self.slot_key[slot as usize] = Some(key);
+        self.lru.push_back(slot);
+    }
+
+    /// Partition request keys into T1 hits `(request_index, slot)` and misses
+    /// `(request_index)`. Read-only — the caller `touch`es the hits after the
+    /// copy so a failed copy doesn't perturb LRU order.
+    pub fn plan_read(&self, keys: &[GroupKey]) -> (Vec<(usize, u32)>, Vec<usize>) {
+        let mut hits = Vec::new();
+        let mut misses = Vec::new();
+        for (i, k) in keys.iter().enumerate() {
+            match self.lookup.get(k) {
+                Some(&slot) => hits.push((i, slot)),
+                None => misses.push(i),
+            }
+        }
+        (hits, misses)
+    }
+
+    /// Every resident `(key, slot)` — used to flush the whole cache on drop.
+    pub fn residents(&self) -> Vec<(GroupKey, u32)> {
+        self.lookup.iter().map(|(&k, &s)| (k, s)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::KvKind;
+
+    fn k(block: u32) -> GroupKey {
+        GroupKey::new(0, block, 0, KvKind::K)
+    }
+
+    #[test]
+    fn free_slots_then_overwrite_in_place() {
+        let mut c = SlotCache::new(3);
+        let p0 = c.plan_write(k(0));
+        assert_eq!(p0.flush_victim, None);
+        let p1 = c.plan_write(k(1));
+        assert_ne!(p1.slot, p0.slot);
+        // Re-write k(0): same slot, no victim.
+        let p0b = c.plan_write(k(0));
+        assert_eq!(p0b.slot, p0.slot);
+        assert_eq!(p0b.flush_victim, None);
+    }
+
+    #[test]
+    fn fill_then_evict_lru_tail() {
+        let mut c = SlotCache::new(2);
+        let s0 = c.plan_write(k(0)).slot;
+        let _s1 = c.plan_write(k(1)).slot;
+        // Touch k(0) so k(1) becomes LRU.
+        let (hits, _) = c.plan_read(&[k(0)]);
+        c.touch(hits[0].1);
+        // Write k(2) → evicts k(1) (LRU), reusing its slot.
+        let p2 = c.plan_write(k(2));
+        assert_eq!(p2.flush_victim.map(|(vk, _)| vk), Some(k(1)));
+        // k(2) reuses k(1)'s (evicted) slot, not k(0)'s still-resident slot.
+        assert_ne!(p2.slot, s0);
+    }
+
+    #[test]
+    fn hit_miss_partition() {
+        let mut c = SlotCache::new(4);
+        c.plan_write(k(0));
+        c.plan_write(k(2));
+        let (hits, misses) = c.plan_read(&[k(0), k(1), k(2), k(3)]);
+        let hit_idx: Vec<usize> = hits.iter().map(|(i, _)| *i).collect();
+        assert_eq!(hit_idx, vec![0, 2]);
+        assert_eq!(misses, vec![1, 3]);
+    }
+
+    #[test]
+    fn residents_lists_all_live_groups() {
+        let mut c = SlotCache::new(3);
+        c.plan_write(k(0));
+        c.plan_write(k(1));
+        let mut r: Vec<GroupKey> = c.residents().into_iter().map(|(k, _)| k).collect();
+        r.sort_by_key(|g| g.block);
+        assert_eq!(r, vec![k(0), k(1)]);
+    }
+
+    #[test]
+    fn evicted_group_is_no_longer_a_hit() {
+        let mut c = SlotCache::new(1);
+        c.plan_write(k(0));
+        let p = c.plan_write(k(1)); // evicts k(0)
+        assert_eq!(p.flush_victim.map(|(vk, _)| vk), Some(k(0)));
+        let (hits, misses) = c.plan_read(&[k(0), k(1)]);
+        assert_eq!(hits.iter().map(|(i, _)| *i).collect::<Vec<_>>(), vec![1]);
+        assert_eq!(misses, vec![0]);
+    }
+}

--- a/crates/spark-storage/src/cuda_min.rs
+++ b/crates/spark-storage/src/cuda_min.rs
@@ -21,6 +21,7 @@ unsafe extern "C" {
     fn cuMemFree_v2(dptr: u64) -> i32;
     fn cuMemAllocHost_v2(pp: *mut *mut c_void, bytesize: usize) -> i32;
     fn cuMemFreeHost(p: *mut c_void) -> i32;
+    fn cuMemHostGetDevicePointer_v2(pdptr: *mut u64, p: *mut c_void, flags: u32) -> i32;
     fn cuMemcpyHtoDAsync_v2(dst: u64, src: *const c_void, bytes: usize, stream: u64) -> i32;
     fn cuMemcpyDtoHAsync_v2(dst: *mut c_void, src: u64, bytes: usize, stream: u64) -> i32;
     fn cuMemGetInfo_v2(free: *mut usize, total: *mut usize) -> i32;
@@ -131,6 +132,21 @@ impl PinnedBuffer {
             bail!("cuMemAllocHost_v2({bytes}) failed: {s}");
         }
         Ok(Self { ptr: p, bytes })
+    }
+
+    /// Device pointer the GPU uses to address this pinned host allocation.
+    ///
+    /// On GB10's unified LPDDR (unified addressing) this equals the host
+    /// pointer numerically — the property the UMA zero-copy expert arena relies
+    /// on. `cuMemAllocHost` memory is portable + page-locked + device-accessible,
+    /// so no `Mapped` flag is required.
+    pub fn device_ptr(&self) -> Result<u64> {
+        let mut dptr = 0u64;
+        let s = unsafe { cuMemHostGetDevicePointer_v2(&mut dptr, self.ptr, 0) };
+        if s != 0 {
+            bail!("cuMemHostGetDevicePointer_v2 failed: {s}");
+        }
+        Ok(dptr)
     }
 }
 

--- a/crates/spark-storage/src/expert.rs
+++ b/crates/spark-storage/src/expert.rs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Expert identity + on-disk record geometry for the MoE expert streamer.
+//
+// This is the expert-streaming analogue of `group.rs`: where a *group* is the
+// unit of NVMe <-> HBM movement for the KV cache (one `(layer, block, kv_head)`
+// K/V stripe), an *expert record* is the unit of movement for MoE weights — one
+// `(moe_layer, expert)` tuple's full set of gate/up/down projections, stored
+// contiguously and rounded up to the device's optimal I/O block (4 KiB).
+//
+// The engine that moves these records is the exact one that already ships for
+// KV (`backend::{IoUringBackend, PosixBackend}` driven off a `Layout`): the
+// backend only ever calls `fd(layer)`, `offset(key)` and `*_bytes()`. So the
+// streamer reuses that machinery unchanged by presenting expert geometry
+// through the same trio of accessors.
+//
+// Two facts make expert geometry simpler than KV geometry:
+//   * There is no K/V duplication and no per-head striping — one record per
+//     expert, period.
+//   * On every Atlas MoE checkpoint the expert dims are uniform across MoE
+//     layers, so `record_stride` is a single constant for the whole model.
+//
+// The bijection `(layer, expert) <-> record` is computed deterministically from
+// the dims; nothing stores the inverse.
+
+/// Dense 64-bit expert-record id (analogue of `group::GroupId`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ExpertRecordId(pub u64);
+
+/// Identifies one expert's weight record: `(moe_layer, expert)`.
+///
+/// `layer` is a *dense MoE-layer index* (0..num_moe_layers), not the model's
+/// absolute layer index — dense attention layers carry no experts and are
+/// skipped when the index is built.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ExpertKey {
+    pub layer: u32,
+    pub expert: u32,
+}
+
+impl ExpertKey {
+    pub fn new(layer: u32, expert: u32) -> Self {
+        Self { layer, expert }
+    }
+}
+
+/// The three projections that make up one routed expert, in a fixed order.
+///
+/// Order is load-bearing: it is the order sub-buffers are laid out inside a
+/// record and the order the streamer patches pointer tables in. Never reorder
+/// without bumping [`ExpertRecordHeader::VERSION`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Proj {
+    Gate = 0,
+    Up = 1,
+    Down = 2,
+}
+
+impl Proj {
+    pub const ALL: [Proj; 3] = [Proj::Gate, Proj::Up, Proj::Down];
+}
+
+/// Byte geometry of one NVFP4 projection sub-buffer inside an expert record.
+///
+/// NVFP4 (W4A4, group_size 16) stores each projection as two device buffers:
+///   * `packed`  — E2M1 nibbles, 2 values/byte, `[K/2, N]` in prefill-resident
+///     (transposed) layout, so `packed_bytes = N * K / 2`.
+///   * `scale`   — per-group FP8-E4M3 block scales, `[K/16, N]`, so
+///     `scale_bytes = N * K / group_size`.
+///
+/// The two per-projection scalars (`weight_scale_2`, `input_scale`) are carried
+/// in the record header, which is why they are absent here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProjBytes {
+    pub packed_bytes: u64,
+    pub scale_bytes: u64,
+}
+
+impl ProjBytes {
+    /// `n` = output rows, `k` = contraction dim, `group_size` = NVFP4 block.
+    pub fn nvfp4(n: u64, k: u64, group_size: u64) -> Self {
+        Self {
+            packed_bytes: n * k / 2,
+            scale_bytes: n * k / group_size,
+        }
+    }
+}
+
+/// Where every sub-buffer of one expert record sits, relative to the record's
+/// base. Shared by the offline builder (to place bytes) and the streamer (to
+/// compute the device pointers it patches into the `ExpertPtrTable`).
+///
+/// Layout within a record (all offsets are relative to the record base and are
+/// aligned to `sub_align`, which must satisfy the fused MoE kernels' pointer
+/// alignment requirement):
+///
+/// ```text
+///   [ header (ExpertRecordHeader::BYTES) ]
+///   [ gate.packed ][ gate.scale ]
+///   [ up.packed   ][ up.scale   ]
+///   [ down.packed ][ down.scale ]
+///   [ pad to record_stride ]
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExpertRecordSpec {
+    pub inter: u64,
+    pub hidden: u64,
+    pub group_size: u64,
+    pub sub_align: u64,
+    /// `[packed_off, scale_off]` for gate, up, down — relative to record base.
+    offsets: [(u64, u64); 3],
+    bytes: [ProjBytes; 3],
+    /// Total raw bytes (header + all sub-buffers), before rounding to a device
+    /// I/O block. `ExpertLayout` rounds this up to `record_stride`.
+    raw_bytes: u64,
+}
+
+/// Rounds `off` up to the next multiple of `align` (align must be a power of 2).
+#[inline]
+fn align_up(off: u64, align: u64) -> u64 {
+    (off + align - 1) & !(align - 1)
+}
+
+impl ExpertRecordSpec {
+    /// Build the canonical record layout for a model whose experts have the
+    /// given `inter`(mediate) and `hidden` dims. `sub_align` is the alignment
+    /// applied to every sub-buffer (256 is a safe default for CUTLASS/MMQ).
+    pub fn new(inter: u64, hidden: u64, group_size: u64, sub_align: u64) -> Self {
+        assert!(
+            sub_align.is_power_of_two(),
+            "sub_align must be a power of two"
+        );
+        // gate/up: N=inter, K=hidden ; down: N=hidden, K=inter.
+        // packed = N*K/2 and scale = N*K/group_size are symmetric in (N,K),
+        // so all three projections have identical byte sizes — but we keep them
+        // per-projection so a future non-square expert stays correct.
+        let bytes = [
+            ProjBytes::nvfp4(inter, hidden, group_size), // gate
+            ProjBytes::nvfp4(inter, hidden, group_size), // up
+            ProjBytes::nvfp4(hidden, inter, group_size), // down
+        ];
+        let mut cursor = align_up(ExpertRecordHeader::BYTES, sub_align);
+        let mut offsets = [(0u64, 0u64); 3];
+        for i in 0..3 {
+            let packed_off = cursor;
+            cursor = align_up(packed_off + bytes[i].packed_bytes, sub_align);
+            let scale_off = cursor;
+            cursor = align_up(scale_off + bytes[i].scale_bytes, sub_align);
+            offsets[i] = (packed_off, scale_off);
+        }
+        Self {
+            inter,
+            hidden,
+            group_size,
+            sub_align,
+            offsets,
+            bytes,
+            raw_bytes: cursor,
+        }
+    }
+
+    pub fn proj_bytes(&self, p: Proj) -> ProjBytes {
+        self.bytes[p as usize]
+    }
+
+    /// Offset of a projection's packed-weight sub-buffer within the record.
+    pub fn packed_off(&self, p: Proj) -> u64 {
+        self.offsets[p as usize].0
+    }
+
+    /// Offset of a projection's block-scale sub-buffer within the record.
+    pub fn scale_off(&self, p: Proj) -> u64 {
+        self.offsets[p as usize].1
+    }
+
+    /// Total raw record bytes (header + sub-buffers), before I/O-block rounding.
+    pub fn raw_bytes(&self) -> u64 {
+        self.raw_bytes
+    }
+
+    /// Sum of all six sub-buffer payloads (excludes header + alignment padding).
+    pub fn payload_bytes(&self) -> u64 {
+        self.bytes
+            .iter()
+            .map(|b| b.packed_bytes + b.scale_bytes)
+            .sum()
+    }
+}
+
+/// Fixed-size, versioned header written at the front of every expert record.
+///
+/// Invariant D of the streaming-experts plan: *disk format = resident format*.
+/// Nothing is transformed at fetch time, so the format must be self-describing
+/// and versioned — there is no runtime enforcement otherwise. The header
+/// carries exactly the per-expert data that is *not* recomputable from the
+/// model dims: the two NVFP4 scalars per projection (`weight_scale_2` and
+/// `input_scale`), plus enough identity/shape to detect a mismatched file.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExpertRecordHeader {
+    pub layer: u32,
+    pub expert: u32,
+    pub inter: u32,
+    pub hidden: u32,
+    pub group_size: u32,
+    /// Per-projection `weight_scale_2` (per-tensor FP32 scale), gate/up/down.
+    pub scale2: [f32; 3],
+    /// Per-projection `input_scale` (activation scale). `None` = weight-only
+    /// W4A16 path with no activation scale (the streamer patches a NULL device
+    /// pointer). Presence is stored out of band in a flags byte, so equality is
+    /// exact (no NaN sentinel to break `PartialEq`).
+    pub input_scale: [Option<f32>; 3],
+}
+
+impl ExpertRecordHeader {
+    pub const MAGIC: u32 = 0x5850_5254; // "XPRT"
+    pub const VERSION: u32 = 1;
+    /// Reserved on-disk header size. Generous vs. the packed fields so the
+    /// format can grow without moving sub-buffer offsets.
+    pub const BYTES: u64 = 256;
+
+    /// Serialize into the fixed 256-byte on-disk header block. Layout:
+    ///   u32 magic, u32 version, u32 layer, u32 expert,
+    ///   u32 inter, u32 hidden, u32 group_size, u32 input_scale_flags,
+    ///   f32 scale2[3], f32 input_scale[3] (0.0 where absent), zero pad to 256.
+    /// `input_scale_flags` bit `i` set => projection `i` has an activation scale.
+    pub fn to_bytes(&self) -> [u8; Self::BYTES as usize] {
+        let mut out = [0u8; Self::BYTES as usize];
+        let mut w = |off: usize, v: u32| out[off..off + 4].copy_from_slice(&v.to_le_bytes());
+        w(0, Self::MAGIC);
+        w(4, Self::VERSION);
+        w(8, self.layer);
+        w(12, self.expert);
+        w(16, self.inter);
+        w(20, self.hidden);
+        w(24, self.group_size);
+        let mut flags = 0u32;
+        for (i, s) in self.input_scale.iter().enumerate() {
+            if s.is_some() {
+                flags |= 1 << i;
+            }
+        }
+        w(28, flags);
+        for (i, s) in self.scale2.iter().enumerate() {
+            out[32 + i * 4..36 + i * 4].copy_from_slice(&s.to_le_bytes());
+        }
+        for (i, s) in self.input_scale.iter().enumerate() {
+            let v = s.unwrap_or(0.0);
+            out[44 + i * 4..48 + i * 4].copy_from_slice(&v.to_le_bytes());
+        }
+        out
+    }
+
+    /// Parse a header block, validating magic + version. Returns `None` on any
+    /// mismatch (wrong file, wrong version) — never panics on bad input.
+    pub fn from_bytes(buf: &[u8]) -> Option<Self> {
+        if buf.len() < Self::BYTES as usize {
+            return None;
+        }
+        let r = |off: usize| -> u32 {
+            u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]])
+        };
+        let rf = |off: usize| -> f32 {
+            f32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]])
+        };
+        if r(0) != Self::MAGIC || r(4) != Self::VERSION {
+            return None;
+        }
+        let flags = r(28);
+        let iscale = |i: usize, off: usize| -> Option<f32> {
+            if flags & (1 << i) != 0 {
+                Some(rf(off))
+            } else {
+                None
+            }
+        };
+        Some(Self {
+            layer: r(8),
+            expert: r(12),
+            inter: r(16),
+            hidden: r(20),
+            group_size: r(24),
+            scale2: [rf(32), rf(36), rf(40)],
+            input_scale: [iscale(0, 44), iscale(1, 48), iscale(2, 52)],
+        })
+    }
+}
+
+/// Deterministic file geometry for a directory of per-MoE-layer expert files.
+///
+/// One file per MoE layer (`experts_{layer:05}.xpr`), each holding
+/// `num_experts` fixed-stride records back to back. `record_stride` is the raw
+/// record size rounded up to `fs_block_size` (O_DIRECT requires the read
+/// offset and length to be block-aligned). Mirrors `group::GroupLayout`'s
+/// `fd`/`offset`/`*_bytes` surface so the KV backends drive it verbatim.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExpertLayout {
+    pub num_layers: u32,
+    pub num_experts: u32,
+    /// Fixed per-expert record stride on disk (a multiple of `fs_block_size`).
+    pub record_stride: u64,
+    pub fs_block_size: u64,
+}
+
+impl ExpertLayout {
+    /// Build a layout from a record spec. `record_stride` is `spec.raw_bytes()`
+    /// rounded up to `fs_block_size`.
+    pub fn from_spec(
+        num_layers: u32,
+        num_experts: u32,
+        spec: &ExpertRecordSpec,
+        fs_block_size: u64,
+    ) -> Self {
+        let record_stride = spec.raw_bytes().div_ceil(fs_block_size) * fs_block_size;
+        Self {
+            num_layers,
+            num_experts,
+            record_stride,
+            fs_block_size,
+        }
+    }
+
+    /// Bytes occupied by one MoE layer's file (all experts, back to back).
+    pub fn bytes_per_layer(&self) -> u64 {
+        (self.num_experts as u64) * self.record_stride
+    }
+
+    /// File offset of `key`'s record within its layer file.
+    pub fn file_offset(&self, key: ExpertKey) -> u64 {
+        debug_assert!(key.expert < self.num_experts);
+        (key.expert as u64) * self.record_stride
+    }
+
+    /// Dense record id across the whole model (layer-major).
+    pub fn record_id(&self, key: ExpertKey) -> ExpertRecordId {
+        ExpertRecordId((key.layer as u64) * (self.num_experts as u64) + (key.expert as u64))
+    }
+
+    /// Bytes of one record on disk (== `record_stride`); the fixed read size.
+    pub fn record_bytes(&self) -> u64 {
+        self.record_stride
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Qwen3.5-35B-A3B dims: inter=512, hidden=2048, group_size=16.
+    const A3B_INTER: u64 = 512;
+    const A3B_HIDDEN: u64 = 2048;
+    const GS: u64 = 16;
+
+    #[test]
+    fn a3b_per_expert_payload_matches_formula() {
+        // Plan formula: per-expert payload = 3 * inter * hidden * 9/16.
+        let spec = ExpertRecordSpec::new(A3B_INTER, A3B_HIDDEN, GS, 256);
+        let expected = 3 * A3B_INTER * A3B_HIDDEN * 9 / 16;
+        assert_eq!(spec.payload_bytes(), expected);
+        assert_eq!(expected, 1_769_472); // 1.6875 MiB, from recon.
+    }
+
+    #[test]
+    fn projection_bytes_split_8_to_1() {
+        // packed is 8/9 of payload, scale is 1/9 (0.5 byte/elem vs 1 byte/16).
+        let pb = ProjBytes::nvfp4(A3B_INTER, A3B_HIDDEN, GS);
+        assert_eq!(pb.packed_bytes, A3B_INTER * A3B_HIDDEN / 2);
+        assert_eq!(pb.scale_bytes, A3B_INTER * A3B_HIDDEN / 16);
+        assert_eq!(pb.packed_bytes, 8 * pb.scale_bytes);
+    }
+
+    #[test]
+    fn sub_buffers_are_aligned_and_non_overlapping() {
+        let align = 256;
+        let spec = ExpertRecordSpec::new(A3B_INTER, A3B_HIDDEN, GS, align);
+        // Header first, everything after it aligned and monotonic.
+        let mut prev_end = ExpertRecordHeader::BYTES;
+        for p in Proj::ALL {
+            let po = spec.packed_off(p);
+            let so = spec.scale_off(p);
+            let pb = spec.proj_bytes(p);
+            assert_eq!(po % align, 0, "packed off aligned");
+            assert_eq!(so % align, 0, "scale off aligned");
+            assert!(po >= prev_end, "packed does not overlap previous");
+            assert!(so >= po + pb.packed_bytes, "scale does not overlap packed");
+            prev_end = so + pb.scale_bytes;
+        }
+        assert!(spec.raw_bytes() >= prev_end);
+    }
+
+    #[test]
+    fn layout_offsets_are_record_strided() {
+        let spec = ExpertRecordSpec::new(A3B_INTER, A3B_HIDDEN, GS, 256);
+        let layout = ExpertLayout::from_spec(40, 256, &spec, 4096);
+        assert_eq!(layout.record_stride % 4096, 0, "O_DIRECT alignment");
+        assert!(layout.record_stride >= spec.raw_bytes());
+        assert_eq!(layout.file_offset(ExpertKey::new(3, 0)), 0);
+        assert_eq!(
+            layout.file_offset(ExpertKey::new(3, 5)),
+            5 * layout.record_stride
+        );
+        assert_eq!(layout.bytes_per_layer(), 256 * layout.record_stride);
+    }
+
+    #[test]
+    fn record_id_is_dense_layer_major() {
+        let spec = ExpertRecordSpec::new(A3B_INTER, A3B_HIDDEN, GS, 256);
+        let layout = ExpertLayout::from_spec(40, 256, &spec, 4096);
+        assert_eq!(layout.record_id(ExpertKey::new(0, 0)).0, 0);
+        assert_eq!(layout.record_id(ExpertKey::new(0, 255)).0, 255);
+        assert_eq!(layout.record_id(ExpertKey::new(1, 0)).0, 256);
+    }
+
+    #[test]
+    fn header_round_trips() {
+        let h = ExpertRecordHeader {
+            layer: 7,
+            expert: 42,
+            inter: A3B_INTER as u32,
+            hidden: A3B_HIDDEN as u32,
+            group_size: GS as u32,
+            scale2: [0.5, 0.25, 1.5],
+            input_scale: [Some(2.0), None, Some(3.0)],
+        };
+        let bytes = h.to_bytes();
+        assert_eq!(bytes.len(), ExpertRecordHeader::BYTES as usize);
+        let back = ExpertRecordHeader::from_bytes(&bytes).expect("valid header");
+        // Exact struct equality now holds (no NaN sentinel).
+        assert_eq!(back, h);
+        assert_eq!(back.scale2, [0.5, 0.25, 1.5]);
+        assert_eq!(back.input_scale, [Some(2.0), None, Some(3.0)]);
+    }
+
+    #[test]
+    fn header_rejects_bad_magic_and_version() {
+        let mut bytes = ExpertRecordHeader {
+            layer: 0,
+            expert: 0,
+            inter: 1,
+            hidden: 1,
+            group_size: GS as u32,
+            scale2: [1.0; 3],
+            input_scale: [Some(1.0); 3],
+        }
+        .to_bytes();
+        // Corrupt the magic.
+        bytes[0] ^= 0xFF;
+        assert!(ExpertRecordHeader::from_bytes(&bytes).is_none());
+        // Too-short buffer.
+        assert!(ExpertRecordHeader::from_bytes(&bytes[..10]).is_none());
+    }
+
+    #[test]
+    fn a3b_record_stride_is_4k_aligned_and_reasonable() {
+        // The full-model on-disk size should land near the recon's ~200 GB for
+        // 397B and a small multiple of payload for a3b. Here just sanity-check
+        // a3b: stride within one 4K block of the raw size.
+        let spec = ExpertRecordSpec::new(A3B_INTER, A3B_HIDDEN, GS, 256);
+        let layout = ExpertLayout::from_spec(40, 256, &spec, 4096);
+        assert!(layout.record_stride - spec.raw_bytes() < 4096);
+    }
+}

--- a/crates/spark-storage/src/expert.rs
+++ b/crates/spark-storage/src/expert.rs
@@ -221,7 +221,7 @@ impl ExpertRecordHeader {
     /// Serialize into the fixed 256-byte on-disk header block. Layout:
     ///   u32 magic, u32 version, u32 layer, u32 expert,
     ///   u32 inter, u32 hidden, u32 group_size, u32 input_scale_flags,
-    ///   f32 scale2[3], f32 input_scale[3] (0.0 where absent), zero pad to 256.
+    ///   `f32 scale2[3]`, `f32 input_scale[3]` (0.0 where absent), zero pad to 256.
     /// `input_scale_flags` bit `i` set => projection `i` has an activation scale.
     pub fn to_bytes(&self) -> [u8; Self::BYTES as usize] {
         let mut out = [0u8; Self::BYTES as usize];

--- a/crates/spark-storage/src/expert_arena.rs
+++ b/crates/spark-storage/src/expert_arena.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The UMA zero-copy expert arena — the one genuinely-new primitive of the
+// streaming-experts feature.
+//
+// A pinned LPDDR buffer (`cuMemAllocHost`) organized as a ring of `num_slabs`
+// slabs, each holding `slots_per_slab` fixed-stride expert records. On GB10 the
+// pinned allocation is GPU-addressable at the *same* virtual address (Gate
+// 0(b)), so a record read straight into a slot — by O_DIRECT NVMe today, by
+// one-sided RDMA_READ later — is immediately consumable by the fused MoE
+// kernels with no `cuMemcpyHtoD` bounce: the expert pointer table is simply
+// patched to point at the slot's device VA.
+//
+// This module owns the memory + geometry only. Who *fills* a slot (NVMe vs
+// RDMA) is an `ExpertTier` concern; the arena is registrable as an RDMA MR
+// (Stage 4) exactly because it is ordinary page-locked host memory.
+
+use anyhow::{Context, Result, bail};
+use std::ffi::c_void;
+
+use crate::cuda_min::PinnedBuffer;
+
+/// A ring of pinned per-layer slabs. Slot geometry is one expert record
+/// (`record_stride`, a 4 KiB multiple so O_DIRECT / RDMA landings are aligned).
+pub struct ExpertArena {
+    pinned: PinnedBuffer,
+    /// Device VA of the arena base. On GB10 this equals the host VA.
+    dev_base: u64,
+    num_slabs: u32,
+    slots_per_slab: u32,
+    record_stride: usize,
+}
+
+impl ExpertArena {
+    /// Allocate `num_slabs * slots_per_slab * record_stride` bytes of pinned
+    /// LPDDR and confirm the GB10 same-VA property (fail loudly otherwise — the
+    /// zero-copy patch would be silently wrong on a host without it).
+    pub fn new(num_slabs: u32, slots_per_slab: u32, record_stride: usize) -> Result<Self> {
+        if num_slabs == 0 || slots_per_slab == 0 || record_stride == 0 {
+            bail!("ExpertArena: zero geometry ({num_slabs},{slots_per_slab},{record_stride})");
+        }
+        if !record_stride.is_multiple_of(4096) {
+            bail!("ExpertArena: record_stride {record_stride} must be a 4 KiB multiple (O_DIRECT)");
+        }
+        let total = (num_slabs as usize)
+            .checked_mul(slots_per_slab as usize)
+            .and_then(|v| v.checked_mul(record_stride))
+            .context("ExpertArena: size overflow")?;
+        let pinned = PinnedBuffer::new(total)?;
+        let dev_base = pinned.device_ptr()?;
+        let host_base = pinned.ptr as u64;
+        if dev_base != host_base {
+            // Not fatal to correctness on a mapped device, but it means the
+            // ptr-table patch must use dev_base (not the host VA) and the
+            // zero-copy assumption behind our bandwidth model is weaker. On
+            // GB10 they are equal; assert so a non-UMA host is caught early.
+            bail!(
+                "ExpertArena: pinned host VA {host_base:#x} != device VA {dev_base:#x} \
+                 — host is not unified-addressing (UMA zero-copy unavailable)"
+            );
+        }
+        Ok(Self {
+            pinned,
+            dev_base,
+            num_slabs,
+            slots_per_slab,
+            record_stride,
+        })
+    }
+
+    pub fn num_slabs(&self) -> u32 {
+        self.num_slabs
+    }
+    pub fn slots_per_slab(&self) -> u32 {
+        self.slots_per_slab
+    }
+    pub fn record_stride(&self) -> usize {
+        self.record_stride
+    }
+
+    fn linear_slot(&self, slab: u32, slot: u32) -> Result<usize> {
+        if slab >= self.num_slabs || slot >= self.slots_per_slab {
+            bail!(
+                "ExpertArena: slot ({slab},{slot}) out of range ({},{})",
+                self.num_slabs,
+                self.slots_per_slab
+            );
+        }
+        Ok((slab as usize) * (self.slots_per_slab as usize) + (slot as usize))
+    }
+
+    /// Host pointer of a slot — the O_DIRECT / RDMA landing target.
+    pub fn slot_host_ptr(&self, slab: u32, slot: u32) -> Result<*mut u8> {
+        let i = self.linear_slot(slab, slot)?;
+        // SAFETY: i < num_slabs*slots_per_slab, so the offset is within the
+        // single pinned allocation.
+        Ok(unsafe { (self.pinned.ptr as *mut u8).add(i * self.record_stride) })
+    }
+
+    /// Device VA of a slot — what the expert pointer table is patched to.
+    pub fn slot_dev_va(&self, slab: u32, slot: u32) -> Result<u64> {
+        let i = self.linear_slot(slab, slot)?;
+        Ok(self.dev_base + (i as u64) * (self.record_stride as u64))
+    }
+
+    /// Raw pinned base as a `*mut c_void` (for future `ibv_reg_mr`).
+    pub fn base_ptr(&self) -> *mut c_void {
+        self.pinned.ptr
+    }
+    pub fn total_bytes(&self) -> usize {
+        self.pinned.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pure-geometry checks that don't need a GPU are impossible here (the ctor
+    // allocates pinned CUDA memory), so these are GPU-gated.
+    #[test]
+    #[ignore = "requires GPU"]
+    fn arena_slots_are_strided_and_same_va() {
+        let _ctx = crate::cuda_min::CudaCtx::new(0).unwrap();
+        let stride = 8192; // 2x4KiB
+        let arena = ExpertArena::new(2, 3, stride).unwrap();
+        assert_eq!(arena.total_bytes(), 2 * 3 * stride);
+        // Slot device VAs are contiguous and stride-spaced.
+        let a = arena.slot_dev_va(0, 0).unwrap();
+        let b = arena.slot_dev_va(0, 1).unwrap();
+        let c = arena.slot_dev_va(1, 0).unwrap();
+        assert_eq!(b - a, stride as u64);
+        assert_eq!(c - a, 3 * stride as u64);
+        // Same-VA property already asserted in the ctor; re-confirm host==dev.
+        assert_eq!(
+            arena.slot_host_ptr(1, 2).unwrap() as u64,
+            arena.slot_dev_va(1, 2).unwrap()
+        );
+        // Out-of-range is an error, not a panic.
+        assert!(arena.slot_dev_va(2, 0).is_err());
+    }
+}

--- a/crates/spark-storage/src/expert_pack.rs
+++ b/crates/spark-storage/src/expert_pack.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// On-disk expert-record (de)serialization + the directory manifest.
+//
+// Two layers:
+//   * Pure format functions (`pack_record` / `unpack_record`) that assemble and
+//     parse one fixed-stride record in memory. No I/O, no CUDA, no safetensors —
+//     unit-testable with synthetic bytes.
+//   * A `cfg(unix)` file writer/reader that lays those records into one file per
+//     MoE layer, plus an `ExpertIndex` manifest (JSON) describing the geometry
+//     so the streamer can reconstruct `ExpertRecordSpec` / `ExpertLayout` and
+//     open the files without re-deriving anything from the checkpoint.
+//
+// The offline builder (checkpoint -> resident records) is the sole writer; the
+// runtime streamer is a reader. This module is the contract between them.
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::expert::{ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordSpec, Proj};
+
+/// Borrowed packed+scale bytes for one projection, as they will sit on disk
+/// (prefill-resident / transposed layout).
+#[derive(Clone, Copy, Debug)]
+pub struct ProjData<'a> {
+    pub packed: &'a [u8],
+    pub scale: &'a [u8],
+}
+
+/// Borrowed view of one projection's sub-buffers inside a parsed record.
+#[derive(Clone, Copy, Debug)]
+pub struct ProjView<'a> {
+    pub packed: &'a [u8],
+    pub scale: &'a [u8],
+}
+
+/// Assemble one complete `stride`-byte record: header at offset 0, each
+/// projection's packed+scale bytes placed at the spec's sub-offsets, zero
+/// padding everywhere else. Returns exactly `stride` bytes.
+///
+/// Errors (never panics) if any projection's byte lengths disagree with the
+/// spec, or if the assembled payload would not fit in `stride` — those are
+/// builder bugs we want surfaced loudly, not silently truncated records.
+pub fn pack_record(
+    spec: &ExpertRecordSpec,
+    stride: u64,
+    header: &ExpertRecordHeader,
+    projs: &[ProjData; 3],
+) -> Result<Vec<u8>> {
+    let stride = stride as usize;
+    if (spec.raw_bytes() as usize) > stride {
+        bail!(
+            "record stride {} smaller than raw record bytes {}",
+            stride,
+            spec.raw_bytes()
+        );
+    }
+    let mut buf = vec![0u8; stride];
+    let hdr = header.to_bytes();
+    buf[..hdr.len()].copy_from_slice(&hdr);
+
+    for p in Proj::ALL {
+        let pb = spec.proj_bytes(p);
+        let d = &projs[p as usize];
+        if d.packed.len() as u64 != pb.packed_bytes {
+            bail!(
+                "{:?} packed len {} != expected {}",
+                p,
+                d.packed.len(),
+                pb.packed_bytes
+            );
+        }
+        if d.scale.len() as u64 != pb.scale_bytes {
+            bail!(
+                "{:?} scale len {} != expected {}",
+                p,
+                d.scale.len(),
+                pb.scale_bytes
+            );
+        }
+        let po = spec.packed_off(p) as usize;
+        let so = spec.scale_off(p) as usize;
+        buf[po..po + d.packed.len()].copy_from_slice(d.packed);
+        buf[so..so + d.scale.len()].copy_from_slice(d.scale);
+    }
+    Ok(buf)
+}
+
+/// Parse a record `buf` (>= `spec.raw_bytes()`), returning the header and
+/// borrowed views of each projection's sub-buffers. Validates the header magic
+/// and version; returns an error on any mismatch.
+pub fn unpack_record<'a>(
+    spec: &ExpertRecordSpec,
+    buf: &'a [u8],
+) -> Result<(ExpertRecordHeader, [ProjView<'a>; 3])> {
+    if (buf.len() as u64) < spec.raw_bytes() {
+        bail!(
+            "record buffer {} smaller than raw record bytes {}",
+            buf.len(),
+            spec.raw_bytes()
+        );
+    }
+    let header = ExpertRecordHeader::from_bytes(buf)
+        .context("record header magic/version mismatch (wrong file or format version?)")?;
+    let mut views = [ProjView {
+        packed: &[],
+        scale: &[],
+    }; 3];
+    for p in Proj::ALL {
+        let pb = spec.proj_bytes(p);
+        let po = spec.packed_off(p) as usize;
+        let so = spec.scale_off(p) as usize;
+        views[p as usize] = ProjView {
+            packed: &buf[po..po + pb.packed_bytes as usize],
+            scale: &buf[so..so + pb.scale_bytes as usize],
+        };
+    }
+    Ok((header, views))
+}
+
+/// Directory manifest describing a built expert store. Serialized as
+/// `manifest.json` next to the per-layer `.xpr` files. This is the streamer's
+/// entry point — everything it needs to reconstruct geometry and open files.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExpertIndex {
+    /// Format version; must equal [`ExpertRecordHeader::VERSION`].
+    pub version: u32,
+    pub num_moe_layers: u32,
+    pub num_experts: u32,
+    pub inter: u64,
+    pub hidden: u64,
+    pub group_size: u64,
+    pub sub_align: u64,
+    pub fs_block_size: u64,
+    pub record_stride: u64,
+    pub record_raw_bytes: u64,
+    /// `printf`-style template for per-layer file names, e.g. `experts_{:05}.xpr`.
+    pub file_template: String,
+    /// Dense MoE-layer index -> absolute model layer index. Lets the runtime map
+    /// a model layer back to its expert file (dense attention layers are absent).
+    pub moe_layer_to_model_layer: Vec<u32>,
+}
+
+impl ExpertIndex {
+    pub const FILE_TEMPLATE: &'static str = "experts_{:05}.xpr";
+    pub const MANIFEST_NAME: &'static str = "manifest.json";
+
+    pub fn new(
+        inter: u64,
+        hidden: u64,
+        group_size: u64,
+        sub_align: u64,
+        fs_block_size: u64,
+        moe_layer_to_model_layer: Vec<u32>,
+        num_experts: u32,
+    ) -> Self {
+        let spec = ExpertRecordSpec::new(inter, hidden, group_size, sub_align);
+        let layout = ExpertLayout::from_spec(
+            moe_layer_to_model_layer.len() as u32,
+            num_experts,
+            &spec,
+            fs_block_size,
+        );
+        Self {
+            version: ExpertRecordHeader::VERSION,
+            num_moe_layers: moe_layer_to_model_layer.len() as u32,
+            num_experts,
+            inter,
+            hidden,
+            group_size,
+            sub_align,
+            fs_block_size,
+            record_stride: layout.record_stride,
+            record_raw_bytes: spec.raw_bytes(),
+            file_template: Self::FILE_TEMPLATE.to_string(),
+            moe_layer_to_model_layer,
+        }
+    }
+
+    /// Load just the manifest (`manifest.json`) from a store dir — geometry
+    /// only, no file handles. Lets the streamer size its arena before opening a
+    /// tier. Validates the format version.
+    #[cfg(unix)]
+    pub fn load(dir: &std::path::Path) -> Result<Self> {
+        let p = dir.join(Self::MANIFEST_NAME);
+        let json = std::fs::read_to_string(&p).with_context(|| format!("read {}", p.display()))?;
+        let index: ExpertIndex =
+            serde_json::from_str(&json).with_context(|| format!("parse {}", p.display()))?;
+        if index.version != ExpertRecordHeader::VERSION {
+            bail!(
+                "manifest version {} != supported {}",
+                index.version,
+                ExpertRecordHeader::VERSION
+            );
+        }
+        Ok(index)
+    }
+
+    pub fn spec(&self) -> ExpertRecordSpec {
+        ExpertRecordSpec::new(self.inter, self.hidden, self.group_size, self.sub_align)
+    }
+
+    pub fn layout(&self) -> ExpertLayout {
+        ExpertLayout::from_spec(
+            self.num_moe_layers,
+            self.num_experts,
+            &self.spec(),
+            self.fs_block_size,
+        )
+    }
+
+    /// Per-layer file name for a dense MoE-layer index.
+    pub fn file_name(&self, moe_layer: u32) -> String {
+        // Only `{:05}` is supported; kept simple + explicit rather than a format
+        // mini-language. Bump this if `file_template` ever needs to vary.
+        format!("experts_{moe_layer:05}.xpr")
+    }
+
+    /// Total on-disk bytes across all layer files.
+    pub fn total_bytes(&self) -> u64 {
+        (self.num_moe_layers as u64) * self.layout().bytes_per_layer()
+    }
+}
+
+#[cfg(unix)]
+pub use fs_impl::{ExpertFileReader, ExpertFileWriter};
+
+#[cfg(unix)]
+#[path = "expert_pack_fs.rs"]
+mod fs_impl;
+
+#[cfg(test)]
+#[path = "expert_pack_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/expert_pack_fs.rs
+++ b/crates/spark-storage/src/expert_pack_fs.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Unix file reader/writer for expert packs — the `fs_impl` submodule of
+//! `expert_pack`, split out to keep the parent under the 500-LoC cap.
+
+use super::*;
+use std::fs::{File, OpenOptions};
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+
+/// Offline writer: creates the manifest + one file per MoE layer and places
+/// records at their strided offsets. Plain buffered writes (no O_DIRECT) —
+/// alignment only matters on the streamer's read path, and the record stride
+/// is already a 4 KiB multiple, so the files are O_DIRECT-readable.
+pub struct ExpertFileWriter {
+    dir: PathBuf,
+    index: ExpertIndex,
+    spec: ExpertRecordSpec,
+    layout: ExpertLayout,
+    files: Vec<File>,
+}
+
+impl ExpertFileWriter {
+    pub fn create(dir: &Path, index: ExpertIndex) -> Result<Self> {
+        std::fs::create_dir_all(dir).with_context(|| format!("mkdir {}", dir.display()))?;
+        let spec = index.spec();
+        let layout = index.layout();
+        let mut files = Vec::with_capacity(index.num_moe_layers as usize);
+        for l in 0..index.num_moe_layers {
+            let p = dir.join(index.file_name(l));
+            let f = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&p)
+                .with_context(|| format!("create {}", p.display()))?;
+            f.set_len(layout.bytes_per_layer())
+                .with_context(|| format!("set_len {}", p.display()))?;
+            files.push(f);
+        }
+        Ok(Self {
+            dir: dir.to_path_buf(),
+            index,
+            spec,
+            layout,
+            files,
+        })
+    }
+
+    pub fn spec(&self) -> &ExpertRecordSpec {
+        &self.spec
+    }
+
+    /// Assemble and write one expert record at its strided offset.
+    pub fn write_record(
+        &self,
+        key: ExpertKey,
+        header: &ExpertRecordHeader,
+        projs: &[ProjData; 3],
+    ) -> Result<()> {
+        if key.layer >= self.index.num_moe_layers {
+            bail!("layer {} out of range", key.layer);
+        }
+        if key.expert >= self.index.num_experts {
+            bail!("expert {} out of range", key.expert);
+        }
+        let rec = pack_record(&self.spec, self.layout.record_stride, header, projs)?;
+        let off = self.layout.file_offset(key);
+        self.files[key.layer as usize]
+            .write_all_at(&rec, off)
+            .with_context(|| format!("write record {:?} at {off}", key))?;
+        Ok(())
+    }
+
+    /// Flush the manifest to `manifest.json`. Call once, last.
+    pub fn finish(self) -> Result<()> {
+        for f in &self.files {
+            f.sync_all().context("fsync layer file")?;
+        }
+        let p = self.dir.join(ExpertIndex::MANIFEST_NAME);
+        let json = serde_json::to_string_pretty(&self.index)?;
+        std::fs::write(&p, json).with_context(|| format!("write {}", p.display()))?;
+        Ok(())
+    }
+}
+
+/// Reader used by tests / tooling to verify a built store without a GPU.
+/// The production streamer reads via the O_DIRECT `backend::*` engine; this
+/// is a plain-pread reference for the acceptance round-trip.
+pub struct ExpertFileReader {
+    index: ExpertIndex,
+    spec: ExpertRecordSpec,
+    layout: ExpertLayout,
+    files: Vec<File>,
+}
+
+impl ExpertFileReader {
+    pub fn open(dir: &Path) -> Result<Self> {
+        let mp = dir.join(ExpertIndex::MANIFEST_NAME);
+        let json =
+            std::fs::read_to_string(&mp).with_context(|| format!("read {}", mp.display()))?;
+        let index: ExpertIndex =
+            serde_json::from_str(&json).with_context(|| format!("parse {}", mp.display()))?;
+        if index.version != ExpertRecordHeader::VERSION {
+            bail!(
+                "manifest version {} != supported {}",
+                index.version,
+                ExpertRecordHeader::VERSION
+            );
+        }
+        let spec = index.spec();
+        let layout = index.layout();
+        let mut files = Vec::with_capacity(index.num_moe_layers as usize);
+        for l in 0..index.num_moe_layers {
+            let p = dir.join(index.file_name(l));
+            files.push(File::open(&p).with_context(|| format!("open {}", p.display()))?);
+        }
+        Ok(Self {
+            index,
+            spec,
+            layout,
+            files,
+        })
+    }
+
+    pub fn index(&self) -> &ExpertIndex {
+        &self.index
+    }
+    pub fn spec(&self) -> &ExpertRecordSpec {
+        &self.spec
+    }
+
+    /// Read one record's raw `record_stride` bytes into a fresh buffer.
+    pub fn read_record_raw(&self, key: ExpertKey) -> Result<Vec<u8>> {
+        // Graceful Err on a bad layer (a direct Vec index would panic —
+        // the sibling UmaArenaTier bounds-checks, so match it).
+        if key.layer as usize >= self.files.len() {
+            bail!(
+                "ExpertFileReader: layer {} out of range ({} layer files)",
+                key.layer,
+                self.files.len()
+            );
+        }
+        let mut buf = vec![0u8; self.layout.record_stride as usize];
+        let off = self.layout.file_offset(key);
+        self.files[key.layer as usize]
+            .read_exact_at(&mut buf, off)
+            .with_context(|| format!("read record {:?} at {off}", key))?;
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod fs_tests {
+    use super::*;
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "atlas-xpr-{}-{}-{}",
+            tag,
+            std::process::id(),
+            // cheap unique-ish suffix without pulling in rand here
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    // Tiny synthetic model: 2 MoE layers, 3 experts, small dims.
+    fn synth_index() -> ExpertIndex {
+        // inter/hidden multiples of 32 so packed/scale byte counts are exact.
+        ExpertIndex::new(64, 128, 16, 256, 4096, vec![0, 1], 3)
+    }
+
+    fn synth_projs(spec: &ExpertRecordSpec, seed: u8) -> [Vec<(Vec<u8>, Vec<u8>)>; 1] {
+        let mut out = Vec::new();
+        for p in Proj::ALL {
+            let pb = spec.proj_bytes(p);
+            let packed: Vec<u8> = (0..pb.packed_bytes)
+                .map(|i| (i as u8).wrapping_add(seed).wrapping_add(p as u8))
+                .collect();
+            let scale: Vec<u8> = (0..pb.scale_bytes)
+                .map(|i| (i as u8).wrapping_mul(3).wrapping_add(seed))
+                .collect();
+            out.push((packed, scale));
+        }
+        [out]
+    }
+
+    #[test]
+    fn write_then_read_round_trips_bit_identical() {
+        let dir = tmpdir("rt");
+        let index = synth_index();
+        let spec = index.spec();
+
+        // Build expected payloads per (layer, expert).
+        let mut expected = std::collections::HashMap::new();
+        {
+            let w = ExpertFileWriter::create(&dir, index.clone()).unwrap();
+            for layer in 0..index.num_moe_layers {
+                for expert in 0..index.num_experts {
+                    let seed = (layer as u8) << 4 | expert as u8;
+                    let raw = synth_projs(&spec, seed);
+                    let projs = [
+                        ProjData {
+                            packed: &raw[0][0].0,
+                            scale: &raw[0][0].1,
+                        },
+                        ProjData {
+                            packed: &raw[0][1].0,
+                            scale: &raw[0][1].1,
+                        },
+                        ProjData {
+                            packed: &raw[0][2].0,
+                            scale: &raw[0][2].1,
+                        },
+                    ];
+                    let header = ExpertRecordHeader {
+                        layer,
+                        expert,
+                        inter: index.inter as u32,
+                        hidden: index.hidden as u32,
+                        group_size: index.group_size as u32,
+                        scale2: [seed as f32, seed as f32 + 0.5, seed as f32 + 1.0],
+                        input_scale: [Some(1.0), None, Some(2.0)],
+                    };
+                    w.write_record(ExpertKey::new(layer, expert), &header, &projs)
+                        .unwrap();
+                    expected.insert((layer, expert), (raw, header));
+                }
+            }
+            w.finish().unwrap();
+        }
+
+        // Read back and compare bit-for-bit.
+        let r = ExpertFileReader::open(&dir).unwrap();
+        assert_eq!(r.index(), &index);
+        for layer in 0..index.num_moe_layers {
+            for expert in 0..index.num_experts {
+                let key = ExpertKey::new(layer, expert);
+                let buf = r.read_record_raw(key).unwrap();
+                let (hdr, views) = unpack_record(r.spec(), &buf).unwrap();
+                let (raw, exp_hdr) = &expected[&(layer, expert)];
+                assert_eq!(&hdr, exp_hdr, "header {:?}", key);
+                for p in Proj::ALL {
+                    assert_eq!(
+                        views[p as usize].packed,
+                        &raw[0][p as usize].0[..],
+                        "packed {:?} {:?}",
+                        key,
+                        p
+                    );
+                    assert_eq!(
+                        views[p as usize].scale,
+                        &raw[0][p as usize].1[..],
+                        "scale {:?} {:?}",
+                        key,
+                        p
+                    );
+                }
+            }
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn wrong_projection_length_errors() {
+        let index = synth_index();
+        let spec = index.spec();
+        let header = ExpertRecordHeader {
+            layer: 0,
+            expert: 0,
+            inter: index.inter as u32,
+            hidden: index.hidden as u32,
+            group_size: index.group_size as u32,
+            scale2: [1.0; 3],
+            input_scale: [Some(1.0); 3],
+        };
+        let bad = vec![0u8; 8]; // deliberately wrong length
+        let ok_scale = vec![0u8; spec.proj_bytes(Proj::Gate).scale_bytes as usize];
+        let projs = [
+            ProjData {
+                packed: &bad,
+                scale: &ok_scale,
+            },
+            ProjData {
+                packed: &bad,
+                scale: &ok_scale,
+            },
+            ProjData {
+                packed: &bad,
+                scale: &ok_scale,
+            },
+        ];
+        let err = pack_record(&spec, index.record_stride, &header, &projs);
+        assert!(err.is_err(), "short packed buffer must error");
+    }
+
+    #[test]
+    fn read_record_raw_rejects_out_of_range_layer() {
+        let dir = tmpdir("oob");
+        let index = synth_index(); // 2 MoE layers
+        ExpertFileWriter::create(&dir, index)
+            .unwrap()
+            .finish()
+            .unwrap();
+        let r = ExpertFileReader::open(&dir).unwrap();
+        // Valid layer is fine; an out-of-range layer is a graceful Err, not a panic.
+        assert!(r.read_record_raw(ExpertKey::new(0, 0)).is_ok());
+        assert!(r.read_record_raw(ExpertKey::new(99, 0)).is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn manifest_geometry_round_trips_through_json() {
+        let index = synth_index();
+        let json = serde_json::to_string(&index).unwrap();
+        let back: ExpertIndex = serde_json::from_str(&json).unwrap();
+        assert_eq!(index, back);
+        // Derived geometry is stable across the JSON hop.
+        assert_eq!(index.layout().record_stride, back.layout().record_stride);
+        assert_eq!(index.spec().raw_bytes(), back.spec().raw_bytes());
+    }
+}

--- a/crates/spark-storage/src/expert_pack_tests.rs
+++ b/crates/spark-storage/src/expert_pack_tests.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Unit tests for the `expert_pack` record codec + index (split from the
+//! parent module to keep it under the 500-LoC cap).
+
+use super::*;
+
+fn spec() -> ExpertRecordSpec {
+    ExpertRecordSpec::new(64, 128, 16, 256)
+}
+
+#[test]
+fn pack_unpack_round_trips_in_memory() {
+    let spec = spec();
+    let stride = ExpertLayout::from_spec(1, 1, &spec, 4096).record_stride;
+    let mk = |p: Proj, base: u8| {
+        let pb = spec.proj_bytes(p);
+        let packed: Vec<u8> = (0..pb.packed_bytes).map(|i| i as u8 ^ base).collect();
+        let scale: Vec<u8> = (0..pb.scale_bytes)
+            .map(|i| (i as u8).wrapping_add(base))
+            .collect();
+        (packed, scale)
+    };
+    let g = mk(Proj::Gate, 1);
+    let u = mk(Proj::Up, 2);
+    let d = mk(Proj::Down, 3);
+    let projs = [
+        ProjData {
+            packed: &g.0,
+            scale: &g.1,
+        },
+        ProjData {
+            packed: &u.0,
+            scale: &u.1,
+        },
+        ProjData {
+            packed: &d.0,
+            scale: &d.1,
+        },
+    ];
+    let header = ExpertRecordHeader {
+        layer: 2,
+        expert: 1,
+        inter: 64,
+        hidden: 128,
+        group_size: 16,
+        scale2: [0.1, 0.2, 0.3],
+        input_scale: [Some(1.0), Some(2.0), None],
+    };
+    let rec = pack_record(&spec, stride, &header, &projs).unwrap();
+    assert_eq!(rec.len() as u64, stride);
+    let (hdr, views) = unpack_record(&spec, &rec).unwrap();
+    assert_eq!(hdr.layer, 2);
+    assert_eq!(hdr.expert, 1);
+    assert_eq!(hdr.input_scale[2], None);
+    assert_eq!(views[Proj::Gate as usize].packed, &g.0[..]);
+    assert_eq!(views[Proj::Up as usize].scale, &u.1[..]);
+    assert_eq!(views[Proj::Down as usize].packed, &d.0[..]);
+}
+
+#[test]
+fn unpack_rejects_undersized_buffer() {
+    let spec = spec();
+    let tiny = vec![0u8; 8];
+    assert!(unpack_record(&spec, &tiny).is_err());
+}
+
+#[test]
+fn index_total_bytes_matches_layout() {
+    let index = ExpertIndex::new(512, 2048, 16, 256, 4096, vec![0, 1, 2], 256);
+    let per_layer = index.layout().bytes_per_layer();
+    assert_eq!(index.total_bytes(), 3 * per_layer);
+}

--- a/crates/spark-storage/src/expert_peer.rs
+++ b/crates/spark-storage/src/expert_peer.rs
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Expert weight-serving peer + wire protocol (Stage 4, Phase A: TCP).
+//
+// The RDMA weight-tier's first incarnation: a peer that holds the resident
+// expert store and serves records to a streaming client over a socket, into the
+// client's pinned arena. This proves the residency-tier abstraction (a peer as
+// a fetch tier, distinct from EP sharding) with zero verbs risk, over the RoCE
+// Ethernet netdev. Phase B swaps the transport for one-sided RDMA_READ into the
+// SAME arena (see RESEARCH-RDMA-TIER.md) — the protocol geometry is identical.
+//
+// Wire protocol (little-endian), connection-oriented:
+//   1. On accept the server sends the manifest: [u32 len][len bytes of JSON].
+//      The client parses it to size its arena (same ExpertIndex geometry).
+//   2. Request loop: client sends [u32 layer][u32 expert]; server replies
+//      [u8 status][record_stride bytes] (status 0 = OK, nonzero = error, no
+//      payload). A layer/expert of u32::MAX/u32::MAX is a graceful shutdown.
+//
+// The peer is pure I/O (no CUDA); the client half lives in the cuda-gated
+// `expert_tier_rdma` module because it lands bytes in the pinned arena.
+
+use anyhow::{Context, Result, bail};
+
+// The handshake wire codecs moved verbatim to the CUDA-free `atlas-rdma`
+// crate (extracted to atlas-rdma); re-exported here at their old paths so
+// the server below and every external user are zero-diff. The byte layouts
+// are golden-pinned in `tests/rdma_wire_golden.rs` and frozen vs the live
+// gx10 peer.
+pub use atlas_rdma::wire::{
+    MODE_TCP, MODE_VERBS, STATUS_ERR, STATUS_OK, VerbsClientParams, VerbsServerParams,
+    read_server_rails, write_server_rails,
+};
+
+/// Sentinel request that asks the server to close the connection.
+pub const SHUTDOWN_MARKER: u32 = u32::MAX;
+
+/// Serialize a request: `(layer, expert)`.
+pub fn encode_request(layer: u32, expert: u32) -> [u8; 8] {
+    let mut b = [0u8; 8];
+    b[0..4].copy_from_slice(&layer.to_le_bytes());
+    b[4..8].copy_from_slice(&expert.to_le_bytes());
+    b
+}
+
+/// Parse a request buffer.
+pub fn decode_request(b: &[u8; 8]) -> (u32, u32) {
+    let layer = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+    let expert = u32::from_le_bytes([b[4], b[5], b[6], b[7]]);
+    (layer, expert)
+}
+
+#[cfg(unix)]
+pub use server_impl::{RdmaConfig, serve};
+
+#[cfg(unix)]
+mod server_impl {
+    use super::*;
+    use crate::expert::ExpertKey;
+    use crate::expert_pack::ExpertFileReader;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    /// RDMA device selection for the verbs (`MODE_VERBS`) transport. Ignored for
+    /// TCP clients. One `(device, gid_idx)` per CX7 adapter: a dual-rail client
+    /// requests N rails and the peer registers each layer mmap on every rail so
+    /// the client can stripe expert fetches across both adapters. The default is
+    /// a SINGLE rail (`roceP2p1s0f1`, RoCEv2 GID index 3) — the pre-dual-rail
+    /// behavior, unchanged for `verify_verbs.sh`; add a second `--rail` to serve
+    /// dual-rail clients.
+    #[derive(Clone, Debug)]
+    pub struct RdmaConfig {
+        /// `(device, gid_idx)` per rail, in link order (rail 0 = the cabled link).
+        pub rails: Vec<(String, u32)>,
+        /// Ceiling on total registered store RAM across concurrent verbs
+        /// connections, in bytes. `0` = unlimited (the default). Each verbs
+        /// connection registers the whole store (`index.total_bytes()`) once (the
+        /// N per-rail MRs share the same mmap pages), so this bounds the number of
+        /// concurrent store registrations.
+        pub max_blade_bytes: u64,
+    }
+
+    impl Default for RdmaConfig {
+        fn default() -> Self {
+            Self {
+                rails: vec![("roceP2p1s0f1".into(), 3)],
+                max_blade_bytes: 0,
+            }
+        }
+    }
+
+    /// Serve records from `dir` on `addr` until interrupted. One thread per
+    /// connection. Blocking; intended to run as its own process (`atlas-expert-peer`).
+    pub fn serve<A: ToSocketAddrs>(dir: &Path, addr: A, rdma: RdmaConfig) -> Result<()> {
+        let reader = Arc::new(ExpertFileReader::open(dir)?);
+        let manifest = serde_json::to_vec(reader.index())?;
+        let dir: Arc<PathBuf> = Arc::new(dir.to_path_buf());
+        let rdma = Arc::new(rdma);
+        // One process-global ledger; each verbs connection reserves the store
+        // size before it mmaps/registers the layer files.
+        let ledger = Arc::new(crate::blade_cap::CommitLedger::new(rdma.max_blade_bytes));
+        let listener = TcpListener::bind(addr).context("bind expert-peer listener")?;
+        let local = listener.local_addr().ok();
+        tracing::info!(
+            "expert-peer serving {} ({} layers, {} experts, stride {}) on {:?} \
+             (verbs rails {:?}, cap {})",
+            dir.display(),
+            reader.index().num_moe_layers,
+            reader.index().num_experts,
+            reader.index().record_stride,
+            local,
+            rdma.rails,
+            if rdma.max_blade_bytes == 0 {
+                "unlimited".to_string()
+            } else {
+                format!(
+                    "{:.1} GiB",
+                    rdma.max_blade_bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+                )
+            },
+        );
+        for conn in listener.incoming() {
+            let stream = match conn {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("expert-peer accept error: {e}");
+                    continue;
+                }
+            };
+            let reader = reader.clone();
+            let manifest = manifest.clone();
+            let dir = dir.clone();
+            let rdma = rdma.clone();
+            let ledger = ledger.clone();
+            std::thread::spawn(move || {
+                if let Err(e) = handle_conn(stream, &reader, &manifest, &dir, &rdma, &ledger) {
+                    tracing::warn!("expert-peer connection ended: {e}");
+                }
+            });
+        }
+        Ok(())
+    }
+
+    fn handle_conn(
+        mut stream: TcpStream,
+        reader: &ExpertFileReader,
+        manifest: &[u8],
+        dir: &Path,
+        rdma: &RdmaConfig,
+        ledger: &Arc<crate::blade_cap::CommitLedger>,
+    ) -> Result<()> {
+        stream.set_nodelay(true).ok();
+        // 1. Send the manifest.
+        stream.write_all(&(manifest.len() as u32).to_le_bytes())?;
+        stream.write_all(manifest)?;
+
+        // 2. The client picks a transport. TCP `pread`s on demand and pins no
+        // RAM, so only the verbs path (which mmaps + registers the store) is
+        // charged against the ledger.
+        let mut mode = [0u8; 1];
+        stream
+            .read_exact(&mut mode)
+            .context("read transport mode")?;
+        match mode[0] {
+            MODE_TCP => serve_tcp(stream, reader),
+            MODE_VERBS => serve_verbs(stream, reader, dir, rdma, ledger),
+            other => bail!("client requested unknown transport mode {other}"),
+        }
+    }
+
+    /// Two-sided record streaming (Phase A). The request loop is unchanged.
+    fn serve_tcp(mut stream: TcpStream, reader: &ExpertFileReader) -> Result<()> {
+        let stride = reader.index().record_stride as usize;
+        let mut req = [0u8; 8];
+        loop {
+            if stream.read_exact(&mut req).is_err() {
+                break; // client hung up
+            }
+            let (layer, expert) = decode_request(&req);
+            if layer == SHUTDOWN_MARKER && expert == SHUTDOWN_MARKER {
+                break;
+            }
+            match reader.read_record_raw(ExpertKey::new(layer, expert)) {
+                Ok(rec) => {
+                    debug_assert_eq!(rec.len(), stride);
+                    stream.write_all(&[STATUS_OK])?;
+                    stream.write_all(&rec)?;
+                }
+                Err(e) => {
+                    tracing::warn!("expert-peer read {layer}/{expert}: {e}");
+                    stream.write_all(&[STATUS_ERR])?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(not(atlas_rdma_verbs))]
+    fn serve_verbs(
+        _stream: TcpStream,
+        _reader: &ExpertFileReader,
+        _dir: &Path,
+        _rdma: &RdmaConfig,
+        _ledger: &Arc<crate::blade_cap::CommitLedger>,
+    ) -> Result<()> {
+        bail!("client requested verbs transport but this peer was built without rdma-core");
+    }
+
+    /// One-sided RDMA READ (Phase B). The server `mmap`s + registers each layer
+    /// file with REMOTE_READ, publishes the MRs' `{base, rkey}` + its QP params,
+    /// connects to the client's QP, then goes idle: the client pulls records
+    /// directly out of these MRs. The server CPU never touches a record byte.
+    #[cfg(atlas_rdma_verbs)]
+    fn serve_verbs(
+        mut stream: TcpStream,
+        reader: &ExpertFileReader,
+        dir: &Path,
+        rdma: &RdmaConfig,
+        ledger: &Arc<crate::blade_cap::CommitLedger>,
+    ) -> Result<()> {
+        use atlas_rdma::verbs::Verbs;
+
+        let index = reader.index();
+        let num_layers = index.num_moe_layers;
+
+        // The client requests how many rails it wants to stripe across (default
+        // 1). Validate against what this peer is configured to serve.
+        let mut b1 = [0u8; 1];
+        stream.read_exact(&mut b1).context("read n_rails")?;
+        let n_rails = b1[0] as usize;
+        if n_rails == 0 || n_rails > rdma.rails.len() {
+            bail!(
+                "client asked for {n_rails} rails; peer has {}",
+                rdma.rails.len()
+            );
+        }
+
+        // Admission gate: charge the deterministic store size (identical for
+        // every client) ONCE — the N per-rail MRs pin the SAME refcounted mmap
+        // pages, so the committed footprint is `total_bytes`, not total*n_rails.
+        // Reserve BEFORE any mmap/reg_mr; the RAII guard releases on every exit
+        // below (early bail, reg_mr error, hangup).
+        let _reservation = ledger
+            .try_reserve(index.total_bytes())
+            .context("expert blade cap")?;
+
+        // One QP per rail (distinct per-rail PSN so successive clients/rails
+        // don't collide).
+        let pid = std::process::id();
+        let mut rails: Vec<Verbs> = Vec::with_capacity(n_rails);
+        for (i, (dev, gid)) in rdma.rails.iter().take(n_rails).enumerate() {
+            let psn = (0x424242 ^ pid ^ ((i as u32) << 20)) & 0xff_ffff;
+            rails.push(Verbs::create(dev, *gid, psn)?);
+        }
+
+        // mmap each layer file ONCE (REMOTE_READ) and register that SAME virtual
+        // range on EVERY rail's PD — one rkey per (rail, layer), identical base
+        // VA, shared physical pages (not N× RAM). Keep the mappings alive for the
+        // whole connection — the NIC DMAs out of them.
+        let mut mmaps: Vec<Mmap> = Vec::with_capacity(num_layers as usize);
+        let mut per_rail_layers: Vec<Vec<(u64, u32)>> = (0..n_rails)
+            .map(|_| Vec::with_capacity(num_layers as usize))
+            .collect();
+        for l in 0..num_layers {
+            let path = dir.join(index.file_name(l));
+            let m = Mmap::open_ro(&path).with_context(|| format!("mmap {}", path.display()))?;
+            for (ri, v) in rails.iter_mut().enumerate() {
+                // SAFETY: the mapping covers `m.len` bytes at `m.addr` and
+                // outlives every rail's Verbs (mmaps dropped after rails below).
+                let keys = unsafe { v.reg_mr(m.addr as *mut _, m.len, true)? };
+                per_rail_layers[ri].push((m.addr as u64, keys.rkey));
+            }
+            mmaps.push(m);
+        }
+
+        // Publish one VerbsServerParams per rail (shared base, per-rail rkey).
+        let sp: Vec<VerbsServerParams> = rails
+            .iter()
+            .enumerate()
+            .map(|(ri, v)| VerbsServerParams {
+                qpn: v.qpn(),
+                psn: v.psn(),
+                gid: v.gid(),
+                layers: std::mem::take(&mut per_rail_layers[ri]),
+            })
+            .collect();
+        write_server_rails(&mut stream, &sp).context("send verbs server params")?;
+
+        // Learn each client rail's QP, connect, ack.
+        stream.read_exact(&mut b1).context("read client n_rails")?;
+        if b1[0] as usize != n_rails {
+            bail!("client rail count mismatch");
+        }
+        for v in rails.iter_mut() {
+            let cp =
+                VerbsClientParams::read_from(&mut stream).context("read verbs client params")?;
+            v.connect(cp.qpn, cp.psn, &cp.gid)?;
+        }
+        stream
+            .write_all(&[STATUS_OK])
+            .context("send verbs ready ack")?;
+        tracing::info!(
+            "expert-peer verbs client connected ({n_rails} rail(s), {} layer MRs/rail)",
+            num_layers,
+        );
+
+        // Idle until the client hangs up. All record movement is one-sided RDMA
+        // READ initiated by the client; the server just holds the MRs open.
+        let mut sink = [0u8; 8];
+        loop {
+            match stream.read(&mut sink) {
+                Ok(0) => break, // client closed
+                Ok(_) => {}     // ignore (shutdown marker or stray bytes)
+                Err(_) => break,
+            }
+        }
+        // Drop order: `rails` (which dereg's every MR) must fall before `mmaps`
+        // are unmapped, so dereg happens over live mappings. Drop rails first.
+        drop(rails);
+        drop(mmaps);
+        Ok(())
+    }
+
+    /// A read-only `mmap` of a whole file, unmapped on drop.
+    #[cfg(atlas_rdma_verbs)]
+    struct Mmap {
+        addr: *mut libc::c_void,
+        len: usize,
+    }
+
+    #[cfg(atlas_rdma_verbs)]
+    impl Mmap {
+        fn open_ro(path: &Path) -> Result<Self> {
+            use std::os::fd::AsRawFd;
+            let f = std::fs::File::open(path)?;
+            let len = f.metadata()?.len() as usize;
+            if len == 0 {
+                bail!("empty layer file {}", path.display());
+            }
+            // SAFETY: fd is a valid open RO file; MAP_SHARED read mapping of `len`
+            // bytes. The kernel keeps the mapping valid after the fd closes.
+            let addr = unsafe {
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    len,
+                    libc::PROT_READ,
+                    libc::MAP_SHARED,
+                    f.as_raw_fd(),
+                    0,
+                )
+            };
+            if addr == libc::MAP_FAILED {
+                bail!(
+                    "mmap {} failed: {}",
+                    path.display(),
+                    std::io::Error::last_os_error()
+                );
+            }
+            Ok(Self { addr, len })
+        }
+    }
+
+    #[cfg(atlas_rdma_verbs)]
+    impl Drop for Mmap {
+        fn drop(&mut self) {
+            // SAFETY: addr/len came from a successful mmap and are unmapped once.
+            unsafe { libc::munmap(self.addr, self.len) };
+        }
+    }
+}
+
+/// Read the length-prefixed manifest from a freshly-connected stream and parse
+/// it. Shared by the client (`expert_tier_rdma`).
+#[cfg(unix)]
+pub fn read_manifest<R: std::io::Read>(stream: &mut R) -> Result<crate::expert_pack::ExpertIndex> {
+    let mut lenb = [0u8; 4];
+    stream
+        .read_exact(&mut lenb)
+        .context("read manifest length")?;
+    let len = u32::from_le_bytes(lenb) as usize;
+    if len == 0 || len > 16 * 1024 * 1024 {
+        bail!("implausible peer manifest length: {len}");
+    }
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf).context("read manifest json")?;
+    let index: crate::expert_pack::ExpertIndex =
+        serde_json::from_slice(&buf).context("parse peer manifest")?;
+    Ok(index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trips() {
+        let b = encode_request(7, 42);
+        assert_eq!(decode_request(&b), (7, 42));
+        let s = encode_request(SHUTDOWN_MARKER, SHUTDOWN_MARKER);
+        assert_eq!(decode_request(&s), (SHUTDOWN_MARKER, SHUTDOWN_MARKER));
+    }
+
+    // The codec round-trip / validation tests moved WITH the codecs to
+    // `crates/atlas-rdma/tests/wire_roundtrip.rs` (extracted to atlas-rdma);
+    // the exact byte layouts stay pinned by `tests/rdma_wire_golden.rs` here.
+}

--- a/crates/spark-storage/src/expert_tier.rs
+++ b/crates/spark-storage/src/expert_tier.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// ExpertTier — the residency abstraction the expert streamer fetches through.
+//
+// Sits ABOVE the record layer (`ExpertFileReader` / `ExpertIndex`), not as a
+// `StorageBackend` impl: that trait is GroupKey/KV-tile shaped and synchronizes
+// the stream on return, the wrong shape for pull-on-demand MoE experts. A tier
+// lands one expert record into a slot and returns the six device addresses the
+// fused kernels read (already resident / prefill-transposed layout — nothing is
+// transformed at fetch time, invariant D).
+//
+// Three tiers, one interface (residency order device < UMA-over-NVMe < RDMA):
+//   * `PosixTier`    — deterministic bounce oracle (pread -> copy_h2d into a
+//                      device buffer). The bit-identical acceptance reference.
+//   * `UmaArenaTier` — the zero-copy path: O_DIRECT NVMe fill straight into the
+//                      pinned arena; the ptr table points at the pinned VA, no
+//                      HtoD copy.
+//   * RdmaTier       — Stage 4: one-sided RDMA_READ into the SAME pinned arena.
+//
+// All three feed the identical ptr-table patch, so swapping tiers cannot change
+// a single byte the GEMM reads — which the Tier-1 parity test proves.
+
+use anyhow::{Context, Result, bail};
+use std::fs::OpenOptions;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use crate::cuda_min::{DeviceBuffer, copy_h_to_d_async, stream_sync};
+use crate::expert::{ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordSpec, Proj};
+use crate::expert_arena::ExpertArena;
+use crate::expert_pack::{ExpertFileReader, ExpertIndex};
+
+/// The six sub-buffer device addresses (+ scalars) of one resident expert —
+/// exactly what the ptr-table patcher writes into the shadow tables.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExpertResidency {
+    /// gate/up/down B_packed device VA.
+    pub packed_addr: [u64; 3],
+    /// gate/up/down B_scale device VA.
+    pub scale_addr: [u64; 3],
+    /// gate/up/down per-tensor weight_scale_2.
+    pub scale2: [f32; 3],
+    /// gate/up/down input_scale (None = weight-only W4A16).
+    pub input_scale: [Option<f32>; 3],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TierKind {
+    Posix,
+    Uma,
+    Rdma,
+}
+
+/// A destination slot in the residency ring: which slab, which slot within it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ArenaSlot {
+    pub slab: u32,
+    pub slot: u32,
+}
+
+impl ArenaSlot {
+    pub fn new(slab: u32, slot: u32) -> Self {
+        Self { slab, slot }
+    }
+}
+
+/// Fetch an expert record into a slot; return the addresses to patch.
+pub trait ExpertTier: Send {
+    fn fetch(&mut self, key: ExpertKey, slot: ArenaSlot, stream: u64) -> Result<ExpertResidency>;
+    fn kind(&self) -> TierKind;
+    /// Graceful-degradation probe (RDMA link health at Stage 4). Default: up.
+    fn healthy(&self) -> bool {
+        true
+    }
+}
+
+/// Turn a record buffer's header + a base device VA into an `ExpertResidency`
+/// using the record spec's sub-offsets. Shared by every tier so they cannot
+/// disagree on layout.
+pub(crate) fn residency_from(
+    spec: &ExpertRecordSpec,
+    record: &[u8],
+    base_dev_va: u64,
+    key: ExpertKey,
+) -> Result<ExpertResidency> {
+    let hdr = ExpertRecordHeader::from_bytes(record)
+        .context("expert record header magic/version mismatch")?;
+    // Invariant D at fetch time: the header carries identity precisely so a
+    // misplaced/corrupt record is caught here, not served silently.
+    if hdr.layer != key.layer || hdr.expert != key.expert {
+        bail!(
+            "expert record identity mismatch: header ({},{}) != requested {:?}",
+            hdr.layer,
+            hdr.expert,
+            key
+        );
+    }
+    let mut packed_addr = [0u64; 3];
+    let mut scale_addr = [0u64; 3];
+    for p in Proj::ALL {
+        packed_addr[p as usize] = base_dev_va + spec.packed_off(p);
+        scale_addr[p as usize] = base_dev_va + spec.scale_off(p);
+    }
+    Ok(ExpertResidency {
+        packed_addr,
+        scale_addr,
+        scale2: hdr.scale2,
+        input_scale: hdr.input_scale,
+    })
+}
+
+/// Deterministic bounce oracle: pread the record (no O_DIRECT) into a host
+/// buffer, `copy_h2d` into a per-slot device buffer, stream-synced. This is the
+/// reference every other tier must match byte-for-byte.
+pub struct PosixTier {
+    reader: ExpertFileReader,
+    spec: ExpertRecordSpec,
+    layout: ExpertLayout,
+    /// One contiguous device buffer holding num_slabs*slots_per_slab records.
+    dev: DeviceBuffer,
+    slots_per_slab: u32,
+    num_slabs: u32,
+}
+
+impl PosixTier {
+    pub fn open(dir: &Path, num_slabs: u32, slots_per_slab: u32) -> Result<Self> {
+        let reader = ExpertFileReader::open(dir)?;
+        let index: &ExpertIndex = reader.index();
+        let spec = index.spec();
+        let layout = index.layout();
+        if num_slabs == 0 || slots_per_slab == 0 {
+            bail!("PosixTier: zero geometry ({num_slabs},{slots_per_slab})");
+        }
+        let stride = layout.record_stride as usize;
+        // Checked like the sibling ExpertArena ctor — a wrapped product must
+        // never yield a small alloc that slot_dev_va then addresses past.
+        let total = (num_slabs as usize)
+            .checked_mul(slots_per_slab as usize)
+            .and_then(|v| v.checked_mul(stride))
+            .context("PosixTier: arena size overflow")?;
+        let dev = DeviceBuffer::new(total)?;
+        Ok(Self {
+            reader,
+            spec,
+            layout,
+            dev,
+            slots_per_slab,
+            num_slabs,
+        })
+    }
+
+    fn slot_dev_va(&self, slot: ArenaSlot) -> Result<u64> {
+        if slot.slab >= self.num_slabs || slot.slot >= self.slots_per_slab {
+            bail!("PosixTier: slot {:?} out of range", slot);
+        }
+        let i = (slot.slab as u64) * (self.slots_per_slab as u64) + (slot.slot as u64);
+        Ok(self.dev.ptr + i * self.layout.record_stride)
+    }
+}
+
+impl ExpertTier for PosixTier {
+    fn fetch(&mut self, key: ExpertKey, slot: ArenaSlot, stream: u64) -> Result<ExpertResidency> {
+        let record = self.reader.read_record_raw(key)?; // host bytes
+        let dev_va = self.slot_dev_va(slot)?;
+        copy_h_to_d_async(dev_va, record.as_ptr() as *const _, record.len(), stream)?;
+        stream_sync(stream)?; // single bounce would be overwritten otherwise
+        residency_from(&self.spec, &record, dev_va, key)
+    }
+    fn kind(&self) -> TierKind {
+        TierKind::Posix
+    }
+}
+
+/// The zero-copy path: O_DIRECT the record straight into the pinned arena slot;
+/// the returned addresses point INTO the arena (GPU-addressable at the same
+/// VA), no `copy_h2d`.
+pub struct UmaArenaTier {
+    files: Vec<OwnedFd>, // one O_DIRECT fd per MoE layer
+    spec: ExpertRecordSpec,
+    layout: ExpertLayout,
+    arena: ExpertArena,
+}
+
+impl UmaArenaTier {
+    pub fn open(dir: &Path, num_slabs: u32, slots_per_slab: u32) -> Result<Self> {
+        let reader = ExpertFileReader::open(dir)?;
+        let index: &ExpertIndex = reader.index();
+        let spec = index.spec();
+        let layout = index.layout();
+        // Re-open each layer file with O_DIRECT for aligned zero-copy reads.
+        let mut files = Vec::with_capacity(index.num_moe_layers as usize);
+        for l in 0..index.num_moe_layers {
+            let p = dir.join(index.file_name(l));
+            let f = OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_DIRECT)
+                .open(&p)
+                .with_context(|| format!("open O_DIRECT {}", p.display()))?;
+            files.push(f.into());
+        }
+        let arena = ExpertArena::new(num_slabs, slots_per_slab, layout.record_stride as usize)?;
+        Ok(Self {
+            files,
+            spec,
+            layout,
+            arena,
+        })
+    }
+
+    pub fn arena(&self) -> &ExpertArena {
+        &self.arena
+    }
+}
+
+impl ExpertTier for UmaArenaTier {
+    fn fetch(&mut self, key: ExpertKey, slot: ArenaSlot, _stream: u64) -> Result<ExpertResidency> {
+        let stride = self.layout.record_stride as usize;
+        let host = self.arena.slot_host_ptr(slot.slab, slot.slot)?;
+        let fd = self
+            .files
+            .get(key.layer as usize)
+            .with_context(|| format!("UmaArenaTier: no file for layer {}", key.layer))?
+            .as_raw_fd();
+        let off = self.layout.file_offset(key);
+        // O_DIRECT pread of the whole (4 KiB-aligned) record into the pinned,
+        // GPU-addressable slot — this is the "delete the bounce copy" step.
+        let mut done = 0usize;
+        while done < stride {
+            // SAFETY: `host` points at a slot of `stride` bytes inside the pinned
+            // arena; offset/len stay within it. fd is a valid O_DIRECT handle.
+            let n = unsafe {
+                libc::pread(
+                    fd,
+                    host.add(done) as *mut libc::c_void,
+                    stride - done,
+                    (off + done as u64) as libc::off_t,
+                )
+            };
+            if n < 0 {
+                bail!(
+                    "UmaArenaTier pread {:?} at {off}: {}",
+                    key,
+                    std::io::Error::last_os_error()
+                );
+            }
+            if n == 0 {
+                bail!("UmaArenaTier: short read for {:?} ({done}/{stride})", key);
+            }
+            done += n as usize;
+        }
+        // SAFETY: the slot holds `stride` valid bytes just read from disk.
+        let record = unsafe { std::slice::from_raw_parts(host, stride) };
+        let dev_va = self.arena.slot_dev_va(slot.slab, slot.slot)?;
+        residency_from(&self.spec, record, dev_va, key)
+    }
+    fn kind(&self) -> TierKind {
+        TierKind::Uma
+    }
+}
+
+/// Open the tier named by `backend` over a built store:
+///   * `posix` / `uma` — read `dir` locally (bounce oracle / zero-copy).
+///   * `rdma`          — connect to `$ATLAS_EXPERT_PEER` over TWO-SIDED TCP.
+///   * `rdma-verbs`    — connect to `$ATLAS_EXPERT_PEER` over ONE-SIDED RDMA READ
+///     (verbs); device/GID from `$ATLAS_EXPERT_RDMA_DEV`/`$ATLAS_EXPERT_RDMA_GID`.
+///
+/// Both peer backends serve the store's records over the RoCE fabric.
+pub fn open_tier(
+    backend: &str,
+    dir: &Path,
+    num_slabs: u32,
+    slots_per_slab: u32,
+) -> Result<Box<dyn ExpertTier>> {
+    let rdma = |use_verbs: bool| -> Result<Box<dyn ExpertTier>> {
+        let flag = if use_verbs { "rdma-verbs" } else { "rdma" };
+        let addr = std::env::var("ATLAS_EXPERT_PEER").map_err(|_| {
+            anyhow::anyhow!("--expert-backend {flag} needs $ATLAS_EXPERT_PEER=host:port")
+        })?;
+        Ok(Box::new(crate::expert_tier_rdma::RdmaTier::connect(
+            &addr,
+            num_slabs,
+            slots_per_slab,
+            use_verbs,
+        )?))
+    };
+    match backend {
+        "posix" => Ok(Box::new(PosixTier::open(dir, num_slabs, slots_per_slab)?)),
+        "uma" => Ok(Box::new(UmaArenaTier::open(
+            dir,
+            num_slabs,
+            slots_per_slab,
+        )?)),
+        "rdma" => rdma(false),
+        "rdma-verbs" => rdma(true),
+        other => bail!("unknown expert backend '{other}' (want posix|uma|rdma|rdma-verbs)"),
+    }
+}
+
+/// Copy `len` bytes from a device VA to a fresh host `Vec` (test/verify helper).
+pub fn read_device(dev_va: u64, len: usize, stream: u64) -> Result<Vec<u8>> {
+    use crate::cuda_min::copy_d_to_h_async;
+    let mut out = vec![0u8; len];
+    copy_d_to_h_async(out.as_mut_ptr() as *mut _, dev_va, len, stream)?;
+    stream_sync(stream)?;
+    Ok(out)
+}

--- a/crates/spark-storage/src/expert_tier_rdma.rs
+++ b/crates/spark-storage/src/expert_tier_rdma.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RdmaTier — the peer weight-fetch tier (Stage 4).
+//
+// Fetches expert records from an `atlas-expert-peer` straight into the pinned
+// arena, then returns residency addresses pointing INTO that arena — exactly
+// like `UmaArenaTier`, only the source is a peer instead of local NVMe. Two
+// transports share the tier and the arena machinery:
+//
+//   * `Transport::Tcp`   — Phase A: two-sided record streaming. The peer `pread`s
+//     each record and writes it back over the socket; simple, bit-identical, but
+//     the peer CPU is busy and single-stream bandwidth is ~5 GB/s.
+//   * `Transport::Verbs` — Phase B: one-sided `IBV_WR_RDMA_READ`. The client
+//     pulls each record directly out of the peer's registered store MR into the
+//     arena slot with zero peer-CPU involvement (~14 GB/s, measured). This is a
+//     pure transport swap — the bytes still land in the same pinned LPDDR that
+//     the GPU reads at the same VA, and `residency_from` + the record header's
+//     identity check catch any misplacement, so it cannot change a GEMM byte.
+//
+// The transport is chosen by the `--expert-backend` value: `rdma` = TCP,
+// `rdma-verbs` = one-sided verbs. Device/GID for verbs come from
+// `$ATLAS_EXPERT_RDMA_DEV` (default `roceP2p1s0f1`) / `$ATLAS_EXPERT_RDMA_GID`
+// (default 3, the RoCEv2 IPv4 GID on GB10/CX7).
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use anyhow::{Context, Result, bail};
+
+use crate::expert::{ExpertKey, ExpertLayout, ExpertRecordSpec};
+use crate::expert_arena::ExpertArena;
+use crate::expert_peer::{MODE_TCP, STATUS_OK, encode_request, read_manifest};
+use crate::expert_tier::{ArenaSlot, ExpertResidency, ExpertTier, TierKind, residency_from};
+
+/// The active peer transport. `Verbs` only exists where the shim is compiled.
+/// The verbs transport is N-rail: one `Rail` per CX7 adapter, and a fetch is
+/// striped to `rail = expert % n_rails` (single-rail = the unchanged path).
+enum Transport {
+    Tcp,
+    #[cfg(atlas_rdma_verbs)]
+    Verbs(Vec<Rail>),
+}
+
+/// One-sided verbs state for a single rail: the QP, this rail's arena MR lkey,
+/// and the per-layer remote MR `{base, rkey}` table the peer published for it.
+/// The base VA is shared across rails (the peer mmaps each layer once); only the
+/// rkey (and QP/NIC) differ per rail.
+#[cfg(atlas_rdma_verbs)]
+struct Rail {
+    verbs: atlas_rdma::verbs::Verbs,
+    arena_lkey: u32,
+    /// `(remote_base_addr, rkey)` per MoE layer, layer-indexed.
+    layers: Vec<(u64, u32)>,
+}
+
+pub struct RdmaTier {
+    stream: TcpStream,
+    // `transport` is declared BEFORE `arena` so it drops first: the verbs rails
+    // hold MRs registered over the arena's pinned pages, so their `ibv_dereg_mr`
+    // must run before the arena frees those pages. (Struct fields drop in
+    // declaration order.) With N rails this is load-bearing — reverting the order
+    // would dereg N MRs over freed memory.
+    transport: Transport,
+    arena: ExpertArena,
+    spec: ExpertRecordSpec,
+    layout: ExpertLayout,
+    healthy: bool,
+}
+
+impl RdmaTier {
+    /// Connect to a peer at `addr`, receive its manifest, allocate the arena, and
+    /// bring up the chosen transport. The peer's `ExpertIndex` geometry defines
+    /// the record stride, so the arena matches the remote store exactly.
+    pub fn connect(
+        addr: &str,
+        num_slabs: u32,
+        slots_per_slab: u32,
+        use_verbs: bool,
+    ) -> Result<Self> {
+        let mut stream =
+            TcpStream::connect(addr).with_context(|| format!("connect expert peer {addr}"))?;
+        stream.set_nodelay(true).ok();
+        let index = read_manifest(&mut stream)?;
+        let spec = index.spec();
+        let layout = index.layout();
+        let arena = ExpertArena::new(num_slabs, slots_per_slab, layout.record_stride as usize)?;
+
+        let transport = if use_verbs {
+            #[cfg(atlas_rdma_verbs)]
+            {
+                connect_verbs(&mut stream, &arena, index.num_moe_layers)?
+            }
+            // Built without rdma-core (no C shim) — verbs is unavailable; the
+            // TCP `rdma` backend still works. Keeps the crate compiling under
+            // ATLAS_SKIP_BUILD / hosts without libibverbs.
+            #[cfg(not(atlas_rdma_verbs))]
+            {
+                let _ = &arena;
+                bail!(
+                    "--expert-backend rdma-verbs needs a build with rdma-core \
+                     (atlas_rdma_verbs cfg); use --expert-backend rdma (TCP) instead"
+                );
+            }
+        } else {
+            stream
+                .write_all(&[MODE_TCP])
+                .context("send TCP transport mode")?;
+            Transport::Tcp
+        };
+
+        let label = match &transport {
+            Transport::Tcp => "TCP".to_string(),
+            #[cfg(atlas_rdma_verbs)]
+            Transport::Verbs(rails) => {
+                format!("verbs (one-sided RDMA READ, {} rail(s))", rails.len())
+            }
+        };
+        tracing::info!(
+            "RdmaTier[{label}] connected to {addr}: {} layers, {} experts, stride {}",
+            index.num_moe_layers,
+            index.num_experts,
+            layout.record_stride
+        );
+        Ok(Self {
+            stream,
+            arena,
+            spec,
+            layout,
+            transport,
+            healthy: true,
+        })
+    }
+
+    pub fn arena(&self) -> &ExpertArena {
+        &self.arena
+    }
+
+    /// Two-sided TCP fetch: request the record, read `[status][stride bytes]`
+    /// straight into the pinned slot.
+    fn fetch_tcp(&mut self, key: ExpertKey, host: *mut u8, stride: usize) -> Result<()> {
+        if let Err(e) = self
+            .stream
+            .write_all(&encode_request(key.layer, key.expert))
+        {
+            self.healthy = false;
+            return Err(e).with_context(|| format!("peer request {:?}", key));
+        }
+        let mut status = [0u8; 1];
+        if let Err(e) = self.stream.read_exact(&mut status) {
+            self.healthy = false;
+            return Err(e).with_context(|| format!("peer status {:?}", key));
+        }
+        if status[0] != STATUS_OK {
+            bail!("peer returned error status {} for {:?}", status[0], key);
+        }
+        // Land the record bytes DIRECTLY into the pinned, GPU-addressable slot.
+        // SAFETY: `host` points at a `stride`-byte slot inside the pinned arena.
+        let dst = unsafe { std::slice::from_raw_parts_mut(host, stride) };
+        if let Err(e) = self.stream.read_exact(dst) {
+            self.healthy = false;
+            return Err(e).with_context(|| format!("peer payload {:?}", key));
+        }
+        Ok(())
+    }
+}
+
+/// Bring up the one-sided verbs transport via [`atlas_rdma::railset::RailSet`]:
+/// create N rails, register the arena on each, exchange per-rail QP params over
+/// the TCP control channel, connect INIT->RTR->RTS, await the ack. Dual-rail is
+/// env-driven (ATLAS_EXPERT_DUAL_RAIL=1): rail 0 = ATLAS_EXPERT_RDMA_DEV/GID
+/// (the existing single-rail defaults), rail 1 = ATLAS_EXPERT_RAIL2_DEV/GID
+/// (default rocep1s0f1 / 3). Single-rail is the default and is byte-for-byte
+/// the previous path.
+#[cfg(atlas_rdma_verbs)]
+fn connect_verbs(
+    stream: &mut TcpStream,
+    arena: &ExpertArena,
+    num_layers: u32,
+) -> Result<Transport> {
+    use crate::expert_peer::MODE_VERBS;
+    use atlas_rdma::env::{first_set, first_set_u32};
+    use atlas_rdma::railset::{RailSet, RailSpec};
+
+    stream
+        .write_all(&[MODE_VERBS])
+        .context("send verbs transport mode")?;
+
+    // Rail 0 from the expert env (the cabled CX7 link); rail 1 from the expert
+    // rail-2 env. Dual-rail only when ATLAS_EXPERT_DUAL_RAIL=1. PSN = fresh
+    // random 24-bit per rail (caller-supplied by RailSet design).
+    let spec = |dev: String, gid: u32| RailSpec::new(dev, gid, rand::random::<u32>() & 0xff_ffff);
+    let rail0 = spec(
+        first_set(&["ATLAS_EXPERT_RDMA_DEV"], "roceP2p1s0f1"),
+        first_set_u32(&["ATLAS_EXPERT_RDMA_GID"], 3),
+    );
+    let dual = std::env::var("ATLAS_EXPERT_DUAL_RAIL").ok().as_deref() == Some("1");
+    let specs: Vec<RailSpec> = if dual {
+        let rail1 = spec(
+            first_set(&["ATLAS_EXPERT_RAIL2_DEV"], "rocep1s0f1"),
+            first_set_u32(&["ATLAS_EXPERT_RAIL2_GID"], 3),
+        );
+        vec![rail0, rail1]
+    } else {
+        vec![rail0]
+    };
+
+    // [u8 n_rails] + one QP per rail, then register the WHOLE arena as each
+    // rail's READ landing MR (LOCAL_WRITE only — `remote_read == false` is the
+    // access-flag invariant for every client landing buffer). The N MRs pin the
+    // SAME arena pages (one lkey per rail).
+    let mut rs = RailSet::begin(stream, &specs)?;
+    let mut arena_lkeys: Vec<u32> = Vec::with_capacity(rs.n_rails());
+    for rail in &mut rs.rails {
+        // SAFETY: the arena's pinned buffer lives as long as the tier (and thus
+        // every MR); base_ptr()/total_bytes() describe exactly that allocation.
+        let keys = unsafe {
+            rail.verbs
+                .reg_mr(arena.base_ptr(), arena.total_bytes(), false)?
+        };
+        arena_lkeys.push(keys.lkey);
+    }
+
+    // Peer publishes N per-rail QP + per-layer MR tables; validate each rail's
+    // layer count against the manifest BEFORE replying (a mismatch must bail
+    // with no client params written — the pre-RailSet behavior).
+    let server = rs
+        .read_server_ro(stream)
+        .context("read verbs server params")?;
+    for sp in &server {
+        if sp.layers.len() != num_layers as usize {
+            bail!(
+                "verbs peer published {} layer MRs but manifest has {num_layers} MoE layers",
+                sp.layers.len()
+            );
+        }
+    }
+
+    // Reply with each rail's client QP, connect each rail, await the ack.
+    rs.complete(stream, &server, "verbs peer")?;
+    let rails: Vec<Rail> = rs
+        .into_verbs()
+        .into_iter()
+        .zip(arena_lkeys)
+        .zip(server)
+        .map(|((verbs, arena_lkey), sp)| Rail {
+            verbs,
+            arena_lkey,
+            layers: sp.layers,
+        })
+        .collect();
+    Ok(Transport::Verbs(rails))
+}
+
+impl ExpertTier for RdmaTier {
+    fn fetch(&mut self, key: ExpertKey, slot: ArenaSlot, _stream: u64) -> Result<ExpertResidency> {
+        let stride = self.layout.record_stride as usize;
+        let host = self.arena.slot_host_ptr(slot.slab, slot.slot)?;
+        let dev_va = self.arena.slot_dev_va(slot.slab, slot.slot)?;
+        let spec = self.spec; // Copy — release the field borrow before matching.
+
+        match &mut self.transport {
+            Transport::Tcp => {
+                self.fetch_tcp(key, host, stride)?;
+            }
+            #[cfg(atlas_rdma_verbs)]
+            Transport::Verbs(rails) => {
+                // Stripe the fetch onto rail = expert % n_rails. Single-rail
+                // (n == 1) => always rail 0, the unchanged path.
+                let ri = (key.expert as usize) % rails.len();
+                let rail = &mut rails[ri];
+                let (base, rkey) = *rail.layers.get(key.layer as usize).with_context(|| {
+                    format!("verbs: no layer MR for layer {} ({:?})", key.layer, key)
+                })?;
+                let remote_addr = base + (key.expert as u64) * (stride as u64);
+                let wr_id = ((key.layer as u64) << 32) | (key.expert as u64);
+                // SAFETY: `host` is a `stride`-byte slot inside this rail's arena
+                // MR (arena_lkey); remote_addr/rkey address the peer's layer MR on
+                // the SAME rail.
+                let post = unsafe {
+                    rail.verbs.post_read(
+                        host as *mut std::ffi::c_void,
+                        rail.arena_lkey,
+                        remote_addr,
+                        rkey,
+                        stride as u32,
+                        wr_id,
+                    )
+                };
+                if let Err(e) = post {
+                    self.healthy = false;
+                    return Err(e).with_context(|| format!("verbs post_read {:?}", key));
+                }
+                match rail.verbs.poll() {
+                    Ok(got) if got == wr_id => {}
+                    Ok(got) => {
+                        self.healthy = false;
+                        bail!("verbs completion wr_id {got:#x} != expected {wr_id:#x} ({key:?})");
+                    }
+                    Err(e) => {
+                        self.healthy = false;
+                        return Err(e).with_context(|| format!("verbs poll {:?}", key));
+                    }
+                }
+            }
+        }
+
+        // SAFETY: the slot now holds `stride` valid bytes (landed by TCP or RDMA).
+        let record = unsafe { std::slice::from_raw_parts(host, stride) };
+        residency_from(&spec, record, dev_va, key)
+    }
+
+    fn kind(&self) -> TierKind {
+        TierKind::Rdma
+    }
+
+    /// Link health: false after any transport error so the streamer can fall
+    /// back to the local NVMe UMA tier (graceful degradation on CX7 flap).
+    fn healthy(&self) -> bool {
+        self.healthy
+    }
+}

--- a/crates/spark-storage/src/group.rs
+++ b/crates/spark-storage/src/group.rs
@@ -108,6 +108,13 @@ impl GroupLayout {
     pub fn group_bytes(&self) -> u64 {
         self.group_stride
     }
+
+    /// Bytes in one full block: `K` + `V` across all kv-heads, each a
+    /// `group_stride`-pitch group. This is the contiguous unit the
+    /// block-granular `StorageBackend` ops read/write in one operation.
+    pub fn block_bytes(&self) -> u64 {
+        2 * (self.num_kv_heads as u64) * self.group_stride
+    }
 }
 
 #[cfg(test)]

--- a/crates/spark-storage/src/high_speed_swap/disk_id_tests.rs
+++ b/crates/spark-storage/src/high_speed_swap/disk_id_tests.rs
@@ -13,6 +13,7 @@ fn dims() -> ModelDims {
         num_kv_heads: 8,
         head_dim: 128,
         block_size: 16,
+        model_fp: None,
     }
 }
 

--- a/crates/spark-storage/src/kv_paging.rs
+++ b/crates/spark-storage/src/kv_paging.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! KV as a first-class paging kind (part of the tiered-cache
+//! consolidation, DEFAULT-OFF behind `ATLAS_KV_PAGING`).
+//!
+//! The flag-OFF KV overflow tier (`rdma_kv_backend`) takes the "dumb
+//! one-sided path": the peer registers ONE RW MR and the CLIENT owns a static
+//! allocator (`base + group_id × group_stride`) over a fixed arena — no peer
+//! residency, no NVMe spill. It selects that mode with the v2
+//! header's `blob_bytes == 0` RAW sentinel (the bare `[u64 total_bytes]`
+//! handshake is retired).
+//! This module is the alternative client: it sends the paging handshake
+//! (`PAGING_MAGIC_V2`, kind = `PagingKind::KV`) so KV inherits what the SSM
+//! snapshot tier already has — peer-owned residency, an NVMe-backed cold tier
+//! (unbounded depth with `--swap-cap-gb-kv 0`), and peer capacity pooling.
+//! The peer side is ALREADY wired: the `(kind, blob_bytes)` arena registry
+//! accepts kind 1 and `--swap-cap-gb-kv` parses; the whole feature is this
+//! client.
+//!
+//! Layout: the paging RECORD is one whole KV block (`GroupLayout::
+//! block_bytes()` = `2·num_kv_heads·group_stride`) — exactly the fixed-size
+//! record `atlas_tier::Residency` demands, one contiguous blob at one pointer
+//! on both ends, and 1 control RTT per block instead of `2·num_kv_heads`.
+//! Keys fold the per-model fingerprint + full layout identity + a per-client
+//! salt (see [`ns`]); `PagingKind::KV` in the handshake plus the
+//! [`ns::KV_DOMAIN`] fold domain-separate KV from SSM.
+//!
+//! FLAG OFF (`ATLAS_KV_PAGING` unset/0) the selection helper returns the raw
+//! one-sided `RdmaKvBackend` — identical data plane (v2 RAW handshake since
+//! the v2 handshake), so any regression bisects on this single flag.
+
+pub mod ns;
+
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+mod backend;
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+mod connect;
+
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+pub use backend::{KvPagingBackend, KvPagingConnect};
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+pub use connect::connect_kv_peer_backend;
+
+/// The hard-error a KV paging GET miss maps to. `StorageBackend::read` has no
+/// miss channel and an evicted KV block is UNRECOVERABLE without recomputing
+/// the prefix (unlike SSM snapshots, which recompute on miss by design) — so
+/// ST_MISS is corruption-equivalent and must fail loudly, naming the peer
+/// config that makes the KV kind miss-proof.
+pub fn kv_miss_error(layer: u32, block: u32) -> anyhow::Error {
+    anyhow::anyhow!(
+        "kv-paging: block (layer {layer}, disk block {block}) is not on the peer — an \
+         evicted KV block is unrecoverable (silent KV loss would corrupt long-context \
+         output). Run the peer with --swap-cap-gb-kv 0 (unbounded KV disk) and size \
+         --max-blade-gb / ATLAS_KV_PAGING_ARENA_GB for the working set"
+    )
+}
+
+#[cfg(test)]
+mod isolation_tests;

--- a/crates/spark-storage/src/kv_paging/backend.rs
+++ b/crates/spark-storage/src/kv_paging/backend.rs
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `KvPagingBackend` — the KV overflow tier as a PAGING client (flag-ON arm
+//! of `ATLAS_KV_PAGING`), plus [`connect_kv_peer_backend`], the single
+//! selection seam `HighSpeedSwap` calls (flag OFF ⇒ the raw one-sided
+//! `RdmaKvBackend`, identical data plane; its handshake is the
+//! v2 header with `blob_bytes == 0`).
+//!
+//! Data plane (strictly synchronous, ONE control op in flight — the peer's
+//! read-pin lifecycle releases a GET pin on the connection's NEXT op, which
+//! is only sound because this client never pipelines; pipelining needs N
+//! control connections or a PIN/UNPIN protocol extension and is a measured
+//! follow-up, NOT this MVP):
+//!   PUT  = ALLOC(RTT, offset) → RDMA-WRITE block → poll → COMMIT(RTT)
+//!   GET  = GET(RTT, offset)   → RDMA-READ block  → poll (BEFORE the next
+//!          control op, so the pinned slot can never be evicted mid-read)
+//!
+//! Zero-copy landing (`ATLAS_KV_ZERO_COPY=1`) is preserved: the whole UMA
+//! scratch pool registers as ONE landing MR per rail
+//! (`register_landing_region`, `remote_read == false`) and a GET's RDMA READ
+//! lands directly in the destination slot — only the raddr provenance changed
+//! (GET-reply offset instead of `base + group_id·stride`). The leading WAR
+//! `stream_sync` is kept verbatim from `RdmaKvBackend::read_zero_copy` (the
+//! NIC write is off-stream). The MR-dereg-before-pool-free drop order is
+//! inherited: `HighSpeedSwap` declares `backend` before `pool`, and this
+//! backend's rails (whose `Verbs` own the MRs) drop with it.
+//!
+//! MISS = HARD ERROR ([`super::kv_miss_error`]): deployment requirement is a
+//! miss-proof peer (`--swap-cap-gb-kv 0`).
+
+use std::ffi::c_void;
+use std::io::Write;
+use std::net::TcpStream;
+use std::num::NonZeroU64;
+
+use anyhow::{Context, Result, bail};
+
+use super::ns;
+use crate::backend::{BlockReadRequest, ReadRequest, StorageBackend};
+use crate::cuda_min::{PinnedBuffer, copy_h_to_d_async, stream_sync};
+use crate::group::{GroupKey, GroupLayout, KvKind};
+use crate::snapshot_swap::{
+    PagingKind, client_alloc, client_bye, client_commit, client_get, encode_paging_v2_header,
+};
+use atlas_rdma::verbs::Verbs;
+
+/// Fully-resolved connect parameters (env resolution lives in
+/// [`connect_kv_peer_backend`]; the smoke example constructs this directly
+/// with exact byte sizes / explicit salts).
+#[derive(Clone, Copy, Debug)]
+pub struct KvPagingConnect {
+    /// Peer warm-arena bytes: non-zero multiple of `layout.block_bytes()`.
+    pub arena_bytes: u64,
+    /// The KV namespace (see [`ns::derive_kv_ns`]) — model fp + layout
+    /// identity + per-client salt already folded.
+    pub ns: NonZeroU64,
+}
+
+/// One QP on one CX7 adapter with a single registered block-sized bounce.
+struct PagingRail {
+    verbs: Verbs,
+    bounce: PinnedBuffer,
+    bounce_lkey: u32,
+    remote_rkey: u32,
+    /// Pre-registered whole UMA landing region `(base, len, lkey)` for
+    /// zero-copy restore (per-slot sub-registration fails on GB10).
+    region: Option<(u64, u64, u32)>,
+}
+
+pub struct KvPagingBackend {
+    rails: Vec<PagingRail>,
+    layout: GroupLayout,
+    remote_base: u64,
+    ns: NonZeroU64,
+    zero_copy: bool,
+    rr: usize,
+    next_wr: u64,
+    /// The live paging control channel (ALLOC/COMMIT/GET ride here; data
+    /// moves one-sided over the rails).
+    ctrl: TcpStream,
+}
+
+// SAFETY: mirrors `RdmaKvBackend` — both `StorageBackend` methods take
+// `&mut self` and no `&self` method touches a QP/bounce, so `Sync` is sound
+// (the swap orchestrator owns it single-threaded regardless).
+unsafe impl Sync for KvPagingBackend {}
+
+impl KvPagingBackend {
+    /// Connect to a paging peer at `addr` with the v2 handshake
+    /// (`[PAGING_MAGIC_V2][kind=KV][arena_bytes][blob_bytes=block_bytes]`),
+    /// bring up the rails (same env triple as the legacy KV backend:
+    /// `ATLAS_EXPERT_RDMA_DEV`/`GID` = rail 0, `ATLAS_KV_DUAL_RAIL=1` +
+    /// `ATLAS_KV_RAIL2_DEV`/`GID` = rail 1), and register one block-sized
+    /// bounce per rail (`remote_read == false`, invariant).
+    pub fn connect(addr: &str, layout: GroupLayout, cfg: KvPagingConnect) -> Result<Self> {
+        use atlas_rdma::env::{first_set, first_set_u32};
+        use atlas_rdma::railset::{RailSet, RailSpec};
+
+        let block_bytes = layout.block_bytes();
+        if cfg.arena_bytes == 0 || !cfg.arena_bytes.is_multiple_of(block_bytes) {
+            bail!(
+                "kv-paging: arena_bytes {} must be a non-zero multiple of block_bytes {block_bytes}",
+                cfg.arena_bytes
+            );
+        }
+        let spec =
+            |dev: String, gid: u32| RailSpec::new(dev, gid, rand::random::<u32>() & 0xff_ffff);
+        let rail0 = spec(
+            first_set(&["ATLAS_EXPERT_RDMA_DEV"], "roceP2p1s0f1"),
+            first_set_u32(&["ATLAS_EXPERT_RDMA_GID"], 3),
+        );
+        let dual = std::env::var("ATLAS_KV_DUAL_RAIL").ok().as_deref() == Some("1");
+        let specs: Vec<RailSpec> = if dual {
+            vec![
+                rail0,
+                spec(
+                    first_set(&["ATLAS_KV_RAIL2_DEV"], "rocep1s0f1"),
+                    first_set_u32(&["ATLAS_KV_RAIL2_GID"], 3),
+                ),
+            ]
+        } else {
+            vec![rail0]
+        };
+
+        let mut stream =
+            TcpStream::connect(addr).with_context(|| format!("connect kv paging peer {addr}"))?;
+        stream.set_nodelay(true).ok();
+        stream
+            .write_all(&encode_paging_v2_header(
+                PagingKind::KV,
+                cfg.arena_bytes,
+                block_bytes,
+            ))
+            .context("send kv paging v2 header")?;
+
+        let bb = block_bytes as usize;
+        // `parts` (the pinned bounce buffers) MUST be declared BEFORE `rs` (the
+        // Verbs that hold the MRs registered against those buffers). reg_mr's
+        // contract: the addr must outlive the Verbs (the MR is dereg'd on
+        // `Verbs::drop` → rs_destroy). On the SUCCESS path both are consumed
+        // into `PagingRail { verbs, bounce }`, whose field order dereg's before
+        // free. But on ANY early return between reg_mr and building `rails`
+        // (e.g. `finish_rw` failing when the peer rejects), the two are dropped
+        // as locals in REVERSE declaration order — so `parts` last means the
+        // pinned memory is freed AFTER `rs` deregisters the MRs, not before.
+        let mut parts: Vec<(PinnedBuffer, u32)> = Vec::new();
+        let mut rs = RailSet::begin(&mut stream, &specs)?;
+        parts.reserve(rs.n_rails());
+        for rail in &mut rs.rails {
+            let bounce = PinnedBuffer::new(bb).context("alloc pinned kv paging bounce")?;
+            // SAFETY: bounce lives as long as the rail (and thus the MR) — on
+            // both the success path (co-owned in PagingRail) and the error path
+            // (parts outlives rs by declaration order above).
+            let keys = unsafe { rail.verbs.reg_mr(bounce.ptr, bb, false)? };
+            parts.push((bounce, keys.lkey));
+        }
+        let server = rs.finish_rw(&mut stream, "kv paging peer")?;
+        let base = server.last().map(|sp| sp.base_addr).unwrap_or(0);
+        let rails: Vec<PagingRail> = rs
+            .into_verbs()
+            .into_iter()
+            .zip(parts)
+            .zip(&server)
+            .map(|((verbs, (bounce, bounce_lkey)), sp)| PagingRail {
+                verbs,
+                bounce,
+                bounce_lkey,
+                remote_rkey: sp.rkey,
+                region: None,
+            })
+            .collect();
+        let zero_copy = std::env::var("ATLAS_KV_ZERO_COPY").ok().as_deref() == Some("1");
+        tracing::info!(
+            "KvPagingBackend connected to {addr}: kind=KV, blob {block_bytes} B, arena {:.3} GiB, \
+             ns {:#018x}, {} rail(s), zero_copy={zero_copy} (strictly synchronous MVP: 1 control \
+             op in flight)",
+            cfg.arena_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+            cfg.ns.get(),
+            rails.len(),
+        );
+        Ok(Self {
+            rails,
+            layout,
+            remote_base: base,
+            ns: cfg.ns,
+            zero_copy,
+            rr: 0,
+            next_wr: 1, // 0 == "no completion yet" sentinel convention
+            ctrl: stream,
+        })
+    }
+
+    /// The wire key of one KV block (base dense group id folded with the ns).
+    fn block_key(&self, layer: u32, block: u32) -> u64 {
+        let base = self
+            .layout
+            .group_id(GroupKey::new(layer, block, 0, KvKind::K))
+            .0;
+        ns::wire_key(self.ns, base)
+    }
+
+    /// Control GET: the peer offset of `(layer, block)`. A miss is a HARD
+    /// error — see the module doc / `kv_miss_error`.
+    fn get_block_offset(&mut self, layer: u32, block: u32) -> Result<u64> {
+        let key = self.block_key(layer, block);
+        match client_get(&mut self.ctrl, key)? {
+            Some(off) => Ok(off),
+            None => Err(super::kv_miss_error(layer, block)),
+        }
+    }
+
+    fn pick_rail(&mut self) -> (usize, u64) {
+        let ri = self.rr % self.rails.len();
+        self.rr = self.rr.wrapping_add(1);
+        let wr = self.next_wr;
+        self.next_wr = self.next_wr.wrapping_add(1).max(1);
+        (ri, wr)
+    }
+
+    /// RDMA-READ `len` bytes from the peer into the rail bounce (drained),
+    /// then `copy_h2d` to `dst` and sync `stream` — the sync is the bounce
+    /// reuse guard (each rail has ONE bounce; the next op may refill it).
+    fn rdma_read_bounce(&mut self, raddr: u64, len: usize, dst: u64, stream: u64) -> Result<()> {
+        let (ri, wr) = self.pick_rail();
+        let rail = &mut self.rails[ri];
+        // SAFETY: bounce is a live registered MR of >= len; raddr/rkey are the
+        // peer arena (a GET-pinned slot, released on our next control op).
+        unsafe {
+            rail.verbs.post_read(
+                rail.bounce.ptr,
+                rail.bounce_lkey,
+                raddr,
+                rail.remote_rkey,
+                len as u32,
+                wr,
+            )?;
+        }
+        while rail.verbs.poll()? != wr {}
+        copy_h_to_d_async(dst, rail.bounce.ptr as *const c_void, len, stream)?;
+        stream_sync(stream)
+    }
+
+    /// Zero-copy RDMA-READ straight into the (UMA) destination via the
+    /// pre-registered landing region (caller checked coverage + did the
+    /// leading WAR sync). On poll the bytes are GPU-visible at `dst`.
+    fn rdma_read_direct(&mut self, raddr: u64, len: usize, dst: u64) -> Result<()> {
+        let (ri, wr) = self.pick_rail();
+        let rail = &mut self.rails[ri];
+        let (_, _, lkey) = rail.region.expect("caller verified region coverage");
+        // SAFETY: dst is inside the live UMA landing MR (lkey); raddr/rkey
+        // address the peer arena. The NIC DMAs straight into dst.
+        unsafe {
+            rail.verbs.post_read(
+                dst as *mut c_void,
+                lkey,
+                raddr,
+                rail.remote_rkey,
+                len as u32,
+                wr,
+            )?;
+        }
+        while rail.verbs.poll()? != wr {}
+        Ok(())
+    }
+
+    /// Whether every rail's landing region covers `[dst, dst+len)`.
+    fn all_regions_cover(&self, dst: u64, len: usize) -> bool {
+        self.rails.iter().all(|r| match r.region {
+            Some((base, rlen, _)) => dst >= base && dst + len as u64 <= base + rlen,
+            None => false,
+        })
+    }
+}
+
+impl StorageBackend for KvPagingBackend {
+    /// Per-head restore: GET the block (pinning it), then RDMA-READ the one
+    /// `group_stride` stripe at `offset + (kind·nkv + kv_head)·gs`. Reachable
+    /// only via un-coalesced callers (construction requires coalescing, so
+    /// this is a correctness backstop, not a hot path).
+    fn read(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()> {
+        let gs = self.layout.group_stride;
+        let nkv = self.layout.num_kv_heads as u64;
+        for req in requests {
+            let g = req.group;
+            let off = self.get_block_offset(g.layer, g.block)?;
+            let idx = (g.kv_kind as u64) * nkv + g.kv_head as u64;
+            let raddr = self.remote_base + off + idx * gs;
+            self.rdma_read_bounce(raddr, gs as usize, req.dst_dev_ptr, stream)?;
+        }
+        Ok(())
+    }
+
+    // read_async: default = the synchronous `read` (correct, just not async).
+    // The sync control RTT at the prefetch boundary is the documented MVP
+    // cost; the parent measures it on hardware before any default flip.
+
+    /// Block-granular restore — ONE control GET + ONE RDMA READ per block
+    /// (the whole point of block-sized paging records).
+    fn read_blocks(&mut self, requests: &[BlockReadRequest], stream: u64) -> Result<()> {
+        if requests.is_empty() {
+            return Ok(());
+        }
+        let bb = self.layout.block_bytes() as usize;
+        let zc = self.zero_copy
+            && requests
+                .iter()
+                .all(|r| self.all_regions_cover(r.dst_dev_ptr, bb));
+        if zc {
+            // WAR barrier (verbatim from RdmaKvBackend::read_zero_copy): the
+            // NIC is about to DMA into UMA slots a previous tile's attention
+            // kernel may still be reading on `stream`; the NIC write is
+            // off-stream, so drain in-flight consumers first.
+            stream_sync(stream)?;
+        }
+        for req in requests {
+            let off = self.get_block_offset(req.base_key.layer, req.base_key.block)?;
+            let raddr = self.remote_base + off;
+            if zc {
+                self.rdma_read_direct(raddr, bb, req.dst_dev_ptr)?;
+            } else {
+                self.rdma_read_bounce(raddr, bb, req.dst_dev_ptr, stream)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Per-head writes cannot be served by a peer-owned BLOCK arena: ALLOC
+    /// hands out a whole-block slot, so committing after one `group_stride`
+    /// stripe would mark `2·nkv − 1` garbage stripes resident. Construction
+    /// requires block coalescing precisely so this is unreachable.
+    fn write_from_host(&mut self, key: GroupKey, _src: &[u8]) -> Result<()> {
+        bail!(
+            "kv-paging: per-head write_from_host (layer {}, block {}) is unsupported — the \
+             paging record is one whole KV block; run with ATLAS_HSS_COALESCE_BLOCKS on \
+             (default) so offload uses write_block_from_host",
+            key.layer,
+            key.block
+        )
+    }
+
+    /// Offload one whole block: ALLOC (never full — the peer spills its
+    /// coldest to NVMe) → RDMA-WRITE via the rail bounce → poll → COMMIT.
+    /// Commit-before-get visibility replaces the legacy drain-before-read.
+    fn write_block_from_host(&mut self, base_key: GroupKey, src: &[u8]) -> Result<()> {
+        let bb = self.layout.block_bytes() as usize;
+        if src.len() != bb {
+            bail!(
+                "kv-paging write_block_from_host: src len {} != block bytes {bb}",
+                src.len()
+            );
+        }
+        let key = self.block_key(base_key.layer, base_key.block);
+        let off = client_alloc(&mut self.ctrl, key).with_context(|| {
+            format!(
+                "kv-paging ALLOC (layer {}, block {}) refused — peer arena exhausted by \
+                 reservations/read-pins? Grow ATLAS_KV_PAGING_ARENA_GB (and the peer's \
+                 --max-blade-gb)",
+                base_key.layer, base_key.block
+            )
+        })?;
+        let raddr = self.remote_base + off;
+        let (ri, wr) = self.pick_rail();
+        let rail = &mut self.rails[ri];
+        // SAFETY: bounce is a live MR of block_bytes; copy the block image in,
+        // RDMA-WRITE it to the ALLOC-reserved (peer-pinned) slot, drain.
+        unsafe {
+            std::ptr::copy_nonoverlapping(src.as_ptr(), rail.bounce.ptr as *mut u8, bb);
+            rail.verbs.post_write(
+                rail.bounce.ptr,
+                rail.bounce_lkey,
+                raddr,
+                rail.remote_rkey,
+                bb as u32,
+                wr,
+            )?;
+        }
+        while rail.verbs.poll()? != wr {}
+        client_commit(&mut self.ctrl, key)
+    }
+
+    // write_blocks_run: default fans out to write_block_from_host — correct;
+    // peer-assigned slots are non-contiguous in disk-id space, so wide-write
+    // coalescing is layout-incompatible here (see below).
+
+    /// Peer-assigned paging slots are NOT contiguous in disk-id space —
+    /// claiming run coalescing would corrupt the caller's layout assumptions.
+    fn supports_write_run_coalescing(&self) -> bool {
+        false
+    }
+
+    fn group_layout(&self) -> GroupLayout {
+        self.layout
+    }
+
+    /// Register the whole (UMA) scratch pool as ONE landing MR per rail so
+    /// zero-copy restore reuses that lkey for every slot (per-slot
+    /// registration fails on GB10). `remote_read == false` — invariant.
+    fn register_landing_region(&mut self, base: u64, len: usize) -> Result<()> {
+        for rail in &mut self.rails {
+            // SAFETY: base/len describe the pool's live UMA allocation, which
+            // outlives every rail (backend declared before pool ⇒ MRs dereg
+            // before cuMemFreeHost).
+            let keys = unsafe { rail.verbs.reg_mr(base as *mut c_void, len, false) }
+                .context("kv-paging: register UMA landing region")?;
+            rail.region = Some((base, len as u64, keys.lkey));
+        }
+        tracing::info!(
+            "KvPagingBackend: registered UMA landing region {:.1} MiB on {} rail(s) — \
+             zero-copy restore live",
+            len as f64 / (1024.0 * 1024.0),
+            self.rails.len(),
+        );
+        Ok(())
+    }
+}
+
+impl Drop for KvPagingBackend {
+    fn drop(&mut self) {
+        // Strictly synchronous: no in-flight RDMA ops to drain. Tell the peer
+        // to close the paging loop (releases any lingering read-pin).
+        let _ = client_bye(&mut self.ctrl);
+    }
+}

--- a/crates/spark-storage/src/kv_paging/connect.rs
+++ b/crates/spark-storage/src/kv_paging/connect.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The KV-paging selection seam: env-driven choice between the raw
+//! one-sided `RdmaKvBackend` (flag OFF) and the peer-paging
+//! `KvPagingBackend` (`ATLAS_KV_PAGING=1`). Split from `backend.rs` to keep
+//! it under the 500-LoC cap.
+
+use std::num::NonZeroU64;
+
+use anyhow::{Result, anyhow, bail};
+
+use super::backend::{KvPagingBackend, KvPagingConnect};
+use super::ns;
+use crate::backend::StorageBackend;
+use crate::group::GroupLayout;
+use crate::model_dims::ModelDims;
+
+/// THE selection seam `HighSpeedSwap::new_on_stream` calls when
+/// `$ATLAS_KV_PEER` is set. Flag OFF (`ATLAS_KV_PAGING` unset/0) ⇒ the raw
+/// one-sided `RdmaKvBackend::connect(peer, layout)` — the identical call and
+/// data plane (its handshake is the v2 header with blob == 0),
+/// so a regression bisects on this one flag. Flag ON ⇒ resolve the required
+/// env (PCND: fail fast), derive the namespace, and connect the paging
+/// backend.
+pub fn connect_kv_peer_backend(
+    peer: &str,
+    layout: GroupLayout,
+    model: &ModelDims,
+    elem_bytes: u32,
+    coalesce_blocks: bool,
+) -> Result<Box<dyn StorageBackend>> {
+    let paging = ns::kv_paging_selected(std::env::var("ATLAS_KV_PAGING").ok().as_deref())?;
+    if !paging {
+        // DEFAULT: the dumb one-sided path, untouched.
+        return Ok(Box::new(crate::rdma_kv_backend::RdmaKvBackend::connect(
+            peer, layout,
+        )?));
+    }
+    if !coalesce_blocks {
+        bail!(
+            "ATLAS_KV_PAGING=1 requires block coalescing (ATLAS_HSS_COALESCE_BLOCKS, the \
+             default): the paging record is one whole KV block, and the per-head offload \
+             write path cannot be served by a peer-owned block arena"
+        );
+    }
+    let arena_bytes = ns::resolve_arena_bytes_from(
+        std::env::var("ATLAS_KV_PAGING_ARENA_GB").ok().as_deref(),
+        layout.block_bytes(),
+    )?;
+    let ns = match std::env::var("ATLAS_KV_PAGING_NS").ok() {
+        Some(raw) => {
+            let ns = ns::resolve_kv_ns_from(Some(&raw), NonZeroU64::new(1).expect("nonzero"))?;
+            tracing::info!(
+                "kv-paging: namespace OVERRIDDEN via ATLAS_KV_PAGING_NS={:#018x} — two clients \
+                 sharing one explicit ns on one peer WILL cross-serve KV blocks",
+                ns.get()
+            );
+            ns
+        }
+        None => {
+            // The per-model fingerprint is REQUIRED for the derived namespace
+            // (PCND: no model-blind default — that is exactly the silent
+            // cross-serve the SSM fix made unrepresentable).
+            let fp = model.model_fp.ok_or_else(|| {
+                anyhow!(
+                    "ATLAS_KV_PAGING=1 requires a model fingerprint (ModelDims::model_fp) and \
+                     the loader did not derive one — fix the model config, or set \
+                     ATLAS_KV_PAGING_NS to an explicit non-zero u64"
+                )
+            })?;
+            let salt =
+                ns::resolve_salt_from(std::env::var("ATLAS_KV_PAGING_SALT").ok().as_deref())?
+                    .unwrap_or_else(rand::random::<u64>);
+            let derived = ns::derive_kv_ns(
+                fp.get(),
+                &layout,
+                elem_bytes,
+                model.block_size as u32,
+                model.head_dim as u32,
+                salt,
+            );
+            tracing::info!(
+                "kv-paging: derived namespace {:#018x} (fp {:#018x}, client salt {salt:#018x} — \
+                 pin via ATLAS_KV_PAGING_SALT to reproduce; the salt makes keys CLIENT-PRIVATE: \
+                 capacity pooling yes, cross-client warm hits no)",
+                derived.get(),
+                fp.get(),
+            );
+            derived
+        }
+    };
+    tracing::info!(
+        "kv-paging: connecting {peer} (arena {:.3} GiB, blob {} B); peer must run with \
+         --swap-cap-gb-kv 0 (a KV disk cap turns evictions into unrecoverable KV loss)",
+        arena_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+        layout.block_bytes(),
+    );
+    Ok(Box::new(KvPagingBackend::connect(
+        peer,
+        layout,
+        KvPagingConnect { arena_bytes, ns },
+    )?))
+}

--- a/crates/spark-storage/src/kv_paging/isolation_tests.rs
+++ b/crates/spark-storage/src/kv_paging/isolation_tests.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! KV paging isolation pins — hardware-free, mirroring spark-model's
+//! `paging_isolation_tests.rs`. The "peer" here is the EXACT residency type
+//! the real peer's `SharedPaging` owns (`atlas_tier::Residency`, via the
+//! `snapshot_swap` re-export), keyed purely by the u64 wire key — so these
+//! tests prove the client-side namespace fold is the only thing standing
+//! between two models (or two same-model clients) and silent KV cross-serve,
+//! and that it stands.
+
+use std::collections::HashMap;
+use std::num::NonZeroU64;
+
+use super::ns::{derive_kv_ns, wire_key};
+use crate::group::{GroupKey, GroupLayout, KvKind};
+use crate::snapshot_swap::{MemSwapStore, Residency, VecSlotArena};
+
+/// Tiny fake block for the mock peer (the real block_bytes is layout-derived;
+/// isolation semantics don't depend on the size).
+const BB: usize = 64;
+
+fn layout() -> GroupLayout {
+    // 4 layers × 16 blocks × 2 kv_heads, bs 16, hd 128, BF16.
+    GroupLayout::new(4, 16, 2, 16, 128, 2, 4096)
+}
+
+type MockPeer = Residency<VecSlotArena, MemSwapStore>;
+
+/// A shared peer arena: `slots` hot slots over an UNBOUNDED in-memory swap —
+/// the miss-proof (`--swap-cap-gb-kv 0`) configuration the KV kind requires.
+fn peer(slots: usize) -> MockPeer {
+    Residency::new(VecSlotArena::new(BB, slots), MemSwapStore::new(BB)).unwrap()
+}
+
+/// One simulated KV paging client: its namespace, folding keys exactly as
+/// `KvPagingBackend::block_key` does (base dense group id → wire_key).
+struct Client {
+    ns: NonZeroU64,
+}
+
+impl Client {
+    fn new(fp: u64, salt: u64) -> Self {
+        Self {
+            ns: derive_kv_ns(fp, &layout(), 2, 16, 128, salt),
+        }
+    }
+    fn key(&self, layer: u32, block: u32) -> u64 {
+        let base = layout()
+            .group_id(GroupKey::new(layer, block, 0, KvKind::K))
+            .0;
+        wire_key(self.ns, base)
+    }
+    fn put(&self, peer: &mut MockPeer, layer: u32, block: u32, tag: u8) {
+        peer.put_blob(self.key(layer, block), &[tag; BB]).unwrap();
+    }
+    fn get(&self, peer: &mut MockPeer, layer: u32, block: u32) -> Option<Vec<u8>> {
+        let mut out = vec![0u8; BB];
+        peer.get_blob(self.key(layer, block), &mut out)
+            .unwrap()
+            .then_some(out)
+    }
+}
+
+const FP_A: u64 = 0x5629_922c_51a1_6a10; // spark-model's pinned hybrid fp
+const FP_B: u64 = 0x971e_b3b4_bd13_22f1; // spark-model's pinned dense fp
+const SALT: u64 = 0x0BAD_5EED;
+
+// ── T1: two MODELS, same client-local (layer, block), one shared peer ────
+
+#[test]
+fn two_models_do_not_cross_serve() {
+    let mut peer = peer(8);
+    let a = Client::new(FP_A, SALT);
+    let b = Client::new(FP_B, SALT);
+    a.put(&mut peer, 1, 3, 0xAA);
+    assert_eq!(
+        b.get(&mut peer, 1, 3),
+        None,
+        "model B must MISS model A's KV block for the same (layer, block)"
+    );
+    // …while model A still hits its own entry (isolation, not amnesia).
+    assert_eq!(a.get(&mut peer, 1, 3), Some(vec![0xAA; BB]));
+}
+
+// ── T2 (the KV-specific hazard): SAME model, two CLIENTS. GroupKey.block is
+// a client-local pool index, so without the salt this would be a cache HIT
+// with the OTHER client's attention state — guaranteed corruption, silent.
+// The same mechanism models a client RESTART (fresh salt ⇒ its own stale
+// pre-restart blocks become unreachable instead of being served back). ──────
+
+#[test]
+fn same_model_two_salts_do_not_cross_serve() {
+    let mut peer = peer(8);
+    let c1 = Client::new(FP_A, 0x1111);
+    let c2 = Client::new(FP_A, 0x2222);
+    assert_ne!(c1.ns, c2.ns, "the salt must separate same-model clients");
+    c1.put(&mut peer, 0, 0, 0xC1);
+    assert_eq!(
+        c2.get(&mut peer, 0, 0),
+        None,
+        "same model + same block id + different client ⇒ MISS, never the other \
+         client's bytes"
+    );
+    c2.put(&mut peer, 0, 0, 0xC2);
+    // Both coexist on one peer (capacity pooling), each seeing only its own.
+    assert_eq!(c1.get(&mut peer, 0, 0), Some(vec![0xC1; BB]));
+    assert_eq!(c2.get(&mut peer, 0, 0), Some(vec![0xC2; BB]));
+}
+
+// ── T3: same model + same salt is DETERMINISTIC across derivations (a
+// reconnect that pins ATLAS_KV_PAGING_SALT resumes its own keyspace). ───────
+
+#[test]
+fn same_model_same_salt_round_trips_across_instances() {
+    let mut peer = peer(8);
+    let c1 = Client::new(FP_A, SALT);
+    let c2 = Client::new(FP_A, SALT); // independent derivation, same inputs
+    assert_eq!(c1.ns, c2.ns);
+    c1.put(&mut peer, 2, 5, 0x77);
+    assert_eq!(c2.get(&mut peer, 2, 5), Some(vec![0x77; BB]));
+}
+
+// ── T4: cross-KIND. The peer's registry keys arenas by (kind, blob_bytes):
+// each kind gets its OWN residency map + swap file, so an SSM key can never
+// be looked up in the KV arena even if numerically equal AND blob_bytes
+// coincide. Pin that structural guarantee (this must never collapse) —
+// the KV_DOMAIN fold in the ns is defense-in-depth on top. ──────────────────
+
+#[test]
+fn cross_kind_registry_never_mixes() {
+    // The registry shape: (kind, blob_bytes) → its own residency.
+    let mut registry: HashMap<(u8, usize), MockPeer> = HashMap::new();
+    registry.insert((0, BB), peer(4)); // SSM arena
+    registry.insert((1, BB), peer(4)); // KV arena — same blob_bytes!
+    let key = 0xDEAD_BEEF_DEAD_BEEFu64; // numerically equal in both keyspaces
+    registry
+        .get_mut(&(1, BB))
+        .unwrap()
+        .put_blob(key, &[0x4B; BB]) // "K"
+        .unwrap();
+    let mut out = vec![0u8; BB];
+    assert!(
+        !registry
+            .get_mut(&(0, BB))
+            .unwrap()
+            .get_blob(key, &mut out)
+            .unwrap(),
+        "an SSM lookup must never see a KV entry, even with equal key AND blob_bytes"
+    );
+    assert!(
+        registry
+            .get_mut(&(1, BB))
+            .unwrap()
+            .get_blob(key, &mut out)
+            .unwrap()
+    );
+    assert_eq!(out, vec![0x4B; BB]);
+}
+
+// ── T5: KV-shaped spill/fault byte-identity on a miss-proof peer. Far more
+// blocks than hot slots ⇒ the residency MUST spill coldest to the (unbounded)
+// swap and fault them back byte-identical — never a drop. This is the peer
+// behavior the KV kind depends on under --swap-cap-gb-kv 0. ─────────────────
+
+#[test]
+fn kv_blocks_survive_spill_and_fault_byte_identical() {
+    let mut peer = peer(4); // 4 hot slots
+    let c = Client::new(FP_A, SALT);
+    let pat = |layer: u32, block: u32| ((layer * 31 + block) & 0xFF) as u8;
+    // 2 layers × 16 blocks = 32 blocks through 4 slots ⇒ 28 forced spills.
+    for layer in 0..2u32 {
+        for block in 0..16u32 {
+            c.put(&mut peer, layer, block, pat(layer, block));
+        }
+    }
+    for layer in 0..2u32 {
+        for block in 0..16u32 {
+            assert_eq!(
+                c.get(&mut peer, layer, block),
+                Some(vec![pat(layer, block); BB]),
+                "block (L{layer},B{block}) must fault back byte-identical, never drop"
+            );
+        }
+    }
+    assert!(
+        peer.stats().spills_to_disk > 0,
+        "the test must force spills"
+    );
+    assert!(peer.stats().faults_from_disk > 0);
+    assert_eq!(
+        peer.stats().disk_evictions,
+        0,
+        "miss-proof: nothing dropped"
+    );
+}
+
+// ── T6: overwrite-in-place (disk-id reuse). HighSpeedSwap recycles freed
+// disk_block_ids, so the SAME wire key is re-PUT with new bytes; the peer's
+// alloc→commit must overwrite, and a subsequent GET must see the NEW bytes. ─
+
+#[test]
+fn disk_id_reuse_overwrites_in_place() {
+    let mut peer = peer(4);
+    let c = Client::new(FP_A, SALT);
+    c.put(&mut peer, 0, 7, 0x01);
+    c.put(&mut peer, 0, 7, 0x02); // freed + reallocated id, new sequence data
+    assert_eq!(c.get(&mut peer, 0, 7), Some(vec![0x02; BB]));
+}

--- a/crates/spark-storage/src/kv_paging/ns.rs
+++ b/crates/spark-storage/src/kv_paging/ns.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! KV paging namespace + wire-key derivation (`ATLAS_KV_PAGING`, part of
+//! the tiered-cache consolidation).
+//!
+//! The paging peer (atlas-cache-peer) keys its KV arena purely by the u64 the
+//! client sends, so the namespace folded into every key is the ONLY thing
+//! preventing (a) two MODELS and (b) two same-model CLIENTS from silently
+//! serving each other's KV blocks. Unlike the SSM tier's content-derived
+//! `prefix_hash`, a KV `GroupKey.block` is a CLIENT-LOCAL disk-block-pool
+//! index (`HighSpeedSwap::alloc_disk_block_id`), so identical keys from two
+//! same-model clients hold UNRELATED sequence data — a model-only namespace
+//! would cross-serve with certainty (every colliding block id), not 2^-64,
+//! and a restarted client would hit its own stale pre-restart blocks. The
+//! namespace therefore folds a per-client `client_salt` (fresh random per
+//! connect; `ATLAS_KV_PAGING_SALT` pins it for tests/harness). Consequence,
+//! stated honestly: the KV paging win is peer residency + NVMe depth +
+//! capacity pooling, NOT cross-client warm hits (those need content-addressed
+//! keys — a separate chunk, same seam as the SSM decode-ns residual).
+//!
+//! The SSM `ModelFingerprint` VALUE alone is insufficient here by documented
+//! design: it excludes the KV dtype and every block-geometry field
+//! (fingerprint.rs "a future KV paging tier must fold its own dtype /
+//! block_size mix-in at its own call site"), and `GroupLayout::group_id`
+//! numbering is layout-relative (`num_blocks` changes with the GPU-memory
+//! budget). So the namespace re-folds the full layout identity alongside the
+//! fingerprint.
+//!
+//! Everything here is a DURABLE on-peer contract (the peer's swap file
+//! outlives client rebuilds): the tagged encoding is frozen behind
+//! [`KV_NS_VERSION`], and the hash primitives are vendored byte-for-byte
+//! (FNV-1a/64 + the splitmix64 finalizer, ~25 dependency-free lines) and
+//! golden-pinned against spark-model's copies (`ns_tests.rs` here,
+//! `fingerprint_tests.rs` there share frozen literals) so the two crates can
+//! never drift. spark-storage stays `ModelConfig`-free: the fingerprint
+//! arrives as a plain u64 (`ModelDims::model_fp`).
+
+use std::num::NonZeroU64;
+
+use anyhow::{Result, anyhow};
+
+use crate::group::GroupLayout;
+
+/// Bump = deliberate fleet-wide KV cache-key rotation (document it).
+pub const KV_NS_VERSION: u64 = 1;
+
+/// Domain separator folded into every KV namespace so a KV wire key is
+/// domain-separated from SSM keys IN THE KEY MATERIAL, not merely by the
+/// peer's `(kind, blob_bytes)` registry keying (which already gives each kind
+/// its own residency map + swap file — this fold makes cross-kind aliasing
+/// unrepresentable even if that registry keying were ever collapsed).
+/// Frozen; mnemonic `"KV"` + `"PAGE"` + 1. The SSM decode tier's analog is
+/// `atlas_kernels::DECODE_DOMAIN`.
+pub const KV_DOMAIN: u64 = 0x4B56_5041_4745_0001;
+
+/// Vendored FNV-1a/64 — byte-identical to spark-model's `fingerprint.rs`
+/// copy; both are pinned to the published FNV reference vectors.
+pub(crate) use atlas_tier::hash::{FNV_OFFSET, fnv1a_64};
+
+// SSOT: this was a FOURTH transcription of the splitmix64 constants — its own doc
+// comment asserted it was "byte-identical to spark-model's mix64", which is the
+// violation stating itself. One definition, in atlas_tier::hash.
+pub(crate) use atlas_tier::hash::mix64;
+
+fn put_u64(buf: &mut Vec<u8>, tag: u8, v: u64) {
+    buf.push(tag);
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+/// Derive the KV paging namespace. FROZEN tagged encoding (injective:
+/// fixed-width `[tag][8-byte LE]` records) — any field or order change is a
+/// deliberate fleet cache flush and must bump [`KV_NS_VERSION`]:
+///
+/// | tag  | field           | tag  | field          | tag  | field         |
+/// |------|-----------------|------|----------------|------|---------------|
+/// | 0x00 | KV_NS_VERSION   | 0x04 | block_size     | 0x08 | num_kv_heads  |
+/// | 0x01 | model_fp        | 0x05 | head_dim       | 0x09 | fs_block_size |
+/// | 0x02 | KV_DOMAIN       | 0x06 | num_layers     | 0x0a | group_stride  |
+/// | 0x03 | elem_bytes      | 0x07 | num_blocks     | 0x0b | client_salt   |
+///
+/// `model_fp` carries the quant identity + model_type + `ATLAS_MODEL_ID`
+/// salt (`ModelFingerprint::derive_kv` in spark-model); the geometry fields
+/// make the layout identity explicit because `group_id` numbering is
+/// layout-relative. Zero-avoidance falls back to `FNV_OFFSET` (p = 2^-64),
+/// keeping the result total — ns = 0 stays unrepresentable end-to-end.
+pub fn derive_kv_ns(
+    model_fp: u64,
+    layout: &GroupLayout,
+    elem_bytes: u32,
+    block_size: u32,
+    head_dim: u32,
+    client_salt: u64,
+) -> NonZeroU64 {
+    let mut buf = Vec::with_capacity(12 * 9);
+    for (tag, v) in [
+        (0x00u8, KV_NS_VERSION),
+        (0x01, model_fp),
+        (0x02, KV_DOMAIN),
+        (0x03, elem_bytes as u64),
+        (0x04, block_size as u64),
+        (0x05, head_dim as u64),
+        (0x06, layout.num_layers as u64),
+        (0x07, layout.num_blocks as u64),
+        (0x08, layout.num_kv_heads as u64),
+        (0x09, layout.fs_block_size),
+        (0x0a, layout.group_stride),
+        (0x0b, client_salt),
+    ] {
+        put_u64(&mut buf, tag, v);
+    }
+    let h = fnv1a_64(&buf);
+    NonZeroU64::new(h).unwrap_or(NonZeroU64::new(FNV_OFFSET).expect("FNV offset is non-zero"))
+}
+
+/// Wire key for one KV block: the namespace fold of the block's BASE dense
+/// group id — `group_id(GroupKey::new(layer, block, 0, K))`, injective across
+/// `(layer, block)` within a layout (layout identity rides in the ns, so
+/// cross-layout ids cannot alias). Same splitmix fold as the SSM tier's
+/// `PagingSnapshotStore::wire` — bijective per namespace, so no birthday risk
+/// over the dense group-id keyspace.
+pub fn wire_key(ns: NonZeroU64, base_group_id: u64) -> u64 {
+    mix64(base_group_id, ns.get())
+}
+
+/// Strict u64 parser for the env overrides (decimal or `0x`-hex). Junk is a
+/// startup ERROR, never a silent fallthrough (PCND).
+pub fn parse_u64_strict(var: &str, raw: &str) -> Result<u64> {
+    let s = raw.trim();
+    let parsed = match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        Some(hex) => u64::from_str_radix(hex, 16),
+        None => s.parse::<u64>(),
+    };
+    parsed.map_err(|e| anyhow!("{var}={raw:?} is not a valid u64 (decimal or 0x-hex): {e}"))
+}
+
+/// `ATLAS_KV_PAGING_NS` override (env-free core): strict parse, 0 rejected —
+/// a shared peer must always be namespaced (the ns=0 passthrough is
+/// unrepresentable, mirroring the landed SSM fix). `None` ⇒ the derived ns.
+pub fn resolve_kv_ns_from(override_raw: Option<&str>, derived: NonZeroU64) -> Result<NonZeroU64> {
+    match override_raw {
+        None => Ok(derived),
+        Some(raw) => {
+            let v = parse_u64_strict("ATLAS_KV_PAGING_NS", raw)?;
+            NonZeroU64::new(v).ok_or_else(|| {
+                anyhow!(
+                    "ATLAS_KV_PAGING_NS=0 is invalid: ns=0 is unrepresentable (it would \
+                     cross-serve KV state on a shared peer); unset it to use the derived \
+                     namespace (logged at INFO on connect)"
+                )
+            })
+        }
+    }
+}
+
+/// `ATLAS_KV_PAGING_SALT` override (env-free core): strict; `Ok(None)` ⇒ the
+/// caller generates a fresh random per-connect salt (client isolation +
+/// self-healing restart staleness — old-salt peer entries become unreachable
+/// and LRU-age out), INFO-logging it for reproducibility.
+pub fn resolve_salt_from(raw: Option<&str>) -> Result<Option<u64>> {
+    raw.map(|r| parse_u64_strict("ATLAS_KV_PAGING_SALT", r))
+        .transpose()
+}
+
+/// `ATLAS_KV_PAGING` selection (env-free core): unset or `0` ⇒ the raw dumb
+/// one-sided `RdmaKvBackend` path (client-owned allocator; its
+/// handshake is the v2 header with `blob_bytes == 0`); `1` ⇒ the peer-owned
+/// paging backend. Anything else is a startup ERROR (PCND — a typo must never
+/// silently pick a path).
+pub fn kv_paging_selected(raw: Option<&str>) -> Result<bool> {
+    match raw.map(str::trim) {
+        None | Some("0") => Ok(false),
+        Some("1") => Ok(true),
+        Some(other) => Err(anyhow!(
+            "ATLAS_KV_PAGING={other:?} is invalid: 1 = peer-owned paging KV, 0/unset = the \
+             raw one-sided KV blade"
+        )),
+    }
+}
+
+/// `ATLAS_KV_PAGING_ARENA_GB` (REQUIRED when the flag is on — no implicit
+/// default, PCND): the peer warm-arena size in GiB (fractional accepted),
+/// floored to a multiple of `block_bytes` and required to hold ≥ 1 block.
+/// The raw path sized the peer to `num_groups × group_stride` (every group
+/// a guaranteed slot); the paging arena is a deliberately smaller warm cache
+/// over the peer's NVMe swap, so the operator must choose it explicitly.
+pub fn resolve_arena_bytes_from(raw: Option<&str>, block_bytes: u64) -> Result<u64> {
+    let raw = raw.ok_or_else(|| {
+        anyhow!(
+            "ATLAS_KV_PAGING=1 requires ATLAS_KV_PAGING_ARENA_GB (peer warm-arena size in \
+             GiB, fractional ok) — explicit config or fail fast (PCND)"
+        )
+    })?;
+    let gb: f64 = raw
+        .trim()
+        .parse()
+        .map_err(|e| anyhow!("ATLAS_KV_PAGING_ARENA_GB={raw:?} is not a number: {e}"))?;
+    if !gb.is_finite() || gb <= 0.0 {
+        return Err(anyhow!(
+            "ATLAS_KV_PAGING_ARENA_GB={raw:?} must be a finite value > 0"
+        ));
+    }
+    let bb = block_bytes.max(1);
+    let arena = ((gb * (1u64 << 30) as f64) as u64 / bb) * bb;
+    if arena == 0 {
+        return Err(anyhow!(
+            "ATLAS_KV_PAGING_ARENA_GB={raw} is smaller than one KV block ({bb} B) — the \
+             warm arena must hold at least one block"
+        ));
+    }
+    Ok(arena)
+}
+
+/// Startup guard (env-free core): the cascade T1 (`ATLAS_KV_LOCAL_GB > 0`)
+/// flushes evictions DOWN via per-head `write_from_host`, which the
+/// block-record paging backend refuses — that combination must fail fast at
+/// construction (PCND), never bail mid-decode on the first T1 eviction.
+/// Returns `true` iff the incompatible combination is selected.
+pub fn cascade_conflicts_with_paging(kv_peer_set: bool, flag_raw: Option<&str>) -> Result<bool> {
+    Ok(kv_peer_set && kv_paging_selected(flag_raw)?)
+}
+
+#[cfg(test)]
+#[path = "ns_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/kv_paging/ns_tests.rs
+++ b/crates/spark-storage/src/kv_paging/ns_tests.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! KV namespace derivation pins: frozen golden literals (the ns is a DURABLE
+//! on-peer key contract), per-field sensitivity (the fingerprint-exclusion
+//! trap: elem_bytes / block geometry are NOT in the SSM fp and must flip the
+//! ns here), cross-crate hash-primitive pins (spark-model's vendored copies
+//! share these exact literals in `fingerprint_tests.rs` — drift fails one
+//! side), and the strict env resolvers (PCND).
+
+use std::num::NonZeroU64;
+
+use super::*;
+use crate::group::GroupLayout;
+
+/// Holo-like layout: 80 layers × 4096 blocks × 8 kv_heads, bs 16, hd 128,
+/// BF16 → group_stride 4096, block_bytes 65536.
+fn layout() -> GroupLayout {
+    GroupLayout::new(80, 4096, 8, 16, 128, 2, 4096)
+}
+
+const FP: u64 = 0x5629_922c_51a1_6a10; // spark-model's pinned hybrid-config fp
+const SALT: u64 = 0xD00D_F00D_0000_0001;
+
+fn ns_with(f: impl FnOnce(&mut (u64, GroupLayout, u32, u32, u32, u64))) -> NonZeroU64 {
+    let mut a = (FP, layout(), 2u32, 16u32, 128u32, SALT);
+    f(&mut a);
+    derive_kv_ns(a.0, &a.1, a.2, a.3, a.4, a.5)
+}
+
+// ── frozen contracts ─────────────────────────────────────────────────────
+
+#[test]
+// The protocol-constant pins below are deliberate constant asserts: they are
+// load-bearing frozen contracts (durable on-peer keys), kept as visible
+// runtime test failures.
+#[allow(clippy::assertions_on_constants)]
+fn version_and_domain_frozen() {
+    assert_eq!(KV_NS_VERSION, 1);
+    assert_eq!(KV_DOMAIN, 0x4B56_5041_4745_0001, "\"KV\" + \"PAGE\" + 1");
+    assert_ne!(KV_DOMAIN, 0, "the domain must be a usable ns fallback");
+}
+
+/// The vendored FNV-1a/64 matches the published reference vectors — the SAME
+/// vectors spark-model's `fingerprint_tests.rs` pins its copy to, so the two
+/// vendored primitives cannot drift apart without failing one crate.
+#[test]
+fn fnv1a_64_matches_reference_vectors() {
+    assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+    assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+}
+
+/// Cross-crate splitmix pin: these EXACT literals are also asserted against
+/// spark-model's `mix64` (fingerprint_tests.rs `mix64_frozen_literals`). The
+/// fold is what turns (group_id, ns) into the durable wire key on BOTH the
+/// SSM and KV paths, so a drifted constant rotates or collides on-disk keys.
+#[test]
+fn mix64_frozen_literals() {
+    assert_eq!(mix64(0, 0), 0x0); // splitmix64's fixed point at zero
+    assert_eq!(mix64(1, 2), 0xbeeb_8da1_658e_ec67);
+    assert_eq!(
+        mix64(0x5EED_F00D_CAFE_D00D, 0xD3C0_DE12_A5B6_C7D8),
+        0xe567_5d86_f750_1640
+    );
+}
+
+/// The full derivation is frozen: same inputs → this literal, forever (bump
+/// KV_NS_VERSION to rotate deliberately).
+#[test]
+fn derive_kv_ns_golden() {
+    assert_eq!(ns_with(|_| {}).get(), 0x74b4_02b0_f421_5375);
+}
+
+#[test]
+fn wire_key_golden_and_mechanism() {
+    let ns = ns_with(|_| {});
+    // wire_key IS the splitmix fold (same as PagingSnapshotStore::wire).
+    assert_eq!(wire_key(ns, 42), mix64(42, ns.get()));
+    assert_eq!(wire_key(ns, 42), 0x6d2d_470e_f594_7d4b);
+    // Deterministic; distinct namespaces fold the same id differently.
+    assert_eq!(wire_key(ns, 42), wire_key(ns, 42));
+    let other = ns_with(|a| a.5 ^= 1);
+    assert_ne!(wire_key(ns, 42), wire_key(other, 42));
+}
+
+// ── per-field sensitivity: the fingerprint-exclusion trap ────────────────
+// elem_bytes / block_size / head_dim / num_blocks etc. are ABSENT from the
+// SSM ModelFingerprint (by documented design); each must flip the KV ns or
+// two byte-incompatible serves would share keys.
+
+#[test]
+fn every_field_flips_the_namespace() {
+    let base = ns_with(|_| {});
+    let variants: [(&str, NonZeroU64); 9] = [
+        ("model_fp", ns_with(|a| a.0 ^= 1)),
+        ("elem_bytes", ns_with(|a| a.2 = 1)), // fp8 KV vs bf16 KV
+        ("block_size", ns_with(|a| a.3 = 32)),
+        ("head_dim", ns_with(|a| a.4 = 64)),
+        (
+            "num_layers",
+            ns_with(|a| a.1 = GroupLayout::new(48, 4096, 8, 16, 128, 2, 4096)),
+        ),
+        (
+            "num_blocks", // a different --gpu-memory budget renumbers group_ids
+            ns_with(|a| a.1 = GroupLayout::new(80, 2048, 8, 16, 128, 2, 4096)),
+        ),
+        (
+            "num_kv_heads",
+            ns_with(|a| a.1 = GroupLayout::new(80, 4096, 4, 16, 128, 2, 4096)),
+        ),
+        (
+            "fs_block_size", // also moves group_stride padding
+            ns_with(|a| a.1 = GroupLayout::new(80, 4096, 8, 16, 128, 2, 512)),
+        ),
+        ("client_salt", ns_with(|a| a.5 = SALT ^ 0xFFFF)),
+    ];
+    for (name, v) in variants {
+        assert_ne!(v, base, "changing {name} must flip the KV namespace");
+    }
+}
+
+// ── strict env resolvers (env-free cores; PCND) ──────────────────────────
+
+#[test]
+fn flag_selection_is_strict() {
+    // Flag OFF (unset / "0") ⇒ the raw dumb one-sided path
+    // (connect_kv_peer_backend calls RdmaKvBackend::connect — same data
+    // plane; its handshake is the v2 header with blob == 0).
+    assert!(!kv_paging_selected(None).unwrap());
+    assert!(!kv_paging_selected(Some("0")).unwrap());
+    assert!(kv_paging_selected(Some("1")).unwrap());
+    // A typo must never silently pick a path.
+    assert!(kv_paging_selected(Some("yes")).is_err());
+    assert!(kv_paging_selected(Some("")).is_err());
+}
+
+/// Flag OFF wire half (the bare `total_bytes` handshake is retired):
+/// `RdmaKvBackend` now sends the v2 header with `blob_bytes == 0` (RAW
+/// one-sided mode). Pin that a REALISTIC Holo-like total round-trips through
+/// encode/parse and stays under the peer's explicit arena sanity bound.
+#[test]
+fn flag_off_raw_v2_header_round_trips() {
+    use crate::snapshot_swap::{PagingKind, encode_paging_v2_header, parse_paging_header};
+    let l = layout();
+    let num_groups = (l.num_layers as u64) * 2 * (l.num_blocks as u64) * (l.num_kv_heads as u64);
+    let total = num_groups * l.group_stride; // what RdmaKvBackend::connect sizes
+    assert!(
+        total <= (1 << 42),
+        "raw totals stay under the peer's arena sanity bound"
+    );
+    let w = encode_paging_v2_header(PagingKind::KV, total, 0);
+    let first = u64::from_le_bytes(w[0..8].try_into().unwrap());
+    let mut c = std::io::Cursor::new(w[8..].to_vec());
+    assert_eq!(
+        parse_paging_header(first, &mut c).unwrap(),
+        (PagingKind::KV, total, 0),
+        "flag-OFF clients ride the RAW one-sided mode (blob_bytes == 0)"
+    );
+}
+
+#[test]
+fn cascade_paging_conflict_is_detected() {
+    // Only the (peer set AND flag on) combination conflicts.
+    assert!(cascade_conflicts_with_paging(true, Some("1")).unwrap());
+    assert!(!cascade_conflicts_with_paging(true, None).unwrap());
+    assert!(!cascade_conflicts_with_paging(true, Some("0")).unwrap());
+    assert!(!cascade_conflicts_with_paging(false, Some("1")).unwrap());
+    // Strictness propagates (a typo'd flag is still a startup error).
+    assert!(cascade_conflicts_with_paging(true, Some("junk")).is_err());
+}
+
+#[test]
+fn ns_override_is_strict() {
+    let derived = NonZeroU64::new(0xFEED).unwrap();
+    assert_eq!(resolve_kv_ns_from(None, derived).unwrap(), derived);
+    assert_eq!(
+        resolve_kv_ns_from(Some("0xD3C0"), derived).unwrap().get(),
+        0xD3C0
+    );
+    assert_eq!(resolve_kv_ns_from(Some("77"), derived).unwrap().get(), 77);
+    assert!(resolve_kv_ns_from(Some("junk"), derived).is_err());
+    assert!(
+        resolve_kv_ns_from(Some("0"), derived).is_err(),
+        "ns=0 stays unrepresentable"
+    );
+}
+
+#[test]
+fn salt_override_is_strict() {
+    assert_eq!(resolve_salt_from(None).unwrap(), None); // caller randomizes
+    assert_eq!(resolve_salt_from(Some("0x10")).unwrap(), Some(0x10));
+    assert_eq!(resolve_salt_from(Some("7")).unwrap(), Some(7));
+    assert!(resolve_salt_from(Some("nope")).is_err());
+}
+
+#[test]
+fn arena_resolution_is_strict_and_block_aligned() {
+    let bb = 65536u64; // Holo-like block_bytes
+    // REQUIRED: absence is an error naming the variable (PCND).
+    let err = resolve_arena_bytes_from(None, bb).unwrap_err().to_string();
+    assert!(err.contains("ATLAS_KV_PAGING_ARENA_GB"), "{err}");
+    // 1 GiB is already a block multiple.
+    assert_eq!(resolve_arena_bytes_from(Some("1"), bb).unwrap(), 1 << 30);
+    // Fractional GiB floors to a block multiple.
+    let a = resolve_arena_bytes_from(Some("0.001"), bb).unwrap();
+    assert_eq!(a % bb, 0);
+    assert!(a > 0 && a <= (0.001 * (1u64 << 30) as f64) as u64);
+    // Junk / zero / negative / sub-block all fail fast.
+    assert!(resolve_arena_bytes_from(Some("lots"), bb).is_err());
+    assert!(resolve_arena_bytes_from(Some("0"), bb).is_err());
+    assert!(resolve_arena_bytes_from(Some("-1"), bb).is_err());
+    assert!(resolve_arena_bytes_from(Some("0.00000001"), bb).is_err());
+}
+
+/// The MISS hard-error names the peer flag that makes KV miss-proof — the
+/// message is the operator's runbook line, so pin its load-bearing parts.
+#[test]
+fn miss_error_names_the_miss_proof_config() {
+    let e = super::super::kv_miss_error(3, 77).to_string();
+    assert!(e.contains("layer 3"), "{e}");
+    assert!(e.contains("--swap-cap-gb-kv 0"), "{e}");
+    assert!(e.contains("unrecoverable"), "{e}");
+}

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -77,6 +77,12 @@ pub mod backend;
 #[cfg(feature = "cuda")]
 pub mod bench;
 #[cfg(feature = "cuda")]
+pub mod expert_arena;
+#[cfg(feature = "cuda")]
+pub mod expert_tier;
+#[cfg(feature = "cuda")]
+pub mod expert_tier_rdma;
+#[cfg(feature = "cuda")]
 pub mod high_speed_swap;
 #[cfg(feature = "cuda")]
 pub mod predictor;
@@ -94,9 +100,17 @@ pub use eviction::EvictionPolicy;
 pub use expert::{
     ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordId, ExpertRecordSpec, Proj, ProjBytes,
 };
+#[cfg(feature = "cuda")]
+pub use expert_arena::ExpertArena;
 #[cfg(unix)]
 pub use expert_pack::{ExpertFileReader, ExpertFileWriter};
 pub use expert_pack::{ExpertIndex, ProjData, ProjView, pack_record, unpack_record};
+#[cfg(feature = "cuda")]
+pub use expert_tier::{
+    ArenaSlot, ExpertResidency, ExpertTier, PosixTier, TierKind, UmaArenaTier, open_tier,
+};
+#[cfg(feature = "cuda")]
+pub use expert_tier_rdma::RdmaTier;
 #[cfg(feature = "cuda")]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
 pub use rdma_snapshot::RdmaSnapshotArena;

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -50,6 +50,10 @@ pub mod projection;
 pub mod rdma_kv_backend;
 pub mod rdma_snapshot;
 pub mod snapshot_swap;
+// RDMA weight-staging peer (RO): serves a model's safetensors shards to the
+// weight loader over one-sided READ for fast model swaps. `manifest`/`wire` are
+// un-gated; `serve`/`shard` are `cfg(unix)` internally.
+pub mod weight_peer;
 
 // KV overflow blade (cache-peer): a passive remote-RAM RW tier for the
 // high-speed-swap KV cache, served over one-sided RDMA. `cache_peer` is the
@@ -158,3 +162,4 @@ pub use probe::{Backend, ProbeConfig, ProbeResult, run_probe};
 pub use projection::{PredictorShape, build_projection};
 #[cfg(feature = "cuda")]
 pub use tiled_attention::{TiledAttention, TiledAttentionDims};
+pub use weight_peer::{WeightManifest, WeightTensorRecord};

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -41,6 +41,17 @@ pub mod projection;
 pub mod rdma_snapshot;
 pub mod snapshot_swap;
 
+// KV overflow blade (cache-peer): a passive remote-RAM RW tier for the
+// high-speed-swap KV cache, served over one-sided RDMA. `cache_peer` is the
+// server; `blade_cap` is the process-global commit ledger it (and the
+// weight/expert peers) reserve against — CUDA-free arithmetic, so it's
+// `#[allow(dead_code)]` on verbs-OFF builds where the handshake that consumes
+// it is compiled out.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub(crate) mod blade_cap;
+pub mod cache_peer;
+
 // `ModelDims` is a plain POD struct (no GPU state) that
 // `spark-model`'s public surface threads through every layer's
 // forward signature; it must stay reachable on metal builds even

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -34,6 +34,9 @@ pub use cuda_module::{CudaEvent, CudaModule, launch_kernel};
 pub mod attention_ref;
 pub mod config;
 pub mod eviction;
+pub mod expert;
+pub mod expert_pack;
+pub mod expert_peer;
 pub mod group;
 pub mod model_dims;
 pub mod predictor_ref;
@@ -88,6 +91,12 @@ pub mod tiled_attention;
 pub use backend::{IoUringBackend, PosixBackend, ReadRequest, StorageBackend};
 pub use config::HighSpeedSwapConfig;
 pub use eviction::EvictionPolicy;
+pub use expert::{
+    ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordId, ExpertRecordSpec, Proj, ProjBytes,
+};
+#[cfg(unix)]
+pub use expert_pack::{ExpertFileReader, ExpertFileWriter};
+pub use expert_pack::{ExpertIndex, ProjData, ProjView, pack_record, unpack_record};
 #[cfg(feature = "cuda")]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
 pub use rdma_snapshot::RdmaSnapshotArena;

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -106,6 +106,15 @@ pub mod probe;
 pub mod scratch_pool;
 #[cfg(feature = "cuda")]
 pub mod tiled_attention;
+// RDMA weight loader — the cuda client of `weight_peer` that one-sided-READs a
+// model's tensors into a `spark_runtime::weights::WeightStore` for fast swaps.
+// RDMA-stage a PEFT adapter's A/B tensors straight into a resident LoRA pool
+// slot (reuses the weight_peer manifest + wire; landing byte-identical to the
+// disk pack).
+#[cfg(feature = "cuda")]
+pub mod weight_lora_rdma;
+#[cfg(feature = "cuda")]
+pub mod weight_tier_rdma;
 
 #[cfg(feature = "cuda")]
 pub use backend::{IoUringBackend, PosixBackend, ReadRequest, StorageBackend};
@@ -162,4 +171,8 @@ pub use probe::{Backend, ProbeConfig, ProbeResult, run_probe};
 pub use projection::{PredictorShape, build_projection};
 #[cfg(feature = "cuda")]
 pub use tiled_attention::{TiledAttention, TiledAttentionDims};
+#[cfg(feature = "cuda")]
+pub use weight_lora_rdma::{LoraAbKind, LoraLandTarget, RdmaLoraLoader};
 pub use weight_peer::{WeightManifest, WeightTensorRecord};
+#[cfg(feature = "cuda")]
+pub use weight_tier_rdma::RdmaWeightLoader;

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -38,6 +38,8 @@ pub mod group;
 pub mod model_dims;
 pub mod predictor_ref;
 pub mod projection;
+pub mod rdma_snapshot;
+pub mod snapshot_swap;
 
 // `ModelDims` is a plain POD struct (no GPU state) that
 // `spark-model`'s public surface threads through every layer's
@@ -77,6 +79,20 @@ pub use config::HighSpeedSwapConfig;
 pub use eviction::EvictionPolicy;
 #[cfg(feature = "cuda")]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
+pub use rdma_snapshot::RdmaSnapshotArena;
+
+/// `true` iff `atlas_rdma_verbs` was re-emitted for this crate by build.rs (the
+/// one-sided verbs shim lives in the CUDA-free `atlas-rdma` crate; `rustc-cfg`
+/// doesn't cross crates, so build.rs re-emits it off atlas-rdma's `links`
+/// metadata). `rdma_verbs_probe_tests` asserts it, so a silent cfg evaporation
+/// fails `cargo test -p spark-storage --lib` on verbs hosts instead of
+/// green-building with the gated modules compiled out.
+pub const fn rdma_verbs_enabled() -> bool {
+    cfg!(atlas_rdma_verbs)
+}
+
+#[cfg(test)]
+mod rdma_verbs_probe_tests;
 
 // Non-cuda stub surface — same names as the real CUDA orchestrator
 // above so spark-model's call sites compile unchanged. `with_local`

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -41,6 +41,11 @@ pub mod group;
 pub mod model_dims;
 pub mod predictor_ref;
 pub mod projection;
+// The one-sided RDMA KV transport backend — a `StorageBackend` impl that
+// offloads/restores KV groups to a `cache_peer` blade over verbs. cuda (for the
+// pinned-host bounce + copy_h2d) + the verbs shim.
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+pub mod rdma_kv_backend;
 pub mod rdma_snapshot;
 pub mod snapshot_swap;
 
@@ -113,6 +118,8 @@ pub use expert_tier::{
 pub use expert_tier_rdma::RdmaTier;
 #[cfg(feature = "cuda")]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+pub use rdma_kv_backend::RdmaKvBackend;
 pub use rdma_snapshot::RdmaSnapshotArena;
 
 /// `true` iff `atlas_rdma_verbs` was re-emitted for this crate by build.rs (the

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -38,6 +38,7 @@ pub mod expert;
 pub mod expert_pack;
 pub mod expert_peer;
 pub mod group;
+pub mod kv_paging;
 pub mod model_dims;
 pub mod predictor_ref;
 pub mod projection;
@@ -118,6 +119,8 @@ pub use expert_tier::{
 pub use expert_tier_rdma::RdmaTier;
 #[cfg(feature = "cuda")]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+pub use kv_paging::KvPagingBackend;
 #[cfg(all(feature = "cuda", atlas_rdma_verbs))]
 pub use rdma_kv_backend::RdmaKvBackend;
 pub use rdma_snapshot::RdmaSnapshotArena;

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -32,6 +32,7 @@ pub use cuda_module::{CudaEvent, CudaModule, launch_kernel};
 
 // Pure CPU-side modules — types, configs, references. Always compiled.
 pub mod attention_ref;
+pub mod cascade_policy;
 pub mod config;
 pub mod eviction;
 pub mod expert;
@@ -82,6 +83,9 @@ pub mod layout;
 pub mod backend;
 #[cfg(feature = "cuda")]
 pub mod bench;
+// T1 write-back cache composite (wraps any StorageBackend). cuda but not verbs.
+#[cfg(feature = "cuda")]
+pub mod cascade_backend;
 #[cfg(feature = "cuda")]
 pub mod expert_arena;
 #[cfg(feature = "cuda")]

--- a/crates/spark-storage/src/model_dims.rs
+++ b/crates/spark-storage/src/model_dims.rs
@@ -15,4 +15,12 @@ pub struct ModelDims {
     pub num_kv_heads: u16,
     pub head_dim: u16,
     pub block_size: u16,
+    /// Config-derived model fingerprint (spark-model's `ModelFingerprint`,
+    /// KV convention `derive_kv`: blob_bytes = 0) — the per-model identity
+    /// the KV paging namespace folds (`kv_paging::ns::derive_kv_ns`) so two
+    /// models sharing one paging peer can never collide. `None` when the
+    /// loader could not derive one (or in geometry-only tests/benches);
+    /// `ATLAS_KV_PAGING=1` then fails fast at connect unless
+    /// `ATLAS_KV_PAGING_NS` is set explicitly. Unread on every other path.
+    pub model_fp: Option<std::num::NonZeroU64>,
 }

--- a/crates/spark-storage/src/rdma_kv_backend.rs
+++ b/crates/spark-storage/src/rdma_kv_backend.rs
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RdmaKvBackend — the KV cache overflow tier over one-sided RDMA.
+//
+// A drop-in `StorageBackend` (same trait the io_uring / posix NVMe backends
+// implement), except the store is a peer's RAM blade (`cache_peer`) reached over
+// RoCE instead of a local file:
+//   * `write_from_host` (offload a cold group) -> `IBV_WR_RDMA_WRITE` the group
+//     into the peer at `base + group_id * group_stride`.
+//   * `read` (restore groups)                  -> `IBV_WR_RDMA_READ` them back
+//     into pinned bounces, then `copy_h2d` to the HBM destinations.
+//
+// PIPELINED + DUAL-RAIL. Each RAIL is a QP on one CX7 adapter with its own ring
+// of `depth` registered bounce buffers (env `ATLAS_KV_PIPELINE_DEPTH`, default
+// 16). With `ATLAS_KV_DUAL_RAIL=1` the client opens 2 rails (env
+// `ATLAS_EXPERT_RDMA_DEV`/`GID` = rail 0, `ATLAS_KV_RAIL2_DEV`/`GID` = rail 1)
+// and stripes ops round-robin across both adapters — the two GB10 CX7 ports are
+// independent PCIe paths (~1.75x aggregate). The peer registers its arena once
+// per rail (shared physical pages, refcounted pinning → not N× RAM).
+//
+// The pipeline keeps up to `depth` RDMA ops in flight per rail so per-op latency
+// overlaps across a batch and RDMA READs overlap `copy_h2d`. `read` posts the
+// batch across all rails and reaps completions (interleaved so both rails run in
+// parallel), one `stream_sync` at the end. `write_from_host` posts async and
+// reaps lazily; writes are drained before any read (a restore always sees prior
+// offloads) and on drop for durability.
+//
+// This is the "faster than the SSD" tier: peer RAM over CX7 vs the ~2 GB/s USB
+// SSD. Peer CPU idle (one-sided); each group belongs to one client, no coherence.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::io::Write;
+use std::net::TcpStream;
+
+use anyhow::{Context, Result, bail};
+
+use crate::backend::{ReadRequest, StorageBackend};
+use crate::cuda_min::{PinnedBuffer, stream_sync};
+use crate::group::{GroupKey, GroupLayout};
+
+mod rail;
+
+use rail::{Bounce, Rail};
+
+pub struct RdmaKvBackend {
+    rails: Vec<Rail>,
+    layout: GroupLayout,
+    remote_base: u64,
+    rr: usize, // round-robin rail cursor for writes
+    /// Zero-copy restore (ATLAS_KV_ZERO_COPY=1): RDMA READ lands directly into
+    /// the (UMA) destination, skipping the bounce + copy_h2d that otherwise caps
+    /// restore at the copy-engine bandwidth.
+    zero_copy: bool,
+    _stream: TcpStream,
+}
+
+// See the single-rail rationale: both trait methods take `&mut self` and no
+// `&self` method touches a QP, so `Sync` is sound (the swap orchestrator owns it
+// single-threaded regardless).
+unsafe impl Sync for RdmaKvBackend {}
+
+impl RdmaKvBackend {
+    /// Connect to a KV blade at `addr`, size + register the peer arena, bring up
+    /// N rails (RC QPs across the CX7 adapters) via
+    /// [`atlas_rdma::railset::RailSet`], and allocate each rail's ring.
+    pub fn connect(addr: &str, layout: GroupLayout) -> Result<Self> {
+        use atlas_rdma::env::{first_set, first_set_u32};
+        use atlas_rdma::railset::{RailSet, RailSpec};
+
+        let group_bytes = layout.group_bytes() as usize;
+        let num_groups = (layout.num_layers as u64)
+            * 2
+            * (layout.num_blocks as u64)
+            * (layout.num_kv_heads as u64);
+        let total_bytes = num_groups * layout.group_stride;
+
+        // Rail devices: rail 0 from the expert env (shared CX7 link), rail 1 from
+        // the KV rail-2 env. Dual-rail only when ATLAS_KV_DUAL_RAIL=1. Fresh
+        // random 24-bit PSN per rail.
+        let spec =
+            |dev: String, gid: u32| RailSpec::new(dev, gid, rand::random::<u32>() & 0xff_ffff);
+        let rail0 = spec(
+            first_set(&["ATLAS_EXPERT_RDMA_DEV"], "roceP2p1s0f1"),
+            first_set_u32(&["ATLAS_EXPERT_RDMA_GID"], 3),
+        );
+        let dual = std::env::var("ATLAS_KV_DUAL_RAIL").ok().as_deref() == Some("1");
+        let specs: Vec<RailSpec> = if dual {
+            let rail1 = spec(
+                first_set(&["ATLAS_KV_RAIL2_DEV"], "rocep1s0f1"),
+                first_set_u32(&["ATLAS_KV_RAIL2_GID"], 3),
+            );
+            vec![rail0, rail1]
+        } else {
+            vec![rail0]
+        };
+        let n_rails = specs.len();
+        let depth: usize = first_set_u32(&["ATLAS_KV_PIPELINE_DEPTH"], 16).clamp(1, 128) as usize;
+
+        let mut stream =
+            TcpStream::connect(addr).with_context(|| format!("connect kv peer {addr}"))?;
+        stream.set_nodelay(true).ok();
+        // v2 RAW one-sided mode: blob_bytes == 0 tells the peer to
+        // hand this connection a private fixed arena with a CLIENT-owned
+        // allocator — the same data plane the pre-Step-C bare `total_bytes`
+        // handshake selected, now signalled explicitly.
+        stream
+            .write_all(&crate::snapshot_swap::encode_paging_v2_header(
+                crate::snapshot_swap::PagingKind::KV,
+                total_bytes,
+                0,
+            ))
+            .context("send kv raw-mode v2 header")?;
+
+        // [u8 n_rails] + one QP per rail, then each rail's bounce ring
+        // (LOCAL_WRITE-only landing MRs — `remote_read == false`, invariant).
+        let mut rs = RailSet::begin(&mut stream, &specs)?;
+        let mut rings: Vec<Vec<Bounce>> = Vec::with_capacity(n_rails);
+        for rail in &mut rs.rails {
+            let mut bounces = Vec::with_capacity(depth);
+            for _ in 0..depth {
+                let buf = PinnedBuffer::new(group_bytes).context("alloc pinned kv bounce")?;
+                // SAFETY: buf lives as long as the rail (and thus the MR).
+                let keys = unsafe { rail.verbs.reg_mr(buf.ptr, group_bytes, false)? };
+                bounces.push(Bounce {
+                    buf,
+                    lkey: keys.lkey,
+                    copy_done: None,
+                });
+            }
+            rings.push(bounces);
+        }
+
+        // Peer's per-rail QP + rkey (shared base), client params, connect, ack.
+        let server = rs.finish_rw(&mut stream, "kv peer")?;
+        // Shared arena base: every rail publishes the same one (keep the LAST,
+        // the pre-RailSet loop-overwrite behavior).
+        let base = server.last().map(|sp| sp.base_addr).unwrap_or(0);
+        let rails: Vec<Rail> = rs
+            .into_verbs()
+            .into_iter()
+            .zip(rings)
+            .zip(&server)
+            .map(|((verbs, bounces), sp)| Rail {
+                verbs,
+                remote_rkey: sp.rkey,
+                free: (0..depth).collect(),
+                bounces,
+                inflight: HashMap::new(),
+                next_wr: 0,
+                dst_lkeys: HashMap::new(),
+                region: None,
+                direct_inflight: 0,
+            })
+            .collect();
+        tracing::info!(
+            "RdmaKvBackend connected to {addr}: {:.1} GiB blade, {n_rails} rail(s), \
+             group_stride {}, pipeline depth {depth}",
+            total_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+            layout.group_stride,
+        );
+        Ok(Self {
+            rails,
+            layout,
+            remote_base: base,
+            rr: 0,
+            zero_copy: std::env::var("ATLAS_KV_ZERO_COPY").ok().as_deref() == Some("1"),
+            _stream: stream,
+        })
+    }
+
+    #[inline]
+    fn remote_addr(&self, key: GroupKey) -> u64 {
+        self.remote_base + self.layout.group_id(key).0 * self.layout.group_stride
+    }
+
+    /// Zero-copy restore: RDMA READ each group DIRECTLY into its (UMA) HBM dest —
+    /// the dst is registered as the landing MR, so there is no bounce and no
+    /// `copy_h2d`. On completion the bytes are already GPU-visible at `dst`
+    /// (same host==dev VA), so no `stream_sync` either. Removes the copy-engine
+    /// bottleneck that pinned single-rail restore at ~9.7 GB/s, letting it
+    /// dual-rail. Requires UMA destinations (else `reg_dst` errors clearly).
+    fn read_zero_copy(
+        &mut self,
+        requests: &[ReadRequest],
+        bytes: usize,
+        stream: u64,
+    ) -> Result<()> {
+        // WAR barrier: the NIC is about to DMA into UMA slots that the PREVIOUS
+        // tile's attention kernel may still be reading on `stream`. Unlike the
+        // bounce path (whose copy_h2d is stream-ordered after attention + ends in
+        // stream_sync), the NIC write is off-stream, so we must drain in-flight
+        // consumers of these slots first — else zero-copy restore under eviction
+        // pressure silently corrupts KV. This restores the bounce path's implicit
+        // barrier. (RAW is already safe: the poll below means the bytes have
+        // landed before the next kernel that reads them is queued.)
+        stream_sync(stream)?;
+        let n = self.rails.len();
+        let depth = self.rails[0].bounces.len(); // in-flight cap per rail
+        let mut pend: Vec<std::collections::VecDeque<usize>> = vec![Default::default(); n];
+        for (j, _) in requests.iter().enumerate() {
+            pend[j % n].push_back(j);
+        }
+        loop {
+            let mut active = false;
+            for (ri, rail) in self.rails.iter_mut().enumerate() {
+                while rail.direct_inflight < depth {
+                    let Some(j) = pend[ri].pop_front() else { break };
+                    let dst = requests[j].dst_dev_ptr;
+                    let lkey = rail.reg_dst(dst, bytes)?;
+                    let raddr = self.remote_base
+                        + self.layout.group_id(requests[j].group).0 * self.layout.group_stride;
+                    let wr = rail.fresh_wr();
+                    // SAFETY: dst is a live UMA MR (lkey) of `bytes`; raddr/rkey
+                    // address the peer blade. The NIC DMAs straight into the
+                    // GPU-addressable dst.
+                    unsafe {
+                        rail.verbs.post_read(
+                            dst as *mut c_void,
+                            lkey,
+                            raddr,
+                            rail.remote_rkey,
+                            bytes as u32,
+                            wr,
+                        )?;
+                    }
+                    rail.direct_inflight += 1;
+                }
+                if rail.direct_inflight > 0 {
+                    rail.verbs.poll()?; // completion => bytes GPU-visible in dst
+                    rail.direct_inflight -= 1;
+                    active = true;
+                }
+            }
+            if !active && pend.iter().all(|q| q.is_empty()) {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl RdmaKvBackend {
+    /// Body shared by `read` (sync) and `read_async` (#11-refinement). Bounce
+    /// path only differs by `is_async`:
+    ///   * sync  (`false`): LIFO bounce reuse (`pop_back` = original `pop`),
+    ///     `track=false` (no per-bounce copy event), terminal host `stream_sync`.
+    ///     Byte-identical to the pre-refinement `read`; `wait_bounce_free` is a
+    ///     pure no-op (all `copy_done == None`).
+    ///   * async (`true`): FIFO bounce reuse (`pop_front` — reuse the OLDEST
+    ///     freed bounce so its `copy_done` has had `depth`-many copy-times to
+    ///     drain, making `wait_bounce_free` a steady-state no-op; LIFO would
+    ///     stall on every reuse and defeat run-ahead), `track=true` (record a
+    ///     copy event per reaped READ), and NO terminal `stream_sync` — mirror-
+    ///     RAW is closed by the caller's `kv_prefetch_done`.
+    ///
+    /// The zero-copy branch is shared verbatim (see `read_zero_copy` / §G: it
+    /// keeps its own leading WAR host sync, the one honestly-unremovable block).
+    fn read_common(&mut self, requests: &[ReadRequest], stream: u64, is_async: bool) -> Result<()> {
+        let bytes = self.layout.group_bytes() as usize;
+        // Ensure any pending offloads land first, so a restore sees them.
+        for rail in &mut self.rails {
+            rail.drain(bytes, stream)?;
+        }
+        if self.zero_copy {
+            if requests.is_empty() {
+                return Ok(());
+            }
+            // Register EVERY dst on EVERY rail up front — before any RDMA READ is
+            // posted — so a reg_mr failure (dst not UMA-registerable on some rail)
+            // degrades to the bounce path CLEANLY, with no half-posted batch. A
+            // per-slot / per-rail probe is required: rail 1's device/PD can reject
+            // a host region rail 0 accepted, and later scratch slots differ from
+            // the first. reg_dst caches, so read_zero_copy reuses these lkeys.
+            let mut all_ok = true;
+            'reg: for req in requests {
+                for rail in &mut self.rails {
+                    if let Err(e) = rail.reg_dst(req.dst_dev_ptr, bytes) {
+                        tracing::warn!(
+                            "kv restore dst not UMA-registerable ({e:#}); \
+                             permanently using bounce restore"
+                        );
+                        all_ok = false;
+                        break 'reg;
+                    }
+                }
+            }
+            if all_ok {
+                return self.read_zero_copy(requests, bytes, stream);
+            }
+            // Non-UMA dst — fall through to the bounce path for this and all
+            // future reads.
+            self.zero_copy = false;
+        }
+        let n = self.rails.len();
+        // Per-rail queues of pending request indices, striped round-robin.
+        let mut pend: Vec<std::collections::VecDeque<usize>> = vec![Default::default(); n];
+        for (j, _) in requests.iter().enumerate() {
+            pend[j % n].push_back(j);
+        }
+        // Drive all rails in parallel: each outer pass fills every rail's free
+        // bounces with new READs, then reaps one from each rail that has work.
+        loop {
+            let mut active = false;
+            for (ri, rail) in self.rails.iter_mut().enumerate() {
+                while !rail.free.is_empty() {
+                    let Some(j) = pend[ri].pop_front() else { break };
+                    // FIFO on async (oldest freed bounce, copy_done drained),
+                    // LIFO on sync (== original `pop()`, byte-identical order).
+                    let b = if is_async {
+                        rail.free.pop_front()
+                    } else {
+                        rail.free.pop_back()
+                    }
+                    .unwrap();
+                    // Reuse gate: wait any async copy_h2d still draining this
+                    // bounce before the NIC refills it. No-op unless a prior
+                    // read_async left a copy_done on `b` (always None on the pure
+                    // sync/prefetch-OFF path → byte-identical).
+                    rail.wait_bounce_free(b)?;
+                    let raddr = self.remote_base
+                        + self.layout.group_id(requests[j].group).0 * self.layout.group_stride;
+                    // SAFETY: bounce b is a live MR; raddr/rkey are the blade.
+                    unsafe { rail.post_read(b, raddr, bytes, requests[j].dst_dev_ptr)? };
+                }
+                if !rail.inflight.is_empty() {
+                    rail.reap_one(bytes, stream, is_async)?;
+                    active = true;
+                }
+            }
+            if !active && pend.iter().all(|q| q.is_empty()) {
+                break;
+            }
+        }
+        if !is_async {
+            // Sync path: finalise the stream (PosixBackend semantics). The async
+            // path deliberately omits this — that deleted host block IS the win.
+            stream_sync(stream)?;
+        }
+        Ok(())
+    }
+}
+
+impl StorageBackend for RdmaKvBackend {
+    fn read(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()> {
+        self.read_common(requests, stream, false)
+    }
+
+    fn read_async(&mut self, requests: &[ReadRequest], stream: u64) -> Result<()> {
+        self.read_common(requests, stream, true)
+    }
+
+    fn register_landing_region(&mut self, base: u64, len: usize) -> Result<()> {
+        // Register the whole (UMA) scratch pool as one MR per rail so zero-copy
+        // restore reuses that lkey for every slot — no per-slot registration.
+        for rail in &mut self.rails {
+            rail.register_region(base, len)?;
+        }
+        tracing::info!(
+            "RdmaKvBackend: registered UMA landing region {:.1} MiB on {} rail(s) — zero-copy restore live",
+            len as f64 / (1024.0 * 1024.0),
+            self.rails.len(),
+        );
+        Ok(())
+    }
+
+    fn write_from_host(&mut self, key: GroupKey, src: &[u8]) -> Result<()> {
+        let bytes = self.layout.group_bytes() as usize;
+        if src.len() != bytes {
+            bail!(
+                "write_from_host: src len {} != group bytes {bytes}",
+                src.len()
+            );
+        }
+        let raddr = self.remote_addr(key);
+        let n = self.rails.len();
+        let ri = self.rr % n;
+        self.rr = self.rr.wrapping_add(1);
+        let rail = &mut self.rails[ri];
+        // Acquire a free bounce on this rail, reaping a completion if full.
+        if rail.free.is_empty() {
+            rail.reap_one(bytes, 0, false)?; // only writes are in flight here (no copy)
+        }
+        let b = rail.free.pop_back().expect("free bounce after reap");
+        // #11-refinement: an offload staging-write must not race a still-draining
+        // async prefetch copy_h2d out of this bounce. No-op unless a prior
+        // read_async left a copy_done on `b` (always None on the pure sync path);
+        // when it fires it is on the offload/eviction path, off the decode loop.
+        rail.wait_bounce_free(b)?;
+        // SAFETY: bounce b holds `bytes`; copy the group in, then RDMA-WRITE it.
+        unsafe {
+            std::ptr::copy_nonoverlapping(src.as_ptr(), rail.bounces[b].buf.ptr as *mut u8, bytes);
+            rail.post_write(b, raddr, bytes)?;
+        }
+        Ok(()) // async — reaped lazily / drained before the next read
+    }
+
+    fn group_layout(&self) -> GroupLayout {
+        // Inherits the DEFAULT block read/write (per-head fan-out over the
+        // one-sided verbs path) — correct, un-coalesced. Native multi-group RDMA
+        // coalescing is a noted follow-up.
+        self.layout
+    }
+}
+
+impl Drop for RdmaKvBackend {
+    fn drop(&mut self) {
+        let bytes = self.layout.group_bytes() as usize;
+        for rail in &mut self.rails {
+            let _ = rail.drain(bytes, 0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/spark-storage/src/rdma_kv_backend/rail.rs
+++ b/crates/spark-storage/src/rdma_kv_backend/rail.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Per-rail state for the RDMA KV backend: the registered pinned bounce ring,
+// the in-flight work-request map, and the rail's post/poll/drain loop. Split
+// out of rdma_kv_backend.rs (was 715 LoC) to satisfy the CI 500-LoC cap — pure
+// code motion, no behavior change. `InFlight` stays private here; only
+// `Bounce` and `Rail` are needed by the parent module.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use anyhow::{Context, Result};
+
+use crate::cuda_min::{CudaEvent, PinnedBuffer, copy_h_to_d_async};
+use atlas_rdma::verbs::Verbs;
+
+/// One registered pinned bounce in a rail's pipeline ring.
+pub(super) struct Bounce {
+    pub(super) buf: PinnedBuffer,
+    pub(super) lkey: u32,
+    /// #11-refinement: async prefetch reuse guard. `read_async` records a CUDA
+    /// event on the copy stream AFTER `copy_h_to_d_async` drains this bounce;
+    /// the next reuse of this bounce `sync`s it first (via `wait_bounce_free`),
+    /// so the host cannot re-fill the bounce before the device copy has read it —
+    /// the reuse hazard the deleted terminal host stream_sync used to prevent.
+    /// `None` on the synchronous path (that path keeps its terminal stream_sync),
+    /// so the guard is a pure no-op there → byte-identical for prefetch-OFF.
+    pub(super) copy_done: Option<CudaEvent>,
+}
+
+/// An in-flight RDMA op, keyed by its `wr_id`, so a completion can be dispatched.
+pub(super) enum InFlight {
+    /// A restore: after the READ lands, copy the bounce to this HBM dest.
+    Read { bounce: usize, dst: u64 },
+    /// An offload: the WRITE from this bounce; just free it on completion.
+    Write { bounce: usize },
+}
+
+/// One QP on one CX7 adapter, with its own bounce ring + completion tracking.
+pub(super) struct Rail {
+    pub(super) verbs: Verbs,
+    pub(super) remote_rkey: u32,
+    pub(super) bounces: Vec<Bounce>,
+    pub(super) free: std::collections::VecDeque<usize>,
+    pub(super) inflight: HashMap<u64, InFlight>,
+    pub(super) next_wr: u64,
+    /// Zero-copy restore: lkeys of destination MRs registered on demand (a UMA
+    /// dst is GPU-addressable, so RDMA lands there directly — no bounce, no
+    /// copy_h2d). Cached by dst address; KV scratch slots are reused.
+    pub(super) dst_lkeys: HashMap<u64, u32>,
+    /// Pre-registered whole landing region `(base, len, lkey)`: one MR covering
+    /// the entire (UMA) scratch pool. Any dst inside it reuses this lkey, so we
+    /// never register per-slot sub-regions (which fail on GB10).
+    pub(super) region: Option<(u64, u64, u32)>,
+    /// In-flight direct (zero-copy) reads on this rail — no bounce to free.
+    pub(super) direct_inflight: usize,
+}
+
+impl Rail {
+    #[inline]
+    pub(super) fn fresh_wr(&mut self) -> u64 {
+        let w = self.next_wr;
+        self.next_wr = self.next_wr.wrapping_add(1);
+        w
+    }
+
+    /// Register (once, cached) a `bytes`-sized destination MR at `addr` for a
+    /// zero-copy RDMA READ landing. On GB10 UMA the dst is GPU-addressable pinned
+    /// host memory, so `ibv_reg_mr` on its VA succeeds and the GPU reads the
+    /// landed bytes at the same address — no `copy_h2d`.
+    /// Register `[base, base+len)` as ONE landing MR on this rail (the whole UMA
+    /// scratch pool). Called once, before any restore.
+    pub(super) fn register_region(&mut self, base: u64, len: usize) -> Result<()> {
+        // SAFETY: base/len describe the pool's live UMA (pinned) allocation,
+        // which outlives every rail (deregistered on drop before the pool frees).
+        let keys = unsafe { self.verbs.reg_mr(base as *mut c_void, len, false) }
+            .context("register UMA landing region")?;
+        self.region = Some((base, len as u64, keys.lkey));
+        Ok(())
+    }
+
+    pub(super) fn reg_dst(&mut self, addr: u64, bytes: usize) -> Result<u32> {
+        // Whole-region fast path: any dst inside the pre-registered pool reuses
+        // its single lkey (no per-slot registration — that fails on GB10).
+        if let Some((base, len, lkey)) = self.region
+            && addr >= base
+            && addr + bytes as u64 <= base + len
+        {
+            return Ok(lkey);
+        }
+        if let Some(&lk) = self.dst_lkeys.get(&addr) {
+            return Ok(lk);
+        }
+        // SAFETY: caller guarantees zero-copy mode => addr is a live UMA buffer
+        // of at least `bytes` (else reg_mr fails, surfacing a clear error).
+        let keys = unsafe { self.verbs.reg_mr(addr as *mut c_void, bytes, false) }
+            .context("zero-copy restore needs a UMA (GPU-addressable) dst; reg_mr failed")?;
+        self.dst_lkeys.insert(addr, keys.lkey);
+        Ok(keys.lkey)
+    }
+
+    /// Reap exactly one completion on this rail, freeing its bounce. For a READ,
+    /// first `copy_h2d` the landed bytes to its HBM dest on `stream`. When
+    /// `track` is set (async prefetch), record a CUDA event on `stream` after
+    /// that copy so a later reuse of this bounce can `sync` on the copy draining
+    /// the bounce (replacing the deleted terminal host stream_sync). `track` is
+    /// only ever true on `read_async`'s READ reaps; the sync path and all write
+    /// drains pass false, leaving `copy_done = None` → byte-identical.
+    pub(super) fn reap_one(&mut self, group_bytes: usize, stream: u64, track: bool) -> Result<()> {
+        let wr = self.verbs.poll()?;
+        let op = self
+            .inflight
+            .remove(&wr)
+            .with_context(|| format!("kv: completion for unknown wr_id {wr:#x}"))?;
+        let bounce = match op {
+            InFlight::Read { bounce, dst } => {
+                copy_h_to_d_async(
+                    dst,
+                    self.bounces[bounce].buf.ptr as *const _,
+                    group_bytes,
+                    stream,
+                )?;
+                if track {
+                    let ev = CudaEvent::new()?;
+                    ev.record(stream)?;
+                    self.bounces[bounce].copy_done = Some(ev);
+                }
+                bounce
+            }
+            InFlight::Write { bounce } => bounce,
+        };
+        self.free.push_back(bounce);
+        Ok(())
+    }
+
+    /// #11-refinement: before reusing bounce `b`, wait for any still-in-flight
+    /// async copy_h2d that is draining it (recorded by a prior `read_async`
+    /// reap). No-op on the sync path (`copy_done` is always `None`), so it never
+    /// perturbs prefetch-OFF. Off the decode run-ahead loop it only ever fires
+    /// under genuine copy-engine backpressure (correct async pushback).
+    pub(super) fn wait_bounce_free(&mut self, b: usize) -> Result<()> {
+        if let Some(ev) = self.bounces[b].copy_done.take() {
+            ev.sync()?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn drain(&mut self, group_bytes: usize, stream: u64) -> Result<()> {
+        while !self.inflight.is_empty() {
+            // Drained ops here are writes (before a read) or teardown reaps — no
+            // new mirror-RAW consumer needs the copy event, so track=false.
+            self.reap_one(group_bytes, stream, false)?;
+        }
+        Ok(())
+    }
+
+    /// # Safety: bounce/len/remote must describe a live MR and the peer arena.
+    pub(super) unsafe fn post_read(
+        &mut self,
+        bounce: usize,
+        raddr: u64,
+        bytes: usize,
+        dst: u64,
+    ) -> Result<()> {
+        let wr = self.fresh_wr();
+        unsafe {
+            self.verbs.post_read(
+                self.bounces[bounce].buf.ptr,
+                self.bounces[bounce].lkey,
+                raddr,
+                self.remote_rkey,
+                bytes as u32,
+                wr,
+            )?;
+        }
+        self.inflight.insert(wr, InFlight::Read { bounce, dst });
+        Ok(())
+    }
+
+    /// # Safety: as `post_read`; `src` bytes already copied into the bounce.
+    pub(super) unsafe fn post_write(
+        &mut self,
+        bounce: usize,
+        raddr: u64,
+        bytes: usize,
+    ) -> Result<()> {
+        let wr = self.fresh_wr();
+        unsafe {
+            self.verbs.post_write(
+                self.bounces[bounce].buf.ptr,
+                self.bounces[bounce].lkey,
+                raddr,
+                self.remote_rkey,
+                bytes as u32,
+                wr,
+            )?;
+        }
+        self.inflight.insert(wr, InFlight::Write { bounce });
+        Ok(())
+    }
+}

--- a/crates/spark-storage/src/rdma_kv_backend/tests.rs
+++ b/crates/spark-storage/src/rdma_kv_backend/tests.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Tests for the RDMA KV backend. Moved out of an inline `#[cfg(test)] mod tests`
+// per the repo convention (tests live in their own files). Pure code motion.
+
+use super::*;
+use crate::cuda_min::CudaCtx;
+use crate::group::KvKind;
+
+// Read a UMA (pinned, host==dev VA) dst's bytes host-side — valid for both
+// the bounce path (copy_h2d lands there) and zero-copy (RDMA lands there).
+unsafe fn uma_bytes(buf: &PinnedBuffer, n: usize) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(buf.ptr as *const u8, n) }
+}
+
+#[test]
+#[ignore = "requires GPU + live cache-peer at $ATLAS_KV_PEER"]
+fn rdma_kv_round_trip() {
+    let _ctx = CudaCtx::new(0).expect("cuda init");
+    let peer = std::env::var("ATLAS_KV_PEER").expect("set ATLAS_KV_PEER=host:port");
+    let layout = GroupLayout::new(2, 4, 2, 16, 128, 2, 4096);
+    let bytes = layout.group_bytes() as usize;
+    let mut be = RdmaKvBackend::connect(&peer, layout).expect("connect kv peer");
+    let keys = [
+        GroupKey::new(0, 0, 0, KvKind::K),
+        GroupKey::new(0, 3, 1, KvKind::V),
+        GroupKey::new(1, 2, 0, KvKind::V),
+        GroupKey::new(1, 0, 1, KvKind::K),
+    ];
+    let pat = |i: usize| -> Vec<u8> { (0..bytes).map(|b| ((b + i * 37) & 0xFF) as u8).collect() };
+    for (i, k) in keys.iter().enumerate() {
+        be.write_from_host(*k, &pat(i)).expect("write_from_host");
+    }
+    // UMA dsts so the same test validates both the bounce and zero-copy paths.
+    let devs: Vec<_> = keys
+        .iter()
+        .map(|_| PinnedBuffer::new(bytes).unwrap())
+        .collect();
+    let reqs: Vec<_> = keys
+        .iter()
+        .zip(&devs)
+        .map(|(k, d)| ReadRequest {
+            group: *k,
+            dst_dev_ptr: d.device_ptr().unwrap(),
+        })
+        .collect();
+    be.read(&reqs, _ctx.stream).expect("read");
+    for (i, d) in devs.iter().enumerate() {
+        let back = unsafe { uma_bytes(d, bytes) };
+        assert_eq!(
+            back,
+            &pat(i)[..],
+            "group {:?} corrupted through the RDMA blade",
+            keys[i]
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires GPU + live cache-peer at $ATLAS_KV_PEER"]
+fn rdma_kv_bandwidth() {
+    let ctx = CudaCtx::new(0).expect("cuda init");
+    let peer = std::env::var("ATLAS_KV_PEER").expect("set ATLAS_KV_PEER=host:port");
+    let layout = GroupLayout::new(16, 64, 8, 64, 128, 2, 4096);
+    let gbytes = layout.group_bytes() as usize;
+    let mut be = RdmaKvBackend::connect(&peer, layout).expect("connect kv peer");
+    let ngroups =
+        (layout.num_layers as u64) * 2 * (layout.num_blocks as u64) * (layout.num_kv_heads as u64);
+    let total = ngroups * gbytes as u64;
+    let keys: Vec<GroupKey> = (0..layout.num_layers)
+        .flat_map(|l| {
+            (0..layout.num_blocks).flat_map(move |b| {
+                (0..layout.num_kv_heads).flat_map(move |h| {
+                    [
+                        GroupKey::new(l, b, h, KvKind::K),
+                        GroupKey::new(l, b, h, KvKind::V),
+                    ]
+                })
+            })
+        })
+        .collect();
+    let src = vec![0xABu8; gbytes];
+    // UMA dst so zero-copy (ATLAS_KV_ZERO_COPY=1) can RDMA straight in.
+    let dst = PinnedBuffer::new(gbytes).unwrap();
+    let dptr = dst.device_ptr().unwrap();
+
+    let t0 = std::time::Instant::now();
+    for k in &keys {
+        be.write_from_host(*k, &src).expect("write");
+    }
+    for rail in &mut be.rails {
+        rail.drain(gbytes, 0).expect("drain");
+    }
+    let wdt = t0.elapsed().as_secs_f64();
+
+    let reqs: Vec<_> = keys
+        .iter()
+        .map(|k| ReadRequest {
+            group: *k,
+            dst_dev_ptr: dptr,
+        })
+        .collect();
+    let t1 = std::time::Instant::now();
+    be.read(&reqs, ctx.stream).expect("read");
+    let rdt = t1.elapsed().as_secs_f64();
+
+    let gbps = |dt: f64| (total as f64) / dt / 1e9;
+    println!(
+        "\nRDMA KV tier ({} rail(s), {}, pipelined): {} groups × {} B = {:.0} MiB\n  \
+         OFFLOAD (RDMA WRITE): {:.3}s => {:.2} GB/s\n  \
+         RESTORE (RDMA READ): {:.3}s => {:.2} GB/s",
+        be.rails.len(),
+        if be.zero_copy {
+            "zero-copy"
+        } else {
+            "bounce+h2d"
+        },
+        ngroups,
+        gbytes,
+        total as f64 / 1048576.0,
+        wdt,
+        gbps(wdt),
+        rdt,
+        gbps(rdt),
+    );
+}

--- a/crates/spark-storage/src/rdma_snapshot.rs
+++ b/crates/spark-storage/src/rdma_snapshot.rs
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Offset-addressed RDMA arena for the SSM-snapshot spill tier.
+//!
+//! A minimal, **synchronous** transport over the CX7 verbs + RW-blade paging
+//! peer protocol the KV overflow tier uses, but addressed by a flat byte
+//! **offset** (snapshots are keyed by an opaque id → arena slot) rather than the
+//! KV `GroupKey`/`group_stride` layout — reusing that layout would corrupt live
+//! KV (its `write_from_host` asserts `src.len()==group_bytes`).
+//!
+//! The paging peer is layout-agnostic (client sends `total_bytes`, the peer
+//! registers ONE RW MR and serves `base+offset`), so a second peer instance on
+//! its own port serves the snapshot arena with zero peer-side change. Each op is
+//! drained to completion before returning (one blob ~64 MB, ~5–7 ms — the
+//! spill/fault path is latency-, not throughput-critical), so the caller's
+//! `SnapshotBlobStore::{put,get}` contract (durable on return) holds.
+//!
+//! Gathering the scattered per-layer SSM state into the contiguous blob and all
+//! device-stream ordering already happen in `SsmSnapshotPool::{spill_slot,
+//! fault_in_slot}`; this transport only moves host bytes.
+
+// The real transport needs the CUDA pinned bounce + the verbs FFI; when either
+// is absent, a stub whose `connect` always errors lets dependents reference the
+// type unconditionally (the tier selector then falls back to host-RAM).
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+pub use imp::RdmaSnapshotArena;
+#[cfg(not(all(feature = "cuda", atlas_rdma_verbs)))]
+pub use stub::RdmaSnapshotArena;
+
+#[cfg(not(all(feature = "cuda", atlas_rdma_verbs)))]
+mod stub {
+    use anyhow::{Result, bail};
+    /// Placeholder when RDMA verbs / CUDA aren't built. `connect` always errors,
+    /// so [`crate`] dependents degrade to the host-RAM tier; `write`/`read` are
+    /// unreachable (a stub arena is never successfully constructed).
+    pub struct RdmaSnapshotArena;
+    impl RdmaSnapshotArena {
+        pub fn connect(_addr: &str, _arena_bytes: u64, _blob_bytes: usize) -> Result<Self> {
+            bail!("RDMA snapshot tier not built (needs feature `cuda` + atlas_rdma_verbs)")
+        }
+        pub fn connect_paging(_addr: &str, _arena_bytes: u64, _blob_bytes: usize) -> Result<Self> {
+            bail!("RDMA snapshot tier not built (needs feature `cuda` + atlas_rdma_verbs)")
+        }
+        pub fn write(&self, _offset: u64, _bytes: &[u8]) -> Result<()> {
+            unreachable!("stub RdmaSnapshotArena is never constructed")
+        }
+        pub fn read(&self, _offset: u64, _out: &mut [u8]) -> Result<()> {
+            unreachable!("stub RdmaSnapshotArena is never constructed")
+        }
+        pub fn paging_put(&self, _key: u64, _bytes: &[u8]) -> Result<()> {
+            unreachable!("stub RdmaSnapshotArena is never constructed")
+        }
+        pub fn paging_get(&self, _key: u64, _out: &mut [u8]) -> Result<bool> {
+            unreachable!("stub RdmaSnapshotArena is never constructed")
+        }
+        pub fn paging_remove(&self, _key: u64) -> Result<()> {
+            unreachable!("stub RdmaSnapshotArena is never constructed")
+        }
+    }
+}
+
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+mod imp {
+    use std::io::Write;
+    use std::net::TcpStream;
+    use std::sync::Mutex;
+
+    use anyhow::{Result, bail};
+
+    use crate::cuda_min::PinnedBuffer;
+    use atlas_rdma::env::{first_set, first_set_u32};
+    use atlas_rdma::railset::{RailSet, RailSpec};
+    use atlas_rdma::verbs::Verbs;
+
+    /// One rail: its QP + a single persistent registered bounce (`blob_bytes`).
+    struct SnapRail {
+        verbs: Verbs,
+        bounce: PinnedBuffer,
+        lkey: u32,
+        remote_rkey: u32,
+        /// lkey for the SHARED striped-staging buffer registered on THIS rail (0 if
+        /// staging disabled). Every rail registers the SAME contiguous staging
+        /// buffer, so whichever rail fetches a chunk it lands at its true offset.
+        staging_lkey: u32,
+    }
+
+    /// Mutable rail state, serialized under one lock (the trait exposes `&self`).
+    struct ArenaInner {
+        rails: Vec<SnapRail>,
+        /// ONE contiguous `blob_bytes` staging buffer for the striped/pipelined
+        /// dual-rail path (ATLAS_SSM_STAGING); None = single-WR bounce fallback.
+        staging: Option<PinnedBuffer>,
+        rr: usize,
+        next_wr: u64,
+        /// In raw (dumb one-sided) mode: kept alive for the QP's lifetime, else idle.
+        /// In paging mode: the live control channel — alloc/commit/get/remove
+        /// requests ride this stream, interleaved with the RDMA data plane below.
+        stream: TcpStream,
+    }
+
+    /// Offset-addressed RDMA snapshot arena. Connect to the paging peer sized for
+    /// `arena_slots × blob_bytes`; `write`/`read` move one `blob_bytes` blob to/from
+    /// `base + offset`.
+    pub struct RdmaSnapshotArena {
+        inner: Mutex<ArenaInner>,
+        remote_base: u64,
+        blob_bytes: usize,
+    }
+
+    // SAFETY: every access to the raw verbs/bounce state goes through `inner`'s
+    // Mutex, so there is no unsynchronized sharing; mirrors the KV backend's
+    // single-owner contract. `Verbs` is `Send`; `PinnedBuffer` is `Send + Sync`.
+    unsafe impl Send for RdmaSnapshotArena {}
+    unsafe impl Sync for RdmaSnapshotArena {}
+
+    impl RdmaSnapshotArena {
+        /// Handshake with the snapshot peer at `addr` and register `blob_bytes`
+        /// bounces. Rail devices/GIDs reuse the KV env (`ATLAS_EXPERT_RDMA_DEV`/`GID`
+        /// = rail 0, `ATLAS_KV_RAIL2_DEV`/`GID` = rail 1, dual only when
+        /// `ATLAS_KV_DUAL_RAIL=1`). `arena_bytes` = `arena_slots × blob_bytes`.
+        pub fn connect(addr: &str, arena_bytes: u64, blob_bytes: usize) -> Result<Self> {
+            Self::connect_inner(addr, arena_bytes, blob_bytes, false)
+        }
+
+        /// Paging-mode connect: the peer arena becomes a page-cache over an
+        /// NVMe swap file and OWNS residency; this client uses the control channel
+        /// (`paging_put`/`paging_get`/`paging_remove`) instead of a client-side
+        /// allocator. Requires the peer be started with `--swap-dir`.
+        pub fn connect_paging(addr: &str, arena_bytes: u64, blob_bytes: usize) -> Result<Self> {
+            Self::connect_inner(addr, arena_bytes, blob_bytes, true)
+        }
+
+        fn connect_inner(
+            addr: &str,
+            arena_bytes: u64,
+            blob_bytes: usize,
+            paging: bool,
+        ) -> Result<Self> {
+            // Rail env: the KV triple verbatim (shared CX7 fabric config). Fresh
+            // random 24-bit PSN per rail.
+            let spec =
+                |dev: String, gid: u32| RailSpec::new(dev, gid, rand::random::<u32>() & 0xff_ffff);
+            let rail0 = spec(
+                first_set(&["ATLAS_EXPERT_RDMA_DEV"], "roceP2p1s0f1"),
+                first_set_u32(&["ATLAS_EXPERT_RDMA_GID"], 3),
+            );
+            let dual = std::env::var("ATLAS_KV_DUAL_RAIL").ok().as_deref() == Some("1");
+            let specs: Vec<RailSpec> = if dual {
+                let rail1 = spec(
+                    first_set(&["ATLAS_KV_RAIL2_DEV"], "rocep1s0f1"),
+                    first_set_u32(&["ATLAS_KV_RAIL2_GID"], 3),
+                );
+                vec![rail0, rail1]
+            } else {
+                vec![rail0]
+            };
+            let n_rails = specs.len();
+
+            let mut stream = TcpStream::connect(addr)
+                .map_err(|e| anyhow::anyhow!("connect snapshot peer {addr}: {e}"))?;
+            stream.set_nodelay(true).ok();
+            // v2 handshake: both modes send the same 25-byte header.
+            // Paging carries the real blob size; the raw (dumb one-sided) mode
+            // signals itself with blob_bytes == 0 — the peer then hands this
+            // connection a private arena with a client-owned allocator.
+            stream.write_all(&crate::snapshot_swap::encode_paging_v2_header(
+                crate::snapshot_swap::PagingKind::SSM,
+                arena_bytes,
+                if paging { blob_bytes as u64 } else { 0 },
+            ))?;
+            // [u8 n_rails] + one QP per rail.
+            let mut rs = RailSet::begin(&mut stream, &specs)?;
+
+            // ONE contiguous staging buffer (ATLAS_SSM_STAGING) registered on EVERY
+            // rail → each rail gets its own lkey over the SAME memory, so a chunk
+            // striped to any rail lands at its true offset (the inc-6 reassembly fix).
+            let staging_on = std::env::var("ATLAS_SSM_STAGING").ok().as_deref() == Some("1");
+            let staging = if staging_on {
+                Some(PinnedBuffer::new(blob_bytes)?)
+            } else {
+                None
+            };
+
+            // Per-rail bounce + shared staging MRs, both LOCAL_WRITE only
+            // (`remote_read == false`, invariant — we WRITE from and READ into them).
+            let mut parts: Vec<(PinnedBuffer, u32, u32)> = Vec::with_capacity(n_rails);
+            for rail in &mut rs.rails {
+                let bounce = PinnedBuffer::new(blob_bytes)?;
+                // SAFETY: bounce lives as long as the rail (and thus the MR).
+                let keys = unsafe { rail.verbs.reg_mr(bounce.ptr, blob_bytes, false)? };
+                // SAFETY: staging outlives the rail (both live in ArenaInner,
+                // dropped together).
+                let staging_lkey = match &staging {
+                    Some(s) => unsafe { rail.verbs.reg_mr(s.ptr, blob_bytes, false)?.lkey },
+                    None => 0,
+                };
+                parts.push((bounce, keys.lkey, staging_lkey));
+            }
+
+            // Peer's per-rail QP + shared arena base/rkey, client params, connect,
+            // ack. Shared base: keep the LAST (pre-RailSet loop-overwrite behavior).
+            let server = rs.finish_rw(&mut stream, "snapshot peer")?;
+            let base = server.last().map(|sp| sp.base_addr).unwrap_or(0);
+            let rails: Vec<SnapRail> = rs
+                .into_verbs()
+                .into_iter()
+                .zip(parts)
+                .zip(&server)
+                .map(|((verbs, (bounce, lkey, staging_lkey)), sp)| SnapRail {
+                    verbs,
+                    bounce,
+                    lkey,
+                    remote_rkey: sp.rkey,
+                    staging_lkey,
+                })
+                .collect();
+            tracing::info!(
+                "RdmaSnapshotArena connected to {addr}: {:.1} GiB arena, {n_rails} rail(s), blob {blob_bytes} B",
+                arena_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+            );
+            Ok(Self {
+                inner: Mutex::new(ArenaInner {
+                    rails,
+                    staging,
+                    rr: 0,
+                    next_wr: 1, // 0 == "no completion yet" sentinel in the poll loop
+                    stream,
+                }),
+                remote_base: base,
+                blob_bytes,
+            })
+        }
+
+        #[inline]
+        pub fn blob_bytes(&self) -> usize {
+            self.blob_bytes
+        }
+
+        /// RDMA-WRITE one `blob_bytes` blob to `base + offset`, drained to completion.
+        pub fn write(&self, offset: u64, bytes: &[u8]) -> Result<()> {
+            if bytes.len() != self.blob_bytes {
+                bail!(
+                    "snapshot write: {} != blob_bytes {}",
+                    bytes.len(),
+                    self.blob_bytes
+                );
+            }
+            let mut g = self.inner.lock().expect("snapshot arena mutex");
+            self.rdma_write_locked(&mut g, self.remote_base + offset, bytes)
+        }
+
+        /// RDMA-READ one `blob_bytes` blob from `base + offset` into `out`, drained.
+        pub fn read(&self, offset: u64, out: &mut [u8]) -> Result<()> {
+            if out.len() != self.blob_bytes {
+                bail!(
+                    "snapshot read: {} != blob_bytes {}",
+                    out.len(),
+                    self.blob_bytes
+                );
+            }
+            let mut g = self.inner.lock().expect("snapshot arena mutex");
+            self.rdma_read_locked(&mut g, self.remote_base + offset, out)
+        }
+
+        /// Pick a rail (round-robin) and a fresh wr id.
+        fn rail_and_wr(g: &mut ArenaInner) -> (usize, u64) {
+            let n = g.rails.len();
+            let ri = g.rr % n;
+            g.rr = g.rr.wrapping_add(1);
+            let wr = g.next_wr;
+            g.next_wr = g.next_wr.wrapping_add(1).max(1);
+            (ri, wr)
+        }
+
+        fn rdma_write_locked(&self, g: &mut ArenaInner, raddr: u64, bytes: &[u8]) -> Result<()> {
+            if g.staging.is_some() {
+                return self.rdma_staged(g, raddr, Some(bytes), None);
+            }
+            let (ri, wr) = Self::rail_and_wr(g);
+            let rail = &mut g.rails[ri];
+            // SAFETY: bounce is a live registered MR of blob_bytes; copy the blob in,
+            // RDMA-WRITE it to the peer arena, drain the single completion.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bytes.as_ptr(),
+                    rail.bounce.ptr as *mut u8,
+                    self.blob_bytes,
+                );
+                rail.verbs.post_write(
+                    rail.bounce.ptr,
+                    rail.lkey,
+                    raddr,
+                    rail.remote_rkey,
+                    self.blob_bytes as u32,
+                    wr,
+                )?;
+            }
+            while rail.verbs.poll()? != wr {}
+            Ok(())
+        }
+
+        fn rdma_read_locked(&self, g: &mut ArenaInner, raddr: u64, out: &mut [u8]) -> Result<()> {
+            if g.staging.is_some() {
+                return self.rdma_staged(g, raddr, None, Some(out));
+            }
+            let (ri, wr) = Self::rail_and_wr(g);
+            let rail = &mut g.rails[ri];
+            // SAFETY: read into the live bounce MR, drain, then copy host-side to out.
+            unsafe {
+                rail.verbs.post_read(
+                    rail.bounce.ptr,
+                    rail.lkey,
+                    raddr,
+                    rail.remote_rkey,
+                    self.blob_bytes as u32,
+                    wr,
+                )?;
+            }
+            while rail.verbs.poll()? != wr {}
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    rail.bounce.ptr as *const u8,
+                    out.as_mut_ptr(),
+                    self.blob_bytes,
+                );
+            }
+            Ok(())
+        }
+
+        /// Striped, pipelined, dual-rail transfer of ONE blob through the shared
+        /// contiguous staging buffer (ATLAS_SSM_STAGING). `write_src` set = WRITE
+        /// (memcpy in, stripe out); `read_dst` set = READ (stripe in, memcpy out).
+        /// Chunks round-robin across rails, ≤ depth in-flight per rail (bounds the
+        /// send queue). Because every rail registers the SAME staging buffer, chunk
+        /// j lands at its true offset regardless of rail → one memcpy reassembles.
+        fn rdma_staged(
+            &self,
+            g: &mut ArenaInner,
+            raddr: u64,
+            write_src: Option<&[u8]>,
+            read_dst: Option<&mut [u8]>,
+        ) -> Result<()> {
+            let staging = g.staging.as_ref().expect("staging present").ptr as *mut u8;
+            let is_read = read_dst.is_some();
+            if let Some(src) = write_src {
+                // WRITE: assemble the whole blob into staging first.
+                unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), staging, self.blob_bytes) };
+            }
+            let n = g.rails.len();
+            let chunk = crate::snapshot_swap::staging_chunk_bytes();
+            let depth = crate::snapshot_swap::staging_depth();
+            let plan = crate::snapshot_swap::stripe_plan(self.blob_bytes, chunk, n);
+            let total: usize = plan.iter().map(|w| w.len()).sum();
+            let mut posted = vec![0usize; n];
+            let mut reaped = vec![0usize; n];
+            let mut done = 0usize;
+            while done < total {
+                // Post up to `depth` in-flight per rail (bounds each SQ).
+                for ri in 0..n {
+                    while posted[ri] < plan[ri].len() && (posted[ri] - reaped[ri]) < depth {
+                        let (off, len) = plan[ri][posted[ri]];
+                        let wr = g.next_wr;
+                        g.next_wr = g.next_wr.wrapping_add(1).max(1);
+                        let rail = &mut g.rails[ri];
+                        let local = unsafe { staging.add(off) } as *mut _;
+                        let raddr_chunk = raddr + off as u64;
+                        unsafe {
+                            if is_read {
+                                rail.verbs.post_read(
+                                    local,
+                                    rail.staging_lkey,
+                                    raddr_chunk,
+                                    rail.remote_rkey,
+                                    len as u32,
+                                    wr,
+                                )?;
+                            } else {
+                                rail.verbs.post_write(
+                                    local,
+                                    rail.staging_lkey,
+                                    raddr_chunk,
+                                    rail.remote_rkey,
+                                    len as u32,
+                                    wr,
+                                )?;
+                            }
+                        }
+                        posted[ri] += 1;
+                    }
+                }
+                // Reap one completion from each rail with work outstanding.
+                for ri in 0..n {
+                    if posted[ri] > reaped[ri] {
+                        g.rails[ri].verbs.poll()?;
+                        reaped[ri] += 1;
+                        done += 1;
+                    }
+                }
+            }
+            if let Some(dst) = read_dst {
+                // READ: one memcpy reassembles (every chunk is at its true offset).
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        staging as *const u8,
+                        dst.as_mut_ptr(),
+                        self.blob_bytes,
+                    )
+                };
+            }
+            Ok(())
+        }
+
+        // ─────────────────────────── paging data path ───────────────────────
+        // The peer owns residency; we ALLOC a slot (control), RDMA-WRITE the blob,
+        // then COMMIT — all under one lock so the peer's single-threaded per-conn
+        // request order is respected. GET faults from the peer's NVMe swap if needed.
+
+        /// PUT `key`'s blob into the tier. Never "full" — the peer spills to NVMe.
+        pub fn paging_put(&self, key: u64, bytes: &[u8]) -> Result<()> {
+            if bytes.len() != self.blob_bytes {
+                bail!(
+                    "paging_put: {} != blob_bytes {}",
+                    bytes.len(),
+                    self.blob_bytes
+                );
+            }
+            let mut g = self.inner.lock().expect("snapshot arena mutex");
+            let off = crate::snapshot_swap::client_alloc(&mut g.stream, key)?;
+            self.rdma_write_locked(&mut g, self.remote_base + off, bytes)?;
+            crate::snapshot_swap::client_commit(&mut g.stream, key)
+        }
+
+        /// GET `key`'s blob into `out`. `Ok(false)` = the peer has no such key.
+        pub fn paging_get(&self, key: u64, out: &mut [u8]) -> Result<bool> {
+            if out.len() != self.blob_bytes {
+                bail!(
+                    "paging_get: {} != blob_bytes {}",
+                    out.len(),
+                    self.blob_bytes
+                );
+            }
+            let mut g = self.inner.lock().expect("snapshot arena mutex");
+            match crate::snapshot_swap::client_get(&mut g.stream, key)? {
+                Some(off) => {
+                    self.rdma_read_locked(&mut g, self.remote_base + off, out)?;
+                    Ok(true)
+                }
+                None => Ok(false),
+            }
+        }
+
+        /// Drop `key` from the peer cache.
+        pub fn paging_remove(&self, key: u64) -> Result<()> {
+            let mut g = self.inner.lock().expect("snapshot arena mutex");
+            crate::snapshot_swap::client_remove(&mut g.stream, key)
+        }
+    }
+}

--- a/crates/spark-storage/src/rdma_verbs_probe_tests.rs
+++ b/crates/spark-storage/src/rdma_verbs_probe_tests.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Permanent witness that `cfg(atlas_rdma_verbs)` survived the move of the
+// verbs shim into the `atlas-rdma` crate.
+//
+// `rustc-cfg` does not propagate across crates: spark-storage's build.rs must
+// re-emit the cfg from atlas-rdma's `links` metadata
+// (DEP_ATLAS_RDMA_SHIM_HAS_VERBS). If that re-emit ever silently breaks, every
+// `#[cfg(atlas_rdma_verbs)]` module in this crate compiles OUT while `cargo
+// check` stays green — these tests turn that into a `cargo test -p
+// spark-storage --lib` failure on verbs hosts.
+
+/// On a verbs host (Linux + rdma-core, ATLAS_SKIP_BUILD unset) this test
+/// EXISTS only when the cfg is on for this crate, and then asserts the
+/// always-compiled witness agrees. On skip/macOS builds the cfg is off and
+/// the test compiles out — that is the documented OFF state, not a failure.
+#[cfg(atlas_rdma_verbs)]
+#[test]
+fn verbs_cfg_is_on_for_spark_storage() {
+    assert!(crate::rdma_verbs_enabled());
+    // And it must agree with the upstream crate that owns the shim: if
+    // atlas-rdma built the shim but our re-emit vanished, the module gates
+    // in THIS crate silently disagree with atlas-rdma's.
+    assert!(atlas_rdma::verbs_enabled());
+}
+
+/// Both crates must always agree on the cfg, in BOTH states (they build in the
+/// same cargo invocation with the same env + target, and the decision is made
+/// in exactly one place: atlas-rdma/build.rs).
+#[test]
+fn verbs_cfg_agrees_with_atlas_rdma() {
+    assert_eq!(crate::rdma_verbs_enabled(), atlas_rdma::verbs_enabled());
+}

--- a/crates/spark-storage/src/snapshot_swap.rs
+++ b/crates/spark-storage/src/snapshot_swap.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Peer-side paging core for the SSM-snapshot spill tier.
+//
+// Turns the paging peer's fixed RDMA arena into a bounded page-cache over an
+// UNBOUNDED lower tier (an NVMe swap file) — infinite depth. The peer owns the
+// residency map (so all fleet clients SHARE one warm cache instead of each
+// owning a colliding client-side allocator), and the stable per-rail arena MR
+// is NEVER re-registered — bytes swap under the fixed rkey, driven by a TCP
+// control channel.
+//
+// The GENERIC half of this module — the `SlotArena`/`SwapStore` seams, the
+// `Residency` page table and the O_DIRECT
+// `DirectSwapFile` — lives in the CUDA-/verbs-free `atlas-tier` crate and is
+// re-exported below, so consumers keep their `crate::snapshot_swap::*` paths
+// unchanged. What REMAINS here is the peer-specific half: the TCP control
+// protocol (byte-frozen, golden-pinned — what the fleet peer binary speaks),
+// the paging loops, the client codec, and the `MmapSlotArena` over the peer's
+// RDMA-registered mmap MR — split into the `wire` and `mmap_arena` sub-modules.
+
+#![allow(dead_code)]
+
+/// The generic paging core, lifted to `atlas-tier` (CUDA- and verbs-free).
+/// Re-exported under the `atlas_tier` names (no historical aliases).
+pub use atlas_tier::{
+    DirectSwapFile, MemSwapStore, Residency, SlotArena, SwapStats, SwapStore, VecSlotArena,
+};
+
+mod mmap_arena;
+mod wire;
+
+pub use mmap_arena::MmapSlotArena;
+pub use wire::*;

--- a/crates/spark-storage/src/snapshot_swap/mmap_arena.rs
+++ b/crates/spark-storage/src/snapshot_swap/mmap_arena.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// ─────────────────────────── real peer-mmap arena ───────────────────────────
+
+use anyhow::{Result, bail};
+
+use super::SlotArena;
+
+/// `SlotArena` over the peer's RDMA-registered `mmap` region (a raw base ptr).
+/// The peer memcpys between an arena slot and the disk swap on spill/fault; the
+/// client one-sided-RDMAs into/out of the same slots. The base VA is stable and
+/// registered ONCE per rail — this NEVER re-registers (no MR churn).
+///
+/// SAFETY: `base` must point at a live mapping of at least `num_slots *
+/// slot_bytes` bytes, page-aligned (mmap guarantees this), outliving the arena.
+/// (Peer-specific — deliberately NOT lifted into atlas-tier: the lifted crate
+/// carries no unsafe raw-pointer arena types.)
+pub struct MmapSlotArena {
+    base: *mut u8,
+    slot_bytes: usize,
+    num_slots: usize,
+}
+unsafe impl Send for MmapSlotArena {}
+
+impl MmapSlotArena {
+    /// # Safety
+    /// `base` must be a valid, writable mapping of `>= num_slots*slot_bytes`
+    /// bytes that outlives this arena.
+    pub unsafe fn new(base: *mut u8, slot_bytes: usize, num_slots: usize) -> Self {
+        Self {
+            base,
+            slot_bytes,
+            num_slots,
+        }
+    }
+    fn slot_ptr(&self, slot: usize) -> *mut u8 {
+        // slot < num_slots enforced by callers (residency free-list).
+        unsafe { self.base.add(slot * self.slot_bytes) }
+    }
+}
+
+impl SlotArena for MmapSlotArena {
+    fn slot_bytes(&self) -> usize {
+        self.slot_bytes
+    }
+    fn num_slots(&self) -> usize {
+        self.num_slots
+    }
+    fn read_slot(&self, slot: usize, out: &mut [u8]) -> Result<()> {
+        if slot >= self.num_slots || out.len() != self.slot_bytes {
+            bail!("read_slot({slot}) out of range / size mismatch");
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(self.slot_ptr(slot), out.as_mut_ptr(), self.slot_bytes)
+        };
+        Ok(())
+    }
+    fn write_slot(&mut self, slot: usize, bytes: &[u8]) -> Result<()> {
+        if slot >= self.num_slots || bytes.len() != self.slot_bytes {
+            bail!("write_slot({slot}) out of range / size mismatch");
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), self.slot_ptr(slot), self.slot_bytes)
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "mmap_arena_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/snapshot_swap/mmap_arena_tests.rs
+++ b/crates/spark-storage/src/snapshot_swap/mmap_arena_tests.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Peer-specific MmapSlotArena test (moved from the pre-split snapshot_swap.rs).
+
+use super::*;
+
+/// `MmapSlotArena` over a real page-aligned heap buffer round-trips bytes.
+#[test]
+fn mmap_slot_arena_roundtrips() {
+    let slot_bytes = 4096usize;
+    let n = 3usize;
+    // Page-aligned heap buffer (AlignedBuf moved to atlas-tier as a private
+    // helper — allocate directly here).
+    let mut p: *mut libc::c_void = std::ptr::null_mut();
+    let rc = unsafe { libc::posix_memalign(&mut p, 4096, slot_bytes * n) };
+    assert!(rc == 0 && !p.is_null(), "posix_memalign failed rc={rc}");
+    {
+        let mut arena = unsafe { MmapSlotArena::new(p as *mut u8, slot_bytes, n) };
+        let pat = vec![0x3C_u8; slot_bytes];
+        arena.write_slot(1, &pat).unwrap();
+        let mut out = vec![0u8; slot_bytes];
+        arena.read_slot(1, &mut out).unwrap();
+        assert_eq!(out, pat);
+        assert!(
+            arena.write_slot(3, &pat).is_err(),
+            "slot out of range rejected"
+        );
+    } // arena dropped before the backing buffer is freed
+    unsafe { libc::free(p) };
+}

--- a/crates/spark-storage/src/snapshot_swap/wire.rs
+++ b/crates/spark-storage/src/snapshot_swap/wire.rs
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// ───────────────────────────── control protocol ─────────────────────────────
+//
+// The TCP control channel between a paging client and the peer. It rides the
+// SAME stream the peer used for the RDMA handshake (which today just idles).
+// v2-only: EVERY client's first bytes are
+// `[u64 PAGING_MAGIC_V2][u8 kind][u64 arena_bytes][u64 blob_bytes]`.
+// `blob_bytes == 0` selects the RAW one-sided mode (per-connection arena,
+// client-owned allocator, no residency — the legacy data plane,
+// now selected explicitly); anything else is a paging arena. The retired v1
+// magic and the bare-`total_bytes` legacy escape are affirmatively rejected.
+//
+// After the shared rail handshake, the loop is: client sends [op][key], peer
+// replies [status] (+ [offset] for ALLOC/GET-hit). Data still moves one-sided
+// over RDMA into/out of `slot_offset(slot)`; only tiny control messages cross
+// TCP. Peer and client halves deliberately share this ONE module so the wire
+// format (byte-frozen, golden-pinned — it is what the fleet peer binary
+// speaks) can never drift.
+
+use std::io::{Read, Write};
+
+use anyhow::{Context, Result, bail};
+
+use super::{Residency, SlotArena, SwapStore};
+
+/// The RETIRED v1 first-u64 ("PAGE" + 1). Recognized ONLY to reject it with a
+/// dedicated diagnostic — the v1 dialect was deleted (no kind byte) and the
+/// bare-`total_bytes` legacy escape, so a stale binary fails legibly at
+/// handshake instead of being reinterpreted.
+const PAGING_MAGIC_V1_RETIRED: u64 = 0x5041_4745_0000_0001;
+
+/// The ONLY accepted first u64 on the RW paging port ("PAGE" + 2, v2-only
+///): after the magic comes a `[u8 kind]` byte so ONE peer serves
+/// a registry of per-(kind, shape) arenas, then `[u64 arena_bytes]`
+/// `[u64 blob_bytes]` — `blob_bytes == 0` selects the RAW one-sided mode.
+pub const PAGING_MAGIC_V2: u64 = 0x5041_4745_0000_0002;
+
+/// The tier a paging arena serves. Only the RW paging kinds (SSM, KV-as-paging)
+/// ride the `CacheServerParams` single-base+rkey reply; the read-only tiers
+/// (experts/weights/lora) speak a different manifest+VerbsServerParams dialect
+/// and are NOT accepted on this handshake (rejected in `parse_paging_header`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PagingKind(pub u8);
+impl PagingKind {
+    pub const SSM: PagingKind = PagingKind(0);
+    pub const KV: PagingKind = PagingKind(1);
+    /// Whether this kind is servable on the RW paging (CacheServerParams) path.
+    pub fn is_paging_rw(self) -> bool {
+        self.0 <= 1
+    }
+}
+
+/// Parse the paging handshake header after the caller has read the first u64.
+/// v2-only: the first u64 MUST be [`PAGING_MAGIC_V2`], then
+/// `[u8 kind][u64 arena_bytes][u64 blob_bytes]`. `blob_bytes == 0` = the RAW
+/// one-sided mode (per-connection arena, client-owned allocator — the caller
+/// routes it OFF the paging registry). Rejects unsupported kinds (≥2), the
+/// retired v1 magic (dedicated diagnostic so a stale binary fails legibly),
+/// and any other first u64 (e.g. a bare legacy `total_bytes`).
+pub fn parse_paging_header<R: Read>(first: u64, r: &mut R) -> Result<(PagingKind, u64, u64)> {
+    if first == PAGING_MAGIC_V1_RETIRED {
+        bail!(
+            "paging: v1 client no longer supported (magic {first:#x}); rebuild the client — \
+             every connect now sends [u64 PAGING_MAGIC_V2][u8 kind][u64 arena_bytes][u64 blob_bytes]"
+        );
+    }
+    if first != PAGING_MAGIC_V2 {
+        bail!(
+            "paging: first u64 {first:#x} is not PAGING_MAGIC_V2 (the bare legacy total_bytes \
+             handshake was retired; RAW one-sided clients send the v2 header with \
+             blob_bytes == 0)"
+        );
+    }
+    let mut kb = [0u8; 1];
+    r.read_exact(&mut kb).context("read paging kind")?;
+    let kind = PagingKind(kb[0]);
+    if !kind.is_paging_rw() {
+        bail!(
+            "paging: unsupported kind {} (only SSM/KV ride this handshake)",
+            kb[0]
+        );
+    }
+    let mut b8 = [0u8; 8];
+    r.read_exact(&mut b8).context("read paging arena_bytes")?;
+    let arena_bytes = u64::from_le_bytes(b8);
+    r.read_exact(&mut b8).context("read paging blob_bytes")?;
+    let blob_bytes = u64::from_le_bytes(b8);
+    Ok((kind, arena_bytes, blob_bytes))
+}
+
+/// Encode the CLIENT half of the v2 paging handshake header — what EVERY
+/// paging client sends first: KV paging, SSM paging (`connect_paging`), and
+/// both RAW one-sided modes (via `blob_bytes == 0`):
+/// `[u64 PAGING_MAGIC_V2 LE][u8 kind][u64 arena_bytes LE][u64 blob_bytes LE]`
+/// — 25 bytes, followed by the unchanged `[u8 n_rails]` RailSet exchange.
+/// Lives in this ONE shared module (beside `parse_paging_header`, its peer
+/// half) so writer and reader can never drift; byte-frozen and golden-pinned
+/// in `wire_tests.rs`.
+pub fn encode_paging_v2_header(kind: PagingKind, arena_bytes: u64, blob_bytes: u64) -> [u8; 25] {
+    let mut w = [0u8; 25];
+    w[0..8].copy_from_slice(&PAGING_MAGIC_V2.to_le_bytes());
+    w[8] = kind.0;
+    w[9..17].copy_from_slice(&arena_bytes.to_le_bytes());
+    w[17..25].copy_from_slice(&blob_bytes.to_le_bytes());
+    w
+}
+
+/// Round-robin stripe a `blob_bytes` transfer into `chunk_bytes` chunks across
+/// `n_rails`, returning per-rail lists of `(offset, len)`. The offset is the
+/// chunk's position in BOTH the (single, contiguous) staging buffer and the peer
+/// arena slot — so whichever rail fetches chunk j, it lands at its true offset
+/// and one memcpy reassembles the blob (the verified inc-6 reassembly fix). The
+/// tail chunk carries the short remainder, never `chunk_bytes`.
+pub fn stripe_plan(
+    blob_bytes: usize,
+    chunk_bytes: usize,
+    n_rails: usize,
+) -> Vec<Vec<(usize, usize)>> {
+    let n = n_rails.max(1);
+    let cb = chunk_bytes.max(1);
+    let mut rails: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n];
+    let mut off = 0usize;
+    let mut j = 0usize;
+    while off < blob_bytes {
+        let len = cb.min(blob_bytes - off);
+        rails[j % n].push((off, len));
+        off += len;
+        j += 1;
+    }
+    rails
+}
+
+/// Chunk size for the striped snapshot pipeline (ATLAS_SSM_CHUNK_BYTES, default
+/// 1 MiB) and pipeline depth (ATLAS_SSM_PIPELINE_DEPTH, default 16, clamped
+/// 1..=128, mirroring the KV backend).
+pub fn staging_chunk_bytes() -> usize {
+    std::env::var("ATLAS_SSM_CHUNK_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&v| v >= 4096)
+        .unwrap_or(1024 * 1024)
+}
+pub fn staging_depth() -> usize {
+    std::env::var("ATLAS_SSM_PIPELINE_DEPTH")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(16)
+        .clamp(1, 128)
+}
+
+pub const OP_BYE: u8 = 0;
+pub const OP_ALLOC: u8 = 1;
+pub const OP_COMMIT: u8 = 2;
+pub const OP_GET: u8 = 3;
+pub const OP_REMOVE: u8 = 4;
+
+pub const ST_OK: u8 = 0;
+pub const ST_MISS: u8 = 1;
+pub const ST_ERR: u8 = 2;
+
+/// Result of one control request, ready to serialize.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PagingReply {
+    /// ST_OK with a following u64 arena offset (ALLOC and GET-hit).
+    Located(u64),
+    /// ST_OK with no payload (COMMIT, REMOVE).
+    Ok,
+    /// ST_MISS — unknown key (GET).
+    Miss,
+    /// ST_ERR — operation failed (e.g. arena exhausted by reservations).
+    Err,
+    /// Client asked to close.
+    Bye,
+}
+
+/// Execute one control op against the residency and return the reply. Pure over
+/// the (already unit-tested) `Residency`, so the protocol is testable
+/// without a socket or RDMA.
+pub fn dispatch<A: SlotArena, S: SwapStore>(
+    res: &mut Residency<A, S>,
+    op: u8,
+    key: u64,
+) -> PagingReply {
+    match op {
+        OP_BYE => PagingReply::Bye,
+        OP_ALLOC => match res.alloc(key) {
+            Ok(slot) => PagingReply::Located(res.slot_offset(slot)),
+            Err(e) => {
+                tracing::warn!("paging ALLOC {key:#x} failed: {e:#}");
+                PagingReply::Err
+            }
+        },
+        OP_COMMIT => match res.commit(key) {
+            Ok(()) => PagingReply::Ok,
+            Err(e) => {
+                tracing::warn!("paging COMMIT {key:#x} failed: {e:#}");
+                PagingReply::Err
+            }
+        },
+        OP_GET => match res.locate(key) {
+            Ok(Some(slot)) => PagingReply::Located(res.slot_offset(slot)),
+            Ok(None) => PagingReply::Miss,
+            Err(e) => {
+                tracing::warn!("paging GET {key:#x} failed: {e:#}");
+                PagingReply::Err
+            }
+        },
+        OP_REMOVE => {
+            res.remove(key);
+            PagingReply::Ok
+        }
+        other => {
+            tracing::warn!("paging: unknown op {other}");
+            PagingReply::Err
+        }
+    }
+}
+
+fn write_reply<W: Write>(w: &mut W, reply: &PagingReply) -> Result<()> {
+    match reply {
+        PagingReply::Located(off) => {
+            w.write_all(&[ST_OK])?;
+            w.write_all(&off.to_le_bytes())?;
+        }
+        PagingReply::Ok => w.write_all(&[ST_OK])?,
+        PagingReply::Miss => w.write_all(&[ST_MISS])?,
+        PagingReply::Err => w.write_all(&[ST_ERR])?,
+        PagingReply::Bye => {}
+    }
+    w.flush()?;
+    Ok(())
+}
+
+/// The peer-side control loop: read `[op][u64 key]` requests, dispatch against
+/// `res`, write replies, until BYE or hangup. Generic over the stream so it runs
+/// against a real `TcpStream` in the peer and a fake duplex in tests.
+/// One control op with connection-scoped read-pin lifecycle. Releases this
+/// connection's previous GET read-pin — its RDMA READ has necessarily drained,
+/// because the client is synchronous and only sends its NEXT op after the read
+/// completes — then dispatches, and pins a fresh GET hit so a concurrent ALLOC
+/// on another connection cannot evict the slot mid-read. `pinned` threads the
+/// connection's currently-pinned key across calls. Needs NO new opcode and no
+/// client change (auto-release on next op / disconnect) → wire-compatible with
+/// the frozen control protocol.
+fn handle_paging_op<A: SlotArena, S: SwapStore>(
+    res: &mut Residency<A, S>,
+    op: u8,
+    key: u64,
+    pinned: &mut Option<u64>,
+) -> PagingReply {
+    if let Some(prev) = pinned.take() {
+        res.unpin_read(prev);
+    }
+    let reply = dispatch(res, op, key);
+    if op == OP_GET && matches!(reply, PagingReply::Located(_)) {
+        res.pin_read(key);
+        *pinned = Some(key);
+    }
+    reply
+}
+
+pub fn run_paging_loop<T: Read + Write, A: SlotArena, S: SwapStore>(
+    stream: &mut T,
+    res: &mut Residency<A, S>,
+) -> Result<()> {
+    let mut pinned: Option<u64> = None;
+    loop {
+        let mut op = [0u8; 1];
+        if stream.read_exact(&mut op).is_err() {
+            break; // client hung up
+        }
+        if op[0] == OP_BYE {
+            break;
+        }
+        let mut kb = [0u8; 8];
+        stream.read_exact(&mut kb).context("read paging key")?;
+        let key = u64::from_le_bytes(kb);
+        let reply = handle_paging_op(res, op[0], key, &mut pinned);
+        write_reply(stream, &reply)?;
+    }
+    // Release this connection's outstanding read-pin on hangup / BYE.
+    if let Some(pk) = pinned {
+        res.unpin_read(pk);
+    }
+    Ok(())
+}
+
+// ─────────────────────── client-side protocol helpers ───────────────────────
+//
+// The CLIENT half of the control channel, sharing the wire format above so peer
+// and client can never drift. Each sends `[op][u64 key]` and reads the reply.
+// The RDMA data-plane WRITE/READ (client-side) happens between `client_alloc`
+// and `client_commit` (PUT) or after `client_get` (GET) — see RdmaSnapshotArena.
+
+fn send_req<T: Write>(s: &mut T, op: u8, key: u64) -> Result<()> {
+    let mut buf = [0u8; 9];
+    buf[0] = op;
+    buf[1..].copy_from_slice(&key.to_le_bytes());
+    s.write_all(&buf)?;
+    s.flush()?;
+    Ok(())
+}
+
+fn read_status<T: Read>(s: &mut T) -> Result<u8> {
+    let mut st = [0u8; 1];
+    s.read_exact(&mut st).context("read paging status")?;
+    Ok(st[0])
+}
+
+fn read_offset<T: Read>(s: &mut T) -> Result<u64> {
+    let mut b = [0u8; 8];
+    s.read_exact(&mut b).context("read paging offset")?;
+    Ok(u64::from_le_bytes(b))
+}
+
+/// PUT step 1: reserve a slot for `key`; returns the arena offset to RDMA-WRITE.
+pub fn client_alloc<T: Read + Write>(s: &mut T, key: u64) -> Result<u64> {
+    send_req(s, OP_ALLOC, key)?;
+    match read_status(s)? {
+        ST_OK => read_offset(s),
+        st => bail!("paging ALLOC {key:#x} refused (status {st})"),
+    }
+}
+
+/// PUT step 2: the RDMA-WRITE has drained; mark `key` resident.
+pub fn client_commit<T: Read + Write>(s: &mut T, key: u64) -> Result<()> {
+    send_req(s, OP_COMMIT, key)?;
+    match read_status(s)? {
+        ST_OK => Ok(()),
+        st => bail!("paging COMMIT {key:#x} failed (status {st})"),
+    }
+}
+
+/// GET: `Some(offset)` to RDMA-READ, or `None` if the peer has no such key.
+pub fn client_get<T: Read + Write>(s: &mut T, key: u64) -> Result<Option<u64>> {
+    send_req(s, OP_GET, key)?;
+    match read_status(s)? {
+        ST_OK => Ok(Some(read_offset(s)?)),
+        ST_MISS => Ok(None),
+        st => bail!("paging GET {key:#x} error (status {st})"),
+    }
+}
+
+/// Drop `key` from the peer cache.
+pub fn client_remove<T: Read + Write>(s: &mut T, key: u64) -> Result<()> {
+    send_req(s, OP_REMOVE, key)?;
+    match read_status(s)? {
+        ST_OK => Ok(()),
+        st => bail!("paging REMOVE {key:#x} failed (status {st})"),
+    }
+}
+
+/// Politely tell the peer to close the paging loop.
+pub fn client_bye<T: Write>(s: &mut T) -> Result<()> {
+    send_req(s, OP_BYE, 0)
+}
+
+/// Shared variant of [`run_paging_loop`]: many connection threads drive ONE
+/// process-global residency, locking it per request. This is what makes the
+/// peer a SHARED warm cache — a snapshot PUT by one client is GET-able by
+/// another (same namespace). The lock is held only for the (fast) map op + any
+/// spill/fault byte move, never across a TCP read.
+pub fn run_paging_loop_shared<T: Read + Write, A: SlotArena, S: SwapStore>(
+    stream: &mut T,
+    res: &std::sync::Mutex<Residency<A, S>>,
+) -> Result<()> {
+    // Per-connection read-pin (see `handle_paging_op`): a GET hit is pinned OUT
+    // of the LRU under the same lock as the dispatch, so a concurrent ALLOC on
+    // another connection can't evict the slot while THIS client RDMA-reads it.
+    // Released on the connection's next op (its read has drained) or disconnect.
+    let mut pinned: Option<u64> = None;
+    loop {
+        let mut op = [0u8; 1];
+        if stream.read_exact(&mut op).is_err() {
+            break;
+        }
+        if op[0] == OP_BYE {
+            break;
+        }
+        let mut kb = [0u8; 8];
+        stream.read_exact(&mut kb).context("read paging key")?;
+        let key = u64::from_le_bytes(kb);
+        let reply = {
+            let mut g = res.lock().expect("shared residency mutex poisoned");
+            handle_paging_op(&mut g, op[0], key, &mut pinned)
+        };
+        write_reply(stream, &reply)?;
+    }
+    if let Some(pk) = pinned {
+        res.lock()
+            .expect("shared residency mutex poisoned")
+            .unpin_read(pk);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "wire_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/snapshot_swap/wire_tests.rs
+++ b/crates/spark-storage/src/snapshot_swap/wire_tests.rs
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Protocol tests: header parse, stripe plan, wire-golden bytes,
+//! dispatch/loop/codec, connection-scoped pins.
+//!
+//! The residency-semantics test suite (disk cap, infinite depth, read-pins,
+//! reserved-slot pinning, overwrite/remove, size laws) moved to atlas-tier
+//! with the core; the peer-specific MmapSlotArena test lives next to
+//! `mmap_arena.rs`.
+
+use super::super::{MemSwapStore, VecSlotArena};
+use super::*;
+
+type TestResidency = Residency<VecSlotArena, MemSwapStore>;
+
+const B: usize = 8; // tiny blob for tests
+
+fn blob(tag: u8) -> Vec<u8> {
+    vec![tag; B]
+}
+
+/// Client-side helper: alloc → write bytes into the arena slot → commit.
+fn put(r: &mut TestResidency, key: u64, tag: u8) {
+    let slot = r.alloc(key).unwrap();
+    r.arena_mut().write_slot(slot, &blob(tag)).unwrap();
+    r.commit(key).unwrap();
+}
+fn get(r: &mut TestResidency, key: u64) -> Option<Vec<u8>> {
+    r.locate(key).unwrap().map(|slot| {
+        let mut out = vec![0u8; B];
+        r.arena().read_slot(slot, &mut out).unwrap();
+        out
+    })
+}
+
+fn residency(slots: usize) -> TestResidency {
+    Residency::new(VecSlotArena::new(B, slots), MemSwapStore::new(B)).unwrap()
+}
+
+/// The connection-scoped auto-release: `handle_paging_op` pins a GET hit and
+/// releases it on the SAME connection's next op — no new opcode, no client
+/// change. During the window the slot survives a concurrent ALLOC.
+#[test]
+fn handle_paging_op_pins_get_and_auto_releases() {
+    let mut r = residency(2);
+    put(&mut r, 0, 0);
+    put(&mut r, 1, 1);
+    let mut pinned: Option<u64> = None;
+
+    // Connection A: GET 0 → pinned.
+    let reply = handle_paging_op(&mut r, OP_GET, 0, &mut pinned);
+    assert!(matches!(reply, PagingReply::Located(_)));
+    assert_eq!(pinned, Some(0));
+    assert_eq!(r.read_pin_count(0), 1);
+
+    // Concurrent ALLOC (another connection) evicts the unpinned key 1, not 0.
+    put(&mut r, 2, 2);
+    assert_eq!(
+        get(&mut r, 0),
+        Some(blob(0)),
+        "pinned GET slot survived the ALLOC"
+    );
+
+    // Connection A's NEXT op releases the pin (its RDMA read has drained).
+    handle_paging_op(&mut r, OP_REMOVE, 99, &mut pinned);
+    assert_eq!(pinned, None);
+    assert_eq!(r.read_pin_count(0), 0, "pin auto-released on next op");
+}
+
+// ─────────────────────────── protocol tests ───────────────────────────
+
+#[test]
+fn stripe_plan_covers_every_byte_once() {
+    for (blob, chunk, rails) in [
+        (64usize, 16usize, 2usize), // even split
+        (70, 16, 2),                // tail remainder
+        (64, 16, 1),                // single rail
+        (10, 64, 2),                // chunk > blob → one chunk
+        (64, 64, 2),                // chunk == blob
+        (66846720, 1048576, 2),     // real 66MB SSM blob, 1MiB chunks, dual-rail
+    ] {
+        let plan = stripe_plan(blob, chunk, rails);
+        assert_eq!(plan.len(), rails.max(1));
+        // Flatten and assert every byte [0,blob) is covered exactly once.
+        let mut covered = vec![0u8; blob];
+        for rail in &plan {
+            for &(off, len) in rail {
+                assert!(
+                    len <= chunk && off + len <= blob,
+                    "chunk oob {off}+{len}>{blob}"
+                );
+                for b in &mut covered[off..off + len] {
+                    assert_eq!(*b, 0, "byte {off} double-covered");
+                    *b = 1;
+                }
+            }
+        }
+        assert!(
+            covered.iter().all(|&b| b == 1),
+            "gap in coverage blob={blob}"
+        );
+    }
+    // Zero blob → empty plan (no chunks).
+    assert!(stripe_plan(0, 16, 2).iter().all(|r| r.is_empty()));
+}
+
+/// v2-only header parse: SSM, KV, the RAW-mode blob==0 sentinel, and
+/// every rejection arm — unsupported kind, bare legacy total_bytes, v1 magic.
+#[test]
+fn paging_header_v2_parse_and_reject() {
+    // v2 SSM: [kind][arena][blob].
+    let mut body = vec![PagingKind::SSM.0];
+    body.extend_from_slice(&0x1000u64.to_le_bytes());
+    body.extend_from_slice(&0x40u64.to_le_bytes());
+    let mut c = std::io::Cursor::new(body);
+    assert_eq!(
+        parse_paging_header(PAGING_MAGIC_V2, &mut c).unwrap(),
+        (PagingKind::SSM, 0x1000, 0x40)
+    );
+    // v2 KV.
+    let mut body = vec![PagingKind::KV.0];
+    body.extend_from_slice(&0x2000u64.to_le_bytes());
+    body.extend_from_slice(&0x80u64.to_le_bytes());
+    let mut c = std::io::Cursor::new(body);
+    assert_eq!(
+        parse_paging_header(PAGING_MAGIC_V2, &mut c).unwrap(),
+        (PagingKind::KV, 0x2000, 0x80)
+    );
+    // v2 RAW mode: blob_bytes == 0 PARSES — routing it off the paging
+    // registry (per-connection arena, client-owned allocator) is the peer's
+    // job, not the parser's.
+    let mut body = vec![PagingKind::KV.0];
+    body.extend_from_slice(&0x3000u64.to_le_bytes());
+    body.extend_from_slice(&0u64.to_le_bytes());
+    let mut c = std::io::Cursor::new(body);
+    assert_eq!(
+        parse_paging_header(PAGING_MAGIC_V2, &mut c).unwrap(),
+        (PagingKind::KV, 0x3000, 0)
+    );
+    // A bare legacy total_bytes first-u64 → hard error (retired;
+    // the legacy handshake silently selected the dumb one-sided path).
+    let mut c = std::io::Cursor::new(Vec::new());
+    assert!(parse_paging_header(12345, &mut c).is_err());
+    // unsupported kind (RO tier) → hard error, never a bogus arena.
+    let mut body = vec![3u8];
+    body.extend_from_slice(&[0u8; 16]);
+    let mut c = std::io::Cursor::new(body);
+    assert!(parse_paging_header(PAGING_MAGIC_V2, &mut c).is_err());
+}
+
+/// WIRE-GOLDEN: the RETIRED v1 magic 0x5041_4745_0000_0001 is
+/// AFFIRMATIVELY rejected with a dedicated, legible diagnostic — never
+/// reinterpreted as a size or a v2 header — so a stale legacy binary
+/// fails loudly at handshake instead of silently degrading.
+#[test]
+fn v1_magic_is_affirmatively_rejected() {
+    let mut c = std::io::Cursor::new(Vec::new());
+    let err = parse_paging_header(0x5041_4745_0000_0001, &mut c).unwrap_err();
+    assert!(
+        err.to_string().contains("v1 client no longer supported"),
+        "v1 rejection must be the dedicated diagnostic, got: {err}"
+    );
+    // The retired constant itself stays pinned (it is what stale binaries send).
+    assert_eq!(PAGING_MAGIC_V1_RETIRED, 0x5041_4745_0000_0001);
+}
+
+/// WIRE-GOLDEN: the RAW one-sided mode header — `blob_bytes == 0` —
+/// exactly what a RAW one-sided KV client (ATLAS_KV_PAGING off) and the bounded/unified
+/// snapshot fallback send in place of the retired bare `total_bytes`.
+#[test]
+fn v2_raw_mode_wire_golden() {
+    assert_eq!(
+        encode_paging_v2_header(PagingKind::KV, 0x4_0000_0000, 0).to_vec(),
+        vec![
+            0x02, 0x00, 0x00, 0x00, 0x45, 0x47, 0x41, 0x50, // PAGING_MAGIC_V2 LE
+            0x01, // kind = KV
+            0x00, 0x00, 0x00, 0x00, 0x04, 0, 0, 0, // arena = 16 GiB
+            0x00, 0, 0, 0, 0, 0, 0, 0, // blob = 0 → RAW one-sided mode
+        ],
+        "v2 RAW-mode handshake bytes are frozen"
+    );
+}
+
+/// WIRE-GOLDEN — the exact 25-byte `encode_paging_v2_header` emission, one
+/// vector per kind, with DISTINCT field byte values so a symmetric
+/// writer+reader field swap cannot hide. Frozen: the fleet peer speaks these
+/// bytes, so any drift here is an on-wire break.
+#[test]
+fn v2_handshake_wire_golden() {
+    // KV (kind = 1): what a KV paging client sends first.
+    assert_eq!(
+        encode_paging_v2_header(PagingKind::KV, 0x2000, 0x80).to_vec(),
+        vec![
+            0x02, 0x00, 0x00, 0x00, 0x45, 0x47, 0x41, 0x50, // PAGING_MAGIC_V2 LE ("PAGE" + 2)
+            0x01, // kind = KV
+            0x00, 0x20, 0, 0, 0, 0, 0, 0, // arena 0x2000
+            0x80, 0, 0, 0, 0, 0, 0, 0, // blob 0x80
+        ],
+        "v2 KV handshake bytes are frozen (the deployed fleet peer parses them)"
+    );
+    // SSM (kind = 0): what connect_paging sends (now v2).
+    assert_eq!(
+        encode_paging_v2_header(PagingKind::SSM, 0x1000, 0x40).to_vec(),
+        vec![
+            0x02, 0x00, 0x00, 0x00, 0x45, 0x47, 0x41, 0x50, // PAGING_MAGIC_V2 LE
+            0x00, // kind = SSM
+            0x00, 0x10, 0, 0, 0, 0, 0, 0, // arena 0x1000
+            0x40, 0, 0, 0, 0, 0, 0, 0, // blob 0x40
+        ],
+        "v2 SSM handshake bytes are frozen"
+    );
+    // n_rails follows via RailSet::begin, exactly as v1 (unchanged framing).
+}
+
+/// The encoder and the peer parser are inverse halves of ONE module: every
+/// encoded header parses back to exactly (kind, arena, blob).
+#[test]
+fn v2_encode_parses_back() {
+    for (kind, arena, blob) in [
+        (PagingKind::KV, 0x40_0000u64, 0x1_0000u64),
+        (PagingKind::SSM, 0x1000, 0x40),
+        (PagingKind::KV, 0x3000, 0),  // RAW one-sided (RAW one-sided KV)
+        (PagingKind::SSM, 0x2000, 0), // RAW one-sided (snapshot fallback)
+    ] {
+        let w = encode_paging_v2_header(kind, arena, blob);
+        let first = u64::from_le_bytes(w[0..8].try_into().unwrap());
+        let mut c = std::io::Cursor::new(w[8..].to_vec());
+        assert_eq!(
+            parse_paging_header(first, &mut c).unwrap(),
+            (kind, arena, blob)
+        );
+    }
+}
+
+/// One PUT (alloc→arena write→commit) then GET, driven through `dispatch`,
+/// with the caller's RDMA-write emulated by writing the returned slot.
+#[test]
+fn dispatch_put_then_get_roundtrips() {
+    let mut r = residency(4);
+    // ALLOC key 7
+    let PagingReply::Located(off) = dispatch(&mut r, OP_ALLOC, 7) else {
+        panic!("alloc reply")
+    };
+    let slot = (off as usize) / B;
+    // client RDMA-WRITE emulation
+    r.arena_mut().write_slot(slot, &blob(0xAB)).unwrap();
+    assert_eq!(dispatch(&mut r, OP_COMMIT, 7), PagingReply::Ok);
+    // GET key 7
+    let PagingReply::Located(goff) = dispatch(&mut r, OP_GET, 7) else {
+        panic!("get reply")
+    };
+    let mut out = vec![0u8; B];
+    r.arena().read_slot((goff as usize) / B, &mut out).unwrap();
+    assert_eq!(out, blob(0xAB));
+    // unknown key → miss
+    assert_eq!(dispatch(&mut r, OP_GET, 999), PagingReply::Miss);
+}
+
+/// Fake bidirectional stream: scripted input, captured output.
+struct Duplex {
+    inp: std::io::Cursor<Vec<u8>>,
+    out: Vec<u8>,
+}
+impl Read for Duplex {
+    fn read(&mut self, b: &mut [u8]) -> std::io::Result<usize> {
+        self.inp.read(b)
+    }
+}
+impl Write for Duplex {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.out.extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn req(op: u8, key: u64) -> Vec<u8> {
+    let mut v = vec![op];
+    v.extend_from_slice(&key.to_le_bytes());
+    v
+}
+
+/// Drive the full `run_paging_loop` over a scripted request stream and
+/// assert the reply bytes — the protocol end-to-end (sans RDMA data plane).
+#[test]
+fn run_paging_loop_scripts_ok() {
+    let mut r = residency(4);
+    // ALLOC 1 → we need its offset before we can COMMIT meaningfully, but
+    // run_paging_loop reads all input at once; emulate the client by first
+    // allocating via dispatch to learn the slot, writing bytes, THEN scripting
+    // commit+get through the loop. (Mirrors real client ordering.)
+    let PagingReply::Located(off) = dispatch(&mut r, OP_ALLOC, 1) else {
+        panic!()
+    };
+    r.arena_mut()
+        .write_slot((off as usize) / B, &blob(0x5A))
+        .unwrap();
+
+    let mut script = Vec::new();
+    script.extend(req(OP_COMMIT, 1));
+    script.extend(req(OP_GET, 1));
+    script.extend(req(OP_GET, 42)); // miss
+    script.extend(req(OP_REMOVE, 1));
+    script.extend(req(OP_BYE, 0));
+    let mut dx = Duplex {
+        inp: std::io::Cursor::new(script),
+        out: Vec::new(),
+    };
+    run_paging_loop(&mut dx, &mut r).unwrap();
+
+    // Expected replies: COMMIT→[OK]; GET1→[OK][off]; GET42→[MISS]; REMOVE→[OK].
+    let mut exp = Vec::new();
+    exp.push(ST_OK); // commit
+    exp.push(ST_OK);
+    exp.extend_from_slice(&off.to_le_bytes()); // get 1 (same slot/offset)
+    exp.push(ST_MISS); // get 42
+    exp.push(ST_OK); // remove
+    assert_eq!(dx.out, exp);
+}
+
+/// Client codec: request bytes on the wire + reply decode.
+#[test]
+fn client_codec_alloc_get_miss() {
+    // ALLOC → [ST_OK][offset 0x40]
+    let mut reply = vec![ST_OK];
+    reply.extend_from_slice(&0x40u64.to_le_bytes());
+    let mut dx = Duplex {
+        inp: std::io::Cursor::new(reply),
+        out: Vec::new(),
+    };
+    let off = client_alloc(&mut dx, 0xAB).unwrap();
+    assert_eq!(off, 0x40);
+    assert_eq!(dx.out, req(OP_ALLOC, 0xAB), "request bytes on the wire");
+
+    // GET miss → [ST_MISS]
+    let mut dx = Duplex {
+        inp: std::io::Cursor::new(vec![ST_MISS]),
+        out: Vec::new(),
+    };
+    assert_eq!(client_get(&mut dx, 7).unwrap(), None);
+
+    // COMMIT ok → [ST_OK]
+    let mut dx = Duplex {
+        inp: std::io::Cursor::new(vec![ST_OK]),
+        out: Vec::new(),
+    };
+    client_commit(&mut dx, 9).unwrap();
+    assert_eq!(dx.out, req(OP_COMMIT, 9));
+}
+
+/// End-to-end loopback: the client codec's request bytes feed the peer
+/// `dispatch`; the peer's reply bytes feed the client codec — the two halves
+/// agree on the wire and a PUT→GET round-trips a blob byte-identical (the
+/// RDMA data plane emulated via direct arena writes at the returned offset).
+#[test]
+fn client_peer_loopback_roundtrip() {
+    let mut r = residency(4);
+    // Run one client request through the peer and return the client-decoded
+    // reply channel (a cursor over the peer's reply bytes).
+    fn peer_roundtrip(r: &mut TestResidency, req_bytes: &[u8]) -> std::io::Cursor<Vec<u8>> {
+        let op = req_bytes[0];
+        let key = u64::from_le_bytes(req_bytes[1..9].try_into().unwrap());
+        let mut reply = Vec::new();
+        write_reply(&mut reply, &dispatch(r, op, key)).unwrap();
+        std::io::Cursor::new(reply)
+    }
+
+    // PUT key 3: ALLOC → emulate RDMA write → COMMIT.
+    let mut wire = Vec::new();
+    send_req(&mut wire, OP_ALLOC, 3).unwrap();
+    let mut rep = peer_roundtrip(&mut r, &wire);
+    assert_eq!(read_status(&mut rep).unwrap(), ST_OK);
+    let off = read_offset(&mut rep).unwrap();
+    r.arena_mut()
+        .write_slot((off as usize) / B, &blob(0x77))
+        .unwrap();
+
+    wire.clear();
+    send_req(&mut wire, OP_COMMIT, 3).unwrap();
+    assert_eq!(
+        read_status(&mut peer_roundtrip(&mut r, &wire)).unwrap(),
+        ST_OK
+    );
+
+    // GET key 3 → read back byte-identical.
+    wire.clear();
+    send_req(&mut wire, OP_GET, 3).unwrap();
+    let mut rep = peer_roundtrip(&mut r, &wire);
+    assert_eq!(read_status(&mut rep).unwrap(), ST_OK);
+    let goff = read_offset(&mut rep).unwrap();
+    let mut out = vec![0u8; B];
+    r.arena().read_slot((goff as usize) / B, &mut out).unwrap();
+    assert_eq!(
+        out,
+        blob(0x77),
+        "PUT→GET round-trips byte-identical over the protocol"
+    );
+}

--- a/crates/spark-storage/src/weight_lora_rdma.rs
+++ b/crates/spark-storage/src/weight_lora_rdma.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RdmaLoraLoader — RDMA-stage a PEFT adapter's A/B tensors straight into a
+// resident LoRA pool SLOT for fast rotation (vs a disk reload).
+//
+// This is the client half for LoRA rotation over the RDMA weight tier. It
+// reuses the SAME `weight_peer` wire protocol + verbs stack as
+// `weight_tier_rdma`: connect, request an adapter dir by id/path, read the
+// manifest, then one-sided RDMA-READ each `lora_A/lora_B` tensor's bytes into a
+// pinned bounce. The ONLY difference from `weight_tier_rdma` is the landing:
+// instead of a fresh per-tensor GPU buffer, each tensor lands into a caller-
+// computed pool-slot SUB-REGION (`LoraLandTarget.dst`) after the SAME host
+// F16/F32→BF16 conversion the disk adapter loader does
+// (`spark-runtime .../adapter.rs`) and the SAME B row-repack (stride r →
+// max_rank) the pool pack does (`spark-model .../lora/mod.rs`). Landing bytes
+// are therefore byte-identical to the disk pack — post_read-into-bounce simply
+// replaces the disk loader's copy_d2h.
+//
+// The plan (which tensor lands where, with what geometry) is computed by
+// spark-model (`lora::rdma_stage`, the only place `classify_key` + slot offsets
+// live) and passed in as `&[LoraLandTarget]`, keeping this crate free of any
+// spark-model dependency (spark-model → spark-storage is the acyclic direction).
+//
+// Like `weight_tier_rdma`, the verbs data path is gated on `atlas_rdma_verbs`;
+// without rdma-core the loader compiles but `stage_into_slot` returns a clear
+// runtime error.
+
+use anyhow::Result;
+
+/// Which half of a LoRA pair a target lands. A is copied contiguous into the
+/// head of the padded `[max_rank, in]` region; B is row-repacked from stride
+/// `r` to stride `max_rank` into `[out, max_rank]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LoraAbKind {
+    A,
+    B,
+}
+
+/// One landing instruction: the adapter tensor `tensor_name` (a manifest key),
+/// which half it is, the device destination address (a pool-slot sub-region
+/// base, already `pool + slot*slot_bytes + a_off|b_off`), and the geometry the
+/// convert/repack needs. `rank` is the adapter's real r; `max_rank` the pool's
+/// padded rank.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoraLandTarget {
+    pub tensor_name: String,
+    pub kind: LoraAbKind,
+    /// Destination device address (`DevicePtr.0`) of the slot sub-region.
+    pub dst: u64,
+    /// Output dim (B rows). Unused for A.
+    pub out_dim: usize,
+    /// Input dim (A cols). Unused for B.
+    pub in_dim: usize,
+    /// Adapter real rank r (A rows / B cols).
+    pub rank: usize,
+    /// Pool padded rank (B destination row stride).
+    pub max_rank: usize,
+}
+
+const BF16_BYTES: usize = 2;
+
+/// Host F16/F32/BF16 → BF16, byte-for-byte matching the disk adapter loader
+/// (`load_adapter_safetensors`): `half::bf16::from_f32` (round-to-nearest-even)
+/// for the float conversions. Any other dtype is a hard error — a PEFT adapter
+/// is only ever F32 (default), F16, or BF16.
+pub fn convert_to_bf16(raw: &[u8], dtype: &str) -> Result<Vec<u8>> {
+    use half::{bf16, f16};
+    Ok(match dtype {
+        "BF16" => raw.to_vec(),
+        "F16" => raw
+            .chunks_exact(2)
+            .flat_map(|c| bf16::from_f32(f16::from_le_bytes([c[0], c[1]]).to_f32()).to_le_bytes())
+            .collect(),
+        "F32" => raw
+            .chunks_exact(4)
+            .flat_map(|c| {
+                bf16::from_f32(f32::from_le_bytes([c[0], c[1], c[2], c[3]])).to_le_bytes()
+            })
+            .collect(),
+        other => anyhow::bail!(
+            "REJECT[lora-rdma-dtype]: adapter tensor dtype '{other}' (want F32/F16/BF16)"
+        ),
+    })
+}
+
+/// Row-repack a BF16 B tensor `[out_dim, r]` into the pool's padded
+/// `[out_dim, max_rank]` layout: per row, `r` BF16 elements copied from stride
+/// `r` to stride `max_rank`; pad columns stay zero. Byte-identical to the disk
+/// pack's B repack. Returns `out_dim * max_rank * 2` bytes.
+pub fn repack_b_to_padded(src_bf16: &[u8], out_dim: usize, r: usize, max_rank: usize) -> Vec<u8> {
+    let mut dst = vec![0u8; out_dim * max_rank * BF16_BYTES];
+    for row in 0..out_dim {
+        let d = row * max_rank * BF16_BYTES;
+        let s = row * r * BF16_BYTES;
+        dst[d..d + r * BF16_BYTES].copy_from_slice(&src_bf16[s..s + r * BF16_BYTES]);
+    }
+    dst
+}
+
+/// The final host bytes to `copy_h2d` for a target, given the raw on-wire
+/// tensor bytes (as landed in the bounce). A: convert only. B: convert + repack.
+/// Factored out (un-gated) so the byte-identity logic is unit-testable off the
+/// RDMA path — the verbs loop calls this so tested and shipped logic agree.
+pub fn land_bytes_for_target(target: &LoraLandTarget, raw: &[u8], dtype: &str) -> Result<Vec<u8>> {
+    let bf16 = convert_to_bf16(raw, dtype)?;
+    Ok(match target.kind {
+        LoraAbKind::A => bf16, // [r, in] contiguous → head of padded region
+        LoraAbKind::B => repack_b_to_padded(&bf16, target.out_dim, target.rank, target.max_rank),
+    })
+}
+
+/// RDMA-stage a named adapter's A/B into pre-computed pool-slot sub-regions.
+pub struct RdmaLoraLoader {
+    /// `host:port` of the weight peer (from `$ATLAS_LORA_PEER`).
+    pub peer_addr: String,
+    /// Adapter dir id/path the peer staged (its `adapter_model.safetensors`).
+    pub adapter_id: String,
+}
+
+impl RdmaLoraLoader {
+    pub fn new(peer_addr: String, adapter_id: String) -> Self {
+        Self {
+            peer_addr,
+            adapter_id,
+        }
+    }
+}
+
+#[cfg(all(feature = "cuda", not(atlas_rdma_verbs)))]
+impl RdmaLoraLoader {
+    /// Stub: no rdma-core in this build.
+    pub fn stage_into_slot(
+        &self,
+        _gpu: &dyn spark_runtime::gpu::GpuBackend,
+        _targets: &[LoraLandTarget],
+    ) -> Result<()> {
+        anyhow::bail!(
+            "$ATLAS_LORA_PEER is set but this build has no rdma-core (atlas_rdma_verbs \
+             cfg); rebuild with rdma-core, or unset ATLAS_LORA_PEER to rotate from disk"
+        )
+    }
+}
+
+#[cfg(all(feature = "cuda", atlas_rdma_verbs))]
+impl RdmaLoraLoader {
+    /// Connect, request the adapter, and RDMA-READ each `lora_A/lora_B` tensor
+    /// into its pool-slot sub-region (single rail — an adapter is one small
+    /// shard). Convert + (B) repack land bytes byte-identical to the disk pack.
+    pub fn stage_into_slot(
+        &self,
+        gpu: &dyn spark_runtime::gpu::GpuBackend,
+        targets: &[LoraLandTarget],
+    ) -> Result<()> {
+        use std::collections::HashMap;
+        use std::ffi::c_void;
+        use std::io::Write;
+        use std::net::TcpStream;
+
+        use anyhow::{Context, bail};
+
+        use crate::expert_peer::MODE_VERBS;
+        use crate::weight_peer::{read_weight_manifest, tensor_remote_addr, write_model_request};
+        use atlas_rdma::env::{first_set, first_set_u32};
+        use atlas_rdma::railset::{RailSet, RailSpec};
+
+        let by_name: HashMap<&str, &LoraLandTarget> = targets
+            .iter()
+            .map(|t| (t.tensor_name.as_str(), t))
+            .collect();
+
+        // 1. Connect + request the adapter + read the manifest.
+        let mut stream = TcpStream::connect(&self.peer_addr)
+            .with_context(|| format!("connect lora peer {}", self.peer_addr))?;
+        stream.set_nodelay(true).ok();
+        write_model_request(&mut stream, &self.adapter_id).context("send adapter request")?;
+        let manifest = read_weight_manifest(&mut stream).context("read adapter manifest")?;
+        let num_shards = manifest.num_shards();
+
+        // Only the tensors we have a landing target for (all lora_A/lora_B).
+        let retained: Vec<&crate::weight_peer::WeightTensorRecord> = manifest
+            .tensors
+            .iter()
+            .filter(|t| by_name.contains_key(t.name.as_str()))
+            .collect();
+        if retained.is_empty() {
+            bail!(
+                "lora peer manifest matched none of the {} land targets",
+                targets.len()
+            );
+        }
+
+        // 2. Single-rail verbs handshake via RailSet (adapter = one shard, few
+        // MB). LoRA env: DEV chains LORA→WEIGHT→EXPERT (an exported-but-EMPTY
+        // var counts as set — `first_set`); GID reads ONLY ATLAS_LORA_RDMA_GID
+        // (no chain, deliberately). Always 1 rail; fresh random 24-bit PSN.
+        let specs = vec![RailSpec::new(
+            first_set(
+                &[
+                    "ATLAS_LORA_RDMA_DEV",
+                    "ATLAS_WEIGHT_RDMA_DEV",
+                    "ATLAS_EXPERT_RDMA_DEV",
+                ],
+                "roceP2p1s0f1",
+            ),
+            first_set_u32(&["ATLAS_LORA_RDMA_GID"], 3),
+            rand::random::<u32>() & 0xff_ffff,
+        )];
+
+        stream.write_all(&[MODE_VERBS]).context("send verbs mode")?;
+        let mut rs = RailSet::begin(&mut stream, &specs)?;
+
+        let max_len = retained.iter().map(|t| t.len).max().unwrap_or(0);
+        if max_len > u32::MAX as u64 {
+            bail!("adapter tensor {max_len} bytes exceeds single-WR RDMA READ limit");
+        }
+        let bounce_len = (max_len as usize).max(1);
+
+        let bounce = gpu
+            .alloc_host_pinned(bounce_len)
+            .context("alloc pinned RDMA landing bounce")?;
+        // LOCAL_WRITE-only landing MR (`remote_read == false`, invariant).
+        // SAFETY: `bounce` backs `bounce_len` pinned bytes that outlive the MR.
+        let keys = unsafe {
+            rs.rails[0]
+                .verbs
+                .reg_mr(bounce as *mut c_void, bounce_len, false)
+        }
+        .context("register RDMA landing bounce")?;
+
+        // Validate the shard table BEFORE replying (bail = no client params).
+        let server = rs
+            .read_server_ro(&mut stream)
+            .context("read verbs server params")?;
+        let sp = server[0].clone();
+        if sp.layers.len() != num_shards {
+            bail!(
+                "peer published {} shard MRs but manifest has {num_shards}",
+                sp.layers.len()
+            );
+        }
+
+        rs.complete(&mut stream, &server, "lora peer")?;
+        let mut verbs = rs
+            .into_verbs()
+            .into_iter()
+            .next()
+            .expect("single lora rail");
+
+        // 3. Pull each tensor into the bounce, convert/repack, land into slot.
+        for (idx, rec) in retained.iter().enumerate() {
+            let (shard_base, rkey) = *sp
+                .layers
+                .get(rec.shard_index as usize)
+                .with_context(|| format!("no shard MR {} for {}", rec.shard_index, rec.name))?;
+            let remote_addr = tensor_remote_addr(shard_base, rec.offset_in_shard);
+            let len = rec.len as usize;
+            let wr_id = idx as u64;
+            // SAFETY: bounce backs >= len pinned bytes in this MR; remote_addr/
+            // rkey address the peer's shard MR; len <= u32::MAX.
+            unsafe {
+                verbs
+                    .post_read(
+                        bounce as *mut c_void,
+                        keys.lkey,
+                        remote_addr,
+                        rkey,
+                        len as u32,
+                        wr_id,
+                    )
+                    .with_context(|| format!("post_read {}", rec.name))?;
+            }
+            match verbs.poll() {
+                Ok(got) if got == wr_id => {}
+                Ok(got) => bail!("completion wr_id {got:#x} != {wr_id:#x} ({})", rec.name),
+                Err(e) => return Err(e).with_context(|| format!("poll {}", rec.name)),
+            }
+            // SAFETY: bounce now holds `len` valid bytes from the READ.
+            let raw = unsafe { std::slice::from_raw_parts(bounce, len) };
+            let target = by_name[rec.name.as_str()];
+            let host = land_bytes_for_target(target, raw, &rec.dtype)?;
+            gpu.copy_h2d(&host, spark_runtime::gpu::DevicePtr(target.dst))?;
+        }
+
+        drop(verbs);
+        let _ = gpu.free_host_pinned(bounce, bounce_len);
+        tracing::info!(
+            "RDMA-staged adapter '{}' into {} slot targets",
+            manifest.model_id,
+            retained.len(),
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "weight_lora_rdma_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/weight_lora_rdma_tests.rs
+++ b/crates/spark-storage/src/weight_lora_rdma_tests.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for the RDMA LoRA landing byte-transforms (convert + B repack),
+//! byte-identical to the disk pack.
+
+use super::*;
+use half::{bf16, f16};
+
+#[test]
+fn convert_f32_halves_len_and_rounds_like_disk() {
+    // Two f32 values → 4 BF16 bytes, matching half::bf16::from_f32.
+    let vals = [1.5f32, -2.25f32];
+    let raw: Vec<u8> = vals.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let out = convert_to_bf16(&raw, "F32").unwrap();
+    assert_eq!(out.len(), 4, "F32 [n] → BF16 [n] halves the byte count");
+    let expect: Vec<u8> = vals
+        .iter()
+        .flat_map(|v| bf16::from_f32(*v).to_le_bytes())
+        .collect();
+    assert_eq!(out, expect);
+}
+
+#[test]
+fn convert_f16_preserves_len() {
+    let raw: Vec<u8> = [f16::from_f32(0.5), f16::from_f32(3.0)]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    let out = convert_to_bf16(&raw, "F16").unwrap();
+    assert_eq!(out.len(), 4, "F16 [n] → BF16 [n] same byte count");
+}
+
+#[test]
+fn convert_bf16_is_identity() {
+    let raw: Vec<u8> = (0..8).collect();
+    assert_eq!(convert_to_bf16(&raw, "BF16").unwrap(), raw);
+}
+
+#[test]
+fn convert_rejects_unknown_dtype() {
+    assert!(convert_to_bf16(&[0u8; 4], "F8_E4M3").is_err());
+}
+
+#[test]
+fn repack_b_pads_columns_zero_and_preserves_rows() {
+    // out_dim=2, r=1, max_rank=3. src = 2 rows × 1 bf16 = [A0,A1].
+    // dst = 2 rows × 3 bf16, real col at head, pads zero.
+    let src: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0xDD]; // row0=[AA BB], row1=[CC DD]
+    let dst = repack_b_to_padded(&src, 2, 1, 3);
+    assert_eq!(dst.len(), 2 * 3 * 2);
+    assert_eq!(&dst[0..2], &[0xAA, 0xBB]); // row0 real
+    assert_eq!(&dst[2..6], &[0, 0, 0, 0]); // row0 pad cols
+    assert_eq!(&dst[6..8], &[0xCC, 0xDD]); // row1 real
+    assert_eq!(&dst[8..12], &[0, 0, 0, 0]); // row1 pad cols
+}
+
+#[test]
+fn land_a_is_convert_only() {
+    let t = LoraLandTarget {
+        tensor_name: "x".into(),
+        kind: LoraAbKind::A,
+        dst: 0,
+        out_dim: 0,
+        in_dim: 2,
+        rank: 1,
+        max_rank: 4,
+    };
+    let raw: Vec<u8> = [1.0f32, 2.0f32]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    let out = land_bytes_for_target(&t, &raw, "F32").unwrap();
+    assert_eq!(out.len(), 4); // r*in*2 = 1*2*2, no padding for A columns
+}
+
+#[test]
+fn land_b_converts_then_repacks() {
+    let t = LoraLandTarget {
+        tensor_name: "y".into(),
+        kind: LoraAbKind::B,
+        dst: 0,
+        out_dim: 2,
+        in_dim: 0,
+        rank: 1,
+        max_rank: 3,
+    };
+    // B = [out=2, r=1] f32 → convert → repack to [2,3] bf16.
+    let raw: Vec<u8> = [5.0f32, 6.0f32]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    let out = land_bytes_for_target(&t, &raw, "F32").unwrap();
+    assert_eq!(out.len(), 2 * 3 * 2);
+    // Row real cols == bf16 of the source values.
+    assert_eq!(&out[0..2], &bf16::from_f32(5.0).to_le_bytes());
+    assert_eq!(&out[6..8], &bf16::from_f32(6.0).to_le_bytes());
+}

--- a/crates/spark-storage/src/weight_peer.rs
+++ b/crates/spark-storage/src/weight_peer.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Weight-serving peer + wire protocol — the RDMA weight-staging tier.
+//
+// Generalizes `expert_peer` from (layer, expert) expert records to ALL of a
+// model's safetensors tensors, for FAST MODEL SWAPS. A peer holds one or more
+// staged models' shard files mmap'd + `ibv_reg_mr`'d REMOTE_READ in its RAM; a
+// client (`weight_tier_rdma::RdmaWeightLoader`) requests a model by id/path,
+// reads the peer's MANIFEST, then one-sided RDMA-READs each tensor's bytes
+// straight out of the shard MRs (~24 GB/s dual-rail) instead of the ~2 GB/s USB
+// SSD. Weights are READ-ONLY → one-sided READ, no coherence — the exact
+// expert-tier pattern.
+//
+// It's a CACHE: the FIRST stage of a model into the blade faults its pages in
+// from disk (slow); every later swap reads them out of the peer's warm RAM
+// (fast). Pre-warm the rotation set by connecting once.
+//
+// Wire protocol (little-endian), connection-oriented, server responds to the
+// client's model choice first:
+//   1. Client sends the model request: `[u32 len][len bytes of model id/path]`.
+//   2. Server stages that model (mmap + parse headers, cached across
+//      connections) and sends the manifest: `[u32 len][len bytes of JSON]`
+//      (`WeightManifest` — per-tensor {name,dtype,shape,offset,len,shard}).
+//   3. Client sends `[u8 transport_mode]` (only `MODE_VERBS` is served).
+//   4. Verbs handshake (reused verbatim from `expert_peer`): `[u8 n_rails]`,
+//      then per rail a `VerbsServerParams` whose `layers` vector carries this
+//      model's per-SHARD `(mr_base, rkey)` (shards play the role experts' layer
+//      files do). The client replies with its QP params, the server connects
+//      and idles — the client pulls all tensor bytes one-sided.
+//
+// Per-tensor geometry rides the JSON manifest (like `ExpertIndex`); only the
+// per-shard `(base, rkey)` rides `VerbsServerParams` (like the expert peer's
+// per-layer `(base, rkey)`) — keeping shard counts well under the 4096/8 wire
+// caps and the 512-MR-per-QP shim limit (real models have tens of shards).
+//
+// Module layout (SDD split — the client-facing half is un-gated + verbs-free so LoRA lifts it cleanly):
+//   * `manifest` — the manifest types + address/rail math (un-gated).
+//   * `wire`     — the length-prefixed model-request / manifest codec (un-gated).
+//   * `serve`    — the `atlas-weight-peer` daemon (unix; holds the reg_mr true).
+//   * `shard`    — shard resolution + safetensors parse + the warm RO mmap (unix).
+
+mod manifest;
+#[cfg(unix)]
+mod serve;
+#[cfg(unix)]
+mod shard;
+mod wire;
+
+pub use manifest::{WeightManifest, WeightTensorRecord, rail_for_tensor, tensor_remote_addr};
+#[cfg(unix)]
+pub use serve::{WeightPeerConfig, serve};
+pub use wire::{
+    MODEL_REQUEST_MAX, read_model_request, read_weight_manifest, write_model_request,
+    write_weight_manifest,
+};

--- a/crates/spark-storage/src/weight_peer/manifest.rs
+++ b/crates/spark-storage/src/weight_peer/manifest.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Weight-staging manifest types + address math (un-gated, CUDA-free, verbs-free).
+//
+// This half is exactly what the RDMA clients import: `WeightManifest`,
+// `WeightTensorRecord`, `rail_for_tensor`, `tensor_remote_addr`. Keeping it free
+// of any back-edge into the server (`serve`/`shard`) is what makes the LoRA
+// carve-out (`weight_lora_rdma`) a clean lift.
+
+use serde::{Deserialize, Serialize};
+
+/// One tensor's placement inside a staged model, mirroring the safetensors
+/// header exactly: `offset_in_shard` is the ABSOLUTE file offset (8-byte size
+/// prefix + header + the tensor's data-section start), `len` is the raw
+/// contiguous byte count (`data_offsets[1] - data_offsets[0]`). The client
+/// RDMA-READs exactly `[shard_base + offset_in_shard .. + len)`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WeightTensorRecord {
+    /// HuggingFace tensor name — the `WeightStore` key, verbatim.
+    pub name: String,
+    /// Raw safetensors dtype string (`"BF16"`, `"F8_E4M3"`, `"I8"`, …). The
+    /// client maps it via `WeightDtype::from_safetensors_str` — the same closed
+    /// mapping the disk loaders use.
+    pub dtype: String,
+    pub shape: Vec<u64>,
+    /// Absolute byte offset of the tensor's first byte within its shard file.
+    pub offset_in_shard: u64,
+    /// Tensor byte length (authoritative — do NOT recompute from shape; packed
+    /// NVFP4 lengths differ from `numel * byte_size`).
+    pub len: u64,
+    /// Index into [`WeightManifest::shard_files`].
+    pub shard_index: u32,
+    /// True for tensors from `extra_weights.safetensors` (grafted MTP etc.):
+    /// loaded with NO expert-skip filter, exactly like the disk loaders.
+    pub extra: bool,
+}
+
+/// A staged model's manifest: the geometry the client needs to reconstruct a
+/// byte-identical `WeightStore`. Published as length-prefixed JSON right after
+/// the client's model request. The per-shard `(base, rkey)` MR handles ride the
+/// verbs handshake separately (see the module doc).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WeightManifest {
+    pub version: u32,
+    /// The resolved model id/path the peer staged (echo for the client's log).
+    pub model_id: String,
+    /// Shard file names, shard-indexed. `shard_index` in each tensor record
+    /// indexes this list; the verbs `layers` vector is per-shard in this order.
+    pub shard_files: Vec<String>,
+    /// Byte length of each shard file, shard-indexed (parallels `shard_files`).
+    pub shard_lens: Vec<u64>,
+    pub tensors: Vec<WeightTensorRecord>,
+}
+
+impl WeightManifest {
+    pub const VERSION: u32 = 1;
+
+    /// Number of shard files (== the per-rail `layers` MR count the peer
+    /// publishes and the client validates against).
+    pub fn num_shards(&self) -> usize {
+        self.shard_files.len()
+    }
+
+    /// Total registered bytes across all shards (the whole-file MRs) — the
+    /// figure charged against the blade `CommitLedger` once per staged model.
+    pub fn total_shard_bytes(&self) -> u64 {
+        self.shard_lens.iter().sum()
+    }
+}
+
+/// Rail selection for a tensor under dual-rail striping: tensor `N` is served
+/// over rail `N % n_rails`. Factored out (un-gated) so the striping is unit-
+/// testable off the RDMA path — the client's read loop calls this so the tested
+/// logic and the shipped logic are the same. `n_rails` is clamped to `>= 1`.
+pub fn rail_for_tensor(tensor_index: usize, n_rails: usize) -> usize {
+    tensor_index % n_rails.max(1)
+}
+
+/// Absolute peer virtual address of a tensor's first byte: the shard's whole-
+/// file REMOTE_READ MR base plus the tensor's ABSOLUTE in-shard offset (the
+/// safetensors data-section offset, which already includes the 8-byte size
+/// prefix + header). The client RDMA-READs `[addr .. addr + len)`. Factored out
+/// (un-gated) so the address math is unit-testable off the RDMA path.
+pub fn tensor_remote_addr(shard_base: u64, offset_in_shard: u64) -> u64 {
+    shard_base + offset_in_shard
+}
+
+#[cfg(test)]
+#[path = "manifest_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/weight_peer/manifest_tests.rs
+++ b/crates/spark-storage/src/weight_peer/manifest_tests.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+
+fn sample_manifest() -> WeightManifest {
+    WeightManifest {
+        version: WeightManifest::VERSION,
+        model_id: "qwen3.6-35b-a3b".to_string(),
+        shard_files: vec![
+            "model.safetensors-00001-of-00002.safetensors".to_string(),
+            "model.safetensors-00002-of-00002.safetensors".to_string(),
+        ],
+        shard_lens: vec![1_000_000, 2_000_000],
+        tensors: vec![
+            WeightTensorRecord {
+                name: "model.embed_tokens.weight".to_string(),
+                dtype: "BF16".to_string(),
+                shape: vec![152064, 4096],
+                offset_in_shard: 4096,
+                len: 152064 * 4096 * 2,
+                shard_index: 0,
+                extra: false,
+            },
+            WeightTensorRecord {
+                name: "mtp.experts.5.gate_proj.weight_packed".to_string(),
+                dtype: "I8".to_string(),
+                shape: vec![2048, 1024],
+                offset_in_shard: 8192,
+                len: 2048 * 1024,
+                shard_index: 1,
+                extra: true,
+            },
+        ],
+    }
+}
+
+#[test]
+fn total_shard_bytes_sums_lens() {
+    let m = sample_manifest();
+    assert_eq!(m.total_shard_bytes(), 3_000_000);
+    assert_eq!(m.num_shards(), 2);
+}
+
+#[test]
+fn tensor_remote_addr_adds_absolute_offset() {
+    // remote_addr = shard MR base + the tensor's ABSOLUTE in-shard offset.
+    // The offset already includes the 8-byte size prefix + header, so no
+    // extra rebasing — a bug here reads header bytes off the shard front.
+    assert_eq!(tensor_remote_addr(0x1_0000_0000, 4096), 0x1_0000_1000);
+    assert_eq!(tensor_remote_addr(0, 0), 0);
+    // Matches the manifest records verbatim (offset_in_shard is absolute).
+    let m = sample_manifest();
+    let base = 0xdead_0000u64;
+    let t = &m.tensors[0];
+    assert_eq!(tensor_remote_addr(base, t.offset_in_shard), base + 4096);
+}
+
+#[test]
+fn rail_for_tensor_stripes_round_robin() {
+    // Single rail: everything on rail 0.
+    for i in 0..5 {
+        assert_eq!(rail_for_tensor(i, 1), 0);
+    }
+    // Dual rail: even → 0, odd → 1.
+    assert_eq!(rail_for_tensor(0, 2), 0);
+    assert_eq!(rail_for_tensor(1, 2), 1);
+    assert_eq!(rail_for_tensor(2, 2), 0);
+    assert_eq!(rail_for_tensor(3, 2), 1);
+    // n_rails == 0 must not divide-by-zero (clamped to 1).
+    assert_eq!(rail_for_tensor(7, 0), 0);
+}

--- a/crates/spark-storage/src/weight_peer/serve.rs
+++ b/crates/spark-storage/src/weight_peer/serve.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The `atlas-weight-peer` daemon (unix, server-side). Accepts a model request,
+// stages the model (warm mmaps + parsed manifest via `shard`), publishes the
+// manifest (`wire`), then serves the shards one-sided REMOTE_READ over verbs.
+// This module holds the sole `reg_mr(.., true)` — the REMOTE_READ registration
+// pinned by `tests/reg_mr_flag_audit.rs`.
+
+use anyhow::{Context, Result, bail};
+use std::collections::HashMap;
+use std::io::Read;
+use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use super::manifest::WeightManifest;
+use super::shard::{Mmap, build_manifest};
+use super::wire::{read_model_request, write_weight_manifest};
+use crate::expert_peer::MODE_VERBS;
+
+/// Peer configuration: the RDMA rails, the memory ceiling, and how the peer
+/// resolves a model request to a directory.
+#[derive(Clone, Debug)]
+pub struct WeightPeerConfig {
+    /// `(device, gid_idx)` per rail, in link order (rail 0 = the cabled
+    /// link). Mirrors `expert_peer::RdmaConfig::rails`.
+    pub rails: Vec<(String, u32)>,
+    /// Ceiling on total registered (staged) RAM in bytes across ALL staged
+    /// models. `0` = unlimited. Each model is charged its shard bytes once,
+    /// at first stage (the per-connection MRs share the same warm pages).
+    pub max_blade_bytes: u64,
+    /// Model directories to pre-stage at startup. Also the allow-list when
+    /// `allow_any_path` is false: a client may only request a model whose
+    /// resolved path matches one of these (or its basename).
+    pub staged_dirs: Vec<PathBuf>,
+    /// When true, a client may request ANY filesystem path and the peer
+    /// stages it on demand (convenient for a trusted LAN; off by default).
+    pub allow_any_path: bool,
+}
+
+impl Default for WeightPeerConfig {
+    fn default() -> Self {
+        Self {
+            rails: vec![("roceP2p1s0f1".into(), 3)],
+            max_blade_bytes: 0,
+            staged_dirs: Vec::new(),
+            allow_any_path: false,
+        }
+    }
+}
+
+/// A staged model held resident: the persistent shard mmaps (kept mapped so
+/// their pages stay warm in RAM across connections), the manifest, and the
+/// ledger reservation released when the model is dropped. Per-connection
+/// `reg_mr` re-registers these same base VAs on each client QP's PD.
+struct StagedModel {
+    // Read only by the verbs serve path (reg_mr each shard); on a build
+    // without rdma-core the mmaps still hold pages warm but aren't iterated.
+    #[cfg_attr(not(atlas_rdma_verbs), allow(dead_code))]
+    shard_mmaps: Vec<Mmap>,
+    manifest: WeightManifest,
+    _reservation: crate::blade_cap::Reservation,
+}
+
+type StagedMap = Arc<Mutex<HashMap<String, Arc<StagedModel>>>>;
+
+/// Serve staged models on `addr` until interrupted. One thread per
+/// connection; blocking. Intended to run as its own process
+/// (`atlas-weight-peer`).
+pub fn serve<A: ToSocketAddrs>(addr: A, cfg: WeightPeerConfig) -> Result<()> {
+    let cfg = Arc::new(cfg);
+    let ledger = Arc::new(crate::blade_cap::CommitLedger::new(cfg.max_blade_bytes));
+    let staged: StagedMap = Arc::new(Mutex::new(HashMap::new()));
+
+    // Pre-stage the configured directories (first stage is the slow one —
+    // do it up front so the first client swap is already warm).
+    for dir in &cfg.staged_dirs {
+        match stage_model(&staged, &ledger, dir) {
+            Ok(m) => tracing::info!(
+                "weight-peer pre-staged {} ({} shards, {} tensors, {:.1} GiB)",
+                m.manifest.model_id,
+                m.manifest.num_shards(),
+                m.manifest.tensors.len(),
+                m.manifest.total_shard_bytes() as f64 / (1024.0 * 1024.0 * 1024.0),
+            ),
+            Err(e) => tracing::warn!("weight-peer pre-stage {} failed: {e}", dir.display()),
+        }
+    }
+
+    let listener = TcpListener::bind(addr).context("bind weight-peer listener")?;
+    let local = listener.local_addr().ok();
+    tracing::info!(
+        "weight-peer serving on {:?} (verbs rails {:?}, cap {}, allow_any_path {})",
+        local,
+        cfg.rails,
+        if cfg.max_blade_bytes == 0 {
+            "unlimited".to_string()
+        } else {
+            format!(
+                "{:.1} GiB",
+                cfg.max_blade_bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+            )
+        },
+        cfg.allow_any_path,
+    );
+
+    for conn in listener.incoming() {
+        let stream = match conn {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("weight-peer accept error: {e}");
+                continue;
+            }
+        };
+        let cfg = cfg.clone();
+        let ledger = ledger.clone();
+        let staged = staged.clone();
+        std::thread::spawn(move || {
+            if let Err(e) = handle_conn(stream, &cfg, &ledger, &staged) {
+                tracing::warn!("weight-peer connection ended: {e}");
+            }
+        });
+    }
+    Ok(())
+}
+
+fn handle_conn(
+    mut stream: TcpStream,
+    cfg: &WeightPeerConfig,
+    ledger: &Arc<crate::blade_cap::CommitLedger>,
+    staged: &StagedMap,
+) -> Result<()> {
+    stream.set_nodelay(true).ok();
+
+    // 1. Client tells us which model it wants.
+    let request = read_model_request(&mut stream)?;
+    let dir = resolve_request(cfg, &request)?;
+
+    // 2. Stage it (or reuse the warm one) and publish the manifest.
+    let model = stage_model(staged, ledger, &dir)?;
+    write_weight_manifest(&mut stream, &model.manifest).context("send manifest")?;
+
+    // 3. Transport selection. Only verbs is served for weights.
+    let mut mode = [0u8; 1];
+    stream
+        .read_exact(&mut mode)
+        .context("read transport mode")?;
+    match mode[0] {
+        MODE_VERBS => serve_verbs(stream, &model, cfg),
+        other => bail!("weight-peer only serves verbs; client asked for mode {other}"),
+    }
+}
+
+/// Resolve a client's model request string to a directory, honoring the
+/// allow-list / `allow_any_path` policy.
+fn resolve_request(cfg: &WeightPeerConfig, request: &str) -> Result<PathBuf> {
+    let req = Path::new(request);
+    // Exact path match against a staged dir, or basename match.
+    for d in &cfg.staged_dirs {
+        if d == req
+            || d.file_name().and_then(|n| n.to_str()) == Some(request)
+            || d.to_string_lossy() == request
+        {
+            return Ok(d.clone());
+        }
+    }
+    if cfg.allow_any_path && req.is_dir() {
+        return Ok(req.to_path_buf());
+    }
+    bail!(
+        "model '{request}' is not staged (and allow_any_path is off); \
+         pass it to the peer with --stage <dir>"
+    );
+}
+
+/// Look up a warm staged model or stage it now (mmap shards + parse headers
+/// + charge the ledger). Idempotent per resolved-path key.
+fn stage_model(
+    staged: &StagedMap,
+    ledger: &Arc<crate::blade_cap::CommitLedger>,
+    dir: &Path,
+) -> Result<Arc<StagedModel>> {
+    let key = dir.to_string_lossy().into_owned();
+    {
+        let map = staged.lock().unwrap();
+        if let Some(m) = map.get(&key) {
+            return Ok(m.clone());
+        }
+    }
+
+    // Build the manifest (resolve shards + parse each shard's header) and
+    // mmap every shard REMOTE-read + warm.
+    let (shard_paths, manifest) = build_manifest(dir, &key)?;
+    // Charge the ledger BEFORE pinning any pages; the RAII guard lives in
+    // the StagedModel and releases if we bail below or when it's dropped.
+    let reservation = ledger
+        .try_reserve(manifest.total_shard_bytes())
+        .context("weight blade cap")?;
+
+    let mut shard_mmaps = Vec::with_capacity(shard_paths.len());
+    for p in &shard_paths {
+        shard_mmaps.push(Mmap::open_ro(p).with_context(|| format!("mmap {}", p.display()))?);
+    }
+
+    let model = Arc::new(StagedModel {
+        shard_mmaps,
+        manifest,
+        _reservation: reservation,
+    });
+    let mut map = staged.lock().unwrap();
+    // Another thread may have staged it while we worked; prefer the existing
+    // one (drops ours, releasing its reservation).
+    Ok(map.entry(key).or_insert(model).clone())
+}
+
+/// One-sided RDMA READ weight serving. Registers each shard mmap REMOTE_READ
+/// on every rail, publishes the per-shard `(base, rkey)`, connects to the
+/// client's QPs, then idles — the client pulls all tensor bytes one-sided.
+#[cfg(not(atlas_rdma_verbs))]
+fn serve_verbs(
+    _stream: TcpStream,
+    _model: &Arc<StagedModel>,
+    _cfg: &WeightPeerConfig,
+) -> Result<()> {
+    bail!("client requested verbs transport but this peer was built without rdma-core");
+}
+
+#[cfg(atlas_rdma_verbs)]
+fn serve_verbs(
+    mut stream: TcpStream,
+    model: &Arc<StagedModel>,
+    cfg: &WeightPeerConfig,
+) -> Result<()> {
+    use crate::expert_peer::{STATUS_OK, VerbsClientParams, VerbsServerParams, write_server_rails};
+    use atlas_rdma::verbs::Verbs;
+    use std::io::Write;
+
+    let num_shards = model.shard_mmaps.len();
+
+    // Negotiate the rail count.
+    let mut b1 = [0u8; 1];
+    stream.read_exact(&mut b1).context("read n_rails")?;
+    let n_rails = b1[0] as usize;
+    if n_rails == 0 || n_rails > cfg.rails.len() {
+        bail!(
+            "client asked for {n_rails} rails; peer has {}",
+            cfg.rails.len()
+        );
+    }
+
+    // One QP per rail (distinct per-rail PSN so successive clients don't
+    // collide). No ledger charge here — staging already charged the pages;
+    // the N per-rail MRs share those same refcounted mmap pages.
+    let pid = std::process::id();
+    let mut rails: Vec<Verbs> = Vec::with_capacity(n_rails);
+    for (i, (dev, gid)) in cfg.rails.iter().take(n_rails).enumerate() {
+        let psn = (0x77_7777 ^ pid ^ ((i as u32) << 20)) & 0xff_ffff;
+        rails.push(Verbs::create(dev, *gid, psn)?);
+    }
+
+    // Register each shard mmap (REMOTE_READ) on EVERY rail's PD — one rkey
+    // per (rail, shard), identical base VA, shared physical pages. The mmaps
+    // live in the persistent StagedModel, so they outlive these MRs.
+    let mut per_rail_shards: Vec<Vec<(u64, u32)>> = (0..n_rails)
+        .map(|_| Vec::with_capacity(num_shards))
+        .collect();
+    for m in &model.shard_mmaps {
+        for (ri, v) in rails.iter_mut().enumerate() {
+            // SAFETY: the mapping covers `m.len` bytes at `m.addr` and lives
+            // in the StagedModel Arc, which outlives every rail here.
+            let keys = unsafe { v.reg_mr(m.addr as *mut _, m.len, true)? };
+            per_rail_shards[ri].push((m.addr as u64, keys.rkey));
+        }
+    }
+
+    // Publish one VerbsServerParams per rail; `layers` carries per-SHARD
+    // (base, rkey) in shard order (shards play experts' per-layer role).
+    let sp: Vec<VerbsServerParams> = rails
+        .iter()
+        .enumerate()
+        .map(|(ri, v)| VerbsServerParams {
+            qpn: v.qpn(),
+            psn: v.psn(),
+            gid: v.gid(),
+            layers: std::mem::take(&mut per_rail_shards[ri]),
+        })
+        .collect();
+    write_server_rails(&mut stream, &sp).context("send verbs server params")?;
+
+    // Learn each client rail's QP, connect, ack.
+    stream.read_exact(&mut b1).context("read client n_rails")?;
+    if b1[0] as usize != n_rails {
+        bail!("client rail count mismatch");
+    }
+    for v in rails.iter_mut() {
+        let cp = VerbsClientParams::read_from(&mut stream).context("read verbs client params")?;
+        v.connect(cp.qpn, cp.psn, &cp.gid)?;
+    }
+    stream
+        .write_all(&[STATUS_OK])
+        .context("send verbs ready ack")?;
+    tracing::info!(
+        "weight-peer verbs client connected to {} ({n_rails} rail(s), {num_shards} shard MRs/rail)",
+        model.manifest.model_id,
+    );
+
+    // Idle until the client hangs up. All movement is one-sided RDMA READ.
+    let mut sink = [0u8; 8];
+    loop {
+        match stream.read(&mut sink) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+    // Drop rails (dereg MRs) BEFORE the StagedModel Arc frees anything — the
+    // mmaps persist in the map regardless, but dropping rails first keeps
+    // dereg strictly over live mappings.
+    drop(rails);
+    Ok(())
+}

--- a/crates/spark-storage/src/weight_peer/shard.rs
+++ b/crates/spark-storage/src/weight_peer/shard.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Shard resolution + safetensors header parsing + the warm RO mmap (unix,
+// server-side). Builds a [`WeightManifest`] from a model directory and holds
+// each shard file mapped PROT_READ so its pages stay resident for one-sided
+// RDMA reads. No verbs here — the mmap's raw base is handed to `serve`'s
+// `reg_mr` unchanged.
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use super::manifest::{WeightManifest, WeightTensorRecord};
+
+/// Resolve shard files (index / single / glob), parse each shard's header,
+/// and assemble the [`WeightManifest`]. Mirrors the resolution order in
+/// `spark_runtime::fast_weights::header::resolve_shards`.
+pub(super) fn build_manifest(dir: &Path, model_id: &str) -> Result<(Vec<PathBuf>, WeightManifest)> {
+    let (shard_paths, weight_map) = resolve_shards(dir)?;
+
+    let mut shard_files = Vec::with_capacity(shard_paths.len());
+    let mut shard_lens = Vec::with_capacity(shard_paths.len());
+    let mut tensors: Vec<WeightTensorRecord> = Vec::new();
+
+    for (idx, path) in shard_paths.iter().enumerate() {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let len = std::fs::metadata(path)
+            .with_context(|| format!("stat {}", path.display()))?
+            .len();
+        // Only publish tensors the index actually routes (weight_map). A
+        // shard header may list orphan/tied/aux tensors absent from the
+        // index; the disk loaders iterate weight_map keys and never load
+        // those, so filtering here keeps the RDMA store byte-identical
+        // (same key set, not a superset). No index (single/glob) => keep all.
+        parse_shard_header(path, idx as u32, false, weight_map.as_ref(), &mut tensors)?;
+        shard_files.push(name);
+        shard_lens.push(len);
+    }
+
+    // extra_weights.safetensors: an extra shard whose tensors are NEVER
+    // expert-skipped (grafted MTP etc.), exactly like the disk loaders.
+    let extra = dir.join("extra_weights.safetensors");
+    if extra.exists() {
+        let idx = shard_paths.len();
+        let mut shard_paths = shard_paths.clone();
+        let len = std::fs::metadata(&extra)?.len();
+        // extra_weights.safetensors is never in the index weight_map; its
+        // tensors are always fully published (extra=true), so pass no filter.
+        parse_shard_header(&extra, idx as u32, true, None, &mut tensors)?;
+        shard_files.push("extra_weights.safetensors".to_string());
+        shard_lens.push(len);
+        shard_paths.push(extra);
+        let manifest = WeightManifest {
+            version: WeightManifest::VERSION,
+            model_id: model_id.to_string(),
+            shard_files,
+            shard_lens,
+            tensors,
+        };
+        return Ok((shard_paths, manifest));
+    }
+
+    let manifest = WeightManifest {
+        version: WeightManifest::VERSION,
+        model_id: model_id.to_string(),
+        shard_files,
+        shard_lens,
+        tensors,
+    };
+    Ok((shard_paths, manifest))
+}
+
+/// Resolved shard set: the shard file paths (shard-index order) plus the
+/// index `weight_map` (tensor name -> shard file) when an index exists, or
+/// `None` for a single-file / glob checkpoint (keep every header tensor).
+type ShardResolution = (Vec<PathBuf>, Option<HashMap<String, String>>);
+
+/// Shard discovery, resolution order identical to the disk loaders:
+/// (1) model.safetensors.index.json, else consolidated.safetensors.index.json;
+/// (2) single model.safetensors; (3) glob model.safetensors-* / consolidated-*.
+pub(super) fn resolve_shards(dir: &Path) -> Result<ShardResolution> {
+    let index = dir.join("model.safetensors.index.json");
+    let consolidated = dir.join("consolidated.safetensors.index.json");
+    let actual = if index.exists() {
+        Some(index)
+    } else if consolidated.exists() {
+        Some(consolidated)
+    } else {
+        None
+    };
+
+    if let Some(ip) = actual {
+        let json =
+            std::fs::read_to_string(&ip).with_context(|| format!("read {}", ip.display()))?;
+        let v: Value = serde_json::from_str(&json)?;
+        let map = v
+            .get("weight_map")
+            .and_then(|m| m.as_object())
+            .context("index json missing weight_map object")?;
+        let weight_map: HashMap<String, String> = map
+            .iter()
+            .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect();
+        let mut shards: Vec<String> = weight_map
+            .values()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        shards.sort();
+        let files = shards.iter().map(|s| dir.join(s)).collect();
+        return Ok((files, Some(weight_map)));
+    }
+
+    let single = dir.join("model.safetensors");
+    if single.exists() {
+        return Ok((vec![single], None));
+    }
+
+    // PEFT adapter dir: a single `adapter_model.safetensors` (its keys are
+    // the lora_A/lora_B tensors, classified client-side). Staged for LoRA
+    // rotation over the RDMA tier (`weight_lora_rdma`).
+    let adapter = dir.join("adapter_model.safetensors");
+    if adapter.exists() {
+        return Ok((vec![adapter], None));
+    }
+
+    let mut shards: Vec<PathBuf> = std::fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                (n.starts_with("model.safetensors-") || n.starts_with("consolidated-"))
+                    && n.ends_with(".safetensors")
+            })
+        })
+        .collect();
+    shards.sort();
+    if shards.is_empty() {
+        bail!("no safetensor files found in {}", dir.display());
+    }
+    Ok((shards, None))
+}
+
+/// Parse one shard's safetensors header, pushing a [`WeightTensorRecord`]
+/// per tensor. Byte layout: `[u64 LE header_size][header_size JSON]`; data
+/// section starts at `8 + header_size`; each tensor's `data_offsets` are
+/// relative to that. We publish ABSOLUTE offsets so the client's
+/// `remote_addr = shard_base + offset_in_shard` reads out of the whole-file
+/// MR directly. Validates dtype against the disk loaders' closed set.
+fn parse_shard_header(
+    path: &Path,
+    shard_index: u32,
+    extra: bool,
+    weight_map: Option<&HashMap<String, String>>,
+    out: &mut Vec<WeightTensorRecord>,
+) -> Result<()> {
+    let mut f = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut size_buf = [0u8; 8];
+    f.read_exact(&mut size_buf)
+        .with_context(|| format!("read header size of {}", path.display()))?;
+    let header_size = u64::from_le_bytes(size_buf) as usize;
+    if header_size > 64 * 1024 * 1024 {
+        bail!(
+            "{}: safetensor header too large ({header_size} bytes)",
+            path.display()
+        );
+    }
+    let mut header_buf = vec![0u8; header_size];
+    f.read_exact(&mut header_buf)
+        .with_context(|| format!("read header of {}", path.display()))?;
+    let data_start = 8 + header_size as u64;
+
+    let json: Value = serde_json::from_slice(&header_buf)?;
+    let obj = json
+        .as_object()
+        .with_context(|| format!("{}: header is not a JSON object", path.display()))?;
+
+    for (name, info) in obj {
+        if name == "__metadata__" {
+            continue;
+        }
+        // Skip header tensors the index doesn't route (orphan/tied/aux) so the
+        // published set matches the disk loaders' weight_map iteration exactly.
+        if let Some(map) = weight_map
+            && !map.contains_key(name)
+        {
+            continue;
+        }
+        let dtype = info["dtype"].as_str().unwrap_or("BF16").to_string();
+        validate_dtype(&dtype, name)?;
+        let shape: Vec<u64> = info["shape"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_u64()).collect())
+            .unwrap_or_default();
+        let offsets = info["data_offsets"]
+            .as_array()
+            .with_context(|| format!("tensor {name} missing data_offsets"))?;
+        let rel_start = offsets[0].as_u64().context("bad data_offsets[0]")?;
+        let rel_end = offsets[1].as_u64().context("bad data_offsets[1]")?;
+        out.push(WeightTensorRecord {
+            name: name.clone(),
+            dtype,
+            shape,
+            offset_in_shard: data_start + rel_start,
+            len: rel_end - rel_start,
+            shard_index,
+            extra,
+        });
+    }
+    Ok(())
+}
+
+/// The disk loaders' closed dtype set (mirrors
+/// `WeightDtype::from_safetensors_str`). Fail at STAGE time on anything
+/// unsupported rather than shipping a bad manifest.
+fn validate_dtype(dtype: &str, tensor: &str) -> Result<()> {
+    match dtype {
+        // F16 is accepted for PEFT LoRA adapter shards (default PEFT save
+        // is F32, some export F16); the `weight_lora_rdma` client converts
+        // F16/F32 → BF16 host-side before landing. The base-weight disk
+        // loaders never see F16 (they load model.safetensors, not adapters).
+        "F32" | "F16" | "BF16" | "U8" | "I8" | "F8_E4M3" | "F8_E8M0" | "I64" => Ok(()),
+        other => bail!("unsupported safetensors dtype '{other}' for tensor {tensor}"),
+    }
+}
+
+/// A read-only whole-file `mmap`, warmed (MADV_WILLNEED) and unmapped on
+/// drop. Held persistently in a `StagedModel` so pages stay resident across
+/// connections (the weight-cache property). `Send`/`Sync`: the raw pointer
+/// is only ever handed to `ibv_reg_mr` as a base and read by the NIC; the
+/// Rust side never dereferences it.
+pub(super) struct Mmap {
+    pub(super) addr: *mut libc::c_void,
+    pub(super) len: usize,
+}
+
+// SAFETY: see the doc above — addr/len are an immutable mapping description;
+// the memory is read only by the HCA, never mutated through this pointer.
+unsafe impl Send for Mmap {}
+unsafe impl Sync for Mmap {}
+
+impl Mmap {
+    pub(super) fn open_ro(path: &Path) -> Result<Self> {
+        use std::os::fd::AsRawFd;
+        let f = std::fs::File::open(path)?;
+        let len = f.metadata()?.len() as usize;
+        if len == 0 {
+            bail!("empty shard file {}", path.display());
+        }
+        // SAFETY: fd is a valid open RO file; MAP_SHARED read mapping of
+        // `len` bytes. The kernel keeps the mapping valid after the fd
+        // closes.
+        let addr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_SHARED,
+                f.as_raw_fd(),
+                0,
+            )
+        };
+        if addr == libc::MAP_FAILED {
+            bail!(
+                "mmap {} failed: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            );
+        }
+        // Warm the pages into RAM so the first (and every) RDMA read hits
+        // resident memory — the cache property. Best-effort.
+        // SAFETY: addr/len came from the successful mmap above.
+        unsafe { libc::posix_madvise(addr, len, libc::POSIX_MADV_WILLNEED) };
+        Ok(Self { addr, len })
+    }
+}
+
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        // SAFETY: addr/len came from a successful mmap and are unmapped once.
+        unsafe { libc::munmap(self.addr, self.len) };
+    }
+}
+
+#[cfg(test)]
+#[path = "shard_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/weight_peer/shard_tests.rs
+++ b/crates/spark-storage/src/weight_peer/shard_tests.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+use std::io::Write;
+
+/// Write a minimal safetensors file: `[u64 LE header_len][header][data]`.
+fn write_st(path: &Path, header: &str, data: &[u8]) {
+    let hb = header.as_bytes();
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(&(hb.len() as u64).to_le_bytes()).unwrap();
+    f.write_all(hb).unwrap();
+    f.write_all(data).unwrap();
+}
+
+/// A shard header may list tensors the index `weight_map` does not route
+/// (orphan/tied/aux). The disk loaders iterate weight_map keys and never
+/// load those; `build_manifest` must filter identically so the RDMA store
+/// is byte-identical (same key set, not a superset).
+#[test]
+fn build_manifest_filters_orphan_tensors() {
+    let dir = std::env::temp_dir().join(format!("wpeer-orphan-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let shard = "model-00001.safetensors";
+    // Two f32[2] tensors in the header; only `a.weight` is in the index.
+    let header = r#"{"a.weight":{"dtype":"F32","shape":[2],"data_offsets":[0,8]},"orphan.weight":{"dtype":"F32","shape":[2],"data_offsets":[8,16]}}"#;
+    write_st(&dir.join(shard), header, &[0u8; 16]);
+    std::fs::write(
+        dir.join("model.safetensors.index.json"),
+        format!(r#"{{"weight_map":{{"a.weight":"{shard}"}}}}"#),
+    )
+    .unwrap();
+
+    let (_paths, manifest) = build_manifest(&dir, "test").unwrap();
+    let names: Vec<&str> = manifest.tensors.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["a.weight"],
+        "orphan tensor (not in weight_map) must not be published"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// With no index (single-file checkpoint) every header tensor is kept —
+/// there is no weight_map to filter against.
+#[test]
+fn build_manifest_keeps_all_when_no_index() {
+    let dir = std::env::temp_dir().join(format!("wpeer-single-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let header = r#"{"a.weight":{"dtype":"F32","shape":[2],"data_offsets":[0,8]},"b.weight":{"dtype":"F32","shape":[2],"data_offsets":[8,16]}}"#;
+    write_st(&dir.join("model.safetensors"), header, &[0u8; 16]);
+
+    let (_paths, manifest) = build_manifest(&dir, "test").unwrap();
+    let mut names: Vec<&str> = manifest.tensors.iter().map(|t| t.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["a.weight", "b.weight"]);
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/spark-storage/src/weight_peer/wire.rs
+++ b/crates/spark-storage/src/weight_peer/wire.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Weight-staging wire codec (un-gated, CUDA-free, verbs-free).
+//
+// The length-prefixed framing the daemon and its clients speak: the model
+// request `[u32 len][bytes]` and the manifest `[u32 len][JSON]`. Kept beside
+// `manifest` (which it references) and free of any server dependency so the
+// LoRA client (`weight_lora_rdma`) imports only this + `manifest`.
+
+use anyhow::{Context, Result, bail};
+
+use super::manifest::WeightManifest;
+
+fn read_u32<R: std::io::Read>(r: &mut R) -> Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).context("read u32")?;
+    Ok(u32::from_le_bytes(b))
+}
+
+/// Longest model id/path the wire accepts (a corrupt/hostile length must not
+/// trigger a huge allocation).
+pub const MODEL_REQUEST_MAX: usize = 8192;
+
+/// Wire form of the model request: `[u32 len][len bytes UTF-8 id/path]`.
+pub fn write_model_request<W: std::io::Write>(w: &mut W, id: &str) -> Result<()> {
+    let bytes = id.as_bytes();
+    if bytes.is_empty() || bytes.len() > MODEL_REQUEST_MAX {
+        bail!("implausible model request length: {}", bytes.len());
+    }
+    w.write_all(&(bytes.len() as u32).to_le_bytes())?;
+    w.write_all(bytes)?;
+    Ok(())
+}
+
+/// Read a model request written by [`write_model_request`].
+pub fn read_model_request<R: std::io::Read>(r: &mut R) -> Result<String> {
+    let len = read_u32(r)? as usize;
+    if len == 0 || len > MODEL_REQUEST_MAX {
+        bail!("implausible model request length: {len}");
+    }
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).context("read model request body")?;
+    String::from_utf8(buf).context("model request is not valid UTF-8")
+}
+
+/// Serialize + frame a manifest as `[u32 len][len bytes JSON]`.
+pub fn write_weight_manifest<W: std::io::Write>(w: &mut W, m: &WeightManifest) -> Result<()> {
+    let json = serde_json::to_vec(m).context("serialize weight manifest")?;
+    w.write_all(&(json.len() as u32).to_le_bytes())?;
+    w.write_all(&json)?;
+    Ok(())
+}
+
+/// Read + parse a length-prefixed manifest. Shared by the client tier.
+pub fn read_weight_manifest<R: std::io::Read>(r: &mut R) -> Result<WeightManifest> {
+    let len = read_u32(r)? as usize;
+    if len == 0 || len > 256 * 1024 * 1024 {
+        bail!("implausible weight manifest length: {len}");
+    }
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)
+        .context("read weight manifest json")?;
+    let m: WeightManifest = serde_json::from_slice(&buf).context("parse weight manifest json")?;
+    if m.version != WeightManifest::VERSION {
+        bail!(
+            "weight manifest version {} != supported {}",
+            m.version,
+            WeightManifest::VERSION
+        );
+    }
+    if m.shard_files.len() != m.shard_lens.len() {
+        bail!(
+            "manifest shard_files ({}) / shard_lens ({}) length mismatch",
+            m.shard_files.len(),
+            m.shard_lens.len()
+        );
+    }
+    Ok(m)
+}
+
+#[cfg(test)]
+#[path = "wire_tests.rs"]
+mod tests;

--- a/crates/spark-storage/src/weight_peer/wire_tests.rs
+++ b/crates/spark-storage/src/weight_peer/wire_tests.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::{
+    MODEL_REQUEST_MAX, read_model_request, read_weight_manifest, write_model_request,
+    write_weight_manifest,
+};
+use crate::weight_peer::{WeightManifest, WeightTensorRecord};
+
+fn sample_manifest() -> WeightManifest {
+    WeightManifest {
+        version: WeightManifest::VERSION,
+        model_id: "qwen3.6-35b-a3b".to_string(),
+        shard_files: vec![
+            "model.safetensors-00001-of-00002.safetensors".to_string(),
+            "model.safetensors-00002-of-00002.safetensors".to_string(),
+        ],
+        shard_lens: vec![1_000_000, 2_000_000],
+        tensors: vec![
+            WeightTensorRecord {
+                name: "model.embed_tokens.weight".to_string(),
+                dtype: "BF16".to_string(),
+                shape: vec![152064, 4096],
+                offset_in_shard: 4096,
+                len: 152064 * 4096 * 2,
+                shard_index: 0,
+                extra: false,
+            },
+            WeightTensorRecord {
+                name: "mtp.experts.5.gate_proj.weight_packed".to_string(),
+                dtype: "I8".to_string(),
+                shape: vec![2048, 1024],
+                offset_in_shard: 8192,
+                len: 2048 * 1024,
+                shard_index: 1,
+                extra: true,
+            },
+        ],
+    }
+}
+
+#[test]
+fn manifest_round_trips() {
+    let m = sample_manifest();
+    let mut buf = Vec::new();
+    write_weight_manifest(&mut buf, &m).unwrap();
+    let back = read_weight_manifest(&mut &buf[..]).unwrap();
+    assert_eq!(m, back);
+}
+
+#[test]
+fn manifest_rejects_bad_version() {
+    let mut m = sample_manifest();
+    m.version = 999;
+    let mut buf = Vec::new();
+    write_weight_manifest(&mut buf, &m).unwrap();
+    assert!(read_weight_manifest(&mut &buf[..]).is_err());
+}
+
+#[test]
+fn manifest_rejects_shard_len_mismatch() {
+    let mut m = sample_manifest();
+    m.shard_lens.pop(); // now 2 files, 1 len
+    let mut buf = Vec::new();
+    write_weight_manifest(&mut buf, &m).unwrap();
+    assert!(read_weight_manifest(&mut &buf[..]).is_err());
+}
+
+#[test]
+fn model_request_round_trips() {
+    let mut buf = Vec::new();
+    write_model_request(&mut buf, "/tank/models/qwen3.6-35b-a3b").unwrap();
+    let back = read_model_request(&mut &buf[..]).unwrap();
+    assert_eq!(back, "/tank/models/qwen3.6-35b-a3b");
+}
+
+#[test]
+fn model_request_rejects_empty() {
+    let mut buf = Vec::new();
+    assert!(write_model_request(&mut buf, "").is_err());
+}
+
+#[test]
+fn model_request_rejects_oversize_read() {
+    // A hostile length prefix must not attempt a giant allocation.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&(MODEL_REQUEST_MAX as u32 + 1).to_le_bytes());
+    assert!(read_model_request(&mut &buf[..]).is_err());
+}

--- a/crates/spark-storage/src/weight_tier_rdma.rs
+++ b/crates/spark-storage/src/weight_tier_rdma.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RdmaWeightLoader — the client half of the RDMA weight-staging tier.
+//
+// A `spark_runtime::weights::WeightLoader` (the same trait the disk loaders
+// impl) whose source is a peer's RAM blade (`weight_peer`) over one-sided RDMA
+// instead of the local SSD. For FAST MODEL SWAPS: connect, request a model by
+// id/path, read the peer's manifest, then RDMA-READ every resident tensor's
+// bytes straight out of the peer's shard MRs into a pinned bounce and
+// `copy_h2d` to a freshly-alloc'd GPU buffer — one buffer per tensor, keyed by
+// the exact safetensors name, byte-identical to the disk path.
+//
+// It composes with expert streaming: `stream_all_experts` / EP filtering skip
+// the routed experts (served separately by `expert_peer`), so this loads only
+// the resident set (attention, router gate, shared expert, norms, embed,
+// lm_head, MTP) — the exact `should_skip_tensor` predicate the disk loaders use.
+//
+// Bounce path (option a): tensors are MB-sized and bandwidth-bound, so the
+// bounce + copy_h2d overhead is negligible (unlike the 8 KiB KV groups that
+// needed zero-copy). Reuses the dual-rail striping template (tensor % n_rails).
+//
+// Like `expert_tier_rdma`, the verbs data path is gated on `atlas_rdma_verbs`;
+// without rdma-core the loader compiles but `load` returns a clear runtime error
+// (the selection lives in the server's `load_weight_store`, keyed on
+// `$ATLAS_WEIGHT_PEER`).
+
+use anyhow::Result;
+use std::path::Path;
+
+use spark_runtime::gpu::GpuBackend;
+use spark_runtime::weights::{WeightLoader, WeightStore, parse_expert_index};
+
+use crate::weight_peer::WeightTensorRecord;
+
+/// Loads a model's resident weights from a `weight_peer` over one-sided RDMA.
+pub struct RdmaWeightLoader {
+    /// `host:port` of the weight peer (from `$ATLAS_WEIGHT_PEER`).
+    pub peer_addr: String,
+    /// Model id/path to request. When `None`, the loader sends the `model_dir`
+    /// path passed to `load` (so the client and peer agree on the local path).
+    pub model_id: Option<String>,
+    pub ep_rank: usize,
+    pub ep_world_size: usize,
+    pub num_experts: usize,
+    /// Expert streaming: skip ALL routed-expert tensors (served from the expert
+    /// peer). Set from `config.expert_streaming` at the call site.
+    pub stream_all_experts: bool,
+    /// Pre-flight OOM multiplier override (advisory; parity with disk loaders).
+    pub peak_memory_multiplier: Option<f64>,
+}
+
+impl RdmaWeightLoader {
+    pub fn new(peer_addr: String) -> Self {
+        Self {
+            peer_addr,
+            model_id: None,
+            ep_rank: 0,
+            ep_world_size: 1,
+            num_experts: 0,
+            stream_all_experts: false,
+            peak_memory_multiplier: None,
+        }
+    }
+
+    pub fn with_ep(
+        peer_addr: String,
+        ep_rank: usize,
+        ep_world_size: usize,
+        num_experts: usize,
+    ) -> Self {
+        Self {
+            peer_addr,
+            model_id: None,
+            ep_rank,
+            ep_world_size,
+            num_experts,
+            stream_all_experts: false,
+            peak_memory_multiplier: None,
+        }
+    }
+
+    /// The exact skip predicate the disk loaders use (`SafetensorsLoader` /
+    /// `FastSafetensorsLoader::should_skip_tensor`), applied to a manifest
+    /// record. `extra_weights` tensors (`rec.extra`) are NEVER skipped, matching
+    /// the disk path's no-skip pass for `extra_weights.safetensors`.
+    // Only reached from the `atlas_rdma_verbs` load path; on a cuda host without
+    // rdma-core the whole data path runtime-bails, leaving this unreferenced.
+    #[cfg_attr(not(atlas_rdma_verbs), allow(dead_code))]
+    fn should_skip_tensor(&self, rec: &WeightTensorRecord) -> bool {
+        if rec.extra {
+            return false;
+        }
+        // MTP head experts are small — always replicate, never skip.
+        if rec.name.starts_with("mtp.") {
+            return false;
+        }
+        // Expert streaming: routed experts stream from the expert peer.
+        if self.stream_all_experts && parse_expert_index(&rec.name).is_some() {
+            return true;
+        }
+        if self.ep_world_size <= 1 {
+            return false;
+        }
+        if let Some(idx) = parse_expert_index(&rec.name) {
+            let per_rank = self.num_experts / self.ep_world_size;
+            let local_start = self.ep_rank * per_rank;
+            let local_end = if self.ep_rank == self.ep_world_size - 1 {
+                self.num_experts
+            } else {
+                local_start + per_rank
+            };
+            idx < local_start || idx >= local_end
+        } else {
+            false
+        }
+    }
+}
+
+impl WeightLoader for RdmaWeightLoader {
+    fn load(
+        &self,
+        model_dir: &Path,
+        gpu: &dyn GpuBackend,
+        oom_reserve_bytes: usize,
+    ) -> Result<WeightStore> {
+        self.load_impl(model_dir, gpu, oom_reserve_bytes)
+    }
+}
+
+#[cfg(not(atlas_rdma_verbs))]
+impl RdmaWeightLoader {
+    fn load_impl(
+        &self,
+        _model_dir: &Path,
+        _gpu: &dyn GpuBackend,
+        _oom_reserve_bytes: usize,
+    ) -> Result<WeightStore> {
+        anyhow::bail!(
+            "$ATLAS_WEIGHT_PEER is set but this build has no rdma-core (atlas_rdma_verbs \
+             cfg); rebuild with rdma-core, or unset ATLAS_WEIGHT_PEER to load from disk"
+        )
+    }
+}
+
+#[cfg(atlas_rdma_verbs)]
+impl RdmaWeightLoader {
+    fn load_impl(
+        &self,
+        model_dir: &Path,
+        gpu: &dyn GpuBackend,
+        oom_reserve_bytes: usize,
+    ) -> Result<WeightStore> {
+        use std::collections::HashMap;
+        use std::ffi::c_void;
+        use std::io::Write;
+        use std::net::TcpStream;
+
+        use anyhow::{Context, bail};
+
+        use crate::expert_peer::MODE_VERBS;
+        use crate::weight_peer::{
+            rail_for_tensor, read_weight_manifest, tensor_remote_addr, write_model_request,
+        };
+        use atlas_rdma::env::{first_nonempty, first_set_u32};
+        use atlas_rdma::railset::{RailSet, RailSpec};
+        use atlas_rdma::verbs::Verbs;
+        use spark_runtime::weights::{WeightDtype, WeightTensor};
+
+        // 1. Connect + request the model + read the manifest.
+        let mut stream = TcpStream::connect(&self.peer_addr)
+            .with_context(|| format!("connect weight peer {}", self.peer_addr))?;
+        stream.set_nodelay(true).ok();
+        let model_id = self
+            .model_id
+            .clone()
+            .unwrap_or_else(|| model_dir.to_string_lossy().into_owned());
+        write_model_request(&mut stream, &model_id).context("send model request")?;
+        let manifest = read_weight_manifest(&mut stream).context("read weight manifest")?;
+        let num_shards = manifest.num_shards();
+
+        // 2. Filter to the resident set (skip streamed/EP experts). extra_weights
+        // tensors are always kept (should_skip_tensor honors rec.extra).
+        let retained: Vec<&WeightTensorRecord> = manifest
+            .tensors
+            .iter()
+            .filter(|t| !self.should_skip_tensor(t))
+            .collect();
+
+        // 3. Advisory OOM pre-flight (parity with the disk loaders — estimate
+        // from the manifest, not local headers).
+        {
+            let est: u64 = retained.iter().map(|t| t.len).sum();
+            let fp8: u64 = retained
+                .iter()
+                .filter(|t| t.dtype == "F8_E4M3")
+                .map(|t| t.len)
+                .sum();
+            let fp8_frac = if est > 0 {
+                fp8 as f64 / est as f64
+            } else {
+                0.0
+            };
+            let mult =
+                self.peak_memory_multiplier
+                    .unwrap_or(if fp8_frac > 0.5 { 1.5 } else { 1.3 });
+            let peak = (est as f64 * mult) as usize;
+            let free = gpu.free_memory()?;
+            let gib = |b: usize| b as f64 / (1024.0 * 1024.0 * 1024.0);
+            tracing::info!(
+                "RDMA weight load pre-flight: {:.2} GB manifest, {:.1}x = {:.2} GB peak, \
+                 {:.2} GB free, {:.1} GB reserve (FP8 {:.0}%)",
+                gib(est as usize),
+                mult,
+                gib(peak),
+                gib(free),
+                gib(oom_reserve_bytes),
+                fp8_frac * 100.0,
+            );
+            if peak + oom_reserve_bytes > free {
+                bail!(
+                    "OOM pre-flight (RDMA weight peer): peak {:.2} GB + {:.2} GB reserve > {:.2} GB free",
+                    gib(peak),
+                    gib(oom_reserve_bytes),
+                    gib(free),
+                );
+            }
+        }
+
+        // 4. Verbs handshake via RailSet. Rail 0 defaults to the shared expert
+        // CX7 link; dual-rail is opt-in (ATLAS_WEIGHT_DUAL_RAIL=1). ATLAS_WEIGHT_*
+        // overrides fall back to the ATLAS_EXPERT_* names so a single fabric
+        // config serves both tiers (weight semantics: an exported-but-EMPTY
+        // override is SKIPPED — `first_nonempty`). Fresh random 24-bit PSN/rail.
+        let spec =
+            |dev: String, gid: u32| RailSpec::new(dev, gid, rand::random::<u32>() & 0xff_ffff);
+        let rail0 = spec(
+            first_nonempty(
+                &["ATLAS_WEIGHT_RDMA_DEV", "ATLAS_EXPERT_RDMA_DEV"],
+                "roceP2p1s0f1",
+            ),
+            first_set_u32(&["ATLAS_WEIGHT_RDMA_GID", "ATLAS_EXPERT_RDMA_GID"], 3),
+        );
+        let dual = std::env::var("ATLAS_WEIGHT_DUAL_RAIL").ok().as_deref() == Some("1");
+        let specs: Vec<RailSpec> = if dual {
+            let rail1 = spec(
+                first_nonempty(
+                    &["ATLAS_WEIGHT_RAIL2_DEV", "ATLAS_EXPERT_RAIL2_DEV"],
+                    "rocep1s0f1",
+                ),
+                first_set_u32(&["ATLAS_WEIGHT_RAIL2_GID", "ATLAS_EXPERT_RAIL2_GID"], 3),
+            );
+            vec![rail0, rail1]
+        } else {
+            vec![rail0]
+        };
+        let n_rails = specs.len();
+
+        stream.write_all(&[MODE_VERBS]).context("send verbs mode")?;
+        // [u8 n_rails] + one QP per rail.
+        let mut rs = RailSet::begin(&mut stream, &specs)?;
+
+        // One pinned, registered bounce per rail, sized to the largest retained
+        // tensor. Tensors are processed serially per rail (post → poll), so one
+        // bounce per rail suffices; pipelining is deferred (bandwidth-bound).
+        let max_len = retained.iter().map(|t| t.len).max().unwrap_or(0);
+        if max_len > u32::MAX as u64 {
+            bail!(
+                "tensor of {} bytes exceeds the 4 GiB single-WR RDMA READ limit \
+                 (per-tensor chunking not implemented)",
+                max_len
+            );
+        }
+        let bounce_len = (max_len as usize).max(1);
+
+        // LOCAL_WRITE-only landing MRs (`remote_read == false`, invariant).
+        // Track pinned allocations to free AFTER the rails (MRs) are dropped.
+        let mut pinned: Vec<*mut u8> = Vec::with_capacity(n_rails);
+        let mut bounce_lkeys: Vec<u32> = Vec::with_capacity(n_rails);
+        for rail in &mut rs.rails {
+            let ptr = gpu
+                .alloc_host_pinned(bounce_len)
+                .context("alloc pinned RDMA landing bounce")?;
+            // SAFETY: ptr backs `bounce_len` pinned bytes that outlive the MR
+            // (freed after the rails are dropped below).
+            let keys = unsafe { rail.verbs.reg_mr(ptr as *mut c_void, bounce_len, false) }
+                .context("register RDMA landing bounce")?;
+            pinned.push(ptr);
+            bounce_lkeys.push(keys.lkey);
+        }
+
+        // Peer publishes per-rail per-SHARD (base, rkey). Validate shard counts
+        // BEFORE replying (a mismatch bails with no client params written).
+        let server = rs
+            .read_server_ro(&mut stream)
+            .context("read verbs server params")?;
+        for sp in &server {
+            if sp.layers.len() != num_shards {
+                bail!(
+                    "peer published {} shard MRs but manifest has {num_shards} shards",
+                    sp.layers.len()
+                );
+            }
+        }
+
+        // Reply with our QP params, connect each rail, await the ready ack.
+        rs.complete(&mut stream, &server, "weight peer")?;
+        struct Rail {
+            verbs: Verbs,
+            bounce_ptr: *mut u8,
+            bounce_lkey: u32,
+        }
+        let mut rails: Vec<Rail> = rs
+            .into_verbs()
+            .into_iter()
+            .zip(&pinned)
+            .zip(&bounce_lkeys)
+            .map(|((verbs, &bounce_ptr), &bounce_lkey)| Rail {
+                verbs,
+                bounce_ptr,
+                bounce_lkey,
+            })
+            .collect();
+        tracing::info!(
+            "RDMA weight loader connected to {} ({} shards, {} resident tensors, {n_rails} rail(s))",
+            manifest.model_id,
+            num_shards,
+            retained.len(),
+        );
+
+        // 5. RDMA-READ each resident tensor into its rail's bounce, then copy_h2d
+        // into a fresh per-tensor GPU buffer. Byte-identical: the manifest offset
+        // is absolute (shard_base + offset reads the raw data slice), `len` is
+        // authoritative, dtype/shape come from the header verbatim.
+        let mut weights: HashMap<String, WeightTensor> = HashMap::new();
+        let mut offload_logged = false;
+        for (idx, rec) in retained.iter().enumerate() {
+            let ri = rail_for_tensor(idx, n_rails);
+            let sp = &server[ri];
+            let (shard_base, rkey) = *sp
+                .layers
+                .get(rec.shard_index as usize)
+                .with_context(|| format!("no shard MR {} for {}", rec.shard_index, rec.name))?;
+            let remote_addr = tensor_remote_addr(shard_base, rec.offset_in_shard);
+            let len = rec.len as usize;
+            let wr_id = idx as u64;
+
+            let rail = &mut rails[ri];
+            // SAFETY: bounce_ptr backs `bounce_len >= len` pinned bytes in this
+            // rail's MR; remote_addr/rkey address the peer's shard MR on this
+            // same rail; len <= u32::MAX (checked above).
+            unsafe {
+                rail.verbs
+                    .post_read(
+                        rail.bounce_ptr as *mut c_void,
+                        rail.bounce_lkey,
+                        remote_addr,
+                        rkey,
+                        len as u32,
+                        wr_id,
+                    )
+                    .with_context(|| format!("post_read {}", rec.name))?;
+            }
+            match rail.verbs.poll() {
+                Ok(got) if got == wr_id => {}
+                Ok(got) => bail!(
+                    "completion wr_id {got:#x} != expected {wr_id:#x} ({})",
+                    rec.name
+                ),
+                Err(e) => return Err(e).with_context(|| format!("poll {}", rec.name)),
+            }
+
+            // SAFETY: the bounce now holds `len` valid bytes landed by the READ.
+            let src = unsafe { std::slice::from_raw_parts(rail.bounce_ptr, len) };
+            let dtype = WeightDtype::from_safetensors_str(&rec.dtype)
+                .with_context(|| format!("tensor {}", rec.name))?;
+            let shape: Vec<usize> = rec.shape.iter().map(|&d| d as usize).collect();
+
+            let ptr = match gpu.alloc(len) {
+                Ok(p) => {
+                    gpu.copy_h2d(src, p)?;
+                    p
+                }
+                Err(_) => {
+                    if !offload_logged {
+                        tracing::warn!(
+                            "GPU alloc failed for {} ({len} bytes) — switching to managed (UVM) memory",
+                            rec.name
+                        );
+                        offload_logged = true;
+                    }
+                    let p = gpu.alloc_managed(len)?;
+                    // SAFETY: managed ptr is host-addressable UVM of `len` bytes;
+                    // src is the pinned bounce of `len` bytes. Matches the disk
+                    // loaders' CPU-memcpy fallback.
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(src.as_ptr(), p.0 as *mut u8, len);
+                    }
+                    p
+                }
+            };
+            weights.insert(rec.name.clone(), WeightTensor { ptr, shape, dtype });
+        }
+
+        // 6. Tear down: drop the rails (dereg MRs) BEFORE freeing the pinned
+        // bounces they registered, then release the pinned host memory.
+        drop(rails);
+        for ptr in pinned {
+            let _ = gpu.free_host_pinned(ptr, bounce_len);
+        }
+
+        tracing::info!("RDMA-loaded {} weight tensors", weights.len());
+        Ok(WeightStore::from_map(weights))
+    }
+}

--- a/crates/spark-storage/tests/expert_stream_parity.rs
+++ b/crates/spark-storage/tests/expert_stream_parity.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Tier-1 acceptance: the streamer delivers byte-identical bytes regardless of
+// tier, so a forward pass CANNOT differ by tier. Proves, at the byte layer:
+//   * PosixTier (bounce oracle) == UmaArenaTier (O_DIRECT zero-copy) across all
+//     six NVFP4 sub-buffers + scale2/input_scale (foundation for the Stage-2
+//     bit-identical logit gate);
+//   * capped-arena slab reuse still matches the oracle (invariant C at bytes);
+//   * one fetch touches only its own slot (byte-layer basis for invariant E's
+//     local_expert_range scoping, fully tested at Stage 2).
+//
+// GPU-gated (each tier allocates CUDA memory) and O_DIRECT-gated (UMA reads need
+// a block-backed fs — tmpfs returns EINVAL), so these are `#[ignore]` and run
+// explicitly: `cargo test -p spark-storage --test expert_stream_parity -- --ignored`.
+// The store is written under CARGO_TARGET_TMPDIR (target/, ext4) not /tmp.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use spark_storage::cuda_min::CudaCtx;
+use spark_storage::expert::{ExpertKey, Proj};
+use spark_storage::expert_tier::{ArenaSlot, ExpertTier, PosixTier, UmaArenaTier, read_device};
+use spark_storage::expert_tier_rdma::RdmaTier;
+use spark_storage::{ExpertFileWriter, ExpertIndex, ExpertRecordHeader, ProjData};
+
+const LAYERS: u32 = 3;
+const EXPERTS: u32 = 4;
+const INTER: u64 = 64;
+const HIDDEN: u64 = 128;
+const GS: u64 = 16;
+
+struct Expected {
+    packed: [Vec<u8>; 3],
+    scale: [Vec<u8>; 3],
+    scale2: [f32; 3],
+    input_scale: [Option<f32>; 3],
+}
+
+fn fill(n: usize, seed: u64) -> Vec<u8> {
+    let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(0xABCD);
+    (0..n)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            (s & 0xFF) as u8
+        })
+        .collect()
+}
+
+fn proj_nk(p: Proj) -> (u64, u64) {
+    match p {
+        Proj::Gate | Proj::Up => (INTER, HIDDEN),
+        Proj::Down => (HIDDEN, INTER),
+    }
+}
+
+/// Write a synthetic store on an O_DIRECT-capable fs; return the expected bytes.
+fn build_store(tag: &str) -> (PathBuf, HashMap<(u32, u32), Expected>) {
+    // Compile-time env (target/, ext4) — not /tmp (tmpfs rejects O_DIRECT).
+    let root = env!("CARGO_TARGET_TMPDIR");
+    let dir = PathBuf::from(root).join(format!("xpr-parity-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let index = ExpertIndex::new(INTER, HIDDEN, GS, 256, 4096, (0..LAYERS).collect(), EXPERTS);
+    let spec = index.spec();
+    let writer = ExpertFileWriter::create(&dir, index).expect("create store");
+    let mut expected = HashMap::new();
+
+    for layer in 0..LAYERS {
+        for expert in 0..EXPERTS {
+            let mut packed: [Vec<u8>; 3] = Default::default();
+            let mut scale: [Vec<u8>; 3] = Default::default();
+            for p in Proj::ALL {
+                let (n, k) = proj_nk(p);
+                let seed = (layer as u64) << 24 | (expert as u64) << 8 | p as u64;
+                packed[p as usize] = fill((n * k / 2) as usize, seed);
+                scale[p as usize] = fill((n * k / GS) as usize, seed ^ 0x5555);
+                assert_eq!(
+                    packed[p as usize].len() as u64,
+                    spec.proj_bytes(p).packed_bytes
+                );
+                assert_eq!(
+                    scale[p as usize].len() as u64,
+                    spec.proj_bytes(p).scale_bytes
+                );
+            }
+            let scale2 = [
+                1.0 + layer as f32,
+                2.0 + expert as f32,
+                0.5 + (layer + expert) as f32,
+            ];
+            let input_scale = [Some(0.25), None, Some(1.75)];
+            let header = ExpertRecordHeader {
+                layer,
+                expert,
+                inter: INTER as u32,
+                hidden: HIDDEN as u32,
+                group_size: GS as u32,
+                scale2,
+                input_scale,
+            };
+            let projs = [
+                ProjData {
+                    packed: &packed[0],
+                    scale: &scale[0],
+                },
+                ProjData {
+                    packed: &packed[1],
+                    scale: &scale[1],
+                },
+                ProjData {
+                    packed: &packed[2],
+                    scale: &scale[2],
+                },
+            ];
+            writer
+                .write_record(ExpertKey::new(layer, expert), &header, &projs)
+                .expect("write record");
+            expected.insert(
+                (layer, expert),
+                Expected {
+                    packed,
+                    scale,
+                    scale2,
+                    input_scale,
+                },
+            );
+        }
+    }
+    writer.finish().expect("finish store");
+    (dir, expected)
+}
+
+/// Read a tier's residency back from the device and compare to `exp`.
+fn assert_matches(
+    tier: &mut dyn ExpertTier,
+    key: ExpertKey,
+    slot: ArenaSlot,
+    stream: u64,
+    exp: &Expected,
+) {
+    let r = tier.fetch(key, slot, stream).expect("fetch");
+    assert_eq!(r.scale2, exp.scale2, "{:?} scale2 ({:?})", key, tier.kind());
+    assert_eq!(
+        r.input_scale,
+        exp.input_scale,
+        "{:?} input_scale ({:?})",
+        key,
+        tier.kind()
+    );
+    for p in Proj::ALL {
+        let pl = exp.packed[p as usize].len();
+        let sl = exp.scale[p as usize].len();
+        let got_packed = read_device(r.packed_addr[p as usize], pl, stream).unwrap();
+        let got_scale = read_device(r.scale_addr[p as usize], sl, stream).unwrap();
+        assert_eq!(
+            got_packed,
+            exp.packed[p as usize],
+            "{:?} {:?} packed via {:?}",
+            key,
+            p,
+            tier.kind()
+        );
+        assert_eq!(
+            got_scale,
+            exp.scale[p as usize],
+            "{:?} {:?} scale via {:?}",
+            key,
+            p,
+            tier.kind()
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires GPU + O_DIRECT-capable fs"]
+fn posix_equals_uma_byte_identical() {
+    let ctx = CudaCtx::new(0).expect("cuda ctx");
+    let (dir, expected) = build_store("full");
+    // One slab per layer, one slot per expert — no reuse.
+    let mut posix = PosixTier::open(&dir, LAYERS, EXPERTS).expect("posix tier");
+    let mut uma = UmaArenaTier::open(&dir, LAYERS, EXPERTS).expect("uma tier");
+
+    for layer in 0..LAYERS {
+        for expert in 0..EXPERTS {
+            let key = ExpertKey::new(layer, expert);
+            let slot = ArenaSlot::new(layer, expert);
+            let exp = &expected[&(layer, expert)];
+            // Each tier independently reproduces the source bytes...
+            assert_matches(&mut posix, key, slot, ctx.stream, exp);
+            assert_matches(&mut uma, key, slot, ctx.stream, exp);
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[ignore = "requires GPU + O_DIRECT-capable fs"]
+fn capped_arena_eviction_parity() {
+    // Only 2 slabs for a 3-layer store: layer 2 reuses slab 0, forcing eviction.
+    let ctx = CudaCtx::new(0).expect("cuda ctx");
+    let (dir, expected) = build_store("capped");
+    let num_slabs = 2u32;
+    let mut uma = UmaArenaTier::open(&dir, num_slabs, EXPERTS).expect("uma tier");
+    let mut posix = PosixTier::open(&dir, num_slabs, EXPERTS).expect("posix tier");
+
+    for layer in 0..LAYERS {
+        for expert in 0..EXPERTS {
+            let key = ExpertKey::new(layer, expert);
+            let slot = ArenaSlot::new(layer % num_slabs, expert); // reuse slabs
+            let exp = &expected[&(layer, expert)];
+            // Even under slab reuse, each fetch lands the correct record and
+            // still matches the oracle — eviction doesn't corrupt bytes.
+            assert_matches(&mut uma, key, slot, ctx.stream, exp);
+            assert_matches(&mut posix, key, slot, ctx.stream, exp);
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[ignore = "requires GPU + O_DIRECT-capable fs"]
+fn rdma_tier_matches_oracle_over_loopback() {
+    // Stage 4 (Phase A): a peer serves the store over TCP; RdmaTier lands records
+    // in the pinned arena and must be byte-identical to the Posix oracle — proving
+    // the peer-as-tier abstraction with zero verbs risk.
+    let ctx = CudaCtx::new(0).expect("cuda ctx");
+    let (dir, expected) = build_store("rdma");
+    let port = 20000 + (std::process::id() % 10000) as u16;
+    let addr = format!("127.0.0.1:{port}");
+
+    // Serve in a background thread (leaks on test exit — fine).
+    let serve_dir = dir.clone();
+    let serve_addr = addr.clone();
+    std::thread::spawn(move || {
+        let _ = spark_storage::expert_peer::serve(
+            &serve_dir,
+            serve_addr.as_str(),
+            spark_storage::expert_peer::RdmaConfig::default(),
+        );
+    });
+    // Wait for the listener to come up.
+    let mut connected = None;
+    for _ in 0..50 {
+        if std::net::TcpStream::connect(&addr).is_ok() {
+            connected = Some(());
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    connected.expect("peer never accepted a connection");
+
+    let mut rdma = RdmaTier::connect(&addr, LAYERS, EXPERTS, false).expect("rdma connect");
+    let mut posix = PosixTier::open(&dir, LAYERS, EXPERTS).expect("posix tier");
+    for layer in 0..LAYERS {
+        for expert in 0..EXPERTS {
+            let key = ExpertKey::new(layer, expert);
+            let slot = ArenaSlot::new(layer, expert);
+            let exp = &expected[&(layer, expert)];
+            assert_matches(&mut rdma, key, slot, ctx.stream, exp);
+            assert_matches(&mut posix, key, slot, ctx.stream, exp);
+        }
+    }
+    assert!(rdma.healthy(), "rdma tier should still be healthy");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[ignore = "requires GPU + O_DIRECT-capable fs"]
+fn fetch_touches_only_its_slot() {
+    // Byte-layer basis for invariant E: filling one expert's slot must not
+    // disturb another slot's bytes (the install loop's per-expert scoping
+    // relies on this). Full local_expert_range scoping is a Stage-2 test.
+    let ctx = CudaCtx::new(0).expect("cuda ctx");
+    let (dir, expected) = build_store("isolation");
+    let mut uma = UmaArenaTier::open(&dir, 1, EXPERTS).expect("uma tier");
+
+    let k0 = ExpertKey::new(0, 0);
+    let k1 = ExpertKey::new(0, 1);
+    let r0 = uma.fetch(k0, ArenaSlot::new(0, 0), ctx.stream).unwrap();
+    // Fetch a different expert into a different slot...
+    let _r1 = uma.fetch(k1, ArenaSlot::new(0, 1), ctx.stream).unwrap();
+    // ...slot 0's bytes are unchanged.
+    let e0 = &expected[&(0, 0)];
+    for p in Proj::ALL {
+        let got = read_device(
+            r0.packed_addr[p as usize],
+            e0.packed[p as usize].len(),
+            ctx.stream,
+        )
+        .unwrap();
+        assert_eq!(
+            got, e0.packed[p as usize],
+            "slot 0 {:?} disturbed by slot 1 fetch",
+            p
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/spark-storage/tests/high_speed_swap_e2e.rs
+++ b/crates/spark-storage/tests/high_speed_swap_e2e.rs
@@ -162,6 +162,7 @@ fn orchestrator_multi_tile_with_eviction() {
         num_kv_heads: NUM_KV_HEADS,
         head_dim: HEAD_DIM,
         block_size: BLOCK_SIZE,
+        model_fp: None,
     };
     let mut hss = HighSpeedSwap::new(&ctx, cfg, model).unwrap();
 

--- a/docker/gb10/Dockerfile
+++ b/docker/gb10/Dockerfile
@@ -16,7 +16,7 @@
 FROM nvidia/cuda:13.0.0-devel-ubuntu24.04@sha256:1e8ac7a54c184a1af8ef2167f28fa98281892a835c981ebcddb1fad04bdd452d AS builder
 
 RUN apt-get update -qq && \
-    apt-get install -y -qq curl build-essential pkg-config git cmake libclang-dev && \
+    apt-get install -y -qq curl build-essential pkg-config git cmake libclang-dev libibverbs-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
Re-cut of #316 (@rsafier) onto current `main`, so we can push fixes to the branch directly. **All 23 of Richard's commits are carried verbatim, authorship intact** — this is his work; the only additions are two one-line build fixes (below) and a merge of current `main` (his branch was 4 behind; it merged clean, no conflicts).

Supersedes #316. Opened here only because the fork had `maintainerCanModify=false`, so the fixes could not be pushed to the original branch.

## What it is

HSS / tiered-storage stack: two new crates (`atlas-rdma` — CUDA-free one-sided RDMA verbs + RailSet; `atlas-tier` — CUDA-free tiered-cache core), the expert-pack substrate + residency tiers, a cascade T1 write-back `StorageBackend`, the cache-peer RW blade daemon, Marconi snapshot spill-not-drop reclaim, and an adapter-correct prefix cache + SSM snapshot index.

**138 files, +18,312 / −346.**

## The two fixes added on top

**1. `fix(docker)`: the GB10 image did not build.** `atlas-rdma`'s C shim includes `<infiniband/verbs.h>`, but the Dockerfile's *builder* stage had no rdma-core headers:

```
warning: atlas-rdma@0.1.0: src/rdma_shim.c:20:10: fatal error: infiniband/verbs.h: No such file or directory
error: failed to run custom build command for `atlas-rdma v0.1.0`
```

The *runtime* stage already installs `libibverbs1`; the builder just needed `libibverbs-dev`. One line.

> **CI is structurally blind to this.** `atlas-rdma/build.rs` deliberately does no header probing ("on Linux with the skip unset and headers missing, cc fails the build loudly"), and CI sets `ATLAS_SKIP_BUILD=1`, which compiles the shim out entirely. So every check can be green while the deployable image is broken. **A CI job that actually builds the GB10 image would close this hole** — worth doing as a follow-up, independent of this PR.

We considered dropping the C shim for pure-Rust FFI instead. It isn't viable: `ibv_post_send` / `ibv_poll_cq` are `static inline` in `verbs.h` and dispatch through `qp->context->ops`, so they are not symbols in `libibverbs.so` and cannot be `extern "C"`-linked. Every Rust RDMA binding ships a shim for exactly this reason. Keeping the shim; fixing the Dockerfile.

**2. `fix(docs)`: `Build mdBook + rustdoc` failure.** `scale2[3]` / `input_scale[3]` in an `expert.rs` doc comment parse as intra-doc links → `error: unresolved link to \`3\`` under `deny(warnings)`. Backticked.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --tests` (CI-exact env) clean, 0 errors
- `cargo doc -p spark-storage --no-deps` clean (was the rustdoc failure)
- GB10 image builds end-to-end with the Dockerfile fix

Full benchmark gates (35B webserver_ok · ST-995 BFCL · warm-TTFT regression guard · dense-27B MLPerf ST-995) are running on GB10 now against a same-box `main` control — results to follow in a comment.

Credit: @rsafier — all 23 feature commits.
