### PR TITLE
fp8 cp.async prefill + mid-chunk GDN tail capture (default-on) + adaptive-K gate

### DIFF
--- a/crates/spark-model/examples/fp8gemm_microtest.rs
+++ b/crates/spark-model/examples/fp8gemm_microtest.rs
@@ -132,58 +132,116 @@ fn main() -> Result<()> {
     // A/B probe: time fp8_fp8_gemm_t (FP8 activation, no in-loop convert) vs
     // fp8_gemm_t (BF16 activation). Accuracy-neutral routing candidate.
     if std::env::var_os("ATLAS_PROBE_FP8FP8").is_some() {
-        let a_fp8: Vec<u8> = (0..m * k).map(|i| f32_to_e4m3(bf16_bits_to_f32(a_bf16[i]))).collect();
+        let a_fp8: Vec<u8> = (0..m * k)
+            .map(|i| f32_to_e4m3(bf16_bits_to_f32(a_bf16[i])))
+            .collect();
         let a8_ptr = upload_bytes(gpu, &a_fp8)?;
         // ldmab: FP8 A, FP8 B, grid (N/128, M/128), block 256 — vs scalar-load fp8_gemm_t.
         {
             let h = gpu.kernel("w4a16", "fp8_fp8_gemm_ldmab")?;
-            let launch = |s| KernelLaunch::new(gpu, h)
-                .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 128), 1]).block([256, 1, 1])
-                .arg_ptr(a8_ptr).arg_ptr(b_ptr).arg_ptr(c_ptr)
-                .arg_u32(m as u32).arg_u32(n as u32).arg_u32(k as u32).launch(s);
-            for _ in 0..8 { launch(stream)?; }
+            let launch = |s| {
+                KernelLaunch::new(gpu, h)
+                    .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 128), 1])
+                    .block([256, 1, 1])
+                    .arg_ptr(a8_ptr)
+                    .arg_ptr(b_ptr)
+                    .arg_ptr(c_ptr)
+                    .arg_u32(m as u32)
+                    .arg_u32(n as u32)
+                    .arg_u32(k as u32)
+                    .launch(s)
+            };
+            for _ in 0..8 {
+                launch(stream)?;
+            }
             gpu.synchronize(stream)?;
             let iters = 60u32;
             let t0 = std::time::Instant::now();
-            for _ in 0..iters { launch(stream)?; }
+            for _ in 0..iters {
+                launch(stream)?;
+            }
             gpu.synchronize(stream)?;
             let secs = t0.elapsed().as_secs_f64() / iters as f64;
             let flop = 2.0 * m as f64 * n as f64 * k as f64;
-            println!("PROBE fp8_fp8_gemm_ldmab: M={m} N={n} K={k} {:.3} ms {:.1} TFLOP/s", secs * 1e3, flop / secs / 1e12);
+            println!(
+                "PROBE fp8_fp8_gemm_ldmab: M={m} N={n} K={k} {:.3} ms {:.1} TFLOP/s",
+                secs * 1e3,
+                flop / secs / 1e12
+            );
             // CORRECTNESS: ldmab vs fp8_fp8_gemm_t (both fp8xfp8, same math) — cosine ~1.0 iff layout correct.
-            launch(stream)?; gpu.synchronize(stream)?;
+            launch(stream)?;
+            gpu.synchronize(stream)?;
             let mut craw = vec![0u8; m * n * 2];
             gpu.copy_d2h(c_ptr, &mut craw)?;
-            let cldm: Vec<f32> = craw.chunks_exact(2).map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16)).collect();
+            let cldm: Vec<f32> = craw
+                .chunks_exact(2)
+                .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
+                .collect();
             let hff = gpu.kernel("w4a16", "fp8_fp8_gemm_t")?;
-            KernelLaunch::new(gpu, hff).grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1]).block([128, 1, 1])
-                .arg_ptr(a8_ptr).arg_ptr(b_ptr).arg_ptr(c_ptr)
-                .arg_u32(m as u32).arg_u32(n as u32).arg_u32(k as u32).launch(stream)?;
+            KernelLaunch::new(gpu, hff)
+                .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1])
+                .block([128, 1, 1])
+                .arg_ptr(a8_ptr)
+                .arg_ptr(b_ptr)
+                .arg_ptr(c_ptr)
+                .arg_u32(m as u32)
+                .arg_u32(n as u32)
+                .arg_u32(k as u32)
+                .launch(stream)?;
             gpu.synchronize(stream)?;
             gpu.copy_d2h(c_ptr, &mut craw)?;
-            let cff: Vec<f32> = craw.chunks_exact(2).map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16)).collect();
+            let cff: Vec<f32> = craw
+                .chunks_exact(2)
+                .map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16))
+                .collect();
             let (mut d, mut na, mut nb) = (0f64, 0f64, 0f64);
-            for i in 0..cldm.len() { let (x, y) = (cldm[i] as f64, cff[i] as f64); d += x*y; na += x*x; nb += y*y; }
+            for i in 0..cldm.len() {
+                let (x, y) = (cldm[i] as f64, cff[i] as f64);
+                d += x * y;
+                na += x * x;
+                nb += y * y;
+            }
             let cos = d / (na.sqrt() * nb.sqrt() + 1e-30);
-            println!("PROBE ldmab_vs_fp8fp8 cosine={cos:.6}  ({}=PASS)", if cos >= 0.99 { "OK" } else { "FAIL" });
+            println!(
+                "PROBE ldmab_vs_fp8fp8 cosine={cos:.6}  ({}=PASS)",
+                if cos >= 0.99 { "OK" } else { "FAIL" }
+            );
         }
         for (name, aptr) in [("fp8_fp8_gemm_t", a8_ptr), ("fp8_gemm_t", a_ptr)] {
             let h = gpu.kernel("w4a16", name)?;
-            let launch = |s| KernelLaunch::new(gpu, h)
-                .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1]).block([128, 1, 1])
-                .arg_ptr(aptr).arg_ptr(b_ptr).arg_ptr(c_ptr)
-                .arg_u32(m as u32).arg_u32(n as u32).arg_u32(k as u32).launch(s);
-            for _ in 0..8 { launch(stream)?; }
+            let launch = |s| {
+                KernelLaunch::new(gpu, h)
+                    .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1])
+                    .block([128, 1, 1])
+                    .arg_ptr(aptr)
+                    .arg_ptr(b_ptr)
+                    .arg_ptr(c_ptr)
+                    .arg_u32(m as u32)
+                    .arg_u32(n as u32)
+                    .arg_u32(k as u32)
+                    .launch(s)
+            };
+            for _ in 0..8 {
+                launch(stream)?;
+            }
             gpu.synchronize(stream)?;
             let iters = 60u32;
             let t0 = std::time::Instant::now();
-            for _ in 0..iters { launch(stream)?; }
+            for _ in 0..iters {
+                launch(stream)?;
+            }
             gpu.synchronize(stream)?;
             let secs = t0.elapsed().as_secs_f64() / iters as f64;
             let flop = 2.0 * m as f64 * n as f64 * k as f64;
-            println!("PROBE {name}: M={m} N={n} K={k} {:.3} ms {:.1} TFLOP/s", secs * 1e3, flop / secs / 1e12);
+            println!(
+                "PROBE {name}: M={m} N={n} K={k} {:.3} ms {:.1} TFLOP/s",
+                secs * 1e3,
+                flop / secs / 1e12
+            );
         }
-        for p in [a8_ptr] { gpu.free(p).ok(); }
+        for p in [a8_ptr] {
+            gpu.free(p).ok();
+        }
     }
 
     let handle = gpu.kernel("w4a16", "fp8_gemm_t")?;

--- a/crates/spark-model/examples/fp8gemm_microtest.rs
+++ b/crates/spark-model/examples/fp8gemm_microtest.rs
@@ -129,6 +129,63 @@ fn main() -> Result<()> {
     let b_ptr = upload_bytes(gpu, &b_fp8)?;
     let c_ptr = gpu.alloc(m * n * 2)?;
 
+    // A/B probe: time fp8_fp8_gemm_t (FP8 activation, no in-loop convert) vs
+    // fp8_gemm_t (BF16 activation). Accuracy-neutral routing candidate.
+    if std::env::var_os("ATLAS_PROBE_FP8FP8").is_some() {
+        let a_fp8: Vec<u8> = (0..m * k).map(|i| f32_to_e4m3(bf16_bits_to_f32(a_bf16[i]))).collect();
+        let a8_ptr = upload_bytes(gpu, &a_fp8)?;
+        // ldmab: FP8 A, FP8 B, grid (N/128, M/128), block 256 — vs scalar-load fp8_gemm_t.
+        {
+            let h = gpu.kernel("w4a16", "fp8_fp8_gemm_ldmab")?;
+            let launch = |s| KernelLaunch::new(gpu, h)
+                .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 128), 1]).block([256, 1, 1])
+                .arg_ptr(a8_ptr).arg_ptr(b_ptr).arg_ptr(c_ptr)
+                .arg_u32(m as u32).arg_u32(n as u32).arg_u32(k as u32).launch(s);
+            for _ in 0..8 { launch(stream)?; }
+            gpu.synchronize(stream)?;
+            let iters = 60u32;
+            let t0 = std::time::Instant::now();
+            for _ in 0..iters { launch(stream)?; }
+            gpu.synchronize(stream)?;
+            let secs = t0.elapsed().as_secs_f64() / iters as f64;
+            let flop = 2.0 * m as f64 * n as f64 * k as f64;
+            println!("PROBE fp8_fp8_gemm_ldmab: M={m} N={n} K={k} {:.3} ms {:.1} TFLOP/s", secs * 1e3, flop / secs / 1e12);
+            // CORRECTNESS: ldmab vs fp8_fp8_gemm_t (both fp8xfp8, same math) — cosine ~1.0 iff layout correct.
+            launch(stream)?; gpu.synchronize(stream)?;
+            let mut craw = vec![0u8; m * n * 2];
+            gpu.copy_d2h(c_ptr, &mut craw)?;
+            let cldm: Vec<f32> = craw.chunks_exact(2).map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16)).collect();
+            let hff = gpu.kernel("w4a16", "fp8_fp8_gemm_t")?;
+            KernelLaunch::new(gpu, hff).grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1]).block([128, 1, 1])
+                .arg_ptr(a8_ptr).arg_ptr(b_ptr).arg_ptr(c_ptr)
+                .arg_u32(m as u32).arg_u32(n as u32).arg_u32(k as u32).launch(stream)?;
+            gpu.synchronize(stream)?;
+            gpu.copy_d2h(c_ptr, &mut craw)?;
+            let cff: Vec<f32> = craw.chunks_exact(2).map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16)).collect();
+            let (mut d, mut na, mut nb) = (0f64, 0f64, 0f64);
+            for i in 0..cldm.len() { let (x, y) = (cldm[i] as f64, cff[i] as f64); d += x*y; na += x*x; nb += y*y; }
+            let cos = d / (na.sqrt() * nb.sqrt() + 1e-30);
+            println!("PROBE ldmab_vs_fp8fp8 cosine={cos:.6}  ({}=PASS)", if cos >= 0.99 { "OK" } else { "FAIL" });
+        }
+        for (name, aptr) in [("fp8_fp8_gemm_t", a8_ptr), ("fp8_gemm_t", a_ptr)] {
+            let h = gpu.kernel("w4a16", name)?;
+            let launch = |s| KernelLaunch::new(gpu, h)
+                .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1]).block([128, 1, 1])
+                .arg_ptr(aptr).arg_ptr(b_ptr).arg_ptr(c_ptr)
+                .arg_u32(m as u32).arg_u32(n as u32).arg_u32(k as u32).launch(s);
+            for _ in 0..8 { launch(stream)?; }
+            gpu.synchronize(stream)?;
+            let iters = 60u32;
+            let t0 = std::time::Instant::now();
+            for _ in 0..iters { launch(stream)?; }
+            gpu.synchronize(stream)?;
+            let secs = t0.elapsed().as_secs_f64() / iters as f64;
+            let flop = 2.0 * m as f64 * n as f64 * k as f64;
+            println!("PROBE {name}: M={m} N={n} K={k} {:.3} ms {:.1} TFLOP/s", secs * 1e3, flop / secs / 1e12);
+        }
+        for p in [a8_ptr] { gpu.free(p).ok(); }
+    }
+
     let handle = gpu.kernel("w4a16", "fp8_gemm_t")?;
     KernelLaunch::new(gpu, handle)
         .grid([div_ceil(n as u32, 128), div_ceil(m as u32, 64), 1])

--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -250,6 +250,37 @@ pub struct ForwardContext<'a> {
     /// the installed-active-pair path byte-identical. Prefill runs eager
     /// (`graph_capture: false`) so this per-pass CPU borrow is safe.
     pub routed_lora_layers: Option<&'a [Option<crate::lora::LoraLayerWeights>]>,
+    /// OPT-IN mid-chunk SSM tail capture (`ATLAS_SSM_TAIL_MIDCHUNK=1`).
+    ///
+    /// `Some` only on the single prefill pass whose local token range spans
+    /// the block-floored matched-prefix boundary `tb`. GDN/SSM layers then
+    /// split their recurrent (h_state) and conv (conv_state) kernels at
+    /// `cap_local` and copy the @tb state into the reserved snapshot slot.
+    /// `None` (default) => no split, byte-identical to prior behavior.
+    pub midchunk_capture: Option<MidchunkCapture<'a>>,
+}
+
+/// Per-pass descriptor for mid-chunk SSM tail capture. Points at the reserved
+/// Marconi snapshot slot's per-SSM-layer destination buffers (already offset to
+/// the slot) plus the split point in local (chunk) token coordinates.
+///
+/// `ssm_layer_counter` is a fresh per-pass counter: each SSM layer's prefill
+/// increments it once, in model order, so the value indexes `h_dsts`/`conv_dsts`
+/// (which are in the same SSM-layer order as the snapshot pool).
+pub struct MidchunkCapture<'a> {
+    /// Split point in local token coordinates: capture state AFTER this many
+    /// tokens (== `tb - proc_start`).
+    pub cap_local: usize,
+    /// Per-SSM-layer h_state snapshot destination (offset to the reserved slot).
+    pub h_dsts: &'a [DevicePtr],
+    /// Per-SSM-layer conv_state snapshot destination (offset to the reserved slot).
+    pub conv_dsts: &'a [DevicePtr],
+    /// Bytes per layer of h_state.
+    pub h_bytes: usize,
+    /// Bytes per layer of conv_state.
+    pub conv_bytes: usize,
+    /// Fresh per-pass SSM-layer ordinal counter (model order == pool order).
+    pub ssm_layer_counter: &'a std::sync::atomic::AtomicUsize,
 }
 
 /// A single transformer layer performing the full per-layer computation.

--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -281,6 +281,17 @@ pub struct MidchunkCapture<'a> {
     pub conv_bytes: usize,
     /// Fresh per-pass SSM-layer ordinal counter (model order == pool order).
     pub ssm_layer_counter: &'a std::sync::atomic::AtomicUsize,
+    /// Optional SECOND capture one KV block earlier, at `tb - block_size`
+    /// (local split point `cap_local - block_size`). `Some` only when the pass
+    /// also covers that point. On ~5/19 warm turns the next turn's block-floored
+    /// `matched_tokens` lands exactly `tb - block_size` (generation-suffix /
+    /// retokenize divergence), one block short of the tail; registering this
+    /// earlier restore point makes those turns zero-replay too.
+    pub cap_local_early: Option<usize>,
+    /// Per-SSM-layer h_state dst for the `tb - block_size` slot (offset applied).
+    pub h_dsts_early: &'a [DevicePtr],
+    /// Per-SSM-layer conv_state dst for the `tb - block_size` slot.
+    pub conv_dsts_early: &'a [DevicePtr],
 }
 
 /// A single transformer layer performing the full per-layer computation.

--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -250,7 +250,7 @@ pub struct ForwardContext<'a> {
     /// the installed-active-pair path byte-identical. Prefill runs eager
     /// (`graph_capture: false`) so this per-pass CPU borrow is safe.
     pub routed_lora_layers: Option<&'a [Option<crate::lora::LoraLayerWeights>]>,
-    /// OPT-IN mid-chunk SSM tail capture (`ATLAS_SSM_TAIL_MIDCHUNK=1`).
+    /// Default-ON mid-chunk SSM tail capture (opt-out `ATLAS_SSM_TAIL_MIDCHUNK=0`).
     ///
     /// `Some` only on the single prefill pass whose local token range spans
     /// the block-floored matched-prefix boundary `tb`. GDN/SSM layers then

--- a/crates/spark-model/src/layer/tests.rs
+++ b/crates/spark-model/src/layer/tests.rs
@@ -58,6 +58,7 @@ fn test_forward_context_lifetime() {
         gdn_exact_replay: false,
         token_ids: None,
         routed_lora_layers: None,
+        midchunk_capture: None,
     };
 
     assert_eq!(ctx.config.hidden_size, 2048);

