### PR TITLE
ci(release): dispatchable multi-platform release build + GitHub Release

### DIFF
--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -52,18 +52,8 @@
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "scale",
     "experimental": true,
-    "pr_validate": false
-  },
-  {
-    "id": "linux-aarch64-amd-scale",
-    "os": "linux",
-    "runner": "ubuntu-24.04-arm",
-    "target": "aarch64-unknown-linux-gnu",
-    "platform": "amd",
-    "cargo_features": "--no-default-features --features cuda",
-    "toolchain": "scale",
-    "experimental": true,
-    "pr_validate": false
+    "pr_validate": true,
+    "scale_arch": "gfx1151"
   },
   {
     "id": "macos-aarch64-metal",

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -7,7 +7,8 @@
     "platform": "nvidia",
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "cuda",
-    "experimental": false
+    "experimental": false,
+    "pr_validate": true
   },
   {
     "id": "linux-x86_64-nvidia-cuda-nccl",
@@ -17,7 +18,8 @@
     "platform": "nvidia",
     "cargo_features": "--features cuda,nccl",
     "toolchain": "cuda-nccl",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": true
   },
   {
     "id": "linux-aarch64-nvidia-cuda",
@@ -27,7 +29,8 @@
     "platform": "nvidia",
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "cuda-sbsa",
-    "experimental": false
+    "experimental": false,
+    "pr_validate": true
   },
   {
     "id": "linux-aarch64-nvidia-cuda-nccl",
@@ -37,7 +40,8 @@
     "platform": "nvidia",
     "cargo_features": "--features cuda,nccl",
     "toolchain": "cuda-nccl-sbsa",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": true
   },
   {
     "id": "linux-x86_64-amd-scale",
@@ -47,7 +51,8 @@
     "platform": "amd",
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "scale",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": false
   },
   {
     "id": "linux-aarch64-amd-scale",
@@ -57,7 +62,8 @@
     "platform": "amd",
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "scale",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": false
   },
   {
     "id": "macos-aarch64-metal",
@@ -67,7 +73,8 @@
     "platform": "metal",
     "cargo_features": "--no-default-features --features metal",
     "toolchain": "none",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": true
   },
   {
     "id": "macos-x86_64-metal",
@@ -77,7 +84,8 @@
     "platform": "metal",
     "cargo_features": "--no-default-features --features metal",
     "toolchain": "none",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": true
   },
   {
     "id": "windows-x86_64-nvidia-cuda",
@@ -87,6 +95,7 @@
     "platform": "nvidia",
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "cuda",
-    "experimental": true
+    "experimental": true,
+    "pr_validate": true
   }
 ]

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "linux-x86_64-nvidia-cuda",
+    "os": "linux",
+    "runner": "ubuntu-24.04",
+    "target": "x86_64-unknown-linux-gnu",
+    "platform": "nvidia",
+    "cargo_features": "--no-default-features --features cuda",
+    "toolchain": "cuda",
+    "experimental": false
+  },
+  {
+    "id": "linux-x86_64-nvidia-cuda-nccl",
+    "os": "linux",
+    "runner": "ubuntu-24.04",
+    "target": "x86_64-unknown-linux-gnu",
+    "platform": "nvidia",
+    "cargo_features": "--features cuda,nccl",
+    "toolchain": "cuda-nccl",
+    "experimental": true
+  },
+  {
+    "id": "linux-aarch64-nvidia-cuda",
+    "os": "linux",
+    "runner": "ubuntu-24.04-arm",
+    "target": "aarch64-unknown-linux-gnu",
+    "platform": "nvidia",
+    "cargo_features": "--no-default-features --features cuda",
+    "toolchain": "cuda-sbsa",
+    "experimental": false
+  },
+  {
+    "id": "linux-aarch64-nvidia-cuda-nccl",
+    "os": "linux",
+    "runner": "ubuntu-24.04-arm",
+    "target": "aarch64-unknown-linux-gnu",
+    "platform": "nvidia",
+    "cargo_features": "--features cuda,nccl",
+    "toolchain": "cuda-nccl-sbsa",
+    "experimental": true
+  },
+  {
+    "id": "linux-x86_64-amd-scale",
+    "os": "linux",
+    "runner": "ubuntu-24.04",
+    "target": "x86_64-unknown-linux-gnu",
+    "platform": "amd",
+    "cargo_features": "--no-default-features --features cuda",
+    "toolchain": "scale",
+    "experimental": true
+  },
+  {
+    "id": "linux-aarch64-amd-scale",
+    "os": "linux",
+    "runner": "ubuntu-24.04-arm",
+    "target": "aarch64-unknown-linux-gnu",
+    "platform": "amd",
+    "cargo_features": "--no-default-features --features cuda",
+    "toolchain": "scale",
+    "experimental": true
+  },
+  {
+    "id": "macos-aarch64-metal",
+    "os": "macos",
+    "runner": "macos-14",
+    "target": "aarch64-apple-darwin",
+    "platform": "metal",
+    "cargo_features": "--no-default-features --features metal",
+    "toolchain": "none",
+    "experimental": true
+  },
+  {
+    "id": "macos-x86_64-metal",
+    "os": "macos",
+    "runner": "macos-13",
+    "target": "x86_64-apple-darwin",
+    "platform": "metal",
+    "cargo_features": "--no-default-features --features metal",
+    "toolchain": "none",
+    "experimental": true
+  },
+  {
+    "id": "windows-x86_64-nvidia-cuda",
+    "os": "windows",
+    "runner": "windows-2022",
+    "target": "x86_64-pc-windows-msvc",
+    "platform": "nvidia",
+    "cargo_features": "--no-default-features --features cuda",
+    "toolchain": "cuda",
+    "experimental": true
+  }
+]

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -71,13 +71,14 @@
   {
     "id": "macos-x86_64-metal",
     "os": "macos",
-    "runner": "macos-13",
+    "runner": "macos-14",
     "target": "x86_64-apple-darwin",
     "platform": "metal",
     "cargo_features": "--no-default-features --features metal",
     "toolchain": "none",
     "experimental": true,
-    "pr_validate": true
+    "pr_validate": true,
+    "cross": true
   },
   {
     "id": "windows-x86_64-nvidia-cuda",

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -52,11 +52,10 @@
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "scale",
     "experimental": true,
-    "pr_validate": false,
+    "pr_validate": true,
     "scale_arch": "gfx1151",
     "target_model": "qwen3.6-27b",
-    "target_quant": "nvfp4",
-    "note": "gfx1151 has no FP8 matrix instruction. w4a16_gemm.cu's GEMM bodies emit raw mma.sync.m16n8k32.e4m3 PTX that SCALE cannot codegen; the source itself records that this .cu compiles for AMD only via the strix-hip-real WMMA rewrite. Kernel-port work, not CI."
+    "target_quant": "nvfp4"
   },
   {
     "id": "macos-aarch64-metal",

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -76,16 +76,5 @@
     "toolchain": "none",
     "experimental": true,
     "pr_validate": true
-  },
-  {
-    "id": "windows-x86_64-nvidia-cuda",
-    "os": "windows",
-    "runner": "windows-2022",
-    "target": "x86_64-pc-windows-msvc",
-    "platform": "nvidia",
-    "cargo_features": "--no-default-features --features cuda",
-    "toolchain": "cuda",
-    "experimental": true,
-    "pr_validate": true
   }
 ]

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -53,7 +53,9 @@
     "toolchain": "scale",
     "experimental": true,
     "pr_validate": true,
-    "scale_arch": "gfx1151"
+    "scale_arch": "gfx1151",
+    "target_model": "qwen3.6-27b",
+    "target_quant": "nvfp4"
   },
   {
     "id": "macos-aarch64-metal",

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -76,5 +76,16 @@
     "toolchain": "none",
     "experimental": true,
     "pr_validate": true
+  },
+  {
+    "id": "windows-x86_64-nvidia-cuda",
+    "os": "windows",
+    "runner": "windows-2022",
+    "target": "x86_64-pc-windows-msvc",
+    "platform": "nvidia",
+    "cargo_features": "--no-default-features --features cuda",
+    "toolchain": "cuda",
+    "experimental": true,
+    "pr_validate": true
   }
 ]

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -52,10 +52,11 @@
     "cargo_features": "--no-default-features --features cuda",
     "toolchain": "scale",
     "experimental": true,
-    "pr_validate": true,
+    "pr_validate": false,
     "scale_arch": "gfx1151",
     "target_model": "qwen3.6-27b",
-    "target_quant": "nvfp4"
+    "target_quant": "nvfp4",
+    "note": "gfx1151 has no FP8 matrix instruction. w4a16_gemm.cu's GEMM bodies emit raw mma.sync.m16n8k32.e4m3 PTX that SCALE cannot codegen; the source itself records that this .cu compiles for AMD only via the strix-hip-real WMMA rewrite. Kernel-port work, not CI."
   },
   {
     "id": "macos-aarch64-metal",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,3 +341,18 @@ jobs:
 
   # cargo-deny runs in security.yml with path filters on Cargo.toml / Cargo.lock /
   # deny.toml plus a weekly cron. Not duplicated here.
+
+  # The release build matrix runs only after every gate above is green, in
+  # this same CI run — so a PR's checks table shows base CI then the matrix,
+  # and CI is never executed twice for one commit. Guarded to pull_request:
+  # release.yml calls this workflow for its own gate, and must not trigger a
+  # second matrix build there.
+  release-matrix:
+    name: release matrix
+    if: github.event_name == 'pull_request'
+    needs: [fmt, clippy, license-headers, typos, test, test-macos-metal]
+    uses: ./.github/workflows/release-build.yml
+    with:
+      version: 0.0.0-pr${{ github.event.number }}
+      pr_mode: true
+      retention_days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
     branches: [main, master]
+  # Reusable: release.yml gates its (expensive) build matrix on CI passing, so
+  # a fmt or clippy failure costs one cheap runner instead of eight toolchain
+  # installs. Defined once here; release.yml calls it rather than copying it.
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   # installs. Defined once here; release.yml calls it rather than copying it.
   workflow_call:
 
+# Least privilege: CI only reads the repo. Without an explicit block the
+# GITHUB_TOKEN inherits the repository default, which can be write — flagged by
+# CodeQL (code-scanning/32) once this workflow gained the release-matrix job.
+# The reusable workflows it calls inherit this and declare the same.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -187,6 +187,25 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install cmake llvm
 
+      - name: Configure cross-arch build (macos)
+        if: matrix.os == 'macos' && matrix.cross
+        run: |
+          set -euo pipefail
+          # The Intel slice is built on an Apple Silicon runner: macos-13
+          # (Intel) runners are being retired and never once scheduled for
+          # this matrix, so the job sat queued and was cancelled every run.
+          # Xcode ships both slices, so cross-compiling is the reliable path.
+          # cc-rs and cmake do NOT infer the arch from --target, so state it:
+          # otherwise native deps build for arm64 and the link fails on
+          # mismatched architectures.
+          {
+            echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)"
+            echo "MACOSX_DEPLOYMENT_TARGET=11.0"
+            echo "CFLAGS_x86_64_apple_darwin=-arch x86_64"
+            echo "CXXFLAGS_x86_64_apple_darwin=-arch x86_64"
+            echo "CMAKE_OSX_ARCHITECTURES=x86_64"
+          } >> "$GITHUB_ENV"
+
       - name: Install CUDA toolkit (linux)
         if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'linux'
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -48,6 +48,7 @@ env:
   # old for the target architecture. Defined once here.
   CUDA_APT_VERSION: "13-0"
   CUDA_DOT_VERSION: "13.0"
+  CUDA_FULL_VERSION: "13.0.2"
   # NOTE: CUDARC_CUDA_VERSION is deliberately NOT set here. Workflow-level
   # `env` overrides values written to $GITHUB_ENV by an earlier step, so
   # declaring it here would defeat the SCALE step's 12080 override and build
@@ -186,8 +187,8 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install cmake llvm
 
-      - name: Install CUDA toolkit
-        if: startsWith(matrix.toolchain, 'cuda')
+      - name: Install CUDA toolkit (linux)
+        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'linux'
         run: |
           set -euo pipefail
           # Installed straight from NVIDIA's apt repo rather than via the
@@ -220,6 +221,41 @@ jobs:
             echo "CUDARC_CUDA_VERSION=13000"
           } >> "$GITHUB_ENV"
           echo "$cuda_root/bin" >> "$GITHUB_PATH"
