### PR TITLE
fix(w4a16): restore n-fast grid contract on the shared m128 launcher (fixes dense-27B garbage / BFCL 11.26)

### DIFF
--- a/crates/spark-model/src/layers/ops/gemm_dense.rs
+++ b/crates/spark-model/src/layers/ops/gemm_dense.rs
@@ -273,6 +273,14 @@ pub fn w4a16_gemm_n128_m128_v2(
 ///
 /// Grid: (ceil(N/128), ceil(M/128), 1)  Block: (128, 1, 1)
 /// SMEM: ~29.8 KB → 3 blocks/SM (vs 5 for m64 at ~19.6 KB).
+///
+/// GRID CONTRACT — N is the FAST axis (blockIdx.x = N-block, blockIdx.y = M-block).
+/// Every `w4a16_gemm_t_m128` kernel across all model dirs reads it this way. This
+/// launcher is SHARED (qwen3_attention, dense_ffn, qwen3_ssm, nemotron_*), so the
+/// axes must NOT be swapped here to suit one model: doing so silently mis-maps every
+/// CTA for the other 18 kernels and produces garbage output with no error. If a model
+/// wants the m-fast (L2-friendly) order, add a SEPARATELY NAMED kernel + launcher
+/// (see `w4a4_gemm_mfast` / `fp8_gemm_t_m128_mfast`) rather than mutating this one.
 #[allow(clippy::too_many_arguments)]
 pub fn w4a16_gemm_n128_m128(
     gpu: &dyn GpuBackend,
@@ -286,7 +294,7 @@ pub fn w4a16_gemm_n128_m128(
     stream: u64,
 ) -> Result<()> {
     KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(m, 128), div_ceil(n, 128), 1])
+        .grid([div_ceil(n, 128), div_ceil(m, 128), 1])
         .block([128, 1, 1])
         .arg_ptr(input)
         .arg_ptr(weight.weight)

--- a/kernels/gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4/w4a16_gemm.cu
@@ -990,16 +990,16 @@ void w4a16_gemm_t_m128(
     __nv_bfloat16* __restrict__ C,
     unsigned int M, unsigned int N, unsigned int K
 ) {
-    // Grid axes are SWAPPED relative to the other GEMMs: blockIdx.x is the
-    // M-block, blockIdx.y is the N-block.
+    // GRID CONTRACT — N is the FAST axis, matching the SHARED launcher
+    // `ops::w4a16_gemm_n128_m128` and every other model's `w4a16_gemm_t_m128`.
     //
-    // Every m-block re-reads the whole B panel for its n-column. With n on the
-    // fast axis, the 8 m-blocks sharing a B panel are scheduled ~141 blocks
-    // apart, so the panel is evicted from L2 between them and B is fetched from
-    // DRAM 8x (~20 GB across the 112 calls in one 1k prefill). Putting m on the
-    // fast axis makes those 8 blocks co-resident, so 7 of the 8 reads hit L2.
-    const unsigned int cta_n  = blockIdx.y * N_TILE_LG;
-    const unsigned int cta_m  = blockIdx.x * (2 * M_TILE);  // base row for this block
+    // Do NOT swap these to m-fast here. This kernel is reached through a launcher
+    // shared by all NVFP4 models; swapping the axes in one model's copy while the
+    // launcher feeds every model made 18 other kernels mis-map every CTA (silent
+    // garbage, no error — it read as a dense-27B numerical break). If the m-fast
+    // L2 ordering is wanted, add a separately named `_mfast` kernel + launcher.
+    const unsigned int cta_n  = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m  = blockIdx.y * (2 * M_TILE);  // base row for this block
     if (cta_m >= M) return;
 
     const unsigned int warp_id = threadIdx.x / 32;


### PR DESCRIPTION
## What broke

#281 swapped the grid axes of `ops::w4a16_gemm_n128_m128` to m-fast (for L2-friendly B-panel reuse) and updated only the `nemotron-h-puzzle` copy of the kernel to read them that way.

That launcher is **shared by every NVFP4 model**. The other 18 `w4a16_gemm_t_m128` kernels still read `blockIdx.x` as the N-block while the launcher fed them an M-fast grid, so every CTA computed the wrong tile.

There is no crash and no error. The model just emits numerically garbage output.

## Impact

On the dense 27B (`unsloth/Qwen3.6-27B-NVFP4`, the MLPerf-edge model) it degenerates into rambling text and stops emitting tool calls entirely:

| metric | baseline | broken main | floor |
|---|---|---|---|
| overall_accuracy | 87.44 | **11.26** | 83.64 |
| normalized_single_turn | 88.53 | **33.33** | 85.32 |

The category split is the tell: `non_live 0.0`, `live 0.0`, but `hallucination 100.0` and `irrelevance 100.0`. It scores perfectly on every category where NOT calling a tool is the correct answer, which is the signature of zero tool calls rather than degraded ones.

This affects **every NVFP4 model** routing through the launcher at `n > 128` (`qwen3_attention/prefill_weights`, `dense_ffn`, `qwen3_ssm`, `multi_seq/qkv`), not just the 27B.

The 35B flagship never surfaced it: `Qwen3.6-35B-A3B-FP8` takes the FP8 launcher and never reaches this path, so gate B scored an exact baseline (84.66 / 83.32) while the MLPerf model was broken.

## Isolation

Bisected on one box, same checkpoint (`ccdaab7e`), same golden serve flags. Only the code differs:

| code | 27B tool call |
|---|---|
| `b45af988` baseline | OK |
| `#303` / `#313` / `#314` dflash | OK |
| `955f0257` (#317 HSS) | OK |
| `d9ff8671` (#315) | OK |
| `287e73d3` (#322) | OK, last good |
| `5ced18a3` (#281) | **garbage, first bad** |
| `a135e68a` (#321) | garbage |
| `45cc093b` main tip | no tool call |
| `45cc093b` + this fix | **OK, 27B coherent again** |

#283 and #306 were both eliminated despite being the obvious suspects.

## The fix

Restore both the shared launcher and the nemotron kernel to n-fast so all 19 kernels and the launcher agree, and write the grid contract down at both ends. The underlying defect was an undocumented implicit convention that #281 forked unilaterally.

## Trade-off: m-fast vs n-fast

The m-fast ordering was a real win and this gives it up:

- **n-fast** (`blockIdx.x` = N-block): every M-block re-reads the whole B panel for its N column. The M-blocks sharing a panel are scheduled `N/128` blocks apart, so the panel is evicted from L2 between them and B is refetched from DRAM once per M-block.
- **m-fast** (`blockIdx.x` = M-block): the M-blocks sharing a B panel run co-resident, so the panel stays in L2 and B streams from DRAM once.

Measured on nemotron: **1k TTFT 494ms -> 464ms**, for free, same weights.

It is given up here because **correctness beats 30ms**, and because the win cannot be taken by mutating a shared launcher. The right way to reclaim it is a **separately named `_mfast` kernel + launcher** so each model opts in explicitly. That is the pattern #281 already used correctly for `w4a4_gemm_mfast` and `fp8_gemm_t_m128_mfast`; this call site simply did not follow it. Reclaiming the 30ms that way is a clean follow-up.

## Gates

Full A/B/C/D suite is running against this branch. Results to follow in a comment.