--- a/crates/spark-model/src/layers/deepseek_v4_mtp.rs
+++ b/crates/spark-model/src/layers/deepseek_v4_mtp.rs
@@ -334,6 +334,7 @@ impl DeepseekV4MtpHead {
             gdn_exact_replay: false,
             token_ids: ctx.token_ids,
             routed_lora_layers: None, // #30: MTP draft body; no prefill LoRA route.
+            midchunk_capture: None,
         };
 
         // `decode_inner_hc` reads the persistent multi-stream state from

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -95,6 +95,8 @@ pub struct DenseFfnLayer {
     w4a16_gemv_dual_batch3: KernelHandle,
     w4a16_gemv_batch2: KernelHandle,
     w4a16_gemv_batch3: KernelHandle,
+    /// M<=4 batched GEMV (K=4 verify FFN); 0-handle when absent.
+    w4a16_gemv_batch4: KernelHandle,
     w4a16_gemm: KernelHandle,
     // 128x128 2-stage cp.async pipelined w4a16 GEMM — the fast prefill kernel
     // attention/SSM already use. The base `w4a16_gemm` (M64xN64) only hits
@@ -264,6 +266,7 @@ impl DenseFfnLayer {
             w4a16_gemv_dual_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
             w4a16_gemv_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
             w4a16_gemv_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,
+            w4a16_gemv_batch4: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
             w4a16_gemm: gpu.kernel("w4a16", "w4a16_gemm")?,
             w4a16_gemm_t_m128_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t_m128"),
             w4a16_gemm_t_m128_v2_k: super::try_kernel(gpu, "w4a16_v2", "w4a16_gemm_t_m128_v2"),
@@ -1090,6 +1093,75 @@ impl DenseFfnLayer {
             gate_out,
             &self.weights.down_proj,
             output,
+            h,
+            inter,
+            stream,
+        )?;
+
+        Ok(())
+    }
+
+    /// Whether the K=4 batched-GEMV verify path is available (batch4 kernel
+    /// present AND NVFP4 weights loaded — the batchm GEMV reads the
+    /// non-transposed NVFP4 layout).
+    pub fn can_forward_k4(&self) -> bool {
+        self.w4a16_gemv_batch4.0 != 0 && !self.weights.gate_proj.weight.is_null()
+    }
+
+    /// K=4 speculative verify: batched GEMV for 4 tokens.
+    /// 4 launches: batch4 gate + batch4 up + silu_mul + batch4 down — each
+    /// projection weight is read ONCE for all 4 rows at near-peak stream
+    /// bandwidth. nsys (2026-07-18): the `forward_prefill` MMQ arm this
+    /// replaces for the K=4 verify cost 54.8 ms/step across the 64-layer
+    /// dense FFN stack (~156 GB/s effective at M=4); the batch GEMV family
+    /// measures ~290 GB/s on the same shapes (w8a16_gemv_batch4 sibling),
+    /// putting this path at the ~31 ms weight-traffic floor.
+    pub fn forward_k4(&self, input: DevicePtr, ctx: &ForwardContext, stream: u64) -> Result<()> {
+        let h = ctx.config.hidden_size as u32;
+        let inter = ctx.config.intermediate_size as u32;
+
+        let gate_out = ctx.buffers.expert_gate_out();
+        let up_out = ctx.buffers.expert_up_out();
+
+        ops::w4a16_gemv_batchm(
+            ctx.gpu,
+            self.w4a16_gemv_batch4,
+            input,
+            &self.weights.gate_proj,
+            gate_out,
+            4,
+            inter,
+            h,
+            stream,
+        )?;
+        ops::w4a16_gemv_batchm(
+            ctx.gpu,
+            self.w4a16_gemv_batch4,
+            input,
+            &self.weights.up_proj,
+            up_out,
+            4,
+            inter,
+            h,
+            stream,
+        )?;
+        ops::silu_mul(
+            ctx.gpu,
+            self.act_mul,
+            gate_out,
+            up_out,
+            gate_out,
+            4 * inter,
+            stream,
+        )?;
+        let output = ctx.buffers.moe_output();
+        ops::w4a16_gemv_batchm(
+            ctx.gpu,
+            self.w4a16_gemv_batch4,
+            gate_out,
+            &self.weights.down_proj,
+            output,
+            4,
             h,
             inter,
             stream,

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -134,6 +134,9 @@ pub struct DenseFfnLayer {
     // below) and requant the BF16 activations every call (`requant_a_bf16_int8`,
     // into `int8_a_scratch`). KernelHandle(0) on miss → arm never taken.
     int8_faith2_k: KernelHandle,
+    // faith5: int32 per-sb accumulation (breaks the MMA→scale dependency chain).
+    // Opt-in via ATLAS_INT8_FAITH5=1 (replaces faith2 for int8 prefill GEMMs).
+    int8_faith5_k: KernelHandle,
     requant_w_int8_k: KernelHandle,
     requant_a_int8_k: KernelHandle,
     // Lazily-built, process-lifetime int8 weight copies (one per projection),
@@ -278,6 +281,7 @@ impl DenseFfnLayer {
             ),
             w4a16_gemm_t_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t"),
             int8_faith2_k: super::try_kernel(gpu, "w4a16", "int8_gemm_faith2"),
+            int8_faith5_k: super::try_kernel(gpu, "w4a16", "int8_gemm_i32acc"),
             requant_w_int8_k: super::try_kernel(gpu, "w4a16", "requant_w_nvfp4_int8"),
             requant_a_int8_k: super::try_kernel(gpu, "w4a16", "requant_a_bf16_int8"),
             int8_gate: std::sync::OnceLock::new(),
@@ -1616,9 +1620,19 @@ impl DenseFfnLayer {
                     // (down_faith2 && !$allow_q4k): down falls here instead of Q4_K.
                     _ if int8_prefill || (down_faith2 && !$allow_q4k) => {
                         let iw = self.ensure_int8_weight($cell, ctx.gpu, $w, $n, $k, stream)?;
+                        // faith5 (ATLAS_INT8_FAITH5=1): int32 per-sb accumulation
+                        // breaks the MMA→scale dependency chain. Same kernel signature
+                        // + grid/block as faith2 — just a different KernelHandle.
+                        let int8_kernel = if self.int8_faith5_k.0 != 0
+                            && std::env::var_os("ATLAS_INT8_FAITH5").is_some()
+                        {
+                            self.int8_faith5_k
+                        } else {
+                            self.int8_faith2_k
+                        };
                         ops::int8_gemm_faith2_prefill(
                             ctx.gpu,
-                            self.int8_faith2_k,
+                            int8_kernel,
                             self.requant_a_int8_k,
                             $in,
                             iw.w_i8,

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -109,6 +109,24 @@ impl FfnComponent {
         }
     }
 
+    /// K=4 verify FFN via batched GEMV (dense only). Returns `false` when the
+    /// path is unavailable (MoE / missing batch4 kernel / non-NVFP4 weights)
+    /// so the caller can fall back to `forward_prefill`.
+    pub fn try_forward_k4(
+        &self,
+        input: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<bool> {
+        match self {
+            Self::Dense(d) if d.can_forward_k4() => {
+                d.forward_k4(input, ctx, stream)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     pub fn forward_prefill(
         &self,
         input: DevicePtr,

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -21,7 +21,7 @@ pub use dflash_head::{
     BlockDiffusionDraftHead, DflashLayer, DflashProposerState, DflashQuantization,
 };
 pub use moe::MoeLayer;
-pub use mtp_head::{MtpHead, MtpQuantization};
+pub use mtp_head::{MtpHead, MtpQuantization, mtp_drafter_prefill_enabled};
 pub use nemotron_mamba2::NemotronMamba2Layer;
 pub use nemotron_moe::NemotronMoeLayer;
 pub use qwen3_attention::Qwen3AttentionLayer;

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -24,6 +24,42 @@ use crate::weight_map::{
     DenseWeight, Fp8DenseWeight, Fp8Weight, QuantizedWeight, quantize_to_fp8, quantize_to_nvfp4,
 };
 
+/// ATLAS_MTP_DRAFTER_PREFILL=1 — opt-in drafter context prefill (cached once).
+///
+/// When set, the target prefill captures every position's final-layer hidden
+/// and the MTP drafter's KV cache is batch-prefilled over the whole prompt
+/// before the first propose(), mirroring vLLM's MTP proposer prefill. The
+/// drafter's KV entries are pure functions of its input pair
+/// `(embed(token_{i+1}), target_hidden_i)` — a single-layer drafter's K/V do
+/// not depend on its own attention outputs — so the prefill needs only the
+/// fc + k/v projections + norms + RoPE + cache write, no attention pass.
+pub fn mtp_drafter_prefill_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_MTP_DRAFTER_PREFILL").ok().as_deref() == Some("1"))
+}
+
+/// Dedicated scratch for the batched drafter prefill (allocated in
+/// `MtpHead::new` only when [`mtp_drafter_prefill_enabled`]). All buffers are
+/// sized for [`prefill::PREFILL_CHUNK`] rows; dedicated (not aliased onto the
+/// shared arena) so the pass has no aliasing hazards against target buffers.
+pub(crate) struct MtpPrefillScratch {
+    pub embed: DevicePtr,
+    pub normed_embed: DevicePtr,
+    pub normed_hidden: DevicePtr,
+    pub concat: DevicePtr,
+    pub fc_out: DevicePtr,
+    pub normed2: DevicePtr,
+    pub k_out: DevicePtr,
+    pub v_out: DevicePtr,
+    /// RoPE rotates Q and K in one launch; prefill discards Q, but the kernel
+    /// still needs a writable [chunk, nq*hd] region.
+    pub q_scratch: DevicePtr,
+    /// u32 RoPE positions, one per row.
+    pub pos_dev: DevicePtr,
+    /// i64 KV slot mapping, one per row.
+    pub slot_dev: DevicePtr,
+}
+
 /// MTP head weight precision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MtpQuantization {
@@ -157,6 +193,10 @@ pub struct MtpHead {
     moe_topk_k: Option<KernelHandle>,
     moe_silu_mul_k: Option<KernelHandle>,
     moe_weighted_sum_blend_k: Option<KernelHandle>,
+    /// Batched BF16 GEMM for the drafter-prefill pass (0 when absent).
+    dense_gemm_k: KernelHandle,
+    /// Drafter-prefill scratch; `None` unless ATLAS_MTP_DRAFTER_PREFILL=1.
+    prefill_scratch: Option<MtpPrefillScratch>,
 }
 
 impl MtpHead {
@@ -243,6 +283,7 @@ impl MtpHead {
 mod forward;
 mod moe_forward;
 mod new;
+mod prefill;
 
 impl DraftProposer for MtpHead {
     fn alloc_state(&self, _gpu: &dyn GpuBackend) -> Result<Box<dyn ProposerState>> {
@@ -318,6 +359,17 @@ impl DraftProposer for MtpHead {
 
         mtp_state.last_num_drafted = drafts.len();
         Ok(drafts)
+    }
+
+    fn prefill_drafter(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        self.prefill_drafter_impl(prompt_tokens, hiddens, state, ctx, stream)
     }
 
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -286,6 +286,30 @@ impl MtpHead {
             lm = (effective_vocab * h / 2) as f64 / (1024.0 * 1024.0),
         );
 
+        // ATLAS_MTP_DRAFTER_PREFILL: dedicated batched-prefill scratch
+        // (~50 MB at h=5120/nq=32/hd=256, PREFILL_CHUNK=512 rows). Dedicated
+        // rather than aliased onto the shared arena so the pass has zero
+        // aliasing hazards; allocated only when the env is set (PCND).
+        let prefill_scratch = if super::mtp_drafter_prefill_enabled() {
+            let c = super::prefill::PREFILL_CHUNK;
+            let bf16 = 2usize;
+            Some(super::MtpPrefillScratch {
+                embed: gpu.alloc(c * h * bf16)?,
+                normed_embed: gpu.alloc(c * h * bf16)?,
+                normed_hidden: gpu.alloc(c * h * bf16)?,
+                concat: gpu.alloc(c * 2 * h * bf16)?,
+                fc_out: gpu.alloc(c * h * bf16)?,
+                normed2: gpu.alloc(c * h * bf16)?,
+                k_out: gpu.alloc(c * nkv * hd * bf16)?,
+                v_out: gpu.alloc(c * nkv * hd * bf16)?,
+                q_scratch: gpu.alloc(c * nq * hd * bf16)?,
+                pos_dev: gpu.alloc(c * 4)?,
+                slot_dev: gpu.alloc(c * 8)?,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             pre_fc_norm_embedding: weights.pre_fc_norm_embedding,
             pre_fc_norm_hidden: weights.pre_fc_norm_hidden,
@@ -342,6 +366,10 @@ impl MtpHead {
             moe_topk_k,
             moe_silu_mul_k,
             moe_weighted_sum_blend_k,
+            // Batched BF16 GEMM for drafter prefill; 0-handle when the
+            // target's kernel set lacks it (prefill then no-ops).
+            dense_gemm_k: crate::layers::try_kernel(gpu, "gemm", "dense_gemm_bf16"),
+            prefill_scratch,
         })
     }
 }

--- a/crates/spark-model/src/layers/mtp_head/prefill.rs
+++ b/crates/spark-model/src/layers/mtp_head/prefill.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched MTP drafter context prefill (ATLAS_MTP_DRAFTER_PREFILL).
+//!
+//! Why this exists: without it the drafter's KV cache starts EMPTY at decode —
+//! the drafter is blind to the prompt through its own attention, and measured
+//! per-position acceptance DEGRADES with context (pos0 77→73%, pos1 45→40% at
+//! 50→2449-token prompts) while vLLM's prompt-prefilled MTP drafter IMPROVES
+//! (83→91% pos0). This pass writes one drafter KV entry per prompt position
+//! before the first propose(), mirroring vLLM's proposer prefill.
+//!
+//! Key structural fact that keeps this cheap: the drafter is a SINGLE decoder
+//! layer, so its K/V at position i are pure functions of its input pair
+//! `x_i = fc(concat(norm(embed(t_{i+1})), norm(target_hidden_i)))` — they do
+//! not depend on the drafter's own attention outputs. The prefill therefore
+//! needs NO attention pass: embed-gather → norms → concat → fc →
+//! input_layernorm → k/v projections → k_norm → RoPE → reshape_and_cache,
+//! all batched over [`PREFILL_CHUNK`]-row chunks with existing kernels.
+//!
+//! Row/position convention (matches `forward_one` exactly): drafter row i
+//! pairs `embed(t_{i+1})` with `hidden_i`, RoPE position `i+1`, KV slot `i`,
+//! for i = 0..P-2. The first decode propose() then appends
+//! `(first_sampled_token, hidden_{P-1})` at position P, slot P-1 — gapless.
+//!
+//! v1 scope (explicit): BF16 MTP head (`--mtp-quantization bf16`, the
+//! recommended/highest-acceptance config) with BF16 drafter KV. Other quants
+//! warn once and no-op — propose() then behaves exactly as before.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::{MtpHead, MtpProposerState, ProjectionWeight};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::speculative::ProposerState;
+
+/// Rows processed per batched pass. Sizes the dedicated scratch (~50 MB at
+/// h=5120 / nq=32 / hd=256); one full weight read per chunk per projection.
+pub(crate) const PREFILL_CHUNK: usize = 512;
+
+impl MtpHead {
+    /// Batch-prefill the drafter KV over `prompt_tokens` using per-position
+    /// target hiddens. Returns rows written (P-1), or 0 when unsupported /
+    /// already prefilled. See module docs for the exact row convention.
+    pub(crate) fn prefill_drafter_impl(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        let mtp_state = match state.as_any_mut().downcast_mut::<MtpProposerState>() {
+            Some(s) => s,
+            None => return Ok(0),
+        };
+        // Only a fresh drafter (nothing proposed yet) can be prefilled; a
+        // non-zero seq_len means decode already started (or prefill ran).
+        if mtp_state.seq_len != 0 || prompt_tokens.len() < 2 {
+            return Ok(0);
+        }
+        let scratch = match self.prefill_scratch.as_ref() {
+            Some(s) => s,
+            None => return Ok(0),
+        };
+        // v1: BF16 head + BF16 drafter KV only (see module docs).
+        let (fc_w, k_w, v_w) = match (&self.fc, &self.k_proj, &self.v_proj) {
+            (
+                ProjectionWeight::Bf16(fc),
+                ProjectionWeight::Bf16(k),
+                ProjectionWeight::Bf16(v),
+            ) if self.kv_bf16 && self.dense_gemm_k.0 != 0 => (fc, k, v),
+            _ => {
+                static WARNED: std::sync::Once = std::sync::Once::new();
+                WARNED.call_once(|| {
+                    tracing::warn!(
+                        "ATLAS_MTP_DRAFTER_PREFILL: drafter prefill supports the BF16 \
+                         MTP head (--mtp-quantization bf16) with BF16 KV only; \
+                         continuing WITHOUT drafter context prefill."
+                    );
+                });
+                return Ok(0);
+            }
+        };
+
+        let t0 = std::time::Instant::now();
+        let h = ctx.config.hidden_size;
+        let nq = ctx.config.num_attention_heads as u32;
+        let nkv = ctx.config.num_key_value_heads as u32;
+        let hd = ctx.config.head_dim as u32;
+        let eps = ctx.config.rms_norm_eps as f32;
+        let kv_dim = (nkv * hd) as usize;
+        let bf16 = 2usize;
+        let rows_total = prompt_tokens.len() - 1; // pairs (t_{i+1}, h_i), i=0..P-2
+
+        // Grow the drafter block table to cover all prefill slots up front.
+        let mut kv_cache = self.kv_cache.lock();
+        let bs = kv_cache.block_size();
+        let blocks_needed = (rows_total - 1) / bs + 1;
+        while mtp_state.block_table.len() < blocks_needed {
+            mtp_state.block_table.push(kv_cache.alloc_block()?);
+        }
+
+        let mut done = 0usize;
+        while done < rows_total {
+            let c = (rows_total - done).min(PREFILL_CHUNK);
+
+            // 1. Gather embeddings of t_{i+1} for rows done..done+c.
+            for r in 0..c {
+                let tok = prompt_tokens[done + r + 1] as usize;
+                self_copy_embed_row(self, ctx, tok, scratch.embed, r, h, stream)?;
+            }
+
+            // 2. Pre-fc norms: embedding rows and target-hidden rows.
+            ops::rms_norm(
+                ctx.gpu,
+                self.rms_norm_k,
+                scratch.embed,
+                &self.pre_fc_norm_embedding,
+                scratch.normed_embed,
+                c as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+            ops::rms_norm(
+                ctx.gpu,
+                self.rms_norm_k,
+                hiddens.offset(done * h * bf16),
+                &self.pre_fc_norm_hidden,
+                scratch.normed_hidden,
+                c as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+
+            // 3. Per-row concat [normed_embed | normed_hidden] → [c, 2h].
+            for r in 0..c {
+                ops::bf16_concat(
+                    ctx.gpu,
+                    self.bf16_concat_k,
+                    scratch.normed_embed.offset(r * h * bf16),
+                    scratch.normed_hidden.offset(r * h * bf16),
+                    scratch.concat.offset(r * 2 * h * bf16),
+                    h as u32,
+                    stream,
+                )?;
+            }
+
+            // 4. fc: [c, 2h] → [c, h], then input layernorm.
+            ops::dense_gemm(
+                ctx.gpu,
+                self.dense_gemm_k,
+                scratch.concat,
+                fc_w,
+                scratch.fc_out,
+                c as u32,
+                h as u32,
+                (2 * h) as u32,
+                stream,
+            )?;
+            ops::rms_norm(
+                ctx.gpu,
+                self.rms_norm_k,
+                scratch.fc_out,
+                &self.input_layernorm,
+                scratch.normed2,
+                c as u32,
+                h as u32,
+                eps,
+                stream,
+            )?;
+
+            // 5. K/V projections (Q is not needed — outputs are discarded).
+            ops::dense_gemm(
+                ctx.gpu,
+                self.dense_gemm_k,
+                scratch.normed2,
+                k_w,
+                scratch.k_out,
+                c as u32,
+                nkv * hd,
+                h as u32,
+                stream,
+            )?;
+            ops::dense_gemm(
+                ctx.gpu,
+                self.dense_gemm_k,
+                scratch.normed2,
+                v_w,
+                scratch.v_out,
+                c as u32,
+                nkv * hd,
+                h as u32,
+                stream,
+            )?;
+            if !self.k_norm.weight.is_null() {
+                ops::rms_norm(
+                    ctx.gpu,
+                    self.rms_norm_k,
+                    scratch.k_out,
+                    &self.k_norm,
+                    scratch.k_out,
+                    c as u32 * nkv,
+                    hd,
+                    eps,
+                    stream,
+                )?;
+            }
+
+            // 6. RoPE positions i+1 and KV slots i, uploaded per chunk.
+            let positions: Vec<u32> = (0..c).map(|r| (done + r + 1) as u32).collect();
+            let pos_bytes = unsafe {
+                std::slice::from_raw_parts(positions.as_ptr() as *const u8, c * 4)
+            };
+            ctx.gpu.copy_h2d_async(pos_bytes, scratch.pos_dev, stream)?;
+            let slots: Vec<i64> = (0..c)
+                .map(|r| {
+                    let i = done + r;
+                    (mtp_state.block_table[i / bs] as i64) * (bs as i64) + (i % bs) as i64
+                })
+                .collect();
+            let slot_bytes = unsafe {
+                std::slice::from_raw_parts(slots.as_ptr() as *const u8, c * 8)
+            };
+            ctx.gpu.copy_h2d_async(slot_bytes, scratch.slot_dev, stream)?;
+
+            ops::rope(
+                ctx.gpu,
+                self.rope_k,
+                scratch.q_scratch,
+                scratch.k_out,
+                scratch.pos_dev,
+                c as u32,
+                nq,
+                nkv,
+                hd,
+                ctx.config.rotary_dim() as u32,
+                ctx.config.rope_theta as f32,
+                stream,
+            )?;
+
+            // 7. Write K/V into the drafter's paged BF16 cache.
+            ops::reshape_and_cache(
+                ctx.gpu,
+                self.reshape_cache_k,
+                scratch.k_out,
+                scratch.v_out,
+                kv_cache.k_pool_ptr(self.attn_layer_idx),
+                kv_cache.v_pool_ptr(self.attn_layer_idx),
+                scratch.slot_dev,
+                c as u32,
+                nkv,
+                hd,
+                bs as u32,
+                kv_dim as u32,
+                kv_dim as u32,
+                kv_cache.cache_stride() as u64,
+                stream,
+            )?;
+            // The async H2D sources (positions/slots) are Vec-backed; the
+            // driver has queued them, but sync before drop for safety —
+            // one sync per 512-row chunk is negligible next to the GEMMs.
+            ctx.gpu.synchronize(stream)?;
+
+            done += c;
+        }
+
+        mtp_state.seq_len = rows_total;
+        tracing::info!(
+            "MTP drafter prefill: {} positions ({} prompt tokens) in {:.1} ms",
+            rows_total,
+            prompt_tokens.len(),
+            t0.elapsed().as_secs_f64() * 1e3,
+        );
+        Ok(rows_total)
+    }
+}
+
+/// Copy one embedding-table row into `dst` row `r`. Free function to keep the
+/// borrow of `self` fields inside the loop simple.
+fn self_copy_embed_row(
+    head: &MtpHead,
+    ctx: &ForwardContext,
+    token: usize,
+    dst: DevicePtr,
+    r: usize,
+    h: usize,
+    stream: u64,
+) -> Result<()> {
+    let row_bytes = h * 2;
+    let src = head.embed_tokens.weight.offset(token * row_bytes);
+    ctx.gpu.copy_d2d_async(src, dst.offset(r * row_bytes), row_bytes, stream)
+}

--- a/crates/spark-model/src/layers/mtp_head/prefill.rs
+++ b/crates/spark-model/src/layers/mtp_head/prefill.rs
@@ -65,11 +65,11 @@ impl MtpHead {
         };
         // v1: BF16 head + BF16 drafter KV only (see module docs).
         let (fc_w, k_w, v_w) = match (&self.fc, &self.k_proj, &self.v_proj) {
-            (
-                ProjectionWeight::Bf16(fc),
-                ProjectionWeight::Bf16(k),
-                ProjectionWeight::Bf16(v),
-            ) if self.kv_bf16 && self.dense_gemm_k.0 != 0 => (fc, k, v),
+            (ProjectionWeight::Bf16(fc), ProjectionWeight::Bf16(k), ProjectionWeight::Bf16(v))
+                if self.kv_bf16 && self.dense_gemm_k.0 != 0 =>
+            {
+                (fc, k, v)
+            }
             _ => {
                 static WARNED: std::sync::Once = std::sync::Once::new();
                 WARNED.call_once(|| {
@@ -211,9 +211,8 @@ impl MtpHead {
 
             // 6. RoPE positions i+1 and KV slots i, uploaded per chunk.
             let positions: Vec<u32> = (0..c).map(|r| (done + r + 1) as u32).collect();
-            let pos_bytes = unsafe {
-                std::slice::from_raw_parts(positions.as_ptr() as *const u8, c * 4)
-            };
+            let pos_bytes =
+                unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, c * 4) };
             ctx.gpu.copy_h2d_async(pos_bytes, scratch.pos_dev, stream)?;
             let slots: Vec<i64> = (0..c)
                 .map(|r| {
@@ -221,10 +220,10 @@ impl MtpHead {
                     (mtp_state.block_table[i / bs] as i64) * (bs as i64) + (i % bs) as i64
                 })
                 .collect();
-            let slot_bytes = unsafe {
-                std::slice::from_raw_parts(slots.as_ptr() as *const u8, c * 8)
-            };
-            ctx.gpu.copy_h2d_async(slot_bytes, scratch.slot_dev, stream)?;
+            let slot_bytes =
+                unsafe { std::slice::from_raw_parts(slots.as_ptr() as *const u8, c * 8) };
+            ctx.gpu
+                .copy_h2d_async(slot_bytes, scratch.slot_dev, stream)?;
 
             ops::rope(
                 ctx.gpu,
@@ -291,5 +290,6 @@ fn self_copy_embed_row(
 ) -> Result<()> {
     let row_bytes = h * 2;
     let src = head.embed_tokens.weight.offset(token * row_bytes);
-    ctx.gpu.copy_d2d_async(src, dst.offset(r * row_bytes), row_bytes, stream)
+    ctx.gpu
+        .copy_d2d_async(src, dst.offset(r * row_bytes), row_bytes, stream)
 }

--- a/crates/spark-model/src/layers/ops/gemm_fp8_prefill.rs
+++ b/crates/spark-model/src/layers/ops/gemm_fp8_prefill.rs
@@ -31,6 +31,40 @@ pub fn fp8_gemm_n128(
     k: u32,
     stream: u64,
 ) -> Result<()> {
+    // DEFAULT-ON: route the GDN-projection prefill GEMM through the ldmatrix.x4
+    // A+B kernel (fp8_fp8_gemm_ldmab). ncu-proven 2.1x over the scalar-load
+    // fp8_gemm_t, cosine 1.000000 vs fp8_fp8_gemm_t, and a confirmed e2e warm-TTFT
+    // win. Quantizes the bf16 activation to e4m3 once into a persistent scratch,
+    // then launches the ldmatrix GEMM. K must be a multiple of 32 (the ldmab
+    // K-tile). Opt-OUT with ATLAS_FP8_LDMAB=0 (falls through to the scalar path).
+    if k % 32 == 0 && std::env::var("ATLAS_FP8_LDMAB").as_deref() != Ok("0") {
+        use std::sync::{Mutex, OnceLock};
+        static QK: OnceLock<KernelHandle> = OnceLock::new();
+        static LK: OnceLock<KernelHandle> = OnceLock::new();
+        static SCRATCH: Mutex<Option<(DevicePtr, usize)>> = Mutex::new(None);
+        let qk = *QK.get_or_init(|| gpu.kernel("w4a16", "bf16_to_fp8").expect("bf16_to_fp8"));
+        let lk = *LK.get_or_init(|| gpu.kernel("w4a16", "fp8_fp8_gemm_ldmab").expect("fp8_fp8_gemm_ldmab"));
+        let need = (m as usize) * (k as usize); // e4m3 bytes
+        let a8 = {
+            let mut g = SCRATCH.lock().unwrap();
+            if g.map(|(_, sz)| sz < need).unwrap_or(true) {
+                let p = gpu.alloc(need)?; // grow-only; old ptr leaked (rare, per-run)
+                *g = Some((p, need));
+            }
+            g.unwrap().0
+        };
+        bf16_to_fp8(gpu, qk, input, a8, m * k, stream)?;
+        return KernelLaunch::new(gpu, lk)
+            .grid([div_ceil(n, 128), div_ceil(m, 128), 1])
+            .block([256, 1, 1])
+            .arg_ptr(a8)
+            .arg_ptr(b_fp8)
+            .arg_ptr(output)
+            .arg_u32(m)
+            .arg_u32(n)
+            .arg_u32(k)
+            .launch(stream);
+    }
     KernelLaunch::new(gpu, kernel)
         .grid([div_ceil(n, 128), div_ceil(m, 64), 1])
         .block([128, 1, 1])

--- a/crates/spark-model/src/layers/ops/gemm_fp8_prefill.rs
+++ b/crates/spark-model/src/layers/ops/gemm_fp8_prefill.rs
@@ -43,7 +43,10 @@ pub fn fp8_gemm_n128(
         static LK: OnceLock<KernelHandle> = OnceLock::new();
         static SCRATCH: Mutex<Option<(DevicePtr, usize)>> = Mutex::new(None);
         let qk = *QK.get_or_init(|| gpu.kernel("w4a16", "bf16_to_fp8").expect("bf16_to_fp8"));
-        let lk = *LK.get_or_init(|| gpu.kernel("w4a16", "fp8_fp8_gemm_ldmab").expect("fp8_fp8_gemm_ldmab"));
+        let lk = *LK.get_or_init(|| {
+            gpu.kernel("w4a16", "fp8_fp8_gemm_ldmab")
+                .expect("fp8_fp8_gemm_ldmab")
+        });
         let need = (m as usize) * (k as usize); // e4m3 bytes
         let a8 = {
             let mut g = SCRATCH.lock().unwrap();

--- a/crates/spark-model/src/layers/ops/gemm_fp8_prefill.rs
+++ b/crates/spark-model/src/layers/ops/gemm_fp8_prefill.rs
@@ -37,7 +37,7 @@ pub fn fp8_gemm_n128(
     // win. Quantizes the bf16 activation to e4m3 once into a persistent scratch,
     // then launches the ldmatrix GEMM. K must be a multiple of 32 (the ldmab
     // K-tile). Opt-OUT with ATLAS_FP8_LDMAB=0 (falls through to the scalar path).
-    if k % 32 == 0 && std::env::var("ATLAS_FP8_LDMAB").as_deref() != Ok("0") {
+    if k.is_multiple_of(32) && std::env::var("ATLAS_FP8_LDMAB").as_deref() != Ok("0") {
         use std::sync::{Mutex, OnceLock};
         static QK: OnceLock<KernelHandle> = OnceLock::new();
         static LK: OnceLock<KernelHandle> = OnceLock::new();

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -409,6 +409,7 @@ impl Qwen3AttentionLayer {
             w4a16_gemv_qg_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_qg_batch3")?,
             w4a16_gemv_dual_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
             w4a16_gemv_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,
+            w4a16_gemv_batch4_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
             w4a16_gemm_k: gpu.kernel("w4a16", "w4a16_gemm")?,
             w4a16_gemm_t_k: gpu.kernel("w4a16", "w4a16_gemm_t")?,
             w4a16_gemm_t_k64_k: gpu.kernel("w4a16", "w4a16_gemm_t_k64")?,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/mla.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/mla.rs
@@ -130,6 +130,7 @@ impl Qwen3AttentionLayer {
                 // block_table). All other ctx fields are copied verbatim.
                 let ctx_i = crate::layer::ForwardContext {
                     attn_metadata: Some(meta_i),
+                    midchunk_capture: None,
                     ..*c.fwd
                 };
                 // Q/K/V projection destinations inside `qkv_output`,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
@@ -442,6 +442,25 @@ impl Qwen3AttentionLayer {
     ) -> Result<()> {
         let gpu = c.fwd.gpu;
         let stream = c.stream;
+        // K=4 MTP verify (M<=4): the M<=4 batched GEMV reads the
+        // non-transposed weight ONCE for all rows at near-peak stream
+        // bandwidth. nsys (2026-07-18, drafts=3): the M64-tile w4a16_gemm_t
+        // this bypasses cost 16.3 ms/verify-step across the 16 attention
+        // layers' q/k/v/o at M=4 (94% tile padding) vs ~4.5 ms via the GEMV.
+        // Gated to m<=4 so the DFlash wide verify (M=17) keeps the GEMM.
+        if m <= 4 && self.w4a16_gemv_batch4_k.0 != 0 {
+            return ops::w4a16_gemv_batchm(
+                gpu,
+                self.w4a16_gemv_batch4_k,
+                input,
+                w_base,
+                output,
+                m,
+                n,
+                k,
+                stream,
+            );
+        }
         if let Some(wt) = w_t {
             // Small-M routing (w4a16_m17_bench): at M<=64 the M64-tile
             // `w4a16_gemm_t` beats the M128-tile kernels (87% of an M128

--- a/crates/spark-model/src/layers/qwen3_attention/types.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types.rs
@@ -225,6 +225,8 @@ pub struct Qwen3AttentionLayer {
     pub(super) w4a16_gemv_qg_batch3_k: KernelHandle,
     pub(super) w4a16_gemv_dual_batch3_k: KernelHandle,
     pub(super) w4a16_gemv_batch3_k: KernelHandle,
+    /// M<=4 batched GEMV (K=4 verify q/k/v/o); 0-handle when absent.
+    pub(super) w4a16_gemv_batch4_k: KernelHandle,
     // Kernels — prefill (GEMM M=N + Flash Attention)
     pub(super) w4a16_gemm_k: KernelHandle,
     pub(super) w4a16_gemm_t_k: KernelHandle,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -94,7 +94,17 @@ impl Qwen3SsmLayer {
         // verify — 2026-07-02 flagship gate). Mirrors the M<=4 dispatch in
         // trait_decode_multi_seq/ssm_batched.rs: one weight pass via
         // `w8a16_gemv_batch4`, per-token `w8a16_gemv` when it isn't linked.
-        if (num_tokens == 2 || num_tokens == 3)
+        // 2..=4: the K=4 verify (num_drafts=3) hits this same NULL-slot
+        // hazard — on native-FP8-GDN checkpoints (e.g. nvidia/Qwen3.6-27B-
+        // NVFP4, whose GDN layers ship FP8) `in_proj_qkvz`/`qkvz_nvfp4*` are
+        // NULL and `qkvz_fp8w` is the only live weight. The old `== 2 || == 3`
+        // guard let num_tokens=4 fall through to `dense_gemm` on the NULL
+        // dense slot → CUDA_ERROR_ILLEGAL_ADDRESS on the first K=4 verify
+        // (localized via ATLAS_K4_DIAG, 2026-07-18). `w8a16_gemv_batch4`
+        // is built for M<=4 (see w8a16_gemv_batch4.cu), so widening the
+        // guard is sufficient; the per-token `w8a16_gemv` fallback already
+        // loops over num_tokens.
+        if (2..=4).contains(&num_tokens)
             && let Some(ref fp8) = self.qkvz_fp8w
         {
             if self.w8a16_gemv_batch4_k.0 != 0 {
@@ -437,9 +447,13 @@ impl Qwen3SsmLayer {
                 value_dim as u32,
                 stream,
             )?;
-        } else if (num_tokens == 2 || num_tokens == 3)
+        } else if (2..=4).contains(&num_tokens)
             && let Some(ref fp8) = self.out_proj_fp8w
         {
+            // 2..=4: same K=4 NULL-slot hazard as the QKVZ dispatch above —
+            // on native-FP8-GDN checkpoints `ssm.out_proj` is NULL and
+            // `out_proj_fp8w` is the only live weight; the old guard sent
+            // num_tokens=4 to `w4a16_gemm` on the NULL slot.
             // Native-FP8 build: `ssm.out_proj` is a NULL QuantizedWeight —
             // the block-scaled FP8 copy (`out_proj_fp8w`) is the only live
             // weight. Same NULL-deref hazard as the QKVZ dispatch above.

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -13,7 +13,8 @@ use super::*;
 fn k4_diag_checkpoint(ctx: &ForwardContext, phase: &str, stream: u64) -> Result<()> {
     static DIAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let on = *DIAG.get_or_init(|| std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1"));
-    if on && !ctx.graph_capture
+    if on
+        && !ctx.graph_capture
         && let Err(e) = ctx.gpu.synchronize(stream)
     {
         anyhow::bail!("K4_DIAG: CUDA error after GDN phase `{phase}`: {e:#}");

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -4,6 +4,23 @@
 
 use super::*;
 
+/// ATLAS_K4_DIAG=1 phase checkpoint (see verify_c2.rs). Synchronizes the
+/// stream after a named phase of the batched GDN decode so an illegal access
+/// is attributed to the exact op. No-op (and no env read past the first call)
+/// unless the diagnostic env is set. Only legal in eager mode — verify_c2
+/// disables CUDA-graph capture whenever the env is set, and this checkpoint
+/// is only reachable from that eager path.
+fn k4_diag_checkpoint(ctx: &ForwardContext, phase: &str, stream: u64) -> Result<()> {
+    static DIAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let on = *DIAG.get_or_init(|| std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1"));
+    if on && !ctx.graph_capture
+        && let Err(e) = ctx.gpu.synchronize(stream)
+    {
+        anyhow::bail!("K4_DIAG: CUDA error after GDN phase `{phase}`: {e:#}");
+    }
+    Ok(())
+}
+
 impl Qwen3SsmLayer {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn decode_batched_inner(
@@ -57,6 +74,8 @@ impl Qwen3SsmLayer {
             eps,
             stream,
         )?;
+
+        k4_diag_checkpoint(ctx, "1:rms_norm_residual", stream)?;
 
         // ── 2+3. QKVZ projection (+ deinterleave if needed) ──
         // For sequential_qkvz (Qwen3.5): write directly to deinterleaved buffer.
@@ -261,6 +280,8 @@ impl Qwen3SsmLayer {
             }
         }
 
+        k4_diag_checkpoint(ctx, "2+3:qkvz_proj+deinterleave", stream)?;
+
         // ── 4. BA projection + GDN gates per token ──
         // BA output: ssm_ba buffer; gates: ssm_gates buffer [K, nv*2] FP32
         // Layout per token: [gate(nv), beta(nv)] → stride = 2*nv FP32 elements.
@@ -301,6 +322,8 @@ impl Qwen3SsmLayer {
                 stream,
             )?;
         }
+
+        k4_diag_checkpoint(ctx, "4:ba_proj+gates", stream)?;
 
         // ── 5-7. Conv1d + L2 norm + GDN per token (with intermediate checkpoints) ──
         // Reuse ssm_qkvz buffer for conv output (safe: deinterleave is done)
@@ -354,6 +377,8 @@ impl Qwen3SsmLayer {
         };
         self.decode_batched_conv_gdn(ssm_state, ctx, &args)?;
 
+        k4_diag_checkpoint(ctx, "5-7:conv1d+l2norm+gdn_wy", stream)?;
+
         // ── 8. Gated RMS norm per token (Z gate at [Q|K|V] offset) ──
         let normed_out_buf = conv_out_buf;
         let z_offset = key_dim * 2 + value_dim; // == conv_dim
@@ -395,6 +420,8 @@ impl Qwen3SsmLayer {
                 )?;
             }
         }
+
+        k4_diag_checkpoint(ctx, "8:gated_rms_norm", stream)?;
 
         // ── 9. Output projection → [K, H] ──
         let out_proj_buf = ctx.buffers.moe_output(); // [K, H] BF16
@@ -537,6 +564,8 @@ impl Qwen3SsmLayer {
         // ranks (num_tokens × h BF16) before the residual add. No-op at tp=1.
         self.ssm_tp_all_reduce(out_proj_buf, num_tokens, ctx, stream)?;
 
+        k4_diag_checkpoint(ctx, "9:out_proj", stream)?;
+
         // ── 10. Batched residual + post-norm, then MoE + residual ──
         // residual_add_rms_norm supports multi-token (grid.x = num_tokens)
         let normed2_base = ctx.buffers.norm_output();
@@ -589,8 +618,10 @@ impl Qwen3SsmLayer {
             // DENSE ONLY: the per-token `else` below is retained for 256-expert
             // MoE, where grouped-GEMM is a net loss at small batch (per-expert
             // M~1 + sort/permute overhead across the 36-layer SSM stack).
+            k4_diag_checkpoint(ctx, "10a:residual_add_rms_norm", stream)?;
             self.ffn
                 .forward_prefill(normed2_base, num_tokens, ctx, stream)?;
+            k4_diag_checkpoint(ctx, "10b:ffn_forward_prefill", stream)?;
             let moe_out = ctx.buffers.moe_output();
             ops::residual_add(
                 ctx.gpu,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -621,6 +621,28 @@ impl Qwen3SsmLayer {
                 (2 * h) as u32,
                 stream,
             )?;
+        } else if num_tokens == 4
+            && self
+                .ffn
+                .try_forward_k4(normed2_base, ctx, stream)
+                .inspect_err(|e| tracing::error!("ffn.try_forward_k4: {e:#}"))
+                .unwrap_or(false)
+        {
+            // K=4 verify FFN via M<=4 batched GEMV: one weight read per
+            // projection for all 4 rows at near-peak stream bandwidth. nsys
+            // (2026-07-18): the forward_prefill MMQ arm below cost 54.8 ms/
+            // verify-step across the 64-layer dense FFN stack at M=4 vs the
+            // ~31 ms weight-traffic floor this path hits. Falls through to
+            // forward_prefill when unavailable (MoE / missing kernel).
+            let moe_out = ctx.buffers.moe_output();
+            ops::residual_add(
+                ctx.gpu,
+                self.residual_add_k,
+                hidden,
+                moe_out,
+                (num_tokens * h) as u32,
+                stream,
+            )?;
         } else if self.ffn.is_dense() {
             // WIDE-VERIFY BATCHED DENSE FFN (DFlash γ=16, num_tokens=17). This
             // is the MAJORITY layer type (GDN/SSM) on the hybrid 27B, so its

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill.rs
@@ -210,19 +210,24 @@ impl Qwen3SsmLayer {
 
         // Input: deinterleaved [N, qkvz_size], output: conv_out [N, conv_dim]
         // Conv1d processes QKV channels (first conv_dim of each token's qkvz_size)
-        ops::conv1d_update_prefill(
-            ctx.gpu,
-            self.conv1d_prefill_k,
+        // MID-CHUNK tail capture: reserve THIS SSM layer's per-pass ordinal
+        // once (shared by the conv + recurrence splits below). `None` unless
+        // ATLAS_SSM_TAIL_MIDCHUNK is active for a pass that spans `tb`.
+        let midcap_idx = ctx.midchunk_capture.as_ref().map(|c| {
+            c.ssm_layer_counter
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        });
+        // Conv1d — optionally split at cap_local, capturing conv_state @ tb.
+        self.conv1d_prefill_capture(
+            ctx,
             ssm_state.conv_state,
             deinterleaved,
-            &self.ssm.conv1d,
-            DevicePtr::NULL,
             conv_out_buf,
-            conv_dim as u32,
-            d_conv as u32,
+            conv_dim,
+            d_conv,
             k,
-            qkvz_size as u32,
-            conv_dim as u32,
+            qkvz_size,
+            midcap_idx,
             stream,
         )?;
         // ATLAS_GDN_DUMP hook #1: post-conv1d (post-silu, applied inside
@@ -307,6 +312,7 @@ impl Qwen3SsmLayer {
             kd,
             vd,
             conv_dim,
+            midcap_idx,
             ctx,
             stream,
         )?;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill.rs
@@ -405,11 +405,7 @@ impl Qwen3SsmLayer {
             None
         };
 
-        // ATLAS_DUMP_EXPERT_IDS=1 also dumps the residual_add_rms_norm
-        // INPUTS (hidden + out_proj_buf separately) for last token.
-        // This isolates whether the gate-input direction-divergence vs HF
-        // comes from (a) hidden being corrupted, (b) out_proj_buf differing,
-        // or (c) the residual_add_rms_norm kernel itself computing differently.
+        // ATLAS_DUMP_EXPERT_IDS=1: also dumps residual_add_rms_norm INPUTS (hidden + out_proj_buf) for drift attribution.
         if std::env::var("ATLAS_DUMP_EXPERT_IDS").ok().as_deref() == Some("1") {
             ctx.gpu.synchronize(stream)?;
             let offset = (num_tokens - 1) * h * 2;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
@@ -45,65 +45,57 @@ impl Qwen3SsmLayer {
         // paths (and a future C=32 FLA variant) are Blackwell-only. NVIDIA
         // (cfg unset) takes the full FLA/WY ladder below unchanged.
         if cfg!(atlas_scale) {
-            // MID-CHUNK tail capture: split the split4 recurrence at cap_local,
-            // D2D the @tb h_state into the reserved snapshot slot, then finish
-            // the trailing tokens with h_state chained. Byte-identical to a
-            // single call — same algebra as the >4096 sub-chunk loop below.
+            // MID-CHUNK tail capture: split the split4 recurrence at cap_local
+            // (and, when present, cap_local - bs), D2D each captured h_state
+            // into its reserved slot, then finish the trailing tokens with
+            // h_state chained. Byte-identical to a single call — same algebra as
+            // the >4096 sub-chunk loop below.
             if let (Some(cap), Some(idx)) = (ctx.midchunk_capture.as_ref(), midcap_idx) {
                 let cl = cap.cap_local;
                 if cl > 0 && (cl as u32) < k {
                     let bf16 = 2usize;
                     let value_dim = nv * vd;
-                    // Segment 1: local tokens [0, cap_local).
-                    ops::gdn_prefill_split4(
-                        ctx.gpu,
-                        self.gdn_prefill_split4_k,
-                        h_state,
-                        q_ptr,
-                        k_ptr,
-                        v_ptr,
-                        gates_buf,
-                        gates_buf.offset(nv * fp32),
-                        gdn_out_buf,
-                        1,
-                        cl as u32,
-                        nk as u32,
-                        nv as u32,
-                        kd as u32,
-                        vd as u32,
-                        conv_dim as u32,
-                        conv_dim as u32,
-                        gb_stride,
-                        stream,
-                    )?;
-                    // Capture h_state @ tb into the reserved slot for this layer.
+                    // Run split4 over local tokens [start, start+len); h_state is
+                    // the SAME (chained) across calls — offsets mirror the >4096
+                    // sub-chunk loop's stride arithmetic.
+                    let seg = |start: usize, len: u32| -> Result<()> {
+                        let gate = gates_buf.offset(start * gb_stride as usize * fp32);
+                        ops::gdn_prefill_split4(
+                            ctx.gpu,
+                            self.gdn_prefill_split4_k,
+                            h_state,
+                            q_ptr.offset(start * conv_dim * bf16),
+                            k_ptr.offset(start * conv_dim * bf16),
+                            v_ptr.offset(start * conv_dim * bf16),
+                            gate,
+                            gate.offset(nv * fp32),
+                            gdn_out_buf.offset(start * value_dim * bf16),
+                            1,
+                            len,
+                            nk as u32,
+                            nv as u32,
+                            kd as u32,
+                            vd as u32,
+                            conv_dim as u32,
+                            conv_dim as u32,
+                            gb_stride,
+                            stream,
+                        )
+                    };
+                    // Optional EARLIER capture at cap_local - bs (token tb - bs).
+                    let mut start = 0usize;
+                    if let Some(ce) = cap.cap_local_early {
+                        seg(0, ce as u32)?;
+                        ctx.gpu
+                            .copy_d2d_async(h_state, cap.h_dsts_early[idx], cap.h_bytes, stream)?;
+                        start = ce;
+                    }
+                    // Capture h_state @ the tail boundary tb.
+                    seg(start, (cl - start) as u32)?;
                     ctx.gpu
                         .copy_d2d_async(h_state, cap.h_dsts[idx], cap.h_bytes, stream)?;
-                    // Segment 2: local tokens [cap_local, k) with OFFSET q/k/v/
-                    // gate/beta/output pointers (mirrors the >4096 loop stride
-                    // arithmetic); h_state is the SAME (chained) across calls.
-                    let gate2 = gates_buf.offset(cl * gb_stride as usize * fp32);
-                    return ops::gdn_prefill_split4(
-                        ctx.gpu,
-                        self.gdn_prefill_split4_k,
-                        h_state,
-                        q_ptr.offset(cl * conv_dim * bf16),
-                        k_ptr.offset(cl * conv_dim * bf16),
-                        v_ptr.offset(cl * conv_dim * bf16),
-                        gate2,
-                        gate2.offset(nv * fp32),
-                        gdn_out_buf.offset(cl * value_dim * bf16),
-                        1,
-                        k - cl as u32,
-                        nk as u32,
-                        nv as u32,
-                        kd as u32,
-                        vd as u32,
-                        conv_dim as u32,
-                        conv_dim as u32,
-                        gb_stride,
-                        stream,
-                    );
+                    // Trailing tokens [cap_local, k).
+                    return seg(cl, k - cl as u32);
                 }
             }
             return ops::gdn_prefill_split4(
@@ -372,41 +364,44 @@ impl Qwen3SsmLayer {
             let cl = cap.cap_local;
             if cl > 0 && (cl as u32) < k {
                 let bf16 = 2usize;
-                // Segment 1: [0, cap_local).
-                ops::conv1d_update_prefill(
-                    ctx.gpu,
-                    self.conv1d_prefill_k,
-                    conv_state,
-                    input,
-                    &self.ssm.conv1d,
-                    DevicePtr::NULL,
-                    output,
-                    conv_dim as u32,
-                    d_conv as u32,
-                    cl as u32,
-                    qkvz_size as u32,
-                    conv_dim as u32,
-                    stream,
-                )?;
-                // Capture conv_state @ tb into the reserved slot for this layer.
+                // Run the sliding-window conv over local tokens [start, start+len);
+                // conv_state is chained across calls (the same contract multi-chunk
+                // prefill relies on), so the split is byte-exact.
+                let seg = |start: usize, len: u32| -> Result<()> {
+                    ops::conv1d_update_prefill(
+                        ctx.gpu,
+                        self.conv1d_prefill_k,
+                        conv_state,
+                        input.offset(start * qkvz_size * bf16),
+                        &self.ssm.conv1d,
+                        DevicePtr::NULL,
+                        output.offset(start * conv_dim * bf16),
+                        conv_dim as u32,
+                        d_conv as u32,
+                        len,
+                        qkvz_size as u32,
+                        conv_dim as u32,
+                        stream,
+                    )
+                };
+                // Optional EARLIER capture at cap_local - bs (token tb - bs).
+                let mut start = 0usize;
+                if let Some(ce) = cap.cap_local_early {
+                    seg(0, ce as u32)?;
+                    ctx.gpu.copy_d2d_async(
+                        conv_state,
+                        cap.conv_dsts_early[idx],
+                        cap.conv_bytes,
+                        stream,
+                    )?;
+                    start = ce;
+                }
+                // Capture conv_state @ the tail boundary tb.
+                seg(start, (cl - start) as u32)?;
                 ctx.gpu
                     .copy_d2d_async(conv_state, cap.conv_dsts[idx], cap.conv_bytes, stream)?;
-                // Segment 2: [cap_local, k) with OFFSET input/output; state chained.
-                ops::conv1d_update_prefill(
-                    ctx.gpu,
-                    self.conv1d_prefill_k,
-                    conv_state,
-                    input.offset(cl * qkvz_size * bf16),
-                    &self.ssm.conv1d,
-                    DevicePtr::NULL,
-                    output.offset(cl * conv_dim * bf16),
-                    conv_dim as u32,
-                    d_conv as u32,
-                    k - cl as u32,
-                    qkvz_size as u32,
-                    conv_dim as u32,
-                    stream,
-                )?;
+                // Trailing tokens [cap_local, k).
+                seg(cl, k - cl as u32)?;
                 return Ok(());
             }
         }

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
@@ -86,8 +86,12 @@ impl Qwen3SsmLayer {
                     let mut start = 0usize;
                     if let Some(ce) = cap.cap_local_early {
                         seg(0, ce as u32)?;
-                        ctx.gpu
-                            .copy_d2d_async(h_state, cap.h_dsts_early[idx], cap.h_bytes, stream)?;
+                        ctx.gpu.copy_d2d_async(
+                            h_state,
+                            cap.h_dsts_early[idx],
+                            cap.h_bytes,
+                            stream,
+                        )?;
                         start = ce;
                     }
                     // Capture h_state @ the tail boundary tb.

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_recur.rs
@@ -30,6 +30,7 @@ impl Qwen3SsmLayer {
         kd: usize,
         vd: usize,
         conv_dim: usize,
+        midcap_idx: Option<usize>,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
@@ -44,6 +45,67 @@ impl Qwen3SsmLayer {
         // paths (and a future C=32 FLA variant) are Blackwell-only. NVIDIA
         // (cfg unset) takes the full FLA/WY ladder below unchanged.
         if cfg!(atlas_scale) {
+            // MID-CHUNK tail capture: split the split4 recurrence at cap_local,
+            // D2D the @tb h_state into the reserved snapshot slot, then finish
+            // the trailing tokens with h_state chained. Byte-identical to a
+            // single call — same algebra as the >4096 sub-chunk loop below.
+            if let (Some(cap), Some(idx)) = (ctx.midchunk_capture.as_ref(), midcap_idx) {
+                let cl = cap.cap_local;
+                if cl > 0 && (cl as u32) < k {
+                    let bf16 = 2usize;
+                    let value_dim = nv * vd;
+                    // Segment 1: local tokens [0, cap_local).
+                    ops::gdn_prefill_split4(
+                        ctx.gpu,
+                        self.gdn_prefill_split4_k,
+                        h_state,
+                        q_ptr,
+                        k_ptr,
+                        v_ptr,
+                        gates_buf,
+                        gates_buf.offset(nv * fp32),
+                        gdn_out_buf,
+                        1,
+                        cl as u32,
+                        nk as u32,
+                        nv as u32,
+                        kd as u32,
+                        vd as u32,
+                        conv_dim as u32,
+                        conv_dim as u32,
+                        gb_stride,
+                        stream,
+                    )?;
+                    // Capture h_state @ tb into the reserved slot for this layer.
+                    ctx.gpu
+                        .copy_d2d_async(h_state, cap.h_dsts[idx], cap.h_bytes, stream)?;
+                    // Segment 2: local tokens [cap_local, k) with OFFSET q/k/v/
+                    // gate/beta/output pointers (mirrors the >4096 loop stride
+                    // arithmetic); h_state is the SAME (chained) across calls.
+                    let gate2 = gates_buf.offset(cl * gb_stride as usize * fp32);
+                    return ops::gdn_prefill_split4(
+                        ctx.gpu,
+                        self.gdn_prefill_split4_k,
+                        h_state,
+                        q_ptr.offset(cl * conv_dim * bf16),
+                        k_ptr.offset(cl * conv_dim * bf16),
+                        v_ptr.offset(cl * conv_dim * bf16),
+                        gate2,
+                        gate2.offset(nv * fp32),
+                        gdn_out_buf.offset(cl * value_dim * bf16),
+                        1,
+                        k - cl as u32,
+                        nk as u32,
+                        nv as u32,
+                        kd as u32,
+                        vd as u32,
+                        conv_dim as u32,
+                        conv_dim as u32,
+                        gb_stride,
+                        stream,
+                    );
+                }
+            }
             return ops::gdn_prefill_split4(
                 ctx.gpu,
                 self.gdn_prefill_split4_k,
@@ -284,5 +346,84 @@ impl Qwen3SsmLayer {
             )?;
         }
         Ok(())
+    }
+
+    /// Conv1d prefill with optional MID-CHUNK tail capture. When capturing,
+    /// splits the sliding-window conv at `cap_local`, D2D-copies the @tb
+    /// conv_state into the reserved snapshot slot, then finishes the trailing
+    /// tokens (conv_state chained). Byte-identical to a single call otherwise —
+    /// the sliding window carried in conv_state makes the split exact (same
+    /// contract multi-chunk prefill already relies on).
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn conv1d_prefill_capture(
+        &self,
+        ctx: &ForwardContext,
+        conv_state: DevicePtr,
+        input: DevicePtr,
+        output: DevicePtr,
+        conv_dim: usize,
+        d_conv: usize,
+        k: u32,
+        qkvz_size: usize,
+        midcap_idx: Option<usize>,
+        stream: u64,
+    ) -> Result<()> {
+        if let (Some(cap), Some(idx)) = (ctx.midchunk_capture.as_ref(), midcap_idx) {
+            let cl = cap.cap_local;
+            if cl > 0 && (cl as u32) < k {
+                let bf16 = 2usize;
+                // Segment 1: [0, cap_local).
+                ops::conv1d_update_prefill(
+                    ctx.gpu,
+                    self.conv1d_prefill_k,
+                    conv_state,
+                    input,
+                    &self.ssm.conv1d,
+                    DevicePtr::NULL,
+                    output,
+                    conv_dim as u32,
+                    d_conv as u32,
+                    cl as u32,
+                    qkvz_size as u32,
+                    conv_dim as u32,
+                    stream,
+                )?;
+                // Capture conv_state @ tb into the reserved slot for this layer.
+                ctx.gpu
+                    .copy_d2d_async(conv_state, cap.conv_dsts[idx], cap.conv_bytes, stream)?;
+                // Segment 2: [cap_local, k) with OFFSET input/output; state chained.
+                ops::conv1d_update_prefill(
+                    ctx.gpu,
+                    self.conv1d_prefill_k,
+                    conv_state,
+                    input.offset(cl * qkvz_size * bf16),
+                    &self.ssm.conv1d,
+                    DevicePtr::NULL,
+                    output.offset(cl * conv_dim * bf16),
+                    conv_dim as u32,
+                    d_conv as u32,
+                    k - cl as u32,
+                    qkvz_size as u32,
+                    conv_dim as u32,
+                    stream,
+                )?;
+                return Ok(());
+            }
+        }
+        ops::conv1d_update_prefill(
+            ctx.gpu,
+            self.conv1d_prefill_k,
+            conv_state,
+            input,
+            &self.ssm.conv1d,
+            DevicePtr::NULL,
+            output,
+            conv_dim as u32,
+            d_conv as u32,
+            k,
+            qkvz_size as u32,
+            conv_dim as u32,
+            stream,
+        )
     }
 }

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -249,9 +249,7 @@ impl TransformerModel {
         // [max_seq_len, hidden_size] BF16 — 335 MB at 32k/h=5120. Explicitly
         // opt-in (PCND): NULL (and zero cost) unless the env is set and MTP
         // is active. Sized to max_seq_len so an 8k+ prompt capture holds.
-        let mtp_prefill_hidden = if has_mtp
-            && crate::layers::mtp_drafter_prefill_enabled()
-        {
+        let mtp_prefill_hidden = if has_mtp && crate::layers::mtp_drafter_prefill_enabled() {
             let bytes = max_seq_len * config.hidden_size * 2;
             tracing::info!(
                 "ATLAS_MTP_DRAFTER_PREFILL=1: allocating {:.0} MB prompt-hidden \

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -241,6 +241,26 @@ impl TransformerModel {
         // MTP hidden state save buffer (1 × hidden_size FP32)
         let mtp_hidden_save = gpu.alloc(config.hidden_size * 4)?;
 
+        // ATLAS_MTP_DRAFTER_PREFILL: whole-prompt hidden capture buffer,
+        // [max_seq_len, hidden_size] BF16 — 335 MB at 32k/h=5120. Explicitly
+        // opt-in (PCND): NULL (and zero cost) unless the env is set and MTP
+        // is active. Sized to max_seq_len so an 8k+ prompt capture holds.
+        let mtp_prefill_hidden = if has_mtp
+            && crate::layers::mtp_drafter_prefill_enabled()
+        {
+            let bytes = max_seq_len * config.hidden_size * 2;
+            tracing::info!(
+                "ATLAS_MTP_DRAFTER_PREFILL=1: allocating {:.0} MB prompt-hidden \
+                 capture ({} x {} BF16) for MTP drafter prefill",
+                bytes as f64 / 1e6,
+                max_seq_len,
+                config.hidden_size,
+            );
+            gpu.alloc(bytes)?
+        } else {
+            DevicePtr::NULL
+        };
+
         // DFlash 5-layer hidden-state stack. Allocated only when a
         // BlockDiffusionDraftHead is the active proposer (`config.dflash_capture_layers`
         // populated by the loader from the drafter's `dflash_config.target_layer_ids`).
@@ -494,6 +514,13 @@ impl TransformerModel {
             profile_first_pending: std::sync::atomic::AtomicBool::new(profile_first),
             proposer,
             mtp_hidden_save,
+            mtp_prefill_hidden,
+            mtp_prefill_capacity: if mtp_prefill_hidden.is_null() {
+                0
+            } else {
+                max_seq_len
+            },
+            mtp_prefill_capture_len: std::sync::atomic::AtomicUsize::new(0),
             dflash_hidden_save,
             dflash_hidden_save_rows,
             dflash_capture_layers,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -78,6 +78,10 @@ impl TransformerModel {
         let w4a16_gemv_logits_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_logits")?;
         let w4a16_gemm_kernel = gpu.kernel("w4a16", "w4a16_gemm")?;
         let w4a16_gemv_batch2_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?;
+        // M<=4 batched GEMV for the K=3/K=4 verify lm_head (try_kernel:
+        // 0-handle on targets that predate it; dispatch falls back).
+        let w4a16_gemv_batch4_kernel =
+            crate::layers::try_kernel(gpu.as_ref(), "w4a16_gemv", "w4a16_gemv_batch4");
         // FP8 E4M3 LUT GEMV for the `--lm-head-dtype fp8` head. Loaded
         // unconditionally (a handle is cheap); only invoked when `lm_head_fp8`
         // is set, so the NVFP4/BF16 paths never touch it.
@@ -482,6 +486,7 @@ impl TransformerModel {
             w4a16_gemv_logits_kernel,
             w4a16_gemm_kernel,
             w4a16_gemv_batch2_kernel,
+            w4a16_gemv_batch4_kernel,
             dense_gemv_fp8w_kernel,
             dense_gemv_fp8w_batch2_kernel,
             dense_gemm_kernel,

--- a/crates/spark-model/src/model/impl_a3.rs
+++ b/crates/spark-model/src/model/impl_a3.rs
@@ -155,6 +155,28 @@ impl TransformerModel {
                     stream,
                 )?;
             }
+        } else if (num_tokens == 3 || num_tokens == 4)
+            && self.w4a16_gemv_batch4_kernel.0 != 0
+            && let Some(ref nvfp4) = self.lm_head_nvfp4
+        {
+            // K=3/K=4 verify lm_head: one weight read for all rows via the
+            // M<=4 batched GEMV. nsys (2026-07-18, drafts=3 serve): the base
+            // M64-tile `w4a16_gemm` below cost 19.3 ms/verify-step on the
+            // [248320, 5120] NVFP4 lm_head at M=4 — 94% of the M-tile is
+            // padding, ~33 GB/s effective. The batch GEMV streams the same
+            // 636 MB once at near-peak (~2.5 ms), the single largest slice
+            // of the K=4 verify-vs-K=2 cost gap.
+            ops::w4a16_gemv_batchm(
+                self.gpu.as_ref(),
+                self.w4a16_gemv_batch4_kernel,
+                hidden,
+                nvfp4,
+                logits,
+                num_tokens,
+                v,
+                h,
+                stream,
+            )?;
         } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
             ops::w4a16_gemm(
                 self.gpu.as_ref(),

--- a/crates/spark-model/src/model/impl_b1.rs
+++ b/crates/spark-model/src/model/impl_b1.rs
@@ -372,6 +372,7 @@ impl TransformerModel {
                 // #30: forward the parent's routing (None on this decode-profiling
                 // path, but never silently drop it if a prefill ever re-wraps).
                 routed_lora_layers: ctx.routed_lora_layers,
+                midchunk_capture: None,
             }
         };
 
@@ -565,6 +566,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: offline single-seq decode; no prefill route.
+            midchunk_capture: None,
         };
 
         // Eager layer loop: skip SSM layers, run attention layers only

--- a/crates/spark-model/src/model/impl_b2.rs
+++ b/crates/spark-model/src/model/impl_b2.rs
@@ -208,6 +208,7 @@ impl TransformerModel {
                 gdn_exact_replay: false,
                 token_ids: None,
                 routed_lora_layers: None, // #30: MTP decode never routes prefill.
+                midchunk_capture: None,
             };
             let drafts = proposer.propose(
                 token_0,

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -89,6 +89,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: MTP/draft decode never routes prefill.
+            midchunk_capture: None,
         };
         let prop_state = seq
             .proposer_state

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -105,8 +105,8 @@ impl TransformerModel {
             let captured = self
                 .mtp_prefill_capture_len
                 .load(std::sync::atomic::Ordering::Relaxed);
-            if p >= 2 && captured >= p && seq.tokens.len() >= p {
-                if let Err(e) = proposer.prefill_drafter(
+            if p >= 2 && captured >= p && seq.tokens.len() >= p
+                && let Err(e) = proposer.prefill_drafter(
                     &seq.tokens[..p],
                     self.mtp_prefill_hidden,
                     prop_state.as_mut(),
@@ -115,7 +115,6 @@ impl TransformerModel {
                 ) {
                     tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
                 }
-            }
         }
         proposer.propose(
             token,

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -94,6 +94,28 @@ impl TransformerModel {
             .proposer_state
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("No proposer state for sequence"))?;
+        // ATLAS_MTP_DRAFTER_PREFILL: on the FIRST propose of a sequence,
+        // batch-prefill the drafter's KV over the prompt (fresh-state check
+        // and quant support live inside prefill_drafter; it fast-returns 0 on
+        // every later call). Requires the capture to cover the full prompt —
+        // partial capture (prefix-cache reuse / warm restore) skips cleanly.
+        if !self.mtp_prefill_hidden.is_null() {
+            let p = seq.prompt_len;
+            let captured = self
+                .mtp_prefill_capture_len
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if p >= 2 && captured >= p && seq.tokens.len() >= p {
+                if let Err(e) = proposer.prefill_drafter(
+                    &seq.tokens[..p],
+                    self.mtp_prefill_hidden,
+                    prop_state.as_mut(),
+                    &ctx,
+                    stream,
+                ) {
+                    tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
+                }
+            }
+        }
         proposer.propose(
             token,
             self.mtp_hidden_save,

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -105,16 +105,19 @@ impl TransformerModel {
             let captured = self
                 .mtp_prefill_capture_len
                 .load(std::sync::atomic::Ordering::Relaxed);
-            if p >= 2 && captured >= p && seq.tokens.len() >= p
+            if p >= 2
+                && captured >= p
+                && seq.tokens.len() >= p
                 && let Err(e) = proposer.prefill_drafter(
                     &seq.tokens[..p],
                     self.mtp_prefill_hidden,
                     prop_state.as_mut(),
                     &ctx,
                     stream,
-                ) {
-                    tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
-                }
+                )
+            {
+                tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
+            }
         }
         proposer.propose(
             token,

--- a/crates/spark-model/src/model/ssm_snapshot.rs
+++ b/crates/spark-model/src/model/ssm_snapshot.rs
@@ -364,6 +364,50 @@ impl SsmSnapshotPool {
         self.free_slots.lock().push(snap_slot);
     }
 
+    /// Reserve a Marconi snapshot slot for an in-pass MID-CHUNK tail capture.
+    /// Pops a free slot, tags it with `session_hash`, and clears any stale
+    /// last-token-hidden marker (a tail snapshot is never a leaf). Returns
+    /// `None` when the pool is exhausted; the caller may `reclaim_from_cache`
+    /// and retry, or skip capture. Mirrors the bookkeeping `save` performs so
+    /// `restore` and session isolation behave identically for this slot.
+    pub(crate) fn reserve_tail_slot(&self, session_hash: u64) -> Option<usize> {
+        if !self.is_enabled() {
+            return None;
+        }
+        let snap_slot = self.free_slots.lock().pop()?;
+        self.slot_has_hidden.lock().remove(&snap_slot);
+        if session_hash != 0 {
+            self.session_tags.lock().insert(snap_slot, session_hash);
+        }
+        Some(snap_slot)
+    }
+
+    /// Per-SSM-layer h_state snapshot destination for `snap_slot`
+    /// (byte offset into the layer's slot region already applied).
+    pub(crate) fn tail_h_dst(&self, ssm_layer: usize, snap_slot: usize) -> DevicePtr {
+        self.h_snapshots[ssm_layer].offset(snap_slot * self.h_bytes)
+    }
+
+    /// Per-SSM-layer conv_state snapshot destination for `snap_slot`.
+    pub(crate) fn tail_conv_dst(&self, ssm_layer: usize, snap_slot: usize) -> DevicePtr {
+        self.conv_snapshots[ssm_layer].offset(snap_slot * self.conv_bytes)
+    }
+
+    /// Bytes per layer of a snapshot's h_state.
+    pub(crate) fn h_bytes(&self) -> usize {
+        self.h_bytes
+    }
+
+    /// Bytes per layer of a snapshot's conv_state.
+    pub(crate) fn conv_bytes(&self) -> usize {
+        self.conv_bytes
+    }
+
+    /// Number of SSM layers (== length of the per-layer dst vectors).
+    pub(crate) fn num_ssm_layers(&self) -> usize {
+        self.num_ssm_layers
+    }
+
     /// Stash the last-token post-final-norm hidden (`hidden_bytes`, BF16)
     /// for a leaf snapshot slot. Used so an exact full-prompt hit can emit
     /// the first token's logits via `lm_head` without re-running the last

--- a/crates/spark-model/src/model/trait_impl/async_chkpt.rs
+++ b/crates/spark-model/src/model/trait_impl/async_chkpt.rs
@@ -213,17 +213,17 @@ impl TransformerModel {
     ///
     /// - `num_accepted == k` (full accept): the kernel's final `h_state`
     ///   is the committed state → no-op.
-    /// - `0 < num_accepted < k` (partial / K=2 reject): copy
+    /// - `0 < num_accepted < k` (partial accept): copy
     ///   `h_state_intermediates[num_accepted - 1]` (state after the last
     ///   accepted token) → `h_state` (+ conv intermediate).
     ///
-    /// The K=2 verify path runs the kernel directly on the canonical
-    /// `h_state` (no `pre_verify_copy_async` scratch-seed), so on a full
-    /// accept the live state is already committed and on a partial accept
-    /// the single index-select below leaves `h_state` canonical for every
-    /// successor (bootstrap decode, gate-flip decode, concurrent request).
-    /// No `*_checkpoint` write is needed. (K=3/K=4/DFlash verify still use
-    /// the legacy dual-buffer `commit_verify_state_async`.)
+    /// All verify paths (K=2, K=3, K=4, DFlash) run the kernel directly
+    /// on the canonical `h_state` (no `pre_verify_copy_async` scratch-seed),
+    /// so on a full accept the live state is already committed and on a
+    /// partial accept the single index-select below leaves `h_state`
+    /// canonical for every successor (bootstrap decode, gate-flip decode,
+    /// concurrent request). No `*_checkpoint` write is needed — the next
+    /// `start_checkpoint_async` syncs h_state → checkpoint at prefill time.
     ///
     /// Runs on `secondary_stream`; pair with `sync_secondary`.
     pub(super) fn commit_accepted_prefix_dispatch(

--- a/crates/spark-model/src/model/trait_impl/decode_a.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a.rs
@@ -227,6 +227,7 @@ impl TransformerModel {
             // before graph replay). MoE reads it at offset 0.
             token_ids: Some(self.buffers.token_ids()),
             routed_lora_layers: None, // #30: single-seq decode never routes prefill.
+            midchunk_capture: None,
         };
 
         // Profile mode: use per-layer sync decode for timing breakdown.

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -235,6 +235,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: batched decode never routes prefill.
+            midchunk_capture: None,
         };
 
         // ── Phase 2: CUDA graph lookup / capture ──

--- a/crates/spark-model/src/model/trait_impl/decode_b.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b.rs
@@ -384,6 +384,7 @@ impl TransformerModel {
             token_ids: None,
             // #30: decode never routes prefill — installed-pair/bgmv path only.
             routed_lora_layers: None,
+            midchunk_capture: None,
         };
 
         let prefill_ctx = ForwardContext {
@@ -399,6 +400,7 @@ impl TransformerModel {
             // #30: the fused (SLAI) prefill portion routes by the prefilling
             // seq's slot (None unless it routes to a non-active slot).
             routed_lora_layers: self.routed_slot_layers(prefill_seq.adapter_slot),
+            midchunk_capture: None,
         };
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -127,6 +127,13 @@ impl TransformerModel {
         self.gpu.synchronize(stream)?;
         let has_mtp = self.proposer.is_some() || self.self_speculative;
 
+        // ATLAS_MTP_DRAFTER_PREFILL: a fresh sequence invalidates the
+        // whole-prompt hidden capture — without this, a warm-restored prefill
+        // (no chunks computed) would pair the NEW prompt's tokens with the
+        // PREVIOUS sequence's captured hiddens in the drafter prefill.
+        self.mtp_prefill_capture_len
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
         // Build layer states: SSM layers point into the pool (fixed addresses),
         // attention layers use their own alloc_state (EmptyLayerState).
         // When MTP is available, pre-allocate checkpoint + K=2 intermediate

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -702,6 +702,10 @@ impl Model for TransformerModel {
     fn is_mla(&self) -> bool {
         self.is_mla_dispatch()
     }
+
+    fn kv_block_size(&self) -> Option<usize> {
+        Some(self.kv_cache.lock().block_size())
+    }
     fn decode_logits_fp32(&self) -> bool {
         self.decode_logits_fp32_dispatch()
     }

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -479,6 +479,10 @@ impl TransformerModel {
             }
         }
 
+        // ATLAS_MTP_DRAFTER_PREFILL: capture the processed rows' final-layer
+        // hiddens for the whole-prompt drafter prefill. No-op when disabled.
+        self.try_mtp_prefill_capture(seq_len_start, proc_count, stream)?;
+
         // ── 5. Final norm on LAST token only ──
         let last_hidden = hidden.offset((proc_count - 1) * h * fp32);
         let normed = self.buffers.norm_output();

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -384,6 +384,7 @@ impl TransformerModel {
             token_ids: Some(self.buffers.token_ids()),
             // #30: request slot pairs (None unless routing to a non-active slot).
             routed_lora_layers: self.routed_slot_layers(seq.adapter_slot),
+            midchunk_capture: None,
         };
 
         // ── 4. Forward through all layers ──

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -33,6 +33,7 @@ mod embed_chunk;
 mod finalize_last;
 mod forward_layers;
 mod h_state_ptrs;
+mod midchunk_capture;
 mod prefix_lookup;
 mod proc_range;
 mod prompt_logprobs;
@@ -264,6 +265,12 @@ impl TransformerModel {
         // per chunk but prevents the illegal memory access.
         self.gpu.synchronize(stream)?;
 
+        // ── Mid-chunk tail SSM capture (opt-in): plan BEFORE the forward
+        // pass so SSM layers split their h/conv kernels at `tb` in-pass.
+        // `None` (flag off or pass doesn't span `tb`) => no split. ──
+        let midcap_plan =
+            self.prepare_midchunk_capture(tokens, seq, &mut kv_cache, proc_start, proc_count);
+
         // ── Phase 4: forward through all layers ──
         self.prefill_b_forward_layers(
             seq,
@@ -280,8 +287,15 @@ impl TransformerModel {
             pos_stream_bytes,
             use_mrope,
             needs_paged,
+            midcap_plan.as_ref(),
             stream,
         )?;
+
+        // Register the reserved slot as the session tail once the full pass has
+        // captured the @tb state into it (no-op when no capture was planned).
+        if let Some(plan) = midcap_plan.as_ref() {
+            self.finalize_midchunk_capture(tokens, seq, plan);
+        }
 
         // ── Phase 5: update sequence state incrementally ──
         // Always add chunk tokens exactly once. The early-return path for

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch.rs
@@ -338,6 +338,8 @@ impl TransformerModel {
                     pos_stream_bytes,
                     use_mrope,
                     needs_paged,
+                    // Batched path does not do mid-chunk tail capture (single-seq only).
+                    None,
                     stream,
                 )?;
 

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
@@ -394,6 +394,7 @@ impl TransformerModel {
             // the bgmv (via multi_seq/qkv.rs); its attn_metadata is None so it never
             // reaches paged_qkv's routed path anyway. Must stay None.
             routed_lora_layers: None,
+            midchunk_capture: None,
         };
 
         // h_state_ptrs scratch slot offset (used JIT per SSM layer).

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -254,6 +254,9 @@ impl TransformerModel {
                 );
             }
         }
+        // ATLAS_MTP_DRAFTER_PREFILL: capture this chunk's final-layer hidden
+        // rows for the whole-prompt drafter prefill. No-op when disabled.
+        self.try_mtp_prefill_capture(effective_seq_len_start, proc_count, stream)?;
         if let Some(t0) = prefill_t0 {
             self.gpu.synchronize(stream)?;
             let total_us = t0.elapsed().as_micros();

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -96,6 +96,9 @@ impl TransformerModel {
             h_bytes: p.h_bytes,
             conv_bytes: p.conv_bytes,
             ssm_layer_counter: &midcap_counter,
+            cap_local_early: p.cap_local_early,
+            h_dsts_early: &p.h_dsts_early,
+            conv_dsts_early: &p.conv_dsts_early,
         });
 
         let ctx = ForwardContext {

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -31,6 +31,7 @@ impl TransformerModel {
         pos_stream_bytes: usize,
         use_mrope: bool,
         needs_paged: bool,
+        midcap: Option<&super::midchunk_capture::MidCapturePlan>,
         stream: u64,
     ) -> Result<()> {
         let h = self.config.hidden_size;
@@ -84,6 +85,19 @@ impl TransformerModel {
                 .profile_first_pending
                 .swap(false, std::sync::atomic::Ordering::Relaxed);
 
+        // Mid-chunk tail capture (opt-in): fresh per-pass SSM-layer ordinal
+        // counter; each SSM layer's prefill increments it once, in model order,
+        // to index the plan's per-layer snapshot destinations.
+        let midcap_counter = std::sync::atomic::AtomicUsize::new(0);
+        let midchunk_capture = midcap.map(|p| crate::layer::MidchunkCapture {
+            cap_local: p.cap_local,
+            h_dsts: &p.h_dsts,
+            conv_dsts: &p.conv_dsts,
+            h_bytes: p.h_bytes,
+            conv_bytes: p.conv_bytes,
+            ssm_layer_counter: &midcap_counter,
+        });
+
         let ctx = ForwardContext {
             buffers: &self.buffers,
             gpu: self.gpu.as_ref(),
@@ -100,6 +114,7 @@ impl TransformerModel {
             token_ids: Some(self.buffers.token_ids()),
             // #30: request slot pairs (None unless routing to a non-active slot).
             routed_lora_layers: self.routed_slot_layers(seq.adapter_slot),
+            midchunk_capture,
         };
 
         // When proc_count == 1 (warm prefix cache hit), use the decode layer path

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -10,15 +10,29 @@
 //! splitting only the two cheap per-token GDN kernels (split4 recurrence +
 //! conv1d) — no extra pass, no projection/FFN re-run.
 //!
+//! Two capture points per pass:
+//!   * `tb` — the block-floored matched-prefix boundary, registered as the
+//!     session TAIL snapshot.
+//!   * `tb - block_size` — one KV block earlier, registered as a NON-TAIL
+//!     intermediate. On ~5/19 warm turns the next turn's block-floored
+//!     `matched_tokens` lands exactly `tb - block_size` (the chat-template
+//!     generation-suffix / detokenize-retokenize divergence puts the longest
+//!     common prefix one block short of the tail). The tail@`tb` is then
+//!     filtered by `token_count > matched_tokens`, so without this earlier
+//!     restore point those turns fall back to a coarse checkpoint and replay
+//!     up to ~479 SSM tokens. With it, `matched ∈ {tb, tb-bs}` are both exact.
+//!
 //! Flow:
 //!   1. [`TransformerModel::prepare_midchunk_capture`] (before `forward_layers`)
-//!      decides whether this pass spans `tb`, reserves a snapshot slot, and
-//!      precomputes the per-SSM-layer destination pointers.
+//!      decides whether this pass spans `tb` (and optionally `tb-bs`), reserves
+//!      one or two snapshot slots, and precomputes the per-SSM-layer dst pointers.
 //!   2. `forward_layers` threads the plan into `ForwardContext::midchunk_capture`;
 //!      each SSM layer's `prefill_inner` splits its h_state/conv_state kernels at
-//!      `cap_local` and D2D-copies the @tb state into the reserved slot.
+//!      `cap_local` (and `cap_local - bs` when present) and D2D-copies each
+//!      captured state into its reserved slot.
 //!   3. [`TransformerModel::finalize_midchunk_capture`] (after `forward_layers`)
-//!      registers the reserved slot as the session's tail snapshot in the index.
+//!      registers the tail slot as the session tail and the earlier slot as an
+//!      intermediate snapshot in the index.
 //!
 //! All behavior is gated on `ssm_tail_midchunk_enabled()` — flag off is a no-op
 //! (returns `None`) and byte-identical to prior behavior.
@@ -37,9 +51,9 @@ use crate::traits::SequenceState;
 pub(in crate::model) struct MidCapturePlan {
     /// Split point in local (chunk) token coordinates (`tb - proc_start`).
     pub cap_local: usize,
-    /// Reserved snapshot slot (== snapshot id used for registration).
+    /// Reserved TAIL snapshot slot (== snapshot id used for registration).
     pub snap_slot: usize,
-    /// Block-floored matched-prefix boundary the snapshot represents.
+    /// Block-floored matched-prefix boundary the tail snapshot represents.
     pub tb: usize,
     /// Per-SSM-layer h_state destination (offset to `snap_slot`).
     pub h_dsts: Vec<DevicePtr>,
@@ -49,16 +63,55 @@ pub(in crate::model) struct MidCapturePlan {
     pub h_bytes: usize,
     /// Bytes per layer of conv_state.
     pub conv_bytes: usize,
+    /// Block size (`ssm_tail_boundary`'s grid) — used to register the earlier
+    /// intermediate and to derive `tb - bs`.
+    pub bs: usize,
+    /// EARLIER capture at `tb - bs`: split point in local coords
+    /// (`cap_local - bs`). `Some` only when the pass also covers it AND a
+    /// second slot could be reserved.
+    pub cap_local_early: Option<usize>,
+    /// Reserved intermediate slot for the `tb - bs` snapshot.
+    pub snap_slot_early: Option<usize>,
+    /// Token boundary the earlier snapshot represents (`tb - bs`).
+    pub tb_early: Option<usize>,
+    /// Per-SSM-layer h_state destination for the `tb - bs` slot.
+    pub h_dsts_early: Vec<DevicePtr>,
+    /// Per-SSM-layer conv_state destination for the `tb - bs` slot.
+    pub conv_dsts_early: Vec<DevicePtr>,
 }
 
 impl TransformerModel {
+    /// Reserve a Marconi snapshot slot, reclaiming one from the cache on
+    /// exhaustion. Returns `None` only when the pool is full and nothing is
+    /// evictable — the caller then degrades gracefully (fewer/no captures).
+    fn reserve_snapshot_slot(
+        &self,
+        session_hash: u64,
+        kv_cache: &mut PagedKvCache,
+    ) -> Option<usize> {
+        match self.ssm_snapshots.reserve_tail_slot(session_hash) {
+            Some(s) => Some(s),
+            None => {
+                if self
+                    .ssm_snapshots
+                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
+                {
+                    self.ssm_snapshots.reserve_tail_slot(session_hash)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
     /// Decide + set up an in-pass mid-chunk tail capture for the prefill pass
     /// over local token range `[proc_start, proc_start + proc_count)`.
     ///
     /// Returns `None` (=> no capture, byte-identical behavior) when the flag is
     /// off, the snapshot pool is disabled, there is no `tb`, the pass does not
     /// strictly span `tb`, or no snapshot slot can be reserved (even after a
-    /// cache reclaim). Never fails the prefill — capture is best-effort.
+    /// cache reclaim). The earlier `tb - bs` capture is best-effort on top: if a
+    /// second slot cannot be reserved, only the tail is captured.
     pub(in crate::model) fn prepare_midchunk_capture(
         &self,
         tokens: &[u32],
@@ -77,29 +130,39 @@ impl TransformerModel {
             return None;
         }
         let cap_local = tb - proc_start;
-
-        // Reserve a slot; on exhaustion reclaim one from the cache and retry.
-        let snap_slot = match self.ssm_snapshots.reserve_tail_slot(seq.session_hash) {
-            Some(s) => s,
-            None => {
-                if self
-                    .ssm_snapshots
-                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
-                {
-                    self.ssm_snapshots.reserve_tail_slot(seq.session_hash)?
-                } else {
-                    return None;
-                }
-            }
-        };
-
         let n = self.ssm_snapshots.num_ssm_layers();
+
+        // TAIL slot @ tb — required. Reserve first (reclaim on exhaustion).
+        let snap_slot = self.reserve_snapshot_slot(seq.session_hash, kv_cache)?;
         let mut h_dsts = Vec::with_capacity(n);
         let mut conv_dsts = Vec::with_capacity(n);
         for l in 0..n {
             h_dsts.push(self.ssm_snapshots.tail_h_dst(l, snap_slot));
             conv_dsts.push(self.ssm_snapshots.tail_conv_dst(l, snap_slot));
         }
+
+        // EARLIER slot @ tb - bs — optional. Only when the pass covers that
+        // point (cap_local - bs > 0, equivalently proc_start < tb - bs) AND a
+        // second slot is available. Best-effort: degrade to tail-only on miss.
+        let mut cap_local_early = None;
+        let mut snap_slot_early = None;
+        let mut tb_early = None;
+        let mut h_dsts_early = Vec::new();
+        let mut conv_dsts_early = Vec::new();
+        if bs > 0 && cap_local > bs && tb > bs {
+            if let Some(slot2) = self.reserve_snapshot_slot(seq.session_hash, kv_cache) {
+                cap_local_early = Some(cap_local - bs);
+                snap_slot_early = Some(slot2);
+                tb_early = Some(tb - bs);
+                h_dsts_early = Vec::with_capacity(n);
+                conv_dsts_early = Vec::with_capacity(n);
+                for l in 0..n {
+                    h_dsts_early.push(self.ssm_snapshots.tail_h_dst(l, slot2));
+                    conv_dsts_early.push(self.ssm_snapshots.tail_conv_dst(l, slot2));
+                }
+            }
+        }
+
         Some(MidCapturePlan {
             cap_local,
             snap_slot,
@@ -108,12 +171,21 @@ impl TransformerModel {
             conv_dsts,
             h_bytes: self.ssm_snapshots.h_bytes(),
             conv_bytes: self.ssm_snapshots.conv_bytes(),
+            bs,
+            cap_local_early,
+            snap_slot_early,
+            tb_early,
+            h_dsts_early,
+            conv_dsts_early,
         })
     }
 
-    /// Register the reserved slot as this session's tail snapshot after the
-    /// full forward pass has captured the @tb state into it. Frees any
-    /// snapshot id displaced by the supersede.
+    /// Register the captured slots after the full forward pass has copied the
+    /// @tb (and, when present, @tb-bs) state into them:
+    ///   * TAIL slot -> `insert_tail_snapshot` (supersedes the session tail).
+    ///   * EARLIER slot -> `insert_intermediate_snapshot` (a NON-tail entry, so
+    ///     it does NOT evict the tail; both become valid restore points).
+    /// Frees any snapshot id displaced by either insert.
     pub(in crate::model) fn finalize_midchunk_capture(
         &self,
         tokens: &[u32],
@@ -131,5 +203,27 @@ impl TransformerModel {
             plan.tb,
             plan.snap_slot
         );
+
+        if let (Some(tb_early), Some(slot2)) = (plan.tb_early, plan.snap_slot_early) {
+            // Intermediate (non-tail): the radix-tree nodes for [0, tb_early)
+            // are laid down by this turn's finalize_last `insert([0, total))`,
+            // so this is index-only (block_table/disk are ignored by the impl).
+            if let Some(old) = self.prefix_cache.insert_intermediate_snapshot(
+                &tokens[..tb_early],
+                &[],
+                &[],
+                plan.bs,
+                slot2,
+                seq.session_hash,
+                tb_early,
+            ) {
+                self.ssm_snapshots.free(old);
+            }
+            tracing::info!(
+                "midchunk EARLY tail SSM capture at token {} (snap {})",
+                tb_early,
+                slot2
+            );
+        }
     }
 }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! MID-CHUNK SSM tail capture (`ATLAS_SSM_TAIL_MIDCHUNK=1`).
+//!
+//! The clamp-based `ATLAS_SSM_TAIL_CKPT` path lands a chunk boundary on
+//! `ssm_tail_boundary(tb)` and saves the SSM snapshot there via an extra
+//! forward pass over the trailing tokens (~868 ms — cancels the replay win).
+//! This path instead lets the prefill chunk run its natural full span and
+//! captures each GDN layer's recurrent + conv state exactly at `tb` by
+//! splitting only the two cheap per-token GDN kernels (split4 recurrence +
+//! conv1d) — no extra pass, no projection/FFN re-run.
+//!
+//! Flow:
+//!   1. [`TransformerModel::prepare_midchunk_capture`] (before `forward_layers`)
+//!      decides whether this pass spans `tb`, reserves a snapshot slot, and
+//!      precomputes the per-SSM-layer destination pointers.
+//!   2. `forward_layers` threads the plan into `ForwardContext::midchunk_capture`;
+//!      each SSM layer's `prefill_inner` splits its h_state/conv_state kernels at
+//!      `cap_local` and D2D-copies the @tb state into the reserved slot.
+//!   3. [`TransformerModel::finalize_midchunk_capture`] (after `forward_layers`)
+//!      registers the reserved slot as the session's tail snapshot in the index.
+//!
+//! All behavior is gated on `ssm_tail_midchunk_enabled()` — flag off is a no-op
+//! (returns `None`) and byte-identical to prior behavior.
+
+#![allow(unused_imports, dead_code, clippy::too_many_arguments)]
+
+use spark_runtime::gpu::DevicePtr;
+use spark_runtime::kv_cache::PagedKvCache;
+
+use super::super::super::types::TransformerModel;
+use crate::traits::SequenceState;
+
+/// Per-pass plan for a mid-chunk tail capture. Owns the per-SSM-layer
+/// destination pointer vectors that `ForwardContext::midchunk_capture`
+/// borrows for the duration of `forward_layers`.
+pub(in crate::model) struct MidCapturePlan {
+    /// Split point in local (chunk) token coordinates (`tb - proc_start`).
+    pub cap_local: usize,
+    /// Reserved snapshot slot (== snapshot id used for registration).
+    pub snap_slot: usize,
+    /// Block-floored matched-prefix boundary the snapshot represents.
+    pub tb: usize,
+    /// Per-SSM-layer h_state destination (offset to `snap_slot`).
+    pub h_dsts: Vec<DevicePtr>,
+    /// Per-SSM-layer conv_state destination (offset to `snap_slot`).
+    pub conv_dsts: Vec<DevicePtr>,
+    /// Bytes per layer of h_state.
+    pub h_bytes: usize,
+    /// Bytes per layer of conv_state.
+    pub conv_bytes: usize,
+}
+
+impl TransformerModel {
+    /// Decide + set up an in-pass mid-chunk tail capture for the prefill pass
+    /// over local token range `[proc_start, proc_start + proc_count)`.
+    ///
+    /// Returns `None` (=> no capture, byte-identical behavior) when the flag is
+    /// off, the snapshot pool is disabled, there is no `tb`, the pass does not
+    /// strictly span `tb`, or no snapshot slot can be reserved (even after a
+    /// cache reclaim). Never fails the prefill — capture is best-effort.
+    pub(in crate::model) fn prepare_midchunk_capture(
+        &self,
+        tokens: &[u32],
+        seq: &SequenceState,
+        kv_cache: &mut PagedKvCache,
+        proc_start: usize,
+        proc_count: usize,
+    ) -> Option<MidCapturePlan> {
+        if !spark_runtime::ssm_tail_midchunk_enabled() || !self.ssm_snapshots.is_enabled() {
+            return None;
+        }
+        let bs = kv_cache.block_size();
+        let tb = spark_runtime::ssm_tail_boundary(tokens.len(), bs)?;
+        // Only capture when this pass strictly crosses tb.
+        if !(proc_start < tb && tb < proc_start + proc_count) {
+            return None;
+        }
+        let cap_local = tb - proc_start;
+
+        // Reserve a slot; on exhaustion reclaim one from the cache and retry.
+        let snap_slot = match self.ssm_snapshots.reserve_tail_slot(seq.session_hash) {
+            Some(s) => s,
+            None => {
+                if self
+                    .ssm_snapshots
+                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
+                {
+                    self.ssm_snapshots.reserve_tail_slot(seq.session_hash)?
+                } else {
+                    return None;
+                }
+            }
+        };
+
+        let n = self.ssm_snapshots.num_ssm_layers();
+        let mut h_dsts = Vec::with_capacity(n);
+        let mut conv_dsts = Vec::with_capacity(n);
+        for l in 0..n {
+            h_dsts.push(self.ssm_snapshots.tail_h_dst(l, snap_slot));
+            conv_dsts.push(self.ssm_snapshots.tail_conv_dst(l, snap_slot));
+        }
+        Some(MidCapturePlan {
+            cap_local,
+            snap_slot,
+            tb,
+            h_dsts,
+            conv_dsts,
+            h_bytes: self.ssm_snapshots.h_bytes(),
+            conv_bytes: self.ssm_snapshots.conv_bytes(),
+        })
+    }
+
+    /// Register the reserved slot as this session's tail snapshot after the
+    /// full forward pass has captured the @tb state into it. Frees any
+    /// snapshot id displaced by the supersede.
+    pub(in crate::model) fn finalize_midchunk_capture(
+        &self,
+        tokens: &[u32],
+        seq: &SequenceState,
+        plan: &MidCapturePlan,
+    ) {
+        for old in
+            self.prefix_cache
+                .insert_tail_snapshot(&tokens[..plan.tb], plan.snap_slot, seq.session_hash)
+        {
+            self.ssm_snapshots.free(old);
+        }
+        tracing::info!(
+            "midchunk tail SSM capture at token {} (snap {})",
+            plan.tb,
+            plan.snap_slot
+        );
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -93,10 +93,12 @@ impl TransformerModel {
         match self.ssm_snapshots.reserve_tail_slot(session_hash) {
             Some(s) => Some(s),
             None => {
-                if self
-                    .ssm_snapshots
-                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache, self.ssm_tier_store.as_deref(), self.gpu.as_ref())
-                {
+                if self.ssm_snapshots.reclaim_from_cache(
+                    self.prefix_cache.as_ref(),
+                    kv_cache,
+                    self.ssm_tier_store.as_deref(),
+                    self.gpu.as_ref(),
+                ) {
                     self.ssm_snapshots.reserve_tail_slot(session_hash)
                 } else {
                     None
@@ -150,18 +152,20 @@ impl TransformerModel {
         let mut tb_early = None;
         let mut h_dsts_early = Vec::new();
         let mut conv_dsts_early = Vec::new();
-        if bs > 0 && cap_local > bs && tb > bs
+        if bs > 0
+            && cap_local > bs
+            && tb > bs
             && let Some(slot2) = self.reserve_snapshot_slot(seq.session_hash, kv_cache)
         {
-                cap_local_early = Some(cap_local - bs);
-                snap_slot_early = Some(slot2);
-                tb_early = Some(tb - bs);
-                h_dsts_early = Vec::with_capacity(n);
-                conv_dsts_early = Vec::with_capacity(n);
-                for l in 0..n {
-                    h_dsts_early.push(self.ssm_snapshots.tail_h_dst(l, slot2));
-                    conv_dsts_early.push(self.ssm_snapshots.tail_conv_dst(l, slot2));
-                }
+            cap_local_early = Some(cap_local - bs);
+            snap_slot_early = Some(slot2);
+            tb_early = Some(tb - bs);
+            h_dsts_early = Vec::with_capacity(n);
+            conv_dsts_early = Vec::with_capacity(n);
+            for l in 0..n {
+                h_dsts_early.push(self.ssm_snapshots.tail_h_dst(l, slot2));
+                conv_dsts_early.push(self.ssm_snapshots.tail_conv_dst(l, slot2));
+            }
         }
 
         Some(MidCapturePlan {
@@ -195,10 +199,12 @@ impl TransformerModel {
         seq: &SequenceState,
         plan: &MidCapturePlan,
     ) {
-        for old in
-            self.prefix_cache
-                .insert_tail_snapshot(&tokens[..plan.tb], plan.snap_slot, seq.session_hash, seq.adapter_id)
-        {
+        for old in self.prefix_cache.insert_tail_snapshot(
+            &tokens[..plan.tb],
+            plan.snap_slot,
+            seq.session_hash,
+            seq.adapter_id,
+        ) {
             self.ssm_snapshots.free(old);
         }
         tracing::info!(

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! MID-CHUNK SSM tail capture (`ATLAS_SSM_TAIL_MIDCHUNK=1`).
+//! MID-CHUNK SSM tail capture (default-on, opt-out `ATLAS_SSM_TAIL_MIDCHUNK=0`).
 //!
 //! The clamp-based `ATLAS_SSM_TAIL_CKPT` path lands a chunk boundary on
 //! `ssm_tail_boundary(tb)` and saves the SSM snapshot there via an extra
@@ -34,8 +34,9 @@
 //!      registers the tail slot as the session tail and the earlier slot as an
 //!      intermediate snapshot in the index.
 //!
-//! All behavior is gated on `ssm_tail_midchunk_enabled()` — flag off is a no-op
-//! (returns `None`) and byte-identical to prior behavior.
+//! All behavior is gated on `ssm_tail_midchunk_enabled()` — opt-out
+//! (`ATLAS_SSM_TAIL_MIDCHUNK=0`) is a no-op (returns `None`) and byte-identical
+//! to prior behavior.
 
 #![allow(unused_imports, dead_code, clippy::too_many_arguments)]
 

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -94,7 +94,7 @@ impl TransformerModel {
             None => {
                 if self
                     .ssm_snapshots
-                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache)
+                    .reclaim_from_cache(self.prefix_cache.as_ref(), kv_cache, self.ssm_tier_store.as_deref(), self.gpu.as_ref())
                 {
                     self.ssm_snapshots.reserve_tail_slot(session_hash)
                 } else {
@@ -149,8 +149,9 @@ impl TransformerModel {
         let mut tb_early = None;
         let mut h_dsts_early = Vec::new();
         let mut conv_dsts_early = Vec::new();
-        if bs > 0 && cap_local > bs && tb > bs {
-            if let Some(slot2) = self.reserve_snapshot_slot(seq.session_hash, kv_cache) {
+        if bs > 0 && cap_local > bs && tb > bs
+            && let Some(slot2) = self.reserve_snapshot_slot(seq.session_hash, kv_cache)
+        {
                 cap_local_early = Some(cap_local - bs);
                 snap_slot_early = Some(slot2);
                 tb_early = Some(tb - bs);
@@ -160,7 +161,6 @@ impl TransformerModel {
                     h_dsts_early.push(self.ssm_snapshots.tail_h_dst(l, slot2));
                     conv_dsts_early.push(self.ssm_snapshots.tail_conv_dst(l, slot2));
                 }
-            }
         }
 
         Some(MidCapturePlan {
@@ -182,9 +182,11 @@ impl TransformerModel {
 
     /// Register the captured slots after the full forward pass has copied the
     /// @tb (and, when present, @tb-bs) state into them:
-    ///   * TAIL slot -> `insert_tail_snapshot` (supersedes the session tail).
-    ///   * EARLIER slot -> `insert_intermediate_snapshot` (a NON-tail entry, so
-    ///     it does NOT evict the tail; both become valid restore points).
+    ///
+    /// * TAIL slot -> `insert_tail_snapshot` (supersedes the session tail).
+    /// * EARLIER slot -> `insert_intermediate_snapshot` (a NON-tail entry, so
+    ///   it does NOT evict the tail; both become valid restore points).
+    ///
     /// Frees any snapshot id displaced by either insert.
     pub(in crate::model) fn finalize_midchunk_capture(
         &self,
@@ -194,7 +196,7 @@ impl TransformerModel {
     ) {
         for old in
             self.prefix_cache
-                .insert_tail_snapshot(&tokens[..plan.tb], plan.snap_slot, seq.session_hash)
+                .insert_tail_snapshot(&tokens[..plan.tb], plan.snap_slot, seq.session_hash, seq.adapter_id)
         {
             self.ssm_snapshots.free(old);
         }
@@ -216,6 +218,7 @@ impl TransformerModel {
                 slot2,
                 seq.session_hash,
                 tb_early,
+                seq.adapter_id,
             ) {
                 self.ssm_snapshots.free(old);
             }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
@@ -133,21 +133,6 @@ impl TransformerModel {
             self.ssm_snapshots.free(snap_id);
             return Ok(());
         }
-        if is_tail {
-            // Index-only: `finalize_last` inserts [0, total) for this same turn and
-            // owns the ref_count/disk-ref bookkeeping. Re-inserting the whole prefix
-            // here measured ~0.9 s/turn. Superseding the session's previous tail keeps
-            // the cold 512-grid checkpoints alive (they are the fallback restore points).
-            for old in self.prefix_cache.insert_tail_snapshot(
-                boundary_tokens,
-                snap_id,
-                seq.session_hash,
-            ) {
-                self.ssm_snapshots.free(old);
-            }
-            tracing::info!("tail SSM checkpoint saved at token {end_token} (snapshot_id {snap_id})");
-            return Ok(());
-        }
         let boundary_disk = if seq.disk_block_ids.len() >= end_block {
             &seq.disk_block_ids[..end_block]
         } else {

--- a/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/save_checkpoint.rs
@@ -133,6 +133,21 @@ impl TransformerModel {
             self.ssm_snapshots.free(snap_id);
             return Ok(());
         }
+        if is_tail {
+            // Index-only: `finalize_last` inserts [0, total) for this same turn and
+            // owns the ref_count/disk-ref bookkeeping. Re-inserting the whole prefix
+            // here measured ~0.9 s/turn. Superseding the session's previous tail keeps
+            // the cold 512-grid checkpoints alive (they are the fallback restore points).
+            for old in self.prefix_cache.insert_tail_snapshot(
+                boundary_tokens,
+                snap_id,
+                seq.session_hash,
+            ) {
+                self.ssm_snapshots.free(old);
+            }
+            tracing::info!("tail SSM checkpoint saved at token {end_token} (snapshot_id {snap_id})");
+            return Ok(());
+        }
         let boundary_disk = if seq.disk_block_ids.len() >= end_block {
             &seq.disk_block_ids[..end_block]
         } else {

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -434,6 +434,7 @@ impl TransformerModel {
             token_ids: None,
             // #30: request slot pairs (None unless routing to a non-active slot).
             routed_lora_layers: self.routed_slot_layers(seq.adapter_slot),
+            midchunk_capture: None,
         };
 
         // ── 4. Per-layer forward: SSM uses three-phase, attention uses standard ──

--- a/crates/spark-model/src/model/trait_impl/speculative.rs
+++ b/crates/spark-model/src/model/trait_impl/speculative.rs
@@ -129,7 +129,8 @@ impl TransformerModel {
             proc_count * h * bf16,
             stream,
         )?;
-        self.mtp_prefill_capture_len.store(new_len, Ordering::Relaxed);
+        self.mtp_prefill_capture_len
+            .store(new_len, Ordering::Relaxed);
         Ok(())
     }
 

--- a/crates/spark-model/src/model/trait_impl/speculative.rs
+++ b/crates/spark-model/src/model/trait_impl/speculative.rs
@@ -91,6 +91,48 @@ impl TransformerModel {
         TransformerModel::decode_draft(self, token, seq, stream)
     }
 
+    /// ATLAS_MTP_DRAFTER_PREFILL: copy this prefill chunk's final-layer
+    /// hiddens (`[proc_count, h]` BF16, contiguous at the head of the hidden
+    /// buffer) into the whole-prompt capture at row `chunk_start`.
+    ///
+    /// Contiguity-tracked: `chunk_start == 0` (re)starts the capture; a chunk
+    /// extending the current range appends; anything else (prefix-cache
+    /// reuse, Marconi warm restore — rows whose hiddens were never computed)
+    /// leaves the tracked length short, which safely disables the drafter
+    /// prefill for that sequence via the coverage check at the propose site.
+    pub(super) fn try_mtp_prefill_capture(
+        &self,
+        chunk_start: usize,
+        proc_count: usize,
+        stream: u64,
+    ) -> Result<()> {
+        if self.mtp_prefill_hidden.is_null() || proc_count == 0 {
+            return Ok(());
+        }
+        use std::sync::atomic::Ordering;
+        let len = self.mtp_prefill_capture_len.load(Ordering::Relaxed);
+        let new_len = if chunk_start == 0 {
+            proc_count
+        } else if chunk_start == len {
+            len + proc_count
+        } else {
+            return Ok(());
+        };
+        if chunk_start + proc_count > self.mtp_prefill_capacity {
+            return Ok(());
+        }
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        self.gpu.copy_d2d_async(
+            self.buffers.hidden_states(),
+            self.mtp_prefill_hidden.offset(chunk_start * h * bf16),
+            proc_count * h * bf16,
+            stream,
+        )?;
+        self.mtp_prefill_capture_len.store(new_len, Ordering::Relaxed);
+        Ok(())
+    }
+
     pub(super) fn save_hidden_for_mtp_dispatch(
         &self,
         token_idx: usize,

--- a/crates/spark-model/src/model/trait_impl/verify_a.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_a.rs
@@ -144,6 +144,7 @@ impl TransformerModel {
                         gdn_exact_replay: false,
                         token_ids: None,
                         routed_lora_layers: None, // #30: verify decode; no prefill route.
+                        midchunk_capture: None,
                     };
 
                     let h_t = hidden.offset(t * h * fp32);
@@ -174,6 +175,7 @@ impl TransformerModel {
                     gdn_exact_replay: false,
                     token_ids: None,
                     routed_lora_layers: None, // #30: verify decode; no prefill route.
+                    midchunk_capture: None,
                 };
 
                 layer.decode_batched(

--- a/crates/spark-model/src/model/trait_impl/verify_b.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_b.rs
@@ -225,6 +225,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: Some(self.buffers.token_ids()),
             routed_lora_layers: None, // #30: decode/verify never routes prefill.
+            midchunk_capture: None,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_b.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_b.rs
@@ -55,7 +55,7 @@ impl TransformerModel {
         // dual-buffer pre-verify copy (~60 MB h_state + conv D2D per K=2
         // step) is gone. The CUDA-graph capture below is unaffected: the
         // captured nodes take the same `h_state` pointer, which never moves.
-        // (K=3/K=4/DFlash verify still run pre_verify_copy_async.)
+        // (K=3/K=4/DFlash verify share the same in-place convention.)
 
         let hidden = self.buffers.hidden_states();
         let residual = self.buffers.residual();

--- a/crates/spark-model/src/model/trait_impl/verify_c.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c.rs
@@ -180,6 +180,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: decode/verify never routes prefill.
+            midchunk_capture: None,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_c.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c.rs
@@ -56,8 +56,12 @@ impl TransformerModel {
         let fp32 = 2usize;
         let k = 3usize;
 
-        // F62 (2026-04-27): SpecMamba dual-buffer pre-verify copy.
-        self.pre_verify_copy_async(seq)?;
+        // Item #2 (STree-style in-place K=3 verify): `h_state` IS canonical
+        // — the verify kernel reads/writes it directly and the commit
+        // (`commit_accepted_prefix`) rewinds it in place on reject. There is
+        // no scratch/canonical split to seed, so the legacy SpecMamba
+        // dual-buffer pre-verify copy (~90 MB h_state+conv D2D per K=3
+        // step) is gone. Modeled on verify_b.rs (K=2 in-place).
 
         let hidden = self.buffers.hidden_states();
         let residual = self.buffers.residual();

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -153,7 +153,14 @@ impl TransformerModel {
         let hss_engaged = kv_cache.config().cache_blocks_per_seq.is_some();
         // ATLAS_LORA_EAGER: LoRA graph-vs-eager debugging hatch (see decode_a).
         let lora_eager = self.lora.is_some() && crate::lora::lora_eager_env();
-        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager;
+        // ATLAS_K4_DIAG=1: run the K=4 verify EAGERLY (no CUDA graph) with a
+        // stream-synchronize checkpoint after every layer, so an illegal
+        // access is attributed to the exact layer instead of surfacing as an
+        // opaque status-700 on the post-graph D2H. Mirrors ATLAS_K2_DIAG on
+        // the K=2 path (verify_b.rs). Diagnostic only — default behavior is
+        // byte-for-byte unchanged when the env is unset.
+        let k4_diag = std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1");
+        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager && !k4_diag;
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -258,6 +265,15 @@ impl TransformerModel {
                 // silently. Must be inside the graph capture region.
                 // No-op when DFlash is disabled.
                 self.try_dflash_capture(layer_idx, k - 1, stream)?;
+
+                // ATLAS_K4_DIAG checkpoint: surface an illegal access at the
+                // layer that raised it (eager mode only — sync is illegal
+                // under graph capture, and use_graphs is false when k4_diag).
+                if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                    anyhow::bail!(
+                        "K4_DIAG: CUDA error after layer {layer_idx} ({layer_type:?}): {e:#}"
+                    );
+                }
             }
 
             // Final norm [4, H]
@@ -274,8 +290,16 @@ impl TransformerModel {
                 stream,
             )?;
 
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG: CUDA error after final norm: {e:#}");
+            }
+
             // LM head for 4 tokens
             self.lm_head_batched(normed, k as u32, self.buffers.logits(), stream)?;
+
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG: CUDA error after lm_head_batched: {e:#}");
+            }
 
             // Argmax inside graph
             let vocab = self.config.vocab_size;
@@ -291,6 +315,10 @@ impl TransformerModel {
                     vocab as u32,
                     stream,
                 )?;
+            }
+
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG: CUDA error after argmax: {e:#}");
             }
 
             if use_graphs {

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -177,6 +177,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: decode/verify never routes prefill.
+            midchunk_capture: None,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -45,8 +45,12 @@ impl TransformerModel {
         let fp32 = 2usize;
         let k = 4usize;
 
-        // F62 (2026-04-27): SpecMamba dual-buffer pre-verify copy.
-        self.pre_verify_copy_async(seq)?;
+        // Item #2 (STree-style in-place K=4 verify): `h_state` IS canonical
+        // — the verify kernel reads/writes it directly and the commit
+        // (`commit_accepted_prefix`) rewinds it in place on reject. There is
+        // no scratch/canonical split to seed, so the legacy SpecMamba
+        // dual-buffer pre-verify copy (~120 MB h_state+conv D2D per K=4
+        // step) is gone. Modeled on verify_b.rs (K=2 in-place).
 
         let hidden = self.buffers.hidden_states();
         let residual = self.buffers.residual();

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -52,8 +52,11 @@ impl TransformerModel {
         let bf16 = 2usize;
         let fp32 = 2usize;
 
-        // F62 (2026-04-27): SpecMamba dual-buffer pre-verify copy.
-        self.pre_verify_copy_async(seq)?;
+        // Item #2 (STree-style in-place K=γ verify): `h_state` IS canonical
+        // — the verify kernel reads/writes it directly and the commit
+        // (`commit_accepted_prefix`) rewinds it in place on reject. No
+        // scratch/canonical split — dual-buffer pre-verify copy eliminated.
+        // Modeled on verify_b.rs (K=2 in-place).
 
         let hidden = self.buffers.hidden_states();
         let residual = self.buffers.residual();

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -177,6 +177,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: decode/verify never routes prefill.
+            midchunk_capture: None,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_fused.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_fused.rs
@@ -197,6 +197,7 @@ impl TransformerModel {
             gdn_exact_replay: false,
             token_ids: None,
             routed_lora_layers: None, // #30: decode/verify never routes prefill.
+            midchunk_capture: None,
         };
 
         // ── Phase 2: CUDA graph capture / replay ──

--- a/crates/spark-model/src/model/trait_impl/verify_fused.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_fused.rs
@@ -63,8 +63,8 @@ impl TransformerModel {
         let m = tokens.len(); // 1 + k
         let vocab = self.config.vocab_size;
 
-        // SSM dual-buffer pre-verify copy (same as verify_b/c).
-        self.pre_verify_copy_async(seq)?;
+        // In-place verify: h_state IS canonical — no pre_verify_copy_async
+        // needed. Modeled on verify_b.rs (K=2 in-place).
 
         let hidden = self.buffers.hidden_states();
         let residual = self.buffers.residual();

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -128,6 +128,21 @@ pub struct TransformerModel {
     /// Size: hidden_size * 4 bytes (one FP32 vector). MTP overwrites shared
     /// buffers (norm_output etc.), so the target hidden must be saved here first.
     pub(super) mtp_hidden_save: DevicePtr,
+    /// ATLAS_MTP_DRAFTER_PREFILL: per-position final-layer hidden capture for
+    /// the whole prompt, `[max_seq_len, hidden_size]` BF16 (~335 MB at 32k /
+    /// h=5120). NULL unless the env is set AND an MTP proposer is built.
+    /// Filled contiguously by the prefill chunk epilogues; consumed once by
+    /// the drafter-prefill pass on the first propose() of a sequence.
+    pub(super) mtp_prefill_hidden: DevicePtr,
+    /// Row capacity of `mtp_prefill_hidden` (== max_seq_len at alloc; 0 when
+    /// the feature is off). SSOT for the capture bounds check.
+    pub(super) mtp_prefill_capacity: usize,
+    /// Rows of `mtp_prefill_hidden` captured contiguously from position 0 for
+    /// the CURRENT sequence. Reset to 0 on `alloc_sequence`; a chunk whose
+    /// start does not extend the contiguous range (prefix-cache reuse, warm
+    /// restore) leaves it stale-short, which safely disables drafter-prefill
+    /// for that sequence (coverage check at the propose site).
+    pub(super) mtp_prefill_capture_len: std::sync::atomic::AtomicUsize,
     /// DFlash 5-layer hidden-state stack. Allocated only when a
     /// `BlockDiffusionDraftHead` proposer is built. Layout:
     /// `[5 × hidden_size × bf16]` shallow-to-deep at the layer indices

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -68,6 +68,11 @@ pub struct TransformerModel {
     pub(super) w4a16_gemv_logits_kernel: KernelHandle, // FP32 output for LM head
     pub(super) w4a16_gemm_kernel: KernelHandle,
     pub(super) w4a16_gemv_batch2_kernel: KernelHandle,
+    /// Batched M<=4 NVFP4 GEMV for the K=3/K=4 verify lm_head (one weight
+    /// read for all rows; nsys 2026-07-18: the M64-tile `w4a16_gemm` at M=4
+    /// cost 19.3 ms/verify-step on the 248320-row lm_head — 94% tile padding).
+    /// 0-handle when the target lacks the kernel (dispatch falls back).
+    pub(super) w4a16_gemv_batch4_kernel: KernelHandle,
     /// FP8 E4M3 LUT GEMV (M=1) for the FP8 LM head. Only used when
     /// `lm_head_fp8.is_some()`; loaded unconditionally (cheap handle) so the
     /// dispatch in `lm_head` / batched-decode / verify can reference it.

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -64,6 +64,27 @@ pub trait DraftProposer: Send + Sync {
         target_hidden_stack: Option<DevicePtr>,
     ) -> Result<Vec<u32>>;
 
+    /// Prefill the drafter's own context (KV cache) over the prompt, before
+    /// the first `propose()` of a sequence (ATLAS_MTP_DRAFTER_PREFILL).
+    ///
+    /// * `prompt_tokens` — the prompt token ids `t_0..t_{P-1}`.
+    /// * `hiddens` — device buffer `[P, hidden_size]` BF16; row `i` is the
+    ///   target's final-layer (pre-final-norm) hidden after processing `t_i`.
+    ///
+    /// Returns the number of drafter positions written (0 = unsupported /
+    /// already prefilled / nothing to do). Default: no-op.
+    fn prefill_drafter(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        let _ = (prompt_tokens, hiddens, state, ctx, stream);
+        Ok(0)
+    }
+
     /// Read the draft token ID stored on GPU by the last `propose()` call
     /// that used `draft_embed_target = Some(...)`. Returns 0 if not supported.
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -750,6 +750,14 @@ pub trait Model: Send + Sync {
         false
     }
 
+    /// Tokens per paged-KV block, or `None` when the model has no paged KV.
+    /// The scheduler uses this to land a prefill chunk boundary exactly on the
+    /// block boundary a warm turn will match at (see
+    /// `spark_runtime::ssm_tail_boundary`).
+    fn kv_block_size(&self) -> Option<usize> {
+        None
+    }
+
     /// EP broadcast: send a command (u32) to all worker ranks.
     ///
     /// Called by rank 0 before each model operation to synchronize workers.

--- a/crates/spark-model/src/weight_map/loaders_moe.rs
+++ b/crates/spark-model/src/weight_map/loaders_moe.rs
@@ -200,7 +200,14 @@ pub(crate) fn load_mtp(
             Nvfp4Variant::Fp8Dequanted => dense_auto(store, name, gpu),
             // Bf16Raw fine-tunes already store .weight as BF16; no dequant needed.
             Nvfp4Variant::Bf16Raw => dense(store, name),
-            _ => dense(store, name),
+            // Standard & friends: usually BF16 on disk (dense_auto's BF16 arm
+            // returns the raw pointer, identical to `dense`), but checkpoints
+            // that quantize the MTP head too (e.g. centml modelopt W4A4:
+            // mtp.fc/*_proj as packed NVFP4 + weight_scale/_2) route through
+            // dense_auto's UInt8 arm for a one-time NVFP4->BF16 dequant.
+            // Feeding the packed U8 pointer to the BF16 GEMV read 4x past the
+            // allocation (cuMemsetD8Async status 700 on first decode).
+            _ => dense_auto(store, name, gpu),
         }
     };
 

--- a/crates/spark-model/src/weight_map/quant_helpers.rs
+++ b/crates/spark-model/src/weight_map/quant_helpers.rs
@@ -320,6 +320,23 @@ pub(crate) fn dense_auto(
                 dequant_fp8_to_bf16(store, prefix, gpu)
             }
         }
+        WeightDtype::UInt8 => {
+            // 4-bit-packed NVFP4, 2 values/byte: on-disk shape is [n, k/2] U8.
+            // Quantized MTP heads (centml modelopt W4A4 exports) ship every
+            // mtp.* projection this way; dense GEMV/GEMM needs BF16, so
+            // dequant once at load via the shared modelopt-aware helper
+            // (weight + weight_scale + weight_scale_2).
+            let prefix = name
+                .strip_suffix(".weight")
+                .ok_or_else(|| anyhow::anyhow!("NVFP4 tensor {name} doesn't end with .weight"))?;
+            if w.shape.len() != 2 {
+                anyhow::bail!(
+                    "dense_auto: packed NVFP4 {name} must be 2-D, got {:?}",
+                    w.shape
+                );
+            }
+            crate::weight_map::dequant_nvfp4_to_bf16(store, prefix, w.shape[0], w.shape[1] * 2, gpu)
+        }
         other => anyhow::bail!("dense_auto: unsupported dtype {:?} for {name}", other),
     }
 }

--- a/crates/spark-runtime/src/fast_weights/header.rs
+++ b/crates/spark-runtime/src/fast_weights/header.rs
@@ -21,6 +21,10 @@ struct SafetensorsIndex {
 pub(super) struct TensorMeta {
     pub(super) name: String,
     pub(super) dtype: WeightDtype,
+    /// True when the shard stores this tensor as IEEE F16. The tensor is
+    /// staged as BF16 (`dtype` above) and the copy loop converts the bytes —
+    /// same 2-byte element size, different bit layout.
+    pub(super) from_f16: bool,
     pub(super) shape: Vec<usize>,
     /// Absolute byte offset in the file where the tensor bytes start.
     pub(super) abs_offset: u64,
@@ -115,19 +119,23 @@ pub(super) fn parse_header(file: &mut File) -> Result<Vec<TensorMeta>> {
             continue;
         }
         let dtype_str = info["dtype"].as_str().unwrap_or("BF16");
-        let dtype = match dtype_str {
-            "F32" => WeightDtype::FP32,
-            "BF16" => WeightDtype::BF16,
-            "U8" => WeightDtype::UInt8,
+        let (dtype, from_f16) = match dtype_str {
+            "F32" => (WeightDtype::FP32, false),
+            "BF16" => (WeightDtype::BF16, false),
+            // F16 is not store-legal (WeightDtype is closed to store dtypes):
+            // stage as BF16 and mark for byte conversion in the copy loop.
+            // centml modelopt W4A4 exports ship all unquantized tensors as F16.
+            "F16" => (WeightDtype::BF16, true),
+            "U8" => (WeightDtype::UInt8, false),
             // I8 is a 1-byte raw container; DeepSeek-V4-Flash-NVFP4 ships its MTP
             // experts' 4-bit-packed weights as I8 (vs U8 for the main layers).
             // Signedness is irrelevant for packed FP4 — the dequant kernel extracts
             // nibbles by bit ops — so treat I8 as raw bytes (UInt8), matching the
             // NVFP4 expert path.
-            "I8" => WeightDtype::UInt8,
-            "F8_E4M3" => WeightDtype::FP8E4M3,
-            "F8_E8M0" => WeightDtype::FP8E8M0,
-            "I64" => WeightDtype::Int64,
+            "I8" => (WeightDtype::UInt8, false),
+            "F8_E4M3" => (WeightDtype::FP8E4M3, false),
+            "F8_E8M0" => (WeightDtype::FP8E8M0, false),
+            "I64" => (WeightDtype::Int64, false),
             other => bail!("Unsupported safetensors dtype '{other}' for tensor {name}"),
         };
         let shape: Vec<usize> = info["shape"]
@@ -147,6 +155,7 @@ pub(super) fn parse_header(file: &mut File) -> Result<Vec<TensorMeta>> {
         out.push(TensorMeta {
             name: name.clone(),
             dtype,
+            from_f16,
             shape,
             abs_offset: data_start + rel_start,
             len,

--- a/crates/spark-runtime/src/fast_weights/mod.rs
+++ b/crates/spark-runtime/src/fast_weights/mod.rs
@@ -19,7 +19,7 @@
 use crate::gpu::GpuBackend;
 use crate::weights::{
     WeightLoader, WeightStore, WeightTensor, check_oom_guard, estimate_has_fp8,
-    estimate_load_bytes, evict_page_cache, parse_expert_index,
+    estimate_load_bytes, evict_page_cache, f16_to_bf16_bytes, parse_expert_index,
 };
 use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
@@ -339,7 +339,16 @@ fn load_shard_fast(
     for result in rx {
         let (idx, buf, slice_start) = result?;
         let meta = &tensors[idx];
-        let src = &buf.as_slice()[slice_start..slice_start + meta.len];
+        let raw = &buf.as_slice()[slice_start..slice_start + meta.len];
+        // F16 shards: convert bytes to BF16 before upload (same length,
+        // different bit layout — meta.dtype is already staged as BF16).
+        let converted: Vec<u8>;
+        let src: &[u8] = if meta.from_f16 {
+            converted = f16_to_bf16_bytes(raw);
+            &converted
+        } else {
+            raw
+        };
 
         let ptr = match gpu.alloc(meta.len) {
             Ok(p) => {

--- a/crates/spark-runtime/src/lib.rs
+++ b/crates/spark-runtime/src/lib.rs
@@ -37,3 +37,49 @@ pub mod prefix_cache;
 pub mod radix_tree;
 pub mod sampler;
 pub mod weights;
+
+/// Last paged-KV block boundary strictly below `total_tokens`.
+///
+/// A warm multi-turn hit can never match past this point: the chat template's
+/// generation-prompt suffix (assistant header, and the empty `<think></think>`
+/// block emitted when thinking is disabled) is not reproduced when the next
+/// turn re-renders the *completed* assistant message, so the longest common
+/// prefix diverges inside the prompt's final block. `RadixTree::walk` then
+/// floors `matched_tokens` to this boundary. Placing an SSM snapshot here makes
+/// the next turn's restore exact (zero recurrence replay); without it the
+/// lookup falls back to the coarse `--ssm-checkpoint-interval` grid.
+///
+/// Returns `None` when the prompt is too short to have such a boundary.
+pub fn ssm_tail_boundary(total_tokens: usize, block_size: usize) -> Option<usize> {
+    if block_size == 0 || total_tokens <= block_size {
+        return None;
+    }
+    let boundary = ((total_tokens - 1) / block_size) * block_size;
+    (boundary > 0).then_some(boundary)
+}
+
+/// OPT-IN switch for the tail checkpoint (`ATLAS_SSM_TAIL_CKPT=1`).
+///
+/// Default OFF. The 3-traj A/B (2026-07-10, 174 samples/arm) showed it is
+/// perf-NEUTRAL: it removes the SSM replay on ~89% of warm turns (mean 254 -> 25
+/// tokens), but the prefill-chunk split needed to land a snapshot on
+/// `ssm_tail_boundary` costs a median 868 ms extra forward pass for a median of 8
+/// trailing tokens, which cancels the ~1374 ms of replay it saves. It becomes a
+/// clear win only once the SSM state can be captured MID-CHUNK (in the GDN prefill
+/// kernel) instead of via an extra pass. Until then it stays off by default and
+/// ungated for accuracy.
+pub fn ssm_tail_ckpt_enabled() -> bool {
+    matches!(std::env::var("ATLAS_SSM_TAIL_CKPT").as_deref(), Ok("1"))
+}
+
+/// OPT-IN switch for MID-CHUNK tail SSM capture (`ATLAS_SSM_TAIL_MIDCHUNK=1`).
+///
+/// Default OFF => byte-identical to current behavior. When set, the prefill
+/// chunk is NOT clamped to `ssm_tail_boundary`; instead each GDN layer's
+/// recurrent (h_state) and conv (conv_state) kernels are split at the block-
+/// floored matched-prefix boundary and the @tb state is copied into a reserved
+/// Marconi snapshot slot in-pass, removing the ~868 ms extra forward pass the
+/// clamp-based `ATLAS_SSM_TAIL_CKPT` path costs.
+pub fn ssm_tail_midchunk_enabled() -> bool {
+    matches!(std::env::var("ATLAS_SSM_TAIL_MIDCHUNK").as_deref(), Ok("1"))
+}

--- a/crates/spark-runtime/src/lib.rs
+++ b/crates/spark-runtime/src/lib.rs
@@ -72,14 +72,21 @@ pub fn ssm_tail_ckpt_enabled() -> bool {
     matches!(std::env::var("ATLAS_SSM_TAIL_CKPT").as_deref(), Ok("1"))
 }
 
-/// OPT-IN switch for MID-CHUNK tail SSM capture (`ATLAS_SSM_TAIL_MIDCHUNK=1`).
+/// Default-ON switch for MID-CHUNK tail SSM capture (opt-out `ATLAS_SSM_TAIL_MIDCHUNK=0`).
 ///
-/// Default OFF => byte-identical to current behavior. When set, the prefill
+/// Default ON => mid-chunk capture fires on prefill passes spanning the
+/// block-floored matched-prefix boundary. When disabled, the prefill
 /// chunk is NOT clamped to `ssm_tail_boundary`; instead each GDN layer's
 /// recurrent (h_state) and conv (conv_state) kernels are split at the block-
 /// floored matched-prefix boundary and the @tb state is copied into a reserved
 /// Marconi snapshot slot in-pass, removing the ~868 ms extra forward pass the
 /// clamp-based `ATLAS_SSM_TAIL_CKPT` path costs.
 pub fn ssm_tail_midchunk_enabled() -> bool {
-    matches!(std::env::var("ATLAS_SSM_TAIL_MIDCHUNK").as_deref(), Ok("1"))
+    // Default ON (2026-07-19): mid-chunk GDN tail capture eliminates the warm-turn
+    // SSM replay (~1.17s component of warm TTFT) by capturing state in-pass at the
+    // block-floored matched-prefix boundary. Validated: flag-off byte-identical to
+    // the prior baseline; warm-TTFT -9.3% median / -54% max (tail-spike elimination);
+    // 20/20 contamination-clean (session-gate prevents cross-request SSM corruption);
+    // BFCL e2e 1007/1007. Opt OUT with ATLAS_SSM_TAIL_MIDCHUNK=0.
+    !matches!(std::env::var("ATLAS_SSM_TAIL_MIDCHUNK").as_deref(), Ok("0"))
 }

--- a/crates/spark-runtime/src/prefix_cache.rs
+++ b/crates/spark-runtime/src/prefix_cache.rs
@@ -235,6 +235,16 @@ pub trait PrefixCache: Send + Sync {
         adapter_id: u64,
     ) -> Option<usize>;
 
+    /// Register the per-session TAIL snapshot in the index WITHOUT touching the
+    /// radix tree (the final chunk's `insert` covers those blocks). Supersedes
+    /// this session's previous tail; returns displaced snapshot ids to free.
+    fn insert_tail_snapshot(
+        &self,
+        tokens: &[u32],
+        snapshot_id: usize,
+        session_hash: u64,
+    ) -> Vec<usize>;
+
     /// Release ref_counts on blocks that were acquired via `lookup`.
     ///
     /// Called when a sequence finishes. Decrements ref_count on cache
@@ -336,6 +346,15 @@ impl PrefixCache for NoPrefixCaching {
         _adapter_id: u64,
     ) -> Option<usize> {
         None
+    }
+
+    fn insert_tail_snapshot(
+        &self,
+        _tokens: &[u32],
+        _snapshot_id: usize,
+        _session_hash: u64,
+    ) -> Vec<usize> {
+        Vec::new()
     }
 
     fn release(&self, _tokens: &[u32], _block_size: usize, _adapter_id: u64) {}

--- a/crates/spark-runtime/src/prefix_cache.rs
+++ b/crates/spark-runtime/src/prefix_cache.rs
@@ -243,6 +243,7 @@ pub trait PrefixCache: Send + Sync {
         tokens: &[u32],
         snapshot_id: usize,
         session_hash: u64,
+        adapter_id: u64,
     ) -> Vec<usize>;
 
     /// Release ref_counts on blocks that were acquired via `lookup`.
@@ -353,6 +354,7 @@ impl PrefixCache for NoPrefixCaching {
         _tokens: &[u32],
         _snapshot_id: usize,
         _session_hash: u64,
+        _adapter_id: u64,
     ) -> Vec<usize> {
         Vec::new()
     }

--- a/crates/spark-runtime/src/radix_tree.rs
+++ b/crates/spark-runtime/src/radix_tree.rs
@@ -183,6 +183,21 @@ impl PrefixCache for RadixTree {
         (displaced, newly_acquired)
     }
 
+    fn insert_tail_snapshot(
+        &self,
+        tokens: &[u32],
+        snapshot_id: usize,
+        session_hash: u64,
+    ) -> Vec<usize> {
+        // Index only. The tree nodes for [0, tokens.len()) are inserted by the
+        // final chunk's `insert` (finalize_last); re-inserting the whole prefix
+        // here cost ~0.9 s/turn for zero benefit.
+        let prefix_hash = hash_token_prefix(tokens, tokens.len());
+        self.snapshot_index
+            .lock()
+            .insert_tail(prefix_hash, snapshot_id, session_hash, tokens.len())
+    }
+
     fn insert_intermediate_snapshot(
         &self,
         tokens: &[u32],

--- a/crates/spark-runtime/src/radix_tree.rs
+++ b/crates/spark-runtime/src/radix_tree.rs
@@ -188,11 +188,12 @@ impl PrefixCache for RadixTree {
         tokens: &[u32],
         snapshot_id: usize,
         session_hash: u64,
+        adapter_id: u64,
     ) -> Vec<usize> {
         // Index only. The tree nodes for [0, tokens.len()) are inserted by the
         // final chunk's `insert` (finalize_last); re-inserting the whole prefix
         // here cost ~0.9 s/turn for zero benefit.
-        let prefix_hash = hash_token_prefix(tokens, tokens.len());
+        let prefix_hash = hash_token_prefix(tokens, tokens.len(), adapter_id);
         self.snapshot_index
             .lock()
             .insert_tail(prefix_hash, snapshot_id, session_hash, tokens.len())

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -186,6 +186,7 @@ impl SsmSnapshotIndex {
             prefix_hash,
             last_access: self.access_counter,
             hit_count: 0,
+            tiered: false,
             is_tail: true,
         });
         displaced

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -25,6 +25,9 @@ pub(super) struct SnapshotEntry {
     /// and the state is addressed by `prefix_hash` (the tier key). Always
     /// `false` when `ATLAS_SSM_TIER` is off, so the default path is unchanged.
     tiered: bool,
+    /// True for the per-session TAIL snapshot (the restore point the next turn's
+    /// block-floored `matched_tokens` looks up). Exactly one is kept per session.
+    is_tail: bool,
 }
 
 /// Where a matched snapshot's state currently lives (Phase 1b).
@@ -134,8 +137,58 @@ impl SsmSnapshotIndex {
             last_access: self.access_counter,
             hit_count: 0,
             tiered: false,
+            is_tail: false,
         });
         None
+    }
+
+    /// Insert the per-session TAIL snapshot, superseding this session's previous one.
+    ///
+    /// Keeping every turn's tail grows the index by one entry per turn, which evicts
+    /// the cold 512-grid checkpoints laid down during the trajectory's COLD prefill.
+    /// Measured cost of not doing this: fallback replays up to 3712 tokens and a 57 s
+    /// TTFT tail. Returns every displaced snapshot_id for the caller to free.
+    pub(super) fn insert_tail(
+        &mut self,
+        prefix_hash: u64,
+        snapshot_id: usize,
+        session_hash: u64,
+        token_count: usize,
+    ) -> Vec<usize> {
+        let mut displaced = Vec::new();
+        if session_hash != 0 {
+            let mut i = 0;
+            while i < self.entries.len() {
+                if self.entries[i].is_tail && self.entries[i].session_hash == session_hash {
+                    displaced.push(self.entries.swap_remove(i).snapshot_id);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+        for entry in &mut self.entries {
+            if entry.prefix_hash == prefix_hash {
+                displaced.push(entry.snapshot_id);
+                entry.snapshot_id = snapshot_id;
+                entry.session_hash = session_hash;
+                entry.token_count = token_count;
+                entry.is_tail = true;
+                self.access_counter += 1;
+                entry.last_access = self.access_counter;
+                return displaced;
+            }
+        }
+        self.access_counter += 1;
+        self.entries.push(SnapshotEntry {
+            snapshot_id,
+            session_hash,
+            token_count,
+            prefix_hash,
+            last_access: self.access_counter,
+            hit_count: 0,
+            is_tail: true,
+        });
+        displaced
     }
 
     /// Find deepest snapshot matching session within matched_tokens range.
@@ -266,7 +319,7 @@ impl SsmSnapshotIndex {
         // ENTIRE deep checkpoint chain stays resident until every other (completed/
         // dormant) conversation is gone. Within the victim session, drop its lowest
         // forecast-score entry. This is "prefix caching like llama" for SSM state:
-        // the live conversation never re-recomputes what it already computed.
+        // the live conversation never re-computes what it already computed.
         // Selecting a different victim is correctness-safe — restore re-validates
         // (session_hash + prefix_hash) before using any snapshot; eviction only
         // frees a slot.

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -225,6 +225,14 @@ impl SsmSnapshotIndex {
             if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
                 continue;
             }
+            // A TAIL snapshot (midchunk-captured next-turn restore point) bleeds a
+            // little past the exact prefix boundary, so it is byte-safe ONLY for the
+            // SAME non-zero session. Cross-request / single-turn (session_hash == 0)
+            // reuse of another session's tail corrupts SSM state -> garbled tool calls
+            // (project_midchunk_cross_request_corruption). Force those to recompute.
+            if entry.is_tail && (session_hash == 0 || entry.session_hash != session_hash) {
+                continue;
+            }
             let h = hash_token_prefix(tokens, entry.token_count, adapter_id);
             if h != entry.prefix_hash {
                 continue;

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -143,11 +143,7 @@ impl SsmSnapshotIndex {
     }
 
     /// Insert the per-session TAIL snapshot, superseding this session's previous one.
-    ///
-    /// Keeping every turn's tail grows the index by one entry per turn, which evicts
-    /// the cold 512-grid checkpoints laid down during the trajectory's COLD prefill.
-    /// Measured cost of not doing this: fallback replays up to 3712 tokens and a 57 s
-    /// TTFT tail. Returns every displaced snapshot_id for the caller to free.
+    /// Returns displaced snapshot_ids for the caller to free.
     pub(super) fn insert_tail(
         &mut self,
         prefix_hash: u64,
@@ -226,11 +222,8 @@ impl SsmSnapshotIndex {
             if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
                 continue;
             }
-            // A TAIL snapshot (midchunk-captured next-turn restore point) bleeds a
-            // little past the exact prefix boundary, so it is byte-safe ONLY for the
-            // SAME non-zero session. Cross-request / single-turn (session_hash == 0)
-            // reuse of another session's tail corrupts SSM state -> garbled tool calls
-            // (project_midchunk_cross_request_corruption). Force those to recompute.
+            // TAIL snapshots bleed past the exact prefix — byte-safe ONLY for the
+            // same non-zero session. Cross-request reuse corrupts SSM state.
             if entry.is_tail && (session_hash == 0 || entry.session_hash != session_hash) {
                 continue;
             }
@@ -312,30 +305,14 @@ impl SsmSnapshotIndex {
         if self.entries.is_empty() {
             return None;
         }
-        // Per-entry forecast score (B.4, Marconi paper §4): old AND cold first.
-        // last_access * (1 + hit_count) — recent/hot survive. #155 fixed the
-        // inverted (÷) form that evicted just-selected snapshots.
+        // Per-entry forecast score: last_access * (1 + hit_count) — old/cold first.
         let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
 
-        // SESSION-AWARE eviction (default ON; ATLAS_SNAP_EVICT_LEGACY=1 → old
-        // per-entry policy). The agentic workload interleaves ~20 multi-turn
-        // conversations; per-entry LRU evicts the active conversation's OWN deep
-        // checkpoints whenever it goes briefly dormant (its unique deep snapshots
-        // have hit_count=0 and a stale last_access vs another conversation's fresh
-        // ones), so its next warm turn full-recomputes the SSM state (TTFT 1s→50s).
-        // Fix: evict from the STALEST conversation first — rank by the session's
-        // freshness (max last_access over its entries), so the active conversation's
-        // ENTIRE deep checkpoint chain stays resident until every other (completed/
-        // dormant) conversation is gone. Within the victim session, drop its lowest
-        // forecast-score entry. This is "prefix caching like llama" for SSM state:
-        // the live conversation never re-computes what it already computed.
-        // Selecting a different victim is correctness-safe — restore re-validates
-        // (session_hash + prefix_hash) before using any snapshot; eviction only
-        // frees a slot.
+        // SESSION-AWARE eviction (default ON; ATLAS_SNAP_EVICT_LEGACY=1 → old per-entry).
         if std::env::var_os("ATLAS_SNAP_EVICT_LEGACY").is_none() {
             let tail_protect = self.last_lookup_session != 0
                 && std::env::var_os("ATLAS_SSM_TAIL_PROTECT").is_some();
-            // Skip tiered entries — they hold no HBM slot to free.
+            // Skip tiered entries (no HBM slot to free).
             let victim_idx = self.session_aware_victim(tail_protect, true)?;
             let entry = self.entries.swap_remove(victim_idx);
             self.stats.evictions += 1;
@@ -359,31 +336,11 @@ impl SsmSnapshotIndex {
         Some(entry.snapshot_id)
     }
 
-    /// Pure victim selection for the session-aware eviction policy (default
-    /// path). Returns the index into `self.entries` to drop. Split out so it
-    /// is unit-testable without mutating process env.
-    ///
-    /// Ranking: evict the STALEST conversation first (by session freshness =
-    /// max `last_access` over its entries), then the lowest per-entry forecast
-    /// score within it — the live conversation's whole deep chain stays
-    /// resident until every dormant conversation is gone.
-    ///
-    /// `tail_protect` (ATLAS_SSM_TAIL_PROTECT, ported from #278): additionally
-    /// exempt the live conversation's DEEPEST snapshot — its next warm turn
-    /// restores from it. Session-aware ranking alone only protects the live
-    /// session vs *dormant* ones; within a single/dominant session it falls
-    /// through to lowest-escore = the just-aged deep tail (hit_count=0), which
-    /// the hot token-8192 anchor out-scores, so warm restore falls back to 8192
-    /// and recomputes thousands of SSM tokens (~4400 tok, ~7.6s TTFT/turn).
-    /// Exactly ONE entry is exempted, scoped to the active session, so any pool
-    /// \>=2 always has a victim and never deadlocks. Correctness-safe: restore
-    /// re-validates session_hash+prefix_hash+depth, so changing the victim
-    /// cannot cause a wrong-position restore.
-    ///
-    /// `skip_tiered` (Phase 1b): ignore entries already spilled to the byte tier
-    /// — they hold no HBM slot, so they are neither a valid drop victim (freeing
-    /// their stale `snapshot_id` would double-free) nor a spill candidate.
-    /// Returns `None` when no eligible entry exists (all spilled / empty).
+    /// Pure victim selection for session-aware eviction. Split out for unit tests.
+    /// Ranking: stalest session first, then lowest forecast score within it.
+    /// `tail_protect`: exempt the live session's deepest snapshot (one entry,
+    /// scoped, so pools ≥2 never deadlock). Correctness-safe (restore re-validates).
+    /// `skip_tiered`: ignore spilled entries (no HBM slot). Returns `None` if none eligible.
     fn session_aware_victim(&self, tail_protect: bool, skip_tiered: bool) -> Option<usize> {
         let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
         let eligible = |e: &SnapshotEntry| !(skip_tiered && e.tiered);
@@ -428,21 +385,10 @@ impl SsmSnapshotIndex {
         victim.map(|(i, _)| i)
     }
 
-    // ─────────────────────────── Phase 1b: spill tier ───────────────────────
-    // Location state machine over the same `entries`: an entry is either
-    // resident (`tiered == false`, state at `snapshot_id`) or spilled
-    // (`tiered == true`, state at `prefix_hash` in the byte tier). Only reached
-    // when the caller has ATLAS_SSM_TIER on; the default path never tiers.
-    // Consumed via the `PrefixCache` trait (`evict_snapshot_to_tier`,
-    // `promote_snapshot`) and `RadixTree::lookup`'s tier-aware sub-lookup.
+    // ─── Phase 1b: spill tier ─── resident vs spilled state machine (ATLAS_SSM_TIER).
 
-    /// **Spill victim selection** (replaces `evict_lru`'s drop when the tier is
-    /// engaged). Pick the same session-aware/tail-protected victim as the drop
-    /// path but among HBM-resident entries only, mark it spilled, and return
-    /// `(freed_slot, key)` so the caller moves its bytes to the tier and reuses
-    /// the slot. The entry STAYS in the index (findable by `lookup_tiered`), so
-    /// a later warm turn faults it back in instead of recomputing.
-    /// `None` ⇒ nothing HBM-resident to free (all already spilled / empty).
+    /// Spill victim selection (tier engaged). Marks the victim spilled, returns
+    /// `(freed_slot, key)`. Entry stays in the index for `lookup_tiered` fault-in.
     pub(super) fn evict_to_tier(&mut self) -> Option<(usize, u64)> {
         if self.entries.is_empty() {
             return None;

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -19,6 +19,7 @@ fn entry(
         last_access,
         hit_count,
         tiered: false,
+        is_tail: false,
     }
 }
 

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -89,6 +89,25 @@ impl WeightDtype {
     }
 }
 
+/// Convert a little-endian IEEE-754 half-precision (F16) tensor byte buffer
+/// to BF16 bytes. F16 and BF16 are both 2 bytes/element but have different
+/// bit layouts (5-bit vs 8-bit exponent), so the bytes cannot be
+/// reinterpreted — each value goes f16 → f32 (exact) → bf16
+/// (round-to-nearest-even). Shared by both disk loaders so F16 checkpoints
+/// (e.g. centml modelopt W4A4 exports, which ship all unquantized tensors as
+/// F16) land in the store as BF16; [`WeightDtype`] itself stays closed to
+/// store-legal dtypes and F16 can never appear on the RDMA wire.
+pub(crate) fn f16_to_bf16_bytes(src: &[u8]) -> Vec<u8> {
+    use half::{bf16, f16};
+    debug_assert_eq!(src.len() % 2, 0, "F16 tensor byte length must be even");
+    let mut out = Vec::with_capacity(src.len());
+    for pair in src.chunks_exact(2) {
+        let h = f16::from_le_bytes([pair[0], pair[1]]);
+        out.extend_from_slice(&bf16::from_f32(h.to_f32()).to_le_bytes());
+    }
+    out
+}
+
 /// A weight tensor on the GPU.
 pub struct WeightTensor {
     pub ptr: DevicePtr,
@@ -285,7 +304,28 @@ mod from_str_tests {
                 "dtype {s}"
             );
         }
+        // F16 is converted to BF16 at disk-load; a store (and therefore a
+        // peer manifest) can never contain it, so the wire mapping rejects it.
         assert!(WeightDtype::from_safetensors_str("F16").is_err());
         assert!(WeightDtype::from_safetensors_str("bogus").is_err());
+    }
+
+    #[test]
+    fn f16_bytes_convert_to_bf16_via_f32() {
+        use half::{bf16, f16};
+        // Cover sign, exact powers of two, a value needing mantissa rounding
+        // (f16 has 10 mantissa bits, bf16 only 7), f16 max, and a subnormal.
+        let vals = [0.0f32, 1.0, -1.5, 0.1, 65504.0, -6.1035156e-5];
+        let src: Vec<u8> = vals
+            .iter()
+            .flat_map(|v| f16::from_f32(*v).to_le_bytes())
+            .collect();
+        let out = super::f16_to_bf16_bytes(&src);
+        assert_eq!(out.len(), src.len());
+        for (i, v) in vals.iter().enumerate() {
+            let got = bf16::from_le_bytes([out[2 * i], out[2 * i + 1]]);
+            let want = bf16::from_f32(f16::from_f32(*v).to_f32());
+            assert_eq!(got, want, "value {v}");
+        }
     }
 }

--- a/crates/spark-runtime/src/weights/loader/load_fns.rs
+++ b/crates/spark-runtime/src/weights/loader/load_fns.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::super::{WeightDtype, WeightTensor, evict_page_cache};
+use super::super::{WeightDtype, WeightTensor, evict_page_cache, f16_to_bf16_bytes};
 use super::{SafetensorsIndex, check_oom_guard, estimate_has_fp8, estimate_load_bytes};
 use crate::gpu::GpuBackend;
 
@@ -99,9 +99,16 @@ pub(super) fn load_sharded(
                 continue;
             }
             let view = tensors.tensor(name)?;
-            let dtype = WeightDtype::from_safetensors(view.dtype())?;
             let shape: Vec<usize> = view.shape().to_vec();
-            let data = view.data();
+            // F16 shards: convert bytes to BF16 before upload (same length,
+            // different bit layout). WeightDtype stays closed to store dtypes.
+            let converted: Vec<u8>;
+            let (data, dtype): (&[u8], _) = if view.dtype() == safetensors::Dtype::F16 {
+                converted = f16_to_bf16_bytes(view.data());
+                (&converted, WeightDtype::BF16)
+            } else {
+                (view.data(), WeightDtype::from_safetensors(view.dtype())?)
+            };
 
             // Try GPU alloc first; if OOM, fall back to managed (UVM) memory.
             // On GB10 unified memory, managed alloc uses Linux swap for overflow.
@@ -180,9 +187,15 @@ pub(super) fn load_single(
         if skip_fn(&name) {
             continue;
         }
-        let dtype = WeightDtype::from_safetensors(view.dtype())?;
         let shape: Vec<usize> = view.shape().to_vec();
-        let data = view.data();
+        // F16: convert to BF16 at load — see load_sharded above.
+        let converted: Vec<u8>;
+        let (data, dtype): (&[u8], _) = if view.dtype() == safetensors::Dtype::F16 {
+            converted = f16_to_bf16_bytes(view.data());
+            (&converted, WeightDtype::BF16)
+        } else {
+            (view.data(), WeightDtype::from_safetensors(view.dtype())?)
+        };
 
         let ptr = gpu.alloc(data.len())?;
         gpu.copy_h2d(data, ptr)?;

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -570,6 +570,7 @@ pub fn run(
                             // proposed) is a representative sample; a bootstrap-
                             // only step proposes the first draft and is skipped.
                             let had_draft = !active[0].pending_drafts.is_empty();
+                            let seq_len_before = active[0].seq.seq_len;
                             let t0 = std::time::Instant::now();
                             step_mtp(
                                 &*model,
@@ -583,6 +584,16 @@ pub fn run(
                                     .as_mut()
                                     .expect("gate present")
                                     .record_verify(t0.elapsed());
+                                // Adaptive-K: report acceptance (tokens emitted
+                                // minus the 1 bonus token) so the gate's disable
+                                // threshold uses the MEASURED expected tokens,
+                                // not the theoretical 1+K max.
+                                let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
+                                let accepted = emitted.saturating_sub(1);
+                                mtp_gate
+                                    .as_mut()
+                                    .expect("gate present")
+                                    .record_acceptance(accepted);
                             }
                         }
                     }
@@ -623,6 +634,8 @@ pub fn run(
                     );
                 } else {
                     // MTP wins in this regime (or no gate): speculative decode.
+                    let was_verify = !active[0].pending_drafts.is_empty();
+                    let seq_len_before = active[0].seq.seq_len;
                     step_mtp(
                         &*model,
                         &mut active,
@@ -630,6 +643,26 @@ pub fn run(
                         &verify_ctx,
                         dflash_verify_raw_argmax,
                     );
+                    // Adaptive-K: feed ongoing acceptance to the gate so it can
+                    // detect a drop below break-even and re-measure (which may
+                    // disable MTP if the workload shifted to lower-acceptance
+                    // territory at the same depth).
+                    if was_verify {
+                        let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
+                        let accepted = emitted.saturating_sub(1);
+                        if let Some(gate) = mtp_gate.as_mut() {
+                            gate.record_acceptance(accepted);
+                            if gate.should_reconsider() {
+                                tracing::info!(
+                                    "MTP gate: acceptance dropped below break-even \
+                                     (ema={:.2}, m={:.2}) — re-measuring",
+                                    gate.acceptance_ema_debug(),
+                                    gate.measured_multiplier_debug(),
+                                );
+                                gate.force_remeasure();
+                            }
+                        }
+                    }
                 }
             } else {
                 // Batch decode (no MTP). Clear stale drafts when transitioning out of MTP mode.

--- a/crates/spark-server/src/scheduler/mtp_gate.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate.rs
@@ -137,6 +137,19 @@ pub struct MtpGate {
     phase: Phase,
     decode_samples: Vec<Duration>,
     verify_samples: Vec<Duration>,
+    /// Acceptance samples (num_accepted per verify step) collected during the
+    /// Verify measurement phase, parallel to `verify_samples`. Used to compute
+    /// the MEASURED expected tokens per step (`1 + mean_accepted`) for the
+    /// adaptive disable threshold — strictly tighter than the theoretical
+    /// `max_effective = 1 + K` (which assumes 100% acceptance).
+    acceptance_samples: Vec<usize>,
+    /// Exponential moving average of num_accepted, updated after the initial
+    /// decision for ongoing adaptation. If it drops below the break-even
+    /// (`1 + ema < measured_multiplier`), the gate re-opens measurement.
+    acceptance_ema: f64,
+    /// The measured verify/decode multiplier at the last `finalize`. Used by
+    /// [`Self::should_reconsider`] for the ongoing acceptance-drop check.
+    measured_multiplier: f64,
     decision: Option<GateDecision>,
     /// Sequence depth (tokens) most recently observed while sampling; frozen
     /// into `measured_at_depth` when a decision is reached.
@@ -158,6 +171,9 @@ impl MtpGate {
             phase: Phase::Decode,
             decode_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
             verify_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
+            acceptance_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
+            acceptance_ema: 0.0,
+            measured_multiplier: 0.0,
             decision: None,
             observed_depth: 0,
             measured_at_depth: 0,
@@ -191,6 +207,7 @@ impl MtpGate {
             self.phase = Phase::Decode;
             self.decode_samples.clear();
             self.verify_samples.clear();
+            self.acceptance_samples.clear();
             self.decision = None;
             self.fresh_decision = None;
         }
@@ -246,6 +263,56 @@ impl MtpGate {
         }
     }
 
+    /// Record the number of drafts accepted in a verify step. During the
+    /// measurement phase this populates `acceptance_samples` (parallel to
+    /// `verify_samples`). After the decision, it updates the rolling EMA for
+    /// ongoing adaptation — if acceptance drops below the break-even
+    /// (`1 + ema < measured_multiplier`), [`Self::should_reconsider`] flags
+    /// it so the scheduler can re-measure or disable.
+    pub fn record_acceptance(&mut self, num_accepted: usize) {
+        if self.phase == Phase::Verify {
+            self.acceptance_samples.push(num_accepted);
+        } else if self.phase == Phase::Done {
+            // EMA update (alpha=0.2 — responds within ~5 steps to a shift).
+            self.acceptance_ema = 0.8 * self.acceptance_ema + 0.2 * num_accepted as f64;
+        }
+    }
+
+    /// Ongoing adaptation check: after the initial decision, if the rolling
+    /// acceptance EMA has dropped below the break-even for the measured
+    /// multiplier, MTP is now net-negative at the current acceptance even
+    /// though it was profitable when measured. The scheduler should call
+    /// this and, if true, re-open measurement (which may disable MTP).
+    pub fn should_reconsider(&self) -> bool {
+        self.phase == Phase::Done
+            && self.decision == Some(GateDecision::KeepMtp)
+            && self.measured_multiplier > 0.0
+            && 1.0 + self.acceptance_ema < self.measured_multiplier
+    }
+
+    /// Unconditionally re-open measurement (called by the scheduler when
+    /// [`Self::should_reconsider`] fires — the acceptance drop is a
+    /// workload-shift signal, not a depth-regime change).
+    pub fn force_remeasure(&mut self) {
+        if self.phase != Phase::Done {
+            return;
+        }
+        self.phase = Phase::Decode;
+        self.decode_samples.clear();
+        self.verify_samples.clear();
+        self.acceptance_samples.clear();
+        self.decision = None;
+        self.fresh_decision = None;
+    }
+
+    /// Debug accessors for the reconsider log line.
+    pub fn acceptance_ema_debug(&self) -> f64 {
+        self.acceptance_ema
+    }
+    pub fn measured_multiplier_debug(&self) -> f64 {
+        self.measured_multiplier
+    }
+
     /// Median of the post-warmup samples for a step type, in seconds.
     fn median_secs(samples: &[Duration]) -> f64 {
         let mut timed: Vec<f64> = samples
@@ -267,30 +334,55 @@ impl MtpGate {
         } else {
             f64::INFINITY
         };
-        let decision = if multiplier >= self.max_effective {
+        // Adaptive threshold: use the MEASURED expected tokens per step
+        // (1 + mean_accepted) instead of the theoretical max (1 + K). This
+        // disables MTP when it is ACTUALLY net-negative at the current
+        // acceptance rate, not just at the impossible 100%-acceptance worst
+        // case. Example: K=3 (max_effective=4) at m=2.5 with mean_accepted=1.0
+        // → effective=2.0 < 2.5 → DISABLE (the old gate would keep it:
+        // 2.5 < 4). With mean_accepted=2.0 → effective=3.0 > 2.5 → KEEP.
+        let mean_accepted = if self.acceptance_samples.len() > WARMUP_SAMPLES {
+            let timed: Vec<usize> =
+                self.acceptance_samples.iter().copied().skip(WARMUP_SAMPLES).collect();
+            let n = timed.len();
+            timed.iter().map(|&x| x as f64).sum::<f64>() / n.max(1) as f64
+        } else {
+            // No acceptance data (e.g. all bootstraps) — fall back to the
+            // theoretical max, preserving the prior conservative behavior.
+            self.max_effective - 1.0
+        };
+        let effective_tokens = 1.0 + mean_accepted;
+        // Keep MTP only if the measured expected tokens exceed the verify
+        // cost multiplier (speedup > 1.0). Also keep the hard upper bound
+        // (m >= max_effective → disable regardless of acceptance).
+        let decision = if multiplier >= self.max_effective || multiplier >= effective_tokens {
             GateDecision::DisableMtp
         } else {
             GateDecision::KeepMtp
         };
         match decision {
             GateDecision::DisableMtp => tracing::info!(
-                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1} \
-                 (decode={:.2}ms verify={:.2}ms, depth={}) => DISABLED for this depth \
-                 regime (net-negative at any acceptance; re-measures on regime change)",
+                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1}, \
+                 measured_effective={effective_tokens:.2} (mean_accepted={mean_accepted:.2}, \
+                 decode={:.2}ms verify={:.2}ms, depth={}) => DISABLED for this depth \
+                 regime (net-negative at current acceptance; re-measures on regime change)",
                 self.max_effective,
                 decode_s * 1000.0,
                 verify_s * 1000.0,
                 self.observed_depth,
             ),
             GateDecision::KeepMtp => tracing::info!(
-                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1} \
-                 (decode={:.2}ms verify={:.2}ms, depth={}) => ENABLED",
+                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1}, \
+                 measured_effective={effective_tokens:.2} (mean_accepted={mean_accepted:.2}, \
+                 decode={:.2}ms verify={:.2}ms, depth={}) => ENABLED",
                 self.max_effective,
                 decode_s * 1000.0,
                 verify_s * 1000.0,
                 self.observed_depth,
             ),
         }
+        self.measured_multiplier = multiplier;
+        self.acceptance_ema = mean_accepted;
         self.measured_at_depth = self.observed_depth;
         self.decision = Some(decision);
         self.fresh_decision = Some(decision);

--- a/crates/spark-server/src/scheduler/mtp_gate.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate.rs
@@ -2,77 +2,23 @@
 
 //! Throughput-aware MTP runtime gate.
 //!
-//! MTP speculative decode is economical only when a single verify step
-//! (which advances up to `1 + num_drafts` tokens) is cheaper per produced
-//! token than running that many plain single-token decode steps. Whether it
-//! pays off is a property of the *measured* per-step cost on this exact
-//! model + quantization + hardware combination — NOT of the weight format.
-//! For example, on a hybrid SSM model the verify pass re-runs the full
-//! layer / MoE / lm_head stack, and on FP8 weights that makes one verify
-//! step cost ~2.3x a plain decode step even though draft acceptance is
-//! healthy (~80%); on NVFP4 weights the 4-bit weight traffic makes the same
-//! verify step cost only ~1.1x. An acceptance-only gate is therefore wrong:
-//! acceptance is healthy in the FP8 case yet MTP still loses.
-//!
-//! This gate measures the verify-cost multiplier
-//!   `m = verify_step_wall / decode_step_wall`
-//! over the first decode steps of a single-sequence serving session, then
-//! applies a PROVABLE bound:
-//!
-//! For `K_drafts = num_drafts` drafts per step, a verify step advances at
-//! MOST `1 + K_drafts` tokens (perfect acceptance). So its best-case
-//! tokens-per-wall is `(1 + K_drafts) / m` (in units of decode steps). If
-//!   `m >= 1 + K_drafts`
-//! then even at 100% acceptance the verify step produces no more tokens per
-//! unit wall than `1 + K_drafts` plain decode steps would — MTP is
-//! net-negative at ANY acceptance and is disabled. No acceptance estimate is
-//! needed for this decision; it is a hard upper bound.
-//!
-//! When `m < 1 + K_drafts`, MTP *can* win, and does so once acceptance clears
-//! the break-even `m - 1` drafts-accepted-per-step. We keep MTP on in that
-//! regime (the live K-summary logging in the verify steps already surfaces
-//! acceptance for observability).
-//!
-//! ## The multiplier is DEPTH-DEPENDENT — decisions are per-regime, not permanent
-//!
-//! `m` is not a constant of the model+hardware: it is a function of context
-//! depth, because WHAT a decode step is bound by changes with depth. At short
-//! context on a fine-grained MoE, a decode step is expert-WEIGHT-read bound;
-//! the `1 + K` verify tokens route to (mostly) distinct experts, so a verify
-//! step reads ~`(1 + K)x` the expert weights and `m ≈ 1 + K` — provably
-//! net-negative. At deep context the step is KV/SSM-READ bound; the verify's
-//! `1 + K` tokens SHARE one pass over the context state, so `m → ~1.1` and
-//! MTP wins big. Measured on Qwen3.6-35B-A3B-FP8 (GB10): `m = 4.13` at
-//! short context vs `m = 1.09` at ~17k agentic depth — same engine, same
-//! flags. A decision latched from whichever request happens to arrive first
-//! is therefore wrong for the other regime (a short warm-up probe would
-//! permanently disable MTP for a long agentic session, and vice versa).
-//! The gate records the depth at which it measured and re-measures when the
-//! live depth leaves that regime (see [`REMEASURE_DEPTH_FACTOR`]).
+//! Measures `m = verify_step_wall / decode_step_wall` over the first decode
+//! steps, then disables MTP when net-negative. The disable threshold uses the
+//! MEASURED expected tokens (`1 + mean_accepted`), not the theoretical `1 + K`
+//! max — so MTP is disabled at the ACTUAL acceptance rate, not just the
+//! impossible 100% worst case. `m` is depth-dependent (weight-bound at short
+//! context, KV/SSM-bound at depth), so the gate re-measures when the live
+//! depth leaves the measured regime (see [`REMEASURE_DEPTH_FACTOR`]). Ongoing
+//! adaptation: if the acceptance EMA drops below break-even, re-opens
+//! measurement (see [`Self::should_reconsider`]).
 
 use std::time::Duration;
 
-/// Depth-regime factor that triggers re-measurement, in either direction.
-/// Factor 2, not 4: the verify multiplier crosses the break-even (m=2.0 at
-/// K=2) over a NARROW depth band on this hybrid MoE — measured m=2.01 at
-/// ~7k, 1.86 at ~13k (Qwen3.6-35B-A3B-FP8/GB10). A factor-4 window let a
-/// session that STARTS shallow (agentic tool sessions begin ~5k) grow into
-/// the MTP-profitable band (~10-13k) WITHOUT ever re-measuring — only a
-/// 5k→20k jump would trip factor 4 — so it stayed gated off session-wide,
-/// wasting the win exactly where sessions deepen the most. Factor 2 re-checks
-/// at ~10k, flipping MTP on for the deep majority of the session. Each
-/// re-measurement is `2 * (WARMUP_SAMPLES + TIMED_SAMPLES)` steps that emit
-/// real, correct tokens (verify and plain decode are greedy-equivalent), so a
-/// re-measure — even one that flips back near the boundary — costs only the
-/// sub-optimal step type during its own ~14-step window, never correctness.
+/// Factor that triggers re-measurement when live depth leaves the measured
+/// regime (either direction). Factor 2 re-checks at ~2× depth.
 const REMEASURE_DEPTH_FACTOR: usize = 2;
 
-/// Floor for the regime comparison: below this depth every context is
-/// "short" — the KV/SSM state read per step is far below the per-step expert
-/// weight traffic, so factor comparisons between tiny depths (e.g. 32 vs 130
-/// tokens) would re-measure inside one and the same weight-bound regime.
-/// 512 tokens of bf16 KV across the attention layers is still ≪ the ~GB of
-/// active-expert weights read per step on the models this gate serves.
+/// Floor for the regime comparison (below this, all contexts are "shallow").
 const REMEASURE_DEPTH_FLOOR: usize = 512;
 
 /// Number of leading samples of each step type discarded as graph-capture /
@@ -334,27 +280,21 @@ impl MtpGate {
         } else {
             f64::INFINITY
         };
-        // Adaptive threshold: use the MEASURED expected tokens per step
-        // (1 + mean_accepted) instead of the theoretical max (1 + K). This
-        // disables MTP when it is ACTUALLY net-negative at the current
-        // acceptance rate, not just at the impossible 100%-acceptance worst
-        // case. Example: K=3 (max_effective=4) at m=2.5 with mean_accepted=1.0
-        // → effective=2.0 < 2.5 → DISABLE (the old gate would keep it:
-        // 2.5 < 4). With mean_accepted=2.0 → effective=3.0 > 2.5 → KEEP.
+        // Adaptive threshold: use MEASURED expected tokens (1 + mean_accepted)
+        // instead of theoretical max (1 + K). Disables MTP at the ACTUAL
+        // acceptance rate, not the impossible 100% worst case.
         let mean_accepted = if self.acceptance_samples.len() > WARMUP_SAMPLES {
-            let timed: Vec<usize> =
-                self.acceptance_samples.iter().copied().skip(WARMUP_SAMPLES).collect();
-            let n = timed.len();
-            timed.iter().map(|&x| x as f64).sum::<f64>() / n.max(1) as f64
+            let timed: Vec<usize> = self
+                .acceptance_samples
+                .iter()
+                .copied()
+                .skip(WARMUP_SAMPLES)
+                .collect();
+            timed.iter().map(|&x| x as f64).sum::<f64>() / timed.len().max(1) as f64
         } else {
-            // No acceptance data (e.g. all bootstraps) — fall back to the
-            // theoretical max, preserving the prior conservative behavior.
-            self.max_effective - 1.0
+            self.max_effective - 1.0 // no acceptance data → theoretical max fallback
         };
         let effective_tokens = 1.0 + mean_accepted;
-        // Keep MTP only if the measured expected tokens exceed the verify
-        // cost multiplier (speedup > 1.0). Also keep the hard upper bound
-        // (m >= max_effective → disable regardless of acceptance).
         let decision = if multiplier >= self.max_effective || multiplier >= effective_tokens {
             GateDecision::DisableMtp
         } else {

--- a/crates/spark-server/src/scheduler/mtp_gate.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate.rs
@@ -10,7 +10,7 @@
 //! context, KV/SSM-bound at depth), so the gate re-measures when the live
 //! depth leaves the measured regime (see [`REMEASURE_DEPTH_FACTOR`]). Ongoing
 //! adaptation: if the acceptance EMA drops below break-even, re-opens
-//! measurement (see [`Self::should_reconsider`]).
+//! measurement (see `should_reconsider`).
 
 use std::time::Duration;
 

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
@@ -55,6 +55,19 @@ pub(super) fn run_batched_mixed_step(
             max_prefill_tokens
         };
         let mut chunk_len = remaining.min(effective_max);
+        // Land a chunk boundary on `ssm_tail_boundary` so the SSM snapshot saved
+        // there is exactly what the NEXT turn's block-floored `matched_tokens`
+        // looks up — otherwise the warm restore falls back to the coarse
+        // --ssm-checkpoint-interval grid and replays ~254 SSM tokens per turn.
+        if spark_runtime::ssm_tail_ckpt_enabled()
+            && !spark_runtime::ssm_tail_midchunk_enabled()
+            && let Some(bs) = model.kv_block_size()
+            && let Some(tb) = spark_runtime::ssm_tail_boundary(p.prompt_tokens.len(), bs)
+            && p.chunk_offset < tb
+            && p.chunk_offset + chunk_len > tb
+        {
+            chunk_len = tb - p.chunk_offset;
+        }
         let is_last = p.chunk_offset + chunk_len >= p.prompt_tokens.len();
         if !is_last && chunk_len >= 4 {
             chunk_len = (chunk_len / 4) * 4;

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -70,6 +70,21 @@ pub(super) fn run_standard_chunk_loop(
         effective_max.min(slice_budget)
     };
     let mut chunk_len = remaining.min(cap);
+    // Land a chunk boundary on `ssm_tail_boundary` so the SSM snapshot saved
+    // there is exactly what the NEXT turn's block-floored `matched_tokens`
+    // looks up — otherwise the warm restore falls back to the coarse
+    // --ssm-checkpoint-interval grid and replays ~254 SSM tokens per turn.
+    // Suppressed when mid-chunk capture is ON (it captures in-pass, no clamp
+    // needed) and when the abandoned ATLAS_SSM_TAIL_CKPT is OFF (default).
+    if spark_runtime::ssm_tail_ckpt_enabled()
+        && !spark_runtime::ssm_tail_midchunk_enabled()
+        && let Some(bs) = model.kv_block_size()
+        && let Some(tb) = spark_runtime::ssm_tail_boundary(p.prompt_tokens.len(), bs)
+        && p.chunk_offset < tb
+        && p.chunk_offset + chunk_len > tb
+    {
+        chunk_len = tb - p.chunk_offset;
+    }
     let is_last = p.chunk_offset + chunk_len >= p.prompt_tokens.len();
     // Align intermediate chunks to GDN WY4 boundary (4 tokens).
     if !is_last && chunk_len >= 4 {

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -191,21 +191,16 @@ pub fn step_verify_dflash(
         a.seq.seq_len,
     );
 
-    // SSM commit / rollback. Hybrid models (Qwen3.6-A3B has 30 GDN layers)
-    // advance recurrent SSM state per-position during verify; without this
-    // commit, the canonical h_state stays at position+γ even if only a few
-    // drafts were accepted, producing gibberish on subsequent decodes.
-    //
-    // Semantics (default trait impl):
-    //  - num_accepted == k_verify (full accept): canonical = h_state
-    //  - 0 < num_accepted < k_verify (partial): canonical = intermediate[num_accepted-1]
-    //  - num_accepted == 0: canonical untouched (rollback to checkpoint)
+    // Item #2 (STree-style in-place verify commit). h_state is canonical:
+    //  - num_accepted == k_verify (full accept): no-op (h_state already correct)
+    //  - 0 < num_accepted < k_verify (partial): intermediate[total_accepted-1] → h_state
+    // No checkpoint write needed — the next start_checkpoint_async syncs.
     //
     // k_verify = drafts.len() + 1 (the prefix bonus position is also verified).
     let k_verify = drafts.len() + 1;
     let total_accepted = num_accepted + 1; // bonus is always "accepted"
-    if let Err(e) = model.commit_verify_state_async(&mut a.seq, total_accepted, k_verify) {
-        tracing::error!("commit_verify_state_async (dflash): {e:#}");
+    if let Err(e) = model.commit_accepted_prefix(&mut a.seq, total_accepted, k_verify) {
+        tracing::error!("commit_accepted_prefix (dflash): {e:#}");
         a.finished = true;
         return;
     }

--- a/crates/spark-server/src/scheduler/verify_k3_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k3_step.rs
@@ -168,9 +168,11 @@ pub fn step_verify_k3(
         }
         a.last_token = v2;
 
-        // F62/F63 (2026-04-27): SpecMamba commit. K=3 full accept.
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 3, 3) {
-            tracing::error!("commit_verify_state_async (K=3 accept-3): {e:#}");
+        // Item #2 (STree-style in-place K=3 verify commit). Full accept
+        // (num_accepted=k=3): the verify kernel already wrote the canonical
+        // h_state, so the commit is a no-op.
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 3, 3) {
+            tracing::error!("commit_accepted_prefix (K=3 accept-3): {e:#}");
             return;
         }
         if let Err(e) = model.save_hidden_for_mtp(2, 0) {
@@ -208,9 +210,10 @@ pub fn step_verify_k3(
         if let Err(e) = model.trim_proposer_state(&mut a.seq, 1, 0) {
             tracing::error!("trim_proposer_state: {e:#}");
         }
-        // F62/F63 (2026-04-27): K=3 partial accept (2 of 3).
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 2, 3) {
-            tracing::error!("commit_verify_state_async (K=3 accept-2): {e:#}");
+        // Item #2 (STree-style in-place K=3 verify commit). Partial accept
+        // (num_accepted=2 < k=3): rewind live h_state to intermediate[1].
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 2, 3) {
+            tracing::error!("commit_accepted_prefix (K=3 accept-2): {e:#}");
             a.finished = true;
             return;
         }
@@ -255,9 +258,10 @@ pub fn step_verify_k3(
         if let Err(e) = model.trim_proposer_state(&mut a.seq, 0, 0) {
             tracing::error!("trim_proposer_state: {e:#}");
         }
-        // F62/F63 (2026-04-27): K=3 partial accept (1 of 3).
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 1, 3) {
-            tracing::error!("commit_verify_state_async (K=3 accept-1): {e:#}");
+        // Item #2 (STree-style in-place K=3 verify commit). Partial accept
+        // (num_accepted=1 < k=3): rewind live h_state to intermediate[0].
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 1, 3) {
+            tracing::error!("commit_accepted_prefix (K=3 accept-1): {e:#}");
             a.finished = true;
             return;
         }

--- a/crates/spark-server/src/scheduler/verify_k4_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_step.rs
@@ -180,9 +180,11 @@ pub fn step_verify_k4(
         }
         a.last_token = v3;
 
-        // F62/F63 (2026-04-27): SpecMamba commit. K=4 full accept.
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 4, 4) {
-            tracing::error!("commit_verify_state_async (K=4 accept-4): {e:#}");
+        // Item #2 (STree-style in-place K=4 verify commit). Full accept
+        // (num_accepted=k=4): the verify kernel already wrote the canonical
+        // h_state, so the commit is a no-op.
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 4, 4) {
+            tracing::error!("commit_accepted_prefix (K=4 accept-4): {e:#}");
             return;
         }
         if let Err(e) = model.save_hidden_for_mtp(3, 0) {
@@ -220,9 +222,11 @@ pub fn step_verify_k4(
         if let Err(e) = model.trim_proposer_state(&mut a.seq, 2, 0) {
             tracing::error!("trim_proposer_state: {e:#}");
         }
-        // F62/F63 (2026-04-27): K=4 partial accept (3 of 4).
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 3, 4) {
-            tracing::error!("commit_verify_state_async (K=4 accept-3): {e:#}");
+        // Item #2 (STree-style in-place K=4 verify commit). Partial accept
+        // (num_accepted=3 < k=4): rewind live h_state to intermediate[2]
+        // (state after the third accepted token).
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 3, 4) {
+            tracing::error!("commit_accepted_prefix (K=4 accept-3): {e:#}");
             a.finished = true;
             return;
         }
@@ -270,9 +274,10 @@ pub fn step_verify_k4(
         if let Err(e) = model.trim_proposer_state(&mut a.seq, 1, 0) {
             tracing::error!("trim_proposer_state: {e:#}");
         }
-        // F62/F63 (2026-04-27): K=4 partial accept (2 of 4).
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 2, 4) {
-            tracing::error!("commit_verify_state_async (K=4 accept-2): {e:#}");
+        // Item #2 (STree-style in-place K=4 verify commit). Partial accept
+        // (num_accepted=2 < k=4): rewind live h_state to intermediate[1].
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 2, 4) {
+            tracing::error!("commit_accepted_prefix (K=4 accept-2): {e:#}");
             a.finished = true;
             return;
         }
@@ -318,9 +323,11 @@ pub fn step_verify_k4(
         if let Err(e) = model.trim_proposer_state(&mut a.seq, 0, 0) {
             tracing::error!("trim_proposer_state: {e:#}");
         }
-        // F62/F63 (2026-04-27): K=4 partial accept (1 of 4).
-        if let Err(e) = model.commit_verify_state_async(&mut a.seq, 1, 4) {
-            tracing::error!("commit_verify_state_async (K=4 accept-1): {e:#}");
+        // Item #2 (STree-style in-place K=4 verify commit). Partial accept
+        // (num_accepted=1 < k=4): rewind live h_state to intermediate[0]
+        // (state after the always-accepted bonus token).
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 1, 4) {
+            tracing::error!("commit_accepted_prefix (K=4 accept-1): {e:#}");
             a.finished = true;
             return;
         }

--- a/kernels/gb10/common/inferspark_prefill_paged.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — BF16 KV cache variant.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_batched.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_batched.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Q12 Phase 3: Paged Prefill Flash Attention — BF16 KV cache, batched
 // same-chunk-len variant. See inferspark_prefill_paged.cu for the

--- a/kernels/gb10/common/inferspark_prefill_paged_fp8.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_fp8.cu
@@ -32,6 +32,17 @@ __device__ __forceinline__ __nv_bfloat16 fp8_to_bf16(__nv_fp8_storage_t b, float
 // in prefill_paged_compute.cuh uses fp8x2_to_*_bits). OOB rows (pos >= kv_len)
 // are zeroed synchronously (uint4) — safe because the committed cp.async group
 // covers only valid-row entries. cache_stride is in FP8 elements (1 byte each).
+//
+// ALIGNMENT (2026-07-19 fix): FP8-smem elements are 1 byte, so the row stride
+// HDIM_PAD must itself be 16-aligned for the 16-byte atlas_cp16 and uint4
+// stores. With the default PAD_KV=8 → HDIM_PAD=264 → 264 mod 16 = 8 (odd rows
+// misaligned → silent cp.async misalignment fault, 1/8 tool-call coherence).
+// Override PAD_KV=16 → HDIM_PAD=272 → 272 mod 16 = 0 before including the
+// shared header (which is #ifndef-guarded so the override sticks). The BF16 /
+// NVFP4 paths don't define ATLAS_ATTN_FP8_SMEM, so they keep PAD_KV=8.
+#ifdef ATLAS_ATTN_FP8_SMEM
+#define PAD_KV 16
+#endif
 #define LOAD_KV_TILE(cache, bt, smem, kv_s, kv_l, kvh, t, stride) \
     do { \
         const unsigned int _cpr = HDIM / 16; \

--- a/kernels/gb10/common/inferspark_prefill_paged_fp8.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_fp8.cu
@@ -15,42 +15,43 @@ __device__ __forceinline__ __nv_bfloat16 fp8_to_bf16(__nv_fp8_storage_t b, float
     return __float2bfloat16(v);
 }
 
-// FP8-smem occupancy variant (NVIDIA GB10, FP8-KV, HDIM=256): keep K/V in
-// shared memory as raw E4M3 bytes and dequant in-register before each MMA,
-// halving smem_K + smem_V so 2 CTAs/SM fit. Output is bit-identical to the
-// BF16-smem path (same fp8_to_bf16 + k_scale/v_scale). Comment out this
-// define to revert to BF16-smem dequant-on-load.
-// GATED 2026-06-28 (dgx1): bit-identical (cosine 1.0) + occupancy 1->2 CTAs/SM
-// CONFIRMED via ncu, BUT per-attn-layer prefill time UNCHANGED (~18ms cold,
-// warm 360 vs 350ms baseline) => occupancy-NEUTRAL, attention is per-warp
-// dependency-latency bound (QK->softmax->PV), not occupancy bound. Disabled on
-// the serving path (no speed win); code kept validated for a future larger-BR
-// retile that USES the freed ~25KB smem. See MMQ_PORT_HANDOFF.md.
-// #define ATLAS_ATTN_FP8_SMEM
+// FP8-smem + cp.async pipelining (Lever #2, 2026-07-19): K/V kept in shared
+// memory as raw E4M3 bytes (__nv_fp8_storage_t, halving smem_K + smem_V) and
+// dequantized in-register before each MMA. Tile loads use cp.async (16 FP8
+// elements per atlas_cp16) so KV-load latency is hidden behind QK^T compute
+// of the previous tile — the synchronous fp8→bf16 dequant that made FP8 KV
+// 10% SLOWER than BF16 is now deferred to the register read. The in-register
+// dequant uses the same fp8_to_bf16 + k_scale/v_scale as the original sync
+// path, making the MMA operands (and therefore the kernel output) bit-identical.
+// See also: inferspark_prefill_paged_bf16k_turbo4v.cu (BF16 cp.async pattern).
+#define ATLAS_ATTN_FP8_SMEM
 
-// FP8 tile loader: manual load + dequant + store to smem.
-// cache_stride is in FP8 elements (1 byte each).
+// FP8 tile loader: cp.async copy of raw E4M3 bytes into fp8-storage smem.
+// 16 FP8 elements (16 bytes) per atlas_cp16, matching the 16-byte transaction
+// size. Dequant is deferred to in-register MMA read (ATLAS_ATTN_FP8_SMEM path
+// in prefill_paged_compute.cuh uses fp8x2_to_*_bits). OOB rows (pos >= kv_len)
+// are zeroed synchronously (uint4) — safe because the committed cp.async group
+// covers only valid-row entries. cache_stride is in FP8 elements (1 byte each).
 #define LOAD_KV_TILE(cache, bt, smem, kv_s, kv_l, kvh, t, stride) \
     do { \
-        const unsigned int _cpr = HDIM / 8; \
-        for (unsigned int _i = t; _i < TILE_CHUNKS; _i += (stride)) { \
-            unsigned int _row = _i / _cpr, _col = (_i % _cpr) * 8; \
+        const unsigned int _cpr = HDIM / 16; \
+        for (unsigned int _i = t; _i < TILE_CHUNKS / 2; _i += (stride)) { \
+            unsigned int _row = _i / _cpr, _col = (_i % _cpr) * 16; \
             unsigned int _pos = (kv_s) + _row; \
             if (_pos < (kv_l)) { \
                 unsigned int _lb = _pos / cache_block_size; \
                 unsigned int _bo = _pos % cache_block_size; \
                 unsigned int _pb = (unsigned int)(bt)[_lb]; \
-                const __nv_fp8_storage_t* _base = (const __nv_fp8_storage_t*)(cache) \
+                const void* _base = (const void*)( \
+                    (const __nv_fp8_storage_t*)(cache) \
                     + (unsigned long long)_pb * fp8_cache_stride \
                     + (unsigned long long)_bo * num_kv_heads * head_dim \
-                    + (unsigned long long)(kvh) * head_dim + _col; \
-                __nv_bfloat16 _v[8]; \
-                for (int _j = 0; _j < 8; _j++) \
-                    _v[_j] = fp8_to_bf16(_base[_j], dq_scale); \
-                *((uint4*)&(smem)[_row][_col]) = *((uint4*)_v); \
-            } else { *((uint4*)&(smem)[_row][_col]) = make_uint4(0,0,0,0); } \
+                    + (unsigned long long)(kvh) * head_dim + _col); \
+                atlas_cp16(&((__nv_fp8_storage_t(*)[HDIM_PAD])(smem))[_row][_col], _base); \
+            } else { \
+                *((uint4*)&((__nv_fp8_storage_t(*)[HDIM_PAD])(smem))[_row][_col]) = make_uint4(0,0,0,0); \
+            } \
         } \
-        /* No cp.async used; emit dummy commit so shared header's wait works */ \
     } while(0)
 
 #define KERNEL_NAME inferspark_prefill_paged_fp8
@@ -61,75 +62,9 @@ __device__ __forceinline__ __nv_bfloat16 fp8_to_bf16(__nv_fp8_storage_t b, float
     , const float k_scale \
     , const float v_scale \
     , const unsigned long long fp8_cache_stride
-#define KERNEL_PREAMBLE \
-    const float dq_scale = (K_cache == V_cache) ? k_scale : \
-        ((const void*)smem_Q == (const void*)smem_V ? v_scale : k_scale); \
-    /* This hack won't work; we need separate K/V dequant scales. */ \
-    /* Actually: dq_scale is set per LOAD_KV_TILE call via the cache ptr. */ \
-    /* For now, use a shared approach: k_scale for K loads, v_scale for V loads. */ \
-    /* The LOAD_KV_TILE macro captures `dq_scale` from scope. */ \
-    /* We'll set it before each load in the compute header... */ \
-    /* FIXME: For FP8, we need K and V to use different scales. */ \
-    /* Simple approach: the compute header loads K with dq_scale=k_scale, V with dq_scale=v_scale. */ \
-    (void)0;
-
-/* Problem: the shared compute header uses LOAD_KV_TILE for both K and V,
-   but FP8 needs different scales. Override with a scale-aware approach. */
-
-/* Actually, let me take a different approach. For FP8, the scale depends on
-   whether we're loading K or V. The compute header calls LOAD_KV_TILE with
-   K_cache for K tiles and V_cache for V tiles. We can use the cache pointer
-   to determine which scale to use. */
-
-#undef LOAD_KV_TILE
-#ifdef ATLAS_ATTN_FP8_SMEM
-// FP8-smem: copy raw E4M3 bytes into shared memory (8 bytes / chunk via uint2);
-// dequant is deferred to the in-register MMA read (fp8x2_to_*_bits). smem here
-// is __nv_fp8_storage_t, so a chunk of 8 elements is 8 bytes, not 16.
-#define LOAD_KV_TILE(cache, bt, smem, kv_s, kv_l, kvh, t, stride) \
-    do { \
-        const unsigned int _cpr = HDIM / 8; \
-        for (unsigned int _i = t; _i < TILE_CHUNKS; _i += (stride)) { \
-            unsigned int _row = _i / _cpr, _col = (_i % _cpr) * 8; \
-            unsigned int _pos = (kv_s) + _row; \
-            if (_pos < (kv_l)) { \
-                unsigned int _lb = _pos / cache_block_size; \
-                unsigned int _bo = _pos % cache_block_size; \
-                unsigned int _pb = (unsigned int)(bt)[_lb]; \
-                const __nv_fp8_storage_t* _base = (const __nv_fp8_storage_t*)(cache) \
-                    + (unsigned long long)_pb * fp8_cache_stride \
-                    + (unsigned long long)_bo * num_kv_heads * head_dim \
-                    + (unsigned long long)(kvh) * head_dim + _col; \
-                *((uint2*)&(smem)[_row][_col]) = *((const uint2*)_base); \
-            } else { *((uint2*)&(smem)[_row][_col]) = make_uint2(0,0); } \
-        } \
-    } while(0)
-#else
-#define LOAD_KV_TILE(cache, bt, smem, kv_s, kv_l, kvh, t, stride) \
-    do { \
-        const float _sc = ((const void*)(cache) == (const void*)K_cache) ? k_scale : v_scale; \
-        const unsigned int _cpr = HDIM / 8; \
-        for (unsigned int _i = t; _i < TILE_CHUNKS; _i += (stride)) { \
-            unsigned int _row = _i / _cpr, _col = (_i % _cpr) * 8; \
-            unsigned int _pos = (kv_s) + _row; \
-            if (_pos < (kv_l)) { \
-                unsigned int _lb = _pos / cache_block_size; \
-                unsigned int _bo = _pos % cache_block_size; \
-                unsigned int _pb = (unsigned int)(bt)[_lb]; \
-                const __nv_fp8_storage_t* _base = (const __nv_fp8_storage_t*)(cache) \
-                    + (unsigned long long)_pb * fp8_cache_stride \
-                    + (unsigned long long)_bo * num_kv_heads * head_dim \
-                    + (unsigned long long)(kvh) * head_dim + _col; \
-                __nv_bfloat16 _v[8]; \
-                for (int _j = 0; _j < 8; _j++) \
-                    _v[_j] = fp8_to_bf16(_base[_j], _sc); \
-                *((uint4*)&(smem)[_row][_col]) = *((uint4*)_v); \
-            } else { *((uint4*)&(smem)[_row][_col]) = make_uint4(0,0,0,0); } \
-        } \
-    } while(0)
-#endif
-
-#undef KERNEL_PREAMBLE
+// KERNEL_PREAMBLE: empty — ATLAS_ATTN_FP8_SMEM path defers fp8→bf16 dequant
+// to in-register MMA reads (fp8x2_to_*_bits in prefill_paged_compute.cuh), so
+// no load-time dq_scale is needed on the host side.
 #define KERNEL_PREAMBLE /* nothing */
 
 #include "prefill_paged_compute.cuh"

--- a/kernels/gb10/common/inferspark_prefill_paged_fp8.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_fp8.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — FP8 E4M3 KV cache variant.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_fp8_batched.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_fp8_batched.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Q12 Phase 3: Paged Prefill Flash Attention — FP8 E4M3 KV cache,
 // batched same-chunk-len variant. See inferspark_prefill_paged_fp8.cu

--- a/kernels/gb10/common/inferspark_prefill_paged_indirect.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_indirect.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 //
 // Paged Prefill Flash Attention — BF16 KV cache, INDIRECT scalar args.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_nvfp4.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_nvfp4.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — NVFP4 (E2M1 + FP8 group scales) KV cache variant.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_nvfp4_batched.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_nvfp4_batched.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Q12 Phase 3: Paged Prefill Flash Attention — NVFP4 KV cache, batched
 // same-chunk-len variant. See inferspark_prefill_paged_nvfp4.cu for the

--- a/kernels/gb10/common/inferspark_prefill_paged_turbo2.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_turbo2.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — Turbo2 (2-bit Lloyd-Max + FP8 group scales) KV cache variant.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_turbo3.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_turbo3.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — Turbo3 (3-bit Lloyd-Max + FP8 group scales) KV cache variant.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_turbo4.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_turbo4.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — Turbo4 (4-bit Lloyd-Max + FP8 group scales) KV cache variant.
 //

--- a/kernels/gb10/common/inferspark_prefill_paged_turbo8.cu
+++ b/kernels/gb10/common/inferspark_prefill_paged_turbo8.cu
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// ldmatrix-enabled rebuild (header content change forces kernel cache miss)
 
 // Paged Prefill Flash Attention — Turbo8 (FP8 E4M3 + BF16 group scales) KV cache variant.
 //

--- a/kernels/gb10/common/prefill_paged_compute.cuh
+++ b/kernels/gb10/common/prefill_paged_compute.cuh
@@ -129,6 +129,16 @@ __device__ __forceinline__ float sw_exp(float x) {
 #endif
 #define HDIM_PAD (HDIM + PAD_KV)
 #define PAD_P 8
+
+// ATLAS_ATTN_LDMATRIX: use ldmatrix.x4 for the A-operand (Q for QK^T, P for PV)
+// smem loads instead of 4 scalar unsigned-int loads. One PTX instruction
+// replaces 4 manual loads, shortening the load→MMA dependency chain this
+// latency-bound prefill kernel is gated on. PROVEN on GB10/SM121 (ldmatrix_probe.cu
+// cosine 1.0; commit 7dbdfe41 "bit-identical, +2%"). Default ON — opt OUT with
+// -DATLAS_DISABLE_ATTN_LDMATRIX (the prior default-off) if a regression appears.
+#ifndef ATLAS_DISABLE_ATTN_LDMATRIX
+#define ATLAS_ATTN_LDMATRIX
+#endif
 #define N_TILES_PER_WARP ((HDIM / 8) / 2)
 #define TILE_CHUNKS (BR * (HDIM / 8))
 

--- a/kernels/gb10/common/prefill_paged_compute.cuh
+++ b/kernels/gb10/common/prefill_paged_compute.cuh
@@ -119,7 +119,14 @@ __device__ __forceinline__ float sw_exp(float x) {
 #ifndef HDIM
 #define HDIM 256
 #endif
+// PAD_KV may be overridden by a kernel before including this header (e.g. the
+// FP8-smem cp.async path needs a 16-aligned row stride for 16-byte cp.async /
+// uint4 stores; FP8 elements are 1 byte so PAD_KV=8 → 264 = only 8-aligned,
+// whereas PAD_KV=16 → 272 = 16-aligned). Default 8 keeps the BF16 row stride
+// (256+8)*2 = 528 bytes 16-aligned, as before.
+#ifndef PAD_KV
 #define PAD_KV 8
+#endif
 #define HDIM_PAD (HDIM + PAD_KV)
 #define PAD_P 8
 #define N_TILES_PER_WARP ((HDIM / 8) / 2)

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -84,47 +84,53 @@ extern "C" __global__ void w4a16_gemv(
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
     __syncthreads();
 
-    float acc = 0.0f;
+    float acc0 = 0.0f, acc1 = 0.0f;
 
-    // Vectorized: process 16 K-values per iteration (2× uint4 activation + uint64 weight)
-    // One scale per GROUP_SIZE=16, so each iteration uses exactly 1 scale lookup.
-    for (unsigned int k16 = lane; k16 < K16; k16 += threads_per_out) {
-        const unsigned int base_k = k16 * 16;
+    // Vectorized: 16 K-values per chunk (2× uint4 activation + uint64 weight),
+    // TWO chunks in flight per iteration with independent accumulators. Keeping 2
+    // outstanding weight loads per thread hides DRAM latency (ncu: 72% of warp
+    // stalls are long-scoreboard on GB10). The FP8 group scale is factored out of
+    // the inner 16-FMA block (exact regroup: sum(s*w*a) == s*sum(w*a)).
+    const unsigned int stride2 = threads_per_out * 2u;
+    for (unsigned int k16 = lane * 2u; k16 < K16 + 1u; k16 += stride2) {
+        #pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const unsigned int kk = k16 + (unsigned int)c;
+            if (kk >= K16) break;
 
-        // Load 16 BF16 activations as 2× uint4 (256-bit total)
-        uint4 a_lo = ((const uint4*)A)[k16 * 2];
-        uint4 a_hi = ((const uint4*)A)[k16 * 2 + 1];
-        const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
-                                        a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+            // Load 16 BF16 activations as 2× uint4 (256-bit total)
+            uint4 a_lo = ((const uint4*)A)[kk * 2];
+            uint4 a_hi = ((const uint4*)A)[kk * 2 + 1];
+            const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
 
-        // Load 8 packed weight bytes as uint64 (16 FP4 values)
-        unsigned long long packed8 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + k16 * 8);
+            // Load 8 packed weight bytes as uint64 (16 FP4 values)
+            unsigned long long packed8 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk * 8);
 
-        // Load single FP8 scale — 16 values = exactly 1 group
-        unsigned int scale_group = base_k / GROUP_SIZE;
-        unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + scale_group];
-        __nv_fp8_e4m3 fp8;
-        *(unsigned char*)&fp8 = scale_byte;
+            // Load single FP8 scale — 16 values = exactly 1 group (group index == kk)
+            unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
 #if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-        float scale = scl_fp8(scale_byte) * scale2;
+            float scale = scl_fp8(scale_byte) * scale2;
 #else
-        float scale = (float)fp8 * scale2;
+            float scale = (float)fp8 * scale2;
 #endif
 
-        // Unpack 8 bytes × 2 nibbles = 16 weight values, FMA with activations
-        #pragma unroll
-        for (int b = 0; b < 8; b++) {
-            unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-            float w_lo = s_lut[byte_val & 0xF] * scale;
-            float w_hi = s_lut[byte_val >> 4] * scale;
-
-            __nv_bfloat16 a_lo_bf, a_hi_bf;
-            *(unsigned short*)&a_lo_bf = (unsigned short)(a_raw[b] & 0xFFFF);
-            *(unsigned short*)&a_hi_bf = (unsigned short)(a_raw[b] >> 16);
-            acc += __bfloat162float(a_lo_bf) * w_lo;
-            acc += __bfloat162float(a_hi_bf) * w_hi;
+            // Unpack 8 bytes × 2 nibbles = 16 weight values, FMA with activations
+            float part = 0.0f;
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+                part = fmaf(af.x, s_lut[byte_val & 0xF], part);
+                part = fmaf(af.y, s_lut[byte_val >> 4], part);
+            }
+            if (c == 0) acc0 = fmaf(scale, part, acc0);
+            else        acc1 = fmaf(scale, part, acc1);
         }
     }
+    float acc = acc0 + acc1;
 
     // Warp shuffle reduction within each group of 64 threads
     // First reduce within each warp (32 threads)

--- a/kernels/gb10/common/w4a16_gemv_fused.cu
+++ b/kernels/gb10/common/w4a16_gemv_fused.cu
@@ -76,48 +76,57 @@ extern "C" __global__ void w4a16_gemv_dual(
 
     const unsigned int half_K = K / 2;
     const unsigned int num_groups = K / GROUP_SIZE;
-    const unsigned int K8 = K / 8;
+    const unsigned int K16 = K / 16;
 
     __shared__ float s_lut[16];
     __shared__ float smem[N_PER_BLOCK * 2];
     if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_FUSED_W4[threadIdx.x];
     __syncthreads();
 
-    float acc = 0.0f;
+    float acc0 = 0.0f, acc1 = 0.0f;
 
-    for (unsigned int k8 = lane; k8 < K8; k8 += threads_per_out) {
-        const unsigned int base_k = k8 * 8;
+    // 16 K-values per chunk (uint64 weight load), TWO chunks in flight per
+    // iteration with independent accumulators — hides DRAM latency (ncu: 72% of
+    // warp stalls are long-scoreboard on GB10). Scale factored out of the inner
+    // block (exact regroup). Requires K % 16 == 0 (was K % 8).
+    const unsigned int stride2 = threads_per_out * 2u;
+    for (unsigned int k16 = lane * 2u; k16 < K16 + 1u; k16 += stride2) {
+        #pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const unsigned int kk = k16 + (unsigned int)c;
+            if (kk >= K16) break;
 
-        uint4 a_data = ((const uint4*)A)[k8];
-        const unsigned int a_raw[4] = {a_data.x, a_data.y, a_data.z, a_data.w};
+            uint4 a_lo4 = ((const uint4*)A)[kk * 2];
+            uint4 a_hi4 = ((const uint4*)A)[kk * 2 + 1];
+            const unsigned int a_raw[8] = {a_lo4.x, a_lo4.y, a_lo4.z, a_lo4.w,
+                                            a_hi4.x, a_hi4.y, a_hi4.z, a_hi4.w};
 
-        unsigned int packed4 = *(const unsigned int*)(
-            B_packed + (unsigned long long)n * half_K + k8 * 4);
+            unsigned long long packed8 = *(const unsigned long long*)(
+                B_packed + (unsigned long long)n * half_K + kk * 8);
 
-        unsigned int scale_group = base_k / GROUP_SIZE;
-        unsigned char scale_byte = B_scale[
-            (unsigned long long)n * num_groups + scale_group];
-        __nv_fp8_e4m3 fp8;
-        *(unsigned char*)&fp8 = scale_byte;
+            unsigned char scale_byte = B_scale[
+                (unsigned long long)n * num_groups + kk];
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
 #if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-        float scale = scl_fp8(scale_byte) * scale2;
+            float scale = scl_fp8(scale_byte) * scale2;
 #else
-        float scale = (float)fp8 * scale2;
+            float scale = (float)fp8 * scale2;
 #endif
 
-        #pragma unroll
-        for (int b = 0; b < 4; b++) {
-            unsigned char byte_val = (packed4 >> (b * 8)) & 0xFF;
-            float w_lo = s_lut[byte_val & 0xF] * scale;
-            float w_hi = s_lut[byte_val >> 4] * scale;
-
-            __nv_bfloat16 a_lo, a_hi;
-            *(unsigned short*)&a_lo = (unsigned short)(a_raw[b] & 0xFFFF);
-            *(unsigned short*)&a_hi = (unsigned short)(a_raw[b] >> 16);
-            acc += __bfloat162float(a_lo) * w_lo;
-            acc += __bfloat162float(a_hi) * w_hi;
+            float part = 0.0f;
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+                part = fmaf(af.x, s_lut[byte_val & 0xF], part);
+                part = fmaf(af.y, s_lut[byte_val >> 4], part);
+            }
+            if (c == 0) acc0 = fmaf(scale, part, acc0);
+            else        acc1 = fmaf(scale, part, acc1);
         }
     }
+    float acc = acc0 + acc1;
 
     const unsigned int warp_lane = threadIdx.x % WARP_SIZE;
 

--- a/kernels/gb10/qwen3.6-27b/MODEL.toml
+++ b/kernels/gb10/qwen3.6-27b/MODEL.toml
@@ -129,20 +129,16 @@ thinking_in_tools = true
 # 2026-05-23 sweep: 512 → 2048 (project-wide reasoning headroom bump).
 max_thinking_budget = 2048
 default_num_drafts = 1
-# BF16 KV cache for long-context prefill (2026-06-21 prefill-32k study).
-# The 16 full-attention layers (head_dim=256, full_attention_interval=4)
-# dominate long-context prefill, and at depth they are KV-load-latency bound.
-# The FP8 paged-attn prefill kernel (inferspark_prefill_paged_fp8.cu) loads +
-# dequants KV SYNCHRONOUSLY (no cp.async pipelining); the BF16 kernel pipelines
-# KV tile loads via cp.async, hiding the latency. Measured on dgx1, cold 32k
-# c=1 prefill (Qwen3.6-27B-FP8): FP8 KV 435.8 tok/s vs BF16 KV 480.2 tok/s
-# (+10.2%); per-chunk gaps grow steeper for FP8 (8.9→11.5s) than BF16
-# (8.8→10.0s), confirming the unhidden FP8 KV-load latency. BF16 KV is also
-# higher quality (no FP8 KV quant drift on the large-magnitude deep-layer K/V)
-# and decode is unregressed (9.6 vs 9.7 tok/s @ d32768). Resolution rule 3 in
-# serve_phases/kv_cache.rs applies this when the recipe passes the CLI default
-# `--kv-cache-dtype fp8`; an explicit non-fp8 override still wins.
-default_kv_dtype = "bf16"
+# FP8 KV cache (enabled 2026-07-19): lever #2 — cp.async pipelining in
+# inferspark_prefill_paged_fp8.cu hides KV-load latency behind QK^T compute.
+# The old sync fp8->bf16 dequant path was 10.2% SLOWER than BF16 KV (435.8
+# vs 480.2 tok/s @32k c=1 cold prefill). With cp.async pipelining (matching
+# the BF16 kernel's 2-stage pattern), the FP8 kernel's load latency is now
+# hidden, so FP8 KV is expected to be FASTER than BF16 KV (smaller DV75
+# bandwidth, same compute epic). Resolution rule 3 in
+# serve_phases/kv_cache.rs is now a no-op since the MODEL.toml default
+# already matches the CLI default `--kv-cache-dtype fp8`.
+default_kv_dtype = "fp8"
 
 # Upstream Qwen/Qwen3.6-27B reports `model_type = "qwen3_5"` in config.json.
 # Atlas's `parse_qwen3_5_config` (atlas-core/src/config.rs) rewrites this to

--- a/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
@@ -3997,7 +3997,172 @@ void int8_gemm_faith2(
 #undef F2_SB
 #undef F2W
 
-// int8 W4A8 FAITH3 — faith2 + B-fragment ILP. ncu on faith2 showed the dominant
+// int8 W4A8 I32ACC — faith2 + INT32 per-sb accumulation (break the MMA→scale
+// dependency chain). The ncu diagnosis of faith2: "pure dependency-latency
+// (Compute 26%/Mem 33%, NOTHING saturates)" — the kernel is gated on the
+// 4-deep chain MMA→int2float→mul(wsc)→mul(asc)→add(acc) that SERIALIZES each
+// MMA behind the previous one's scale. faith3 (B-frag ILP) was NEUTRAL because
+// it didn't break the chain — the scale still blocks each MMA.
+//
+// I32ACC fix: accumulate the mma.sync.s32 result in INT32 (iacc += s, 1-cycle
+// int add — no float conversion) so the 8 independent j-iteration MMAs issue
+// back-to-back without waiting for the scale. The per-block scale (wsc*asc,
+// constant within one sb) is applied ONCE at the sb boundary, converting the
+// int32 partial to float and adding to the persistent float accumulator.
+//
+// Register cost: +64 int32 (iacc[2][8][4], reused per sb) on top of faith2's
+// 64 float (facc[2][8][4], persistent). ~128 regs/thread → 1 CTA/SM (from 2).
+// OK because the kernel is latency-bound (ncu: nothing saturates) — cutting
+// occupancy doesn't hurt a kernel that's waiting on dependency chains, and
+// breaking the chain is the win.
+// ═════════════════════════════════════════════════════════════════
+#define I32A_TILE 128
+#define I32A_SB   (I32A_TILE/32)
+#define I32AW     36
+#define ATLAS_MMA_S8_I32A(d, a0,a1,a2,a3, b0,b1) \
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 " \
+        "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+        : "=r"((d)[0]), "=r"((d)[1]), "=r"((d)[2]), "=r"((d)[3]) \
+        : "r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+          "r"((d)[0]),"r"((d)[1]),"r"((d)[2]),"r"((d)[3]))
+
+extern "C" __global__
+__launch_bounds__(256, 1)
+void int8_gemm_i32acc(
+    const signed char* __restrict__ A_i8,
+    const signed char* __restrict__ B_i8,
+    const float* __restrict__ A_scale,
+    const float* __restrict__ B_scale,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * 128;
+    const unsigned int cta_m = blockIdx.y * 128;
+    if (cta_m >= M || cta_n >= N) return;
+    const unsigned int t = threadIdx.x;
+    const unsigned int warp_id = t >> 5;
+    const unsigned int lane = t & 31;
+    const unsigned int ng = warp_id >> 1;
+    const unsigned int mh = warp_id & 1;
+    const unsigned int nb = K >> 5;
+
+    __shared__ int   sW[128][I32AW];
+    __shared__ int   sA[128][I32AW];
+    __shared__ float sWs[128][I32A_SB];
+    __shared__ float sAs[128][I32A_SB];
+
+    // Persistent float accumulator (survives across sb iterations).
+    float facc[2][8][4];
+    #pragma unroll
+    for (int n=0;n<2;n++) for(int j=0;j<8;j++){facc[n][j][0]=0;facc[n][j][1]=0;facc[n][j][2]=0;facc[n][j][3]=0;}
+
+    for (unsigned int kb = 0; kb < K; kb += I32A_TILE) {
+        // ── Load tile (same as faith2) ──
+        const unsigned I32A_CPR = I32A_TILE/16;
+        #pragma unroll
+        for (int c = 0; c < I32A_TILE/32; c++) {
+            unsigned lin = c*256 + t;
+            unsigned row = lin / I32A_CPR;
+            unsigned col = (lin % I32A_CPR) << 4;
+            unsigned gk = kb + col;
+            signed char* wdst = ((signed char*)&sW[row][0]) + col;
+            signed char* adst = ((signed char*)&sA[row][0]) + col;
+            cp_async_pred_16(wdst, &B_i8[(unsigned long long)(cta_n+row)*K + gk], (cta_n+row<N)&&(gk+15<K));
+            cp_async_pred_16(adst, &A_i8[(unsigned long long)(cta_m+row)*K + gk], (cta_m+row<M)&&(gk+15<K));
+        }
+        if (t < 128) {
+            unsigned blk = kb >> 5;
+            #pragma unroll
+            for (int s=0;s<I32A_SB;s++){
+                sWs[t][s] = (cta_n+t<N)?B_scale[(unsigned long long)(cta_n+t)*nb + blk + s]:0.f;
+                sAs[t][s] = (cta_m+t<M)?A_scale[(unsigned long long)(cta_m+t)*nb + blk + s]:0.f;
+            }
+        }
+        cp_async_commit(); cp_async_wait_all(); __syncthreads();
+
+        // ── sb loop: int32 accumulation, scale at sb boundary ──
+        #pragma unroll
+        for (int sb=0; sb<I32A_SB; sb++){
+            unsigned WA[2][4];
+            float    wsc[2][2];
+            #pragma unroll
+            for (int n=0;n<2;n++){
+                unsigned wbase_row = ng*32 + n*16;
+                const int* xs = &sW[wbase_row][0] + (lane%16)*I32AW + sb*8 + (lane/16)*4;
+                asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0,%1,%2,%3},[%4];"
+                    : "=r"(WA[n][0]),"=r"(WA[n][1]),"=r"(WA[n][2]),"=r"(WA[n][3]) : "l"(xs));
+                wsc[n][0] = sWs[wbase_row + lane/4][sb];
+                wsc[n][1] = sWs[wbase_row + 8 + lane/4][sb];
+            }
+
+            // Int32 per-sb accumulators — live across the j-loop (no float ops).
+            int iacc[2][8][4];
+            #pragma unroll
+            for (int n=0;n<2;n++) for(int j=0;j<8;j++){iacc[n][j][0]=0;iacc[n][j][1]=0;iacc[n][j][2]=0;iacc[n][j][3]=0;}
+            // Stash asc per j for the sb-boundary scale (asc varies with j).
+            float ascs[8][2];
+
+            // j-loop: PURE int32 MMAs — no float conversion, no scale chain.
+            // The 8 independent j-iteration MMAs pipeline back-to-back.
+            #pragma unroll
+            for (int j=0;j<8;j++){
+                unsigned mcol0 = mh*64 + j*8;
+                ascs[j][0] = sAs[mcol0 + (lane%4)*2][sb];
+                ascs[j][1] = sAs[mcol0 + (lane%4)*2 + 1][sb];
+                const int* abase = &sA[mcol0 + lane/4][0] + sb*8;
+                unsigned b0 = abase[lane%4];
+                unsigned b1 = abase[lane%4 + 4];
+                #pragma unroll
+                for (int n=0;n<2;n++){
+                    int s[4]={0,0,0,0};
+                    ATLAS_MMA_S8_I32A(s, WA[n][0],WA[n][1],WA[n][2],WA[n][3], b0,b1);
+                    // INT32 accumulate — no float chain, MMAs pipeline freely.
+                    iacc[n][j][0] += s[0];
+                    iacc[n][j][1] += s[1];
+                    iacc[n][j][2] += s[2];
+                    iacc[n][j][3] += s[3];
+                }
+            }
+
+            // sb boundary: convert + scale ALL (n,j) at once.
+            // The float ops are OUTSIDE the MMA critical path.
+            #pragma unroll
+            for (int n=0;n<2;n++){
+                #pragma unroll
+                for (int j=0;j<8;j++){
+                    float sc0 = wsc[n][0] * ascs[j][0];
+                    float sc1 = wsc[n][0] * ascs[j][1];
+                    float sc2 = wsc[n][1] * ascs[j][0];
+                    float sc3 = wsc[n][1] * ascs[j][1];
+                    facc[n][j][0] += (float)iacc[n][j][0] * sc0;
+                    facc[n][j][1] += (float)iacc[n][j][1] * sc1;
+                    facc[n][j][2] += (float)iacc[n][j][2] * sc2;
+                    facc[n][j][3] += (float)iacc[n][j][3] * sc3;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    // ── Epilogue: write facc to C (same as faith2) ──
+    #pragma unroll
+    for (int n=0;n<2;n++){
+        unsigned nrow0 = cta_n + ng*32 + n*16 + lane/4;
+        #pragma unroll
+        for (int j=0;j<8;j++){
+            unsigned mcol = cta_m + mh*64 + j*8 + (lane%4)*2;
+            unsigned cN0=nrow0, cN1=nrow0+8;
+            if (mcol<M   && cN0<N) C[(unsigned long long)mcol*N + cN0]     = __float2bfloat16(facc[n][j][0]);
+            if (mcol+1<M && cN0<N) C[(unsigned long long)(mcol+1)*N + cN0] = __float2bfloat16(facc[n][j][1]);
+            if (mcol<M   && cN1<N) C[(unsigned long long)mcol*N + cN1]     = __float2bfloat16(facc[n][j][2]);
+            if (mcol+1<M && cN1<N) C[(unsigned long long)(mcol+1)*N + cN1] = __float2bfloat16(facc[n][j][3]);
+        }
+    }
+}
+#undef ATLAS_MMA_S8_I32A
+#undef I32A_TILE
+#undef I32A_SB
+#undef I32AW
 // stall is SHORT_SCOREBOARD (smem-read latency) 47% of 7.2 cyc/instr; occupancy
 // is dead (raising CTA/SM regressed). The remaining lever is ILP on the smem reads:
 // faith2 loads the activation B-fragment (2 scalar smem loads) INSIDE the j-loop,

--- a/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
@@ -3195,6 +3195,97 @@ void int8_gemm_8w_ldmab(
 #undef ATLAS_MMA_S8
 
 // ═══════════════════════════════════════════════════════════════════
+// FP8 W8A8, 8-warp + ldmatrix.x4 for BOTH A AND B (fp8_fp8_gemm_ldmab).
+// The ldmatrix port of the GDN-projection prefill GEMM: fp8_gemm_t ran at
+// ncu 10.7% SM / 56% MIO-queue stall because the A+B MMA fragments were read
+// with ~32 scalar smem loads/K-step. FP8 e4m3 uses the SAME m16n8k32 8-bit
+// fragment layout as s8, so the ldmatrix.x4 loads proven bit-exact for
+// int8_gemm_8w_ldmab port verbatim; only the MMA (s8->e4m3) and the epilogue
+// (int32+scale -> direct f32 accumulate; fp8_gemm_t is unscaled, scale folded
+// into weights upstream) change. A is pre-quantized to e4m3 by the caller
+// (bf16_to_fp8), B is the pre-dequanted e4m3 weight. Grid (N/128,M/128) blk 256.
+#define ATLAS_MMA_E4M3F(d, a0,a1,a2,a3, b0,b1) \
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+        "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+        : "=f"((d)[0]),"=f"((d)[1]),"=f"((d)[2]),"=f"((d)[3]) \
+        : "r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+          "f"((d)[0]),"f"((d)[1]),"f"((d)[2]),"f"((d)[3]))
+
+extern "C" __global__
+__launch_bounds__(256, 2)
+void fp8_fp8_gemm_ldmab(
+    const unsigned char* __restrict__ A_fp8,   // [M, K] e4m3
+    const unsigned char* __restrict__ B_fp8,   // [N, K] e4m3
+    __nv_bfloat16* __restrict__ C,             // [M, N] bf16
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_m = blockIdx.y * 128;
+    const unsigned int cta_n = blockIdx.x * 128;
+    if (cta_m >= M) return;
+    const unsigned int t = threadIdx.x;
+    const unsigned int warp_id = t >> 5;
+    const unsigned int lane = t & 31;
+    const unsigned int group_id = lane >> 2;
+    const unsigned int t4 = lane & 3;
+    const unsigned int wrow = warp_id * 16;
+
+    __shared__ unsigned char smem_Ai[2][128][32];
+    __shared__ unsigned char smem_Bi[2][128][32];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) { acc[i][0]=0.f; acc[i][1]=0.f; acc[i][2]=0.f; acc[i][3]=0.f; }
+
+    #define LABF_LOADS(buf, kb) do { \
+        { unsigned ar = t >> 1; unsigned ac = (t & 1) << 4; unsigned gc = (kb) + ac; unsigned gr = cta_m + ar; \
+          cp_async_pred_16(&smem_Ai[(buf)][ar][ac], &A_fp8[(unsigned long long)gr*K+gc], (gr<M)&&(gc+15<K)); } \
+        { unsigned an = t >> 1; unsigned ac = (t & 1) << 4; unsigned gc = (kb) + ac; unsigned gn = cta_n + an; \
+          cp_async_pred_16(&smem_Bi[(buf)][an][ac], &B_fp8[(unsigned long long)gn*K+gc], (gn<N)&&(gc+15<K)); } \
+    } while(0)
+
+    #define LABF_COMPUTE(buf) do { \
+        unsigned a0,a1,a2,a3; \
+        const int* xs = (const int*)&smem_Ai[(buf)][wrow][0] + (lane % 16)*8 + (lane / 16)*4; \
+        asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0,%1,%2,%3},[%4];" \
+            : "=r"(a0),"=r"(a1),"=r"(a2),"=r"(a3) : "l"(xs)); \
+        _Pragma("unroll") for (int p = 0; p < 8; p++) { \
+            unsigned nt0 = 2*p, nt1 = 2*p+1; \
+            unsigned brow = ((lane<16)?nt0:nt1)*8 + (lane&7); \
+            const void* bxs = &smem_Bi[(buf)][brow][((lane>>3)&1)*16]; \
+            unsigned q0,q1,q2,q3; \
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0,%1,%2,%3},[%4];" \
+                : "=r"(q0),"=r"(q1),"=r"(q2),"=r"(q3) : "l"(bxs)); \
+            ATLAS_MMA_E4M3F(acc[nt0], a0,a1,a2,a3, q0,q1); \
+            ATLAS_MMA_E4M3F(acc[nt1], a0,a1,a2,a3, q2,q3); \
+        } \
+    } while(0)
+
+    LABF_LOADS(0, 0); cp_async_commit(); cp_async_wait_all(); __syncthreads();
+    int cur = 0;
+    for (unsigned int kb = 32; kb < K; kb += 32) {
+        int nxt = 1 - cur;
+        LABF_LOADS(nxt, kb); cp_async_commit();
+        LABF_COMPUTE(cur);
+        cp_async_wait_all(); __syncthreads();
+        cur = nxt;
+    }
+    LABF_COMPUTE(cur);
+    #undef LABF_LOADS
+    #undef LABF_COMPUTE
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned c0 = cta_n + nt*8 + t4*2, c1 = c0 + 1;
+        unsigned r0 = cta_m + wrow + group_id, r1 = r0 + 8;
+        if (r0<M&&c0<N) C[r0*N+c0]=__float2bfloat16(acc[nt][0]);
+        if (r0<M&&c1<N) C[r0*N+c1]=__float2bfloat16(acc[nt][1]);
+        if (r1<M&&c0<N) C[r1*N+c0]=__float2bfloat16(acc[nt][2]);
+        if (r1<M&&c1<N) C[r1*N+c1]=__float2bfloat16(acc[nt][3]);
+    }
+}
+#undef ATLAS_MMA_E4M3F
+
+// ═══════════════════════════════════════════════════════════════════
 // int8 W4A8, 8-warp + ldmatrix.x4 A-fragment load (int8_gemm_8w_ilp).
 // THE load-bearing MMQ lever: replace the manual scalar smem loads of the
 // weight (A) fragment with ONE ldmatrix.sync.aligned.m8n8.x4.b16 (proven


### PR DESCRIPTION
## Summary

Three inference optimizations for Qwen3.6-27B-NVFP4 (dense) and Qwen3.6-35B-A3B-FP8 (MoE flagship) on GB10, validated with full BFCL e2e on both models.

### 1. fp8 cp.async paged-prefill: fix 16-byte alignment fault (1/8 → 8/8)

The cp.async pipelining kernel for FP8 KV cache stored raw E4M3 K/V tiles into `__nv_fp8_storage_t` smem and issued 16-byte `atlas_cp16` loads + `uint4` OOB zero-stores. With the default `PAD_KV=8` → `HDIM_PAD=264` and FP8 elements at 1 byte each, the row stride was 264 bytes = only **8-byte aligned**. PTX `cp.async.cg.shared.global size=16` requires 16-byte alignment of both src and dst; odd rows were misaligned → silent data corruption → **1/8 tool-call coherence**.

**Fix**: `#ifndef`-guard `PAD_KV` in `prefill_paged_compute.cuh` (default 8 unchanged for BF16/NVFP4); override `PAD_KV=16` in `inferspark_prefill_paged_fp8.cu` under `#ifdef ATLAS_ATTN_FP8_SMEM` → `HDIM_PAD=272` (16-aligned). Zero blast radius on BF16/NVFP4 paths.

**Verified**: fp8 KV 1/8 → 8/8; cold-prefill TTFT fp8 ≤ bf16 on all 3 true-cold buckets; fp8 KV now delivers **2× KV capacity** at prefill parity. MODEL.toml `default_kv_dtype` → fp8.

### 2. Mid-chunk GDN tail capture: eliminate warm-turn SSM replay (default-on)

On warm multi-turn requests, the engine replayed ~273 GDN tokens/turn across all SSM layers to rebuild state at the match point (~1.17s of warm TTFT). The mid-chunk capture splits the two per-token GDN kernels at the block-floored matched-prefix boundary `tb` (and `tb-block_size` in v2) and D2D-copies the boundary state into a reserved snapshot slot — no extra forward pass.

**Rebased** `fdcebfe3` (v1) + `82e88f24` (v2 dual capture) + `2af4df64` (session-gate fix) onto the current baseline. 32-file conflict resolved (ForwardContext fields, SnapshotEntry fields, adapter_id threading for #321 LoRA-aware prefix hash, session-aware eviction kept).

**Default-on**: `ssm_tail_midchunk_enabled()` returns true unless `ATLAS_SSM_TAIL_MIDCHUNK=0` (opt-out). The session-gate (`is_tail` entries are byte-safe only for the same non-zero session) makes default-on safe.

**Verified (27B dense, dgx1)**:
- flag-off **byte-identical** to the baseline (32-file rebase is safe)
- warm TTFT: **-9.3% median** (4412→4002ms), **-54% max** (10508→4882ms — tail-spike elimination)
- contamination (session-gate): **20/20 + 15/15** single-turn probes, 0 garbled
- BFCL e2e: **1007/1007, 86.63%**, 2004 captures firing, 0 errors

**Verified (35B MoE flagship, dgx3)**:
- fp8 KV **8/8 coherent** (Lever A applies to the 35B too)
- midchunk captures firing (30 GDN layers)
- BFCL e2e (thinking-off + fp8 KV + midchunk): **1007/1007, 85.73%**, **24.37 TPS**, 0 errors

### 3. Adaptive-K MTP gate

The gate's disable threshold now uses the **measured** expected tokens per step (`1 + mean_accepted`) instead of the theoretical max (`1 + K`). This disables MTP when it is actually net-negative at the current acceptance rate. Ongoing adaptation: if the acceptance EMA drops below break-even, the gate re-opens measurement.

**Verified on 27B**: gate logs show `measured_effective=1.5-3.0, mean_accepted=0.5-2.0, m=1.3-1.4 → ENABLED` (correct: MTP is profitable at depth). Acceptance-drop re-measurement fires correctly. 10/10 unit tests pass.

### 4. int8_gemm_i32acc — documented negative result

Attempted to break the faith2 FFN GEMM plateau (44.7 TFLOP/s) by accumulating mma.sync.s32 results in int32 and scaling only at the sb boundary. **Result: 6-10× slower** (register spills from ~156 regs/thread overwhelm the latency improvement). Confirms the memory's finding that faith2 is a hard plateau requiring a different structure (q8_1 interleaved weights + deep cp.async pipeline). Kept as a documented experiment.

### 35B config recommendation

The 35B MoE flagship's `--max-thinking-budget 512` generates up to 512 thinking tokens per request — pure decode overhead. Disabling thinking (`--disable-thinking`) delivers **24.37 TPS** (1.75× the 27B's 13.92 TPS) at **85.73% BFCL** (slightly higher than thinking-on 85.38%). This is a config change, not a code change — but it's the single biggest e2e-TPS lever for the 35B.

### Commits (18)
- 9 MTP/ldmatrix cherry-picks (overnight campaign: K=3/K=4 batched verify, drafter prefill, ldmatrix GDN GEMM, in-place GDN K=4 verify)
- 2 fp8 cp.async + alignment fix
- 3 midchunk cherry-picks (v1 + v2 + session-gate fix)
- 1 rebase resolution (32-file conflict + adapter_id threading + clippy)
- 1 adaptive-K gate + ldmatrix A-operand loads + midchunk default-on
- 1 i32acc negative result
- 1 w4a16 decode GEMV ILP