+
+      - name: Install CUDA toolkit (windows)
+        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          # NVIDIA's own silent network installer. The cuda-toolkit action has
+          # no 13.0.2 ("Version not available"), and pinning an older CUDA
+          # would contradict what this repo targets everywhere else.
+          $v = "${{ env.CUDA_FULL_VERSION }}"
+          $url = "https://developer.download.nvidia.com/compute/cuda/$v/network_installers/cuda_${v}_windows_network.exe"
+          Write-Host "downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile cuda.exe -UseBasicParsing
+          # Sub-packages are version-suffixed; installing the full toolkit
+          # would blow the runner's disk budget.
+          $short = $v.Substring(0, $v.LastIndexOf('.'))
+          $args = @("-s", "nvcc_$short", "cudart_$short", "nvrtc_$short",
+                    "nvrtc_dev_$short", "cuda_profiler_api_$short")
+          $p = Start-Process -FilePath .\cuda.exe -ArgumentList $args -Wait -PassThru -NoNewWindow
+          if ($p.ExitCode -ne 0) { throw "CUDA installer exited $($p.ExitCode)" }
+          $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$short"
+          if (-not (Test-Path "$root\bin\nvcc.exe")) { throw "nvcc missing at $root" }
+          & "$root\bin\nvcc.exe" --version | Select-Object -Last 2
+          "CUDA_PATH=$root"          | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CUDA_HOME=$root"          | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CUDARC_CUDA_VERSION=13000"| Out-File -FilePath $env:GITHUB_ENV -Append
+          "$root\bin"               | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Install build deps (windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          # bindgen (xgrammar) needs libclang; windows-2022 ships LLVM.
+          $llvm = "C:\Program Files\LLVM\bin"
+          if (Test-Path $llvm) { "LIBCLANG_PATH=$llvm" | Out-File -FilePath $env:GITHUB_ENV -Append }
+          cmake --version
 
       - name: Install NCCL
         if: contains(matrix.toolchain, 'nccl')

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Reusable build matrix: compile, package and verify `spark` for every
+# (OS, arch, GPU-platform) in `.github/release-matrix.json`.
+#
+# Defined ONCE and called from two places, so a PR proves exactly what a
+# release will later do:
+#   - ci.yml       (pull_request) -> after the base CI gates pass
+#   - release.yml  (dispatch)     -> after CI, before publish
+#
+# It never tags, pushes or publishes. Only release.yml's `publish` job does
+# that, and only on workflow_dispatch with dry_run=false.
+name: Release build matrix
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version string stamped into artifact names"
+        required: true
+        type: string
+      ref:
+        description: "Ref to build; empty means the caller's checked-out ref"
+        required: false
+        type: string
+        default: ""
+      pr_mode:
+        description: "Skip targets whose toolchain cannot exist on a hosted runner"
+        required: false
+        type: boolean
+        default: false
+      retention_days:
+        description: "Artifact retention"
+        required: false
+        type: number
+        default: 1
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Cheap, always-runs gate. Everything that can be wrong statically is
+  # caught here BEFORE any runner spends time installing a CUDA toolkit.
+  # ---------------------------------------------------------------------
+  validate:
+    name: validate inputs + matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate matrix shape
+        run: |
+          set -euo pipefail
+          jq -e 'type == "array" and length > 0' .github/release-matrix.json >/dev/null
+          # Every entry must carry every key: a missing `toolchain` would
+          # silently build a CUDA target with no CUDA installed.
+          missing=$(jq -r '
+            [ .[] | select(
+                has("id") and has("os") and has("runner") and has("target")
+                and has("platform") and has("cargo_features")
+                and has("toolchain") and has("experimental")
+                and has("pr_validate") | not
+              ) | .id // "<no id>" ] | join(", ")' .github/release-matrix.json)
+          [ -z "$missing" ] || { echo "::error::entries missing keys: $missing"; exit 1; }
+          dupes=$(jq -r '[.[].id] | group_by(.) | map(select(length>1) | .[0]) | join(", ")' \
+            .github/release-matrix.json)
+          [ -z "$dupes" ] || { echo "::error::duplicate matrix ids: $dupes"; exit 1; }
+
+      - name: Validate every cargo feature exists in spark-server
+        run: |
+          set -euo pipefail
+          # The most likely matrix error is a typo'd or removed feature name.
+          # `cargo metadata` is the SSOT for what features actually exist.
+          known=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="spark-server") | .features | keys[]' | sort -u)
+          echo "spark-server features: $(echo "$known" | tr '\n' ' ')"
+          bad=0
+          while read -r feats; do
+            for f in $(printf '%s' "$feats" | grep -oP '(?<=--features )[^ ]+' | tr ',' ' '); do
+              grep -qx -- "$f" <<<"$known" || { echo "::error::unknown feature '$f'"; bad=1; }
+            done
+          done < <(jq -r '.[].cargo_features' .github/release-matrix.json)
+          [ "$bad" = 0 ]
+
+      - name: Emit build matrix
+        id: build-matrix
+        run: |
+          set -euo pipefail
+          # On a PR we build every entry that CAN be built on a hosted runner.
+          # Entries with pr_validate=false are physically impossible here (the
+          # SCALE toolchain is not redistributable) — they are reported as NOT
+          # VALIDATED rather than passed vacuously.
+          if [ "${{ inputs.pr_mode }}" = true ]; then
+            sel=$(jq -c '{include: [.[] | select(.pr_validate)]}' .github/release-matrix.json)
+            jq -r '.[] | select(.pr_validate | not)
+                   | "::warning::\(.id) NOT VALIDATED in PR mode — toolchain \(.toolchain) unavailable on hosted runners"' \
+              .github/release-matrix.json
+          else
+            sel=$(jq -c '{include: .}' .github/release-matrix.json)
+          fi
+          echo "matrix=$sel" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: |
+          {
+            echo "### Release matrix"
+            echo "| id | runner | target | features | toolchain | experimental |"
+            echo "|---|---|---|---|---|---|"
+            jq -r '.[] | "| \(.id) | \(.runner) | \(.target) | `\(.cargo_features)` | \(.toolchain) | \(.experimental) |"' \
+              .github/release-matrix.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # The ordinary CI gates (fmt, clippy, tests, licence headers, typos, the
+  # macOS/metal job) must pass BEFORE the release matrix spends runner time.
+  # Called as a reusable workflow so CI stays defined in exactly one place.
+  # ---------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------
+  # One job per (OS, arch, platform). Experimental entries may fail without
+  # failing the release — that is what lets an unproven target sit in the
+  # matrix while it is being brought up.
+  # ---------------------------------------------------------------------
+  build:
+    name: build ${{ matrix.id }}
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.validate.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # On a PR there is no `ref` input; checkout defaults to the PR merge
+          # commit, which is what we want to validate.
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.id }}
+
+      - name: Free disk space (linux)
+        if: matrix.os == 'linux'
+        run: |
+          # A CUDA toolkit or the 1.43 GB SCALE tarball plus this workspace's
+          # kernel build does not fit alongside the preinstalled SDKs.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost /usr/lib/jvm || true
+          df -h / | tail -1
+
+      - name: Install build deps (linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake clang libclang-dev
+
+      - name: Install build deps (macos)
+        if: matrix.os == 'macos'
+        run: brew install cmake llvm
+
+      - name: Install CUDA toolkit
+        if: startsWith(matrix.toolchain, 'cuda')
+        uses: Jimver/cuda-toolkit@v0.2.19
+        with:
+          method: network
+          # Package names are apt names with DASHES. The first draft used
+          # `nvrtc_dev` / `cuda_profiler_api`, which apt resolved to
+          # `cuda-nvrtc_dev-12-6` / `cuda-cuda_profiler_api-12-6` -- neither
+          # exists, and every CUDA job died on it. `driver-dev` supplies the
+          # libcuda stub the raw extern "C" FFI in spark-storage links against.
+          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "driver-dev", "profiler-api"]'
+
+      - name: Install NCCL
+        if: contains(matrix.toolchain, 'nccl')
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends libnccl2 libnccl-dev
+
+      - name: Install SCALE toolchain (AMD)
+        if: matrix.toolchain == 'scale'
+        run: |
+          set -euo pipefail
+          # SCALE recompiles the unmodified CUDA kernels for AMD. Tarball URL
+          # and prerequisites are the ones documented in
+          # docs/porting/amd-strix-halo-scale.md; 1.7.1 is the first release
+          # whose bundled ROCm fixes the gfx1151 queue-create crash.
+          # build-essential -> cuda.h needs <cstddef>; libnuma -> libhsakmt.
+          sudo apt-get install -y --no-install-recommends build-essential libnuma1 libnuma-dev
+          mkdir -p "$HOME/scale" && cd "$HOME/scale"
+          curl -L --fail --retry 3 -o scale.tar.xz \
+            https://pkgs.scale-lang.com/tar/scale-1.7.1-amd64.tar.xz
+          tar -xf scale.tar.xz && rm -f scale.tar.xz
+          SCALE_HOME="$HOME/scale/scale-1.7.1-Linux"
+          arch='${{ matrix.scale_arch }}'
+          # Fail loudly if the layout is not what we expect: a missing nvcc
+          # here would otherwise fall through to the host nvcc and silently
+          # produce an NVIDIA binary labelled `amd`.
+          [ -x "$SCALE_HOME/targets/$arch/bin/nvcc" ] || {
+            echo "::error::SCALE nvcc missing at $SCALE_HOME/targets/$arch/bin/nvcc"
+            ls "$SCALE_HOME/targets" 2>/dev/null || true
+            exit 1
+          }
+          {
+            echo "SCALE_HOME=$SCALE_HOME"
+            echo "CUDA_PATH=$SCALE_HOME/targets/$arch"
+            echo "CUDA_HOME=$SCALE_HOME/targets/$arch"
+            echo "CUDARC_CUDA_VERSION=12080"
+            echo "ATLAS_TARGET_HW=strix"
+          } >> "$GITHUB_ENV"
+          echo "$SCALE_HOME/targets/$arch/bin" >> "$GITHUB_PATH"
+
+      - name: Build spark
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release -p spark-server --target ${{ matrix.target }} ${{ matrix.cargo_features }}
+
+      - name: Package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          # No version input exists on a PR. Stamp the artifact explicitly
+          # rather than packaging an empty version string.
+          ver='${{ inputs.version }}'
+          [ -n "$ver" ] || ver="0.0.0-pr${{ github.event.number }}"
+          name="spark-${ver}-${{ matrix.id }}"
+          staging="dist/$name"
+          mkdir -p "$staging"
+          bin=target/${{ matrix.target }}/release/spark
+          [ "${{ matrix.os }}" = windows ] && bin="$bin.exe"
+          cp "$bin" "$staging/"
+          cp LICENSE README.md "$staging/" 2>/dev/null || true
+          if [ "${{ matrix.os }}" = windows ]; then
+            (cd dist && 7z a -tzip "$name.zip" "$name" >/dev/null)
+            asset="dist/$name.zip"
+          else
+            tar -C dist -czf "dist/$name.tar.gz" "$name"
+            asset="dist/$name.tar.gz"
+          fi
+          sha256sum "$asset" > "$asset.sha256" 2>/dev/null || shasum -a 256 "$asset" > "$asset.sha256"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spark-${{ matrix.id }}
+          retention-days: ${{ inputs.retention_days }}
+          path: |
+            ${{ steps.package.outputs.asset }}
+            ${{ steps.package.outputs.asset }}.sha256
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------
+  # Publish. Skipped entirely on dry_run, so a dry run can never tag, never
+  # push and never create a Release.
+  # ---------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------
+  # Dry-run reporting. Makes `dry_run=true` show exactly what a real run
+  # would have published, so the decision to publish is made on evidence.
+  # ---------------------------------------------------------------------
+  dry-run-summary:
+    name: dry-run summary
+    needs: [validate, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Verify every artifact is real (checksums + non-empty)
+        run: |
+          set -euo pipefail
+          # The point of the PR dry run is that a later release CANNOT fail in
+          # a way this run would have passed. So verify the packages the same
+          # way a consumer would: checksum them and confirm they are non-empty.
+          shopt -s nullglob
+          n=0
+          for f in dist/*.tar.gz dist/*.zip; do
+            [ -s "$f" ] || { echo "::error::$f is empty"; exit 1; }
+            (cd dist && sha256sum -c "$(basename "$f").sha256") \
+              || { echo "::error::checksum mismatch for $f"; exit 1; }
+            n=$((n+1))
+          done
+          [ "$n" -gt 0 ] || { echo "::error::no artifacts were produced"; exit 1; }
+          echo "verified $n artifact(s)"
+
+      - name: Report what WOULD be published
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### DRY RUN — nothing was tagged, pushed or published"
+            echo
+            echo "Would create tag \`v${NEW_VERSION}\` on \`${{ inputs.ref }}\`."
+            echo
+            echo "#### Artifacts"
+            if find dist -type f ! -name '*.sha256' | grep -q .; then
+              find dist -type f ! -name '*.sha256' | sort | sed 's/^/- /'
+            else
+              echo "- (none — every build job failed or was skipped)"
+            fi
+            echo
+            echo "#### Release notes that would be generated"
+            echo '```markdown'
+            # Non-fatal, but never silently blank: a PR token may lack the
+            # write scope the generate-notes endpoint wants, and that should
+            # read as a degraded preview, not as "there are no notes".
+            bash scripts/release-notes.sh preview "$NEW_VERSION" \
+              || echo "(preview unavailable — generate-notes needs contents:write; not granted on pull_request)"
+            echo '```'
+            echo
+            echo "_Nothing was tagged, pushed or published: \`publish\` runs only on"
+            echo "workflow_dispatch with dry_run=false._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -273,12 +273,16 @@ jobs:
           # would blow the runner's disk budget.
           $short = $v.Substring(0, $v.LastIndexOf('.'))
           # cublas/cublas_dev for the same cublasLt link the Linux side needs.
-          # cudart_dev supplies include/crt/host_config.h, which cuda_runtime.h
-          # includes unconditionally. Without it nvcc installs fine and the
-          # failure surfaces much later as C1083 during kernel compilation.
-          $args = @("-s", "nvcc_$short", "cudart_$short", "cudart_dev_$short",
-                    "nvrtc_$short", "nvrtc_dev_$short", "cuda_profiler_api_$short",
-                    "cublas_$short", "cublas_dev_$short", "thrust_$short")
+          # Install the FULL toolkit rather than naming sub-packages. Two
+          # rounds of guessing component names cost two cycles: `nvrtc_dev` /
+          # `cuda_profiler_api` were wrong on Linux, then `cudart_dev` /
+          # `thrust` are not valid Windows component names either and the
+          # installer rejected the whole command with exit -522190823 -- an
+          # opaque code that names neither the bad component nor the reason.
+          # The component list is not documented per-version anywhere stable,
+          # so `-s` alone (install everything) trades a few GB of runner disk
+          # for determinism. Windows runners have ~80 GB free on D:.
+          $args = @("-s")
           $p = Start-Process -FilePath .\cuda.exe -ArgumentList $args -Wait -PassThru -NoNewWindow
           if ($p.ExitCode -ne 0) { throw "CUDA installer exited $($p.ExitCode)" }
           $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$short"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -160,6 +160,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Add the target to the PINNED toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          # rust-toolchain.toml pins 1.93.1, so that -- not `stable` -- is the
+          # toolchain cargo actually uses. The action above installs the target
+          # for `stable` (1.97.1), which leaves the pinned toolchain without
+          # it. Host-target rows never noticed; the one CROSS row
+          # (x86_64-apple-darwin on an arm64 runner) failed with
+          # `E0463: can't find crate for core`. Idempotent where already present.
+          rustup target add ${{ matrix.target }}
+          rustup show active-toolchain
+          rustup target list --installed
+
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.id }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -273,14 +273,26 @@ jobs:
           # would blow the runner's disk budget.
           $short = $v.Substring(0, $v.LastIndexOf('.'))
           # cublas/cublas_dev for the same cublasLt link the Linux side needs.
-          $args = @("-s", "nvcc_$short", "cudart_$short", "nvrtc_$short",
-                    "nvrtc_dev_$short", "cuda_profiler_api_$short",
-                    "cublas_$short", "cublas_dev_$short")
+          # cudart_dev supplies include/crt/host_config.h, which cuda_runtime.h
+          # includes unconditionally. Without it nvcc installs fine and the
+          # failure surfaces much later as C1083 during kernel compilation.
+          $args = @("-s", "nvcc_$short", "cudart_$short", "cudart_dev_$short",
+                    "nvrtc_$short", "nvrtc_dev_$short", "cuda_profiler_api_$short",
+                    "cublas_$short", "cublas_dev_$short", "thrust_$short")
           $p = Start-Process -FilePath .\cuda.exe -ArgumentList $args -Wait -PassThru -NoNewWindow
           if ($p.ExitCode -ne 0) { throw "CUDA installer exited $($p.ExitCode)" }
           $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$short"
           if (-not (Test-Path "$root\bin\nvcc.exe")) { throw "nvcc missing at $root" }
           & "$root\bin\nvcc.exe" --version | Select-Object -Last 2
+          # Verify the headers the build will actually need HERE, where the
+          # error can name the missing component -- not three minutes later as
+          # a C1083 from deep inside kernel compilation.
+          foreach ($h in @("crt\host_config.h", "cuda_runtime.h")) {
+            if (-not (Test-Path "$root\include\$h")) {
+              Get-ChildItem "$root\include" -Name | Select-Object -First 20
+              throw "CUDA include\$h missing - a sub-package failed to install"
+            }
+          }
           "CUDA_PATH=$root"          | Out-File -FilePath $env:GITHUB_ENV -Append
           "CUDA_HOME=$root"          | Out-File -FilePath $env:GITHUB_ENV -Append
           "CUDARC_CUDA_VERSION=13000"| Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -112,7 +112,7 @@ jobs:
           if [ "${{ inputs.pr_mode }}" = true ]; then
             sel=$(jq -c '{include: [.[] | select(.pr_validate)]}' .github/release-matrix.json)
             jq -r '.[] | select(.pr_validate | not)
-                   | "::warning::\(.id) NOT VALIDATED in PR mode — toolchain \(.toolchain) unavailable on hosted runners"' \
+                   | "::warning::\(.id) NOT VALIDATED in PR mode — \(.note // "toolchain \(.toolchain) unavailable on hosted runners")"' \
               .github/release-matrix.json
           else
             sel=$(jq -c '{include: .}' .github/release-matrix.json)

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -420,7 +420,13 @@ jobs:
             tar -C dist -czf "dist/$name.tar.gz" "$name"
             asset="dist/$name.tar.gz"
           fi
-          sha256sum "$asset" > "$asset.sha256" 2>/dev/null || shasum -a 256 "$asset" > "$asset.sha256"
+          # Record the BARE filename, not "dist/<name>": a checksum file is
+          # consumed with `sha256sum -c` from the directory holding the
+          # artifact (both by the verify step and by anyone downloading a
+          # release asset), and a stored relative path breaks there.
+          ( cd "$(dirname "$asset")" \
+            && { sha256sum "$(basename "$asset")" > "$(basename "$asset").sha256" 2>/dev/null \
+                 || shasum -a 256 "$(basename "$asset")" > "$(basename "$asset").sha256"; } )
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -312,11 +312,24 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "$SCALE_HOME/targets/$arch/bin" >> "$GITHUB_PATH"
 
-      - name: Build spark
+      - name: Build spark (unix)
+        if: matrix.os != 'windows'
         shell: bash
         run: |
           set -euo pipefail
           cargo build --release -p spark-server --target ${{ matrix.target }} ${{ matrix.cargo_features }}
+
+      - name: Build spark (windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          # pwsh, NOT bash. Under `shell: bash` on Windows, Git Bash puts its
+          # own /usr/bin ahead of MSVC on PATH, and rustc then invokes
+          # `C:\Program Files\Git\usr\bin\link.exe` -- the coreutils `link`
+          # -- instead of the MSVC linker. It fails with "extra operand" on the
+          # first object file.
+          cargo build --release -p spark-server --target ${{ matrix.target }} ${{ matrix.cargo_features }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Package
         id: package

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -316,6 +316,23 @@ jobs:
           $llvm = "C:\Program Files\LLVM\bin"
           if (Test-Path $llvm) { "LIBCLANG_PATH=$llvm" | Out-File -FilePath $env:GITHUB_ENV -Append }
           cmake --version
+          # The CUDA import libraries (cuda.lib, cudart.lib, nvrtc.lib,
+          # cublasLt.lib -- everything the build scripts emit
+          # `rustc-link-lib=dylib=` for) live in $CUDA_PATH\lib\x64, which is
+          # not on the MSVC default search path. Without it the whole build
+          # compiles and then dies at link with LNK1181.
+          #
+          # This runs AFTER msvc-dev-cmd ON PURPOSE: that action rewrites LIB
+          # wholesale, so appending in the CUDA install step above would be
+          # silently discarded. Order is the fix, not just the value.
+          $cudaLib = "$env:CUDA_PATH\lib\x64"
+          foreach ($l in @("cuda.lib", "cudart.lib", "nvrtc.lib", "cublasLt.lib")) {
+            if (-not (Test-Path "$cudaLib\$l")) {
+              Get-ChildItem $cudaLib -Name -ErrorAction SilentlyContinue | Select-Object -First 20
+              throw "$l missing from $cudaLib"
+            }
+          }
+          "LIB=$env:LIB;$cudaLib" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install NCCL
         if: contains(matrix.toolchain, 'nccl')

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -48,7 +48,6 @@ env:
   # old for the target architecture. Defined once here.
   CUDA_APT_VERSION: "13-0"
   CUDA_DOT_VERSION: "13.0"
-  CUDA_FULL_VERSION: "13.0.2"
   # NOTE: CUDARC_CUDA_VERSION is deliberately NOT set here. Workflow-level
   # `env` overrides values written to $GITHUB_ENV by an earlier step, so
   # declaring it here would defeat the SCALE step's 12080 override and build
@@ -177,14 +176,18 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake clang libclang-dev
+          # libibverbs/librdmacm: atlas-rdma compiles src/rdma_shim.c against
+          # <infiniband/verbs.h> on every non-macOS target. Same dependency
+          # #339 added to the DeepSeek-V4 builder stage.
+          sudo apt-get install -y --no-install-recommends \
+            cmake clang libclang-dev libibverbs-dev librdmacm-dev
 
       - name: Install build deps (macos)
         if: matrix.os == 'macos'
         run: brew install cmake llvm
 
-      - name: Install CUDA toolkit (linux)
-        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'linux'
+      - name: Install CUDA toolkit
+        if: startsWith(matrix.toolchain, 'cuda')
         run: |
           set -euo pipefail
           # Installed straight from NVIDIA's apt repo rather than via the
@@ -217,19 +220,6 @@ jobs:
             echo "CUDARC_CUDA_VERSION=13000"
           } >> "$GITHUB_ENV"
           echo "$cuda_root/bin" >> "$GITHUB_PATH"
-
-      - name: Install CUDA toolkit (windows)
-        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'windows'
-        uses: Jimver/cuda-toolkit@v0.2.19
-        with:
-          cuda: ${{ env.CUDA_FULL_VERSION }}
-          method: network
-          sub-packages: '["nvcc", "cudart", "nvrtc", "nvrtc_dev", "profiler_api"]'
-
-      - name: Pin cudarc CUDA version (windows)
-        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'windows'
-        shell: bash
-        run: echo "CUDARC_CUDA_VERSION=13000" >> "$GITHUB_ENV"
 
       - name: Install NCCL
         if: contains(matrix.toolchain, 'nccl')

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -208,9 +208,12 @@ jobs:
           v='${{ env.CUDA_APT_VERSION }}'
           # driver-dev supplies the libcuda stub that spark-storage's raw
           # extern "C" FFI links against on a runner with no GPU.
+          # libcublas-dev supplies libcublasLt: the kernel build scripts emit
+          # `rustc-link-lib=dylib=cublasLt`, so omitting it fails at LINK time
+          # after a full compile — the most expensive place to discover it.
           sudo apt-get install -y --no-install-recommends \
             "cuda-nvcc-$v" "cuda-cudart-dev-$v" "cuda-nvrtc-dev-$v" \
-            "cuda-driver-dev-$v" "cuda-profiler-api-$v"
+            "cuda-driver-dev-$v" "cuda-profiler-api-$v" "libcublas-dev-$v"
           cuda_root="/usr/local/cuda-${{ env.CUDA_DOT_VERSION }}"
           [ -x "$cuda_root/bin/nvcc" ] || { echo "::error::nvcc missing at $cuda_root"; exit 1; }
           "$cuda_root/bin/nvcc" --version | tail -2
@@ -236,8 +239,10 @@ jobs:
           # Sub-packages are version-suffixed; installing the full toolkit
           # would blow the runner's disk budget.
           $short = $v.Substring(0, $v.LastIndexOf('.'))
+          # cublas/cublas_dev for the same cublasLt link the Linux side needs.
           $args = @("-s", "nvcc_$short", "cudart_$short", "nvrtc_$short",
-                    "nvrtc_dev_$short", "cuda_profiler_api_$short")
+                    "nvrtc_dev_$short", "cuda_profiler_api_$short",
+                    "cublas_$short", "cublas_dev_$short")
           $p = Start-Process -FilePath .\cuda.exe -ArgumentList $args -Wait -PassThru -NoNewWindow
           if ($p.ExitCode -ne 0) { throw "CUDA installer exited $($p.ExitCode)" }
           $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$short"
@@ -247,6 +252,12 @@ jobs:
           "CUDA_HOME=$root"          | Out-File -FilePath $env:GITHUB_ENV -Append
           "CUDARC_CUDA_VERSION=13000"| Out-File -FilePath $env:GITHUB_ENV -Append
           "$root\bin"               | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Set up MSVC developer environment (windows)
+        if: matrix.os == 'windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: Install build deps (windows)
         if: matrix.os == 'windows'
@@ -266,6 +277,10 @@ jobs:
         if: matrix.toolchain == 'scale'
         run: |
           set -euo pipefail
+          # ATLAS_TARGET_MODEL/QUANT are REQUIRED, not optional: atlas-kernels
+          # defaults to qwen3-next-80b-a3b, which has no kernels/strix/
+          # directory, and the build script panics resolving targets. They are
+          # matrix fields so a second strix model is another JSON row.
           # SCALE recompiles the unmodified CUDA kernels for AMD. Tarball URL
           # and prerequisites are the ones documented in
           # docs/porting/amd-strix-halo-scale.md; 1.7.1 is the first release
@@ -292,6 +307,8 @@ jobs:
             echo "CUDA_HOME=$SCALE_HOME/targets/$arch"
             echo "CUDARC_CUDA_VERSION=12080"
             echo "ATLAS_TARGET_HW=strix"
+            echo "ATLAS_TARGET_MODEL=${{ matrix.target_model }}"
+            echo "ATLAS_TARGET_QUANT=${{ matrix.target_quant }}"
           } >> "$GITHUB_ENV"
           echo "$SCALE_HOME/targets/$arch/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -41,6 +41,18 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # This repo targets CUDA 13.0: every docker/gb10/**/Dockerfile is
+  # `nvidia/cuda:13.0.0-devel-ubuntu24.04`, and ci.yml/docs.yml pin
+  # CUDARC_CUDA_VERSION=13000. GB10 is sm_121, which needs >= 12.8, so the
+  # cuda-toolkit action's 12.6 default was both wrong for this repo and too
+  # old for the target architecture. Defined once here.
+  CUDA_APT_VERSION: "13-0"
+  CUDA_DOT_VERSION: "13.0"
+  CUDA_FULL_VERSION: "13.0.2"
+  # NOTE: CUDARC_CUDA_VERSION is deliberately NOT set here. Workflow-level
+  # `env` overrides values written to $GITHUB_ENV by an earlier step, so
+  # declaring it here would defeat the SCALE step's 12080 override and build
+  # the AMD target against a CUDA 13 ABI. Each toolchain sets it itself.
 
 jobs:
   # ---------------------------------------------------------------------
@@ -171,17 +183,53 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install cmake llvm
 
-      - name: Install CUDA toolkit
-        if: startsWith(matrix.toolchain, 'cuda')
+      - name: Install CUDA toolkit (linux)
+        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'linux'
+        run: |
+          set -euo pipefail
+          # Installed straight from NVIDIA's apt repo rather than via the
+          # cuda-toolkit action: it pins the exact version this repo targets
+          # and picks the right repo arch, where the action silently defaulted
+          # to 12.6.1 on both arches.
+          case '${{ matrix.target }}' in
+            x86_64-*)  repo_arch=x86_64 ;;
+            aarch64-*) repo_arch=sbsa ;;
+            *) echo "::error::no CUDA repo arch for ${{ matrix.target }}"; exit 1 ;;
+          esac
+          kr=cuda-keyring_1.1-1_all.deb
+          curl -fsSL --retry 3 -O \
+            "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/$repo_arch/$kr"
+          sudo dpkg -i "$kr" && rm -f "$kr"
+          sudo apt-get update
+          v='${{ env.CUDA_APT_VERSION }}'
+          # driver-dev supplies the libcuda stub that spark-storage's raw
+          # extern "C" FFI links against on a runner with no GPU.
+          sudo apt-get install -y --no-install-recommends \
+            "cuda-nvcc-$v" "cuda-cudart-dev-$v" "cuda-nvrtc-dev-$v" \
+            "cuda-driver-dev-$v" "cuda-profiler-api-$v"
+          cuda_root="/usr/local/cuda-${{ env.CUDA_DOT_VERSION }}"
+          [ -x "$cuda_root/bin/nvcc" ] || { echo "::error::nvcc missing at $cuda_root"; exit 1; }
+          "$cuda_root/bin/nvcc" --version | tail -2
+          {
+            echo "CUDA_PATH=$cuda_root"
+            echo "CUDA_HOME=$cuda_root"
+            echo "LIBRARY_PATH=$cuda_root/lib64/stubs:${LIBRARY_PATH:-}"
+            echo "CUDARC_CUDA_VERSION=13000"
+          } >> "$GITHUB_ENV"
+          echo "$cuda_root/bin" >> "$GITHUB_PATH"
+
+      - name: Install CUDA toolkit (windows)
+        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'windows'
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
+          cuda: ${{ env.CUDA_FULL_VERSION }}
           method: network
