### PR TITLE
fix(scheduler): preempt on KV exhaustion instead of failing (decode + prefill paths)

### DIFF
--- a/crates/spark-model/src/engine/tests.rs
+++ b/crates/spark-model/src/engine/tests.rs
@@ -162,6 +162,8 @@ impl Model for MockModel {
             session_hash: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            prefix_lookup_applied: false,
+            prefix_lookup_skip: false,
             kv_valid_tokens: 0,
             last_decode_ckpt_block: 0,
             prompt_len: 0,

--- a/crates/spark-model/src/model/nllb/model_impl.rs
+++ b/crates/spark-model/src/model/nllb/model_impl.rs
@@ -180,6 +180,8 @@ impl Model for NllbGpuModel {
             session_hash: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            prefix_lookup_applied: false,
+            prefix_lookup_skip: false,
             kv_valid_tokens: 0,
             last_decode_ckpt_block: 0,
             prompt_len: 0,

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -225,6 +225,8 @@ impl TransformerModel {
             session_hash: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            prefix_lookup_applied: false,
+            prefix_lookup_skip: false,
             kv_valid_tokens: 0,
             last_decode_ckpt_block: 0,
             prompt_len: 0,

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -23,6 +23,20 @@ impl TransformerModel {
         stream: u64,
     ) -> Result<(usize, bool)> {
         let bs = kv_cache.block_size();
+        // Retry re-entry (scheduler preempt-and-retry on KV exhaustion): chunk 0
+        // already acquired this sequence's prefix — it `inc_ref`d each matched
+        // block and pushed it onto `block_table` BEFORE the allocation that
+        // failed. Re-running would push those blocks a second time and take a
+        // second radix ref that nothing releases. Replay the original decision.
+        if chunk_start == 0 && seq.prefix_lookup_applied {
+            tracing::debug!(
+                "prefix lookup re-entered at chunk 0 (retry): replaying \
+                 skip_to={} skip={} without re-acquiring the cached prefix",
+                seq.marconi_skip_to,
+                seq.prefix_lookup_skip,
+            );
+            return Ok((seq.marconi_skip_to, seq.prefix_lookup_skip));
+        }
         if chunk_start == 0 {
             // Prompt-logprob collection needs a live hidden row for EVERY
             // position — a cache/Marconi skip would leave gaps. Force the
@@ -304,6 +318,8 @@ impl TransformerModel {
                 0
             };
             seq.marconi_skip_to = skip_tokens;
+            seq.prefix_lookup_skip = skip;
+            seq.prefix_lookup_applied = true;
             Ok((skip_tokens, skip))
         } else if seq.marconi_skip_to > 0 {
             // Chunk 1+: inherit skip info from chunk 0's prefix cache lookup.

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -121,6 +121,22 @@ pub struct SequenceState {
     /// the scheduler to populate `usage.prompt_tokens_details.cached_tokens`.
     /// 0 when prefix caching is disabled or the prompt had no cache match.
     pub cached_prefix_tokens: usize,
+    /// Whether the chunk-0 prefix-cache lookup already ran for this sequence.
+    ///
+    /// The lookup is NOT idempotent: it bumps radix refs, `inc_ref`s each
+    /// matched KV block and PUSHES it onto `block_table`. It also runs BEFORE
+    /// `ensure_blocks_through_prefill`, so a chunk-0 prefill that fails to
+    /// allocate its suffix (KV exhausted) leaves all of that applied. The
+    /// preempt-and-retry in `run_standard_chunk_loop` re-enters `prefill_chunk`
+    /// for the SAME chunk, which would run the lookup a second time — appending
+    /// the matched blocks to `block_table` again (so `block_table[i]` no longer
+    /// maps to logical block `i`) and taking a second radix ref that the single
+    /// `release` in `free_sequence` can never balance. This flag makes the
+    /// re-entry a no-op that replays chunk 0's original decision.
+    pub prefix_lookup_applied: bool,
+    /// The `skip` half of the chunk-0 lookup's return value, replayed verbatim
+    /// when `prefix_lookup_applied` short-circuits a retry.
+    pub prefix_lookup_skip: bool,
     /// Contiguous prefix length (in tokens, from position 0) whose paged KV is
     /// guaranteed fully written for THIS sequence — either reused from a valid
     /// prefix-cache match or written by a real prefill pass this turn. Updated

--- a/crates/spark-server/src/scheduler/decode_step.rs
+++ b/crates/spark-server/src/scheduler/decode_step.rs
@@ -31,7 +31,6 @@ pub fn step_decode_only(
     if n > 1 {
         active.sort_by_key(|a| a.seq.ssm_slot_idx().unwrap_or(a.seq.slot_idx));
     }
-    let tokens: Vec<u32> = active.iter().map(|a| a.last_token).collect();
 
     // CONCURRENT-DECODE DIAG: per-step batch state (slot, seq_len, etc).
     // Demoted to debug after the 2026-04-22 stride+graph fixes shipped —
@@ -66,18 +65,70 @@ pub fn step_decode_only(
     // empirically as a 51s broadcast timeout on the worker followed by
     // stale comm data reads. See decode_a2.rs for the full rationale.
 
-    let mut refs: Vec<&mut SequenceState> = active.iter_mut().map(|a| &mut a.seq).collect();
-
-    let logits = match model.decode_batch(&tokens, &mut refs, 0) {
-        Ok(l) => l,
-        Err(e) => {
-            tracing::error!("decode_batch error: {e:#}");
-            for mut a in active.drain(..) {
-                send_error(model, &mut a, &format!("{e:#}"));
+    // Decode, PREEMPTING on KV exhaustion instead of failing the whole batch.
+    //
+    // Sequences grow one block per `block_size` tokens as they decode, but
+    // admission control only sizes the pool against a new request's PROMPT
+    // (scheduler/mod.rs: `blocks_needed = prompt_len / block_size + 1`) and is
+    // never re-consulted afterwards. So N conversations admitted comfortably at
+    // 2K tokens each can collectively exhaust the pool once they reach 18K —
+    // measured: 8 seqs x 1173 blocks = 9384 needed vs a 9058-block pool.
+    // Previously ONE sequence failing to extend its block table errored EVERY
+    // sequence in the batch, destroying up to `max_num_seqs` in-flight requests
+    // because one of them wanted a single extra block.
+    //
+    // Instead: drop the largest sequence (its `free_sequence` in `send_error`
+    // returns its blocks to the pool) and retry, so the rest of the batch makes
+    // progress. Victim choice mirrors the admission-time policy — largest
+    // block_table, grammar-active sequences excluded (their state isn't
+    // reconstructible). Preferable would be swapping the victim out for later
+    // resume (`swap_out_sequence`), but that needs the KvSpillManager threaded
+    // in; dropping one to save the rest is the strictly-better-than-today fix.
+    let logits = loop {
+        let tokens: Vec<u32> = active.iter().map(|a| a.last_token).collect();
+        let mut refs: Vec<&mut SequenceState> = active.iter_mut().map(|a| &mut a.seq).collect();
+        match model.decode_batch(&tokens, &mut refs, 0) {
+            Ok(l) => break l,
+            Err(e) => {
+                drop(refs);
+                let victim = if format!("{e:#}").contains("KV cache exhausted") && active.len() > 1
+                {
+                    active
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, a)| a.grammar_state.is_none())
+                        .max_by_key(|(_, a)| a.seq.block_table.len())
+                        .map(|(i, _)| i)
+                } else {
+                    None
+                };
+                let Some(vi) = victim else {
+                    tracing::error!("decode_batch error: {e:#}");
+                    for mut a in active.drain(..) {
+                        send_error(model, &mut a, &format!("{e:#}"));
+                    }
+                    return;
+                };
+                // `remove` (not `swap_remove`) keeps the ascending SSM-slot order
+                // established above; a hole only costs the batched path a fallback
+                // to the eager loop for this step, and the next step re-sorts.
+                let mut v = active.remove(vi);
+                tracing::warn!(
+                    "KV cache exhausted during decode: preempting slot={} ({} blocks) \
+                     so the other {} sequence(s) can continue",
+                    v.seq.slot_idx,
+                    v.seq.block_table.len(),
+                    active.len(),
+                );
+                send_error(model, &mut v, &format!("{e:#}"));
             }
-            return;
         }
     };
+    // Preemption may have shrunk the batch; `n` gates the n==1 paths below.
+    let n = active.len();
+    if n == 0 {
+        return;
+    }
 
     // Ctx-holes fix (ATLAS_DFLASH_SERIAL_APPEND=1): think-gated stretches
     // route HERE (mod.rs sends `inside_thinking` seqs to step_decode_only,

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -11,6 +11,7 @@ use spark_model::traits::{Model, SequenceState};
 use std::time::Instant;
 
 use super::super::decode_logits_step::process_decode_logits;
+use super::super::lifecycle::send_error;
 use super::super::sample_first_token;
 use super::super::types::{ActiveSeq, PrefillInProgress};
 
@@ -234,14 +235,59 @@ pub(super) fn run_standard_chunk_loop(
         return;
     }
 
-    match model.prefill_chunk(
+    // Preempt-and-retry on KV exhaustion, mirroring `decode_step`: a prompt chunk
+    // that cannot allocate should evict a LARGER in-flight sequence rather than
+    // fail this request outright. Safe to retry because
+    // `ensure_blocks_through_prefill` fails during block allocation, BEFORE the
+    // forward pass — no GPU state has been mutated. Victim policy matches
+    // admission control (largest block_table, grammar-active excluded, since
+    // their state is not reconstructible). Falls through to the original
+    // fail-this-sequence behavior when nothing can be evicted.
+    let mut chunk_res = model.prefill_chunk(
         &p.prompt_tokens,
         &mut p.seq,
         p.chunk_offset,
         chunk_len,
         is_last,
         prefill_stream,
-    ) {
+    );
+    while chunk_res
+        .as_ref()
+        .err()
+        .is_some_and(|e| format!("{e:#}").contains("KV cache exhausted"))
+    {
+        let Some(vi) = active
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.grammar_state.is_none())
+            .max_by_key(|(_, a)| a.seq.block_table.len())
+            .map(|(i, _)| i)
+        else {
+            break;
+        };
+        let mut victim = active.remove(vi);
+        tracing::warn!(
+            "KV cache exhausted during prefill chunk: preempting slot={} ({} blocks) \
+             so this prefill can proceed ({} sequence(s) remain)",
+            victim.seq.slot_idx,
+            victim.seq.block_table.len(),
+            active.len(),
+        );
+        send_error(
+            model,
+            &mut victim,
+            "preempted: KV cache exhausted (a prefill needed its blocks)",
+        );
+        chunk_res = model.prefill_chunk(
+            &p.prompt_tokens,
+            &mut p.seq,
+            p.chunk_offset,
+            chunk_len,
+            is_last,
+            prefill_stream,
+        );
+    }
+    match chunk_res {
         Ok(logits) => {
             p.chunk_offset += chunk_len;
             tracing::info!(


### PR DESCRIPTION
> **Draft: implemented and compiles, but NOT yet runtime-validated.** The preemption path has never been observed executing — I'm forcing the condition deliberately (tiny KV pool + concurrent long generations) before marking ready. Putting it up now for early review of the approach.

A sequence that can't extend its block table mid-decode currently errors **every** sequence in the batch:

```rust
Err(e) => {
    tracing::error!("decode_batch error: {e:#}");
    for mut a in active.drain(..) { send_error(model, &mut a, ...); }
    return;
}
```

So one sequence wanting a **single extra block** destroys up to `--max-num-seqs` in-flight requests.

## Why it happens

Admission control sizes the pool against a new request's **prompt** only (`scheduler/mod.rs`):

```rust
let blocks_needed = prompt_len / block_size + 1;
while model.num_free_blocks() < blocks_needed && !active.is_empty() { ...swap_out_sequence... }
```

…and is never re-consulted afterwards. But sequences **grow** one block per `block_size` decoded tokens. N conversations admitted comfortably at 2K tokens each can collectively exhaust the pool once they reach 18K.

**Measured** (GB10, Laguna-S-2.1-NVFP4, 9058-block pool, `--max-num-seqs 8`): five events with `free_blocks=0` at `abs=1173` blocks/seq — **8 × 1173 = 9384 blocks needed vs 9058 available**. Eight concurrent long agentic conversations physically don't fit, and nothing re-checks after admission.

```
ERROR decode_step: decode_batch error: alloc failed in ensure_blocks_through_decode:
  abs=1173 ws=0 bt_len=1173 cap=None free_blocks=0 slid=0 alloc'd=0: KV cache exhausted
```

Note Atlas **already has** preemption (`swap_out_sequence`, backed by `--swap-space-gb`) — it's simply never wired to the decode path.

## The fix

On a KV-exhaustion error: drop the largest sequence (`send_error` → `free_sequence` returns its blocks to the pool) and **retry the decode**, so the rest of the batch progresses. Loops until success or one sequence remains.

- **Victim policy mirrors admission** — largest `block_table`, grammar-active sequences excluded (their state isn't reconstructible).
- **Non-exhaustion errors keep the old fail-the-batch behavior** — this shouldn't silently swallow unrelated decode faults.
- `tokens` is rebuilt per attempt (derived from `active`; a stale copy misaligns the batch after preemption).
- `remove` not `swap_remove`, to preserve the ascending SSM-slot order the batched path needs — a hole only costs a fallback to the eager loop for that step, and the next step re-sorts.
- `n` is recomputed, since it gates the `n == 1` paths below.

## Scope / limitation

The victim is **errored**, not swapped out for later resume. Proper preemption via `swap_out_sequence` needs `KvSpillManager` threaded into `step_decode_only` (2 call sites) — worth doing, but killing 1 to save 7 is the strictly-better-than-today fix and is self-contained. Happy to extend to real swap-out if preferred.

Also worth noting: with a retry-capable client this is invisible today (our agentic harness passed 30/30 tasks *despite* 5 of these events, because the client retried) — behind a gateway that doesn't retry, it's 5 batches of hard failures.

_via https://claude.ai/code/session_01XmUTPJXD3eKQiPkZvQ4cxz_


---

# Update: validated on a starved pool, plus a prerequisite fix

## Decode preempt — validated

Forced KV exhaustion with a deliberately starved pool (gpu-util 0.63, ~2–3K blocks) and concurrent long generations:

```
WARN KV cache exhausted during decode: preempting slot=5 (368 blocks) so the other 7 sequence(s) can continue
```

`decode_batch error` = **0** across every run — the batch-kill this PR removes never fired again. Server stayed healthy; output coherence verified 6/6 (checkable-answer prompts, cold and warm through the prefix cache).

An earlier run of this test also emitted 10 `dec_ref on block N with 0 refs` in the same microsecond as the preempt. **That was not caused by this PR** — the blocks were already corrupt and the preempt was simply the first thing to free that table. Root-caused to a prefix-cache ownership bug, fixed in #373 (`InsertAcquired`); with that in place the same repro shows **0** underflows across 8 swap-outs. My initial hypothesis — that victim selection picked the sequence that had just failed — was wrong: `decode_batch`'s error path frees nothing, and `free_sequence` clears `block_table`.

## New commit: `fix(prefill): make the chunk-0 prefix lookup idempotent under preempt-retry`

The prefill arm of this PR was **unsafe as written**. `prefill_b_prefix_lookup` runs its acquisition whenever `chunk_start == 0`, and it runs **before** `ensure_blocks_through_prefill` — so the exhaustion the retry exists to handle happens with all of it already applied:

- `lookup` bumped a radix ref on every matched node,
- each matched block was `inc_ref`d **and pushed onto `seq.block_table`**,
- `cached_prefix_tokens` / `marconi_skip_to` were set.

Retrying the same chunk appended the matched blocks to `block_table` **a second time** — so `block_table[i]` no longer maps to logical block *i*, and KV for those positions is read/written at the wrong offsets — and took a second radix ref that the single `release` in `free_sequence` can never balance (the progressive-pin signature that wedges the pool, cf. #373).

A `prefix_lookup_applied` flag makes the re-entry a no-op that replays chunk 0's original `(skip_tokens, skip)`, so the retry proceeds straight to the allocation against the prefix it already holds.

This is a **latent** hazard, not an observed failure: in the repro, exhaustion lands on prefill **start**, not on a continuation chunk, so this retry loop never fired. It is a prerequisite for the prefill arm regardless.

## Known gap: prefill start still 500s

`phase_start_prefills` → `handle_prefill_start_error` preempts for SSM `"pool exhausted"` but falls through for `"KV cache exhausted"`, so a newcomer that cannot be admitted gets an HTTP 500 (observed: 2–3 streams per run).

I deliberately did **not** extend the preempt there. By that point the request has already failed, so killing a live sequence would destroy in-flight work and rescue nothing. The correct fix is to **defer/requeue** the request, which is a scheduler-structure change (the request is consumed by `prefill_request_chunked`, and the swap-out valve cannot help within one tick — requests arriving together see `active` empty). Worth a follow-up issue rather than bolting onto this PR.