### PR TITLE
site: mobile overhaul, news band, MLPerf v6.1 and AMD Strix desktop

### DIFF
--- a/site/src/app.css
+++ b/site/src/app.css
@@ -327,20 +327,10 @@ footer { border-top: 1px solid var(--border); padding: 3rem 2rem 2.5rem; backgro
 .footer-legal { max-width: 1080px; margin: 2rem auto 0; padding-top: 1.5rem; border-top: 1px solid var(--border); font-size: 0.68rem; color: var(--t3); line-height: 1.6; }
 .footer-legal .tm { margin-top: 0.6rem; }
 
-/* ---- responsive ----------------------------------------------------------- */
-@media (max-width: 900px) {
-  .hero-inner, .star-wrap, .verified-grid, .hw-grid, .run-grid { grid-template-columns: 1fr; gap: 2rem; }
-  .verified-grid .receipt { max-width: 460px; }
-}
-@media (max-width: 680px) {
-  .nav-links { display: none; }
-  section { padding: 4rem 1.25rem; }
-  .hero { padding: 3.5rem 1.25rem 3rem; }
-  .gift-inner { padding: 0.6rem 1.25rem; }
-  .mnav-vendors, .mnav-subs { flex-wrap: nowrap; overflow-x: auto; scrollbar-width: thin; padding-bottom: 0.3rem; }
-  .mnav-vendor, .mnav-sub { flex-shrink: 0; }
-  .ms-grid { grid-template-columns: 1fr; padding: 0 1.1rem 1.25rem; }
-}
+/* ---- responsive -----------------------------------------------------------
+   Every viewport rule lives in styles/mobile.css, loaded after this file.
+   Nothing width-conditional belongs here.
+   -------------------------------------------------------------------------- */
 
 @media (prefers-reduced-motion: reduce) {
   * { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }
@@ -428,13 +418,3 @@ section { padding: 7rem 2rem; }
 .reach-card h3 { font-size: 1.05rem; font-weight: 780; margin-bottom: 0.4rem; }
 .reach-card p { font-size: 0.9rem; color: var(--t2); line-height: 1.6; }
 
-@media (max-width: 900px) {
-  .community-band { grid-template-columns: 1fr; gap: 1.75rem; padding: 2.25rem; }
-  .reach-grid { grid-template-columns: 1fr; }
-  .reach-head { align-items: flex-start; }
-}
-@media (max-width: 680px) {
-  section { padding: 4.5rem 1.25rem; }
-  .proof-strip { gap: 0.6rem 1.25rem; }
-  .gift-inner { font-size: 0.82rem; }
-}

--- a/site/src/app.html
+++ b/site/src/app.html
@@ -14,7 +14,7 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Atlas, inference for the machine on your desk" />
-    <meta property="og:description" content="Open source, pure Rust + CUDA. Verified on DGX Spark (GB10), in bring-up on AMD Strix Halo. Every number is a receipt." />
+    <meta property="og:description" content="Open source, pure Rust + CUDA. Verified on DGX Spark (GB10) and running on AMD Strix Halo. Submitted to MLPerf Inference v6.1. Every number is a receipt." />
     <meta property="og:url" content="https://atlasinference.io/" />
     <meta property="og:image" content="https://atlasinference.io/og-image.png" />
     <meta property="og:image:width" content="1200" />

--- a/site/src/lib/components/GiftBanner.svelte
+++ b/site/src/lib/components/GiftBanner.svelte
@@ -9,5 +9,6 @@
     </svg>
     <span class="gift-line">{gifts.line}</span>
     <span class="gift-sub">{gifts.sub}</span>
+    <a class="gift-cta" href={gifts.ctaUrl} target="_blank" rel="noopener">{gifts.ctaText} ↗</a>
   </div>
 </div>

--- a/site/src/lib/components/Nav.svelte
+++ b/site/src/lib/components/Nav.svelte
@@ -1,10 +1,23 @@
 <script>
-  import { githubUrl, discordUrl, xUrl } from '$lib/data.js';
+  // Desktop bar + mobile drawer render from the SAME `nav.links` in data.js.
+  // Below the drawer breakpoint (styles/mobile.css) the bar hides and the
+  // toggle appears, so phones keep every link the desktop has.
+  import { nav, githubUrl, discordUrl, xUrl } from '$lib/data.js';
   import stars from '$lib/stars.generated.json';
   import GithubIcon from './GithubIcon.svelte';
   import DiscordIcon from './DiscordIcon.svelte';
   import XIcon from './XIcon.svelte';
+
+  let open = $state(false);
+
+  // No body scroll lock on purpose. Measured on this page, body.overflow hidden
+  // is a no-op because scrolling lives on the viewport and body already carries
+  // overflow-x clip, so the page keeps scrolling anyway. The drawer is a short
+  // panel pinned under the bar rather than a full screen sheet, so there is
+  // nothing to lock. The scrim absorbs stray taps and closes the menu.
 </script>
+
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape') open = false; }} />
 
 <nav>
   <div class="nav-inner">
@@ -13,16 +26,47 @@
       <span class="nav-wordmark">Atlas</span>
     </a>
     <div class="nav-links">
-      <a href="#verified">Verified</a>
-      <a href="#hardware">Hardware</a>
-      <a href="#models">Models</a>
-      <a href="#run">Get running</a>
-      <a href="#contribute">Contribute</a>
+      {#each nav.links as l}
+        <a href={l.href}>{l.text}</a>
+      {/each}
       <a class="nav-icon-link" href={discordUrl} aria-label="Discord" target="_blank" rel="noopener"><DiscordIcon size={18} /></a>
       <a class="nav-icon-link" href={xUrl} aria-label="X / Twitter" target="_blank" rel="noopener"><XIcon size={16} /></a>
       <a class="nav-star-btn" href={githubUrl} target="_blank" rel="noopener">
         <GithubIcon size={15} /> Star <span class="nav-star-count">{stars.count}</span>
       </a>
     </div>
+
+    <button
+      type="button"
+      class="nav-toggle"
+      aria-expanded={open}
+      aria-controls="nav-drawer"
+      aria-label={open ? nav.closeLabel : nav.menuLabel}
+      onclick={() => (open = !open)}
+    >
+      <span class="nav-burger" class:is-x={open} aria-hidden="true"><span></span><span></span><span></span></span>
+    </button>
+  </div>
+
+  <div id="nav-drawer" class="nav-drawer" class:is-open={open}>
+    {#each nav.links as l}
+      <a class="nav-drawer-link" href={l.href} tabindex={open ? 0 : -1} onclick={() => (open = false)}>{l.text}</a>
+    {/each}
+    <div class="nav-drawer-foot">
+      <a class="nav-star-btn" href={githubUrl} target="_blank" rel="noopener" tabindex={open ? 0 : -1}>
+        <GithubIcon size={15} /> Star <span class="nav-star-count">{stars.count}</span>
+      </a>
+      <a class="nav-icon-link" href={discordUrl} aria-label="Discord" target="_blank" rel="noopener" tabindex={open ? 0 : -1}><DiscordIcon size={22} /></a>
+      <a class="nav-icon-link" href={xUrl} aria-label="X / Twitter" target="_blank" rel="noopener" tabindex={open ? 0 : -1}><XIcon size={19} /></a>
+    </div>
   </div>
 </nav>
+
+<button
+  type="button"
+  class="nav-scrim"
+  class:is-on={open}
+  aria-label={nav.closeLabel}
+  tabindex={open ? 0 : -1}
+  onclick={() => (open = false)}
+></button>

--- a/site/src/lib/components/News.svelte
+++ b/site/src/lib/components/News.svelte
@@ -1,0 +1,28 @@
+<script>
+  // News band. Presentation only, every card comes from `news` in data.js so the
+  // page can never carry an announcement that is not in the SSOT.
+  import { news } from '$lib/data.js';
+</script>
+
+<section id="news">
+  <div class="container">
+    <div class="slabel">{news.label}</div>
+    <h2 class="stitle">{news.title}</h2>
+    <p class="ssub">{news.sub}</p>
+
+    <div class="news-grid">
+      {#each news.items as item}
+        <article class="news-card" class:is-featured={item.featured}>
+          {#if item.featured}<span class="news-accent" aria-hidden="true"></span>{/if}
+          <div class="news-top">
+            <span class="news-tag">{item.tag}</span>
+            <span class="news-date mono">{item.date}</span>
+          </div>
+          <h3>{item.title}</h3>
+          <p>{item.body}</p>
+          <a class="news-link" href={item.url} target="_blank" rel="noopener">{item.cta} →</a>
+        </article>
+      {/each}
+    </div>
+  </div>
+</section>

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -39,6 +39,8 @@ export const qwenAmbassadorUrl = 'https://qwen.ai/ambassador';
 export const strixPrUrl = 'https://github.com/Avarok-Cybersecurity/atlas/pull/187';
 export const mlperfResultsUrl = 'https://mlcommons.org/benchmarks/inference-datacenter/';
 export const mlcommonsEndpointsPrUrl = 'https://github.com/mlcommons/endpoints/pull/346';
+export const mlcommonsArticleUrl =
+  'https://mlcommons.org/2026/07/mlperf-inference-v61-edge-agentic/';
 
 // --- brand -------------------------------------------------------------------
 export const tagline = 'Pure Rust inference, tuned for the machine on your desk.';
@@ -53,7 +55,23 @@ export const runCommandRaw =
 // --- hardware acknowledgment (modest banner) ---------------------------------
 export const gifts = {
   line: 'Thank you NVIDIA and AMD.',
-  sub: 'DGX Spark gifted by NVIDIA, Strix Halo gifted by AMD. Both camps handed us silicon and we intend to contnue proving to the world the raw power of these machines.'
+  sub: 'DGX Spark gifted by NVIDIA, Strix Halo gifted by AMD, and now a Strix Halo desktop from AMD too. That desktop is the box we ran our MLPerf submission on.',
+  ctaText: 'See the post',
+  ctaUrl: xUrl
+};
+
+// --- nav (SSOT for both the desktop bar and the mobile drawer) ---------------
+export const nav = {
+  links: [
+    { text: 'News', href: '#news' },
+    { text: 'Verified', href: '#verified' },
+    { text: 'Hardware', href: '#hardware' },
+    { text: 'Models', href: '#models' },
+    { text: 'Get running', href: '#run' },
+    { text: 'Contribute', href: '#contribute' }
+  ],
+  menuLabel: 'Menu',
+  closeLabel: 'Close menu'
 };
 
 // --- hero --------------------------------------------------------------------
@@ -79,14 +97,54 @@ export const proof = {
   items: [
     { text: 'Merged into Hugging Face Transformers', url: transformersPrUrl },
     { text: 'Qwen Dev Ambassadors', url: qwenAmbassadorUrl },
-    { text: 'MLPerf Agentic Edge task force', url: mlcommonsEndpointsPrUrl },
+    { text: 'MLPerf Edge Agentic task force', url: mlcommonsArticleUrl },
     { text: 'Built with SCALE by Spectral Compute', url: scaleUrl }
+  ]
+};
+
+// --- news band ----------------------------------------------------------------
+// Newest first. Every card points at a primary source, no numbers before
+// MLCommons publishes. See CLAIM POLICY at the top of this file.
+export const news = {
+  label: '// 01 · news',
+  title: 'What just happened.',
+  sub:
+    'Three things landed this month and every card links straight to the primary source.',
+  items: [
+    {
+      tag: 'MLCommons',
+      date: 'July 2026',
+      featured: true,
+      title: 'We helped build the MLPerf Edge Agentic benchmark',
+      body:
+        'MLCommons published the new MLPerf Inference v6.1 edge agentic benchmark and Atlas Inference is named as a contributor alongside NVIDIA. It measures multi turn agentic LLMs on a single edge accelerator, BFCL v4 for accuracy and replayed agentic coding trajectories for performance. We helped shape it because it is the benchmark that actually looks like the work.',
+      cta: 'Read the MLCommons announcement',
+      url: mlcommonsArticleUrl
+    },
+    {
+      tag: 'AMD',
+      date: 'July 2026',
+      title: 'AMD sent us a Strix Halo desktop',
+      body:
+        'Big thanks to AMD for the Strix Halo desktop. We took Atlas to ROCm to show what this silicon can really do when it is paired with custom kernels, and that desktop is the box we ran and submitted MLPerf on.',
+      cta: 'See the post on X',
+      url: xUrl
+    },
+    {
+      tag: 'MLPerf v6.1',
+      date: 'Submitted',
+      title: 'Our MLPerf submission is in',
+      body:
+        'Atlas is submitted to MLPerf Inference v6.1 in the closed edge division, the same CUDA source across NVIDIA GB10 and AMD gfx1151. llama.cpp is the bar we measure ourselves against on this workload and we like where we landed. Results stay under embargo until MLCommons publishes, so stay tuned.',
+      cta: 'Follow along in Discord',
+      url: discordUrl
+    }
   ]
 };
 
 // --- star / social proof -----------------------------------------------------
 export const stars = {
-  label: '// 01 · momentum',
+  label: '// 02 · momentum',
   title: 'Built in the open, starred in the open.',
   sub:
     'Atlas went from one Reddit post to a whole crew of builders running it on their own Sparks. The curve below is live, regenerated from the GitHub API on every deploy.',
@@ -129,13 +187,13 @@ export const community = {
 
 // --- verified performance (the gate receipt) ---------------------------------
 export const verified = {
-  label: '// 02 · verified',
+  label: '// 03 · verified',
   title: 'Every number is a receipt.',
   sub:
     'The website is a build artifact of the repo. Models come from recipes, performance comes from committed gate enforced baselines, stamped with commit and date. If a number is not in the repo, it is not on this page.',
-  pendingHeadline: 'MLPerf submission in progress',
+  pendingHeadline: 'MLPerf v6.1 submitted',
   pendingBody:
-    'We are prepping our numbers for a public MLPerf Inference submission. When they land they render right here in this receipt, gate enforced, reproducible, stamped. Until then the release gate holds every image to liveness and coherence, and you can reproduce any run yourself.',
+    'Our MLPerf Inference v6.1 submission is in, closed edge division, on both GB10 and gfx1151. The numbers render right here in this receipt the moment MLCommons publishes them, gate enforced, reproducible, stamped. Until then the release gate holds every image to liveness and coherence, and you can reproduce any run yourself.',
   mechanism:
     'A release that ships slower than the committed baseline fails our gate. That one sentence is the whole positioning.',
   reproLead: 'Reproduce the matrix',
@@ -146,15 +204,15 @@ export const mlperfCopy = {
   preparing:
     'We are prepping a submission to MLPerf Inference v6.1, the same CUDA source submitted across NVIDIA GB10 and AMD gfx1151. Aiming to be the first to run identical CUDA on both.',
   submitted:
-    'Submitted to MLPerf Inference v6.1 across NVIDIA GB10 and AMD gfx1151. Results are under embargo until MLCommons publishes.',
+    'Submitted to MLPerf Inference v6.1 in the closed edge division, the same CUDA source across NVIDIA GB10 and AMD gfx1151. Results are under embargo until MLCommons publishes them, so stay tuned.',
   published: 'Published in MLPerf Inference v6.1 across NVIDIA GB10 and AMD gfx1151.'
 };
 
 export const mlcommons = {
   line:
-    'Atlas is a member of MLCommons and sits on the MLPerf Agentic Edge task force, where we helped shape the BFCL-v4 edge agentic benchmark.',
-  linkText: 'the edge agentic benchmark work',
-  url: mlcommonsEndpointsPrUrl
+    'Atlas is a member of MLCommons and sits on the Edge LLM taskforce, where we helped shape the new v6.1 edge agentic benchmark. MLCommons names Atlas Inference as a contributor in the announcement.',
+  linkText: 'read the announcement',
+  url: mlcommonsArticleUrl
 };
 
 export const mlperfTrademark =
@@ -162,7 +220,7 @@ export const mlperfTrademark =
 
 // --- hardware ----------------------------------------------------------------
 export const hardware = {
-  label: '// 03 · hardware',
+  label: '// 04 · hardware',
   title: 'Prosumer first. Desk machines, not clusters.',
   cards: [
     {
@@ -178,11 +236,11 @@ export const hardware = {
     {
       name: 'AMD Strix Halo',
       chip: 'gfx1151 · RDNA 3.5',
-      status: 'bringup',
-      statusText: 'In bring up',
+      status: 'verified',
+      statusText: 'MLPerf submitted',
       gift: true,
       body:
-        'One codebase, both camps. Our CUDA kernels compile straight for AMD gfx1151 with SCALE by Spectral Compute. No HIP port, no second kernel tree. Serving Qwen at NVFP4 quality on a dev branch and stabilizing now.',
+        'One codebase, both camps. Our CUDA kernels compile straight for AMD gfx1151 with SCALE by Spectral Compute. No HIP port, no second kernel tree. AMD sent us a Strix Halo desktop and that is the box we ran and submitted our MLPerf Inference v6.1 numbers on.',
       cta: { text: 'Join the bring up, PR #187', url: strixPrUrl },
       scale: { text: 'Built with SCALE by Spectral Compute', url: scaleUrl }
     }
@@ -191,7 +249,7 @@ export const hardware = {
 
 // --- models ------------------------------------------------------------------
 export const models = {
-  label: '// 04 · models',
+  label: '// 05 · models',
   title: 'Every model here has a recipe.',
   sub:
     'Pick a vendor, then a family. Every card maps to one recipe in atlas-recipes, so the site cannot list a model we do not ship. Copy the command and run it as is. Qwen3.6 leads because it is our flagship.',
@@ -207,7 +265,7 @@ export const models = {
 
 // --- get running -------------------------------------------------------------
 export const getRunning = {
-  label: '// 05 · get running',
+  label: '// 06 · get running',
   title: 'Up and running in one command.',
   sub:
     'This is the first 60 seconds. Everything after, per model recipes, EP=2, tuning, lives in the docs.',
@@ -219,18 +277,18 @@ export const getRunning = {
 
 // --- mission -----------------------------------------------------------------
 export const mission = {
-  label: '// 06 · mission',
+  label: '// 07 · mission',
   title: 'Local AI worth having, open to all.',
   body: [
     'AI worth having should run on hardware you own. Prosumer machines like DGX Spark and Strix Halo are the first generation that makes that real, and we build for them first.',
-    'Pure Rust because the whole stack should be inspectable by one person, HTTP to kernel dispatch, no interpreter in the hot path. We develop on machines granted by NVIDIA and AMD. Both camps handed us silicon and we intend to contnue proving to the world the raw power of these machines.',
+    'Pure Rust because the whole stack should be inspectable by one person, HTTP to kernel dispatch, no interpreter in the hot path. We develop on machines granted by NVIDIA and AMD. Both camps handed us silicon and we intend to continue proving to the world the raw power of these machines.',
     'Open to all. The test fleet is the community desks. If a model matters to you, it matters to us.'
   ]
 };
 
 // --- contribute --------------------------------------------------------------
 export const contribute = {
-  label: '// 07 · contribute',
+  label: '// 08 · contribute',
   title: 'Your machine is the test fleet.',
   sub:
     'Atlas grows from the desks it runs on. Every path below is real and linked. Contributions ship in the Community Edition under AGPLv3, and the CLA lets us re license for the Enterprise Edition.',
@@ -265,7 +323,7 @@ export const contribute = {
 
 // --- roadmap (next up + artifact-linked) -------------------------------------
 export const roadmap = {
-  label: '// 08 · next up',
+  label: '// 09 · next up',
   title: 'What we are building next.',
   sub: 'Everything real links to an issue, a PR, or the Discord where the work happens. The teasers are teasers, and we say so.',
   items: [
@@ -286,18 +344,18 @@ export const roadmap = {
     },
     {
       title: 'AMD Strix Halo',
-      status: 'In bring up',
+      status: 'MLPerf submitted',
       gift: true,
-      body: 'Native gfx1151 through SCALE. Serving Qwen at NVFP4 quality on a branch and stabilizing CI.',
+      body: 'Native gfx1151 through SCALE. AMD sent us a Strix Halo desktop and we took Atlas to ROCm on it, custom kernels and all.',
       cta: 'PR #187',
       url: strixPrUrl
     },
     {
       title: 'MLPerf Inference v6.1',
-      status: 'Prepping',
-      body: 'The same CUDA source submitted across GB10 and gfx1151. No numbers until MLCommons publishes.',
-      cta: 'MLCommons',
-      url: mlperfResultsUrl
+      status: 'Submitted',
+      body: 'The same CUDA source submitted across GB10 and gfx1151, closed edge division. No numbers until MLCommons publishes.',
+      cta: 'Read the benchmark announcement',
+      url: mlcommonsArticleUrl
     },
     {
       title: 'Qwen GDN kernel upstream',
@@ -318,7 +376,7 @@ export const roadmap = {
 
 // --- reach out ---------------------------------------------------------------
 export const reachout = {
-  label: '// 09 · reach out',
+  label: '// 10 · reach out',
   title: 'Come work with us.',
   sub:
     'Building on Spark or Strix, bringing hardware to the table, or wanting to partner or talk business. We want to hear from you and we move fast.',

--- a/site/src/lib/mlperf.json
+++ b/site/src/lib/mlperf.json
@@ -1,7 +1,7 @@
 {
-  "status": "preparing",
+  "status": "submitted",
   "round": "v6.1",
-  "division": "",
+  "division": "closed, edge",
   "expected_publish_date": "",
   "note": "Status-driven copy. status one of: preparing | submitted | published. Numbers only ever appear when published, in MLCommons citation format. See scripts/gen-benchmarks.mjs header.",
   "entries": []

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -1,5 +1,9 @@
 <script>
+  // Load order matters. app.css is the desktop-first design system, news.css adds
+  // the news band, mobile.css is the SSOT for every viewport rule and must land last.
   import '../app.css';
+  import '../styles/news.css';
+  import '../styles/mobile.css';
   import { tagline, githubUrl, recipesUrl, discordUrl, xUrl } from '$lib/data.js';
   let { children } = $props();
 </script>

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import GiftBanner from '$lib/components/GiftBanner.svelte';
   import Hero from '$lib/components/Hero.svelte';
   import Proof from '$lib/components/Proof.svelte';
+  import News from '$lib/components/News.svelte';
   import StarProof from '$lib/components/StarProof.svelte';
   import Community from '$lib/components/Community.svelte';
   import Verified from '$lib/components/Verified.svelte';
@@ -20,6 +21,7 @@
 <GiftBanner />
 <Hero />
 <Proof />
+<News />
 <StarProof />
 <Community />
 <Verified />

--- a/site/src/styles/mobile.css
+++ b/site/src/styles/mobile.css
@@ -1,0 +1,218 @@
+/* =============================================================================
+   Atlas responsive layer. SSOT for every viewport rule on the site, plus the
+   mobile nav drawer it depends on. Loaded LAST (see routes/+layout.svelte) so
+   it narrows the desktop-first system in app.css.
+
+   Breakpoints: 1040 tablet · 900 two-column collapse · 860 nav drawer
+                680 phone · 480 small phone · 380 tiny.
+   ========================================================================== */
+
+/* ---- width safety, every viewport ----------------------------------------- */
+img, svg, video { max-width: 100%; }
+
+/* Grid and flex items default to min-width auto, which resolves to their
+   min-content. One nowrap command line (.repro, .hero-cmd, .cmd-pill) therefore
+   forced its whole track to the width of the command, blowing the page out to
+   ~694px on a 390px phone. Zeroing the automatic minimum lets the track shrink
+   and the command scroll inside its own box, which is what those boxes already
+   set up with overflow-x auto. */
+.hero-inner > *, .verified-grid > *, .star-wrap > *, .run-grid > *, .hw-grid > *,
+.news-grid > *, .road-grid > *, .contrib-grid > *, .reach-grid > *, .tstrip > *,
+.ms-grid > *, .community-band > *, .footer-inner > *, .mnav-vendors > *,
+.proof-strip > * { min-width: 0; }
+.repro, .hero-cmd, .cmd-pill, .term, .method-card, .receipt, .run-side { min-width: 0; }
+/* auto-fit tracks must never demand more than the viewport can give */
+.tstrip { grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr)); }
+.contrib-grid { grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); }
+.road-grid { grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr)); }
+.ms-grid { grid-template-columns: repeat(auto-fill, minmax(min(100%, 290px), 1fr)); }
+.hero-cmd code, .repro code, .cmd-text { -webkit-overflow-scrolling: touch; }
+
+/* ---- mobile nav drawer (hidden until the 860 breakpoint) ------------------ */
+.nav-toggle {
+  display: none; align-items: center; justify-content: center;
+  width: 44px; height: 44px; flex-shrink: 0;
+  background: transparent; color: var(--t1);
+  border: 1px solid var(--border-strong); border-radius: 10px; cursor: pointer;
+}
+.nav-burger { position: relative; display: block; width: 18px; height: 12px; }
+.nav-burger span {
+  position: absolute; left: 0; width: 100%; height: 2px; border-radius: 2px;
+  background: currentColor; transition: transform 0.22s, opacity 0.18s, top 0.22s;
+}
+.nav-burger span:nth-child(1) { top: 0; }
+.nav-burger span:nth-child(2) { top: 5px; }
+.nav-burger span:nth-child(3) { top: 10px; }
+.nav-burger.is-x span:nth-child(1) { top: 5px; transform: rotate(45deg); }
+.nav-burger.is-x span:nth-child(2) { opacity: 0; }
+.nav-burger.is-x span:nth-child(3) { top: 5px; transform: rotate(-45deg); }
+
+.nav-drawer {
+  display: none; flex-direction: column;
+  padding: 0.35rem 1.15rem 1.15rem;
+  border-top: 1px solid var(--border);
+  background: rgba(244, 240, 232, 0.98);
+  max-height: calc(100dvh - 56px); overflow-y: auto;
+  animation: drawerin 0.18s ease-out both;
+}
+@keyframes drawerin { from { opacity: 0; transform: translateY(-6px); } to { opacity: 1; transform: none; } }
+.nav-drawer-link {
+  display: flex; align-items: center; min-height: 50px;
+  padding: 0.25rem; font-size: 1rem; font-weight: 650;
+  color: var(--t1); text-decoration: none; border-bottom: 1px solid var(--border);
+}
+.nav-drawer-link:active { color: var(--accent); }
+.nav-drawer-foot { display: flex; align-items: center; gap: 1.25rem; padding-top: 1.1rem; }
+.nav-drawer-foot .nav-star-btn { padding: 0.65rem 1.1rem; font-size: 0.9rem; }
+.nav-scrim {
+  display: none; position: fixed; inset: 0; z-index: 80;
+  border: 0; padding: 0; background: rgba(26, 24, 21, 0.4); cursor: default;
+  touch-action: none; /* dragging the dimmed area must not scroll the page behind */
+}
+
+/* ---- 1040 ----------------------------------------------------------------- */
+@media (max-width: 1040px) {
+  section { padding: 5.5rem 1.75rem; }
+  .hero { padding: 4.5rem 1.75rem 4rem; }
+  .nav-inner, .gift-inner, .footer-inner { padding-left: 1.75rem; padding-right: 1.75rem; }
+  footer { padding-left: 1.75rem; padding-right: 1.75rem; }
+}
+
+/* ---- 900, the two-column collapse ----------------------------------------- */
+@media (max-width: 900px) {
+  .hero-inner, .star-wrap, .verified-grid, .hw-grid, .run-grid { grid-template-columns: 1fr; gap: 2rem; }
+  .verified-grid .receipt, .hero-receipt .receipt { max-width: 460px; }
+  .community-band { grid-template-columns: 1fr; gap: 1.75rem; padding: 2.25rem; }
+  .reach-grid { grid-template-columns: 1fr; }
+  .reach-head { align-items: flex-start; }
+  .reach-cta { min-width: 0; width: 100%; }
+}
+
+/* ---- 860, desktop bar becomes a drawer ------------------------------------ */
+@media (max-width: 860px) {
+  html { scroll-padding-top: 76px; }
+  .nav-inner { height: 56px; }
+  .nav-links { display: none; }
+  .nav-toggle { display: inline-flex; }
+  .nav-drawer.is-open { display: flex; }
+  .nav-scrim.is-on { display: block; }
+  .gift { margin-top: 56px; top: 56px; }
+}
+
+/* ---- 680, phone ----------------------------------------------------------- */
+@media (max-width: 680px) {
+  section { padding: 3.5rem 1.15rem; }
+  .hero { padding: 2.5rem 1.15rem 3rem; }
+  .nav-inner, .gift-inner, .footer-inner { padding-left: 1.15rem; padding-right: 1.15rem; }
+  footer { padding: 2.5rem 1.15rem 2rem; }
+
+  /* the banner scrolls away on a phone instead of eating the viewport */
+  .gift { position: static; }
+  .gift-inner { flex-direction: column; gap: 0.3rem; padding-top: 0.75rem; padding-bottom: 0.75rem; }
+  .gift-line { font-size: 0.85rem; }
+  .gift-sub { font-size: 0.78rem; line-height: 1.5; }
+
+  /* type scale */
+  .hero h1 { font-size: clamp(1.95rem, 7.4vw, 2.7rem); }
+  .hero-sub { font-size: 1rem; max-width: none; }
+  .stitle { font-size: clamp(1.6rem, 6.4vw, 2.2rem); }
+  .ssub { font-size: 0.97rem; }
+  .hero-badge { border-radius: 14px; line-height: 1.45; align-items: flex-start; margin-bottom: 1.1rem; }
+  .hero-badge .dot { margin-top: 0.42rem; flex-shrink: 0; }
+
+  /* full-bleed tap targets */
+  .hero-buttons .btn, .star-cta-row .btn, .run-copy .btn, .community-cta .btn {
+    width: 100%; justify-content: center;
+  }
+  .community-cta { align-items: stretch; }
+  .proof-strip { justify-content: flex-start; gap: 0.6rem 1.25rem; }
+  .proof-item { font-size: 0.86rem; }
+
+  /* cards and instruments */
+  .verified-grid .receipt, .hero-receipt .receipt { max-width: none; }
+  .hw-card { padding: 1.5rem 1.35rem; }
+  .news-card, .reach-card, .road-card, .contrib-card { padding: 1.35rem 1.3rem; }
+  .method-card { padding: 1.25rem 1.3rem; }
+  .community-band { padding: 1.85rem 1.35rem; border-radius: 20px; }
+  .term-body { padding: 0.9rem 1rem; }
+  .subcard-hf { white-space: normal; overflow-wrap: anywhere; }
+  .ms-famhead { padding: 1.15rem 1.15rem 0.75rem; }
+  .ms-grid { grid-template-columns: 1fr; padding: 0 1.15rem 1.25rem; }
+  .mnav-vendors, .mnav-subs {
+    flex-wrap: nowrap; overflow-x: auto; scrollbar-width: thin;
+    padding-bottom: 0.35rem; scroll-snap-type: x proximity;
+  }
+  .mnav-vendor, .mnav-sub { flex-shrink: 0; scroll-snap-align: start; }
+
+  /* star chart labels are drawn in SVG user units, scale them up as the svg shrinks */
+  .star-chart { padding: 0.9rem 0.9rem 0.5rem; }
+  .star-chart .axis-y, .star-chart .axis-x { font-size: 17px; }
+  .star-chart .axis-val { font-size: 20px; }
+  .star-figure { font-size: 3.1rem; }
+
+  /* footer stacks */
+  .footer-inner { flex-direction: column; gap: 1.9rem; }
+  .footer-brand { max-width: none; }
+}
+
+/* ---- legibility floor, tablet and down -------------------------------------
+   Micro type that reads fine on a 27 inch monitor is unreadable at arm's length.
+   This block sits after the layout breakpoints on purpose, so nothing above it
+   can push the small end of the scale back down.
+   -------------------------------------------------------------------------- */
+@media (max-width: 900px) {
+  .chip { font-size: 0.72rem; }
+  .mnav-sub-count { font-size: 0.68rem; }
+  .news-tag, .receipt-title, .receipt-hw, .road-status, .ms-count,
+  .receipt-pending .tag, .cmd-copy, .email-btn-copy { font-size: 0.74rem; }
+  .slabel { font-size: 0.75rem; }
+  .hw-chip, .hw-status, .news-date, .term-title, .hero-challenge .fine { font-size: 0.78rem; }
+  .subcard-hf, .cmd-text, .receipt-foot, .copy-btn, .term-body { font-size: 0.76rem; }
+  .trademark, .footer-legal, .cla-line { font-size: 0.74rem; }
+  .hw-card p, .news-card p, .road-card p, .contrib-card p, .reach-card p,
+  .method-card p, .tcard blockquote, .run-note, .ms-foot { font-size: 0.94rem; }
+  .fcol a, .footer-brand p { font-size: 0.88rem; }
+}
+
+/* ---- 480, small phone ----------------------------------------------------- */
+@media (max-width: 480px) {
+  section { padding: 3rem 1rem; }
+  .hero { padding: 2.25rem 1rem 2.5rem; }
+  .nav-inner, .gift-inner, .footer-inner { padding-left: 1rem; padding-right: 1rem; }
+  footer { padding: 2.25rem 1rem 1.75rem; }
+  .nav-wordmark { font-size: 1.2rem; }
+  .nav-mark { height: 30px; width: 30px; }
+
+  .hero-challenge { font-size: 0.86rem; }
+  .receipt-body { padding: 1.15rem 1.05rem 1.3rem; }
+  .receipt-row { font-size: 0.78rem; gap: 0.45rem; }
+  .mech-line { font-size: 0.94rem; padding-left: 0.75rem; }
+
+  .email-btn-addr { font-size: 0.76rem; padding: 0.65rem 0.7rem; }
+  .email-btn-copy { padding: 0 0.7rem; }
+  .reach-card, .news-card, .road-card, .contrib-card { padding: 1.2rem 1.15rem; }
+  .news-top { flex-wrap: wrap; gap: 0.4rem; }
+  .news-card h3 { font-size: 1rem; }
+  .tcard { padding: 1.1rem 1.15rem; }
+  .mission-body p { font-size: 1.02rem; }
+  .star-figure { font-size: 2.7rem; }
+}
+
+/* ---- 380, tiny ------------------------------------------------------------ */
+@media (max-width: 380px) {
+  section { padding: 2.75rem 0.9rem; }
+  .hero { padding: 2rem 0.9rem 2.25rem; }
+  .nav-inner, .gift-inner, .footer-inner { padding-left: 0.9rem; padding-right: 0.9rem; }
+  .hero h1 { font-size: 1.85rem; }
+  .stitle { font-size: 1.5rem; }
+  .email-btn-addr { font-size: 0.7rem; }
+}
+
+/* ---- touch targets, any coarse pointer ------------------------------------ */
+@media (pointer: coarse) {
+  .copy-btn, .cmd-copy, .email-btn-copy { min-height: 42px; }
+  .nav-icon-link, .proof-item { min-height: 40px; align-items: center; }
+  .fcol a { padding-block: 0.3rem; }
+  .news-link, .hw-links a, .road-card a, .contrib-card a { padding-block: 0.35rem; }
+  .subcard:hover, .news-card:hover, .reach-card:hover, .contrib-card:hover { transform: none; }
+}

--- a/site/src/styles/news.css
+++ b/site/src/styles/news.css
@@ -1,0 +1,51 @@
+/* =============================================================================
+   News band. Same floating-card language as .reach-card / .road-card, with a
+   copper accent rail on the featured item. Auto-fit grid so it reflows from
+   three columns to one without a single media query.
+   ========================================================================== */
+.news-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 290px), 1fr));
+  gap: 1.25rem;
+  margin-top: 2.5rem;
+}
+.news-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: #fcfbf8;
+  border: 1px solid rgba(205, 191, 168, 0.45);
+  border-radius: 18px;
+  padding: 1.6rem 1.7rem;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(58, 44, 20, 0.03), 0 16px 44px -20px rgba(58, 44, 20, 0.24);
+  transition: transform 0.2s, border-color 0.2s;
+}
+.news-card:hover { transform: translateY(-3px); border-color: var(--accent); }
+.news-accent { position: absolute; inset: 0 0 auto 0; height: 4px; background: var(--bar); }
+.news-card.is-featured { padding-top: 1.8rem; }
+
+.news-top { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+.news-tag {
+  font-family: var(--font-mono); font-size: 0.66rem; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-deep);
+  background: var(--accent-soft); border: 1px solid rgba(181, 98, 47, 0.3);
+  border-radius: 5px; padding: 0.2rem 0.5rem; white-space: nowrap;
+}
+.news-date { font-size: 0.72rem; color: var(--t3); white-space: nowrap; }
+.news-card h3 { font-size: 1.05rem; font-weight: 780; letter-spacing: -0.02em; line-height: 1.3; }
+.news-card p { font-size: 0.9rem; color: var(--t2); line-height: 1.62; }
+.news-link {
+  margin-top: auto; padding-top: 0.35rem;
+  font-size: 0.84rem; font-weight: 650; color: var(--accent); text-decoration: none;
+}
+.news-link:hover { text-decoration: underline; }
+
+/* gift banner call to action, sits inline with the thank-you line */
+.gift-cta {
+  font-size: 0.82rem; font-weight: 700; color: var(--accent);
+  text-decoration: none; white-space: nowrap;
+  border-bottom: 1px solid rgba(181, 98, 47, 0.35);
+}
+.gift-cta:hover { border-bottom-color: var(--accent); }

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -1,10 +1,11 @@
 # Atlas Inference
 
-Pure Rust + CUDA LLM inference engine, hand-tuned for prosumer AI machines (NVIDIA DGX Spark / GB10 today, AMD Strix Halo in bring-up).
+Pure Rust + CUDA LLM inference engine, hand-tuned for prosumer AI machines (NVIDIA DGX Spark / GB10 and AMD Strix Halo / gfx1151). Submitted to MLPerf Inference v6.1, closed edge division, on both.
 
 ## Links
 
 - Repo: https://github.com/Avarok-Cybersecurity/atlas
+- MLPerf Edge Agentic benchmark (Atlas Inference named as a contributor): https://mlcommons.org/2026/07/mlperf-inference-v61-edge-agentic/
 - Deployment guide: https://github.com/Avarok-Cybersecurity/atlas/blob/main/docs/GB10_DEPLOYMENT_GUIDE.md
 - Recipes (model SSOT): https://github.com/Avarok-Cybersecurity/atlas-recipes
 - Discord: https://discord.gg/6vDbKaKrKD


### PR DESCRIPTION
## Why

The site was unreadable on a phone, and it was missing two things worth shouting about.

## The mobile bug was real overflow, not a missing breakpoint

`document.scrollWidth` was **710px at a 390px viewport**. Under mobile emulation the layout viewport expands to that, so a phone laid the whole site out at ~710px and scaled it down.

Root cause: grid items default to `min-width: auto`, which resolves to min-content. `.repro` holds the reproduce command as one `white-space: nowrap` line, so it forced its entire grid track to 694px and dragged the page with it. Zeroing the automatic minimum on grid and flex items lets the command scroll inside its own box, which is what its `overflow-x: auto` already intended.

Also fixed:

- **No nav at all below 680px.** `.nav-links { display: none }` with nothing replacing it. Adds a drawer rendering from the same `nav.links` SSOT as the desktop bar, 50px tap targets, escape and scrim to close.
- **Sticky gift banner ate the viewport** on phones. It now scrolls away below 680px.
- **9.6px text** in chips, tags and statuses. Adds a legibility floor at 900px and down, placed after the layout blocks so nothing can push it back.
- Consolidates every viewport rule into `styles/mobile.css` (1040 / 900 / 860 / 680 / 480 / 380) instead of four media blocks scattered across two places, plus coarse-pointer tap targets and star-chart labels that scale as the chart shrinks.

## Content

New news band with three cards, each linking a primary source:

- The MLCommons edge agentic announcement, which names Atlas Inference as a contributor alongside NVIDIA.
- The AMD Strix Halo desktop, also acknowledged in the gift banner.
- The MLPerf v6.1 submission.

`mlperf.json` flips to `submitted`, so the receipt and the status copy follow the SSOT rather than hardcoded strings. No performance numbers anywhere. llama.cpp is named only as the bar we measure against, and results stay under embargo until MLCommons publishes.

Strix moves from "In bring up" to "MLPerf submitted" across the hardware card, roadmap, OG description and `llms.txt`.

## Verification

Headless Chromium at 320 / 360 / 390 / 414 / 768 / 1024 / 1280 / 1600:

- zero horizontal overflow at every width
- no console errors
- drawer opens, closes on escape, anchor links land 77px below the fixed bar
- desktop layout unchanged

Generated `*.generated.json` files are deliberately not in this diff; CI regenerates them at build time.