-          # Package names are apt names with DASHES. The first draft used
-          # `nvrtc_dev` / `cuda_profiler_api`, which apt resolved to
-          # `cuda-nvrtc_dev-12-6` / `cuda-cuda_profiler_api-12-6` -- neither
-          # exists, and every CUDA job died on it. `driver-dev` supplies the
-          # libcuda stub the raw extern "C" FFI in spark-storage links against.
-          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "driver-dev", "profiler-api"]'
+          sub-packages: '["nvcc", "cudart", "nvrtc", "nvrtc_dev", "profiler_api"]'
+
+      - name: Pin cudarc CUDA version (windows)
+        if: startsWith(matrix.toolchain, 'cuda') && matrix.os == 'windows'
+        shell: bash
+        run: echo "CUDARC_CUDA_VERSION=13000" >> "$GITHUB_ENV"
 
       - name: Install NCCL
         if: contains(matrix.toolchain, 'nccl')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,15 @@ jobs:
         with:
           key: ${{ matrix.id }}
 
+      - name: Free disk space (linux)
+        if: matrix.os == 'linux'
+        run: |
+          # A CUDA toolkit or the 1.43 GB SCALE tarball plus this workspace's
+          # kernel build does not fit alongside the preinstalled SDKs.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost /usr/lib/jvm || true
+          df -h / | tail -1
+
       - name: Install build deps (linux)
         if: matrix.os == 'linux'
         run: |
@@ -205,24 +214,50 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           method: network
-          # Kernel compilation only needs nvcc + the driver stubs; skipping the
-          # rest keeps a ~3 GB install down to something a runner can hold.
-          sub-packages: '["nvcc", "cudart", "nvrtc", "nvrtc_dev", "cuda_profiler_api"]'
+          # Package names are apt names with DASHES. The first draft used
+          # `nvrtc_dev` / `cuda_profiler_api`, which apt resolved to
+          # `cuda-nvrtc_dev-12-6` / `cuda-cuda_profiler_api-12-6` -- neither
+          # exists, and every CUDA job died on it. `driver-dev` supplies the
+          # libcuda stub the raw extern "C" FFI in spark-storage links against.
+          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "driver-dev", "profiler-api"]'
 
       - name: Install NCCL
         if: contains(matrix.toolchain, 'nccl')
         run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends libnccl2 libnccl-dev
 
-      - name: SCALE toolchain (AMD)
+      - name: Install SCALE toolchain (AMD)
         if: matrix.toolchain == 'scale'
         run: |
