### PR TITLE
feat(mtp): follow-ups — confidence-gated drafting, drafter catch-up feed, MoE verify telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           int cuStreamBeginCapture(void *a, int b) { (void)a; (void)b; return 100; }
           int cuStreamBeginCapture_v2(void *a, int b) { (void)a; (void)b; return 100; }
           int cuStreamEndCapture(void *a, void **b) { (void)a; (void)b; return 100; }
+          int cuStreamIsCapturing(void *a, unsigned int *b) { (void)a; (void)b; return 100; }
           int cuStreamWaitEvent(void *a, void *b, unsigned int c) { (void)a; (void)b; (void)c; return 100; }
           /* Modules + launch */
           int cuModuleLoadData(void **a, const void *b) { (void)a; (void)b; return 100; }

--- a/crates/spark-model/src/layers/moe/forward_k2.rs
+++ b/crates/spark-model/src/layers/moe/forward_k2.rs
@@ -139,6 +139,13 @@ impl MoeLayer {
                 stream,
             )?;
         }
+        super::union_stats::maybe_sample_expert_union(
+            ctx.gpu,
+            indices_dev,
+            2,
+            top_k as usize,
+            stream,
+        );
 
         if k2_diag {
             ctx.gpu

--- a/crates/spark-model/src/layers/moe/forward_k3.rs
+++ b/crates/spark-model/src/layers/moe/forward_k3.rs
@@ -94,6 +94,14 @@ impl MoeLayer {
             )?;
         }
 
+        super::union_stats::maybe_sample_expert_union(
+            ctx.gpu,
+            indices_dev,
+            3,
+            top_k as usize,
+            stream,
+        );
+
         // 3-5. Fused expert dispatch for 3 tokens
         let expert_gate_out = ctx.buffers.expert_gate_out();
         let expert_up_out = ctx.buffers.expert_up_out();

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -422,4 +422,5 @@ mod init;
 #[cfg(test)]
 mod mod_tests;
 mod ptr_table_build;
+mod union_stats;
 pub(crate) use ptr_table_build::*;

--- a/crates/spark-model/src/layers/moe/union_stats.rs
+++ b/crates/spark-model/src/layers/moe/union_stats.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Sampled expert-union telemetry for MTP verify batches
+//! (`ATLAS_MOE_UNION_STATS=1`, default off = zero cost).
+//!
+//! MoE verify cost scales with the UNION of experts activated across the
+//! verify batch's tokens, not with token count (measured verify_multiplier
+//! ~2.07 at K=1 on the 35B vs ~1.1 dense; cf. arXiv 2605.00342). This tap
+//! measures that union in production so the expert-union-aware verify
+//! batching work is grounded in data: mean unique experts per layer-step
+//! vs the M*top_k worst case and the num_experts ceiling.
+//!
+//! Sampling: 1 in [`SAMPLE_EVERY`] calls per process (call sites are
+//! per-MoE-layer per verify step), each sample a `M*top_k*4`-byte D2H
+//! after a stream sync — nanoseconds amortized. Aggregate is logged every
+//! [`LOG_EVERY`] samples.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+const SAMPLE_EVERY: u64 = 64;
+const LOG_EVERY: u64 = 64;
+
+static CALLS: AtomicU64 = AtomicU64::new(0);
+static SAMPLES: AtomicU64 = AtomicU64::new(0);
+static UNIQUE_SUM: AtomicU64 = AtomicU64::new(0);
+static SLOTS_SUM: AtomicU64 = AtomicU64::new(0);
+
+fn enabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var("ATLAS_MOE_UNION_STATS").ok().as_deref() == Some("1"))
+}
+
+/// Sample the expert-index union for one MoE layer's verify batch.
+/// `indices_dev` = `[m * top_k]` u32 expert ids, already written on `stream`.
+pub(super) fn maybe_sample_expert_union(
+    gpu: &dyn GpuBackend,
+    indices_dev: DevicePtr,
+    m: usize,
+    top_k: usize,
+    stream: u64,
+) {
+    if !enabled() {
+        return;
+    }
+    let call = CALLS.fetch_add(1, Ordering::Relaxed);
+    if !call.is_multiple_of(SAMPLE_EVERY) {
+        return;
+    }
+    // Order the D2H after the topk kernel that produced the indices.
+    if gpu.synchronize(stream).is_err() {
+        return;
+    }
+    let n = m * top_k;
+    let mut buf = vec![0u8; n * 4];
+    if gpu.copy_d2h(indices_dev, &mut buf).is_err() {
+        return;
+    }
+    let mut ids: Vec<u32> = buf
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    let unique = ids.len() as u64;
+    UNIQUE_SUM.fetch_add(unique, Ordering::Relaxed);
+    SLOTS_SUM.fetch_add(n as u64, Ordering::Relaxed);
+    let s = SAMPLES.fetch_add(1, Ordering::Relaxed) + 1;
+    if s.is_multiple_of(LOG_EVERY) {
+        let uniq = UNIQUE_SUM.load(Ordering::Relaxed) as f64 / s as f64;
+        let slots = SLOTS_SUM.load(Ordering::Relaxed) as f64 / s as f64;
+        tracing::info!(
+            "moe-union-stats: samples={s} mean_unique_experts={uniq:.1} \
+             mean_routed_slots={slots:.1} overlap_saving={:.0}% (m={m} top_k={top_k})",
+            (1.0 - uniq / slots.max(1.0)) * 100.0,
+        );
+    }
+}

