### PR TITLE
fix(metrics): RAII-guard atlas_requests_active so it cannot leak (relates to #368)

### DIFF
--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -128,14 +128,13 @@ pub(crate) async fn chat_completions_inner(
     dump_seq: Option<u64>,
 ) -> ChatOutcome {
     crate::metrics::REQUESTS_TOTAL.inc();
-    crate::metrics::REQUESTS_ACTIVE.inc();
+    // RAII: decrements on EVERY exit path, including this future being dropped
+    // when the client disconnects (see ActiveRequestGuard / atlas#368). Moved
+    // into the SSE stream for streaming requests so it outlives this function.
+    let active_guard = crate::metrics::ActiveRequestGuard::new();
 
     // ── Input validation + cross-turn F-feature guards ──
     if let Err(resp) = super::chat_phases::validate_input(&req) {
-        // Balance the REQUESTS_ACTIVE gauge incremented above: every other
-        // terminal path decrements it, but this fail-fast 400 returns before
-        // reaching a dispatch handler.
-        crate::metrics::REQUESTS_ACTIVE.dec();
         return ChatOutcome::Http(resp);
     }
 
@@ -374,6 +373,7 @@ pub(crate) async fn chat_completions_inner(
             grammar_spec.clone(),
             top_logprobs,
             timeout_at,
+            active_guard,
         )
         .await;
     }

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -170,7 +170,7 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> super::chat::Ch
         };
 
         if state.request_tx.send(request).await.is_err() {
-                return super::chat::ChatOutcome::Http(openai_error_response(
+            return super::chat::ChatOutcome::Http(openai_error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "Scheduler queue full".to_string(),
             ));
@@ -179,13 +179,13 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> super::chat::Ch
         let response = match rx.await {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
-                        return super::chat::ChatOutcome::Http(openai_error_response(
+                return super::chat::ChatOutcome::Http(openai_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Inference error: {e}"),
                 ));
             }
             Err(_) => {
-                        return super::chat::ChatOutcome::Http(openai_error_response(
+                return super::chat::ChatOutcome::Http(openai_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Inference cancelled".to_string(),
                 ));

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -170,8 +170,7 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> super::chat::Ch
         };
 
         if state.request_tx.send(request).await.is_err() {
-            crate::metrics::REQUESTS_ACTIVE.dec();
-            return super::chat::ChatOutcome::Http(openai_error_response(
+                return super::chat::ChatOutcome::Http(openai_error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "Scheduler queue full".to_string(),
             ));
@@ -180,15 +179,13 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> super::chat::Ch
         let response = match rx.await {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
-                crate::metrics::REQUESTS_ACTIVE.dec();
-                return super::chat::ChatOutcome::Http(openai_error_response(
+                        return super::chat::ChatOutcome::Http(openai_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Inference error: {e}"),
                 ));
             }
             Err(_) => {
-                crate::metrics::REQUESTS_ACTIVE.dec();
-                return super::chat::ChatOutcome::Http(openai_error_response(
+                        return super::chat::ChatOutcome::Http(openai_error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Inference cancelled".to_string(),
                 ));
@@ -502,7 +499,7 @@ fn finalize_response(
         response_tokens_per_second: tokens_per_second,
     };
 
-    crate::metrics::REQUESTS_ACTIVE.dec();
+    // REQUESTS_ACTIVE released by the caller's ActiveRequestGuard on return.
     crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(prompt_len as u64);
     crate::metrics::GENERATION_TOKENS_TOTAL.inc_by(total_completion_tokens as u64);
     crate::metrics::TTFT_SECONDS.observe(first_ttft / 1000.0);

--- a/crates/spark-server/src/api/chat_stream/ctx.rs
+++ b/crates/spark-server/src/api/chat_stream/ctx.rs
@@ -11,6 +11,11 @@ use crate::AppState;
 use crate::tool_parser;
 
 pub(super) struct StreamCtx {
+    /// Holds `atlas_requests_active` for the stream's whole lifetime. `StreamCtx`
+    /// is moved into the SSE `flat_map` closure, so this drops — releasing the
+    /// gauge exactly once — on normal completion, on error, AND when the client
+    /// disconnects and axum drops the stream. Never read; existence is the point.
+    pub(super) _active_guard: crate::metrics::ActiveRequestGuard,
     pub(super) state: Arc<AppState>,
     pub(super) model: String,
     pub(super) id: String,

--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -228,8 +228,9 @@ pub(super) fn handle_done(
         token_ids: state.take_ids_if(ctx.req_return_token_ids),
     });
 
-    // Metrics.
-    crate::metrics::REQUESTS_ACTIVE.dec();
+    // Metrics. (REQUESTS_ACTIVE is released by the ActiveRequestGuard in
+    // StreamCtx when the stream is dropped — not here, so a stream that ends
+    // without a terminal event still decrements.)
     crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(ctx.prompt_len as u64);
     crate::metrics::GENERATION_TOKENS_TOTAL.inc_by(completion_tokens as u64);
     crate::metrics::TTFT_SECONDS.observe(time_to_first_token_ms / 1000.0);

--- a/crates/spark-server/src/api/chat_stream/handle_error.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_error.rs
@@ -9,7 +9,7 @@ use super::ctx::StreamCtx;
 type DeltaVec = Vec<StreamDelta>;
 
 pub(super) fn handle_error(ctx: &StreamCtx, msg: String) -> DeltaVec {
-    crate::metrics::REQUESTS_ACTIVE.dec();
+    // REQUESTS_ACTIVE released by StreamCtx's ActiveRequestGuard on drop.
     // Abandoned stream — refund the full reservation.
     if let Some(ref rctx) = ctx.req_ctx {
         ctx.state

--- a/crates/spark-server/src/api/chat_stream/mod.rs
+++ b/crates/spark-server/src/api/chat_stream/mod.rs
@@ -92,6 +92,7 @@ pub(crate) async fn run_chat_stream(
     req_return_token_ids: bool,
     req_ctx: Option<crate::rate_limiter::RequestContext>,
     dump_seq: Option<u64>,
+    active_guard: crate::metrics::ActiveRequestGuard,
 ) -> Result<crate::ir::DeltaStream, (StatusCode, String)> {
     // Channel capacity sized for ~30s of decode at 50 tok/s. The previous
     // 64-slot buffer would fill in <2s under any HTTP-flush stall and silently
@@ -231,6 +232,7 @@ pub(crate) async fn run_chat_stream(
         grammar_spec: grammar_spec_for_retry,
         max_tokens,
         timeout_at,
+        _active_guard: active_guard,
     };
 
     let mut stream_state = StreamState::new(

--- a/crates/spark-server/src/api/chat_stream_dispatch.rs
+++ b/crates/spark-server/src/api/chat_stream_dispatch.rs
@@ -61,9 +61,10 @@ pub(super) async fn dispatch_streaming(
     grammar_spec: Option<GrammarSpec>,
     top_logprobs: Option<u8>,
     timeout_at: Option<std::time::Instant>,
+    active_guard: crate::metrics::ActiveRequestGuard,
 ) -> super::chat::ChatOutcome {
     if req.n > 1 {
-        crate::metrics::REQUESTS_ACTIVE.dec();
+        // active_guard drops here -> gauge decremented.
         return super::chat::ChatOutcome::Http(openai_error_response(
             StatusCode::BAD_REQUEST,
             "n > 1 is not supported in streaming mode".to_string(),
@@ -122,6 +123,7 @@ pub(super) async fn dispatch_streaming(
         req_return_token_ids,
         ctx_for_stream,
         dump_seq,
+        active_guard,
     )
     .await
     {

--- a/crates/spark-server/src/metrics.rs
+++ b/crates/spark-server/src/metrics.rs
@@ -67,3 +67,37 @@ lazy_static! {
             "Total successful tool calls emitted by the server"
         ).unwrap();
 }
+
+/// RAII guard for the `atlas_requests_active` gauge: increments on construction,
+/// decrements exactly once on drop.
+///
+/// Replaces a hand-balanced `inc()` + seven scattered `dec()` calls. That shape
+/// leaked: any terminal path that forgot to decrement — or, critically, a
+/// handler future DROPPED because the client disconnected (axum drops the future
+/// on disconnect, so no `dec()` in the body ever runs) — pinned the gauge
+/// forever. Orphans then accumulate monotonically and can exhaust the scheduler's
+/// admission accounting while `/health` still reports ready.
+/// See Avarok-Cybersecurity/atlas#368.
+///
+/// For streaming the guard is moved into `StreamCtx`, which the SSE `flat_map`
+/// closure owns — so it also drops when the client hangs up mid-stream.
+pub struct ActiveRequestGuard(());
+
+impl ActiveRequestGuard {
+    pub fn new() -> Self {
+        REQUESTS_ACTIVE.inc();
+        Self(())
+    }
+}
+
+impl Default for ActiveRequestGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        REQUESTS_ACTIVE.dec();
+    }
+}


### PR DESCRIPTION
`atlas_requests_active` leaks: it climbs monotonically and never returns to 0, so the gauge becomes useless for load/health monitoring. Relates to #368 (see scope note at the bottom — this fixes the metric, not the slot wedge).

## The bug

The gauge was hand-balanced: **one `inc()`** in `chat_completions_inner` against **seven `dec()` calls scattered over five files**. Correctness depended on every terminal path remembering to decrement — and one class of path *structurally cannot*: when a client disconnects, **axum drops the handler future**, so no `dec()` in the body ever runs. The gauge is then pinned for the process lifetime.

## Measured (Laguna-S-2.1-NVFP4, GB10, before the fix)

On an **idle** server with **zero client processes**:

| | 13:57:16 | 13:57:31 | 13:57:46 |
|---|---|---|---|
| `atlas_requests_active` | **21** | **21** | **21** |
| `atlas_generation_tokens_total` | 36,496 | 36,496 | 36,496 |
| `atlas_requests_total` | 190 | 190 | 190 |

21 phantom "active" requests, flat for 45s, with generation **and** request counters completely frozen. It was also observed at **21 with `--max-num-seqs 8`** under purely sequential traffic — exceeding the sequence limit is itself proof the count is fictional.

## The fix

Replace the inc/dec bookkeeping with `metrics::ActiveRequestGuard` — increments on construction, decrements exactly once on `Drop`. (Same RAII pattern already used for SSM pool slots.)

- **Blocking path** — the guard lives in `chat_completions_inner`, which awaits `run_blocking_path` (its only caller). Scope covers all four former dec sites *and* a dropped future.
- **Streaming path** — the guard is threaded into `StreamCtx`, which is moved into the SSE `flat_map` closure. It therefore releases on normal completion, on error, and on mid-stream hangup — including a stream that ends **without** a terminal event (e.g. a prefill chunk error), which previously leaked.

Net: all 7 manual `dec()` calls are gone; no exit path can forget, including ones nobody wrote code for.

## Validation

| Scenario | `requests_active` |
|---|---|
| Idle (before fix, 0 clients) | 21 — frozen |
| Idle (after fix) | **0** |
| After 3 completed requests | **0** |
| **After a request aborted mid-flight** (client-disconnect repro) | **0** |

## Scope note re #368

`REQUESTS_ACTIVE` is a **pure metric** — nothing reads it, so it gates no admission control. This PR fixes the observable gauge leak (which is #368's headline evidence), but it does **not** by itself reap an orphaned scheduler *sequence*. If #368's wedge is real slot exhaustion, that needs scheduler-side reaping on disconnect and is **not** addressed here. Flagging explicitly so this isn't mistaken for a full fix of that issue.

_via https://claude.ai/code/session_01XmUTPJXD3eKQiPkZvQ4cxz_
