### PR TITLE
fix(deepseek-v4): read FP32 attn_sink as float, not bf16 — restores 7 hard-zeroed heads

### DIFF
--- a/crates/spark-model/src/weight_loader/deepseek_v4.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4.rs
@@ -6,6 +6,7 @@
 //! MLA attention pattern as Mistral Small 4 with DeepSeek weight naming.
 
 mod assemble;
+mod attn_sink;
 mod compute;
 mod load_layers;
 // MTP draft-module loader for nvidia/DeepSeek-V4-Flash-NVFP4.

--- a/crates/spark-model/src/weight_loader/deepseek_v4/assemble.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/assemble.rs
@@ -427,10 +427,11 @@ pub fn assemble_layer(
     };
 
     // Per-head attention sink logit (s_aux); present on all V4 attention layers.
-    let attn_sink = store
-        .get(&format!("{lp}.attn.attn_sink"))
-        .map(|w| w.ptr)
-        .unwrap_or(DevicePtr::NULL);
+    // Normalized to the canonical FP32 dtype contract (F32 pass-through / BF16
+    // widen / else fail); the sink-consuming kernels index it as `const float*`.
+    // Reading the checkpoint-native fp32 buffer as bf16 hard-zeroed 7 query heads.
+    let attn_sink =
+        super::attn_sink::load_attn_sink_f32(store, &format!("{lp}.attn.attn_sink"), gpu)?;
 
     // Native block-scaled FP8 weights for the hot decode GEMVs (the checkpoint
     // ships wq_a/wq_b/wo_b as FP8-E4M3 + 128×128 block scales). The decode path

