### PR TITLE
build(deepseek-v4): add libibverbs-dev + librdmacm-dev to the DS4F builder stage

### DIFF
--- a/docker/gb10/deepseek-v4-flash/nvfp4/Dockerfile
+++ b/docker/gb10/deepseek-v4-flash/nvfp4/Dockerfile
@@ -23,7 +23,8 @@
 FROM nvidia/cuda:13.0.0-devel-ubuntu24.04 AS builder
 
 RUN apt-get update -qq && \
-    apt-get install -y -qq curl build-essential pkg-config git cmake libclang-dev && \
+    apt-get install -y -qq curl build-essential pkg-config git cmake libclang-dev \
+      libibverbs-dev librdmacm-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
The DeepSeek-V4-Flash NVFP4 image builder stage installs the RDMA **runtime** libs (`libibverbs1`/`librdmacm1`) in the runtime stage, but not the `-dev` headers in the **builder** stage.

`atlas-rdma`'s `build.rs` compiles `src/rdma_shim.c`, which `#include <infiniband/verbs.h>`. Without the headers the release build fails:

```
src/rdma_shim.c:20:10: fatal error: infiniband/verbs.h: No such file or directory
error: failed to run custom build command for `atlas-rdma`
... cargo build --release -p spark-server ... exit code: 101
```

So `docker/gb10/deepseek-v4-flash/nvfp4/Dockerfile` cannot build as-is on `main`.

**Fix:** add `libibverbs-dev` + `librdmacm-dev` to the builder-stage `apt install`. Build-env only — no sink/CSA/model/kernel/runtime change.

**Verified:** `docker build -f docker/gb10/deepseek-v4-flash/nvfp4/Dockerfile` completes clean from the committed tree (no local patch) — 165 kernels compiled, `spark-server` release build finished, image produced (4.77 GB). GB10 / CUDA 13.0.

AI-generated, attributed.
