### PR TITLE
fix(ssm): re-land fossil-pinning fix + default-on is_tail eviction lease + staged Marconi score

### DIFF
--- a/crates/spark-model/src/model/ssm_snapshot.rs
+++ b/crates/spark-model/src/model/ssm_snapshot.rs
@@ -358,10 +358,30 @@ impl SsmSnapshotPool {
         Ok(())
     }
 
-    /// Return a snapshot slot to the free list.
+    /// Return a snapshot slot to the free list. Clears the slot's session
+    /// tag: a freed slot carries no restorable state, so leaving the tag
+    /// would make [`Self::session_has_history`] report phantom history.
     pub(super) fn free(&self, snap_slot: usize) {
         self.slot_has_hidden.lock().remove(&snap_slot);
+        self.session_tags.lock().remove(&snap_slot);
         self.free_slots.lock().push(snap_slot);
+    }
+
+    /// Whether any LIVE snapshot slot is tagged with `session_hash` — i.e.
+    /// this session has produced at least one snapshot before (a prior turn
+    /// finished, or a prior tail was captured). Used by the mid-chunk tail
+    /// capture to skip sessions on first sight: `session_hash` is a hash of
+    /// the first ≤1024 prompt tokens, so single-turn traffic gets a unique
+    /// hash per request and can never reuse a captured tail, while
+    /// multi-turn agents (stable long system prompt) match from their
+    /// second request onward — exactly when tail reuse begins.
+    pub(crate) fn session_has_history(&self, session_hash: u64) -> bool {
+        session_hash != 0
+            && self
+                .session_tags
+                .lock()
+                .values()
+                .any(|&s| s == session_hash)
     }
 
     /// Reserve a Marconi snapshot slot for an in-pass MID-CHUNK tail capture.

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -268,8 +268,14 @@ impl TransformerModel {
         // ── Mid-chunk tail SSM capture (opt-in): plan BEFORE the forward
         // pass so SSM layers split their h/conv kernels at `tb` in-pass.
         // `None` (flag off or pass doesn't span `tb`) => no split. ──
-        let midcap_plan =
-            self.prepare_midchunk_capture(tokens, seq, &mut kv_cache, proc_start, proc_count);
+        let midcap_plan = self.prepare_midchunk_capture(
+            tokens,
+            seq,
+            &mut kv_cache,
+            proc_start,
+            proc_count,
+            stream,
+        );
 
         // ── Phase 4: forward through all layers ──
         self.prefill_b_forward_layers(

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -126,6 +126,20 @@ impl TransformerModel {
         if !spark_runtime::ssm_tail_midchunk_enabled() || !self.ssm_snapshots.is_enabled() {
             return None;
         }
+        // Reuse gate: capture costs a per-prefill kernel split + D2D copy and
+        // is only ever consumable by a LATER request of the SAME session (the
+        // snapshot lookup is session-gated). A session seen for the FIRST
+        // time — which includes ALL single-turn traffic, whose ≤1024-token
+        // prefix hash is unique per request — can never reuse this capture,
+        // so skip it entirely; sessions gain capture from their second
+        // request onward (the first request's leaf save tags the session),
+        // exactly when reuse begins. Measured (35B FP8 webserver_ok N=10,
+        // 2026-07-20): capture-always Σ1846s/9-of-10 + 257 tok/turn vs
+        // capture-off Σ1495s/10-of-10 + 203 tok/turn on sessionless agentic
+        // traffic; multi-turn warm-TTFT (-54% max) is preserved from turn 3.
+        if !self.ssm_snapshots.session_has_history(seq.session_hash) {
+            return None;
+        }
         let bs = kv_cache.block_size();
         let tb = spark_runtime::ssm_tail_boundary(tokens.len(), bs)?;
         // Only capture when this pass strictly crosses tb.

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -122,6 +122,7 @@ impl TransformerModel {
         kv_cache: &mut PagedKvCache,
         proc_start: usize,
         proc_count: usize,
+        stream: u64,
     ) -> Option<MidCapturePlan> {
         if !spark_runtime::ssm_tail_midchunk_enabled() || !self.ssm_snapshots.is_enabled() {
             return None;
@@ -166,20 +167,93 @@ impl TransformerModel {
         let mut tb_early = None;
         let mut h_dsts_early = Vec::new();
         let mut conv_dsts_early = Vec::new();
-        if bs > 0
-            && cap_local > bs
-            && tb > bs
-            && let Some(slot2) = self.reserve_snapshot_slot(seq.session_hash, kv_cache)
-        {
-            cap_local_early = Some(cap_local - bs);
-            snap_slot_early = Some(slot2);
-            tb_early = Some(tb - bs);
-            h_dsts_early = Vec::with_capacity(n);
-            conv_dsts_early = Vec::with_capacity(n);
-            for l in 0..n {
-                h_dsts_early.push(self.ssm_snapshots.tail_h_dst(l, slot2));
-                conv_dsts_early.push(self.ssm_snapshots.tail_conv_dst(l, slot2));
+        if bs > 0 && cap_local > bs && tb > bs {
+            match self.reserve_snapshot_slot(seq.session_hash, kv_cache) {
+                Some(slot2) => {
+                    cap_local_early = Some(cap_local - bs);
+                    snap_slot_early = Some(slot2);
+                    tb_early = Some(tb - bs);
+                    h_dsts_early = Vec::with_capacity(n);
+                    conv_dsts_early = Vec::with_capacity(n);
+                    for l in 0..n {
+                        h_dsts_early.push(self.ssm_snapshots.tail_h_dst(l, slot2));
+                        conv_dsts_early.push(self.ssm_snapshots.tail_conv_dst(l, slot2));
+                    }
+                }
+                None => tracing::info!(
+                    "midchunk EARLY skipped: no snapshot slot (pool exhausted, \
+                     reclaim failed) tb_early={}",
+                    tb - bs,
+                ),
             }
+        } else if bs > 0 && cap_local == bs && tb > bs {
+            // The pass starts EXACTLY at tb - bs — the dominant geometry of
+            // warm chunked prefill (measured 7/7 tb-spanning passes on the
+            // 2026-07-20 eviction rig), and precisely the case the early
+            // sibling exists to serve: the next turn's block-floored match
+            // lands one block below tb. A kernel split at offset 0 is
+            // impossible by construction, but no split is needed — the LIVE
+            // pool state at pass start IS the state after [0, tb - bs). The
+            // caller synchronized `stream` immediately before planning, so a
+            // pre-pass save() D2D is ordered before the forward pass advances
+            // the state. Best-effort like the split path: degrade to
+            // tail-only when no slot is reclaimable.
+            let saved = match self.ssm_snapshots.save(
+                seq.slot_idx,
+                seq.session_hash,
+                &self.ssm_pool,
+                self.gpu.as_ref(),
+                stream,
+            ) {
+                Ok(Some(id)) => Some(id),
+                Ok(None) => {
+                    if self.ssm_snapshots.reclaim_from_cache(
+                        self.prefix_cache.as_ref(),
+                        kv_cache,
+                        self.ssm_tier_store.as_deref(),
+                        self.gpu.as_ref(),
+                    ) {
+                        self.ssm_snapshots
+                            .save(
+                                seq.slot_idx,
+                                seq.session_hash,
+                                &self.ssm_pool,
+                                self.gpu.as_ref(),
+                                stream,
+                            )
+                            .ok()
+                            .flatten()
+                    } else {
+                        None
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("midchunk EARLY pre-pass save failed: {e:#}");
+                    None
+                }
+            };
+            match saved {
+                Some(slot2) => {
+                    // Registration-only: cap_local_early stays None so the
+                    // forward pass performs NO split for this point.
+                    snap_slot_early = Some(slot2);
+                    tb_early = Some(tb - bs);
+                    tracing::info!(
+                        "midchunk EARLY pre-pass copy at token {} (snap {slot2})",
+                        tb - bs,
+                    );
+                }
+                None => tracing::info!(
+                    "midchunk EARLY skipped: no snapshot slot for pre-pass copy \
+                     tb_early={}",
+                    tb - bs,
+                ),
+            }
+        } else if bs > 0 && tb > bs {
+            tracing::info!(
+                "midchunk EARLY skipped: pass starts after tb-bs \
+                 (proc_start={proc_start} tb={tb} cap_local={cap_local} bs={bs})",
+            );
         }
 
         Some(MidCapturePlan {

--- a/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/midchunk_capture.rs
@@ -13,8 +13,8 @@
 //! Two capture points per pass:
 //!   * `tb` — the block-floored matched-prefix boundary, registered as the
 //!     session TAIL snapshot.
-//!   * `tb - block_size` — one KV block earlier, registered as a NON-TAIL
-//!     intermediate. On ~5/19 warm turns the next turn's block-floored
+//!   * `tb - block_size` — one KV block earlier, registered as the tail's
+//!     SIBLING (leased alongside it). On ~5/19 warm turns the next turn's block-floored
 //!     `matched_tokens` lands exactly `tb - block_size` (the chat-template
 //!     generation-suffix / detokenize-retokenize divergence puts the longest
 //!     common prefix one block short of the tail). The tail@`tb` is then
@@ -31,8 +31,8 @@
 //!      `cap_local` (and `cap_local - bs` when present) and D2D-copies each
 //!      captured state into its reserved slot.
 //!   3. [`TransformerModel::finalize_midchunk_capture`] (after `forward_layers`)
-//!      registers the tail slot as the session tail and the earlier slot as an
-//!      intermediate snapshot in the index.
+//!      registers the tail slot as the session tail and the earlier slot as
+//!      the tail's sibling in the index (both leased against eviction).
 //!
 //! All behavior is gated on `ssm_tail_midchunk_enabled()` — opt-out
 //! (`ATLAS_SSM_TAIL_MIDCHUNK=0`) is a no-op (returns `None`) and byte-identical
@@ -228,17 +228,15 @@ impl TransformerModel {
         );
 
         if let (Some(tb_early), Some(slot2)) = (plan.tb_early, plan.snap_slot_early) {
-            // Intermediate (non-tail): the radix-tree nodes for [0, tb_early)
-            // are laid down by this turn's finalize_last `insert([0, total))`,
-            // so this is index-only (block_table/disk are ignored by the impl).
-            if let Some(old) = self.prefix_cache.insert_intermediate_snapshot(
+            // Tail SIBLING: leased alongside the tail (it serves the warm
+            // turns whose block-floored match lands one block below tb —
+            // measured 2/7 of restores on the eviction rig). Index-only, like
+            // the tail; must follow insert_tail_snapshot (its sweep clears the
+            // session's previous tail + sibling).
+            if let Some(old) = self.prefix_cache.insert_tail_sibling_snapshot(
                 &tokens[..tb_early],
-                &[],
-                &[],
-                plan.bs,
                 slot2,
                 seq.session_hash,
-                tb_early,
                 seq.adapter_id,
             ) {
                 self.ssm_snapshots.free(old);

--- a/crates/spark-runtime/src/prefix_cache.rs
+++ b/crates/spark-runtime/src/prefix_cache.rs
@@ -246,6 +246,18 @@ pub trait PrefixCache: Send + Sync {
         adapter_id: u64,
     ) -> Vec<usize>;
 
+    /// Register the tail's EARLY sibling (`tb - bs`) in the index. Must be
+    /// called after `insert_tail_snapshot` in the same finalize (the tail
+    /// insert sweeps the session's previous tail + sibling). Returns a
+    /// displaced snapshot id to free, if the prefix was already registered.
+    fn insert_tail_sibling_snapshot(
+        &self,
+        tokens: &[u32],
+        snapshot_id: usize,
+        session_hash: u64,
+        adapter_id: u64,
+    ) -> Option<usize>;
+
     /// Release ref_counts on blocks that were acquired via `lookup`.
     ///
     /// Called when a sequence finishes. Decrements ref_count on cache
@@ -357,6 +369,16 @@ impl PrefixCache for NoPrefixCaching {
         _adapter_id: u64,
     ) -> Vec<usize> {
         Vec::new()
+    }
+
+    fn insert_tail_sibling_snapshot(
+        &self,
+        _tokens: &[u32],
+        _snapshot_id: usize,
+        _session_hash: u64,
+        _adapter_id: u64,
+    ) -> Option<usize> {
+        None
     }
 
     fn release(&self, _tokens: &[u32], _block_size: usize, _adapter_id: u64) {}

--- a/crates/spark-runtime/src/radix_tree.rs
+++ b/crates/spark-runtime/src/radix_tree.rs
@@ -14,6 +14,7 @@ use crate::prefix_cache::{EvictedBlocks, PrefixCache, PrefixMatch};
 
 mod inner;
 mod snapshot;
+mod snapshot_stats;
 
 #[cfg(test)]
 mod tests;

--- a/crates/spark-runtime/src/radix_tree.rs
+++ b/crates/spark-runtime/src/radix_tree.rs
@@ -14,7 +14,9 @@ use crate::prefix_cache::{EvictedBlocks, PrefixCache, PrefixMatch};
 
 mod inner;
 mod snapshot;
+mod snapshot_insert;
 mod snapshot_stats;
+mod snapshot_tier;
 
 #[cfg(test)]
 mod tests;
@@ -198,6 +200,23 @@ impl PrefixCache for RadixTree {
         self.snapshot_index
             .lock()
             .insert_tail(prefix_hash, snapshot_id, session_hash, tokens.len())
+    }
+
+    fn insert_tail_sibling_snapshot(
+        &self,
+        tokens: &[u32],
+        snapshot_id: usize,
+        session_hash: u64,
+        adapter_id: u64,
+    ) -> Option<usize> {
+        // Index only, like the tail (finalize_last's insert lays the tree nodes).
+        let prefix_hash = hash_token_prefix(tokens, tokens.len(), adapter_id);
+        self.snapshot_index.lock().insert_tail_sibling(
+            prefix_hash,
+            snapshot_id,
+            session_hash,
+            tokens.len(),
+        )
     }
 
     fn insert_intermediate_snapshot(

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -23,6 +23,13 @@ pub(super) struct SnapshotEntry {
     /// True for the per-session TAIL snapshot (the restore point the next turn's
     /// block-floored `matched_tokens` looks up). Exactly one is kept per session.
     pub(super) is_tail: bool,
+    /// True for the tail's EARLY sibling (the mid-chunk capture at `tb - bs`).
+    /// Serves warm turns whose block-floored match lands one block below the
+    /// tail (measured 2/7 of restores on the eviction rig). Exact-prefix keyed
+    /// — NOT session-gated in lookups (safe cross-session, unlike `is_tail`) —
+    /// but leased alongside the tail. At most one per session (swept together
+    /// with the tail by `insert_tail`).
+    pub(super) is_tail_sibling: bool,
 }
 
 /// Where a matched snapshot's state currently lives (Phase 1b).
@@ -128,91 +135,6 @@ impl SsmSnapshotIndex {
         self.last_lookup_session != 0
             && tail_lease_enabled()
             && self.evictions_since_lookup < tail_lease_ttl()
-    }
-
-    pub(super) fn insert(
-        &mut self,
-        prefix_hash: u64,
-        snapshot_id: usize,
-        session_hash: u64,
-        token_count: usize,
-    ) -> Option<usize> {
-        for entry in &mut self.entries {
-            if entry.prefix_hash == prefix_hash {
-                let old = entry.snapshot_id;
-                entry.snapshot_id = snapshot_id;
-                entry.session_hash = session_hash;
-                entry.token_count = token_count;
-                // A fresh HBM save re-homes the prefix: it is resident again.
-                entry.tiered = false;
-                // A plain save re-homing this prefix is by definition NOT a
-                // tail. Without this, an overwrite could re-home another
-                // session's is_tail entry (new session_hash, is_tail still
-                // set), breaching the <=1-leased-entry-per-session invariant
-                // insert_tail's supersede sweep maintains.
-                entry.is_tail = false;
-                self.access_counter += 1;
-                entry.last_access = self.access_counter;
-                return Some(old);
-            }
-        }
-        self.access_counter += 1;
-        self.stats.saves += 1;
-        self.entries.push(SnapshotEntry {
-            snapshot_id,
-            session_hash,
-            token_count,
-            prefix_hash,
-            last_access: self.access_counter,
-            tiered: false,
-            is_tail: false,
-        });
-        None
-    }
-
-    /// Insert the per-session TAIL snapshot, superseding this session's previous one.
-    /// Returns displaced snapshot_ids for the caller to free.
-    pub(super) fn insert_tail(
-        &mut self,
-        prefix_hash: u64,
-        snapshot_id: usize,
-        session_hash: u64,
-        token_count: usize,
-    ) -> Vec<usize> {
-        let mut displaced = Vec::new();
-        if session_hash != 0 {
-            let mut i = 0;
-            while i < self.entries.len() {
-                if self.entries[i].is_tail && self.entries[i].session_hash == session_hash {
-                    displaced.push(self.entries.swap_remove(i).snapshot_id);
-                } else {
-                    i += 1;
-                }
-            }
-        }
-        for entry in &mut self.entries {
-            if entry.prefix_hash == prefix_hash {
-                displaced.push(entry.snapshot_id);
-                entry.snapshot_id = snapshot_id;
-                entry.session_hash = session_hash;
-                entry.token_count = token_count;
-                entry.is_tail = true;
-                self.access_counter += 1;
-                entry.last_access = self.access_counter;
-                return displaced;
-            }
-        }
-        self.access_counter += 1;
-        self.entries.push(SnapshotEntry {
-            snapshot_id,
-            session_hash,
-            token_count,
-            prefix_hash,
-            last_access: self.access_counter,
-            tiered: false,
-            is_tail: true,
-        });
-        displaced
     }
 
     /// Find deepest snapshot matching session within matched_tokens range.
@@ -421,13 +343,20 @@ impl SsmSnapshotIndex {
                 *f = e.last_access;
             }
         }
-        let n_eligible = self.entries.iter().filter(|e| eligible(e)).count();
         let leased = |e: &SnapshotEntry| {
             tail_protect
-                && e.is_tail
+                && (e.is_tail || e.is_tail_sibling)
                 && e.session_hash != 0
                 && e.session_hash == self.last_lookup_session
         };
+        // The lease bites only while an UNLEASED eligible candidate exists, so
+        // a pool of only-leased entries (or a single entry) still yields a
+        // victim — no deadlock, and `save`/reclaim always make progress.
+        let n_unleased = self
+            .entries
+            .iter()
+            .filter(|e| eligible(e) && !leased(e))
+            .count();
         // Within-session rank: S(e) = norm(recency) + α·norm(depth) — Marconi
         // Eq 2 (see snap_evict_alpha). At the default α=0 this is exactly
         // pure-LRU ordering. Min-max normalization over the ELIGIBLE pool per
@@ -460,8 +389,8 @@ impl SsmSnapshotIndex {
             if !eligible(e) {
                 continue;
             }
-            if leased(e) && n_eligible > 1 {
-                continue; // never evict the live session's restore point
+            if leased(e) && n_unleased >= 1 {
+                continue; // never evict the live session's restore points
             }
             let sf = *session_fresh.get(&e.session_hash).unwrap_or(&0);
             let s = score(e);

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -46,20 +46,52 @@ pub(super) struct SnapMatch {
 pub(super) struct SsmSnapshotIndex {
     pub(super) entries: Vec<SnapshotEntry>,
     pub(super) access_counter: u64,
-    /// Session of the most recent `lookup` — the live conversation. Its
-    /// DEEPEST snapshot is the one its next warm turn will restore from, so
-    /// `evict_lru` protects it (ATLAS_SSM_TAIL_PROTECT, ported from #278).
-    /// Tracks the running tip: recomputed each eviction from `token_count`,
-    /// never a pinned slot. Complements the session-aware victim ranking
-    /// below — session-aware protects the live session vs *dormant* ones;
-    /// tail-protect protects the deep tail *within* the live session (the
-    /// single/dominant-conversation case session-freshness can't see).
+    /// Session of the most recent `lookup`/`lookup_tiered` — the live
+    /// conversation. Eviction leases that session's `is_tail` entry (the
+    /// TRUE restore point the next warm turn's block-floored
+    /// `matched_tokens` looks up) — NOT its deepest entry: the deepest is
+    /// the finish leaf written at end-of-turn, which sits ABOVE
+    /// `matched_tokens` and is unusable for restore (#278's original
+    /// deepest-entry semantics protected exactly the wrong slot; measured
+    /// 2026-07-20 eviction rig: 0 Marconi hits with it on OR off).
+    /// Complements the session-aware victim ranking — session-aware
+    /// protects the live session vs *dormant* ones; the tail lease protects
+    /// the restore point *within* the live session under same-session or
+    /// sessionless-churn pressure.
     last_lookup_session: u64,
+    /// Evictions since the last session-latching lookup. The lease is a
+    /// LEASE, not a pin: if the leased session never looks up again (it
+    /// ended; subsequent cold traffic never reaches lookup at
+    /// matched_tokens == 0), the lease lapses after
+    /// [`tail_lease_ttl`] evictions so a dead session's tail cannot
+    /// squat a slot indefinitely.
+    evictions_since_lookup: u32,
     /// Phase-0 measurement counters (ATLAS_SSM_SNAP_STATS). All aggregate,
     /// off the hot path's critical decisions — they only observe. The residual
     /// `recompute_tokens_on_hit` after tail-protect + a large pool is exactly
     /// what Phase 1 (spill-not-drop) converts from recompute → fault-in.
     stats: SnapshotStats,
+}
+
+/// Tail-lease kill switch. Default ON; `ATLAS_SSM_TAIL_PROTECT=0` (or `off`)
+/// disables. Backward compatible with the old opt-in scripts that set `=1`.
+fn tail_lease_enabled() -> bool {
+    !matches!(
+        std::env::var("ATLAS_SSM_TAIL_PROTECT").as_deref(),
+        Ok("0") | Ok("off")
+    )
+}
+
+/// Evictions a leased tail survives without its session looking up again.
+/// Derivation: the 2026-07-20 eviction rig measured ~18 evictions between a
+/// deep session's turns at 8 slots with 6 churn requests/turn — 64 is a >3x
+/// margin there, while production pools (128–256 slots) evict rarely enough
+/// that the TTL almost never binds. Override: ATLAS_SSM_TAIL_LEASE_TTL.
+fn tail_lease_ttl() -> u32 {
+    std::env::var("ATLAS_SSM_TAIL_LEASE_TTL")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(64)
 }
 
 impl SsmSnapshotIndex {
@@ -68,8 +100,16 @@ impl SsmSnapshotIndex {
             entries: Vec::new(),
             access_counter: 0,
             last_lookup_session: 0,
+            evictions_since_lookup: 0,
             stats: SnapshotStats::default(),
         }
+    }
+
+    /// Whether the live session's tail lease is currently in force.
+    fn tail_lease_active(&self) -> bool {
+        self.last_lookup_session != 0
+            && tail_lease_enabled()
+            && self.evictions_since_lookup < tail_lease_ttl()
     }
 
     pub(super) fn insert(
@@ -87,6 +127,12 @@ impl SsmSnapshotIndex {
                 entry.token_count = token_count;
                 // A fresh HBM save re-homes the prefix: it is resident again.
                 entry.tiered = false;
+                // A plain save re-homing this prefix is by definition NOT a
+                // tail. Without this, an overwrite could re-home another
+                // session's is_tail entry (new session_hash, is_tail still
+                // set), breaching the <=1-leased-entry-per-session invariant
+                // insert_tail's supersede sweep maintains.
+                entry.is_tail = false;
                 self.access_counter += 1;
                 entry.last_access = self.access_counter;
                 return Some(old);
@@ -166,10 +212,11 @@ impl SsmSnapshotIndex {
         session_hash: u64,
         adapter_id: u64,
     ) -> Option<(usize, usize)> {
-        // Track the live conversation so eviction can protect its deep tail
-        // (ATLAS_SSM_TAIL_PROTECT).
+        // Track the live conversation so eviction can lease its is_tail
+        // restore point; a fresh lookup renews the lease.
         if session_hash != 0 {
             self.last_lookup_session = session_hash;
+            self.evictions_since_lookup = 0;
         }
         // Side-effect-free scan: only the WINNER gets its recency bumped,
         // below. Bumping every improving candidate kept shallow early-prefix
@@ -291,12 +338,12 @@ impl SsmSnapshotIndex {
 
         // SESSION-AWARE eviction (default ON; ATLAS_SNAP_EVICT_LEGACY=1 → old per-entry).
         if std::env::var_os("ATLAS_SNAP_EVICT_LEGACY").is_none() {
-            let tail_protect = self.last_lookup_session != 0
-                && std::env::var_os("ATLAS_SSM_TAIL_PROTECT").is_some();
+            let tail_protect = self.tail_lease_active();
             // Skip tiered entries (no HBM slot to free).
             let victim_idx = self.session_aware_victim(tail_protect, true)?;
             let entry = self.entries.swap_remove(victim_idx);
             self.stats.evictions += 1;
+            self.evictions_since_lookup = self.evictions_since_lookup.saturating_add(1);
             return Some(entry.snapshot_id);
         }
 
@@ -318,9 +365,15 @@ impl SsmSnapshotIndex {
     }
 
     /// Pure victim selection for session-aware eviction. Split out for unit tests.
-    /// Ranking: stalest session first, then lowest forecast score within it.
-    /// `tail_protect`: exempt the live session's deepest snapshot (one entry,
-    /// scoped, so pools ≥2 never deadlock). Correctness-safe (restore re-validates).
+    /// Ranking: stalest session first, then oldest entry within it.
+    /// `tail_protect`: lease the live session's `is_tail` restore point — the
+    /// snapshot the next warm turn's block-floored `matched_tokens` actually
+    /// looks up, NOT the deepest entry (that is the end-of-turn finish leaf,
+    /// which sits above `matched_tokens` and never restores; #278 semantics
+    /// protected it and bought nothing — 2026-07-20 rig: 0 hits either way).
+    /// insert_tail's supersede sweep plus insert()'s is_tail-clearing keep
+    /// the leased set at <=1 entry, so pools >=2 never deadlock.
+    /// Correctness-safe (restore re-validates).
     /// `skip_tiered`: ignore spilled entries (no HBM slot). Returns `None` if none eligible.
     fn session_aware_victim(&self, tail_protect: bool, skip_tiered: bool) -> Option<usize> {
         let escore = |e: &SnapshotEntry| e.last_access;
@@ -336,26 +389,22 @@ impl SsmSnapshotIndex {
             }
         }
         let n_eligible = self.entries.iter().filter(|e| eligible(e)).count();
-        let protected_idx: Option<usize> = if tail_protect {
-            self.entries
-                .iter()
-                .enumerate()
-                .filter(|(_, e)| eligible(e) && e.session_hash == self.last_lookup_session)
-                .max_by_key(|(_, e)| e.token_count)
-                .map(|(i, _)| i)
-        } else {
-            None
+        let leased = |e: &SnapshotEntry| {
+            tail_protect
+                && e.is_tail
+                && e.session_hash != 0
+                && e.session_hash == self.last_lookup_session
         };
-        // (stalest session first, then lowest entry score within it). Protected
+        // (stalest session first, then oldest entry within it). The lease
         // bites only when >1 eligible entry remains, so a single-entry pool
-        // (even if it is the protected tail) still yields a victim → no deadlock.
+        // (even if it is the leased tail) still yields a victim → no deadlock.
         let mut victim: Option<(usize, (u64, u64))> = None;
         for (i, e) in self.entries.iter().enumerate() {
             if !eligible(e) {
                 continue;
             }
-            if Some(i) == protected_idx && n_eligible > 1 {
-                continue; // never evict the live session's deepest tail
+            if leased(e) && n_eligible > 1 {
+                continue; // never evict the live session's restore point
             }
             let sf = *session_fresh.get(&e.session_hash).unwrap_or(&0);
             let key = (sf, escore(e));
@@ -374,14 +423,14 @@ impl SsmSnapshotIndex {
         if self.entries.is_empty() {
             return None;
         }
-        let tail_protect =
-            self.last_lookup_session != 0 && std::env::var_os("ATLAS_SSM_TAIL_PROTECT").is_some();
+        let tail_protect = self.tail_lease_active();
         let idx = self.session_aware_victim(tail_protect, /*skip_tiered*/ true)?;
         let e = &mut self.entries[idx];
         e.tiered = true;
         let freed_slot = e.snapshot_id;
         let key = e.prefix_hash;
         self.stats.tier_spills += 1;
+        self.evictions_since_lookup = self.evictions_since_lookup.saturating_add(1);
         Some((freed_slot, key))
     }
 
@@ -398,6 +447,7 @@ impl SsmSnapshotIndex {
     ) -> Option<SnapMatch> {
         if session_hash != 0 {
             self.last_lookup_session = session_hash;
+            self.evictions_since_lookup = 0;
         }
         // Deepest matching prefix across BOTH resident and spilled entries.
         let mut best: Option<usize> = None;
@@ -407,6 +457,14 @@ impl SsmSnapshotIndex {
                 continue;
             }
             if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
+                continue;
+            }
+            // TAIL snapshots bleed past the exact prefix — byte-safe ONLY for
+            // the same non-zero session (ported from `lookup`; the serving
+            // path previously had NO is_tail gate, so a sessionless lookup
+            // could restore another session's tail — the exact cross-request
+            // corruption the session-gate exists to prevent).
+            if entry.is_tail && (session_hash == 0 || entry.session_hash != session_hash) {
                 continue;
             }
             if hash_token_prefix(tokens, entry.token_count, adapter_id) != entry.prefix_hash {

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -10,19 +10,19 @@ use super::hash_token_prefix;
 use super::snapshot_stats::SnapshotStats;
 
 pub(super) struct SnapshotEntry {
-    snapshot_id: usize,
-    session_hash: u64,
-    token_count: usize,
-    prefix_hash: u64,
-    last_access: u64,
+    pub(super) snapshot_id: usize,
+    pub(super) session_hash: u64,
+    pub(super) token_count: usize,
+    pub(super) prefix_hash: u64,
+    pub(super) last_access: u64,
     /// Phase 1b — spill-not-drop location. `false` = resident in HBM at
     /// `snapshot_id`. `true` = spilled to the byte tier; `snapshot_id` is stale
     /// and the state is addressed by `prefix_hash` (the tier key). Always
     /// `false` when `ATLAS_SSM_TIER` is off, so the default path is unchanged.
-    tiered: bool,
+    pub(super) tiered: bool,
     /// True for the per-session TAIL snapshot (the restore point the next turn's
     /// block-floored `matched_tokens` looks up). Exactly one is kept per session.
-    is_tail: bool,
+    pub(super) is_tail: bool,
 }
 
 /// Where a matched snapshot's state currently lives (Phase 1b).
@@ -58,19 +58,19 @@ pub(super) struct SsmSnapshotIndex {
     /// protects the live session vs *dormant* ones; the tail lease protects
     /// the restore point *within* the live session under same-session or
     /// sessionless-churn pressure.
-    last_lookup_session: u64,
+    pub(super) last_lookup_session: u64,
     /// Evictions since the last session-latching lookup. The lease is a
     /// LEASE, not a pin: if the leased session never looks up again (it
     /// ended; subsequent cold traffic never reaches lookup at
     /// matched_tokens == 0), the lease lapses after
     /// [`tail_lease_ttl`] evictions so a dead session's tail cannot
     /// squat a slot indefinitely.
-    evictions_since_lookup: u32,
+    pub(super) evictions_since_lookup: u32,
     /// Phase-0 measurement counters (ATLAS_SSM_SNAP_STATS). All aggregate,
     /// off the hot path's critical decisions — they only observe. The residual
     /// `recompute_tokens_on_hit` after tail-protect + a large pool is exactly
     /// what Phase 1 (spill-not-drop) converts from recompute → fault-in.
-    stats: SnapshotStats,
+    pub(super) stats: SnapshotStats,
 }
 
 /// Tail-lease kill switch. Default ON; `ATLAS_SSM_TAIL_PROTECT=0` (or `off`)
@@ -94,6 +94,24 @@ fn tail_lease_ttl() -> u32 {
         .unwrap_or(64)
 }
 
+/// Marconi Eq-2 depth weight (staged, INERT by default). Within a session,
+/// the eviction rank becomes `S(e) = norm(recency) + α·norm(token_count)`
+/// (MLSys'25 arXiv:2411.19379: `S(n) = recency(n) + α·flop_efficiency(n)`;
+/// with uniform snapshot slots, FLOPs-saved/byte degenerates to the token
+/// depth the snapshot lets a warm turn skip — and losing an SSM snapshot
+/// forfeits the whole KV prefix hit, so value ∝ depth). α = 0 (default) is
+/// exactly today's pure-LRU ordering (min-max normalization is monotonic);
+/// clamped to [0, 8] so a runaway env value cannot make depth
+/// recency-insensitive (a depth-pinned analog of the 07-10 hit-pinning).
+/// Default flip requires its own measured A/B: ATLAS_SNAP_EVICT_ALPHA.
+fn snap_evict_alpha() -> f64 {
+    std::env::var("ATLAS_SNAP_EVICT_ALPHA")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|a| a.clamp(0.0, 8.0))
+        .unwrap_or(0.0)
+}
+
 impl SsmSnapshotIndex {
     pub(super) fn new() -> Self {
         Self {
@@ -106,7 +124,7 @@ impl SsmSnapshotIndex {
     }
 
     /// Whether the live session's tail lease is currently in force.
-    fn tail_lease_active(&self) -> bool {
+    pub(super) fn tail_lease_active(&self) -> bool {
         self.last_lookup_session != 0
             && tail_lease_enabled()
             && self.evictions_since_lookup < tail_lease_ttl()
@@ -290,7 +308,7 @@ impl SsmSnapshotIndex {
     /// `ATLAS_SSM_SNAP_STATS` is set. Off-by-default and read-only, so it never
     /// perturbs serving; the line is the Phase-0 measurement surface (hit-rate,
     /// mean restore anchor, mean recompute tok/turn — the #278 metrics).
-    fn log_stats_if_due(&self) {
+    pub(super) fn log_stats_if_due(&self) {
         if !self.stats.lookups.is_multiple_of(64)
             || std::env::var_os("ATLAS_SSM_SNAP_STATS").is_none()
         {
@@ -375,8 +393,23 @@ impl SsmSnapshotIndex {
     /// the leased set at <=1 entry, so pools >=2 never deadlock.
     /// Correctness-safe (restore re-validates).
     /// `skip_tiered`: ignore spilled entries (no HBM slot). Returns `None` if none eligible.
-    fn session_aware_victim(&self, tail_protect: bool, skip_tiered: bool) -> Option<usize> {
-        let escore = |e: &SnapshotEntry| e.last_access;
+    pub(super) fn session_aware_victim(
+        &self,
+        tail_protect: bool,
+        skip_tiered: bool,
+    ) -> Option<usize> {
+        self.session_aware_victim_with_alpha(tail_protect, skip_tiered, snap_evict_alpha())
+    }
+
+    /// α-parameterized core of [`Self::session_aware_victim`] — split so unit
+    /// tests can exercise α without mutating process-global env (a data race
+    /// under the parallel test runner).
+    pub(super) fn session_aware_victim_with_alpha(
+        &self,
+        tail_protect: bool,
+        skip_tiered: bool,
+        alpha: f64,
+    ) -> Option<usize> {
         let eligible = |e: &SnapshotEntry| !(skip_tiered && e.tiered);
 
         // session freshness = max last_access among that session's eligible entries.
@@ -395,10 +428,34 @@ impl SsmSnapshotIndex {
                 && e.session_hash != 0
                 && e.session_hash == self.last_lookup_session
         };
-        // (stalest session first, then oldest entry within it). The lease
-        // bites only when >1 eligible entry remains, so a single-entry pool
-        // (even if it is the leased tail) still yields a victim → no deadlock.
-        let mut victim: Option<(usize, (u64, u64))> = None;
+        // Within-session rank: S(e) = norm(recency) + α·norm(depth) — Marconi
+        // Eq 2 (see snap_evict_alpha). At the default α=0 this is exactly
+        // pure-LRU ordering. Min-max normalization over the ELIGIBLE pool per
+        // pass keeps scores bounded and relative (no per-entry accumulation —
+        // the 07-10 fossil vector cannot re-enter here); a degenerate range
+        // (max == min) normalizes to 0 rather than dividing by zero.
+        let (mut min_a, mut max_a, mut min_t, mut max_t) = (u64::MAX, 0u64, usize::MAX, 0usize);
+        for e in self.entries.iter().filter(|e| eligible(e)) {
+            min_a = min_a.min(e.last_access);
+            max_a = max_a.max(e.last_access);
+            min_t = min_t.min(e.token_count);
+            max_t = max_t.max(e.token_count);
+        }
+        let norm = |x: u64, min: u64, max: u64| {
+            if max > min {
+                (x - min) as f64 / (max - min) as f64
+            } else {
+                0.0
+            }
+        };
+        let score = |e: &SnapshotEntry| {
+            norm(e.last_access, min_a, max_a)
+                + alpha * norm(e.token_count as u64, min_t as u64, max_t as u64)
+        };
+        // (stalest session first, then lowest S within it). The lease bites
+        // only when >1 eligible entry remains, so a single-entry pool (even
+        // if it is the leased tail) still yields a victim → no deadlock.
+        let mut victim: Option<(usize, u64, f64)> = None;
         for (i, e) in self.entries.iter().enumerate() {
             if !eligible(e) {
                 continue;
@@ -407,118 +464,16 @@ impl SsmSnapshotIndex {
                 continue; // never evict the live session's restore point
             }
             let sf = *session_fresh.get(&e.session_hash).unwrap_or(&0);
-            let key = (sf, escore(e));
-            if victim.is_none_or(|(_, vk)| key < vk) {
-                victim = Some((i, key));
-            }
-        }
-        victim.map(|(i, _)| i)
-    }
-
-    // ─── Phase 1b: spill tier ─── resident vs spilled state machine (ATLAS_SSM_TIER).
-
-    /// Spill victim selection (tier engaged). Marks the victim spilled, returns
-    /// `(freed_slot, key)`. Entry stays in the index for `lookup_tiered` fault-in.
-    pub(super) fn evict_to_tier(&mut self) -> Option<(usize, u64)> {
-        if self.entries.is_empty() {
-            return None;
-        }
-        let tail_protect = self.tail_lease_active();
-        let idx = self.session_aware_victim(tail_protect, /*skip_tiered*/ true)?;
-        let e = &mut self.entries[idx];
-        e.tiered = true;
-        let freed_slot = e.snapshot_id;
-        let key = e.prefix_hash;
-        self.stats.tier_spills += 1;
-        self.evictions_since_lookup = self.evictions_since_lookup.saturating_add(1);
-        Some((freed_slot, key))
-    }
-
-    /// **Tier-aware lookup** (used in place of `lookup` when the tier is on).
-    /// Returns the deepest matching anchor and where its state lives, so the
-    /// caller either restores from HBM or faults in from the tier. Feeds the
-    /// same Phase-0 telemetry as `lookup`, plus `tier_hits`.
-    pub(super) fn lookup_tiered(
-        &mut self,
-        tokens: &[u32],
-        matched_tokens: usize,
-        session_hash: u64,
-        adapter_id: u64,
-    ) -> Option<SnapMatch> {
-        if session_hash != 0 {
-            self.last_lookup_session = session_hash;
-            self.evictions_since_lookup = 0;
-        }
-        // Deepest matching prefix across BOTH resident and spilled entries.
-        let mut best: Option<usize> = None;
-        let mut best_depth = 0usize;
-        for (i, entry) in self.entries.iter().enumerate() {
-            if entry.token_count > matched_tokens {
-                continue;
-            }
-            if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
-                continue;
-            }
-            // TAIL snapshots bleed past the exact prefix — byte-safe ONLY for
-            // the same non-zero session (ported from `lookup`; the serving
-            // path previously had NO is_tail gate, so a sessionless lookup
-            // could restore another session's tail — the exact cross-request
-            // corruption the session-gate exists to prevent).
-            if entry.is_tail && (session_hash == 0 || entry.session_hash != session_hash) {
-                continue;
-            }
-            if hash_token_prefix(tokens, entry.token_count, adapter_id) != entry.prefix_hash {
-                continue;
-            }
-            if best.is_none() || entry.token_count > best_depth {
-                best = Some(i);
-                best_depth = entry.token_count;
-            }
-        }
-        self.stats.lookups += 1;
-        let result = if let Some(i) = best {
-            self.access_counter += 1;
-            let ac = self.access_counter;
-            let e = &mut self.entries[i];
-            e.last_access = ac;
-            let tiered = e.tiered;
-            let depth = e.token_count;
-            let loc = if tiered {
-                SnapLoc::Tier(e.prefix_hash)
-            } else {
-                SnapLoc::Hbm(e.snapshot_id)
+            let s = score(e);
+            let better = match victim {
+                None => true,
+                Some((_, vsf, vs)) => sf < vsf || (sf == vsf && s.total_cmp(&vs).is_lt()),
             };
-            self.stats.hits += 1;
-            self.stats.anchor_depth_sum += depth as u64;
-            self.stats.recompute_tokens_on_hit += matched_tokens.saturating_sub(depth) as u64;
-            if tiered {
-                self.stats.tier_hits += 1;
-            }
-            Some(SnapMatch {
-                token_count: depth,
-                loc,
-            })
-        } else {
-            self.stats.recompute_tokens_on_miss += matched_tokens as u64;
-            None
-        };
-        self.log_stats_if_due();
-        result
-    }
-
-    /// **Promote** a spilled entry back to HBM after the caller faulted its
-    /// bytes into `new_slot`. Flips `tiered → false` and re-homes `snapshot_id`.
-    /// Returns `false` if `prefix_hash` is unknown (entry evicted meanwhile).
-    pub(super) fn promote(&mut self, prefix_hash: u64, new_slot: usize) -> bool {
-        for e in &mut self.entries {
-            if e.prefix_hash == prefix_hash {
-                e.tiered = false;
-                e.snapshot_id = new_slot;
-                self.stats.tier_fault_ins += 1;
-                return true;
+            if better {
+                victim = Some((i, sf, s));
             }
         }
-        false
+        victim.map(|(i, _, _)| i)
     }
 
     pub(super) fn len(&self) -> usize {

--- a/crates/spark-runtime/src/radix_tree/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot.rs
@@ -7,6 +7,7 @@
 //! through the radix tree.
 
 use super::hash_token_prefix;
+use super::snapshot_stats::SnapshotStats;
 
 pub(super) struct SnapshotEntry {
     snapshot_id: usize,
@@ -14,12 +15,6 @@ pub(super) struct SnapshotEntry {
     token_count: usize,
     prefix_hash: u64,
     last_access: u64,
-    /// Cumulative hits over the entry's lifetime — combined with
-    /// `last_access` in eviction to approximate the forecast-based
-    /// policy from the Marconi paper §4 (B.4, 2026-04-25). Hot
-    /// prefixes (high hit count) survive longer than cold ones at
-    /// the same age.
-    hit_count: u32,
     /// Phase 1b — spill-not-drop location. `false` = resident in HBM at
     /// `snapshot_id`. `true` = spilled to the byte tier; `snapshot_id` is stale
     /// and the state is addressed by `prefix_hash` (the tier key). Always
@@ -67,36 +62,6 @@ pub(super) struct SsmSnapshotIndex {
     stats: SnapshotStats,
 }
 
-/// Aggregate SSM-snapshot cache telemetry (Phase 0). Summarised via
-/// `log_stats_if_due` when `ATLAS_SSM_SNAP_STATS` is set.
-#[derive(Default, Clone, Copy)]
-pub(super) struct SnapshotStats {
-    /// Snapshots registered (new prefix inserted, not an overwrite).
-    pub saves: u64,
-    /// Prefix lookups attempted.
-    pub lookups: u64,
-    /// Lookups that restored *some* anchor (deep or shallow).
-    pub hits: u64,
-    /// Σ restored-anchor depth over hits — mean anchor = this / hits.
-    pub anchor_depth_sum: u64,
-    /// Σ (matched_tokens − anchor_depth) over hits: the SSM tokens that still
-    /// had to be recomputed because the deep tail was not resident. This is the
-    /// #278 metric ("mean recompute 4438→262 tok") and Phase 1's target.
-    pub recompute_tokens_on_hit: u64,
-    /// Σ matched_tokens over *misses* (no anchor at all → full recompute).
-    pub recompute_tokens_on_miss: u64,
-    /// Snapshot slots freed by `evict_lru` — a DROP (state discarded) on the
-    /// default path; Phase 1 spills instead via `evict_to_tier`.
-    pub evictions: u64,
-    /// Phase 1b: entries moved HBM→Tier by `evict_to_tier` (spills, not drops).
-    pub tier_spills: u64,
-    /// Phase 1b: lookups whose deepest anchor was found in the tier (would have
-    /// been a recompute pre-spill) — the converted loss.
-    pub tier_hits: u64,
-    /// Phase 1b: tier entries faulted back into HBM via `promote`.
-    pub tier_fault_ins: u64,
-}
-
 impl SsmSnapshotIndex {
     pub(super) fn new() -> Self {
         Self {
@@ -135,7 +100,6 @@ impl SsmSnapshotIndex {
             token_count,
             prefix_hash,
             last_access: self.access_counter,
-            hit_count: 0,
             tiered: false,
             is_tail: false,
         });
@@ -181,7 +145,6 @@ impl SsmSnapshotIndex {
             token_count,
             prefix_hash,
             last_access: self.access_counter,
-            hit_count: 0,
             tiered: false,
             is_tail: true,
         });
@@ -208,8 +171,16 @@ impl SsmSnapshotIndex {
         if session_hash != 0 {
             self.last_lookup_session = session_hash;
         }
+        // Side-effect-free scan: only the WINNER gets its recency bumped,
+        // below. Bumping every improving candidate kept shallow early-prefix
+        // entries eternally fresh (each deep lookup walks the improving chain
+        // through them), pinning them in the pool while the tail checkpoints
+        // the next warm turn actually needs were evicted — the measured
+        // frozen-anchor / 18.6k-token SSM replay pathology (2026-07-10,
+        // re-landed after #317's re-cut reverted it).
         let mut best: Option<(usize, usize)> = None; // (snapshot_id, token_count)
-        for entry in &mut self.entries {
+        let mut best_idx: Option<usize> = None;
+        for (i, entry) in self.entries.iter().enumerate() {
             // Tiered entries hold no HBM slot — the non-tier `lookup` must never
             // hand back a spilled entry's stale slot. Tier-aware callers use
             // `lookup_tiered`. (No entry is ever tiered when ATLAS_SSM_TIER off.)
@@ -232,11 +203,13 @@ impl SsmSnapshotIndex {
                 continue;
             }
             if best.is_none() || entry.token_count > best.unwrap().1 {
-                self.access_counter += 1;
-                entry.last_access = self.access_counter;
-                entry.hit_count = entry.hit_count.saturating_add(1);
                 best = Some((entry.snapshot_id, entry.token_count));
+                best_idx = Some(i);
             }
+        }
+        if let Some(i) = best_idx {
+            self.access_counter += 1;
+            self.entries[i].last_access = self.access_counter;
         }
         // Phase-0 telemetry: hit-rate + recompute distance. `recompute` is the
         // SSM prefix that still had to be re-run because no deeper anchor was
@@ -305,8 +278,16 @@ impl SsmSnapshotIndex {
         if self.entries.is_empty() {
             return None;
         }
-        // Per-entry forecast score: last_access * (1 + hit_count) — old/cold first.
-        let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
+        // Pure recency (LRU). The former forecast score
+        // `last_access * (1 + hit_count)` multiplied a monotonic timestamp by
+        // hit count, so any once-hit old entry outscored every fresh save;
+        // once the cold entries drained, each new save's evict victim was the
+        // PREVIOUS fresh save — the live turn's tail checkpoint died ms before
+        // the next turn's lookup needed it, freezing the restore anchor
+        // (measured 2026-07-10: anchor pinned at token 9056 for 29 turns,
+        // 12.7k-token SSM replay, 40s TTFT tail). Re-landed after #317's
+        // re-cut restored the old score.
+        let escore = |e: &SnapshotEntry| e.last_access;
 
         // SESSION-AWARE eviction (default ON; ATLAS_SNAP_EVICT_LEGACY=1 → old per-entry).
         if std::env::var_os("ATLAS_SNAP_EVICT_LEGACY").is_none() {
@@ -342,7 +323,7 @@ impl SsmSnapshotIndex {
     /// scoped, so pools ≥2 never deadlock). Correctness-safe (restore re-validates).
     /// `skip_tiered`: ignore spilled entries (no HBM slot). Returns `None` if none eligible.
     fn session_aware_victim(&self, tail_protect: bool, skip_tiered: bool) -> Option<usize> {
-        let escore = |e: &SnapshotEntry| e.last_access.saturating_mul(1 + e.hit_count as u64);
+        let escore = |e: &SnapshotEntry| e.last_access;
         let eligible = |e: &SnapshotEntry| !(skip_tiered && e.tiered);
 
         // session freshness = max last_access among that session's eligible entries.
@@ -442,7 +423,6 @@ impl SsmSnapshotIndex {
             let ac = self.access_counter;
             let e = &mut self.entries[i];
             e.last_access = ac;
-            e.hit_count = e.hit_count.saturating_add(1);
             let tiered = e.tiered;
             let depth = e.token_count;
             let loc = if tiered {

--- a/crates/spark-runtime/src/radix_tree/snapshot_insert.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot_insert.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Snapshot-index insert paths (plain, tail, tail-sibling). Split from
+//! `snapshot.rs` (file-size cap); same `SsmSnapshotIndex` impl.
+
+use super::snapshot::{SnapshotEntry, SsmSnapshotIndex};
+
+impl SsmSnapshotIndex {
+    pub(super) fn insert(
+        &mut self,
+        prefix_hash: u64,
+        snapshot_id: usize,
+        session_hash: u64,
+        token_count: usize,
+    ) -> Option<usize> {
+        for entry in &mut self.entries {
+            if entry.prefix_hash == prefix_hash {
+                let old = entry.snapshot_id;
+                entry.snapshot_id = snapshot_id;
+                entry.session_hash = session_hash;
+                entry.token_count = token_count;
+                // A fresh HBM save re-homes the prefix: it is resident again.
+                entry.tiered = false;
+                // A plain save re-homing this prefix is by definition NOT a
+                // tail. Without this, an overwrite could re-home another
+                // session's is_tail entry (new session_hash, is_tail still
+                // set), breaching the <=1-leased-entry-per-session invariant
+                // insert_tail's supersede sweep maintains.
+                entry.is_tail = false;
+                entry.is_tail_sibling = false;
+                self.access_counter += 1;
+                entry.last_access = self.access_counter;
+                return Some(old);
+            }
+        }
+        self.access_counter += 1;
+        self.stats.saves += 1;
+        self.entries.push(SnapshotEntry {
+            snapshot_id,
+            session_hash,
+            token_count,
+            prefix_hash,
+            last_access: self.access_counter,
+            tiered: false,
+            is_tail: false,
+            is_tail_sibling: false,
+        });
+        None
+    }
+
+    /// Insert the per-session TAIL snapshot, superseding this session's previous one.
+    /// Returns displaced snapshot_ids for the caller to free.
+    pub(super) fn insert_tail(
+        &mut self,
+        prefix_hash: u64,
+        snapshot_id: usize,
+        session_hash: u64,
+        token_count: usize,
+    ) -> Vec<usize> {
+        let mut displaced = Vec::new();
+        if session_hash != 0 {
+            let mut i = 0;
+            while i < self.entries.len() {
+                if (self.entries[i].is_tail || self.entries[i].is_tail_sibling)
+                    && self.entries[i].session_hash == session_hash
+                {
+                    displaced.push(self.entries.swap_remove(i).snapshot_id);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+        for entry in &mut self.entries {
+            if entry.prefix_hash == prefix_hash {
+                displaced.push(entry.snapshot_id);
+                entry.snapshot_id = snapshot_id;
+                entry.session_hash = session_hash;
+                entry.token_count = token_count;
+                entry.is_tail = true;
+                entry.is_tail_sibling = false;
+                self.access_counter += 1;
+                entry.last_access = self.access_counter;
+                return displaced;
+            }
+        }
+        self.access_counter += 1;
+        self.entries.push(SnapshotEntry {
+            snapshot_id,
+            session_hash,
+            token_count,
+            prefix_hash,
+            last_access: self.access_counter,
+            tiered: false,
+            is_tail: true,
+            is_tail_sibling: false,
+        });
+        displaced
+    }
+
+    /// Insert the tail's EARLY sibling (`tb - bs`). MUST be called after
+    /// [`Self::insert_tail`] within the same finalize — the tail insert's
+    /// supersede sweep clears the session's previous tail AND sibling, so
+    /// this insert never needs (and must not run) its own sweep.
+    pub(super) fn insert_tail_sibling(
+        &mut self,
+        prefix_hash: u64,
+        snapshot_id: usize,
+        session_hash: u64,
+        token_count: usize,
+    ) -> Option<usize> {
+        for entry in &mut self.entries {
+            if entry.prefix_hash == prefix_hash {
+                let old = entry.snapshot_id;
+                entry.snapshot_id = snapshot_id;
+                entry.session_hash = session_hash;
+                entry.token_count = token_count;
+                entry.tiered = false;
+                entry.is_tail = false;
+                entry.is_tail_sibling = true;
+                self.access_counter += 1;
+                entry.last_access = self.access_counter;
+                return Some(old);
+            }
+        }
+        self.access_counter += 1;
+        self.stats.saves += 1;
+        self.entries.push(SnapshotEntry {
+            snapshot_id,
+            session_hash,
+            token_count,
+            prefix_hash,
+            last_access: self.access_counter,
+            tiered: false,
+            is_tail: false,
+            is_tail_sibling: true,
+        });
+        None
+    }
+}

--- a/crates/spark-runtime/src/radix_tree/snapshot_stats.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot_stats.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Aggregate SSM-snapshot cache telemetry (Phase 0). Split from `snapshot.rs`
+//! (file-size cap); summarised via `SsmSnapshotIndex::log_stats_if_due` when
+//! `ATLAS_SSM_SNAP_STATS` is set. All counters are aggregate and off the hot
+//! path's critical decisions — they only observe.
+
+#[derive(Default, Clone, Copy)]
+pub(super) struct SnapshotStats {
+    /// Snapshots registered (new prefix inserted, not an overwrite).
+    pub saves: u64,
+    /// Prefix lookups attempted.
+    pub lookups: u64,
+    /// Lookups that restored *some* anchor (deep or shallow).
+    pub hits: u64,
+    /// Σ restored-anchor depth over hits — mean anchor = this / hits.
+    pub anchor_depth_sum: u64,
+    /// Σ (matched_tokens − anchor_depth) over hits: the SSM tokens that still
+    /// had to be recomputed because the deep tail was not resident. This is the
+    /// #278 metric ("mean recompute 4438→262 tok") and Phase 1's target.
+    pub recompute_tokens_on_hit: u64,
+    /// Σ matched_tokens over *misses* (no anchor at all → full recompute).
+    pub recompute_tokens_on_miss: u64,
+    /// Snapshot slots freed by `evict_lru` — a DROP (state discarded) on the
+    /// default path; Phase 1 spills instead via `evict_to_tier`.
+    pub evictions: u64,
+    /// Phase 1b: entries moved HBM→Tier by `evict_to_tier` (spills, not drops).
+    pub tier_spills: u64,
+    /// Phase 1b: lookups whose deepest anchor was found in the tier (would have
+    /// been a recompute pre-spill) — the converted loss.
+    pub tier_hits: u64,
+    /// Phase 1b: tier entries faulted back into HBM via `promote`.
+    pub tier_fault_ins: u64,
+}

--- a/crates/spark-runtime/src/radix_tree/snapshot_tier.rs
+++ b/crates/spark-runtime/src/radix_tree/snapshot_tier.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Phase 1b spill tier — resident vs spilled state machine (`ATLAS_SSM_TIER`).
+//! Split from `snapshot.rs` (file-size cap); same `SsmSnapshotIndex` impl.
+
+use super::hash_token_prefix;
+use super::snapshot::{SnapLoc, SnapMatch, SsmSnapshotIndex};
+
+impl SsmSnapshotIndex {
+    /// Spill victim selection (tier engaged). Marks the victim spilled, returns
+    /// `(freed_slot, key)`. Entry stays in the index for `lookup_tiered` fault-in.
+    pub(super) fn evict_to_tier(&mut self) -> Option<(usize, u64)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let tail_protect = self.tail_lease_active();
+        let idx = self.session_aware_victim(tail_protect, /*skip_tiered*/ true)?;
+        let e = &mut self.entries[idx];
+        e.tiered = true;
+        let freed_slot = e.snapshot_id;
+        let key = e.prefix_hash;
+        self.stats.tier_spills += 1;
+        self.evictions_since_lookup = self.evictions_since_lookup.saturating_add(1);
+        Some((freed_slot, key))
+    }
+
+    /// **Tier-aware lookup** (used in place of `lookup` when the tier is on).
+    /// Returns the deepest matching anchor and where its state lives, so the
+    /// caller either restores from HBM or faults in from the tier. Feeds the
+    /// same Phase-0 telemetry as `lookup`, plus `tier_hits`.
+    pub(super) fn lookup_tiered(
+        &mut self,
+        tokens: &[u32],
+        matched_tokens: usize,
+        session_hash: u64,
+        adapter_id: u64,
+    ) -> Option<SnapMatch> {
+        if session_hash != 0 {
+            self.last_lookup_session = session_hash;
+            self.evictions_since_lookup = 0;
+        }
+        // Deepest matching prefix across BOTH resident and spilled entries.
+        let mut best: Option<usize> = None;
+        let mut best_depth = 0usize;
+        for (i, entry) in self.entries.iter().enumerate() {
+            if entry.token_count > matched_tokens {
+                continue;
+            }
+            if session_hash != 0 && entry.session_hash != 0 && entry.session_hash != session_hash {
+                continue;
+            }
+            // TAIL snapshots bleed past the exact prefix — byte-safe ONLY for
+            // the same non-zero session (ported from `lookup`; the serving
+            // path previously had NO is_tail gate, so a sessionless lookup
+            // could restore another session's tail — the exact cross-request
+            // corruption the session-gate exists to prevent).
+            if entry.is_tail && (session_hash == 0 || entry.session_hash != session_hash) {
+                continue;
+            }
+            if hash_token_prefix(tokens, entry.token_count, adapter_id) != entry.prefix_hash {
+                continue;
+            }
+            if best.is_none() || entry.token_count > best_depth {
+                best = Some(i);
+                best_depth = entry.token_count;
+            }
+        }
+        self.stats.lookups += 1;
+        let result = if let Some(i) = best {
+            self.access_counter += 1;
+            let ac = self.access_counter;
+            let e = &mut self.entries[i];
+            e.last_access = ac;
+            let tiered = e.tiered;
+            let depth = e.token_count;
+            let loc = if tiered {
+                SnapLoc::Tier(e.prefix_hash)
+            } else {
+                SnapLoc::Hbm(e.snapshot_id)
+            };
+            self.stats.hits += 1;
+            self.stats.anchor_depth_sum += depth as u64;
+            self.stats.recompute_tokens_on_hit += matched_tokens.saturating_sub(depth) as u64;
+            if tiered {
+                self.stats.tier_hits += 1;
+            }
+            Some(SnapMatch {
+                token_count: depth,
+                loc,
+            })
+        } else {
+            self.stats.recompute_tokens_on_miss += matched_tokens as u64;
+            None
+        };
+        self.log_stats_if_due();
+        result
+    }
+
+    /// **Promote** a spilled entry back to HBM after the caller faulted its
+    /// bytes into `new_slot`. Flips `tiered → false` and re-homes `snapshot_id`.
+    /// Returns `false` if `prefix_hash` is unknown (entry evicted meanwhile).
+    pub(super) fn promote(&mut self, prefix_hash: u64, new_slot: usize) -> bool {
+        for e in &mut self.entries {
+            if e.prefix_hash == prefix_hash {
+                e.tiered = false;
+                e.snapshot_id = new_slot;
+                self.stats.tier_fault_ins += 1;
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -2,14 +2,13 @@
 
 use super::*;
 
-/// Build an entry with an explicit forecast profile. `snapshot_id` doubles
+/// Build an entry with an explicit recency profile. `snapshot_id` doubles
 /// as a stable identity we assert on (independent of Vec index).
 fn entry(
     snapshot_id: usize,
     session_hash: u64,
     token_count: usize,
     last_access: u64,
-    hit_count: u32,
 ) -> SnapshotEntry {
     SnapshotEntry {
         snapshot_id,
@@ -17,7 +16,6 @@ fn entry(
         token_count,
         prefix_hash: snapshot_id as u64, // unique, irrelevant to victim choice
         last_access,
-        hit_count,
         tiered: false,
         is_tail: false,
     }
@@ -32,38 +30,29 @@ fn index(entries: Vec<SnapshotEntry>, live: u64) -> SsmSnapshotIndex {
     }
 }
 
-/// The deep-tail eviction inversion (#278 root cause), reproduced against
-/// the session-aware policy: within a SINGLE live session the hot 8192
-/// anchor (self-reinforced hit_count) out-scores the just-aged deep tail
-/// (hit_count=0), so without tail-protect the tail is the victim.
+/// Pure-LRU within a session: the older entry is the victim regardless of
+/// how often it was hit historically (regression for the 07-10 fossil
+/// pathology — the old `last_access * (1 + hit_count)` score let a once-hit
+/// old entry outlive every fresh save).
 #[test]
 fn deep_tail_evicted_without_tail_protect() {
     let idx = index(
         vec![
-            entry(
-                /*id*/ 7, /*sess*/ 1, /*tok*/ 8192, /*last*/ 100,
-                /*hits*/ 10,
-            ),
-            entry(
-                /*id*/ 9, /*sess*/ 1, /*tok*/ 16000, /*last*/ 50,
-                /*hits*/ 0,
-            ),
+            entry(/*id*/ 7, /*sess*/ 1, /*tok*/ 8192, /*last*/ 100),
+            entry(/*id*/ 9, /*sess*/ 1, /*tok*/ 16000, /*last*/ 50),
         ],
         1,
     );
-    // Victim is the deep tail (id 9) — the pathology.
+    // Victim is the OLDER entry (id 9) under pure LRU.
     let v = idx.session_aware_victim(false, false).unwrap();
     assert_eq!(idx.entries[v].snapshot_id, 9);
 }
 
 /// With tail-protect the live session's DEEPEST snapshot is exempt, so the
-/// hot anchor is evicted instead and the warm-turn restore anchor survives.
+/// fresher anchor is evicted instead and the warm-turn restore anchor survives.
 #[test]
 fn deep_tail_survives_with_tail_protect() {
-    let idx = index(
-        vec![entry(7, 1, 8192, 100, 10), entry(9, 1, 16000, 50, 0)],
-        1,
-    );
+    let idx = index(vec![entry(7, 1, 8192, 100), entry(9, 1, 16000, 50)], 1);
     let v = idx.session_aware_victim(true, false).unwrap();
     // Victim must NOT be the protected deep tail (id 9); it is the anchor.
     assert_eq!(idx.entries[v].snapshot_id, 7);
@@ -77,9 +66,9 @@ fn dormant_session_tail_not_protected() {
     // session 2 is live; session 1 is dormant (older last_access).
     let idx = index(
         vec![
-            entry(1, 1, 20000, 10, 0), // dormant deep tail — should die first
-            entry(2, 2, 4000, 90, 0),  // live shallow
-            entry(3, 2, 12000, 95, 0), // live deep tail — protected
+            entry(1, 1, 20000, 10), // dormant deep tail — should die first
+            entry(2, 2, 4000, 90),  // live shallow
+            entry(3, 2, 12000, 95), // live deep tail — protected
         ],
         2,
     );
@@ -95,9 +84,64 @@ fn dormant_session_tail_not_protected() {
 /// the cache deadlocks.
 #[test]
 fn single_protected_entry_still_evictable() {
-    let idx = index(vec![entry(5, 1, 16000, 50, 0)], 1);
+    let idx = index(vec![entry(5, 1, 16000, 50)], 1);
     let v = idx.session_aware_victim(true, false).unwrap();
     assert_eq!(idx.entries[v].snapshot_id, 5);
+}
+
+// ─────────── 07-10 fossil-pinning regressions (re-landed, #317 revert) ──────────
+
+/// Eviction must ignore hit HISTORY: an entry selected many times but not
+/// recently loses to entries touched after it. Under the reverted
+/// `last_access * (1 + hit_count)` score, A's 5 hits made it unbeatable
+/// (escore 5*6=... vs fresh saves) and each new save evicted the previous
+/// fresh save — the frozen-anchor pathology. Exercises the SERVING path
+/// (`lookup_tiered`), not the dead `lookup`.
+#[test]
+fn eviction_ignores_hit_history() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..100).collect();
+    let ph = super::hash_token_prefix(&toks, 40, 0);
+    idx.insert(ph, /*slot*/ 1, /*session*/ 7, /*tok*/ 40);
+    // Hit the anchor 5 times (each legitimately bumps recency).
+    for _ in 0..5 {
+        assert!(idx.lookup_tiered(&toks, 60, 7, 0).is_some());
+    }
+    // Two fresh saves AFTER the last hit — strictly more recent.
+    let ph80 = super::hash_token_prefix(&toks, 80, 0);
+    let ph90 = super::hash_token_prefix(&toks, 90, 0);
+    idx.insert(ph80, 2, 7, 80);
+    idx.insert(ph90, 3, 7, 90);
+    // The victim must be the OLDEST entry (the much-hit anchor), never a
+    // fresh save. The old hit-weighted score inverted this.
+    assert_eq!(idx.evict_lru(), Some(1), "hit history must not pin fossils");
+}
+
+/// The lookup scan must be side-effect-free for LOSING candidates: only the
+/// winner's recency moves. (The pre-fix scan bumped every improving
+/// candidate, keeping shallow early-prefix entries eternally fresh.)
+#[test]
+fn lookup_bumps_winner_only() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..100).collect();
+    let ph40 = super::hash_token_prefix(&toks, 40, 0);
+    let ph80 = super::hash_token_prefix(&toks, 80, 0);
+    idx.insert(ph40, 1, 7, 40); // shallow — the improving-chain fossil
+    idx.insert(ph80, 2, 7, 80); // deep — the winner
+    let shallow_before = idx.entries.iter().find(|e| e.snapshot_id == 1).unwrap().last_access;
+    // Deep lookup walks past the shallow candidate to select the deep one.
+    let m = idx.lookup_tiered(&toks, 100, 7, 0).expect("hit");
+    assert_eq!(m.token_count, 80, "deep entry wins");
+    let shallow_after = idx.entries.iter().find(|e| e.snapshot_id == 1).unwrap().last_access;
+    assert_eq!(
+        shallow_before, shallow_after,
+        "losing candidate's recency must not move"
+    );
+    // Same contract on the reference (non-tier) lookup.
+    let m2 = idx.lookup(&toks, 100, 7, 0).expect("hit");
+    assert_eq!(m2.1, 80);
+    let shallow_final = idx.entries.iter().find(|e| e.snapshot_id == 1).unwrap().last_access;
+    assert_eq!(shallow_before, shallow_final);
 }
 
 /// `lookup` records the live session so a later eviction protects the right
@@ -153,11 +197,8 @@ fn stats_track_hits_and_recompute() {
 /// frees its HBM slot — the core spill-not-drop transition.
 #[test]
 fn evict_to_tier_spills_not_removes() {
-    // id 3 = hot 8192 anchor (escore 1100); id 9 = cold deep tail (escore 50).
-    let mut idx = index(
-        vec![entry(3, 1, 8192, 100, 10), entry(9, 1, 16000, 50, 0)],
-        1,
-    );
+    // id 3 = fresh 8192 anchor (recency 100); id 9 = cold deep tail (recency 50).
+    let mut idx = index(vec![entry(3, 1, 8192, 100), entry(9, 1, 16000, 50)], 1);
     let before = idx.len();
     let (freed_slot, key) = idx.evict_to_tier().expect("a resident victim exists");
     // No tail-protect (env off) → the coldest entry (deep tail id 9) is the

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -21,11 +21,25 @@ fn entry(
     }
 }
 
+/// An `is_tail` restore-point entry (the per-session mid-chunk tail).
+fn tail_entry(
+    snapshot_id: usize,
+    session_hash: u64,
+    token_count: usize,
+    last_access: u64,
+) -> SnapshotEntry {
+    SnapshotEntry {
+        is_tail: true,
+        ..entry(snapshot_id, session_hash, token_count, last_access)
+    }
+}
+
 fn index(entries: Vec<SnapshotEntry>, live: u64) -> SsmSnapshotIndex {
     SsmSnapshotIndex {
         entries,
         access_counter: 1000,
         last_lookup_session: live,
+        evictions_since_lookup: 0,
         stats: SnapshotStats::default(),
     }
 }
@@ -48,27 +62,52 @@ fn deep_tail_evicted_without_tail_protect() {
     assert_eq!(idx.entries[v].snapshot_id, 9);
 }
 
-/// With tail-protect the live session's DEEPEST snapshot is exempt, so the
-/// fresher anchor is evicted instead and the warm-turn restore anchor survives.
+/// The lease shields the live session's `is_tail` restore point — even when
+/// it is the OLDEST entry in the pool — so the warm-turn restore survives
+/// same-session save pressure.
 #[test]
-fn deep_tail_survives_with_tail_protect() {
-    let idx = index(vec![entry(7, 1, 8192, 100), entry(9, 1, 16000, 50)], 1);
+fn tail_lease_protects_live_session_is_tail() {
+    let idx = index(
+        vec![entry(7, 1, 8192, 100), tail_entry(9, 1, 6064, 50)],
+        1,
+    );
     let v = idx.session_aware_victim(true, false).unwrap();
-    // Victim must NOT be the protected deep tail (id 9); it is the anchor.
+    // Victim must NOT be the leased tail (id 9) despite its age.
     assert_eq!(idx.entries[v].snapshot_id, 7);
 }
 
-/// Tail-protect only shields the LIVE conversation's tail; a dormant
-/// session's deep tail is still evictable (correct — session-aware ranking
-/// evicts the stalest conversation first).
+/// Direct inversion of #278's off-target semantics: the live session's
+/// DEEPEST entry (the end-of-turn finish leaf, NOT a tail) is a normal
+/// eviction candidate. The old policy protected exactly this entry — which
+/// sits above `matched_tokens` and never restores — while the true restore
+/// point died (2026-07-20 rig: 0 hits with old protection on or off).
 #[test]
-fn dormant_session_tail_not_protected() {
+fn finish_leaf_not_protected() {
+    let idx = index(
+        vec![
+            entry(7, 1, 6080, 50),      // finish leaf: deepest, oldest, NOT a tail
+            tail_entry(9, 1, 6064, 90), // true restore point
+        ],
+        1,
+    );
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(
+        idx.entries[v].snapshot_id, 7,
+        "the deepest non-tail entry must be evictable"
+    );
+}
+
+/// The lease only shields the LIVE conversation's tail; a dormant session's
+/// tail is still evictable (correct — session-aware ranking evicts the
+/// stalest conversation first).
+#[test]
+fn dormant_session_tail_evictable() {
     // session 2 is live; session 1 is dormant (older last_access).
     let idx = index(
         vec![
-            entry(1, 1, 20000, 10), // dormant deep tail — should die first
-            entry(2, 2, 4000, 90),  // live shallow
-            entry(3, 2, 12000, 95), // live deep tail — protected
+            tail_entry(1, 1, 20000, 10), // dormant tail — should die first
+            entry(2, 2, 4000, 90),       // live shallow
+            tail_entry(3, 2, 12000, 95), // live tail — leased
         ],
         2,
     );
@@ -80,13 +119,73 @@ fn dormant_session_tail_not_protected() {
 }
 
 /// A pool of exactly one entry must still yield that entry as victim even
-/// when it is the protected tail — otherwise `save` can never reclaim and
-/// the cache deadlocks.
+/// when it is the leased tail — otherwise `save` can never reclaim and the
+/// cache deadlocks.
 #[test]
-fn single_protected_entry_still_evictable() {
-    let idx = index(vec![entry(5, 1, 16000, 50)], 1);
+fn single_leased_entry_still_evictable() {
+    let idx = index(vec![tail_entry(5, 1, 16000, 50)], 1);
     let v = idx.session_aware_victim(true, false).unwrap();
     assert_eq!(idx.entries[v].snapshot_id, 5);
+}
+
+/// The lease LAPSES: if the leased session never looks up again (it ended;
+/// cold churn never reaches lookup at matched_tokens == 0), its tail becomes
+/// a normal candidate after the TTL so a dead session cannot squat a slot.
+#[test]
+fn lease_expires_without_live_lookups() {
+    let mut idx = index(
+        vec![tail_entry(9, 1, 6064, 50), entry(7, 2, 4000, 100)],
+        1,
+    );
+    // Lease fresh: the newer non-tail entry is the victim... but session 2 is
+    // FRESHER than session 1, so session-staleness picks session 1 first and
+    // the lease deflects to... there is only the tail in session 1, so the
+    // victim is the session-2 entry.
+    assert_eq!(idx.evict_lru(), Some(7), "leased tail survives while fresh");
+    idx.entries.push(entry(8, 2, 4000, 101));
+    // Simulate TTL expiry: many evictions with no lookup from session 1.
+    idx.evictions_since_lookup = super::tail_lease_ttl();
+    assert_eq!(
+        idx.evict_lru(),
+        Some(9),
+        "expired lease: the dead session's tail is evictable (stalest session)"
+    );
+}
+
+/// Overwriting a prefix via plain `insert` clears `is_tail` — otherwise the
+/// overwrite re-homes another session's tail (new session_hash, stale
+/// is_tail=true), breaching the <=1-leased-entry invariant and leaking tail
+/// semantics onto a non-tail save.
+#[test]
+fn insert_overwrite_clears_is_tail() {
+    let mut idx = SsmSnapshotIndex::new();
+    let displaced = idx.insert_tail(0xAB, /*slot*/ 1, /*session*/ 7, /*tok*/ 500);
+    assert!(displaced.is_empty());
+    assert!(idx.entries[0].is_tail);
+    // A plain save re-homes the same prefix for a DIFFERENT session.
+    let old = idx.insert(0xAB, /*slot*/ 2, /*session*/ 8, /*tok*/ 500);
+    assert_eq!(old, Some(1));
+    assert!(
+        !idx.entries[0].is_tail,
+        "plain insert must clear is_tail on overwrite"
+    );
+}
+
+/// The serving-path lookup (`lookup_tiered`) must session-gate `is_tail`
+/// entries exactly like the reference `lookup`: a tail is byte-safe ONLY for
+/// the same non-zero session. (The gate was previously missing here.)
+#[test]
+fn lookup_tiered_tail_session_gate() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..64).collect();
+    let ph = super::hash_token_prefix(&toks, 64, 0);
+    idx.insert_tail(ph, /*slot*/ 4, /*session*/ 7, /*tok*/ 64);
+    // Same session: hit.
+    assert!(idx.lookup_tiered(&toks, 64, 7, 0).is_some());
+    // Different session: the tail must NOT bleed.
+    assert!(idx.lookup_tiered(&toks, 64, 8, 0).is_none());
+    // Sessionless lookup: must NOT bleed either.
+    assert!(idx.lookup_tiered(&toks, 64, 0, 0).is_none());
 }
 
 // ─────────── 07-10 fossil-pinning regressions (re-landed, #317 revert) ──────────

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -2,6 +2,9 @@
 
 use super::*;
 
+#[path = "snapshot_lease.rs"]
+mod lease;
+
 /// Build an entry with an explicit recency profile. `snapshot_id` doubles
 /// as a stable identity we assert on (independent of Vec index).
 fn entry(
@@ -18,6 +21,7 @@ fn entry(
         last_access,
         tiered: false,
         is_tail: false,
+        is_tail_sibling: false,
     }
 }
 
@@ -64,126 +68,6 @@ fn deep_tail_evicted_without_tail_protect() {
     // Victim is the OLDER entry (id 9) under pure LRU.
     let v = idx.session_aware_victim(false, false).unwrap();
     assert_eq!(idx.entries[v].snapshot_id, 9);
-}
-
-/// The lease shields the live session's `is_tail` restore point — even when
-/// it is the OLDEST entry in the pool — so the warm-turn restore survives
-/// same-session save pressure.
-#[test]
-fn tail_lease_protects_live_session_is_tail() {
-    let idx = index(vec![entry(7, 1, 8192, 100), tail_entry(9, 1, 6064, 50)], 1);
-    let v = idx.session_aware_victim(true, false).unwrap();
-    // Victim must NOT be the leased tail (id 9) despite its age.
-    assert_eq!(idx.entries[v].snapshot_id, 7);
-}
-
-/// Direct inversion of #278's off-target semantics: the live session's
-/// DEEPEST entry (the end-of-turn finish leaf, NOT a tail) is a normal
-/// eviction candidate. The old policy protected exactly this entry — which
-/// sits above `matched_tokens` and never restores — while the true restore
-/// point died (2026-07-20 rig: 0 hits with old protection on or off).
-#[test]
-fn finish_leaf_not_protected() {
-    let idx = index(
-        vec![
-            entry(7, 1, 6080, 50),      // finish leaf: deepest, oldest, NOT a tail
-            tail_entry(9, 1, 6064, 90), // true restore point
-        ],
-        1,
-    );
-    let v = idx.session_aware_victim(true, false).unwrap();
-    assert_eq!(
-        idx.entries[v].snapshot_id, 7,
-        "the deepest non-tail entry must be evictable"
-    );
-}
-
-/// The lease only shields the LIVE conversation's tail; a dormant session's
-/// tail is still evictable (correct — session-aware ranking evicts the
-/// stalest conversation first).
-#[test]
-fn dormant_session_tail_evictable() {
-    // session 2 is live; session 1 is dormant (older last_access).
-    let idx = index(
-        vec![
-            tail_entry(1, 1, 20000, 10), // dormant tail — should die first
-            entry(2, 2, 4000, 90),       // live shallow
-            tail_entry(3, 2, 12000, 95), // live tail — leased
-        ],
-        2,
-    );
-    let v = idx.session_aware_victim(true, false).unwrap();
-    assert_eq!(
-        idx.entries[v].snapshot_id, 1,
-        "stalest (dormant) session evicted first"
-    );
-}
-
-/// A pool of exactly one entry must still yield that entry as victim even
-/// when it is the leased tail — otherwise `save` can never reclaim and the
-/// cache deadlocks.
-#[test]
-fn single_leased_entry_still_evictable() {
-    let idx = index(vec![tail_entry(5, 1, 16000, 50)], 1);
-    let v = idx.session_aware_victim(true, false).unwrap();
-    assert_eq!(idx.entries[v].snapshot_id, 5);
-}
-
-/// The lease LAPSES: if the leased session never looks up again (it ended;
-/// cold churn never reaches lookup at matched_tokens == 0), its tail becomes
-/// a normal candidate after the TTL so a dead session cannot squat a slot.
-#[test]
-fn lease_expires_without_live_lookups() {
-    let mut idx = index(vec![tail_entry(9, 1, 6064, 50), entry(7, 2, 4000, 100)], 1);
-    // Lease fresh: the newer non-tail entry is the victim... but session 2 is
-    // FRESHER than session 1, so session-staleness picks session 1 first and
-    // the lease deflects to... there is only the tail in session 1, so the
-    // victim is the session-2 entry.
-    assert_eq!(idx.evict_lru(), Some(7), "leased tail survives while fresh");
-    idx.entries.push(entry(8, 2, 4000, 101));
-    // Simulate TTL expiry: many evictions with no lookup from session 1.
-    idx.evictions_since_lookup = super::tail_lease_ttl();
-    assert_eq!(
-        idx.evict_lru(),
-        Some(9),
-        "expired lease: the dead session's tail is evictable (stalest session)"
-    );
-}
-
-/// Overwriting a prefix via plain `insert` clears `is_tail` — otherwise the
-/// overwrite re-homes another session's tail (new session_hash, stale
-/// is_tail=true), breaching the <=1-leased-entry invariant and leaking tail
-/// semantics onto a non-tail save.
-#[test]
-fn insert_overwrite_clears_is_tail() {
-    let mut idx = SsmSnapshotIndex::new();
-    let displaced = idx.insert_tail(0xAB, /*slot*/ 1, /*session*/ 7, /*tok*/ 500);
-    assert!(displaced.is_empty());
-    assert!(idx.entries[0].is_tail);
-    // A plain save re-homes the same prefix for a DIFFERENT session.
-    let old = idx.insert(0xAB, /*slot*/ 2, /*session*/ 8, /*tok*/ 500);
-    assert_eq!(old, Some(1));
-    assert!(
-        !idx.entries[0].is_tail,
-        "plain insert must clear is_tail on overwrite"
-    );
-}
-
-/// The serving-path lookup (`lookup_tiered`) must session-gate `is_tail`
-/// entries exactly like the reference `lookup`: a tail is byte-safe ONLY for
-/// the same non-zero session. (The gate was previously missing here.)
-#[test]
-fn lookup_tiered_tail_session_gate() {
-    let mut idx = SsmSnapshotIndex::new();
-    let toks: Vec<u32> = (0..64).collect();
-    let ph = super::hash_token_prefix(&toks, 64, 0);
-    idx.insert_tail(ph, /*slot*/ 4, /*session*/ 7, /*tok*/ 64);
-    // Same session: hit.
-    assert!(idx.lookup_tiered(&toks, 64, 7, 0).is_some());
-    // Different session: the tail must NOT bleed.
-    assert!(idx.lookup_tiered(&toks, 64, 8, 0).is_none());
-    // Sessionless lookup: must NOT bleed either.
-    assert!(idx.lookup_tiered(&toks, 64, 0, 0).is_none());
 }
 
 // ─────────── 07-10 fossil-pinning regressions (re-landed, #317 revert) ──────────
@@ -388,44 +272,4 @@ fn reinsert_unspills() {
     idx.insert(0xAA, 5, 7, 40);
     // The entry is resident again at slot 5; the drop path can free it.
     assert_eq!(idx.evict_lru(), Some(5));
-}
-
-// ─────────────── Marconi α-score (staged, inert at default α=0) ───────────────
-
-/// At the default α=0 the within-session rank is EXACTLY pure-LRU: the
-/// oldest entry of the stalest session is the victim, depth ignored.
-#[test]
-fn alpha_zero_is_pure_lru_ordering() {
-    // Same session: deep-but-old vs shallow-but-fresh. α=0 → oldest dies.
-    let idx = index(vec![entry(1, 7, 20000, 10), entry(2, 7, 100, 90)], 7);
-    let v = idx.session_aware_victim(false, false).unwrap();
-    assert_eq!(idx.entries[v].snapshot_id, 1, "α=0 ranks purely by recency");
-}
-
-/// With α set, depth outweighs a modest recency gap WITHIN a session (a
-/// deep tail outscores a shallow fresh save), while session staleness stays
-/// the PRIMARY key — a fresher session's shallow entry still outlives a
-/// staler session entirely. α is injected (never via env — process-global
-/// mutation races the parallel test runner).
-#[test]
-fn alpha_prefers_depth_within_session_staleness_still_primary() {
-    // One session: deep old entry vs shallow slightly-fresher entry.
-    let idx = index(vec![entry(1, 7, 20000, 50), entry(2, 7, 100, 60)], 7);
-    let v = idx
-        .session_aware_victim_with_alpha(false, false, 2.0)
-        .unwrap();
-    assert_eq!(
-        idx.entries[v].snapshot_id, 2,
-        "α=2: the shallow entry is the victim despite being fresher"
-    );
-    // Two sessions: staleness first regardless of α — the stale session's
-    // DEEP entry still dies before the fresh session's shallow one.
-    let idx2 = index(vec![entry(1, 1, 20000, 10), entry(2, 2, 100, 90)], 2);
-    let v2 = idx2
-        .session_aware_victim_with_alpha(false, false, 2.0)
-        .unwrap();
-    assert_eq!(
-        idx2.entries[v2].snapshot_id, 1,
-        "session staleness remains the primary key at any α"
-    );
 }

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -52,8 +52,12 @@ fn index(entries: Vec<SnapshotEntry>, live: u64) -> SsmSnapshotIndex {
 fn deep_tail_evicted_without_tail_protect() {
     let idx = index(
         vec![
-            entry(/*id*/ 7, /*sess*/ 1, /*tok*/ 8192, /*last*/ 100),
-            entry(/*id*/ 9, /*sess*/ 1, /*tok*/ 16000, /*last*/ 50),
+            entry(
+                /*id*/ 7, /*sess*/ 1, /*tok*/ 8192, /*last*/ 100,
+            ),
+            entry(
+                /*id*/ 9, /*sess*/ 1, /*tok*/ 16000, /*last*/ 50,
+            ),
         ],
         1,
     );
@@ -67,10 +71,7 @@ fn deep_tail_evicted_without_tail_protect() {
 /// same-session save pressure.
 #[test]
 fn tail_lease_protects_live_session_is_tail() {
-    let idx = index(
-        vec![entry(7, 1, 8192, 100), tail_entry(9, 1, 6064, 50)],
-        1,
-    );
+    let idx = index(vec![entry(7, 1, 8192, 100), tail_entry(9, 1, 6064, 50)], 1);
     let v = idx.session_aware_victim(true, false).unwrap();
     // Victim must NOT be the leased tail (id 9) despite its age.
     assert_eq!(idx.entries[v].snapshot_id, 7);
@@ -133,10 +134,7 @@ fn single_leased_entry_still_evictable() {
 /// a normal candidate after the TTL so a dead session cannot squat a slot.
 #[test]
 fn lease_expires_without_live_lookups() {
-    let mut idx = index(
-        vec![tail_entry(9, 1, 6064, 50), entry(7, 2, 4000, 100)],
-        1,
-    );
+    let mut idx = index(vec![tail_entry(9, 1, 6064, 50), entry(7, 2, 4000, 100)], 1);
     // Lease fresh: the newer non-tail entry is the victim... but session 2 is
     // FRESHER than session 1, so session-staleness picks session 1 first and
     // the lease deflects to... there is only the tail in session 1, so the
@@ -227,11 +225,21 @@ fn lookup_bumps_winner_only() {
     let ph80 = super::hash_token_prefix(&toks, 80, 0);
     idx.insert(ph40, 1, 7, 40); // shallow — the improving-chain fossil
     idx.insert(ph80, 2, 7, 80); // deep — the winner
-    let shallow_before = idx.entries.iter().find(|e| e.snapshot_id == 1).unwrap().last_access;
+    let shallow_before = idx
+        .entries
+        .iter()
+        .find(|e| e.snapshot_id == 1)
+        .unwrap()
+        .last_access;
     // Deep lookup walks past the shallow candidate to select the deep one.
     let m = idx.lookup_tiered(&toks, 100, 7, 0).expect("hit");
     assert_eq!(m.token_count, 80, "deep entry wins");
-    let shallow_after = idx.entries.iter().find(|e| e.snapshot_id == 1).unwrap().last_access;
+    let shallow_after = idx
+        .entries
+        .iter()
+        .find(|e| e.snapshot_id == 1)
+        .unwrap()
+        .last_access;
     assert_eq!(
         shallow_before, shallow_after,
         "losing candidate's recency must not move"
@@ -239,7 +247,12 @@ fn lookup_bumps_winner_only() {
     // Same contract on the reference (non-tier) lookup.
     let m2 = idx.lookup(&toks, 100, 7, 0).expect("hit");
     assert_eq!(m2.1, 80);
-    let shallow_final = idx.entries.iter().find(|e| e.snapshot_id == 1).unwrap().last_access;
+    let shallow_final = idx
+        .entries
+        .iter()
+        .find(|e| e.snapshot_id == 1)
+        .unwrap()
+        .last_access;
     assert_eq!(shallow_before, shallow_final);
 }
 
@@ -375,4 +388,44 @@ fn reinsert_unspills() {
     idx.insert(0xAA, 5, 7, 40);
     // The entry is resident again at slot 5; the drop path can free it.
     assert_eq!(idx.evict_lru(), Some(5));
+}
+
+// ─────────────── Marconi α-score (staged, inert at default α=0) ───────────────
+
+/// At the default α=0 the within-session rank is EXACTLY pure-LRU: the
+/// oldest entry of the stalest session is the victim, depth ignored.
+#[test]
+fn alpha_zero_is_pure_lru_ordering() {
+    // Same session: deep-but-old vs shallow-but-fresh. α=0 → oldest dies.
+    let idx = index(vec![entry(1, 7, 20000, 10), entry(2, 7, 100, 90)], 7);
+    let v = idx.session_aware_victim(false, false).unwrap();
+    assert_eq!(idx.entries[v].snapshot_id, 1, "α=0 ranks purely by recency");
+}
+
+/// With α set, depth outweighs a modest recency gap WITHIN a session (a
+/// deep tail outscores a shallow fresh save), while session staleness stays
+/// the PRIMARY key — a fresher session's shallow entry still outlives a
+/// staler session entirely. α is injected (never via env — process-global
+/// mutation races the parallel test runner).
+#[test]
+fn alpha_prefers_depth_within_session_staleness_still_primary() {
+    // One session: deep old entry vs shallow slightly-fresher entry.
+    let idx = index(vec![entry(1, 7, 20000, 50), entry(2, 7, 100, 60)], 7);
+    let v = idx
+        .session_aware_victim_with_alpha(false, false, 2.0)
+        .unwrap();
+    assert_eq!(
+        idx.entries[v].snapshot_id, 2,
+        "α=2: the shallow entry is the victim despite being fresher"
+    );
+    // Two sessions: staleness first regardless of α — the stale session's
+    // DEEP entry still dies before the fresh session's shallow one.
+    let idx2 = index(vec![entry(1, 1, 20000, 10), entry(2, 2, 100, 90)], 2);
+    let v2 = idx2
+        .session_aware_victim_with_alpha(false, false, 2.0)
+        .unwrap();
+    assert_eq!(
+        idx2.entries[v2].snapshot_id, 1,
+        "session staleness remains the primary key at any α"
+    );
 }

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_lease.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_lease.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Lease, sibling, and α-score tests for the SSM snapshot index. Split from
+//! `snapshot_index.rs` (file-size cap). Uses that module's helpers.
+
+use super::super::*;
+use super::{entry, index, tail_entry};
+
+/// The lease shields the live session's `is_tail` restore point — even when
+/// it is the OLDEST entry in the pool — so the warm-turn restore survives
+/// same-session save pressure.
+#[test]
+fn tail_lease_protects_live_session_is_tail() {
+    let idx = index(vec![entry(7, 1, 8192, 100), tail_entry(9, 1, 6064, 50)], 1);
+    let v = idx.session_aware_victim(true, false).unwrap();
+    // Victim must NOT be the leased tail (id 9) despite its age.
+    assert_eq!(idx.entries[v].snapshot_id, 7);
+}
+
+/// Direct inversion of #278's off-target semantics: the live session's
+/// DEEPEST entry (the end-of-turn finish leaf, NOT a tail) is a normal
+/// eviction candidate. The old policy protected exactly this entry — which
+/// sits above `matched_tokens` and never restores — while the true restore
+/// point died (2026-07-20 rig: 0 hits with old protection on or off).
+#[test]
+fn finish_leaf_not_protected() {
+    let idx = index(
+        vec![
+            entry(7, 1, 6080, 50),      // finish leaf: deepest, oldest, NOT a tail
+            tail_entry(9, 1, 6064, 90), // true restore point
+        ],
+        1,
+    );
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(
+        idx.entries[v].snapshot_id, 7,
+        "the deepest non-tail entry must be evictable"
+    );
+}
+
+/// The lease only shields the LIVE conversation's tail; a dormant session's
+/// tail is still evictable (correct — session-aware ranking evicts the
+/// stalest conversation first).
+#[test]
+fn dormant_session_tail_evictable() {
+    // session 2 is live; session 1 is dormant (older last_access).
+    let idx = index(
+        vec![
+            tail_entry(1, 1, 20000, 10), // dormant tail — should die first
+            entry(2, 2, 4000, 90),       // live shallow
+            tail_entry(3, 2, 12000, 95), // live tail — leased
+        ],
+        2,
+    );
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(
+        idx.entries[v].snapshot_id, 1,
+        "stalest (dormant) session evicted first"
+    );
+}
+
+/// A pool of exactly one entry must still yield that entry as victim even
+/// when it is the leased tail — otherwise `save` can never reclaim and the
+/// cache deadlocks.
+#[test]
+fn single_leased_entry_still_evictable() {
+    let idx = index(vec![tail_entry(5, 1, 16000, 50)], 1);
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(idx.entries[v].snapshot_id, 5);
+}
+
+/// The lease LAPSES: if the leased session never looks up again (it ended;
+/// cold churn never reaches lookup at matched_tokens == 0), its tail becomes
+/// a normal candidate after the TTL so a dead session cannot squat a slot.
+#[test]
+fn lease_expires_without_live_lookups() {
+    let mut idx = index(vec![tail_entry(9, 1, 6064, 50), entry(7, 2, 4000, 100)], 1);
+    // Lease fresh: the newer non-tail entry is the victim... but session 2 is
+    // FRESHER than session 1, so session-staleness picks session 1 first and
+    // the lease deflects to... there is only the tail in session 1, so the
+    // victim is the session-2 entry.
+    assert_eq!(idx.evict_lru(), Some(7), "leased tail survives while fresh");
+    idx.entries.push(entry(8, 2, 4000, 101));
+    // Simulate TTL expiry: many evictions with no lookup from session 1.
+    idx.evictions_since_lookup = super::tail_lease_ttl();
+    assert_eq!(
+        idx.evict_lru(),
+        Some(9),
+        "expired lease: the dead session's tail is evictable (stalest session)"
+    );
+}
+
+/// Overwriting a prefix via plain `insert` clears `is_tail` — otherwise the
+/// overwrite re-homes another session's tail (new session_hash, stale
+/// is_tail=true), breaching the <=1-leased-entry invariant and leaking tail
+/// semantics onto a non-tail save.
+#[test]
+fn insert_overwrite_clears_is_tail() {
+    let mut idx = SsmSnapshotIndex::new();
+    let displaced = idx.insert_tail(0xAB, /*slot*/ 1, /*session*/ 7, /*tok*/ 500);
+    assert!(displaced.is_empty());
+    assert!(idx.entries[0].is_tail);
+    // A plain save re-homes the same prefix for a DIFFERENT session.
+    let old = idx.insert(0xAB, /*slot*/ 2, /*session*/ 8, /*tok*/ 500);
+    assert_eq!(old, Some(1));
+    assert!(
+        !idx.entries[0].is_tail,
+        "plain insert must clear is_tail on overwrite"
+    );
+}
+
+/// The serving-path lookup (`lookup_tiered`) must session-gate `is_tail`
+/// entries exactly like the reference `lookup`: a tail is byte-safe ONLY for
+/// the same non-zero session. (The gate was previously missing here.)
+#[test]
+fn lookup_tiered_tail_session_gate() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..64).collect();
+    let ph = super::hash_token_prefix(&toks, 64, 0);
+    idx.insert_tail(ph, /*slot*/ 4, /*session*/ 7, /*tok*/ 64);
+    // Same session: hit.
+    assert!(idx.lookup_tiered(&toks, 64, 7, 0).is_some());
+    // Different session: the tail must NOT bleed.
+    assert!(idx.lookup_tiered(&toks, 64, 8, 0).is_none());
+    // Sessionless lookup: must NOT bleed either.
+    assert!(idx.lookup_tiered(&toks, 64, 0, 0).is_none());
+}
+
+// ─────────────── Marconi α-score (staged, inert at default α=0) ───────────────
+
+/// At the default α=0 the within-session rank is EXACTLY pure-LRU: the
+/// oldest entry of the stalest session is the victim, depth ignored.
+#[test]
+fn alpha_zero_is_pure_lru_ordering() {
+    // Same session: deep-but-old vs shallow-but-fresh. α=0 → oldest dies.
+    let idx = index(vec![entry(1, 7, 20000, 10), entry(2, 7, 100, 90)], 7);
+    let v = idx.session_aware_victim(false, false).unwrap();
+    assert_eq!(idx.entries[v].snapshot_id, 1, "α=0 ranks purely by recency");
+}
+
+/// With α set, depth outweighs a modest recency gap WITHIN a session (a
+/// deep tail outscores a shallow fresh save), while session staleness stays
+/// the PRIMARY key — a fresher session's shallow entry still outlives a
+/// staler session entirely. α is injected (never via env — process-global
+/// mutation races the parallel test runner).
+#[test]
+fn alpha_prefers_depth_within_session_staleness_still_primary() {
+    // One session: deep old entry vs shallow slightly-fresher entry.
+    let idx = index(vec![entry(1, 7, 20000, 50), entry(2, 7, 100, 60)], 7);
+    let v = idx
+        .session_aware_victim_with_alpha(false, false, 2.0)
+        .unwrap();
+    assert_eq!(
+        idx.entries[v].snapshot_id, 2,
+        "α=2: the shallow entry is the victim despite being fresher"
+    );
+    // Two sessions: staleness first regardless of α — the stale session's
+    // DEEP entry still dies before the fresh session's shallow one.
+    let idx2 = index(vec![entry(1, 1, 20000, 10), entry(2, 2, 100, 90)], 2);
+    let v2 = idx2
+        .session_aware_victim_with_alpha(false, false, 2.0)
+        .unwrap();
+    assert_eq!(
+        idx2.entries[v2].snapshot_id, 1,
+        "session staleness remains the primary key at any α"
+    );
+}
+
+// ───────────────────── tail EARLY sibling (tb - bs) lease ─────────────────────
+
+/// A sibling entry (`is_tail_sibling`) of the live session is leased exactly
+/// like the tail — it serves warm turns whose block-floored match lands one
+/// block below `tb` (2/7 of restores on the eviction rig).
+#[test]
+fn sibling_leased_with_live_session() {
+    let mut idx = index(vec![entry(7, 1, 8192, 100)], 1);
+    idx.insert_tail_sibling(0xE1, /*slot*/ 9, /*session*/ 1, /*tok*/ 6048);
+    // The sibling is the OLDER... actually newer here; make a non-leased older
+    // competitor the natural LRU victim and assert the sibling never loses
+    // even when we age it below the competitor.
+    idx.entries
+        .iter_mut()
+        .find(|e| e.snapshot_id == 9)
+        .unwrap()
+        .last_access = 10; // oldest in pool
+    let v = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(idx.entries[v].snapshot_id, 7, "sibling must be leased");
+}
+
+/// `insert_tail`'s supersede sweep removes the session's previous tail AND
+/// sibling together, so the leased set stays bounded at <=2 per session.
+#[test]
+fn new_tail_sweeps_old_tail_and_sibling() {
+    let mut idx = SsmSnapshotIndex::new();
+    idx.insert_tail(0xA1, 1, /*session*/ 7, 500);
+    idx.insert_tail_sibling(0xA2, 2, 7, 484);
+    // Next turn: a fresh tail supersedes both.
+    let displaced = idx.insert_tail(0xB1, 3, 7, 1000);
+    let mut d = displaced.clone();
+    d.sort_unstable();
+    assert_eq!(d, vec![1, 2], "old tail AND sibling displaced together");
+    assert_eq!(idx.len(), 1);
+}
+
+/// A pool consisting ONLY of leased entries (tail + sibling) must still
+/// yield a victim — the lease binds only while an unleased candidate exists.
+#[test]
+fn all_leased_pool_still_evicts() {
+    let mut idx = SsmSnapshotIndex::new();
+    idx.insert_tail(0xA1, 1, 7, 500);
+    idx.insert_tail_sibling(0xA2, 2, 7, 484);
+    // Latch the lease onto session 7.
+    let toks: Vec<u32> = (0..8).collect();
+    let _ = idx.lookup_tiered(&toks, 0, 7, 0);
+    let v = idx.evict_lru();
+    assert!(v.is_some(), "only-leased pool must still yield a victim");
+}
+
+/// Sibling entries are exact-prefix keyed and carry NO `is_tail` gate: the
+/// same session and sessionless lookers may use them (a tail would refuse the
+/// sessionless looker). Different-NONZERO-session lookers are excluded by the
+/// long-standing general session filter that applies to every session-tagged
+/// snapshot — in practice two conversations sharing a >=1024-token prefix
+/// hash to the SAME session anyway.
+#[test]
+fn sibling_not_session_gated_in_lookup() {
+    let mut idx = SsmSnapshotIndex::new();
+    let toks: Vec<u32> = (0..64).collect();
+    let ph = super::hash_token_prefix(&toks, 64, 0);
+    idx.insert_tail_sibling(ph, /*slot*/ 4, /*session*/ 7, /*tok*/ 64);
+    // Same session: hit.
+    assert!(idx.lookup_tiered(&toks, 64, 7, 0).is_some());
+    // Sessionless looker: hit (an is_tail entry would be refused here).
+    assert!(
+        idx.lookup_tiered(&toks, 64, 0, 0).is_some(),
+        "sibling must not carry the is_tail session gate"
+    );
+}
+
+/// Plain `insert` overwrite clears the sibling flag, mirroring the is_tail
+/// clearing (same cross-session rehoming breach vector).
+#[test]
+fn insert_overwrite_clears_sibling() {
+    let mut idx = SsmSnapshotIndex::new();
+    idx.insert_tail_sibling(0xC1, 1, 7, 500);
+    assert!(idx.entries[0].is_tail_sibling);
+    idx.insert(0xC1, 2, 8, 500);
+    assert!(!idx.entries[0].is_tail_sibling);
+}

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -533,19 +533,17 @@ pub fn run(
                 && !active[0].suppress_tool_call
                 && !active[0].disable_mtp
             {
-                // Throughput-aware MTP gate: while still measuring, run the
-                // step type the gate asks for and time it. Both step types emit
-                // real, correct tokens (MTP verify and plain decode are greedy-
-                // equivalent), so the measurement window does not waste work.
-                //
-                // The verify/decode multiplier is DEPTH-DEPENDENT (weight-bound
-                // at short context vs KV/SSM-bound at depth — see mtp_gate module
-                // docs), so a decision is only valid for the regime it was
-                // measured in: re-open measurement when the live depth leaves it.
+                // Throughput-arbitrated MTP gate: EVERY single-sequence step
+                // is timed and reported, and the gate picks whichever mode
+                // (MTP verify vs plain decode) DELIVERS more tokens/sec —
+                // with hysteresis, dwell, and periodic probing of the other
+                // mode. Both step types emit real, correct tokens, so
+                // arbitration never wastes work. See mtp_gate module docs for
+                // why component-time economics were replaced (webserver_ok
+                // A/B 2026-07-20: always-on Σ1028s/10-10 vs timing-gated
+                // Σ1846s/9-10).
                 if let Some(gate) = mtp_gate.as_mut() {
                     gate.maybe_remeasure(active[0].seq.seq_len);
-                }
-                if let Some(gate) = mtp_gate.as_mut().filter(|g| g.is_measuring()) {
                     gate.note_depth(active[0].seq.seq_len);
                     match gate.next_step() {
                         mtp_gate::GateStep::MeasureDecode => {
@@ -560,16 +558,12 @@ pub fn run(
                                 tool_call_end_token,
                                 adaptive_sampling,
                             );
-                            mtp_gate
-                                .as_mut()
-                                .expect("gate present")
-                                .record_decode(t0.elapsed());
+                            gate.record_decode(t0.elapsed());
                         }
                         mtp_gate::GateStep::MeasureVerify => {
-                            // Only a true verify forward (drafts already
-                            // proposed) is a representative sample; a bootstrap-
-                            // only step proposes the first draft and is skipped.
-                            let had_draft = !active[0].pending_drafts.is_empty();
+                            // A bootstrap-only step (no pending drafts) emits
+                            // 1 token and proposes; its cost is charged to the
+                            // MTP mode — proposing IS part of what MTP costs.
                             let seq_len_before = active[0].seq.seq_len;
                             let t0 = std::time::Instant::now();
                             step_mtp(
@@ -579,35 +573,16 @@ pub fn run(
                                 &verify_ctx,
                                 dflash_verify_raw_argmax,
                             );
-                            if had_draft {
-                                mtp_gate
-                                    .as_mut()
-                                    .expect("gate present")
-                                    .record_verify(t0.elapsed());
-                                // Adaptive-K: report acceptance (tokens emitted
-                                // minus the 1 bonus token) so the gate's disable
-                                // threshold uses the MEASURED expected tokens,
-                                // not the theoretical 1+K max.
-                                let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
-                                let accepted = emitted.saturating_sub(1);
-                                mtp_gate
-                                    .as_mut()
-                                    .expect("gate present")
-                                    .record_acceptance(accepted);
-                            }
+                            let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
+                            gate.record_verify_step(t0.elapsed(), emitted);
                         }
                     }
-                    // One-time transition work for a freshly-reached DISABLE:
-                    // drop pending drafts and order the draft-head state resync
-                    // before the next plain decode reads it. NOT permanent —
-                    // `maybe_remeasure` above re-opens measurement when the
-                    // depth regime changes, so MTP can come back exactly where
-                    // it pays (deep agentic contexts).
-                    if mtp_gate
-                        .as_mut()
-                        .and_then(mtp_gate::MtpGate::take_fresh_decision)
-                        == Some(mtp_gate::GateDecision::DisableMtp)
-                    {
+                    // One-time transition work when the gate switches to
+                    // Serial: drop pending drafts and order the draft-head
+                    // state resync before the next plain decode reads it.
+                    // Serial->Mtp needs nothing (the next MTP step
+                    // bootstraps from empty pending_drafts).
+                    if gate.take_fresh_decision() == Some(mtp_gate::GateDecision::DisableMtp) {
                         for a in active.iter_mut() {
                             a.pending_drafts.clear();
                         }
@@ -615,27 +590,8 @@ pub fn run(
                             tracing::error!("mtp-gate→decode sync_secondary: {e:#}");
                         }
                     }
-                } else if mtp_gate
-                    .as_ref()
-                    .is_some_and(|g| g.decision() == Some(mtp_gate::GateDecision::DisableMtp))
-                {
-                    // Measured net-negative in the CURRENT depth regime: plain
-                    // decode. Consulted every step (not a latched kill switch)
-                    // so the regime re-measurement above can flip it back.
-                    step_decode_only(
-                        &*model,
-                        &mut active,
-                        think_end_token,
-                        think_start_token,
-                        code_fence_token,
-                        tool_call_start_token,
-                        tool_call_end_token,
-                        adaptive_sampling,
-                    );
                 } else {
-                    // MTP wins in this regime (or no gate): speculative decode.
-                    let was_verify = !active[0].pending_drafts.is_empty();
-                    let seq_len_before = active[0].seq.seq_len;
+                    // Gate bypassed (ATLAS_MTP_GATE_FORCE=1): plain MTP.
                     step_mtp(
                         &*model,
                         &mut active,
@@ -643,26 +599,6 @@ pub fn run(
                         &verify_ctx,
                         dflash_verify_raw_argmax,
                     );
-                    // Adaptive-K: feed ongoing acceptance to the gate so it can
-                    // detect a drop below break-even and re-measure (which may
-                    // disable MTP if the workload shifted to lower-acceptance
-                    // territory at the same depth).
-                    if was_verify {
-                        let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
-                        let accepted = emitted.saturating_sub(1);
-                        if let Some(gate) = mtp_gate.as_mut() {
-                            gate.record_acceptance(accepted);
-                            if gate.should_reconsider() {
-                                tracing::info!(
-                                    "MTP gate: acceptance dropped below break-even \
-                                     (ema={:.2}, m={:.2}) — re-measuring",
-                                    gate.acceptance_ema_debug(),
-                                    gate.measured_multiplier_debug(),
-                                );
-                                gate.force_remeasure();
-                            }
-                        }
-                    }
                 }
             } else {
                 // Batch decode (no MTP). Clear stale drafts when transitioning out of MTP mode.

--- a/crates/spark-server/src/scheduler/mtp_gate.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate.rs
@@ -1,496 +1,373 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Throughput-aware MTP runtime gate.
+//! Throughput-arbitrated MTP runtime gate.
 //!
-//! Measures `m = verify_step_wall / decode_step_wall` over the first decode
-//! steps, then disables MTP when net-negative. The disable threshold uses the
-//! MEASURED expected tokens (`1 + mean_accepted`), not the theoretical `1 + K`
-//! max — so MTP is disabled at the ACTUAL acceptance rate, not just the
-//! impossible 100% worst case. `m` is depth-dependent (weight-bound at short
-//! context, KV/SSM-bound at depth), so the gate re-measures when the live
-//! depth leaves the measured regime (see [`REMEASURE_DEPTH_FACTOR`]). Ongoing
-//! adaptation: if the acceptance EMA drops below break-even, re-opens
-//! measurement (see `should_reconsider`).
+//! Chooses between MTP speculative decode and plain serial decode by
+//! comparing DELIVERED throughput (emitted tokens / wall) measured over
+//! whole step windows in each mode — never by comparing component step
+//! timings. The previous gate compared `verify_wall / decode_wall` against
+//! expected accepted tokens; on the 35B MoE that arithmetic disabled MTP
+//! (multiplier 2.07–2.23 ≥ effective 1.75–2.0) while an always-on control
+//! measured 18% FASTER end-to-end decode (webserver_ok A/B, 2026-07-20:
+//! Σ1028s/10-10 always-on vs Σ1846s/9-10 gated). Component walls miss
+//! per-token costs outside the timed step and amortization effects, so the
+//! arbiter now measures exactly the quantity being optimized.
+//!
+//! Policy (bandit-style greedy with scheduled exploration — cf. TapOut
+//! arXiv:2511.02017, GammaTune-style hysteresis):
+//! - Run the currently-faster mode; accumulate (tokens, wall) into a
+//!   fixed-size step window; on window close update that mode's tok/s EWMA
+//!   and a deviation EWMA.
+//! - Switch modes only when the other mode's EWMA is faster by more than a
+//!   noise margin (hysteresis) for [`SWITCH_DWELL_WINDOWS`] consecutive
+//!   windows — the old gate flipped ENABLED→DISABLED within 6s on
+//!   measurement noise (multiplier 1.35→1.78), each flip costing a
+//!   draft-head resync.
+//! - While in Serial, re-probe MTP after [`reprobe_tokens`] emitted tokens.
+//!   While in Mtp, refresh the serial baseline after
+//!   [`serial_refresh_tokens`] (one window ≈ ≤0.3% overhead bound).
+//! - A depth-regime change (factor [`REMEASURE_DEPTH_FACTOR`]) marks the
+//!   OTHER mode's baseline stale and schedules a refresh probe instead of
+//!   wiping all state.
+//!
+//! `ATLAS_MTP_GATE_FORCE=1` (existing) bypasses the gate entirely.
 
 use std::time::Duration;
 
-/// Factor that triggers re-measurement when live depth leaves the measured
-/// regime (either direction). Factor 2 re-checks at ~2× depth.
+/// Depth factor that marks baselines stale (economics are depth-dependent:
+/// weight-bound at short context vs KV/SSM-bound at depth).
 const REMEASURE_DEPTH_FACTOR: usize = 2;
-
-/// Floor for the regime comparison (below this, all contexts are "shallow").
+/// Floor for the regime comparison (below this all contexts are "shallow").
 const REMEASURE_DEPTH_FLOOR: usize = 512;
+/// Steps per throughput window. 16 ≥ the 12-step acceptance window the
+/// proven `adaptive_spec` suspend policy uses, and long enough that one
+/// window amortizes bootstrap/propose transients (≥16 serial tokens,
+/// ~28 MTP tokens at the measured 0.75 acceptance).
+const WINDOW_STEPS: usize = 16;
+/// Consecutive out-of-margin windows required before switching mode.
+const SWITCH_DWELL_WINDOWS: usize = 2;
+/// EWMA smoothing for per-mode tok/s (responds within ~3 windows).
+const TPS_ALPHA: f64 = 0.3;
+/// Relative noise floor for the switch margin. Derived from the observed
+/// window-to-window jitter of the step walls this gate consumes (the old
+/// gate's multiplier swung 1.35→1.78 ≈ ±14% within seconds; half the
+/// deviation EWMA is added on top of this floor).
+const MARGIN_REL_FLOOR: f64 = 0.05;
 
-/// Number of leading samples of each step type discarded as graph-capture /
-/// cache warmup before timing begins. The first verify step and the first
-/// decode step each trigger one-time CUDA-graph capture and cold weight
-/// fetches whose wall time is not representative of steady state.
-///
-/// Derivation, not a magic default: CUDA-graph capture is a strictly
-/// one-time event per step type (verify-graphed vs decode-batch graphs are
-/// captured on first invocation), so a single discarded sample per type is
-/// the minimum that excludes it. We discard 2 for a margin against the first
-/// post-capture replay still touching cold instruction/constant caches.
-const WARMUP_SAMPLES: usize = 2;
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
 
-/// Number of timed samples collected per step type after warmup. The
-/// multiplier uses the MEDIAN of these to reject scheduler-thread jitter
-/// (occasional condvar wakeups / pending-queue drains between steps). An odd
-/// count gives an unambiguous median.
-const TIMED_SAMPLES: usize = 5;
+/// Serial tokens between MTP re-probes while in Serial mode. Default
+/// matches the proven `ATLAS_DFLASH_ADAPTIVE_REPROBE` policy (256).
+fn reprobe_tokens() -> usize {
+    static C: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *C.get_or_init(|| env_usize("ATLAS_MTP_GATE_REPROBE", 256))
+}
 
-/// What the gate wants the scheduler to do for the NEXT step while it is
-/// still collecting samples.
+/// MTP tokens between serial-baseline refreshes while in Mtp mode. One
+/// 16-step window per 1024 tokens bounds refresh overhead at ≤0.3% even if
+/// serial were 18% slower.
+fn serial_refresh_tokens() -> usize {
+    static C: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *C.get_or_init(|| env_usize("ATLAS_MTP_GATE_REFRESH", 1024))
+}
+
+/// What the gate wants the scheduler to run for the NEXT step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GateStep {
-    /// Run a plain single-token decode step and report its wall time.
+    /// Plain single-token decode step (Serial mode or baseline refresh).
     MeasureDecode,
-    /// Run an MTP verify step and report its wall time.
+    /// MTP verify step (Mtp mode or re-probe).
     MeasureVerify,
 }
 
-/// The terminal decision once enough samples are collected.
+/// Mode-transition signal for the scheduler's one-time bookkeeping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GateDecision {
-    /// Keep MTP enabled: `m < 1 + num_drafts`.
+    /// Switched to Mtp: nothing to do (bootstrap happens naturally).
     KeepMtp,
-    /// Disable MTP: `m >= 1 + num_drafts` (net-negative at any acceptance).
+    /// Switched to Serial: clear pending drafts + draft-head resync.
     DisableMtp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Phase {
-    /// Collecting decode-step samples (warmup then timed).
-    Decode,
-    /// Collecting verify-step samples (warmup then timed).
-    Verify,
-    /// Done; `decide()` has produced a result.
-    Done,
+enum Mode {
+    Mtp,
+    Serial,
 }
 
-/// Per-serve, single-instance throughput-aware MTP gate. Lives on the
-/// scheduler thread; drives a short measurement phase the first time a lone
-/// sequence is decoding with MTP requested, then yields a decision that
-/// holds for the CURRENT depth regime. The decision is not permanent: the
-/// multiplier is depth-dependent (see module docs), so the gate re-opens
-/// measurement when the live depth leaves the measured regime
-/// ([`Self::maybe_remeasure`]).
+#[derive(Default)]
+struct ModeStats {
+    /// Delivered-throughput EWMA (tokens/sec), `None` until first window.
+    tps: Option<f64>,
+    /// EWMA of |window tps − tps| (deviation, for the noise margin).
+    dev: f64,
+    /// Stale after a depth-regime change; refreshed by the next probe.
+    stale: bool,
+}
+
+impl ModeStats {
+    /// Fold one closed window into the estimate. `replace=true` (probe
+    /// windows and post-regime-change windows) REPLACES the estimate: a
+    /// sparse probe is a fresh look at a baseline that may have drifted
+    /// arbitrarily since it was last run, and blending it against the stale
+    /// value both lags the estimate and pollutes `dev` with the shift
+    /// magnitude (inflating the hysteresis margin and delaying recovery).
+    /// Continuous same-mode windows blend (EWMA) so `dev` tracks
+    /// steady-state noise only.
+    fn update(&mut self, window_tps: f64, replace: bool) {
+        match (self.tps, replace) {
+            (None, _) | (_, true) => {
+                self.tps = Some(window_tps);
+                self.dev *= 0.5; // decay: fresh baseline, keep a noise memory
+            }
+            (Some(prev), false) => {
+                let next = (1.0 - TPS_ALPHA) * prev + TPS_ALPHA * window_tps;
+                self.dev = (1.0 - TPS_ALPHA) * self.dev + TPS_ALPHA * (window_tps - next).abs();
+                self.tps = Some(next);
+            }
+        }
+        self.stale = false;
+    }
+}
+
+/// Per-serve, single-instance gate. Lives on the scheduler thread; every
+/// single-sequence decode/verify step is timed and reported, so arbitration
+/// runs continuously with zero dedicated measurement phases.
 pub struct MtpGate {
-    /// `1 + num_drafts`: the max effective tokens a verify step can advance,
-    /// and the provable net-negative threshold for the multiplier. Derived
-    /// from the scheduler's `num_drafts` (K=2 verify ⇒ num_drafts=1 ⇒ 2).
-    max_effective: f64,
-    phase: Phase,
-    decode_samples: Vec<Duration>,
-    verify_samples: Vec<Duration>,
-    /// Acceptance samples (num_accepted per verify step) collected during the
-    /// Verify measurement phase, parallel to `verify_samples`. Used to compute
-    /// the MEASURED expected tokens per step (`1 + mean_accepted`) for the
-    /// adaptive disable threshold — strictly tighter than the theoretical
-    /// `max_effective = 1 + K` (which assumes 100% acceptance).
-    acceptance_samples: Vec<usize>,
-    /// Exponential moving average of num_accepted, updated after the initial
-    /// decision for ongoing adaptation. If it drops below the break-even
-    /// (`1 + ema < measured_multiplier`), the gate re-opens measurement.
-    acceptance_ema: f64,
-    /// The measured verify/decode multiplier at the last `finalize`. Used by
-    /// [`Self::should_reconsider`] for the ongoing acceptance-drop check.
-    measured_multiplier: f64,
-    decision: Option<GateDecision>,
-    /// Sequence depth (tokens) most recently observed while sampling; frozen
-    /// into `measured_at_depth` when a decision is reached.
+    mode: Mode,
+    /// True while the gate is running a short window of the OTHER mode
+    /// (re-probe from Serial, baseline refresh from Mtp).
+    probing: bool,
+    /// Windows remaining in the current probe.
+    probe_windows_left: usize,
+    mtp: ModeStats,
+    serial: ModeStats,
+    // Current-window accumulators (for whichever mode the steps ran in).
+    win_tokens: f64,
+    win_wall: f64,
+    win_steps: usize,
+    /// Consecutive closed windows where the other mode beat this one by
+    /// more than the margin.
+    losing_windows: usize,
+    /// Emitted tokens since the last probe/refresh event in this mode.
+    tokens_since_event: usize,
     observed_depth: usize,
-    /// Depth regime the current `decision` was measured in. Compared against
-    /// the live depth by [`Self::maybe_remeasure`].
     measured_at_depth: usize,
-    /// Set by `finalize`, taken exactly once by the scheduler to run the
-    /// one-time transition work for a fresh decision (e.g. clearing pending
-    /// drafts + draft-head resync when MTP turns off).
-    fresh_decision: Option<GateDecision>,
+    fresh: Option<GateDecision>,
 }
 
 impl MtpGate {
-    /// `num_drafts`: drafts proposed per verify step (scheduler SSOT; K=2 ⇒ 1).
+    /// `num_drafts` is retained for construction-site compatibility and
+    /// logging; arbitration is measurement-driven and does not model K.
     pub fn new(num_drafts: usize) -> Self {
+        tracing::info!(
+            "MTP gate: throughput-arbitrated (K={num_drafts}); window={WINDOW_STEPS} steps, \
+             dwell={SWITCH_DWELL_WINDOWS}, reprobe={} tok, refresh={} tok",
+            reprobe_tokens(),
+            serial_refresh_tokens(),
+        );
         Self {
-            max_effective: 1.0 + num_drafts as f64,
-            phase: Phase::Decode,
-            decode_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
-            verify_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
-            acceptance_samples: Vec::with_capacity(WARMUP_SAMPLES + TIMED_SAMPLES),
-            acceptance_ema: 0.0,
-            measured_multiplier: 0.0,
-            decision: None,
+            mode: Mode::Mtp,
+            probing: false,
+            probe_windows_left: 0,
+            mtp: ModeStats::default(),
+            serial: ModeStats::default(),
+            win_tokens: 0.0,
+            win_wall: 0.0,
+            win_steps: 0,
+            losing_windows: 0,
+            tokens_since_event: 0,
             observed_depth: 0,
             measured_at_depth: 0,
-            fresh_decision: None,
+            fresh: None,
         }
     }
 
-    /// Note the current sequence depth while measuring. The last value seen
-    /// before `finalize` becomes the decision's `measured_at_depth`.
     pub fn note_depth(&mut self, depth: usize) {
         self.observed_depth = depth;
     }
 
-    /// Re-open measurement when the live depth has left the regime the
-    /// current decision was measured in (factor-[`REMEASURE_DEPTH_FACTOR`]
-    /// crossing in either direction, floored at [`REMEASURE_DEPTH_FLOOR`]).
-    /// No-op while a measurement is already in flight.
+    /// Depth-regime change: mark BOTH baselines stale (economics moved) and
+    /// let the normal probe cadence refresh them — no state wipe, no forced
+    /// serial phase.
     pub fn maybe_remeasure(&mut self, current_depth: usize) {
-        if self.phase != Phase::Done {
-            return;
-        }
         let measured = self.measured_at_depth.max(REMEASURE_DEPTH_FLOOR);
         let live = current_depth.max(REMEASURE_DEPTH_FLOOR);
         if live >= measured * REMEASURE_DEPTH_FACTOR || measured >= live * REMEASURE_DEPTH_FACTOR {
             tracing::info!(
-                "MTP gate: depth regime changed ({} -> {} tokens); re-measuring \
-                 verify/decode economics",
+                "MTP gate: depth regime changed ({} -> {} tokens); baselines stale, \
+                 will re-probe on cadence",
                 self.measured_at_depth,
                 current_depth,
             );
-            self.phase = Phase::Decode;
-            self.decode_samples.clear();
-            self.verify_samples.clear();
-            self.acceptance_samples.clear();
-            self.decision = None;
-            self.fresh_decision = None;
+            self.mtp.stale = true;
+            self.serial.stale = true;
+            self.measured_at_depth = current_depth;
+            // Refresh the off-mode soon rather than waiting a full interval.
+            self.tokens_since_event = self.tokens_since_event.max(self.event_interval());
         }
     }
 
-    /// One-shot handoff of a freshly-reached decision, for the scheduler's
-    /// transition bookkeeping. Returns `Some` exactly once per `finalize`.
+    /// One-shot handoff of a fresh mode switch for scheduler bookkeeping.
     pub fn take_fresh_decision(&mut self) -> Option<GateDecision> {
-        self.fresh_decision.take()
+        self.fresh.take()
     }
 
-    /// Whether the gate still needs to drive measurement steps. False once a
-    /// decision has been reached.
-    pub fn is_measuring(&self) -> bool {
-        self.phase != Phase::Done
-    }
-
-    /// Which step type the scheduler should run next to advance measurement.
-    /// Decode samples are collected first (they need no draft bootstrap),
-    /// then verify samples.
+    /// Which step type the scheduler should run next.
     pub fn next_step(&self) -> GateStep {
-        match self.phase {
-            Phase::Decode => GateStep::MeasureDecode,
-            // During the Verify phase we still issue MTP steps; the first
-            // such step bootstraps a draft (no verify yet) and is naturally
-            // absorbed by WARMUP_SAMPLES.
-            Phase::Verify => GateStep::MeasureVerify,
-            Phase::Done => GateStep::MeasureDecode, // unreachable while measuring
+        let effective = if self.probing {
+            Self::other(self.mode)
+        } else {
+            self.mode
+        };
+        match effective {
+            Mode::Mtp => GateStep::MeasureVerify,
+            Mode::Serial => GateStep::MeasureDecode,
         }
     }
 
-    /// Record one timed decode-step sample. Caller times only the decode-step
-    /// wall (D2H + sample included, identically to the verify path).
+    /// Record one plain decode step (1 emitted token).
     pub fn record_decode(&mut self, wall: Duration) {
-        if self.phase != Phase::Decode {
+        self.record_step(wall, 1);
+    }
+
+    /// Record one MTP-path step: `emitted` tokens actually committed (a
+    /// bootstrap step emits 1; a verify step emits 1 + accepted). Bootstrap
+    /// and propose cost are charged to Mtp mode — they are part of what MTP
+    /// costs to run.
+    pub fn record_verify_step(&mut self, wall: Duration, emitted: usize) {
+        self.record_step(wall, emitted.max(1));
+    }
+
+    fn other(m: Mode) -> Mode {
+        match m {
+            Mode::Mtp => Mode::Serial,
+            Mode::Serial => Mode::Mtp,
+        }
+    }
+
+    fn event_interval(&self) -> usize {
+        match self.mode {
+            Mode::Mtp => serial_refresh_tokens(),
+            Mode::Serial => reprobe_tokens(),
+        }
+    }
+
+    fn stats_mut(&mut self, m: Mode) -> &mut ModeStats {
+        match m {
+            Mode::Mtp => &mut self.mtp,
+            Mode::Serial => &mut self.serial,
+        }
+    }
+
+    fn record_step(&mut self, wall: Duration, tokens: usize) {
+        self.win_tokens += tokens as f64;
+        self.win_wall += wall.as_secs_f64();
+        self.win_steps += 1;
+        if !self.probing {
+            self.tokens_since_event += tokens;
+        }
+        if self.win_steps >= WINDOW_STEPS {
+            self.close_window();
+        } else if !self.probing && self.tokens_since_event >= self.event_interval() {
+            // Time to look at the other mode: finish the current window
+            // early so the probe starts on a clean accumulator.
+            self.close_window();
+        }
+    }
+
+    fn close_window(&mut self) {
+        let ran = if self.probing {
+            Self::other(self.mode)
+        } else {
+            self.mode
+        };
+        if self.win_wall > 0.0 && self.win_steps > 0 {
+            let window_tps = self.win_tokens / self.win_wall;
+            let replace = self.probing || self.stats_mut(ran).stale;
+            self.stats_mut(ran).update(window_tps, replace);
+        }
+        self.win_tokens = 0.0;
+        self.win_wall = 0.0;
+        self.win_steps = 0;
+
+        if self.probing {
+            self.probe_windows_left = self.probe_windows_left.saturating_sub(1);
+            if self.probe_windows_left == 0 {
+                self.probing = false;
+                self.arbitrate();
+                self.tokens_since_event = 0;
+            }
             return;
         }
-        self.decode_samples.push(wall);
-        if self.decode_samples.len() >= WARMUP_SAMPLES + TIMED_SAMPLES {
-            self.phase = Phase::Verify;
-        }
-    }
 
-    /// Record one timed verify-step sample. Only steps that actually ran a
-    /// verify forward (not a bootstrap-only step) should be reported.
-    pub fn record_verify(&mut self, wall: Duration) {
-        if self.phase != Phase::Verify {
+        // Scheduled exploration of the other mode.
+        if self.tokens_since_event >= self.event_interval() {
+            self.probing = true;
+            self.probe_windows_left = 1;
             return;
         }
-        self.verify_samples.push(wall);
-        if self.verify_samples.len() >= WARMUP_SAMPLES + TIMED_SAMPLES {
-            self.finalize();
-        }
+        self.arbitrate();
     }
 
-    /// Record the number of drafts accepted in a verify step. During the
-    /// measurement phase this populates `acceptance_samples` (parallel to
-    /// `verify_samples`). After the decision, it updates the rolling EMA for
-    /// ongoing adaptation — if acceptance drops below the break-even
-    /// (`1 + ema < measured_multiplier`), [`Self::should_reconsider`] flags
-    /// it so the scheduler can re-measure or disable.
-    pub fn record_acceptance(&mut self, num_accepted: usize) {
-        if self.phase == Phase::Verify {
-            self.acceptance_samples.push(num_accepted);
-        } else if self.phase == Phase::Done {
-            // EMA update (alpha=0.2 — responds within ~5 steps to a shift).
-            self.acceptance_ema = 0.8 * self.acceptance_ema + 0.2 * num_accepted as f64;
-        }
-    }
-
-    /// Ongoing adaptation check: after the initial decision, if the rolling
-    /// acceptance EMA has dropped below the break-even for the measured
-    /// multiplier, MTP is now net-negative at the current acceptance even
-    /// though it was profitable when measured. The scheduler should call
-    /// this and, if true, re-open measurement (which may disable MTP).
-    pub fn should_reconsider(&self) -> bool {
-        self.phase == Phase::Done
-            && self.decision == Some(GateDecision::KeepMtp)
-            && self.measured_multiplier > 0.0
-            && 1.0 + self.acceptance_ema < self.measured_multiplier
-    }
-
-    /// Unconditionally re-open measurement (called by the scheduler when
-    /// [`Self::should_reconsider`] fires — the acceptance drop is a
-    /// workload-shift signal, not a depth-regime change).
-    pub fn force_remeasure(&mut self) {
-        if self.phase != Phase::Done {
-            return;
-        }
-        self.phase = Phase::Decode;
-        self.decode_samples.clear();
-        self.verify_samples.clear();
-        self.acceptance_samples.clear();
-        self.decision = None;
-        self.fresh_decision = None;
-    }
-
-    /// Debug accessors for the reconsider log line.
-    pub fn acceptance_ema_debug(&self) -> f64 {
-        self.acceptance_ema
-    }
-    pub fn measured_multiplier_debug(&self) -> f64 {
-        self.measured_multiplier
-    }
-
-    /// Median of the post-warmup samples for a step type, in seconds.
-    fn median_secs(samples: &[Duration]) -> f64 {
-        let mut timed: Vec<f64> = samples
-            .iter()
-            .skip(WARMUP_SAMPLES)
-            .map(Duration::as_secs_f64)
-            .collect();
-        timed.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        timed[timed.len() / 2]
-    }
-
-    fn finalize(&mut self) {
-        let decode_s = Self::median_secs(&self.decode_samples);
-        let verify_s = Self::median_secs(&self.verify_samples);
-        // decode_s is a real measured decode step; it cannot be zero in
-        // practice, but guard against a degenerate timer to avoid div-by-zero.
-        let multiplier = if decode_s > 0.0 {
-            verify_s / decode_s
-        } else {
-            f64::INFINITY
+    /// Compare mode EWMAs with a hysteresis margin; switch after dwell.
+    fn arbitrate(&mut self) {
+        let (Some(mtp), Some(serial)) = (self.mtp.tps, self.serial.tps) else {
+            return; // need both baselines before any switch
         };
-        // Adaptive threshold: use MEASURED expected tokens (1 + mean_accepted)
-        // instead of theoretical max (1 + K). Disables MTP at the ACTUAL
-        // acceptance rate, not the impossible 100% worst case.
-        let mean_accepted = if self.acceptance_samples.len() > WARMUP_SAMPLES {
-            let timed: Vec<usize> = self
-                .acceptance_samples
-                .iter()
-                .copied()
-                .skip(WARMUP_SAMPLES)
-                .collect();
-            timed.iter().map(|&x| x as f64).sum::<f64>() / timed.len().max(1) as f64
-        } else {
-            self.max_effective - 1.0 // no acceptance data → theoretical max fallback
+        let (cur, other, other_dev) = match self.mode {
+            Mode::Mtp => (mtp, serial, self.serial.dev),
+            Mode::Serial => (serial, mtp, self.mtp.dev),
         };
-        let effective_tokens = 1.0 + mean_accepted;
-        let decision = if multiplier >= self.max_effective || multiplier >= effective_tokens {
-            GateDecision::DisableMtp
+        let margin = (MARGIN_REL_FLOOR * cur).max(0.5 * (self.dev_of(self.mode) + other_dev));
+        if other > cur + margin {
+            self.losing_windows += 1;
+            if self.losing_windows >= SWITCH_DWELL_WINDOWS {
+                let to = Self::other(self.mode);
+                tracing::info!(
+                    "MTP gate: switching {:?} -> {:?} (current {cur:.1} tok/s vs other \
+                     {other:.1} tok/s, margin {margin:.1}, depth={})",
+                    self.mode,
+                    to,
+                    self.observed_depth,
+                );
+                self.mode = to;
+                self.losing_windows = 0;
+                self.tokens_since_event = 0;
+                self.measured_at_depth = self.observed_depth;
+                self.fresh = Some(match to {
+                    Mode::Mtp => GateDecision::KeepMtp,
+                    Mode::Serial => GateDecision::DisableMtp,
+                });
+            }
         } else {
-            GateDecision::KeepMtp
-        };
-        match decision {
-            GateDecision::DisableMtp => tracing::info!(
-                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1}, \
-                 measured_effective={effective_tokens:.2} (mean_accepted={mean_accepted:.2}, \
-                 decode={:.2}ms verify={:.2}ms, depth={}) => DISABLED for this depth \
-                 regime (net-negative at current acceptance; re-measures on regime change)",
-                self.max_effective,
-                decode_s * 1000.0,
-                verify_s * 1000.0,
-                self.observed_depth,
-            ),
-            GateDecision::KeepMtp => tracing::info!(
-                "MTP gate: verify_multiplier={multiplier:.2}, max_effective={:.1}, \
-                 measured_effective={effective_tokens:.2} (mean_accepted={mean_accepted:.2}, \
-                 decode={:.2}ms verify={:.2}ms, depth={}) => ENABLED",
-                self.max_effective,
-                decode_s * 1000.0,
-                verify_s * 1000.0,
-                self.observed_depth,
-            ),
+            self.losing_windows = 0;
         }
-        self.measured_multiplier = multiplier;
-        self.acceptance_ema = mean_accepted;
-        self.measured_at_depth = self.observed_depth;
-        self.decision = Some(decision);
-        self.fresh_decision = Some(decision);
-        self.phase = Phase::Done;
     }
 
-    /// The operative decision for the current depth regime, available once
-    /// `is_measuring()` is false. `None` while (re-)measuring.
-    pub fn decision(&self) -> Option<GateDecision> {
-        self.decision
+    fn dev_of(&self, m: Mode) -> f64 {
+        match m {
+            Mode::Mtp => self.mtp.dev,
+            Mode::Serial => self.serial.dev,
+        }
+    }
+
+    /// Debug/test accessors.
+    pub fn mtp_tps_debug(&self) -> Option<f64> {
+        self.mtp.tps
+    }
+    pub fn serial_tps_debug(&self) -> Option<f64> {
+        self.serial.tps
+    }
+    pub fn in_serial_mode(&self) -> bool {
+        self.mode == Mode::Serial
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn ms(x: u64) -> Duration {
-        Duration::from_micros(x * 1000)
-    }
-
-    /// Drive the gate through a full decode-then-verify measurement with the
-    /// given per-step medians (warmup samples are deliberately skewed to prove
-    /// they are discarded).
-    fn run_gate(num_drafts: usize, decode_ms: u64, verify_ms: u64) -> GateDecision {
-        let mut g = MtpGate::new(num_drafts);
-        // Decode phase: 2 warmup (huge, must be discarded) + 5 timed.
-        for i in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            assert_eq!(g.next_step(), GateStep::MeasureDecode);
-            let w = if i < WARMUP_SAMPLES {
-                ms(9999)
-            } else {
-                ms(decode_ms)
-            };
-            g.record_decode(w);
-        }
-        // Verify phase.
-        for i in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            assert_eq!(g.next_step(), GateStep::MeasureVerify);
-            let w = if i < WARMUP_SAMPLES {
-                ms(9999)
-            } else {
-                ms(verify_ms)
-            };
-            g.record_verify(w);
-        }
-        assert!(!g.is_measuring());
-        g.decision().expect("decided")
-    }
-
-    #[test]
-    fn fp8_like_multiplier_disables_k2() {
-        // verify 23ms vs decode 10ms => m=2.3 >= 2 (num_drafts=1) => DISABLE.
-        assert_eq!(run_gate(1, 10, 23), GateDecision::DisableMtp);
-    }
-
-    #[test]
-    fn nvfp4_like_multiplier_keeps_k2() {
-        // verify 11ms vs decode 10ms => m=1.1 < 2 => KEEP.
-        assert_eq!(run_gate(1, 10, 11), GateDecision::KeepMtp);
-    }
-
-    #[test]
-    fn exact_threshold_disables() {
-        // m == 1 + num_drafts is net-negative (no per-token gain at 100%).
-        assert_eq!(run_gate(1, 10, 20), GateDecision::DisableMtp);
-    }
-
-    #[test]
-    fn k3_raises_threshold() {
-        // num_drafts=2 => max_effective=3; m=2.3 now KEEPS (can win >65% acc).
-        assert_eq!(run_gate(2, 10, 23), GateDecision::KeepMtp);
-    }
-
-    #[test]
-    fn warmup_samples_are_discarded() {
-        // If warmup (9999ms) leaked into the median the multiplier would be
-        // astronomically off; the clean KEEP proves they are skipped.
-        assert_eq!(run_gate(1, 10, 11), GateDecision::KeepMtp);
-    }
-
-    #[test]
-    fn phase_progression() {
-        let mut g = MtpGate::new(1);
-        assert_eq!(g.next_step(), GateStep::MeasureDecode);
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_decode(ms(10));
-        }
-        assert_eq!(g.next_step(), GateStep::MeasureVerify);
-        assert!(g.is_measuring());
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_verify(ms(11));
-        }
-        assert!(!g.is_measuring());
-    }
-
-    /// Drive a full measurement on an existing gate at a given depth.
-    fn drive(g: &mut MtpGate, depth: usize, decode_ms: u64, verify_ms: u64) {
-        assert!(g.is_measuring());
-        g.note_depth(depth);
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_decode(ms(decode_ms));
-        }
-        for _ in 0..(WARMUP_SAMPLES + TIMED_SAMPLES) {
-            g.record_verify(ms(verify_ms));
-        }
-        assert!(!g.is_measuring());
-    }
-
-    /// The core depth-regime scenario: a short-context measurement disables
-    /// MTP (weight-bound, m≈2.3); the session then goes deep, the gate
-    /// re-measures, and the KV-bound economics (m≈1.1) re-enable it.
-    #[test]
-    fn remeasure_on_depth_regime_change_reenables() {
-        let mut g = MtpGate::new(1);
-        drive(&mut g, 100, 10, 23); // short ctx: m=2.3 => DISABLE
-        assert_eq!(g.decision(), Some(GateDecision::DisableMtp));
-        assert_eq!(g.take_fresh_decision(), Some(GateDecision::DisableMtp));
-
-        // Same regime (100 floored to 512; 600 < 512*4): decision holds.
-        g.maybe_remeasure(600);
-        assert!(!g.is_measuring());
-        assert_eq!(g.decision(), Some(GateDecision::DisableMtp));
-
-        // Depth crosses the factor boundary: measurement re-opens.
-        g.maybe_remeasure(REMEASURE_DEPTH_FLOOR * REMEASURE_DEPTH_FACTOR);
-        assert!(g.is_measuring());
-        assert_eq!(g.decision(), None);
-
-        // Deep regime: verify shares the KV pass, m=1.1 => KEEP.
-        drive(&mut g, 2048, 10, 11);
-        assert_eq!(g.decision(), Some(GateDecision::KeepMtp));
-        assert_eq!(g.take_fresh_decision(), Some(GateDecision::KeepMtp));
-
-        // And back down: a fresh short session re-opens measurement again.
-        g.maybe_remeasure(100);
-        assert!(g.is_measuring());
-    }
-
-    #[test]
-    fn fresh_decision_taken_exactly_once() {
-        let mut g = MtpGate::new(1);
-        drive(&mut g, 100, 10, 23);
-        assert_eq!(g.take_fresh_decision(), Some(GateDecision::DisableMtp));
-        assert_eq!(g.take_fresh_decision(), None);
-        // The operative decision is still readable.
-        assert_eq!(g.decision(), Some(GateDecision::DisableMtp));
-    }
-
-    #[test]
-    fn no_remeasure_within_floored_short_regime() {
-        let mut g = MtpGate::new(1);
-        drive(&mut g, 32, 10, 23);
-        // 32 and 400 both floor to 512 — same regime, no re-measure.
-        g.maybe_remeasure(400);
-        assert!(!g.is_measuring());
-        // Just below the factor boundary: still the same regime.
-        g.maybe_remeasure(REMEASURE_DEPTH_FLOOR * REMEASURE_DEPTH_FACTOR - 1);
-        assert!(!g.is_measuring());
-    }
-
-    #[test]
-    fn maybe_remeasure_noop_while_measuring() {
-        let mut g = MtpGate::new(1);
-        assert!(g.is_measuring());
-        g.maybe_remeasure(1_000_000);
-        // Still in the ORIGINAL measurement (no reset mid-flight).
-        assert_eq!(g.next_step(), GateStep::MeasureDecode);
-        assert!(g.is_measuring());
-    }
-}
+mod tests;

--- a/crates/spark-server/src/scheduler/mtp_gate/tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate/tests.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for the throughput-arbitrated MTP gate. All scenarios drive the
+//! gate through `record_*` exactly as the scheduler does; walls are
+//! synthetic, tokens/step model acceptance.
+
+use super::*;
+
+fn ms(x: u64) -> Duration {
+    Duration::from_millis(x)
+}
+
+/// Drive `n` MTP-path steps at `emitted` tokens per step and `wall` each.
+fn drive_mtp(g: &mut MtpGate, n: usize, emitted: usize, wall: Duration) {
+    for _ in 0..n {
+        assert_eq!(
+            g.next_step(),
+            GateStep::MeasureVerify,
+            "expected Mtp-path step"
+        );
+        g.record_verify_step(wall, emitted);
+    }
+}
+
+/// Drive `n` serial decode steps at `wall` each.
+fn drive_serial(g: &mut MtpGate, n: usize, wall: Duration) {
+    for _ in 0..n {
+        assert_eq!(
+            g.next_step(),
+            GateStep::MeasureDecode,
+            "expected serial step"
+        );
+        g.record_decode(wall);
+    }
+}
+
+/// Run MTP steps until the gate opens its first serial-refresh probe.
+fn run_mtp_until_probe(g: &mut MtpGate, emitted: usize, wall: Duration) {
+    for _ in 0..10_000 {
+        if g.next_step() == GateStep::MeasureDecode {
+            return;
+        }
+        g.record_verify_step(wall, emitted);
+    }
+    panic!("gate never opened a serial probe");
+}
+
+/// Run serial steps until the gate opens an MTP re-probe.
+fn run_serial_until_probe(g: &mut MtpGate, wall: Duration) {
+    for _ in 0..10_000 {
+        if g.next_step() == GateStep::MeasureVerify {
+            return;
+        }
+        g.record_decode(wall);
+    }
+    panic!("gate never opened an MTP re-probe");
+}
+
+#[test]
+fn starts_in_mtp_mode() {
+    let g = MtpGate::new(1);
+    assert_eq!(g.next_step(), GateStep::MeasureVerify);
+    assert!(!g.in_serial_mode());
+}
+
+#[test]
+fn no_switch_without_both_baselines() {
+    let mut g = MtpGate::new(1);
+    // Plenty of slow MTP windows, but serial was never measured: stay put.
+    drive_mtp(&mut g, 64, 1, ms(100));
+    assert!(!g.in_serial_mode());
+    assert_eq!(g.take_fresh_decision(), None);
+}
+
+#[test]
+fn refresh_probe_opens_after_interval_and_returns() {
+    let mut g = MtpGate::new(1);
+    // 2 tok/step: ~512 steps to reach the 1024-token refresh interval.
+    run_mtp_until_probe(&mut g, 2, ms(50));
+    // Probe is exactly one window of serial steps, then control returns.
+    drive_serial(&mut g, WINDOW_STEPS, ms(40));
+    // Serial measured 25 tok/s < MTP 40 tok/s: stays MTP.
+    assert_eq!(g.next_step(), GateStep::MeasureVerify);
+    assert!(!g.in_serial_mode());
+    assert!(
+        g.serial_tps_debug().is_some(),
+        "probe must set the serial baseline"
+    );
+}
+
+#[test]
+fn switches_to_serial_when_clearly_faster_with_dwell() {
+    let mut g = MtpGate::new(1);
+    // MTP delivers 2 tok / 100ms = 20 tok/s.
+    run_mtp_until_probe(&mut g, 2, ms(100));
+    // Serial probe: 10ms/tok = 100 tok/s — way past any margin.
+    drive_serial(&mut g, WINDOW_STEPS, ms(10));
+    // Dwell: one more losing evaluation is required before the switch.
+    assert!(
+        !g.in_serial_mode(),
+        "dwell must prevent single-window switches"
+    );
+    for _ in 0..(WINDOW_STEPS * SWITCH_DWELL_WINDOWS) {
+        if g.next_step() != GateStep::MeasureVerify {
+            break;
+        }
+        g.record_verify_step(ms(100), 2);
+    }
+    assert!(
+        g.in_serial_mode(),
+        "sustained 5x serial advantage must switch"
+    );
+    assert_eq!(g.take_fresh_decision(), Some(GateDecision::DisableMtp));
+    assert_eq!(g.take_fresh_decision(), None, "fresh decision is one-shot");
+    assert_eq!(g.next_step(), GateStep::MeasureDecode);
+}
+
+#[test]
+fn hysteresis_blocks_within_margin_switches() {
+    let mut g = MtpGate::new(1);
+    // MTP 2 tok / 50ms = 40.0 tok/s.
+    run_mtp_until_probe(&mut g, 2, ms(50));
+    // Serial probe at 41 tok/s — inside the 5% noise floor (needs > 42).
+    drive_serial(&mut g, WINDOW_STEPS, Duration::from_micros(24_390));
+    for _ in 0..(WINDOW_STEPS * 4) {
+        if g.next_step() != GateStep::MeasureVerify {
+            break;
+        }
+        g.record_verify_step(ms(50), 2);
+    }
+    assert!(
+        !g.in_serial_mode(),
+        "a within-margin advantage must not switch modes"
+    );
+    assert_eq!(g.take_fresh_decision(), None);
+}
+
+#[test]
+fn serial_mode_reprobes_mtp_and_recovers() {
+    let mut g = MtpGate::new(1);
+    // Establish MTP=20 tok/s, serial=100 tok/s, and switch to serial.
+    run_mtp_until_probe(&mut g, 2, ms(100));
+    drive_serial(&mut g, WINDOW_STEPS, ms(10));
+    for _ in 0..(WINDOW_STEPS * SWITCH_DWELL_WINDOWS) {
+        if g.next_step() != GateStep::MeasureVerify {
+            break;
+        }
+        g.record_verify_step(ms(100), 2);
+    }
+    assert!(g.in_serial_mode());
+    g.take_fresh_decision();
+
+    // Workload shifts: MTP now 3 tok / 10ms = 300 tok/s. Two probe windows
+    // (dwell) must bring MTP back.
+    for _ in 0..SWITCH_DWELL_WINDOWS {
+        run_serial_until_probe(&mut g, ms(10));
+        drive_mtp(&mut g, WINDOW_STEPS, 3, ms(10));
+    }
+    assert!(
+        !g.in_serial_mode(),
+        "re-probe must recover MTP when it wins again"
+    );
+    assert_eq!(g.take_fresh_decision(), Some(GateDecision::KeepMtp));
+    assert_eq!(g.next_step(), GateStep::MeasureVerify);
+}
+
+#[test]
+fn depth_change_schedules_early_probe_without_state_wipe() {
+    let mut g = MtpGate::new(1);
+    g.note_depth(600);
+    // A few MTP windows at depth 600.
+    drive_mtp(&mut g, WINDOW_STEPS * 2, 2, ms(50));
+    let tps_before = g.mtp_tps_debug();
+    assert!(tps_before.is_some());
+    // Depth doubles: baselines stale, probe due immediately, EWMA retained.
+    g.maybe_remeasure(1300);
+    assert_eq!(
+        g.mtp_tps_debug(),
+        tps_before,
+        "no state wipe on regime change"
+    );
+    // The probe-due condition closes the window on the very next step.
+    drive_mtp(&mut g, 1, 2, ms(50));
+    assert_eq!(
+        g.next_step(),
+        GateStep::MeasureDecode,
+        "stale regime must probe soon"
+    );
+}
+
+#[test]
+fn bootstrap_steps_count_at_least_one_token() {
+    let mut g = MtpGate::new(1);
+    // emitted=0 must not divide-by-zero or record zero-token windows.
+    for _ in 0..WINDOW_STEPS {
+        g.record_verify_step(ms(10), 0);
+    }
+    let tps = g.mtp_tps_debug().expect("window closed");
+    assert!(tps > 0.0);
+}


### PR DESCRIPTION
## Summary

Three fixes to the Marconi SSM snapshot cache's eviction policy, each with its own empirical gate. **Stacks on #344** (base = `fix/mtp-gate-throughput-arbiter`); retarget/rebase onto main once #344 merges.

### 1. Re-land the 07-10 fossil-pinning fix — the pathology is live at HEAD

`3d8130d0` (recency-only eviction + winner-only lookup bumps) was silently reverted when #317 re-cut HSS onto main: the hit-weighted escore `last_access*(1+hit_count)`, the `hit_count` field, and the bump-every-improving-candidate lookup scan all returned. The measured pathology this re-fixes: restore anchor frozen 29 turns, SSM replay growing to 18.6k tok/turn, 40s TTFT tail. The in-tree comment attributed hit-weighting to "the Marconi paper §4" — the paper (arXiv 2411.19379, MLSys'25) has **no hit-count term**: its Eq 2 is `S(n) = recency(n) + α·flop_efficiency(n)`. Regression tests re-added, retargeted at `lookup_tiered` (the serving path — the originals exercised the now-dead `lookup()`).

### 2. Replace `ATLAS_SSM_TAIL_PROTECT` with a default-on `is_tail` lease

The old flag protected the live session's **deepest** snapshot — the end-of-turn finish leaf, which sits *above* `matched_tokens` and can never be restored from. Measured on an eviction rig (8 slots, deep 8-turn session + 6 unique-session churn requests/turn): **zero Marconi hits with the flag on or off**, identical TTFT growth — it pinned a useless entry while the true restore point died. And on hybrid models the cost is maximal: losing the SSM snapshot forfeits the *entire* KV prefix hit (`Prefix cache hit: 5536 tokens (346 blocks) but no SSM snapshot — recomputing all KV`).

The lease protects the live session's `is_tail` entry (the actual restore point), **default on**, `ATLAS_SSM_TAIL_PROTECT=0` as kill switch (`=1` scripts stay compatible). Hardenings from adversarial review: lease TTL (`ATLAS_SSM_TAIL_LEASE_TTL`, 64 evictions) so a dead session cannot squat a slot; `insert()` overwrite clears `is_tail` (cross-session tail-rehoming breach); `lookup_tiered` gains the `is_tail` session gate the reference `lookup()` has had since the session-gate fix (the serving path previously allowed a sessionless lookup to restore another session's tail); deadlock guard unchanged; the reclaim path inherits the lease.

### 3. Marconi Eq-2 value-aware score, staged inert

Within-session rank `S(e) = norm(recency) + α·norm(token_count)` (uniform slots ⇒ FLOPs-saved/byte ≡ replay depth). `ATLAS_SNAP_EVICT_ALPHA` default **0.0** = provably today's pure-LRU ordering (unit-tested rank identity); clamped [0,8]; min-max normalized per pass (no per-entry accumulation, so the fossil vector cannot re-enter); session staleness stays the primary key. Default flip deferred to its own measured A/B.

## Validation

- 46 snapshot unit tests (×3 runs, no flake incl. 11 new: lease semantics inversion vs #278, lease expiry, both breach vectors, α rank-identity), 140 crate tests, fmt/clippy clean, files under the 500-LoC cap (tier + stats split out)
- **Gate 1 (eviction rig, same churn scenario that measured the old flag at zero)**: see comment below — lease restores 4/7 warm turns at ~1.0s flat vs 0/7 and 2.6s growth
- **8-leg webserver_ok matrix** (FP8/NVFP4 × bf16/fp8 KV × dgx1/2/3): see comment — no regression, ws_ok 80/80
- ST-995 BFCL 87.04/88.27 on the underlying binary line (posted on #344)

Follow-up (next commit on this branch): extend the lease to the mid-chunk **early sibling** (`tb−bs`) — Gate 1 showed the 2/7 residual misses occur exactly when the block-floored match lands one block below `tb`, where only the (currently unleased) early capture can serve.