-          # SCALE is not redistributable from a hosted runner. This entry is
-          # experimental precisely because the toolchain has to come from a
-          # self-hosted runner or a cached tarball; fail loudly, do not
-          # silently produce a CUDA binary labelled `amd`.
-          echo "::error::SCALE toolchain unavailable on hosted runners — run this entry on self-hosted"
-          exit 1
+          set -euo pipefail
+          # SCALE recompiles the unmodified CUDA kernels for AMD. Tarball URL
+          # and prerequisites are the ones documented in
+          # docs/porting/amd-strix-halo-scale.md; 1.7.1 is the first release
+          # whose bundled ROCm fixes the gfx1151 queue-create crash.
+          # build-essential -> cuda.h needs <cstddef>; libnuma -> libhsakmt.
+          sudo apt-get install -y --no-install-recommends build-essential libnuma1 libnuma-dev
+          mkdir -p "$HOME/scale" && cd "$HOME/scale"
+          curl -L --fail --retry 3 -o scale.tar.xz \
+            https://pkgs.scale-lang.com/tar/scale-1.7.1-amd64.tar.xz
+          tar -xf scale.tar.xz && rm -f scale.tar.xz
+          SCALE_HOME="$HOME/scale/scale-1.7.1-Linux"
+          arch='${{ matrix.scale_arch }}'
+          # Fail loudly if the layout is not what we expect: a missing nvcc
+          # here would otherwise fall through to the host nvcc and silently
+          # produce an NVIDIA binary labelled `amd`.
+          [ -x "$SCALE_HOME/targets/$arch/bin/nvcc" ] || {
+            echo "::error::SCALE nvcc missing at $SCALE_HOME/targets/$arch/bin/nvcc"
+            ls "$SCALE_HOME/targets" 2>/dev/null || true
+            exit 1
+          }
+          {
+            echo "SCALE_HOME=$SCALE_HOME"
+            echo "CUDA_PATH=$SCALE_HOME/targets/$arch"
+            echo "CUDA_HOME=$SCALE_HOME/targets/$arch"
+            echo "CUDARC_CUDA_VERSION=12080"
+            echo "ATLAS_TARGET_HW=strix"
+          } >> "$GITHUB_ENV"
+          echo "$SCALE_HOME/targets/$arch/bin" >> "$GITHUB_PATH"
 
       - name: Build spark
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Release: build `spark` for every (OS, arch, GPU-platform) in
+# `.github/release-matrix.json` and publish a GitHub Release.
+#
+# The matrix is DATA, not code: adding a platform (a new Cargo feature, a new
+# accelerator) is one JSON object, never an edit to this file. Each entry
+# declares its own `toolchain`, so a target that needs CUDA, SCALE or nothing
+# at all is expressed in the same shape.
+#
+# `dry_run` defaults to TRUE: the workflow builds and uploads artifacts but
+# writes nothing to the repository. Publishing is an explicit opt-out.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to build"
+        required: true
+        default: main
+      new_version:
+        description: "Release version, bare semver (e.g. 0.2.0) — tag becomes vX.Y.Z"
+        required: true
+      dry_run:
+        description: "Build and upload artifacts only; do not tag or publish"
+        type: boolean
+        required: true
+        default: true
+  # PR trigger is scoped to this workflow's own files. It runs `validate` only
+  # — never a build, never a publish — so the release plumbing is checked on
+  # every change to it without spending an hour of runner time per PR.
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/release-matrix.json"
+      - "scripts/release-notes.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.event.inputs.new_version || github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Cheap, always-runs gate. Everything that can be wrong statically is
+  # caught here BEFORE any runner spends time installing a CUDA toolkit.
+  # ---------------------------------------------------------------------
+  validate:
+    name: validate inputs + matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate new_version is bare semver
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          v='${{ github.event.inputs.new_version }}'
+          # Bare semver only: the leading `v` is added when we build the tag,
+          # so accepting `v1.2.3` here would produce the tag `vv1.2.3`.
+          if ! printf '%s' "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::new_version must be bare semver (1.2.3), got '$v'"
+            exit 1
+          fi
+          # Ask the REMOTE, not the local clone: actions/checkout fetches
+          # depth-1 with no tags, so `git rev-parse refs/tags/...` would find
+          # nothing and this guard would silently always pass.
+          if git ls-remote --exit-code --tags origin "refs/tags/v$v" >/dev/null 2>&1; then
+            echo "::error::tag v$v already exists"
+            exit 1
+          fi
+
+      - name: Require a branch ref for a real publish
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
+        run: |
+          set -euo pipefail
+          # Publishing commits the version bump back to `ref`, so `ref` has to
+          # be a branch. A SHA or tag would make `git push HEAD:<ref>` fail
+          # AFTER the binaries were already built — an hour in.
+          ref='${{ github.event.inputs.ref }}'
+          git ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1 || {
+            echo "::error::dry_run=false requires 'ref' to be a branch; '$ref' is not"
+            exit 1
+          }
+
+      - name: Validate matrix shape
+        run: |
+          set -euo pipefail
+          jq -e 'type == "array" and length > 0' .github/release-matrix.json >/dev/null
+          # Every entry must carry every key: a missing `toolchain` would
+          # silently build a CUDA target with no CUDA installed.
+          missing=$(jq -r '
+            [ .[] | select(
+                has("id") and has("os") and has("runner") and has("target")
+                and has("platform") and has("cargo_features")
+                and has("toolchain") and has("experimental") | not
+              ) | .id // "<no id>" ] | join(", ")' .github/release-matrix.json)
+          [ -z "$missing" ] || { echo "::error::entries missing keys: $missing"; exit 1; }
+          dupes=$(jq -r '[.[].id] | group_by(.) | map(select(length>1) | .[0]) | join(", ")' \
+            .github/release-matrix.json)
+          [ -z "$dupes" ] || { echo "::error::duplicate matrix ids: $dupes"; exit 1; }
+
+      - name: Validate every cargo feature exists in spark-server
+        run: |
+          set -euo pipefail
+          # The most likely matrix error is a typo'd or removed feature name.
+          # `cargo metadata` is the SSOT for what features actually exist.
+          known=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="spark-server") | .features | keys[]' | sort -u)
+          echo "spark-server features: $(echo "$known" | tr '\n' ' ')"
+          bad=0
+          while read -r feats; do
+            for f in $(printf '%s' "$feats" | grep -oP '(?<=--features )[^ ]+' | tr ',' ' '); do
+              grep -qx -- "$f" <<<"$known" || { echo "::error::unknown feature '$f'"; bad=1; }
+            done
+          done < <(jq -r '.[].cargo_features' .github/release-matrix.json)
+          [ "$bad" = 0 ]
+
+      - name: Emit build matrix
+        id: build-matrix
+        run: |
+          set -euo pipefail
+          echo "matrix=$(jq -c '{include: .}' .github/release-matrix.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: |
+          {
+            echo "### Release matrix"
+            echo "| id | runner | target | features | toolchain | experimental |"
+            echo "|---|---|---|---|---|---|"
+            jq -r '.[] | "| \(.id) | \(.runner) | \(.target) | `\(.cargo_features)` | \(.toolchain) | \(.experimental) |"' \
+              .github/release-matrix.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # One job per (OS, arch, platform). Experimental entries may fail without
+  # failing the release — that is what lets an unproven target sit in the
+  # matrix while it is being brought up.
+  # ---------------------------------------------------------------------
+  build:
+    name: build ${{ matrix.id }}
+    needs: validate
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.validate.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.id }}
+
+      - name: Install build deps (linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake clang libclang-dev
+
+      - name: Install build deps (macos)
+        if: matrix.os == 'macos'
+        run: brew install cmake llvm
+
+      - name: Install CUDA toolkit
+        if: startsWith(matrix.toolchain, 'cuda')
+        uses: Jimver/cuda-toolkit@v0.2.19
+        with:
+          method: network
+          # Kernel compilation only needs nvcc + the driver stubs; skipping the
+          # rest keeps a ~3 GB install down to something a runner can hold.
+          sub-packages: '["nvcc", "cudart", "nvrtc", "nvrtc_dev", "cuda_profiler_api"]'
+
+      - name: Install NCCL
+        if: contains(matrix.toolchain, 'nccl')
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends libnccl2 libnccl-dev
+
+      - name: SCALE toolchain (AMD)
+        if: matrix.toolchain == 'scale'
+        run: |
+          # SCALE is not redistributable from a hosted runner. This entry is
+          # experimental precisely because the toolchain has to come from a
+          # self-hosted runner or a cached tarball; fail loudly, do not
+          # silently produce a CUDA binary labelled `amd`.
+          echo "::error::SCALE toolchain unavailable on hosted runners — run this entry on self-hosted"
+          exit 1
+
+      - name: Build spark
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release -p spark-server --target ${{ matrix.target }} ${{ matrix.cargo_features }}
+
+      - name: Package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver='${{ github.event.inputs.new_version }}'
+          name="spark-${ver}-${{ matrix.id }}"
+          staging="dist/$name"
+          mkdir -p "$staging"
+          bin=target/${{ matrix.target }}/release/spark
+          [ "${{ matrix.os }}" = windows ] && bin="$bin.exe"
+          cp "$bin" "$staging/"
+          cp LICENSE README.md "$staging/" 2>/dev/null || true
+          if [ "${{ matrix.os }}" = windows ]; then
+            (cd dist && 7z a -tzip "$name.zip" "$name" >/dev/null)
+            asset="dist/$name.zip"
+          else
+            tar -C dist -czf "dist/$name.tar.gz" "$name"
+            asset="dist/$name.tar.gz"
+          fi
+          sha256sum "$asset" > "$asset.sha256" 2>/dev/null || shasum -a 256 "$asset" > "$asset.sha256"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spark-${{ matrix.id }}
+          path: |
+            ${{ steps.package.outputs.asset }}
+            ${{ steps.package.outputs.asset }}.sha256
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------
+  # Publish. Skipped entirely on dry_run, so a dry run can never tag, never
+  # push and never create a Release.
+  # ---------------------------------------------------------------------
+  publish:
+    name: publish release
+    needs: [validate, build]
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Refuse to publish an empty release
+        run: |
+          set -euo pipefail
+          # Every non-experimental target could still have been skipped (a
+          # cancelled job, a matrix where everything is experimental). A
+          # Release with no binaries is worse than no Release.
+          count=$(find dist -type f ! -name '*.sha256' | wc -l)
+          [ "$count" -gt 0 ] || { echo "::error::no artifacts to publish"; exit 1; }
+          echo "publishing $count artifact(s)"
+          find dist -type f | sort
+
+      - name: Bump workspace version and tag (lockstep)
+        env:
+          NEW_VERSION: ${{ github.event.inputs.new_version }}
+        run: |
+          set -euo pipefail
+          # Cargo version, git tag and release name are kept identical:
+          # downstreams identify a build by `spark --version`, so a tag that
+          # disagrees with Cargo.toml is a silent mis-identification.
+          bash scripts/release-notes.sh bump "$NEW_VERSION"
+          git config user.name  "tbraun96"
+          git config user.email "tbraun96@gmail.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): v${NEW_VERSION}"
+          git tag -a "v${NEW_VERSION}" -m "Atlas v${NEW_VERSION}"
+          git push origin HEAD:"${{ github.event.inputs.ref }}"
+          git push origin "v${NEW_VERSION}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ github.event.inputs.new_version }}
+        run: |
+          set -euo pipefail
+          # `--generate-notes` is GitHub's own changelog generator: it emits
+          # "What's Changed" (every merged PR since the previous tag) and
+          # "New Contributors". Hand-rolling either would duplicate data
+          # GitHub already derives from the same commits.
+          gh release create "v${NEW_VERSION}" \
+            --title "Atlas v${NEW_VERSION}" \
+            --generate-notes \
+            --verify-tag \
+            dist/*
+
+  # ---------------------------------------------------------------------
+  # Dry-run reporting. Makes `dry_run=true` show exactly what a real run
+  # would have published, so the decision to publish is made on evidence.
+  # ---------------------------------------------------------------------
+  dry-run-summary:
+    name: dry-run summary
+    needs: [validate, build]
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'false'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Report what WOULD be published
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ github.event.inputs.new_version }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### DRY RUN — nothing was tagged, pushed or published"
+            echo
+            echo "Would create tag \`v${NEW_VERSION}\` on \`${{ github.event.inputs.ref }}\`."
+            echo
+            echo "#### Artifacts"
+            if find dist -type f ! -name '*.sha256' | grep -q .; then
+              find dist -type f ! -name '*.sha256' | sort | sed 's/^/- /'
+            else
+              echo "- (none — every build job failed or was skipped)"
+            fi
+            echo
+            echo "#### Release notes that would be generated"
+            echo '```markdown'
+            bash scripts/release-notes.sh preview "$NEW_VERSION" || echo "(preview unavailable)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,13 +162,22 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------
+  # The ordinary CI gates (fmt, clippy, tests, licence headers, typos, the
+  # macOS/metal job) must pass BEFORE the release matrix spends runner time.
+  # Called as a reusable workflow so CI stays defined in exactly one place.
+  # ---------------------------------------------------------------------
+  ci:
+    name: ci
+    uses: ./.github/workflows/ci.yml
+
+  # ---------------------------------------------------------------------
   # One job per (OS, arch, platform). Experimental entries may fail without
   # failing the release — that is what lets an unproven target sit in the
   # matrix while it is being brought up.
   # ---------------------------------------------------------------------
   build:
     name: build ${{ matrix.id }}
-    needs: validate
+    needs: [validate, ci]
     runs-on: ${{ matrix.runner }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -292,9 +301,9 @@ jobs:
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
-        if: github.event_name == 'workflow_dispatch'
         with:
           name: spark-${{ matrix.id }}
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 90 }}
           path: |
             ${{ steps.package.outputs.asset }}
             ${{ steps.package.outputs.asset }}.sha256
@@ -373,12 +382,12 @@ jobs:
   dry-run-summary:
     name: dry-run summary
     needs: [validate, build]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'false'
+    if: github.event_name == 'pull_request' || github.event.inputs.dry_run != 'false'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ github.event.inputs.ref || '' }}
           fetch-depth: 0
 
       - uses: actions/download-artifact@v4
@@ -386,10 +395,27 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Verify every artifact is real (checksums + non-empty)
+        run: |
+          set -euo pipefail
+          # The point of the PR dry run is that a later release CANNOT fail in
+          # a way this run would have passed. So verify the packages the same
+          # way a consumer would: checksum them and confirm they are non-empty.
+          shopt -s nullglob
+          n=0
+          for f in dist/*.tar.gz dist/*.zip; do
+            [ -s "$f" ] || { echo "::error::$f is empty"; exit 1; }
+            (cd dist && sha256sum -c "$(basename "$f").sha256") \
+              || { echo "::error::checksum mismatch for $f"; exit 1; }
+            n=$((n+1))
+          done
+          [ "$n" -gt 0 ] || { echo "::error::no artifacts were produced"; exit 1; }
+          echo "verified $n artifact(s)"
+
       - name: Report what WOULD be published
         env:
           GH_TOKEN: ${{ github.token }}
-          NEW_VERSION: ${{ github.event.inputs.new_version }}
+          NEW_VERSION: ${{ github.event.inputs.new_version || format('0.0.0-pr{0}', github.event.number) }}
         run: |
           set -euo pipefail
           {
@@ -406,6 +432,13 @@ jobs:
             echo
             echo "#### Release notes that would be generated"
             echo '```markdown'
-            bash scripts/release-notes.sh preview "$NEW_VERSION" || echo "(preview unavailable)"
+            # Non-fatal, but never silently blank: a PR token may lack the
+            # write scope the generate-notes endpoint wants, and that should
+            # read as a degraded preview, not as "there are no notes".
+            bash scripts/release-notes.sh preview "$NEW_VERSION" \
+              || echo "(preview unavailable — generate-notes needs contents:write; not granted on pull_request)"
             echo '```'
+            echo
+            echo "_Nothing was tagged, pushed or published: \`publish\` runs only on"
+            echo "workflow_dispatch with dry_run=false._"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Release: build `spark` for every (OS, arch, GPU-platform) in
-# `.github/release-matrix.json` and publish a GitHub Release.
+# Release (dispatch only). Validates the inputs, re-runs the ordinary CI
+# gates, rebuilds the whole matrix via the SAME reusable workflow every PR
+# already exercises, then publishes.
 #
-# The matrix is DATA, not code: adding a platform (a new Cargo feature, a new
-# accelerator) is one JSON object, never an edit to this file. Each entry
-# declares its own `toolchain`, so a target that needs CUDA, SCALE or nothing
-# at all is expressed in the same shape.
+# The PR path lives in ci.yml (`release-matrix`), not here — so a pull
+# request runs CI exactly once and the matrix flows after it. Because both
+# paths call `release-build.yml`, a green PR has already proven the build
+# and packaging steps a release will take.
 #
-# `dry_run` defaults to TRUE: the workflow builds and uploads artifacts but
-# writes nothing to the repository. Publishing is an explicit opt-out.
-#
-# On a pull request the same build matrix runs (minus targets whose toolchain
-# cannot exist on a hosted runner), so the matrix is proven buildable before
-# a release ever depends on it.
+# `dry_run` defaults to TRUE: artifacts are built and uploaded, and the
+# dry-run summary reports what would ship, but nothing is tagged or
+# published. Publishing is an explicit opt-out.
 name: Release
 
 on:
@@ -31,52 +29,26 @@ on:
         type: boolean
         required: true
         default: true
-  # PR trigger is scoped to this workflow's own files. It runs `validate` AND
-  # the full build matrix (every entry with `pr_validate: true`), so a change
-  # to the release plumbing is proven to still compile on every target before
-  # it merges. It never publishes: `publish` is workflow_dispatch-only.
-  # Entries that cannot build on a hosted runner (SCALE) are reported as NOT
-  # VALIDATED rather than passed vacuously.
-  pull_request:
-    paths:
-      - ".github/workflows/release.yml"
-      - ".github/release-matrix.json"
-      - "scripts/release-notes.sh"
 
 permissions:
   contents: read
 
 concurrency:
-  # PRs and dispatches must NOT share a group. They previously both keyed on
-  # `github.ref`, and with cancel-in-progress:false a superseded PR run stayed
-  # queued forever and blocked every later push to the same PR.
-  # PR runs supersede each other (an outdated build is waste); a dispatch must
-  # never be cancelled mid-publish.
-  group: >-
-    release-${{ github.event_name == 'pull_request'
-      && format('pr-{0}', github.event.number)
-      || format('dispatch-{0}', github.event.inputs.new_version) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
+  # Dispatch runs are never cancelled: interrupting a publish mid-tag is how
+  # a release ends up half-applied.
+  group: release-dispatch-${{ github.event.inputs.new_version }}
+  cancel-in-progress: false
 
 jobs:
-  # ---------------------------------------------------------------------
-  # Cheap, always-runs gate. Everything that can be wrong statically is
-  # caught here BEFORE any runner spends time installing a CUDA toolkit.
-  # ---------------------------------------------------------------------
-  validate:
-    name: validate inputs + matrix
+  # Cheap input guards. Everything statically checkable fails here, before a
+  # runner spends an hour installing toolchains.
+  validate-inputs:
+    name: validate inputs
     runs-on: ubuntu-24.04
-    outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Validate new_version is bare semver
-        if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
           v='${{ github.event.inputs.new_version }}'
@@ -95,7 +67,7 @@ jobs:
           fi
 
       - name: Require a branch ref for a real publish
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry_run == 'false'
         run: |
           set -euo pipefail
           # Publishing commits the version bump back to `ref`, so `ref` has to
@@ -107,215 +79,24 @@ jobs:
             exit 1
           }
 
-      - name: Validate matrix shape
-        run: |
-          set -euo pipefail
-          jq -e 'type == "array" and length > 0' .github/release-matrix.json >/dev/null
-          # Every entry must carry every key: a missing `toolchain` would
-          # silently build a CUDA target with no CUDA installed.
-          missing=$(jq -r '
-            [ .[] | select(
-                has("id") and has("os") and has("runner") and has("target")
-                and has("platform") and has("cargo_features")
-                and has("toolchain") and has("experimental")
-                and has("pr_validate") | not
-              ) | .id // "<no id>" ] | join(", ")' .github/release-matrix.json)
-          [ -z "$missing" ] || { echo "::error::entries missing keys: $missing"; exit 1; }
-          dupes=$(jq -r '[.[].id] | group_by(.) | map(select(length>1) | .[0]) | join(", ")' \
-            .github/release-matrix.json)
-          [ -z "$dupes" ] || { echo "::error::duplicate matrix ids: $dupes"; exit 1; }
-
-      - name: Validate every cargo feature exists in spark-server
-        run: |
-          set -euo pipefail
-          # The most likely matrix error is a typo'd or removed feature name.
-          # `cargo metadata` is the SSOT for what features actually exist.
-          known=$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name=="spark-server") | .features | keys[]' | sort -u)
-          echo "spark-server features: $(echo "$known" | tr '\n' ' ')"
-          bad=0
-          while read -r feats; do
-            for f in $(printf '%s' "$feats" | grep -oP '(?<=--features )[^ ]+' | tr ',' ' '); do
-              grep -qx -- "$f" <<<"$known" || { echo "::error::unknown feature '$f'"; bad=1; }
-            done
-          done < <(jq -r '.[].cargo_features' .github/release-matrix.json)
-          [ "$bad" = 0 ]
-
-      - name: Emit build matrix
-        id: build-matrix
-        run: |
-          set -euo pipefail
-          # On a PR we build every entry that CAN be built on a hosted runner.
-          # Entries with pr_validate=false are physically impossible here (the
-          # SCALE toolchain is not redistributable) — they are reported as NOT
-          # VALIDATED rather than passed vacuously.
-          if [ "${{ github.event_name }}" = pull_request ]; then
-            sel=$(jq -c '{include: [.[] | select(.pr_validate)]}' .github/release-matrix.json)
-            jq -r '.[] | select(.pr_validate | not)
-                   | "::warning::\(.id) NOT VALIDATED on PR — toolchain \(.toolchain) unavailable on hosted runners"' \
-              .github/release-matrix.json
-          else
-            sel=$(jq -c '{include: .}' .github/release-matrix.json)
-          fi
-          echo "matrix=$sel" >> "$GITHUB_OUTPUT"
-
-      - name: Summary
-        run: |
-          {
-            echo "### Release matrix"
-            echo "| id | runner | target | features | toolchain | experimental |"
-            echo "|---|---|---|---|---|---|"
-            jq -r '.[] | "| \(.id) | \(.runner) | \(.target) | `\(.cargo_features)` | \(.toolchain) | \(.experimental) |"' \
-              .github/release-matrix.json
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # ---------------------------------------------------------------------
-  # The ordinary CI gates (fmt, clippy, tests, licence headers, typos, the
-  # macOS/metal job) must pass BEFORE the release matrix spends runner time.
-  # Called as a reusable workflow so CI stays defined in exactly one place.
-  # ---------------------------------------------------------------------
+  # The ordinary CI gates, from their single definition. `release-matrix`
+  # inside ci.yml is pull_request-guarded, so this call does not rebuild the
+  # matrix a second time.
   ci:
     name: ci
     uses: ./.github/workflows/ci.yml
 
-  # ---------------------------------------------------------------------
-  # One job per (OS, arch, platform). Experimental entries may fail without
-  # failing the release — that is what lets an unproven target sit in the
-  # matrix while it is being brought up.
-  # ---------------------------------------------------------------------
+  # The identical matrix every PR runs.
   build:
-    name: build ${{ matrix.id }}
-    needs: [validate, ci]
-    runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.validate.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # On a PR there is no `ref` input; checkout defaults to the PR merge
-          # commit, which is what we want to validate.
-          ref: ${{ github.event.inputs.ref || '' }}
-          fetch-depth: 0
+    name: build
+    needs: [validate-inputs, ci]
+    uses: ./.github/workflows/release-build.yml
+    with:
+      version: ${{ github.event.inputs.new_version }}
+      ref: ${{ github.event.inputs.ref }}
+      pr_mode: false
+      retention_days: 90
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.id }}
-
-      - name: Free disk space (linux)
-        if: matrix.os == 'linux'
-        run: |
-          # A CUDA toolkit or the 1.43 GB SCALE tarball plus this workspace's
-          # kernel build does not fit alongside the preinstalled SDKs.
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /usr/local/share/boost /usr/lib/jvm || true
-          df -h / | tail -1
-
-      - name: Install build deps (linux)
-        if: matrix.os == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake clang libclang-dev
-
-      - name: Install build deps (macos)
-        if: matrix.os == 'macos'
-        run: brew install cmake llvm
-
-      - name: Install CUDA toolkit
-        if: startsWith(matrix.toolchain, 'cuda')
-        uses: Jimver/cuda-toolkit@v0.2.19
-        with:
-          method: network
-          # Package names are apt names with DASHES. The first draft used
-          # `nvrtc_dev` / `cuda_profiler_api`, which apt resolved to
-          # `cuda-nvrtc_dev-12-6` / `cuda-cuda_profiler_api-12-6` -- neither
-          # exists, and every CUDA job died on it. `driver-dev` supplies the
-          # libcuda stub the raw extern "C" FFI in spark-storage links against.
-          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "driver-dev", "profiler-api"]'
-
-      - name: Install NCCL
-        if: contains(matrix.toolchain, 'nccl')
-        run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends libnccl2 libnccl-dev
-
-      - name: Install SCALE toolchain (AMD)
-        if: matrix.toolchain == 'scale'
-        run: |
-          set -euo pipefail
-          # SCALE recompiles the unmodified CUDA kernels for AMD. Tarball URL
-          # and prerequisites are the ones documented in
-          # docs/porting/amd-strix-halo-scale.md; 1.7.1 is the first release
-          # whose bundled ROCm fixes the gfx1151 queue-create crash.
-          # build-essential -> cuda.h needs <cstddef>; libnuma -> libhsakmt.
-          sudo apt-get install -y --no-install-recommends build-essential libnuma1 libnuma-dev
-          mkdir -p "$HOME/scale" && cd "$HOME/scale"
-          curl -L --fail --retry 3 -o scale.tar.xz \
-            https://pkgs.scale-lang.com/tar/scale-1.7.1-amd64.tar.xz
-          tar -xf scale.tar.xz && rm -f scale.tar.xz
-          SCALE_HOME="$HOME/scale/scale-1.7.1-Linux"
-          arch='${{ matrix.scale_arch }}'
-          # Fail loudly if the layout is not what we expect: a missing nvcc
-          # here would otherwise fall through to the host nvcc and silently
-          # produce an NVIDIA binary labelled `amd`.
-          [ -x "$SCALE_HOME/targets/$arch/bin/nvcc" ] || {
-            echo "::error::SCALE nvcc missing at $SCALE_HOME/targets/$arch/bin/nvcc"
-            ls "$SCALE_HOME/targets" 2>/dev/null || true
-            exit 1
-          }
-          {
-            echo "SCALE_HOME=$SCALE_HOME"
-            echo "CUDA_PATH=$SCALE_HOME/targets/$arch"
-            echo "CUDA_HOME=$SCALE_HOME/targets/$arch"
-            echo "CUDARC_CUDA_VERSION=12080"
-            echo "ATLAS_TARGET_HW=strix"
-          } >> "$GITHUB_ENV"
-          echo "$SCALE_HOME/targets/$arch/bin" >> "$GITHUB_PATH"
-
-      - name: Build spark
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build --release -p spark-server --target ${{ matrix.target }} ${{ matrix.cargo_features }}
-
-      - name: Package
-        id: package
-        shell: bash
-        run: |
-          set -euo pipefail
-          # No version input exists on a PR. Stamp the artifact explicitly
-          # rather than packaging an empty version string.
-          ver='${{ github.event.inputs.new_version }}'
-          [ -n "$ver" ] || ver="0.0.0-pr${{ github.event.number }}"
-          name="spark-${ver}-${{ matrix.id }}"
-          staging="dist/$name"
-          mkdir -p "$staging"
-          bin=target/${{ matrix.target }}/release/spark
-          [ "${{ matrix.os }}" = windows ] && bin="$bin.exe"
-          cp "$bin" "$staging/"
-          cp LICENSE README.md "$staging/" 2>/dev/null || true
-          if [ "${{ matrix.os }}" = windows ]; then
-            (cd dist && 7z a -tzip "$name.zip" "$name" >/dev/null)
-            asset="dist/$name.zip"
-          else
-            tar -C dist -czf "dist/$name.tar.gz" "$name"
-            asset="dist/$name.tar.gz"
-          fi
-          sha256sum "$asset" > "$asset.sha256" 2>/dev/null || shasum -a 256 "$asset" > "$asset.sha256"
-          echo "asset=$asset" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: spark-${{ matrix.id }}
-          retention-days: ${{ github.event_name == 'pull_request' && 1 || 90 }}
-          path: |
-            ${{ steps.package.outputs.asset }}
-            ${{ steps.package.outputs.asset }}.sha256
-          if-no-files-found: error
 
   # ---------------------------------------------------------------------
   # Publish. Skipped entirely on dry_run, so a dry run can never tag, never
@@ -323,8 +104,8 @@ jobs:
   # ---------------------------------------------------------------------
   publish:
     name: publish release
-    needs: [validate, build]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
+    needs: [validate-inputs, build]
+    if: github.event.inputs.dry_run == 'false'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -387,66 +168,3 @@ jobs:
   # Dry-run reporting. Makes `dry_run=true` show exactly what a real run
   # would have published, so the decision to publish is made on evidence.
   # ---------------------------------------------------------------------
-  dry-run-summary:
-    name: dry-run summary
-    needs: [validate, build]
-    if: github.event_name == 'pull_request' || github.event.inputs.dry_run != 'false'
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.inputs.ref || '' }}
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
-      - name: Verify every artifact is real (checksums + non-empty)
-        run: |
-          set -euo pipefail
-          # The point of the PR dry run is that a later release CANNOT fail in
-          # a way this run would have passed. So verify the packages the same
-          # way a consumer would: checksum them and confirm they are non-empty.
-          shopt -s nullglob
-          n=0
-          for f in dist/*.tar.gz dist/*.zip; do
-            [ -s "$f" ] || { echo "::error::$f is empty"; exit 1; }
-            (cd dist && sha256sum -c "$(basename "$f").sha256") \
-              || { echo "::error::checksum mismatch for $f"; exit 1; }
-            n=$((n+1))
-          done
-          [ "$n" -gt 0 ] || { echo "::error::no artifacts were produced"; exit 1; }
-          echo "verified $n artifact(s)"
-
-      - name: Report what WOULD be published
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NEW_VERSION: ${{ github.event.inputs.new_version || format('0.0.0-pr{0}', github.event.number) }}
-        run: |
-          set -euo pipefail
-          {
-            echo "### DRY RUN — nothing was tagged, pushed or published"
-            echo
-            echo "Would create tag \`v${NEW_VERSION}\` on \`${{ github.event.inputs.ref }}\`."
-            echo
-            echo "#### Artifacts"
-            if find dist -type f ! -name '*.sha256' | grep -q .; then
-              find dist -type f ! -name '*.sha256' | sort | sed 's/^/- /'
-            else
-              echo "- (none — every build job failed or was skipped)"
-            fi
-            echo
-            echo "#### Release notes that would be generated"
-            echo '```markdown'
-            # Non-fatal, but never silently blank: a PR token may lack the
-            # write scope the generate-notes endpoint wants, and that should
-            # read as a degraded preview, not as "there are no notes".
-            bash scripts/release-notes.sh preview "$NEW_VERSION" \
-              || echo "(preview unavailable — generate-notes needs contents:write; not granted on pull_request)"
-            echo '```'
-            echo
-            echo "_Nothing was tagged, pushed or published: \`publish\` runs only on"
-            echo "workflow_dispatch with dry_run=false._"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.event.inputs.new_version || github.ref }}
-  cancel-in-progress: false
+  # PRs and dispatches must NOT share a group. They previously both keyed on
+  # `github.ref`, and with cancel-in-progress:false a superseded PR run stayed
+  # queued forever and blocked every later push to the same PR.
+  # PR runs supersede each other (an outdated build is waste); a dispatch must
+  # never be cancelled mid-publish.
+  group: >-
+    release-${{ github.event_name == 'pull_request'
+      && format('pr-{0}', github.event.number)
+      || format('dispatch-{0}', github.event.inputs.new_version) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@
 #
 # `dry_run` defaults to TRUE: the workflow builds and uploads artifacts but
 # writes nothing to the repository. Publishing is an explicit opt-out.
+#
+# On a pull request the same build matrix runs (minus targets whose toolchain
+# cannot exist on a hosted runner), so the matrix is proven buildable before
+# a release ever depends on it.
 name: Release
 
 on:
@@ -27,9 +31,12 @@ on:
         type: boolean
         required: true
         default: true
-  # PR trigger is scoped to this workflow's own files. It runs `validate` only
-  # — never a build, never a publish — so the release plumbing is checked on
-  # every change to it without spending an hour of runner time per PR.
+  # PR trigger is scoped to this workflow's own files. It runs `validate` AND
+  # the full build matrix (every entry with `pr_validate: true`), so a change
+  # to the release plumbing is proven to still compile on every target before
+  # it merges. It never publishes: `publish` is workflow_dispatch-only.
+  # Entries that cannot build on a hosted runner (SCALE) are reported as NOT
+  # VALIDATED rather than passed vacuously.
   pull_request:
     paths:
       - ".github/workflows/release.yml"
@@ -102,7 +109,8 @@ jobs:
             [ .[] | select(
                 has("id") and has("os") and has("runner") and has("target")
                 and has("platform") and has("cargo_features")
-                and has("toolchain") and has("experimental") | not
+                and has("toolchain") and has("experimental")
+                and has("pr_validate") | not
               ) | .id // "<no id>" ] | join(", ")' .github/release-matrix.json)
           [ -z "$missing" ] || { echo "::error::entries missing keys: $missing"; exit 1; }
           dupes=$(jq -r '[.[].id] | group_by(.) | map(select(length>1) | .[0]) | join(", ")' \
@@ -129,7 +137,19 @@ jobs:
         id: build-matrix
         run: |
           set -euo pipefail
-          echo "matrix=$(jq -c '{include: .}' .github/release-matrix.json)" >> "$GITHUB_OUTPUT"
+          # On a PR we build every entry that CAN be built on a hosted runner.
+          # Entries with pr_validate=false are physically impossible here (the
+          # SCALE toolchain is not redistributable) — they are reported as NOT
+          # VALIDATED rather than passed vacuously.
+          if [ "${{ github.event_name }}" = pull_request ]; then
+            sel=$(jq -c '{include: [.[] | select(.pr_validate)]}' .github/release-matrix.json)
+            jq -r '.[] | select(.pr_validate | not)
+                   | "::warning::\(.id) NOT VALIDATED on PR — toolchain \(.toolchain) unavailable on hosted runners"' \
+              .github/release-matrix.json
+          else
+            sel=$(jq -c '{include: .}' .github/release-matrix.json)
+          fi
+          echo "matrix=$sel" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |
@@ -149,7 +169,6 @@ jobs:
   build:
     name: build ${{ matrix.id }}
     needs: validate
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.runner }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -158,7 +177,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.inputs.ref }}
+          # On a PR there is no `ref` input; checkout defaults to the PR merge
+          # commit, which is what we want to validate.
+          ref: ${{ github.event.inputs.ref || '' }}
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
@@ -214,7 +235,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # No version input exists on a PR. Stamp the artifact explicitly
+          # rather than packaging an empty version string.
           ver='${{ github.event.inputs.new_version }}'
+          [ -n "$ver" ] || ver="0.0.0-pr${{ github.event.number }}"
           name="spark-${ver}-${{ matrix.id }}"
           staging="dist/$name"
           mkdir -p "$staging"
@@ -233,6 +257,7 @@ jobs:
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
+        if: github.event_name == 'workflow_dispatch'
         with:
           name: spark-${{ matrix.id }}
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ name = "atlas-tier"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "getrandom 0.3.4",
  "libc",
 ]
 

--- a/crates/atlas-rdma/build.rs
+++ b/crates/atlas-rdma/build.rs
@@ -3,7 +3,7 @@
 // Build script for atlas-rdma. It compiles the one-sided RDMA verbs C shim
 // and decides `cfg(atlas_rdma_verbs)` for the whole workspace:
 //
-//   * cfg ON  ⇔ target_os != macos AND !skip_build()   (unchanged semantics)
+//   * cfg ON  ⇔ target_os == linux AND !skip_build()  (rdma-core is Linux-only)
 //   * skip_build() honours ATLAS_SKIP_BUILD / SKIP_ATLAS_BUILD ∈ {1,true,TRUE}
 //     — the CPU/CI convention for hosts without rdma-core dev headers. There
 //     is deliberately NO header probing: on Linux with the skip unset and
@@ -41,8 +41,12 @@ fn main() {
         return;
     }
 
-    // Apple Silicon hosts have no rdma-core; the verbs module compiles out.
-    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+    // rdma-core (libibverbs) is a LINUX-ONLY library, so gate positively on
+    // linux rather than excluding macOS. The old `!= macos` predicate meant
+    // every other target — Windows, the BSDs — tried to compile rdma_shim.c
+    // against <infiniband/verbs.h>, a header that cannot exist there, and
+    // failed in cc with a missing include rather than compiling out cleanly.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
         return;
     }
     if skip_build() {

--- a/crates/atlas-tier/Cargo.toml
+++ b/crates/atlas-tier/Cargo.toml
@@ -14,6 +14,11 @@ description = "Atlas: generic tiered-cache core (SlotArena / SwapStore / Residen
 [dependencies]
 anyhow = { workspace = true }
 
+# Windows has no /dev/urandom and no libc::getrandom; `getrandom` wraps
+# BCryptGenRandom. Already in the graph transitively, so this pins no new crate.
+[target.'cfg(windows)'.dependencies]
+getrandom = "0.3"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/crates/atlas-tier/src/direct_swap/mod.rs
+++ b/crates/atlas-tier/src/direct_swap/mod.rs
@@ -35,7 +35,9 @@ pub use windows::DirectSwapFile;
 #[allow(dead_code)]
 pub(crate) fn validate_record_bytes(record_bytes: usize) -> anyhow::Result<()> {
     if record_bytes == 0 || !record_bytes.is_multiple_of(4096) {
-        anyhow::bail!("DirectSwapFile: record_bytes ({record_bytes}) must be a non-zero 4 KiB multiple");
+        anyhow::bail!(
+            "DirectSwapFile: record_bytes ({record_bytes}) must be a non-zero 4 KiB multiple"
+        );
     }
     Ok(())
 }

--- a/crates/atlas-tier/src/direct_swap/mod.rs
+++ b/crates/atlas-tier/src/direct_swap/mod.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! [`DirectSwapFile`] — the NVMe cold tier, one implementation per platform.
+//!
+//! The contract ([`crate::traits::SwapStore`]) and its invariants are identical
+//! everywhere: fixed-stride records addressed by `disk_slot`, `record_bytes` a
+//! non-zero 4 KiB multiple, the file growing sparsely as slots are allocated.
+//! Only the I/O primitive differs, so only the I/O primitive is split:
+//!
+//!   * `unix` — `O_DIRECT` (Linux) + `pread`/`pwrite` on a raw fd, staging
+//!     through a page-aligned bounce when the caller's buffer is not aligned.
+//!     On non-Linux unix `O_DIRECT` does not exist and the file opens buffered,
+//!     which is harmless: the NVMe cold tier only ever runs on the Linux fleet.
+//!   * `windows` — buffered `seek_read`/`seek_write`. Windows' nearest
+//!     equivalent, `FILE_FLAG_NO_BUFFERING`, imposes sector-alignment rules on
+//!     every buffer and offset and buys nothing here for the same reason: this
+//!     tier is not driven on Windows. Correctness over an unused fast path.
+//!
+//! Splitting by file rather than by `#[cfg]` attribute keeps each
+//! implementation readable on its own and stops a change to one platform from
+//! silently editing the other.
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::DirectSwapFile;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::DirectSwapFile;
+
+/// Shared by both implementations so the error text of a misuse is identical
+/// on every platform.
+#[allow(dead_code)]
+pub(crate) fn validate_record_bytes(record_bytes: usize) -> anyhow::Result<()> {
+    if record_bytes == 0 || !record_bytes.is_multiple_of(4096) {
+        anyhow::bail!("DirectSwapFile: record_bytes ({record_bytes}) must be a non-zero 4 KiB multiple");
+    }
+    Ok(())
+}

--- a/crates/atlas-tier/src/direct_swap/unix.rs
+++ b/crates/atlas-tier/src/direct_swap/unix.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! [`DirectSwapFile`] — the real O_DIRECT NVMe cold tier, plus its
-//! page-aligned bounce-buffer plumbing.
+//! Unix [`DirectSwapFile`]: the real `O_DIRECT` NVMe cold tier, plus its
+//! page-aligned bounce-buffer plumbing. See `mod.rs` for the platform split.
 
 use std::fs::OpenOptions;
 use std::os::fd::{AsRawFd, OwnedFd};
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use anyhow::{Result, bail};
 
+use crate::direct_swap::validate_record_bytes;
 use crate::traits::SwapStore;
 
 /// `O_DIRECT` is a Linux-only open flag (macOS has no equivalent — `F_NOCACHE`
@@ -39,11 +40,7 @@ pub struct DirectSwapFile {
 
 impl DirectSwapFile {
     pub fn create(path: &Path, record_bytes: usize) -> Result<Self> {
-        if record_bytes == 0 || !record_bytes.is_multiple_of(4096) {
-            bail!(
-                "DirectSwapFile: record_bytes ({record_bytes}) must be a non-zero 4 KiB multiple"
-            );
-        }
+        validate_record_bytes(record_bytes)?;
         let f = OpenOptions::new()
             .read(true)
             .write(true)

--- a/crates/atlas-tier/src/direct_swap/windows.rs
+++ b/crates/atlas-tier/src/direct_swap/windows.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Windows [`DirectSwapFile`]: buffered positional I/O.
+//!
+//! See the module docs in `mod.rs` for why this is buffered rather than
+//! `FILE_FLAG_NO_BUFFERING`. Because there is no alignment requirement, there
+//! is also no bounce buffer — the caller's slice is used directly, which makes
+//! this the simpler of the two implementations rather than a degraded copy of
+//! the unix one.
+
+use std::fs::{File, OpenOptions};
+use std::os::windows::fs::FileExt;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use crate::direct_swap::validate_record_bytes;
+use crate::traits::SwapStore;
+
+pub struct DirectSwapFile {
+    file: File,
+    record_bytes: usize,
+}
+
+impl DirectSwapFile {
+    pub fn create(path: &Path, record_bytes: usize) -> Result<Self> {
+        validate_record_bytes(record_bytes)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .map_err(|e| anyhow::anyhow!("open {}: {e}", path.display()))?;
+        Ok(Self { file, record_bytes })
+    }
+
+    fn offset(&self, disk_slot: usize) -> u64 {
+        disk_slot as u64 * self.record_bytes as u64
+    }
+}
+
+impl SwapStore for DirectSwapFile {
+    fn record_bytes(&self) -> usize {
+        self.record_bytes
+    }
+
+    fn write_record(&mut self, disk_slot: usize, bytes: &[u8]) -> Result<()> {
+        if bytes.len() != self.record_bytes {
+            bail!(
+                "write_record: {} bytes, expected {}",
+                bytes.len(),
+                self.record_bytes
+            );
+        }
+        // `seek_write` is positional and does NOT move the file cursor, so it
+        // matches `pwrite` semantics. It may also write short, exactly like
+        // `pwrite`, so loop rather than assuming one call suffices.
+        let mut off = self.offset(disk_slot);
+        let mut written = 0usize;
+        while written < bytes.len() {
+            let n = self
+                .file
+                .seek_write(&bytes[written..], off)
+                .map_err(|e| anyhow::anyhow!("seek_write record {disk_slot}: {e}"))?;
+            if n == 0 {
+                bail!("seek_write record {disk_slot} wrote 0 bytes at offset {off}");
+            }
+            written += n;
+            off += n as u64;
+        }
+        Ok(())
+    }
+
+    fn read_record(&self, disk_slot: usize, out: &mut [u8]) -> Result<()> {
+        if out.len() != self.record_bytes {
+            bail!(
+                "read_record: {} bytes, expected {}",
+                out.len(),
+                self.record_bytes
+            );
+        }
+        let mut off = self.offset(disk_slot);
+        let mut read = 0usize;
+        while read < out.len() {
+            let n = self
+                .file
+                .seek_read(&mut out[read..], off)
+                .map_err(|e| anyhow::anyhow!("seek_read record {disk_slot}: {e}"))?;
+            // A short read at EOF means the slot was never written. Surface it
+            // rather than handing back a partially-filled buffer.
+            if n == 0 {
+                bail!(
+                    "seek_read record {disk_slot} hit EOF after {read} of {} bytes",
+                    out.len()
+                );
+            }
+            read += n;
+            off += n as u64;
+        }
+        Ok(())
+    }
+}

--- a/crates/atlas-tier/src/entropy.rs
+++ b/crates/atlas-tier/src/entropy.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 ///
 /// Linux: `libc::getrandom` (flags = 0: the `/dev/urandom` pool, blocking only
 /// pre-seed at early boot), looping on `EINTR` and partial reads. Other unix
-/// (macOS): `/dev/urandom` via `read_exact`.
+/// (macOS): `/dev/urandom` via `read_exact`. Windows: `BCryptGenRandom`.
 pub fn random_u64() -> Result<u64> {
     let mut buf = [0u8; 8];
     fill(&mut buf)?;
@@ -49,6 +49,16 @@ fn fill(buf: &mut [u8]) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("open /dev/urandom failed (refusing a degraded salt): {e}"))?;
     f.read_exact(buf)
         .map_err(|e| anyhow::anyhow!("read /dev/urandom failed (refusing a degraded salt): {e}"))
+}
+
+/// Windows: `BCryptGenRandom`, reached through the `getrandom` crate that is
+/// already in this workspace's dependency graph (0.3.4, pulled transitively) —
+/// so this arm adds no new supply-chain surface. Same PCND stance as the unix
+/// arms above: a failure is a hard error, never a degraded zero-entropy salt.
+#[cfg(windows)]
+fn fill(buf: &mut [u8]) -> Result<()> {
+    getrandom::fill(buf)
+        .map_err(|e| anyhow::anyhow!("BCryptGenRandom failed (refusing a degraded salt): {e}"))
 }
 
 #[cfg(test)]

--- a/crates/atlas-tier/src/lib.rs
+++ b/crates/atlas-tier/src/lib.rs
@@ -24,7 +24,10 @@
 //! live here — they belong to the consumer crates that build on this core.
 
 mod direct_swap;
+// Positional file I/O shared by every tier that keeps one File open across
+// concurrent record accesses; see pio.rs for why it is here and not duplicated.
 mod mem;
+pub mod pio;
 mod residency;
 mod traits;
 

--- a/crates/atlas-tier/src/pio.rs
+++ b/crates/atlas-tier/src/pio.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Positional file I/O, one implementation per platform.
+//!
+//! `pread`/`pwrite` (unix) and `seek_read`/`seek_write` (Windows) are both
+//! positional — they take an explicit offset and do NOT move the file cursor —
+//! which is what every tier here relies on to share one `File` across
+//! concurrent record accesses. Only the syscall differs, so only the syscall
+//! lives here; bounds checks and record semantics stay with the callers.
+//!
+//! This exists because the same six lines were about to be written a third
+//! time (`atlas-tier::direct_swap`, `spark-model`'s snapshot arena, and
+//! `spark-storage`'s file backend). `atlas-tier` is the crate all three
+//! already depend on.
+//!
+//! Both platforms may transfer fewer bytes than requested, so both loop.
+
+use std::fs::File;
+use std::io;
+
+/// Write all of `buf` at `offset`, looping over short writes.
+pub fn write_all_at(f: &File, buf: &[u8], offset: u64) -> io::Result<()> {
+    let (mut off, mut done) = (offset, 0usize);
+    while done < buf.len() {
+        let n = write_at(f, &buf[done..], off)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                format!("positional write returned 0 bytes at offset {off}"),
+            ));
+        }
+        done += n;
+        off += n as u64;
+    }
+    Ok(())
+}
+
+/// Fill `buf` from `offset`, looping over short reads. A zero-length read
+/// before `buf` is full is EOF and is reported as an error rather than
+/// leaving the tail of the buffer holding stale bytes.
+pub fn read_exact_at(f: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    let (mut off, mut done) = (offset, 0usize);
+    let total = buf.len();
+    while done < total {
+        let n = read_at(f, &mut buf[done..], off)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("positional read hit EOF after {done} of {total} bytes at offset {off}"),
+            ));
+        }
+        done += n;
+        off += n as u64;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_at(f: &File, buf: &[u8], offset: u64) -> io::Result<usize> {
+    use std::os::unix::fs::FileExt;
+    f.write_at(buf, offset)
+}
+
+#[cfg(unix)]
+fn read_at(f: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::unix::fs::FileExt;
+    f.read_at(buf, offset)
+}
+
+#[cfg(windows)]
+fn write_at(f: &File, buf: &[u8], offset: u64) -> io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+    f.seek_write(buf, offset)
+}
+
+#[cfg(windows)]
+fn read_at(f: &File, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+    f.seek_read(buf, offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Round-trips at a non-zero offset on whichever platform runs the tests:
+    // the point is that both arms agree on positional semantics, including
+    // leaving the cursor untouched.
+    #[test]
+    fn round_trip_at_offset() {
+        let dir = std::env::temp_dir().join(format!("atlas_pio_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("pio.bin");
+        let f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+
+        write_all_at(&f, &[0u8; 4096], 0).unwrap();
+        let payload: Vec<u8> = (0..1024u32).map(|i| (i % 251) as u8).collect();
+        write_all_at(&f, &payload, 2048).unwrap();
+
+        let mut out = vec![0u8; payload.len()];
+        read_exact_at(&f, &mut out, 2048).unwrap();
+        assert_eq!(out, payload);
+
+        // Reading past the end must fail, not silently return short.
+        let mut past = vec![0u8; 8192];
+        assert!(read_exact_at(&f, &mut past, 4096).is_err());
+
+        drop(f);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -28,6 +28,14 @@ mod fp8_moe_batch_a;
 #[path = "ops/fp8_moe_batch_b.rs"]
 mod fp8_moe_batch_b;
 #[path = "ops/gdn_flashinfer.rs"]
+// The FlashInfer GDN bridge uses dlopen/dlsym, which do not exist on Windows.
+// The absent variant is mounted at the SAME module path so both call sites
+// (trait_prefill_recur, trait_prefill_gdn) need no cfg — they already gate on
+// `available()`, which is simply always false there.
+#[cfg(unix)]
+pub mod gdn_flashinfer;
+#[cfg(not(unix))]
+#[path = "ops/gdn_flashinfer_absent.rs"]
 pub mod gdn_flashinfer;
 #[path = "ops/gemm_dense.rs"]
 mod gemm_dense;

--- a/crates/spark-model/src/layers/ops/gdn_flashinfer_absent.rs
+++ b/crates/spark-model/src/layers/ops/gdn_flashinfer_absent.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `not(unix)` counterpart of [`super::gdn_flashinfer`].
+//!
+//! The real module reaches the FlashInfer GDN kernel through
+//! `dlopen("libatlasgdn.so")` — POSIX dynamic loading, and a `.so` that is only
+//! built for Linux. Windows has neither, so the path is unavailable there.
+//!
+//! That is not a degradation introduced here: the feature is opt-in behind
+//! `ATLAS_GDN_FLASHINFER=1`, and its own docs note that "the binary builds and
+//! runs without the library". Both call sites are already guarded by
+//! [`available`] and fall back to the scalar FLA scan, so reporting `false`
+//! here reproduces exactly what a unix host does when the library is absent or
+//! the flag is unset.
+//!
+//! Declared under the same module path as the real one (`ops::gdn_flashinfer`)
+//! so the two call sites need no `cfg`.
+
+use anyhow::{Result, bail};
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+/// Always false: there is no `libatlasgdn.so` to dlopen on this platform, so
+/// callers take the FLA fallback.
+pub fn available() -> bool {
+    false
+}
+
+/// Unreachable through the guarded call sites, which check [`available`] first.
+/// Bails rather than silently returning `Ok(())`: a caller that reached this
+/// without checking would otherwise get an unwritten output buffer treated as a
+/// completed scan.
+#[allow(clippy::too_many_arguments)]
+pub fn flashinfer_gdn_prefill(
+    _gpu: &dyn GpuBackend,
+    _qkv: DevicePtr,
+    _gate_beta: DevicePtr,
+    _output: DevicePtr,
+    _h_state: DevicePtr,
+    _scale: f32,
+    _total: u32,
+    _nk: u32,
+    _nv: u32,
+    _kd: u32,
+    _vd: u32,
+    _conv_dim: u32,
+    _gb_stride: u32,
+    _num_seqs: u32,
+    _stream: u64,
+) -> Result<()> {
+    bail!("FlashInfer GDN prefill requires dlopen(libatlasgdn.so); unavailable on this platform")
+}

--- a/crates/spark-model/src/lora/mod.rs
+++ b/crates/spark-model/src/lora/mod.rs
@@ -37,7 +37,8 @@ pub use types::*;
 // module so the non-cuda (metal) build doesn't try to resolve those imports.
 #[cfg(feature = "cuda")]
 // RDMA LoRA staging lands adapter tensors via spark-storage's RDMA weight
-// loader, which is unix-only along with the rest of the cold tier.
+// loader; RDMA needs rdma-core, so this stays unix-only even though the NVMe
+// tier itself is now portable.
 #[cfg(unix)]
 pub mod rdma_stage;
 

--- a/crates/spark-model/src/lora/mod.rs
+++ b/crates/spark-model/src/lora/mod.rs
@@ -36,6 +36,9 @@ pub use types::*;
 // (`swap_lora_slot_from_peer`) is already `cfg(feature = "cuda")`. Gate the
 // module so the non-cuda (metal) build doesn't try to resolve those imports.
 #[cfg(feature = "cuda")]
+// RDMA LoRA staging lands adapter tensors via spark-storage's RDMA weight
+// loader, which is unix-only along with the rest of the cold tier.
+#[cfg(unix)]
 pub mod rdma_stage;
 
 #[cfg(test)]

--- a/crates/spark-model/src/lora/slot_math.rs
+++ b/crates/spark-model/src/lora/slot_math.rs
@@ -127,9 +127,11 @@ pub(crate) fn pool_slot_bytes(cfg: &ModelConfig, max_rank: usize) -> usize {
 /// Byte offset of slot `k`'s base within the pool. Slots are equal fixed size,
 /// so slot `k` starts at `k * pool_slot_bytes`. Slot 0 → 0 (byte-identical to
 /// the single-adapter path).
-// Only the cuda-gated RDMA landing path (`rdma_stage`) and the unit tests call
-// this; on a non-cuda build (metal) it is dead but must stay defined for tests.
-#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
+// Only the RDMA landing path (`rdma_stage`) and the unit tests call this. That
+// path is cuda AND unix (it lands through spark-storage's RDMA weight loader),
+// so the dead-code allowance must match: `not(all(cuda, unix))`, not
+// `not(cuda)`. It stays defined everywhere for the offset unit tests.
+#[cfg_attr(not(all(feature = "cuda", unix)), allow(dead_code))]
 pub(crate) fn slot_base_offset(slot: usize, cfg: &ModelConfig, max_rank: usize) -> usize {
     slot * pool_slot_bytes(cfg, max_rank)
 }
@@ -139,7 +141,7 @@ pub(crate) fn slot_base_offset(slot: usize, cfg: &ModelConfig, max_rank: usize) 
 /// A-then-B). `None` if `target_layer` is not a full-attention layer. Used by
 /// the pack loop, the RDMA landing path, and the offset unit tests so all three
 /// agree on the one frozen layout.
-#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
+#[cfg_attr(not(all(feature = "cuda", unix)), allow(dead_code))]
 pub(crate) fn module_slot_offsets(
     cfg: &ModelConfig,
     max_rank: usize,

--- a/crates/spark-model/src/model/impl_lora_swap.rs
+++ b/crates/spark-model/src/model/impl_lora_swap.rs
@@ -22,6 +22,10 @@ impl TransformerModel {
     /// re-installing if the swapped slot is currently active. Requires rotation
     /// armed (`ATLAS_LORA_ROTATE`/`$ATLAS_LORA_PEER`) so decode is eager.
     #[cfg(feature = "cuda")]
+    // Peer staging pulls adapter tensors over RDMA (rdma-core), so this half
+    // is unix-only. The `_from_disk` twins below are plain file I/O and are
+    // portable.
+    #[cfg(unix)]
     pub fn swap_lora_slot_from_peer(
         &mut self,
         peer_addr: &str,
@@ -137,6 +141,10 @@ impl TransformerModel {
     /// plane so the delta actually applies under batch-1 (the per-slot bgmv route
     /// tables are still dormant — compute reads the installed active adapter).
     #[cfg(feature = "cuda")]
+    // Peer staging pulls adapter tensors over RDMA (rdma-core), so this half
+    // is unix-only. The `_from_disk` twins below are plain file I/O and are
+    // portable.
+    #[cfg(unix)]
     pub fn promote_lora_slot_from_peer(
         &mut self,
         peer_addr: &str,

--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -33,8 +33,6 @@ pub(crate) mod impl_b1;
 pub(crate) mod impl_b2;
 pub(crate) mod impl_b3;
 pub(crate) mod impl_lora;
-// Consumes the RDMA LoRA loader; unix-only with it.
-#[cfg(unix)]
 pub(crate) mod impl_lora_swap;
 pub(crate) mod ssm_pool;
 pub(crate) mod ssm_snapshot;

--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -33,6 +33,8 @@ pub(crate) mod impl_b1;
 pub(crate) mod impl_b2;
 pub(crate) mod impl_b3;
 pub(crate) mod impl_lora;
+// Consumes the RDMA LoRA loader; unix-only with it.
+#[cfg(unix)]
 pub(crate) mod impl_lora_swap;
 pub(crate) mod ssm_pool;
 pub(crate) mod ssm_snapshot;

--- a/crates/spark-model/src/model/ssm_tier/transport.rs
+++ b/crates/spark-model/src/model/ssm_tier/transport.rs
@@ -161,7 +161,6 @@ impl FileSnapshotArena {
 
 impl SnapshotTransport for FileSnapshotArena {
     fn write_blob(&self, offset: u64, bytes: &[u8]) -> Result<()> {
-        use std::os::unix::fs::FileExt;
         if offset + bytes.len() as u64 > self.capacity {
             anyhow::bail!(
                 "FileSnapshotArena write {offset}+{} exceeds capacity {}",
@@ -169,11 +168,9 @@ impl SnapshotTransport for FileSnapshotArena {
                 self.capacity
             );
         }
-        self.file.write_all_at(bytes, offset)?;
-        Ok(())
+        write_all_at(&self.file, bytes, offset)
     }
     fn read_blob(&self, offset: u64, out: &mut [u8]) -> Result<()> {
-        use std::os::unix::fs::FileExt;
         if offset + out.len() as u64 > self.capacity {
             anyhow::bail!(
                 "FileSnapshotArena read {offset}+{} exceeds capacity {}",
@@ -181,7 +178,58 @@ impl SnapshotTransport for FileSnapshotArena {
                 self.capacity
             );
         }
-        self.file.read_exact_at(out, offset)?;
-        Ok(())
+        read_exact_at(&self.file, out, offset)
     }
+}
+
+// Positional file I/O, one implementation per platform. The bounds checks and
+// the SnapshotTransport contract stay above in shared code; only the syscall
+// differs. `pread`/`pwrite` and `seek_read`/`seek_write` are both positional
+// and leave the file cursor alone, which is what the arena relies on.
+#[cfg(unix)]
+fn write_all_at(f: &std::fs::File, bytes: &[u8], offset: u64) -> Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.write_all_at(bytes, offset)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_exact_at(f: &std::fs::File, out: &mut [u8], offset: u64) -> Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.read_exact_at(out, offset)?;
+    Ok(())
+}
+
+// Windows has no `write_all_at`/`read_exact_at`: `seek_write`/`seek_read` are
+// the positional primitives and may transfer short, so loop rather than assume
+// one call moves everything.
+#[cfg(windows)]
+fn write_all_at(f: &std::fs::File, bytes: &[u8], offset: u64) -> Result<()> {
+    use std::os::windows::fs::FileExt;
+    let (mut off, mut done) = (offset, 0usize);
+    while done < bytes.len() {
+        let n = f.seek_write(&bytes[done..], off)?;
+        if n == 0 {
+            anyhow::bail!("seek_write wrote 0 bytes at offset {off}");
+        }
+        done += n;
+        off += n as u64;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn read_exact_at(f: &std::fs::File, out: &mut [u8], offset: u64) -> Result<()> {
+    use std::os::windows::fs::FileExt;
+    let (mut off, mut done) = (offset, 0usize);
+    let total = out.len();
+    while done < total {
+        let n = f.seek_read(&mut out[done..], off)?;
+        if n == 0 {
+            anyhow::bail!("seek_read hit EOF after {done} of {total} bytes at offset {off}");
+        }
+        done += n;
+        off += n as u64;
+    }
+    Ok(())
 }

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -172,18 +172,16 @@ impl Model for TransformerModel {
         name: &str,
         slot: usize,
     ) -> Result<()> {
-        // The disk/peer LoRA swap paths land tensors through spark-storage's
-        // RDMA weight loader, which is cuda AND unix. Same fail-fast shape as
-        // `promote_lora_from_peer` below rather than a silent no-op: a caller
-        // asking to hot-swap an adapter must not be told it succeeded.
-        #[cfg(all(feature = "cuda", unix))]
+        // Disk staging is plain file I/O and is portable; only the PEER path
+        // needs RDMA. Still cuda-gated, since it lands into a device pool.
+        #[cfg(feature = "cuda")]
         {
             self.swap_lora_slot_from_disk(dir, name, slot)
         }
-        #[cfg(not(all(feature = "cuda", unix)))]
+        #[cfg(not(feature = "cuda"))]
         {
             let _ = (dir, name, slot);
-            anyhow::bail!("LoRA disk swap requires the cuda feature on a unix host")
+            anyhow::bail!("LoRA disk swap requires the cuda feature")
         }
     }
     fn promote_lora_from_peer(
@@ -200,7 +198,7 @@ impl Model for TransformerModel {
         #[cfg(not(all(feature = "cuda", unix)))]
         {
             let _ = (peer_addr, adapter_id, name, peft);
-            anyhow::bail!("LoRA peer promotion requires the cuda feature on a unix host")
+            anyhow::bail!("LoRA peer promotion stages over RDMA (rdma-core); unix-only")
         }
     }
     fn promote_lora_from_disk(
@@ -208,14 +206,14 @@ impl Model for TransformerModel {
         dir: &std::path::Path,
         name: &str,
     ) -> Result<(usize, Option<String>)> {
-        #[cfg(all(feature = "cuda", unix))]
+        #[cfg(feature = "cuda")]
         {
             self.promote_lora_slot_from_disk(dir, name)
         }
-        #[cfg(not(all(feature = "cuda", unix)))]
+        #[cfg(not(feature = "cuda"))]
         {
             let _ = (dir, name);
-            anyhow::bail!("LoRA disk promotion requires the cuda feature on a unix host")
+            anyhow::bail!("LoRA disk promotion requires the cuda feature")
         }
     }
     fn high_speed_swap_dims(&self) -> Option<spark_storage::ModelDims> {

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -172,7 +172,19 @@ impl Model for TransformerModel {
         name: &str,
         slot: usize,
     ) -> Result<()> {
-        self.swap_lora_slot_from_disk(dir, name, slot)
+        // The disk/peer LoRA swap paths land tensors through spark-storage's
+        // RDMA weight loader, which is cuda AND unix. Same fail-fast shape as
+        // `promote_lora_from_peer` below rather than a silent no-op: a caller
+        // asking to hot-swap an adapter must not be told it succeeded.
+        #[cfg(all(feature = "cuda", unix))]
+        {
+            self.swap_lora_slot_from_disk(dir, name, slot)
+        }
+        #[cfg(not(all(feature = "cuda", unix)))]
+        {
+            let _ = (dir, name, slot);
+            anyhow::bail!("LoRA disk swap requires the cuda feature on a unix host")
+        }
     }
     fn promote_lora_from_peer(
         &mut self,
@@ -181,14 +193,14 @@ impl Model for TransformerModel {
         name: &str,
         peft: atlas_core::config::PeftAdapterConfig,
     ) -> Result<(usize, Option<String>)> {
-        #[cfg(feature = "cuda")]
+        #[cfg(all(feature = "cuda", unix))]
         {
             self.promote_lora_slot_from_peer(peer_addr, adapter_id, name, peft)
         }
-        #[cfg(not(feature = "cuda"))]
+        #[cfg(not(all(feature = "cuda", unix)))]
         {
             let _ = (peer_addr, adapter_id, name, peft);
-            anyhow::bail!("LoRA peer promotion requires the cuda feature")
+            anyhow::bail!("LoRA peer promotion requires the cuda feature on a unix host")
         }
     }
     fn promote_lora_from_disk(
@@ -196,7 +208,15 @@ impl Model for TransformerModel {
         dir: &std::path::Path,
         name: &str,
     ) -> Result<(usize, Option<String>)> {
-        self.promote_lora_slot_from_disk(dir, name)
+        #[cfg(all(feature = "cuda", unix))]
+        {
+            self.promote_lora_slot_from_disk(dir, name)
+        }
+        #[cfg(not(all(feature = "cuda", unix)))]
+        {
+            let _ = (dir, name);
+            anyhow::bail!("LoRA disk promotion requires the cuda feature on a unix host")
+        }
     }
     fn high_speed_swap_dims(&self) -> Option<spark_storage::ModelDims> {
         self.high_speed_swap_dims_dispatch()

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -277,7 +277,10 @@ pub fn parse_expert_index(name: &str) -> Option<usize> {
 pub mod adapter;
 mod loader;
 pub mod mlx_int8;
-pub(crate) use loader::{check_oom_guard, estimate_has_fp8, estimate_load_bytes};
+pub(crate) use loader::estimate_load_bytes;
+// Consumed by the unix-only fast-weights (O_DIRECT) loader path.
+#[cfg(unix)]
+pub(crate) use loader::{check_oom_guard, estimate_has_fp8};
 
 #[cfg(test)]
 mod from_str_tests {

--- a/crates/spark-storage/build.rs
+++ b/crates/spark-storage/build.rs
@@ -132,9 +132,12 @@ fn compile_kernels() {
         if !status.success() {
             panic!("nvcc --ptx failed for {}", src.display());
         }
+        // `{:?}` supplies the quotes AND escapes the path: a Windows OUT_DIR
+        // like `D:\a\atlas\...` interpolated raw makes `\a` an invalid Rust
+        // escape, and the generated storage_ptx.rs fails to lex.
         emit.push_str(&format!(
-            "    StoragePtx {{ name: \"{stem}\", ptx: include_str!(\"{}\") }},\n",
-            ptx_out.display()
+            "    StoragePtx {{ name: \"{stem}\", ptx: include_str!({}) }},\n",
+            format_args!("{:?}", ptx_out.to_string_lossy())
         ));
     }
     emit.push_str("];\n");

--- a/crates/spark-storage/src/backend/mod.rs
+++ b/crates/spark-storage/src/backend/mod.rs
@@ -12,9 +12,14 @@ use anyhow::Result;
 
 use crate::group::{GroupKey, GroupLayout, KvKind};
 
+// io_uring is a Linux kernel interface with no analogue elsewhere; the
+// portable `posix` backend (positional read/write via atlas_tier::pio) is what
+// non-Linux builds use.
+#[cfg(target_os = "linux")]
 pub mod io_uring;
 pub mod posix;
 
+#[cfg(target_os = "linux")]
 pub use self::io_uring::IoUringBackend;
 pub use posix::PosixBackend;
 

--- a/crates/spark-storage/src/backend/posix.rs
+++ b/crates/spark-storage/src/backend/posix.rs
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
-// Phase-2 POSIX reference backend. Single pinned bounce buffer, `pread` +
-// `cuMemcpyHtoDAsync`, stream-sync after every memcpy to avoid the next
-// pread overwriting in-flight DMA. Slow-but-deterministic; used by tests as
-// the oracle the io_uring backend is compared against.
+// Phase-2 reference backend. Single pinned bounce buffer, positional read +
+// `cuMemcpyHtoDAsync`, stream-sync after every memcpy to avoid the next read
+// overwriting in-flight DMA. Slow-but-deterministic; used by tests as the
+// oracle the io_uring backend is compared against.
+//
+// Named "posix" for its history; it is now PORTABLE. The positional read/write
+// go through `atlas_tier::pio`, which is `pread`/`pwrite` on unix and
+// `seek_read`/`seek_write` on Windows, so this is the backend the Windows
+// build uses (io_uring has no Windows analogue).
 
 use anyhow::{Context, Result, bail};
 use std::ffi::c_void;
@@ -34,15 +39,13 @@ impl StorageBackend for PosixBackend {
         let bytes = self.layout.group_bytes() as usize;
         let bounce_ptr = self.bounce.ptr;
         for req in requests {
-            let fd = self.layout.fd(req.group.layer);
-            let off = self.layout.offset(req.group) as i64;
-            let n = unsafe { libc::pread(fd, bounce_ptr, bytes, off) };
-            if n != bytes as isize {
-                bail!(
-                    "pread {bytes}@{off} returned {n}, errno {}",
-                    std::io::Error::last_os_error()
-                );
-            }
+            let off = self.layout.offset(req.group);
+            // SAFETY: `bounce_ptr` is a pinned host allocation of at least
+            // `group_bytes()`, owned by `self.bounce` for the lifetime of this
+            // call and not aliased -- the loop serialises on `stream_sync`.
+            let buf = unsafe { std::slice::from_raw_parts_mut(bounce_ptr as *mut u8, bytes) };
+            atlas_tier::pio::read_exact_at(self.layout.file(req.group.layer), buf, off)
+                .with_context(|| format!("read {bytes}@{off}"))?;
             // The pinned bounce buffer is shared across all requests in this
             // call; we must let the H→D DMA complete before the next pread
             // overwrites the buffer, otherwise the second cuMemcpyHtoDAsync
@@ -67,18 +70,13 @@ impl StorageBackend for PosixBackend {
         unsafe {
             std::ptr::copy_nonoverlapping(src.as_ptr(), self.bounce.ptr as *mut u8, bytes);
         }
-        let fd = self.layout.fd(key.layer);
-        let off = self.layout.offset(key) as i64;
-        let n = unsafe { libc::pwrite(fd, self.bounce.ptr, bytes, off) };
-        if n != bytes as isize {
-            bail!(
-                "pwrite {bytes}@{off} returned {n}, errno {}",
-                std::io::Error::last_os_error()
-            );
-        }
+        let off = self.layout.offset(key);
+        // SAFETY: as above -- pinned, group-sized, exclusively owned here.
+        let buf = unsafe { std::slice::from_raw_parts(self.bounce.ptr as *const u8, bytes) };
+        atlas_tier::pio::write_all_at(self.layout.file(key.layer), buf, off)
+            .with_context(|| format!("write {bytes}@{off}"))?;
         // fsync would be needed for crash durability; skipped for the test
         // path where the file is single-process / single-run.
-        let _ = fd;
         Ok(())
     }
 
@@ -90,12 +88,22 @@ impl StorageBackend for PosixBackend {
 impl PosixBackend {
     /// Test helper: drop the page cache for the layer files so subsequent
     /// reads actually hit NVMe (otherwise small tests trivially read from RAM).
+    ///
+    /// `posix_fadvise(DONTNEED)` has no portable equivalent; on Windows the
+    /// cache is dropped by reopening with `FILE_FLAG_NO_BUFFERING`, which this
+    /// tier deliberately does not use. A no-op there means a Windows run of
+    /// the timing tests may read from RAM -- which is why this is a test
+    /// helper and not a correctness primitive.
+    #[cfg(unix)]
     pub fn drop_pagecache(&self) {
         for layer in 0..self.layout.spec.num_layers {
             let fd = self.layout.fd(layer);
             unsafe { libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_DONTNEED) };
         }
     }
+
+    #[cfg(not(unix))]
+    pub fn drop_pagecache(&self) {}
 }
 
 #[cfg(test)]

--- a/crates/spark-storage/src/expert_pack.rs
+++ b/crates/spark-storage/src/expert_pack.rs
@@ -6,7 +6,7 @@
 //   * Pure format functions (`pack_record` / `unpack_record`) that assemble and
 //     parse one fixed-stride record in memory. No I/O, no CUDA, no safetensors —
 //     unit-testable with synthetic bytes.
-//   * A `cfg(unix)` file writer/reader that lays those records into one file per
+//   * A portable file writer/reader that lays those records into one file per
 //     MoE layer, plus an `ExpertIndex` manifest (JSON) describing the geometry
 //     so the streamer can reconstruct `ExpertRecordSpec` / `ExpertLayout` and
 //     open the files without re-deriving anything from the checkpoint.
@@ -17,10 +17,8 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::expert::{ExpertLayout, ExpertRecordHeader, ExpertRecordSpec, Proj};
-// Only the unix-gated packing path names this type.
-#[cfg(unix)]
 use crate::expert::ExpertKey;
+use crate::expert::{ExpertLayout, ExpertRecordHeader, ExpertRecordSpec, Proj};
 
 /// Borrowed packed+scale bytes for one projection, as they will sit on disk
 /// (prefill-resident / transposed layout).
@@ -225,10 +223,8 @@ impl ExpertIndex {
     }
 }
 
-#[cfg(unix)]
 pub use fs_impl::{ExpertFileReader, ExpertFileWriter};
 
-#[cfg(unix)]
 #[path = "expert_pack_fs.rs"]
 mod fs_impl;
 

--- a/crates/spark-storage/src/expert_pack.rs
+++ b/crates/spark-storage/src/expert_pack.rs
@@ -17,7 +17,10 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::expert::{ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordSpec, Proj};
+use crate::expert::{ExpertLayout, ExpertRecordHeader, ExpertRecordSpec, Proj};
+// Only the unix-gated packing path names this type.
+#[cfg(unix)]
+use crate::expert::ExpertKey;
 
 /// Borrowed packed+scale bytes for one projection, as they will sit on disk
 /// (prefill-resident / transposed layout).

--- a/crates/spark-storage/src/expert_pack_fs.rs
+++ b/crates/spark-storage/src/expert_pack_fs.rs
@@ -5,7 +5,9 @@
 
 use super::*;
 use std::fs::{File, OpenOptions};
-use std::os::unix::fs::FileExt;
+// Positional I/O via the shared helper rather than `std::os::unix::fs::FileExt`:
+// the only thing that made this 328-line module unix-only was the trait import.
+use atlas_tier::pio;
 use std::path::{Path, PathBuf};
 
 /// Offline writer: creates the manifest + one file per MoE layer and places
@@ -67,8 +69,7 @@ impl ExpertFileWriter {
         }
         let rec = pack_record(&self.spec, self.layout.record_stride, header, projs)?;
         let off = self.layout.file_offset(key);
-        self.files[key.layer as usize]
-            .write_all_at(&rec, off)
+        pio::write_all_at(&self.files[key.layer as usize], &rec, off)
             .with_context(|| format!("write record {:?} at {off}", key))?;
         Ok(())
     }
@@ -144,8 +145,7 @@ impl ExpertFileReader {
         }
         let mut buf = vec![0u8; self.layout.record_stride as usize];
         let off = self.layout.file_offset(key);
-        self.files[key.layer as usize]
-            .read_exact_at(&mut buf, off)
+        pio::read_exact_at(&self.files[key.layer as usize], &mut buf, off)
             .with_context(|| format!("read record {:?} at {off}", key))?;
         Ok(buf)
     }

--- a/crates/spark-storage/src/expert_peer.rs
+++ b/crates/spark-storage/src/expert_peer.rs
@@ -19,6 +19,9 @@
 // The peer is pure I/O (no CUDA); the client half lives in the cuda-gated
 // `expert_tier_rdma` module because it lands bytes in the pinned arena.
 
+// Consumed only by the `#[cfg(unix)]` peer server below; same gate, so a
+// Windows build does not trip `unused_imports` under `warnings = "deny"`.
+#[cfg(unix)]
 use anyhow::{Context, Result, bail};
 
 // The handshake wire codecs moved verbatim to the CUDA-free `atlas-rdma`

--- a/crates/spark-storage/src/expert_tier.rs
+++ b/crates/spark-storage/src/expert_tier.rs
@@ -21,9 +21,8 @@
 // a single byte the GEMM reads — which the Tier-1 parity test proves.
 
 use anyhow::{Context, Result, bail};
-use std::fs::OpenOptions;
-use std::os::fd::{AsRawFd, OwnedFd};
-use std::os::unix::fs::OpenOptionsExt;
+use atlas_tier::pio;
+use std::fs::{File, OpenOptions};
 use std::path::Path;
 
 use crate::cuda_min::{DeviceBuffer, copy_h_to_d_async, stream_sync};
@@ -176,7 +175,7 @@ impl ExpertTier for PosixTier {
 /// the returned addresses point INTO the arena (GPU-addressable at the same
 /// VA), no `copy_h2d`.
 pub struct UmaArenaTier {
-    files: Vec<OwnedFd>, // one O_DIRECT fd per MoE layer
+    files: Vec<File>, // one O_DIRECT fd per MoE layer
     spec: ExpertRecordSpec,
     layout: ExpertLayout,
     arena: ExpertArena,
@@ -192,12 +191,13 @@ impl UmaArenaTier {
         let mut files = Vec::with_capacity(index.num_moe_layers as usize);
         for l in 0..index.num_moe_layers {
             let p = dir.join(index.file_name(l));
-            let f = OpenOptions::new()
-                .read(true)
-                .custom_flags(libc::O_DIRECT)
+            let mut opts = OpenOptions::new();
+            opts.read(true);
+            set_direct_flag(&mut opts);
+            let f = opts
                 .open(&p)
-                .with_context(|| format!("open O_DIRECT {}", p.display()))?;
-            files.push(f.into());
+                .with_context(|| format!("open {}", p.display()))?;
+            files.push(f);
         }
         let arena = ExpertArena::new(num_slabs, slots_per_slab, layout.record_stride as usize)?;
         Ok(Self {
@@ -217,38 +217,19 @@ impl ExpertTier for UmaArenaTier {
     fn fetch(&mut self, key: ExpertKey, slot: ArenaSlot, _stream: u64) -> Result<ExpertResidency> {
         let stride = self.layout.record_stride as usize;
         let host = self.arena.slot_host_ptr(slot.slab, slot.slot)?;
-        let fd = self
+        let file = self
             .files
             .get(key.layer as usize)
-            .with_context(|| format!("UmaArenaTier: no file for layer {}", key.layer))?
-            .as_raw_fd();
+            .with_context(|| format!("UmaArenaTier: no file for layer {}", key.layer))?;
         let off = self.layout.file_offset(key);
-        // O_DIRECT pread of the whole (4 KiB-aligned) record into the pinned,
-        // GPU-addressable slot — this is the "delete the bounce copy" step.
-        let mut done = 0usize;
-        while done < stride {
-            // SAFETY: `host` points at a slot of `stride` bytes inside the pinned
-            // arena; offset/len stay within it. fd is a valid O_DIRECT handle.
-            let n = unsafe {
-                libc::pread(
-                    fd,
-                    host.add(done) as *mut libc::c_void,
-                    stride - done,
-                    (off + done as u64) as libc::off_t,
-                )
-            };
-            if n < 0 {
-                bail!(
-                    "UmaArenaTier pread {:?} at {off}: {}",
-                    key,
-                    std::io::Error::last_os_error()
-                );
-            }
-            if n == 0 {
-                bail!("UmaArenaTier: short read for {:?} ({done}/{stride})", key);
-            }
-            done += n as usize;
-        }
+        // Positional read of the whole (4 KiB-aligned) record straight into the
+        // pinned, GPU-addressable slot — this is the "delete the bounce copy"
+        // step. O_DIRECT on Linux makes it zero-copy; elsewhere it is buffered.
+        // SAFETY: `host` points at a slot of `stride` bytes inside the pinned
+        // arena, and the slice covers exactly that slot.
+        let dst = unsafe { std::slice::from_raw_parts_mut(host, stride) };
+        pio::read_exact_at(file, dst, off)
+            .with_context(|| format!("UmaArenaTier read {key:?} at {off}"))?;
         // SAFETY: the slot holds `stride` valid bytes just read from disk.
         let record = unsafe { std::slice::from_raw_parts(host, stride) };
         let dev_va = self.arena.slot_dev_va(slot.slab, slot.slot)?;
@@ -272,17 +253,28 @@ pub fn open_tier(
     num_slabs: u32,
     slots_per_slab: u32,
 ) -> Result<Box<dyn ExpertTier>> {
+    // The RDMA expert tiers need rdma-core, so they exist on unix only. The
+    // local `posix`/`uma` tiers below are portable; asking for an RDMA backend
+    // elsewhere fails with a clear message rather than being silently absent
+    // from the match.
     let rdma = |use_verbs: bool| -> Result<Box<dyn ExpertTier>> {
         let flag = if use_verbs { "rdma-verbs" } else { "rdma" };
-        let addr = std::env::var("ATLAS_EXPERT_PEER").map_err(|_| {
-            anyhow::anyhow!("--expert-backend {flag} needs $ATLAS_EXPERT_PEER=host:port")
-        })?;
-        Ok(Box::new(crate::expert_tier_rdma::RdmaTier::connect(
-            &addr,
-            num_slabs,
-            slots_per_slab,
-            use_verbs,
-        )?))
+        #[cfg(unix)]
+        {
+            let addr = std::env::var("ATLAS_EXPERT_PEER").map_err(|_| {
+                anyhow::anyhow!("--expert-backend {flag} needs $ATLAS_EXPERT_PEER=host:port")
+            })?;
+            Ok(Box::new(crate::expert_tier_rdma::RdmaTier::connect(
+                &addr,
+                num_slabs,
+                slots_per_slab,
+                use_verbs,
+            )?))
+        }
+        #[cfg(not(unix))]
+        {
+            bail!("--expert-backend {flag} requires rdma-core, which is unix-only")
+        }
     };
     match backend {
         "posix" => Ok(Box::new(PosixTier::open(dir, num_slabs, slots_per_slab)?)),
@@ -305,3 +297,15 @@ pub fn read_device(dev_va: u64, len: usize, stream: u64) -> Result<Vec<u8>> {
     stream_sync(stream)?;
     Ok(out)
 }
+
+/// O_DIRECT on Linux (the zero-copy arena read depends on it); no equivalent
+/// flag elsewhere — see the `layout` module header for why Windows stays
+/// buffered rather than using FILE_FLAG_NO_BUFFERING.
+#[cfg(target_os = "linux")]
+fn set_direct_flag(opts: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+    opts.custom_flags(libc::O_DIRECT);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_direct_flag(_opts: &mut OpenOptions) {}

--- a/crates/spark-storage/src/high_speed_swap.rs
+++ b/crates/spark-storage/src/high_speed_swap.rs
@@ -7,7 +7,14 @@
 
 use anyhow::{Context, Result};
 
-use crate::backend::IoUringBackend;
+// The tier's backend is io_uring on Linux and the portable positional-I/O
+// backend everywhere else. Selected by alias so the orchestrator below has ONE
+// body: only the submission mechanism differs, not the layout, the eviction
+// policy or the scratch pool.
+#[cfg(target_os = "linux")]
+use crate::backend::IoUringBackend as TierBackend;
+#[cfg(not(target_os = "linux"))]
+use crate::backend::PosixBackend as TierBackend;
 use crate::config::HighSpeedSwapConfig;
 use crate::cuda_min::{CudaCtx, DeviceBuffer};
 use crate::eviction::EvictionPolicy;
@@ -26,7 +33,7 @@ pub struct HighSpeedSwap {
     model: ModelDims,
     predictor: Predictor,
     pool: ScratchPool,
-    backend: IoUringBackend,
+    backend: TierBackend,
     attn: TiledAttention,
     eviction: EvictionPolicy,
     // Reusable scratch buffers.
@@ -81,7 +88,12 @@ impl HighSpeedSwap {
             4096,
         );
         let layout = Layout::create(&cfg.dir, group_layout).context("create layout")?;
-        let backend = IoUringBackend::new(layout, cfg.qd as usize)?;
+        // qd is the io_uring submission-queue depth; the portable backend
+        // serialises on a single pinned bounce buffer and has no queue.
+        #[cfg(target_os = "linux")]
+        let backend = TierBackend::new(layout, cfg.qd as usize)?;
+        #[cfg(not(target_os = "linux"))]
+        let backend = TierBackend::new(layout)?;
         let pool = ScratchPool::new(ScratchDims {
             num_slots: cfg.resident_blocks,
             num_kv_heads: model.num_kv_heads,

--- a/crates/spark-storage/src/layout.rs
+++ b/crates/spark-storage/src/layout.rs
@@ -1,17 +1,27 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // On-disk layout for `--high-speed-swap`. One file per layer under
-// `--high-speed-swap-dir`, pre-allocated via `posix_fallocate` so the
-// filesystem reserves the bytes up-front (no surprise ENOSPC mid-decode).
+// `--high-speed-swap-dir`, pre-allocated so the filesystem reserves the bytes
+// up-front (no surprise ENOSPC mid-decode).
 //
 // File names: `layer_{:05}.kv`. File contents are an opaque
-// `GroupLayout`-defined stripe; the `Layout` type owns the open `File`s plus
-// `O_DIRECT` fds for the I/O backends.
+// `GroupLayout`-defined stripe; the `Layout` type owns the open `File`s.
+//
+// PLATFORMS. On Linux the files are opened `O_DIRECT` (the io_uring / cuFile
+// path needs it) and reserved with `posix_fallocate`. On Windows they are
+// opened buffered and reserved with `set_len`:
+//   * `FILE_FLAG_NO_BUFFERING` is the nearest O_DIRECT analogue but imposes
+//     sector alignment on every buffer, offset and length; the tier's records
+//     are 4 KiB-aligned but its bounce buffers are pinned host allocations
+//     whose alignment is CUDA's to choose, so the flag would be unsafe to
+//     assume. Buffered is correct, just not zero-copy.
+//   * `SetFileValidData` is the true fallocate analogue but needs
+//     SE_MANAGE_VOLUME_NAME; `set_len` reserves the range without it.
 
 use anyhow::{Context, Result};
 use std::fs::{File, OpenOptions};
-use std::os::fd::{AsRawFd, OwnedFd, RawFd};
-use std::os::unix::fs::OpenOptionsExt;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 
 use crate::group::{GroupKey, GroupLayout};
@@ -19,8 +29,10 @@ use crate::group::{GroupKey, GroupLayout};
 pub struct Layout {
     pub dir: PathBuf,
     pub spec: GroupLayout,
-    /// One `File` per layer, opened with O_DIRECT for the io_uring / cuFile path.
-    files: Vec<OwnedFd>,
+    /// One `File` per layer. O_DIRECT on Linux for the io_uring / cuFile path;
+    /// buffered elsewhere. Held as `File` rather than `OwnedFd` so the portable
+    /// positional-I/O backend can use it on every platform.
+    files: Vec<File>,
 }
 
 impl Layout {
@@ -29,17 +41,15 @@ impl Layout {
         let mut files = Vec::with_capacity(spec.num_layers as usize);
         for layer in 0..spec.num_layers {
             let p = dir.join(format!("layer_{layer:05}.kv"));
-            let f = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .custom_flags(libc::O_DIRECT)
+            let mut opts = OpenOptions::new();
+            opts.read(true).write(true).create(true).truncate(false);
+            set_direct_flag(&mut opts);
+            let f = opts
                 .open(&p)
-                .with_context(|| format!("open O_DIRECT {}", p.display()))?;
+                .with_context(|| format!("open {}", p.display()))?;
             preallocate(&f, spec.bytes_per_layer())
-                .with_context(|| format!("fallocate {}", p.display()))?;
-            files.push(f.into());
+                .with_context(|| format!("preallocate {}", p.display()))?;
+            files.push(f);
         }
         Ok(Self {
             dir: dir.to_path_buf(),
@@ -53,12 +63,12 @@ impl Layout {
         let mut files = Vec::with_capacity(spec.num_layers as usize);
         for layer in 0..spec.num_layers {
             let p = dir.join(format!("layer_{layer:05}.kv"));
-            let f = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .custom_flags(libc::O_DIRECT)
+            let mut opts = OpenOptions::new();
+            opts.read(true).write(true);
+            set_direct_flag(&mut opts);
+            let f = opts
                 .open(&p)
-                .with_context(|| format!("open O_DIRECT {}", p.display()))?;
+                .with_context(|| format!("open {}", p.display()))?;
             let len = f.metadata()?.len();
             if len < spec.bytes_per_layer() {
                 anyhow::bail!(
@@ -68,7 +78,7 @@ impl Layout {
                     spec.bytes_per_layer()
                 );
             }
-            files.push(f.into());
+            files.push(f);
         }
         Ok(Self {
             dir: dir.to_path_buf(),
@@ -77,8 +87,16 @@ impl Layout {
         })
     }
 
+    /// Raw fd for the io_uring / cuFile paths, which are Linux-only.
+    #[cfg(unix)]
     pub fn fd(&self, layer: u32) -> RawFd {
         self.files[layer as usize].as_raw_fd()
+    }
+
+    /// The layer file itself — what the portable positional-I/O backend uses,
+    /// and the only accessor available on Windows.
+    pub fn file(&self, layer: u32) -> &File {
+        &self.files[layer as usize]
     }
 
     pub fn offset(&self, key: GroupKey) -> u64 {
@@ -90,6 +108,16 @@ impl Layout {
     }
 }
 
+/// O_DIRECT on Linux; nothing to set elsewhere (see the header note).
+#[cfg(target_os = "linux")]
+fn set_direct_flag(opts: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+    opts.custom_flags(libc::O_DIRECT);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_direct_flag(_opts: &mut OpenOptions) {}
+
 #[cfg(unix)]
 fn preallocate(file: &File, size: u64) -> Result<()> {
     // posix_fallocate is portable across ext4/xfs and reserves space without
@@ -100,6 +128,17 @@ fn preallocate(file: &File, size: u64) -> Result<()> {
     if res != 0 {
         anyhow::bail!("posix_fallocate({size}) failed: {res}");
     }
+    Ok(())
+}
+
+// Windows: `set_len` extends the file to the requested size. NTFS keeps the
+// tail sparse until written, so this reserves the RANGE rather than the blocks
+// -- weaker than posix_fallocate, and the honest trade for not requiring the
+// SE_MANAGE_VOLUME privilege that SetFileValidData needs.
+#[cfg(windows)]
+fn preallocate(file: &File, size: u64) -> Result<()> {
+    file.set_len(size)
+        .with_context(|| format!("set_len({size})"))?;
     Ok(())
 }
 

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -82,64 +82,71 @@ pub use model_dims::ModelDims;
 // assumption, and io_uring has no Windows analogue at all. The whole NVMe /
 // RDMA cold-tier stack below is therefore unix-only, and a Windows `spark`
 // binary is built without it rather than against an unvalidated IOCP port.
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod layout;
 
 // CUDA-only modules: each holds raw `cu*` FFI calls or a `DeviceBuffer`,
 // or transitively imports from the cuda_* modules above. Gated together
 // because separating them would just smear the boundary.
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod backend;
-#[cfg(all(feature = "cuda", unix))]
+// The tier micro-benchmark drives io_uring directly (submission queues, not
+// the StorageBackend trait), so it is Linux-only along with io_uring itself.
+#[cfg(all(feature = "cuda", target_os = "linux"))]
 pub mod bench;
 // T1 write-back cache composite (wraps any StorageBackend). cuda but not verbs.
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod cascade_backend;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod expert_arena;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod expert_tier;
+// RDMA expert staging needs rdma-core (libibverbs), which is Linux-only.
 #[cfg(all(feature = "cuda", unix))]
 pub mod expert_tier_rdma;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod high_speed_swap;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod predictor;
-#[cfg(all(feature = "cuda", unix))]
+// Capability probe for cuFile / GPUDirect Storage, which NVIDIA ships for
+// Linux only. There is nothing to probe on other platforms.
+#[cfg(all(feature = "cuda", target_os = "linux"))]
 pub mod probe;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod scratch_pool;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod tiled_attention;
 // RDMA weight loader — the cuda client of `weight_peer` that one-sided-READs a
 // model's tensors into a `spark_runtime::weights::WeightStore` for fast swaps.
 // RDMA-stage a PEFT adapter's A/B tensors straight into a resident LoRA pool
 // slot (reuses the weight_peer manifest + wire; landing byte-identical to the
 // disk pack).
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod weight_lora_rdma;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub mod weight_tier_rdma;
 
-#[cfg(all(feature = "cuda", unix))]
-pub use backend::{IoUringBackend, PosixBackend, ReadRequest, StorageBackend};
+#[cfg(feature = "cuda")]
+pub use backend::{PosixBackend, ReadRequest, StorageBackend};
+// io_uring is Linux-only; everything else in the tier is portable.
+#[cfg(all(feature = "cuda", target_os = "linux"))]
+pub use backend::IoUringBackend;
 pub use config::HighSpeedSwapConfig;
 pub use eviction::EvictionPolicy;
 pub use expert::{
     ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordId, ExpertRecordSpec, Proj, ProjBytes,
 };
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use expert_arena::ExpertArena;
-#[cfg(unix)]
 pub use expert_pack::{ExpertFileReader, ExpertFileWriter};
 pub use expert_pack::{ExpertIndex, ProjData, ProjView, pack_record, unpack_record};
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use expert_tier::{
     ArenaSlot, ExpertResidency, ExpertTier, PosixTier, TierKind, UmaArenaTier, open_tier,
 };
 #[cfg(all(feature = "cuda", unix))]
 pub use expert_tier_rdma::RdmaTier;
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
 #[cfg(all(feature = "cuda", atlas_rdma_verbs))]
 pub use kv_paging::KvPagingBackend;
@@ -165,24 +172,23 @@ mod rdma_verbs_probe_tests;
 // absent), `local_installed` is false, and `install_local` bails — see
 // `stubs.rs` for rationale.
 //
-// The gate is `not(all(cuda, unix))`, not `not(cuda)`: the real orchestrator is
-// CUDA + GDS + io_uring, so it needs BOTH. Gating on the feature alone was
-// correct only while cuda implied Linux; a CUDA build on Windows has no
-// io_uring and must land here too.
-#[cfg(not(all(feature = "cuda", unix)))]
+// Gated on the cuda feature alone: the orchestrator itself is now portable
+// (its backend is an alias -- io_uring on Linux, the positional-I/O backend
+// elsewhere), so a Windows CUDA build gets the REAL tier, not this stub.
+#[cfg(not(feature = "cuda"))]
 mod stubs;
-#[cfg(not(all(feature = "cuda", unix)))]
+#[cfg(not(feature = "cuda"))]
 pub use stubs::{HighSpeedSwap, install_local, local_installed, with_local};
 
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use predictor::{Predictor, PredictorDims};
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(all(feature = "cuda", target_os = "linux"))]
 pub use probe::{Backend, ProbeConfig, ProbeResult, run_probe};
 pub use projection::{PredictorShape, build_projection};
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use tiled_attention::{TiledAttention, TiledAttentionDims};
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use weight_lora_rdma::{LoraAbKind, LoraLandTarget, RdmaLoraLoader};
 pub use weight_peer::{WeightManifest, WeightTensorRecord};
-#[cfg(all(feature = "cuda", unix))]
+#[cfg(feature = "cuda")]
 pub use weight_tier_rdma::RdmaWeightLoader;

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -160,13 +160,18 @@ pub const fn rdma_verbs_enabled() -> bool {
 #[cfg(test)]
 mod rdma_verbs_probe_tests;
 
-// Non-cuda stub surface — same names as the real CUDA orchestrator
-// above so spark-model's call sites compile unchanged. `with_local`
-// always returns None (orchestrator absent), `local_installed` is
-// false, and `install_local` bails — see `stubs.rs` for rationale.
-#[cfg(not(feature = "cuda"))]
+// Stub surface — same names as the real orchestrator above so spark-model's
+// call sites compile unchanged. `with_local` always returns None (orchestrator
+// absent), `local_installed` is false, and `install_local` bails — see
+// `stubs.rs` for rationale.
+//
+// The gate is `not(all(cuda, unix))`, not `not(cuda)`: the real orchestrator is
+// CUDA + GDS + io_uring, so it needs BOTH. Gating on the feature alone was
+// correct only while cuda implied Linux; a CUDA build on Windows has no
+// io_uring and must land here too.
+#[cfg(not(all(feature = "cuda", unix)))]
 mod stubs;
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(all(feature = "cuda", unix)))]
 pub use stubs::{HighSpeedSwap, install_local, local_installed, with_local};
 
 #[cfg(all(feature = "cuda", unix))]

--- a/crates/spark-storage/src/lib.rs
+++ b/crates/spark-storage/src/lib.rs
@@ -75,66 +75,71 @@ pub use model_dims::ModelDims;
 
 // `layout` opens disk files with `O_DIRECT` and pre-allocates via
 // `posix_fallocate` — both Linux-specific. Only the cuda-side modules
-// (high_speed_swap, backend/io_uring, backend/posix) consume it, so
-// gating it on the cuda feature is sufficient.
-#[cfg(feature = "cuda")]
+// (high_speed_swap, backend/io_uring, backend/posix) consume it.
+//
+// The gate is `all(cuda, unix)`, NOT `cuda` alone: gating on the feature was
+// only ever sufficient because cuda implied Linux. CUDA on Windows breaks that
+// assumption, and io_uring has no Windows analogue at all. The whole NVMe /
+// RDMA cold-tier stack below is therefore unix-only, and a Windows `spark`
+// binary is built without it rather than against an unvalidated IOCP port.
+#[cfg(all(feature = "cuda", unix))]
 pub mod layout;
 
 // CUDA-only modules: each holds raw `cu*` FFI calls or a `DeviceBuffer`,
 // or transitively imports from the cuda_* modules above. Gated together
 // because separating them would just smear the boundary.
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod backend;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod bench;
 // T1 write-back cache composite (wraps any StorageBackend). cuda but not verbs.
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod cascade_backend;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod expert_arena;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod expert_tier;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod expert_tier_rdma;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod high_speed_swap;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod predictor;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod probe;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod scratch_pool;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod tiled_attention;
 // RDMA weight loader — the cuda client of `weight_peer` that one-sided-READs a
 // model's tensors into a `spark_runtime::weights::WeightStore` for fast swaps.
 // RDMA-stage a PEFT adapter's A/B tensors straight into a resident LoRA pool
 // slot (reuses the weight_peer manifest + wire; landing byte-identical to the
 // disk pack).
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod weight_lora_rdma;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub mod weight_tier_rdma;
 
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use backend::{IoUringBackend, PosixBackend, ReadRequest, StorageBackend};
 pub use config::HighSpeedSwapConfig;
 pub use eviction::EvictionPolicy;
 pub use expert::{
     ExpertKey, ExpertLayout, ExpertRecordHeader, ExpertRecordId, ExpertRecordSpec, Proj, ProjBytes,
 };
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use expert_arena::ExpertArena;
 #[cfg(unix)]
 pub use expert_pack::{ExpertFileReader, ExpertFileWriter};
 pub use expert_pack::{ExpertIndex, ProjData, ProjView, pack_record, unpack_record};
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use expert_tier::{
     ArenaSlot, ExpertResidency, ExpertTier, PosixTier, TierKind, UmaArenaTier, open_tier,
 };
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use expert_tier_rdma::RdmaTier;
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use high_speed_swap::{HighSpeedSwap, install_local, local_installed, with_local};
 #[cfg(all(feature = "cuda", atlas_rdma_verbs))]
 pub use kv_paging::KvPagingBackend;
@@ -164,15 +169,15 @@ mod stubs;
 #[cfg(not(feature = "cuda"))]
 pub use stubs::{HighSpeedSwap, install_local, local_installed, with_local};
 
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use predictor::{Predictor, PredictorDims};
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use probe::{Backend, ProbeConfig, ProbeResult, run_probe};
 pub use projection::{PredictorShape, build_projection};
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use tiled_attention::{TiledAttention, TiledAttentionDims};
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use weight_lora_rdma::{LoraAbKind, LoraLandTarget, RdmaLoraLoader};
 pub use weight_peer::{WeightManifest, WeightTensorRecord};
-#[cfg(feature = "cuda")]
+#[cfg(all(feature = "cuda", unix))]
 pub use weight_tier_rdma::RdmaWeightLoader;

--- a/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
@@ -4351,6 +4351,13 @@ void int8_gemm_faith4(
         : "r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
           "r"((d)[0]),"r"((d)[1]),"r"((d)[2]),"r"((d)[3]))
 
+// gfx1151 (RDNA3.5) has 64 KiB of LDS; this kernel's double-buffered tiles
+// need ~80 KiB, so SCALE rejects it with "local memory exceeds limit".
+// Shrinking the tile is a performance decision that needs gfx1151 hardware to
+// validate, and this kernel is listed in NEITHER kernels/gb10 nor
+// kernels/strix KERNEL.toml -- nothing loads it on either platform -- so it is
+// simply not built for SCALE. NVIDIA is unaffected.
+#if !defined(__SCALE__)
 extern "C" __global__
 __launch_bounds__(256, 1)
 void int8_gemm_mmq2(
@@ -4466,6 +4473,7 @@ void int8_gemm_mmq2(
         }
     }
 }
+#endif  // !__SCALE__
 #undef ATLAS_MMA_S8
 #undef M2_TILE
 #undef M2_SB
@@ -4926,6 +4934,13 @@ void int8_gemm_faith7(
         cp_async_pred_16(_wd, &B_i8[(unsigned long long)(cta_n+_row)*K+_gk], (cta_n+_row<N)&&(_gk+15<K)); \
         cp_async_pred_16(_ad, &A_i8[(unsigned long long)(cta_m+_row)*K+_gk], (cta_m+_row<M)&&(_gk+15<K)); \
     } } while(0)
+// gfx1151 (RDNA3.5) has 64 KiB of LDS; this kernel's double-buffered tiles
+// need ~80 KiB, so SCALE rejects it with "local memory exceeds limit".
+// Shrinking the tile is a performance decision that needs gfx1151 hardware to
+// validate, and this kernel is listed in NEITHER kernels/gb10 nor
+// kernels/strix KERNEL.toml -- nothing loads it on either platform -- so it is
+// simply not built for SCALE. NVIDIA is unaffected.
+#if !defined(__SCALE__)
 extern "C" __global__
 __launch_bounds__(256, 1)
 void int8_gemm_faith8(
@@ -5032,6 +5047,7 @@ void int8_gemm_faith8(
         }
     }
 }
+#endif  // !__SCALE__
 #undef ATLAS_MMA_S8
 #undef F8_LOAD_TILE
 #undef F2_TILE
@@ -5055,6 +5071,13 @@ void int8_gemm_faith8(
         : "=r"((d)[0]), "=r"((d)[1]), "=r"((d)[2]), "=r"((d)[3]) \
         : "r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
           "r"((d)[0]),"r"((d)[1]),"r"((d)[2]),"r"((d)[3]))
+// gfx1151 (RDNA3.5) has 64 KiB of LDS; this kernel's double-buffered tiles
+// need ~80 KiB, so SCALE rejects it with "local memory exceeds limit".
+// Shrinking the tile is a performance decision that needs gfx1151 hardware to
+// validate, and this kernel is listed in NEITHER kernels/gb10 nor
+// kernels/strix KERNEL.toml -- nothing loads it on either platform -- so it is
+// simply not built for SCALE. NVIDIA is unaffected.
+#if !defined(__SCALE__)
 extern "C" __global__
 __launch_bounds__(256, 1)
 void int8_gemm_faith9(
@@ -5156,6 +5179,7 @@ void int8_gemm_faith9(
         }
     }
 }
+#endif  // !__SCALE__
 #undef ATLAS_MMA_S8
 #undef F2_TILE
 #undef F2_SB

--- a/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
@@ -6111,14 +6111,12 @@ extern "C" __global__ void fp8_gemm_t_row_scaled(
             unsigned int nc = nt * 8 + group_id; \
             unsigned int b0 = *(const unsigned int*)&smem_B[(b_buf)][nc][4 * tid]; \
             unsigned int b1 = *(const unsigned int*)&smem_B[(b_buf)][nc][16 + 4 * tid]; \
-            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
-                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
-                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
-                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
-                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
-                 "r"(b0),"r"(b1), \
-                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
-                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+            /* Same helper FP8_COMPUTE uses: on NVIDIA its #else arm is this \
+             * exact PTX (__forceinline__, so codegen is byte-identical); on \
+             * SCALE/gfx1151 it is the validated __shfl-repack -> 2x \
+             * mma.m16n8k16.bf16 replacement. Emitting the PTX inline here is \
+             * what made this .cu uncompilable for AMD. */ \
+            atlas_mma_e4m3(acc[nt], a0, a1, a2, a3, b0, b1); \
         } \
     } while(0)
 
