### PR TITLE
fix(mtp-gate): throughput-arbitrated MTP gate + reuse-gated mid-chunk capture — restore 35B agentic wall-time

### DIFF
--- a/crates/spark-model/src/model/ssm_snapshot.rs
+++ b/crates/spark-model/src/model/ssm_snapshot.rs
@@ -358,10 +358,30 @@ impl SsmSnapshotPool {
         Ok(())
     }
 
-    /// Return a snapshot slot to the free list.
+    /// Return a snapshot slot to the free list. Clears the slot's session
+    /// tag: a freed slot carries no restorable state, so leaving the tag
+    /// would make [`Self::session_has_history`] report phantom history.
     pub(super) fn free(&self, snap_slot: usize) {
         self.slot_has_hidden.lock().remove(&snap_slot);
+        self.session_tags.lock().remove(&snap_slot);
         self.free_slots.lock().push(snap_slot);
+    }
+
+    /// Whether any LIVE snapshot slot is tagged with `session_hash` — i.e.
+    /// this session has produced at least one snapshot before (a prior turn
+    /// finished, or a prior tail was captured). Used by the mid-chunk tail
+    /// capture to skip sessions on first sight: `session_hash` is a hash of
+    /// the first ≤1024 prompt tokens, so single-turn traffic gets a unique
+    /// hash per request and can never reuse a captured tail, while
+    /// multi-turn agents (stable long system prompt) match from their
+    /// second request onward — exactly when tail reuse begins.
+    pub(crate) fn session_has_history(&self, session_hash: u64) -> bool {
+        session_hash != 0
+            && self
+                .session_tags
+                .lock()
+                .values()
+                .any(|&s| s == session_hash)
     }
 
     /// Reserve a Marconi snapshot slot for an in-pass MID-CHUNK tail capture.

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -126,6 +126,20 @@ impl TransformerModel {
         if !spark_runtime::ssm_tail_midchunk_enabled() || !self.ssm_snapshots.is_enabled() {
             return None;
         }
+        // Reuse gate: capture costs a per-prefill kernel split + D2D copy and
+        // is only ever consumable by a LATER request of the SAME session (the
+        // snapshot lookup is session-gated). A session seen for the FIRST
+        // time — which includes ALL single-turn traffic, whose ≤1024-token
+        // prefix hash is unique per request — can never reuse this capture,
+        // so skip it entirely; sessions gain capture from their second
+        // request onward (the first request's leaf save tags the session),
+        // exactly when reuse begins. Measured (35B FP8 webserver_ok N=10,
+        // 2026-07-20): capture-always Σ1846s/9-of-10 + 257 tok/turn vs
+        // capture-off Σ1495s/10-of-10 + 203 tok/turn on sessionless agentic
+        // traffic; multi-turn warm-TTFT (-54% max) is preserved from turn 3.
+        if !self.ssm_snapshots.session_has_history(seq.session_hash) {
+            return None;
+        }
         let bs = kv_cache.block_size();
         let tb = spark_runtime::ssm_tail_boundary(tokens.len(), bs)?;
         // Only capture when this pass strictly crosses tb.

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -533,19 +533,17 @@ pub fn run(
                 && !active[0].suppress_tool_call
                 && !active[0].disable_mtp
             {
-                // Throughput-aware MTP gate: while still measuring, run the
-                // step type the gate asks for and time it. Both step types emit
-                // real, correct tokens (MTP verify and plain decode are greedy-
-                // equivalent), so the measurement window does not waste work.
-                //
-                // The verify/decode multiplier is DEPTH-DEPENDENT (weight-bound
-                // at short context vs KV/SSM-bound at depth — see mtp_gate module
-                // docs), so a decision is only valid for the regime it was
-                // measured in: re-open measurement when the live depth leaves it.
+                // Throughput-arbitrated MTP gate: EVERY single-sequence step
+                // is timed and reported, and the gate picks whichever mode
+                // (MTP verify vs plain decode) DELIVERS more tokens/sec —
+                // with hysteresis, dwell, and periodic probing of the other
+                // mode. Both step types emit real, correct tokens, so
+                // arbitration never wastes work. See mtp_gate module docs for
+                // why component-time economics were replaced (webserver_ok
+                // A/B 2026-07-20: always-on Σ1028s/10-10 vs timing-gated
+                // Σ1846s/9-10).
                 if let Some(gate) = mtp_gate.as_mut() {
                     gate.maybe_remeasure(active[0].seq.seq_len);
-                }
-                if let Some(gate) = mtp_gate.as_mut().filter(|g| g.is_measuring()) {
                     gate.note_depth(active[0].seq.seq_len);
                     match gate.next_step() {
                         mtp_gate::GateStep::MeasureDecode => {
@@ -560,16 +558,12 @@ pub fn run(
                                 tool_call_end_token,
                                 adaptive_sampling,
                             );
-                            mtp_gate
-                                .as_mut()
-                                .expect("gate present")
-                                .record_decode(t0.elapsed());
+                            gate.record_decode(t0.elapsed());
                         }
                         mtp_gate::GateStep::MeasureVerify => {
-                            // Only a true verify forward (drafts already
-                            // proposed) is a representative sample; a bootstrap-
-                            // only step proposes the first draft and is skipped.
-                            let had_draft = !active[0].pending_drafts.is_empty();
+                            // A bootstrap-only step (no pending drafts) emits
+                            // 1 token and proposes; its cost is charged to the
+                            // MTP mode — proposing IS part of what MTP costs.
                             let seq_len_before = active[0].seq.seq_len;
                             let t0 = std::time::Instant::now();
                             step_mtp(
@@ -579,35 +573,16 @@ pub fn run(
                                 &verify_ctx,
                                 dflash_verify_raw_argmax,
                             );
-                            if had_draft {
-                                mtp_gate
-                                    .as_mut()
-                                    .expect("gate present")
-                                    .record_verify(t0.elapsed());
-                                // Adaptive-K: report acceptance (tokens emitted
-                                // minus the 1 bonus token) so the gate's disable
-                                // threshold uses the MEASURED expected tokens,
-                                // not the theoretical 1+K max.
-                                let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
-                                let accepted = emitted.saturating_sub(1);
-                                mtp_gate
-                                    .as_mut()
-                                    .expect("gate present")
-                                    .record_acceptance(accepted);
-                            }
+                            let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
+                            gate.record_verify_step(t0.elapsed(), emitted);
                         }
                     }
-                    // One-time transition work for a freshly-reached DISABLE:
-                    // drop pending drafts and order the draft-head state resync
-                    // before the next plain decode reads it. NOT permanent —
-                    // `maybe_remeasure` above re-opens measurement when the
-                    // depth regime changes, so MTP can come back exactly where
-                    // it pays (deep agentic contexts).
-                    if mtp_gate
-                        .as_mut()
-                        .and_then(mtp_gate::MtpGate::take_fresh_decision)
-                        == Some(mtp_gate::GateDecision::DisableMtp)
-                    {
+                    // One-time transition work when the gate switches to
+                    // Serial: drop pending drafts and order the draft-head
+                    // state resync before the next plain decode reads it.
+                    // Serial->Mtp needs nothing (the next MTP step
+                    // bootstraps from empty pending_drafts).
+                    if gate.take_fresh_decision() == Some(mtp_gate::GateDecision::DisableMtp) {
                         for a in active.iter_mut() {
                             a.pending_drafts.clear();
                         }
@@ -615,27 +590,8 @@ pub fn run(
                             tracing::error!("mtp-gate→decode sync_secondary: {e:#}");
                         }
                     }
-                } else if mtp_gate
-                    .as_ref()
-                    .is_some_and(|g| g.decision() == Some(mtp_gate::GateDecision::DisableMtp))
-                {
-                    // Measured net-negative in the CURRENT depth regime: plain
-                    // decode. Consulted every step (not a latched kill switch)
-                    // so the regime re-measurement above can flip it back.
-                    step_decode_only(
-                        &*model,
-                        &mut active,
-                        think_end_token,
-                        think_start_token,
-                        code_fence_token,
-                        tool_call_start_token,
-                        tool_call_end_token,
-                        adaptive_sampling,
-                    );
                 } else {
-                    // MTP wins in this regime (or no gate): speculative decode.
-                    let was_verify = !active[0].pending_drafts.is_empty();
-                    let seq_len_before = active[0].seq.seq_len;
+                    // Gate bypassed (ATLAS_MTP_GATE_FORCE=1): plain MTP.
                     step_mtp(
                         &*model,
                         &mut active,
@@ -643,26 +599,6 @@ pub fn run(
                         &verify_ctx,
                         dflash_verify_raw_argmax,
                     );
-                    // Adaptive-K: feed ongoing acceptance to the gate so it can
-                    // detect a drop below break-even and re-measure (which may
-                    // disable MTP if the workload shifted to lower-acceptance
-                    // territory at the same depth).
-                    if was_verify {
-                        let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
-                        let accepted = emitted.saturating_sub(1);
-                        if let Some(gate) = mtp_gate.as_mut() {
-                            gate.record_acceptance(accepted);
-                            if gate.should_reconsider() {
-                                tracing::info!(
-                                    "MTP gate: acceptance dropped below break-even \
-                                     (ema={:.2}, m={:.2}) — re-measuring",
-                                    gate.acceptance_ema_debug(),
-                                    gate.measured_multiplier_debug(),
-                                );
-                                gate.force_remeasure();
-                            }
-                        }
-                    }
                 }
             } else {
                 // Batch decode (no MTP). Clear stale drafts when transitioning out of MTP mode.

--- a/crates/spark-server/src/scheduler/mtp_gate.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate.rs
@@ -1,496 +1,373 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Throughput-aware MTP runtime gate.
+//! Throughput-arbitrated MTP runtime gate.
 //!
-//! Measures `m = verify_step_wall / decode_step_wall` over the first decode
-//! steps, then disables MTP when net-negative. The disable threshold uses the
-//! MEASURED expected tokens (`1 + mean_accepted`), not the theoretical `1 + K`
-//! max — so MTP is disabled at the ACTUAL acceptance rate, not just the
-//! impossible 100% worst case. `m` is depth-dependent (weight-bound at short
-//! context, KV/SSM-bound at depth), so the gate re-measures when the live
-//! depth leaves the measured regime (see [`REMEASURE_DEPTH_FACTOR`]). Ongoing
-//! adaptation: if the acceptance EMA drops below break-even, re-opens
-//! measurement (see `should_reconsider`).
+//! Chooses between MTP speculative decode and plain serial decode by
+//! comparing DELIVERED throughput (emitted tokens / wall) measured over
+//! whole step windows in each mode — never by comparing component step
+//! timings. The previous gate compared `verify_wall / decode_wall` against
+//! expected accepted tokens; on the 35B MoE that arithmetic disabled MTP
+//! (multiplier 2.07–2.23 ≥ effective 1.75–2.0) while an always-on control
+//! measured 18% FASTER end-to-end decode (webserver_ok A/B, 2026-07-20:
+//! Σ1028s/10-10 always-on vs Σ1846s/9-10 gated). Component walls miss
+//! per-token costs outside the timed step and amortization effects, so the
+//! arbiter now measures exactly the quantity being optimized.
+//!
+//! Policy (bandit-style greedy with scheduled exploration — cf. TapOut
+//! arXiv:2511.02017, GammaTune-style hysteresis):
+//! - Run the currently-faster mode; accumulate (tokens, wall) into a
+//!   fixed-size step window; on window close update that mode's tok/s EWMA
+//!   and a deviation EWMA.
+//! - Switch modes only when the other mode's EWMA is faster by more than a
+//!   noise margin (hysteresis) for [`SWITCH_DWELL_WINDOWS`] consecutive
+//!   windows — the old gate flipped ENABLED→DISABLED within 6s on
+//!   measurement noise (multiplier 1.35→1.78), each flip costing a
+//!   draft-head resync.
+//! - While in Serial, re-probe MTP after [`reprobe_tokens`] emitted tokens.
+//!   While in Mtp, refresh the serial baseline after
+//!   [`serial_refresh_tokens`] (one window ≈ ≤0.3% overhead bound).
+//! - A depth-regime change (factor [`REMEASURE_DEPTH_FACTOR`]) marks the
+//!   OTHER mode's baseline stale and schedules a refresh probe instead of
+//!   wiping all state.
+//!
+//! `ATLAS_MTP_GATE_FORCE=1` (existing) bypasses the gate entirely.
 
 use std::time::Duration;
 
-/// Factor that triggers re-measurement when live depth leaves the measured
-/// regime (either direction). Factor 2 re-checks at ~2× depth.
+/// Depth factor that marks baselines stale (economics are depth-dependent:
+/// weight-bound at short context vs KV/SSM-bound at depth).
 const REMEASURE_DEPTH_FACTOR: usize = 2;
-
-/// Floor for the regime comparison (below this, all contexts are "shallow").
+/// Floor for the regime comparison (below this all contexts are "shallow").
 const REMEASURE_DEPTH_FLOOR: usize = 512;
+/// Steps per throughput window. 16 ≥ the 12-step acceptance window the
+/// proven `adaptive_spec` suspend policy uses, and long enough that one
+/// window amortizes bootstrap/propose transients (≥16 serial tokens,
+/// ~28 MTP tokens at the measured 0.75 acceptance).
+const WINDOW_STEPS: usize = 16;
+/// Consecutive out-of-margin windows required before switching mode.
+const SWITCH_DWELL_WINDOWS: usize = 2;
+/// EWMA smoothing for per-mode tok/s (responds within ~3 windows).
+const TPS_ALPHA: f64 = 0.3;
+/// Relative noise floor for the switch margin. Derived from the observed
+/// window-to-window jitter of the step walls this gate consumes (the old
+/// gate's multiplier swung 1.35→1.78 ≈ ±14% within seconds; half the
+/// deviation EWMA is added on top of this floor).
+const MARGIN_REL_FLOOR: f64 = 0.05;
 
-/// Number of leading samples of each step type discarded as graph-capture /
-/// cache warmup before timing begins. The first verify step and the first
-/// decode step each trigger one-time CUDA-graph capture and cold weight
-/// fetches whose wall time is not representative of steady state.
-///
-/// Derivation, not a magic default: CUDA-graph capture is a strictly
-/// one-time event per step type (verify-graphed vs decode-batch graphs are
-/// captured on first invocation), so a single discarded sample per type is
-/// the minimum that excludes it. We discard 2 for a margin against the first
-/// post-capture replay still touching cold instruction/constant caches.
-const WARMUP_SAMPLES: usize = 2;
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
 
-/// Number of timed samples collected per step type after warmup. The
-/// multiplier uses the MEDIAN of these to reject scheduler-thread jitter
-/// (occasional condvar wakeups / pending-queue drains between steps). An odd
-/// count gives an unambiguous median.
-const TIMED_SAMPLES: usize = 5;
+/// Serial tokens between MTP re-probes while in Serial mode. Default
+/// matches the proven `ATLAS_DFLASH_ADAPTIVE_REPROBE` policy (256).
+fn reprobe_tokens() -> usize {
+    static C: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *C.get_or_init(|| env_usize("ATLAS_MTP_GATE_REPROBE", 256))
+}
 
-/// What the gate wants the scheduler to do for the NEXT step while it is
-/// still collecting samples.
+/// MTP tokens between serial-baseline refreshes while in Mtp mode. One
+/// 16-step window per 1024 tokens bounds refresh overhead at ≤0.3% even if
+/// serial were 18% slower.
+fn serial_refresh_tokens() -> usize {
+    static C: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *C.get_or_init(|| env_usize("ATLAS_MTP_GATE_REFRESH", 1024))
+}
+
+/// What the gate wants the scheduler to run for the NEXT step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GateStep {
-    /// Run a plain single-token decode step and report its wall time.
+    /// Plain single-token decode step (Serial mode or baseline refresh).
     MeasureDecode,
-    /// Run an MTP verify step and report its wall time.
+    /// MTP verify step (Mtp mode or re-probe).
     MeasureVerify,
 }
 
-/// The terminal decision once enough samples are collected.
+/// Mode-transition signal for the scheduler's one-time bookkeeping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GateDecision {
-    /// Keep MTP enabled: `m < 1 + num_drafts`.
+    /// Switched to Mtp: nothing to do (bootstrap happens naturally).
     KeepMtp,
-    /// Disable MTP: `m >= 1 + num_drafts` (net-negative at any acceptance).
+    /// Switched to Serial: clear pending drafts + draft-head resync.
     DisableMtp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Phase {
-    /// Collecting decode-step samples (warmup then timed).
-    Decode,
-    /// Collecting verify-step samples (warmup then timed).
-    Verify,
-    /// Done; `decide()` has produced a result.
-    Done,
+enum Mode {
+    Mtp,
+    Serial,
 }
 
-/// Per-serve, single-instance throughput-aware MTP gate. Lives on the
-/// scheduler thread; drives a short measurement phase the first time a lone
-/// sequence is decoding with MTP requested, then yields a decision that
-/// holds for the CURRENT depth regime. The decision is not permanent: the
-/// multiplier is depth-dependent (see module docs), so the gate re-opens
-/// measurement when the live depth leaves the measured regime
-/// ([`Self::maybe_remeasure`]).
+#[derive(Default)]
+struct ModeStats {
+    /// Delivered-throughput EWMA (tokens/sec), `None` until first window.
+    tps: Option<f64>,
+    /// EWMA of |window tps − tps| (deviation, for the noise margin).
+    dev: f64,
+    /// Stale after a depth-regime change; refreshed by the next probe.
+    stale: bool,
+}
+
+impl ModeStats {
+    /// Fold one closed window into the estimate. `replace=true` (probe
+    /// windows and post-regime-change windows) REPLACES the estimate: a
+    /// sparse probe is a fresh look at a baseline that may have drifted
+    /// arbitrarily since it was last run, and blending it against the stale
+    /// value both lags the estimate and pollutes `dev` with the shift
+    /// magnitude (inflating the hysteresis margin and delaying recovery).
+    /// Continuous same-mode windows blend (EWMA) so `dev` tracks
+    /// steady-state noise only.
+    fn update(&mut self, window_tps: f64, replace: bool) {
+        match (self.tps, replace) {
+            (None, _) | (_, true) => {
+                self.tps = Some(window_tps);
+                self.dev *= 0.5; // decay: fresh baseline, keep a noise memory
+            }
+            (Some(prev), false) => {
+                let next = (1.0 - TPS_ALPHA) * prev + TPS_ALPHA * window_tps;
+                self.dev = (1.0 - TPS_ALPHA) * self.dev + TPS_ALPHA * (window_tps - next).abs();
+                self.tps = Some(next);
+            }
+        }
+        self.stale = false;
+    }
+}
+
+/// Per-serve, single-instance gate. Lives on the scheduler thread; every
+/// single-sequence decode/verify step is timed and reported, so arbitration
+/// runs continuously with zero dedicated measurement phases.
 pub struct MtpGate {
-    /// `1 + num_drafts`: the max effective tokens a verify step can advance,
-    /// and the provable net-negative threshold for the multiplier. Derived
-    /// from the scheduler's `num_drafts` (K=2 verify ⇒ num_drafts=1 ⇒ 2).
-    max_effective: f64,
-    phase: Phase,
-    decode_samples: Vec<Duration>,
-    verify_samples: Vec<Duration>,
-    /// Acceptance samples (num_accepted per verify step) collected during the
-    /// Verify measurement phase, parallel to `verify_samples`. Used to compute
-    /// the MEASURED expected tokens per step (`1 + mean_accepted`) for the
-    /// adaptive disable threshold — strictly tighter than the theoretical
-    /// `max_effective = 1 + K` (which assumes 100% acceptance).
-    acceptance_samples: Vec<usize>,
-    /// Exponential moving average of num_accepted, updated after the initial
-    /// decision for ongoing adaptation. If it drops below the break-even
-    /// (`1 + ema < measured_multiplier`), the gate re-opens measurement.
-    acceptance_ema: f64,
-    /// The measured verify/decode multiplier at the last `finalize`. Used by
-    /// [`Self::should_reconsider`] for the ongoing acceptance-drop check.
-    measured_multiplier: f64,
-    decision: Option<GateDecision>,
-    /// Sequence depth (tokens) most recently observed while sampling; frozen
-    /// into `measured_at_depth` when a decision is reached.
+    mode: Mode,
+    /// True while the gate is running a short window of the OTHER mode
+    /// (re-probe from Serial, baseline refresh from Mtp).
+    probing: bool,
+    /// Windows remaining in the current probe.
+    probe_windows_left: usize,
+    mtp: ModeStats,
+    serial: ModeStats,
+    // Current-window accumulators (for whichever mode the steps ran in).
+    win_tokens: f64,
+    win_wall: f64,
+    win_steps: usize,
+    /// Consecutive closed windows where the other mode beat this one by
+    /// more than the margin.
+    losing_windows: usize,
+    /// Emitted tokens since the last probe/refresh event in this mode.
+    tokens_since_event: usize,
     observed_depth: usize,
-    /// Depth regime the current `decision` was measured in. Compared against
-    /// the live depth by [`Self::maybe_remeasure`].
     measured_at_depth: usize,
-    /// Set by `finalize`, taken exactly once by the scheduler to run the
-    /// one-time transition work for a fresh decision (e.g. clearing pending
-    /// drafts + draft-head resync when MTP turns off).
-    fresh_decision: Option<GateDecision>,
+    fresh: Option<GateDecision>,
 }
 
 impl MtpGate {
-    /// `num_drafts`: drafts proposed per verify step (scheduler SSOT; K=2 ⇒ 1).
+    /// `num_drafts` is retained for construction-site compatibility and
+    /// logging; arbitration is measurement-driven and does not model K.
     pub fn new(num_drafts: usize) -> Self {
+        tracing::info!(
+            "MTP gate: throughput-arbitrated (K={num_drafts}); window={WINDOW_STEPS} steps, \
+             dwell={SWITCH_DWELL_WINDOWS}, reprobe={} tok, refresh={} tok",
+            reprobe_tokens(),
+            serial_refresh_tokens(),
+        );
         Self {
-            max_effective: 1.0 + num_drafts as f64,
-            phase: Phase::Decode,
-            decode_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
-            verify_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
-            acceptance_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
-            acceptance_ema: 0.0,
-            measured_multiplier: 0.0,
-            decision: None,
+            mode: Mode::Mtp,
+            probing: false,
+            probe_windows_left: 0,
+            mtp: ModeStats::default(),
+            serial: ModeStats::default(),
+            win_tokens: 0.0,
+            win_wall: 0.0,
+            win_steps: 0,
+            losing_windows: 0,
+            tokens_since_event: 0,
             observed_depth: 0,
             measured_at_depth: 0,
-            fresh_decision: None,
+            fresh: None,
         }
     }
 
-    /// Note the current sequence depth while measuring. The last value seen
-    /// before `finalize` becomes the decision's `measured_at_depth`.
     pub fn note_depth(&mut self, depth: usize) {
         self.observed_depth = depth;
     }
 
-    /// Re-open measurement when the live depth has left the regime the
-    /// current decision was measured in (factor-[`REMEASURE_DEPTH_FACTOR`]
-    /// crossing in either direction, floored at [`REMEASURE_DEPTH_FLOOR`]).
-    /// No-op while a measurement is already in flight.
+    /// Depth-regime change: mark BOTH baselines stale (economics moved) and
+    /// let the normal probe cadence refresh them — no state wipe, no forced
+    /// serial phase.
     pub fn maybe_remeasure(&mut self, current_depth: usize) {
-        if self.phase != Phase::Done {
-            return;
-        }
         let measured = self.measured_at_depth.max(REMEASURE_DEPTH_FLOOR);
         let live = current_depth.max(REMEASURE_DEPTH_FLOOR);
         if live >= measured * REMEASURE_DEPTH_FACTOR || measured >= live * REMEASURE_DEPTH_FACTOR {
             tracing::info!(
-                "MTP gate: depth regime changed ({} -> {} tokens); re-measuring \
-                 verify/decode economics",
+                "MTP gate: depth regime changed ({} -> {} tokens); baselines stale, \
+                 will re-probe on cadence",
                 self.measured_at_depth,
                 current_depth,
             );
-            self.phase = Phase::Decode;
-            self.decode_samples.clear();
-            self.verify_samples.clear();
-            self.acceptance_samples.clear();
-            self.decision = None;
-            self.fresh_decision = None;
+            self.mtp.stale = true;
+            self.serial.stale = true;
+            self.measured_at_depth = current_depth;
+            // Refresh the off-mode soon rather than waiting a full interval.
+            self.tokens_since_event = self.tokens_since_event.max(self.event_interval());
         }
     }
 
-    /// One-shot handoff of a freshly-reached decision, for the scheduler's
-    /// transition bookkeeping. Returns `Some` exactly once per `finalize`.
+    /// One-shot handoff of a fresh mode switch for scheduler bookkeeping.
     pub fn take_fresh_decision(&mut self) -> Option<GateDecision> {
-        self.fresh_decision.take()
+        self.fresh.take()
     }
 
-    /// Whether the gate still needs to drive measurement steps. False once a
-    /// decision has been reached.
-    pub fn is_measuring(&self) -> bool {
-        self.phase != Phase::Done
-    }
-
-    /// Which step type the scheduler should run next to advance measurement.
-    /// Decode samples are collected first (they need no draft bootstrap),
-    /// then verify samples.
+    /// Which step type the scheduler should run next.
     pub fn next_step(&self) -> GateStep {
-        match self.phase {
-            Phase::Decode => GateStep::MeasureDecode,
-            // During the Verify phase we still issue MTP steps; the first
-            // such step bootstraps a draft (no verify yet) and is naturally
-            // absorbed by WARMUP_SAMPLES.
-            Phase::Verify => GateStep::MeasureVerify,
-            Phase::Done => GateStep::MeasureDecode, // unreachable while measuring
+        let effective = if self.probing {
+            Self::other(self.mode)
+        } else {
+            self.mode
+        };
+        match effective {
+            Mode::Mtp => GateStep::MeasureVerify,
+            Mode::Serial => GateStep::MeasureDecode,
         }
     }
 
-    /// Record one timed decode-step sample. Caller times only the decode-step
-    /// wall (D2H + sample included, identically to the verify path).
+    /// Record one plain decode step (1 emitted token).
     pub fn record_decode(&mut self, wall: Duration) {
-        if self.phase != Phase::Decode {
+        self.record_step(wall, 1);
+    }
+
+    /// Record one MTP-path step: `emitted` tokens actually committed (a
+    /// bootstrap step emits 1; a verify step emits 1 + accepted). Bootstrap
+    /// and propose cost are charged to Mtp mode — they are part of what MTP
+    /// costs to run.
+    pub fn record_verify_step(&mut self, wall: Duration, emitted: usize) {
+        self.record_step(wall, emitted.max(1));
+    }
+
+    fn other(m: Mode) -> Mode {
+        match m {
+            Mode::Mtp => Mode::Serial,
+            Mode::Serial => Mode::Mtp,
+        }
+    }
+
+    fn event_interval(&self) -> usize {
+        match self.mode {
+            Mode::Mtp => serial_refresh_tokens(),
+            Mode::Serial => reprobe_tokens(),
+        }
+    }
+
+    fn stats_mut(&mut self, m: Mode) -> &mut ModeStats {
+        match m {
+            Mode::Mtp => &mut self.mtp,
+            Mode::Serial => &mut self.serial,
+        }
+    }
+
+    fn record_step(&mut self, wall: Duration, tokens: usize) {
+        self.win_tokens += tokens as f64;
+        self.win_wall += wall.as_secs_f64();
+        self.win_steps += 1;
+        if !self.probing {
+            self.tokens_since_event += tokens;
+        }
+        if self.win_steps >= WINDOW_STEPS {
+            self.close_window();
+        } else if !self.probing && self.tokens_since_event >= self.event_interval() {
+            // Time to look at the other mode: finish the current window
+            // early so the probe starts on a clean accumulator.
+            self.close_window();
+        }
+    }
+
+    fn close_window(&mut self) {
+        let ran = if self.probing {
+            Self::other(self.mode)
+        } else {
+            self.mode
+        };
+        if self.win_wall > 0.0 && self.win_steps > 0 {
+            let window_tps = self.win_tokens / self.win_wall;
+            let replace = self.probing || self.stats_mut(ran).stale;
+            self.stats_mut(ran).update(window_tps, replace);
+        }
+        self.win_tokens = 0.0;
+        self.win_wall = 0.0;
+        self.win_steps = 0;
+
+        if self.probing {
+            self.probe_windows_left = self.probe_windows_left.saturating_sub(1);
+            if self.probe_windows_left == 0 {
+                self.probing = false;
+                self.arbitrate();
+                self.tokens_since_event = 0;
+            }
             return;
         }
-        self.decode_samples.push(wall);
-        if self.decode_samples.len() >= WARMUP_SAMPLES + TIMED_SAMPLES {
-            self.phase = Phase::Verify;
-        }
-    }
 
-    /// Record one timed verify-step sample. Only steps that actually ran a
-    /// verify forward (not a bootstrap-only step) should be reported.
-    pub fn record_verify(&mut self, wall: Duration) {
-        if self.phase != Phase::Verify {
+        // Scheduled exploration of the other mode.
+        if self.tokens_since_event >= self.event_interval() {
+            self.probing = true;
+            self.probe_windows_left = 1;
             return;
         }
-        self.verify_samples.push(wall);
-        if self.verify_samples.len() >= WARMUP_SAMPLES + TIMED_SAMPLES {
-            self.finalize();
-        }
+        self.arbitrate();
     }
 
-    /// Record the number of drafts accepted in a verify step. During the
-    /// measurement phase this populates `acceptance_samples` (parallel to
-    /// `verify_samples`). After the decision, it updates the rolling EMA for
-    /// ongoing adaptation — if acceptance drops below the break-even
-    /// (`1 + ema < measured_multiplier`), [`Self::should_reconsider`] flags
-    /// it so the scheduler can re-measure or disable.
-    pub fn record_acceptance(&mut self, num_accepted: usize) {
-        if self.phase == Phase::Verify {
-            self.acceptance_samples.push(num_accepted);
-        } else if self.phase == Phase::Done {
-            // EMA update (alpha=0.2 — responds within ~5 steps to a shift).
-            self.acceptance_ema = 0.8 * self.acceptance_ema + 0.2 * num_accepted as f64;
-        }
-    }
-
-    /// Ongoing adaptation check: after the initial decision, if the rolling
-    /// acceptance EMA has dropped below the break-even for the measured
-    /// multiplier, MTP is now net-negative at the current acceptance even
-    /// though it was profitable when measured. The scheduler should call
-    /// this and, if true, re-open measurement (which may disable MTP).
-    pub fn should_reconsider(&self) -> bool {
-        self.phase == Phase::Done
-            && self.decision == Some(GateDecision::KeepMtp)
-            && self.measured_multiplier > 0.0
-            && 1.0 + self.acceptance_ema < self.measured_multiplier
-    }
-
-    /// Unconditionally re-open measurement (called by the scheduler when
-    /// [`Self::should_reconsider`] fires — the acceptance drop is a
-    /// workload-shift signal, not a depth-regime change).
-    pub fn force_remeasure(&mut self) {
-        if self.phase != Phase::Done {
-            return;
-        }
-        self.phase = Phase::Decode;
-        self.decode_samples.clear();
-        self.verify_samples.clear();
-        self.acceptance_samples.clear();
-        self.decision = None;
-        self.fresh_decision = None;
-    }
-
-    /// Debug accessors for the reconsider log line.
-    pub fn acceptance_ema_debug(&self) -> f64 {
-        self.acceptance_ema
-    }
-    pub fn measured_multiplier_debug(&self) -> f64 {
-        self.measured_multiplier
-    }
-
-    /// Median of the post-warmup samples for a step type, in seconds.
-    fn median_secs(samples: &[Duration]) -> f64 {
-        let mut timed: Vec<f64> = samples
-            .iter()
-            .skip(WARMUP_SAMPLES)
-            .map(Duration::as_secs_f64)
-            .collect();
-        timed.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        timed[timed.len() / 2]
-    }
-
-    fn finalize(&mut self) {
-        let decode_s = Self::median_secs(&self.decode_samples);
-        let verify_s = Self::median_secs(&self.verify_samples);
-        // decode_s is a real measured decode step; it cannot be zero in
-        // practice, but guard against a degenerate timer to avoid div-by-zero.
-        let multiplier = if decode_s > 0.0 {
-            verify_s / decode_s
-        } else {
-            f64::INFINITY
+    /// Compare mode EWMAs with a hysteresis margin; switch after dwell.
+    fn arbitrate(&mut self) {
+        let (Some(mtp), Some(serial)) = (self.mtp.tps, self.serial.tps) else {
+            return; // need both baselines before any switch
         };
-        // Adaptive threshold: use MEASURED expected tokens (1 + mean_accepted)
-        // instead of theoretical max (1 + K). Disables MTP at the ACTUAL
-        // acceptance rate, not the impossible 100% worst case.
-        let mean_accepted = if self.acceptance_samples.len() > WARMUP_SAMPLES {
-            let timed: Vec<usize> = self
-                .acceptance_samples
-                .iter()
-                .copied()
-                .skip(WARMUP_SAMPLES)
-                .collect();
-            timed.iter().map(|&x| x as f64).sum::<f64>() / timed.len().max(1) as f64
-        } else {
-            self.max_effective - 1.0 // no acceptance data → theoretical max fallback
+        let (cur, other, other_dev) = match self.mode {
+            Mode::Mtp => (mtp, serial, self.serial.dev),
+            Mode::Serial => (serial, mtp, self.mtp.dev),
         };
-        let effective_tokens = 1.0 + mean_accepted;
-        let decision = if multiplier >= self.max_effective || multiplier >= effective_tokens {
-            GateDecision::DisableMtp
+        let margin = (MARGIN_REL_FLOOR * cur).max(0.5 * (self.dev_of(self.mode) + other_dev));
+        if other > cur + margin {
+            self.losing_windows += 1;
+            if self.losing_windows >= SWITCH_DWELL_WINDOWS {
+                let to = Self::other(self.mode);
+                tracing::info!(
+                    "MTP gate: switching {:?} -> {:?} (current {cur:.1} tok/s vs other \
+                     {other:.1} tok/s, margin {margin:.1}, depth={})",
+                    self.mode,
+                    to,
+                    self.observed_depth,
+                );
+                self.mode = to;
+                self.losing_windows = 0;
+                self.tokens_since_event = 0;
+                self.measured_at_depth = self.observed_depth;
+                self.fresh = Some(match to {
+                    Mode::Mtp => GateDecision::KeepMtp,
+                    Mode::Serial => GateDecision::DisableMtp,
+                });
+            }
         } else {
-            GateDecision::KeepMtp
-        };
-        match decision {
-            GateDecision::DisableMtp => tracing::info!(
-                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1}, \
-                 measured_effective={effective_tokens:.2} (mean_accepted={mean_accepted:.2}, \
-                 decode={:.2}ms verify={:.2}ms, depth={}) => DISABLED for this depth \
-                 regime (net-negative at current acceptance; re-measures on regime change)",
-                self.max_effective,
-                decode_s * 1000.0,
-                verify_s * 1000.0,
-                self.observed_depth,
-            ),
-            GateDecision::KeepMtp => tracing::info!(
-                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1}, \
-                 measured_effective={effective_tokens:.2} (mean_accepted={mean_accepted:.2}, \
-                 decode={:.2}ms verify={:.2}ms, depth={}) => ENABLED",
-                self.max_effective,
-                decode_s * 1000.0,
-                verify_s * 1000.0,
-                self.observed_depth,
-            ),
+            self.losing_windows = 0;
         }
-        self.measured_multiplier = multiplier;
-        self.acceptance_ema = mean_accepted;
-        self.measured_at_depth = self.observed_depth;
-        self.decision = Some(decision);
-        self.fresh_decision = Some(decision);
-        self.phase = Phase::Done;
     }
 
-    /// The operative decision for the current depth regime, available once
-    /// `is_measuring()` is false. `None` while (re-)measuring.
-    pub fn decision(&self) -> Option<GateDecision> {
-        self.decision
+    fn dev_of(&self, m: Mode) -> f64 {
+        match m {
+            Mode::Mtp => self.mtp.dev,
+            Mode::Serial => self.serial.dev,
+        }
+    }
+
+    /// Debug/test accessors.
+    pub fn mtp_tps_debug(&self) -> Option<f64> {
+        self.mtp.tps
+    }
+    pub fn serial_tps_debug(&self) -> Option<f64> {
+        self.serial.tps
+    }
+    pub fn in_serial_mode(&self) -> bool {
+        self.mode == Mode::Serial
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn ms(x: u64) -> Duration {
-        Duration::from_micros(x * 1000)
-    }
-
-    /// Drive the gate through a full decode-then-verify measurement with the
-    /// given per-step medians (warmup samples are deliberately skewed to prove
-    /// they are discarded).
-    fn run_gate(num_drafts: usize, decode_ms: u64, verify_ms: u64) -> GateDecision {
-        let mut g = MtpGate::new(num_drafts);
-        // Decode phase: 2 warmup (huge, must be discarded) + 5 timed.
-        for i in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            assert_eq!(g.next_step(), GateStep::MeasureDecode);
-            let w = if i < WARMUP_SAMPLES {
-                ms(9999)
-            } else {
-                ms(decode_ms)
-            };
-            g.record_decode(w);
-        }
-        // Verify phase.
-        for i in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            assert_eq!(g.next_step(), GateStep::MeasureVerify);
-            let w = if i < WARMUP_SAMPLES {
-                ms(9999)
-            } else {
-                ms(verify_ms)
-            };
-            g.record_verify(w);
-        }
-        assert!(!g.is_measuring());
-        g.decision().expect("decided")
-    }
-
-    #[test]
-    fn fp8_like_multiplier_disables_k2() {
-        // verify 23ms vs decode 10ms => m=2.3 >= 2 (num_drafts=1) => DISABLE.
-        assert_eq!(run_gate(1, 10, 23), GateDecision::DisableMtp);
-    }
-
-    #[test]
-    fn nvfp4_like_multiplier_keeps_k2() {
-        // verify 11ms vs decode 10ms => m=1.1 < 2 => KEEP.
-        assert_eq!(run_gate(1, 10, 11), GateDecision::KeepMtp);
-    }
-
-    #[test]
-    fn exact_threshold_disables() {
-        // m == 1 + num_drafts is net-negative (no per-token gain at 100%).
-        assert_eq!(run_gate(1, 10, 20), GateDecision::DisableMtp);
-    }
-
-    #[test]
-    fn k3_raises_threshold() {
-        // num_drafts=2 => max_effective=3; m=2.3 now KEEPS (can win >65% acc).
-        assert_eq!(run_gate(2, 10, 23), GateDecision::KeepMtp);
-    }
-
-    #[test]
-    fn warmup_samples_are_discarded() {
-        // If warmup (9999ms) leaked into the median the multiplier would be
-        // astronomically off; the clean KEEP proves they are skipped.
-        assert_eq!(run_gate(1, 10, 11), GateDecision::KeepMtp);
-    }
-
-    #[test]
-    fn phase_progression() {
-        let mut g = MtpGate::new(1);
-        assert_eq!(g.next_step(), GateStep::MeasureDecode);
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_decode(ms(10));
-        }
-        assert_eq!(g.next_step(), GateStep::MeasureVerify);
-        assert!(g.is_measuring());
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_verify(ms(11));
-        }
-        assert!(!g.is_measuring());
-    }
-
-    /// Drive a full measurement on an existing gate at a given depth.
-    fn drive(g: &mut MtpGate, depth: usize, decode_ms: u64, verify_ms: u64) {
-        assert!(g.is_measuring());
-        g.note_depth(depth);
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_decode(ms(decode_ms));
-        }
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_verify(ms(verify_ms));
-        }
-        assert!(!g.is_measuring());
-    }
-
-    /// The core depth-regime scenario: a short-context measurement disables
-    /// MTP (weight-bound, m≈2.3); the session then goes deep, the gate
-    /// re-measures, and the KV-bound economics (m≈1.1) re-enable it.
-    #[test]
-    fn remeasure_on_depth_regime_change_reenables() {
-        let mut g = MtpGate::new(1);
-        drive(&mut g, 100, 10, 23); // short ctx: m=2.3 => DISABLE
-        assert_eq!(g.decision(), Some(GateDecision::DisableMtp));
-        assert_eq!(g.take_fresh_decision(), Some(GateDecision::DisableMtp));
-
-        // Same regime (100 floored to 512; 600 < 512*4): decision holds.
-        g.maybe_remeasure(600);
-        assert!(!g.is_measuring());
-        assert_eq!(g.decision(), Some(GateDecision::DisableMtp));
-
-        // Depth crosses the factor boundary: measurement re-opens.
-        g.maybe_remeasure(REMEASURE_DEPTH_FLOOR * REMEASURE_DEPTH_FACTOR);
-        assert!(g.is_measuring());
-        assert_eq!(g.decision(), None);
-
-        // Deep regime: verify shares the KV pass, m=1.1 => KEEP.
-        drive(&mut g, 2048, 10, 11);
-        assert_eq!(g.decision(), Some(GateDecision::KeepMtp));
-        assert_eq!(g.take_fresh_decision(), Some(GateDecision::KeepMtp));
-
-        // And back down: a fresh short session re-opens measurement again.
-        g.maybe_remeasure(100);
-        assert!(g.is_measuring());
-    }
-
-    #[test]
-    fn fresh_decision_taken_exactly_once() {
-        let mut g = MtpGate::new(1);
-        drive(&mut g, 100, 10, 23);
-        assert_eq!(g.take_fresh_decision(), Some(GateDecision::DisableMtp));
-        assert_eq!(g.take_fresh_decision(), None);
-        // The operative decision is still readable.
-        assert_eq!(g.decision(), Some(GateDecision::DisableMtp));
-    }
-
-    #[test]
-    fn no_remeasure_within_floored_short_regime() {
-        let mut g = MtpGate::new(1);
-        drive(&mut g, 32, 10, 23);
-        // 32 and 400 both floor to 512 — same regime, no re-measure.
-        g.maybe_remeasure(400);
-        assert!(!g.is_measuring());
-        // Just below the factor boundary: still the same regime.
-        g.maybe_remeasure(REMEASURE_DEPTH_FLOOR * REMEASURE_DEPTH_FACTOR - 1);
-        assert!(!g.is_measuring());
-    }
-
-    #[test]
-    fn maybe_remeasure_noop_while_measuring() {
-        let mut g = MtpGate::new(1);
-        assert!(g.is_measuring());
-        g.maybe_remeasure(1_000_000);
-        // Still in the ORIGINAL measurement (no reset mid-flight).
-        assert_eq!(g.next_step(), GateStep::MeasureDecode);
-        assert!(g.is_measuring());
-    }
-}
+mod tests;

--- a/crates/spark-server/src/scheduler/mtp_gate/tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate/tests.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for the throughput-arbitrated MTP gate. All scenarios drive the
+//! gate through `record_*` exactly as the scheduler does; walls are
+//! synthetic, tokens/step model acceptance.
+
+use super::*;
+
+fn ms(x: u64) -> Duration {
+    Duration::from_millis(x)
+}
+
+/// Drive `n` MTP-path steps at `emitted` tokens per step and `wall` each.
+fn drive_mtp(g: &mut MtpGate, n: usize, emitted: usize, wall: Duration) {
+    for _ in 0..n {
+        assert_eq!(
+            g.next_step(),
+            GateStep::MeasureVerify,
+            "expected Mtp-path step"
+        );
+        g.record_verify_step(wall, emitted);
+    }
+}
+
+/// Drive `n` serial decode steps at `wall` each.
+fn drive_serial(g: &mut MtpGate, n: usize, wall: Duration) {
+    for _ in 0..n {
+        assert_eq!(
+            g.next_step(),
+            GateStep::MeasureDecode,
+            "expected serial step"
+        );
+        g.record_decode(wall);
+    }
+}
+
+/// Run MTP steps until the gate opens its first serial-refresh probe.
+fn run_mtp_until_probe(g: &mut MtpGate, emitted: usize, wall: Duration) {
+    for _ in 0..10_000 {
+        if g.next_step() == GateStep::MeasureDecode {
+            return;
+        }
+        g.record_verify_step(wall, emitted);
+    }
+    panic!("gate never opened a serial probe");
+}
+
+/// Run serial steps until the gate opens an MTP re-probe.
+fn run_serial_until_probe(g: &mut MtpGate, wall: Duration) {
+    for _ in 0..10_000 {
+        if g.next_step() == GateStep::MeasureVerify {
+            return;
+        }
+        g.record_decode(wall);
+    }
+    panic!("gate never opened an MTP re-probe");
+}
+
+#[test]
+fn starts_in_mtp_mode() {
+    let g = MtpGate::new(1);
+    assert_eq!(g.next_step(), GateStep::MeasureVerify);
+    assert!(!g.in_serial_mode());
+}
+
+#[test]
+fn no_switch_without_both_baselines() {
+    let mut g = MtpGate::new(1);
+    // Plenty of slow MTP windows, but serial was never measured: stay put.
+    drive_mtp(&mut g, 64, 1, ms(100));
+    assert!(!g.in_serial_mode());
+    assert_eq!(g.take_fresh_decision(), None);
+}
+
+#[test]
+fn refresh_probe_opens_after_interval_and_returns() {
+    let mut g = MtpGate::new(1);
+    // 2 tok/step: ~512 steps to reach the 1024-token refresh interval.
+    run_mtp_until_probe(&mut g, 2, ms(50));
+    // Probe is exactly one window of serial steps, then control returns.
+    drive_serial(&mut g, WINDOW_STEPS, ms(40));
+    // Serial measured 25 tok/s < MTP 40 tok/s: stays MTP.
+    assert_eq!(g.next_step(), GateStep::MeasureVerify);
+    assert!(!g.in_serial_mode());
+    assert!(
+        g.serial_tps_debug().is_some(),
+        "probe must set the serial baseline"
+    );
+}
+
+#[test]
+fn switches_to_serial_when_clearly_faster_with_dwell() {
+    let mut g = MtpGate::new(1);
+    // MTP delivers 2 tok / 100ms = 20 tok/s.
+    run_mtp_until_probe(&mut g, 2, ms(100));
+    // Serial probe: 10ms/tok = 100 tok/s — way past any margin.
+    drive_serial(&mut g, WINDOW_STEPS, ms(10));
+    // Dwell: one more losing evaluation is required before the switch.
+    assert!(
+        !g.in_serial_mode(),
+        "dwell must prevent single-window switches"
+    );
+    for _ in 0..(WINDOW_STEPS * SWITCH_DWELL_WINDOWS) {
+        if g.next_step() != GateStep::MeasureVerify {
+            break;
+        }
+        g.record_verify_step(ms(100), 2);
+    }
+    assert!(
+        g.in_serial_mode(),
+        "sustained 5x serial advantage must switch"
+    );
+    assert_eq!(g.take_fresh_decision(), Some(GateDecision::DisableMtp));
+    assert_eq!(g.take_fresh_decision(), None, "fresh decision is one-shot");
+    assert_eq!(g.next_step(), GateStep::MeasureDecode);
+}
+
+#[test]
+fn hysteresis_blocks_within_margin_switches() {
+    let mut g = MtpGate::new(1);
+    // MTP 2 tok / 50ms = 40.0 tok/s.
+    run_mtp_until_probe(&mut g, 2, ms(50));
+    // Serial probe at 41 tok/s — inside the 5% noise floor (needs > 42).
+    drive_serial(&mut g, WINDOW_STEPS, Duration::from_micros(24_390));
+    for _ in 0..(WINDOW_STEPS * 4) {
+        if g.next_step() != GateStep::MeasureVerify {
+            break;
+        }
+        g.record_verify_step(ms(50), 2);
+    }
+    assert!(
+        !g.in_serial_mode(),
+        "a within-margin advantage must not switch modes"
+    );
+    assert_eq!(g.take_fresh_decision(), None);
+}
+
+#[test]
+fn serial_mode_reprobes_mtp_and_recovers() {
+    let mut g = MtpGate::new(1);
+    // Establish MTP=20 tok/s, serial=100 tok/s, and switch to serial.
+    run_mtp_until_probe(&mut g, 2, ms(100));
+    drive_serial(&mut g, WINDOW_STEPS, ms(10));
+    for _ in 0..(WINDOW_STEPS * SWITCH_DWELL_WINDOWS) {
+        if g.next_step() != GateStep::MeasureVerify {
+            break;
+        }
+        g.record_verify_step(ms(100), 2);
+    }
+    assert!(g.in_serial_mode());
+    g.take_fresh_decision();
+
+    // Workload shifts: MTP now 3 tok / 10ms = 300 tok/s. Two probe windows
+    // (dwell) must bring MTP back.
+    for _ in 0..SWITCH_DWELL_WINDOWS {
+        run_serial_until_probe(&mut g, ms(10));
+        drive_mtp(&mut g, WINDOW_STEPS, 3, ms(10));
+    }
+    assert!(
+        !g.in_serial_mode(),
+        "re-probe must recover MTP when it wins again"
+    );
+    assert_eq!(g.take_fresh_decision(), Some(GateDecision::KeepMtp));
+    assert_eq!(g.next_step(), GateStep::MeasureVerify);
+}
+
+#[test]
+fn depth_change_schedules_early_probe_without_state_wipe() {
+    let mut g = MtpGate::new(1);
+    g.note_depth(600);
+    // A few MTP windows at depth 600.
+    drive_mtp(&mut g, WINDOW_STEPS * 2, 2, ms(50));
+    let tps_before = g.mtp_tps_debug();
+    assert!(tps_before.is_some());
+    // Depth doubles: baselines stale, probe due immediately, EWMA retained.
+    g.maybe_remeasure(1300);
+    assert_eq!(
+        g.mtp_tps_debug(),
+        tps_before,
+        "no state wipe on regime change"
+    );
+    // The probe-due condition closes the window on the very next step.
+    drive_mtp(&mut g, 1, 2, ms(50));
+    assert_eq!(
+        g.next_step(),
+        GateStep::MeasureDecode,
+        "stale regime must probe soon"
+    );
+}
+
+#[test]
+fn bootstrap_steps_count_at_least_one_token() {
+    let mut g = MtpGate::new(1);
+    // emitted=0 must not divide-by-zero or record zero-token windows.
+    for _ in 0..WINDOW_STEPS {
+        g.record_verify_step(ms(10), 0);
+    }
+    let tps = g.mtp_tps_debug().expect("window closed");
+    assert!(tps > 0.0);
+}


### PR DESCRIPTION
## Summary

Fixes the 35B-flagship agentic wall-time regression introduced by #337 (webserver_ok gate: ~1000-1300s historical → 1846s + first-ever correctness failure), root-caused by same-box single-delta A/Bs to two independent mechanisms, each fixed on its own evidence:

1. **Mid-chunk GDN tail capture fired on every prefill** — including sessionless/single-turn traffic whose captures can never be reused (the snapshot lookup is session-gated; `session_hash` is a hash of the first ≤1024 prompt tokens, unique per single-turn request). Each capture costs a kernel split + D2D copy per prefill, and the split's accumulation-order change measurably perturbs trajectories (+18% tokens/turn). Now **reuse-gated**: capture fires only for sessions with live snapshot history — i.e. from a session's second request onward, exactly when reuse begins. `free()` clears session tags so freed slots can't report phantom history.

2. **The MTP gate compared component step timings and got the wrong answer** — on the 35B MoE, `verify_wall/decode_wall` = 2.07-2.23 ≥ `max_effective` 2.0 at K=1 disabled MTP essentially unconditionally (even at `mean_accepted=1.00`), while an always-on control measured **18% faster delivered decode**. Component walls miss per-token costs outside the timed region and the amortization of fixed per-step overhead across accepted tokens. The gate also thrashed (ENABLED→DISABLED within 6s on measurement noise, a draft-head resync per flip). Replaced with **throughput arbitration**: delivered tokens/wall per mode over 16-step windows, hysteresis margin + 2-window dwell, Serial re-probes MTP every 256 tokens, Mtp refreshes the serial baseline every 1024 tokens (≤0.3% overhead bound), probe windows replace stale baselines rather than blending. Knobs: `ATLAS_MTP_GATE_REPROBE`, `ATLAS_MTP_GATE_REFRESH`; `ATLAS_MTP_GATE_FORCE=1` still bypasses entirely. (Design informed by the training-free dynamic-speculation line: TapOut arXiv:2511.02017, AdaSD arXiv:2512.11280, SVIP arXiv:2411.18462; MoE verify-cost model per arXiv:2605.00342 — MoE verify scales with the expert union, which is why K=1 multipliers sit near 2 on the 35B and why measuring delivered throughput beats modeling it.)

Per-step confidence-driven draft length (AdaSD/SVIP-style entropy stopping in the proposer, with continuous drafter feed) is the planned follow-up; this PR restores the regression with the arbitration layer that follow-up builds on.

## Evidence

All webserver_ok N=10, 35B FP8, identical box (dgx1)/harness/recipe; single deltas as noted.

### Bisection (what regressed)

| tier | binary | midchunk | K / gate | Σ wall | ws_ok | followed |
|---|---|---|---|---|---|---|
| control | pre-#337 (`pr307`) | absent | 1, no gate | **1028s** | 10/10 | 10/10 |
| regressed | main (#337+#340) | always-capture | 1, timing gate | **1846s** | 9/10 | 9/10 |
| bisect A | main | **off** (env) | 1, timing gate | 1495s | 10/10 | 10/10 |
| bisect B | main | always-capture | **2**, timing gate | 1523s | 10/10 | 10/10 |

Each mechanism alone recovers ~40%; both are needed. The lone correctness failure (non-compiling generated Rust, 360s timeout) occurs only in the fully-regressed config.

### Mechanism decomposition (control vs regressed)

| | control | regressed | delta |
|---|---|---|---|
| decode tok/s p50/p90 | 38.4 / 43.2 | 31.5 / 34.2 | −18% |
| tokens per turn | 217 | 257 | +18% |
| turns (10 runs) | 128 | 166 | +30% |
| total tokens | 27,851 | 42,711 | +53% |

1.53 (more tokens) × 1.22 (slower per token) ≈ the observed 1.80× wall.

### This PR (fixed binary)

| tier | midchunk | Σ wall | ws_ok | followed | decode p50/p90 | tok/turn |
|---|---|---|---|---|---|---|
| fixval | default-on, reuse-gated | 1252s | **10/10** | **10/10** | 36.8 / 42.4 | 197 |
| fixval2 | **off** (env) | 1274s | **10/10** | **10/10** | 36.5 / 41.8 | 209 |

New gate held MTP on for the entire tier (0 mode switches) — matching the control's proven always-on behavior while retaining the ability to shed MTP on genuinely low-acceptance workloads.

**Midchunk default stays ON.** With the reuse-gate, default-on (fixval, 1252s) and fully-off (fixval2, 1274s) are statistically identical on this gate — the reuse-gate removes the cost for traffic that cannot benefit, while deep multi-turn sessions keep the warm-TTFT wins (-54% max) from their third request onward. Both legs sit inside the historical passing band (950-1287s across 321ws/307A/bmain/fixA/main45cc) with full 10/10+10/10; the pre-#337 control's 1028s was a favorable draw within that band, not the acceptance bar (Gate A: sum <= 1300s).

## Validation

- `cargo test -p spark-server` 732 tests green (8 new gate tests: dwell, hysteresis, re-probe recovery, stale-baseline replacement, depth-regime probe, bootstrap accounting)
- `cargo fmt --check`, `cargo clippy --tests` clean; touched files within the 500-LoC cap
- Empirical gates above on the exact regressed recipe