--- a/crates/spark-model/src/weight_loader/deepseek_v4/attn_sink.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/attn_sink.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! DeepSeek-V4 per-head attention sink (`s_aux`) — canonical FP32 dtype contract.
+//!
+//! The checkpoint ships `layers.N.attn.attn_sink` as F32 `[num_q_heads]`, and every
+//! DS4F sink-consuming kernel indexes it as `const float*`. This module is the single
+//! place that normalizes the loaded buffer to that contract, so a kernel can never
+//! index an fp32 buffer as bf16 (a 2-byte stride over 4-byte elements that reads the
+//! low-mantissa half of the wrong element — historically hard-zeroing 7 query heads
+//! whose misread decoded large-positive and collapsed the softmax value accumulator).
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::weights::{WeightDtype, WeightStore};
+
+/// Load the per-head attention sink as the canonical device **FP32** buffer.
+///
+/// - **F32 checkpoint** (the DSpark case): pass the store buffer through unchanged
+///   (byte no-op vs the raw pointer).
+/// - **BF16 checkpoint**: widen once here into a freshly allocated FP32 buffer
+///   (process-lifetime, same ownership model as the other derived loader buffers,
+///   e.g. `main_inv_freq`).
+/// - **Missing**: `DevicePtr::NULL` (the layer has no sink; kernels skip the branch).
+/// - **Any other dtype**: fail loudly with the tensor key and dtype.
+pub(super) fn load_attn_sink_f32(
+    store: &WeightStore,
+    key: &str,
+    gpu: &dyn GpuBackend,
+) -> Result<DevicePtr> {
+    let t = match store.get(key) {
+        Err(_) => return Ok(DevicePtr::NULL), // checkpoint has no sink for this layer
+        Ok(t) => t,
+    };
+    match t.dtype {
+        WeightDtype::FP32 => Ok(t.ptr),
+        WeightDtype::BF16 => {
+            let mut bf16_buf = vec![0u8; t.num_elements() * 2];
+            gpu.copy_d2h(t.ptr, &mut bf16_buf)?;
+            let f32_buf = bf16_bytes_to_f32_bytes(&bf16_buf);
+            let ptr = gpu.alloc(f32_buf.len())?;
+            gpu.copy_h2d(&f32_buf, ptr)?;
+            Ok(ptr)
+        }
+        other => anyhow::bail!(
+            "DeepSeek-V4 attn_sink '{key}': unexpected dtype {:?} \
+             (sink kernels require F32; only F32 pass-through or BF16 widening supported)",
+            other
+        ),
+    }
+}
+
+/// Widen a bf16 byte buffer to f32 bytes, exactly (no rounding): bf16 is the high
+/// 16 bits of the f32 word, so the two bf16 bytes become the high two f32 bytes and
+/// the low two are zero. Pure/deterministic → unit-tested.
+pub(crate) fn bf16_bytes_to_f32_bytes(bf16: &[u8]) -> Vec<u8> {
+    let n = bf16.len() / 2;
+    let mut out = vec![0u8; n * 4];
+    for i in 0..n {
+        out[i * 4 + 2] = bf16[i * 2];
+        out[i * 4 + 3] = bf16[i * 2 + 1];
+    }
+    out
+}
+
+#[cfg(test)]
+mod attn_sink_dtype_tests {
+    //! Regression tests for the DS4F `attn_sink` FP32 contract. The checkpoint
+    //! ships `attn_sink` as F32 `[num_q_heads]`; the kernels index it as
+    //! `const float*`. The historical defect indexed the same fp32 buffer as
+    //! bf16 (2-byte stride), so even head `2k` read the low-mantissa half of
+    //! fp32 element `k`; 7 such reads were large-positive and collapsed the
+    //! softmax value accumulator to exactly zero. These tests lock the true
+    //! fp32 read and reproduce the old bf16 misread's exact seven-head set.
+    use super::bf16_bytes_to_f32_bytes;
+
+    // First 128 bytes of the banked device `attn_sink` buffer for L0 (q5),
+    // captured from the running engine (tap G3_L0_attn_sink_r0.bin, node n3).
+    // 128 bytes = 32 fp32 elements (heads 0..31), i.e. what a bf16 index reads
+    // for heads 0..63.
+    const DEV_SINK_BYTES: [u8; 128] = [
+        0x96, 0x80, 0x84, 0x3f, 0x47, 0xf9, 0x01, 0x3f, 0xb3, 0xd3, 0xfb, 0x3e, 0x76, 0x45, 0x4b,
+        0x3e, 0x2f, 0x0e, 0xbe, 0x3f, 0x52, 0x76, 0x23, 0x3f, 0x42, 0x5c, 0xbd, 0xbd, 0xbd, 0xb7,
+        0xc3, 0x3f, 0x07, 0xc6, 0xd0, 0x3e, 0xd1, 0xd9, 0xb6, 0x3f, 0x9d, 0x7b, 0x70, 0x3e, 0x25,
+        0x3c, 0xe2, 0xbd, 0x37, 0xe8, 0x31, 0x3f, 0xaa, 0xb8, 0x6b, 0x3f, 0x51, 0x49, 0x93, 0x3f,
+        0xc2, 0xf3, 0x10, 0x3e, 0x32, 0xe5, 0x8a, 0x3f, 0xad, 0x46, 0xe5, 0xbe, 0xf0, 0x33, 0xd0,
+        0x3f, 0x57, 0x9f, 0x25, 0x3f, 0x73, 0x33, 0xc1, 0x3f, 0xa2, 0xba, 0xa3, 0xbf, 0x6b, 0xb2,
+        0x48, 0x3f, 0x75, 0x3f, 0x94, 0xbe, 0x15, 0x51, 0x6f, 0xbf, 0x72, 0x14, 0xf9, 0x3c, 0x60,
+        0x01, 0x63, 0x3f, 0x05, 0xab, 0x8b, 0x3f, 0xbc, 0x94, 0x8a, 0x3f, 0xfb, 0x13, 0x42, 0x3f,
+        0x79, 0x17, 0x28, 0x3e, 0x33, 0x08, 0x29, 0x3f,
+    ];
+
+    // True fp32 sink logits (checkpoint), heads 0..31.
+    const SINK_TRUE_0_31: [f32; 32] = [
+        1.035, 0.508, 0.492, 0.199, 1.485, 0.639, -0.092, 1.529, 0.408, 1.429, 0.235, -0.11, 0.695,
+        0.921, 1.151, 0.142, 1.085, -0.448, 1.627, 0.647, 1.509, -1.279, 0.784, -0.29, -0.935,
+        0.03, 0.887, 1.091, 1.083, 0.758, 0.164, 0.66,
+    ];
+
+    fn f32_from_le(b: &[u8]) -> f32 {
+        f32::from_le_bytes([b[0], b[1], b[2], b[3]])
+    }
+
+    #[test]
+    fn bf16_widen_is_exact() {
+        let cases: [(u16, f32); 4] = [
+            (0x3F80, 1.0),
+            (0x3FC0, 1.5),
+            (0xBF80, -1.0),
+            (0xBDBC, f32::from_bits(0xBDBC0000)),
+        ];
+        for (bits, expect) in cases {
+            let bf = bits.to_le_bytes();
+            let out = bf16_bytes_to_f32_bytes(&bf);
+            assert_eq!(out.len(), 4);
+            assert_eq!(f32_from_le(&out), expect, "bf16 {bits:#06x} widened");
+            assert_eq!(out[0], 0);
+            assert_eq!(out[1], 0);
+        }
+        for &v in &[0.5f32, -3.25, 12.0, 0.235] {
+            let hi = (v.to_bits() >> 16) as u16;
+            let widened = f32_from_le(&bf16_bytes_to_f32_bytes(&hi.to_le_bytes()));
+            assert_eq!(widened.to_bits(), (hi as u32) << 16);
+        }
+    }
+
+    #[test]
+    fn fp32_read_returns_true_sink_values() {
+        for h in 0..32usize {
+            let v = f32_from_le(&DEV_SINK_BYTES[h * 4..h * 4 + 4]);
+            assert!(
+                (v - SINK_TRUE_0_31[h]).abs() < 1e-3,
+                "head {h}: fp32 read {v} != true {}",
+                SINK_TRUE_0_31[h]
+            );
+        }
+    }
+
+    #[test]
+    fn bf16_misread_reproduces_seven_zeroed_heads() {
+        const MAX_LOGIT: f32 = 6.0;
+        let mut zeroed = Vec::new();
+        for h in 0..64usize {
+            let off = 2 * h;
+            let bits = (DEV_SINK_BYTES[off] as u32) | ((DEV_SINK_BYTES[off + 1] as u32) << 8);
+            let sg = f32::from_bits(bits << 16);
+            let m_new = MAX_LOGIT.max(sg);
+            let exp_old = (MAX_LOGIT - m_new).min(0.0).exp();
+            if exp_old < 1e-6 {
+                zeroed.push(h);
+            }
+        }
+        assert_eq!(zeroed, vec![6, 10, 12, 20, 28, 34, 48], "bug fingerprint");
+        assert!(zeroed.iter().all(|h| h % 2 == 0));
+    }
+}