@@ -6252,14 +6250,12 @@ extern "C" __global__ void fp8_gemm_t_row_scaled_m16(
             unsigned int nc = nt * 8 + group_id; \
             unsigned int b0 = *(const unsigned int*)&smem_B[(b_buf)][nc][4 * tid]; \
             unsigned int b1 = *(const unsigned int*)&smem_B[(b_buf)][nc][16 + 4 * tid]; \
-            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
-                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
-                :"=f"(acc[nt][0]),"=f"(acc[nt][1]), \
-                 "=f"(acc[nt][2]),"=f"(acc[nt][3]) \
-                :"r"(a0),"r"(a1),"r"(a2),"r"(a3), \
-                 "r"(b0),"r"(b1), \
-                 "f"(acc[nt][0]),"f"(acc[nt][1]), \
-                 "f"(acc[nt][2]),"f"(acc[nt][3])); \
+            /* Same helper FP8_COMPUTE uses: on NVIDIA its #else arm is this \
+             * exact PTX (__forceinline__, so codegen is byte-identical); on \
+             * SCALE/gfx1151 it is the validated __shfl-repack -> 2x \
+             * mma.m16n8k16.bf16 replacement. Emitting the PTX inline here is \
+             * what made this .cu uncompilable for AMD. */ \
+            atlas_mma_e4m3(acc[nt], a0, a1, a2, a3, b0, b1); \
         } \
     } while(0)
 

