### PR TITLE
feat(tui): ratatui dashboard for spark serve — branded, observable, crash-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +435,20 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "compact_str"
@@ -544,6 +564,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,8 +621,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -595,12 +650,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -652,7 +731,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -764,6 +843,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -935,13 +1020,24 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -1017,6 +1113,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1026,12 +1123,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1168,6 +1270,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1382,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1288,6 +1418,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1382,6 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1794,6 +1934,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.2",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +2039,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1885,7 +2059,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2056,6 +2230,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,13 +2367,17 @@ dependencies = [
  "atlas-kernels",
  "axum",
  "clap",
+ "crossterm",
  "futures",
+ "http-body",
  "hyper",
  "hyper-util",
  "lazy_static",
+ "libc",
  "minijinja",
  "parking_lot",
  "prometheus",
+ "ratatui",
  "rayon",
  "serde",
  "serde_json",
@@ -2196,6 +2395,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tui-textarea",
+ "unicode-width 0.2.0",
  "xgrammar",
 ]
 
@@ -2251,6 +2452,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2522,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2390,7 +2613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "compact_str",
+ "compact_str 0.9.0",
  "daachorse",
  "dary_heap",
  "derive_builder",
@@ -2619,6 +2842,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2878,29 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode_categories"
@@ -2733,6 +2996,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -683,6 +683,9 @@ impl Model for TransformerModel {
     fn num_free_blocks(&self) -> usize {
         self.num_free_blocks_dispatch()
     }
+    fn num_total_blocks(&self) -> usize {
+        self.num_total_blocks_dispatch()
+    }
     fn start_checkpoint_async(&self, seq: &mut SequenceState) -> Result<()> {
         self.start_checkpoint_async_dispatch(seq)
     }

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -418,4 +418,8 @@ impl TransformerModel {
     pub(super) fn num_free_blocks_dispatch(&self) -> usize {
         self.kv_cache.lock().num_free_blocks()
     }
+
+    pub(super) fn num_total_blocks_dispatch(&self) -> usize {
+        self.kv_cache.lock().num_blocks()
+    }
 }

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -912,6 +912,12 @@ pub trait Model: Send + Sync {
         0
     }
 
+    /// Total KV blocks in the paged cache (denominator for occupancy
+    /// gauges). Default 0 for backends without a paged cache.
+    fn num_total_blocks(&self) -> usize {
+        0
+    }
+
     /// Return the default CUDA stream handle.
     fn default_stream(&self) -> u64 {
         0

--- a/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/qwen35/load_layers.rs
@@ -846,6 +846,7 @@ pub(super) fn load_layers(
         if (i + 1) % 10 == 0 || i < 5 {
             let free_gb = gpu.free_memory()? as f64 / (1024.0 * 1024.0 * 1024.0);
             tracing::info!("Loaded layers 0..{} — {free_gb:.1} GB free", i + 1);
+            spark_runtime::progress::layer(i + 1, config.num_hidden_layers);
         }
     }
 

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -890,6 +890,7 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
 
             if (i + 1) % 10 == 0 {
                 tracing::info!("Loaded layers 0..{}", i + 1);
+                spark_runtime::progress::layer(i + 1, config.num_hidden_layers);
             }
         }
 

--- a/crates/spark-runtime/src/fast_weights/mod.rs
+++ b/crates/spark-runtime/src/fast_weights/mod.rs
@@ -149,6 +149,7 @@ impl WeightLoader for FastSafetensorsLoader {
                 gib(oom_reserve_bytes),
                 has_fp8,
             );
+            crate::progress::preflight(gib(estimated), gib(free));
             if peak + oom_reserve_bytes > free {
                 bail!(
                     "OOM pre-flight: peak {:.2} GB + {:.2} GB reserve exceeds {:.2} GB free. \
@@ -190,6 +191,7 @@ impl WeightLoader for FastSafetensorsLoader {
                     .map(|v| format!(" ({} tensors)", v.len()))
                     .unwrap_or_default(),
             );
+            crate::progress::shard_start(i + 1, total_shards, shard_name);
 
             load_shard_fast(
                 shard_path,
@@ -207,6 +209,12 @@ impl WeightLoader for FastSafetensorsLoader {
             let used = initial_free.saturating_sub(free_now);
             tracing::info!(
                 "  Shard {}/{} done — GPU memory: {:.2} GB used, {:.2} GB free",
+                i + 1,
+                total_shards,
+                used as f64 / (1024.0 * 1024.0 * 1024.0),
+                free_now as f64 / (1024.0 * 1024.0 * 1024.0),
+            );
+            crate::progress::shard_done(
                 i + 1,
                 total_shards,
                 used as f64 / (1024.0 * 1024.0 * 1024.0),

--- a/crates/spark-runtime/src/kernel_audit.rs
+++ b/crates/spark-runtime/src/kernel_audit.rs
@@ -38,6 +38,23 @@ fn ptx_hash(bytes: &[u8]) -> String {
     format!("{:012x}", h & 0xffff_ffff_ffff)
 }
 
+/// Structured resolution rows for observers (e.g. the TUI kernel table):
+/// deduped `(module, func, loaded)`, sorted. `loaded` is true if ANY lookup
+/// of that (module, func) resolved.
+pub fn audit_rows() -> Vec<(String, String, bool)> {
+    let mut resolved: BTreeMap<(String, String), bool> = BTreeMap::new();
+    if let Ok(v) = AUDIT.lock() {
+        for (m, f, ok) in v.iter() {
+            let e = resolved.entry((m.clone(), f.clone())).or_insert(false);
+            *e = *e || *ok;
+        }
+    }
+    resolved
+        .into_iter()
+        .map(|((m, f), ok)| (m, f, ok))
+        .collect()
+}
+
 /// Render the embedded kernel set (`embedded` = the binary's `ptx_modules()`,
 /// passed in since spark-runtime doesn't depend on atlas-kernels) plus the
 /// runtime resolution overlay. `set_hash` is `atlas_kernels::KERNEL_SET_HASH`.

--- a/crates/spark-runtime/src/lib.rs
+++ b/crates/spark-runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod kv_spill;
 #[cfg(feature = "metal")]
 pub mod metal_backend;
 pub mod prefix_cache;
+pub mod progress;
 pub mod radix_tree;
 pub mod sampler;
 pub mod weights;

--- a/crates/spark-runtime/src/progress.rs
+++ b/crates/spark-runtime/src/progress.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Structured startup-progress events for the Atlas TUI.
+//!
+//! Call sites next to the existing human-readable log lines emit ADDITIONAL
+//! `debug!`-level events under the dedicated [`TARGET`]. They are invisible on
+//! the plain-log path at the default `info` filter — the grepped output the
+//! benchmark rigs depend on does not change by a byte — while the TUI's
+//! capture layer enables this target unconditionally and decodes the typed
+//! fields.
+//!
+//! Discriminated by the `ev` field:
+//!   `phase`       — `phase` (0..=11), `name`
+//!   `preflight`   — `disk_gb`, `free_gb`
+//!   `shard_start` — `shard` (1-based), `total`, `name`
+//!   `shard_done`  — `shard`, `total`, `used_gb`, `free_gb`
+//!   `layer`       — `layer` (0-based highest loaded), `total`
+//!   `ready`       — `port`
+
+/// Tracing target the TUI capture layer filters on. Keep in sync with
+/// `spark-server/src/tui/capture_layer.rs`.
+pub const TARGET: &str = "atlas::tui::progress";
+
+/// A named startup phase has begun. `phase` is the serve() phase index.
+pub fn phase(phase: u8, name: &str) {
+    tracing::debug!(target: "atlas::tui::progress", ev = "phase", phase, name);
+}
+
+/// Weight-load preflight: total on-disk GB (the overall-bar denominator).
+pub fn preflight(disk_gb: f64, free_gb: f64) {
+    tracing::debug!(target: "atlas::tui::progress", ev = "preflight", disk_gb, free_gb);
+}
+
+/// A safetensors shard load has started.
+pub fn shard_start(shard: usize, total: usize, name: &str) {
+    tracing::debug!(target: "atlas::tui::progress", ev = "shard_start", shard, total, name);
+}
+
+/// A shard finished; GPU memory snapshot alongside.
+pub fn shard_done(shard: usize, total: usize, used_gb: f64, free_gb: f64) {
+    tracing::debug!(
+        target: "atlas::tui::progress",
+        ev = "shard_done",
+        shard,
+        total,
+        used_gb,
+        free_gb
+    );
+}
+
+/// Layer-build progress (sampled by the weight loaders).
+pub fn layer(layer: usize, total: usize) {
+    tracing::debug!(target: "atlas::tui::progress", ev = "layer", layer, total);
+}
+
+/// The server is listening; startup is complete.
+pub fn ready(port: u16) {
+    tracing::debug!(target: "atlas::tui::progress", ev = "ready", port);
+}

--- a/crates/spark-server/Cargo.toml
+++ b/crates/spark-server/Cargo.toml
@@ -52,10 +52,21 @@ axum = { version = "0.8", features = ["json"] }
 # Direct hyper/hyper-util/tower access for the manual accept loop in
 # `serve_router.rs` — `axum::serve` does not expose hyper's connection-layer
 # `header_read_timeout`, which is what bounds a slowloris (slow-header) client.
-hyper = { version = "1", features = ["server", "http1", "http2"] }
-hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
+http-body = "1"
+hyper = { version = "1", features = ["server", "http1", "http2", "client"] }
+hyper-util = { version = "0.1", features = ["server-auto", "client-legacy", "http1", "tokio"] }
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["full", "parking_lot"] }
+# ── Atlas TUI (crates/spark-server/src/tui/) ──
+# ratatui pins its own crossterm; the version here MUST match ratatui 0.29's
+# (crossterm 0.28) or two raw-mode stacks fight over the terminal.
+ratatui = "0.29"
+crossterm = "0.28"
+# Single/multi-line inputs (log filter, library search, REPL, chat). MIT.
+tui-textarea = "0.7"
+unicode-width = "0.2"
+# stderr redirection while the TUI owns the screen (terminal_guard).
+libc = "0.2"
 tokio-stream = "0.1"
 futures = "0.3"
 rayon = "1.12"

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -218,8 +218,7 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> super::chat::Ch
             tools_active,
             cwd_hint.as_deref(),
             choice_idx,
-        )
-        .await;
+        );
         choice.index = choice_idx;
         choice.matched_stop = matched_stop;
         choice.logprobs = build_logprobs(&state, &response);
@@ -294,8 +293,13 @@ fn decode_response_text(
 /// Build the assistant message + finish_reason for one choice. Tool
 /// parsing, validation, content-strip + refusal-classifier all live
 /// here.
+///
+/// Deliberately NOT `async`: it awaits nothing, and marking pure CPU work as
+/// async only hides where that work runs. If it ever grows expensive enough to
+/// matter, that becomes a visible decision to move it to the blocking pool
+/// rather than something already buried inside a future.
 #[allow(clippy::too_many_arguments)]
-async fn build_choice_message(
+fn build_choice_message(
     state: &AppState,
     req: &crate::ir::ChatRequest,
     response: &super::inference_types::InferenceResponse,

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use std::path::PathBuf;
 
 /// Arguments for the `serve` subcommand.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct ServeArgs {
     /// HuggingFace model ID (e.g. "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4")
     /// or a local directory path containing config.json.
@@ -457,6 +457,12 @@ pub struct ServeArgs {
     /// Setting `ATLAS_FAST_LOAD=0` has the same effect.
     #[arg(long, default_value_t = false)]
     pub no_fast_load: bool,
+
+    /// Disable the interactive TUI dashboard even on a TTY, keeping the plain
+    /// log stream. The TUI also auto-disables when stdout/stdin is not an
+    /// interactive terminal (pipes, `docker -d`, CI) or `ATLAS_NO_TUI=1`.
+    #[arg(long, default_value_t = false)]
+    pub no_tui: bool,
 
     /// Ask the fast loader to prefetch each buffered shard before per-tensor
     /// reads. Useful on NFS-backed model stores with many small tensors per

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -98,25 +98,38 @@ async fn main() -> Result<()> {
         Some(progress_rx)
     };
 
-    // Race startup against shutdown. `serve()` is async but does not await
-    // between the banner and the accept loop — startup is one blocking sequence
-    // — so awaiting it inline made `q`/Ctrl+C look ignored for the whole model
-    // load: nothing could poll a shutdown future until loading finished. Spawning
-    // puts startup on its own task, so this `select!` can actually win.
+    // Race the server against shutdown. No spawn: `serve()` is a real future that
+    // yields while its blocking startup runs on the blocking pool, so pinning it
+    // here is enough for `select!` to poll the other branch. (It would NOT be
+    // enough if startup still blocked inside the future — `select!` chooses at
+    // await points, it does not preempt.)
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<&'static str>();
     tui::shutdown::arm_startup_escape(shutdown_tx);
     let result = match cli.command {
         Command::Serve(args) => {
-            let serving = tokio::spawn(serve(args, tui_channels));
+            let serving = serve(args, tui_channels);
+            tokio::pin!(serving);
+            // A CLOSED channel is not a shutdown. `disarm_startup_escape` drops the
+            // sender once the accept loop takes over, which resolves the receiver
+            // with `Err(RecvError)` — taken at face value that fires this branch
+            // the instant the server comes up and exits a healthy process. Only an
+            // actual send means shutdown; a drop means "startup finished", so the
+            // branch parks forever instead.
+            let shutdown_signal = async {
+                match shutdown_rx.await {
+                    Ok(reason) => reason,
+                    Err(_) => std::future::pending::<&'static str>().await,
+                }
+            };
+            tokio::pin!(shutdown_signal);
             tokio::select! {
-                res = serving => res.unwrap_or_else(|e| Err(anyhow::anyhow!("serve task: {e}"))),
-                reason = shutdown_rx => {
+                res = &mut serving => res,
+                reason = &mut shutdown_signal => {
                     // Cancelled before the server came up. Nothing is in flight
                     // and no client is connected, so there is nothing to drain —
                     // the startup task is abandoned where it stands.
                     tracing::info!(
-                        "Shutdown requested ({}) during startup — exiting before the server came up",
-                        reason.unwrap_or("unknown")
+                        "Shutdown requested ({reason}) during startup — exiting before the server came up"
                     );
                     // Cleanup that would otherwise run below, then exit without
                     // waiting on the runtime: a task parked inside a synchronous

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -109,12 +109,10 @@ async fn main() -> Result<()> {
         Command::Serve(args) => {
             let serving = serve(args, tui_channels);
             tokio::pin!(serving);
-            // A CLOSED channel is not a shutdown. `disarm_startup_escape` drops the
-            // sender once the accept loop takes over, which resolves the receiver
-            // with `Err(RecvError)` — taken at face value that fires this branch
-            // the instant the server comes up and exits a healthy process. Only an
-            // actual send means shutdown; a drop means "startup finished", so the
-            // branch parks forever instead.
+            // Only a SEND means shutdown. The sender is parked for the life of the
+            // process rather than dropped when startup ends, so the channel should
+            // never close; this arm exists so that if one ever did, a closed
+            // channel could not masquerade as a shutdown and kill a healthy server.
             let shutdown_signal = async {
                 match shutdown_rx.await {
                     Ok(reason) => reason,

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -98,8 +98,37 @@ async fn main() -> Result<()> {
         Some(progress_rx)
     };
 
+    // Race startup against shutdown. `serve()` is async but does not await
+    // between the banner and the accept loop — startup is one blocking sequence
+    // — so awaiting it inline made `q`/Ctrl+C look ignored for the whole model
+    // load: nothing could poll a shutdown future until loading finished. Spawning
+    // puts startup on its own task, so this `select!` can actually win.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<&'static str>();
+    tui::shutdown::arm_startup_escape(shutdown_tx);
     let result = match cli.command {
-        Command::Serve(args) => serve(args, tui_channels).await,
+        Command::Serve(args) => {
+            let serving = tokio::spawn(serve(args, tui_channels));
+            tokio::select! {
+                res = serving => res.unwrap_or_else(|e| Err(anyhow::anyhow!("serve task: {e}"))),
+                reason = shutdown_rx => {
+                    // Cancelled before the server came up. Nothing is in flight
+                    // and no client is connected, so there is nothing to drain —
+                    // the startup task is abandoned where it stands.
+                    tracing::info!(
+                        "Shutdown requested ({}) during startup — exiting before the server came up",
+                        reason.unwrap_or("unknown")
+                    );
+                    // Cleanup that would otherwise run below, then exit without
+                    // waiting on the runtime: a task parked inside a synchronous
+                    // CUDA call cannot be aborted, and dropping the runtime would
+                    // block on it — reintroducing the very wait this fixes.
+                    tui::stop_and_join(std::time::Duration::from_secs(2));
+                    tui::terminal_guard::restore();
+                    tui::init::flush_tee();
+                    std::process::exit(0);
+                }
+            }
+        }
     };
     // If serve() returned while the TUI owned the screen (startup error, clean
     // shutdown), stop the dashboard thread and wait for its TerminalGuard to

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -60,6 +60,7 @@ mod tool_arg_dedup;
 pub mod tool_parser;
 mod tool_rag;
 mod tscg;
+pub mod tui;
 
 use anyhow::Result;
 use clap::Parser;
@@ -74,15 +75,39 @@ pub type ModelBehavior = atlas_kernels::ModelBehavior;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
-        .init();
-
+    // Parse BEFORE subscriber install so the TUI gate can see `--no-tui`.
+    // clap emits no tracing events, so plain-mode output is unchanged.
     let cli = Cli::parse();
+    let no_tui = match &cli.command {
+        Command::Serve(args) => args.no_tui || args.rank > 0,
+    };
 
-    match cli.command {
-        Command::Serve(args) => serve(args).await,
-    }
+    let tui_channels = if tui::plain_mode(no_tui) {
+        // The pre-TUI init, byte-for-byte: this exact fmt layout is the
+        // contract every benchmark driver and gate script greps.
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| "info".into()),
+            )
+            .init();
+        None
+    } else {
+        let (progress_tx, progress_rx) = std::sync::mpsc::channel();
+        tui::init::install_tty_subscriber(progress_tx);
+        Some(progress_rx)
+    };
+
+    let result = match cli.command {
+        Command::Serve(args) => serve(args, tui_channels).await,
+    };
+    // If serve() returned while the TUI owned the screen (startup error, clean
+    // shutdown), stop the dashboard thread and wait for its TerminalGuard to
+    // drop BEFORE the error prints — main's exit never runs another thread's
+    // Drop, and a bare restore() races the thread's raw-mode entry when
+    // serve() fails within milliseconds. restore() stays as the backstop.
+    tui::stop_and_join(std::time::Duration::from_secs(2));
+    tui::terminal_guard::restore();
+    tui::init::flush_tee();
+    result
 }

--- a/crates/spark-server/src/main_modules/byte_count.rs
+++ b/crates/spark-server/src/main_modules/byte_count.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! HTTP byte accounting for the TUI Server Stats panel.
+//!
+//! Request side: `Content-Length` when the client declares it (all real Atlas
+//! clients do — JSON bodies). Response side: a wrapping `http_body::Body`
+//! counts frames as they are actually written, so streaming/SSE responses —
+//! where `Content-Length` does not exist — are counted correctly.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::metrics::{HTTP_BYTES_IN, HTTP_BYTES_OUT};
+
+/// Counting wrapper over the response body.
+struct CountedBody {
+    inner: Body,
+}
+
+impl http_body::Body for CountedBody {
+    type Data = axum::body::Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        // axum::body::Body is Unpin, so structural pinning is unnecessary.
+        let this = self.get_mut();
+        let polled = Pin::new(&mut this.inner).poll_frame(cx);
+        if let Poll::Ready(Some(Ok(frame))) = &polled
+            && let Some(data) = frame.data_ref()
+        {
+            HTTP_BYTES_OUT.inc_by(data.len() as u64);
+        }
+        polled
+    }
+}
+
+/// Axum middleware: count request bytes in, wrap the response to count out.
+pub(crate) async fn byte_count_middleware(req: Request<Body>, next: Next) -> Response {
+    if let Some(len) = req
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        HTTP_BYTES_IN.inc_by(len);
+    }
+    let resp = next.run(req).await;
+    let (parts, body) = resp.into_parts();
+    Response::from_parts(parts, Body::new(CountedBody { inner: body }))
+}

--- a/crates/spark-server/src/main_modules/mod.rs
+++ b/crates/spark-server/src/main_modules/mod.rs
@@ -3,12 +3,13 @@
 //! Sub-modules of `main.rs`, factored out to keep the binary entry-point file ≤500 LoC.
 
 pub(crate) mod app_state;
+pub(crate) mod byte_count;
 pub(crate) mod kv_dtypes;
 pub(crate) mod middleware;
 pub(crate) mod promotion;
 pub(crate) mod serve;
 pub(crate) mod serve_phases;
-pub(crate) mod serve_router;
+mod serve_router;
 
 #[cfg(test)]
 mod tests;

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -22,9 +22,28 @@ use crate::{
     session_manager,
 };
 
-pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
+pub(crate) async fn serve(
+    mut args: cli::ServeArgs,
+    tui_progress: Option<std::sync::mpsc::Receiver<crate::tui::capture_layer::ProgressEvent>>,
+) -> Result<()> {
     tracing::info!("Atlas Spark starting...");
     tracing::info!("Licensed under AGPL-3.0-only — see /LICENSE in this container");
+    spark_runtime::progress::phase(0, "banner");
+
+    // Clean shutdown: SIGINT/SIGTERM now request a drain-and-exit instead of
+    // killing the process mid-write. In TUI mode Ctrl+C additionally arrives
+    // as a key event (raw mode) and calls the same request().
+    crate::tui::shutdown::install_signal_listeners();
+
+    // Start the dashboard thread as early as possible so the operator watches
+    // the load, not a blank screen. Everything it reads is process-global
+    // (log ring, progress channel, metrics, scheduler snapshot) plus this
+    // args snapshot for the badge chips. Head node only.
+    if let Some(progress_rx) = tui_progress
+        && args.rank == 0
+    {
+        crate::tui::start(args.clone(), progress_rx);
+    }
 
     // Reject contradictory flag combinations up front (issue #288) — before the
     // multi-minute model load — with a message that tells humans and AI agents
@@ -34,6 +53,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     }
 
     // 0. Resolve model directory from HF ID or path
+    spark_runtime::progress::phase(1, "model resolve");
     let model_dir = serve_phases::resolve_model_dir(&args)?;
 
     tracing::info!("Port: {}", args.port);
@@ -41,6 +61,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     tracing::info!("SSM decode dtype: f32 (full precision)");
 
     // 1. Load model config (supports HF config.json and Mistral params.json)
+    spark_runtime::progress::phase(2, "config");
     let (mut config, config_json) = serve_phases::load_model_config(&model_dir)?;
 
     // CLI `--lm-head-dtype` override (replaces ATLAS_LMHEAD_BF16). Validate eagerly (PCND).
@@ -93,6 +114,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     );
 
     // 2. Select kernel target and initialize GPU backend
+    spark_runtime::progress::phase(3, "gpu init");
     //
     // Each kernel target declares which (model_type, hidden_size) pairs it supports
     // via [[model_types]] in MODEL.toml. Exact hidden_size matches win over wildcards.
@@ -197,6 +219,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     tracing::info!("OOM watchdog started (threshold: 2 GB, interval: 2s)");
 
     // 2b. Resolve TP / EP topology and set on model config.
+    spark_runtime::progress::phase(4, "topology");
     let serve_phases::Topology {
         world_size,
         tp_size: _tp_size,
@@ -212,6 +235,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     };
 
     // 3. Load model weights
+    spark_runtime::progress::phase(5, "weight load");
     let oom_reserve_bytes = args.oom_guard_mb * 1024 * 1024;
     tracing::info!("OOM guard reserve: {} MB", args.oom_guard_mb);
     let store = serve_phases::load_weight_store(
@@ -278,6 +302,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     )?;
 
     // 5. Build model via factory.
+    spark_runtime::progress::phase(6, "kv cache");
     let serve_phases::PrefillBudget {
         prefill_budget,
         max_batch_tokens,
@@ -459,6 +484,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     // (handle 0 → silent slower-fallback dispatch). Catches build/codegen
     // regressions like a dropped pipelined GEMM at load time, not as a
     // mystery slowdown.
+    spark_runtime::progress::phase(7, "kernel audit");
     tracing::info!(
         "{}",
         spark_runtime::kernel_audit::render_kernel_table(
@@ -508,6 +534,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     } = serve_phases::load_sampling_defaults(&model_dir, &args);
 
     // 6. Load tokenizer
+    spark_runtime::progress::phase(8, "tokenizer");
     // Thinking support is derived from model capabilities, not hardcoded model names.
     // Models with SSM layers or Qwen3.5-style architecture support <think> tokens.
     // The --enable-thinking flag controls OPEN-ENDED vs CLOSED thinking.
@@ -545,6 +572,7 @@ pub(crate) async fn serve(mut args: cli::ServeArgs) -> Result<()> {
     );
 
     // 7. Create scheduler channel + spawn scheduler
+    spark_runtime::progress::phase(9, "scheduler");
     let (request_tx, request_rx) = mpsc::channel::<InferenceRequest>(args.max_num_seqs);
     // LoRA adapter-rotation control channel (POST /v1/lora/active). Small: it
     // carries only control messages, applied one-at-a-time at quiescence.

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -22,10 +22,44 @@ use crate::{
     session_manager,
 };
 
+/// What the blocking startup hands to the async tail.
+type Prepared = (
+    Arc<AppState>,
+    Arc<std::sync::atomic::AtomicBool>,
+    String,
+    u16,
+);
+
+/// Bring the engine up, then serve.
+///
+/// Startup — weight load, KV allocation, kernel audit, graph capture — is ~50s of
+/// SYNCHRONOUS CPU/IO/CUDA work containing not one `await`. Running it in the body
+/// of this future would mean whatever polls the future is blocked for that whole
+/// time: an `async fn` that never yields is a blocking call wearing `async`, and
+/// it is why `q`/Ctrl+C appeared dead during a model load — nothing, not even the
+/// signal listener, could make progress until loading finished.
+///
+/// So startup runs on the blocking pool and is AWAITED here. That await is a real
+/// yield point, which is what lets `main` race this future against a shutdown
+/// channel, and it keeps the async workers free regardless of how the runtime is
+/// sized.
 pub(crate) async fn serve(
-    mut args: cli::ServeArgs,
+    args: cli::ServeArgs,
     tui_progress: Option<std::sync::mpsc::Receiver<crate::tui::capture_layer::ProgressEvent>>,
 ) -> Result<()> {
+    // Signal listeners belong on the runtime, not inside the blocking section.
+    let Some((state, model_ready, bind, port)) =
+        tokio::task::spawn_blocking(move || startup(args, tui_progress)).await??
+    else {
+        return Ok(()); // EP worker: no router on this rank
+    };
+    crate::main_modules::serve_router::build_and_serve(state, model_ready, &bind, port).await
+}
+
+fn startup(
+    mut args: cli::ServeArgs,
+    tui_progress: Option<std::sync::mpsc::Receiver<crate::tui::capture_layer::ProgressEvent>>,
+) -> Result<Option<Prepared>> {
     tracing::info!("Atlas Spark starting...");
     tracing::info!("Licensed under AGPL-3.0-only — see /LICENSE in this container");
     spark_runtime::progress::phase(0, "banner");
@@ -499,7 +533,9 @@ pub(crate) async fn serve(
     // EP worker: rank > 0 enters command loop, returns when head exits.
     let mut model_opt = Some(model);
     if serve_phases::maybe_run_ep_worker(&args, &mut model_opt, &early_high_speed_swap_cfg)? {
-        return Ok(());
+        // An EP worker (rank > 0) never serves HTTP: it ran its command loop and
+        // the head has exited. `None` = nothing for the async tail to do.
+        return Ok(None);
     }
     let model = model_opt.expect("head retains model on rank 0");
 
@@ -936,9 +972,8 @@ pub(crate) async fn serve(
 
     serve_phases::log_behavior_audit(&args, &ptx_set);
 
-    // 9-11. Build router + start HTTP server (extracted: serve_router.rs).
-    crate::main_modules::serve_router::build_and_serve(state, model_ready, &args.bind, args.port)
-        .await
+    // 9-11. Router + HTTP server run on the async side; hand them the pieces.
+    Ok(Some((state, model_ready, args.bind, args.port)))
 }
 
 /// Parse the vLLM-style `--default-chat-template-kwargs` JSON

--- a/crates/spark-server/src/main_modules/serve_router.rs
+++ b/crates/spark-server/src/main_modules/serve_router.rs
@@ -23,6 +23,7 @@ pub(crate) async fn build_and_serve(
     bind: &str,
     port: u16,
 ) -> Result<()> {
+    spark_runtime::progress::phase(10, "router");
     let cors = tower_http::cors::CorsLayer::new()
         .allow_origin(tower_http::cors::Any)
         .allow_methods([
@@ -127,6 +128,9 @@ pub(crate) async fn build_and_serve(
             require_auth_middleware,
         ))
         .layer(axum::middleware::from_fn(openai_observability_middleware))
+        .layer(axum::middleware::from_fn(
+            crate::main_modules::byte_count::byte_count_middleware,
+        ))
         .layer(cors)
         .layer(catch_panic)
         .with_state(state);
@@ -154,7 +158,9 @@ pub(crate) async fn build_and_serve(
         );
     }
     tracing::info!("Listening on {addr}");
+    spark_runtime::progress::phase(11, "listening");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
+    spark_runtime::progress::ready(port);
     serve_with_header_timeout(listener, app).await
 }
 
@@ -187,7 +193,19 @@ async fn serve_with_header_timeout(
     let mut make_service = app.into_make_service_with_connect_info::<std::net::SocketAddr>();
 
     loop {
-        let (socket, peer_addr) = match listener.accept().await {
+        let accepted = tokio::select! {
+            conn = listener.accept() => conn,
+            _ = crate::tui::shutdown::wait() => {
+                // Clean shutdown: stop accepting, give in-flight requests a
+                // bounded grace to finish, then return so `serve()` unwinds
+                // normally (Drop impls: terminal restore, tee flush).
+                crate::tui::shutdown::drain_in_flight(std::time::Duration::from_secs(15)).await;
+                crate::tui::init::flush_tee();
+                tracing::info!("Shutdown complete");
+                return Ok(());
+            }
+        };
+        let (socket, peer_addr) = match accepted {
             Ok(conn) => conn,
             Err(e) => {
                 // Transient accept errors (fd exhaustion, RST races) must not

--- a/crates/spark-server/src/main_modules/serve_router.rs
+++ b/crates/spark-server/src/main_modules/serve_router.rs
@@ -192,6 +192,10 @@ async fn serve_with_header_timeout(
 
     let mut make_service = app.into_make_service_with_connect_info::<std::net::SocketAddr>();
 
+    // Startup is over: shutdown now means "stop accepting and drain in-flight
+    // requests", so main's startup escape must no longer short-circuit it.
+    crate::tui::shutdown::disarm_startup_escape();
+
     loop {
         let accepted = tokio::select! {
             conn = listener.accept() => conn,

--- a/crates/spark-server/src/metrics.rs
+++ b/crates/spark-server/src/metrics.rs
@@ -21,6 +21,17 @@ lazy_static! {
     .unwrap();
     pub static ref GENERATION_TOKENS_TOTAL: IntCounter =
         register_int_counter!("atlas_generation_tokens_total", "Total tokens generated").unwrap();
+    // ── HTTP byte accounting (Atlas TUI Server Stats) ──
+    //
+    // Request side counts body bytes as received by the byte-count
+    // middleware; response side counts bytes actually written through the
+    // wrapped body (streaming/SSE included, where Content-Length lies).
+    pub static ref HTTP_BYTES_IN: IntCounter =
+        register_int_counter!("atlas_http_bytes_in_total", "Total HTTP request body bytes")
+            .unwrap();
+    pub static ref HTTP_BYTES_OUT: IntCounter =
+        register_int_counter!("atlas_http_bytes_out_total", "Total HTTP response body bytes")
+            .unwrap();
     pub static ref PROMPT_TOKENS_TOTAL: IntCounter =
         register_int_counter!("atlas_prompt_tokens_total", "Total prompt tokens processed")
             .unwrap();

--- a/crates/spark-server/src/model_resolver.rs
+++ b/crates/spark-server/src/model_resolver.rs
@@ -212,7 +212,7 @@ fn validate_adapter_dir(dir: PathBuf, spec: &str) -> Result<PathBuf> {
 /// True when the directory contains at least one weight file Atlas's
 /// safetensors loader can pick up. Mirrors the heuristic in
 /// `spark-runtime::weights::SafetensorsLoader::load`.
-fn snapshot_has_weights(dir: &Path) -> bool {
+pub(crate) fn snapshot_has_weights(dir: &Path) -> bool {
     let direct = [
         "model.safetensors",
         "model.safetensors.index.json",
@@ -235,7 +235,7 @@ fn snapshot_has_weights(dir: &Path) -> bool {
 
 /// Pick the most-recently-modified snapshot under `snapshots/` that actually
 /// contains weights. Returns `None` if none of the siblings have weights.
-fn find_snapshot_with_weights(snapshots_root: &Path) -> Option<PathBuf> {
+pub(crate) fn find_snapshot_with_weights(snapshots_root: &Path) -> Option<PathBuf> {
     let entries: Vec<_> = std::fs::read_dir(snapshots_root)
         .ok()?
         .filter_map(|e| e.ok())
@@ -261,7 +261,7 @@ fn find_snapshot_with_weights(snapshots_root: &Path) -> Option<PathBuf> {
 /// 2. `$HF_HUB_CACHE` env var
 /// 3. `$HF_HOME/hub` env var
 /// 4. `~/.cache/huggingface/hub`
-fn resolve_cache_root(cache_dir: Option<&Path>) -> Result<PathBuf> {
+pub(crate) fn resolve_cache_root(cache_dir: Option<&Path>) -> Result<PathBuf> {
     if let Some(dir) = cache_dir {
         return Ok(dir.to_path_buf());
     }

--- a/crates/spark-server/src/request_dumper.rs
+++ b/crates/spark-server/src/request_dumper.rs
@@ -16,12 +16,26 @@
 //! The writer is fail-open: if the file can't be written, the error
 //! is logged once and serving continues. Dump failures MUST NOT kill
 //! live requests.
+//!
+//! **The file I/O runs on a dedicated thread.** Entries are serialised by the
+//! caller and handed to that thread over a bounded queue, because the emit
+//! points sit on async request paths — `handle_done` is a sync fn called from
+//! inside the streaming future, so it cannot `await` a `spawn_blocking`. Writing
+//! inline blocked a tokio worker on a `write + flush` for every request, which is
+//! most costly precisely when `--dump` is on and someone is measuring latency.
 
 use parking_lot::Mutex;
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Queue depth for pending dump lines. Deep enough to absorb a burst without
+/// touching the request path; bounded so a stalled disk cannot grow it without
+/// limit. Overflow drops entries and says so — for a diagnostics file that is
+/// the right trade, but it must never be silent.
+const DUMP_QUEUE_DEPTH: usize = 4096;
 
 /// Shared handle installed in `AppState::dump_writer` when `--dump` is
 /// set. Cloning is cheap (Arc); all clones write to the same file
@@ -32,12 +46,36 @@ pub struct DumpHandle {
 }
 
 struct DumpInner {
-    writer: Mutex<std::io::BufWriter<std::fs::File>>,
+    /// `None` only while `Drop` is closing the queue.
+    tx: Mutex<Option<SyncSender<String>>>,
+    writer: Mutex<Option<std::thread::JoinHandle<()>>>,
     path: std::path::PathBuf,
     seq: AtomicU64,
-    /// Set once the first I/O error has been logged. Prevents the
-    /// server log from flooding if the dump target disappears.
-    io_error_logged: std::sync::atomic::AtomicBool,
+    /// Entries lost to a full queue. Logged once on the first drop so a
+    /// truncated dump file is never mistaken for a complete one.
+    dropped: AtomicU64,
+    drop_logged: std::sync::atomic::AtomicBool,
+}
+
+/// Owns the file. Runs until every `DumpHandle` is gone, then flushes and exits.
+fn writer_loop(
+    rx: std::sync::mpsc::Receiver<String>,
+    file: std::fs::File,
+    path: std::path::PathBuf,
+) {
+    let mut w = std::io::BufWriter::new(file);
+    let mut io_error_logged = false;
+    while let Ok(line) = rx.recv() {
+        // Flush per entry: a dump is read while the server is still running, and
+        // a crash must not swallow the entry that explains it.
+        if let Err(e) = w.write_all(line.as_bytes()).and_then(|_| w.flush())
+            && !io_error_logged
+        {
+            io_error_logged = true;
+            tracing::warn!(path = %path.display(), "dump write failed: {e}");
+        }
+    }
+    let _ = w.flush();
 }
 
 impl DumpHandle {
@@ -49,12 +87,19 @@ impl DumpHandle {
             .create(true)
             .append(true)
             .open(&path)?;
+        let (tx, rx) = sync_channel::<String>(DUMP_QUEUE_DEPTH);
+        let thread_path = path.clone();
+        let handle = std::thread::Builder::new()
+            .name("atlas-dump".into())
+            .spawn(move || writer_loop(rx, file, thread_path))?;
         Ok(Self {
             inner: Arc::new(DumpInner {
-                writer: Mutex::new(std::io::BufWriter::new(file)),
+                tx: Mutex::new(Some(tx)),
+                writer: Mutex::new(Some(handle)),
                 path,
                 seq: AtomicU64::new(0),
-                io_error_logged: std::sync::atomic::AtomicBool::new(false),
+                dropped: AtomicU64::new(0),
+                drop_logged: std::sync::atomic::AtomicBool::new(false),
             }),
         })
     }
@@ -131,17 +176,29 @@ impl DumpHandle {
         };
         line.push('\n');
 
-        // parking_lot::Mutex::lock() returns the guard directly and never
-        // poisons, so the prior "poisoned mutex" recovery branch is gone.
-        let mut w = self.inner.writer.lock();
-        if let Err(e) = w.write_all(line.as_bytes()).and_then(|_| w.flush()) {
-            self.log_io_error_once(&format!("dump write failed: {e}"));
+        // Hand off to the writer thread. Never blocks the caller: a full queue
+        // drops the entry rather than stalling a request on disk.
+        let guard = self.inner.tx.lock();
+        let Some(tx) = guard.as_ref() else { return };
+        if let Err(TrySendError::Full(_)) = tx.try_send(line) {
+            let n = self.inner.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+            if !self.inner.drop_logged.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    path = %self.inner.path.display(),
+                    "dump queue full — dropping entries ({n} so far); the dump file is INCOMPLETE"
+                );
+            }
         }
     }
+}
 
-    fn log_io_error_once(&self, msg: &str) {
-        if !self.inner.io_error_logged.swap(true, Ordering::Relaxed) {
-            tracing::warn!(path = %self.inner.path.display(), "{msg}");
+impl Drop for DumpInner {
+    /// Close the queue and wait for the writer to flush, so a dump file is
+    /// complete once the handle is gone.
+    fn drop(&mut self) {
+        self.tx.lock().take();
+        if let Some(h) = self.writer.lock().take() {
+            let _ = h.join();
         }
     }
 }

--- a/crates/spark-server/src/response_store.rs
+++ b/crates/spark-server/src/response_store.rs
@@ -104,15 +104,109 @@ impl StoreBackend for NoopBackend {
 /// `{dir}/{urlencoded_id}.json`. File names are URL-encoded in case an
 /// id ever contains a path separator (shouldn't happen — our ids are
 /// `resp_<uuid>` / `chatcmpl-<uuid>` — but defense in depth).
+/// Queue depth for pending disk operations. Bounded so a stalled disk cannot
+/// grow it without limit; see [`FilesystemBackend::persist`] for what happens
+/// when it fills (it does NOT drop entries — this is functional state, not
+/// diagnostics).
+const DISK_QUEUE_DEPTH: usize = 1024;
+
+enum DiskOp {
+    Persist(Box<DiskEntry>),
+    Forget(String),
+}
+
+/// Persists entries to disk from a dedicated thread.
+///
+/// `persist` and `forget` are reached from ASYNC request handlers
+/// (`finalize_responses_stream`, `translate_chat_response_to_responses`) through
+/// the sync `ResponseStore::insert`. Writing inline blocked a tokio worker on a
+/// `write + fsync-ish rename` for every completed Responses request. The work now
+/// goes to this thread; ordering is preserved because one queue carries both
+/// writes and deletes, so a persist can never be reordered past the forget that
+/// supersedes it.
 pub struct FilesystemBackend {
     dir: PathBuf,
+    /// `None` only while `Drop` is closing the queue.
+    tx: Mutex<Option<std::sync::mpsc::SyncSender<DiskOp>>>,
+    worker: Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+fn write_to_disk(dir: &std::path::Path, disk: &DiskEntry) {
+    let path = dir.join(format!("{}.json", sanitize_id(&disk.id)));
+    let tmp = path.with_extension("json.tmp");
+    let bytes = match serde_json::to_vec(disk) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("response_store: serialize failed for {}: {e}", disk.id);
+            return;
+        }
+    };
+    // Write-then-rename for crash-atomicity.
+    if let Err(e) = std::fs::write(&tmp, &bytes) {
+        tracing::warn!("response_store: write {}: {e}", tmp.display());
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        tracing::warn!("response_store: rename {}: {e}", path.display());
+    }
+}
+
+fn remove_from_disk(dir: &std::path::Path, id: &str) {
+    let path = dir.join(format!("{}.json", sanitize_id(id)));
+    if let Err(e) = std::fs::remove_file(&path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!("response_store: remove {}: {e}", path.display());
+    }
 }
 
 impl FilesystemBackend {
     pub fn new(dir: impl Into<PathBuf>) -> std::io::Result<Self> {
         let dir = dir.into();
         std::fs::create_dir_all(&dir)?;
-        Ok(Self { dir })
+        let (tx, rx) = std::sync::mpsc::sync_channel::<DiskOp>(DISK_QUEUE_DEPTH);
+        let worker_dir = dir.clone();
+        let worker = std::thread::Builder::new()
+            .name("atlas-respstore".into())
+            .spawn(move || {
+                while let Ok(op) = rx.recv() {
+                    match op {
+                        DiskOp::Persist(d) => write_to_disk(&worker_dir, &d),
+                        DiskOp::Forget(id) => remove_from_disk(&worker_dir, &id),
+                    }
+                }
+            })?;
+        Ok(Self {
+            dir,
+            tx: Mutex::new(Some(tx)),
+            worker: Mutex::new(Some(worker)),
+        })
+    }
+
+    /// Enqueue a disk op, or run it inline if the queue is full.
+    ///
+    /// Unlike the request dumper, dropping is NOT acceptable here: a lost write
+    /// means a resumable response silently disappears after a restart. Under
+    /// sustained overload we take the blocking write rather than the data loss,
+    /// and say so once.
+    fn submit(&self, op: DiskOp) {
+        let guard = self.tx.lock();
+        let Some(tx) = guard.as_ref() else {
+            return;
+        };
+        if let Err(std::sync::mpsc::TrySendError::Full(op)) = tx.try_send(op) {
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    "response_store: disk queue full — falling back to inline writes                      (persistence is keeping up poorly; requests will see the write latency)"
+                );
+            }
+            match op {
+                DiskOp::Persist(d) => write_to_disk(&self.dir, &d),
+                DiskOp::Forget(id) => remove_from_disk(&self.dir, &id),
+            }
+        }
     }
 
     fn path_for(&self, id: &str) -> PathBuf {
@@ -193,6 +287,18 @@ fn messages_to_disk_json(msgs: &[IncomingMessage]) -> serde_json::Value {
     )
 }
 
+impl Drop for FilesystemBackend {
+    /// Close the queue and wait for the writer, so a dropped store has finished
+    /// its disk work — a fresh store replaying the same directory sees every
+    /// entry the old one accepted.
+    fn drop(&mut self) {
+        self.tx.lock().take();
+        if let Some(h) = self.worker.lock().take() {
+            let _ = h.join();
+        }
+    }
+}
+
 impl StoreBackend for FilesystemBackend {
     fn persist(&self, entry: &StoredEntry) {
         let disk = DiskEntry {
@@ -204,32 +310,11 @@ impl StoreBackend for FilesystemBackend {
             body: entry.body.clone(),
             persisted_at_unix: now_unix(),
         };
-        let path = self.path_for(&entry.id);
-        let tmp = path.with_extension("json.tmp");
-        let bytes = match serde_json::to_vec(&disk) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!("response_store: serialize failed for {}: {e}", entry.id);
-                return;
-            }
-        };
-        // Write-then-rename for crash-atomicity.
-        if let Err(e) = std::fs::write(&tmp, &bytes) {
-            tracing::warn!("response_store: write {}: {e}", tmp.display());
-            return;
-        }
-        if let Err(e) = std::fs::rename(&tmp, &path) {
-            tracing::warn!("response_store: rename {}: {e}", path.display());
-        }
+        self.submit(DiskOp::Persist(Box::new(disk)));
     }
 
     fn forget(&self, id: &str) {
-        let path = self.path_for(id);
-        if let Err(e) = std::fs::remove_file(&path)
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            tracing::warn!("response_store: remove {}: {e}", path.display());
-        }
+        self.submit(DiskOp::Forget(id.to_string()));
     }
 
     fn replay(&self, ttl: Duration) -> Vec<StoredEntry> {

--- a/crates/spark-server/src/response_store.rs
+++ b/crates/spark-server/src/response_store.rs
@@ -216,10 +216,28 @@ impl FilesystemBackend {
 
 /// Strip any path separator or control chars. Our ids only contain
 /// `[a-zA-Z0-9_-]`, so this is a belt-and-braces check.
+/// Maximum stem length. Bounds the filename regardless of what a client sends,
+/// which also keeps us inside every filesystem's per-component limit.
+const MAX_STEM: usize = 96;
+
+/// Map a client-supplied response id to a safe filename stem.
+///
+/// Response ids reach this from request bodies, so the result must not be able
+/// to leave the store directory (CWE-22). The allowlist is `[A-Za-z0-9_-]` and
+/// everything else — including `.`, `/`, `\\`, NUL and every Unicode separator —
+/// becomes `_`. Excluding `.` is deliberate: with no dots, `..` cannot be
+/// expressed at all, so traversal is impossible by construction rather than by
+/// argument about what the join does. The length cap bounds the rest.
+///
+/// Dropping `.` changes the on-disk name for ids that contain one. Nothing reads
+/// ids back out of filenames — `replay` takes them from the JSON body — so the
+/// only effect is that a pre-existing file for such an id is no longer matched
+/// by `forget`; TTL replay removes it on the next start.
 fn sanitize_id(id: &str) -> String {
     id.chars()
+        .take(MAX_STEM)
         .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_') {
                 c
             } else {
                 '_'

--- a/crates/spark-server/src/response_store/tests.rs
+++ b/crates/spark-server/src/response_store/tests.rs
@@ -116,3 +116,39 @@ fn filesystem_skips_expired_on_replay() {
     // Expired file was cleaned up.
     assert!(!file.exists());
 }
+
+/// A client-supplied response id must never be able to address a file outside
+/// the store directory (CWE-22). Traversal is prevented by construction: the
+/// stem allowlist has no `.`, so `..` cannot survive sanitisation.
+#[test]
+fn sanitize_id_cannot_escape_the_store_dir() {
+    use super::sanitize_id;
+    let dir = std::path::Path::new("/var/lib/atlas/responses");
+    for hostile in [
+        "../../etc/passwd",
+        "..",
+        "../..",
+        "/etc/shadow",
+        "..\\..\\windows\\system32",
+        "resp\0/../../root",
+        "résp/../../x",
+        &"a".repeat(4096),
+    ] {
+        let stem = sanitize_id(hostile);
+        assert!(
+            !stem.contains('.') && !stem.contains('/') && !stem.contains('\\'),
+            "stem {stem:?} kept a path character"
+        );
+        assert!(
+            stem.len() <= super::MAX_STEM,
+            "stem {stem:?} exceeds the cap"
+        );
+        let p = dir.join(format!("{stem}.json"));
+        assert_eq!(
+            p.parent(),
+            Some(dir),
+            "{hostile:?} escaped to {}",
+            p.display()
+        );
+    }
+}

--- a/crates/spark-server/src/response_store/tests.rs
+++ b/crates/spark-server/src/response_store/tests.rs
@@ -72,9 +72,16 @@ fn filesystem_roundtrip_survives_restart() {
 #[test]
 fn filesystem_forgets_on_eviction() {
     let tmp = tempfile::tempdir().expect("tmpdir");
-    let store = ResponseStore::with_filesystem(1, Duration::from_secs(60), tmp.path()).expect("fs");
-    store.insert(entry("a", StoredKind::Response));
-    store.insert(entry("b", StoredKind::Response));
+    {
+        let store =
+            ResponseStore::with_filesystem(1, Duration::from_secs(60), tmp.path()).expect("fs");
+        store.insert(entry("a", StoredKind::Response));
+        store.insert(entry("b", StoredKind::Response));
+        // Disk work runs on the store's writer thread, so the observable
+        // contract is "once the store is dropped, its disk state is settled" --
+        // the same guarantee `filesystem_roundtrip_survives_restart` relies on.
+        // Asserting mid-flight would be testing scheduling, not eviction.
+    }
     // `a` evicted → file gone.
     let files: Vec<_> = std::fs::read_dir(tmp.path())
         .unwrap()

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -40,6 +40,7 @@ mod prefill_b_step;
 mod repetition;
 mod rollback;
 mod sample_step;
+pub mod snapshot;
 mod spec_step;
 mod ssm_decode_ring;
 mod types;
@@ -308,10 +309,35 @@ pub fn run(
 
     install_high_speed_swap(&*model, high_speed_swap_cfg);
 
+    let mut snapshot_steps: u64 = 0;
     loop {
         // ── Drain pending → start prefill (chunked or full) ──
         let new_reqs =
             drain_pending_requests(&pending, &active, &prefilling, &*policy, max_batch_size);
+
+        // ── Publish the observability snapshot (one uncontended lock + a
+        // ~72-byte memcpy per tick; see scheduler/snapshot.rs). ──
+        snapshot_steps += 1;
+        {
+            let (mtp_mode, delivered_tps) = match mtp_gate.as_ref() {
+                Some(g) => g.observe(),
+                None => (snapshot::MtpModeSnap::Off, 0.0),
+            };
+            snapshot::publish(snapshot::SchedulerSnapshot {
+                active_seqs: active.len() as u32,
+                prefilling_seqs: prefilling.len() as u32,
+                swapped_seqs: swapped.len() as u32,
+                pending_len: new_reqs.len() as u32,
+                kv_blocks_free: model.num_free_blocks() as u32,
+                kv_blocks_total: model.num_total_blocks() as u32,
+                ssm_slots_used: session_manager.session_count() as u32,
+                ssm_slots_total: session_manager.total_slots() as u32,
+                mtp_mode,
+                delivered_tps,
+                steps_total: snapshot_steps,
+                published_at: std::time::Instant::now(),
+            });
+        }
 
         // ── Apply queued LoRA adapter rotations at a QUIESCENT point ──
         // Only when nothing is in flight (no active decode, no in-progress

--- a/crates/spark-server/src/scheduler/mtp_gate.rs
+++ b/crates/spark-server/src/scheduler/mtp_gate.rs
@@ -162,6 +162,25 @@ pub struct MtpGate {
 }
 
 impl MtpGate {
+    /// Observability accessor for the scheduler snapshot: current mode and
+    /// the delivered-throughput EWMA of that mode (0.0 until measured).
+    pub fn observe(&self) -> (super::snapshot::MtpModeSnap, f32) {
+        use super::snapshot::MtpModeSnap;
+        let mode = if self.probing {
+            MtpModeSnap::Probing
+        } else {
+            match self.mode {
+                Mode::Mtp => MtpModeSnap::Mtp,
+                Mode::Serial => MtpModeSnap::Serial,
+            }
+        };
+        let stats = match self.mode {
+            Mode::Mtp => &self.mtp,
+            Mode::Serial => &self.serial,
+        };
+        (mode, stats.tps.unwrap_or(0.0) as f32)
+    }
+
     /// `num_drafts` is retained for construction-site compatibility and
     /// logging; arbitration is measurement-driven and does not model K.
     pub fn new(num_drafts: usize) -> Self {

--- a/crates/spark-server/src/scheduler/snapshot.rs
+++ b/crates/spark-server/src/scheduler/snapshot.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Per-tick scheduler observability snapshot.
+//!
+//! The model + all scheduler state live on a dedicated OS thread and are
+//! thread-local by design; nothing outside could observe active sequences, KV
+//! pressure, or the MTP gate. This module publishes one small `Copy` struct
+//! per loop tick — a single uncontended `parking_lot` lock + memcpy, which is
+//! unmeasurable against a multi-millisecond decode step — for the TUI (and
+//! any future observer) to read.
+//!
+//! Global-static publication (not a channel) matches the established pattern
+//! of `scheduler/helpers.rs` and avoids widening `scheduler::run`'s already
+//! huge signature.
+
+use std::time::Instant;
+
+use parking_lot::Mutex;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MtpModeSnap {
+    Mtp,
+    Serial,
+    Probing,
+    /// Speculation disabled/not applicable (no gate constructed).
+    Off,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SchedulerSnapshot {
+    pub active_seqs: u32,
+    pub prefilling_seqs: u32,
+    pub swapped_seqs: u32,
+    /// Requests drained-but-not-yet-admitted at the observation point.
+    pub pending_len: u32,
+    pub kv_blocks_free: u32,
+    pub kv_blocks_total: u32,
+    pub ssm_slots_used: u32,
+    pub ssm_slots_total: u32,
+    pub mtp_mode: MtpModeSnap,
+    /// The MTP gate's delivered-throughput EWMA for the current mode (tok/s);
+    /// 0.0 when unmeasured.
+    pub delivered_tps: f32,
+    pub steps_total: u64,
+    /// For staleness detection: a snapshot older than a few seconds means the
+    /// scheduler thread is wedged or the server is idle-parked.
+    pub published_at: Instant,
+}
+
+static SNAP: Mutex<Option<SchedulerSnapshot>> = Mutex::new(None);
+
+/// Publish the latest snapshot (scheduler thread, once per loop tick).
+pub fn publish(s: SchedulerSnapshot) {
+    *SNAP.lock() = Some(s);
+}
+
+/// Read the latest snapshot, if the scheduler has published one yet.
+pub fn read() -> Option<SchedulerSnapshot> {
+    *SNAP.lock()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_read_roundtrip() {
+        let s = SchedulerSnapshot {
+            active_seqs: 3,
+            prefilling_seqs: 1,
+            swapped_seqs: 0,
+            pending_len: 2,
+            kv_blocks_free: 100,
+            kv_blocks_total: 200,
+            ssm_slots_used: 4,
+            ssm_slots_total: 128,
+            mtp_mode: MtpModeSnap::Mtp,
+            delivered_tps: 42.5,
+            steps_total: 7,
+            published_at: Instant::now(),
+        };
+        publish(s);
+        let r = read().expect("published");
+        assert_eq!(r.active_seqs, 3);
+        assert_eq!(r.mtp_mode, MtpModeSnap::Mtp);
+    }
+}

--- a/crates/spark-server/src/tui/app.rs
+++ b/crates/spark-server/src/tui/app.rs
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! App state + input reducer. Rendering lives in `render/`; this file owns
+//! what IS, and how key/mouse events change it.
+
+use std::time::Instant;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::chat::ChatState;
+use super::data::kernels::KernelTableModel;
+use super::data::library::LibraryEntry;
+use super::data::metrics_poll::StatsModel;
+use super::progress::ProgressModel;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Section {
+    Main,
+    Stats,
+    Network,
+    Library,
+    Terminal,
+}
+
+impl Section {
+    pub const ALL: [Section; 5] = [
+        Section::Main,
+        Section::Stats,
+        Section::Network,
+        Section::Library,
+        Section::Terminal,
+    ];
+    pub fn label(self) -> &'static str {
+        match self {
+            Section::Main => "Main",
+            Section::Stats => "Stats",
+            Section::Network => "Network",
+            Section::Library => "Library",
+            Section::Terminal => "Terminal",
+        }
+    }
+    pub fn icon(self) -> &'static str {
+        match self {
+            Section::Main => "◆",
+            Section::Stats => "∿",
+            Section::Network => "⬡",
+            Section::Library => "▤",
+            Section::Terminal => "❯",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum MainSub {
+    Overview,
+    Kernels,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum TermSub {
+    Ops,
+    Chat,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Focus {
+    Sidebar,
+    Content,
+    Input,
+}
+
+pub struct Toast {
+    pub text: String,
+    pub error: bool,
+    pub at: Instant,
+}
+
+/// Ops REPL state.
+#[derive(Default)]
+pub struct OpsState {
+    pub input: String,
+    pub history: Vec<String>,
+    pub history_pos: Option<usize>,
+    pub output: Vec<String>,
+    pub scroll_up: usize,
+}
+
+pub struct App {
+    pub args: crate::cli::ServeArgs,
+    pub section: Section,
+    pub main_sub: MainSub,
+    pub term_sub: TermSub,
+    pub focus: Focus,
+    pub progress: ProgressModel,
+    pub stats: StatsModel,
+    pub started: Instant,
+    /// None = follow newest; Some(n) = scrolled up by n lines.
+    pub log_scroll: Option<usize>,
+    pub log_filter: String,
+    pub log_filter_editing: bool,
+    pub kernels: Option<KernelTableModel>,
+    pub kernel_scroll: usize,
+    pub kernel_filter: String,
+    pub library: Vec<LibraryEntry>,
+    pub lib_selected: usize,
+    pub lib_filter: String,
+    pub lib_filter_editing: bool,
+    pub network_selected: usize,
+    pub network_detail: bool,
+    pub ops: OpsState,
+    pub chat: ChatState,
+    pub toasts: Vec<Toast>,
+    pub help_open: bool,
+    pub tick: u64,
+    pub should_quit: bool,
+    pub detach: bool,
+}
+
+impl App {
+    pub fn new(args: crate::cli::ServeArgs) -> Self {
+        Self {
+            args,
+            section: Section::Main,
+            main_sub: MainSub::Overview,
+            term_sub: TermSub::Ops,
+            focus: Focus::Content,
+            progress: ProgressModel::default(),
+            stats: StatsModel::default(),
+            started: Instant::now(),
+            log_scroll: None,
+            log_filter: String::new(),
+            log_filter_editing: false,
+            kernels: None,
+            kernel_scroll: 0,
+            kernel_filter: String::new(),
+            library: Vec::new(),
+            lib_selected: 0,
+            lib_filter: String::new(),
+            lib_filter_editing: false,
+            network_selected: 0,
+            network_detail: false,
+            ops: OpsState::default(),
+            chat: ChatState::default(),
+            toasts: Vec::new(),
+            help_open: false,
+            tick: 0,
+            should_quit: false,
+            detach: false,
+        }
+    }
+
+    pub fn toast(&mut self, text: impl Into<String>, error: bool) {
+        self.toasts.push(Toast {
+            text: text.into(),
+            error,
+            at: Instant::now(),
+        });
+        if self.toasts.len() > 3 {
+            self.toasts.remove(0);
+        }
+    }
+
+    pub fn on_tick(&mut self) {
+        self.tick += 1;
+        self.progress.ease_tick();
+        // Info toasts auto-dismiss after 5s; errors persist.
+        self.toasts
+            .retain(|t| t.error || t.at.elapsed().as_secs() < 5);
+        // Refresh the kernel table once when startup completes.
+        if self.progress.ready && self.kernels.is_none() {
+            let model = super::data::kernels::build();
+            if !model.missing.is_empty() {
+                let n = model.missing.len();
+                self.toast(
+                    format!("{n} kernel lookup(s) unresolved — Main ▸ Kernels"),
+                    false,
+                );
+            }
+            self.kernels = Some(model);
+        }
+    }
+
+    /// True when a text input owns the keyboard.
+    fn in_input(&self) -> bool {
+        self.log_filter_editing
+            || self.lib_filter_editing
+            || (self.section == Section::Terminal && self.focus == Focus::Input)
+    }
+
+    pub fn on_key(&mut self, key: KeyEvent) {
+        // Ctrl+C always requests clean shutdown (raw mode swallows SIGINT).
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            super::shutdown::request("Ctrl+C");
+            self.should_quit = true;
+            return;
+        }
+        if self.help_open {
+            self.help_open = false;
+            return;
+        }
+        if self.in_input() {
+            self.on_input_key(key);
+            return;
+        }
+        match key.code {
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('?') => self.help_open = true,
+            KeyCode::Char('1') => self.jump(Section::Main),
+            KeyCode::Char('2') => self.jump(Section::Stats),
+            KeyCode::Char('3') => self.jump(Section::Network),
+            KeyCode::Char('4') => self.jump(Section::Library),
+            KeyCode::Char('5') => self.jump(Section::Terminal),
+            KeyCode::Tab => self.cycle_section(1),
+            KeyCode::BackTab => self.cycle_section(-1),
+            KeyCode::Char('f') if self.section == Section::Main => {
+                self.log_filter_editing = true;
+            }
+            KeyCode::Char('/') if self.section == Section::Library => {
+                self.lib_filter_editing = true;
+            }
+            KeyCode::Char('i') | KeyCode::Enter
+                if self.section == Section::Terminal && self.focus != Focus::Input =>
+            {
+                self.focus = Focus::Input;
+            }
+            KeyCode::Esc => {
+                self.focus = Focus::Content;
+                self.log_scroll = None;
+            }
+            _ => self.on_section_key(key),
+        }
+    }
+
+    fn jump(&mut self, s: Section) {
+        if self.section == s {
+            // Repeat-press toggles the section's subsections.
+            match s {
+                Section::Main => {
+                    self.main_sub = if self.main_sub == MainSub::Overview {
+                        MainSub::Kernels
+                    } else {
+                        MainSub::Overview
+                    };
+                }
+                Section::Terminal => {
+                    self.term_sub = if self.term_sub == TermSub::Ops {
+                        TermSub::Chat
+                    } else {
+                        TermSub::Ops
+                    };
+                }
+                _ => {}
+            }
+        }
+        self.section = s;
+        self.focus = Focus::Content;
+    }
+
+    fn cycle_section(&mut self, dir: i32) {
+        let i = Section::ALL
+            .iter()
+            .position(|s| *s == self.section)
+            .unwrap_or(0) as i32;
+        let n = Section::ALL.len() as i32;
+        self.section = Section::ALL[((i + dir).rem_euclid(n)) as usize];
+    }
+
+    fn on_section_key(&mut self, key: KeyEvent) {
+        let down = matches!(key.code, KeyCode::Down | KeyCode::Char('j'));
+        let up = matches!(key.code, KeyCode::Up | KeyCode::Char('k'));
+        match self.section {
+            Section::Main => match self.main_sub {
+                MainSub::Overview => {
+                    if up {
+                        let cur = self.log_scroll.unwrap_or(0);
+                        self.log_scroll = Some(cur + 1);
+                    } else if down {
+                        match self.log_scroll {
+                            Some(1) | None => self.log_scroll = None,
+                            Some(n) => self.log_scroll = Some(n - 1),
+                        }
+                    } else if matches!(key.code, KeyCode::Char('G') | KeyCode::End) {
+                        self.log_scroll = None;
+                    }
+                }
+                MainSub::Kernels => {
+                    if down {
+                        self.kernel_scroll = self.kernel_scroll.saturating_add(1);
+                    } else if up {
+                        self.kernel_scroll = self.kernel_scroll.saturating_sub(1);
+                    } else if matches!(key.code, KeyCode::Char('g')) {
+                        self.kernel_scroll = 0;
+                    }
+                }
+            },
+            Section::Library => {
+                let len = self.filtered_library().len();
+                if down && len > 0 {
+                    self.lib_selected = (self.lib_selected + 1).min(len - 1);
+                } else if up {
+                    self.lib_selected = self.lib_selected.saturating_sub(1);
+                }
+            }
+            Section::Network => {
+                let n = self.args.world_size.max(1);
+                if matches!(key.code, KeyCode::Right | KeyCode::Char('l')) && n > 1 {
+                    self.network_selected = (self.network_selected + 1).min(n - 1);
+                } else if matches!(key.code, KeyCode::Left | KeyCode::Char('h')) {
+                    self.network_selected = self.network_selected.saturating_sub(1);
+                } else if key.code == KeyCode::Enter {
+                    self.network_detail = !self.network_detail;
+                }
+            }
+            Section::Terminal | Section::Stats => {}
+        }
+    }
+
+    fn on_input_key(&mut self, key: KeyEvent) {
+        // Which buffer?
+        if self.log_filter_editing {
+            edit_line(&mut self.log_filter, key, &mut self.log_filter_editing);
+            return;
+        }
+        if self.lib_filter_editing {
+            edit_line(&mut self.lib_filter, key, &mut self.lib_filter_editing);
+            self.lib_selected = 0;
+            return;
+        }
+        // Terminal input.
+        match self.term_sub {
+            TermSub::Ops => match key.code {
+                KeyCode::Esc => self.focus = Focus::Content,
+                KeyCode::Enter => {
+                    let line = std::mem::take(&mut self.ops.input);
+                    if !line.trim().is_empty() {
+                        self.ops.history.push(line.clone());
+                        self.ops.history_pos = None;
+                        super::commands::execute(&line, self);
+                    }
+                }
+                KeyCode::Up => {
+                    let h = &self.ops.history;
+                    if !h.is_empty() {
+                        let pos = match self.ops.history_pos {
+                            None => h.len() - 1,
+                            Some(p) => p.saturating_sub(1),
+                        };
+                        self.ops.history_pos = Some(pos);
+                        self.ops.input = h[pos].clone();
+                    }
+                }
+                KeyCode::Backspace => {
+                    self.ops.input.pop();
+                }
+                KeyCode::Char(c) => self.ops.input.push(c),
+                _ => {}
+            },
+            TermSub::Chat => match key.code {
+                KeyCode::Esc => {
+                    self.chat.cancel();
+                    self.focus = Focus::Content;
+                }
+                // Enter sends; a trailing backslash continues onto a new
+                // line (Ctrl+Enter is indistinguishable from Enter in legacy
+                // terminal protocols, so it cannot be the only send chord).
+                KeyCode::Enter => {
+                    if let Some(stripped) = self.chat.input.strip_suffix('\\') {
+                        self.chat.input = format!("{stripped}\n");
+                    } else {
+                        self.chat.send(self.args.port);
+                    }
+                }
+                KeyCode::Backspace => {
+                    self.chat.input.pop();
+                }
+                KeyCode::Char(c) => self.chat.input.push(c),
+                _ => {}
+            },
+        }
+    }
+
+    pub fn filtered_library(&self) -> Vec<&LibraryEntry> {
+        let f = self.lib_filter.to_lowercase();
+        self.library
+            .iter()
+            .filter(|e| f.is_empty() || e.id.to_lowercase().contains(&f))
+            .collect()
+    }
+
+    pub fn sidebar_click(&mut self, row_in_sidebar: usize) {
+        // Rows are laid out by render/mod.rs: one section per visual row,
+        // in Section::ALL order (subsection rows are handled there).
+        if let Some(s) = Section::ALL.get(row_in_sidebar) {
+            self.jump(*s);
+        }
+    }
+}
+
+/// Minimal single-line editor for the two filter boxes.
+fn edit_line(buf: &mut String, key: KeyEvent, editing: &mut bool) {
+    match key.code {
+        KeyCode::Esc => {
+            buf.clear();
+            *editing = false;
+        }
+        KeyCode::Enter => *editing = false,
+        KeyCode::Backspace => {
+            buf.pop();
+        }
+        KeyCode::Char(c) => buf.push(c),
+        _ => {}
+    }
+}

--- a/crates/spark-server/src/tui/app.rs
+++ b/crates/spark-server/src/tui/app.rs
@@ -347,6 +347,19 @@ impl App {
                     self.network_detail = !self.network_detail;
                 }
             }
+            Section::Terminal if self.term_sub == TermSub::Chat => {
+                if up {
+                    self.chat.scroll_by(1);
+                } else if down {
+                    self.chat.scroll_by(-1);
+                } else if matches!(key.code, KeyCode::PageUp) {
+                    self.chat.scroll_by(10);
+                } else if matches!(key.code, KeyCode::PageDown) {
+                    self.chat.scroll_by(-10);
+                } else if matches!(key.code, KeyCode::Char('G') | KeyCode::End) {
+                    self.chat.follow();
+                }
+            }
             Section::Terminal | Section::Stats => {}
         }
     }
@@ -409,6 +422,14 @@ impl App {
                 KeyCode::Backspace => {
                     self.chat.input.pop();
                 }
+                // Transcript scrollback stays live while the input holds focus —
+                // that is where you are while a reply streams, and Up/Down are
+                // otherwise unused here (unlike Ops, which spends them on history).
+                KeyCode::Up => self.chat.scroll_by(1),
+                KeyCode::Down => self.chat.scroll_by(-1),
+                KeyCode::PageUp => self.chat.scroll_by(10),
+                KeyCode::PageDown => self.chat.scroll_by(-10),
+                KeyCode::End => self.chat.follow(),
                 KeyCode::Char(c) => self.chat.input.push(c),
                 _ => {}
             },
@@ -448,47 +469,7 @@ fn edit_line(buf: &mut String, key: KeyEvent, editing: &mut bool) {
     }
 }
 
+// Nav-order tests live in their own mount to keep this file under the 500 LoC cap.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The ⇥ order must contain the subsection rows, in the order the sidebar draws
-    /// them. This is the regression: the traversal list was top-level-only, so
-    /// Main ▸ Kernels and Terminal ▸ Chat could not be reached with Tab at all.
-    #[test]
-    fn nav_rows_include_subsections_in_sidebar_order() {
-        let labels: Vec<String> = App::nav_rows()
-            .iter()
-            .map(|(s, i)| match s.subs().get(*i) {
-                Some(sub) => format!("{}/{}", s.label(), sub),
-                None => s.label().to_string(),
-            })
-            .collect();
-        assert_eq!(
-            labels,
-            [
-                "Main/Overview",
-                "Main/Kernels",
-                "Stats",
-                "Network",
-                "Library",
-                "Terminal/Ops",
-                "Terminal/Chat",
-            ]
-        );
-    }
-
-    /// A section without subsections must still contribute exactly one stop, or ⇥
-    /// would silently skip it.
-    #[test]
-    fn every_section_is_reachable() {
-        let rows = App::nav_rows();
-        for s in Section::ALL {
-            assert!(
-                rows.iter().any(|(r, _)| *r == s),
-                "{} unreachable",
-                s.label()
-            );
-        }
-    }
-}
+#[path = "app_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/tui/app.rs
+++ b/crates/spark-server/src/tui/app.rs
@@ -48,6 +48,17 @@ impl Section {
             Section::Terminal => "❯",
         }
     }
+    /// Subsection labels, in sidebar order. SSOT for three things that must agree:
+    /// what the sidebar draws, what a repeat section-key press cycles, and what
+    /// `⇥` stops on. They were three separate hardcoded lists, so `⇥` skipped
+    /// straight past the subsection rows the sidebar was drawing.
+    pub fn subs(self) -> &'static [&'static str] {
+        match self {
+            Section::Main => &["Overview", "Kernels"],
+            Section::Terminal => &["Ops", "Chat"],
+            Section::Stats | Section::Network | Section::Library => &[],
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -231,38 +242,63 @@ impl App {
         }
     }
 
+    /// Which subsection of `s` is active, as an index into [`Section::subs`].
+    pub fn sub_index(&self, s: Section) -> usize {
+        match s {
+            Section::Main => (self.main_sub == MainSub::Kernels) as usize,
+            Section::Terminal => (self.term_sub == TermSub::Chat) as usize,
+            _ => 0,
+        }
+    }
+
+    fn set_sub(&mut self, s: Section, i: usize) {
+        match s {
+            Section::Main => {
+                self.main_sub = if i == 0 {
+                    MainSub::Overview
+                } else {
+                    MainSub::Kernels
+                }
+            }
+            Section::Terminal => self.term_sub = if i == 0 { TermSub::Ops } else { TermSub::Chat },
+            _ => {}
+        }
+    }
+
+    /// Every navigable sidebar row, flattened in the order the sidebar draws them:
+    /// one entry per subsection, or a single entry for a section that has none.
+    fn nav_rows() -> Vec<(Section, usize)> {
+        Section::ALL
+            .iter()
+            .flat_map(|s| (0..s.subs().len().max(1)).map(move |i| (*s, i)))
+            .collect()
+    }
+
     fn jump(&mut self, s: Section) {
         if self.section == s {
-            // Repeat-press toggles the section's subsections.
-            match s {
-                Section::Main => {
-                    self.main_sub = if self.main_sub == MainSub::Overview {
-                        MainSub::Kernels
-                    } else {
-                        MainSub::Overview
-                    };
-                }
-                Section::Terminal => {
-                    self.term_sub = if self.term_sub == TermSub::Ops {
-                        TermSub::Chat
-                    } else {
-                        TermSub::Ops
-                    };
-                }
-                _ => {}
+            // Repeat-press cycles this section's subsections.
+            let n = s.subs().len();
+            if n > 1 {
+                self.set_sub(s, (self.sub_index(s) + 1) % n);
             }
         }
         self.section = s;
         self.focus = Focus::Content;
     }
 
+    /// `⇥` / `⇧⇥` walk the sidebar exactly as drawn — subsection rows included.
+    /// Previously they stepped over top-level sections only, so Main ▸ Kernels was
+    /// reachable solely by pressing `1` a second time, which nothing on screen said.
     fn cycle_section(&mut self, dir: i32) {
-        let i = Section::ALL
+        let rows = Self::nav_rows();
+        let cur = rows
             .iter()
-            .position(|s| *s == self.section)
+            .position(|(s, i)| *s == self.section && *i == self.sub_index(*s))
             .unwrap_or(0) as i32;
-        let n = Section::ALL.len() as i32;
-        self.section = Section::ALL[((i + dir).rem_euclid(n)) as usize];
+        let (s, i) = rows[((cur + dir).rem_euclid(rows.len() as i32)) as usize];
+        self.section = s;
+        self.set_sub(s, i);
+        self.focus = Focus::Content;
     }
 
     fn on_section_key(&mut self, key: KeyEvent) {
@@ -409,5 +445,50 @@ fn edit_line(buf: &mut String, key: KeyEvent, editing: &mut bool) {
         }
         KeyCode::Char(c) => buf.push(c),
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ⇥ order must contain the subsection rows, in the order the sidebar draws
+    /// them. This is the regression: the traversal list was top-level-only, so
+    /// Main ▸ Kernels and Terminal ▸ Chat could not be reached with Tab at all.
+    #[test]
+    fn nav_rows_include_subsections_in_sidebar_order() {
+        let labels: Vec<String> = App::nav_rows()
+            .iter()
+            .map(|(s, i)| match s.subs().get(*i) {
+                Some(sub) => format!("{}/{}", s.label(), sub),
+                None => s.label().to_string(),
+            })
+            .collect();
+        assert_eq!(
+            labels,
+            [
+                "Main/Overview",
+                "Main/Kernels",
+                "Stats",
+                "Network",
+                "Library",
+                "Terminal/Ops",
+                "Terminal/Chat",
+            ]
+        );
+    }
+
+    /// A section without subsections must still contribute exactly one stop, or ⇥
+    /// would silently skip it.
+    #[test]
+    fn every_section_is_reachable() {
+        let rows = App::nav_rows();
+        for s in Section::ALL {
+            assert!(
+                rows.iter().any(|(r, _)| *r == s),
+                "{} unreachable",
+                s.label()
+            );
+        }
     }
 }

--- a/crates/spark-server/src/tui/app_tests.rs
+++ b/crates/spark-server/src/tui/app_tests.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Unit tests for the [`super`] input reducer.
+
+use super::*;
+
+/// The ⇥ order must contain the subsection rows, in the order the sidebar draws
+/// them. This is the regression: the traversal list was top-level-only, so
+/// Main ▸ Kernels and Terminal ▸ Chat could not be reached with Tab at all.
+#[test]
+fn nav_rows_include_subsections_in_sidebar_order() {
+    let labels: Vec<String> = App::nav_rows()
+        .iter()
+        .map(|(s, i)| match s.subs().get(*i) {
+            Some(sub) => format!("{}/{}", s.label(), sub),
+            None => s.label().to_string(),
+        })
+        .collect();
+    assert_eq!(
+        labels,
+        [
+            "Main/Overview",
+            "Main/Kernels",
+            "Stats",
+            "Network",
+            "Library",
+            "Terminal/Ops",
+            "Terminal/Chat",
+        ]
+    );
+}
+
+/// A section without subsections must still contribute exactly one stop, or ⇥
+/// would silently skip it.
+#[test]
+fn every_section_is_reachable() {
+    let rows = App::nav_rows();
+    for s in Section::ALL {
+        assert!(
+            rows.iter().any(|(r, _)| *r == s),
+            "{} unreachable",
+            s.label()
+        );
+    }
+}
+
+/// Chat scrollback contract, mirroring the Main log pane: `None` follows the tip,
+/// and scrolling back down to (or past) the bottom restores follow rather than
+/// parking at `Some(0)`, which would freeze the view one row off the live tip.
+#[test]
+fn chat_scroll_returns_to_follow_at_the_bottom() {
+    let mut c = crate::tui::chat::ChatState::default();
+    assert_eq!(c.scroll, None, "starts following");
+    c.scroll_by(3);
+    assert_eq!(c.scroll, Some(3));
+    c.scroll_by(-1);
+    assert_eq!(c.scroll, Some(2));
+    c.scroll_by(-5); // overshoot past the bottom
+    assert_eq!(c.scroll, None, "overshoot resumes follow");
+    c.scroll_by(10);
+    c.follow();
+    assert_eq!(c.scroll, None);
+}

--- a/crates/spark-server/src/tui/capture_layer.rs
+++ b/crates/spark-server/src/tui/capture_layer.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Decodes `atlas::tui::progress` events into typed [`ProgressEvent`]s.
+//!
+//! Attached with an always-on per-layer filter for exactly that target, so
+//! progress flows regardless of `RUST_LOG` (the events are `debug!` level and
+//! invisible to the fmt layer at the default `info` filter — the plain-log
+//! grep contract is untouched).
+
+use std::sync::mpsc::Sender;
+
+use tracing::field::{Field, Visit};
+
+/// Typed startup-progress event. Mirrors the schema in
+/// `spark_runtime::progress` (the `ev` field discriminates).
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProgressEvent {
+    Phase {
+        phase: u8,
+        name: String,
+    },
+    Preflight {
+        disk_gb: f64,
+        free_gb: f64,
+    },
+    ShardStart {
+        shard: u64,
+        total: u64,
+        name: String,
+    },
+    ShardDone {
+        shard: u64,
+        total: u64,
+        used_gb: f64,
+        free_gb: f64,
+    },
+    Layer {
+        layer: u64,
+        total: u64,
+    },
+    Ready {
+        port: u16,
+    },
+}
+
+/// Field bag filled by the visitor; `decode` shapes it by `ev`.
+#[derive(Default)]
+struct Fields {
+    ev: String,
+    name: String,
+    phase: u64,
+    shard: u64,
+    total: u64,
+    layer: u64,
+    port: u64,
+    disk_gb: f64,
+    free_gb: f64,
+    used_gb: f64,
+}
+
+impl Visit for Fields {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "phase" => self.phase = value,
+            "shard" => self.shard = value,
+            "total" => self.total = value,
+            "layer" => self.layer = value,
+            "port" => self.port = value,
+            _ => {}
+        }
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_u64(field, value.max(0) as u64);
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        match field.name() {
+            "disk_gb" => self.disk_gb = value,
+            "free_gb" => self.free_gb = value,
+            "used_gb" => self.used_gb = value,
+            _ => {}
+        }
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "ev" => self.ev = value.to_string(),
+            "name" => self.name = value.to_string(),
+            _ => {}
+        }
+    }
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}
+
+fn decode(f: Fields) -> Option<ProgressEvent> {
+    Some(match f.ev.as_str() {
+        "phase" => ProgressEvent::Phase {
+            phase: f.phase.min(u8::MAX as u64) as u8,
+            name: f.name,
+        },
+        "preflight" => ProgressEvent::Preflight {
+            disk_gb: f.disk_gb,
+            free_gb: f.free_gb,
+        },
+        "shard_start" => ProgressEvent::ShardStart {
+            shard: f.shard,
+            total: f.total,
+            name: f.name,
+        },
+        "shard_done" => ProgressEvent::ShardDone {
+            shard: f.shard,
+            total: f.total,
+            used_gb: f.used_gb,
+            free_gb: f.free_gb,
+        },
+        "layer" => ProgressEvent::Layer {
+            layer: f.layer,
+            total: f.total,
+        },
+        "ready" => ProgressEvent::Ready {
+            port: f.port.min(u16::MAX as u64) as u16,
+        },
+        _ => return None,
+    })
+}
+
+/// The layer. Send end of a channel drained by the TUI thread each tick.
+/// Sends never block; if the TUI is gone the error is ignored (server keeps
+/// serving without a dashboard).
+pub struct ProgressCaptureLayer {
+    tx: Sender<ProgressEvent>,
+}
+
+impl ProgressCaptureLayer {
+    pub fn new(tx: Sender<ProgressEvent>) -> Self {
+        Self { tx }
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for ProgressCaptureLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().target() != spark_runtime::progress::TARGET {
+            return;
+        }
+        let mut f = Fields::default();
+        event.record(&mut f);
+        if let Some(ev) = decode(f) {
+            let _ = self.tx.send(ev);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[test]
+    fn decodes_progress_events_and_ignores_others() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let sub = tracing_subscriber::registry().with(ProgressCaptureLayer::new(tx));
+        tracing::subscriber::with_default(sub, || {
+            spark_runtime::progress::phase(3, "gpu init");
+            spark_runtime::progress::shard_start(2, 26, "model-00002.safetensors");
+            tracing::info!("an ordinary log line");
+            spark_runtime::progress::ready(8888);
+        });
+        let got: Vec<ProgressEvent> = rx.try_iter().collect();
+        assert_eq!(
+            got,
+            vec![
+                ProgressEvent::Phase {
+                    phase: 3,
+                    name: "gpu init".into()
+                },
+                ProgressEvent::ShardStart {
+                    shard: 2,
+                    total: 26,
+                    name: "model-00002.safetensors".into()
+                },
+                ProgressEvent::Ready { port: 8888 },
+            ]
+        );
+    }
+}

--- a/crates/spark-server/src/tui/chat.rs
+++ b/crates/spark-server/src/tui/chat.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Chat tab backend: a loopback SSE client against this server's own
+//! `/v1/chat/completions`. Requests traverse the normal HTTP path —
+//! indistinguishable from an external client, zero scheduler coupling.
+//!
+//! The request runs on the tokio runtime (Handle captured at TUI start); the
+//! stream's deltas cross to the TUI thread over a std mpsc that the event
+//! loop drains each tick.
+
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::time::Instant;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Role {
+    User,
+    Model,
+}
+
+pub struct ChatMessage {
+    pub role: Role,
+    pub text: String,
+    /// Reply footer stats (model messages, once complete).
+    pub ttft_ms: Option<f64>,
+    pub tok_per_s: Option<f64>,
+    pub tokens: usize,
+}
+
+pub enum ChatDelta {
+    Token(String),
+    Done {
+        ttft_ms: Option<f64>,
+        tok_per_s: Option<f64>,
+        tokens: usize,
+    },
+    Error(String),
+}
+
+#[derive(Default)]
+pub struct ChatState {
+    pub transcript: Vec<ChatMessage>,
+    pub input: String,
+    pub streaming: bool,
+    rx: Option<Receiver<ChatDelta>>,
+    cancel: Option<tokio::sync::oneshot::Sender<()>>,
+    runtime: Option<tokio::runtime::Handle>,
+}
+
+impl ChatState {
+    pub fn set_runtime(&mut self, handle: tokio::runtime::Handle) {
+        self.runtime = Some(handle);
+    }
+
+    /// Send the current input as a user message and start streaming a reply.
+    pub fn send(&mut self, port: u16) {
+        let prompt = self.input.trim().to_string();
+        if prompt.is_empty() || self.streaming {
+            return;
+        }
+        self.input.clear();
+        self.transcript.push(ChatMessage {
+            role: Role::User,
+            text: prompt.clone(),
+            ttft_ms: None,
+            tok_per_s: None,
+            tokens: 0,
+        });
+        self.transcript.push(ChatMessage {
+            role: Role::Model,
+            text: String::new(),
+            ttft_ms: None,
+            tok_per_s: None,
+            tokens: 0,
+        });
+        let Some(rt) = self.runtime.clone() else {
+            if let Some(last) = self.transcript.last_mut() {
+                last.text = "(chat unavailable: no runtime handle)".into();
+            }
+            return;
+        };
+        let (tx, rx) = channel();
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+        self.rx = Some(rx);
+        self.cancel = Some(cancel_tx);
+        self.streaming = true;
+        // History (excluding the empty model placeholder) for multi-turn.
+        let messages: Vec<(String, String)> = self
+            .transcript
+            .iter()
+            .filter(|m| !(m.role == Role::Model && m.text.is_empty()))
+            .map(|m| {
+                (
+                    match m.role {
+                        Role::User => "user".to_string(),
+                        Role::Model => "assistant".to_string(),
+                    },
+                    m.text.clone(),
+                )
+            })
+            .collect();
+        rt.spawn(async move {
+            tokio::select! {
+                _ = stream_chat(port, messages, tx.clone()) => {}
+                _ = cancel_rx => {
+                    let _ = tx.send(ChatDelta::Done { ttft_ms: None, tok_per_s: None, tokens: 0 });
+                }
+            }
+        });
+    }
+
+    pub fn cancel(&mut self) {
+        if let Some(c) = self.cancel.take() {
+            let _ = c.send(());
+        }
+    }
+
+    /// Drain pending deltas into the transcript (event-loop tick).
+    pub fn pump(&mut self) {
+        let Some(rx) = &self.rx else { return };
+        let deltas: Vec<ChatDelta> = rx.try_iter().collect();
+        for d in deltas {
+            match d {
+                ChatDelta::Token(t) => {
+                    if let Some(m) = self.transcript.last_mut() {
+                        m.text.push_str(&t);
+                        m.tokens += 1;
+                    }
+                }
+                ChatDelta::Done {
+                    ttft_ms,
+                    tok_per_s,
+                    tokens,
+                } => {
+                    if let Some(m) = self.transcript.last_mut() {
+                        m.ttft_ms = ttft_ms;
+                        m.tok_per_s = tok_per_s;
+                        if tokens > 0 {
+                            m.tokens = tokens;
+                        }
+                    }
+                    self.streaming = false;
+                    self.rx = None;
+                    self.cancel = None;
+                    return;
+                }
+                ChatDelta::Error(e) => {
+                    if let Some(m) = self.transcript.last_mut() {
+                        m.text = format!("(error: {e})");
+                    }
+                    self.streaming = false;
+                    self.rx = None;
+                    self.cancel = None;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// POST the chat request and forward SSE deltas. Plain HTTP/1.1 over a
+/// loopback TcpStream — no TLS, no client stack beyond tokio's.
+async fn stream_chat(port: u16, messages: Vec<(String, String)>, tx: Sender<ChatDelta>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let started = Instant::now();
+    let mut first_token: Option<Instant> = None;
+    let mut tokens = 0usize;
+
+    let body = serde_json::json!({
+        "model": "atlas-tui",
+        "stream": true,
+        "messages": messages
+            .iter()
+            .map(|(role, content)| serde_json::json!({"role": role, "content": content}))
+            .collect::<Vec<_>>(),
+    })
+    .to_string();
+
+    let mut stream = match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = tx.send(ChatDelta::Error(format!("connect: {e}")));
+            return;
+        }
+    };
+    let req = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\
+         Content-Type: application/json\r\nAccept: text/event-stream\r\n\
+         Connection: close\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    if let Err(e) = stream.write_all(req.as_bytes()).await {
+        let _ = tx.send(ChatDelta::Error(format!("write: {e}")));
+        return;
+    }
+
+    // Read the whole response incrementally; parse SSE `data:` lines from the
+    // (possibly chunked) body. Chunked framing is tolerated by line-splitting:
+    // SSE data lines never contain bare hex-length lines' shape ambiguity in
+    // practice because each chunk boundary falls between lines for this
+    // server (axum writes whole events).
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 8192];
+    let mut header_done = false;
+    let mut consumed = 0usize;
+    loop {
+        let n = match stream.read(&mut tmp).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) => {
+                let _ = tx.send(ChatDelta::Error(format!("read: {e}")));
+                return;
+            }
+        };
+        buf.extend_from_slice(&tmp[..n]);
+        if !header_done {
+            if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+                let head = String::from_utf8_lossy(&buf[..pos]).to_string();
+                if !head.starts_with("HTTP/1.1 200") && !head.starts_with("HTTP/1.0 200") {
+                    let status = head.lines().next().unwrap_or("?").to_string();
+                    let _ = tx.send(ChatDelta::Error(status));
+                    return;
+                }
+                consumed = pos + 4;
+                header_done = true;
+            } else {
+                continue;
+            }
+        }
+        // Process complete lines.
+        while let Some(nl) = buf[consumed..].iter().position(|b| *b == b'\n') {
+            let line_end = consumed + nl;
+            let line = String::from_utf8_lossy(&buf[consumed..line_end])
+                .trim()
+                .to_string();
+            consumed = line_end + 1;
+            let Some(data) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            if data == "[DONE]" {
+                let ttft = first_token.map(|t| (t - started).as_secs_f64() * 1000.0);
+                let tps = first_token.map(|t| {
+                    let gen_secs = t.elapsed().as_secs_f64().max(1e-3);
+                    tokens as f64 / gen_secs
+                });
+                let _ = tx.send(ChatDelta::Done {
+                    ttft_ms: ttft,
+                    tok_per_s: tps,
+                    tokens,
+                });
+                return;
+            }
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data)
+                && let Some(delta) = v["choices"][0]["delta"]["content"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+            {
+                if first_token.is_none() {
+                    first_token = Some(Instant::now());
+                }
+                tokens += 1;
+                if tx.send(ChatDelta::Token(delta.to_string())).is_err() {
+                    return; // TUI gone
+                }
+            }
+        }
+    }
+    let _ = tx.send(ChatDelta::Done {
+        ttft_ms: None,
+        tok_per_s: None,
+        tokens,
+    });
+}
+
+fn find_subslice(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    hay.windows(needle.len()).position(|w| w == needle)
+}

--- a/crates/spark-server/src/tui/chat.rs
+++ b/crates/spark-server/src/tui/chat.rs
@@ -41,6 +41,10 @@ pub struct ChatState {
     pub transcript: Vec<ChatMessage>,
     pub input: String,
     pub streaming: bool,
+    /// Transcript viewport, in WRAPPED rows above the bottom. `None` follows the
+    /// streaming tip; `Some(n)` holds station n rows up. Same contract as the Main
+    /// log pane's `log_scroll`, so both panes answer to the same keys.
+    pub scroll: Option<usize>,
     rx: Option<Receiver<ChatDelta>>,
     cancel: Option<tokio::sync::oneshot::Sender<()>>,
     runtime: Option<tokio::runtime::Handle>,
@@ -51,6 +55,20 @@ impl ChatState {
         self.runtime = Some(handle);
     }
 
+    /// Scroll the transcript by `rows` (positive = back toward older turns).
+    /// Landing at or past the bottom restores follow, so a stream that is running
+    /// keeps painting its tip without a second keypress.
+    pub fn scroll_by(&mut self, rows: i32) {
+        let cur = self.scroll.unwrap_or(0) as i32;
+        let next = cur + rows;
+        self.scroll = if next <= 0 { None } else { Some(next as usize) };
+    }
+
+    /// Snap back to the live tip.
+    pub fn follow(&mut self) {
+        self.scroll = None;
+    }
+
     /// Send the current input as a user message and start streaming a reply.
     pub fn send(&mut self, port: u16) {
         let prompt = self.input.trim().to_string();
@@ -58,6 +76,8 @@ impl ChatState {
             return;
         }
         self.input.clear();
+        // Sending is an explicit "show me the new reply" — resume follow.
+        self.follow();
         self.transcript.push(ChatMessage {
             role: Role::User,
             text: prompt.clone(),

--- a/crates/spark-server/src/tui/commands.rs
+++ b/crates/spark-server/src/tui/commands.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Ops-tab slash commands. Every command maps to an existing SAFE mechanism —
+//! read-only globals or already-atomic setters. Nothing here races the
+//! scheduler thread's locals; commands that would (kill-seq, flush-KV, pause)
+//! are deliberately absent.
+
+use super::app::App;
+
+pub const COMMANDS: &[(&str, &str)] = &[
+    ("/help", "list commands"),
+    ("/status", "scheduler snapshot + request counters"),
+    (
+        "/metrics [substr]",
+        "in-process prometheus dump, optionally filtered",
+    ),
+    (
+        "/kernels [substr]",
+        "kernel resolution rows, optionally filtered",
+    ),
+    ("/gpu", "GPU + host memory"),
+    ("/cache", "prefix-cache hit statistics"),
+    ("/watchdog on|off", "toggle the loop watchdog"),
+    ("/detach", "leave the TUI, keep serving with plain logs"),
+    ("/quit", "clean shutdown (drain in-flight, then exit)"),
+];
+
+/// Ghost-text completion for the input line.
+pub fn complete(input: &str) -> Option<&'static str> {
+    if !input.starts_with('/') || input.contains(' ') {
+        return None;
+    }
+    COMMANDS
+        .iter()
+        .map(|(c, _)| c.split(' ').next().unwrap_or(c))
+        .find(|c| c.starts_with(input) && *c != input)
+}
+
+/// Execute one line. Output is appended to the ops pane; chat-style bare text
+/// is routed to the Chat tab's engine instead.
+pub fn execute(line: &str, app: &mut App) {
+    let line = line.trim();
+    app.ops.output.push(format!("❯ {line}"));
+    if !line.starts_with('/') {
+        app.ops
+            .output
+            .push("(bare text goes to the Chat tab — press 5 twice)".into());
+        return;
+    }
+    let mut parts = line.splitn(2, ' ');
+    let cmd = parts.next().unwrap_or("");
+    let arg = parts.next().unwrap_or("").trim();
+    match cmd {
+        "/help" => {
+            for (c, d) in COMMANDS {
+                app.ops.output.push(format!("  {c:<22} {d}"));
+            }
+        }
+        "/status" => cmd_status(app),
+        "/metrics" => cmd_metrics(app, arg),
+        "/kernels" => cmd_kernels(app, arg),
+        "/gpu" => cmd_gpu(app),
+        "/cache" => cmd_cache(app),
+        "/watchdog" => match arg {
+            "on" => {
+                crate::scheduler::set_enable_loop_watchdog(true);
+                app.ops.output.push("loop watchdog: ON".into());
+            }
+            "off" => {
+                crate::scheduler::set_enable_loop_watchdog(false);
+                app.ops.output.push("loop watchdog: OFF".into());
+            }
+            _ => app.ops.output.push("usage: /watchdog on|off".into()),
+        },
+        "/detach" => app.detach = true,
+        "/quit" => {
+            super::shutdown::request("/quit");
+            app.should_quit = true;
+        }
+        other => app
+            .ops
+            .output
+            .push(format!("unknown command {other} — /help")),
+    }
+}
+
+fn cmd_status(app: &mut App) {
+    match crate::scheduler::snapshot::read() {
+        Some(s) => {
+            app.ops.output.push(format!(
+                "  seqs: active {} · prefilling {} · swapped {} · pending {}",
+                s.active_seqs, s.prefilling_seqs, s.swapped_seqs, s.pending_len
+            ));
+            app.ops.output.push(format!(
+                "  kv blocks {}/{} free · ssm slots {}/{} used",
+                s.kv_blocks_free, s.kv_blocks_total, s.ssm_slots_used, s.ssm_slots_total
+            ));
+            app.ops.output.push(format!(
+                "  mtp {:?} · delivered {:.1} tok/s · {} steps",
+                s.mtp_mode, s.delivered_tps, s.steps_total
+            ));
+        }
+        None => app
+            .ops
+            .output
+            .push("  scheduler snapshot not yet published".into()),
+    }
+    app.ops.output.push(format!(
+        "  requests: {} total · {} active · {} gen tok · {} prompt tok",
+        crate::metrics::REQUESTS_TOTAL.get(),
+        crate::metrics::REQUESTS_ACTIVE.get(),
+        crate::metrics::GENERATION_TOKENS_TOTAL.get(),
+        crate::metrics::PROMPT_TOKENS_TOTAL.get(),
+    ));
+}
+
+fn cmd_metrics(app: &mut App, filter: &str) {
+    let mut n = 0;
+    for mf in prometheus::gather() {
+        if !filter.is_empty() && !mf.name().contains(filter) {
+            continue;
+        }
+        let kind = mf.get_field_type();
+        for m in mf.get_metric() {
+            let v = match kind {
+                prometheus::proto::MetricType::COUNTER => m.get_counter().get_value(),
+                prometheus::proto::MetricType::GAUGE => m.get_gauge().get_value(),
+                prometheus::proto::MetricType::HISTOGRAM => {
+                    m.get_histogram().get_sample_count() as f64
+                }
+                _ => continue,
+            };
+            let labels: Vec<String> = m
+                .get_label()
+                .iter()
+                .map(|l| format!("{}={}", l.name(), l.value()))
+                .collect();
+            let suffix = if labels.is_empty() {
+                String::new()
+            } else {
+                format!("{{{}}}", labels.join(","))
+            };
+            app.ops
+                .output
+                .push(format!("  {}{suffix} = {v}", mf.name()));
+            n += 1;
+            if n >= 40 {
+                app.ops
+                    .output
+                    .push("  … (narrow with /metrics <substr>)".into());
+                return;
+            }
+        }
+    }
+    if n == 0 {
+        app.ops.output.push("  (no metrics matched)".into());
+    }
+}
+
+fn cmd_kernels(app: &mut App, filter: &str) {
+    let rows = spark_runtime::kernel_audit::audit_rows();
+    let mut n = 0;
+    for (m, f, ok) in rows {
+        if !filter.is_empty() && !m.contains(filter) && !f.contains(filter) {
+            continue;
+        }
+        app.ops
+            .output
+            .push(format!("  {} {m}::{f}", if ok { "✓" } else { "✗" }));
+        n += 1;
+        if n >= 40 {
+            app.ops
+                .output
+                .push("  … (narrow with /kernels <substr>)".into());
+            return;
+        }
+    }
+    if n == 0 {
+        app.ops.output.push("  (no kernel lookups matched)".into());
+    }
+}
+
+fn cmd_gpu(app: &mut App) {
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let free = spark_runtime::cuda_backend::cuda_free_memory_bytes().map(|b| b as f64 / GIB);
+    let baseline = spark_runtime::gpu::baseline_free_bytes()
+        .map(|b| b as f64 / GIB)
+        .unwrap_or(0.0);
+    match free {
+        Some(f) => {
+            app.ops.output.push(format!(
+                "  gpu free {f:.1} GB · baseline {baseline:.1} GB · atlas ≈ {:.1} GB",
+                (baseline - f).max(0.0)
+            ));
+        }
+        None => app.ops.output.push("  gpu memory query unavailable".into()),
+    }
+}
+
+fn cmd_cache(app: &mut App) {
+    let hits = spark_runtime::prefix_cache::cache_hit_count();
+    let misses = spark_runtime::prefix_cache::cache_miss_count();
+    let toks = spark_runtime::prefix_cache::cache_hit_tokens_total();
+    let rate = if hits + misses > 0 {
+        format!("{:.1}%", hits as f64 * 100.0 / (hits + misses) as f64)
+    } else {
+        "—".into()
+    };
+    app.ops.output.push(format!(
+        "  prefix cache: {hits} hits / {misses} misses ({rate}) · {toks} tokens served warm"
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_finds_unique_prefixes() {
+        assert_eq!(complete("/ker"), Some("/kernels"));
+        assert_eq!(complete("/kernels"), None); // already complete
+        assert_eq!(complete("hello"), None); // not a slash command
+    }
+}

--- a/crates/spark-server/src/tui/commands.rs
+++ b/crates/spark-server/src/tui/commands.rs
@@ -182,7 +182,7 @@ fn cmd_kernels(app: &mut App, filter: &str) {
 
 fn cmd_gpu(app: &mut App) {
     const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
-    let free = spark_runtime::cuda_backend::cuda_free_memory_bytes().map(|b| b as f64 / GIB);
+    let free = super::data::gpu_free_bytes().map(|b| b as f64 / GIB);
     let baseline = spark_runtime::gpu::baseline_free_bytes()
         .map(|b| b as f64 / GIB)
         .unwrap_or(0.0);

--- a/crates/spark-server/src/tui/data/kernels.rs
+++ b/crates/spark-server/src/tui/data/kernels.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Kernel-table model for Main ▸ Kernels: the embedded module set joined with
+//! the runtime resolution audit — the same data `render_kernel_table` prints,
+//! as rows a real `Table` widget can sort/filter.
+
+/// One row of the kernel table.
+#[derive(Clone, Debug)]
+pub struct KernelRow {
+    pub module: String,
+    pub ptx_hash: String,
+    /// None = embedded but never requested ("-"); Some(true) = used;
+    /// Some(false) = lookup FAILED.
+    pub resolution: Option<bool>,
+}
+
+/// A (module, func) lookup that failed — the "missing" list under the table.
+#[derive(Clone, Debug)]
+pub struct MissingKernel {
+    pub module: String,
+    pub func: String,
+}
+
+pub struct KernelTableModel {
+    pub rows: Vec<KernelRow>,
+    pub missing: Vec<MissingKernel>,
+}
+
+/// FNV-1a 12-hex content hash — matches `kernel_audit::ptx_hash`.
+fn ptx_hash(bytes: &[u8]) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{:012x}", h & 0xffff_ffff_ffff)
+}
+
+/// Build the table from the binary's embedded module set + the audit rows.
+/// Cheap enough to refresh on demand (kernel resolution only happens at
+/// startup, so callers refresh once after `ready`).
+pub fn build() -> KernelTableModel {
+    let audit = spark_runtime::kernel_audit::audit_rows();
+    let mut rows: Vec<KernelRow> = atlas_kernels::ptx_modules()
+        .iter()
+        .map(|(module, blob)| {
+            let mut resolution = None;
+            for (m, _f, ok) in &audit {
+                if m == module {
+                    resolution = Some(resolution.unwrap_or(false) || *ok);
+                }
+            }
+            KernelRow {
+                module: (*module).to_string(),
+                ptx_hash: ptx_hash(blob),
+                resolution,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| a.module.cmp(&b.module));
+    let missing = audit
+        .into_iter()
+        .filter(|(_, _, ok)| !ok)
+        .map(|(module, func, _)| MissingKernel { module, func })
+        .collect();
+    KernelTableModel { rows, missing }
+}

--- a/crates/spark-server/src/tui/data/library.rs
+++ b/crates/spark-server/src/tui/data/library.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Library tab data: enumerate locally cached HF models and read their
+//! metadata from config.json — zero GPU, zero weight loading. Reuses the
+//! resolver's cache-root precedence and weights predicate so the list agrees
+//! with what `spark serve <model>` would actually find.
+
+use std::path::{Path, PathBuf};
+
+/// One locally cached model.
+#[derive(Clone, Debug)]
+pub struct LibraryEntry {
+    /// HF id, un-mangled (`org/name`).
+    pub id: String,
+    pub snapshot_dir: PathBuf,
+    pub size_bytes: u64,
+    pub has_weights: bool,
+    /// From config.json (None when parse fails — still listed).
+    pub model_type: String,
+    pub quant: String,
+    pub layers: usize,
+    pub hidden: usize,
+    pub heads: usize,
+    pub experts: usize,
+    pub context: usize,
+    /// A compiled kernel target matches this model's (model_type, hidden).
+    pub optimized: bool,
+}
+
+/// Directory size (recursive, follows no symlinks). Snapshot dirs hardlink
+/// into blobs/, so `len()` of the resolved files is the honest number.
+fn dir_size(dir: &Path) -> u64 {
+    let mut total = 0u64;
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            total += dir_size(&p);
+        } else if let Ok(md) = std::fs::metadata(&p) {
+            total += md.len();
+        }
+    }
+    total
+}
+
+/// Scan the HF cache. `cache_dir` is the `--cache-dir` override, if any.
+pub fn scan(cache_dir: Option<&Path>) -> Vec<LibraryEntry> {
+    let Ok(root) = crate::model_resolver::resolve_cache_root(cache_dir) else {
+        return Vec::new();
+    };
+    let Ok(rd) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for e in rd.flatten() {
+        let name = e.file_name().to_string_lossy().to_string();
+        let Some(mangled) = name.strip_prefix("models--") else {
+            continue;
+        };
+        let id = mangled.replace("--", "/");
+        let snapshots = e.path().join("snapshots");
+        let Some(snap) =
+            crate::model_resolver::find_snapshot_with_weights(&snapshots).or_else(|| {
+                // No weights: still list the newest snapshot if one exists.
+                std::fs::read_dir(&snapshots)
+                    .ok()?
+                    .flatten()
+                    .map(|s| s.path())
+                    .find(|p| p.is_dir())
+            })
+        else {
+            continue;
+        };
+        let has_weights = crate::model_resolver::snapshot_has_weights(&snap);
+        let mut entry = LibraryEntry {
+            id,
+            size_bytes: dir_size(&e.path().join("blobs")),
+            snapshot_dir: snap.clone(),
+            has_weights,
+            model_type: "?".into(),
+            quant: "-".into(),
+            layers: 0,
+            hidden: 0,
+            heads: 0,
+            experts: 0,
+            context: 0,
+            optimized: false,
+        };
+        if let Ok(json) = std::fs::read_to_string(snap.join("config.json"))
+            && let Ok(cfg) = atlas_core::config::parse_config(&json)
+        {
+            entry.model_type = cfg.model_type.clone();
+            entry.layers = cfg.num_hidden_layers;
+            entry.hidden = cfg.hidden_size;
+            entry.heads = cfg.num_attention_heads;
+            entry.experts = cfg.num_experts;
+            entry.context = cfg.max_position_embeddings;
+            if let Some(q) = &cfg.quantization_config {
+                entry.quant = if q.quant_algo.is_empty() {
+                    q.quant_method.clone()
+                } else {
+                    q.quant_algo.to_lowercase()
+                };
+            }
+            entry.optimized =
+                atlas_kernels::ptx_for_config(&cfg.model_type, cfg.hidden_size).is_some();
+        }
+        out.push(entry);
+    }
+    out.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+    out
+}
+
+/// Human size, GiB with one decimal above 1 GiB.
+pub fn human_size(bytes: u64) -> String {
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let g = bytes as f64 / GIB;
+    if g >= 1.0 {
+        format!("{g:.1} GB")
+    } else {
+        format!("{} MB", bytes / (1024 * 1024))
+    }
+}

--- a/crates/spark-server/src/tui/data/metrics_poll.rs
+++ b/crates/spark-server/src/tui/data/metrics_poll.rs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! 1 Hz metrics sampler: diffs the monotone prometheus counters into rates,
+//! reads the scheduler snapshot and the free-standing GPU/memory accessors,
+//! and keeps bounded histories for the Stats sparklines/charts.
+
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use crate::metrics;
+use crate::scheduler::snapshot::{self, SchedulerSnapshot};
+
+const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// Bounded numeric history for a sparkline/chart.
+#[derive(Default)]
+pub struct History {
+    pub points: VecDeque<f64>,
+    cap: usize,
+}
+
+impl History {
+    fn new(cap: usize) -> Self {
+        Self {
+            points: VecDeque::with_capacity(cap),
+            cap,
+        }
+    }
+    fn push(&mut self, v: f64) {
+        if self.points.len() == self.cap {
+            self.points.pop_front();
+        }
+        self.points.push_back(v);
+    }
+    pub fn as_u64(&self) -> Vec<u64> {
+        self.points
+            .iter()
+            .map(|v| (v.max(0.0) * 10.0) as u64)
+            .collect()
+    }
+}
+
+/// One TTFT histogram snapshot: (upper_bound_secs, cumulative_count).
+pub type TtftBuckets = Vec<(f64, u64)>;
+
+pub struct StatsModel {
+    // Totals (straight reads).
+    pub requests_total: u64,
+    pub requests_active: i64,
+    pub gen_tokens_total: u64,
+    pub prompt_tokens_total: u64,
+    pub tool_calls_total: u64,
+    pub bytes_in_total: u64,
+    pub bytes_out_total: u64,
+    // Rates (diffed per sample).
+    pub gen_tps: f64,
+    pub prompt_tps: f64,
+    pub req_rate: f64,
+    pub bytes_in_rate: f64,
+    pub bytes_out_rate: f64,
+    // Histories.
+    pub gen_tps_history: History,
+    pub req_history: History,
+    pub queue_history: History,
+    pub entropy_history: History,
+    // TTFT.
+    pub ttft_buckets: TtftBuckets,
+    pub ttft_p50_ms: Option<f64>,
+    pub ttft_p90_ms: Option<f64>,
+    // Cache & sampler.
+    pub prefix_hit_rate: Option<f64>,
+    pub prefix_hit_tokens: u64,
+    pub entropy: f64,
+    // Spec decode accept per K: (k_label, accepted, total).
+    pub spec_accept: Vec<(String, u64, u64)>,
+    // Memory.
+    pub gpu_free_gb: f64,
+    pub gpu_total_gb: f64,
+    pub atlas_used_gb: f64,
+    pub host_avail_gb: f64,
+    pub host_total_gb: f64,
+    // Scheduler.
+    pub sched: Option<SchedulerSnapshot>,
+    // Internals.
+    last_sample: Option<(Instant, Prev)>,
+}
+
+#[derive(Clone, Copy)]
+struct Prev {
+    requests: u64,
+    gen_tok: u64,
+    prompt: u64,
+    bytes_in: u64,
+    bytes_out: u64,
+}
+
+impl Default for StatsModel {
+    fn default() -> Self {
+        Self {
+            requests_total: 0,
+            requests_active: 0,
+            gen_tokens_total: 0,
+            prompt_tokens_total: 0,
+            tool_calls_total: 0,
+            bytes_in_total: 0,
+            bytes_out_total: 0,
+            gen_tps: 0.0,
+            prompt_tps: 0.0,
+            req_rate: 0.0,
+            bytes_in_rate: 0.0,
+            bytes_out_rate: 0.0,
+            gen_tps_history: History::new(120),
+            req_history: History::new(16),
+            queue_history: History::new(24),
+            entropy_history: History::new(24),
+            ttft_buckets: Vec::new(),
+            ttft_p50_ms: None,
+            ttft_p90_ms: None,
+            prefix_hit_rate: None,
+            prefix_hit_tokens: 0,
+            entropy: 0.0,
+            spec_accept: Vec::new(),
+            gpu_free_gb: 0.0,
+            gpu_total_gb: 0.0,
+            atlas_used_gb: 0.0,
+            host_avail_gb: 0.0,
+            host_total_gb: 0.0,
+            sched: None,
+            last_sample: None,
+        }
+    }
+}
+
+/// Percentile from cumulative histogram buckets (upper-bound interpolation).
+fn hist_percentile(buckets: &TtftBuckets, p: f64) -> Option<f64> {
+    let total = buckets.last().map(|(_, c)| *c)?;
+    if total == 0 {
+        return None;
+    }
+    let rank = (total as f64 * p).ceil() as u64;
+    for (ub, cum) in buckets {
+        if *cum >= rank {
+            return Some(ub * 1000.0);
+        }
+    }
+    None
+}
+
+impl StatsModel {
+    /// Take one sample. Call at ~1 Hz from the TUI event loop.
+    pub fn sample(&mut self) {
+        let now = Instant::now();
+        self.requests_total = metrics::REQUESTS_TOTAL.get();
+        self.requests_active = metrics::REQUESTS_ACTIVE.get();
+        self.gen_tokens_total = metrics::GENERATION_TOKENS_TOTAL.get();
+        self.prompt_tokens_total = metrics::PROMPT_TOKENS_TOTAL.get();
+        self.tool_calls_total = metrics::TOOL_CALLS_TOTAL.get();
+        self.bytes_in_total = metrics::HTTP_BYTES_IN.get();
+        self.bytes_out_total = metrics::HTTP_BYTES_OUT.get();
+
+        if let Some((t0, prev)) = self.last_sample {
+            let dt = now.duration_since(t0).as_secs_f64().max(0.05);
+            self.gen_tps = (self.gen_tokens_total.saturating_sub(prev.gen_tok)) as f64 / dt;
+            self.prompt_tps = (self.prompt_tokens_total.saturating_sub(prev.prompt)) as f64 / dt;
+            self.req_rate = (self.requests_total.saturating_sub(prev.requests)) as f64 / dt;
+            self.bytes_in_rate = (self.bytes_in_total.saturating_sub(prev.bytes_in)) as f64 / dt;
+            self.bytes_out_rate = (self.bytes_out_total.saturating_sub(prev.bytes_out)) as f64 / dt;
+            self.gen_tps_history.push(self.gen_tps);
+            self.req_history.push(self.req_rate);
+        }
+        self.last_sample = Some((
+            now,
+            Prev {
+                requests: self.requests_total,
+                gen_tok: self.gen_tokens_total,
+                prompt: self.prompt_tokens_total,
+                bytes_in: self.bytes_in_total,
+                bytes_out: self.bytes_out_total,
+            },
+        ));
+
+        // TTFT histogram via the prometheus proto (bucket bounds + counts).
+        self.ttft_buckets.clear();
+        for mf in prometheus::gather() {
+            if mf.name() != "atlas_time_to_first_token_seconds" {
+                continue;
+            }
+            if let Some(m) = mf.get_metric().first() {
+                for b in m.get_histogram().get_bucket() {
+                    self.ttft_buckets
+                        .push((b.upper_bound(), b.cumulative_count()));
+                }
+            }
+        }
+        self.ttft_p50_ms = hist_percentile(&self.ttft_buckets, 0.50);
+        self.ttft_p90_ms = hist_percentile(&self.ttft_buckets, 0.90);
+
+        // Spec-decode accept per K from the labeled counter vec.
+        self.spec_accept = spec_accept_from_gather();
+
+        // Prefix cache + sampler globals.
+        let hits = spark_runtime::prefix_cache::cache_hit_count();
+        let misses = spark_runtime::prefix_cache::cache_miss_count();
+        self.prefix_hit_tokens = spark_runtime::prefix_cache::cache_hit_tokens_total();
+        self.prefix_hit_rate = (hits + misses > 0).then(|| hits as f64 / (hits + misses) as f64);
+        self.entropy = spark_runtime::sampler::last_entropy() as f64;
+        self.entropy_history.push(self.entropy);
+
+        // Memory.
+        if let Some(free) = spark_runtime::cuda_backend::cuda_free_memory_bytes() {
+            self.gpu_free_gb = free as f64 / GIB;
+        }
+        if let Some(baseline) = spark_runtime::gpu::baseline_free_bytes() {
+            self.gpu_total_gb = baseline as f64 / GIB;
+            self.atlas_used_gb = (self.gpu_total_gb - self.gpu_free_gb).max(0.0);
+        }
+        if let Some((avail, total)) = host_mem_gb() {
+            self.host_avail_gb = avail;
+            self.host_total_gb = total;
+        }
+
+        // Scheduler snapshot.
+        self.sched = snapshot::read();
+        if let Some(s) = self.sched {
+            self.queue_history.push(s.pending_len as f64);
+        }
+    }
+}
+
+fn spec_accept_from_gather() -> Vec<(String, u64, u64)> {
+    use std::collections::BTreeMap;
+    let mut per_k: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    for mf in prometheus::gather() {
+        if mf.name() != "atlas_spec_decode_verify_total" {
+            continue;
+        }
+        for m in mf.get_metric() {
+            let mut k = String::new();
+            let mut outcome = String::new();
+            for l in m.get_label() {
+                match l.name() {
+                    "k" => k = l.value().to_string(),
+                    "outcome" => outcome = l.value().to_string(),
+                    _ => {}
+                }
+            }
+            let e = per_k.entry(k).or_default();
+            let v = m.get_counter().get_value() as u64;
+            e.1 += v;
+            if outcome.contains("accept") {
+                e.0 += v;
+            }
+        }
+    }
+    per_k.into_iter().map(|(k, (a, t))| (k, a, t)).collect()
+}
+
+/// (available, total) host RAM in GB, from /proc/meminfo.
+fn host_mem_gb() -> Option<(f64, f64)> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let grab = |key: &str| -> Option<f64> {
+        text.lines()
+            .find(|l| l.starts_with(key))?
+            .split_whitespace()
+            .nth(1)?
+            .parse::<f64>()
+            .ok()
+            .map(|kb| kb / (1024.0 * 1024.0))
+    };
+    Some((grab("MemAvailable:")?, grab("MemTotal:")?))
+}

--- a/crates/spark-server/src/tui/data/metrics_poll.rs
+++ b/crates/spark-server/src/tui/data/metrics_poll.rs
@@ -207,7 +207,7 @@ impl StatsModel {
         self.entropy_history.push(self.entropy);
 
         // Memory.
-        if let Some(free) = spark_runtime::cuda_backend::cuda_free_memory_bytes() {
+        if let Some(free) = super::gpu_free_bytes() {
             self.gpu_free_gb = free as f64 / GIB;
         }
         if let Some(baseline) = spark_runtime::gpu::baseline_free_bytes() {

--- a/crates/spark-server/src/tui/data/mod.rs
+++ b/crates/spark-server/src/tui/data/mod.rs
@@ -7,3 +7,20 @@
 pub mod kernels;
 pub mod library;
 pub mod metrics_poll;
+
+/// Free GPU memory in bytes, or `None` where no such query exists.
+///
+/// `spark_runtime::cuda_backend` is behind the `cuda` feature, so a bare call
+/// breaks the metal/CPU builds — which is exactly how the dashboard shipped:
+/// two call sites, no cfg, and the macOS CI job could not compile the crate.
+/// One gated accessor means the next caller cannot repeat that.
+pub fn gpu_free_bytes() -> Option<u64> {
+    #[cfg(feature = "cuda")]
+    {
+        spark_runtime::cuda_backend::cuda_free_memory_bytes()
+    }
+    #[cfg(not(feature = "cuda"))]
+    {
+        None
+    }
+}

--- a/crates/spark-server/src/tui/data/mod.rs
+++ b/crates/spark-server/src/tui/data/mod.rs
@@ -14,7 +14,7 @@ pub mod metrics_poll;
 /// breaks the metal/CPU builds — which is exactly how the dashboard shipped:
 /// two call sites, no cfg, and the macOS CI job could not compile the crate.
 /// One gated accessor means the next caller cannot repeat that.
-pub fn gpu_free_bytes() -> Option<u64> {
+pub fn gpu_free_bytes() -> Option<usize> {
     #[cfg(feature = "cuda")]
     {
         spark_runtime::cuda_backend::cuda_free_memory_bytes()

--- a/crates/spark-server/src/tui/data/mod.rs
+++ b/crates/spark-server/src/tui/data/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Read-side data plane for the dashboard: pure pollers over process-global
+//! state (prometheus counters, scheduler snapshot, kernel audit, HF cache).
+//! Nothing here touches the scheduler thread's locals.
+
+pub mod kernels;
+pub mod library;
+pub mod metrics_poll;

--- a/crates/spark-server/src/tui/events.rs
+++ b/crates/spark-server/src/tui/events.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The TUI event loop. Runs on a dedicated OS thread ("atlas-tui"),
+//! synchronous crossterm polling + a 10 Hz render tick; tokio is never on the
+//! render path. Mirrors the scheduler's dedicated-thread pattern.
+
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::Receiver;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{Event, MouseButton, MouseEventKind};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+
+use super::app::{App, Section};
+use super::capture_layer::ProgressEvent;
+use super::init::TUI_ACTIVE;
+use super::terminal_guard::TerminalGuard;
+use super::{log_ring, render, shutdown};
+
+const TICK: Duration = Duration::from_millis(100);
+const SAMPLE_EVERY: u32 = 10; // 1 Hz metrics sampling at the 10 Hz tick
+
+pub fn run(mut app: App, progress_rx: Receiver<ProgressEvent>) {
+    super::terminal_guard::install_panic_hook(
+        log_ring::dump_to,
+        super::init::tee_file_path().unwrap_or("(no tee file)"),
+    );
+    let guard = match TerminalGuard::enter() {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!("TUI unavailable ({e}); continuing with plain logs");
+            return;
+        }
+    };
+    TUI_ACTIVE.store(true, Ordering::SeqCst);
+    let mut terminal = match Terminal::new(CrosstermBackend::new(std::io::stdout())) {
+        Ok(t) => t,
+        Err(e) => {
+            drop(guard);
+            tracing::warn!("TUI terminal init failed ({e}); plain logs");
+            return;
+        }
+    };
+
+    let mut last_tick = Instant::now();
+    let mut ticks: u32 = 0;
+    let mut library_scanned = false;
+
+    loop {
+        // 1. Input (poll ≤50ms keeps both input latency and tick cadence).
+        if crossterm::event::poll(Duration::from_millis(50)).unwrap_or(false) {
+            match crossterm::event::read() {
+                Ok(Event::Key(k)) if k.kind != crossterm::event::KeyEventKind::Release => {
+                    app.on_key(k)
+                }
+                Ok(Event::Mouse(m)) => on_mouse(&mut app, m, terminal.size().ok()),
+                Ok(Event::Resize(..)) => {}
+                _ => {}
+            }
+        }
+        // 2. Data ingress.
+        for ev in progress_rx.try_iter() {
+            app.progress.apply(ev);
+        }
+        app.chat.pump();
+        // 3. Tick.
+        if last_tick.elapsed() >= TICK {
+            last_tick = Instant::now();
+            ticks = ticks.wrapping_add(1);
+            app.on_tick();
+            if ticks.is_multiple_of(SAMPLE_EVERY) {
+                app.stats.sample();
+            }
+            // Library scan: once, lazily, after entering the tab (fs-only).
+            if !library_scanned && app.section == Section::Library {
+                library_scanned = true;
+                app.library = super::data::library::scan(app.args.cache_dir.as_deref());
+            }
+        }
+        // 4. Render.
+        if let Err(e) = terminal.draw(|f| render::draw(f, &app)) {
+            tracing::warn!("TUI draw error: {e}; detaching");
+            break;
+        }
+        // 5. Exit conditions.
+        if shutdown::requested() {
+            break;
+        }
+        if app.should_quit || app.detach {
+            break;
+        }
+    }
+    TUI_ACTIVE.store(false, Ordering::SeqCst);
+    drop(guard); // restore terminal; logs fall back to stdout
+    if app.should_quit && !app.detach {
+        shutdown::request("TUI quit");
+    } else {
+        tracing::info!(
+            "TUI detached — plain logs resume (full history: {})",
+            super::init::tee_file_path().unwrap_or("-")
+        );
+    }
+}
+
+fn on_mouse(app: &mut App, m: crossterm::event::MouseEvent, size: Option<ratatui::layout::Size>) {
+    let Some(size) = size else { return };
+    let header_h: u16 = if size.height >= 28 { 3 } else { 1 };
+    let sidebar_w: u16 = if size.width >= 96 { 18 } else { 4 };
+    match m.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if m.column < sidebar_w && m.row >= header_h {
+                // Sidebar rows include expanded subsection lines; map the
+                // clicked visual row back to a section index conservatively
+                // (subsections only render under the active section).
+                let mut visual = (m.row - header_h) as usize;
+                let active_idx = Section::ALL
+                    .iter()
+                    .position(|s| *s == app.section)
+                    .unwrap_or(0);
+                let subs = match app.section {
+                    Section::Main | Section::Terminal => 2,
+                    _ => 0,
+                };
+                if visual > active_idx + subs {
+                    visual -= subs;
+                }
+                app.sidebar_click(visual);
+            }
+        }
+        MouseEventKind::ScrollUp => {
+            if app.section == Section::Main {
+                let cur = app.log_scroll.unwrap_or(0);
+                app.log_scroll = Some(cur + 3);
+            }
+        }
+        MouseEventKind::ScrollDown => {
+            if app.section == Section::Main {
+                match app.log_scroll {
+                    Some(n) if n > 3 => app.log_scroll = Some(n - 3),
+                    _ => app.log_scroll = None,
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/spark-server/src/tui/init.rs
+++ b/crates/spark-server/src/tui/init.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Subscriber installation + the switchable log writer.
+//!
+//! Plain mode (`tui::plain_mode()` true) never reaches this file — `main.rs`
+//! keeps the pre-TUI 5-line `fmt().init()` byte-for-byte, which is the format
+//! every benchmark driver greps.
+//!
+//! TUI mode installs a `Registry` with three layers:
+//!  1. fmt layer (`ansi=false`) → [`SwitchableWriter`]: every formatted line
+//!     goes to the tee FILE always (the alternate screen eats stdout, so the
+//!     file is the post-mortem record) and to raw stdout whenever the TUI is
+//!     not active (before attach / after detach / after a panic restore).
+//!  2. [`super::log_ring::LogRingLayer`] — structured lines for the log pane.
+//!  3. [`super::capture_layer::ProgressCaptureLayer`] — typed progress events,
+//!     always-on for its dedicated target.
+//!
+//! Layers 1 and 2 share `RUST_LOG` semantics via two `EnvFilter` instances
+//! built from the same spec, so the pane shows exactly what stdout would.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+
+use parking_lot::Mutex;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer as _;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use super::capture_layer::{ProgressCaptureLayer, ProgressEvent};
+use super::log_ring::LogRingLayer;
+
+/// True while the TUI owns the screen. The writer routes stdout-vs-silent on
+/// this; the event loop flips it on attach/detach.
+pub static TUI_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+static TEE: OnceLock<Mutex<BufWriter<File>>> = OnceLock::new();
+static TEE_PATH: OnceLock<String> = OnceLock::new();
+/// Raw fd of the tee file, for the guard's stderr redirection (-1 = none).
+static TEE_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+/// The tee file's raw fd, if one is open.
+pub fn tee_raw_fd() -> Option<i32> {
+    match TEE_FD.load(Ordering::Relaxed) {
+        -1 => None,
+        fd => Some(fd),
+    }
+}
+
+/// Where the tee file lives: `$ATLAS_TUI_LOG_FILE` or
+/// `~/.cache/atlas/logs/spark-serve-<pid>-<ts>.log`.
+fn tee_path() -> PathBuf {
+    if let Ok(p) = std::env::var("ATLAS_TUI_LOG_FILE") {
+        return PathBuf::from(p);
+    }
+    let base = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    PathBuf::from(base)
+        .join(".cache/atlas/logs")
+        .join(format!("spark-serve-{}-{ts}.log", std::process::id()))
+}
+
+/// The tee file's path, once installed (for the panic hook + header display).
+pub fn tee_file_path() -> Option<&'static str> {
+    TEE_PATH.get().map(String::as_str)
+}
+
+/// Flush the tee file (shutdown path).
+pub fn flush_tee() {
+    if let Some(t) = TEE.get() {
+        let _ = t.lock().flush();
+    }
+}
+
+/// `MakeWriter` whose writers tee to the log file and, when the TUI is not
+/// active, to stdout.
+#[derive(Clone, Copy)]
+pub struct SwitchableWriter;
+
+pub struct SwitchableIo;
+
+impl Write for SwitchableIo {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if let Some(t) = TEE.get() {
+            let _ = t.lock().write_all(buf);
+        }
+        if !TUI_ACTIVE.load(Ordering::Relaxed) {
+            let _ = std::io::stdout().write_all(buf);
+        }
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        flush_tee();
+        if !TUI_ACTIVE.load(Ordering::Relaxed) {
+            std::io::stdout().flush()?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SwitchableWriter {
+    type Writer = SwitchableIo;
+    fn make_writer(&'a self) -> Self::Writer {
+        SwitchableIo
+    }
+}
+
+fn env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into())
+}
+
+/// Install the TTY-mode subscriber stack. Returns the progress-event receiver
+/// hand-off is done by the caller wiring `progress_tx` into the layer here.
+pub fn install_tty_subscriber(progress_tx: Sender<ProgressEvent>) {
+    let path = tee_path();
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(f) = File::create(&path) {
+        use std::os::fd::AsRawFd;
+        TEE_FD.store(f.as_raw_fd(), Ordering::Relaxed);
+        let _ = TEE.set(Mutex::new(BufWriter::new(f)));
+        let _ = TEE_PATH.set(path.display().to_string());
+    }
+    // Filters: one instance per layer, same spec — EnvFilter is not Clone.
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_ansi(false)
+        .with_writer(SwitchableWriter)
+        .with_filter(env_filter());
+    let ring_layer = LogRingLayer.with_filter(env_filter());
+    // Progress layer: its own always-on target filter, independent of RUST_LOG.
+    let progress_layer =
+        ProgressCaptureLayer::new(progress_tx).with_filter(tracing_subscriber::filter::filter_fn(
+            |meta| meta.target() == spark_runtime::progress::TARGET,
+        ));
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(ring_layer)
+        .with(progress_layer)
+        .init();
+}

--- a/crates/spark-server/src/tui/init.rs
+++ b/crates/spark-server/src/tui/init.rs
@@ -124,8 +124,14 @@ pub fn install_tty_subscriber(progress_tx: Sender<ProgressEvent>) {
         let _ = std::fs::create_dir_all(dir);
     }
     if let Ok(f) = File::create(&path) {
-        use std::os::fd::AsRawFd;
-        TEE_FD.store(f.as_raw_fd(), Ordering::Relaxed);
+        // fd juggling is a unix concept; on Windows the tee still captures the
+        // tracing stream, only the stderr redirection in `terminal_guard` is
+        // unavailable (see `tee_raw_fd`).
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            TEE_FD.store(f.as_raw_fd(), Ordering::Relaxed);
+        }
         let _ = TEE.set(Mutex::new(BufWriter::new(f)));
         let _ = TEE_PATH.set(path.display().to_string());
     }

--- a/crates/spark-server/src/tui/log_ring.rs
+++ b/crates/spark-server/src/tui/log_ring.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Structured log capture for the TUI log pane.
+//!
+//! A `tracing_subscriber::Layer` that records every event as a typed
+//! [`LogLine`] (timestamp, level, target, message) into a process-global ring
+//! — no re-parsing of formatted text, so the pane can color/dim columns
+//! independently. The ring is global (not owned by the TUI thread) so the
+//! panic hook can dump it even when the TUI thread is the one panicking.
+//!
+//! Capacity-bounded (`CAP` lines); oldest lines drop first. Writers never
+//! block: the ring lock is uncontended in practice (log emission and one
+//! 10 Hz reader).
+
+use std::collections::VecDeque;
+use std::io::Write;
+use std::time::SystemTime;
+
+use parking_lot::Mutex;
+use tracing::Level;
+use tracing::field::{Field, Visit};
+
+/// Ring capacity in lines. ~10k lines ≈ a few MB; enough scrollback to cover
+/// a full model load plus serving history.
+const CAP: usize = 10_000;
+
+/// One captured log event.
+#[derive(Clone, Debug)]
+pub struct LogLine {
+    pub at: SystemTime,
+    pub level: Level,
+    /// Event target, e.g. `spark_model::weight_loader`.
+    pub target: String,
+    pub message: String,
+}
+
+static RING: Mutex<VecDeque<LogLine>> = Mutex::new(VecDeque::new());
+/// Monotone counter of lines ever pushed — lets the pane detect "n new lines
+/// while scrolled up" without diffing contents.
+static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn push(line: LogLine) {
+    let mut ring = RING.lock();
+    if ring.len() == CAP {
+        ring.pop_front();
+    }
+    ring.push_back(line);
+    SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Total lines ever captured (for new-line badges while scrolled).
+pub fn seq() -> u64 {
+    SEQ.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Clone out the newest `n` lines (oldest-first order preserved).
+pub fn tail(n: usize) -> Vec<LogLine> {
+    let ring = RING.lock();
+    let skip = ring.len().saturating_sub(n);
+    ring.iter().skip(skip).cloned().collect()
+}
+
+/// Panic-hook dump: newest `n` lines, plain text, to `w`. Signature is a
+/// plain `fn` so `terminal_guard::install_panic_hook` can hold it without a
+/// type dependency on this module.
+pub fn dump_to(w: &mut dyn Write, n: usize) {
+    for l in tail(n) {
+        let _ = writeln!(w, "{:>5} {} {}", l.level, l.target, l.message);
+    }
+}
+
+/// Extracts the `message` field of an event.
+#[derive(Default)]
+struct MessageVisitor(String);
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{value:?}");
+        }
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.0.push_str(value);
+        }
+    }
+}
+
+/// The capture layer. Attach with the same `EnvFilter` semantics as the fmt
+/// layer so the pane shows exactly what plain-mode stdout would have shown.
+pub struct LogRingLayer;
+
+impl<S> tracing_subscriber::Layer<S> for LogRingLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        // Progress events have their own channel; keep them out of the pane.
+        if event.metadata().target() == spark_runtime::progress::TARGET {
+            return;
+        }
+        let mut v = MessageVisitor::default();
+        event.record(&mut v);
+        push(LogLine {
+            at: SystemTime::now(),
+            level: *event.metadata().level(),
+            target: event.metadata().target().to_string(),
+            message: v.0,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_caps_and_tails() {
+        for i in 0..(CAP + 10) {
+            push(LogLine {
+                at: SystemTime::now(),
+                level: Level::INFO,
+                target: "t".into(),
+                message: format!("m{i}"),
+            });
+        }
+        let t = tail(5);
+        assert_eq!(t.len(), 5);
+        assert_eq!(t.last().unwrap().message, format!("m{}", CAP + 9));
+        assert!(seq() >= (CAP + 10) as u64);
+    }
+}

--- a/crates/spark-server/src/tui/logo.rs
+++ b/crates/spark-server/src/tui/logo.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Header logo art + CLI flag badge derivation.
+//!
+//! The logo reproduces assets/logo.svg's three chevrons as string constants —
+//! purple, cyan, green, left to right. Two variants: a 1-line `❯❯❯ Atlas` for
+//! short terminals and a 3-row half-block chevron for tall ones. During
+//! LOADING a brightness wave walks the chevrons; it stops permanently once
+//! SERVING (motion restraint per the design spec).
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use super::theme;
+
+/// Rows of one half-block chevron cell. Three cells side by side, one column
+/// gap, colored purple/cyan/green, read unmistakably as `>>>`.
+pub const CHEVRON_ROWS: [&str; 3] = ["▀█▄ ", "  ██", "▄█▀ "];
+
+/// 45%-luminance version of a brand color for the loading wave trough.
+fn dimmed(c: theme::C) -> Color {
+    let s = |v: u8| ((v as f64) * 0.45) as u8;
+    match c.color() {
+        Color::Rgb(r, g, b) => Color::Rgb(s(r), s(g), s(b)),
+        other => other, // 256-color fallback: no dim variant, keep steady
+    }
+}
+
+/// Per-chevron colors for animation step `wave` (None = steady/SERVING).
+fn chevron_colors(wave: Option<usize>) -> [Color; 3] {
+    let brand = [theme::PURPLE, theme::CYAN, theme::GREEN];
+    match wave {
+        None => brand.map(|c| c.color()),
+        Some(step) => {
+            let bright = step % 3;
+            let mut out = [Color::Reset; 3];
+            for (i, c) in brand.iter().enumerate() {
+                out[i] = if i == bright { c.color() } else { dimmed(*c) };
+            }
+            out
+        }
+    }
+}
+
+/// The 1-line logo: `❯❯❯ Atlas`.
+pub fn one_line(wave: Option<usize>) -> Line<'static> {
+    let colors = chevron_colors(wave);
+    let mut spans: Vec<Span> = colors
+        .iter()
+        .map(|c| Span::styled("❯", Style::default().fg(*c).add_modifier(Modifier::BOLD)))
+        .collect();
+    spans.push(Span::styled(
+        " Atlas",
+        theme::text().add_modifier(Modifier::BOLD),
+    ));
+    Line::from(spans)
+}
+
+/// The 3-row logo block with the wordmark. Returns exactly three lines.
+pub fn three_line(wave: Option<usize>) -> [Line<'static>; 3] {
+    let colors = chevron_colors(wave);
+    let row = |r: usize, with_wordmark: Option<(&'static str, Style)>| -> Line<'static> {
+        let mut spans: Vec<Span> = Vec::with_capacity(7);
+        spans.push(Span::raw(" "));
+        for (i, color) in colors.iter().enumerate() {
+            spans.push(Span::styled(CHEVRON_ROWS[r], Style::default().fg(*color)));
+            if i < 2 {
+                spans.push(Span::raw("  "));
+            }
+        }
+        if let Some((text, style)) = with_wordmark {
+            spans.push(Span::raw("   "));
+            spans.push(Span::styled(text, style));
+        }
+        Line::from(spans)
+    };
+    [
+        row(0, None),
+        row(
+            1,
+            Some(("A T L A S", theme::text().add_modifier(Modifier::BOLD))),
+        ),
+        row(2, Some(("I N F E R E N C E   E N G I N E", theme::dim()))),
+    ]
+}
+
+/// One flag badge chip: `label` (dim) + `value` (primary), first-word category
+/// tint applied by the caller via `tint`.
+#[derive(Clone, Debug)]
+pub struct Badge {
+    pub text: String,
+    pub tint: BadgeTint,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BadgeTint {
+    Model,   // purple
+    Quant,   // cyan
+    Role,    // green
+    Neutral, // none
+}
+
+/// Derive the header badge chips from ServeArgs — the "significant CLI flags"
+/// strip on the Main tab. Order is display order; chips wrap.
+pub fn badges(a: &crate::cli::ServeArgs) -> Vec<Badge> {
+    let mut out = Vec::new();
+    let model = a
+        .model_name
+        .clone()
+        .or_else(|| a.model.clone())
+        .unwrap_or_else(|| "<model>".into());
+    out.push(Badge {
+        text: model,
+        tint: BadgeTint::Model,
+    });
+    out.push(Badge {
+        text: format!(
+            "kv {} · lm {} · mtp {}",
+            a.kv_cache_dtype, a.lm_head_dtype, a.mtp_quantization
+        ),
+        tint: BadgeTint::Quant,
+    });
+    if a.dflash {
+        out.push(Badge {
+            text: format!("DFlash γ={}", a.dflash_gamma),
+            tint: BadgeTint::Quant,
+        });
+    } else if a.speculative || a.self_speculative || a.ngram_speculative {
+        out.push(Badge {
+            text: format!("MTP k={}", a.num_drafts + 1),
+            tint: BadgeTint::Quant,
+        });
+    } else {
+        out.push(Badge {
+            text: "spec off".into(),
+            tint: BadgeTint::Neutral,
+        });
+    }
+    out.push(Badge {
+        text: format!("batch {}", a.max_batch_size),
+        tint: BadgeTint::Neutral,
+    });
+    out.push(Badge {
+        text: format!("ctx {}", human_tokens(a.max_seq_len)),
+        tint: BadgeTint::Neutral,
+    });
+    let role = if a.rank == 0 { "head" } else { "worker" };
+    out.push(Badge {
+        text: format!(
+            "{role} {}/{} · tp{} · ep{}",
+            a.rank, a.world_size, a.tp_size, a.ep_size
+        ),
+        tint: BadgeTint::Role,
+    });
+    out.push(Badge {
+        text: format!("sched {}", a.scheduling_policy),
+        tint: BadgeTint::Neutral,
+    });
+    if a.enable_prefix_caching {
+        out.push(Badge {
+            text: format!(
+                "prefix-cache · ssm {}@{}",
+                a.ssm_cache_slots, a.ssm_checkpoint_interval
+            ),
+            tint: BadgeTint::Neutral,
+        });
+    }
+    out.push(Badge {
+        text: format!(":{}", a.port),
+        tint: BadgeTint::Neutral,
+    });
+    out
+}
+
+fn human_tokens(n: usize) -> String {
+    if n >= 1024 && n.is_multiple_of(1024) {
+        format!("{}k", n / 1024)
+    } else {
+        n.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chevron_rows_are_uniform_width() {
+        // The half-block art must be column-stable or the header shears.
+        let w = CHEVRON_ROWS[0].chars().count();
+        assert!(CHEVRON_ROWS.iter().all(|r| r.chars().count() == w));
+    }
+
+    #[test]
+    fn wave_brightens_one_chevron_at_a_time() {
+        // In truecolor mode each wave step has exactly one full-brightness
+        // chevron. (In 256-color fallback dimming is a no-op by design.)
+        unsafe { std::env::set_var("COLORTERM", "truecolor") };
+        for step in 0..3 {
+            let colors = chevron_colors(Some(step));
+            let brand: Vec<Color> = [theme::PURPLE, theme::CYAN, theme::GREEN]
+                .iter()
+                .map(|c| c.color())
+                .collect();
+            let bright = colors.iter().zip(&brand).filter(|(a, b)| a == b).count();
+            assert_eq!(bright, 1, "step {step}");
+        }
+    }
+}

--- a/crates/spark-server/src/tui/mod.rs
+++ b/crates/spark-server/src/tui/mod.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Atlas TUI — the ratatui dashboard for `spark serve`.
+//!
+//! Activation is strictly opt-out-safe: [`plain_mode`] must return `false`
+//! before any TUI machinery is touched, and when it returns `true` the caller
+//! (`main.rs`) installs the pre-TUI `tracing_subscriber::fmt().init()`
+//! UNCHANGED — that plain-log format is a compatibility contract with every
+//! benchmark driver and gate script that greps `docker logs`.
+//!
+//! Module map (each file ≤450 LoC for the CI cap):
+//!   init            subscriber stack, SwitchableWriter, tee file, TUI_ACTIVE
+//!   terminal_guard  raw-mode RAII + idempotent restore + panic hook
+//!   shutdown        one shutdown path: signals, Ctrl+C-as-key, /quit
+//!   log_ring        structured log capture + global ring for the log pane
+//!   capture_layer   typed startup-progress event decoding
+//!   progress        ProgressModel — phases/shards/layers/ETA state machine
+//!   events          input/tick event loop on the dedicated "atlas-tui" thread
+//!   app             App state + reducer (section, focus, per-tab state)
+//!   theme           palette + shared styles (brand chevron colors)
+//!   logo            header art + CLI flag badge derivation
+//!   commands        Terminal tab slash-command parser/dispatch
+//!   chat            loopback SSE chat client for the served model
+//!   data/           pollers: metrics deltas, library scan, kernel rows
+//!   render/         one file per section, pure App-state -> Frame
+
+pub mod capture_layer;
+pub mod init;
+pub mod log_ring;
+pub mod shutdown;
+pub mod terminal_guard;
+
+pub mod app;
+pub mod commands;
+pub mod events;
+pub mod logo;
+pub mod progress;
+pub mod theme;
+
+pub mod chat;
+pub mod data;
+pub mod render;
+
+use std::io::IsTerminal;
+
+/// Start the dashboard thread (head node, TTY mode only — the caller has
+/// already gated on `plain_mode`). Captures the tokio runtime handle for the
+/// chat client; everything else the TUI reads is process-global.
+pub fn start(
+    args: crate::cli::ServeArgs,
+    progress_rx: std::sync::mpsc::Receiver<capture_layer::ProgressEvent>,
+) {
+    let runtime = tokio::runtime::Handle::current();
+    match std::thread::Builder::new()
+        .name("atlas-tui".into())
+        .spawn(move || {
+            let mut app = app::App::new(args);
+            app.chat.set_runtime(runtime);
+            events::run(app, progress_rx);
+        }) {
+        Ok(handle) => {
+            *THREAD.lock() = Some(handle);
+        }
+        Err(e) => tracing::warn!("TUI thread failed to start: {e}"),
+    }
+}
+
+/// The dashboard thread's handle, for the exit-path join.
+static THREAD: parking_lot::Mutex<Option<std::thread::JoinHandle<()>>> =
+    parking_lot::Mutex::new(None);
+
+/// Exit path: ask the TUI loop to stop and wait (bounded) for it to drop its
+/// TerminalGuard. Closes the startup race where `serve()` errors in the
+/// milliseconds BEFORE the thread enters raw mode — a bare `restore()` then
+/// runs as a no-op and the thread wrecks the terminal as the process dies.
+/// After the join (or timeout), the idempotent `restore()` is the backstop.
+pub fn stop_and_join(timeout: std::time::Duration) {
+    let Some(handle) = THREAD.lock().take() else {
+        return;
+    };
+    shutdown::request("process exit");
+    let deadline = std::time::Instant::now() + timeout;
+    while !handle.is_finished() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    if handle.is_finished() {
+        let _ = handle.join();
+    }
+}
+
+/// True when the TUI must NOT start and `main.rs` keeps the byte-identical
+/// plain fmt subscriber.
+///
+/// Gates, in order: explicit `--no-tui`, `ATLAS_NO_TUI=1`, non-interactive
+/// stdout OR stdin (docker `-t` without `-i` therefore stays plain), and
+/// `TERM=dumb`. EP workers are additionally refused in `serve()` — belt and
+/// braces, since rank isn't parsed yet when this runs.
+pub fn plain_mode(no_tui_flag: bool) -> bool {
+    if no_tui_flag {
+        return true;
+    }
+    if std::env::var("ATLAS_NO_TUI").as_deref() == Ok("1") {
+        return true;
+    }
+    if !std::io::stdout().is_terminal() || !std::io::stdin().is_terminal() {
+        return true;
+    }
+    matches!(std::env::var("TERM").as_deref(), Ok("dumb") | Err(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_flag_always_wins() {
+        // Regardless of environment, --no-tui forces plain mode.
+        assert!(plain_mode(true));
+    }
+
+    #[test]
+    fn piped_test_runner_is_plain() {
+        // Under `cargo test` stdout is captured (not a TTY) => plain. This is
+        // exactly the property the benchmark rigs rely on.
+        assert!(plain_mode(false));
+    }
+}

--- a/crates/spark-server/src/tui/progress.rs
+++ b/crates/spark-server/src/tui/progress.rs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! ProgressModel — the Main tab's startup state machine.
+//!
+//! Fed typed [`ProgressEvent`]s from the capture layer; renders nothing
+//! itself. Tracks the 12-phase checklist with per-phase wall times, the
+//! GB-weighted overall bar, the current-shard bar, layer progress, a GPU
+//! memory history for the MEM sparkline, and a load-rate/ETA estimate.
+
+use std::time::Instant;
+
+use super::capture_layer::ProgressEvent;
+
+/// Display names for the 12 serve() phases, in fixed order. Indexes match the
+//  `phase` field emitted by the instrumented call sites.
+pub const PHASE_NAMES: [&str; 12] = [
+    "banner",
+    "model resolve",
+    "config",
+    "gpu init",
+    "topology",
+    "weight load",
+    "kv cache",
+    "kernel audit",
+    "tokenizer",
+    "scheduler",
+    "router",
+    "listening",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PhaseState {
+    Pending,
+    Running,
+    Done,
+}
+
+#[derive(Clone, Debug)]
+pub struct Phase {
+    pub name: &'static str,
+    pub state: PhaseState,
+    pub started: Option<Instant>,
+    pub secs: f64,
+}
+
+/// Startup progress, ready to render.
+pub struct ProgressModel {
+    pub phases: Vec<Phase>,
+    pub started_at: Instant,
+    /// Weight-load denominator from preflight (GB on disk).
+    pub disk_gb: f64,
+    pub shard: u64,
+    pub shard_total: u64,
+    pub shard_name: String,
+    pub layer: u64,
+    pub layer_total: u64,
+    pub gpu_used_gb: f64,
+    pub gpu_free_gb: f64,
+    /// GPU-used history for the MEM sparkline (bounded).
+    pub mem_history: Vec<u64>,
+    /// Ready flag + final port; flips the whole UI into SERVING.
+    pub ready: bool,
+    pub port: u16,
+    pub ready_in_secs: f64,
+    /// Smoothed displayed fractions (motion spec: d += (t-d)*0.35).
+    disp_overall: f64,
+    disp_shard: f64,
+    last_shard_seen: u64,
+}
+
+impl Default for ProgressModel {
+    fn default() -> Self {
+        Self {
+            phases: PHASE_NAMES
+                .iter()
+                .map(|n| Phase {
+                    name: n,
+                    state: PhaseState::Pending,
+                    started: None,
+                    secs: 0.0,
+                })
+                .collect(),
+            started_at: Instant::now(),
+            disk_gb: 0.0,
+            shard: 0,
+            shard_total: 0,
+            shard_name: String::new(),
+            layer: 0,
+            layer_total: 0,
+            gpu_used_gb: 0.0,
+            gpu_free_gb: 0.0,
+            mem_history: Vec::new(),
+            ready: false,
+            port: 0,
+            ready_in_secs: 0.0,
+            disp_overall: 0.0,
+            disp_shard: 0.0,
+            last_shard_seen: 0,
+        }
+    }
+}
+
+impl ProgressModel {
+    pub fn apply(&mut self, ev: ProgressEvent) {
+        match ev {
+            ProgressEvent::Phase { phase, .. } => self.enter_phase(phase as usize),
+            ProgressEvent::Preflight { disk_gb, free_gb } => {
+                self.disk_gb = disk_gb;
+                self.gpu_free_gb = free_gb;
+            }
+            ProgressEvent::ShardStart { shard, total, name } => {
+                self.shard = shard;
+                self.shard_total = total;
+                self.shard_name = name;
+                if shard != self.last_shard_seen {
+                    // Shard rollover snaps to 0 (a backward-easing bar reads
+                    // as an error, per the motion spec).
+                    self.disp_shard = 0.0;
+                    self.last_shard_seen = shard;
+                }
+            }
+            ProgressEvent::ShardDone {
+                shard,
+                total,
+                used_gb,
+                free_gb,
+            } => {
+                self.shard = shard;
+                self.shard_total = total;
+                self.gpu_used_gb = used_gb;
+                self.gpu_free_gb = free_gb;
+                self.mem_history.push((used_gb * 10.0) as u64);
+                if self.mem_history.len() > 64 {
+                    self.mem_history.remove(0);
+                }
+                self.disp_shard = 1.0;
+            }
+            ProgressEvent::Layer { layer, total } => {
+                self.layer = layer;
+                self.layer_total = total;
+            }
+            ProgressEvent::Ready { port } => {
+                self.ready = true;
+                self.port = port;
+                self.ready_in_secs = self.started_at.elapsed().as_secs_f64();
+                for p in &mut self.phases {
+                    if p.state != PhaseState::Done {
+                        Self::finish(p);
+                    }
+                }
+            }
+        }
+    }
+
+    fn enter_phase(&mut self, idx: usize) {
+        for (i, p) in self.phases.iter_mut().enumerate() {
+            match i.cmp(&idx) {
+                std::cmp::Ordering::Less => {
+                    if p.state != PhaseState::Done {
+                        Self::finish(p);
+                    }
+                }
+                std::cmp::Ordering::Equal => {
+                    if p.state == PhaseState::Pending {
+                        p.state = PhaseState::Running;
+                        p.started = Some(Instant::now());
+                    }
+                }
+                std::cmp::Ordering::Greater => {}
+            }
+        }
+    }
+
+    fn finish(p: &mut Phase) {
+        if let Some(s) = p.started {
+            p.secs = s.elapsed().as_secs_f64();
+        }
+        p.state = PhaseState::Done;
+    }
+
+    /// Overall weight-load fraction, GB-weighted when the preflight total is
+    /// known, else shard-count-weighted.
+    pub fn overall_target(&self) -> f64 {
+        if self.shard_total == 0 {
+            return if self.ready { 1.0 } else { 0.0 };
+        }
+        (self.shard as f64 / self.shard_total as f64).clamp(0.0, 1.0)
+    }
+
+    pub fn shard_target(&self) -> f64 {
+        // Within-shard tensor progress isn't streamed; the shard bar advances
+        // start(0) -> done(1), smoothed by the easing below.
+        self.disp_shard
+    }
+
+    /// Advance displayed fractions one tick (10 Hz): d += (t-d)*0.35.
+    pub fn ease_tick(&mut self) {
+        let t = self.overall_target();
+        self.disp_overall += (t - self.disp_overall) * 0.35;
+        if (t - self.disp_overall).abs() < 0.002 {
+            self.disp_overall = t;
+        }
+    }
+
+    pub fn displayed_overall(&self) -> f64 {
+        self.disp_overall
+    }
+
+    /// Load rate estimate (GB/s) and ETA seconds, when enough is known.
+    pub fn rate_eta(&self) -> Option<(f64, f64)> {
+        if self.disk_gb <= 0.0 || self.shard == 0 || self.shard_total == 0 {
+            return None;
+        }
+        let frac = self.shard as f64 / self.shard_total as f64;
+        let elapsed = self.started_at.elapsed().as_secs_f64().max(0.1);
+        let gb_done = self.disk_gb * frac;
+        let rate = gb_done / elapsed;
+        if rate <= 0.0 {
+            return None;
+        }
+        Some((rate, (self.disk_gb - gb_done) / rate))
+    }
+
+    /// Counts for the panel title: (done, total, cumulative secs).
+    pub fn phase_counts(&self) -> (usize, usize, f64) {
+        let done = self
+            .phases
+            .iter()
+            .filter(|p| p.state == PhaseState::Done)
+            .count();
+        let secs = self.started_at.elapsed().as_secs_f64();
+        (done, self.phases.len(), secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_entry_closes_earlier_phases() {
+        let mut m = ProgressModel::default();
+        m.apply(ProgressEvent::Phase {
+            phase: 0,
+            name: "banner".into(),
+        });
+        m.apply(ProgressEvent::Phase {
+            phase: 3,
+            name: "gpu init".into(),
+        });
+        assert_eq!(m.phases[0].state, PhaseState::Done);
+        assert_eq!(m.phases[1].state, PhaseState::Done);
+        assert_eq!(m.phases[3].state, PhaseState::Running);
+        assert_eq!(m.phases[4].state, PhaseState::Pending);
+    }
+
+    #[test]
+    fn ready_completes_everything() {
+        let mut m = ProgressModel::default();
+        m.apply(ProgressEvent::Phase {
+            phase: 5,
+            name: "weight load".into(),
+        });
+        m.apply(ProgressEvent::Ready { port: 8888 });
+        assert!(m.ready);
+        assert!(m.phases.iter().all(|p| p.state == PhaseState::Done));
+    }
+
+    #[test]
+    fn shard_rollover_snaps_shard_bar() {
+        let mut m = ProgressModel::default();
+        m.apply(ProgressEvent::ShardDone {
+            shard: 1,
+            total: 4,
+            used_gb: 2.0,
+            free_gb: 100.0,
+        });
+        assert_eq!(m.shard_target(), 1.0);
+        m.apply(ProgressEvent::ShardStart {
+            shard: 2,
+            total: 4,
+            name: "s2".into(),
+        });
+        assert_eq!(m.shard_target(), 0.0);
+    }
+}

--- a/crates/spark-server/src/tui/progress.rs
+++ b/crates/spark-server/src/tui/progress.rs
@@ -62,6 +62,15 @@ pub struct ProgressModel {
     pub ready: bool,
     pub port: u16,
     pub ready_in_secs: f64,
+    /// The weight-load window, which is what GB/s must be measured over.
+    /// `load_started` is stamped by the FIRST shard event -- NOT process start,
+    /// which would fold CUDA init, model resolution and preflight into the
+    /// divisor and under-report the rate. `load_secs` freezes the window when the
+    /// last shard lands; without it a finished load keeps dividing a constant
+    /// number of bytes by a growing elapsed time, so the displayed rate decays
+    /// toward zero for as long as the server runs.
+    load_started: Option<Instant>,
+    load_secs: Option<f64>,
     /// Smoothed displayed fractions (motion spec: d += (t-d)*0.35).
     disp_overall: f64,
     disp_shard: f64,
@@ -93,6 +102,8 @@ impl Default for ProgressModel {
             ready: false,
             port: 0,
             ready_in_secs: 0.0,
+            load_started: None,
+            load_secs: None,
             disp_overall: 0.0,
             disp_shard: 0.0,
             last_shard_seen: 0,
@@ -109,6 +120,8 @@ impl ProgressModel {
                 self.gpu_free_gb = free_gb;
             }
             ProgressEvent::ShardStart { shard, total, name } => {
+                // First shard opens the load window.
+                self.load_started.get_or_insert_with(Instant::now);
                 self.shard = shard;
                 self.shard_total = total;
                 self.shard_name = name;
@@ -134,6 +147,10 @@ impl ProgressModel {
                     self.mem_history.remove(0);
                 }
                 self.disp_shard = 1.0;
+                // `shard` is 1-based: the last shard done closes the window.
+                if total > 0 && shard >= total {
+                    self.freeze_load_window();
+                }
             }
             ProgressEvent::Layer { layer, total } => {
                 self.layer = layer;
@@ -143,6 +160,9 @@ impl ProgressModel {
                 self.ready = true;
                 self.port = port;
                 self.ready_in_secs = self.started_at.elapsed().as_secs_f64();
+                // Backstop: a load that never emits its final shard_done still
+                // stops the clock here rather than running forever.
+                self.freeze_load_window();
                 for p in &mut self.phases {
                     if p.state != PhaseState::Done {
                         Self::finish(p);
@@ -206,13 +226,34 @@ impl ProgressModel {
         self.disp_overall
     }
 
-    /// Load rate estimate (GB/s) and ETA seconds, when enough is known.
+    /// Stop the load clock, keeping the first close (later events must not extend
+    /// a window that is already measured).
+    fn freeze_load_window(&mut self) {
+        if self.load_secs.is_none()
+            && let Some(t) = self.load_started
+        {
+            self.load_secs = Some(t.elapsed().as_secs_f64());
+        }
+    }
+
+    /// Seconds the weight load took, once it is over. `None` while still loading.
+    pub fn load_secs(&self) -> Option<f64> {
+        self.load_secs
+    }
+
+    /// Load rate (GB/s) and ETA seconds, both measured over the weight-load window
+    /// only. Once the window is frozen the rate is a fixed measurement of what the
+    /// load actually achieved, and the ETA is 0.
     pub fn rate_eta(&self) -> Option<(f64, f64)> {
         if self.disk_gb <= 0.0 || self.shard == 0 || self.shard_total == 0 {
             return None;
         }
-        let frac = self.shard as f64 / self.shard_total as f64;
-        let elapsed = self.started_at.elapsed().as_secs_f64().max(0.1);
+        let elapsed = match self.load_secs {
+            Some(s) => s,
+            None => self.load_started?.elapsed().as_secs_f64(),
+        }
+        .max(0.1);
+        let frac = (self.shard as f64 / self.shard_total as f64).clamp(0.0, 1.0);
         let gb_done = self.disk_gb * frac;
         let rate = gb_done / elapsed;
         if rate <= 0.0 {
@@ -282,5 +323,47 @@ mod tests {
             name: "s2".into(),
         });
         assert_eq!(m.shard_target(), 0.0);
+    }
+
+    /// GB/s must be measured over the weight-load window, not since process start,
+    /// and must stop moving once the load is over. Previously it divided a constant
+    /// number of bytes by an ever-growing elapsed time, so a finished load's rate
+    /// decayed toward zero for as long as the server ran -- and the pre-load time
+    /// (CUDA init, model resolution, preflight) was in the divisor throughout.
+    #[test]
+    fn load_rate_is_windowed_and_freezes_at_the_last_shard() {
+        let ms = |n| std::thread::sleep(std::time::Duration::from_millis(n));
+        let mut m = ProgressModel::default();
+        m.apply(ProgressEvent::Preflight {
+            disk_gb: 10.0,
+            free_gb: 100.0,
+        });
+        ms(120); // pre-load work that must NOT count against the rate
+        for shard in 1..=2u64 {
+            m.apply(ProgressEvent::ShardStart {
+                shard,
+                total: 2,
+                name: "s".into(),
+            });
+            ms(60);
+            m.apply(ProgressEvent::ShardDone {
+                shard,
+                total: 2,
+                used_gb: 1.0,
+                free_gb: 9.0,
+            });
+        }
+        let secs = m.load_secs().expect("last shard closes the window");
+        assert!(
+            secs < m.started_at.elapsed().as_secs_f64() - 0.1,
+            "window {secs}s must exclude the 120ms of pre-load work"
+        );
+        let (rate, eta) = m.rate_eta().expect("rate known once shards are in");
+        assert_eq!(eta, 0.0, "nothing left to load");
+        assert!(rate > 0.0);
+
+        ms(120);
+        let (rate_later, _) = m.rate_eta().unwrap();
+        assert_eq!(rate, rate_later, "a finished load's rate must not drift");
     }
 }

--- a/crates/spark-server/src/tui/render/library_tab.rs
+++ b/crates/spark-server/src/tui/render/library_tab.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Library tab: master/detail over the locally cached HF models.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use super::panel;
+use crate::tui::app::App;
+use crate::tui::data::library::human_size;
+use crate::tui::theme;
+
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+    draw_list(f, app, cols[0]);
+    draw_detail(f, app, cols[1]);
+}
+
+fn draw_list(f: &mut Frame, app: &App, area: Rect) {
+    let entries = app.filtered_library();
+    let search = if app.lib_filter_editing {
+        format!(" search: {}▏", app.lib_filter)
+    } else if !app.lib_filter.is_empty() {
+        format!(" search: {}", app.lib_filter)
+    } else {
+        String::new()
+    };
+    let block = panel(
+        format!("LIBRARY ─ {} models{search} ─", entries.len()),
+        true,
+    );
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let rows_visible = (inner.height / 2) as usize;
+    let first = app
+        .lib_selected
+        .saturating_sub(rows_visible.saturating_sub(1));
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, e) in entries.iter().enumerate().skip(first).take(rows_visible) {
+        let selected = i == app.lib_selected;
+        let bar = if selected {
+            Span::styled("▌", theme::brand_purple())
+        } else {
+            Span::raw(" ")
+        };
+        let check = if e.has_weights {
+            Span::styled("✓ ", theme::brand_green())
+        } else {
+            Span::styled("· ", theme::dim())
+        };
+        let name_style = if selected {
+            theme::text().add_modifier(Modifier::BOLD)
+        } else {
+            theme::text()
+        };
+        let mut top = Line::from(vec![
+            bar.clone(),
+            check,
+            Span::styled(e.id.clone(), name_style),
+            Span::styled(format!("  {}", human_size(e.size_bytes)), theme::dim()),
+        ]);
+        let mut meta_spans = vec![
+            bar,
+            Span::raw("  "),
+            Span::styled(
+                format!("{} · {} · {}L", e.quant, e.model_type, e.layers),
+                theme::dim(),
+            ),
+        ];
+        if e.optimized {
+            meta_spans.push(Span::styled(
+                " ▐optimized▌",
+                theme::brand_purple().bg(theme::BG_RAISED.color()),
+            ));
+        }
+        let mut meta = Line::from(meta_spans);
+        if selected {
+            top = top.style(Style::default().bg(theme::BG_SELECTION.color()));
+            meta = meta.style(Style::default().bg(theme::BG_SELECTION.color()));
+        }
+        lines.push(top);
+        lines.push(meta);
+    }
+    if entries.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no cached models found",
+            theme::dim(),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
+    let entries = app.filtered_library();
+    let Some(e) = entries.get(app.lib_selected) else {
+        f.render_widget(panel("MODEL ─".into(), false), area);
+        return;
+    };
+    let block = panel(format!("MODEL ─ {} ─", e.id), false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let kv = |k: &str, v: String| {
+        Line::from(vec![
+            Span::styled(format!(" {k:<14}"), theme::dim()),
+            Span::styled(v, theme::text()),
+        ])
+    };
+    let mut lines = vec![
+        Line::default(),
+        kv("size on disk", human_size(e.size_bytes)),
+        kv("model_type", e.model_type.clone()),
+        kv("quantization", e.quant.clone()),
+        kv("layers", e.layers.to_string()),
+        kv("hidden", e.hidden.to_string()),
+        kv("heads", e.heads.to_string()),
+    ];
+    if e.experts > 0 {
+        lines.push(kv("experts", e.experts.to_string()));
+    }
+    if e.context > 0 {
+        lines.push(kv("context", format!("{} tok", e.context)));
+    }
+    lines.push(kv(
+        "weights",
+        if e.has_weights {
+            "complete ✓".into()
+        } else {
+            "missing".into()
+        },
+    ));
+    lines.push(kv(
+        "kernels",
+        if e.optimized {
+            "optimized target compiled ✓".into()
+        } else {
+            "generic".into()
+        },
+    ));
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        format!(" {}", e.snapshot_dir.display()),
+        theme::dim(),
+    )));
+    f.render_widget(Paragraph::new(lines), inner);
+}

--- a/crates/spark-server/src/tui/render/main_tab.rs
+++ b/crates/spark-server/src/tui/render/main_tab.rs
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Main tab: startup checklist + weight-load hero (loading), READY strip
+//! (serving), badge chips, live log pane; plus the Kernels subsection table.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Row, Sparkline, Table};
+
+use super::{gradient_bar, panel};
+use crate::tui::app::App;
+use crate::tui::progress::PhaseState;
+use crate::tui::{log_ring, logo, theme};
+
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let loading = !app.progress.ready;
+    let top_h = if loading { 15 } else { 3 };
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(top_h),
+            Constraint::Length(2),
+            Constraint::Min(5),
+        ])
+        .split(area);
+    if loading {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(34), Constraint::Min(30)])
+            .split(rows[0]);
+        draw_phases(f, app, cols[0]);
+        draw_weight_load(f, app, cols[1]);
+    } else {
+        draw_ready_strip(f, app, rows[0]);
+    }
+    draw_chips(f, app, rows[1]);
+    draw_logs(f, app, rows[2]);
+}
+
+fn draw_phases(f: &mut Frame, app: &App, area: Rect) {
+    let (done, total, secs) = app.progress.phase_counts();
+    let block = panel(format!("STARTUP ─ {done}/{total} ── {secs:.1}s ─"), false);
+    let mut lines = Vec::new();
+    for p in &app.progress.phases {
+        let (glyph, gstyle, label_style) = match p.state {
+            PhaseState::Done => ("✓", theme::brand_green(), theme::text2()),
+            PhaseState::Running => (
+                theme::SPINNER[(app.tick as usize) % theme::SPINNER.len()],
+                theme::brand_cyan(),
+                theme::text(),
+            ),
+            PhaseState::Pending => ("○", theme::dim(), theme::dim()),
+        };
+        let secs = match p.state {
+            PhaseState::Done if p.secs > 0.005 => format!("{:>7.1}s", p.secs),
+            PhaseState::Running => {
+                format!(
+                    "{:>7.1}s",
+                    p.started.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0)
+                )
+            }
+            _ => "        ".into(),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {glyph} "), gstyle),
+            Span::styled(format!("{:<18}", p.name), label_style),
+            Span::styled(secs, theme::text2()),
+        ]));
+    }
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn draw_weight_load(f: &mut Frame, app: &App, area: Rect) {
+    let p = &app.progress;
+    let title = if p.shard_name.is_empty() {
+        "WEIGHT LOAD ─".to_string()
+    } else {
+        format!("WEIGHT LOAD ─ {} ─", middle_truncate(&p.shard_name, 34))
+    };
+    let block = panel(title, false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let bar_w = inner.width.saturating_sub(22);
+
+    let mut lines: Vec<Line> = vec![Line::default()];
+    // OVERALL, gradient (the hero).
+    let overall = p.displayed_overall();
+    let mut l = vec![Span::styled(" OVERALL    ", theme::text2())];
+    l.extend(gradient_bar(overall, bar_w).spans);
+    l.push(Span::styled(
+        format!(" {:>3.0}%", overall * 100.0),
+        theme::text().add_modifier(Modifier::BOLD),
+    ));
+    lines.push(Line::from(l));
+    if p.disk_gb > 0.0 {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "            {:.1} / {:.1} GB preflight",
+                p.disk_gb * overall,
+                p.disk_gb
+            ),
+            theme::dim(),
+        )));
+    }
+    lines.push(Line::default());
+    // SHARD, plain cyan (hierarchy: only the hero gets the gradient).
+    if p.shard_total > 0 {
+        let frac = p.shard_target();
+        let filled = (frac * bar_w as f64) as usize;
+        let bar: String = "█".repeat(filled) + &"░".repeat(bar_w as usize - filled);
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(" SHARD {:>2}/{:<3}", p.shard, p.shard_total),
+                theme::text2(),
+            ),
+            Span::styled(bar, theme::brand_cyan()),
+        ]));
+    }
+    if p.layer_total > 0 {
+        lines.push(Line::from(Span::styled(
+            format!(
+                " LAYERS {:>2}/{:<3} GPU used {:.1} · free {:.1} GB",
+                p.layer, p.layer_total, p.gpu_used_gb, p.gpu_free_gb
+            ),
+            theme::text2(),
+        )));
+    }
+    lines.push(Line::default());
+    if let Some((rate, eta)) = p.rate_eta() {
+        lines.push(Line::from(Span::styled(
+            format!(
+                " {rate:.2} GB/s · eta {}:{:02}",
+                (eta as u64) / 60,
+                (eta as u64) % 60
+            ),
+            theme::brand_cyan(),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), inner);
+    // MEM sparkline along the bottom of the panel interior.
+    if !p.mem_history.is_empty() && inner.height >= 8 {
+        let spark_area = Rect {
+            y: inner.y + inner.height - 1,
+            height: 1,
+            x: inner.x + 1,
+            width: inner.width - 2,
+        };
+        f.render_widget(
+            Sparkline::default()
+                .data(&p.mem_history)
+                .style(theme::brand_cyan()),
+            spark_area,
+        );
+    }
+}
+
+fn draw_ready_strip(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("READY ─".into(), false);
+    let model = app
+        .args
+        .model_name
+        .clone()
+        .or_else(|| app.args.model.clone())
+        .unwrap_or_default();
+    let line = Line::from(vec![
+        Span::styled(" ✓ ", theme::brand_green().add_modifier(Modifier::BOLD)),
+        Span::styled(model, theme::text().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!(
+                " · loaded in {:.1}s · listening ",
+                app.progress.ready_in_secs
+            ),
+            theme::text2(),
+        ),
+        Span::styled(
+            format!("{}:{}", app.args.bind, app.args.port),
+            theme::brand_green(),
+        ),
+    ]);
+    f.render_widget(Paragraph::new(line).block(block), area);
+}
+
+fn draw_chips(f: &mut Frame, app: &App, area: Rect) {
+    let chips = logo::badges(&app.args);
+    let mut spans: Vec<Span> = Vec::new();
+    for b in &chips {
+        let tint = match b.tint {
+            logo::BadgeTint::Model => theme::brand_purple(),
+            logo::BadgeTint::Quant => theme::brand_cyan(),
+            logo::BadgeTint::Role => theme::brand_green(),
+            logo::BadgeTint::Neutral => theme::text2(),
+        };
+        spans.push(Span::styled(
+            "▐",
+            Style::default().fg(theme::BG_RAISED.color()),
+        ));
+        // First word tinted, rest secondary — restraint per the spec.
+        let mut words = b.text.splitn(2, ' ');
+        let first = words.next().unwrap_or_default().to_string();
+        let rest = words.next().map(|r| format!(" {r}")).unwrap_or_default();
+        spans.push(Span::styled(first, tint.bg(theme::BG_RAISED.color())));
+        spans.push(Span::styled(
+            rest,
+            theme::text2().bg(theme::BG_RAISED.color()),
+        ));
+        spans.push(Span::styled(
+            "▌",
+            Style::default().fg(theme::BG_RAISED.color()),
+        ));
+        spans.push(Span::raw(" "));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)).wrapped(), area);
+}
+
+fn draw_logs(f: &mut Frame, app: &App, area: Rect) {
+    let follow = app.log_scroll.is_none();
+    let right = if follow {
+        "⏵ follow".to_string()
+    } else {
+        format!("⏸ {}↑", app.log_scroll.unwrap_or(0))
+    };
+    let filter_part = if app.log_filter_editing {
+        format!(" filter: {}▏", app.log_filter)
+    } else if !app.log_filter.is_empty() {
+        format!(" filter: {}", app.log_filter)
+    } else {
+        String::new()
+    };
+    let block = panel(format!("LOGS ── {right}{filter_part} ─"), follow);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let want = inner.height as usize + app.log_scroll.unwrap_or(0);
+    let mut lines: Vec<Line> = log_ring::tail(want.max(64))
+        .into_iter()
+        .filter(|l| {
+            app.log_filter.is_empty()
+                || l.message
+                    .to_lowercase()
+                    .contains(&app.log_filter.to_lowercase())
+                || l.target.contains(&app.log_filter)
+        })
+        .map(|l| {
+            let ts = chrono_lite(l.at);
+            let target_short: String = l
+                .target
+                .split("::")
+                .next()
+                .unwrap_or("")
+                .chars()
+                .take(14)
+                .collect();
+            Line::from(vec![
+                Span::styled(format!("{ts} "), theme::dim()),
+                Span::styled(format!("{:<5} ", l.level), theme::level_style(l.level)),
+                Span::styled(format!("{target_short:<14} "), theme::dim()),
+                Span::styled(l.message, theme::text()),
+            ])
+        })
+        .collect();
+    // Apply scroll: drop from the end when scrolled up.
+    if let Some(up) = app.log_scroll {
+        let keep = lines.len().saturating_sub(up);
+        lines.truncate(keep);
+    }
+    let visible = lines.len().saturating_sub(inner.height as usize);
+    let shown: Vec<Line> = lines.into_iter().skip(visible).collect();
+    f.render_widget(Paragraph::new(shown), inner);
+}
+
+pub fn draw_kernels(f: &mut Frame, app: &App, area: Rect) {
+    let Some(model) = &app.kernels else {
+        let block = panel("KERNELS ─ waiting for startup ─".into(), false);
+        f.render_widget(
+            Paragraph::new(Span::styled(
+                "  kernel audit runs at model load…",
+                theme::dim(),
+            ))
+            .block(block),
+            area,
+        );
+        return;
+    };
+    let mut constraints = vec![Constraint::Min(6)];
+    if !model.missing.is_empty() {
+        constraints.insert(0, Constraint::Length(model.missing.len().min(6) as u16 + 2));
+    }
+    let rows_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(area);
+    let mut idx = 0;
+    if !model.missing.is_empty() {
+        let block = panel(
+            format!("⚠ {} UNRESOLVED KERNEL LOOKUP(S) ─", model.missing.len()),
+            false,
+        )
+        .border_style(theme::warn());
+        let lines: Vec<Line> = model
+            .missing
+            .iter()
+            .take(6)
+            .map(|m| {
+                Line::from(Span::styled(
+                    format!("  {}::{}", m.module, m.func),
+                    theme::warn(),
+                ))
+            })
+            .collect();
+        f.render_widget(Paragraph::new(lines).block(block), rows_layout[idx]);
+        idx += 1;
+    }
+    let filtered: Vec<_> = model
+        .rows
+        .iter()
+        .filter(|r| app.kernel_filter.is_empty() || r.module.contains(&app.kernel_filter))
+        .collect();
+    let title = format!("KERNELS ─ {} modules ─", filtered.len());
+    let header = Row::new(vec!["MODULE", "PTX-HASH", "RESOLUTION"])
+        .style(theme::text2().add_modifier(Modifier::BOLD));
+    let table_rows: Vec<Row> = filtered
+        .iter()
+        .skip(app.kernel_scroll)
+        .map(|r| {
+            let (res, style) = match r.resolution {
+                Some(true) => ("used", theme::brand_cyan()),
+                Some(false) => ("** lookup FAILED **", theme::error()),
+                None => ("-", theme::dim()),
+            };
+            let row_style = if r.resolution.is_none() {
+                theme::dim()
+            } else {
+                theme::text()
+            };
+            Row::new(vec![
+                Span::styled(r.module.clone(), row_style),
+                Span::styled(r.ptx_hash.clone(), theme::dim()),
+                Span::styled(res, style),
+            ])
+        })
+        .collect();
+    let table = Table::new(
+        table_rows,
+        [
+            Constraint::Length(34),
+            Constraint::Length(14),
+            Constraint::Min(10),
+        ],
+    )
+    .header(header)
+    .block(panel(title, true));
+    f.render_widget(table, rows_layout[idx]);
+}
+
+fn middle_truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let half = (max.saturating_sub(1)) / 2;
+    let start: String = s.chars().take(half).collect();
+    let end: String = s
+        .chars()
+        .rev()
+        .take(half)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("{start}…{end}")
+}
+
+/// hh:mm:ss from a SystemTime without a chrono dependency.
+fn chrono_lite(t: std::time::SystemTime) -> String {
+    let secs = t
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (h, m, s) = ((secs / 3600) % 24, (secs / 60) % 60, secs % 60);
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+trait Wrapped {
+    fn wrapped(self) -> Self;
+}
+impl Wrapped for Paragraph<'_> {
+    fn wrapped(self) -> Self {
+        self.wrap(ratatui::widgets::Wrap { trim: false })
+    }
+}

--- a/crates/spark-server/src/tui/render/main_tab.rs
+++ b/crates/spark-server/src/tui/render/main_tab.rs
@@ -129,12 +129,14 @@ fn draw_weight_load(f: &mut Frame, app: &App, area: Rect) {
     }
     lines.push(Line::default());
     if let Some((rate, eta)) = p.rate_eta() {
+        // Once the load window closes the rate is a final measurement, so report
+        // what it took instead of an ETA that is necessarily 0:00.
+        let tail = match p.load_secs() {
+            Some(s) => format!("loaded in {}:{:02}", (s as u64) / 60, (s as u64) % 60),
+            None => format!("eta {}:{:02}", (eta as u64) / 60, (eta as u64) % 60),
+        };
         lines.push(Line::from(Span::styled(
-            format!(
-                " {rate:.2} GB/s · eta {}:{:02}",
-                (eta as u64) / 60,
-                (eta as u64) % 60
-            ),
+            format!(" {rate:.2} GB/s · {tail}"),
             theme::brand_cyan(),
         )));
     }

--- a/crates/spark-server/src/tui/render/mod.rs
+++ b/crates/spark-server/src/tui/render/mod.rs
@@ -161,12 +161,23 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect, full: bool) {
                 theme::text2()
             };
             spans.push(Span::styled(s.label().to_string(), label_style));
-            // Badge: unresolved-kernel dot on Main.
-            if s == Section::Main
-                && let Some(k) = &app.kernels
-                && !k.missing.is_empty()
-            {
-                spans.push(Span::styled("  ●", theme::warn()));
+            // Main's dot is the startup lamp: amber while the engine is coming up,
+            // green once it is serving. It used to mean "unresolved kernel lookups"
+            // and only ever rendered amber, which read as a load that never
+            // finished. That signal is not lost — it moves to the ⚠ below, so the
+            // lamp answers "is it up?" and the glyph answers "is anything off?".
+            if s == Section::Main {
+                let lamp = if app.progress.ready {
+                    theme::brand_green()
+                } else {
+                    theme::warn()
+                };
+                spans.push(Span::styled("  ●", lamp));
+                if let Some(k) = &app.kernels
+                    && !k.missing.is_empty()
+                {
+                    spans.push(Span::styled(" ⚠", theme::warn()));
+                }
             }
         }
         let mut line = Line::from(spans);
@@ -221,7 +232,7 @@ fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
         Section::Stats => "⇥ cycle · 1-5 jump · ? help · q quit",
         Section::Network => "←/→ node · ⏎ detail · ⇥ cycle · 1-5 jump · ? help",
         Section::Library => "j/k move · / search · ⇥ cycle · 1-5 jump · ? help",
-        Section::Terminal => "⏎ input · Ctrl+Enter send · Esc back · ⇥ Ops↔Chat · ? help",
+        Section::Terminal => "⏎ input · Esc back · ↑/↓ scroll · End follow · ⇥ Ops↔Chat · ? help",
     };
     let line = Line::from(vec![
         Span::styled(

--- a/crates/spark-server/src/tui/render/mod.rs
+++ b/crates/spark-server/src/tui/render/mod.rs
@@ -161,11 +161,11 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect, full: bool) {
                 theme::text2()
             };
             spans.push(Span::styled(s.label().to_string(), label_style));
-            // Main's dot is the startup lamp: amber while the engine is coming up,
-            // green once it is serving. It used to mean "unresolved kernel lookups"
-            // and only ever rendered amber, which read as a load that never
-            // finished. That signal is not lost — it moves to the ⚠ below, so the
-            // lamp answers "is it up?" and the glyph answers "is anything off?".
+            // Main's dot is the startup lamp, and only that: amber while the engine
+            // is coming up, green once it is serving. It used to mean "unresolved
+            // kernel lookups" and only ever rendered amber, which read as a load
+            // that never finished. Unresolved kernels are not duplicated here —
+            // the Kernels tab banners them and a startup toast points at it.
             if s == Section::Main {
                 let lamp = if app.progress.ready {
                     theme::brand_green()
@@ -173,11 +173,6 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect, full: bool) {
                     theme::warn()
                 };
                 spans.push(Span::styled("  ●", lamp));
-                if let Some(k) = &app.kernels
-                    && !k.missing.is_empty()
-                {
-                    spans.push(Span::styled(" ⚠", theme::warn()));
-                }
             }
         }
         let mut line = Line::from(spans);

--- a/crates/spark-server/src/tui/render/mod.rs
+++ b/crates/spark-server/src/tui/render/mod.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Frame layout: sticky header (logo + status), sidebar, per-section content,
+//! sticky footer, toasts, help overlay. Pure `App` → `Frame`.
+
+mod library_tab;
+mod main_tab;
+mod network_tab;
+mod stats_tab;
+mod terminal_tab;
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Clear, Paragraph};
+
+use super::app::{App, Focus, MainSub, Section, TermSub};
+use super::{logo, theme};
+
+pub fn draw(f: &mut Frame, app: &App) {
+    let area = f.area();
+    // Paint the base surface.
+    f.render_widget(
+        Block::default().style(Style::default().bg(theme::BG_BASE.color())),
+        area,
+    );
+    let tall = area.height >= 28;
+    let header_h = if tall { 3 } else { 1 };
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(header_h),
+            Constraint::Min(5),
+            Constraint::Length(1),
+        ])
+        .split(area);
+    draw_header(f, app, rows[0], tall);
+
+    let sidebar_w = if area.width >= 96 { 18 } else { 4 };
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(sidebar_w), Constraint::Min(20)])
+        .split(rows[1]);
+    draw_sidebar(f, app, cols[0], sidebar_w >= 18);
+
+    match app.section {
+        Section::Main => match app.main_sub {
+            MainSub::Overview => main_tab::draw(f, app, cols[1]),
+            MainSub::Kernels => main_tab::draw_kernels(f, app, cols[1]),
+        },
+        Section::Stats => stats_tab::draw(f, app, cols[1]),
+        Section::Network => network_tab::draw(f, app, cols[1]),
+        Section::Library => library_tab::draw(f, app, cols[1]),
+        Section::Terminal => terminal_tab::draw(f, app, cols[1]),
+    }
+
+    draw_footer(f, app, rows[2]);
+    draw_toasts(f, app, cols[1]);
+    if app.help_open {
+        draw_help(f, area);
+    }
+}
+
+fn status_pill(app: &App) -> Span<'static> {
+    let (label, bg) = if app.progress.ready {
+        (" ● SERVING ", theme::GREEN)
+    } else {
+        (" ● LOADING ", theme::WARN)
+    };
+    Span::styled(
+        label,
+        Style::default()
+            .bg(bg.color())
+            .fg(theme::BG_BASE.color())
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn draw_header(f: &mut Frame, app: &App, area: Rect, tall: bool) {
+    // Chevron wave only during loading (motion restraint).
+    let wave = if app.progress.ready {
+        None
+    } else {
+        Some((app.tick / 3) as usize % 3)
+    };
+    let up = app.started.elapsed().as_secs();
+    let uptime = format!("up {:02}:{:02}", up / 60 % 100, up % 60);
+    let right = Line::from(vec![
+        status_pill(app),
+        Span::styled(format!("  {uptime} "), theme::text2()),
+    ]);
+    if tall {
+        let lines = logo::three_line(wave);
+        for (i, line) in lines.into_iter().enumerate() {
+            let row = Rect {
+                y: area.y + i as u16,
+                height: 1,
+                ..area
+            };
+            f.render_widget(Paragraph::new(line), row);
+        }
+        // Right cluster row 0; model·quant·port row 1.
+        f.render_widget(
+            Paragraph::new(right).alignment(ratatui::layout::Alignment::Right),
+            Rect {
+                y: area.y,
+                height: 1,
+                ..area
+            },
+        );
+        let model = app
+            .args
+            .model_name
+            .clone()
+            .or_else(|| app.args.model.clone())
+            .unwrap_or_default();
+        let sub = Line::from(Span::styled(
+            format!(
+                "{model} · kv {} · :{} ",
+                app.args.kv_cache_dtype, app.args.port
+            ),
+            theme::text2(),
+        ));
+        f.render_widget(
+            Paragraph::new(sub).alignment(ratatui::layout::Alignment::Right),
+            Rect {
+                y: area.y + 1,
+                height: 1,
+                ..area
+            },
+        );
+    } else {
+        f.render_widget(Paragraph::new(logo::one_line(wave)), area);
+        f.render_widget(
+            Paragraph::new(right).alignment(ratatui::layout::Alignment::Right),
+            area,
+        );
+    }
+}
+
+fn draw_sidebar(f: &mut Frame, app: &App, area: Rect, full: bool) {
+    let mut lines: Vec<Line> = Vec::new();
+    for s in Section::ALL {
+        let selected = app.section == s;
+        let bar = if selected {
+            Span::styled("▌", theme::brand_purple())
+        } else {
+            Span::raw(" ")
+        };
+        let icon_style = if selected {
+            theme::text()
+        } else {
+            theme::text2()
+        };
+        let mut spans = vec![bar, Span::styled(format!("{} ", s.icon()), icon_style)];
+        if full {
+            let label_style = if selected {
+                theme::text().add_modifier(Modifier::BOLD)
+            } else {
+                theme::text2()
+            };
+            spans.push(Span::styled(s.label().to_string(), label_style));
+            // Badge: unresolved-kernel dot on Main.
+            if s == Section::Main
+                && let Some(k) = &app.kernels
+                && !k.missing.is_empty()
+            {
+                spans.push(Span::styled("  ●", theme::warn()));
+            }
+        }
+        let mut line = Line::from(spans);
+        if selected {
+            line = line.style(Style::default().bg(theme::BG_SELECTION.color()));
+        }
+        lines.push(line);
+        // Subsections under the active section (full mode).
+        if full && selected {
+            let subs: &[(&str, bool)] = match s {
+                Section::Main => &[
+                    ("Overview", app.main_sub == MainSub::Overview),
+                    ("Kernels", app.main_sub == MainSub::Kernels),
+                ],
+                Section::Terminal => &[
+                    ("Ops", app.term_sub == TermSub::Ops),
+                    ("Chat", app.term_sub == TermSub::Chat),
+                ],
+                _ => &[],
+            };
+            for (i, (name, active)) in subs.iter().enumerate() {
+                let glyph = if i + 1 == subs.len() { "└" } else { "├" };
+                let style = if *active {
+                    theme::brand_cyan()
+                } else {
+                    theme::dim()
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(format!("   {glyph} "), theme::dim()),
+                    Span::styled(name.to_string(), style),
+                ]));
+            }
+        }
+    }
+    f.render_widget(Paragraph::new(lines), area);
+    // 1-col rule on the right edge.
+    for y in area.y..area.y + area.height {
+        f.render_widget(
+            Paragraph::new(Span::styled("│", theme::dim())),
+            Rect {
+                x: area.x + area.width - 1,
+                y,
+                width: 1,
+                height: 1,
+            },
+        );
+    }
+}
+
+fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
+    let mode = if app.help_open {
+        (" HELP ", theme::TEXT_2)
+    } else if app.focus == Focus::Input || app.log_filter_editing || app.lib_filter_editing {
+        (" INPUT ", theme::CYAN)
+    } else {
+        (" NORMAL ", theme::BORDER_DIM)
+    };
+    let hints = match app.section {
+        Section::Main => "j/k scroll · f filter · 1-5 jump · ⇥ cycle · ? help · q quit",
+        Section::Stats => "1-5 jump · ⇥ cycle · ? help · q quit",
+        Section::Network => "←/→ node · ⏎ detail · 1-5 jump · ? help",
+        Section::Library => "j/k move · / search · 1-5 jump · ? help",
+        Section::Terminal => "⏎ input · Ctrl+Enter send · Esc back · ? help",
+    };
+    let line = Line::from(vec![
+        Span::styled(
+            mode.0,
+            Style::default()
+                .bg(mode.1.color())
+                .fg(theme::BG_BASE.color()),
+        ),
+        Span::styled(format!("  {hints}"), theme::dim()),
+    ]);
+    f.render_widget(
+        Paragraph::new(line).style(Style::default().bg(theme::BG_PANEL.color())),
+        area,
+    );
+}
+
+fn draw_toasts(f: &mut Frame, app: &App, content: Rect) {
+    let width = 42.min(content.width.saturating_sub(2));
+    for (i, t) in app.toasts.iter().rev().take(3).enumerate() {
+        let area = Rect {
+            x: content.x + content.width.saturating_sub(width + 1),
+            y: content.y + 1 + (i as u16) * 2,
+            width,
+            height: 1,
+        };
+        let accent = if t.error {
+            theme::error()
+        } else {
+            theme::brand_green()
+        };
+        let line = Line::from(vec![
+            Span::styled("▌ ", accent),
+            Span::styled(t.text.clone(), theme::text()),
+        ]);
+        f.render_widget(Clear, area);
+        f.render_widget(
+            Paragraph::new(line).style(Style::default().bg(theme::BG_RAISED.color())),
+            area,
+        );
+    }
+}
+
+fn draw_help(f: &mut Frame, area: Rect) {
+    let w = 64.min(area.width.saturating_sub(4));
+    let h = 18.min(area.height.saturating_sub(4));
+    let modal = Rect {
+        x: area.x + (area.width - w) / 2,
+        y: area.y + (area.height - h) / 2,
+        width: w,
+        height: h,
+    };
+    f.render_widget(Clear, modal);
+    let keys = [
+        ("1-5", "jump to section (repeat toggles subsections)"),
+        ("Tab / Shift+Tab", "cycle sections"),
+        ("j/k ↑/↓", "move / scroll"),
+        ("g / G", "top / bottom (follow)"),
+        ("f", "log filter (Main)"),
+        ("/", "search (Library)"),
+        ("←/→ + Enter", "select node / detail (Network)"),
+        ("Enter", "focus input (Terminal)"),
+        ("Ctrl+Enter", "send chat message"),
+        ("Esc", "back / cancel"),
+        ("Ctrl+C", "clean shutdown (drain + exit)"),
+        ("q", "quit TUI"),
+        ("?", "this help"),
+    ];
+    let mut lines = vec![Line::default()];
+    for (k, d) in keys {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {k:<16}"), theme::brand_cyan()),
+            Span::styled(d.to_string(), theme::text2()),
+        ]));
+    }
+    let block = Block::bordered()
+        .border_type(ratatui::widgets::BorderType::Rounded)
+        .border_style(theme::border(false))
+        .title(Span::styled("─ KEYS ─", theme::text2()))
+        .style(Style::default().bg(theme::BG_PANEL.color()));
+    f.render_widget(Paragraph::new(lines).block(block), modal);
+}
+
+/// Shared rounded-panel block.
+pub(super) fn panel(title: String, focused: bool) -> Block<'static> {
+    Block::bordered()
+        .border_type(ratatui::widgets::BorderType::Rounded)
+        .border_style(theme::border(focused))
+        .title(Span::styled(format!("─ {title} "), theme::title(focused)))
+        .style(Style::default().bg(theme::BG_PANEL.color()))
+}
+
+/// The signature gradient bar as a styled line: `█▓░` with per-cell color.
+pub(super) fn gradient_bar(frac: f64, width: u16) -> Line<'static> {
+    let width = width.max(1) as usize;
+    let filled = ((frac.clamp(0.0, 1.0)) * width as f64).round() as usize;
+    let mut spans = Vec::with_capacity(width);
+    for i in 0..width {
+        if i < filled {
+            let t = i as f64 / (width.saturating_sub(1)).max(1) as f64;
+            let ch = if i + 1 == filled && filled < width {
+                "▓"
+            } else {
+                "█"
+            };
+            spans.push(Span::styled(ch, Style::default().fg(theme::gradient_at(t))));
+        } else {
+            spans.push(Span::styled(
+                "░",
+                Style::default().fg(theme::GAUGE_TRACK.color()),
+            ));
+        }
+    }
+    Line::from(spans)
+}

--- a/crates/spark-server/src/tui/render/mod.rs
+++ b/crates/spark-server/src/tui/render/mod.rs
@@ -15,7 +15,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, Paragraph};
 
-use super::app::{App, Focus, MainSub, Section, TermSub};
+use super::app::{App, Focus, MainSub, Section};
 use super::{logo, theme};
 
 pub fn draw(f: &mut Frame, app: &App) {
@@ -176,20 +176,12 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect, full: bool) {
         lines.push(line);
         // Subsections under the active section (full mode).
         if full && selected {
-            let subs: &[(&str, bool)] = match s {
-                Section::Main => &[
-                    ("Overview", app.main_sub == MainSub::Overview),
-                    ("Kernels", app.main_sub == MainSub::Kernels),
-                ],
-                Section::Terminal => &[
-                    ("Ops", app.term_sub == TermSub::Ops),
-                    ("Chat", app.term_sub == TermSub::Chat),
-                ],
-                _ => &[],
-            };
-            for (i, (name, active)) in subs.iter().enumerate() {
+            let subs = s.subs();
+            let active_sub = app.sub_index(s);
+            for (i, name) in subs.iter().enumerate() {
+                let active = i == active_sub;
                 let glyph = if i + 1 == subs.len() { "└" } else { "├" };
-                let style = if *active {
+                let style = if active {
                     theme::brand_cyan()
                 } else {
                     theme::dim()
@@ -225,11 +217,11 @@ fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
         (" NORMAL ", theme::BORDER_DIM)
     };
     let hints = match app.section {
-        Section::Main => "j/k scroll · f filter · 1-5 jump · ⇥ cycle · ? help · q quit",
-        Section::Stats => "1-5 jump · ⇥ cycle · ? help · q quit",
-        Section::Network => "←/→ node · ⏎ detail · 1-5 jump · ? help",
-        Section::Library => "j/k move · / search · 1-5 jump · ? help",
-        Section::Terminal => "⏎ input · Ctrl+Enter send · Esc back · ? help",
+        Section::Main => "j/k scroll · f filter · ⇥ Overview↔Kernels · 1-5 jump · ? help · q quit",
+        Section::Stats => "⇥ cycle · 1-5 jump · ? help · q quit",
+        Section::Network => "←/→ node · ⏎ detail · ⇥ cycle · 1-5 jump · ? help",
+        Section::Library => "j/k move · / search · ⇥ cycle · 1-5 jump · ? help",
+        Section::Terminal => "⏎ input · Ctrl+Enter send · Esc back · ⇥ Ops↔Chat · ? help",
     };
     let line = Line::from(vec![
         Span::styled(
@@ -283,8 +275,11 @@ fn draw_help(f: &mut Frame, area: Rect) {
     };
     f.render_widget(Clear, modal);
     let keys = [
-        ("1-5", "jump to section (repeat toggles subsections)"),
-        ("Tab / Shift+Tab", "cycle sections"),
+        ("1-5", "jump to section (repeat cycles its subsections)"),
+        (
+            "Tab / Shift+Tab",
+            "walk every sidebar row, subsections included",
+        ),
         ("j/k ↑/↓", "move / scroll"),
         ("g / G", "top / bottom (follow)"),
         ("f", "log filter (Main)"),

--- a/crates/spark-server/src/tui/render/network_tab.rs
+++ b/crates/spark-server/src/tui/render/network_tab.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Network tab: TP/EP topology as hand-drawn node cards. The single-node
+//! case is a designed centerpiece, not an empty screen; 2+ nodes join with
+//! labeled connectors. Health/latency shown honestly — never faked.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use super::panel;
+use crate::tui::app::App;
+use crate::tui::theme;
+
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let world = app.args.world_size.max(1);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(60), Constraint::Min(4)])
+        .split(area);
+    if world == 1 {
+        draw_single(f, app, rows[0]);
+    } else {
+        draw_multi(f, app, rows[0], world);
+    }
+    draw_detail(f, app, rows[1]);
+}
+
+fn card_lines(app: &App, rank: usize) -> Vec<Line<'static>> {
+    let s = &app.stats;
+    let is_head = rank == 0;
+    let role = if is_head { "HEAD" } else { "WORKER" };
+    let mut lines = vec![Line::from(Span::styled(
+        format!("⬡ rank {rank} · {role}"),
+        theme::text().add_modifier(Modifier::BOLD),
+    ))];
+    if is_head {
+        lines.push(Line::from(Span::styled(
+            "NVIDIA GB10 · local".to_string(),
+            theme::text2(),
+        )));
+        let used = s.atlas_used_gb;
+        let total = s.gpu_total_gb.max(0.001);
+        let w = 18usize;
+        let filled = ((used / total).clamp(0.0, 1.0) * w as f64) as usize;
+        let bar: String = "█".repeat(filled) + &"░".repeat(w - filled);
+        lines.push(Line::from(vec![
+            Span::styled("mem ", theme::dim()),
+            Span::styled(bar, theme::brand_cyan()),
+            Span::styled(format!(" {used:.0}/{total:.0} GB"), theme::text2()),
+        ]));
+        lines.push(Line::from(Span::styled(
+            format!("{}:{}", app.args.bind, app.args.port),
+            theme::text2(),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            format!("{}:{}", app.args.master_addr, app.args.master_port),
+            theme::text2(),
+        )));
+        lines.push(Line::from(Span::styled(
+            "state not visible from head (no worker HTTP)".to_string(),
+            theme::dim(),
+        )));
+    }
+    lines
+}
+
+fn draw_single(f: &mut Frame, app: &App, area: Rect) {
+    let w = 44.min(area.width.saturating_sub(4));
+    let h = 8.min(area.height.saturating_sub(2));
+    let card = Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    };
+    // Decorative dim chevrons flanking the card (the stage).
+    if card.x >= area.x + 6 {
+        let deco = |x: u16| Rect {
+            x,
+            y: card.y + h / 2,
+            width: 4,
+            height: 1,
+        };
+        let l = Line::from(Span::styled(
+            "❯❯❯",
+            theme::brand_purple().add_modifier(Modifier::DIM),
+        ));
+        f.render_widget(Paragraph::new(l.clone()), deco(area.x + 1));
+        f.render_widget(Paragraph::new(l), deco(card.x + w + 2));
+    }
+    // Heartbeat: border alternates green/dim-green every 2s (2 frames at 10Hz).
+    let beat = (app.tick / 20).is_multiple_of(2);
+    let border = if beat {
+        theme::brand_green()
+    } else {
+        theme::dim()
+    };
+    let block = panel("⬡ rank 0 · HEAD ─".into(), false).border_style(border);
+    f.render_widget(Paragraph::new(card_lines(app, 0)).block(block), card);
+    let caption = format!(
+        "tp {} · ep {} · world 1 — all local",
+        app.args.tp_size, app.args.ep_size
+    );
+    f.render_widget(
+        Paragraph::new(Span::styled(caption, theme::text2())).alignment(Alignment::Center),
+        Rect {
+            y: (card.y + h).min(area.y + area.height - 1),
+            height: 1,
+            ..area
+        },
+    );
+}
+
+fn draw_multi(f: &mut Frame, app: &App, area: Rect, world: usize) {
+    let n = world.min(4);
+    let mut constraints = Vec::new();
+    for _ in 0..n {
+        constraints.push(Constraint::Ratio(1, n as u32));
+    }
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(constraints)
+        .split(area);
+    for rank in 0..n {
+        let selected = app.network_selected == rank;
+        let border = if selected {
+            theme::brand_cyan()
+        } else {
+            theme::brand_green()
+        };
+        let title = format!("⬡ rank {rank} ─");
+        let block = panel(title, selected).border_style(border);
+        let cell = cols[rank];
+        let card = Rect {
+            x: cell.x + 1,
+            y: cell.y + 1,
+            width: cell.width.saturating_sub(2),
+            height: cell.height.saturating_sub(3).min(8),
+        };
+        f.render_widget(Paragraph::new(card_lines(app, rank)).block(block), card);
+        if rank + 1 < n {
+            let link = Rect {
+                x: cell.x + cell.width.saturating_sub(1),
+                y: card.y + card.height / 2,
+                width: 2.min(area.width),
+                height: 1,
+            };
+            f.render_widget(
+                Paragraph::new(Span::styled("══", theme::brand_cyan())),
+                link,
+            );
+        }
+    }
+    let label = if app.args.ep_size > 1 {
+        format!("═ NCCL ═ ep {} · experts sharded", app.args.ep_size)
+    } else {
+        format!("═ NCCL ═ tp {} · ring", app.args.tp_size)
+    };
+    f.render_widget(
+        Paragraph::new(Span::styled(label, theme::brand_cyan())).alignment(Alignment::Center),
+        Rect {
+            y: area.y + area.height.saturating_sub(1),
+            height: 1,
+            ..area
+        },
+    );
+}
+
+fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel(format!("NODE {} ─ detail ─", app.network_selected), false);
+    let mut lines = vec![Line::from(vec![
+        Span::styled(" role ", theme::dim()),
+        Span::styled(
+            if app.network_selected == 0 {
+                "head (serves HTTP, owns scheduler)"
+            } else {
+                "worker (EP shard, no HTTP)"
+            },
+            theme::text(),
+        ),
+    ])];
+    lines.push(Line::from(vec![
+        Span::styled(" bootstrap ", theme::dim()),
+        Span::styled(
+            format!(
+                "{}:{} (NCCL master)",
+                app.args.master_addr, app.args.master_port
+            ),
+            theme::text(),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled(" topology ", theme::dim()),
+        Span::styled(
+            format!(
+                "world {} · tp {} · ep {} · this rank {}",
+                app.args.world_size, app.args.tp_size, app.args.ep_size, app.args.rank
+            ),
+            theme::text(),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled(" latency ", theme::dim()),
+        Span::styled(
+            "— (probes race the collectives; deliberately not measured live)",
+            theme::dim(),
+        ),
+    ]));
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}

--- a/crates/spark-server/src/tui/render/stats_tab.rs
+++ b/crates/spark-server/src/tui/render/stats_tab.rs
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Server Stats: tile row (requests / throughput / TTFT / GPU), TTFT
+//! histogram, throughput chart, sequences & memory gauges, speculation &
+//! cache panel.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::symbols;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Axis, BarChart, Chart, Dataset, LineGauge, Paragraph, Sparkline};
+
+use super::panel;
+use crate::tui::app::App;
+use crate::tui::theme;
+
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Percentage(45),
+            Constraint::Min(8),
+        ])
+        .split(area);
+    draw_tiles(f, app, rows[0]);
+    let mid = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(rows[1]);
+    draw_ttft_hist(f, app, mid[0]);
+    draw_throughput(f, app, mid[1]);
+    let bottom = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(48), Constraint::Percentage(52)])
+        .split(rows[2]);
+    draw_sequences(f, app, bottom[0]);
+    draw_spec_cache(f, app, bottom[1]);
+}
+
+fn tile(f: &mut Frame, area: Rect, title: &str, value: Line, spark: Option<&[u64]>) {
+    let block = panel(format!("{title} ─"), false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(Paragraph::new(value), Rect { height: 1, ..inner });
+    if let Some(data) = spark
+        && inner.height >= 2
+        && !data.is_empty()
+    {
+        f.render_widget(
+            Sparkline::default().data(data).style(theme::brand_cyan()),
+            Rect {
+                y: inner.y + 1,
+                height: 1,
+                ..inner
+            },
+        );
+    }
+}
+
+fn draw_tiles(f: &mut Frame, app: &App, area: Rect) {
+    let s = &app.stats;
+    let tiles = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(area);
+    let req = Line::from(vec![
+        Span::styled(
+            format!(" {}", s.requests_total),
+            theme::text().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  ● {}", s.requests_active),
+            if s.requests_active > 0 {
+                theme::brand_green()
+            } else {
+                theme::dim()
+            },
+        ),
+        Span::styled(
+            format!(
+                "  ↓{}/s ↑{}/s",
+                human_bytes(s.bytes_in_rate),
+                human_bytes(s.bytes_out_rate)
+            ),
+            theme::dim(),
+        ),
+    ]);
+    tile(f, tiles[0], "REQUESTS", req, Some(&s.req_history.as_u64()));
+    let tp = Line::from(Span::styled(
+        format!(" {:.1} tok/s", s.gen_tps),
+        theme::text().add_modifier(Modifier::BOLD),
+    ));
+    tile(
+        f,
+        tiles[1],
+        "THROUGHPUT",
+        tp,
+        Some(&s.gen_tps_history.as_u64()),
+    );
+    let ttft = Line::from(vec![
+        Span::styled(
+            format!(" p50 {}", fmt_ms(s.ttft_p50_ms)),
+            theme::text().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  p90 {}", fmt_ms(s.ttft_p90_ms)), theme::text2()),
+    ]);
+    tile(f, tiles[2], "TTFT", ttft, None);
+    let gpu = Line::from(vec![
+        Span::styled(
+            format!(" atlas {:.1} GB", s.atlas_used_gb),
+            theme::text().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("  free {:.1}", s.gpu_free_gb), theme::text2()),
+    ]);
+    tile(f, tiles[3], "GPU", gpu, None);
+}
+
+fn draw_ttft_hist(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("TTFT DISTRIBUTION ─".into(), false);
+    // De-cumulate buckets into per-bucket counts; collapse the ≥2.5s tail.
+    let mut bars: Vec<(String, u64, bool)> = Vec::new();
+    let mut prev = 0u64;
+    for (ub, cum) in &app.stats.ttft_buckets {
+        if ub.is_infinite() {
+            continue;
+        }
+        let count = cum.saturating_sub(prev);
+        prev = *cum;
+        let label = if *ub < 1.0 {
+            format!(".{:02}", (ub * 100.0) as u32)
+        } else {
+            format!("{ub:.0}")
+        };
+        bars.push((label, count, *ub >= 2.5));
+    }
+    let data: Vec<ratatui::widgets::Bar> = bars
+        .iter()
+        .map(|(label, v, slow)| {
+            ratatui::widgets::Bar::default()
+                .value(*v)
+                .label(Line::from(Span::styled(label.clone(), theme::dim())))
+                .style(if *slow {
+                    theme::warn()
+                } else {
+                    theme::brand_cyan()
+                })
+        })
+        .collect();
+    let chart = BarChart::default()
+        .data(ratatui::widgets::BarGroup::default().bars(&data))
+        .bar_width(3)
+        .bar_gap(1)
+        .block(block);
+    f.render_widget(chart, area);
+}
+
+fn draw_throughput(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("THROUGHPUT ── gen tok/s ─".into(), false);
+    let pts: Vec<(f64, f64)> = app
+        .stats
+        .gen_tps_history
+        .points
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i as f64, *v))
+        .collect();
+    let max_y = pts.iter().map(|(_, v)| *v).fold(10.0_f64, f64::max) * 1.15;
+    let datasets = vec![
+        Dataset::default()
+            .marker(symbols::Marker::Braille)
+            .graph_type(ratatui::widgets::GraphType::Line)
+            .style(theme::brand_cyan())
+            .data(&pts),
+    ];
+    let caption = format!(
+        "gen {:.0} tok/s · prompt {:.0} tok/s",
+        app.stats.gen_tps, app.stats.prompt_tps
+    );
+    let chart = Chart::new(datasets)
+        .x_axis(Axis::default().bounds([0.0, 120.0]))
+        .y_axis(Axis::default().bounds([0.0, max_y]).labels(vec![
+            Span::styled("0", theme::dim()),
+            Span::styled(format!("{max_y:.0}"), theme::dim()),
+        ]))
+        .block(block.title_bottom(Line::from(Span::styled(caption, theme::text2()))));
+    f.render_widget(chart, area);
+}
+
+fn line_gauge(f: &mut Frame, area: Rect, label: &str, used: f64, total: f64, gradient: bool) {
+    let frac = if total > 0.0 {
+        (used / total).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let color = theme::pressure_color(frac).unwrap_or(if gradient {
+        theme::gradient_at(frac)
+    } else {
+        theme::CYAN.color()
+    });
+    let g = LineGauge::default()
+        .ratio(frac)
+        .filled_style(Style::default().fg(color))
+        .unfilled_style(Style::default().fg(theme::GAUGE_TRACK.color()))
+        .label(Span::styled(format!("{label:<4}"), theme::dim()));
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(10), Constraint::Length(16)])
+        .split(area);
+    f.render_widget(g, cols[0]);
+    f.render_widget(
+        Paragraph::new(Span::styled(
+            format!("{used:.0}/{total:.0}"),
+            theme::text2(),
+        )),
+        cols[1],
+    );
+}
+
+fn draw_sequences(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("SEQUENCES & MEMORY ─".into(), false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let s = &app.stats;
+    let (active, prefill, swapped, queue) = s
+        .sched
+        .map(|x| {
+            (
+                x.active_seqs,
+                x.prefilling_seqs,
+                x.swapped_seqs,
+                x.pending_len,
+            )
+        })
+        .unwrap_or_default();
+    let mut y = inner.y;
+    f.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            format!(" active {active} · prefill {prefill} · swapped {swapped} · queue {queue} "),
+            theme::text(),
+        )])),
+        Rect {
+            y,
+            height: 1,
+            ..inner
+        },
+    );
+    y += 1;
+    let qh = s.queue_history.as_u64();
+    if !qh.is_empty() {
+        f.render_widget(
+            Sparkline::default().data(&qh).style(theme::brand_cyan()),
+            Rect {
+                y,
+                height: 1,
+                x: inner.x + 1,
+                width: inner.width.saturating_sub(2),
+            },
+        );
+    }
+    y += 2;
+    if let Some(x) = s.sched {
+        let used = (x.kv_blocks_total - x.kv_blocks_free) as f64;
+        line_gauge(
+            f,
+            Rect {
+                y,
+                height: 1,
+                ..inner
+            },
+            " KV",
+            used,
+            x.kv_blocks_total as f64,
+            true,
+        );
+        y += 1;
+        line_gauge(
+            f,
+            Rect {
+                y,
+                height: 1,
+                ..inner
+            },
+            " SSM",
+            x.ssm_slots_used as f64,
+            x.ssm_slots_total as f64,
+            false,
+        );
+        y += 1;
+    }
+    line_gauge(
+        f,
+        Rect {
+            y,
+            height: 1,
+            ..inner
+        },
+        " GPU",
+        s.atlas_used_gb,
+        s.gpu_total_gb.max(0.001),
+        true,
+    );
+    y += 1;
+    line_gauge(
+        f,
+        Rect {
+            y,
+            height: 1,
+            ..inner
+        },
+        " RAM",
+        (s.host_total_gb - s.host_avail_gb).max(0.0),
+        s.host_total_gb.max(0.001),
+        false,
+    );
+}
+
+fn draw_spec_cache(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("SPECULATION & CACHE ─".into(), false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let s = &app.stats;
+    let mut lines: Vec<Line> = Vec::new();
+    if let Some(x) = s.sched {
+        lines.push(Line::from(vec![
+            Span::styled(format!(" MTP gate {:?}", x.mtp_mode), theme::text()),
+            Span::styled(
+                format!(" · delivered {:.0} tok/s", x.delivered_tps),
+                theme::text2(),
+            ),
+        ]));
+    }
+    for (k, accepted, total) in &s.spec_accept {
+        if *total == 0 {
+            continue;
+        }
+        let rate = *accepted as f64 / *total as f64;
+        let w = 16usize;
+        let filled = (rate * w as f64) as usize;
+        let bar: String = "█".repeat(filled) + &"░".repeat(w - filled);
+        lines.push(Line::from(vec![
+            Span::styled(format!(" accept k={k:<3}"), theme::text2()),
+            Span::styled(bar, theme::brand_cyan()),
+            Span::styled(format!(" {:>3.0}%", rate * 100.0), theme::text()),
+        ]));
+    }
+    lines.push(Line::default());
+    let hit = s
+        .prefix_hit_rate
+        .map(|r| format!("{:.0}%", r * 100.0))
+        .unwrap_or_else(|| "—".into());
+    lines.push(Line::from(Span::styled(
+        format!(" prefix-cache hit {hit} · {} tok warm", s.prefix_hit_tokens),
+        theme::text(),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!(
+            " tool calls {} · entropy {:.2}",
+            s.tool_calls_total, s.entropy
+        ),
+        theme::text2(),
+    )));
+    f.render_widget(Paragraph::new(lines), inner);
+    let eh = s.entropy_history.as_u64();
+    if !eh.is_empty() && inner.height >= 6 {
+        f.render_widget(
+            Sparkline::default().data(&eh).style(theme::brand_cyan()),
+            Rect {
+                y: inner.y + inner.height - 1,
+                height: 1,
+                x: inner.x + 1,
+                width: inner.width.saturating_sub(2),
+            },
+        );
+    }
+}
+
+fn fmt_ms(v: Option<f64>) -> String {
+    match v {
+        Some(ms) if ms >= 1000.0 => format!("{:.1}s", ms / 1000.0),
+        Some(ms) => format!("{ms:.0}ms"),
+        None => "—".into(),
+    }
+}
+
+fn human_bytes(rate: f64) -> String {
+    if rate >= 1_048_576.0 {
+        format!("{:.1}M", rate / 1_048_576.0)
+    } else if rate >= 1024.0 {
+        format!("{:.0}K", rate / 1024.0)
+    } else {
+        format!("{rate:.0}B")
+    }
+}

--- a/crates/spark-server/src/tui/render/terminal_tab.rs
+++ b/crates/spark-server/src/tui/render/terminal_tab.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Terminal tab: Ops REPL + Chat, tab-switched. `❯` purple prompt, ghost-text
+//! completion, role-guttered chat with streaming cursor.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Wrap};
+
+use super::panel;
+use crate::tui::app::{App, Focus, TermSub};
+use crate::tui::chat::Role;
+use crate::tui::{commands, theme};
+
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(4)])
+        .split(area);
+    draw_tabs(f, app, rows[0]);
+    match app.term_sub {
+        TermSub::Ops => draw_ops(f, app, rows[1]),
+        TermSub::Chat => draw_chat(f, app, rows[1]),
+    }
+}
+
+fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
+    let tab = |name: &str, active: bool| {
+        if active {
+            Span::styled(
+                format!(" {name} "),
+                theme::brand_cyan().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            )
+        } else {
+            Span::styled(format!(" {name} "), theme::text2())
+        }
+    };
+    let line = Line::from(vec![
+        tab("Ops", app.term_sub == TermSub::Ops),
+        Span::styled("─", theme::dim()),
+        tab("Chat", app.term_sub == TermSub::Chat),
+        Span::styled("   (5 toggles)", theme::dim()),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn draw_ops(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(3)])
+        .split(area);
+    // Output stream.
+    let out_block = panel(format!("OPS ─ {} lines ─", app.ops.output.len()), false);
+    let inner = out_block.inner(rows[0]);
+    f.render_widget(out_block, rows[0]);
+    let visible = inner.height as usize;
+    let lines: Vec<Line> = app
+        .ops
+        .output
+        .iter()
+        .rev()
+        .take(visible)
+        .rev()
+        .map(|l| {
+            if let Some(cmd) = l.strip_prefix("❯ ") {
+                Line::from(vec![
+                    Span::styled("❯ ", theme::brand_purple().add_modifier(Modifier::BOLD)),
+                    Span::styled(cmd.to_string(), theme::text().add_modifier(Modifier::BOLD)),
+                ])
+            } else {
+                Line::from(Span::styled(l.clone(), theme::text2()))
+            }
+        })
+        .collect();
+    f.render_widget(Paragraph::new(lines), inner);
+    // Input with ghost completion.
+    let focused = app.focus == Focus::Input;
+    let in_block = panel("─".into(), focused);
+    let in_inner = in_block.inner(rows[1]);
+    f.render_widget(in_block, rows[1]);
+    let mut spans = vec![
+        Span::styled("❯ ", theme::brand_purple().add_modifier(Modifier::BOLD)),
+        Span::styled(app.ops.input.clone(), theme::text()),
+    ];
+    if focused {
+        if let Some(ghost) = commands::complete(&app.ops.input) {
+            let rest = &ghost[app.ops.input.len()..];
+            spans.push(Span::styled(rest.to_string(), theme::dim()));
+            spans.push(Span::styled("  ⇥ accept", theme::dim()));
+        } else {
+            spans.push(Span::styled("▏", theme::brand_cyan()));
+        }
+    } else {
+        spans.push(Span::styled("  (Enter to focus · /help)", theme::dim()));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), in_inner);
+}
+
+fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
+    let input_h = (app.chat.input.lines().count().clamp(1, 5) + 2) as u16;
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(input_h)])
+        .split(area);
+    // Transcript.
+    let block = panel(
+        format!(
+            "CHAT ─ {} ─{}",
+            app.args
+                .model_name
+                .clone()
+                .or_else(|| app.args.model.clone())
+                .unwrap_or_default(),
+            if app.chat.streaming {
+                " streaming ─"
+            } else {
+                ""
+            }
+        ),
+        false,
+    );
+    let inner = block.inner(rows[0]);
+    f.render_widget(block, rows[0]);
+    let mut lines: Vec<Line> = Vec::new();
+    for m in &app.chat.transcript {
+        let (gutter, gstyle) = match m.role {
+            Role::User => ("❯ ", theme::brand_purple().add_modifier(Modifier::BOLD)),
+            Role::Model => ("⬢ ", theme::brand_cyan()),
+        };
+        let body_style = match m.role {
+            Role::User => theme::text(),
+            Role::Model => theme::text().bg(theme::BG_PANEL.color()),
+        };
+        for (i, text_line) in m.text.split('\n').enumerate() {
+            let g = if i == 0 {
+                Span::styled(gutter, gstyle)
+            } else {
+                Span::styled("  ", Style::default())
+            };
+            let rule = if m.role == Role::Model {
+                Span::styled("▏", theme::brand_cyan())
+            } else {
+                Span::raw("")
+            };
+            lines.push(Line::from(vec![
+                g,
+                rule,
+                Span::styled(text_line.to_string(), body_style),
+            ]));
+        }
+        // Streaming cursor at the tip of the live message.
+        if m.role == Role::Model
+            && app.chat.streaming
+            && std::ptr::eq(m, app.chat.transcript.last().unwrap())
+            && let Some(last) = lines.last_mut()
+        {
+            last.spans.push(Span::styled("▍", theme::brand_cyan()));
+        }
+        // Footer for completed model replies.
+        if m.role == Role::Model && (m.ttft_ms.is_some() || m.tok_per_s.is_some()) {
+            let footer = format!(
+                "  ttft {} · {} · {} tok",
+                m.ttft_ms
+                    .map(|v| format!("{v:.0} ms"))
+                    .unwrap_or_else(|| "—".into()),
+                m.tok_per_s
+                    .map(|v| format!("{v:.0} tok/s"))
+                    .unwrap_or_else(|| "—".into()),
+                m.tokens
+            );
+            lines.push(Line::from(Span::styled(footer, theme::dim())));
+        }
+        lines.push(Line::default());
+    }
+    let skip = lines.len().saturating_sub(inner.height as usize);
+    let shown: Vec<Line> = lines.into_iter().skip(skip).collect();
+    f.render_widget(Paragraph::new(shown).wrap(Wrap { trim: false }), inner);
+    // Input.
+    let focused = app.focus == Focus::Input;
+    let in_block = panel(
+        if focused {
+            "─ Enter send · \\+Enter newline · Esc cancel ─".into()
+        } else {
+            "─ Enter to focus ─".into()
+        },
+        focused,
+    );
+    let in_inner = in_block.inner(rows[1]);
+    f.render_widget(in_block, rows[1]);
+    let mut text = app.chat.input.clone();
+    if focused {
+        text.push('▏');
+    }
+    f.render_widget(
+        Paragraph::new(text)
+            .style(theme::text())
+            .wrap(Wrap { trim: false }),
+        in_inner,
+    );
+}

--- a/crates/spark-server/src/tui/render/terminal_tab.rs
+++ b/crates/spark-server/src/tui/render/terminal_tab.rs
@@ -8,6 +8,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::panel;
 use crate::tui::app::{App, Focus, TermSub};
@@ -98,6 +99,45 @@ fn draw_ops(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(Paragraph::new(Line::from(spans)), in_inner);
 }
 
+/// Word-wrap `text` into display rows of at most `width` columns.
+///
+/// The chat pane slices its viewport on these rows, so they must be what actually
+/// renders — measured in display columns via `unicode-width`, not `str::len`, or
+/// CJK and emoji replies would compute a tail that is short by a row per line.
+/// A word longer than the pane is hard-split rather than allowed to overhang.
+fn wrap_rows(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![String::new()];
+    }
+    let mut rows = Vec::new();
+    for logical in text.split('\n') {
+        let (mut cur, mut cur_w) = (String::new(), 0usize);
+        for word in logical.split_inclusive(' ') {
+            let w = UnicodeWidthStr::width(word);
+            if cur_w + w > width && !cur.is_empty() {
+                rows.push(std::mem::take(&mut cur));
+                cur_w = 0;
+            }
+            if w > width {
+                for ch in word.chars() {
+                    let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+                    if cur_w + cw > width {
+                        rows.push(std::mem::take(&mut cur));
+                        cur_w = 0;
+                    }
+                    cur.push(ch);
+                    cur_w += cw;
+                }
+            } else {
+                cur.push_str(word);
+                cur_w += w;
+            }
+        }
+        rows.push(cur);
+    }
+    rows
+}
+
 fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
     let input_h = (app.chat.input.lines().count().clamp(1, 5) + 2) as u16;
     let rows = Layout::default()
@@ -113,16 +153,18 @@ fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
                 .clone()
                 .or_else(|| app.args.model.clone())
                 .unwrap_or_default(),
-            if app.chat.streaming {
-                " streaming ─"
-            } else {
-                ""
+            match (app.chat.streaming, app.chat.scroll) {
+                (_, Some(n)) => format!(" ↑{n} ─ End follows ─"),
+                (true, None) => " streaming ─".to_string(),
+                (false, None) => String::new(),
             }
         ),
         false,
     );
     let inner = block.inner(rows[0]);
     f.render_widget(block, rows[0]);
+    // Body width = pane minus the 2-col gutter and the 1-col model rule.
+    let body_w = inner.width.saturating_sub(3) as usize;
     let mut lines: Vec<Line> = Vec::new();
     for m in &app.chat.transcript {
         let (gutter, gstyle) = match m.role {
@@ -133,7 +175,7 @@ fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
             Role::User => theme::text(),
             Role::Model => theme::text().bg(theme::BG_PANEL.color()),
         };
-        for (i, text_line) in m.text.split('\n').enumerate() {
+        for (i, text_line) in wrap_rows(&m.text, body_w).iter().enumerate() {
             let g = if i == 0 {
                 Span::styled(gutter, gstyle)
             } else {
@@ -174,9 +216,20 @@ fn draw_chat(f: &mut Frame, app: &App, area: Rect) {
         }
         lines.push(Line::default());
     }
-    let skip = lines.len().saturating_sub(inner.height as usize);
-    let shown: Vec<Line> = lines.into_iter().skip(skip).collect();
-    f.render_widget(Paragraph::new(shown).wrap(Wrap { trim: false }), inner);
+    // `lines` is already in DISPLAY rows (see wrap_rows), so the tail slice is
+    // exact and needs no Wrap. It used to slice on unwrapped logical lines and let
+    // the widget wrap afterwards: one long reply is a single logical line, so the
+    // slice kept everything, the wrapped result overflowed the pane, and the
+    // streaming tip rendered below the visible area — the stream "stopped
+    // following" precisely when a reply got long enough to matter.
+    let h = inner.height as usize;
+    let max_off = lines.len().saturating_sub(h);
+    let off = match app.chat.scroll {
+        None => max_off,
+        Some(n) => max_off.saturating_sub(n),
+    };
+    let shown: Vec<Line> = lines.into_iter().skip(off).take(h).collect();
+    f.render_widget(Paragraph::new(shown), inner);
     // Input.
     let focused = app.focus == Focus::Input;
     let in_block = panel(

--- a/crates/spark-server/src/tui/shutdown.rs
+++ b/crates/spark-server/src/tui/shutdown.rs
@@ -20,7 +20,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use tokio::sync::Notify;
+use tokio::sync::{Notify, oneshot};
 
 static REQUESTED: AtomicBool = AtomicBool::new(false);
 
@@ -29,10 +29,49 @@ fn notify() -> &'static Notify {
     N.get_or_init(Notify::new)
 }
 
+/// Startup escape hatch: the sending half of `main`'s one-shot, held so that
+/// whichever trigger fires FIRST takes it and the rest are no-ops.
+///
+/// `serve()` is `async` but never awaits between the banner and the accept loop
+/// — startup is one blocking sequence (weight load, KV alloc, kernel audit). So
+/// the accept loop's `select!` on [`wait`] cannot be reached while a model is
+/// loading, and Ctrl+C looked ignored for the whole load. `main` now races the
+/// spawned `serve()` task against this channel, which needs no cooperation from
+/// the blocking code at all.
+///
+/// It is DISARMED by [`disarm_startup_escape`] the moment the accept loop takes
+/// over. After that a shutdown must go through the graceful path below, or a
+/// Ctrl+C on a live server would exit while requests were still in flight.
+static STARTUP_ESCAPE: OnceLock<std::sync::Mutex<Option<oneshot::Sender<&'static str>>>> =
+    OnceLock::new();
+
+fn escape() -> &'static std::sync::Mutex<Option<oneshot::Sender<&'static str>>> {
+    STARTUP_ESCAPE.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Arm the startup escape with `main`'s sender. Called once, before `serve()`.
+pub fn arm_startup_escape(tx: oneshot::Sender<&'static str>) {
+    *escape().lock().expect("shutdown escape poisoned") = Some(tx);
+}
+
+/// Drop the startup escape once the server is accepting: from here on, shutdown
+/// means "stop accepting and drain", not "return from main".
+pub fn disarm_startup_escape() {
+    escape().lock().expect("shutdown escape poisoned").take();
+}
+
 /// Request a clean shutdown. Idempotent; safe from any thread.
-pub fn request(reason: &str) {
+pub fn request(reason: &'static str) {
     if !REQUESTED.swap(true, Ordering::SeqCst) {
         tracing::info!("Shutdown requested ({reason}) — draining in-flight requests");
+    }
+    // Still in startup? Hand the reason to main's select! and let it unwind
+    // there. `take()` means only the first trigger sends; later ones fall
+    // through to the notification below, which is all the accept loop needs.
+    if let Ok(mut slot) = escape().lock()
+        && let Some(tx) = slot.take()
+    {
+        let _ = tx.send(reason);
     }
     notify().notify_waiters();
 }

--- a/crates/spark-server/src/tui/shutdown.rs
+++ b/crates/spark-server/src/tui/shutdown.rs
@@ -49,15 +49,27 @@ fn escape() -> &'static std::sync::Mutex<Option<oneshot::Sender<&'static str>>> 
     STARTUP_ESCAPE.get_or_init(|| std::sync::Mutex::new(None))
 }
 
+/// Whether a shutdown request should still take the startup escape. Cleared when
+/// the accept loop takes over; the SENDER itself is deliberately kept alive (see
+/// [`disarm_startup_escape`]).
+static IN_STARTUP: AtomicBool = AtomicBool::new(true);
+
 /// Arm the startup escape with `main`'s sender. Called once, before `serve()`.
 pub fn arm_startup_escape(tx: oneshot::Sender<&'static str>) {
     *escape().lock().expect("shutdown escape poisoned") = Some(tx);
 }
 
-/// Drop the startup escape once the server is accepting: from here on, shutdown
+/// Close the startup escape once the server is accepting: from here on, shutdown
 /// means "stop accepting and drain", not "return from main".
+///
+/// This only flips a flag — it must NOT drop the sender. Dropping it closes the
+/// channel, which resolves `main`'s receiver with `Err(RecvError)`; that is
+/// indistinguishable from a shutdown unless the receiving side special-cases it,
+/// and taking it at face value exits a healthy server the instant it comes up.
+/// Parking the sender here for the life of the process means the channel simply
+/// never closes and there is no such edge to get wrong.
 pub fn disarm_startup_escape() {
-    escape().lock().expect("shutdown escape poisoned").take();
+    IN_STARTUP.store(false, Ordering::SeqCst);
 }
 
 /// Request a clean shutdown. Idempotent; safe from any thread.
@@ -66,9 +78,12 @@ pub fn request(reason: &'static str) {
         tracing::info!("Shutdown requested ({reason}) — draining in-flight requests");
     }
     // Still in startup? Hand the reason to main's select! and let it unwind
-    // there. `take()` means only the first trigger sends; later ones fall
-    // through to the notification below, which is all the accept loop needs.
-    if let Ok(mut slot) = escape().lock()
+    // there. Taking the sender is the one legitimate way it is consumed — only
+    // the first trigger sends, and the process is on its way out. Once the accept
+    // loop owns shutdown the sender stays parked and untouched, so the channel
+    // never closes and the notification below is what does the work.
+    if IN_STARTUP.load(Ordering::SeqCst)
+        && let Ok(mut slot) = escape().lock()
         && let Some(tx) = slot.take()
     {
         let _ = tx.send(reason);

--- a/crates/spark-server/src/tui/shutdown.rs
+++ b/crates/spark-server/src/tui/shutdown.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! One shutdown path for every trigger.
+//!
+//! Sources that request shutdown:
+//!  * plain mode: `SIGINT` (Ctrl+C) / `SIGTERM` via the tokio signal listener
+//!    installed by [`install_signal_listeners`] — nothing handled these before
+//!    this module; the process just died mid-write.
+//!  * TUI mode: raw mode swallows `SIGINT`, so Ctrl+C arrives as a KEY event —
+//!    the event loop calls [`request`]. (`SIGTERM`, e.g. `docker stop`, still
+//!    arrives as a signal and is caught by the same listener.)
+//!  * `/quit` in the Terminal tab.
+//!
+//! Effect: the router's accept loop (which `select!`s on [`wait`]) stops
+//! accepting, waits for in-flight requests to drain (bounded grace), and
+//! returns — unwinding `serve()` normally so Drop impls (TerminalGuard, tee
+//! flush) run. That IS the clean shutdown: no `exit()` shortcuts.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+static REQUESTED: AtomicBool = AtomicBool::new(false);
+
+fn notify() -> &'static Notify {
+    static N: OnceLock<Notify> = OnceLock::new();
+    N.get_or_init(Notify::new)
+}
+
+/// Request a clean shutdown. Idempotent; safe from any thread.
+pub fn request(reason: &str) {
+    if !REQUESTED.swap(true, Ordering::SeqCst) {
+        tracing::info!("Shutdown requested ({reason}) — draining in-flight requests");
+    }
+    notify().notify_waiters();
+}
+
+/// Has shutdown been requested?
+pub fn requested() -> bool {
+    REQUESTED.load(Ordering::SeqCst)
+}
+
+/// Resolve when shutdown is requested (immediately if it already was).
+pub async fn wait() {
+    if requested() {
+        return;
+    }
+    // Register interest BEFORE re-checking to close the race with `request`.
+    let notified = notify().notified();
+    if requested() {
+        return;
+    }
+    notified.await;
+}
+
+/// Install `SIGINT` + `SIGTERM` listeners on the tokio runtime. Called once
+/// from `serve()`; both modes need it (`SIGTERM` is how `docker stop` speaks
+/// even when the TUI owns the keyboard).
+pub fn install_signal_listeners() {
+    tokio::spawn(async {
+        let ctrl_c = tokio::signal::ctrl_c();
+        #[cfg(unix)]
+        {
+            let mut term =
+                match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!("SIGTERM listener unavailable: {e}");
+                        if ctrl_c.await.is_ok() {
+                            request("SIGINT");
+                        }
+                        return;
+                    }
+                };
+            tokio::select! {
+                r = ctrl_c => { if r.is_ok() { request("SIGINT"); } }
+                _ = term.recv() => { request("SIGTERM"); }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            if ctrl_c.await.is_ok() {
+                request("SIGINT");
+            }
+        }
+    });
+}
+
+/// Post-accept-loop drain: wait until no requests are active or the grace
+/// window expires. Uses the existing `REQUESTS_ACTIVE` gauge — no new
+/// scheduler plumbing, and honest about what "drained" means.
+pub async fn drain_in_flight(grace: Duration) {
+    let start = std::time::Instant::now();
+    loop {
+        let active = crate::metrics::REQUESTS_ACTIVE.get();
+        if active <= 0 {
+            tracing::info!("Drain complete — no active requests");
+            return;
+        }
+        if start.elapsed() >= grace {
+            tracing::warn!(
+                "Drain grace ({}s) expired with {active} request(s) still active — exiting",
+                grace.as_secs()
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}

--- a/crates/spark-server/src/tui/terminal_guard.rs
+++ b/crates/spark-server/src/tui/terminal_guard.rs
@@ -36,6 +36,16 @@ static ORIG_STDERR: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32:
 /// library prints); any one of them scribbles over the raw-mode frame. The
 /// writes land in the tee file instead; `restore()` puts the real stderr back
 /// BEFORE the panic hook prints, so panics stay visible on the terminal.
+/// No-op off unix: `libc::dup`/`dup2` and `std::os::fd` do not exist there, and
+/// the Windows console does not share the fd-2 aliasing this works around. The
+/// TUI still runs; stray `eprintln!`s are simply not captured.
+#[cfg(not(unix))]
+fn redirect_stderr_to_tee() {}
+
+#[cfg(not(unix))]
+fn unredirect_stderr() {}
+
+#[cfg(unix)]
 fn redirect_stderr_to_tee() {
     if let Some(tee_fd) = super::init::tee_raw_fd() {
         // SAFETY: plain fd juggling on fds we own; dup/dup2 are async-signal-
@@ -51,6 +61,7 @@ fn redirect_stderr_to_tee() {
     }
 }
 
+#[cfg(unix)]
 fn unredirect_stderr() {
     let orig = ORIG_STDERR.swap(-1, Ordering::SeqCst);
     if orig >= 0 {

--- a/crates/spark-server/src/tui/terminal_guard.rs
+++ b/crates/spark-server/src/tui/terminal_guard.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Raw-mode/alternate-screen lifecycle with crash safety.
+//!
+//! The terminal MUST be restored on every exit path — clean quit, detach,
+//! `?`-panic on ANY thread (CUDA `.expect()`s in the scheduler thread
+//! included), or the process unwinding out of `main`. Three layers:
+//!
+//!  1. [`TerminalGuard`] — RAII: enters raw mode + alternate screen + mouse
+//!     capture on construction, restores on `Drop`.
+//!  2. [`restore`] — idempotent (an `AtomicBool` guards double-restore), so
+//!     the guard's Drop and the panic hook can both call it safely.
+//!  3. A process-global panic hook (installed once, chained to the previous
+//!     hook) that restores the terminal FIRST — so the panic message and
+//!     backtrace print onto a sane screen — then dumps the newest log-ring
+//!     lines to stderr and points at the tee file.
+//!
+//! SIGKILL cannot be caught; `reset`/`stty sane` is the documented recovery.
+
+use std::io::Write;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+
+/// True while raw mode + alt screen are active. `restore()` flips it false.
+static TERMINAL_TAKEN: AtomicBool = AtomicBool::new(false);
+/// Saved dup of the original stderr fd while it is redirected (-1 = not).
+static ORIG_STDERR: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+/// Redirect fd 2 into the tee file while the TUI owns the screen. Ten-plus
+/// `eprintln!` sites exist in spark-model/spark-runtime (plus anything a C
+/// library prints); any one of them scribbles over the raw-mode frame. The
+/// writes land in the tee file instead; `restore()` puts the real stderr back
+/// BEFORE the panic hook prints, so panics stay visible on the terminal.
+fn redirect_stderr_to_tee() {
+    if let Some(tee_fd) = super::init::tee_raw_fd() {
+        // SAFETY: plain fd juggling on fds we own; dup/dup2 are async-signal-
+        // safe and the saved fd is released in restore().
+        unsafe {
+            let orig = libc::dup(2);
+            if orig >= 0 && libc::dup2(tee_fd, 2) >= 0 {
+                ORIG_STDERR.store(orig, Ordering::SeqCst);
+            } else if orig >= 0 {
+                libc::close(orig);
+            }
+        }
+    }
+}
+
+fn unredirect_stderr() {
+    let orig = ORIG_STDERR.swap(-1, Ordering::SeqCst);
+    if orig >= 0 {
+        // SAFETY: restoring the fd we saved above.
+        unsafe {
+            libc::dup2(orig, 2);
+            libc::close(orig);
+        }
+    }
+}
+
+/// Snapshot fn the panic hook uses to dump recent log lines. Set by
+/// `install_panic_hook`; kept as a plain fn pointer so this module does not
+/// depend on the ring's type.
+static RING_DUMP: OnceLock<fn(&mut dyn Write, usize)> = OnceLock::new();
+/// Tee-file path, printed by the panic hook so operators know where the full
+/// log went while the alt screen was eating stdout.
+static TEE_PATH: OnceLock<String> = OnceLock::new();
+
+/// Idempotently undo raw mode, mouse capture, and the alternate screen.
+///
+/// Safe to call from any thread, any number of times, including inside a
+/// panic hook. Errors are deliberately ignored — there is no better recovery
+/// than trying the next teardown step.
+pub fn restore() {
+    if !TERMINAL_TAKEN.swap(false, Ordering::SeqCst) {
+        return;
+    }
+    unredirect_stderr();
+    let _ = disable_raw_mode();
+    let mut out = std::io::stdout();
+    let _ = crossterm::execute!(out, DisableMouseCapture, LeaveAlternateScreen);
+    let _ = crossterm::execute!(out, crossterm::cursor::Show);
+    let _ = out.flush();
+}
+
+/// RAII terminal ownership for the TUI thread.
+pub struct TerminalGuard;
+
+impl TerminalGuard {
+    /// Enter raw mode + alternate screen + mouse capture.
+    pub fn enter() -> std::io::Result<Self> {
+        enable_raw_mode()?;
+        crossterm::execute!(std::io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+        TERMINAL_TAKEN.store(true, Ordering::SeqCst);
+        redirect_stderr_to_tee();
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        restore();
+    }
+}
+
+/// Install the chained panic hook. `ring_dump(w, n)` writes the newest `n`
+/// captured log lines to `w`; `tee_path` is the always-on log file.
+///
+/// Must be called BEFORE `TerminalGuard::enter` so a panic during entry is
+/// covered too. Installing more than once is a no-op.
+pub fn install_panic_hook(ring_dump: fn(&mut dyn Write, usize), tee_path: &str) {
+    if RING_DUMP.set(ring_dump).is_err() {
+        return; // already installed
+    }
+    let _ = TEE_PATH.set(tee_path.to_string());
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // 1. Sane screen first, so everything below is actually visible.
+        restore();
+        // 2. Recent context: the last lines the operator saw in the TUI.
+        let mut err = std::io::stderr();
+        let _ = writeln!(err, "\n── atlas-tui: panic — last log lines ──");
+        if let Some(dump) = RING_DUMP.get() {
+            dump(&mut err, 50);
+        }
+        if let Some(p) = TEE_PATH.get() {
+            let _ = writeln!(err, "── full log: {p} ──");
+        }
+        // 3. The original hook prints the panic message + backtrace.
+        previous(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_is_idempotent_when_never_taken() {
+        // Never entered: restore must be a no-op that doesn't touch the tty.
+        assert!(!TERMINAL_TAKEN.load(Ordering::SeqCst));
+        restore();
+        restore();
+        assert!(!TERMINAL_TAKEN.load(Ordering::SeqCst));
+    }
+}

--- a/crates/spark-server/src/tui/theme.rs
+++ b/crates/spark-server/src/tui/theme.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The Atlas TUI design system.
+//!
+//! Three brand chevron colors with fixed semantic momentum roles:
+//! purple = identity/selection, cyan = activity/focus, green = success/ready.
+//! Truecolor by default with pinned 256-color fallbacks; the terminal's own
+//! ANSI 0-15 palette is never used, and the app paints its own surfaces so
+//! contrast is controlled everywhere.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// Whether the terminal advertises 24-bit color.
+fn truecolor() -> bool {
+    std::env::var("COLORTERM")
+        .map(|v| v.contains("truecolor") || v.contains("24bit"))
+        .unwrap_or(false)
+}
+
+/// A themed color: truecolor value + 256-palette fallback index.
+#[derive(Clone, Copy)]
+pub struct C(pub u8, pub u8, pub u8, pub u8);
+
+impl C {
+    pub fn color(self) -> Color {
+        if truecolor() {
+            Color::Rgb(self.0, self.1, self.2)
+        } else {
+            Color::Indexed(self.3)
+        }
+    }
+}
+
+// ── Brand ──
+pub const PURPLE: C = C(0xBE, 0x9D, 0xF8, 141);
+pub const CYAN: C = C(0x49, 0xC3, 0xDB, 80);
+pub const GREEN: C = C(0x12, 0xB9, 0x81, 36);
+// ── Surfaces ──
+pub const BG_BASE: C = C(0x0F, 0x11, 0x17, 232);
+pub const BG_PANEL: C = C(0x15, 0x18, 0x23, 233);
+pub const BG_RAISED: C = C(0x1E, 0x22, 0x30, 235);
+pub const BG_SELECTION: C = C(0x2B, 0x26, 0x40, 237);
+// ── Lines & text ──
+pub const BORDER_DIM: C = C(0x2A, 0x2F, 0x3F, 237);
+pub const TEXT: C = C(0xE6, 0xE9, 0xF0, 254);
+pub const TEXT_2: C = C(0x93, 0x97, 0xA0, 246);
+pub const TEXT_DIM: C = C(0x56, 0x5B, 0x68, 240);
+// ── Status ──
+pub const WARN: C = C(0xE5, 0xC0, 0x7B, 179);
+pub const ERROR: C = C(0xF7, 0x76, 0x8E, 204);
+pub const GAUGE_TRACK: C = C(0x25, 0x2A, 0x38, 236);
+
+pub fn text() -> Style {
+    Style::default().fg(TEXT.color())
+}
+pub fn text2() -> Style {
+    Style::default().fg(TEXT_2.color())
+}
+pub fn dim() -> Style {
+    Style::default().fg(TEXT_DIM.color())
+}
+pub fn brand_purple() -> Style {
+    Style::default().fg(PURPLE.color())
+}
+pub fn brand_cyan() -> Style {
+    Style::default().fg(CYAN.color())
+}
+pub fn brand_green() -> Style {
+    Style::default().fg(GREEN.color())
+}
+pub fn warn() -> Style {
+    Style::default().fg(WARN.color())
+}
+pub fn error() -> Style {
+    Style::default()
+        .fg(ERROR.color())
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Panel border style; `focused` flips it to brand cyan (color is the focus
+/// signal — same glyph weight everywhere).
+pub fn border(focused: bool) -> Style {
+    if focused {
+        brand_cyan()
+    } else {
+        Style::default().fg(BORDER_DIM.color())
+    }
+}
+
+/// Panel title style (CAPS text; bold cyan when the panel has focus).
+pub fn title(focused: bool) -> Style {
+    if focused {
+        brand_cyan().add_modifier(Modifier::BOLD)
+    } else {
+        text2()
+    }
+}
+
+/// Log level color, per the spec's level ramp.
+pub fn level_style(level: tracing::Level) -> Style {
+    match level {
+        tracing::Level::ERROR => error(),
+        tracing::Level::WARN => warn(),
+        tracing::Level::INFO => brand_cyan(),
+        _ => dim(),
+    }
+}
+
+/// Interpolate the signature progress gradient at `t ∈ [0,1]`:
+/// purple → cyan on [0,0.5), cyan → green on [0.5,1]. In 256-color mode,
+/// three hard bands (the fallback indices).
+pub fn gradient_at(t: f64) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    if !truecolor() {
+        return if t < 0.34 {
+            Color::Indexed(PURPLE.3)
+        } else if t < 0.67 {
+            Color::Indexed(CYAN.3)
+        } else {
+            Color::Indexed(GREEN.3)
+        };
+    }
+    let lerp = |a: u8, b: u8, f: f64| (a as f64 + (b as f64 - a as f64) * f).round() as u8;
+    let (from, to, f) = if t < 0.5 {
+        (PURPLE, CYAN, t * 2.0)
+    } else {
+        (CYAN, GREEN, (t - 0.5) * 2.0)
+    };
+    Color::Rgb(
+        lerp(from.0, to.0, f),
+        lerp(from.1, to.1, f),
+        lerp(from.2, to.2, f),
+    )
+}
+
+/// Gauge fill color override when nearly full: ≥97% error, ≥90% warn.
+pub fn pressure_color(frac: f64) -> Option<Color> {
+    if frac >= 0.97 {
+        Some(ERROR.color())
+    } else if frac >= 0.90 {
+        Some(WARN.color())
+    } else {
+        None
+    }
+}
+
+/// Braille spinner frames (1 rev/s at the 10 Hz tick).
+pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];


### PR DESCRIPTION
## What this is

A ratatui dashboard for `spark serve` on the head node — five sections (Main / Stats /
Network / Library / Terminal) over a sticky branded header, driven by keyboard or mouse.

* **Main** — live 12-phase startup checklist with a GB-weighted gradient progress hero fed by
  structured weight-loader events, CLI flag badge chips, a filterable log pane, and the kernel
  audit as a real table instead of a wall of log lines.
* **Stats** — 1 Hz server metrics: requests, bytes in/out, tok/s, a TTFT histogram, KV/SSM/GPU/RAM
  gauges, spec-decode accept rates, prefix-cache hit rate.
* **Network** — TP/EP topology.
* **Library** — browse the local HF cache.
* **Terminal** — safe ops slash-commands plus a streaming loopback chat client for the served model.

## Safety contracts

The engine is benchmarked by scripts that grep its log format, so the first requirement was that
none of this can perturb a measured run:

* **TTY-gated.** The TUI activates only when stdin **and** stdout are interactive. Piped or
  daemonized runs keep the pre-existing `fmt()` init **byte-identical** — the exact format every
  benchmark driver and gate script parses. Escapes: `--no-tui`, `ATLAS_NO_TUI=1`. EP workers
  (rank > 0) always stay plain.
* **No existing log line changed.** Startup progress rides *adjacent* debug-level events under a
  dedicated `atlas::tui::progress` target.
* **Crash-safe.** All logs tee to `~/.cache/atlas/logs/` (the alt screen eats stdout), and a chained
  panic hook restores the terminal, dumps the last ring lines to stderr, and prints the tee path —
  CUDA panics on any thread included.
* **Clean shutdown, both modes.** SIGINT/SIGTERM listeners (none existed before) and
  Ctrl+C-as-key in raw mode funnel into one path: the accept loop stops, in-flight requests drain
  (15 s grace via `REQUESTS_ACTIVE`), `Drop` impls run.
* **Scheduler observability is passive.** A ~72-byte `Copy` snapshot published once per loop tick
  behind an uncontended `parking_lot` mutex; the TUI never touches scheduler-thread locals. Chat
  rides the normal loopback HTTP path.

## Validation

Runtime-tested against a real dense-27B NVFP4 serve on a DGX Spark GB10, via a tmux capture matrix
rather than by eye — every tab captured live while serving:

* Chat tab round-tripped against the served model: `ttft 451 ms · 168 tok/s`.
* Stats rendered real values (KV 3/5259, RAM 114/122 GB, populated TTFT histogram and throughput
  sparkline).
* Shutdown returned a clean shell prompt with the terminal restored and zero lingering processes.
* Release build clean; rebased on `main` @ a011abc7 and rebuilt green.

## Notes for review

* New deps: `ratatui` 0.29, `crossterm` 0.28, `tui-textarea`, `unicode-width`, `http-body` — all
  MIT, cargo-deny clean. All 23 new files ≤ 407 LoC, within the repo cap.
* One open question I have not chased: on the **new** clean-shutdown path (previously the process
  simply died) teardown logs `Failed to free pinned staging: cuMemFreeHost failed: status 4`.
  Status 4 is `deinitialized`, which would make it cosmetic ordering, but I would rather confirm
  that than assume it.