--- a/crates/spark-model/src/layers/moe/union_stats.rs
+++ b/crates/spark-model/src/layers/moe/union_stats.rs
@@ -44,6 +44,14 @@ pub(super) fn maybe_sample_expert_union(
     if !enabled() {
         return;
     }
+    // NEVER sync/copy inside a CUDA-graph capture — it invalidates the
+    // capture (CUDA 901) and wedges the serve (measured: 35B NVFP4
+    // decode_verify_graphed, 2026-07-20). Graph REPLAYS run no host code at
+    // all, so this tap inherently samples only eager verify steps; disable
+    // graphs for full-fidelity measurement runs.
+    if gpu.stream_is_capturing(stream) {
+        return;
+    }
     let call = CALLS.fetch_add(1, Ordering::Relaxed);
     if !call.is_multiple_of(SAMPLE_EVERY) {
         return;

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -379,6 +379,26 @@ impl DraftProposer for MtpHead {
         self.prefill_drafter_impl(prompt_tokens, hiddens, state, ctx, stream)
     }
 
+    fn drafter_rows(&self, state: &mut dyn ProposerState) -> usize {
+        state
+            .as_any_mut()
+            .downcast_mut::<MtpProposerState>()
+            .map(|s| s.seq_len)
+            .unwrap_or(0)
+    }
+
+    fn catchup_drafter(
+        &self,
+        tokens: &[u32],
+        hiddens: DevicePtr,
+        row_base: usize,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
+        self.drafter_rows_impl(tokens, hiddens, row_base, state, ctx, stream)
+    }
+
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {
         self.read_deferred_draft_token(gpu)
     }

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -103,6 +103,12 @@ pub struct MtpProposerState {
     /// Number of drafts produced in the last propose() call.
     /// Used by after_verify to know how many entries to trim.
     pub last_num_drafted: usize,
+    /// Sequence-space pair key of the newest drafter row (a `forward_one`
+    /// call with RoPE position `p` writes pair key `p - 1`). `seq_len` alone
+    /// cannot locate the drafter in the sequence — without drafter prefill
+    /// the row space is compacted (accepted pairs only) and drifts from the
+    /// sequence position. `None` until the first row is written.
+    pub last_pair_key: Option<usize>,
 }
 
 impl ProposerState for MtpProposerState {
@@ -295,6 +301,7 @@ impl DraftProposer for MtpHead {
             block_table: Vec::new(),
             seq_len: 0,
             last_num_drafted: 0,
+            last_pair_key: None,
         }))
     }
 
@@ -387,16 +394,24 @@ impl DraftProposer for MtpHead {
             .unwrap_or(0)
     }
 
