### PR TITLE
perf(decode): w4a16 GEMV 2-chunk ILP + fix K=4 verify crash on native-FP8-GDN ckpts

### DIFF
--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -95,6 +95,8 @@ pub struct DenseFfnLayer {
     w4a16_gemv_dual_batch3: KernelHandle,
     w4a16_gemv_batch2: KernelHandle,
     w4a16_gemv_batch3: KernelHandle,
+    /// M<=4 batched GEMV (K=4 verify FFN); 0-handle when absent.
+    w4a16_gemv_batch4: KernelHandle,
     w4a16_gemm: KernelHandle,
     // 128x128 2-stage cp.async pipelined w4a16 GEMM — the fast prefill kernel
     // attention/SSM already use. The base `w4a16_gemm` (M64xN64) only hits
@@ -264,6 +266,7 @@ impl DenseFfnLayer {
             w4a16_gemv_dual_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
             w4a16_gemv_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
             w4a16_gemv_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,
+            w4a16_gemv_batch4: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
             w4a16_gemm: gpu.kernel("w4a16", "w4a16_gemm")?,
             w4a16_gemm_t_m128_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t_m128"),
             w4a16_gemm_t_m128_v2_k: super::try_kernel(gpu, "w4a16_v2", "w4a16_gemm_t_m128_v2"),
@@ -1090,6 +1093,75 @@ impl DenseFfnLayer {
             gate_out,
             &self.weights.down_proj,
             output,
+            h,
+            inter,
+            stream,
+        )?;
+
+        Ok(())
+    }
+
+    /// Whether the K=4 batched-GEMV verify path is available (batch4 kernel
+    /// present AND NVFP4 weights loaded — the batchm GEMV reads the
+    /// non-transposed NVFP4 layout).
+    pub fn can_forward_k4(&self) -> bool {
+        self.w4a16_gemv_batch4.0 != 0 && !self.weights.gate_proj.weight.is_null()
+    }
+
+    /// K=4 speculative verify: batched GEMV for 4 tokens.
+    /// 4 launches: batch4 gate + batch4 up + silu_mul + batch4 down — each
+    /// projection weight is read ONCE for all 4 rows at near-peak stream
+    /// bandwidth. nsys (2026-07-18): the `forward_prefill` MMQ arm this
+    /// replaces for the K=4 verify cost 54.8 ms/step across the 64-layer
+    /// dense FFN stack (~156 GB/s effective at M=4); the batch GEMV family
+    /// measures ~290 GB/s on the same shapes (w8a16_gemv_batch4 sibling),
+    /// putting this path at the ~31 ms weight-traffic floor.
+    pub fn forward_k4(&self, input: DevicePtr, ctx: &ForwardContext, stream: u64) -> Result<()> {
+        let h = ctx.config.hidden_size as u32;
+        let inter = ctx.config.intermediate_size as u32;
+
+        let gate_out = ctx.buffers.expert_gate_out();
+        let up_out = ctx.buffers.expert_up_out();
+
+        ops::w4a16_gemv_batchm(
+            ctx.gpu,
+            self.w4a16_gemv_batch4,
+            input,
+            &self.weights.gate_proj,
+            gate_out,
+            4,
+            inter,
+            h,
+            stream,
+        )?;
+        ops::w4a16_gemv_batchm(
+            ctx.gpu,
+            self.w4a16_gemv_batch4,
+            input,
+            &self.weights.up_proj,
+            up_out,
+            4,
+            inter,
+            h,
+            stream,
+        )?;
+        ops::silu_mul(
+            ctx.gpu,
+            self.act_mul,
+            gate_out,
+            up_out,
+            gate_out,
+            4 * inter,
+            stream,
+        )?;
+        let output = ctx.buffers.moe_output();
+        ops::w4a16_gemv_batchm(
+            ctx.gpu,
+            self.w4a16_gemv_batch4,
+            gate_out,
+            &self.weights.down_proj,
+            output,
+            4,
             h,
             inter,
             stream,

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -109,6 +109,24 @@ impl FfnComponent {
         }
     }
 
+    /// K=4 verify FFN via batched GEMV (dense only). Returns `false` when the
+    /// path is unavailable (MoE / missing batch4 kernel / non-NVFP4 weights)
+    /// so the caller can fall back to `forward_prefill`.
+    pub fn try_forward_k4(
+        &self,
+        input: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<bool> {
+        match self {
+            Self::Dense(d) if d.can_forward_k4() => {
+                d.forward_k4(input, ctx, stream)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     pub fn forward_prefill(
         &self,
         input: DevicePtr,

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -21,7 +21,7 @@ pub use dflash_head::{
     BlockDiffusionDraftHead, DflashLayer, DflashProposerState, DflashQuantization,
 };
 pub use moe::MoeLayer;
-pub use mtp_head::{MtpHead, MtpQuantization};
+pub use mtp_head::{MtpHead, MtpQuantization, mtp_drafter_prefill_enabled};
 pub use nemotron_mamba2::NemotronMamba2Layer;
 pub use nemotron_moe::NemotronMoeLayer;
 pub use qwen3_attention::Qwen3AttentionLayer;

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -24,6 +24,42 @@ use crate::weight_map::{
     DenseWeight, Fp8DenseWeight, Fp8Weight, QuantizedWeight, quantize_to_fp8, quantize_to_nvfp4,
 };
 
+/// ATLAS_MTP_DRAFTER_PREFILL=1 — opt-in drafter context prefill (cached once).
+///
+/// When set, the target prefill captures every position's final-layer hidden
+/// and the MTP drafter's KV cache is batch-prefilled over the whole prompt
+/// before the first propose(), mirroring vLLM's MTP proposer prefill. The
+/// drafter's KV entries are pure functions of its input pair
+/// `(embed(token_{i+1}), target_hidden_i)` — a single-layer drafter's K/V do
+/// not depend on its own attention outputs — so the prefill needs only the
+/// fc + k/v projections + norms + RoPE + cache write, no attention pass.
+pub fn mtp_drafter_prefill_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_MTP_DRAFTER_PREFILL").ok().as_deref() == Some("1"))
+}
+
+/// Dedicated scratch for the batched drafter prefill (allocated in
+/// `MtpHead::new` only when [`mtp_drafter_prefill_enabled`]). All buffers are
+/// sized for [`prefill::PREFILL_CHUNK`] rows; dedicated (not aliased onto the
+/// shared arena) so the pass has no aliasing hazards against target buffers.
+pub(crate) struct MtpPrefillScratch {
+    pub embed: DevicePtr,
+    pub normed_embed: DevicePtr,
+    pub normed_hidden: DevicePtr,
+    pub concat: DevicePtr,
+    pub fc_out: DevicePtr,
+    pub normed2: DevicePtr,
+    pub k_out: DevicePtr,
+    pub v_out: DevicePtr,
+    /// RoPE rotates Q and K in one launch; prefill discards Q, but the kernel
+    /// still needs a writable [chunk, nq*hd] region.
+    pub q_scratch: DevicePtr,
+    /// u32 RoPE positions, one per row.
+    pub pos_dev: DevicePtr,
+    /// i64 KV slot mapping, one per row.
+    pub slot_dev: DevicePtr,
+}
+
 /// MTP head weight precision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MtpQuantization {
@@ -157,6 +193,10 @@ pub struct MtpHead {
     moe_topk_k: Option<KernelHandle>,
     moe_silu_mul_k: Option<KernelHandle>,
     moe_weighted_sum_blend_k: Option<KernelHandle>,
+    /// Batched BF16 GEMM for the drafter-prefill pass (0 when absent).
+    dense_gemm_k: KernelHandle,
+    /// Drafter-prefill scratch; `None` unless ATLAS_MTP_DRAFTER_PREFILL=1.
+    prefill_scratch: Option<MtpPrefillScratch>,
 }
 
 impl MtpHead {
@@ -243,6 +283,7 @@ impl MtpHead {
 mod forward;
 mod moe_forward;
 mod new;
+mod prefill;
 
 impl DraftProposer for MtpHead {
     fn alloc_state(&self, _gpu: &dyn GpuBackend) -> Result<Box<dyn ProposerState>> {
@@ -318,6 +359,17 @@ impl DraftProposer for MtpHead {
 
         mtp_state.last_num_drafted = drafts.len();
         Ok(drafts)
+    }
+
+    fn prefill_drafter(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        self.prefill_drafter_impl(prompt_tokens, hiddens, state, ctx, stream)
     }
 
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -286,6 +286,30 @@ impl MtpHead {
             lm = (effective_vocab * h / 2) as f64 / (1024.0 * 1024.0),
         );
 
+        // ATLAS_MTP_DRAFTER_PREFILL: dedicated batched-prefill scratch
+        // (~50 MB at h=5120/nq=32/hd=256, PREFILL_CHUNK=512 rows). Dedicated
+        // rather than aliased onto the shared arena so the pass has zero
+        // aliasing hazards; allocated only when the env is set (PCND).
+        let prefill_scratch = if super::mtp_drafter_prefill_enabled() {
+            let c = super::prefill::PREFILL_CHUNK;
+            let bf16 = 2usize;
+            Some(super::MtpPrefillScratch {
+                embed: gpu.alloc(c * h * bf16)?,
+                normed_embed: gpu.alloc(c * h * bf16)?,
+                normed_hidden: gpu.alloc(c * h * bf16)?,
+                concat: gpu.alloc(c * 2 * h * bf16)?,
+                fc_out: gpu.alloc(c * h * bf16)?,
+                normed2: gpu.alloc(c * h * bf16)?,
+                k_out: gpu.alloc(c * nkv * hd * bf16)?,
+                v_out: gpu.alloc(c * nkv * hd * bf16)?,
+                q_scratch: gpu.alloc(c * nq * hd * bf16)?,
+                pos_dev: gpu.alloc(c * 4)?,
+                slot_dev: gpu.alloc(c * 8)?,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             pre_fc_norm_embedding: weights.pre_fc_norm_embedding,
             pre_fc_norm_hidden: weights.pre_fc_norm_hidden,
@@ -342,6 +366,10 @@ impl MtpHead {
             moe_topk_k,
             moe_silu_mul_k,
             moe_weighted_sum_blend_k,
+            // Batched BF16 GEMM for drafter prefill; 0-handle when the
+            // target's kernel set lacks it (prefill then no-ops).
+            dense_gemm_k: crate::layers::try_kernel(gpu, "gemm", "dense_gemm_bf16"),
+            prefill_scratch,
         })
     }
 }

--- a/crates/spark-model/src/layers/mtp_head/prefill.rs
+++ b/crates/spark-model/src/layers/mtp_head/prefill.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched MTP drafter context prefill (ATLAS_MTP_DRAFTER_PREFILL).
+//!
+//! Why this exists: without it the drafter's KV cache starts EMPTY at decode —
+//! the drafter is blind to the prompt through its own attention, and measured
+//! per-position acceptance DEGRADES with context (pos0 77→73%, pos1 45→40% at
+//! 50→2449-token prompts) while vLLM's prompt-prefilled MTP drafter IMPROVES
+//! (83→91% pos0). This pass writes one drafter KV entry per prompt position
+//! before the first propose(), mirroring vLLM's proposer prefill.
+//!
+//! Key structural fact that keeps this cheap: the drafter is a SINGLE decoder
+//! layer, so its K/V at position i are pure functions of its input pair
+//! `x_i = fc(concat(norm(embed(t_{i+1})), norm(target_hidden_i)))` — they do
+//! not depend on the drafter's own attention outputs. The prefill therefore
+//! needs NO attention pass: embed-gather → norms → concat → fc →
+//! input_layernorm → k/v projections → k_norm → RoPE → reshape_and_cache,
+//! all batched over [`PREFILL_CHUNK`]-row chunks with existing kernels.
+//!
+//! Row/position convention (matches `forward_one` exactly): drafter row i
+//! pairs `embed(t_{i+1})` with `hidden_i`, RoPE position `i+1`, KV slot `i`,
+//! for i = 0..P-2. The first decode propose() then appends
+//! `(first_sampled_token, hidden_{P-1})` at position P, slot P-1 — gapless.
+//!
+//! v1 scope (explicit): BF16 MTP head (`--mtp-quantization bf16`, the
+//! recommended/highest-acceptance config) with BF16 drafter KV. Other quants
+//! warn once and no-op — propose() then behaves exactly as before.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::{MtpHead, MtpProposerState, ProjectionWeight};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::speculative::ProposerState;
+
+/// Rows processed per batched pass. Sizes the dedicated scratch (~50 MB at
+/// h=5120 / nq=32 / hd=256); one full weight read per chunk per projection.
+pub(crate) const PREFILL_CHUNK: usize = 512;
+
+impl MtpHead {
+    /// Batch-prefill the drafter KV over `prompt_tokens` using per-position
+    /// target hiddens. Returns rows written (P-1), or 0 when unsupported /
+    /// already prefilled. See module docs for the exact row convention.
+    pub(crate) fn prefill_drafter_impl(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        let mtp_state = match state.as_any_mut().downcast_mut::<MtpProposerState>() {
+            Some(s) => s,
+            None => return Ok(0),
+        };
+        // Only a fresh drafter (nothing proposed yet) can be prefilled; a
+        // non-zero seq_len means decode already started (or prefill ran).
+        if mtp_state.seq_len != 0 || prompt_tokens.len() < 2 {
+            return Ok(0);
+        }
+        let scratch = match self.prefill_scratch.as_ref() {
+            Some(s) => s,
+            None => return Ok(0),
+        };
+        // v1: BF16 head + BF16 drafter KV only (see module docs).
+        let (fc_w, k_w, v_w) = match (&self.fc, &self.k_proj, &self.v_proj) {
+            (
+                ProjectionWeight::Bf16(fc),
+                ProjectionWeight::Bf16(k),
+                ProjectionWeight::Bf16(v),
+            ) if self.kv_bf16 && self.dense_gemm_k.0 != 0 => (fc, k, v),
+            _ => {
+                static WARNED: std::sync::Once = std::sync::Once::new();
+                WARNED.call_once(|| {
+                    tracing::warn!(
+                        "ATLAS_MTP_DRAFTER_PREFILL: drafter prefill supports the BF16 \
+                         MTP head (--mtp-quantization bf16) with BF16 KV only; \
+                         continuing WITHOUT drafter context prefill."
+                    );
+                });
+                return Ok(0);
+            }
+        };
+
+        let t0 = std::time::Instant::now();
+        let h = ctx.config.hidden_size;
+        let nq = ctx.config.num_attention_heads as u32;
+        let nkv = ctx.config.num_key_value_heads as u32;
+        let hd = ctx.config.head_dim as u32;
+        let eps = ctx.config.rms_norm_eps as f32;
+        let kv_dim = (nkv * hd) as usize;
+        let bf16 = 2usize;
+        let rows_total = prompt_tokens.len() - 1; // pairs (t_{i+1}, h_i), i=0..P-2
+
+        // Grow the drafter block table to cover all prefill slots up front.
+        let mut kv_cache = self.kv_cache.lock();
+        let bs = kv_cache.block_size();
+        let blocks_needed = (rows_total - 1) / bs + 1;
+        while mtp_state.block_table.len() < blocks_needed {
+            mtp_state.block_table.push(kv_cache.alloc_block()?);
+        }
+
+        let mut done = 0usize;
+        while done < rows_total {
+            let c = (rows_total - done).min(PREFILL_CHUNK);
+
+            // 1. Gather embeddings of t_{i+1} for rows done..done+c.
+            for r in 0..c {
+                let tok = prompt_tokens[done + r + 1] as usize;
+                self_copy_embed_row(self, ctx, tok, scratch.embed, r, h, stream)?;
+            }
+
+            // 2. Pre-fc norms: embedding rows and target-hidden rows.
+            ops::rms_norm(
+                ctx.gpu,
+                self.rms_norm_k,
+                scratch.embed,
+                &self.pre_fc_norm_embedding,
+                scratch.normed_embed,
+                c as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+            ops::rms_norm(
+                ctx.gpu,
+                self.rms_norm_k,
+                hiddens.offset(done * h * bf16),
+                &self.pre_fc_norm_hidden,
+                scratch.normed_hidden,
+                c as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+
+            // 3. Per-row concat [normed_embed | normed_hidden] → [c, 2h].
+            for r in 0..c {
+                ops::bf16_concat(
+                    ctx.gpu,
+                    self.bf16_concat_k,
+                    scratch.normed_embed.offset(r * h * bf16),
+                    scratch.normed_hidden.offset(r * h * bf16),
+                    scratch.concat.offset(r * 2 * h * bf16),
+                    h as u32,
+                    stream,
+                )?;
+            }
+
+            // 4. fc: [c, 2h] → [c, h], then input layernorm.
+            ops::dense_gemm(
+                ctx.gpu,
+                self.dense_gemm_k,
+                scratch.concat,
+                fc_w,
+                scratch.fc_out,
+                c as u32,
+                h as u32,
+                (2 * h) as u32,
+                stream,
+            )?;
+            ops::rms_norm(
+                ctx.gpu,
+                self.rms_norm_k,
+                scratch.fc_out,
+                &self.input_layernorm,
+                scratch.normed2,
+                c as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+
+            // 5. K/V projections (Q is not needed — outputs are discarded).
+            ops::dense_gemm(
+                ctx.gpu,
+                self.dense_gemm_k,
+                scratch.normed2,
+                k_w,
+                scratch.k_out,
+                c as u32,
+                nkv * hd,
+                h as u32,
+                stream,
+            )?;
+            ops::dense_gemm(
+                ctx.gpu,
+                self.dense_gemm_k,
+                scratch.normed2,
+                v_w,
+                scratch.v_out,
+                c as u32,
+                nkv * hd,
+                h as u32,
+                stream,
+            )?;
+            if !self.k_norm.weight.is_null() {
+                ops::rms_norm(
+                    ctx.gpu,
+                    self.rms_norm_k,
+                    scratch.k_out,
+                    &self.k_norm,
+                    scratch.k_out,
+                    c as u32 * nkv,
+                    hd,
+                    eps,
+                    stream,
+                )?;
+            }
+
+            // 6. RoPE positions i+1 and KV slots i, uploaded per chunk.
+            let positions: Vec<u32> = (0..c).map(|r| (done + r + 1) as u32).collect();
+            let pos_bytes = unsafe {
+                std::slice::from_raw_parts(positions.as_ptr() as *const u8, c * 4)
+            };
+            ctx.gpu.copy_h2d_async(pos_bytes, scratch.pos_dev, stream)?;
+            let slots: Vec<i64> = (0..c)
+                .map(|r| {
+                    let i = done + r;
+                    (mtp_state.block_table[i / bs] as i64) * (bs as i64) + (i % bs) as i64
+                })
+                .collect();
+            let slot_bytes = unsafe {
+                std::slice::from_raw_parts(slots.as_ptr() as *const u8, c * 8)
+            };
+            ctx.gpu.copy_h2d_async(slot_bytes, scratch.slot_dev, stream)?;
+
+            ops::rope(
+                ctx.gpu,
+                self.rope_k,
+                scratch.q_scratch,
+                scratch.k_out,
+                scratch.pos_dev,
+                c as u32,
+                nq,
+                nkv,
+                hd,
+                ctx.config.rotary_dim() as u32,
+                ctx.config.rope_theta as f32,
+                stream,
+            )?;
+
+            // 7. Write K/V into the drafter's paged BF16 cache.
+            ops::reshape_and_cache(
+                ctx.gpu,
+                self.reshape_cache_k,
+                scratch.k_out,
+                scratch.v_out,
+                kv_cache.k_pool_ptr(self.attn_layer_idx),
+                kv_cache.v_pool_ptr(self.attn_layer_idx),
+                scratch.slot_dev,
+                c as u32,
+                nkv,
+                hd,
+                bs as u32,
+                kv_dim as u32,
+                kv_dim as u32,
+                kv_cache.cache_stride() as u64,
+                stream,
+            )?;
+            // The async H2D sources (positions/slots) are Vec-backed; the
+            // driver has queued them, but sync before drop for safety —
+            // one sync per 512-row chunk is negligible next to the GEMMs.
+            ctx.gpu.synchronize(stream)?;
+
+            done += c;
+        }
+
+        mtp_state.seq_len = rows_total;
+        tracing::info!(
+            "MTP drafter prefill: {} positions ({} prompt tokens) in {:.1} ms",
+            rows_total,
+            prompt_tokens.len(),
+            t0.elapsed().as_secs_f64() * 1e3,
+        );
+        Ok(rows_total)
+    }
+}
+
+/// Copy one embedding-table row into `dst` row `r`. Free function to keep the
+/// borrow of `self` fields inside the loop simple.
+fn self_copy_embed_row(
+    head: &MtpHead,
+    ctx: &ForwardContext,
+    token: usize,
+    dst: DevicePtr,
+    r: usize,
+    h: usize,
+    stream: u64,
+) -> Result<()> {
+    let row_bytes = h * 2;
+    let src = head.embed_tokens.weight.offset(token * row_bytes);
+    ctx.gpu.copy_d2d_async(src, dst.offset(r * row_bytes), row_bytes, stream)
+}

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -409,6 +409,7 @@ impl Qwen3AttentionLayer {
             w4a16_gemv_qg_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_qg_batch3")?,
             w4a16_gemv_dual_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
             w4a16_gemv_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,
+            w4a16_gemv_batch4_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
             w4a16_gemm_k: gpu.kernel("w4a16", "w4a16_gemm")?,
             w4a16_gemm_t_k: gpu.kernel("w4a16", "w4a16_gemm_t")?,
             w4a16_gemm_t_k64_k: gpu.kernel("w4a16", "w4a16_gemm_t_k64")?,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
@@ -442,6 +442,25 @@ impl Qwen3AttentionLayer {
     ) -> Result<()> {
         let gpu = c.fwd.gpu;
         let stream = c.stream;
+        // K=4 MTP verify (M<=4): the M<=4 batched GEMV reads the
+        // non-transposed weight ONCE for all rows at near-peak stream
+        // bandwidth. nsys (2026-07-18, drafts=3): the M64-tile w4a16_gemm_t
+        // this bypasses cost 16.3 ms/verify-step across the 16 attention
+        // layers' q/k/v/o at M=4 (94% tile padding) vs ~4.5 ms via the GEMV.
+        // Gated to m<=4 so the DFlash wide verify (M=17) keeps the GEMM.
+        if m <= 4 && self.w4a16_gemv_batch4_k.0 != 0 {
+            return ops::w4a16_gemv_batchm(
+                gpu,
+                self.w4a16_gemv_batch4_k,
+                input,
+                w_base,
+                output,
+                m,
+                n,
+                k,
+                stream,
+            );
+        }
         if let Some(wt) = w_t {
             // Small-M routing (w4a16_m17_bench): at M<=64 the M64-tile
             // `w4a16_gemm_t` beats the M128-tile kernels (87% of an M128

--- a/crates/spark-model/src/layers/qwen3_attention/types.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types.rs
@@ -225,6 +225,8 @@ pub struct Qwen3AttentionLayer {
     pub(super) w4a16_gemv_qg_batch3_k: KernelHandle,
     pub(super) w4a16_gemv_dual_batch3_k: KernelHandle,
     pub(super) w4a16_gemv_batch3_k: KernelHandle,
+    /// M<=4 batched GEMV (K=4 verify q/k/v/o); 0-handle when absent.
+    pub(super) w4a16_gemv_batch4_k: KernelHandle,
     // Kernels — prefill (GEMM M=N + Flash Attention)
     pub(super) w4a16_gemm_k: KernelHandle,
     pub(super) w4a16_gemm_t_k: KernelHandle,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -94,7 +94,17 @@ impl Qwen3SsmLayer {
         // verify — 2026-07-02 flagship gate). Mirrors the M<=4 dispatch in
         // trait_decode_multi_seq/ssm_batched.rs: one weight pass via
         // `w8a16_gemv_batch4`, per-token `w8a16_gemv` when it isn't linked.
-        if (num_tokens == 2 || num_tokens == 3)
+        // 2..=4: the K=4 verify (num_drafts=3) hits this same NULL-slot
+        // hazard — on native-FP8-GDN checkpoints (e.g. nvidia/Qwen3.6-27B-
+        // NVFP4, whose GDN layers ship FP8) `in_proj_qkvz`/`qkvz_nvfp4*` are
+        // NULL and `qkvz_fp8w` is the only live weight. The old `== 2 || == 3`
+        // guard let num_tokens=4 fall through to `dense_gemm` on the NULL
+        // dense slot → CUDA_ERROR_ILLEGAL_ADDRESS on the first K=4 verify
+        // (localized via ATLAS_K4_DIAG, 2026-07-18). `w8a16_gemv_batch4`
+        // is built for M<=4 (see w8a16_gemv_batch4.cu), so widening the
+        // guard is sufficient; the per-token `w8a16_gemv` fallback already
+        // loops over num_tokens.
+        if (2..=4).contains(&num_tokens)
             && let Some(ref fp8) = self.qkvz_fp8w
         {
             if self.w8a16_gemv_batch4_k.0 != 0 {
@@ -437,9 +447,13 @@ impl Qwen3SsmLayer {
                 value_dim as u32,
                 stream,
             )?;
-        } else if (num_tokens == 2 || num_tokens == 3)
+        } else if (2..=4).contains(&num_tokens)
             && let Some(ref fp8) = self.out_proj_fp8w
         {
+            // 2..=4: same K=4 NULL-slot hazard as the QKVZ dispatch above —
+            // on native-FP8-GDN checkpoints `ssm.out_proj` is NULL and
+            // `out_proj_fp8w` is the only live weight; the old guard sent
+            // num_tokens=4 to `w4a16_gemm` on the NULL slot.
             // Native-FP8 build: `ssm.out_proj` is a NULL QuantizedWeight —
             // the block-scaled FP8 copy (`out_proj_fp8w`) is the only live
             // weight. Same NULL-deref hazard as the QKVZ dispatch above.

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -4,6 +4,23 @@
 
 use super::*;
 
+/// ATLAS_K4_DIAG=1 phase checkpoint (see verify_c2.rs). Synchronizes the
+/// stream after a named phase of the batched GDN decode so an illegal access
+/// is attributed to the exact op. No-op (and no env read past the first call)
+/// unless the diagnostic env is set. Only legal in eager mode — verify_c2
+/// disables CUDA-graph capture whenever the env is set, and this checkpoint
+/// is only reachable from that eager path.
+fn k4_diag_checkpoint(ctx: &ForwardContext, phase: &str, stream: u64) -> Result<()> {
+    static DIAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let on = *DIAG.get_or_init(|| std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1"));
+    if on && !ctx.graph_capture
+        && let Err(e) = ctx.gpu.synchronize(stream)
+    {
+        anyhow::bail!("K4_DIAG: CUDA error after GDN phase `{phase}`: {e:#}");
+    }
+    Ok(())
+}
+
 impl Qwen3SsmLayer {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn decode_batched_inner(
@@ -57,6 +74,8 @@ impl Qwen3SsmLayer {
             eps,
             stream,
         )?;
+
+        k4_diag_checkpoint(ctx, "1:rms_norm_residual", stream)?;
 
         // ── 2+3. QKVZ projection (+ deinterleave if needed) ──
         // For sequential_qkvz (Qwen3.5): write directly to deinterleaved buffer.
@@ -261,6 +280,8 @@ impl Qwen3SsmLayer {
             }
         }
 
+        k4_diag_checkpoint(ctx, "2+3:qkvz_proj+deinterleave", stream)?;
+
         // ── 4. BA projection + GDN gates per token ──
         // BA output: ssm_ba buffer; gates: ssm_gates buffer [K, nv*2] FP32
         // Layout per token: [gate(nv), beta(nv)] → stride = 2*nv FP32 elements.
@@ -301,6 +322,8 @@ impl Qwen3SsmLayer {
                 stream,
             )?;
         }
+
+        k4_diag_checkpoint(ctx, "4:ba_proj+gates", stream)?;
 
         // ── 5-7. Conv1d + L2 norm + GDN per token (with intermediate checkpoints) ──
         // Reuse ssm_qkvz buffer for conv output (safe: deinterleave is done)
@@ -354,6 +377,8 @@ impl Qwen3SsmLayer {
         };
         self.decode_batched_conv_gdn(ssm_state, ctx, &args)?;
 
+        k4_diag_checkpoint(ctx, "5-7:conv1d+l2norm+gdn_wy", stream)?;
+
         // ── 8. Gated RMS norm per token (Z gate at [Q|K|V] offset) ──
         let normed_out_buf = conv_out_buf;
         let z_offset = key_dim * 2 + value_dim; // == conv_dim
@@ -395,6 +420,8 @@ impl Qwen3SsmLayer {
                 )?;
             }
         }
+
+        k4_diag_checkpoint(ctx, "8:gated_rms_norm", stream)?;
 
         // ── 9. Output projection → [K, H] ──
         let out_proj_buf = ctx.buffers.moe_output(); // [K, H] BF16
@@ -537,6 +564,8 @@ impl Qwen3SsmLayer {
         // ranks (num_tokens × h BF16) before the residual add. No-op at tp=1.
         self.ssm_tp_all_reduce(out_proj_buf, num_tokens, ctx, stream)?;
 
+        k4_diag_checkpoint(ctx, "9:out_proj", stream)?;
+
         // ── 10. Batched residual + post-norm, then MoE + residual ──
         // residual_add_rms_norm supports multi-token (grid.x = num_tokens)
         let normed2_base = ctx.buffers.norm_output();
@@ -589,8 +618,10 @@ impl Qwen3SsmLayer {
             // DENSE ONLY: the per-token `else` below is retained for 256-expert
             // MoE, where grouped-GEMM is a net loss at small batch (per-expert
             // M~1 + sort/permute overhead across the 36-layer SSM stack).
+            k4_diag_checkpoint(ctx, "10a:residual_add_rms_norm", stream)?;
             self.ffn
                 .forward_prefill(normed2_base, num_tokens, ctx, stream)?;
+            k4_diag_checkpoint(ctx, "10b:ffn_forward_prefill", stream)?;
             let moe_out = ctx.buffers.moe_output();
             ops::residual_add(
                 ctx.gpu,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -621,6 +621,28 @@ impl Qwen3SsmLayer {
                 (2 * h) as u32,
                 stream,
             )?;
+        } else if num_tokens == 4
+            && self
+                .ffn
+                .try_forward_k4(normed2_base, ctx, stream)
+                .inspect_err(|e| tracing::error!("ffn.try_forward_k4: {e:#}"))
+                .unwrap_or(false)
+        {
+            // K=4 verify FFN via M<=4 batched GEMV: one weight read per
+            // projection for all 4 rows at near-peak stream bandwidth. nsys
+            // (2026-07-18): the forward_prefill MMQ arm below cost 54.8 ms/
+            // verify-step across the 64-layer dense FFN stack at M=4 vs the
+            // ~31 ms weight-traffic floor this path hits. Falls through to
+            // forward_prefill when unavailable (MoE / missing kernel).
+            let moe_out = ctx.buffers.moe_output();
+            ops::residual_add(
+                ctx.gpu,
+                self.residual_add_k,
+                hidden,
+                moe_out,
+                (num_tokens * h) as u32,
+                stream,
+            )?;
         } else if self.ffn.is_dense() {
             // WIDE-VERIFY BATCHED DENSE FFN (DFlash γ=16, num_tokens=17). This
             // is the MAJORITY layer type (GDN/SSM) on the hybrid 27B, so its

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -241,6 +241,26 @@ impl TransformerModel {
         // MTP hidden state save buffer (1 × hidden_size FP32)
         let mtp_hidden_save = gpu.alloc(config.hidden_size * 4)?;
 
+        // ATLAS_MTP_DRAFTER_PREFILL: whole-prompt hidden capture buffer,
+        // [max_seq_len, hidden_size] BF16 — 335 MB at 32k/h=5120. Explicitly
+        // opt-in (PCND): NULL (and zero cost) unless the env is set and MTP
+        // is active. Sized to max_seq_len so an 8k+ prompt capture holds.
+        let mtp_prefill_hidden = if has_mtp
+            && crate::layers::mtp_drafter_prefill_enabled()
+        {
+            let bytes = max_seq_len * config.hidden_size * 2;
+            tracing::info!(
+                "ATLAS_MTP_DRAFTER_PREFILL=1: allocating {:.0} MB prompt-hidden \
+                 capture ({} x {} BF16) for MTP drafter prefill",
+                bytes as f64 / 1e6,
+                max_seq_len,
+                config.hidden_size,
+            );
+            gpu.alloc(bytes)?
+        } else {
+            DevicePtr::NULL
+        };
+
         // DFlash 5-layer hidden-state stack. Allocated only when a
         // BlockDiffusionDraftHead is the active proposer (`config.dflash_capture_layers`
         // populated by the loader from the drafter's `dflash_config.target_layer_ids`).
@@ -494,6 +514,13 @@ impl TransformerModel {
             profile_first_pending: std::sync::atomic::AtomicBool::new(profile_first),
             proposer,
             mtp_hidden_save,
+            mtp_prefill_hidden,
+            mtp_prefill_capacity: if mtp_prefill_hidden.is_null() {
+                0
+            } else {
+                max_seq_len
+            },
+            mtp_prefill_capture_len: std::sync::atomic::AtomicUsize::new(0),
             dflash_hidden_save,
             dflash_hidden_save_rows,
             dflash_capture_layers,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -78,6 +78,10 @@ impl TransformerModel {
         let w4a16_gemv_logits_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_logits")?;
         let w4a16_gemm_kernel = gpu.kernel("w4a16", "w4a16_gemm")?;
         let w4a16_gemv_batch2_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?;
+        // M<=4 batched GEMV for the K=3/K=4 verify lm_head (try_kernel:
+        // 0-handle on targets that predate it; dispatch falls back).
+        let w4a16_gemv_batch4_kernel =
+            crate::layers::try_kernel(gpu.as_ref(), "w4a16_gemv", "w4a16_gemv_batch4");
         // FP8 E4M3 LUT GEMV for the `--lm-head-dtype fp8` head. Loaded
         // unconditionally (a handle is cheap); only invoked when `lm_head_fp8`
         // is set, so the NVFP4/BF16 paths never touch it.
@@ -482,6 +486,7 @@ impl TransformerModel {
             w4a16_gemv_logits_kernel,
             w4a16_gemm_kernel,
             w4a16_gemv_batch2_kernel,
+            w4a16_gemv_batch4_kernel,
             dense_gemv_fp8w_kernel,
             dense_gemv_fp8w_batch2_kernel,
             dense_gemm_kernel,

--- a/crates/spark-model/src/model/impl_a3.rs
+++ b/crates/spark-model/src/model/impl_a3.rs
@@ -155,6 +155,28 @@ impl TransformerModel {
                     stream,
                 )?;
             }
+        } else if (num_tokens == 3 || num_tokens == 4)
+            && self.w4a16_gemv_batch4_kernel.0 != 0
+            && let Some(ref nvfp4) = self.lm_head_nvfp4
+        {
+            // K=3/K=4 verify lm_head: one weight read for all rows via the
+            // M<=4 batched GEMV. nsys (2026-07-18, drafts=3 serve): the base
+            // M64-tile `w4a16_gemm` below cost 19.3 ms/verify-step on the
+            // [248320, 5120] NVFP4 lm_head at M=4 — 94% of the M-tile is
+            // padding, ~33 GB/s effective. The batch GEMV streams the same
+            // 636 MB once at near-peak (~2.5 ms), the single largest slice
+            // of the K=4 verify-vs-K=2 cost gap.
+            ops::w4a16_gemv_batchm(
+                self.gpu.as_ref(),
+                self.w4a16_gemv_batch4_kernel,
+                hidden,
+                nvfp4,
+                logits,
+                num_tokens,
+                v,
+                h,
+                stream,
+            )?;
         } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
             ops::w4a16_gemm(
                 self.gpu.as_ref(),

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -94,6 +94,28 @@ impl TransformerModel {
             .proposer_state
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("No proposer state for sequence"))?;
+        // ATLAS_MTP_DRAFTER_PREFILL: on the FIRST propose of a sequence,
+        // batch-prefill the drafter's KV over the prompt (fresh-state check
+        // and quant support live inside prefill_drafter; it fast-returns 0 on
+        // every later call). Requires the capture to cover the full prompt —
+        // partial capture (prefix-cache reuse / warm restore) skips cleanly.
+        if !self.mtp_prefill_hidden.is_null() {
+            let p = seq.prompt_len;
+            let captured = self
+                .mtp_prefill_capture_len
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if p >= 2 && captured >= p && seq.tokens.len() >= p {
+                if let Err(e) = proposer.prefill_drafter(
+                    &seq.tokens[..p],
+                    self.mtp_prefill_hidden,
+                    prop_state.as_mut(),
+                    &ctx,
+                    stream,
+                ) {
+                    tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
+                }
+            }
+        }
         proposer.propose(
             token,
             self.mtp_hidden_save,

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -127,6 +127,13 @@ impl TransformerModel {
         self.gpu.synchronize(stream)?;
         let has_mtp = self.proposer.is_some() || self.self_speculative;
 
+        // ATLAS_MTP_DRAFTER_PREFILL: a fresh sequence invalidates the
+        // whole-prompt hidden capture — without this, a warm-restored prefill
+        // (no chunks computed) would pair the NEW prompt's tokens with the
+        // PREVIOUS sequence's captured hiddens in the drafter prefill.
+        self.mtp_prefill_capture_len
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
         // Build layer states: SSM layers point into the pool (fixed addresses),
         // attention layers use their own alloc_state (EmptyLayerState).
         // When MTP is available, pre-allocate checkpoint + K=2 intermediate

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -479,6 +479,10 @@ impl TransformerModel {
             }
         }
 
+        // ATLAS_MTP_DRAFTER_PREFILL: capture the processed rows' final-layer
+        // hiddens for the whole-prompt drafter prefill. No-op when disabled.
+        self.try_mtp_prefill_capture(seq_len_start, proc_count, stream)?;
+
         // ── 5. Final norm on LAST token only ──
         let last_hidden = hidden.offset((proc_count - 1) * h * fp32);
         let normed = self.buffers.norm_output();

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -254,6 +254,9 @@ impl TransformerModel {
                 );
             }
         }
+        // ATLAS_MTP_DRAFTER_PREFILL: capture this chunk's final-layer hidden
+        // rows for the whole-prompt drafter prefill. No-op when disabled.
+        self.try_mtp_prefill_capture(effective_seq_len_start, proc_count, stream)?;
         if let Some(t0) = prefill_t0 {
             self.gpu.synchronize(stream)?;
             let total_us = t0.elapsed().as_micros();

--- a/crates/spark-model/src/model/trait_impl/speculative.rs
+++ b/crates/spark-model/src/model/trait_impl/speculative.rs
@@ -91,6 +91,48 @@ impl TransformerModel {
         TransformerModel::decode_draft(self, token, seq, stream)
     }
 
+    /// ATLAS_MTP_DRAFTER_PREFILL: copy this prefill chunk's final-layer
+    /// hiddens (`[proc_count, h]` BF16, contiguous at the head of the hidden
+    /// buffer) into the whole-prompt capture at row `chunk_start`.
+    ///
+    /// Contiguity-tracked: `chunk_start == 0` (re)starts the capture; a chunk
+    /// extending the current range appends; anything else (prefix-cache
+    /// reuse, Marconi warm restore — rows whose hiddens were never computed)
+    /// leaves the tracked length short, which safely disables the drafter
+    /// prefill for that sequence via the coverage check at the propose site.
+    pub(super) fn try_mtp_prefill_capture(
+        &self,
+        chunk_start: usize,
+        proc_count: usize,
+        stream: u64,
+    ) -> Result<()> {
+        if self.mtp_prefill_hidden.is_null() || proc_count == 0 {
+            return Ok(());
+        }
+        use std::sync::atomic::Ordering;
+        let len = self.mtp_prefill_capture_len.load(Ordering::Relaxed);
+        let new_len = if chunk_start == 0 {
+            proc_count
+        } else if chunk_start == len {
+            len + proc_count
+        } else {
+            return Ok(());
+        };
+        if chunk_start + proc_count > self.mtp_prefill_capacity {
+            return Ok(());
+        }
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        self.gpu.copy_d2d_async(
+            self.buffers.hidden_states(),
+            self.mtp_prefill_hidden.offset(chunk_start * h * bf16),
+            proc_count * h * bf16,
+            stream,
+        )?;
+        self.mtp_prefill_capture_len.store(new_len, Ordering::Relaxed);
+        Ok(())
+    }
+
     pub(super) fn save_hidden_for_mtp_dispatch(
         &self,
         token_idx: usize,

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -153,7 +153,14 @@ impl TransformerModel {
         let hss_engaged = kv_cache.config().cache_blocks_per_seq.is_some();
         // ATLAS_LORA_EAGER: LoRA graph-vs-eager debugging hatch (see decode_a).
         let lora_eager = self.lora.is_some() && crate::lora::lora_eager_env();
-        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager;
+        // ATLAS_K4_DIAG=1: run the K=4 verify EAGERLY (no CUDA graph) with a
+        // stream-synchronize checkpoint after every layer, so an illegal
+        // access is attributed to the exact layer instead of surfacing as an
+        // opaque status-700 on the post-graph D2H. Mirrors ATLAS_K2_DIAG on
+        // the K=2 path (verify_b.rs). Diagnostic only — default behavior is
+        // byte-for-byte unchanged when the env is unset.
+        let k4_diag = std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1");
+        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager && !k4_diag;
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -258,6 +265,15 @@ impl TransformerModel {
                 // silently. Must be inside the graph capture region.
                 // No-op when DFlash is disabled.
                 self.try_dflash_capture(layer_idx, k - 1, stream)?;
+
+                // ATLAS_K4_DIAG checkpoint: surface an illegal access at the
+                // layer that raised it (eager mode only — sync is illegal
+                // under graph capture, and use_graphs is false when k4_diag).
+                if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                    anyhow::bail!(
+                        "K4_DIAG: CUDA error after layer {layer_idx} ({layer_type:?}): {e:#}"
+                    );
+                }
             }
 
             // Final norm [4, H]
@@ -274,8 +290,16 @@ impl TransformerModel {
                 stream,
             )?;
 
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG: CUDA error after final norm: {e:#}");
+            }
+
             // LM head for 4 tokens
             self.lm_head_batched(normed, k as u32, self.buffers.logits(), stream)?;
+
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG: CUDA error after lm_head_batched: {e:#}");
+            }
 
             // Argmax inside graph
             let vocab = self.config.vocab_size;
@@ -291,6 +315,10 @@ impl TransformerModel {
                     vocab as u32,
                     stream,
                 )?;
+            }
+
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG: CUDA error after argmax: {e:#}");
             }
 
             if use_graphs {

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -128,6 +128,21 @@ pub struct TransformerModel {
     /// Size: hidden_size * 4 bytes (one FP32 vector). MTP overwrites shared
     /// buffers (norm_output etc.), so the target hidden must be saved here first.
     pub(super) mtp_hidden_save: DevicePtr,
+    /// ATLAS_MTP_DRAFTER_PREFILL: per-position final-layer hidden capture for
+    /// the whole prompt, `[max_seq_len, hidden_size]` BF16 (~335 MB at 32k /
+    /// h=5120). NULL unless the env is set AND an MTP proposer is built.
+    /// Filled contiguously by the prefill chunk epilogues; consumed once by
+    /// the drafter-prefill pass on the first propose() of a sequence.
+    pub(super) mtp_prefill_hidden: DevicePtr,
+    /// Row capacity of `mtp_prefill_hidden` (== max_seq_len at alloc; 0 when
+    /// the feature is off). SSOT for the capture bounds check.
+    pub(super) mtp_prefill_capacity: usize,
+    /// Rows of `mtp_prefill_hidden` captured contiguously from position 0 for
+    /// the CURRENT sequence. Reset to 0 on `alloc_sequence`; a chunk whose
+    /// start does not extend the contiguous range (prefix-cache reuse, warm
+    /// restore) leaves it stale-short, which safely disables drafter-prefill
+    /// for that sequence (coverage check at the propose site).
+    pub(super) mtp_prefill_capture_len: std::sync::atomic::AtomicUsize,
     /// DFlash 5-layer hidden-state stack. Allocated only when a
     /// `BlockDiffusionDraftHead` proposer is built. Layout:
     /// `[5 × hidden_size × bf16]` shallow-to-deep at the layer indices

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -68,6 +68,11 @@ pub struct TransformerModel {
     pub(super) w4a16_gemv_logits_kernel: KernelHandle, // FP32 output for LM head
     pub(super) w4a16_gemm_kernel: KernelHandle,
     pub(super) w4a16_gemv_batch2_kernel: KernelHandle,
+    /// Batched M<=4 NVFP4 GEMV for the K=3/K=4 verify lm_head (one weight
+    /// read for all rows; nsys 2026-07-18: the M64-tile `w4a16_gemm` at M=4
+    /// cost 19.3 ms/verify-step on the 248320-row lm_head — 94% tile padding).
+    /// 0-handle when the target lacks the kernel (dispatch falls back).
+    pub(super) w4a16_gemv_batch4_kernel: KernelHandle,
     /// FP8 E4M3 LUT GEMV (M=1) for the FP8 LM head. Only used when
     /// `lm_head_fp8.is_some()`; loaded unconditionally (cheap handle) so the
     /// dispatch in `lm_head` / batched-decode / verify can reference it.

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -64,6 +64,27 @@ pub trait DraftProposer: Send + Sync {
         target_hidden_stack: Option<DevicePtr>,
     ) -> Result<Vec<u32>>;
 
+    /// Prefill the drafter's own context (KV cache) over the prompt, before
+    /// the first `propose()` of a sequence (ATLAS_MTP_DRAFTER_PREFILL).
+    ///
+    /// * `prompt_tokens` — the prompt token ids `t_0..t_{P-1}`.
+    /// * `hiddens` — device buffer `[P, hidden_size]` BF16; row `i` is the
+    ///   target's final-layer (pre-final-norm) hidden after processing `t_i`.
+    ///
+    /// Returns the number of drafter positions written (0 = unsupported /
+    /// already prefilled / nothing to do). Default: no-op.
+    fn prefill_drafter(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        let _ = (prompt_tokens, hiddens, state, ctx, stream);
+        Ok(0)
+    }
+
     /// Read the draft token ID stored on GPU by the last `propose()` call
     /// that used `draft_embed_target = Some(...)`. Returns 0 if not supported.
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {

--- a/crates/spark-model/src/weight_map/loaders_moe.rs
+++ b/crates/spark-model/src/weight_map/loaders_moe.rs
@@ -200,7 +200,14 @@ pub(crate) fn load_mtp(
             Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
             // Bf16Raw fine-tunes already store .weight as BF16; no dequant needed.
             Nvfp4Variant::Bf16Raw => dense(store, name),
-            _ => dense(store, name),
+            // Standard & friends: usually BF16 on disk (dense_auto's BF16 arm
+            // returns the raw pointer, identical to `dense`), but checkpoints
+            // that quantize the MTP head too (e.g. centml modelopt W4A4:
+            // mtp.fc/*_proj as packed NVFP4 + weight_scale/_2) route through
+            // dense_auto's UInt8 arm for a one-time NVFP4->BF16 dequant.
+            // Feeding the packed U8 pointer to the BF16 GEMV read 4x past the
+            // allocation (cuMemsetD8Async status 700 on first decode).
+            _ => dense_auto(store, name, gpu),
         }
     };
 

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -320,6 +320,23 @@ pub(crate) fn dense_auto(
                 dequant_fp8_to_bf16(store, prefix, gpu)
             }
         }
+        WeightDtype::UInt8 => {
+            // 4-bit-packed NVFP4, 2 values/byte: on-disk shape is [n, k/2] U8.
+            // Quantized MTP heads (centml modelopt W4A4 exports) ship every
+            // mtp.* projection this way; dense GEMV/GEMM needs BF16, so
+            // dequant once at load via the shared modelopt-aware helper
+            // (weight + weight_scale + weight_scale_2).
+            let prefix = name
+                .strip_suffix(".weight")
+                .ok_or_else(|| anyhow::anyhow!("NVFP4 tensor {name} doesn't end with .weight"))?;
+            if w.shape.len() != 2 {
+                anyhow::bail!(
+                    "dense_auto: packed NVFP4 {name} must be 2-D, got {:?}",
+                    w.shape
+                );
+            }
+            crate::weight_map::dequant_nvfp4_to_bf16(store, prefix, w.shape[0], w.shape[1] * 2, gpu)
+        }
         other => anyhow::bail!("dense_auto: unsupported dtype {:?} for {name}", other),
     }
 }

--- a/crates/spark-runtime/src/fast_weights/header.rs
+++ b/crates/spark-runtime/src/fast_weights/header.rs
@@ -21,6 +21,10 @@ struct SafetensorsIndex {
 pub(super) struct TensorMeta {
     pub(super) name: String,
     pub(super) dtype: WeightDtype,
+    /// True when the shard stores this tensor as IEEE F16. The tensor is
+    /// staged as BF16 (`dtype` above) and the copy loop converts the bytes —
+    /// same 2-byte element size, different bit layout.
+    pub(super) from_f16: bool,
     pub(super) shape: Vec<usize>,
     /// Absolute byte offset in the file where the tensor bytes start.
     pub(super) abs_offset: u64,
@@ -115,19 +119,23 @@ pub(super) fn parse_header(file: &mut File) -> Result<Vec<TensorMeta>> {
             continue;
         }
         let dtype_str = info["dtype"].as_str().unwrap_or("BF16");
-        let dtype = match dtype_str {
-            "F32" => WeightDtype::FP32,
-            "BF16" => WeightDtype::BF16,
-            "U8" => WeightDtype::UInt8,
+        let (dtype, from_f16) = match dtype_str {
+            "F32" => (WeightDtype::FP32, false),
+            "BF16" => (WeightDtype::BF16, false),
+            // F16 is not store-legal (WeightDtype is closed to store dtypes):
+            // stage as BF16 and mark for byte conversion in the copy loop.
+            // centml modelopt W4A4 exports ship all unquantized tensors as F16.
+            "F16" => (WeightDtype::BF16, true),
+            "U8" => (WeightDtype::UInt8, false),
             // I8 is a 1-byte raw container; DeepSeek-V4-Flash-NVFP4 ships its MTP
             // experts' 4-bit-packed weights as I8 (vs U8 for the main layers).
             // Signedness is irrelevant for packed FP4 — the dequant kernel extracts
             // nibbles by bit ops — so treat I8 as raw bytes (UInt8), matching the
             // NVFP4 expert path.
-            "I8" => WeightDtype::UInt8,
-            "F8_E4M3" => WeightDtype::FP8E4M3,
-            "F8_E8M0" => WeightDtype::FP8E8M0,
-            "I64" => WeightDtype::Int64,
+            "I8" => (WeightDtype::UInt8, false),
+            "F8_E4M3" => (WeightDtype::FP8E4M3, false),
+            "F8_E8M0" => (WeightDtype::FP8E8M0, false),
+            "I64" => (WeightDtype::Int64, false),
             other => bail!("Unsupported safetensors dtype '{other}' for tensor {name}"),
         };
         let shape: Vec<usize> = info["shape"]
@@ -147,6 +155,7 @@ pub(super) fn parse_header(file: &mut File) -> Result<Vec<TensorMeta>> {
         out.push(TensorMeta {
             name: name.clone(),
             dtype,
+            from_f16,
             shape,
             abs_offset: data_start + rel_start,
             len,

--- a/crates/spark-runtime/src/fast_weights/mod.rs
+++ b/crates/spark-runtime/src/fast_weights/mod.rs
@@ -19,7 +19,7 @@
 use crate::gpu::GpuBackend;
 use crate::weights::{
     WeightLoader, WeightStore, WeightTensor, check_oom_guard, estimate_has_fp8,
-    estimate_load_bytes, evict_page_cache, parse_expert_index,
+    estimate_load_bytes, evict_page_cache, f16_to_bf16_bytes, parse_expert_index,
 };
 use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
@@ -339,7 +339,16 @@ fn load_shard_fast(
     for result in rx {
         let (idx, buf, slice_start) = result?;
         let meta = &tensors[idx];
-        let src = &buf.as_slice()[slice_start..slice_start + meta.len];
+        let raw = &buf.as_slice()[slice_start..slice_start + meta.len];
+        // F16 shards: convert bytes to BF16 before upload (same length,
+        // different bit layout — meta.dtype is already staged as BF16).
+        let converted: Vec<u8>;
+        let src: &[u8] = if meta.from_f16 {
+            converted = f16_to_bf16_bytes(raw);
+            &converted
+        } else {
+            raw
+        };
 
         let ptr = match gpu.alloc(meta.len) {
             Ok(p) => {

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -89,6 +89,25 @@ impl WeightDtype {
     }
 }
 
+/// Convert a little-endian IEEE-754 half-precision (F16) tensor byte buffer
+/// to BF16 bytes. F16 and BF16 are both 2 bytes/element but have different
+/// bit layouts (5-bit vs 8-bit exponent), so the bytes cannot be
+/// reinterpreted — each value goes f16 → f32 (exact) → bf16
+/// (round-to-nearest-even). Shared by both disk loaders so F16 checkpoints
+/// (e.g. centml modelopt W4A4 exports, which ship all unquantized tensors as
+/// F16) land in the store as BF16; [`WeightDtype`] itself stays closed to
+/// store-legal dtypes and F16 can never appear on the RDMA wire.
+pub(crate) fn f16_to_bf16_bytes(src: &[u8]) -> Vec<u8> {
+    use half::{bf16, f16};
+    debug_assert_eq!(src.len() % 2, 0, "F16 tensor byte length must be even");
+    let mut out = Vec::with_capacity(src.len());
+    for pair in src.chunks_exact(2) {
+        let h = f16::from_le_bytes([pair[0], pair[1]]);
+        out.extend_from_slice(&bf16::from_f32(h.to_f32()).to_le_bytes());
+    }
+    out
+}
+
 /// A weight tensor on the GPU.
 pub struct WeightTensor {
     pub ptr: DevicePtr,
@@ -285,7 +304,28 @@ mod from_str_tests {
                 "dtype {s}"
             );
         }
+        // F16 is converted to BF16 at disk-load; a store (and therefore a
+        // peer manifest) can never contain it, so the wire mapping rejects it.
         assert!(WeightDtype::from_safetensors_str("F16").is_err());
         assert!(WeightDtype::from_safetensors_str("bogus").is_err());
+    }
+
+    #[test]
+    fn f16_bytes_convert_to_bf16_via_f32() {
+        use half::{bf16, f16};
+        // Cover sign, exact powers of two, a value needing mantissa rounding
+        // (f16 has 10 mantissa bits, bf16 only 7), f16 max, and a subnormal.
+        let vals = [0.0f32, 1.0, -1.5, 0.1, 65504.0, -6.1035156e-5];
+        let src: Vec<u8> = vals
+            .iter()
+            .flat_map(|v| f16::from_f32(*v).to_le_bytes())
+            .collect();
+        let out = super::f16_to_bf16_bytes(&src);
+        assert_eq!(out.len(), src.len());
+        for (i, v) in vals.iter().enumerate() {
+            let got = bf16::from_le_bytes([out[2 * i], out[2 * i + 1]]);
+            let want = bf16::from_f32(f16::from_f32(*v).to_f32());
+            assert_eq!(got, want, "value {v}");
+        }
     }
 }

--- a/crates/spark-runtime/src/weights/loader/load_fns.rs
+++ b/crates/spark-runtime/src/weights/loader/load_fns.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::super::{WeightDtype, WeightTensor, evict_page_cache};
+use super::super::{WeightDtype, WeightTensor, evict_page_cache, f16_to_bf16_bytes};
 use super::{SafetensorsIndex, check_oom_guard, estimate_has_fp8, estimate_load_bytes};
 use crate::gpu::GpuBackend;
 
@@ -99,9 +99,16 @@ pub(super) fn load_sharded(
                 continue;
             }
             let view = tensors.tensor(name)?;
-            let dtype = WeightDtype::from_safetensors(view.dtype())?;
             let shape: Vec<usize> = view.shape().to_vec();
-            let data = view.data();
+            // F16 shards: convert bytes to BF16 before upload (same length,
+            // different bit layout). WeightDtype stays closed to store dtypes.
+            let converted: Vec<u8>;
+            let (data, dtype): (&[u8], _) = if view.dtype() == safetensors::Dtype::F16 {
+                converted = f16_to_bf16_bytes(view.data());
+                (&converted, WeightDtype::BF16)
+            } else {
+                (view.data(), WeightDtype::from_safetensors(view.dtype())?)
+            };
 
             // Try GPU alloc first; if OOM, fall back to managed (UVM) memory.
             // On GB10 unified memory, managed alloc uses Linux swap for overflow.
@@ -180,9 +187,15 @@ pub(super) fn load_single(
         if skip_fn(&name) {
             continue;
         }
-        let dtype = WeightDtype::from_safetensors(view.dtype())?;
         let shape: Vec<usize> = view.shape().to_vec();
-        let data = view.data();
+        // F16: convert to BF16 at load — see load_sharded above.
+        let converted: Vec<u8>;
+        let (data, dtype): (&[u8], _) = if view.dtype() == safetensors::Dtype::F16 {
+            converted = f16_to_bf16_bytes(view.data());
+            (&converted, WeightDtype::BF16)
+        } else {
+            (view.data(), WeightDtype::from_safetensors(view.dtype())?)
+        };
 
         let ptr = gpu.alloc(data.len())?;
         gpu.copy_h2d(data, ptr)?;

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -84,47 +84,53 @@ extern "C" __global__ void w4a16_gemv(
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
     __syncthreads();
 
-    float acc = 0.0f;
+    float acc0 = 0.0f, acc1 = 0.0f;
 
-    // Vectorized: process 16 K-values per iteration (2× uint4 activation + uint64 weight)
-    // One scale per GROUP_SIZE=16, so each iteration uses exactly 1 scale lookup.
-    for (unsigned int k16 = lane; k16 < K16; k16 += threads_per_out) {
-        const unsigned int base_k = k16 * 16;
+    // Vectorized: 16 K-values per chunk (2× uint4 activation + uint64 weight),
+    // TWO chunks in flight per iteration with independent accumulators. Keeping 2
+    // outstanding weight loads per thread hides DRAM latency (ncu: 72% of warp
+    // stalls are long-scoreboard on GB10). The FP8 group scale is factored out of
+    // the inner 16-FMA block (exact regroup: sum(s*w*a) == s*sum(w*a)).
+    const unsigned int stride2 = threads_per_out * 2u;
+    for (unsigned int k16 = lane * 2u; k16 < K16 + 1u; k16 += stride2) {
+        #pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const unsigned int kk = k16 + (unsigned int)c;
+            if (kk >= K16) break;
 
-        // Load 16 BF16 activations as 2× uint4 (256-bit total)
-        uint4 a_lo = ((const uint4*)A)[k16 * 2];
-        uint4 a_hi = ((const uint4*)A)[k16 * 2 + 1];
-        const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
-                                        a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+            // Load 16 BF16 activations as 2× uint4 (256-bit total)
+            uint4 a_lo = ((const uint4*)A)[kk * 2];
+            uint4 a_hi = ((const uint4*)A)[kk * 2 + 1];
+            const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
 
-        // Load 8 packed weight bytes as uint64 (16 FP4 values)
-        unsigned long long packed8 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + k16 * 8);
+            // Load 8 packed weight bytes as uint64 (16 FP4 values)
+            unsigned long long packed8 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk * 8);
 
-        // Load single FP8 scale — 16 values = exactly 1 group
-        unsigned int scale_group = base_k / GROUP_SIZE;
-        unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + scale_group];
-        __nv_fp8_e4m3 fp8;
-        *(unsigned char*)&fp8 = scale_byte;
+            // Load single FP8 scale — 16 values = exactly 1 group (group index == kk)
+            unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
 #if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-        float scale = scl_fp8(scale_byte) * scale2;
+            float scale = scl_fp8(scale_byte) * scale2;
 #else
-        float scale = (float)fp8 * scale2;
+            float scale = (float)fp8 * scale2;
 #endif
 
-        // Unpack 8 bytes × 2 nibbles = 16 weight values, FMA with activations
-        #pragma unroll
-        for (int b = 0; b < 8; b++) {
-            unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-            float w_lo = s_lut[byte_val & 0xF] * scale;
-            float w_hi = s_lut[byte_val >> 4] * scale;
-
-            __nv_bfloat16 a_lo_bf, a_hi_bf;
-            *(unsigned short*)&a_lo_bf = (unsigned short)(a_raw[b] & 0xFFFF);
-            *(unsigned short*)&a_hi_bf = (unsigned short)(a_raw[b] >> 16);
-            acc += __bfloat162float(a_lo_bf) * w_lo;
-            acc += __bfloat162float(a_hi_bf) * w_hi;
+            // Unpack 8 bytes × 2 nibbles = 16 weight values, FMA with activations
+            float part = 0.0f;
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+                part = fmaf(af.x, s_lut[byte_val & 0xF], part);
+                part = fmaf(af.y, s_lut[byte_val >> 4], part);
+            }
+            if (c == 0) acc0 = fmaf(scale, part, acc0);
+            else        acc1 = fmaf(scale, part, acc1);
         }
     }
+    float acc = acc0 + acc1;
 
     // Warp shuffle reduction within each group of 64 threads
     // First reduce within each warp (32 threads)

--- a/kernels/gb10/common/w4a16_gemv_fused.cu
+++ b/kernels/gb10/common/w4a16_gemv_fused.cu
@@ -76,48 +76,57 @@ extern "C" __global__ void w4a16_gemv_dual(
 
     const unsigned int half_K = K / 2;
     const unsigned int num_groups = K / GROUP_SIZE;
-    const unsigned int K8 = K / 8;
+    const unsigned int K16 = K / 16;
 
     __shared__ float s_lut[16];
     __shared__ float smem[N_PER_BLOCK * 2];
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_FUSED_W4[threadIdx.x];
     __syncthreads();
 
-    float acc = 0.0f;
+    float acc0 = 0.0f, acc1 = 0.0f;
 
-    for (unsigned int k8 = lane; k8 < K8; k8 += threads_per_out) {
-        const unsigned int base_k = k8 * 8;
+    // 16 K-values per chunk (uint64 weight load), TWO chunks in flight per
+    // iteration with independent accumulators — hides DRAM latency (ncu: 72% of
+    // warp stalls are long-scoreboard on GB10). Scale factored out of the inner
+    // block (exact regroup). Requires K % 16 == 0 (was K % 8).
+    const unsigned int stride2 = threads_per_out * 2u;
+    for (unsigned int k16 = lane * 2u; k16 < K16 + 1u; k16 += stride2) {
+        #pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const unsigned int kk = k16 + (unsigned int)c;
+            if (kk >= K16) break;
 
-        uint4 a_data = ((const uint4*)A)[k8];
-        const unsigned int a_raw[4] = {a_data.x, a_data.y, a_data.z, a_data.w};
+            uint4 a_lo4 = ((const uint4*)A)[kk * 2];
+            uint4 a_hi4 = ((const uint4*)A)[kk * 2 + 1];
+            const unsigned int a_raw[8] = {a_lo4.x, a_lo4.y, a_lo4.z, a_lo4.w,
+                                            a_hi4.x, a_hi4.y, a_hi4.z, a_hi4.w};
 
-        unsigned int packed4 = *(const unsigned int*)(
-            B_packed + (unsigned long long)n * half_K + k8 * 4);
+            unsigned long long packed8 = *(const unsigned long long*)(
+                B_packed + (unsigned long long)n * half_K + kk * 8);
 
-        unsigned int scale_group = base_k / GROUP_SIZE;
-        unsigned char scale_byte = B_scale[
-            (unsigned long long)n * num_groups + scale_group];
-        __nv_fp8_e4m3 fp8;
-        *(unsigned char*)&fp8 = scale_byte;
+            unsigned char scale_byte = B_scale[
+                (unsigned long long)n * num_groups + kk];
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
 #if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-        float scale = scl_fp8(scale_byte) * scale2;
+            float scale = scl_fp8(scale_byte) * scale2;
 #else
-        float scale = (float)fp8 * scale2;
+            float scale = (float)fp8 * scale2;
 #endif
 
-        #pragma unroll
-        for (int b = 0; b < 4; b++) {
-            unsigned char byte_val = (packed4 >> (b * 8)) & 0xFF;
-            float w_lo = s_lut[byte_val & 0xF] * scale;
-            float w_hi = s_lut[byte_val >> 4] * scale;
-
-            __nv_bfloat16 a_lo, a_hi;
-            *(unsigned short*)&a_lo = (unsigned short)(a_raw[b] & 0xFFFF);
-            *(unsigned short*)&a_hi = (unsigned short)(a_raw[b] >> 16);
-            acc += __bfloat162float(a_lo) * w_lo;
-            acc += __bfloat162float(a_hi) * w_hi;
+            float part = 0.0f;
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+                part = fmaf(af.x, s_lut[byte_val & 0xF], part);
+                part = fmaf(af.y, s_lut[byte_val >> 4], part);
+            }
+            if (c == 0) acc0 = fmaf(scale, part, acc0);
+            else        acc1 = fmaf(scale, part, acc1);
         }
     }
+    float acc = acc0 + acc1;
 
     const unsigned int warp_lane = threadIdx.x % WARP_SIZE;
 


### PR DESCRIPTION
Two decode wins for the GB10 line, found via a head-to-head nsys profile against vLLM (same box, same nvidia/Qwen3.6-27B-NVFP4 ckpt, spec off on both): our non-spec kernels are already at parity (12.14 vs 11.82 tok/s) and ~90% of the practical bandwidth bound, and vLLM's entire golden-run edge is speculative decoding. So: squeeze the last latency out of the GEMVs, and unblock our own spec depth.

**1. `perf(w4a16)`: 2-chunk ILP in the decode GEMVs.** Batch-1 decode is DRAM-latency-bound (ncu on a standalone microbench: 71% long-scoreboard stalls, <1% MIO, zero LUT/bank issues). Restructured the k-loop in `w4a16_gemv`/`w4a16_gemv_dual` into two independent chunks with two accumulators (two weight loads in flight per thread), widened dual weight loads 4B→8B, factored the group scale out of the inner FMA block (exact regroup). Microbench +2.9–3.9% per kernel; serve-level 12.141±0.008 → 12.258±0.005 tok/s (+0.96%, N=5 vs N=8, distributions fully separated). gate_up/down bit-exact; lm_head 1-ulp bf16 reassociation.

**2. `fix(mtp)`: K=4 verify crashed with CUDA 700 on native-FP8-GDN checkpoints.** `--num-drafts 3` died on the first verify step: the FP8 arm in `qwen3_ssm/trait_decode_batched.rs` was guarded `num_tokens == 2 || num_tokens == 3`, so K=4 fell through to `dense_gemm` on a NULL weight slot (this ckpt ships GDN FP8-only; the dense/NVFP4 slots are never populated). Widened both guards to `(2..=4)` — `w8a16_gemv_batch4` already handles M≤4. Root-caused via the new `ATLAS_K4_DIAG` eager-verify checkpoints (separate commit, env-gated, default off, zero production impact — mirrors `ATLAS_K2_DIAG`).

**Validation** (dgx2, nvidia/Qwen3.6-27B-NVFP4, util 0.70, full matrix on this exact series @ 56aa136e):

| Config | tok/s | Quality | Stability |
|---|---|---|---|
| non-spec | 12.246 | 8/8 tool probe + coherence | — |
| drafts=1 (golden) | 18.99 | 8/8 + 500-tok coherent | — |
| drafts=3 | 16.52 | 8/8 + coherence | **10/10, zero CUDA errors** (was: instant crash) |

Per-position acceptance and drafts=2/3 economics are unchanged by this PR (acceptance-limited, not verify-cost-limited — measured verify multiplier ≈1.1); a drafter-prefill follow-up addressing the acceptance gap at depth is in progress.