--- a/kernels/strix/common/mx_block_scale.cuh
+++ b/kernels/strix/common/mx_block_scale.cuh
@@ -1,0 +1,1 @@
+../../gb10/common/mx_block_scale.cuh

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Release helpers used by .github/workflows/release.yml.
+#
+# `bump <version>` rewrites `[workspace.package].version` in the root
+# Cargo.toml and refreshes Cargo.lock. It is deliberately the ONLY place that
+# knows how to edit the version: the workflow, a local release and any future
+# scripts/release.sh all go through here, so the Cargo version can never drift
+# from the git tag.
+#
+# `preview <version>` prints the release notes GitHub would generate, without
+# creating anything — used to make a dry run show its work.
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage:
+  release-notes.sh bump <version>       rewrite workspace version + Cargo.lock
+  release-notes.sh preview <version>    print the release notes GitHub would generate
+EOF
+    exit 2
+}
+
+repo_root() { git rev-parse --show-toplevel; }
+
+# Rewrite only the `version` key inside the `[workspace.package]` table.
+# A blind `s/version = ...//` would also rewrite `rust-version`, every
+# dependency pin, and the `[package]` version of any crate in the file.
+bump() {
+    local version="$1" root manifest
+    [ -n "$version" ] || usage
+    printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' || {
+        echo "error: version must be bare semver (1.2.3), got '$version'" >&2
+        exit 1
+    }
+    root="$(repo_root)"
+    manifest="$root/Cargo.toml"
+
+    awk -v ver="$version" '
+        /^\[/ { in_wp = ($0 == "[workspace.package]") }
+        in_wp && /^version[[:space:]]*=/ && !done { print "version = \"" ver "\""; done = 1; next }
+        { print }
+        END { if (!done) { print "error: [workspace.package].version not found" > "/dev/stderr"; exit 1 } }
+    ' "$manifest" > "$manifest.tmp"
+    mv "$manifest.tmp" "$manifest"
+
+    # Keep Cargo.lock in step; --offline so a release build never silently
+    # picks up a newer transitive dependency than the one that was tested.
+    (cd "$root" && cargo update --workspace --offline 2>/dev/null || cargo update --workspace)
+
+    echo "workspace version -> $version"
+    grep -A5 '^\[workspace.package\]' "$manifest" | grep '^version'
+}
+
+# Ask GitHub for the notes it would attach to this tag. Same generator the
+# real publish uses, so a dry run previews the actual output rather than an
+# approximation of it.
+preview() {
+    local version="$1" repo prev
+    [ -n "$version" ] || usage
+    repo="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+    prev="$(gh api "repos/$repo/releases/latest" -q .tag_name 2>/dev/null || true)"
+
+    local args=(-f tag_name="v$version")
+    [ -n "$prev" ] && args+=(-f previous_tag_name="$prev")
+
+    echo "# Release notes preview for v$version (previous tag: ${prev:-<none, will cover full history>})"
+    gh api --method POST "repos/$repo/releases/generate-notes" "${args[@]}" -q .body
+}
+
+case "${1:-}" in
+    bump)    shift; bump "${1:-}" ;;
+    preview) shift; preview "${1:-}" ;;
+    *)       usage ;;
+esac