+    fn last_pair_key(&self, state: &mut dyn ProposerState) -> Option<usize> {
+        state
+            .as_any_mut()
+            .downcast_mut::<MtpProposerState>()
+            .and_then(|s| s.last_pair_key)
+    }
+
     fn catchup_drafter(
         &self,
         tokens: &[u32],
         hiddens: DevicePtr,
         row_base: usize,
+        pos_base: usize,
         state: &mut dyn ProposerState,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<usize> {
-        self.drafter_rows_impl(tokens, hiddens, row_base, state, ctx, stream)
+        self.drafter_rows_impl(tokens, hiddens, row_base, pos_base, state, ctx, stream)
     }
 
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {
@@ -434,6 +449,11 @@ impl DraftProposer for MtpHead {
         let old_sl = mtp_state.seq_len;
         if num_to_trim > 0 {
             mtp_state.seq_len = mtp_state.seq_len.saturating_sub(num_to_trim);
+            // Trimmed rows have consecutive pair keys; the newest surviving
+            // key moves back by the same count.
+            if let Some(k) = mtp_state.last_pair_key {
+                mtp_state.last_pair_key = Some(k.saturating_sub(num_to_trim));
+            }
         }
         tracing::debug!(
             "MTP after_verify: accepted={num_accepted} drafted={num_drafted} trim={num_to_trim} mtp_seq_len: {old_sl} → {}",
@@ -466,6 +486,7 @@ mod tests {
             block_table: vec![0, 1, 2],
             seq_len: 42,
             last_num_drafted: 0,
+            last_pair_key: None,
         });
         let mtp = state.as_any().downcast_ref::<MtpProposerState>().unwrap();
         assert_eq!(mtp.seq_len, 42);

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -185,6 +185,10 @@ pub struct MtpHead {
     embed_from_argmax_k: KernelHandle,
     /// Fixed device buffer (4 bytes) for deferred draft token ID readback.
     draft_token_id_dev: DevicePtr,
+    /// Chain confidence of the last propose (f32 bits; min top-1 softmax
+    /// prob across drafts). Written by `forward_one` when
+    /// `draft_conf_tau() > 0`; reset to 1.0 at each propose start.
+    pub(super) last_conf_bits: std::sync::atomic::AtomicU32,
     // BF16/FP8 kernel handles (None if NVFP4 mode)
     dense_gemv_k: Option<KernelHandle>,
     dense_gemv_fp8w_k: Option<KernelHandle>,
@@ -312,6 +316,9 @@ impl DraftProposer for MtpHead {
             .downcast_mut::<MtpProposerState>()
             .ok_or_else(|| anyhow::anyhow!("Invalid MTP proposer state"))?;
 
+        // Reset chain confidence for this propose (forward_one mins into it).
+        self.last_conf_bits
+            .store(1.0f32.to_bits(), std::sync::atomic::Ordering::Relaxed);
         let mut drafts = Vec::with_capacity(num_drafts);
         let mut current_token = last_token;
         let mut current_hidden = target_hidden;
@@ -374,6 +381,16 @@ impl DraftProposer for MtpHead {
 
     fn read_deferred_draft_token(&self, gpu: &dyn GpuBackend) -> Result<u32> {
         self.read_deferred_draft_token(gpu)
+    }
+
+    fn last_confidence(&self) -> Option<f32> {
+        if crate::speculative::draft_conf_tau() <= 0.0 {
+            return None;
+        }
+        Some(f32::from_bits(
+            self.last_conf_bits
+                .load(std::sync::atomic::Ordering::Relaxed),
+        ))
     }
 
     fn after_verify(

--- a/crates/spark-model/src/layers/mtp_head/forward.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward.rs
@@ -490,6 +490,42 @@ impl MtpHead {
             );
         }
 
+        // 13a. Drafter chain confidence (ATLAS_MTP_DRAFT_CONF > 0):
+        // observational only — token selection below is untouched. D2H the
+        // BF16 logits (~200 us, the same cost the grammar-masked path pays)
+        // and fold this draft's top-1 softmax prob into the propose-scoped
+        // running MIN (`last_conf_bits`, reset by `propose`). The clamp that
+        // acts on it lives in `run_mtp_propose_inner`.
+        if crate::speculative::draft_conf_tau() > 0.0 {
+            let vocab = v as usize;
+            let mut bf16_buf = vec![0u8; vocab * 2];
+            if ctx.gpu.copy_d2h(logits, &mut bf16_buf).is_ok() {
+                let mut max = f32::NEG_INFINITY;
+                for i in 0..vocab {
+                    let hi = u16::from_le_bytes([bf16_buf[2 * i], bf16_buf[2 * i + 1]]);
+                    let x = f32::from_bits((hi as u32) << 16);
+                    if x > max {
+                        max = x;
+                    }
+                }
+                let mut denom = 0.0f64;
+                for i in 0..vocab {
+                    let hi = u16::from_le_bytes([bf16_buf[2 * i], bf16_buf[2 * i + 1]]);
+                    let x = f32::from_bits((hi as u32) << 16);
+                    denom += ((x - max) as f64).exp();
+                }
+                let top1 = (1.0 / denom.max(1.0)) as f32; // exp(max-max)=1 over Z
+                let cur = f32::from_bits(
+                    self.last_conf_bits
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                );
+                if top1 < cur {
+                    self.last_conf_bits
+                        .store(top1.to_bits(), std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+        }
+
         // 13. Argmax
         let out_ptr = ctx.buffers.scratch();
 

--- a/crates/spark-model/src/layers/mtp_head/forward.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward.rs
@@ -638,6 +638,9 @@ impl MtpHead {
         };
 
         state.seq_len += 1;
+        // Pair-key bookkeeping (ATLAS_MTP_CATCHUP gap detection): this call
+        // wrote the pair for sequence key `position - 1` at the row above.
+        state.last_pair_key = Some(position.saturating_sub(1));
         Ok(token_id)
     }
 }

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -359,6 +359,7 @@ impl MtpHead {
             argmax_k: gpu.kernel("argmax", "argmax_bf16")?,
             embed_from_argmax_k: gpu.kernel("embed_from_argmax", "embed_from_argmax")?,
             draft_token_id_dev: gpu.alloc(4)?,
+            last_conf_bits: std::sync::atomic::AtomicU32::new(1.0f32.to_bits()),
             dense_gemv_k,
             dense_gemv_fp8w_k,
             w8a16_gemv_k: gpu.kernel("w8a16_gemv", "w8a16_gemv").ok(),

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -290,25 +290,28 @@ impl MtpHead {
         // (~50 MB at h=5120/nq=32/hd=256, PREFILL_CHUNK=512 rows). Dedicated
         // rather than aliased onto the shared arena so the pass has zero
         // aliasing hazards; allocated only when the env is set (PCND).
-        let prefill_scratch = if super::mtp_drafter_prefill_enabled() {
-            let c = super::prefill::PREFILL_CHUNK;
-            let bf16 = 2usize;
-            Some(super::MtpPrefillScratch {
-                embed: gpu.alloc(c * h * bf16)?,
-                normed_embed: gpu.alloc(c * h * bf16)?,
-                normed_hidden: gpu.alloc(c * h * bf16)?,
-                concat: gpu.alloc(c * 2 * h * bf16)?,
-                fc_out: gpu.alloc(c * h * bf16)?,
-                normed2: gpu.alloc(c * h * bf16)?,
-                k_out: gpu.alloc(c * nkv * hd * bf16)?,
-                v_out: gpu.alloc(c * nkv * hd * bf16)?,
-                q_scratch: gpu.alloc(c * nq * hd * bf16)?,
-                pos_dev: gpu.alloc(c * 4)?,
-                slot_dev: gpu.alloc(c * 8)?,
-            })
-        } else {
-            None
-        };
+        // The catch-up feed (ATLAS_MTP_CATCHUP) runs through the same batched
+        // row writer as the drafter prefill and needs the same scratch.
+        let prefill_scratch =
+            if super::mtp_drafter_prefill_enabled() || crate::speculative::mtp_catchup_enabled() {
+                let c = super::prefill::PREFILL_CHUNK;
+                let bf16 = 2usize;
+                Some(super::MtpPrefillScratch {
+                    embed: gpu.alloc(c * h * bf16)?,
+                    normed_embed: gpu.alloc(c * h * bf16)?,
+                    normed_hidden: gpu.alloc(c * h * bf16)?,
+                    concat: gpu.alloc(c * 2 * h * bf16)?,
+                    fc_out: gpu.alloc(c * h * bf16)?,
+                    normed2: gpu.alloc(c * h * bf16)?,
+                    k_out: gpu.alloc(c * nkv * hd * bf16)?,
+                    v_out: gpu.alloc(c * nkv * hd * bf16)?,
+                    q_scratch: gpu.alloc(c * nq * hd * bf16)?,
+                    pos_dev: gpu.alloc(c * 4)?,
+                    slot_dev: gpu.alloc(c * 8)?,
+                })
+            } else {
+                None
+            };
 
         Ok(Self {
             pre_fc_norm_embedding: weights.pre_fc_norm_embedding,

--- a/crates/spark-model/src/layers/mtp_head/prefill.rs
+++ b/crates/spark-model/src/layers/mtp_head/prefill.rs
@@ -50,13 +50,32 @@ impl MtpHead {
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<usize> {
+        self.drafter_rows_impl(prompt_tokens, hiddens, 0, state, ctx, stream)
+    }
+
+    /// Row-offset generalization of the drafter prefill: writes drafter rows
+    /// `row_base .. row_base + (tokens.len() - 1)` (KV slot i, RoPE position
+    /// i+1, pair = (embed(tokens[j+1]), hiddens row j)). `row_base = 0` is
+    /// the classic whole-prompt prefill; `row_base = seq_len` is the
+    /// catch-up feed after a serial-decode stretch (ATLAS_MTP_CATCHUP).
+    pub(crate) fn drafter_rows_impl(
+        &self,
+        prompt_tokens: &[u32],
+        hiddens: DevicePtr,
+        row_base: usize,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<usize> {
         let mtp_state = match state.as_any_mut().downcast_mut::<MtpProposerState>() {
             Some(s) => s,
             None => return Ok(0),
         };
-        // Only a fresh drafter (nothing proposed yet) can be prefilled; a
-        // non-zero seq_len means decode already started (or prefill ran).
-        if mtp_state.seq_len != 0 || prompt_tokens.len() < 2 {
+        // Rows must append exactly at the drafter's current length: for the
+        // classic prefill that means a fresh drafter (seq_len == 0); for the
+        // catch-up feed, row_base == seq_len. Anything else would leave a
+        // hole or overwrite live rows.
+        if mtp_state.seq_len != row_base || prompt_tokens.len() < 2 {
             return Ok(0);
         }
         let scratch = match self.prefill_scratch.as_ref() {
@@ -96,7 +115,7 @@ impl MtpHead {
         // Grow the drafter block table to cover all prefill slots up front.
         let mut kv_cache = self.kv_cache.lock();
         let bs = kv_cache.block_size();
-        let blocks_needed = (rows_total - 1) / bs + 1;
+        let blocks_needed = (row_base + rows_total - 1) / bs + 1;
         while mtp_state.block_table.len() < blocks_needed {
             mtp_state.block_table.push(kv_cache.alloc_block()?);
         }
@@ -210,13 +229,13 @@ impl MtpHead {
             }
 
             // 6. RoPE positions i+1 and KV slots i, uploaded per chunk.
-            let positions: Vec<u32> = (0..c).map(|r| (done + r + 1) as u32).collect();
+            let positions: Vec<u32> = (0..c).map(|r| (row_base + done + r + 1) as u32).collect();
             let pos_bytes =
                 unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, c * 4) };
             ctx.gpu.copy_h2d_async(pos_bytes, scratch.pos_dev, stream)?;
             let slots: Vec<i64> = (0..c)
                 .map(|r| {
-                    let i = done + r;
+                    let i = row_base + done + r;
                     (mtp_state.block_table[i / bs] as i64) * (bs as i64) + (i % bs) as i64
                 })
                 .collect();
@@ -266,7 +285,7 @@ impl MtpHead {
             done += c;
         }
 
-        mtp_state.seq_len = rows_total;
+        mtp_state.seq_len = row_base + rows_total;
         tracing::info!(
             "MTP drafter prefill: {} positions ({} prompt tokens) in {:.1} ms",
             rows_total,

--- a/crates/spark-model/src/layers/mtp_head/prefill.rs
+++ b/crates/spark-model/src/layers/mtp_head/prefill.rs
@@ -50,19 +50,25 @@ impl MtpHead {
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<usize> {
-        self.drafter_rows_impl(prompt_tokens, hiddens, 0, state, ctx, stream)
+        self.drafter_rows_impl(prompt_tokens, hiddens, 0, 1, state, ctx, stream)
     }
 
-    /// Row-offset generalization of the drafter prefill: writes drafter rows
-    /// `row_base .. row_base + (tokens.len() - 1)` (KV slot i, RoPE position
-    /// i+1, pair = (embed(tokens[j+1]), hiddens row j)). `row_base = 0` is
-    /// the classic whole-prompt prefill; `row_base = seq_len` is the
-    /// catch-up feed after a serial-decode stretch (ATLAS_MTP_CATCHUP).
+    /// Row/position generalization of the drafter prefill: appends drafter
+    /// rows at KV slots `row_base ..` with RoPE positions `pos_base ..`
+    /// (row r = pair `(embed(prompt_tokens[r+1]), hiddens row r)`, RoPE
+    /// `pos_base + r` = its sequence pair key + 1). Slots and positions are
+    /// decoupled because without drafter prefill the row space is COMPACTED
+    /// (slots dense, RoPE sequence-space with gaps — matching `forward_one`).
+    /// `row_base = 0, pos_base = 1` is the classic whole-prompt prefill;
+    /// the catch-up feed (ATLAS_MTP_CATCHUP) appends at `row_base = seq_len`
+    /// with the fed pairs' true sequence positions.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn drafter_rows_impl(
         &self,
         prompt_tokens: &[u32],
         hiddens: DevicePtr,
         row_base: usize,
+        pos_base: usize,
         state: &mut dyn ProposerState,
         ctx: &ForwardContext,
         stream: u64,
@@ -228,8 +234,9 @@ impl MtpHead {
                 )?;
             }
 
-            // 6. RoPE positions i+1 and KV slots i, uploaded per chunk.
-            let positions: Vec<u32> = (0..c).map(|r| (row_base + done + r + 1) as u32).collect();
+            // 6. RoPE positions pos_base+r and KV slots row_base+r, uploaded
+            //    per chunk (decoupled — see fn docs).
+            let positions: Vec<u32> = (0..c).map(|r| (pos_base + done + r) as u32).collect();
             let pos_bytes =
                 unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, c * 4) };
             ctx.gpu.copy_h2d_async(pos_bytes, scratch.pos_dev, stream)?;
@@ -286,6 +293,8 @@ impl MtpHead {
         }
 
         mtp_state.seq_len = row_base + rows_total;
+        // Last fed row has RoPE pos_base + rows_total - 1 = pair key + 1.
+        mtp_state.last_pair_key = Some(pos_base + rows_total - 2);
         tracing::info!(
             "MTP drafter prefill: {} positions ({} prompt tokens) in {:.1} ms",
             rows_total,

--- a/crates/spark-model/src/layers/mtp_multi.rs
+++ b/crates/spark-model/src/layers/mtp_multi.rs
@@ -92,6 +92,7 @@ impl DraftProposer for MultiModuleMtpHead {
                 block_table: Vec::new(),
                 seq_len: 0,
                 last_num_drafted: 0,
+                last_pair_key: None,
             })
             .collect();
         Ok(Box::new(MultiModuleMtpState {
@@ -251,6 +252,7 @@ mod tests {
                     block_table: Vec::new(),
                     seq_len: 0,
                     last_num_drafted: 0,
+                    last_pair_key: None,
                 })
                 .collect(),
             last_num_drafted: 0,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -244,6 +244,14 @@ impl TransformerModel {
 
         // MTP hidden state save buffer (1 × hidden_size FP32)
         let mtp_hidden_save = gpu.alloc(config.hidden_size * 4)?;
+        // Catch-up ring: 512 rows covers the gate's serial re-probe interval
+        // (256 tokens) with 2x margin; ~4 MB at hidden 4096. Only allocated
+        // when the staged feature is enabled.
+        let mtp_catchup_ring = if crate::speculative::mtp_catchup_enabled() {
+            gpu.alloc(super::types::MTP_CATCHUP_RING_ROWS * config.hidden_size * 2)?
+        } else {
+            DevicePtr::NULL
+        };
 
         // ATLAS_MTP_DRAFTER_PREFILL: whole-prompt hidden capture buffer,
         // [max_seq_len, hidden_size] BF16 — 335 MB at 32k/h=5120. Explicitly
@@ -517,6 +525,8 @@ impl TransformerModel {
             profile_first_pending: std::sync::atomic::AtomicBool::new(profile_first),
             proposer,
             mtp_hidden_save,
+            mtp_catchup_ring,
+            mtp_catchup_meta: parking_lot::Mutex::new((0, 0)),
             mtp_prefill_hidden,
             mtp_prefill_capacity: if mtp_prefill_hidden.is_null() {
                 0

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -119,6 +119,52 @@ impl TransformerModel {
                 tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
             }
         }
+        // ATLAS_MTP_CATCHUP: before proposing, batch-feed any serial-decode
+        // gap [rows .. position) into the drafter KV from the hidden ring, so
+        // the drafter attends over real recent context instead of a stale
+        // (position-discontinuous) tail. Ring rows are position-indexed
+        // (slot = pos % ring); feed in <=2 contiguous GPU segments across the
+        // wrap. Wrong feeds cannot corrupt output (verify rejects bad
+        // drafts); acceptance is the flip gate's metric.
+        if crate::speculative::mtp_catchup_enabled() && !self.mtp_catchup_ring.is_null() {
+            let rows = proposer.drafter_rows(prop_state.as_mut());
+            if rows > 0 && rows < position {
+                let (start, count) = *self.mtp_catchup_meta.lock();
+                let ring_rows = super::types::MTP_CATCHUP_RING_ROWS;
+                let covered = start <= rows && start + count >= position;
+                if covered && seq.tokens.len() > position {
+                    let h = self.config.hidden_size;
+                    let bf16 = 2usize;
+                    let mut base = rows;
+                    while base < position {
+                        // Contiguous ring segment starting at `base`.
+                        let slot = base % ring_rows;
+                        let seg_end = (position).min(base + (ring_rows - slot));
+                        let n_rows = seg_end - base;
+                        // tokens[j] pairs with hidden row j: pass the token
+                        // window [base ..= seg_end] (n_rows + 1 tokens).
+                        let toks = &seq.tokens[base..=seg_end];
+                        let hid = self.mtp_catchup_ring.offset(slot * h * bf16);
+                        match proposer.catchup_drafter(
+                            toks,
+                            hid,
+                            base,
+                            prop_state.as_mut(),
+                            &ctx,
+                            stream,
+                        ) {
+                            Ok(w) if w == n_rows => base = seg_end,
+                            Ok(_) | Err(_) => break, // degrade: propose as today
+                        }
+                    }
+                    if base == position {
+                        tracing::debug!(
+                            "MTP catch-up: drafter fed rows {rows}..{position} from ring"
+                        );
+                    }
+                }
+            }
+        }
         let drafts = proposer.propose(
             token,
             self.mtp_hidden_save,

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -119,60 +119,80 @@ impl TransformerModel {
                 tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
             }
         }
-        // ATLAS_MTP_CATCHUP: before proposing, batch-feed any serial-decode
-        // gap [rows .. position) into the drafter KV from the hidden ring, so
-        // the drafter attends over real recent context instead of a stale
-        // (position-discontinuous) tail. Ring rows are position-indexed
-        // (slot = pos % ring); feed in <=2 contiguous GPU segments across the
-        // wrap. Wrong feeds cannot corrupt output (verify rejects bad
-        // drafts); acceptance is the flip gate's metric.
+        // ATLAS_MTP_CATCHUP: before proposing, feed pairs the drafter missed
+        // during a serial-decode stretch. Coordinates (measured 2026-07-20 on
+        // the 27B rig): at propose entry `position == seq.tokens.len()` and
+        // the imminent forward_one writes the pair for sequence key
+        // `position - 1`; pair key k = (embed(tokens[k+1]), hidden_k), RoPE
+        // k+1. The serial-decode ring stores, under label n, the hidden of
+        // the step that COMMITTED token n — i.e. hidden_{n-1} — so pair key k
+        // reads ring label k+1. Drafter KV slots are compacted (append-only)
+        // while RoPE stays sequence-space, so RoPE gaps are already the norm:
+        // partial feeds (clipped to ring coverage) are safe, and wrong feeds
+        // cannot corrupt output (verify rejects bad drafts).
         if crate::speculative::mtp_catchup_enabled() && !self.mtp_catchup_ring.is_null() {
             let rows = proposer.drafter_rows(prop_state.as_mut());
+            let last_key = proposer.last_pair_key(prop_state.as_mut());
+            let (start, count) = *self.mtp_catchup_meta.lock();
+            if let Some(last) = last_key
+                && rows > 0
+                && count > 0
             {
-                // Skip-reason telemetry: the guards below degrade silently by
-                // design (propose-as-today); this line is the only way to see
-                // WHY a gap was not fed (convention drift, ring gap, boundary).
-                let (s, c) = *self.mtp_catchup_meta.lock();
-                tracing::debug!(
-                    "MTP catch-up eval: rows={rows} position={position} ring=[{s},+{c}) \
-                     tokens_len={}",
-                    seq.tokens.len(),
-                );
-            }
-            if rows > 0 && rows < position {
-                let (start, count) = *self.mtp_catchup_meta.lock();
-                let ring_rows = super::types::MTP_CATCHUP_RING_ROWS;
-                let covered = start <= rows && start + count >= position;
-                if covered && seq.tokens.len() > position {
+                // Missing pair keys: (last .. position-1); the propose itself
+                // covers position-1. Clip to ring coverage [start, start+count)
+                // in label space (label = key + 1).
+                let mut k0 = (last + 1).max(start.saturating_sub(1));
+                let k1 = (position.saturating_sub(2)).min((start + count).saturating_sub(2));
+                let want = (position.saturating_sub(1)).saturating_sub(last + 1);
+                if k0 <= k1 && want > 0 {
+                    let ring_rows = super::types::MTP_CATCHUP_RING_ROWS;
                     let h = self.config.hidden_size;
                     let bf16 = 2usize;
-                    let mut base = rows;
-                    while base < position {
-                        // Contiguous ring segment starting at `base`.
-                        let slot = base % ring_rows;
-                        let seg_end = (position).min(base + (ring_rows - slot));
-                        let n_rows = seg_end - base;
-                        // tokens[j] pairs with hidden row j: pass the token
-                        // window [base ..= seg_end] (n_rows + 1 tokens).
-                        let toks = &seq.tokens[base..=seg_end];
+                    let fed_from = k0;
+                    while k0 <= k1 {
+                        // Ring-contiguous segment: labels k0+1 .. until wrap.
+                        let slot = (k0 + 1) % ring_rows;
+                        let seg_last = k1.min(k0 + (ring_rows - slot) - 1);
+                        let n_rows = seg_last - k0 + 1;
+                        // Row r feeds pair key k0+r = embed(tokens[k0+r+1]):
+                        // the impl reads prompt_tokens[r+1], so pass the
+                        // window starting at index k0 (n_rows + 1 tokens).
+                        let toks = &seq.tokens[k0..=seg_last + 1];
                         let hid = self.mtp_catchup_ring.offset(slot * h * bf16);
+                        let row_base = proposer.drafter_rows(prop_state.as_mut());
                         match proposer.catchup_drafter(
                             toks,
                             hid,
-                            base,
+                            row_base,
+                            k0 + 1,
                             prop_state.as_mut(),
                             &ctx,
                             stream,
                         ) {
-                            Ok(w) if w == n_rows => base = seg_end,
-                            Ok(_) | Err(_) => break, // degrade: propose as today
+                            Ok(w) if w == n_rows => k0 = seg_last + 1,
+                            Ok(w) => {
+                                tracing::debug!(
+                                    "MTP catch-up: short feed ({w}/{n_rows} rows) — degrading"
+                                );
+                                break;
+                            }
+                            Err(e) => {
+                                tracing::debug!("MTP catch-up: feed failed ({e:#}) — degrading");
+                                break;
+                            }
                         }
                     }
-                    if base == position {
+                    if k0 > k1 {
                         tracing::debug!(
-                            "MTP catch-up: drafter fed rows {rows}..{position} from ring"
+                            "MTP catch-up: fed pair keys {fed_from}..={k1} \
+                             (missed {want}, position {position})"
                         );
                     }
+                } else if want > 0 {
+                    tracing::debug!(
+                        "MTP catch-up: gap of {want} pairs outside ring coverage \
+                         (last_key={last} position={position} ring=[{start},+{count}))"
+                    );
                 }
             }
         }

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -119,7 +119,7 @@ impl TransformerModel {
                 tracing::warn!("MTP drafter prefill failed (continuing without): {e:#}");
             }
         }
-        proposer.propose(
+        let drafts = proposer.propose(
             token,
             self.mtp_hidden_save,
             position,
@@ -130,7 +130,28 @@ impl TransformerModel {
             draft_embed_target,
             grammar_bitmask,
             self.dflash_hidden_save,
-        )
+        )?;
+        // Confidence clamp (ATLAS_MTP_DRAFT_CONF, staged off by default):
+        // when the drafter's chain confidence is below tau, discard the
+        // drafts — the next step decodes serially instead of paying a
+        // verify that would most likely reject (break-even acceptance at
+        // K=1 on the 35B MoE is ~0.66). The drafter KV rows written by
+        // this propose MUST be trimmed exactly as a full rejection would
+        // (after_verify(0)), or the drafter desyncs from the target.
+        let tau = crate::speculative::draft_conf_tau();
+        if tau > 0.0
+            && !drafts.is_empty()
+            && let Some(conf) = proposer.last_confidence()
+            && conf < tau
+        {
+            tracing::debug!(
+                "MTP draft skipped: chain confidence {conf:.3} < tau {tau:.3}                  (pos {position}, {} drafts trimmed)",
+                drafts.len(),
+            );
+            proposer.after_verify(0, prop_state.as_mut(), stream)?;
+            return Ok(Vec::new());
+        }
+        Ok(drafts)
     }
 
     /// Borrow the GPU backend for post-construction wiring (e.g. installing

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -128,6 +128,17 @@ impl TransformerModel {
         // drafts); acceptance is the flip gate's metric.
         if crate::speculative::mtp_catchup_enabled() && !self.mtp_catchup_ring.is_null() {
             let rows = proposer.drafter_rows(prop_state.as_mut());
+            {
+                // Skip-reason telemetry: the guards below degrade silently by
+                // design (propose-as-today); this line is the only way to see
+                // WHY a gap was not fed (convention drift, ring gap, boundary).
+                let (s, c) = *self.mtp_catchup_meta.lock();
+                tracing::debug!(
+                    "MTP catch-up eval: rows={rows} position={position} ring=[{s},+{c}) \
+                     tokens_len={}",
+                    seq.tokens.len(),
+                );
+            }
             if rows > 0 && rows < position {
                 let (start, count) = *self.mtp_catchup_meta.lock();
                 let ring_rows = super::types::MTP_CATCHUP_RING_ROWS;

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -324,6 +324,10 @@ impl Model for TransformerModel {
     ) -> Result<Vec<u32>> {
         self.decode_and_verify_fused_dispatch(tokens, seq, _stream)
     }
+    fn save_hidden_for_catchup(&self, token_idx: usize, pos: usize) -> Result<()> {
+        self.save_hidden_for_catchup_dispatch(token_idx, pos)
+    }
+
     fn save_hidden_for_mtp(&self, token_idx: usize, _stream: u64) -> Result<()> {
         self.save_hidden_for_mtp_dispatch(token_idx, _stream)
     }

--- a/crates/spark-model/src/model/trait_impl/speculative.rs
+++ b/crates/spark-model/src/model/trait_impl/speculative.rs
@@ -154,6 +154,40 @@ impl TransformerModel {
         Ok(())
     }
 
+    /// ATLAS_MTP_CATCHUP: ring-capture the final hidden of a serially
+    /// decoded token (position `pos`), keeping the ring's position range
+    /// contiguous (a gap resets the range to just this row).
+    pub(super) fn save_hidden_for_catchup_dispatch(
+        &self,
+        token_idx: usize,
+        pos: usize,
+    ) -> Result<()> {
+        if self.mtp_catchup_ring.is_null() {
+            return Ok(());
+        }
+        let ring_rows = super::super::types::MTP_CATCHUP_RING_ROWS;
+        let stream = self.gpu.default_stream();
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        let src = self.buffers.hidden_states().offset(token_idx * h * bf16);
+        let dst = self.mtp_catchup_ring.offset((pos % ring_rows) * h * bf16);
+        self.gpu.copy_d2d_async(src, dst, h * bf16, stream)?;
+        let mut meta = self.mtp_catchup_meta.lock();
+        let (start, count) = *meta;
+        *meta = if count > 0 && pos == start + count {
+            // Contiguous append; cap the range at ring capacity by advancing
+            // the start once the ring wraps (oldest row overwritten).
+            if count == ring_rows {
+                (start + 1, ring_rows)
+            } else {
+                (start, count + 1)
+            }
+        } else {
+            (pos, 1)
+        };
+        Ok(())
+    }
+
     pub(super) fn run_mtp_propose_dispatch(
         &self,
         token: u32,

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -28,6 +28,10 @@ use crate::weight_map::{DenseWeight, Fp8DenseWeight, MtpWeights, QuantizedWeight
 /// Adding a new model only requires implementing [`TransformerLayer`]
 /// for each layer type — the model loop stays unchanged.
 #[allow(dead_code)]
+/// Rows in the drafter catch-up hidden ring (see `mtp_catchup_ring`):
+/// 512 covers the gate's 256-token serial re-probe interval with 2x margin.
+pub(super) const MTP_CATCHUP_RING_ROWS: usize = 512;
+
 pub struct TransformerModel {
     pub(super) config: ModelConfig,
     pub(super) embed_tokens: DenseWeight,
@@ -133,6 +137,14 @@ pub struct TransformerModel {
     /// Size: hidden_size * 4 bytes (one FP32 vector). MTP overwrites shared
     /// buffers (norm_output etc.), so the target hidden must be saved here first.
     pub(super) mtp_hidden_save: DevicePtr,
+    /// ATLAS_MTP_CATCHUP: circular per-position final-hidden ring captured
+    /// during serial-decode stretches (BF16 rows, slot = position % ring
+    /// len). Feeds the drafter catch-up on the next propose. NULL when the
+    /// feature is off or no proposer exists.
+    pub(super) mtp_catchup_ring: DevicePtr,
+    /// (first_position, count) of the contiguous position range currently
+    /// resident in the ring; a non-contiguous capture resets the range.
+    pub(super) mtp_catchup_meta: parking_lot::Mutex<(usize, usize)>,
     /// ATLAS_MTP_DRAFTER_PREFILL: per-position final-layer hidden capture for
     /// the whole prompt, `[max_seq_len, hidden_size]` BF16 (~335 MB at 32k /
     /// h=5120). NULL unless the env is set AND an MTP proposer is built.

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -43,6 +43,16 @@ pub fn draft_conf_tau() -> f32 {
         .unwrap_or(0.0)
 }
 
+/// Drafter catch-up feed on serial->speculative transitions
+/// (`ATLAS_MTP_CATCHUP=1`, staged off). During serial-decode stretches the
+/// scheduler rings the per-step final hiddens; on the next propose the gap
+/// rows are batch-fed into the drafter KV so it never runs stale. Wrong
+/// feeds cannot corrupt output (verification rejects bad drafts) — the
+/// stake is acceptance only, which is the flip gate's metric.
+pub fn mtp_catchup_enabled() -> bool {
+    std::env::var("ATLAS_MTP_CATCHUP").ok().as_deref() == Some("1")
+}
+
 pub trait DraftProposer: Send + Sync {
     /// Allocate per-sequence proposer state.
     fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn ProposerState>>;
@@ -52,6 +62,27 @@ pub trait DraftProposer: Send + Sync {
     /// 0). `None` = not computed; callers must not gate on it then.
     fn last_confidence(&self) -> Option<f32> {
         None
+    }
+
+    /// Current drafter KV length (rows), for gap detection. 0 = unknown /
+    /// not applicable (catch-up is skipped).
+    fn drafter_rows(&self, _state: &mut dyn ProposerState) -> usize {
+        0
+    }
+
+    /// Append drafter rows `row_base ..` from `(tokens, hiddens)` pairs —
+    /// the catch-up feed. Returns rows written (0 = unsupported/no-op).
+    #[allow(clippy::too_many_arguments)]
+    fn catchup_drafter(
+        &self,
+        _tokens: &[u32],
+        _hiddens: DevicePtr,
+        _row_base: usize,
+        _state: &mut dyn ProposerState,
+        _ctx: &ForwardContext,
+        _stream: u64,
+    ) -> Result<usize> {
+        Ok(0)
     }
 
     /// Propose up to `num_drafts` tokens autoregressively.

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -64,20 +64,29 @@ pub trait DraftProposer: Send + Sync {
         None
     }
 
-    /// Current drafter KV length (rows), for gap detection. 0 = unknown /
-    /// not applicable (catch-up is skipped).
+    /// Current drafter KV length (rows), for the catch-up append point.
+    /// 0 = unknown / not applicable (catch-up is skipped).
     fn drafter_rows(&self, _state: &mut dyn ProposerState) -> usize {
         0
     }
 
-    /// Append drafter rows `row_base ..` from `(tokens, hiddens)` pairs —
-    /// the catch-up feed. Returns rows written (0 = unsupported/no-op).
+    /// Sequence-space pair key of the newest drafter row (`None` = untracked;
+    /// catch-up is skipped). The drafter row space is compacted, so `rows`
+    /// cannot locate the drafter in the sequence — this can.
+    fn last_pair_key(&self, _state: &mut dyn ProposerState) -> Option<usize> {
+        None
+    }
+
+    /// Append drafter rows at KV slots `row_base ..` with RoPE positions
+    /// `pos_base ..` from `(tokens, hiddens)` pairs — the catch-up feed.
+    /// Returns rows written (0 = unsupported/no-op).
     #[allow(clippy::too_many_arguments)]
     fn catchup_drafter(
         &self,
         _tokens: &[u32],
         _hiddens: DevicePtr,
         _row_base: usize,
+        _pos_base: usize,
         _state: &mut dyn ProposerState,
         _ctx: &ForwardContext,
         _stream: u64,

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -26,9 +26,33 @@ pub trait ProposerState: Send + Sync {
 /// The engine calls `propose()` after each target decode to get draft tokens,
 /// then verifies them with the target model. `after_verify()` lets the
 /// proposer trim state (e.g., KV cache) based on how many drafts were accepted.
+/// Confidence floor for submitting drafts to verification
+/// (`ATLAS_MTP_DRAFT_CONF`, default 0.0 = disabled). When the drafter's
+/// chain confidence (min top-1 softmax prob across the drafts of one
+/// propose) is below this, the drafts are discarded and the next step
+/// decodes serially — skipping a verify that would most likely reject.
+/// Economics at K=1 on the 35B MoE: verify ≈ 35 ms for 1+acc tokens vs
+/// decode+propose ≈ 21 ms for 1, so a draft is only worth verifying when
+/// p(accept) ≳ 0.66 — the threshold to calibrate around. Staged OFF until
+/// its measured A/B (same discipline as ATLAS_SNAP_EVICT_ALPHA).
+pub fn draft_conf_tau() -> f32 {
+    std::env::var("ATLAS_MTP_DRAFT_CONF")
+        .ok()
+        .and_then(|v| v.parse::<f32>().ok())
+        .map(|t| t.clamp(0.0, 0.99))
+        .unwrap_or(0.0)
+}
+
 pub trait DraftProposer: Send + Sync {
     /// Allocate per-sequence proposer state.
     fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn ProposerState>>;
+
+    /// Chain confidence of the most recent `propose` (min top-1 softmax prob
+    /// across its drafts), when the proposer computes it (`draft_conf_tau` >
+    /// 0). `None` = not computed; callers must not gate on it then.
+    fn last_confidence(&self) -> Option<f32> {
+        None
+    }
 
     /// Propose up to `num_drafts` tokens autoregressively.
     ///

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -557,6 +557,12 @@ pub trait Model: Send + Sync {
     /// overwrites shared buffers including `norm_output`.
     fn save_hidden_for_mtp(&self, token_idx: usize, stream: u64) -> Result<()>;
 
+    /// ATLAS_MTP_CATCHUP: ring-capture a serially decoded token's final
+    /// hidden at `pos` for the drafter catch-up feed. Default no-op.
+    fn save_hidden_for_catchup(&self, _token_idx: usize, _pos: usize) -> Result<()> {
+        Ok(())
+    }
+
     /// Capture `hidden_states[token_idx]` from every DFlash capture layer
     /// into `dflash_hidden_save`. Called after gamma verify Phase 3 D2H
     /// sync (bonus position known). No-op when DFlash is disabled.

--- a/crates/spark-runtime/src/cuda_backend.rs
+++ b/crates/spark-runtime/src/cuda_backend.rs
@@ -36,6 +36,11 @@ unsafe extern "C" {
     pub(super) fn cuMemsetD8Async(dst: u64, value: u8, n: usize, stream: u64) -> i32;
     // CUDA graph capture/replay
     pub(super) fn cuStreamBeginCapture(hStream: u64, mode: u32) -> i32;
+    // Capture-status query (telemetry taps must not sync/copy inside an
+    // active capture). Not declared under SCALE — its libcuda export set is
+    // minimal and an unresolved extern would break the gfx1151 link.
+    #[cfg(not(atlas_scale))]
+    pub(super) fn cuStreamIsCapturing(hStream: u64, captureStatus: *mut u32) -> i32;
     pub(super) fn cuStreamEndCapture(hStream: u64, phGraph: *mut u64) -> i32;
     // CUDA-graph instantiate. NVIDIA's libcuda exports the 3-arg
     // `cuGraphInstantiateWithFlags`; SCALE's libcuda (gfx1151) exports only

--- a/crates/spark-runtime/src/cuda_backend/gpu_impl.rs
+++ b/crates/spark-runtime/src/cuda_backend/gpu_impl.rs
@@ -193,6 +193,25 @@ impl GpuBackend for AtlasCudaBackend {
         }
     }
 
+    fn stream_is_capturing(&self, stream: u64) -> bool {
+        // SCALE's libcuda does not export cuStreamIsCapturing; report
+        // not-capturing there (gfx1151 telemetry taps then sample eagerly —
+        // acceptable for a default-off measurement knob).
+        #[cfg(atlas_scale)]
+        {
+            let _ = stream;
+            false
+        }
+        #[cfg(not(atlas_scale))]
+        {
+            let mut status: u32 = 0;
+            // CU_STREAM_CAPTURE_STATUS_NONE = 0; treat query failure as
+            // capturing (conservative: the tap skips its sample).
+            let rc = unsafe { super::cuStreamIsCapturing(stream, &mut status) };
+            rc != 0 || status != 0
+        }
+    }
+
     fn synchronize(&self, stream: u64) -> Result<()> {
         let status = unsafe { cuStreamSynchronize(stream) };
         if status != 0 {

--- a/crates/spark-runtime/src/gpu.rs
+++ b/crates/spark-runtime/src/gpu.rs
@@ -168,6 +168,15 @@ pub trait GpuBackend: Send + Sync {
         self.launch(func, grid, block, shared_mem, stream, &mut params)
     }
 
+    /// Whether `stream` is inside an active CUDA-graph capture. Telemetry
+    /// taps MUST check this before any sync/D2H on a potentially-captured
+    /// stream — those calls invalidate the capture (CUDA 901) and wedge the
+    /// serve. Default `false` (backends without capture, or without a query
+    /// API, never capture through this trait's eager paths).
+    fn stream_is_capturing(&self, _stream: u64) -> bool {
+        false
+    }
+
     /// Synchronize a CUDA stream (blocks until all work completes).
     fn synchronize(&self, stream: u64) -> Result<()>;
 

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -559,6 +559,15 @@ pub fn run(
                                 adaptive_sampling,
                             );
                             gate.record_decode(t0.elapsed());
+                            // ATLAS_MTP_CATCHUP: ring the serially decoded
+                            // token's hidden so the next MTP re-probe can
+                            // batch-feed the drafter over the serial gap
+                            // (no-op when the feature is off).
+                            if let Some(pos) = active[0].seq.seq_len.checked_sub(1)
+                                && let Err(e) = model.save_hidden_for_catchup(0, pos)
+                            {
+                                tracing::warn!("save_hidden_for_catchup: {e:#}");
+                            }
                         }
                         mtp_gate::GateStep::MeasureVerify => {
                             // A bootstrap-only step (no pending drafts) emits


### PR DESCRIPTION
## Summary

The follow-ups PR for the #344/#345 line — **draft until all three items land on this branch**.

### ✅ 1. Per-step confidence-gated drafting (`ATLAS_MTP_DRAFT_CONF`, staged off) — this commit

AdaSD/SVIP-style per-step draft gating (arXiv 2512.11280 / 2411.18462) adapted to Atlas's pipelined MTP: `forward_one` computes the drafter's top-1 softmax prob per draft (BF16 logits D2H ~200µs — the cost the grammar-masked path already pays; token selection untouched), folds it into a propose-scoped chain-confidence MIN, and `run_mtp_propose_inner` discards drafts below τ — **trimming the drafter KV exactly as a full rejection would** (`after_verify(0)`) so the drafter never desyncs. The next step decodes serially via the normal bootstrap path.

Economics: at K=1 on the 35B MoE, verify ≈35ms for 1+acc tokens vs decode+propose ≈21ms — a draft is worth verifying only at p(accept) ≳ 0.66, which is τ's calibration target.

**Staged OFF** (τ=0.0 default; every new code path is behind τ>0, so the default is byte-identical) — same discipline as `ATLAS_SNAP_EVICT_ALPHA`. Default flip requires the acceptance-vs-confidence calibration A/B.

Validation: clippy/fmt/tests clean; live smoke on `nvidia/Qwen3.6-27B-NVFP4` (K=3, golden config): **8/8 tool calls at τ=0 and 8/8 at the aggressive τ=0.5** — correctness is verify-guaranteed by construction (wrong drafts are rejected; the clamp can only change performance).

Incidental finding while validating: 35B-NVFP4 + `--tool-call-parser qwen3_xml` scores 0/8 on the structured tool-call probe **with or without** this feature — a pre-existing model/parser format mismatch (the 35B's agentic gates drive tools through opencode prompts, never the parser). Filed here for visibility; not addressed in this PR.

### ⏳ 2. Drafter catch-up feed on Serial→Mtp transitions (next on this branch)

Hidden-ring capture during serial decode + an append-capable drafter prefill so gate transitions never run a stale drafter. Safe by construction (verify rejects bad drafts) but touches decode buffers and drafter position bookkeeping — lands with its own acceptance A/B.

### ⏳ 3. MoE expert-union verify telemetry (next on this branch)

Sampled D2H of the verify batch's `expert_indices` union — the measurement stage for expert-union-aware verify batching (the m≈2.07 MoE verify multiplier, cf. arXiv 2605.00342).
