### PR TITLE
fix(deepseek-v4): read compressor APE as FP32 in CSA/HCA compression

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
@@ -97,7 +97,8 @@ pub struct CompressorWeights {
     pub wgate: DenseWeight,
     /// kv_norm weight `[head_dim]` — HF-vanilla RMSNorm (loaded exactly).
     pub norm: DenseWeight,
-    /// position_bias / ape: [ratio, proj_dim] BF16, added to the gate before softmax.
+    /// position_bias / ape: [ratio, proj_dim] **F32** (checkpoint-native; csa_compress
+    /// indexes it as `const float*`), added to the gate before the per-dim softmax.
     pub ape: spark_runtime::gpu::DevicePtr,
     /// compress_rate for this layer (4 = CSA, 128 = HCA).
     pub ratio: usize,

--- a/crates/spark-model/src/weight_loader/deepseek_v4.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4.rs
@@ -7,8 +7,8 @@
 
 mod assemble;
 mod attn_sink;
-mod csa_ape;
 mod compute;
+mod csa_ape;
 mod load_layers;
 // MTP draft-module loader for nvidia/DeepSeek-V4-Flash-NVFP4.
 mod mtp;

--- a/crates/spark-model/src/weight_loader/deepseek_v4.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4.rs
@@ -7,6 +7,7 @@
 
 mod assemble;
 mod attn_sink;
+mod csa_ape;
 mod compute;
 mod load_layers;
 // MTP draft-module loader for nvidia/DeepSeek-V4-Flash-NVFP4.

--- a/crates/spark-model/src/weight_loader/deepseek_v4/assemble.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/assemble.rs
@@ -376,7 +376,10 @@ pub fn assemble_layer(
             let wgate = dense(store, &format!("{cp}.wgate.weight"))?;
             // compressor.norm is a STANDARD RMSNorm → subtract 1 for the offset kernel.
             let norm = dense_auto(store, &format!("{cp}.norm.weight"), gpu)?;
-            let ape = store.get(&format!("{cp}.ape"))?.ptr;
+            // ape is checkpoint-native F32 [ratio, proj_dim]; csa_compress indexes it
+            // as `const float*`. Normalize here so the kernel can never misread it as
+            // bf16 (the L2–L42 window-softmax corruption fixed alongside attn_sink #341).
+            let ape = super::csa_ape::load_ape_f32(store, &format!("{cp}.ape"), gpu)?;
             // 4b: allocate the persistent flat compressed-KV pool for this layer.
             // Sized to the full context (max_position_embeddings // ratio blocks)
             // so decode never overflows; each block is one hd_mla-wide FP8-E4M3

--- a/crates/spark-model/src/weight_loader/deepseek_v4/csa_ape.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/csa_ape.rs
@@ -24,7 +24,11 @@ use spark_runtime::weights::{WeightDtype, WeightStore};
 /// - **BF16 checkpoint**: widen once here into a freshly allocated FP32 buffer
 ///   (process-lifetime, same ownership model as the other derived loader buffers).
 /// - **Any other dtype**: fail loudly with the tensor key and dtype.
-pub(super) fn load_ape_f32(store: &WeightStore, key: &str, gpu: &dyn GpuBackend) -> Result<DevicePtr> {
+pub(super) fn load_ape_f32(
+    store: &WeightStore,
+    key: &str,
+    gpu: &dyn GpuBackend,
+) -> Result<DevicePtr> {
     let t = store.get(key)?;
     match t.dtype {
         WeightDtype::FP32 => Ok(t.ptr),

--- a/crates/spark-model/src/weight_loader/deepseek_v4/csa_ape.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/csa_ape.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! DeepSeek-V4 CSA/HCA compressor absolute-position encoding (`ape`) — canonical
+//! FP32 dtype contract.
+//!
+//! The checkpoint ships `layers.N.attn.compressor.ape` (the `position_bias` added
+//! to the per-window gate before the compressor's per-dim softmax) as F32
+//! `[ratio, proj_dim]` on every compressed layer (CSA ratio 4 → `[4, 2*head_dim]`;
+//! HCA ratio 128 → `[128, head_dim]`). The `csa_compress` kernel indexes it as
+//! `const float*`. This module is the single place that normalizes the loaded
+//! buffer to that contract, so the kernel can never index an fp32 buffer as bf16
+//! (a 2-byte stride over 4-byte elements reads half of the wrong element and
+//! decodes to non-physical magnitudes ≈ ±1e38, corrupting the window softmax on
+//! every compressed layer L2–L42). Same defect class as the `attn_sink` #341 fix.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::weights::{WeightDtype, WeightStore};
+
+/// Load the compressor `ape` as the canonical device **FP32** buffer.
+///
+/// - **F32 checkpoint** (the DSpark case): pass the store buffer through unchanged
+///   (byte no-op vs the raw pointer).
+/// - **BF16 checkpoint**: widen once here into a freshly allocated FP32 buffer
+///   (process-lifetime, same ownership model as the other derived loader buffers).
+/// - **Any other dtype**: fail loudly with the tensor key and dtype.
+pub(super) fn load_ape_f32(store: &WeightStore, key: &str, gpu: &dyn GpuBackend) -> Result<DevicePtr> {
+    let t = store.get(key)?;
+    match t.dtype {
+        WeightDtype::FP32 => Ok(t.ptr),
+        WeightDtype::BF16 => {
+            let mut bf16_buf = vec![0u8; t.num_elements() * 2];
+            gpu.copy_d2h(t.ptr, &mut bf16_buf)?;
+            let f32_buf = super::attn_sink::bf16_bytes_to_f32_bytes(&bf16_buf);
+            let ptr = gpu.alloc(f32_buf.len())?;
+            gpu.copy_h2d(&f32_buf, ptr)?;
+            Ok(ptr)
+        }
+        other => anyhow::bail!(
+            "DeepSeek-V4 compressor.ape '{key}': unexpected dtype {:?} \
+             (csa_compress indexes ape as F32; only F32 pass-through or BF16 widening supported)",
+            other
+        ),
+    }
+}
+
+#[cfg(test)]
+mod csa_ape_dtype_tests {
+    //! Regression tests for the DS4F `compressor.ape` FP32 contract. The checkpoint
+    //! ships `ape` as F32; `csa_compress` indexes it as `const float*`. The historical
+    //! defect (this fix) indexed the same fp32 buffer as bf16 (2-byte stride), reading
+    //! the low half of the wrong element and decoding to non-physical magnitudes that
+    //! corrupted the window softmax gate. These tests lock the true fp32 read and
+    //! reproduce the old bf16-misread's garbage.
+    use super::super::attn_sink::bf16_bytes_to_f32_bytes;
+
+    /// A representative F32 ape row (checkpoint-native values, slot0/dim0 = 0.074).
+    const APE_TRUE: [f32; 8] = [0.074, 1.5, -2.3, 0.5, 0.031, -1.1, 3.25, -0.008];
+
+    /// bf16 → f32 (bf16 is the high 16 bits of the f32 word).
+    fn bf16_to_f32(bits: u16) -> f32 {
+        f32::from_bits((bits as u32) << 16)
+    }
+
+    /// The kernel-arg fix: reading the fp32 buffer as fp32 returns the true values.
+    #[test]
+    fn fp32_read_returns_true_ape() {
+        let mut bytes = Vec::new();
+        for &v in &APE_TRUE {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        for (i, &t) in APE_TRUE.iter().enumerate() {
+            let v = f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap());
+            assert!((v - t).abs() < 1e-6, "elem {i}: fp32 read {v} != true {t}");
+        }
+    }
+
+    /// The bug: indexing that same fp32 byte stream as bf16 (2-byte stride) reads across
+    /// the 4-byte element boundaries, so the decoded sequence diverges grossly from the
+    /// true F32 values — exactly why an fp32 ape must never be read as bf16. (The runtime
+    /// tap saw magnitudes to ±1e38 at the specific straddles; here we only require gross
+    /// divergence, which is robust.)
+    #[test]
+    fn bf16_misread_of_fp32_diverges_grossly() {
+        let mut bytes = Vec::new();
+        for &v in &APE_TRUE {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        // bf16 element i = bytes[2i..2i+2] (little-endian), the kernel's stride.
+        let n_bf16 = bytes.len() / 2;
+        let misread: Vec<f32> = (0..n_bf16)
+            .map(|i| bf16_to_f32(u16::from_le_bytes([bytes[2 * i], bytes[2 * i + 1]])))
+            .collect();
+        // Compare the first APE_TRUE.len() bf16 reads (what the kernel indexed as ape[0..8])
+        // against the true F32 values — a majority must differ materially.
+        let wrong = APE_TRUE
+            .iter()
+            .zip(&misread)
+            .filter(|(t, m)| (**t - **m).abs() > 1e-2)
+            .count();
+        assert!(
+            wrong > APE_TRUE.len() / 2,
+            "bf16 misread must corrupt most elements; only {wrong} of {} diverged",
+            APE_TRUE.len()
+        );
+    }
+
+    /// BF16-checkpoint fallback path: widening is the exact high-half embedding.
+    #[test]
+    fn bf16_widen_roundtrip_exact() {
+        for &v in &[0.074f32, -1.5, 0.5, 12.0] {
+            let hi = (v.to_bits() >> 16) as u16;
+            let widened_bytes = bf16_bytes_to_f32_bytes(&hi.to_le_bytes());
+            let widened = f32::from_le_bytes([
+                widened_bytes[0],
+                widened_bytes[1],
+                widened_bytes[2],
+                widened_bytes[3],
+            ]);
+            assert_eq!(widened.to_bits(), (hi as u32) << 16);
+        }
+    }
+}

--- a/kernels/gb10/deepseek-v4-flash/nvfp4/csa_compress.cu
+++ b/kernels/gb10/deepseek-v4-flash/nvfp4/csa_compress.cu
@@ -20,7 +20,10 @@
 extern "C" __global__ void csa_compress(
     const __nv_bfloat16* __restrict__ kv,   // [S, proj_dim]
     const __nv_bfloat16* __restrict__ gate, // [S, proj_dim]
-    const __nv_bfloat16* __restrict__ ape,  // [ratio, proj_dim]
+    const float* __restrict__ ape,          // [ratio, proj_dim] FP32: checkpoint-native
+                                            // dtype (reading as bf16 read half of the
+                                            // wrong element and corrupted the window
+                                            // softmax gate on every compressed layer)
     __nv_bfloat16* __restrict__ out,        // [n_win, head_dim]
     const unsigned int seq_len,
     const unsigned int ratio,
@@ -43,7 +46,7 @@ extern "C" __global__ void csa_compress(
                 for (unsigned int r = 0; r < ratio; ++r) {
                     const unsigned int tok = (w - 1) * ratio + r;
                     const float g = __bfloat162float(gate[(size_t)tok * proj_dim + d])
-                                  + __bfloat162float(ape[(size_t)r * proj_dim + d]);
+                                  + ape[(size_t)r * proj_dim + d];
                     const float v = __bfloat162float(kv[(size_t)tok * proj_dim + d]);
                     const float mn = fmaxf(m, g);
                     const float eo = __expf(m - mn);
@@ -58,7 +61,7 @@ extern "C" __global__ void csa_compress(
                 const unsigned int tok = w * ratio + r;
                 const unsigned int c = head_dim + d;
                 const float g = __bfloat162float(gate[(size_t)tok * proj_dim + c])
-                              + __bfloat162float(ape[(size_t)r * proj_dim + c]);
+                              + ape[(size_t)r * proj_dim + c];
                 const float v = __bfloat162float(kv[(size_t)tok * proj_dim + c]);
                 const float mn = fmaxf(m, g);
                 const float eo = __expf(m - mn);
@@ -72,7 +75,7 @@ extern "C" __global__ void csa_compress(
             for (unsigned int r = 0; r < ratio; ++r) {
                 const unsigned int tok = w * ratio + r;
                 const float g = __bfloat162float(gate[(size_t)tok * proj_dim + d])
-                              + __bfloat162float(ape[(size_t)r * proj_dim + d]);
+                              + ape[(size_t)r * proj_dim + d];
                 const float v = __bfloat162float(kv[(size_t)tok * proj_dim + d]);
                 const float mn = fmaxf(m, g);
                 const float eo = __expf(m - mn);


### PR DESCRIPTION
The DeepSeek-V4-Flash CSA/HCA compressor's absolute-position encoding (`compressor.ape`, `position_bias`) ships as **FP32** `[ratio, proj_dim]` on every compressed layer (CSA ratio 4 → `[4, 2·head_dim]`; HCA ratio 128 → `[128, head_dim]`; 41 tensors, all FP32). `csa_compress` declared and indexed it as `const __nv_bfloat16*`, advancing a 2-byte stride through the 4-byte buffer and reading across element boundaries — corrupting the per-window softmax gate on every compressed layer (L2–L42). Same defect class as the attn_sink FP32-read-as-BF16 fix (#341).

## Fix

- **Kernel** (`csa_compress.cu`): `ape` argument `const __nv_bfloat16*` → `const float*`; the three reads drop `__bfloat162float`. Launch sites are unchanged — `arg_ptr` passes a type-erased `DevicePtr`, so the pointer ABI is identical.
- **Loader**: new `csa_ape::load_ape_f32` normalizes to the FP32 contract (F32 pass-through / BF16 widen / else fail loudly), mirroring `load_attn_sink_f32`, so a future non-F32 `ape` fails loudly instead of being silently misread.
- **Doc**: `types_weights.rs` `ape` field corrected to F32.

`csa_compress` is the sole `ape` consumer (prefill + decode); the DS4F indexer's `indexer.compressor.ape` is not loaded (Atlas has no indexer).

## Verification (measured — EP=2 GB10, NET/IB RoCE, q5 token-0)

- Checkpoint `compressor.ape` is FP32 but Atlas read it with a BF16 stride; an internal kernel trace showed corrupted `ape` values up to ≈1e38.
- Correct FP32 reads restore compressor replay fidelity: `compressed_prenorm` vs the correct-F32 replay **cos 0.776 → 0.999999**.
- L2 attention output vs vLLM: **cos 0.872 → 0.9965**, relative-L2 **0.496 → 0.086** (≈97% gap closure). L0/L1 and all pre-attention taps unchanged — only L2's attention output moved.
- Neutrality: token-0 `We` (== vLLM); internal tap OFF == ON.
- q3/q5/q8 all completed coherently with `finish=stop` in the seal run.

## Tests

- APE loader regression tests (F32 read / bf16-misread divergence / bf16-widen).
- `cargo test -p spark-model` 193 pass · `cargo test -p spark-server --bin spark` 702 pass.
- `cargo clippy -p spark-model` clean · nvcc `sm_121a` compile · full release build.

## Out of scope

- deeper-layer residual accumulation;
- decode-time CSA append;
- hard-limit enforcement;
- full NIM-parity evaluation;
- instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