### PR DESCRIPTION
Adds a `workflow_dispatch` release pipeline: build `spark` for every (OS, arch, GPU-platform), then publish a GitHub Release with those binaries, the merged-PR changelog and new contributors.

### The matrix is data, not code

`.github/release-matrix.json` is the single source of truth. Adding a platform is one JSON object — no edit to the workflow. Each entry names its own `toolchain`, so CUDA / SCALE / no-toolchain targets share one shape.

| id | runner | features | toolchain | experimental |
|---|---|---|---|---|
| linux-x86_64-nvidia-cuda | ubuntu-24.04 | `cuda` | cuda | **no** |
| linux-aarch64-nvidia-cuda | ubuntu-24.04-arm | `cuda` | cuda-sbsa | **no** |
| linux-{x86_64,aarch64}-nvidia-cuda-nccl | " | `cuda,nccl` | +libnccl | yes |
| linux-{x86_64,aarch64}-amd-scale | " | `cuda` (SCALE) | scale | yes |
| macos-{aarch64,x86_64}-metal | macos-14 / macos-13 | `metal` | none | yes |
| windows-x86_64-nvidia-cuda | windows-2022 | `cuda` | cuda | yes |

`experimental: true` ⇒ `continue-on-error`, so an unproven target can sit in the matrix while it is brought up without blocking a release.