--- a/kernels/gb10/deepseek-v4-flash/nvfp4/inferspark_prefill_512.cu
+++ b/kernels/gb10/deepseek-v4-flash/nvfp4/inferspark_prefill_512.cu
@@ -21,7 +21,7 @@ extern "C" __global__ void inferspark_prefill_512(
     const float inv_sqrt_d,
     const unsigned int causal,
     const unsigned int sliding_window,  // Always 0 for full-attention 512-hd layers; param added for signature consistency
-    const __nv_bfloat16* __restrict__ sinks  // [num_q_heads] per-head sink logit (denominator only); nullptr = no sink
+    const float* __restrict__ sinks  // [num_q_heads] per-head sink logit (denominator only); nullptr = no sink. FP32: checkpoint-native dtype (reading as bf16 hard-zeroed 7 heads)
 ) {
     const unsigned int q_head = blockIdx.x;
     const unsigned int q_block = blockIdx.y;
@@ -118,7 +118,7 @@ extern "C" __global__ void inferspark_prefill_512(
     // attention (non-CSA) prefill layers were missing it, so prefill diverged
     // from the sink-applying decode path and corrupted the prompt's hidden/KV.
     if (sinks != nullptr) {
-        float sg = __bfloat162float(sinks[q_head]);
+        float sg = sinks[q_head];
         float m_new = fmaxf(m, sg);
         float exp_old = __expf(m - m_new);
         float exp_sink = __expf(sg - m_new);

--- a/kernels/gb10/deepseek-v4-flash/nvfp4/mla_paged_decode_fp8.cu
+++ b/kernels/gb10/deepseek-v4-flash/nvfp4/mla_paged_decode_fp8.cu
@@ -53,7 +53,7 @@ extern "C" __global__ void mla_paged_decode_fp8(
     const float v_scale,                             // FP8 scale for V
     const unsigned long long cache_stride_bytes,
     const unsigned int sliding_window,               // 0 = full; else attend only the last `sliding_window` positions
-    const __nv_bfloat16* __restrict__ sinks,         // [num_q_heads] per-head attn sink (s_aux); may be NULL
+    const float* __restrict__ sinks,                 // [num_q_heads] per-head attn sink (s_aux); may be NULL. FP32: checkpoint-native (reading as bf16 hard-zeroed 7 heads)
     const unsigned char* __restrict__ comp_pool,     // 4b: flat FP8 compressed-KV pool [comp_block_count][576]; may be NULL
     const unsigned int comp_block_count              // 4b: # completed compressed blocks to attend; 0 = no compressed arm (ratio-0 layers)
 ) {
@@ -394,7 +394,7 @@ extern "C" __global__ void mla_paged_decode_fp8(
         // eager_attention_forward concats `sinks`, softmaxes, then slices off the
         // sink column). Online-softmax: add exp(sink - running_max) to the sum.
         if (sinks != nullptr) {
-            final_l += __expf((float)sinks[q_head] - smem_m[0]);
+            final_l += __expf(sinks[q_head] - smem_m[0]);
         }
         float inv_l = (final_l > 0.0f) ? (1.0f / final_l) : 0.0f;
         unsigned int* o32 = (unsigned int*)(O + (unsigned long long)q_head * q_head_dim + vec_offset_bf16);

--- a/kernels/gb10/deepseek-v4-flash/nvfp4/prefill_attn_compressed.cu
+++ b/kernels/gb10/deepseek-v4-flash/nvfp4/prefill_attn_compressed.cu
@@ -26,7 +26,7 @@ extern "C" __global__ void prefill_attn_compressed(
     const __nv_bfloat16* __restrict__ V,       // [S, num_kv_heads, head_dim]
     const __nv_bfloat16* __restrict__ Kc,      // [n_comp, head_dim]  (kv head 0)
     const __nv_bfloat16* __restrict__ Vc,      // [n_comp, head_dim]
-    const __nv_bfloat16* __restrict__ sinks,   // [num_q_heads]  per-head sink logit
+    const float* __restrict__ sinks,   // [num_q_heads]  per-head sink logit (FP32: checkpoint-native; reading as bf16 hard-zeroed 7 heads)
     __nv_bfloat16* __restrict__ O,             // [S, num_q_heads, head_dim]
     const unsigned int seq_len,
     const unsigned int num_q_heads,
@@ -101,7 +101,7 @@ extern "C" __global__ void prefill_attn_compressed(
 
     // ── attention sink: per-head logit in the denominator only (no value) ──
     if (valid && sinks != nullptr) {
-        float sg = __bfloat162float(sinks[q_head]);
+        float sg = sinks[q_head];
         float m_new = fmaxf(m, sg);
         float eo = __expf(m - m_new);
         for (unsigned int d = 0; d < 64 && dim_start + d < head_dim; ++d) o_acc[d] *= eo;


### PR DESCRIPTION
## Summary

The DeepSeek-V4-Flash checkpoint ships the attention sink as **FP32** `attn_sink[num_q_heads]`, but the
V4 sink-consuming kernels indexed it as `const __nv_bfloat16*`. A 2-byte stride over the 4-byte buffer made
even head `2k` read the low-mantissa half of `fp32[k]`; 7 heads (**{6, 10, 12, 20, 28, 34, 48}**) decoded to
large positive values, hit the sink-softmax branch, and had their attention accumulator hard-zeroed. The
result was a wrong token-0 and divergence from the reference engine on every full-attention prefill layer
(and the FP8 paged-decode path).

## Fix (6 files, +167/−10)

- New `weight_loader/deepseek_v4/attn_sink.rs`: FP32 pass-through / BF16→FP32 widen / else fail; NULL on
  missing. `mod attn_sink;` + loader call swapped in `assemble.rs`.
- Three sink-consuming kernels take `const float*` and drop the bf16 cast:
  `inferspark_prefill_512.cu`, `prefill_attn_compressed.cu`, `mla_paged_decode_fp8.cu`.
- ABI unchanged (Rust passes a raw device pointer). Single commit; rollback = one clean revert.

## Verification (post-#339 `main`, EP=2 on 2×GB10, NET/IB RoCE)

Built from the committed tree (165/165 nvcc, spark-server recompiled). Greedy (temperature 0), no logprobs.

| Check | Result |
|---|---|
| `attn_sink_dtype_tests` | 3/3 pass — incl. the `{6,10,12,20,28,34,48}` bf16-misread fingerprint and the FP32-read true-value test |
| q5 token-0 (`max_tokens=1`) | `"We"` — matches the reference engine (pre-fix produced `"Thinking"`) |
| q3 behavioral (`max_tokens=1024`) | 262 prompt / 1024 completion / `length` |
| q5 behavioral | 255 prompt / 455 completion / `stop` |
| q8 behavioral | 239 prompt / 660 completion / `stop` |

All three behavioral traces match the prior verified sink build. No theta/rope/mscale or other numerics
touched.

## Supersedes

This replaces #333, which targeted the abandoned base branch `fix/v4-nvfp4-decode-sink`. This PR targets
`main`. The 4th sink consumer on that old base (`mla_paged_decode_nvfp4`) does not exist on `main` and is
correctly not included.

Depends on #339 (merged) for the DS4F image build.

_AI-generated (SeedSource), reviewed against measured cluster results._