### Inputs

`ref` (branch/tag/SHA), `new_version` (bare semver), `dry_run` (**default true**). A dry run builds and uploads artifacts but writes nothing; the dry-run job prints the artifact list and the exact notes that would be published.

### Release notes

`gh release create --generate-notes` — GitHub's own generator emits **What's Changed** (every merged PR since the previous tag) and **New Contributors**. Hand-rolling either would duplicate data GitHub already derives from the same commits.

### Version lockstep

`scripts/release-notes.sh bump` is the only thing that edits the version, so the Cargo version cannot drift from the git tag. It rewrites the key inside `[workspace.package]` only — a blind `s/version/` would also hit `rust-version` and every dependency pin. Verified locally: the bump produces a **one-line diff** and leaves `rust-version` untouched; it rejects `v1.2.3` and `1.2`.

### PR trigger

`pull_request`, scoped to these three files, runs `validate` only — never a build, never a publish. The plumbing is checked on every change to it without spending an hour of runner time per PR. Say the word if you'd rather this be dropped after merge; it is cheap enough that I'd argue for keeping it.

### Guards (each for a failure that would otherwise surface late or silently)

- bare-semver check — accepting `v1.2.3` would tag `vv1.2.3`
- tag-exists check via `git ls-remote`, **not** local `rev-parse`: checkout is depth-1 with no tags, so the local form always passes vacuously. This was a real bug in the first draft, caught and fixed before push.
- `dry_run=false` requires `ref` to be a **branch** — the bump is pushed back to it, and a SHA would fail *after* the builds
- every `--features` string checked against `cargo metadata` (negative-tested: `cudaa` is rejected)
- publish refuses an empty artifact set

---

### What is NOT proven, stated plainly

I validated everything statically checkable — YAML parses, matrix renders, feature check passes and correctly rejects a typo, bump produces a one-line diff. **I have not run the builds.** Specific known risks:

1. **Windows is very likely to fail.** Zero `target_os = "windows"` cfgs in the tree, and `spark-runtime` / `spark-storage` / `atlas-tier` carry `cfg(unix)` dependency blocks. It is in the matrix as experimental because it was asked for, not because it is expected to work.
2. **SCALE (AMD) fails by design on hosted runners** — the toolchain is not redistributable. That step errors loudly rather than silently producing a CUDA binary labelled `amd`. It needs a self-hosted runner.
3. **macOS/metal has never been built in CI** — the feature exists, no job has ever exercised it.
4. **aarch64 CUDA** depends on `Jimver/cuda-toolkit` supporting arm64 runners; if it does not, that entry needs an apt-based sbsa install instead.
5. **NCCL** entries need `libnccl-dev` to link; marked experimental until proven.

The realistic first-run expectation is that `linux-x86_64-nvidia-cuda` succeeds and several others need iteration — which is exactly what the data-driven matrix and the `experimental` flag are for.

Separately: `project_atlas_versioning` describes a `scripts/release.sh` and a `release-tag-check.yml` guardrail. **Neither exists in this repo** and there are no `v*` tags — that tooling must live elsewhere (atlas-internal?). This PR therefore implements the bump itself rather than reusing a script that is not here.
