### PR TITLE
Enterprise Concurrency

### DIFF
--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -197,6 +197,11 @@ fn main() {
 
     // Per-target: (target_idx, vec of (stem, module_name))
     let mut all_target_modules: Vec<Vec<(String, String)>> = Vec::new();
+    // Per-target: (module, kernel) pairs this model's files dropped by shadowing
+    // their `common/` namesakes. Baked into the binary so the startup audit can
+    // separate "dropped by a fork" (fatal) from "never built for this target"
+    // (expected). See `shadowed_dropped_pairs`.
+    let mut all_target_drops: Vec<Vec<(String, String)>> = Vec::new();
 
     // 2026-05-24 dedup+parallel: pre-walk every (target, cu_file) pair
     // and split into two queues:
@@ -336,6 +341,30 @@ fn main() {
 
         all_target_modules.push(modules);
 
+        let drops = shadowed_dropped_pairs(
+            target.common_kernel_dir.as_deref(),
+            &target.model_kernel_dir,
+            source_ext,
+            &target.module_overrides,
+        );
+        if !drops.is_empty() {
+            println!(
+                "cargo:warning=atlas-kernels: ({}, {}) drops {} kernel(s) by shadowing common/: {}. \
+                 A dropped kernel fails CLOSED (try_kernel -> handle 0). If the model genuinely \
+                 cannot use it this is fine; the startup audit will only hard-error if the model's \
+                 dispatch actually requests it.",
+                target.model,
+                target.quant,
+                drops.len(),
+                drops
+                    .iter()
+                    .map(|(m, f)| format!("{m}::{f}"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+        }
+        all_target_drops.push(drops);
+
         println!(
             "cargo:rerun-if-changed={}",
             target.model_kernel_dir.display()
@@ -436,8 +465,13 @@ fn main() {
     }
 
     // ── Generate target_ptx.rs ──
-    let generated =
-        generate_target_ptx_rs(&targets, &all_target_modules, output_ext, uses_cuda_api);
+    let generated = generate_target_ptx_rs(
+        &targets,
+        &all_target_modules,
+        &all_target_drops,
+        output_ext,
+        uses_cuda_api,
+    );
     let gen_path = out_dir.join("target_ptx.rs");
     std::fs::write(&gen_path, &generated)
         .unwrap_or_else(|e| panic!("Failed to write {}: {e}", gen_path.display()));
@@ -1045,3 +1079,120 @@ use build_codegen::generate_target_ptx_rs;
 mod build_target;
 use build_target::resolve_compute_target;
 // Force recompilation 1775404930
+
+/// Every `(module, kernel)` this target's model-specific files drop relative to
+/// their `common/` namesakes.
+///
+/// SHADOWING DRIFT. Shadowing is whole-file, not per-symbol: a model file
+/// replaces its common namesake entirely. When `common/` later gains a kernel
+/// the fork never picked up, that kernel silently vanishes for this model —
+/// `try_kernel` returns handle 0 and whatever depends on it fails CLOSED. That
+/// is exactly how the 27B lost the four multi-sequence decode kernels
+/// (`gated_delta_rule_decode_f32_{norm,conv_norm,strided,strided_norm}`),
+/// pinning every concurrent decode to the per-sequence fallback until
+/// 2026-07-26.
+///
+/// This list is baked into the binary (`TargetPtxSet::shadowed_dropped`) so the
+/// startup kernel audit can tell the two failure classes apart:
+///
+///   * a lookup that failed AND is in this list — the kernel EXISTS in
+///     `common/`, this model's fork dropped it. A build defect: fatal.
+///   * a lookup that failed and is NOT — the kernel was never compiled for this
+///     target at all (typically another architecture's: MLA, hyper-connection,
+///     CSA). Expected, and merely informational.
+///
+/// Without that split the audit prints ~26 benign entries for a Qwen model and
+/// the one that matters hides among them.
+fn shadowed_dropped_pairs(
+    common_dir: Option<&std::path::Path>,
+    model_dir: &std::path::Path,
+    source_ext: &str,
+    module_overrides: &HashMap<String, String>,
+) -> Vec<(String, String)> {
+    let Some(common) = common_dir else {
+        return Vec::new();
+    };
+    let common_by_stem: HashMap<String, PathBuf> = find_cu_files(common, source_ext)
+        .into_iter()
+        .map(|f| (f.file_stem().unwrap().to_str().unwrap().to_string(), f))
+        .collect();
+    let mut out = Vec::new();
+    for f in find_cu_files(model_dir, source_ext) {
+        let stem = f.file_stem().unwrap().to_str().unwrap().to_string();
+        let Some(common_f) = common_by_stem.get(&stem) else {
+            continue;
+        };
+        let module = module_overrides.get(&stem).cloned().unwrap_or(stem);
+        for func in shadowed_missing_symbols(common_f, &f) {
+            out.push((module.clone(), func));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Kernel entry points a shadowing model file drops relative to its `common/`
+/// namesake. Scans for `extern "C" __global__ void <name>` (tolerating an
+/// interposed `__launch_bounds__(...)`), which is how every Atlas kernel entry
+/// point is declared. Text-scan by design: it runs before nvcc, so it cannot
+/// depend on compiled artifacts. Returns sorted names for stable warnings.
+fn shadowed_missing_symbols(
+    common_file: &std::path::Path,
+    model_file: &std::path::Path,
+) -> Vec<String> {
+    fn entry_points(p: &std::path::Path) -> std::collections::BTreeSet<String> {
+        let Ok(text) = std::fs::read_to_string(p) else {
+            return Default::default();
+        };
+        let mut out = std::collections::BTreeSet::new();
+        for (idx, _) in text.match_indices("__global__") {
+            let tail = &text[idx..];
+            // Skip `__global__`, an optional `__launch_bounds__(...)`, and the
+            // return type, then take the identifier before `(`.
+            let Some(paren) = tail.find('(') else {
+                continue;
+            };
+            let mut head = &tail[..paren];
+            if let Some(lb) = head.find("__launch_bounds__") {
+                // `__launch_bounds__(N, M)` — the name follows its close paren.
+                let after = &tail[idx_after_balanced(tail, lb)..];
+                let Some(p2) = after.find('(') else { continue };
+                head = &after[..p2];
+            }
+            if let Some(name) = head.split_whitespace().last() {
+                let name = name.trim_start_matches('*');
+                if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                    out.insert(name.to_string());
+                }
+            }
+        }
+        out
+    }
+    // Index just past the balanced `(...)` that follows `from` in `s`.
+    fn idx_after_balanced(s: &str, from: usize) -> usize {
+        let bytes = s.as_bytes();
+        let mut i = from;
+        while i < bytes.len() && bytes[i] != b'(' {
+            i += 1;
+        }
+        let mut depth = 0usize;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return i + 1;
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        from
+    }
+    entry_points(common_file)
+        .difference(&entry_points(model_file))
+        .cloned()
+        .collect()
+}

--- a/crates/atlas-kernels/build_codegen.rs
+++ b/crates/atlas-kernels/build_codegen.rs
@@ -24,6 +24,7 @@ use super::{SamplingCat, Target};
 pub(super) fn generate_target_ptx_rs(
     targets: &[Target],
     all_modules: &[Vec<(String, String)>],
+    all_drops: &[Vec<(String, String)>],
     output_ext: &str,
     cuda_api: bool,
 ) -> String {
@@ -180,6 +181,7 @@ pub(super) fn generate_target_ptx_rs(
              \x20           }},\n\
              \x20           model_type_matches: vec![{}],\n\
              \x20           dflash: {},\n\
+             \x20           shadowed_dropped: &[{}],\n\
              \x20       }},\n",
             target.model, target.quant,
             fmt_cat(&target.sampling_thinking_text),
@@ -224,6 +226,15 @@ pub(super) fn generate_target_ptx_rs(
                     d.target_layer_ids.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "),
                 ),
             },
+            all_drops
+                .get(idx)
+                .map(|d| {
+                    d.iter()
+                        .map(|(m, f)| format!("(\"{m}\", \"{f}\")"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default(),
         ));
     }
     g.push_str("    ]\n}\n");

--- a/crates/atlas-kernels/src/lib.rs
+++ b/crates/atlas-kernels/src/lib.rs
@@ -354,6 +354,17 @@ pub struct TargetPtxSet {
     /// no `[dflash]` section. Consumed by spark-server when `--dflash` is
     /// set without an explicit `--draft-model` flag.
     pub dflash: Option<DflashConfig>,
+    /// `(module, kernel)` pairs this model's kernel files DROPPED by shadowing
+    /// their `common/` namesakes — the kernel exists in `common/` but this
+    /// model's fork of the file does not define it, so it is not compiled here.
+    ///
+    /// Shadowing is whole-file, so a fork that predates a kernel added to
+    /// `common/` silently loses it: `try_kernel` returns handle 0 and whatever
+    /// depends on it fails CLOSED. The startup audit joins this against the
+    /// kernels the model actually looked up, which separates the two classes of
+    /// missing kernel — dropped-by-fork (a build defect) from
+    /// never-built-for-this-architecture (expected, e.g. MLA on a Qwen model).
+    pub shadowed_dropped: &'static [(&'static str, &'static str)],
 }
 
 /// All compiled kernel targets and their PTX module sets.

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -90,6 +90,10 @@ name = "gdn_cdh_vblock_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]
+name = "w4a16_lmhead_716_repro"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "gemv_fp4_vs_fp8_microtest"
 required-features = ["cuda", "gpu-examples"]
 
@@ -163,6 +167,10 @@ required-features = ["cuda", "gpu-examples"]
 
 [[example]]
 name = "gdn_strided_norm_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "gdn_wy4_batched_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]

--- a/crates/spark-model/examples/conv1d_strided_microtest.rs
+++ b/crates/spark-model/examples/conv1d_strided_microtest.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Bit-exactness gate for the strided multi-sequence conv1d
+//! (`causal_conv1d_update_l2norm_f32_strided`) against the per-sequence loop
+//! it replaces in the concurrent-decode path.
+//!
+//! ## Why
+//! `decode_ms_ssm_recurrent` used to run the conv as an N-launch loop with
+//! pre-offset pointers, because the plain kernel hardcodes BOTH its input and
+//! output row strides as `dim` (= CONV_DIM), while the concurrent path feeds
+//! it from the QKVZ projection whose rows are `QKVZ_SIZE` apart. A `batch=n`
+//! launch of the plain kernel would read sequence b>=1 from `b*CONV_DIM`
+//! instead of `b*QKVZ_SIZE` — landing inside the PREVIOUS sequence's Z-gate
+//! region and feeding garbage into the GDN scan. That is correct at n=1 and
+//! silently corrupt at n>=2, which is the nastiest possible failure mode: it
+//! looks fine in every single-sequence test.
+//!
+//! The strided kernel takes both strides explicitly so the whole batch goes in
+//! ONE launch. This oracle proves it is numerically IDENTICAL to the loop:
+//!
+//!   GOLDEN: `causal_conv1d_update_l2norm_f32` ×N, batch=1, pre-offset
+//!     pointers — exactly what the multi-seq path called before.
+//!   STRIDED: one `causal_conv1d_update_l2norm_f32_strided` launch, batch=N.
+//!   GATE: conv outputs AND committed conv_state byte-identical (same
+//!     accumulation order under --fmad=false); cos reported for diagnostics.
+//!
+//! A deliberate NEGATIVE control also runs: the plain kernel at batch=N (the
+//! bug this fix removes) must MISMATCH. If that ever passes, the test is not
+//! actually exercising the stride difference and the positive result is void.
+//!
+//!   cargo run -p spark-model --release --example conv1d_strided_microtest \
+//!       --features cuda,gpu-examples
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::KernelLaunch;
+
+// Qwen3.6-27B GDN head config (matches production / gdn_conv_kn_microtest).
+const KD: usize = 128;
+const NK: usize = 16;
+const NV: usize = 32;
+const VD: usize = 128;
+const D_CONV: usize = 4;
+
+const KEY_DIM: usize = NK * KD; // 2048
+const VALUE_DIM: usize = NV * VD; // 4096
+const CONV_DIM: usize = KEY_DIM * 2 + VALUE_DIM; // 8192 (Q|K|V)
+const QK_CH: usize = KEY_DIM * 2; // 4096 (Q+K get L2 norm)
+const QKVZ_SIZE: usize = CONV_DIM + VALUE_DIM; // 12288 (Q|K|V|Z)
+
+const N: usize = 5; // concurrent sequences (odd, > any tile count)
+const L2_EPS: f32 = 1e-6;
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 11) as f64) / ((1u64 << 53) as f64)
+    }
+    fn r(&mut self, lo: f64, hi: f64) -> f64 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+fn up_bf16(g: &dyn GpuBackend, d: &[bf16]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|x| x.to_bits().to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+fn up_f32(g: &dyn GpuBackend, d: &[f32]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|x| x.to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+fn dn_bytes(g: &dyn GpuBackend, p: DevicePtr, n: usize) -> Result<Vec<u8>> {
+    let mut b = vec![0u8; n];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b)
+}
+fn as_f32(b: &[u8]) -> Vec<f32> {
+    b.chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+fn cos(a: &[f32], b: &[f32]) -> f64 {
+    let (mut dot, mut na, mut nb) = (0f64, 0f64, 0f64);
+    for (x, y) in a.iter().zip(b) {
+        dot += (*x as f64) * (*y as f64);
+        na += (*x as f64).powi(2);
+        nb += (*y as f64).powi(2);
+    }
+    dot / (na.sqrt() * nb.sqrt() + 1e-12)
+}
+
+struct Inputs {
+    /// N sequences laid out with the PRODUCTION row stride (QKVZ_SIZE), so the
+    /// Z-gate region between consecutive conv rows is real data — that is what
+    /// a stride bug would silently pull in.
+    deinterleaved: Vec<bf16>,
+    conv_state0: Vec<f32>,  // N * CONV_DIM * D_CONV (contiguous pool slots)
+    conv_weight: Vec<bf16>, // CONV_DIM * D_CONV
+}
+
+fn gen_inputs(seed: u64) -> Inputs {
+    let mut r = Lcg(seed);
+    Inputs {
+        deinterleaved: (0..N * QKVZ_SIZE)
+            .map(|_| bf16::from_f64(r.r(-0.5, 0.5)))
+            .collect(),
+        conv_state0: (0..N * CONV_DIM * D_CONV)
+            .map(|_| r.r(-0.3, 0.3) as f32)
+            .collect(),
+        conv_weight: (0..CONV_DIM * D_CONV)
+            .map(|_| bf16::from_f64(r.r(-0.3, 0.3)))
+            .collect(),
+    }
+}
+
+struct Captured {
+    conv_out: Vec<u8>,       // N * CONV_DIM FP32
+    conv_committed: Vec<u8>, // N * CONV_DIM * D_CONV FP32
+}
+
+/// One launch of the plain kernel. `batch`/pointers let this serve BOTH the
+/// golden per-seq loop (batch=1, pre-offset) and the negative control
+/// (batch=N, which mis-strides the input).
+#[allow(clippy::too_many_arguments)]
+fn launch_plain(
+    g: &dyn GpuBackend,
+    k: KernelHandle,
+    conv_state: DevicePtr,
+    input: DevicePtr,
+    weight: DevicePtr,
+    out: DevicePtr,
+    batch: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, k)
+        .grid([CONV_DIM.div_ceil(256) as u32, batch, 1])
+        .block([256, 1, 1])
+        .arg_ptr(conv_state)
+        .arg_ptr(input)
+        .arg_ptr(weight)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_ptr(out)
+        .arg_u32(batch)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32(D_CONV as u32)
+        .arg_u32(QK_CH as u32)
+        .arg_u32(KD as u32)
+        .arg_f32(L2_EPS)
+        .launch(0)
+}
+
+fn run_golden(g: &dyn GpuBackend, k: KernelHandle, inp: &Inputs) -> Result<Captured> {
+    let state = up_f32(g, &inp.conv_state0)?;
+    let input = up_bf16(g, &inp.deinterleaved)?;
+    let weight = up_bf16(g, &inp.conv_weight)?;
+    let out = g.alloc(N * CONV_DIM * 4)?;
+    for i in 0..N {
+        launch_plain(
+            g,
+            k,
+            state.offset(i * CONV_DIM * D_CONV * 4),
+            input.offset(i * QKVZ_SIZE * 2),
+            weight,
+            out.offset(i * CONV_DIM * 4),
+            1,
+        )?;
+    }
+    g.synchronize(0)?;
+    Ok(Captured {
+        conv_out: dn_bytes(g, out, N * CONV_DIM * 4)?,
+        conv_committed: dn_bytes(g, state, N * CONV_DIM * D_CONV * 4)?,
+    })
+}
+
+fn run_strided(g: &dyn GpuBackend, k: KernelHandle, inp: &Inputs) -> Result<Captured> {
+    let state = up_f32(g, &inp.conv_state0)?;
+    let input = up_bf16(g, &inp.deinterleaved)?;
+    let weight = up_bf16(g, &inp.conv_weight)?;
+    let out = g.alloc(N * CONV_DIM * 4)?;
+    KernelLaunch::new(g, k)
+        .grid([CONV_DIM.div_ceil(256) as u32, N as u32, 1])
+        .block([256, 1, 1])
+        .arg_ptr(state)
+        .arg_ptr(input)
+        .arg_ptr(weight)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_ptr(out)
+        .arg_u32(N as u32)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32(D_CONV as u32)
+        .arg_u32(QK_CH as u32)
+        .arg_u32(KD as u32)
+        .arg_f32(L2_EPS)
+        .arg_u32(QKVZ_SIZE as u32) // input row stride
+        .arg_u32(CONV_DIM as u32) // output row stride
+        .launch(0)?;
+    g.synchronize(0)?;
+    Ok(Captured {
+        conv_out: dn_bytes(g, out, N * CONV_DIM * 4)?,
+        conv_committed: dn_bytes(g, state, N * CONV_DIM * D_CONV * 4)?,
+    })
+}
+
+/// NEGATIVE CONTROL: the plain kernel at batch=N — the exact bug this fix
+/// removes. It mis-strides the input, so it MUST differ from golden.
+fn run_plain_batched(g: &dyn GpuBackend, k: KernelHandle, inp: &Inputs) -> Result<Captured> {
+    let state = up_f32(g, &inp.conv_state0)?;
+    let input = up_bf16(g, &inp.deinterleaved)?;
+    let weight = up_bf16(g, &inp.conv_weight)?;
+    let out = g.alloc(N * CONV_DIM * 4)?;
+    launch_plain(g, k, state, input, weight, out, N as u32)?;
+    g.synchronize(0)?;
+    Ok(Captured {
+        conv_out: dn_bytes(g, out, N * CONV_DIM * 4)?,
+        conv_committed: dn_bytes(g, state, N * CONV_DIM * D_CONV * 4)?,
+    })
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &gpu;
+
+    let k_plain = g.kernel("causal_conv1d", "causal_conv1d_update_l2norm_f32")?;
+    let k_strided = g.kernel("causal_conv1d", "causal_conv1d_update_l2norm_f32_strided")?;
+
+    let mut all_ok = true;
+    for seed in [1u64, 99, 12345] {
+        let inp = gen_inputs(seed);
+        let golden = run_golden(g, k_plain, &inp)?;
+        let strided = run_strided(g, k_strided, &inp)?;
+        let bad = run_plain_batched(g, k_plain, &inp)?;
+
+        let out_id = golden.conv_out == strided.conv_out;
+        let st_id = golden.conv_committed == strided.conv_committed;
+        let c_out = cos(&as_f32(&golden.conv_out), &as_f32(&strided.conv_out));
+
+        // The negative control must NOT match, or this test proves nothing.
+        let ctrl_differs = golden.conv_out != bad.conv_out;
+
+        println!(
+            "seed {seed:>5}: conv_out identical={out_id}  conv_state identical={st_id}  \
+             cos={c_out:.9}  [neg-control differs={ctrl_differs}]"
+        );
+        if !out_id || !st_id {
+            println!("  FAIL: strided output diverges from the per-seq loop");
+            all_ok = false;
+        }
+        if !ctrl_differs {
+            println!(
+                "  FAIL: plain kernel at batch=N matched golden — the test is NOT \
+                 exercising the stride difference, so the positive result is void"
+            );
+            all_ok = false;
+        }
+    }
+
+    println!(
+        "\n{}",
+        if all_ok {
+            "PASS — strided batch=N is byte-identical to the per-seq loop, \
+             and the unstrided batch=N control is provably wrong."
+        } else {
+            "FAIL"
+        }
+    );
+    if !all_ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/crates/spark-model/examples/gdn_wy4_batched_microtest.rs
+++ b/crates/spark-model/examples/gdn_wy4_batched_microtest.rs
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Byte-identity gate for `gated_delta_rule_wy4`'s pointer-table addressing.
+//!
+//! Stage 1a of batched speculative verify. Verify must eventually run n
+//! sequences x (K+1) tokens in ONE launch; today every call site passes
+//! batch_size=1. This proves the batched form is byte-identical to n sequential
+//! single-sequence launches BEFORE any orchestration is written.
+//!
+//! It also pins the bug that motivated the change. The kernel used to address
+//! h_state AND its three rollback intermediates with the same batch stride
+//! (`num_v_heads * k_dim * v_dim`). That is the pool's slot stride, correct for
+//! h_state — but the intermediate for (slot, token) lives at
+//! `(slot * ni + token) * h_bytes`, i.e. a stride `ni` times larger. So at
+//! batch_size>1 sequence 1's `Hi0` landed exactly on sequence 0's `Hi1`. This
+//! harness lays the pools out with the REAL strides, so a regression to the old
+//! addressing fails here rather than corrupting rollback under load.
+//!
+//! Run: ATLAS_TARGET_MODEL=qwen3.6-27b cargo run -p spark-model --release \
+//!        --example gdn_wy4_batched_microtest --features cuda,gpu-examples
+
+use anyhow::{Result, bail};
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::kernel_args::KernelLaunch;
+
+const NK: usize = 16;
+const NV: usize = 48;
+const KD: usize = 128;
+const VD: usize = 128;
+const K: usize = 4; // wy4 verifies 4 tokens
+const NI: usize = 4; // pool intermediates per slot (num_drafts + 1)
+const KEY_DIM: usize = NK * KD;
+const VALUE_DIM: usize = NV * VD;
+const CONV_DIM: usize = KEY_DIM * 2 + VALUE_DIM;
+const GB_STRIDE: usize = NV * 2;
+/// Floats in one sequence's h_state (== the pool's per-slot stride).
+const HV: usize = NV * KD * VD;
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (((self.0 >> 11) as f64) / ((1u64 << 53) as f64)) as f32
+    }
+    fn r(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+fn up_f32(g: &dyn GpuBackend, d: &[f32]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|x| x.to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+
+fn up_bf16(g: &dyn GpuBackend, d: &[bf16]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|x| x.to_bits().to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+
+fn down_f32(g: &dyn GpuBackend, p: DevicePtr, n: usize) -> Result<Vec<f32>> {
+    let mut b = vec![0u8; n * 4];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b.chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+/// Device array of pointers, one per sequence — what `state_is_table=1` reads.
+fn up_ptr_table(g: &dyn GpuBackend, ptrs: &[DevicePtr]) -> Result<DevicePtr> {
+    let b: Vec<u8> = ptrs.iter().flat_map(|p| p.0.to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_wy4(
+    g: &dyn GpuBackend,
+    kernel: spark_runtime::gpu::KernelHandle,
+    h: DevicePtr,
+    q: DevicePtr,
+    k: DevicePtr,
+    v: DevicePtr,
+    gate: DevicePtr,
+    beta: DevicePtr,
+    out: DevicePtr,
+    hi0: DevicePtr,
+    hi1: DevicePtr,
+    hi2: DevicePtr,
+    batch: u32,
+    is_table: bool,
+) -> Result<()> {
+    KernelLaunch::new(g, kernel)
+        .grid([NV as u32, batch, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h)
+        .arg_ptr(q)
+        .arg_ptr(k)
+        .arg_ptr(v)
+        .arg_ptr(gate)
+        .arg_ptr(beta)
+        .arg_ptr(out)
+        .arg_ptr(hi0)
+        .arg_ptr(hi1)
+        .arg_ptr(hi2)
+        .arg_u32(batch)
+        .arg_u32(NK as u32)
+        .arg_u32(NV as u32)
+        .arg_u32(KD as u32)
+        .arg_u32(VD as u32)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32(GB_STRIDE as u32)
+        .arg_u32(u32::from(is_table))
+        .launch(0)?;
+    g.synchronize(0)?;
+    Ok(())
+}
+
+fn run_for_n(g: &dyn GpuBackend, kernel: spark_runtime::gpu::KernelHandle, n: usize) -> Result<()> {
+    let mut rng = Lcg(0x5eed_1a2b ^ (n as u64) << 32);
+    let rows = n * K;
+
+    // Inputs: token rows are [seq0_t0..t3, seq1_t0..t3, ...], matching the
+    // kernel's (b*4+T) addressing.
+    let qkv: Vec<bf16> = (0..rows * CONV_DIM)
+        .map(|_| bf16::from_f32(rng.r(-1.0, 1.0)))
+        .collect();
+    let gate: Vec<f32> = (0..rows * GB_STRIDE).map(|_| rng.r(0.90, 0.999)).collect();
+    let beta: Vec<f32> = (0..rows * GB_STRIDE).map(|_| rng.r(0.1, 0.9)).collect();
+    // Distinct per-sequence initial state — the whole point: if the batched form
+    // mixed sequences up, identical states would hide it.
+    let h_init: Vec<f32> = (0..n * HV).map(|_| rng.r(-0.5, 0.5)).collect();
+    // Intermediates pre-filled with a sentinel per (slot, token) so a
+    // cross-sequence write is visible even where the kernel would not write.
+    let hi_init: Vec<f32> = (0..n * NI * HV)
+        .map(|i| -1000.0 - ((i / HV) as f32))
+        .collect();
+
+    let d_q = up_bf16(g, &qkv)?;
+    let d_gate = up_f32(g, &gate)?;
+    let d_beta = up_f32(g, &beta)?;
+
+    // ---- Reference: n sequential launches, batch_size=1, contiguous addressing,
+    // each pointed at its own slot. This is exactly what ships today.
+    let ref_h = up_f32(g, &h_init)?;
+    let ref_hi = up_f32(g, &hi_init)?;
+    let ref_out = g.alloc(rows * VALUE_DIM * 2)?;
+    for i in 0..n {
+        let tok = |stride: usize| DevicePtr(d_q.0 + (i * K * stride * 2) as u64);
+        launch_wy4(
+            g,
+            kernel,
+            DevicePtr(ref_h.0 + (i * HV * 4) as u64),
+            tok(CONV_DIM),
+            tok(CONV_DIM),
+            tok(CONV_DIM),
+            DevicePtr(d_gate.0 + (i * K * GB_STRIDE * 4) as u64),
+            DevicePtr(d_beta.0 + (i * K * GB_STRIDE * 4) as u64),
+            DevicePtr(ref_out.0 + (i * K * NV * VD * 2) as u64),
+            // pool layout: intermediate (slot, t) at (slot*NI + t) * HV
+            DevicePtr(ref_hi.0 + ((i * NI) * HV * 4) as u64),
+            DevicePtr(ref_hi.0 + ((i * NI + 1) * HV * 4) as u64),
+            DevicePtr(ref_hi.0 + ((i * NI + 2) * HV * 4) as u64),
+            1,
+            false,
+        )?;
+    }
+
+    // ---- Test: ONE launch, batch_size=n, pointer tables.
+    let tst_h = up_f32(g, &h_init)?;
+    let tst_hi = up_f32(g, &hi_init)?;
+    let tst_out = g.alloc(rows * VALUE_DIM * 2)?;
+    let h_tbl = up_ptr_table(
+        g,
+        &(0..n)
+            .map(|i| DevicePtr(tst_h.0 + (i * HV * 4) as u64))
+            .collect::<Vec<_>>(),
+    )?;
+    let mk_hi_tbl = |t: usize| -> Result<DevicePtr> {
+        up_ptr_table(
+            g,
+            &(0..n)
+                .map(|i| DevicePtr(tst_hi.0 + ((i * NI + t) * HV * 4) as u64))
+                .collect::<Vec<_>>(),
+        )
+    };
+    launch_wy4(
+        g,
+        kernel,
+        h_tbl,
+        d_q,
+        d_q,
+        d_q,
+        d_gate,
+        d_beta,
+        tst_out,
+        mk_hi_tbl(0)?,
+        mk_hi_tbl(1)?,
+        mk_hi_tbl(2)?,
+        n as u32,
+        true,
+    )?;
+
+    // ---- Compare: state, all intermediates, and output must be BYTE-identical.
+    let (a, b) = (down_f32(g, ref_h, n * HV)?, down_f32(g, tst_h, n * HV)?);
+    if let Some(i) = a
+        .iter()
+        .zip(&b)
+        .position(|(x, y)| x.to_bits() != y.to_bits())
+    {
+        bail!(
+            "n={n}: h_state differs at float {i} (seq {}): ref {} vs batched {}",
+            i / HV,
+            a[i],
+            b[i]
+        );
+    }
+    let (a, b) = (
+        down_f32(g, ref_hi, n * NI * HV)?,
+        down_f32(g, tst_hi, n * NI * HV)?,
+    );
+    if let Some(i) = a
+        .iter()
+        .zip(&b)
+        .position(|(x, y)| x.to_bits() != y.to_bits())
+    {
+        bail!(
+            "n={n}: INTERMEDIATE differs at float {i} (seq {}, token {}): ref {} vs batched {} \
+             — this is the cross-sequence rollback corruption the pointer table fixes",
+            i / (NI * HV),
+            (i / HV) % NI,
+            a[i],
+            b[i]
+        );
+    }
+    let mut ob = vec![0u8; rows * VALUE_DIM * 2];
+    let mut tb = vec![0u8; rows * VALUE_DIM * 2];
+    g.copy_d2h(ref_out, &mut ob)?;
+    g.copy_d2h(tst_out, &mut tb)?;
+    if ob != tb {
+        bail!("n={n}: output bytes differ");
+    }
+    println!("  n={n:2}: h_state + {NI} intermediates + output all BYTE-IDENTICAL");
+    Ok(())
+}
+
+/// Cost gate. The fused verify at M = n*(K+1) must not scale linearly in verify
+/// tokens, or the GDN leg eats the speculation win before orchestration can
+/// deliver it. Compares:
+///   (a) ONE batched wy4 at n=8 (8 seqs x 4 tokens = 32 token-verifies)
+///   (b) the plain single-token batched decode at n=8 (what a non-spec step pays)
+///   (c) 8 SEQUENTIAL wy4 launches — today's per-sequence verify
+/// Gate: (a)/(b) <= 1.6. At C=1 accept rates (~1.8-2.5 tokens/step) that keeps
+/// the GDN leg riding the weight sweep instead of eating it.
+fn cost_gate(g: &dyn GpuBackend, wy4: spark_runtime::gpu::KernelHandle) -> Result<()> {
+    const N: usize = 8;
+    let mut rng = Lcg(0xc0_5701);
+    let rows = N * K;
+    let qkv: Vec<bf16> = (0..rows * CONV_DIM)
+        .map(|_| bf16::from_f32(rng.r(-1.0, 1.0)))
+        .collect();
+    let gate: Vec<f32> = (0..rows * GB_STRIDE).map(|_| rng.r(0.90, 0.999)).collect();
+    let beta: Vec<f32> = (0..rows * GB_STRIDE).map(|_| rng.r(0.1, 0.9)).collect();
+    let h_init: Vec<f32> = (0..N * HV).map(|_| rng.r(-0.5, 0.5)).collect();
+    let hi_init: Vec<f32> = vec![0.0; N * NI * HV];
+
+    let d_q = up_bf16(g, &qkv)?;
+    let d_gate = up_f32(g, &gate)?;
+    let d_beta = up_f32(g, &beta)?;
+    let d_h = up_f32(g, &h_init)?;
+    let d_hi = up_f32(g, &hi_init)?;
+    let d_out = g.alloc(rows * VALUE_DIM * 2)?;
+    let h_tbl = up_ptr_table(
+        g,
+        &(0..N)
+            .map(|i| DevicePtr(d_h.0 + (i * HV * 4) as u64))
+            .collect::<Vec<_>>(),
+    )?;
+    let hi_tbl = |t: usize| -> Result<DevicePtr> {
+        up_ptr_table(
+            g,
+            &(0..N)
+                .map(|i| DevicePtr(d_hi.0 + ((i * NI + t) * HV * 4) as u64))
+                .collect::<Vec<_>>(),
+        )
+    };
+    let (t0, t1, t2) = (hi_tbl(0)?, hi_tbl(1)?, hi_tbl(2)?);
+
+    let time_it = |f: &dyn Fn() -> Result<()>| -> Result<f64> {
+        for _ in 0..3 {
+            f()?;
+        }
+        let start = std::time::Instant::now();
+        const ITERS: u32 = 20;
+        for _ in 0..ITERS {
+            f()?;
+        }
+        Ok(start.elapsed().as_secs_f64() * 1e6 / f64::from(ITERS))
+    };
+
+    let batched = time_it(&|| {
+        launch_wy4(
+            g, wy4, h_tbl, d_q, d_q, d_q, d_gate, d_beta, d_out, t0, t1, t2, N as u32, true,
+        )
+    })?;
+    let sequential = time_it(&|| {
+        for i in 0..N {
+            let tok = |st: usize| DevicePtr(d_q.0 + (i * K * st * 2) as u64);
+            launch_wy4(
+                g,
+                wy4,
+                DevicePtr(d_h.0 + (i * HV * 4) as u64),
+                tok(CONV_DIM),
+                tok(CONV_DIM),
+                tok(CONV_DIM),
+                DevicePtr(d_gate.0 + (i * K * GB_STRIDE * 4) as u64),
+                DevicePtr(d_beta.0 + (i * K * GB_STRIDE * 4) as u64),
+                DevicePtr(d_out.0 + (i * K * NV * VD * 2) as u64),
+                DevicePtr(d_hi.0 + ((i * NI) * HV * 4) as u64),
+                DevicePtr(d_hi.0 + ((i * NI + 1) * HV * 4) as u64),
+                DevicePtr(d_hi.0 + ((i * NI + 2) * HV * 4) as u64),
+                1,
+                false,
+            )?;
+        }
+        Ok(())
+    })?;
+
+    // Plain single-token batched decode at n=8 — the non-spec baseline step.
+    // NOTE this kernel takes FP32 q/k/v (not bf16 like wy4) and carries an
+    // extra out_stride; feeding it wy4's buffers faults.
+    let plain_k = g.kernel("gated_delta_rule", "gated_delta_rule_decode_f32_strided")?;
+    let qf: Vec<f32> = (0..N * CONV_DIM).map(|_| rng.r(-1.0, 1.0)).collect();
+    let gf: Vec<f32> = (0..N * GB_STRIDE).map(|_| rng.r(0.90, 0.999)).collect();
+    let bf: Vec<f32> = (0..N * GB_STRIDE).map(|_| rng.r(0.1, 0.9)).collect();
+    let d_qf = up_f32(g, &qf)?;
+    let d_gf = up_f32(g, &gf)?;
+    let d_bf = up_f32(g, &bf)?;
+    let d_gout = g.alloc(N * VALUE_DIM * 4)?;
+    let plain = time_it(&|| {
+        KernelLaunch::new(g, plain_k)
+            .grid([NV as u32, N as u32, 1])
+            .block([128, 1, 1])
+            .arg_ptr(d_h)
+            .arg_ptr(d_qf)
+            .arg_ptr(d_qf)
+            .arg_ptr(d_qf)
+            .arg_ptr(d_gf)
+            .arg_ptr(d_bf)
+            .arg_ptr(d_gout)
+            .arg_u32(N as u32)
+            .arg_u32(NK as u32)
+            .arg_u32(NV as u32)
+            .arg_u32(KD as u32)
+            .arg_u32(VD as u32)
+            .arg_u32(CONV_DIM as u32)
+            .arg_u32(CONV_DIM as u32)
+            .arg_u32(GB_STRIDE as u32)
+            .arg_u32(VALUE_DIM as u32)
+            .launch(0)?;
+        g.synchronize(0)?;
+        Ok(())
+    })
+    .unwrap_or(f64::NAN);
+
+    println!();
+    println!("cost gate at n={N}, K={K} (M={}):", N * K);
+    println!("  batched wy4 (1 launch)      {batched:8.1} us");
+    println!("  sequential wy4 (8 launches) {sequential:8.1} us   [today's per-seq verify]");
+    println!("  plain decode, n=8, 1 token  {plain:8.1} us   [non-spec baseline]");
+    if plain.is_finite() && plain > 0.0 {
+        let ratio = batched / plain;
+        println!("  batched/plain = {ratio:.2}x   (GATE: <= 1.60x; >= 2.00x means STOP)");
+        if ratio >= 2.0 {
+            bail!(
+                "COST GATE FAILED: {ratio:.2}x >= 2.0 — GDN verify scales ~linearly in \
+                   verify tokens; the fused-verify premise is dead at this layer"
+            );
+        }
+    }
+    println!(
+        "  batched vs sequential speedup {:.2}x",
+        sequential / batched
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &backend;
+    let kernel = g.kernel("gated_delta_rule_wy4", "gated_delta_rule_wy4")?;
+    println!("wy4 batched pointer-table equivalence (nv={NV} kd={KD} vd={VD} K={K} ni={NI})");
+    for n in [2usize, 4, 8, 16] {
+        run_for_n(g, kernel, n)?;
+    }
+    println!("PASS — batched wy4 is byte-identical to n sequential single-sequence launches");
+    cost_gate(g, kernel)?;
+    Ok(())
+}

--- a/crates/spark-model/examples/w4a16_lmhead_716_repro.rs
+++ b/crates/spark-model/examples/w4a16_lmhead_716_repro.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repro rig for the decode lm_head tile-GEMM CUDA 716 fault (gb10-concurrency
+//! campaign, STATE.md "lm_head -> tile GEMM: BUILT TWICE, FAILED TWICE").
+//!
+//! The standalone bench (`w4a16_m17_bench`) runs the exact shape clean, so this
+//! rig reproduces the SERVE-side launch environment piece by piece:
+//!   leg 1 solo          — lm_head GEMM alone on the legacy NULL stream (control)
+//!   leg 2 same-stream   — decode-step kernel sequence (ssm gemms + lm_head +
+//!                         argmax_bf16_batch + 4B D2H) on ONE created stream,
+//!                         M cycling the ladder 2/4/8/12/16 like a serve ramp
+//!   leg 3 cross-stream  — gemms on stream A, argmax on stream B (mirrors
+//!                         `argmax_batch_dispatch` using `default_stream()`
+//!                         while decode runs on its own stream)
+//!   leg 4 conc-prefill  — leg 2 plus prefill-shaped `w4a16_gemm_t_m128` and
+//!                         `memset_async` interleaved on a third stream
+//!   leg 5 undersized-C  — DELIBERATE overrun: C sized 4 rows, M=16 — records
+//!                         the error signature a real overrun produces
+//!
+//! Buffer sizes mirror the serve exactly: logits = 32 rows x vocab x 2
+//! (`buffers/sizes.rs` logits_tokens = m.min(32)); twin = [K/2, N] + [K/16, N]
+//! fresh allocations (`transpose_for_gemm`); launch geometry from
+//! `gemm_dense.rs::w4a16_gemm_n128` and `sampling.rs::argmax_bf16_batch`.
+//!
+//!   ATLAS_TARGET_MODEL=qwen3.6-27b cargo run -p spark-model --release \
+//!       --example w4a16_lmhead_716_repro --features cuda,gpu-examples
+//!
+//! Env: ATLAS_REPRO_ITERS (default 300 per leg), ATLAS_REPRO_LEG (run one leg).
+
+use anyhow::Result;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+const V: u32 = 248_320; // lm_head N (vocab)
+const H: u32 = 5_120; // hidden (K)
+const QKVZ_N: u32 = 16_384;
+const OUTP_N: u32 = 5_120;
+const OUTP_K: u32 = 6_144;
+const FFN_N: u32 = 17_408;
+const PRE_M: u32 = 512; // prefill chunk rows for the m128 leg
+const LADDER: &[u32] = &[2, 4, 8, 12, 16];
+
+struct W {
+    b: DevicePtr,
+    bs: DevicePtr,
+}
+
+fn twin(g: &dyn GpuBackend, n: u32, k: u32) -> Result<W> {
+    let (n, k) = (n as usize, k as usize);
+    let b = g.alloc(n * k / 2)?;
+    let bs = g.alloc(n * k / 16)?;
+    g.memset(b, 0x5A, n * k / 2)?;
+    g.memset(bs, 0x5A, n * k / 16)?;
+    Ok(W { b, bs })
+}
+
+/// Mirror of `gemm_dense.rs::w4a16_gemm_n128`: grid (N/128, M/64), block 128.
+#[allow(clippy::too_many_arguments)]
+fn gemm_t(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    w: &W,
+    c: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 128), div_ceil(m, 64), 1])
+        .block([128, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(w.b)
+        .arg_ptr(w.bs)
+        .arg_f32(1.0)
+        .arg_ptr(c)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)
+}
+
+/// Mirror of `sampling.rs::argmax_bf16_batch`: grid (rows), block 1024.
+fn argmax(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    logits: DevicePtr,
+    out: DevicePtr,
+    rows: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([rows, 1, 1])
+        .block([1024, 1, 1])
+        .arg_ptr(logits)
+        .arg_ptr(out)
+        .arg_u32(V)
+        .arg_u32(V)
+        .launch(stream)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_leg(
+    g: &dyn GpuBackend,
+    leg: &str,
+    iters: usize,
+    kt: KernelHandle,
+    kt64: KernelHandle,
+    km128: Option<KernelHandle>,
+    karg: KernelHandle,
+    s_dec: u64,
+    s_arg: u64,
+    s_pre: Option<u64>,
+    c_logits_rows: u32,
+) -> Result<()> {
+    // Serve-order allocation: twins at "model load", arena after.
+    let w_lm = twin(g, V, H)?;
+    let w_qkvz = twin(g, QKVZ_N, H)?;
+    let w_outp = twin(g, OUTP_N, OUTP_K)?;
+    let w_ffn = twin(g, FFN_N, H)?;
+    let a_norm = g.alloc(64 * H as usize * 2)?;
+    let c_ssm = g.alloc(64 * QKVZ_N as usize * 2)?;
+    let c_out = g.alloc(64 * OUTP_N as usize * 2)?;
+    let c_logits = g.alloc(c_logits_rows as usize * V as usize * 2)?;
+    let a_pre = g.alloc(PRE_M as usize * H as usize * 2)?;
+    let c_pre = g.alloc(PRE_M as usize * FFN_N as usize * 2)?;
+    let amax_out = g.alloc(256)?;
+    for (p, b) in [(a_norm, 64 * H as usize * 2), (a_pre, PRE_M as usize * H as usize * 2)] {
+        g.memset(p, 0x5A, b)?;
+    }
+
+    let mut host = [0u8; 64];
+    let r = (|| -> Result<()> {
+        for it in 0..iters {
+            let m = LADDER[it % LADDER.len()];
+            // lm_head kernel alternates _t / _t_k64 (serve failed with both)
+            let klm = if it % 2 == 0 { kt } else { kt64 };
+            if let (Some(kp), Some(sp)) = (km128, s_pre) {
+                // prefill leg: m128 tile GEMM + the memsets prefill issues
+                g.memset_async(c_pre, 0, PRE_M as usize * FFN_N as usize * 2, sp)?;
+                KernelLaunch::new(g, kp)
+                    .grid([div_ceil(FFN_N, 128), div_ceil(PRE_M, 128), 1])
+                    .block([128, 1, 1])
+                    .arg_ptr(a_pre)
+                    .arg_ptr(w_ffn.b)
+                    .arg_ptr(w_ffn.bs)
+                    .arg_f32(1.0)
+                    .arg_ptr(c_pre)
+                    .arg_u32(PRE_M)
+                    .arg_u32(FFN_N)
+                    .arg_u32(H)
+                    .launch(sp)?;
+            }
+            // decode step: a few ssm-shaped tile GEMMs, then the lm_head GEMM
+            for _ in 0..4 {
+                gemm_t(g, kt, a_norm, &w_qkvz, c_ssm, m, QKVZ_N, H, s_dec)?;
+                gemm_t(g, kt64, a_norm, &w_outp, c_out, m, OUTP_N, OUTP_K, s_dec)?;
+            }
+            gemm_t(g, klm, a_norm, &w_lm, c_logits, m, V, H, s_dec)?;
+            argmax(g, karg, c_logits, amax_out, m, s_arg)?;
+            // 4*m-byte D2H — the exact call that reports 716 in the serve
+            g.copy_d2h(amax_out, &mut host[..4 * m as usize])?;
+        }
+        g.synchronize(s_dec)?;
+        g.synchronize(s_arg)?;
+        if let Some(sp) = s_pre {
+            g.synchronize(sp)?;
+        }
+        Ok(())
+    })();
+    match &r {
+        Ok(()) => eprintln!("leg {leg}: PASS ({iters} iters)"),
+        Err(e) => eprintln!("leg {leg}: FAIL — {e}"),
+    }
+    for p in [
+        w_lm.b, w_lm.bs, w_qkvz.b, w_qkvz.bs, w_outp.b, w_outp.bs, w_ffn.b, w_ffn.bs, a_norm,
+        c_ssm, c_out, c_logits, a_pre, c_pre, amax_out,
+    ] {
+        let _ = g.free(p);
+    }
+    r
+}
+
+fn main() -> Result<()> {
+    let g0 = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &g0;
+    let iters: usize = std::env::var("ATLAS_REPRO_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300);
+    let only = std::env::var("ATLAS_REPRO_LEG").ok();
+
+    let kt = g.kernel("w4a16", "w4a16_gemm_t")?;
+    let kt64 = g.kernel("w4a16", "w4a16_gemm_t_k64")?;
+    let km128 = g.kernel("w4a16", "w4a16_gemm_t_m128").ok();
+    let karg = g.kernel("argmax", "argmax_bf16_batch")?;
+    let s_a = g.create_stream()?;
+    let s_b = g.create_stream()?;
+    let s_c = g.create_stream()?;
+
+    let legs: &[(&str, u64, u64, Option<u64>, u32)] = &[
+        ("1-solo-null-stream", 0, 0, None, 32),
+        ("2-same-stream", s_a, s_a, None, 32),
+        ("3-cross-stream", s_a, s_b, None, 32),
+        ("4-conc-prefill", s_a, s_b, Some(s_c), 32),
+        ("5-undersized-C", s_a, s_a, None, 4),
+    ];
+    for &(name, sd, sa, sp, crows) in legs {
+        if let Some(ref o) = only {
+            if !name.starts_with(o.as_str()) {
+                continue;
+            }
+        }
+        if run_leg(g, name, iters, kt, kt64, km128, karg, sd, sa, sp, crows).is_err() {
+            eprintln!("context may be sticky-dead after a fault; stopping here.");
+            break;
+        }
+    }
+    Ok(())
+}

--- a/crates/spark-model/examples/w4a16_m17_bench.rs
+++ b/crates/spark-model/examples/w4a16_m17_bench.rs
@@ -44,9 +44,17 @@ const ITERS: usize = 100;
 const SHAPES: &[(&str, u32, u32)] = &[
     ("ffn_gate/up  N=17408 K=5120 ", 17408, 5120),
     ("ffn_down     N=5120  K=17408", 5120, 17408),
+    ("ssm_qkvz     N=16384 K=5120 ", 16384, 5120),
+    ("ssm_out_proj N=5120  K=6144 ", 5120, 6144),
+    ("attn_qkv     N=8192  K=5120 ", 8192, 5120),
+    ("attn_o_proj  N=5120  K=6144 ", 5120, 6144),
+    ("attn_k       N=1024  K=5120 ", 1024, 5120),
+    ("attn_v       N=1024  K=5120 ", 1024, 5120),
+    ("attn_qkv_FUSED N=14336 K=5120", 14336, 5120),
+    ("lm_head      N=248320 K=5120", 248320, 5120),
 ];
 
-const M_SWEEP: &[u32] = &[17, 32, 64, 128];
+const M_SWEEP: &[u32] = &[1, 4, 8, 16, 32, 64];
 
 /// Launch geometry per kernel, mirroring the ops wrappers exactly.
 #[derive(Clone, Copy)]
@@ -57,6 +65,17 @@ enum Geom {
     N128M64,
     /// w4a16_gemm_t_m128 via w4a16_gemm_n128_m128: grid (N/128, M/128), block 128
     N128M128,
+    /// w4a16_gemm_t_m128_v2: grid (N/128, M/128), block 256 (8 warps, pipelined).
+    /// Lives in module `w4a16_v2`, and is dispatched today ONLY by the SSM
+    /// batched-decode and FFN paths — never by the multi-seq concurrent decode
+    /// projections, which is what this bench is here to check.
+    N128M128W256,
+    /// w4a16_gemv_batch4/8/16: grid (ceil(N/4), 1, 1), block 256.
+    /// SAME arg signature as the gemm family (A,Bp,Bs,scale2,C,M,N,K), so it
+    /// shares the launch path; only the geometry differs. This is the kernel
+    /// lm_head runs TODAY, and the one the tile-GEMM migration would replace —
+    /// its low-M curve decides whether a threshold is needed.
+    GemvN4,
 }
 
 fn grid_for(g: Geom, m: u32, n: u32) -> [u32; 3] {
@@ -64,6 +83,8 @@ fn grid_for(g: Geom, m: u32, n: u32) -> [u32; 3] {
         Geom::N64M64 => [div_ceil(n, 64), div_ceil(m, 64), 1],
         Geom::N128M64 => [div_ceil(n, 128), div_ceil(m, 64), 1],
         Geom::N128M128 => [div_ceil(n, 128), div_ceil(m, 128), 1],
+        Geom::N128M128W256 => [div_ceil(n, 128), div_ceil(m, 128), 1],
+        Geom::GemvN4 => [div_ceil(n, 4), 1, 1],
     }
 }
 
@@ -82,7 +103,11 @@ fn launch(
 ) -> Result<()> {
     KernelLaunch::new(g, k_h)
         .grid(grid_for(geom, m, n))
-        .block([128, 1, 1])
+        .block([
+            if matches!(geom, Geom::N128M128W256 | Geom::GemvN4) { 256 } else { 128 },
+            1,
+            1,
+        ])
         .arg_ptr(a)
         .arg_ptr(b)
         .arg_ptr(b_scale)
@@ -91,6 +116,11 @@ fn launch(
         .arg_u32(m)
         .arg_u32(n)
         .arg_u32(k)
+        // ldb: transposed-B row stride. `w4a16_gemm_t` gained this parameter when
+        // lm_head needed a padded stride (vocab 248077 is odd and broke its 16-byte
+        // cp.async). The packed case is ldb == n. Harmless for the kernels that do
+        // not declare it — the launch API only reads declared params.
+        .arg_u32(n)
         .launch(0)
 }
 
@@ -117,9 +147,40 @@ fn main() -> Result<()> {
             "w4a16_gemm_t_m128",
             Geom::N128M128,
         ),
+        (
+            "w4a16_gemm_t_m128_v2(W256)",
+            "w4a16_gemm_t_m128_v2",
+            Geom::N128M128W256,
+        ),
+        // LOSSLESS BF16-MMA family. Documented bit-identical to each other
+        // (w4a16_gemm.cu:1816) — the choice between them is purely perf, which
+        // is what this bench settles for the lm_head shape.
+        (
+            "w4a16_gemm_t_m64_bf16 (N128,M64)",
+            "w4a16_gemm_t_m64_bf16",
+            Geom::N128M64,
+        ),
+        (
+            "w4a16_gemm_t_m128_bf16_v2",
+            "w4a16_gemm_t_m128_bf16_v2",
+            Geom::N128M128,
+        ),
+        // The INCUMBENT. lm_head dispatches batch4/8/16 by padded_n today.
+        ("w4a16_gemv_batch4", "w4a16_gemv_batch4", Geom::GemvN4),
+        ("w4a16_gemv_batch8", "w4a16_gemv_batch8", Geom::GemvN4),
+        ("w4a16_gemv_batch16", "w4a16_gemv_batch16", Geom::GemvN4),
     ]
     .into_iter()
-    .filter_map(|(name, func, geom)| match g.kernel("w4a16", func) {
+    .filter_map(|(name, func, geom)| match g.kernel(
+        if func == "w4a16_gemm_t_m128_v2" {
+            "w4a16_v2"
+        } else if func.starts_with("w4a16_gemv") {
+            "w4a16_gemv"
+        } else {
+            "w4a16"
+        },
+        func,
+    ) {
         Ok(h) => Some((name, h, geom)),
         Err(_) => {
             eprintln!("SKIP {name}: kernel w4a16::{func} not in this target's module set");

--- a/crates/spark-model/examples/w4a16_parity_microtest.rs
+++ b/crates/spark-model/examples/w4a16_parity_microtest.rs
@@ -105,6 +105,11 @@ fn launch(
         .arg_u32(M as u32)
         .arg_u32(n as u32)
         .arg_u32(k as u32)
+        // ldb: transposed-B row stride. `w4a16_gemm_t` gained this parameter when
+        // lm_head needed a padded stride (vocab 248077 is odd and broke its 16-byte
+        // cp.async). The packed case is ldb == n. Harmless for the kernels that do
+        // not declare it — the launch API only reads declared params.
+        .arg_u32(n as u32)
         .launch(0)
 }
 
@@ -118,6 +123,8 @@ fn main() -> Result<()> {
         ("w4a16_gemm_t     ", "w4a16_gemm_t"),
         ("w4a16_gemm_t_k64 ", "w4a16_gemm_t_k64"),
         ("w4a16_gemm_t_m128", "w4a16_gemm_t_m128"),
+        // 3-deep weight pipeline: MUST agree with its 2-stage parent.
+        ("w4a16_gemm_t_k64_p3", "w4a16_gemm_t_k64_p3"),
     ]
     .into_iter()
     .filter_map(|(name, f)| g.kernel("w4a16", f).ok().map(|h| (name, h)))

--- a/crates/spark-model/src/engine/tests.rs
+++ b/crates/spark-model/src/engine/tests.rs
@@ -160,6 +160,7 @@ impl Model for MockModel {
             marconi_skip_to: 0,
             marconi_exact_snap: None,
             session_hash: 0,
+            mtp_capture_gen: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
             kv_valid_tokens: 0,

--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -14,7 +14,10 @@ use spark_runtime::buffers::BufferArena;
 use spark_runtime::gpu::{DevicePtr, GpuBackend};
 
 mod transformer_layer;
-pub use transformer_layer::TransformerLayer;
+pub use transformer_layer::{
+    TransformerLayer, VERIFY_WY_LAYER_STRIDE_BYTES, VERIFY_WY_TABLE_SEQS,
+    VERIFY_WY_TABLE_STRIDE_BYTES, VERIFY_WY_TABLES_PER_LAYER,
+};
 
 /// Per-layer persistent state tracked across decode steps.
 ///

--- a/crates/spark-model/src/layer/transformer_layer.rs
+++ b/crates/spark-model/src/layer/transformer_layer.rs
@@ -11,6 +11,32 @@ use super::{BatchedAttnMetadata, ForwardContext, GdnPrefillBuffers, LayerState};
 
 mod default_loops;
 
+/// Batched-verify WY pointer-table layout (SSOT — writer:
+/// `TransformerModel::upload_verify_wy_tables`, reader: the qwen3_ssm
+/// `GdnStates::Multi` batched conv+WY arm).
+///
+/// Per GDN layer, four device pointer tables laid back-to-back:
+/// `[h_state | Hi0 | Hi1 | Hi2]`, each `VERIFY_WY_TABLE_SEQS` u64 entries
+/// (one per batched-verify sequence, unused tail entries zero). The
+/// per-layer slice handed to `decode_verify_multi` is
+/// `VERIFY_WY_LAYER_STRIDE_BYTES` long. At K<4 only the first `k` tables
+/// are filled (`[h | Hi_0..Hi_{k-2}]`); the layout/strides are constant so
+/// the reader's offsets never depend on the ladder step.
+///
+/// 16, not 4: the batched verify runs up to 16 sequences (ladder bottom
+/// step, R = n*2 = 32 rows). At 4 the upload returned NULL for every n>4
+/// batch, which silently declined the whole cross-sequence conv+WY fast
+/// path back to the per-sequence loop at exactly the concurrencies it was
+/// built for. 48 GDN layers x 4 tables x 16 entries x 8 B = 24 KB.
+pub const VERIFY_WY_TABLE_SEQS: usize = 16;
+/// Tables per GDN layer: h_state + Hi0..Hi2 (K=4 verify → 3 intermediates).
+pub const VERIFY_WY_TABLES_PER_LAYER: usize = 4;
+/// Bytes between consecutive tables within a layer slice.
+pub const VERIFY_WY_TABLE_STRIDE_BYTES: usize = VERIFY_WY_TABLE_SEQS * 8;
+/// Bytes between consecutive GDN layers' table slices.
+pub const VERIFY_WY_LAYER_STRIDE_BYTES: usize =
+    VERIFY_WY_TABLES_PER_LAYER * VERIFY_WY_TABLE_STRIDE_BYTES;
+
 pub trait TransformerLayer: Send + Sync {
     /// `&mut dyn Any` downcast hook for post-construction weight overlays (e.g.
     /// the LoRA install walk). Default `None`; overlay-capable layers override.
@@ -491,6 +517,37 @@ pub trait TransformerLayer: Send + Sync {
             ctx,
             stream,
         )
+    }
+
+    /// Batched MTP verify: `n_seqs` sequences × `k` tokens through this layer
+    /// in ONE weight sweep (rows seq-major, `r = i*k + j`, contiguous in
+    /// `hidden`/`residual`). Projections/FFN batch across all `n_seqs*k` rows;
+    /// the stateful recurrence (conv/GDN) runs per-sequence against
+    /// `states[i]` with row-offset buffer bases — per-sequence math is
+    /// byte-identical to the single-sequence `decode_batched` K-token body.
+    ///
+    /// Only SSM layers override (attention layers are handled by the caller
+    /// via `decode_multi_seq`, which already takes per-row block tables and
+    /// seq lens). Default: unsupported.
+    ///
+    /// `wy_tables`: this layer's slice of the model-staged WY pointer tables
+    /// (layout above, `VERIFY_WY_LAYER_STRIDE_BYTES`; refreshed pre-graph
+    /// every step) enabling the single-launch table-form WY batch. NULL →
+    /// the layer keeps its per-sequence WY path.
+    #[allow(clippy::too_many_arguments)]
+    fn decode_verify_multi<'a, 'b: 'a>(
+        &self,
+        _hidden: DevicePtr,
+        _residual: DevicePtr,
+        _n_seqs: usize,
+        _k: usize,
+        _states: &'a mut [&'b mut (dyn LayerState + 'static)],
+        _kv_cache: &mut PagedKvCache,
+        _wy_tables: DevicePtr,
+        _ctx: &ForwardContext,
+        _stream: u64,
+    ) -> Result<()> {
+        anyhow::bail!("decode_verify_multi: unsupported for this layer type")
     }
 
     /// Allocate per-sequence state for this layer.

--- a/crates/spark-model/src/layer/transformer_layer.rs
+++ b/crates/spark-model/src/layer/transformer_layer.rs
@@ -540,7 +540,7 @@ pub trait TransformerLayer: Send + Sync {
         _hidden: DevicePtr,
         _residual: DevicePtr,
         _n_seqs: usize,
-        _k: usize,
+        _ks: &[usize],
         _states: &'a mut [&'b mut (dyn LayerState + 'static)],
         _kv_cache: &mut PagedKvCache,
         _wy_tables: DevicePtr,

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -173,6 +173,13 @@ pub struct DenseFfnLayer {
     // folded in the scaled SiLU-mul. KernelHandle(0) → arm skipped.
     nvfp4_mmq_nc_k: KernelHandle,
     nvfp4_mmq_wc_k: KernelHandle,
+    /// M-sized MMQ tiles for DECODE. The 128 tile issues MMAs for all 128 columns
+    /// regardless of m, so at m=16 it discards 112 of them; these size the tile to
+    /// the batch. try_kernel: 0-handle -> dispatch keeps the 128 tile.
+    nvfp4_mmq16_nc_k: KernelHandle,
+    nvfp4_mmq16_wc_k: KernelHandle,
+    nvfp4_mmq32_nc_k: KernelHandle,
+    nvfp4_mmq32_wc_k: KernelHandle,
     nvfp4_quant_act_k: KernelHandle,
     nvfp4_repack_k: KernelHandle,
     nvfp4_silu_scaled_k: KernelHandle,
@@ -230,6 +237,12 @@ pub struct DenseFfnLayer {
     lora: Option<ops::lora_delta::LoraFfnWeights>,
 }
 
+/// M-sized MMQ tiles: **ON by default**, disabled by `ATLAS_NO_MMQ_SMALL_TILE=1`.
+/// Strict `== "1"` on an `ATLAS_NO_*` name — presence flags here are enabled by `=0`.
+fn mmq_small_tile_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_MMQ_SMALL_TILE").as_deref() != Ok("1"))
+}
 impl DenseFfnLayer {
     pub fn new(weights: DenseFfnWeights, gpu: &dyn GpuBackend) -> Result<Self> {
         Self::new_with_activation(weights, FfnActivation::SiLU, gpu)
@@ -282,7 +295,7 @@ impl DenseFfnLayer {
                 "w4a16",
                 "w4a16_gemm_t_m128_bf16_v2",
             ),
-            w4a16_gemm_t_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t"),
+            w4a16_gemm_t_k: super::tgemm_kernel(gpu),
             int8_faith2_k: super::try_kernel(gpu, "w4a16", "int8_gemm_faith2"),
             int8_faith5_k: super::try_kernel(gpu, "w4a16", "int8_gemm_i32acc"),
             requant_w_int8_k: super::try_kernel(gpu, "w4a16", "requant_w_nvfp4_int8"),
@@ -306,6 +319,10 @@ impl DenseFfnLayer {
             q4k_down: std::sync::OnceLock::new(),
             nvfp4_mmq_nc_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_mmq128_nc"),
             nvfp4_mmq_wc_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_mmq128_wc"),
+            nvfp4_mmq16_nc_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_mmq16_nc"),
+            nvfp4_mmq16_wc_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_mmq16_wc"),
+            nvfp4_mmq32_nc_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_mmq32_nc"),
+            nvfp4_mmq32_wc_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_mmq32_wc"),
             nvfp4_quant_act_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_quantize_bf16"),
             nvfp4_repack_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_repack"),
             nvfp4_silu_scaled_k: super::try_kernel(gpu, "nvfp4_mmq", "atlas_nvfp4_silu_mul_scaled"),
@@ -314,7 +331,7 @@ impl DenseFfnLayer {
             fp4mmq_gate: std::sync::OnceLock::new(),
             fp4mmq_up: std::sync::OnceLock::new(),
             fp4mmq_down: std::sync::OnceLock::new(),
-            w4a16_gemm_t_k64_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t_k64"),
+            w4a16_gemm_t_k64_k: super::k64_kernel(gpu).unwrap_or(KernelHandle(0)),
             act_mul,
             bf16_weights: None,
             dense_gemv_bf16_k,
@@ -1228,7 +1245,10 @@ impl DenseFfnLayer {
         }
         if let Some(wt) = wt {
             if m <= 64 && k.is_multiple_of(32) && small_m_enabled() {
-                if k >= 8192 && k.is_multiple_of(64) && self.w4a16_gemm_t_k64_k.0 != 0 {
+                if k >= crate::layers::w4a16_k64_min_k()
+                    && k.is_multiple_of(64)
+                    && self.w4a16_gemm_t_k64_k.0 != 0
+                {
                     return ops::w4a16_gemm_n128(
                         ctx.gpu,
                         self.w4a16_gemm_t_k64_k,
@@ -1583,17 +1603,24 @@ impl DenseFfnLayer {
                         let _ = $in;
                         let qw =
                             self.ensure_nvfp4_mmq_weight($fp4cell, ctx.gpu, $w, $n, $k, stream)?;
-                        ops::nvfp4_mmq_gemm(
-                            ctx.gpu,
-                            self.nvfp4_mmq_nc_k,
-                            self.nvfp4_mmq_wc_k,
-                            fp4_y,
-                            qw.w,
-                            $out,
-                            m,
-                            $n,
-                            $k,
-                            stream,
+                        // Size the M tile to the batch when the batch is small and
+                        // the small-tile entries are present. m must be <= mmq_x or
+                        // grid.y>1 re-streams the weights per tile.
+                        let (tk_nc, tk_wc, tile) = if m <= 16
+                            && self.nvfp4_mmq16_nc_k.0 != 0
+                            && mmq_small_tile_enabled()
+                        {
+                            (self.nvfp4_mmq16_nc_k, self.nvfp4_mmq16_wc_k, 16u32)
+                        } else if m <= 32
+                            && self.nvfp4_mmq32_nc_k.0 != 0
+                            && mmq_small_tile_enabled()
+                        {
+                            (self.nvfp4_mmq32_nc_k, self.nvfp4_mmq32_wc_k, 32u32)
+                        } else {
+                            (self.nvfp4_mmq_nc_k, self.nvfp4_mmq_wc_k, 128u32)
+                        };
+                        ops::nvfp4_mmq_gemm_tiled(
+                            ctx.gpu, tk_nc, tk_wc, tile, fp4_y, qw.w, $out, m, $n, $k, stream,
                         )?;
                     }
                     // Q4_K MMQ prefill (ATLAS_FFN_MMQ) — next priority, gated per-GEMM by

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -15,6 +15,41 @@ pub mod qwen3_attention;
 pub mod qwen3_ssm;
 pub mod vision_encoder;
 
+/// Minimum K at which the deep-K `w4a16_gemm_t_k64` (K_STEP_T=64) beats the
+/// K_STEP_T=32 `w4a16_gemm_t`.
+///
+/// ★ 6144, not 4096. Measured with `w4a16_m17_bench` on the REAL decode shapes at
+/// M=16 against the STREAM-measured 230 GB/s ceiling — `_k64` is the WORST tile
+/// variant at K=5120 and the best only at K>=6144:
+///
+///   ssm_qkvz     N=16384 K=5120   _t 281.9us   _k64 341.6us   _m128 272.4us
+///   attn qkv     N=14336 K=5120   _t 273.9us   _k64 328.5us   _m128 262.8us
+///   ssm_out_proj N=5120  K=6144   _t 237.7us   _k64 163.3us   _m128 240.7us
+///
+/// The original 4096 threshold (this session) was derived from the ffn/out_proj
+/// shapes and wrongly generalised to K=5120, sending 48 qkvz + 16 fused-qkv
+/// launches per step to the slowest variant. Both variants accumulate K
+/// sequentially, so moving between them is byte-identical.
+///
+/// `ATLAS_NO_W4A16_K64=1` restores the pre-session 8192 threshold.
+pub(crate) fn w4a16_k64_min_k() -> u32 {
+    static MIN_K: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *MIN_K.get_or_init(|| {
+        // Explicit override so an A/B can pin a previous threshold exactly.
+        if let Some(n) = std::env::var("ATLAS_W4A16_K64_MIN_K")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+        {
+            return n;
+        }
+        if std::env::var("ATLAS_NO_W4A16_K64").ok().as_deref() == Some("1") {
+            8192
+        } else {
+            6144
+        }
+    })
+}
+
 pub use deepseek_v4_mtp::{DeepseekV4MtpHead, DeepseekV4MtpProposerState};
 pub use dense_ffn::{DenseFfnLayer, DenseFfnWeights, FfnActivation};
 pub use dflash_head::{
@@ -39,6 +74,46 @@ use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 /// given feature: e.g. Qwen3-Coder-Next (GDN+attention) never calls MLA
 /// kernels, but the layer builder still probes them. Warning on expected
 /// misses drowned out genuine problems in startup logs.
+/// Resolve the N128/M64 tile GEMM, preferring the 3-deep weight-pipeline variant.
+/// **ON by default**; `ATLAS_NO_TGEMM_PIPELINE3` (presence — `=0` is NOT "off")
+/// falls back to the 2-stage parent. Falls back automatically on any target that
+/// does not ship `_p3`.
+///
+/// Same mechanism as [`k64_kernel`]: the parent drains its cp.async group before
+/// the dequant phase, which only a co-resident CTA can cover. This kernel's live
+/// shapes — ssm_qkvz (128 CTAs) and the fused QKV (112) — sit in the exposed
+/// band of the grid.x-vs-efficiency curve. Bit-identical.
+pub fn tgemm_kernel(gpu: &dyn GpuBackend) -> KernelHandle {
+    if std::env::var("ATLAS_NO_TGEMM_PIPELINE3").is_err() {
+        let h = try_kernel(gpu, "w4a16", "w4a16_gemm_t_p3");
+        if h.0 != 0 {
+            return h;
+        }
+    }
+    try_kernel(gpu, "w4a16", "w4a16_gemm_t")
+}
+
+/// Resolve the k64 deep-K tile GEMM, preferring the 3-deep weight-pipeline
+/// variant. **ON by default**; `ATLAS_NO_K64_PIPELINE3` (presence — `=0` is NOT
+/// "off") falls back to the 2-stage parent.
+///
+/// The parent issues one cp.async group then `wait_all`s it before the dequant
+/// phase, so with a small grid there are ZERO outstanding loads across that
+/// phase. The out_proj/o_proj shapes (N=5120, K=6144) launch 40 CTAs on 48 SMs —
+/// exactly 1 CTA/SM — so nothing covers the drain, and they measure ~38% of
+/// achievable while lm_head (1938 CTAs) reaches 83% on the identical loop.
+/// `_p3` keeps step i+2's loads in flight across dequant(i+1). Bit-identical.
+pub fn k64_kernel(gpu: &dyn GpuBackend) -> Result<KernelHandle> {
+    let want_p3 = std::env::var("ATLAS_NO_K64_PIPELINE3").is_err();
+    if want_p3 {
+        let h = try_kernel(gpu, "w4a16", "w4a16_gemm_t_k64_p3");
+        if h.0 != 0 {
+            return Ok(h);
+        }
+    }
+    gpu.kernel("w4a16", "w4a16_gemm_t_k64")
+}
+
 pub fn try_kernel(gpu: &dyn GpuBackend, module: &str, func: &str) -> KernelHandle {
     match gpu.kernel(module, func) {
         Ok(h) => h,

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -247,6 +247,11 @@ pub struct MtpHead {
     /// `argmax_bf16_batch` for the batched-propose per-row argmax (0 when
     /// absent; falls back to the serial per-row scan).
     argmax_batch_k: KernelHandle,
+    /// `argmax_bf16_batch_lp` — the same batched argmax that ALSO emits each
+    /// row's top-1 log-probability. Resolved with `try_kernel`, so 0 means the
+    /// module predates this kernel; D-Cut gates on it and declines rather than
+    /// silently proposing without confidences.
+    argmax_batch_lp_k: KernelHandle,
     /// Drafter-prefill scratch; `None` unless ATLAS_MTP_DRAFTER_PREFILL=1.
     prefill_scratch: Option<MtpPrefillScratch>,
 }

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -223,6 +223,30 @@ pub struct MtpHead {
     moe_weighted_sum_blend_k: Option<KernelHandle>,
     /// Batched BF16 GEMM for the drafter-prefill pass (0 when absent).
     dense_gemm_k: KernelHandle,
+    /// Tensor-core pipelined BF16 GEMM (`dense_gemm_bf16_pipelined`) for the
+    /// batched cross-sequence propose (0 when absent). Measured at M=4 on the
+    /// drafter shapes: 2.7x the 4x-GEMV per-seq loop (5.1 vs 14.4 ms per
+    /// draft position).
+    dense_gemm_pipelined_k: KernelHandle,
+    /// `w4a16_gemv_batch{4,8,16}` for the batched-propose LM head (0 when
+    /// absent): reads the shared NVFP4 LM head once for up to MAX_M
+    /// sequences. Selected per batch width by
+    /// [`MtpHead::lm_head_batch_kernel`]; per-row accumulation order is
+    /// identical across instantiations (one `w4a16_gemv_batchm_impl`), so
+    /// output is bit-identical at matching M.
+    w4a16_gemv_batch4_k: KernelHandle,
+    w4a16_gemv_batch8_k: KernelHandle,
+    w4a16_gemv_batch16_k: KernelHandle,
+    /// Drafter attention metadata for the batched propose:
+    /// `[PROPOSE_META_SEQS, PROPOSE_META_STRIDE]` bytes, one slab per
+    /// sequence. A dedicated allocation, NOT an offset into the shared
+    /// `scratch` arena — the old fixed `scratch + 49152 + i*2048` layout ran
+    /// past the end of a 27B-shaped scratch at n > 8 (silent out-of-range
+    /// H2D → sticky CUDA-700, the #110 failure mode).
+    propose_meta: DevicePtr,
+    /// `argmax_bf16_batch` for the batched-propose per-row argmax (0 when
+    /// absent; falls back to the serial per-row scan).
+    argmax_batch_k: KernelHandle,
     /// Drafter-prefill scratch; `None` unless ATLAS_MTP_DRAFTER_PREFILL=1.
     prefill_scratch: Option<MtpPrefillScratch>,
 }
@@ -308,8 +332,10 @@ impl MtpHead {
     }
 }
 
+mod batch_caps;
 mod draft_proposer;
 mod forward;
+mod forward_batch;
 mod moe_forward;
 mod new;
 mod prefill;

--- a/crates/spark-model/src/layers/mtp_head/batch_caps.rs
+++ b/crates/spark-model/src/layers/mtp_head/batch_caps.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched-propose width policy: how many sequences one drafter forward can
+//! carry, derived (never assumed) from the resolved kernels and the arena
+//! buffer capacities.
+//!
+//! The batched propose used to be hard-capped at 4 (`(2..=4).contains(&n)`),
+//! so the scheduler ran it in groups of <= 4 — 4 drafter forwards per draft
+//! position at n=16, each re-reading the whole BF16 drafter. That is the
+//! second of the three eager costs the n=16 finalizer matrix named (the K=1
+//! verify step measured ~1.9x a plain batch-16 decode step against a ~1.72x
+//! break-even at p1~0.72).
+//!
+//! Nothing structural forced 4: the drafter's per-row loops are index-generic
+//! and every weight-bearing GEMM is M-generic. Only three things were width-
+//! bound, and all three are checked here rather than assumed:
+//!
+//! 1. the LM head ran on `w4a16_gemv_batch4` (MAX_M=4). `w4a16_gemv_batch8`
+//!    and `w4a16_gemv_batch16` are the same template at wider MAX_M and were
+//!    already compiled; [`MtpHead::lm_head_batch_kernel`] picks the narrowest
+//!    resolved kernel that covers `n` (per-row accumulation order is
+//!    identical across instantiations, so the output is bit-identical at
+//!    matching M).
+//! 2. the per-sequence drafter attention metadata lived at a FIXED offset
+//!    inside the shared `scratch` buffer (`scratch + 49152 + i*2048`), which
+//!    at n=16 runs 15 KB past the end of a 27B-shaped scratch allocation —
+//!    a silent out-of-range H2D (the #110 failure mode: sticky CUDA-700).
+//!    The drafter now owns a dedicated `propose_meta` allocation.
+//! 3. the arena rows the forward writes. Most are sized `max_batch_tokens`
+//!    rows of something at least as wide as what the drafter puts there, but
+//!    `ssm_ba` (row = 2*num_value_heads floats) and `ssm_gates` (row =
+//!    2*num_value_heads f32) are NOT — the drafter parks `[n, 2h]` and
+//!    `[n, h]` BF16 there. Both are checked in bytes below.
+
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::KernelHandle;
+
+use atlas_core::config::ModelConfig;
+
+use super::{MtpHead, MtpQuantization, ProjectionWeight};
+
+/// Bytes of drafter attention metadata per sequence in `propose_meta`.
+/// Layout per sequence i at `propose_meta + i*PROPOSE_META_STRIDE` mirrors
+/// `forward_one`: [0..4) position u32 | [8..16) slot i64 | [16..20) seq_len
+/// i32 | [256..) block table i32[]. 2048 bytes caps the block table at 448
+/// entries (a 4096-token drafter at block size 16 needs 257).
+pub(crate) const PROPOSE_META_STRIDE: usize = 2048;
+
+/// Sequences the `propose_meta` allocation is sized for. Matches the batched
+/// verify's 16-slot hidden stash (`verify_hidden_stash`) — the widest chunk
+/// the K-vs-batch ladder can hand a propose. 16 x 2048 = 32 KB.
+pub(crate) const PROPOSE_META_SEQS: usize = 16;
+
+impl MtpHead {
+    /// Narrowest resolved `w4a16_gemv_batch{M}` kernel covering `n` rows, or
+    /// a 0 handle when none is resolved (`try_kernel` misses are a silent 0 —
+    /// gate on the handle, never assume the kernel is in this target's set).
+    pub(crate) fn lm_head_batch_kernel(&self, n: usize) -> KernelHandle {
+        for (max_m, k) in [
+            (4usize, self.w4a16_gemv_batch4_k),
+            (8, self.w4a16_gemv_batch8_k),
+            (16, self.w4a16_gemv_batch16_k),
+        ] {
+            if n <= max_m && k.0 != 0 {
+                return k;
+            }
+        }
+        KernelHandle(0)
+    }
+
+    /// Whether the BF16-everything scope + non-width-dependent kernels the
+    /// batched propose needs are all present. Width is [`Self::propose_batch_max`].
+    fn propose_batch_scope_ok(&self) -> bool {
+        let bf16_proj = |p: &ProjectionWeight| matches!(p, ProjectionWeight::Bf16(_));
+        matches!(self.quant, MtpQuantization::Bf16)
+            && self.kv_bf16
+            && bf16_proj(&self.fc)
+            && bf16_proj(&self.q_proj)
+            && bf16_proj(&self.k_proj)
+            && bf16_proj(&self.v_proj)
+            && bf16_proj(&self.o_proj)
+            && self
+                .dense_ffn_generic
+                .as_ref()
+                .is_some_and(|(g, u, d)| bf16_proj(g) && bf16_proj(u) && bf16_proj(d))
+            && self.dense_gemm_pipelined_k.0 != 0
+            && self.dense_gemv_k.is_some()
+            && self.deinterleave_qg_k.is_some()
+            && self.moe_silu_mul_k.is_some()
+            && !self.propose_meta.is_null()
+    }
+
+    /// The widest batched propose this head can run: `1` means "per-sequence
+    /// only" (the caller must not batch). Every term is a measured capacity,
+    /// not a constant someone hopes is big enough.
+    pub(crate) fn propose_batch_max(&self, buffers: &BufferArena, config: &ModelConfig) -> usize {
+        if !self.propose_batch_scope_ok() {
+            return 1;
+        }
+        let h = config.hidden_size;
+        let bf16 = 2usize;
+        let sizes = buffers.sizes();
+        // Rows each capacity-bound buffer can hold for THIS forward's use of
+        // it. `ssm_ba` holds the [n, 2h] concat; `ssm_gates` the [n, h]
+        // normed hidden. Everything else is arena-row-sized (>= h per row).
+        let rows = |bytes: usize, per_row: usize| {
+            if per_row == 0 { 0 } else { bytes / per_row }
+        };
+        let mut cap = PROPOSE_META_SEQS
+            .min(rows(sizes.ssm_ba, 2 * h * bf16))
+            .min(rows(sizes.ssm_gates, h * bf16))
+            .min(rows(sizes.ssm_qkvz, h * bf16))
+            .min(rows(sizes.ssm_deinterleaved, h * bf16))
+            .min(rows(sizes.hidden_states, h * bf16))
+            .min(rows(sizes.residual, h * bf16))
+            .min(rows(sizes.norm_output, h * bf16))
+            .min(buffers.max_batch_tokens());
+        // The LM head kernels come in discrete widths; shrink to the widest
+        // one that is actually resolved.
+        while cap > 1 && self.lm_head_batch_kernel(cap).0 == 0 {
+            cap -= 1;
+        }
+        cap.max(1)
+    }
+
+    /// Whether the batched cross-sequence propose can run for `n` sequences.
+    /// SSOT: one call into [`Self::propose_batch_max`], no second copy of the
+    /// width policy.
+    pub(crate) fn can_propose_batch(
+        &self,
+        n: usize,
+        buffers: &BufferArena,
+        config: &ModelConfig,
+    ) -> bool {
+        n >= 2 && n <= self.propose_batch_max(buffers, config)
+    }
+}

--- a/crates/spark-model/src/layers/mtp_head/draft_proposer.rs
+++ b/crates/spark-model/src/layers/mtp_head/draft_proposer.rs
@@ -92,6 +92,7 @@ impl DraftProposer for MtpHead {
         states: &mut [&mut dyn ProposerState],
         ctx: &ForwardContext,
         stream: u64,
+        out_conf: Option<&mut Vec<Vec<f32>>>,
     ) -> Result<Option<Vec<Vec<u32>>>> {
         if !self.can_propose_batch(last_tokens.len(), ctx.buffers, ctx.config) {
             return Ok(None);
@@ -113,6 +114,7 @@ impl DraftProposer for MtpHead {
             &mut mtp_states,
             ctx,
             stream,
+            out_conf,
         )
         .map(Some)
     }

--- a/crates/spark-model/src/layers/mtp_head/draft_proposer.rs
+++ b/crates/spark-model/src/layers/mtp_head/draft_proposer.rs
@@ -83,6 +83,48 @@ impl DraftProposer for MtpHead {
         Ok(drafts)
     }
 
+    fn propose_batch(
+        &self,
+        last_tokens: &[u32],
+        target_hiddens: &[DevicePtr],
+        positions: &[usize],
+        num_drafts: usize,
+        states: &mut [&mut dyn ProposerState],
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<Option<Vec<Vec<u32>>>> {
+        if !self.can_propose_batch(last_tokens.len(), ctx.buffers, ctx.config) {
+            return Ok(None);
+        }
+        // All states must downcast to MtpProposerState; any miss means a
+        // mixed-proposer batch — unsupported, fall back per-seq.
+        let mut mtp_states: Vec<&mut MtpProposerState> = Vec::with_capacity(states.len());
+        for s in states.iter_mut() {
+            match s.as_any_mut().downcast_mut::<MtpProposerState>() {
+                Some(st) => mtp_states.push(st),
+                None => return Ok(None),
+            }
+        }
+        self.propose_batch_impl(
+            last_tokens,
+            target_hiddens,
+            positions,
+            num_drafts,
+            &mut mtp_states,
+            ctx,
+            stream,
+        )
+        .map(Some)
+    }
+
+    fn propose_batch_max(
+        &self,
+        buffers: &spark_runtime::buffers::BufferArena,
+        config: &atlas_core::config::ModelConfig,
+    ) -> usize {
+        MtpHead::propose_batch_max(self, buffers, config)
+    }
+
     fn prefill_drafter(
         &self,
         prompt_tokens: &[u32],

--- a/crates/spark-model/src/layers/mtp_head/forward_batch.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward_batch.rs
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched cross-sequence MTP propose: one drafter forward for n sequences.
+//!
+//! The measured C=4 gate shortfall (batched-MTP fixer round 1): with the
+//! verify forward batched, the per-sequence PROPOSE loop dominated the
+//! remaining step — 12 drafter `forward_one` calls x ~5 ms (the BF16 drafter
+//! reads ~850 MB of weights per forward) = ~62 ms of a ~180 ms step at C=4.
+//! Drafts chain autoregressively WITHIN a sequence but are independent
+//! ACROSS sequences, so each draft position batches n sequences into M=n-row
+//! GEMMs that read every weight ONCE.
+//!
+//! Microbenchmarked at M=4 on the real 27B drafter shapes (GB10):
+//! `dense_gemm_bf16_pipelined` 5.1 ms vs the 4x `dense_gemv_bf16` loop
+//! 14.4 ms per draft position (scalar `dense_gemm_bf16`: 8.1 ms). The small
+//! K/V projections (N = nkv*hd) stay on the per-row GEMV (44 us vs 194 us
+//! pipelined at N=1024 — the 128-wide tile under-fills the grid). The LM
+//! head batches through `w4a16_gemv_batch{4,8,16}`, selected per width.
+//!
+//! WIDTH: `n` is bounded by [`super::batch_caps::MtpHead::propose_batch_max`]
+//! (up to 16), NOT by a hardcoded 4 — see that module for what actually
+//! limited it and how each limit is now checked rather than assumed.
+//!
+//! Everything non-weight-bearing (deinterleave, Q/K norms, RoPE, KV write,
+//! paged attention, sigmoid gate) LOOPS per row with `forward_one`'s exact
+//! kernels and arguments — per-sequence math identical, only base addresses
+//! move. Scope mirrors the drafter-prefill v1 contract: BF16 head
+//! (`--mtp-quantization bf16`) with BF16 drafter KV; anything else returns
+//! "unsupported" and the caller falls back to the per-seq `propose` loop.
+//!
+//! Reachability: only from the scheduler's batched K=4 verify step
+//! (`ATLAS_MTP_MAX_SEQS > 1`); C=1 and the default cap never enter.
+
+use anyhow::{Result, ensure};
+use spark_runtime::gpu::DevicePtr;
+
+use super::{MtpHead, MtpProposerState, ProjectionWeight};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::DenseWeight;
+
+use super::batch_caps::PROPOSE_META_STRIDE;
+
+impl MtpHead {
+    /// M=n-row BF16 GEMM dispatch: pipelined tensor-core GEMM for the large
+    /// weight-bearing shapes (reads B once for all rows), per-row GEMV for
+    /// small N where the 128-wide tile under-fills the grid (measured).
+    fn gemm_rows(
+        &self,
+        gpu: &dyn spark_runtime::gpu::GpuBackend,
+        input: DevicePtr,
+        w: &DenseWeight,
+        output: DevicePtr,
+        m: usize,
+        n: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        if n >= 4096 && (k & 7) == 0 {
+            ops::dense_gemm_bf16_pipelined(
+                gpu,
+                self.dense_gemm_pipelined_k,
+                input,
+                w,
+                output,
+                m as u32,
+                n,
+                k,
+                stream,
+            )
+        } else {
+            let gemv_k = self.dense_gemv_k.unwrap();
+            for r in 0..m {
+                ops::dense_gemv(
+                    gpu,
+                    gemv_k,
+                    input.offset(r * k as usize * 2),
+                    w,
+                    output.offset(r * n as usize * 2),
+                    n,
+                    k,
+                    stream,
+                )?;
+            }
+            Ok(())
+        }
+    }
+
+    /// One draft position for n sequences: the M=n-row sibling of
+    /// `forward_one`. Row i consumes `(tokens[i], hiddens[i])` at sequence
+    /// position `positions[i]`, appends one drafter KV row per sequence, and
+    /// returns the n argmax draft ids via ONE small D2H (the per-seq path
+    /// pays one 4-byte sync D2H per sequence per draft).
+    ///
+    /// Buffer layout (row i at offset i*width, matching `forward_one`'s
+    /// buffer choices): embeds ssm_qkvz [n,h] | normed_embed
+    /// ssm_deinterleaved [n,h] | normed_hidden ssm_gates [n,h] | concat
+    /// ssm_ba [n,2h] | hidden hidden_states [n,h] | residual residual [n,h]
+    /// | q/k/v qkv_output [n,qg]+[n,kv]+[n,kv] | attn attn_output [n,q_dim]
+    /// | ffn expert_gate/up_out [n,inter] -> moe_output [n,h] | logits
+    /// [n,vocab].
+    #[allow(clippy::too_many_arguments)]
+    fn forward_batch_position(
+        &self,
+        tokens: &[u32],
+        hiddens: &[DevicePtr],
+        positions: &[usize],
+        states: &mut [&mut MtpProposerState],
+        ctx: &ForwardContext,
+        stream: u64,
+        out_ids: &mut [u32],
+    ) -> Result<()> {
+        let n = tokens.len();
+        let h = ctx.config.hidden_size;
+        let nq = ctx.config.num_attention_heads as u32;
+        let nkv = ctx.config.num_key_value_heads as u32;
+        let hd = ctx.config.head_dim as u32;
+        let eps = ctx.config.rms_norm_eps as f32;
+        let bf16 = 2usize;
+        let gpu = ctx.gpu;
+
+        let q_dim = (nq * hd) as usize;
+        let qg_dim = q_dim * 2;
+        let kv_dim = (nkv * hd) as usize;
+
+        // 1. Embed the n tokens (row i at embeds + i*h).
+        let embeds = ctx.buffers.ssm_qkvz();
+        for (i, &t) in tokens.iter().enumerate() {
+            let src = self.embed_tokens.weight.offset(t as usize * h * bf16);
+            gpu.copy_d2d_async(src, embeds.offset(i * h * bf16), h * bf16, stream)?;
+        }
+
+        // 2. Pre-fc norms. Embeds are contiguous (one n-row call); target
+        // hiddens may be non-contiguous across sequences (stash rows vs the
+        // drafter's own hidden rows) -> per-row calls into a compact buffer.
+        let normed_embed = ctx.buffers.ssm_deinterleaved();
+        ops::rms_norm(
+            gpu,
+            self.rms_norm_k,
+            embeds,
+            &self.pre_fc_norm_embedding,
+            normed_embed,
+            n as u32,
+            h as u32,
+            eps,
+            stream,
+        )?;
+        let normed_hidden = ctx.buffers.ssm_gates();
+        for (i, &hp) in hiddens.iter().enumerate() {
+            ops::rms_norm(
+                gpu,
+                self.rms_norm_k,
+                hp,
+                &self.pre_fc_norm_hidden,
+                normed_hidden.offset(i * h * bf16),
+                1,
+                h as u32,
+                eps,
+                stream,
+            )?;
+        }
+
+        // 3. Per-row concat [normed_embed_i | normed_hidden_i] -> [n, 2h].
+        let concat = ctx.buffers.ssm_ba();
+        for i in 0..n {
+            ops::bf16_concat(
+                gpu,
+                self.bf16_concat_k,
+                normed_embed.offset(i * h * bf16),
+                normed_hidden.offset(i * h * bf16),
+                concat.offset(i * 2 * h * bf16),
+                h as u32,
+                stream,
+            )?;
+        }
+
+        // 4. fc: [n, 2h] -> [n, h]; copy to residual stream.
+        let hidden = ctx.buffers.hidden_states();
+        let (fc_w, q_w, k_w, v_w, o_w) = match (
+            &self.fc,
+            &self.q_proj,
+            &self.k_proj,
+            &self.v_proj,
+            &self.o_proj,
+        ) {
+            (
+                ProjectionWeight::Bf16(fc),
+                ProjectionWeight::Bf16(q),
+                ProjectionWeight::Bf16(k),
+                ProjectionWeight::Bf16(v),
+                ProjectionWeight::Bf16(o),
+            ) => (fc, q, k, v, o),
+            _ => anyhow::bail!("propose_batch: non-BF16 projections (can_propose_batch lied)"),
+        };
+        self.gemm_rows(
+            gpu,
+            concat,
+            fc_w,
+            hidden,
+            n,
+            h as u32,
+            (2 * h) as u32,
+            stream,
+        )?;
+        let residual = ctx.buffers.residual();
+        gpu.copy_d2d_async(hidden, residual, n * h * bf16, stream)?;
+
+        // 5. Input layernorm [n, h].
+        let normed = ctx.buffers.norm_output();
+        ops::rms_norm(
+            gpu,
+            self.rms_norm_k,
+            hidden,
+            &self.input_layernorm,
+            normed,
+            n as u32,
+            h as u32,
+            eps,
+            stream,
+        )?;
+
+        // 6. Q+Gate / K / V projections. Row layout: q [n, qg] at qkv_output,
+        // k [n, kv] after it, v [n, kv] after that (fits: n*(qg+2kv) =
+        // n*qkv_dim rows of the arena).
+        let q_out = ctx.buffers.qkv_output();
+        let k_out = q_out.offset(n * qg_dim * bf16);
+        let v_out = k_out.offset(n * kv_dim * bf16);
+        self.gemm_rows(gpu, normed, q_w, q_out, n, qg_dim as u32, h as u32, stream)?;
+        self.gemm_rows(gpu, normed, k_w, k_out, n, kv_dim as u32, h as u32, stream)?;
+        self.gemm_rows(gpu, normed, v_w, v_out, n, kv_dim as u32, h as u32, stream)?;
+
+        // Per-row Q/Gate deinterleave + Q/K norms (forward_one's exact calls).
+        let deint_k = self.deinterleave_qg_k.unwrap();
+        for i in 0..n {
+            ops::deinterleave_qg(
+                gpu,
+                deint_k,
+                q_out.offset(i * qg_dim * bf16),
+                1,
+                nq,
+                hd,
+                nq * hd * 2,
+                stream,
+            )?;
+        }
+        // Q norm MUST loop per sequence: each sequence's row is a strided
+        // [q(q_dim) | gate(q_dim)] block at stride qg_dim, so a single packed
+        // n*nq-row launch would (a) RMS-norm seq0's sigmoid GATE with q_norm
+        // weights and (b) leave the later sequences' Q heads un-normalized —
+        // the measured batched accept-p1 divergence (0.59-0.71 vs single-seq
+        // 0.70-0.82). nq rows over exactly the q_dim span per seq is
+        // forward_one's exact call. K below is packed [n, kv_dim] and safe.
+        for i in 0..n {
+            let q_row = q_out.offset(i * qg_dim * bf16);
+            ops::rms_norm(
+                gpu,
+                self.rms_norm_k,
+                q_row,
+                &self.q_norm,
+                q_row,
+                nq,
+                hd,
+                eps,
+                stream,
+            )?;
+        }
+        ops::rms_norm(
+            gpu,
+            self.rms_norm_k,
+            k_out,
+            &self.k_norm,
+            k_out,
+            n as u32 * nkv,
+            hd,
+            eps,
+            stream,
+        )?;
+
+        // 7. Per-sequence attention metadata + RoPE + KV write + paged attn.
+        let mut kv_cache = self.kv_cache.lock();
+        let bs = kv_cache.block_size();
+        let scratch = ctx.buffers.scratch();
+        let attn_out = ctx.buffers.attn_output();
+        let inv_sqrt_d = 1.0f32 / (hd as f32).sqrt();
+        let kv_stride = nkv * hd;
+        for i in 0..n {
+            let state = &mut *states[i];
+            let blocks_needed = (state.seq_len / bs) + 1;
+            while state.block_table.len() < blocks_needed {
+                state.block_table.push(kv_cache.alloc_block()?);
+            }
+            let bt_len = state.block_table.len() * 4;
+            ensure!(
+                256 + bt_len <= PROPOSE_META_STRIDE,
+                "propose_batch: drafter block table {} exceeds meta stride",
+                bt_len
+            );
+            let meta_base = self.propose_meta.offset(i * PROPOSE_META_STRIDE);
+            let block_idx = state.block_table[state.seq_len / bs];
+            let global_slot = (block_idx as i64) * (bs as i64) + ((state.seq_len % bs) as i64);
+            let mut meta_buf = vec![0u8; 256 + bt_len];
+            meta_buf[0..4].copy_from_slice(&(positions[i] as u32).to_le_bytes());
+            meta_buf[8..16].copy_from_slice(&global_slot.to_le_bytes());
+            meta_buf[16..20].copy_from_slice(&((state.seq_len + 1) as i32).to_le_bytes());
+            let bt_bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(state.block_table.as_ptr() as *const u8, bt_len)
+            };
+            meta_buf[256..256 + bt_len].copy_from_slice(bt_bytes);
+            gpu.copy_h2d_async(&meta_buf, meta_base, stream)?;
+
+            let q_row = q_out.offset(i * qg_dim * bf16);
+            let k_row = k_out.offset(i * kv_dim * bf16);
+            let v_row = v_out.offset(i * kv_dim * bf16);
+            ops::rope(
+                gpu,
+                self.rope_k,
+                q_row,
+                k_row,
+                meta_base,
+                1,
+                nq,
+                nkv,
+                hd,
+                ctx.config.rotary_dim() as u32,
+                ctx.config.rope_theta as f32,
+                stream,
+            )?;
+            ops::reshape_and_cache(
+                gpu,
+                self.reshape_cache_k,
+                k_row,
+                v_row,
+                kv_cache.k_pool_ptr(self.attn_layer_idx),
+                kv_cache.v_pool_ptr(self.attn_layer_idx),
+                meta_base.offset(8),
+                1,
+                nkv,
+                hd,
+                bs as u32,
+                kv_stride,
+                kv_stride,
+                kv_cache.cache_stride() as u64,
+                stream,
+            )?;
+            ops::paged_decode_attn_bf16(
+                gpu,
+                self.paged_decode_k,
+                q_row,
+                kv_cache.k_pool_ptr(self.attn_layer_idx),
+                kv_cache.v_pool_ptr(self.attn_layer_idx),
+                attn_out.offset(i * q_dim * bf16),
+                meta_base.offset(256),
+                meta_base.offset(16),
+                state.block_table.len() as u32,
+                1,
+                nq,
+                nkv,
+                hd,
+                bs as u32,
+                inv_sqrt_d,
+                nq * hd,
+                0,
+                stream,
+            )?;
+            // Sigmoid gate: attn_i *= sigmoid(gate_i).
+            ops::sigmoid_gate_mul(
+                gpu,
+                self.sigmoid_gate_mul_k,
+                attn_out.offset(i * q_dim * bf16),
+                q_row.offset(q_dim * bf16),
+                attn_out.offset(i * q_dim * bf16),
+                nq * hd,
+                stream,
+            )?;
+        }
+        drop(kv_cache);
+
+        // 8. O projection [n, q_dim] -> [n, h]; residual + post-attn norm.
+        let o_out = ctx.buffers.norm_output();
+        self.gemm_rows(gpu, attn_out, o_w, o_out, n, h as u32, q_dim as u32, stream)?;
+        let normed2 = ctx.buffers.norm_output();
+        ops::residual_add_rms_norm(
+            gpu,
+            self.residual_add_rms_norm_k,
+            hidden,
+            o_out,
+            &self.post_attn_layernorm,
+            normed2,
+            residual,
+            n as u32,
+            h as u32,
+            eps,
+            stream,
+        )?;
+
+        // 9. Dense FFN [n, h] -> [n, h] (dense_ffn_forward_generic, M=n).
+        let inter = if ctx.config.intermediate_size > 0 {
+            ctx.config.intermediate_size as u32
+        } else {
+            ctx.config.moe_intermediate_size as u32
+        };
+        let (gate_w, up_w, down_w) = match self.dense_ffn_generic.as_ref() {
+            Some((
+                ProjectionWeight::Bf16(g),
+                ProjectionWeight::Bf16(u),
+                ProjectionWeight::Bf16(d),
+            )) => (g, u, d),
+            _ => anyhow::bail!("propose_batch: non-BF16 FFN (can_propose_batch lied)"),
+        };
+        let gate_out = ctx.buffers.expert_gate_out();
+        let up_out = ctx.buffers.expert_up_out();
+        self.gemm_rows(gpu, normed2, gate_w, gate_out, n, inter, h as u32, stream)?;
+        self.gemm_rows(gpu, normed2, up_w, up_out, n, inter, h as u32, stream)?;
+        ops::moe_silu_mul(
+            gpu,
+            self.moe_silu_mul_k.unwrap(),
+            gate_out,
+            up_out,
+            gate_out,
+            n as u32 * inter,
+            stream,
+        )?;
+        let ffn_out = ctx.buffers.moe_output();
+        self.gemm_rows(gpu, gate_out, down_w, ffn_out, n, h as u32, inter, stream)?;
+        ops::residual_add(
+            gpu,
+            self.residual_add_k,
+            hidden,
+            ffn_out,
+            n as u32 * h as u32,
+            stream,
+        )?;
+
+        // 10. Final norm [n, h] + batched LM head + per-row argmax.
+        let final_normed = ctx.buffers.norm_output();
+        ops::rms_norm(
+            gpu,
+            self.rms_norm_k,
+            hidden,
+            &self.norm,
+            final_normed,
+            n as u32,
+            h as u32,
+            eps,
+            stream,
+        )?;
+        let v = if self.mtp_vocab_size > 0 {
+            self.mtp_vocab_size.min(ctx.config.vocab_size as u32)
+        } else {
+            ctx.config.vocab_size as u32
+        };
+        let logits = ctx.buffers.logits();
+        ops::w4a16_gemv_batchm(
+            gpu,
+            self.lm_head_batch_kernel(n),
+            final_normed,
+            &self.lm_head_nvfp4,
+            logits,
+            n as u32,
+            v,
+            h as u32,
+            stream,
+        )?;
+        if self.argmax_batch_k.0 != 0 {
+            ops::argmax_bf16_batch(gpu, self.argmax_batch_k, logits, scratch, v, n as u32, v, stream)?;
+        } else {
+            for i in 0..n {
+                ops::argmax_bf16(
+                    gpu,
+                    self.argmax_k,
+                    logits.offset(i * v as usize * bf16),
+                    scratch.offset(i * 4),
+                    v,
+                    stream,
+                )?;
+            }
+        }
+
+        // 11. One sync D2H for the n ids (the per-seq path pays n of these).
+        let mut buf = vec![0u8; n * 4];
+        gpu.copy_d2h(scratch, &mut buf)?;
+        for (i, id) in out_ids.iter_mut().enumerate() {
+            *id = u32::from_le_bytes([buf[i * 4], buf[i * 4 + 1], buf[i * 4 + 2], buf[i * 4 + 3]]);
+        }
+
+        // 12. Bookkeeping (forward_one's tail, per row).
+        for (i, state) in states.iter_mut().enumerate() {
+            state.seq_len += 1;
+            state.last_pair_key = Some(positions[i].saturating_sub(1));
+        }
+        Ok(())
+    }
+
+    /// Batched propose driver: `num_drafts` chained positions, each one
+    /// M=n-row forward. Draft 0 consumes the caller's per-sequence target
+    /// hiddens; draft j>0 consumes the drafter's own hidden row i (written
+    /// by position j-1's fc — read [step 2] strictly before the next fc
+    /// overwrites it [step 4], same stream). Sets `last_num_drafted`
+    /// incrementally so a mid-chain error trims exactly the rows written.
+    pub(crate) fn propose_batch_impl(
+        &self,
+        last_tokens: &[u32],
+        target_hiddens: &[DevicePtr],
+        positions: &[usize],
+        num_drafts: usize,
+        states: &mut [&mut MtpProposerState],
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<Vec<Vec<u32>>> {
+        let n = last_tokens.len();
+        ensure!(
+            n == target_hiddens.len() && n == positions.len() && n == states.len(),
+            "propose_batch: length mismatch"
+        );
+        // Proof of engagement at the WIDE widths this lever exists for: log
+        // once per distinct n (bitmask, not a single Once — a first-hit line
+        // at n=4 would say nothing about n=8/16), naming the LM-head kernel
+        // actually selected so a handle-0 fallback cannot hide.
+        static LOGGED_N: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let bit = 1u32 << (n & 31);
+        if (LOGGED_N.fetch_or(bit, std::sync::atomic::Ordering::Relaxed) & bit) == 0 {
+            tracing::info!(
+                "MTP propose_batch active: n={n} pipelined_gemm={:#x} lm_head_batchm={:#x}",
+                self.dense_gemm_pipelined_k.0,
+                self.lm_head_batch_kernel(n).0
+            );
+        }
+        // Parity with propose(): reset chain confidence (unused here — the
+        // batched path is gated to draft_conf_tau() == 0).
+        self.last_conf_bits
+            .store(1.0f32.to_bits(), std::sync::atomic::Ordering::Relaxed);
+
+        let h = ctx.config.hidden_size;
+        let mut cur_tokens = last_tokens.to_vec();
+        let mut cur_positions = positions.to_vec();
+        let mut ids = vec![0u32; n];
+        let mut all: Vec<Vec<u32>> = vec![Vec::with_capacity(num_drafts); n];
+        for j in 0..num_drafts {
+            let hiddens_j: Vec<DevicePtr> = if j == 0 {
+                target_hiddens.to_vec()
+            } else {
+                (0..n)
+                    .map(|i| ctx.buffers.hidden_states().offset(i * h * 2))
+                    .collect()
+            };
+            self.forward_batch_position(
+                &cur_tokens,
+                &hiddens_j,
+                &cur_positions,
+                states,
+                ctx,
+                stream,
+                &mut ids,
+            )?;
+            for i in 0..n {
+                all[i].push(ids[i]);
+                cur_positions[i] += 1;
+            }
+            cur_tokens.copy_from_slice(&ids);
+            for state in states.iter_mut() {
+                state.last_num_drafted = j + 1;
+            }
+        }
+        Ok(all)
+    }
+}

--- a/crates/spark-model/src/layers/mtp_head/forward_batch.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward_batch.rs
@@ -41,6 +41,12 @@ use crate::weight_map::DenseWeight;
 
 use super::batch_caps::PROPOSE_META_STRIDE;
 
+/// Byte offset inside the shared scratch arena where the batched propose
+/// stages the per-row top-1 log-probabilities (FP32). The n argmax ids live at
+/// scratch[0..n*4) with n <= 16, so 256 clears them with slack; the attention
+/// metadata regions of every other consumer start at +32768.
+const LP_SCRATCH_OFF: usize = 256;
+
 impl MtpHead {
     /// M=n-row BF16 GEMM dispatch: pipelined tensor-core GEMM for the large
     /// weight-bearing shapes (reads B once for all rows), per-row GEMV for
@@ -109,6 +115,7 @@ impl MtpHead {
         ctx: &ForwardContext,
         stream: u64,
         out_ids: &mut [u32],
+        out_lp: Option<&mut [f32]>,
     ) -> Result<()> {
         let n = tokens.len();
         let h = ctx.config.hidden_size;
@@ -461,8 +468,35 @@ impl MtpHead {
             h as u32,
             stream,
         )?;
-        if self.argmax_batch_k.0 != 0 {
-            ops::argmax_bf16_batch(gpu, self.argmax_batch_k, logits, scratch, v, n as u32, v, stream)?;
+        // D-Cut confidence: the LP variant is the SAME single-pass reduction
+        // plus an online-softmax accumulator, so it replaces (never
+        // supplements) the plain batched argmax when confidences are wanted.
+        // Log-probs land at `scratch + LP_SCRATCH_OFF`, clear of the n ids at
+        // scratch[0..n*4) and far below the +32768 attention-metadata region.
+        let want_lp = out_lp.is_some() && self.argmax_batch_lp_k.0 != 0;
+        if want_lp {
+            ops::argmax_bf16_batch_lp(
+                gpu,
+                self.argmax_batch_lp_k,
+                logits,
+                scratch,
+                scratch.offset(LP_SCRATCH_OFF),
+                v,
+                n as u32,
+                v,
+                stream,
+            )?;
+        } else if self.argmax_batch_k.0 != 0 {
+            ops::argmax_bf16_batch(
+                gpu,
+                self.argmax_batch_k,
+                logits,
+                scratch,
+                v,
+                n as u32,
+                v,
+                stream,
+            )?;
         } else {
             for i in 0..n {
                 ops::argmax_bf16(
@@ -477,10 +511,29 @@ impl MtpHead {
         }
 
         // 11. One sync D2H for the n ids (the per-seq path pays n of these).
-        let mut buf = vec![0u8; n * 4];
+        // With confidences wanted the ids and the FP32 log-probs are two
+        // regions of the same scratch buffer — still ONE D2H, widened.
+        let d2h_len = if want_lp {
+            LP_SCRATCH_OFF + n * 4
+        } else {
+            n * 4
+        };
+        let mut buf = vec![0u8; d2h_len];
         gpu.copy_d2h(scratch, &mut buf)?;
         for (i, id) in out_ids.iter_mut().enumerate() {
             *id = u32::from_le_bytes([buf[i * 4], buf[i * 4 + 1], buf[i * 4 + 2], buf[i * 4 + 3]]);
+        }
+        if let Some(lp) = out_lp {
+            for (i, slot) in lp.iter_mut().enumerate().take(n) {
+                *slot = if want_lp {
+                    let o = LP_SCRATCH_OFF + i * 4;
+                    f32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]])
+                } else {
+                    // No LP kernel: report certainty so a caller ranking by
+                    // prefix product never prunes on a value it did not measure.
+                    0.0
+                };
+            }
         }
 
         // 12. Bookkeeping (forward_one's tail, per row).
@@ -506,6 +559,7 @@ impl MtpHead {
         states: &mut [&mut MtpProposerState],
         ctx: &ForwardContext,
         stream: u64,
+        mut out_conf: Option<&mut Vec<Vec<f32>>>,
     ) -> Result<Vec<Vec<u32>>> {
         let n = last_tokens.len();
         ensure!(
@@ -535,6 +589,14 @@ impl MtpHead {
         let mut cur_positions = positions.to_vec();
         let mut ids = vec![0u32; n];
         let mut all: Vec<Vec<u32>> = vec![Vec::with_capacity(num_drafts); n];
+        // D-Cut: per-sequence, per-position top-1 log-probability, filled only
+        // when the caller asked for it (the LP argmax replaces the plain one,
+        // so the cost is the widened D2H, not a second reduction).
+        let mut lp = vec![0f32; n];
+        if let Some(c) = out_conf.as_deref_mut() {
+            c.clear();
+            c.resize(n, Vec::with_capacity(num_drafts));
+        }
         for j in 0..num_drafts {
             let hiddens_j: Vec<DevicePtr> = if j == 0 {
                 target_hiddens.to_vec()
@@ -551,10 +613,20 @@ impl MtpHead {
                 ctx,
                 stream,
                 &mut ids,
+                if out_conf.is_some() {
+                    Some(&mut lp[..])
+                } else {
+                    None
+                },
             )?;
             for i in 0..n {
                 all[i].push(ids[i]);
                 cur_positions[i] += 1;
+            }
+            if let Some(c) = out_conf.as_deref_mut() {
+                for (i, row) in c.iter_mut().enumerate().take(n) {
+                    row.push(lp[i]);
+                }
             }
             cur_tokens.copy_from_slice(&ids);
             for state in states.iter_mut() {

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -373,6 +373,25 @@ impl MtpHead {
             // Batched BF16 GEMM for drafter prefill; 0-handle when the
             // target's kernel set lacks it (prefill then no-ops).
             dense_gemm_k: crate::layers::try_kernel(gpu, "gemm", "dense_gemm_bf16"),
+            dense_gemm_pipelined_k: crate::layers::try_kernel(
+                gpu,
+                "gemm",
+                "dense_gemm_bf16_pipelined",
+            ),
+            w4a16_gemv_batch4_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
+            w4a16_gemv_batch8_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch8"),
+            w4a16_gemv_batch16_k: crate::layers::try_kernel(
+                gpu,
+                "w4a16_gemv",
+                "w4a16_gemv_batch16",
+            ),
+            argmax_batch_k: crate::layers::try_kernel(gpu, "argmax", "argmax_bf16_batch"),
+            // Drafter attention metadata for the batched propose — a
+            // dedicated 32 KB allocation, never an offset into the shared
+            // scratch arena (see the `propose_meta` field docs).
+            propose_meta: gpu.alloc(
+                super::batch_caps::PROPOSE_META_SEQS * super::batch_caps::PROPOSE_META_STRIDE,
+            )?,
             prefill_scratch,
         })
     }

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -386,6 +386,7 @@ impl MtpHead {
                 "w4a16_gemv_batch16",
             ),
             argmax_batch_k: crate::layers::try_kernel(gpu, "argmax", "argmax_bf16_batch"),
+            argmax_batch_lp_k: crate::layers::try_kernel(gpu, "argmax", "argmax_bf16_batch_lp"),
             // Drafter attention metadata for the batched propose — a
             // dedicated 32 KB allocation, never an offset into the shared
             // scratch arena (see the `propose_meta` field docs).

--- a/crates/spark-model/src/layers/ops/embeddings.rs
+++ b/crates/spark-model/src/layers/ops/embeddings.rs
@@ -21,6 +21,58 @@ use super::*;
 /// Block: (128, 1, 1)
 ///
 /// `positions` must be a device pointer to a `u32[seq_len]` array.
+/// Strided RoPE: rotates ALL `num_tokens` rows in ONE launch.
+///
+/// `rope` above derives each row's address from a PACKED layout
+/// (`num_*_heads * head_dim` between tokens). The multi-seq decode buffer is not
+/// packed — Q and K live inside one interleaved `[Q|K|V|gate]` block whose rows
+/// sit `per_seq_qkv` apart — so that path was calling `rope` once per sequence
+/// with `seq_len = 1`: 258 launches/step at 4.6 us = 1.18 ms across the 16
+/// attention layers.
+///
+/// Bit-identical to n packed launches: same math, same ordering, only the row
+/// address differs. Passing the packed strides reproduces `rope` exactly.
+#[allow(clippy::too_many_arguments)]
+pub fn rope_strided(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    q: DevicePtr,
+    k: DevicePtr,
+    positions: DevicePtr,
+    num_tokens: u32,
+    num_q_heads: u32,
+    num_kv_heads: u32,
+    head_dim: u32,
+    rotary_dim: u32,
+    theta: f32,
+    q_row_stride: u32,
+    k_row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    assert!(
+        rotary_dim > 0,
+        "rope_strided: rotary_dim=0, nq={num_q_heads} nkv={num_kv_heads} hd={head_dim}"
+    );
+    let half_rot = (rotary_dim / 2).max(1);
+    let pos_per_block = (128 / half_rot).max(1);
+    let seq_blocks = div_ceil(num_tokens, pos_per_block);
+    KernelLaunch::new(gpu, kernel)
+        .grid([num_q_heads + num_kv_heads, seq_blocks, 1])
+        .block([128, 1, 1])
+        .arg_ptr(q)
+        .arg_ptr(k)
+        .arg_ptr(positions)
+        .arg_u32(num_tokens)
+        .arg_u32(num_q_heads)
+        .arg_u32(num_kv_heads)
+        .arg_u32(head_dim)
+        .arg_u32(rotary_dim)
+        .arg_f32(theta)
+        .arg_u32(q_row_stride)
+        .arg_u32(k_row_stride)
+        .launch(stream)
+}
+
 pub fn rope(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,

--- a/crates/spark-model/src/layers/ops/gemm_dense.rs
+++ b/crates/spark-model/src/layers/ops/gemm_dense.rs
@@ -175,7 +175,15 @@ pub fn w4a16_gemm(
 ///
 /// Grid: (ceil(N/128), ceil(M/64), 1)  Block: (128, 1, 1)
 #[allow(clippy::too_many_arguments)]
-pub fn w4a16_gemm_n128(
+/// `w4a16_gemm_n128` with an explicit transposed-B ROW STRIDE.
+///
+/// Needed when N is not a multiple of 16: the kernel's B loads are 16-byte
+/// `cp.async`, which requires 16-byte-aligned sources, and row r sits at
+/// `r * ldb`. lm_head is the motivating case — its N is the vocab size, 248077
+/// on this checkpoint, which is ODD and made 15 of every 16 k-rows fault with
+/// CUDA_ERROR_MISALIGNED_ADDRESS (the campaign's long-standing "716").
+/// Pass `ldb = align_up(n, 128)` with the pad columns zero-filled.
+pub fn w4a16_gemm_n128_ldb(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,
     input: DevicePtr,
@@ -184,6 +192,7 @@ pub fn w4a16_gemm_n128(
     m: u32,
     n: u32,
     k: u32,
+    ldb: u32,
     stream: u64,
 ) -> Result<()> {
     KernelLaunch::new(gpu, kernel)
@@ -197,8 +206,25 @@ pub fn w4a16_gemm_n128(
         .arg_u32(m)
         .arg_u32(n)
         .arg_u32(k)
+        .arg_u32(ldb)
         .launch(stream)
 }
+
+pub fn w4a16_gemm_n128(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &QuantizedWeight,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    // Packed case: the transposed B rows are exactly N apart.
+    w4a16_gemm_n128_ldb(gpu, kernel, input, weight, output, m, n, k, n, stream)
+}
+
 
 /// W4A16 GEMM v3: MiniMax-only shadow with K_STEP=64 (was 32 in v2).
 /// Halves K-iteration count; doubles per-iter MMA count. 1 CTA/SM
@@ -318,6 +344,37 @@ pub fn w4a16_gemm_n128_m128(
 ///
 /// Grid: (ceil(N/128), ceil(M/128), 1)  Block: (128, 1, 1)
 #[allow(clippy::too_many_arguments)]
+/// `w4a16_gemm_n128_m128_bf16` with an explicit transposed-B row stride, for the
+/// LOSSLESS BF16-MMA path. Needed for the same reason as `w4a16_gemm_n128_ldb`:
+/// the B loads are 16-byte `cp.async` and lm_head's N is the vocab size (248077,
+/// odd), so an unpadded stride misaligns 15 of every 16 k-rows.
+pub fn w4a16_gemm_n128_m128_bf16_ldb(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &QuantizedWeight,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    ldb: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 128), div_ceil(m, 128), 1])
+        .block([128, 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(weight.weight_scale)
+        .arg_f32(weight.weight_scale_2)
+        .arg_ptr(output)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .arg_u32(ldb)
+        .launch(stream)
+}
+
 pub fn w4a16_gemm_n128_m128_bf16(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,

--- a/crates/spark-model/src/layers/ops/norm.rs
+++ b/crates/spark-model/src/layers/ops/norm.rs
@@ -19,6 +19,40 @@ use super::*;
 ///
 /// Kernel: `rms_norm(input, weight, output, hidden_size, eps)`
 /// Grid: (num_tokens, 1, 1)  Block: (min(hidden_size, 1024), 1, 1)
+/// Strided RMS norm: `num_groups` groups of `rows_per_group` rows in ONE launch,
+/// groups `row_stride` ELEMENTS apart, rows packed at `hidden_size` inside a group.
+///
+/// `rms_norm` above assumes one packed [num_tokens, hidden_size] block. The
+/// multi-seq q/k head-norms are packed only WITHIN a sequence — each sequence's
+/// heads sit inside its own interleaved [Q|K|V|gate] block — so that path was
+/// launching the packed kernel once per sequence (516 launches/step, 0.76 ms).
+/// Bit-identical: one block per row either way, same math, same reduction.
+#[allow(clippy::too_many_arguments)]
+pub fn rms_norm_strided(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &DenseWeight,
+    output: DevicePtr,
+    rows_per_group: u32,
+    num_groups: u32,
+    hidden_size: u32,
+    eps: f32,
+    row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([rows_per_group, num_groups, 1])
+        .block([hidden_size.min(1024), 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(output)
+        .arg_u32(hidden_size)
+        .arg_f32(eps)
+        .arg_u32(row_stride)
+        .launch(stream)
+}
+
 pub fn rms_norm(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,

--- a/crates/spark-model/src/layers/ops/nvfp4_mmq.rs
+++ b/crates/spark-model/src/layers/ops/nvfp4_mmq.rs
@@ -23,7 +23,18 @@ pub const NVFP4_BLOCK_BYTES: usize = 36;
 const FP4_MMQ_Y_BLOCK_VALS: u32 = 256;
 const FP4_MMQ_Y_BLOCK_BYTES: usize = 144;
 /// Dynamic shared memory: ids(512) + x-tile(128*MMQ_MMA_TILE_X_K_FP4=76*4) + y-tile(128*144).
-pub const NVFP4_MMQ_SMEM: u32 = 57856;
+pub const NVFP4_MMQ_SMEM: u32 = nvfp4_mmq_smem(128);
+
+/// Dynamic shared memory for a given M-tile, from the vendor's layout:
+/// ids_dst\[mmq_x\] + y-tile\[mmq_x * MMQ_TILE_Y_K(=36) ints, padded to 256\] +
+/// x-tile\[128 * MMQ_MMA_TILE_X_K_FP4(=76) ints\], all 4-byte.
+/// Reproduces the previously-hardcoded 57856 at mmq_x=128, which is the check that
+/// this derivation matches the kernel's actual layout.
+pub const fn nvfp4_mmq_smem(mmq_x: u32) -> u32 {
+    let y = mmq_x * 36;
+    let y_padded = y.div_ceil(256) * 256;
+    4 * (mmq_x + y_padded + 128 * 76)
+}
 const QUANT_BLOCK_THREADS: u32 = 128;
 
 /// Bytes for the block_nvfp4 form of an [n, k] weight (k % 64 == 0).
@@ -123,6 +134,57 @@ pub fn nvfp4_mmq_gemm(
         .launch(stream)
 }
 
+/// NVFP4 W4A4 MMQ GEMM with an M-SIZED TILE.
+///
+/// Same kernel family as [`nvfp4_mmq_gemm`], but the caller picks the M tile. The
+/// 128-wide tile issues MMAs for all 128 tile columns regardless of `m` and discards
+/// the surplus in the write-back predicate, so decode at m=16 wasted 87.5% of its MMA
+/// slots. `mmq_x` must be one of {16, 32, 128} — the instantiated entries.
+///
+/// PREFILL MUST KEEP 128: `grid.y = ceil(m / mmq_x)`, so a small tile re-streams the
+/// whole weight matrix once per M-tile. This is a decode-shape optimisation only.
+#[allow(clippy::too_many_arguments)]
+pub fn nvfp4_mmq_gemm_tiled(
+    gpu: &dyn GpuBackend,
+    kernel_nc: KernelHandle,
+    kernel_wc: KernelHandle,
+    mmq_x: u32,
+    a_fp4: DevicePtr,
+    w_nvfp4: DevicePtr,
+    out_bf16: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    debug_assert!(
+        matches!(mmq_x, 16 | 32 | 128),
+        "mmq_x must be an instantiated tile"
+    );
+    debug_assert!(
+        m <= mmq_x,
+        "grid.y>1 would re-stream the weights per M-tile"
+    );
+    let kernel = if !n.is_multiple_of(128) {
+        kernel_wc
+    } else {
+        kernel_nc
+    };
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 128), div_ceil(m, mmq_x), 1])
+        .block([32, 8, 1])
+        .shared_mem(nvfp4_mmq_smem(mmq_x))
+        .arg_ptr(w_nvfp4)
+        .arg_ptr(a_fp4)
+        .arg_ptr(out_bf16)
+        .arg_u32(n)
+        .arg_u32(m)
+        .arg_u32(k)
+        .arg_u32(k / QK_NVFP4)
+        .arg_u32(m)
+        .arg_u32(n)
+        .launch(stream)
+}
 /// Fused SiLU-mul + block_fp4_mmq quantize for the down-MMQ path: reads RAW gate/up MMQ
 /// outputs, applies the scale2 folds + swiglu clamp + SiLU-mul, and quantizes straight
 /// into the down GEMM's y-format — the intermediate bf16 activation tensor is never

--- a/crates/spark-model/src/layers/ops/sampling.rs
+++ b/crates/spark-model/src/layers/ops/sampling.rs
@@ -36,6 +36,30 @@ pub fn argmax_bf16(
         .launch(stream)
 }
 
+/// Batched argmax: ONE launch, one block per row, instead of n serial launches of
+/// the single-row `argmax_bf16` (which is a one-CTA reduction and so uses 1 of 48
+/// SMs). Byte-identical — each block runs the identical per-row body.
+#[allow(clippy::too_many_arguments)]
+pub fn argmax_bf16_batch(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    logits: DevicePtr,
+    out: DevicePtr,
+    vocab_size: u32,
+    n_rows: u32,
+    row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([n_rows, 1, 1])
+        .block([1024, 1, 1])
+        .arg_ptr(logits)
+        .arg_ptr(out)
+        .arg_u32(vocab_size)
+        .arg_u32(row_stride)
+        .launch(stream)
+}
+
 /// GPU-side argmax + embedding lookup — eliminates D2H sync in MTP propose.
 ///
 /// Reads the argmax result from `argmax_out`, looks up the embedding row

--- a/crates/spark-model/src/layers/ops/sampling.rs
+++ b/crates/spark-model/src/layers/ops/sampling.rs
@@ -60,6 +60,39 @@ pub fn argmax_bf16_batch(
         .launch(stream)
 }
 
+/// Batched argmax that ALSO writes each row's top-1 log-probability
+/// (`out_logprob[row] = log softmax(row)[argmax]`, FP32), computed by online
+/// softmax in the same pass — same bandwidth as `argmax_bf16_batch`, same
+/// index semantics.
+///
+/// Consumer: D-Cut verification-depth pruning, whose ranking key is the prefix
+/// SUM of these log-probabilities (= the log of the prefix product of survival
+/// probabilities). Separate kernel so every existing `argmax_bf16_batch` caller
+/// stays byte-identical and an unresolved handle is a silent 0 the caller gates
+/// on.
+#[allow(clippy::too_many_arguments)]
+pub fn argmax_bf16_batch_lp(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    logits: DevicePtr,
+    out: DevicePtr,
+    out_logprob: DevicePtr,
+    vocab_size: u32,
+    n_rows: u32,
+    row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([n_rows, 1, 1])
+        .block([1024, 1, 1])
+        .arg_ptr(logits)
+        .arg_ptr(out)
+        .arg_ptr(out_logprob)
+        .arg_u32(vocab_size)
+        .arg_u32(row_stride)
+        .launch(stream)
+}
+
 /// GPU-side argmax + embedding lookup — eliminates D2H sync in MTP propose.
 ///
 /// Reads the argmax result from `argmax_out`, looks up the embedding row

--- a/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
+++ b/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
@@ -96,8 +96,23 @@ pub fn gdn_decode_wy2(
     qk_stride: u32,
     v_stride: u32,
     gb_stride: u32,
+    // false = contiguous state bases indexed by (b*num_v_heads+vh);
+    // true  = device pointer TABLES, one entry per sequence. See
+    // `gdn_decode_wy4` for the full rationale — contiguous is only correct at
+    // batch_size==1 because the intermediate's pool stride is
+    // num_intermediates x h_state's.
+    state_is_table: bool,
     stream: u64,
 ) -> Result<()> {
+    // HARD guard, not debug_assert: this compiles out in release, which is
+    // exactly where the corruption would be silent.
+    anyhow::ensure!(
+        state_is_table || batch_size == 1,
+        "gdn_decode_wy2: contiguous state addressing is only valid at \
+         batch_size==1 (got {batch_size}) — the intermediate's pool stride is \
+         num_intermediates x h_state's, so sequence 1's Hi0 would land on \
+         sequence 0's Hi1. Stage pointer tables and pass state_is_table=true."
+    );
     KernelLaunch::new(gpu, kernel)
         .grid([num_v_heads, batch_size, 1])
         .block([128, 1, 1])
@@ -117,6 +132,7 @@ pub fn gdn_decode_wy2(
         .arg_u32(qk_stride)
         .arg_u32(v_stride)
         .arg_u32(gb_stride)
+        .arg_u32(u32::from(state_is_table))
         .launch(stream)
 }
 
@@ -147,8 +163,23 @@ pub fn gdn_decode_wy3(
     qk_stride: u32,
     v_stride: u32,
     gb_stride: u32,
+    // false = contiguous state bases indexed by (b*num_v_heads+vh);
+    // true  = device pointer TABLES, one entry per sequence. See
+    // `gdn_decode_wy4` for the full rationale — contiguous is only correct at
+    // batch_size==1 because the intermediates' pool stride is
+    // num_intermediates x h_state's.
+    state_is_table: bool,
     stream: u64,
 ) -> Result<()> {
+    // HARD guard, not debug_assert: this compiles out in release, which is
+    // exactly where the corruption would be silent.
+    anyhow::ensure!(
+        state_is_table || batch_size == 1,
+        "gdn_decode_wy3: contiguous state addressing is only valid at \
+         batch_size==1 (got {batch_size}) — the intermediates' pool stride is \
+         num_intermediates x h_state's, so sequence 1's Hi0 would land on \
+         sequence 0's Hi1. Stage pointer tables and pass state_is_table=true."
+    );
     KernelLaunch::new(gpu, kernel)
         .grid([num_v_heads, batch_size, 1])
         .block([128, 1, 1])
@@ -169,6 +200,7 @@ pub fn gdn_decode_wy3(
         .arg_u32(qk_stride)
         .arg_u32(v_stride)
         .arg_u32(gb_stride)
+        .arg_u32(u32::from(state_is_table))
         .launch(stream)
 }
 
@@ -201,8 +233,26 @@ pub fn gdn_decode_wy4(
     qk_stride: u32,
     v_stride: u32,
     gb_stride: u32,
+    // false = contiguous state bases indexed by (b*num_v_heads+vh);
+    // true  = device pointer TABLES, one entry per sequence.
+    //
+    // Contiguous is only correct at batch_size==1: it assumes the intermediates
+    // share h_state's batch stride, but the pool's intermediate stride is
+    // num_intermediates x larger, so at n>1 sequence 1's Hi0 lands on sequence
+    // 0's Hi1 — silent cross-sequence rollback corruption. Pass true with staged
+    // tables for any batched verify. false is byte-identical to the old kernel.
+    state_is_table: bool,
     stream: u64,
 ) -> Result<()> {
+    // HARD guard, not debug_assert: this compiles out in release, which is
+    // exactly where the corruption would be silent.
+    anyhow::ensure!(
+        state_is_table || batch_size == 1,
+        "gdn_decode_wy4: contiguous state addressing is only valid at \
+         batch_size==1 (got {batch_size}) — the intermediates' pool stride is \
+         num_intermediates x h_state's, so sequence 1's Hi0 would land on \
+         sequence 0's Hi1. Stage pointer tables and pass state_is_table=true."
+    );
     KernelLaunch::new(gpu, kernel)
         .grid([num_v_heads, batch_size, 1])
         .block([128, 1, 1])
@@ -224,6 +274,7 @@ pub fn gdn_decode_wy4(
         .arg_u32(qk_stride)
         .arg_u32(v_stride)
         .arg_u32(gb_stride)
+        .arg_u32(u32::from(state_is_table))
         .launch(stream)
 }
 
@@ -262,6 +313,19 @@ pub fn gdn_decode_wyn(
     gb_stride: u32,
     stream: u64,
 ) -> Result<()> {
+    // `gdn_decode_wyn`'s kernel hardcodes the CONTIGUOUS state stride
+    // ((b*num_v_heads+vh)*hv) for BOTH h_state and the intermediates. That is
+    // wrong for the intermediates, whose pool stride is num_intermediates x
+    // larger — at batch_size>1 sequence 1's Hi0 lands on sequence 0's Hi1,
+    // silently corrupting cross-sequence rollback. Only wy4 has the
+    // `state_is_table` pointer-table form that sidesteps this. Refuse rather
+    // than corrupt; port the table form (see gated_delta_rule_wy4.cu) before
+    // enabling a batched verify at K<4.
+    anyhow::ensure!(
+        batch_size == 1,
+        "gdn_decode_wyn: contiguous state addressing is only valid at batch_size==1 \
+         (got {batch_size}); port the wy4 `state_is_table` pointer-table form first"
+    );
     KernelLaunch::new(gpu, kernel)
         .grid([num_v_heads, batch_size, 1])
         .block([128, 1, 1])

--- a/crates/spark-model/src/layers/ops/ssm_mamba.rs
+++ b/crates/spark-model/src/layers/ops/ssm_mamba.rs
@@ -88,6 +88,57 @@ pub fn conv1d_update_l2norm(
         .launch(stream)
 }
 
+/// `conv1d_update_l2norm` with INDEPENDENT input/output row strides, so N
+/// concurrent decode sequences go in ONE launch instead of N.
+///
+/// Identical math to `conv1d_update_l2norm`; the only difference is that the
+/// input and output row strides are passed explicitly instead of both being
+/// assumed equal to `d_inner`. The concurrent-decode path feeds this straight
+/// from the QKVZ projection, whose rows are `qkvz_size` apart, while the conv
+/// output is `d_inner`-strided — so the non-strided kernel would read sequence
+/// b>=1 from the previous sequence's Z-gate region (correct at n=1, silently
+/// corrupt at n>=2). See `causal_conv1d_update_l2norm_f32_strided`.
+///
+/// `conv_state` keeps the `(b * d_inner + ch) * d_conv` layout, so the caller
+/// must have verified the per-sequence pool slots are contiguous.
+#[allow(clippy::too_many_arguments)]
+pub fn conv1d_update_l2norm_strided(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    conv_state: DevicePtr,
+    input: DevicePtr,
+    weight: &DenseWeight,
+    output: DevicePtr,
+    d_inner: u32,
+    d_conv: u32,
+    batch_size: u32,
+    qk_channels: u32,
+    head_dim: u32,
+    l2_eps: f32,
+    input_stride: u32,
+    output_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    let bias_ptr = DevicePtr::NULL;
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(d_inner, 256), batch_size, 1])
+        .block([256, 1, 1])
+        .arg_ptr(conv_state)
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(bias_ptr)
+        .arg_ptr(output)
+        .arg_u32(batch_size)
+        .arg_u32(d_inner)
+        .arg_u32(d_conv)
+        .arg_u32(qk_channels)
+        .arg_u32(head_dim)
+        .arg_f32(l2_eps)
+        .arg_u32(input_stride)
+        .arg_u32(output_stride)
+        .launch(stream)
+}
+
 /// STAGE 1 fused K=2 MTP-verify conv1d+L2norm: both draft positions in one
 /// launch, with the position-0 conv-state snapshot written inline (replaces
 /// the per-token `conv1d_update_l2norm` ×2 + intervening `copy_d2d`).
@@ -152,6 +203,67 @@ pub fn gdn_verify_fused_conv_k2(
 ///          conv_state_inter, num_tokens, dim, d_conv, qk_channels, head_dim,
 ///          input_stride, output_stride, inter_stride, l2_eps)`
 /// Grid: (ceil(dim/256), 1, 1)  Block: (256, 1, 1)
+/// BATCHED verify conv: `n_seq` sequences x `num_tokens` positions in ONE launch.
+///
+/// Step 1 of batched speculative decoding. `spec_step.rs:94` currently calls
+/// `decode_verify` one sequence at a time, so MTP at C=n runs n full model
+/// forwards and re-reads ~9.6 GB of weights n times — measured as a 3.4% LOSS at
+/// C=2 and a HALVING of C=4. One launch over gridDim.y = n_seq is the first
+/// piece of making n*(K+1) rows share a single weight read.
+///
+/// Bit-identical to n separate `gdn_verify_fused_conv_kn` calls: each sequence's
+/// conv window is independent, so only the base addresses differ.
+///
+/// Grid: (ceil(d_inner/256), n_seq, 1)  Block: (256, 1, 1)
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_verify_fused_conv_kn_batched(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    conv_state: DevicePtr,
+    new_input: DevicePtr,
+    weight: &DenseWeight,
+    output: DevicePtr,
+    conv_state_inter: DevicePtr,
+    num_tokens: u32,
+    d_inner: u32,
+    d_conv: u32,
+    qk_channels: u32,
+    head_dim: u32,
+    input_stride: u32,
+    output_stride: u32,
+    inter_stride: u32,
+    l2_eps: f32,
+    n_seq: u32,
+    conv_state_seq_stride: u32,
+    input_seq_stride: u32,
+    output_seq_stride: u32,
+    inter_seq_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(d_inner, 256), n_seq, 1])
+        .block([256, 1, 1])
+        .arg_ptr(conv_state)
+        .arg_ptr(new_input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(output)
+        .arg_ptr(conv_state_inter)
+        .arg_u32(num_tokens)
+        .arg_u32(d_inner)
+        .arg_u32(d_conv)
+        .arg_u32(qk_channels)
+        .arg_u32(head_dim)
+        .arg_u32(input_stride)
+        .arg_u32(output_stride)
+        .arg_u32(inter_stride)
+        .arg_f32(l2_eps)
+        .arg_u32(conv_state_seq_stride)
+        .arg_u32(input_seq_stride)
+        .arg_u32(output_seq_stride)
+        .arg_u32(inter_seq_stride)
+        .launch(stream)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn gdn_verify_fused_conv_kn(
     gpu: &dyn GpuBackend,

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -144,6 +144,7 @@ impl Qwen3AttentionLayer {
             hc_post_k: super::super::try_kernel(gpu, "hyper_connection", "hc_post"),
             hc_expand_k: super::super::try_kernel(gpu, "hyper_connection", "hc_expand"),
             hc_head_k: super::super::try_kernel(gpu, "hyper_connection", "hc_head"),
+            qkv_nvfp4_t: None,
             q_nvfp4_t: None,
             k_nvfp4_t: None,
             v_nvfp4_t: None,
@@ -192,6 +193,8 @@ impl Qwen3AttentionLayer {
             ),
             w4a16_gemv_dual_k: gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_dual")?,
             rope_k: gpu.kernel("rope", "rope_forward")?,
+            rope_strided_k: super::super::try_kernel(gpu, "rope", "rope_forward_strided"),
+            rms_norm_strided_k: super::super::try_kernel(gpu, "norm", "rms_norm_strided"),
             rope_mrope_interleaved_k: super::super::try_kernel(
                 gpu,
                 "rope_mrope_interleaved",
@@ -412,8 +415,8 @@ impl Qwen3AttentionLayer {
             w4a16_gemv_batch4_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
             w4a16_gemv_batch8_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch8"),
             w4a16_gemm_k: gpu.kernel("w4a16", "w4a16_gemm")?,
-            w4a16_gemm_t_k: gpu.kernel("w4a16", "w4a16_gemm_t")?,
-            w4a16_gemm_t_k64_k: gpu.kernel("w4a16", "w4a16_gemm_t_k64")?,
+            w4a16_gemm_t_k: crate::layers::tgemm_kernel(gpu),
+            w4a16_gemm_t_k64_k: crate::layers::k64_kernel(gpu)?,
             w4a16_gemm_t_m128_k: gpu.kernel("w4a16", "w4a16_gemm_t_m128")?,
             w4a16_gemm_t_m128_bf16_k: super::super::try_kernel(
                 gpu,

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
@@ -114,6 +114,13 @@ impl Qwen3AttentionLayer {
         self.o_nvfp4_t = o_nvfp4_t;
     }
 
+
+    /// Install the fused [q|k|v] transposed twin. Separate from
+    /// `set_prefill_weights` so the fused path is opt-in per loader and the
+    /// separate twins stay available as the fallback.
+    pub fn set_fused_qkv_prefill_weight(&mut self, qkv_nvfp4_t: Option<QuantizedWeight>) {
+        self.qkv_nvfp4_t = qkv_nvfp4_t;
+    }
     /// Set native FP8 checkpoint weights for the `w8a16_gemv` decode path.
     ///
     /// The block-scaled FP8 weights stored here (weight + per-128 `row_scale`)

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn.rs
@@ -12,6 +12,15 @@ use crate::layer::AttnMetadataDev;
 use crate::layers::ops;
 use crate::layers::qwen3_attention::Qwen3AttentionLayer;
 
+/// One batched `reshape_and_cache` launch for all N sequences instead of one
+/// launch per sequence. Kill switch: `ATLAS_NO_ATTN_BATCH_CACHE_WRITE=1`.
+fn batch_cache_write_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("ATLAS_NO_ATTN_BATCH_CACHE_WRITE").ok().as_deref() != Some("1")
+    })
+}
+
 impl Qwen3AttentionLayer {
     /// Phase 3: per-token RoPE (each sequence has its own position).
     pub(super) fn ms_phase_rope(&self, c: &MultiSeqCtx<'_>, meta: AttnMetadataDev) -> Result<()> {
@@ -22,11 +31,46 @@ impl Qwen3AttentionLayer {
             nq,
             nkv,
             hd,
+            bf16,
             q_proj_bytes,
             per_seq_qkv,
             qkv_buf,
             ..
         } = *c;
+        // ONE launch for all n sequences when the strided kernel is present. The
+        // packed `rope` derives row addresses from num_*_heads*head_dim, but these
+        // rows sit `per_seq_qkv` apart inside the interleaved [Q|K|V|gate] block,
+        // so the per-sequence loop below was calling it n times with seq_len=1 —
+        // 258 launches/step at 4.6 us = 1.18 ms across the 16 attention layers.
+        // Bit-identical: same math and ordering, only the row address differs.
+        // Kill switch: ATLAS_NO_ROPE_STRIDED=1.
+        fn rope_strided_enabled() -> bool {
+            static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *ON.get_or_init(|| {
+                std::env::var("ATLAS_NO_ROPE_STRIDED").ok().as_deref() != Some("1")
+            })
+        }
+        if n > 1 && self.rope_strided_k.0 != 0 && rope_strided_enabled() {
+            let stride_e = (per_seq_qkv / bf16) as u32;
+            return ops::rope_strided(
+                fwd.gpu,
+                self.rope_strided_k,
+                qkv_buf,
+                qkv_buf.offset(q_proj_bytes),
+                meta.positions,
+                n as u32,
+                nq,
+                nkv,
+                hd,
+                self.rotary_dim_override
+                    .unwrap_or(fwd.config.rotary_dim() as u32),
+                self.rope_theta_override
+                    .unwrap_or(fwd.config.rope_theta as f32),
+                stride_e,
+                stride_e,
+                stream,
+            );
+        }
         for i in 0..n {
             let q_out_i = qkv_buf.offset(i * per_seq_qkv);
             let k_out_i = q_out_i.offset(q_proj_bytes);
@@ -72,6 +116,34 @@ impl Qwen3AttentionLayer {
             ..
         } = *c;
         let kv_stride = nkv * hd;
+        // The reshape_and_cache kernels already take `num_tokens` plus explicit
+        // key/value row strides ("row stride may differ", reshape_and_cache.cu),
+        // and their grid is [num_tokens,1,1] — so all N sequences go in ONE
+        // launch. `slot` and `positions` are already contiguous per-sequence
+        // arrays. Each sequence's K row sits `per_seq_qkv` bytes after the last,
+        // so the row stride is that gap in ELEMENTS.
+        //
+        // `ATLAS_NO_ATTN_BATCH_CACHE_WRITE=1` restores the per-sequence loop.
+        let k_out_0 = qkv_buf.offset(q_proj_bytes);
+        let v_out_0 = k_out_0.offset((nkv * hd) as usize * bf16);
+        if n > 1 && batch_cache_write_enabled() && per_seq_qkv.is_multiple_of(bf16) {
+            let row_stride = (per_seq_qkv / bf16) as u32;
+            return self.write_kv_cache(
+                fwd.gpu,
+                k_out_0,
+                v_out_0,
+                kv_cache,
+                meta.slot,
+                n as u32,
+                nkv,
+                hd,
+                bs,
+                row_stride,
+                row_stride,
+                stream,
+                fwd.graph_capture,
+            );
+        }
         for i in 0..n {
             let q_out_i = qkv_buf.offset(i * per_seq_qkv);
             let k_out_i = q_out_i.offset(q_proj_bytes);
@@ -118,28 +190,64 @@ impl Qwen3AttentionLayer {
             qkv_buf,
             ..
         } = *c;
-        // Build contiguous Q buffer [N, nq*hd] for batched attention.
-        let q_contiguous = fwd.buffers.ssm_qkvz();
-        for i in 0..n {
-            let q_out_i = qkv_buf.offset(i * per_seq_qkv);
-            fwd.gpu.copy_d2d_async(
-                q_out_i,
-                q_contiguous.offset(i * q_dim as usize * bf16),
-                q_dim as usize * bf16,
-                stream,
-            )?;
-        }
-        let attn_out = fwd.buffers.attn_output();
-        let inv_sqrt_d = self.effective_attn_scale(hd);
-
         // TurboQuant WHT bookends (mirrors decode/attention_forward.rs).
         // The cache holds WHT(K)/WHT(V) for turbo dtypes: rotate the batched
         // Q rows before the paged decode and rotate the output back after —
         // without these the multi-seq batched decode scores raw Q against
         // rotated K and returns output in the rotated-V basis.
+        // Hoisted above the Q staging below: those rotations mutate the staged
+        // buffer IN PLACE, so they are exactly what makes the copy unskippable.
         let (wht_k_dtype, wht_v_dtype) = self.kv_dtype.kv_pair();
         let k_is_turbo = wht_k_dtype.is_wht_rotated();
         let v_is_turbo = wht_v_dtype.is_wht_rotated();
+
+        // ── Q for the batched paged decode ────────────────────────────────
+        // `run_paged_decode` already takes an explicit `q_stride` and the kernel
+        // indexes `Q + seq_idx*q_stride` (paged_decode_attn.cu:96, splitk twin
+        // :364), so when nothing rewrites Q we can point it straight at the
+        // interleaved [Q|K|V|gate] block and read in place — the rows are simply
+        // `per_seq_qkv` apart instead of packed.
+        //
+        // That removes 16 layers x 16 seqs = 256 D2D copies of 12288 B per step
+        // (0.19 ms of GPU copy plus 0.23 ms of host issue measured by nsys), and
+        // 256 nodes from the captured graph. Bit-identical: same values, same
+        // kernel, only the addressing changes.
+        //
+        // NOT skippable under TurboQuant: the innerQ/WHT bookends below rotate
+        // the staged buffer in place, and `qkv_buf` must not be mutated.
+        // Kill switch: ATLAS_NO_ATTN_Q_INPLACE=1.
+        fn q_inplace_enabled() -> bool {
+            static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *ON.get_or_init(|| {
+                std::env::var("ATLAS_NO_ATTN_Q_INPLACE").ok().as_deref() != Some("1")
+            })
+        }
+        let q_inplace = !k_is_turbo
+            && !v_is_turbo
+            && q_inplace_enabled()
+            && per_seq_qkv.is_multiple_of(bf16);
+        let q_contiguous = if q_inplace {
+            qkv_buf
+        } else {
+            let staged = fwd.buffers.ssm_qkvz();
+            for i in 0..n {
+                let q_out_i = qkv_buf.offset(i * per_seq_qkv);
+                fwd.gpu.copy_d2d_async(
+                    q_out_i,
+                    staged.offset(i * q_dim as usize * bf16),
+                    q_dim as usize * bf16,
+                    stream,
+                )?;
+            }
+            staged
+        };
+        let q_stride = if q_inplace {
+            (per_seq_qkv / bf16) as u32
+        } else {
+            nq * hd
+        };
+        let attn_out = fwd.buffers.attn_output();
+        let inv_sqrt_d = self.effective_attn_scale(hd);
         let weight_pre_rotated = std::env::var("TQ_PLUS_WEIGHT_ROTATION")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
@@ -176,7 +284,7 @@ impl Qwen3AttentionLayer {
             hd,
             bs,
             inv_sqrt_d,
-            nq * hd,
+            q_stride,
             fwd.buffers.splitk_workspace(),
             stream,
         )?;
@@ -213,19 +321,29 @@ impl Qwen3AttentionLayer {
             ..
         } = *c;
         if self.gated {
-            for i in 0..n {
-                let gate_i = qkv_buf.offset(i * per_seq_qkv + q_dim as usize * bf16);
-                let attn_out_i = attn_out.offset(i * q_dim as usize * bf16);
-                ops::sigmoid_gate_mul(
-                    fwd.gpu,
-                    self.sigmoid_gate_mul_k,
-                    attn_out_i,
-                    gate_i,
-                    attn_out_i,
-                    q_dim,
-                    stream,
-                )?;
-            }
+            // ONE launch for all n sequences. `attn_out` is contiguous [n, q_dim]
+            // and the gate lives at a fixed offset inside each sequence's slice of
+            // `qkv_buf`, i.e. strided by per_seq_qkv — which is exactly the layout
+            // `sigmoid_gate_mul_batched` takes (`gate[t * gate_stride + d]`, stride
+            // in ELEMENTS). The PREFILL path already drives this kernel on these
+            // same buffers (prefill/paged.rs); multi-seq decode was looping the
+            // single-token variant instead, n launches per layer x 16 layers.
+            debug_assert_eq!(
+                per_seq_qkv % bf16,
+                0,
+                "gate stride must be whole bf16 elements"
+            );
+            ops::sigmoid_gate_mul_batched(
+                fwd.gpu,
+                self.sigmoid_gate_mul_batched_k,
+                attn_out,
+                qkv_buf.offset(q_dim as usize * bf16),
+                attn_out,
+                q_dim,
+                (per_seq_qkv / bf16) as u32,
+                n as u32,
+                stream,
+            )?;
         }
 
         let o_out = fwd.buffers.moe_output();

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
@@ -15,6 +15,13 @@ use super::ctx::MultiSeqCtx;
 use crate::layers::ops;
 use crate::layers::qwen3_attention::Qwen3AttentionLayer;
 
+/// Fused [q|k|v] projection GEMM (one N=14336 launch instead of three).
+/// Kill switch: `ATLAS_NO_FUSED_QKV=1` restores the three separate GEMMs.
+fn fused_qkv_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_FUSED_QKV").ok().as_deref() != Some("1"))
+}
+
 impl Qwen3AttentionLayer {
     pub(super) fn ms_phase_qkv(&self, c: &MultiSeqCtx<'_>) -> Result<()> {
         let MultiSeqCtx {
@@ -202,11 +209,63 @@ impl Qwen3AttentionLayer {
             nkv,
             hd,
             eps,
+            bf16,
             q_proj_bytes,
             per_seq_qkv,
             qkv_buf,
             ..
         } = *c;
+        // ONE launch per norm for all n sequences. Each sequence's head-rows are
+        // packed at `hd` inside its own [Q|K|V|gate] block, and the blocks sit
+        // `per_seq_qkv` apart — exactly the (rows_per_group, num_groups,
+        // row_stride) shape `rms_norm_strided` takes. The per-sequence loop below
+        // was 516 launches/step across the 16 attention layers (0.76 ms).
+        // Bit-identical: one block per row either way. Kill: ATLAS_NO_QK_NORM_STRIDED=1.
+        fn qk_norm_strided_enabled() -> bool {
+            static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *ON.get_or_init(|| {
+                std::env::var("ATLAS_NO_QK_NORM_STRIDED").ok().as_deref() != Some("1")
+            })
+        }
+        if n > 1
+            && self.rms_norm_strided_k.0 != 0
+            && qk_norm_strided_enabled()
+            && per_seq_qkv.is_multiple_of(bf16)
+        {
+            let stride_e = (per_seq_qkv / bf16) as u32;
+            if !self.attn.q_norm.weight.is_null() {
+                ops::rms_norm_strided(
+                    fwd.gpu,
+                    self.rms_norm_strided_k,
+                    qkv_buf,
+                    &self.attn.q_norm,
+                    qkv_buf,
+                    nq,
+                    n as u32,
+                    hd,
+                    eps,
+                    stride_e,
+                    stream,
+                )?;
+            }
+            if !self.attn.k_norm.weight.is_null() {
+                let k0 = qkv_buf.offset(q_proj_bytes);
+                ops::rms_norm_strided(
+                    fwd.gpu,
+                    self.rms_norm_strided_k,
+                    k0,
+                    &self.attn.k_norm,
+                    k0,
+                    nkv,
+                    n as u32,
+                    hd,
+                    eps,
+                    stride_e,
+                    stream,
+                )?;
+            }
+            return Ok(());
+        }
         for i in 0..n {
             let q_out_i = qkv_buf.offset(i * per_seq_qkv);
             let k_out_i = q_out_i.offset(q_proj_bytes);
@@ -487,7 +546,10 @@ impl Qwen3AttentionLayer {
                 *ON.get_or_init(|| std::env::var("ATLAS_FFN_SMALLM").ok().as_deref() != Some("0"))
             }
             if m <= 64 && k.is_multiple_of(32) && small_m_enabled() {
-                if k >= 8192 && k.is_multiple_of(64) && self.w4a16_gemm_t_k64_k.0 != 0 {
+                if k >= crate::layers::w4a16_k64_min_k()
+                    && k.is_multiple_of(64)
+                    && self.w4a16_gemm_t_k64_k.0 != 0
+                {
                     return ops::w4a16_gemm_n128(
                         gpu,
                         self.w4a16_gemm_t_k64_k,
@@ -586,16 +648,47 @@ impl Qwen3AttentionLayer {
         // the row stride matches the batch3 output — the scatter below is
         // identical.
         let q_scratch = fwd.buffers.ssm_qkvz();
-        self.wide_verify_gemm(
-            c,
-            normed,
-            q_nvfp4,
-            self.q_nvfp4_t.as_ref(),
-            q_scratch,
-            n as u32,
-            q_proj_dim,
-            h as u32,
-        )?;
+        let kv_dim_e = (nkv * hd) as usize;
+        // FUSED [q|k|v]: one N=14336 GEMM instead of three (96/8/8 CTAs). The
+        // k/v shapes are N=1024 => 8 CTAs on 48 SMs, the worst-utilised kernels
+        // in the model (23.6 GB/s, 9.75x off floor). Bit-identical — same dot
+        // products, relocated along N — and the loader only builds the twin when
+        // q/k/v share one `weight_scale_2`.
+        // Kill switch: ATLAS_NO_FUSED_QKV=1.
+        let fused_n = q_proj_dim as usize + 2 * kv_dim_e;
+        // n > 8 is REQUIRED, not an optimisation: `wide_verify_gemm` early-returns
+        // on the batched-GEMV arms for m <= 8 using the BASE (non-transposed)
+        // weight and ignoring `w_t` entirely, so a fused N would read past the
+        // q_proj weight. Only at m > 8 is the transposed tile GEMM guaranteed.
+        // n varies as sequences finish, so this is hit at every concurrency.
+        let use_fused = fused_qkv_enabled() && self.qkv_nvfp4_t.is_some() && n > 8;
+        if use_fused {
+            // per_seq_qkv == q_proj_bytes + 2*kv_bytes == fused_n*bf16, so the
+            // fused GEMM's [n, fused_n] output IS the qkv_buf layout byte for
+            // byte. Write straight into it and skip the scatter entirely —
+            // that removes 3 GEMMs AND 48 D2D copies per attention layer.
+            self.wide_verify_gemm(
+                c,
+                normed,
+                q_nvfp4,
+                self.qkv_nvfp4_t.as_ref(),
+                qkv_buf,
+                n as u32,
+                fused_n as u32,
+                h as u32,
+            )?;
+        } else {
+            self.wide_verify_gemm(
+                c,
+                normed,
+                q_nvfp4,
+                self.q_nvfp4_t.as_ref(),
+                q_scratch,
+                n as u32,
+                q_proj_dim,
+                h as u32,
+            )?;
+        }
         if self.gated && !self.q_lora_active() {
             // Split interleaved [Q|Gate] → deinterleaved, in place, all n rows
             // (grid is per-token). Matches what w4a16_gemv_qg_batch3 does inline.
@@ -604,11 +697,11 @@ impl Qwen3AttentionLayer {
             ops::deinterleave_qg(
                 fwd.gpu,
                 self.deinterleave_qg_k,
-                q_scratch,
+                if use_fused { qkv_buf } else { q_scratch },
                 n as u32,
                 nq,
                 hd,
-                q_proj_dim,
+                if use_fused { fused_n as u32 } else { q_proj_dim },
                 stream,
             )?;
         }
@@ -618,29 +711,32 @@ impl Qwen3AttentionLayer {
         let kv_bytes = kv_dim as usize * bf16;
         let k_scratch = fwd.buffers.attn_output();
         let v_scratch = k_scratch.offset(n * kv_bytes);
-        self.wide_verify_gemm(
-            c,
-            normed,
-            k_nvfp4,
-            self.k_nvfp4_t.as_ref(),
-            k_scratch,
-            n as u32,
-            kv_dim,
-            h as u32,
-        )?;
-        self.wide_verify_gemm(
-            c,
-            normed,
-            v_nvfp4,
-            self.v_nvfp4_t.as_ref(),
-            v_scratch,
-            n as u32,
-            kv_dim,
-            h as u32,
-        )?;
+        if !use_fused {
+            self.wide_verify_gemm(
+                c,
+                normed,
+                k_nvfp4,
+                self.k_nvfp4_t.as_ref(),
+                k_scratch,
+                n as u32,
+                kv_dim,
+                h as u32,
+            )?;
+            self.wide_verify_gemm(
+                c,
+                normed,
+                v_nvfp4,
+                self.v_nvfp4_t.as_ref(),
+                v_scratch,
+                n as u32,
+                kv_dim,
+                h as u32,
+            )?;
+        }
 
         // Scatter contiguous Q/K/V into the per-seq interleaved qkv_buf.
-        for i in 0..n {
+        // Not needed when fused: the GEMM already wrote that exact layout.
+        for i in (0..n).take_while(|_| !use_fused) {
             let q_out_i = qkv_buf.offset(i * per_seq_qkv);
             let k_out_i = q_out_i.offset(q_proj_bytes);
             let v_out_i = k_out_i.offset(kv_bytes);

--- a/crates/spark-model/src/layers/qwen3_attention/types.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types.rs
@@ -100,6 +100,10 @@ pub struct Qwen3AttentionLayer {
     /// HC `hc_head` kernel handle (NULL when HC disabled).
     pub(super) hc_head_k: KernelHandle,
     // ── Transposed weights for prefill GEMM ──
+    /// Fused [q|k|v] transposed twin (N = q_proj_dim + 2*kv_dim). Present only
+    /// when the three projections share one `weight_scale_2` — the GEMM applies
+    /// a single scale2 per launch. `None` => the three separate GEMMs run.
+    pub(super) qkv_nvfp4_t: Option<QuantizedWeight>,
     pub(super) q_nvfp4_t: Option<QuantizedWeight>,
     pub(super) k_nvfp4_t: Option<QuantizedWeight>,
     pub(super) v_nvfp4_t: Option<QuantizedWeight>,
@@ -139,6 +143,10 @@ pub struct Qwen3AttentionLayer {
     pub(super) w8a16_gemm_pipelined_k: KernelHandle,
     pub(super) w4a16_gemv_dual_k: KernelHandle,
     pub(super) rope_k: KernelHandle,
+    /// Strided sibling: rotates all n sequences in ONE launch. 0 when absent.
+    pub(super) rope_strided_k: KernelHandle,
+    /// Strided sibling of `rms_norm_w_k`: all n sequences in ONE launch. 0 when absent.
+    pub(super) rms_norm_strided_k: KernelHandle,
     /// MRoPE-interleaved kernel.
     pub(super) rope_mrope_interleaved_k: KernelHandle,
     /// K-only MRoPE kernel used when Q RoPE is fused into Q deinterleave/norm.

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -53,6 +53,14 @@ impl Qwen3SsmLayer {
             // BF16 kernel via the `.0 != 0` gate at the use site
             // (ssm_forward.rs). Warn instead of error: missing-on-Metal is
             // expected, and a startup `error!` would page on benign cases.
+            // Strided twin of `conv1d_l2norm_f32_k` for the batched multi-seq
+            // decode path. Optional: absent on older kernel sets, where the
+            // multi-seq conv stays a per-sequence loop.
+            conv1d_l2norm_f32_strided_k: super::super::try_kernel(
+                gpu,
+                "causal_conv1d",
+                "causal_conv1d_update_l2norm_f32_strided",
+            ),
             conv1d_l2norm_f32_k: {
                 let h = super::super::try_kernel(
                     gpu,
@@ -94,6 +102,11 @@ impl Qwen3SsmLayer {
                 "gated_delta_rule",
                 "gated_delta_rule_decode_f32_strided_norm",
             ),
+            gdn_f32_strided_norm_half_k: super::super::try_kernel(
+                gpu,
+                "gated_delta_rule",
+                "gated_delta_rule_decode_f32_strided_norm_half",
+            ),
             ba_gates_k: gpu.kernel("ssm_preprocess", "dense_gemv_ba_gates")?,
             residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
             l2_norm_k: gpu.kernel("norm", "l2_norm_bf16")?,
@@ -105,8 +118,8 @@ impl Qwen3SsmLayer {
             ),
             gated_rms_norm_prefill_k: gpu.kernel("norm", "gated_rms_norm_prefill")?,
             w4a16_gemm_k: gpu.kernel("w4a16", "w4a16_gemm")?,
-            w4a16_gemm_t_k: gpu.kernel("w4a16", "w4a16_gemm_t")?,
-            w4a16_gemm_t_k64_k: gpu.kernel("w4a16", "w4a16_gemm_t_k64")?,
+            w4a16_gemm_t_k: crate::layers::tgemm_kernel(gpu),
+            w4a16_gemm_t_k64_k: crate::layers::k64_kernel(gpu)?,
             w4a16_gemm_t_m128_k: gpu.kernel("w4a16", "w4a16_gemm_t_m128")?,
             // 8-warp pipelined M128 (try_kernel: 0 when absent → falls back to m128/n128).
             w4a16_gemm_t_m128_v2_k: super::super::try_kernel(
@@ -220,6 +233,12 @@ impl Qwen3SsmLayer {
                 gpu,
                 "gdn_verify_fused_conv_kn",
                 "gdn_verify_fused_conv_kn",
+            ),
+            // Batched twin (gridDim.y = n_seq) for batched speculative decoding.
+            gdn_verify_fused_conv_kn_batched_k: super::super::try_kernel(
+                gpu,
+                "gdn_verify_fused_conv_kn",
+                "gdn_verify_fused_conv_kn_batched",
             ),
             // wy17 only present in qwen3.6-35b-a3b's PTX module set; NULL on other targets.
             // decode_batched(K=17) checks for non-NULL before dispatching the fused path.

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -64,12 +64,20 @@ pub struct Qwen3SsmLayer {
     conv1d_k: KernelHandle,
     conv1d_l2norm_k: KernelHandle,
     conv1d_l2norm_f32_k: KernelHandle,
+    /// `conv1d_l2norm_f32_k` with explicit input/output row strides, letting
+    /// the concurrent-decode path batch all N sequences into one launch.
+    /// `KernelHandle(0)` on kernel sets that predate it — the multi-seq path
+    /// then falls back to the per-sequence conv loop.
+    conv1d_l2norm_f32_strided_k: KernelHandle,
     gdn_k: KernelHandle,
     gdn_f32_k: KernelHandle,
     gdn_f32_norm_k: KernelHandle,
     gdn_f32_conv_norm_k: KernelHandle,
     gdn_f32_strided_k: KernelHandle,
     gdn_f32_strided_norm_k: KernelHandle,
+    /// Half-width register retention (k_dim==v_dim==128): retains the first 64 H
+    /// columns so the update re-reads only the rest (2R+1W -> 1.5R+1W).
+    gdn_f32_strided_norm_half_k: KernelHandle,
     ba_gates_k: KernelHandle,
     residual_add_k: KernelHandle,
     l2_norm_k: KernelHandle,
@@ -151,6 +159,8 @@ pub struct Qwen3SsmLayer {
     /// default ON when present, kill-switch `ATLAS_GDN_FUSED_CONV17=0`.
     /// NULL handle on targets lacking the .cu → per-token loop unchanged.
     gdn_verify_fused_conv_kn_k: KernelHandle,
+    /// Batched twin (gridDim.y = n_seq) — batched spec decode. 0 when absent.
+    gdn_verify_fused_conv_kn_batched_k: KernelHandle,
     /// WY-Chunkwise K=17 GDN verify (DFlash γ+1). Only present in
     /// qwen3.6-35b-a3b's PTX module set; NULL handle for other targets,
     /// in which case decode_batched(K=17) falls through to the sequential
@@ -209,6 +219,21 @@ impl Qwen3SsmLayer {
             _ => KernelHandle(0),
         }
     }
+
+    /// Transposed-twin tile GEMM handle for reduction depth `k`: the deep-K
+    /// `_k64` variant when the shape qualifies, else the K_STEP_T=32 default.
+    /// Same selection rule as the dense-FFN and attention-QKV paths, so all
+    /// three consume `W4A16_K64_MIN_K` rather than repeating the threshold.
+    fn deep_k_gemm(&self, k: u32) -> KernelHandle {
+        if k >= crate::layers::w4a16_k64_min_k()
+            && k.is_multiple_of(64)
+            && self.w4a16_gemm_t_k64_k.0 != 0
+        {
+            self.w4a16_gemm_t_k64_k
+        } else {
+            self.w4a16_gemm_t_k
+        }
+    }
 }
 
 // ── Sub-files (split for ≤500 LoC) ────────────────────────────────────────
@@ -218,6 +243,7 @@ mod ssm_forward;
 mod trait_decode;
 mod trait_decode_batched;
 mod trait_decode_batched_conv_gdn;
+mod trait_decode_batched_conv_gdn_multi;
 mod trait_decode_batched_conv_gdn_wyn;
 mod trait_decode_multi_seq;
 mod trait_layer;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -22,21 +22,38 @@ fn k4_diag_checkpoint(ctx: &ForwardContext, phase: &str, stream: u64) -> Result<
     Ok(())
 }
 
+/// Presence kill switch for the single-launch fused BA projection + GDN gates
+/// (`ATLAS_NO_BATCHED_BA_GATES` restores the per-token GEMV + `compute_gdn_gates`
+/// pair). Presence, not value — `=0` is NOT "off".
+fn batched_ba_gates_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_BATCHED_BA_GATES").is_err())
+}
+
+/// Presence kill switch for the single-launch gated RMS norm
+/// (`ATLAS_NO_BATCHED_GDN_NORM` restores the per-token loop). The batched kernel
+/// is bit-identical, so this switch exists only to isolate the change in an A/B.
+fn batched_norm_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_BATCHED_GDN_NORM").is_err())
+}
+
 /// GDN-state routing for [`Qwen3SsmLayer::decode_batched_inner`].
 ///
 /// `Single`: today's path — `num_tokens` rows belong to ONE sequence, whose
 /// conv/GDN state advances through all of them (K-token MTP verify, DFlash).
 ///
-/// `Multi`: batched MTP verify — `num_tokens = n*k` seq-major rows
-/// (`r = i*k + j`); projections/FFN batch across all rows, while the
-/// stateful conv/GDN body runs per-sequence against `states[i]` with
-/// row-offset buffer bases (per-sequence math byte-identical to `Single`
-/// at `num_tokens = k`; only base addresses move).
+/// `Multi`: batched MTP verify — `num_tokens = Σ ks` seq-major rows, RAGGED
+/// per sequence since D-Cut (`ks[i]` rows for sequence i, uniform being the
+/// special case); projections/FFN batch across all rows, while the stateful
+/// conv/GDN body runs per-sequence against `states[i]` with row-offset buffer
+/// bases (per-sequence math byte-identical to `Single` at `num_tokens =
+/// ks[i]`; only base addresses move).
 pub(super) enum GdnStates<'a, 'b> {
     Single(&'a mut dyn LayerState),
     Multi {
         states: &'a mut [&'b mut (dyn LayerState + 'static)],
-        k: usize,
+        ks: &'a [usize],
         /// This layer's slice of the model-staged WY pointer tables
         /// (`crate::layer::VERIFY_WY_LAYER_STRIDE_BYTES`; NULL → no
         /// single-launch WY batch, per-sequence loop only).
@@ -371,38 +388,77 @@ impl Qwen3SsmLayer {
         let gates_buf = ctx.buffers.ssm_gates(); // [K, gate(nv) + beta(nv)] FP32
         let gate_beta_stride = nv * 2 * fp32; // bytes per token in gates buffer
         let ba_size = ctx.config.ssm_ba_size(); // 64
-        for t in 0..(num_tokens as u32) {
-            let normed_t = normed.offset(t as usize * h * bf16);
-            let ba_out = ctx.buffers.ssm_ba().offset(t as usize * ba_size * bf16);
-            // Dense GEMV for BA projection (small: 64 outputs)
-            ops::dense_gemv(
+        if batched_ba_gates_enabled() {
+            // ONE fused launch for all rows instead of `num_tokens` × (dense
+            // GEMV + compute_gdn_gates). The per-token loop re-read the whole
+            // [64, hidden] BA weight once PER ROW PER LAYER — 655 KB × 32 rows ×
+            // 48 GDN layers = ~1.0 GB/step of redundant traffic at R=32, plus
+            // 2R launches per layer (3072/step) that the verify CUDA graph then
+            // has to carry as nodes.
+            //
+            // `dense_gemm_ba_gates_prefill` is the token-parallel twin of the
+            // decode-path `dense_gemv_ba_gates` (identical uint4 K-reduction,
+            // identical warp+smem tree, identical gate/beta transforms) and is
+            // ALREADY the shipped form on both the prefill path and the
+            // multi-seq batched-recurrent decode path. It writes the same
+            // [gate(nv) | beta(nv)] interleaved row layout at `gate_stride`
+            // FP32 elements per row that `gates_buf` expects.
+            //
+            // NOT bit-identical to the loop it replaces: fusing removes the
+            // BF16 round-trip through the `ssm_ba` staging buffer, so the gate
+            // and beta transforms see the FP32 projection result directly.
+            // Kill switch below restores the split form.
+            ops::dense_gemm_ba_gates_prefill(
                 ctx.gpu,
-                self.dense_gemv_k,
-                normed_t,
+                self.ba_gates_prefill_k,
+                normed,
                 &self.ssm.in_proj_ba,
-                ba_out,
-                ba_size as u32,
-                h as u32,
-                stream,
-            )?;
-            // Apply gate transforms
-            let gate_t = gates_buf.offset(t as usize * gate_beta_stride);
-            let beta_t = gates_buf.offset(t as usize * gate_beta_stride + nv * fp32);
-            ops::compute_gdn_gates(
-                ctx.gpu,
-                self.compute_gdn_gates_k,
-                ba_out,
                 self.ssm.a_log.weight,
                 self.ssm.dt_bias.weight,
-                gate_t,
-                beta_t,
-                1,
-                nv as u32,
-                nk as u32,
-                vpg as u32,
+                gates_buf,
+                num_tokens as u32,
                 ba_size as u32,
+                h as u32,
+                h as u32,
+                (nv * 2) as u32,
+                nv as u32,
+                vpg as u32,
                 stream,
             )?;
+        } else {
+            for t in 0..(num_tokens as u32) {
+                let normed_t = normed.offset(t as usize * h * bf16);
+                let ba_out = ctx.buffers.ssm_ba().offset(t as usize * ba_size * bf16);
+                // Dense GEMV for BA projection (small: 64 outputs)
+                ops::dense_gemv(
+                    ctx.gpu,
+                    self.dense_gemv_k,
+                    normed_t,
+                    &self.ssm.in_proj_ba,
+                    ba_out,
+                    ba_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+                // Apply gate transforms
+                let gate_t = gates_buf.offset(t as usize * gate_beta_stride);
+                let beta_t = gates_buf.offset(t as usize * gate_beta_stride + nv * fp32);
+                ops::compute_gdn_gates(
+                    ctx.gpu,
+                    self.compute_gdn_gates_k,
+                    ba_out,
+                    self.ssm.a_log.weight,
+                    self.ssm.dt_bias.weight,
+                    gate_t,
+                    beta_t,
+                    1,
+                    nv as u32,
+                    nk as u32,
+                    vpg as u32,
+                    ba_size as u32,
+                    stream,
+                )?;
+            }
         }
 
         k4_diag_checkpoint(ctx, "4:ba_proj+gates", stream)?;
@@ -467,7 +523,7 @@ impl Qwen3SsmLayer {
             }
             GdnStates::Multi {
                 states,
-                k: kk,
+                ks,
                 wy_tables,
             } => {
                 // Batched MTP verify. Fast path: cross-sequence batched
@@ -482,78 +538,111 @@ impl Qwen3SsmLayer {
                 // conv_dim*bf16, gates at nv*2*fp32, gdn_out at value_dim*bf16
                 // per token.
                 anyhow::ensure!(
-                    !states.is_empty() && num_tokens == states.len() * kk,
-                    "decode_batched_inner Multi: num_tokens {} != n {} * k {}",
+                    !states.is_empty()
+                        && ks.len() == states.len()
+                        && num_tokens == ks.iter().sum::<usize>(),
+                    "decode_batched_inner Multi: num_tokens {} != Σ ks {:?} (n {})",
                     num_tokens,
+                    ks,
                     states.len(),
-                    kk,
                 );
-                let base_args = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
-                    num_tokens: kk,
-                    deinterleaved,
-                    gates_buf,
-                    conv_out_buf,
-                    gdn_out_buf,
-                    h_bytes,
-                    conv_bytes,
-                    qkvz_size,
-                    conv_dim,
-                    key_dim,
-                    value_dim,
-                    d_conv,
-                    qk_ch,
-                    nk,
-                    nv,
-                    kd,
-                    vd,
-                    bf16,
-                    fp32,
-                    stream,
-                };
-                let batched =
-                    self.decode_batched_conv_gdn_multi(states, wy_tables, ctx, &base_args)?;
-                if batched {
-                    // Whole batch done in two launches; skip the per-seq loop.
-                } else {
-                    for (i, state) in states.iter_mut().enumerate() {
-                        let ssm_state = state
-                            .as_any_mut()
-                            .downcast_mut::<SsmLayerState>()
-                            .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState"))?;
-                        if ssm_state.h_state_intermediates.len() < kk
-                            || ssm_state.conv_state_intermediates.len() < kk
-                        {
-                            anyhow::bail!(
-                                "SSM MTP intermediate buffers not allocated for batched verify \
-                             (seq {i}: h={}, conv={}, k={kk})",
-                                ssm_state.h_state_intermediates.len(),
-                                ssm_state.conv_state_intermediates.len(),
-                            );
-                        }
-                        let args_i = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
-                            num_tokens: kk,
-                            deinterleaved: deinterleaved.offset(i * kk * qkvz_size * bf16),
-                            gates_buf: gates_buf.offset(i * kk * nv * 2 * fp32),
-                            conv_out_buf: conv_out_buf.offset(i * kk * conv_dim * bf16),
-                            gdn_out_buf: gdn_out_buf.offset(i * kk * value_dim * bf16),
-                            h_bytes,
-                            conv_bytes,
-                            qkvz_size,
-                            conv_dim,
-                            key_dim,
-                            value_dim,
-                            d_conv,
-                            qk_ch,
-                            nk,
-                            nv,
-                            kd,
-                            vd,
-                            bf16,
-                            fp32,
-                            stream,
-                        };
-                        self.decode_batched_conv_gdn(ssm_state, ctx, &args_i)?;
+                // Row offset of each sequence (ragged; `i*k` when uniform).
+                let mut off: Vec<usize> = Vec::with_capacity(states.len());
+                let mut acc = 0usize;
+                for &k in ks.iter() {
+                    off.push(acc);
+                    acc += k;
+                }
+                // Sequences are ordered deepest-first by the scheduler, so
+                // equal depths form CONTIGUOUS runs. One batched conv+WY
+                // attempt per run keeps the two-launch fast path alive under
+                // ragged depths (uniform ⇒ exactly one run = today's call).
+                let mut g0 = 0usize;
+                while g0 < states.len() {
+                    let kk = ks[g0];
+                    let mut g1 = g0 + 1;
+                    while g1 < states.len() && ks[g1] == kk {
+                        g1 += 1;
                     }
+                    let row0 = off[g0];
+                    let run_args = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
+                        num_tokens: kk,
+                        deinterleaved: deinterleaved.offset(row0 * qkvz_size * bf16),
+                        gates_buf: gates_buf.offset(row0 * nv * 2 * fp32),
+                        conv_out_buf: conv_out_buf.offset(row0 * conv_dim * bf16),
+                        gdn_out_buf: gdn_out_buf.offset(row0 * value_dim * bf16),
+                        h_bytes,
+                        conv_bytes,
+                        qkvz_size,
+                        conv_dim,
+                        key_dim,
+                        value_dim,
+                        d_conv,
+                        qk_ch,
+                        nk,
+                        nv,
+                        kd,
+                        vd,
+                        bf16,
+                        fp32,
+                        stream,
+                    };
+                    // Table entries are per sequence in batch order, so a run
+                    // slices them by its own start index (8 B per u64 entry).
+                    let run_tables = if wy_tables.is_null() {
+                        wy_tables
+                    } else {
+                        wy_tables.offset(g0 * 8)
+                    };
+                    let batched = self.decode_batched_conv_gdn_multi(
+                        &mut states[g0..g1],
+                        run_tables,
+                        ctx,
+                        &run_args,
+                    )?;
+                    if !batched {
+                        for i in g0..g1 {
+                            let ssm_state = states[i]
+                                .as_any_mut()
+                                .downcast_mut::<SsmLayerState>()
+                                .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState"))?;
+                            if ssm_state.h_state_intermediates.len() < kk
+                                || ssm_state.conv_state_intermediates.len() < kk
+                            {
+                                anyhow::bail!(
+                                    "SSM MTP intermediate buffers not allocated for batched \
+                                 verify (seq {i}: h={}, conv={}, k={kk})",
+                                    ssm_state.h_state_intermediates.len(),
+                                    ssm_state.conv_state_intermediates.len(),
+                                );
+                            }
+                            let r = off[i];
+                            let args_i = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
+                                num_tokens: kk,
+                                deinterleaved: deinterleaved.offset(r * qkvz_size * bf16),
+                                gates_buf: gates_buf.offset(r * nv * 2 * fp32),
+                                conv_out_buf: conv_out_buf.offset(r * conv_dim * bf16),
+                                gdn_out_buf: gdn_out_buf.offset(r * value_dim * bf16),
+                                h_bytes,
+                                conv_bytes,
+                                qkvz_size,
+                                conv_dim,
+                                key_dim,
+                                value_dim,
+                                d_conv,
+                                qk_ch,
+                                nk,
+                                nv,
+                                kd,
+                                vd,
+                                bf16,
+                                fp32,
+                                stream,
+                            };
+                            self.decode_batched_conv_gdn(ssm_state, ctx, &args_i)?;
+                        }
+                    }
+                    g0 = g1;
                 }
             }
         }
@@ -578,6 +667,31 @@ impl Qwen3SsmLayer {
                 qkvz_size as u32, // deint position stride (BF16 elems)
                 z_offset as u32,  // Z offset within a position
                 value_dim as u32, // gdn/out position stride
+                stream,
+            )?;
+        } else if batched_norm_enabled() {
+            // ONE launch for all (head, row) pairs instead of `num_tokens` of
+            // them. `gated_rms_norm_prefill` is `gated_rms_norm` with the token
+            // index moved to blockIdx.y and the two row strides passed
+            // explicitly — the reduction, the register cache and the quad loop
+            // are line-for-line the same, so this is BIT-IDENTICAL, not an
+            // approximation. The fused K=2 arm above already covers
+            // `num_tokens == 2`; the batched verify (R = n*k, 8..32 rows) never
+            // reached it and was paying R launches per GDN layer, i.e. 1536
+            // launches/step at R=32 across 48 layers.
+            ops::gated_rms_norm_prefill(
+                ctx.gpu,
+                self.gated_rms_norm_prefill_k,
+                gdn_out_buf,
+                deinterleaved.offset(z_offset * bf16),
+                &self.ssm.norm,
+                normed_out_buf,
+                nv as u32,
+                vd as u32,
+                eps,
+                num_tokens as u32,
+                value_dim as u32,
+                qkvz_size as u32,
                 stream,
             )?;
         } else {

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -22,6 +22,28 @@ fn k4_diag_checkpoint(ctx: &ForwardContext, phase: &str, stream: u64) -> Result<
     Ok(())
 }
 
+/// GDN-state routing for [`Qwen3SsmLayer::decode_batched_inner`].
+///
+/// `Single`: today's path — `num_tokens` rows belong to ONE sequence, whose
+/// conv/GDN state advances through all of them (K-token MTP verify, DFlash).
+///
+/// `Multi`: batched MTP verify — `num_tokens = n*k` seq-major rows
+/// (`r = i*k + j`); projections/FFN batch across all rows, while the
+/// stateful conv/GDN body runs per-sequence against `states[i]` with
+/// row-offset buffer bases (per-sequence math byte-identical to `Single`
+/// at `num_tokens = k`; only base addresses move).
+pub(super) enum GdnStates<'a, 'b> {
+    Single(&'a mut dyn LayerState),
+    Multi {
+        states: &'a mut [&'b mut (dyn LayerState + 'static)],
+        k: usize,
+        /// This layer's slice of the model-staged WY pointer tables
+        /// (`crate::layer::VERIFY_WY_LAYER_STRIDE_BYTES`; NULL → no
+        /// single-launch WY batch, per-sequence loop only).
+        wy_tables: DevicePtr,
+    },
+}
+
 impl Qwen3SsmLayer {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn decode_batched_inner(
@@ -29,12 +51,7 @@ impl Qwen3SsmLayer {
         hidden: DevicePtr,
         residual: DevicePtr,
         num_tokens: usize,
-        state: &mut dyn LayerState,
-        _kv_cache: &mut PagedKvCache,
-        _seq_len: usize,
-        _block_table: &mut Vec<u32>,
-        _disk_block_ids: &mut Vec<u32>,
-        _disk_last_offloaded_per_layer: &mut Vec<u32>,
+        gdn: GdnStates<'_, '_>,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
@@ -43,11 +60,6 @@ impl Qwen3SsmLayer {
         let k = num_tokens as u32;
         let bf16 = 2usize; // bytes per BF16
         let fp32 = 4usize; // bytes per FP32
-
-        let ssm_state = state
-            .as_any_mut()
-            .downcast_mut::<SsmLayerState>()
-            .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState"))?;
 
         let nk = ctx.config.linear_num_key_heads;
         let kd = ctx.config.linear_key_head_dim;
@@ -402,50 +414,149 @@ impl Qwen3SsmLayer {
         let h_bytes = self.h_state_bytes;
         let conv_bytes = self.conv_state_bytes;
 
-        // Intermediates are pre-allocated from the pool (fixed GPU addresses for
-        // CUDA graph stability). Verify they exist BEFORE we index into them — a
-        // bare `debug_assert!` is a no-op in release and produces an opaque
-        // out-of-bounds panic instead of an actionable error (see #bugs
-        // m0t0chan EP=2 2026-04-05). Most-common cause: EP=2 worker started
-        // without `--speculative --mtp-quantization` to mirror the head.
-        if ssm_state.h_state_intermediates.len() < num_tokens
-            || ssm_state.conv_state_intermediates.len() < num_tokens
-        {
-            anyhow::bail!(
-                "SSM MTP intermediate buffers not allocated (h_state_intermediates.len()={}, \
-                 conv_state_intermediates.len()={}, num_tokens={}). \
-                 If this is an EP=2 worker, the head node is sending MTP verify commands \
-                 but the worker was started without `--speculative` (and matching \
-                 `--mtp-quantization`/`--num-drafts`). Add those flags to the worker invocation.",
-                ssm_state.h_state_intermediates.len(),
-                ssm_state.conv_state_intermediates.len(),
-                num_tokens,
-            );
-        }
+        match gdn {
+            GdnStates::Single(state) => {
+                let ssm_state = state
+                    .as_any_mut()
+                    .downcast_mut::<SsmLayerState>()
+                    .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState"))?;
+                // Intermediates are pre-allocated from the pool (fixed GPU addresses for
+                // CUDA graph stability). Verify they exist BEFORE we index into them — a
+                // bare `debug_assert!` is a no-op in release and produces an opaque
+                // out-of-bounds panic instead of an actionable error (see #bugs
+                // m0t0chan EP=2 2026-04-05). Most-common cause: EP=2 worker started
+                // without `--speculative --mtp-quantization` to mirror the head.
+                if ssm_state.h_state_intermediates.len() < num_tokens
+                    || ssm_state.conv_state_intermediates.len() < num_tokens
+                {
+                    anyhow::bail!(
+                        "SSM MTP intermediate buffers not allocated (h_state_intermediates.len()={}, \
+                         conv_state_intermediates.len()={}, num_tokens={}). \
+                         If this is an EP=2 worker, the head node is sending MTP verify commands \
+                         but the worker was started without `--speculative` (and matching \
+                         `--mtp-quantization`/`--num-drafts`). Add those flags to the worker invocation.",
+                        ssm_state.h_state_intermediates.len(),
+                        ssm_state.conv_state_intermediates.len(),
+                        num_tokens,
+                    );
+                }
 
-        let args = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
-            num_tokens,
-            deinterleaved,
-            gates_buf,
-            conv_out_buf,
-            gdn_out_buf,
-            h_bytes,
-            conv_bytes,
-            qkvz_size,
-            conv_dim,
-            key_dim,
-            value_dim,
-            d_conv,
-            qk_ch,
-            nk,
-            nv,
-            kd,
-            vd,
-            bf16,
-            fp32,
-            stream,
-        };
-        self.decode_batched_conv_gdn(ssm_state, ctx, &args)?;
+                let args = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
+                    num_tokens,
+                    deinterleaved,
+                    gates_buf,
+                    conv_out_buf,
+                    gdn_out_buf,
+                    h_bytes,
+                    conv_bytes,
+                    qkvz_size,
+                    conv_dim,
+                    key_dim,
+                    value_dim,
+                    d_conv,
+                    qk_ch,
+                    nk,
+                    nv,
+                    kd,
+                    vd,
+                    bf16,
+                    fp32,
+                    stream,
+                };
+                self.decode_batched_conv_gdn(ssm_state, ctx, &args)?;
+            }
+            GdnStates::Multi {
+                states,
+                k: kk,
+                wy_tables,
+            } => {
+                // Batched MTP verify. Fast path: cross-sequence batched
+                // conv+WY — ONE `gdn_verify_fused_conv_kn_batched` launch +
+                // ONE table-form `gdn_decode_wy4` launch for the whole batch
+                // (trait_decode_batched_conv_gdn_multi.rs; preconditions
+                // checked on the actual state pointers, kill switch
+                // ATLAS_NO_VERIFY_GDN_BATCH). Fallback: the SAME per-sequence
+                // conv+GDN body, one call per sequence with row-offset buffer
+                // bases. Strides match decode_batched_conv_gdn's consumers
+                // exactly: deinterleaved rows at qkvz_size*bf16, conv_out at
+                // conv_dim*bf16, gates at nv*2*fp32, gdn_out at value_dim*bf16
+                // per token.
+                anyhow::ensure!(
+                    !states.is_empty() && num_tokens == states.len() * kk,
+                    "decode_batched_inner Multi: num_tokens {} != n {} * k {}",
+                    num_tokens,
+                    states.len(),
+                    kk,
+                );
+                let base_args = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
+                    num_tokens: kk,
+                    deinterleaved,
+                    gates_buf,
+                    conv_out_buf,
+                    gdn_out_buf,
+                    h_bytes,
+                    conv_bytes,
+                    qkvz_size,
+                    conv_dim,
+                    key_dim,
+                    value_dim,
+                    d_conv,
+                    qk_ch,
+                    nk,
+                    nv,
+                    kd,
+                    vd,
+                    bf16,
+                    fp32,
+                    stream,
+                };
+                let batched =
+                    self.decode_batched_conv_gdn_multi(states, wy_tables, ctx, &base_args)?;
+                if batched {
+                    // Whole batch done in two launches; skip the per-seq loop.
+                } else {
+                    for (i, state) in states.iter_mut().enumerate() {
+                        let ssm_state = state
+                            .as_any_mut()
+                            .downcast_mut::<SsmLayerState>()
+                            .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState"))?;
+                        if ssm_state.h_state_intermediates.len() < kk
+                            || ssm_state.conv_state_intermediates.len() < kk
+                        {
+                            anyhow::bail!(
+                                "SSM MTP intermediate buffers not allocated for batched verify \
+                             (seq {i}: h={}, conv={}, k={kk})",
+                                ssm_state.h_state_intermediates.len(),
+                                ssm_state.conv_state_intermediates.len(),
+                            );
+                        }
+                        let args_i = super::trait_decode_batched_conv_gdn::ConvGdnArgs {
+                            num_tokens: kk,
+                            deinterleaved: deinterleaved.offset(i * kk * qkvz_size * bf16),
+                            gates_buf: gates_buf.offset(i * kk * nv * 2 * fp32),
+                            conv_out_buf: conv_out_buf.offset(i * kk * conv_dim * bf16),
+                            gdn_out_buf: gdn_out_buf.offset(i * kk * value_dim * bf16),
+                            h_bytes,
+                            conv_bytes,
+                            qkvz_size,
+                            conv_dim,
+                            key_dim,
+                            value_dim,
+                            d_conv,
+                            qk_ch,
+                            nk,
+                            nv,
+                            kd,
+                            vd,
+                            bf16,
+                            fp32,
+                            stream,
+                        };
+                        self.decode_batched_conv_gdn(ssm_state, ctx, &args_i)?;
+                    }
+                }
+            }
+        }
 
         k4_diag_checkpoint(ctx, "5-7:conv1d+l2norm+gdn_wy", stream)?;
 
@@ -558,6 +669,34 @@ impl Qwen3SsmLayer {
                 self.w4a16_batchm_kernel(num_tokens),
                 normed_out_buf,
                 &self.ssm.out_proj,
+                out_proj_buf,
+                num_tokens as u32,
+                h as u32,
+                value_dim as u32,
+                stream,
+            )?;
+        } else if num_tokens > 8 && self.out_proj_nvfp4_t.is_some() && {
+            // Kill switch, PRESENCE check per house convention (`=0` is NOT
+            // off), cached once.
+            static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            !*OFF.get_or_init(|| std::env::var("ATLAS_NO_VERIFY_OUTPROJ_TGEMM").is_ok())
+        } {
+            // M > 8 (batched K=4 verify, R = n*4 rows; DFlash wide verify):
+            // the pre-dequanted FP8 prefill arm below reads 2x the weight
+            // bytes of NVFP4 — bandwidth-bound at this M, measured 379 us
+            // vs 182 us per call at M=16 N=5120 (fp8_fp8_gemm_ldmab vs
+            // w4a16_gemm_t_k64_p3), ~9.5 ms/step across 48 GDN layers at
+            // C=4. Route to the NVFP4 transposed-twin tile GEMM — the SAME
+            // kernel+handle the multi-seq decode out_proj uses
+            // (`deep_k_gemm`). BF16 activations (vs the FP8 arm's e4m3
+            // downcast) — equal-or-better numerics, not byte-identical.
+            // Kill switch ATLAS_NO_VERIFY_OUTPROJ_TGEMM (PRESENCE check).
+            let nvfp4_t = self.out_proj_nvfp4_t.as_ref().unwrap();
+            ops::w4a16_gemm_n128(
+                ctx.gpu,
+                self.deep_k_gemm(value_dim as u32),
+                normed_out_buf,
+                nvfp4_t,
                 out_proj_buf,
                 num_tokens as u32,
                 h as u32,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -175,6 +175,7 @@ impl Qwen3SsmLayer {
                 conv_dim as u32, // qk_stride
                 conv_dim as u32, // v_stride
                 (nv * 2) as u32, // gb_stride
+                false,           // contiguous state — this site is batch_size=1
                 stream,
             )?;
         } else if num_tokens == 3 {
@@ -233,6 +234,7 @@ impl Qwen3SsmLayer {
                 conv_dim as u32, // qk_stride
                 conv_dim as u32, // v_stride
                 (nv * 2) as u32, // gb_stride
+                false,           // contiguous state — this site is batch_size=1
                 stream,
             )?;
         } else if num_tokens == 2 {
@@ -335,6 +337,7 @@ impl Qwen3SsmLayer {
                 conv_dim as u32, // qk_stride
                 conv_dim as u32, // v_stride
                 (nv * 2) as u32, // gb_stride
+                false,           // contiguous state — this site is batch_size=1
                 stream,
             )?;
         } else if num_tokens == 17 && self.gdn_wy17_k.0 != 0 && wy17_enabled() {

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Cross-sequence batched conv+WY body for the batched K-row MTP verify
+//! (`GdnStates::Multi`, k = 2..=4 from the K-vs-batch ladder). Collapses the
+//! per-sequence loop — n × (k `conv1d_update_l2norm` + (k-1) conv-state
+//! `copy_d2d_async` + 1 `gdn_decode_wy{k}`) = n(2k-1) launches per GDN layer
+//! — into TWO launches:
+//!
+//! 1. `gdn_verify_fused_conv_kn_batched` (gridDim.y = n): all n sequences ×
+//!    K positions of conv1d+SiLU+L2norm in one launch, every per-token
+//!    rollback snapshot written inline. Bit-identical to n separate per-token
+//!    sequences (independent conv windows; only base addresses move — see
+//!    the kernel header in `kernels/gb10/common/gdn_verify_fused_conv_kn.cu`).
+//!    Contract delta vs the per-token loop: the kernel ALSO writes the dead
+//!    t = K-1 snapshot (the per-token path skips it). Harmless: the pool
+//!    allocates `num_intermediates = K` snapshots per slot, and the
+//!    preconditions below verify index K-1 exists and is intra-slot
+//!    contiguous before the launch.
+//! 2. `gdn_decode_wy{2,3,4}` at `batch_size = n` with `state_is_table = true`:
+//!    ONE launch over device pointer tables (one entry per sequence) for
+//!    h_state + the k-1 Hi intermediates — the table form that sidesteps the
+//!    intermediates-stride corruption the contiguous form has at n > 1
+//!    (see the ensure! in `ops::gdn_decode_wy4`). Per-sequence math is
+//!    byte-identical (`b` only selects base addresses).
+//!
+//! K-GENERIC (2026-07-28). This path was gated to k == 4 because only wy4
+//! carried the pointer-table form; every K-vs-batch ladder step below 4
+//! therefore ran the per-sequence loop — n launches per GDN layer instead of
+//! 2 — which is a named suspect for the measured "K=1 verify step costs ~1.9x
+//! a plain batch-16 decode step" (break-even at p1~0.72 is 1.72x). wy2/wy3
+//! now take the same `state_is_table` flag, so k in {2,3,4} all take the
+//! two-launch path. The conv kernel was already K-generic (`num_tokens` is a
+//! runtime arg).
+//!
+//! The conv launch needs UNIFORM per-sequence strides, which holds iff the
+//! batch occupies CONSECUTIVE ssm-pool slots in batch order. That is checked
+//! against the ACTUAL state pointers every call; any mismatch falls back to
+//! the per-sequence loop (logged once, counted — same pattern as
+//! `ssm_batched_recurrent`). The WY tables are staged by the model
+//! (`upload_verify_wy_tables`, verify_e2.rs) into a fixed device buffer
+//! refreshed pre-replay, so both launches are CUDA-graph-stable.
+//!
+//! Kill switch `ATLAS_NO_VERIFY_GDN_BATCH` (PRESENCE check per the house
+//! convention — `=0` is NOT off) forces the per-sequence loop for A/B.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::trait_decode_batched_conv_gdn::ConvGdnArgs;
+use super::{Qwen3SsmLayer, SsmLayerState};
+use crate::layer::{LayerState, VERIFY_WY_TABLE_STRIDE_BYTES};
+use crate::layers::ops;
+
+/// How often the batched conv+WY fast path engaged vs fell back (slot
+/// fragmentation breaks the consecutive-slot precondition as sequences
+/// finish, so fallbacks are expected to recur).
+static BATCHED_OK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static FALLBACK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Bit `k` set once the ENGAGED / DECLINED line has been logged for verify
+/// width `k`. Per-`k` (not a single `Once`) so a serve log PROVES which
+/// ladder widths actually took the two-launch path — a single first-hit line
+/// at k=4 would say nothing about the k=2/k=3 steps this change exists for.
+static ENGAGED_KMASK: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+static DECLINED_KMASK: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Set bit `k` in `mask`; returns true iff this call set it (first time).
+fn first_for_k(mask: &std::sync::atomic::AtomicU32, k: usize) -> bool {
+    let bit = 1u32 << (k & 31);
+    (mask.fetch_or(bit, std::sync::atomic::Ordering::Relaxed) & bit) == 0
+}
+
+/// Kill switch, PRESENCE check (`=0` is NOT off), read once per process.
+fn verify_gdn_batch_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_VERIFY_GDN_BATCH").is_none())
+}
+
+impl Qwen3SsmLayer {
+    /// Attempt the cross-sequence batched conv+WY fast path for the
+    /// `GdnStates::Multi` arm. `args` carries the BASE (un-offset) buffers
+    /// with `args.num_tokens = k` (per-sequence verify width); `states` is
+    /// the n per-sequence SSM states in batch order; `wy_tables` is this
+    /// layer's slice of the model's staged pointer tables (NULL → decline).
+    ///
+    /// Returns `Ok(false)` when any precondition fails — the caller runs the
+    /// existing per-sequence loop, which is byte-identical math. All checks
+    /// are host pointer arithmetic over n <= 4 sequences (no GPU work), and
+    /// their outcome is a pure function of the ssm-slot vector + process-
+    /// static kernel handles/env, so the decision is stable across CUDA
+    /// graph capture/replay for a slot-vector-keyed graph.
+    pub(super) fn decode_batched_conv_gdn_multi(
+        &self,
+        states: &mut [&mut (dyn LayerState + 'static)],
+        wy_tables: DevicePtr,
+        ctx: &crate::layer::ForwardContext,
+        args: &ConvGdnArgs,
+    ) -> Result<bool> {
+        let n = states.len();
+        let kk = args.num_tokens;
+        // wy2/wy3/wy4 all carry the `state_is_table` pointer-table form, so
+        // every K-vs-batch ladder width takes the two-launch path. The handle
+        // is selected here (try_kernel misses are a silent 0 — gate on it,
+        // never assume resolution).
+        let wy_k = match kk {
+            2 => self.gdn_wy2_k,
+            3 => self.gdn_wy3_k,
+            4 => self.gdn_wy4_k,
+            _ => return Ok(false),
+        };
+        if n < 2
+            || !verify_gdn_batch_enabled()
+            || self.gdn_verify_fused_conv_kn_batched_k.0 == 0
+            || wy_k.0 == 0
+            || wy_tables.is_null()
+        {
+            return Ok(false);
+        }
+
+        let conv_bytes = self.conv_state_bytes;
+        // ── Preconditions: consecutive-slot layout, verified on the actual
+        // pointers (never assumed from the scheduler invariant) ──
+        let mut conv_base = DevicePtr::NULL;
+        let mut inter_base = DevicePtr::NULL;
+        let mut inter_seq_stride = 0u64;
+        for i in 0..n {
+            let Some(st) = states[i].as_any().downcast_ref::<SsmLayerState>() else {
+                return Ok(self.gdn_multi_decline(n, kk));
+            };
+            // The batched conv writes snapshots t = 0..K-1 at stride
+            // conv_bytes; every index must exist and be intra-slot contiguous.
+            // h side: the wy4 table entries (staged by the model) need
+            // intermediates 0..2 — existence re-checked here (defense in
+            // depth; the model declines the upload on the same condition).
+            if st.conv_state_intermediates.len() < kk || st.h_state_intermediates.len() < kk - 1 {
+                return Ok(self.gdn_multi_decline(n, kk));
+            }
+            let i0 = st.conv_state_intermediates[0];
+            for t in 1..kk {
+                if st.conv_state_intermediates[t].0 != i0.0 + (t * conv_bytes) as u64 {
+                    return Ok(self.gdn_multi_decline(n, kk));
+                }
+            }
+            if i == 0 {
+                conv_base = st.conv_state;
+                inter_base = i0;
+            } else {
+                if st.conv_state.0 != conv_base.0 + (i * conv_bytes) as u64 {
+                    return Ok(self.gdn_multi_decline(n, kk));
+                }
+                if i == 1 {
+                    inter_seq_stride = i0.0.wrapping_sub(inter_base.0);
+                    // The per-sequence snapshot regions must not overlap the
+                    // kernel's K writes (pool stride is num_intermediates ×
+                    // conv_bytes with num_intermediates >= K, so this holds
+                    // for pool-backed states; checked, not assumed).
+                    if inter_seq_stride < (kk * conv_bytes) as u64 {
+                        return Ok(self.gdn_multi_decline(n, kk));
+                    }
+                } else if i0.0 != inter_base.0 + (i as u64) * inter_seq_stride {
+                    return Ok(self.gdn_multi_decline(n, kk));
+                }
+            }
+        }
+
+        let ConvGdnArgs {
+            deinterleaved,
+            gates_buf,
+            conv_out_buf,
+            gdn_out_buf,
+            qkvz_size,
+            conv_dim,
+            key_dim,
+            d_conv,
+            qk_ch,
+            nk,
+            nv,
+            kd,
+            vd,
+            bf16,
+            fp32,
+            stream,
+            ..
+        } = *args;
+
+        // ── 1 launch: all n sequences × K conv positions + inline snapshots ──
+        ops::gdn_verify_fused_conv_kn_batched(
+            ctx.gpu,
+            self.gdn_verify_fused_conv_kn_batched_k,
+            conv_base,
+            deinterleaved,
+            &self.ssm.conv1d,
+            conv_out_buf,
+            inter_base,
+            kk as u32,
+            conv_dim as u32,
+            d_conv as u32,
+            qk_ch,
+            kd as u32,
+            qkvz_size as u32,        // input stride (BF16 elems between positions)
+            conv_dim as u32,         // output stride (BF16 elems between positions)
+            (conv_bytes / 4) as u32, // snapshot stride (FP32 elems)
+            1e-6,
+            n as u32,
+            (conv_bytes / 4) as u32, // conv_state seq stride (FP32 elems)
+            (kk * qkvz_size) as u32, // input seq stride (BF16 elems)
+            (kk * conv_dim) as u32,  // output seq stride (BF16 elems)
+            (inter_seq_stride / 4) as u32, // snapshot seq stride (FP32 elems)
+            stream,
+        )?;
+
+        // ── 1 launch: WY over all n sequences via pointer tables ──
+        // Activation rows are seq-major (`r = b*k + t`), exactly the kernels'
+        // `(b*K+T)*stride` indexing; the state args become device pointer
+        // tables (h | Hi0 | ..), one `VERIFY_WY_TABLE_STRIDE_BYTES` slab
+        // each, staged by the model pre-graph. Only the first `kk` slabs are
+        // read (wy2 takes h+Hi0, wy3 h+Hi0+Hi1, wy4 h+Hi0..Hi2).
+        let q_ptr = conv_out_buf;
+        let k_ptr = conv_out_buf.offset(key_dim * bf16);
+        let v_ptr = conv_out_buf.offset(key_dim * 2 * bf16);
+        let gate_ptr = gates_buf;
+        let beta_ptr = gates_buf.offset(nv * fp32);
+        let hi = |t: usize| wy_tables.offset(t * VERIFY_WY_TABLE_STRIDE_BYTES);
+        match kk {
+            2 => ops::gdn_decode_wy2(
+                ctx.gpu,
+                wy_k,
+                wy_tables,
+                q_ptr,
+                k_ptr,
+                v_ptr,
+                gate_ptr,
+                beta_ptr,
+                gdn_out_buf,
+                hi(1),
+                n as u32,
+                nk as u32,
+                nv as u32,
+                kd as u32,
+                vd as u32,
+                conv_dim as u32, // qk_stride
+                conv_dim as u32, // v_stride
+                (nv * 2) as u32, // gb_stride
+                true,            // state_is_table — one table entry per sequence
+                stream,
+            )?,
+            3 => ops::gdn_decode_wy3(
+                ctx.gpu,
+                wy_k,
+                wy_tables,
+                q_ptr,
+                k_ptr,
+                v_ptr,
+                gate_ptr,
+                beta_ptr,
+                gdn_out_buf,
+                hi(1),
+                hi(2),
+                n as u32,
+                nk as u32,
+                nv as u32,
+                kd as u32,
+                vd as u32,
+                conv_dim as u32,
+                conv_dim as u32,
+                (nv * 2) as u32,
+                true,
+                stream,
+            )?,
+            _ => ops::gdn_decode_wy4(
+                ctx.gpu,
+                wy_k,
+                wy_tables,
+                q_ptr,
+                k_ptr,
+                v_ptr,
+                gate_ptr,
+                beta_ptr,
+                gdn_out_buf,
+                hi(1),
+                hi(2),
+                hi(3),
+                n as u32,
+                nk as u32,
+                nv as u32,
+                kd as u32,
+                vd as u32,
+                conv_dim as u32,
+                conv_dim as u32,
+                (nv * 2) as u32,
+                true,
+                stream,
+            )?,
+        }
+
+        let ok = BATCHED_OK.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if first_for_k(&ENGAGED_KMASK, kk) {
+            tracing::info!(
+                "batched-verify GDN conv+WY ENGAGED (n={n}, k={kk}): per-layer {} launches \
+                 -> 2 (batched conv kernel + table-form wy{kk}); count logged at debug",
+                n * (kk + kk - 1),
+            );
+        }
+        if ok.is_multiple_of(1024) {
+            tracing::debug!("batched-verify GDN conv+WY engaged x{ok}");
+        }
+        Ok(true)
+    }
+
+    /// Count + first-occurrence log for a declined batched conv+WY call.
+    /// Always returns `false` so call sites read
+    /// `return Ok(self.gdn_multi_decline(n, kk))`.
+    fn gdn_multi_decline(&self, n: usize, kk: usize) -> bool {
+        let n_fb = FALLBACK.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if first_for_k(&DECLINED_KMASK, kk) {
+            tracing::info!(
+                "batched-verify GDN conv+WY DECLINED (n={n}, k={kk}): batch is not on \
+                 consecutive ssm-pool slots (or intermediates/tables unavailable) — running \
+                 the per-sequence loop. Slots fragment as sequences finish, so this can \
+                 recur; count logged at debug."
+            );
+        }
+        tracing::debug!("batched-verify GDN conv+WY fallback #{n_fb} (n={n}, k={kk})");
+        false
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq.rs
@@ -7,6 +7,42 @@ use super::*;
 mod ssm_batched;
 mod ssm_batched_recurrent;
 
+/// Batched dense FFN for wide SSM decode batches: **ON by default**, disabled
+/// only by `ATLAS_NO_SSM_FFN_PREFILL=1`.
+///
+/// Strict `== "1"` on an `ATLAS_NO_*` name rather than a presence check —
+/// presence-checked flags in this codebase are ENABLED by `=0`, a trap that has
+/// burned it before. Read once; the dispatch site is per-layer per-step.
+/// Smallest batch that takes the batched dense FFN. Default 5, MEASURED.
+///
+/// Tunable because the +30% measured at C=16 is LARGER than eliminating the
+/// double weight read alone predicts (~18%), which implies the tile GEMM also
+/// beats the batch-8 GEMV per pass. If that holds, the crossover is below 9 and
+/// C=4/C=8 have headroom too — `ATLAS_SSM_FFN_PREFILL_MIN_N` exists to find it
+/// by measurement rather than assertion. It was: 2 reps/cell, coherence held —
+///   MIN_N=9: C=4 37.7 | C=8 53.4
+///   MIN_N=5: C=4 37.8 | C=8 **57.8**  (+8% at C=8, C=4 untouched)
+///   MIN_N=4: C=4 36.2 | C=8 57.8      (C=4 regresses — GEMV still wins at 4)
+/// So the tile GEMM overtakes the batch-8 GEMV at n=5, not n=9: eliminating the
+/// double weight read was only part of the win, the kernel is simply better per
+/// pass. 5 is the default; 4 is a measured regression; 9 was the conservative
+/// first guess.
+fn ssm_ffn_prefill_min_n() -> usize {
+    static N: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *N.get_or_init(|| {
+        std::env::var("ATLAS_SSM_FFN_PREFILL_MIN_N")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v| v >= 2)
+            .unwrap_or(5)
+    })
+}
+
+fn ssm_ffn_prefill_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_SSM_FFN_PREFILL").as_deref() != Ok("1"))
+}
+
 impl Qwen3SsmLayer {
     #[allow(clippy::too_many_arguments)]
     /// Multi-sequence decode for SSM (gated-delta-net) layers.
@@ -168,6 +204,75 @@ impl Qwen3SsmLayer {
                         h as u32,
                         stream,
                     )?;
+                }
+            }
+            // WIDE BATCH (n>8): one batched dense FFN, weights read ONCE.
+            //
+            // MEASURED 2026-07-27 (ATLAS_SSM_MS_PROFILE, 9168 samples/n): the
+            // chunked arm below costs 751 / 1023 / 2022 us per layer at
+            // n=4/8/16 — n=16 is 1.98x n=8, and FFN-per-sequence is FLAT from
+            // 8 to 16 (127.9 -> 126.3 us). That is the signature of the m<=8
+            // GEMV cap: above 8 the ~7.2 GB of FFN weights are streamed TWICE
+            // per step. A batched FFN is weight-bandwidth-bound, so n=16 should
+            // cost about what n=8 does. Worth ~1000us x 48 layers = ~48 ms of a
+            // 264.9 ms step.
+            //
+            // forward_prefill reads gate/up/down once for all n rows — the
+            // ATTENTION layers already take exactly this branch for dense
+            // models (multi_seq/ffn.rs, "WIDE-VERIFY BATCHED DENSE FFN"). This
+            // is that arm's SSM-side twin.
+            //
+            // n<=8 deliberately KEEPS the chunked GEMV: the recorded crossover
+            // has GEMV winning at M=4, and a single chunk reads the weights
+            // once anyway, so there is nothing to gain there.
+            //
+            // DENSE ONLY: on a 256-expert MoE the grouped-GEMM is a net loss at
+            // small batch (see the per-token arm below), so MoE keeps the loop.
+            n if n >= ssm_ffn_prefill_min_n()
+                && self.ffn.is_dense()
+                && ssm_ffn_prefill_enabled() =>
+            {
+                self.ffn.forward_prefill(normed_base, n, ctx, stream)?;
+                ops::residual_add(
+                    ctx.gpu,
+                    self.residual_add_k,
+                    hidden,
+                    ctx.buffers.moe_output(),
+                    (n * h) as u32,
+                    stream,
+                )?;
+            }
+            4.. if self.ffn.can_forward_km(8.min(n) as u32) => {
+                // MISSING n=4..8 ARM (2026-07-26) — the SSM-side twin of the
+                // attention ladder's 2026-07-24 K=4 gap (multi_seq/ffn.rs:100).
+                // The ladder fell from n==2/3 straight to the per-token loop,
+                // so C=4..8 decode streamed the full dense FFN weights n
+                // TIMES per layer. MS_PROFILE at C=4: 2632us/layer FFN vs
+                // 577us mixer = 63% of the step, 126ms of ~200ms across the
+                // 48-layer SSM stack. forward_km reads each projection ONCE
+                // for all n rows (batched GEMV, ~290 GB/s vs the loop's
+                // per-seq streams). Dense-only by construction:
+                // can_forward_km is false for MoE, which keeps the loop.
+                // n > 8 is processed in chunks of 8 (the batchm GEMV family
+                // caps at m=8): weights are read ceil(n/8) times instead of n.
+                // moe_output[0..m] is reused per chunk, so each chunk's
+                // residual add runs before the next chunk overwrites it.
+                let mut done = 0usize;
+                while done < n {
+                    let m = (n - done).min(8);
+                    let normed_c = normed_base.offset(done * h * bf16);
+                    let used = self.ffn.try_forward_km(normed_c, m as u32, ctx, stream)?;
+                    debug_assert!(used, "can_forward_km checked at branch entry");
+                    let hidden_c = hidden.offset(done * h * residual_elem);
+                    ops::residual_add(
+                        ctx.gpu,
+                        self.residual_add_k,
+                        hidden_c,
+                        ctx.buffers.moe_output(),
+                        (m * h) as u32,
+                        stream,
+                    )?;
+                    done += m;
                 }
             }
             _ => {

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched.rs
@@ -4,6 +4,44 @@
 
 use super::super::*;
 
+/// Tensor-core mixer projections for wide decode batches. **ON by default at
+/// n>=9**; `ATLAS_SSM_TC_PROJ=&lt;n&gt;` moves the threshold, `=0` disables.
+///
+/// WHY: the mixer's qkvz/out_proj run through `w4a16_gemv_batchm`, a SCALAR-FMA
+/// kernel. It reads the weights once for all n rows, but its arithmetic scales
+/// with n, so it stops being weight-bound at about M=3 and measures 2.3-3.0
+/// TFLOP/s at M=16. `w4a16_gemm_t` is an M64/N128 FP8-MMA tile GEMM on the
+/// SAME weights and is roughly flat in M. This is the same class of fix as the
+/// wide dense-FFN arm (+30% at C=16) applied to the other half of the mixer.
+///
+/// Costs nothing to try: `qkvz_nvfp4_t` / `out_proj_nvfp4_t` are transposed
+/// NVFP4 twins ALREADY built at load (init.rs) and already used by the SSM
+/// PREFILL path, so there is no repack, no new buffer and no extra VRAM.
+///
+/// MEASURED 2 reps/cell, coherence identical:
+///   GEMV (old):   C=8 57.8 | C=16 79.6
+///   TC n>=9:      C=8 57.6 | C=16 **86.9  (+9.2%)**
+///   TC n>=5:      C=8 54.9 (**regresses**) | C=16 86.4
+/// So the mixer's crossover is 9 — NOT the FFN's 5. Different shapes, different
+/// crossover; do not assume one transfers to the other.
+///
+/// ACCURACY DEBT: `w4a16_gemm_t` dequants the FP4 weight to E4M3 and converts
+/// the BF16 activations to E4M3 (W4A8) where the GEMV path is W4A16, so this
+/// CAN move a greedy token. It is the production SSM PREFILL path for these
+/// exact two weights, and the coherence smoke is identical, but a BFCL gate is
+/// owed before this merges. Read ONCE — this site runs under graph capture.
+fn ssm_tc_proj_min_n() -> Option<usize> {
+    static N: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
+    *N.get_or_init(
+        || match std::env::var("ATLAS_SSM_TC_PROJ").ok().as_deref() {
+            None => Some(9),
+            Some("0") => None,
+            Some("1") => Some(9),
+            Some(v) => v.parse::<usize>().ok().filter(|&x| x >= 2),
+        },
+    )
+}
+
 impl Qwen3SsmLayer {
     /// Batched-projection SSM mixer for N concurrent decode sequences.
     ///
@@ -40,7 +78,38 @@ impl Qwen3SsmLayer {
             || self.out_proj_dense.is_some()
             || self.qkvz_nvfp4.is_some();
         if n < 2 || !self.sequential_qkvz || !use_f32_conv || !use_f32_gdn || !qkvz_ok || !out_ok {
+            // Say WHY, once. Declining is silent otherwise, and the fallback
+            // re-streams the ~50 MB QKVZ/out_proj weights once per sequence —
+            // the difference between decode that scales with N and decode that
+            // does not. A whole campaign phase was spent measuring the symptom
+            // (SSM time linear in N) without knowing which condition failed.
+            if n >= 2 {
+                static WHY: std::sync::Once = std::sync::Once::new();
+                let (sq, fc, fg, qk, op) = (
+                    self.sequential_qkvz,
+                    use_f32_conv,
+                    use_f32_gdn,
+                    qkvz_ok,
+                    out_ok,
+                );
+                let nvfp4 = self.qkvz_nvfp4.is_some();
+                let b4 = self.w4a16_gemv_batch4_k.0 != 0;
+                WHY.call_once(|| {
+                    tracing::info!(
+                        "SSM batched projections DECLINED (n={n}): sequential_qkvz={sq} \
+                         f32_conv={fc} f32_gdn={fg} qkvz_ok={qk} out_ok={op} \
+                         [qkvz_nvfp4={nvfp4} w4a16_gemv_batch4={b4}] — falling back to the \
+                         per-seq loop, which re-reads QKVZ/out_proj weights n times"
+                    );
+                });
+            }
             return Ok(false);
+        }
+        {
+            static ON: std::sync::Once = std::sync::Once::new();
+            ON.call_once(|| {
+                tracing::info!("SSM batched projections ACTIVE — QKVZ/out_proj read once per step");
+            });
         }
 
         let h = ctx.config.hidden_size;
@@ -177,19 +246,36 @@ impl Qwen3SsmLayer {
                 )?;
             }
         } else if let Some(ref nvfp4) = self.qkvz_nvfp4 {
-            // FP4 batched QKVZ: ONE NVFP4 weight pass for all n seqs
-            // (sequential layout writes the deinterleaved buffer directly).
-            ops::w4a16_gemv_batchm(
-                ctx.gpu,
-                fp4_gemv_batch_k,
-                normed_base,
-                nvfp4,
-                deinterleaved,
-                n as u32,
-                qkvz_size as u32,
-                h as u32,
-                stream,
-            )?;
+            match (ssm_tc_proj_min_n(), self.qkvz_nvfp4_t.as_ref()) {
+                (Some(min_n), Some(nvfp4_t)) if n >= min_n => {
+                    // Tile GEMM on the transposed twin — the same call the SSM
+                    // prefill path makes on this same weight.
+                    ops::w4a16_gemm_n128(
+                        ctx.gpu,
+                        self.deep_k_gemm(h as u32),
+                        normed_base,
+                        nvfp4_t,
+                        deinterleaved,
+                        n as u32,
+                        qkvz_size as u32,
+                        h as u32,
+                        stream,
+                    )?;
+                }
+                // FP4 batched QKVZ: ONE NVFP4 weight pass for all n seqs
+                // (sequential layout writes the deinterleaved buffer directly).
+                _ => ops::w4a16_gemv_batchm(
+                    ctx.gpu,
+                    fp4_gemv_batch_k,
+                    normed_base,
+                    nvfp4,
+                    deinterleaved,
+                    n as u32,
+                    qkvz_size as u32,
+                    h as u32,
+                    stream,
+                )?,
+            }
         } else {
             ops::dense_gemm(
                 ctx.gpu,
@@ -294,20 +380,37 @@ impl Qwen3SsmLayer {
                 stream,
             )?;
         } else if self.qkvz_nvfp4.is_some() {
-            // FP4 batched out_proj: ONE NVFP4 weight pass for all n seqs.
-            // (qkvz_nvfp4.is_some() ⇒ the NVFP4 SSM build, where ssm.out_proj
-            // is the NVFP4 weight the per-seq path also uses via w4a16_gemv.)
-            ops::w4a16_gemv_batchm(
-                ctx.gpu,
-                fp4_gemv_batch_k,
-                normed_out_base,
-                &self.ssm.out_proj,
-                ssm_out_base,
-                n as u32,
-                h as u32,
-                value_dim as u32,
-                stream,
-            )?;
+            match (ssm_tc_proj_min_n(), self.out_proj_nvfp4_t.as_ref()) {
+                (Some(min_n), Some(nvfp4_t)) if n >= min_n => {
+                    // Tile GEMM on the transposed twin — mirrors the SSM
+                    // prefill out_proj call on this same weight.
+                    ops::w4a16_gemm_n128(
+                        ctx.gpu,
+                        self.deep_k_gemm(value_dim as u32),
+                        normed_out_base,
+                        nvfp4_t,
+                        ssm_out_base,
+                        n as u32,
+                        h as u32,
+                        value_dim as u32,
+                        stream,
+                    )?;
+                }
+                // FP4 batched out_proj: ONE NVFP4 weight pass for all n seqs.
+                // (qkvz_nvfp4.is_some() ⇒ the NVFP4 SSM build, where
+                // ssm.out_proj is the NVFP4 weight the per-seq path uses.)
+                _ => ops::w4a16_gemv_batchm(
+                    ctx.gpu,
+                    fp4_gemv_batch_k,
+                    normed_out_base,
+                    &self.ssm.out_proj,
+                    ssm_out_base,
+                    n as u32,
+                    h as u32,
+                    value_dim as u32,
+                    stream,
+                )?,
+            }
         }
         detail_step!("out_proj");
 

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched_recurrent.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched_recurrent.rs
@@ -5,6 +5,13 @@
 
 use super::super::*;
 
+/// How often the batched-recurrent fast path engaged vs fell back to the per-seq
+/// loop. The precondition (pool slots contiguous AND in slice order) fails as
+/// slots fragment, and it used to fail silently.
+static BATCHED_OK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static FALLBACK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static FALLBACK_ONCE: std::sync::Once = std::sync::Once::new();
+
 impl Qwen3SsmLayer {
     /// Recurrent inner of the batched-projection SSM mixer.
     ///
@@ -80,8 +87,38 @@ impl Qwen3SsmLayer {
                 }
             }
             if contiguous {
+                BATCHED_OK.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 Some((h_base, conv_base))
             } else {
+                // Falling back to the per-seq loop costs ~28% on this block
+                // (measured n=16: batched 618 us/layer vs per-seq 853). It used
+                // to happen SILENTLY, so a profile could show both paths in one
+                // run with no way to tell how often or why. Report the first
+                // one with the offending slot, and keep a count.
+                let n_fb = FALLBACK.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                FALLBACK_ONCE.call_once(|| {
+                    let mut broke_at = usize::MAX;
+                    let mut delta = 0i64;
+                    for i in 1..n {
+                        if let Some(st) = states[i].as_any_mut().downcast_mut::<SsmLayerState>() {
+                            let want = h_base.0 + (i * self.h_state_bytes) as u64;
+                            if st.h_state.0 != want {
+                                broke_at = i;
+                                delta = st.h_state.0 as i64 - want as i64;
+                                break;
+                            }
+                        }
+                    }
+                    tracing::info!(
+                        "SSM batched recurrent DECLINED (n={n}): pool slots are not contiguous in \
+                         slice order — seq {broke_at} sits {} slot(s) from where the batch axis \
+                         expects it. The per-seq loop costs ~28% more on this block. Slots \
+                         fragment as sequences finish, so this is expected to recur; count is \
+                         logged at debug on every occurrence.",
+                        delta / self.h_state_bytes.max(1) as i64
+                    );
+                });
+                tracing::debug!("SSM batched recurrent fallback #{n_fb} (n={n})");
                 None
             }
         } else {
@@ -112,33 +149,54 @@ impl Qwen3SsmLayer {
             detail_step!("recurrent_batched_ba");
 
             let conv_out = ctx.buffers.ssm_conv_out_f32();
-            // CONV INPUT-STRIDE FIX: the conv kernel strides its input by `dim`
-            // (= conv_dim), but `deinterleaved` (the QKVZ-projection output) is
-            // laid out [Q|K|V|Z] with stride `qkvz_size` (> conv_dim). A single
-            // batched launch (batch=n) would read seq b>=1 from `b*conv_dim`
-            // instead of `b*qkvz_size`, pulling in the previous seq's Z-gate
-            // region → garbage into the GDN scan (correct at n=1, corrupt at
-            // n>=2). Mirror the proven per-token pattern in
-            // `trait_decode_batched_conv_gdn.rs`: run the cheap conv per-seq
-            // (batch=1) with pre-offset pointers so the qkvz_size input stride
-            // and conv_dim output stride are both honored. The expensive GDN
-            // scan below stays fully batched.
-            for i in 0..n {
-                ops::conv1d_update_l2norm(
+            // CONV INPUT-STRIDE: the conv reads `deinterleaved` (the QKVZ
+            // projection output), whose rows are `qkvz_size` apart, and writes
+            // a `conv_dim`-strided FP32 row. The plain kernel hardcodes BOTH
+            // strides as `dim` (= conv_dim), so a batch=n launch would read
+            // seq b>=1 from `b*conv_dim` instead of `b*qkvz_size` — landing in
+            // the previous seq's Z-gate region and feeding garbage into the
+            // GDN scan (correct at n=1, silently corrupt at n>=2).
+            //
+            // The strided kernel takes both strides explicitly, so the whole
+            // batch goes in ONE launch. Kernel sets that predate it report
+            // handle 0; there we keep the per-seq loop with pre-offset
+            // pointers, which honours the same two strides one row at a time.
+            if self.conv1d_l2norm_f32_strided_k.0 != 0 {
+                ops::conv1d_update_l2norm_strided(
                     ctx.gpu,
-                    self.conv1d_l2norm_f32_k,
-                    conv_state_base.offset(i * self.conv_state_bytes),
-                    deinterleaved.offset(i * qkvz_size * bf16),
+                    self.conv1d_l2norm_f32_strided_k,
+                    conv_state_base,
+                    deinterleaved,
                     &self.ssm.conv1d,
-                    conv_out.offset(i * conv_dim as usize * 4), // FP32 output, conv_dim-strided
+                    conv_out,
                     conv_dim,
                     d_conv,
-                    1,
+                    n as u32,
                     qk_channels,
                     kd as u32,
                     1e-6,
+                    qkvz_size as u32, // input row stride (BF16 elements)
+                    conv_dim,         // output row stride (FP32 elements)
                     stream,
                 )?;
+            } else {
+                for i in 0..n {
+                    ops::conv1d_update_l2norm(
+                        ctx.gpu,
+                        self.conv1d_l2norm_f32_k,
+                        conv_state_base.offset(i * self.conv_state_bytes),
+                        deinterleaved.offset(i * qkvz_size * bf16),
+                        &self.ssm.conv1d,
+                        conv_out.offset(i * conv_dim as usize * 4), // FP32, conv_dim-strided
+                        conv_dim,
+                        d_conv,
+                        1,
+                        qk_channels,
+                        kd as u32,
+                        1e-6,
+                        stream,
+                    )?;
+                }
             }
             detail_step!("recurrent_batched_conv");
 
@@ -146,9 +204,24 @@ impl Qwen3SsmLayer {
                 && std::env::var("ATLAS_GDN_FUSED_NORM").ok().as_deref() == Some("1")
             {
                 let z_base = deinterleaved.offset((key_dim * 2 + value_dim) * bf16);
+                fn gdn_half_reg_enabled() -> bool {
+                    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+                    *ON.get_or_init(|| {
+                        std::env::var("ATLAS_NO_GDN_HALF_REG").ok().as_deref() != Some("1")
+                    })
+                }
+                let gdn_norm_k = if kd == 128
+                    && vd == 128
+                    && self.gdn_f32_strided_norm_half_k.0 != 0
+                    && gdn_half_reg_enabled()
+                {
+                    self.gdn_f32_strided_norm_half_k
+                } else {
+                    self.gdn_f32_strided_norm_k
+                };
                 ops::gdn_decode_f32_strided_norm(
                     ctx.gpu,
-                    self.gdn_f32_strided_norm_k,
+                    gdn_norm_k,
                     h_state_base,
                     conv_out,
                     conv_out.offset(key_dim * 4),

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_layer.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_layer.rs
@@ -68,7 +68,7 @@ impl TransformerLayer for Qwen3SsmLayer {
         hidden: DevicePtr,
         residual: DevicePtr,
         n_seqs: usize,
-        k: usize,
+        ks: &[usize],
         states: &'a mut [&'b mut (dyn LayerState + 'static)],
         _kv_cache: &mut PagedKvCache,
         wy_tables: DevicePtr,
@@ -76,16 +76,17 @@ impl TransformerLayer for Qwen3SsmLayer {
         stream: u64,
     ) -> Result<()> {
         anyhow::ensure!(
-            states.len() == n_seqs,
-            "decode_verify_multi: states/n mismatch"
+            states.len() == n_seqs && ks.len() == n_seqs,
+            "decode_verify_multi: states/ks/n mismatch"
         );
+        let num_tokens: usize = ks.iter().sum();
         self.decode_batched_inner(
             hidden,
             residual,
-            n_seqs * k,
+            num_tokens,
             super::trait_decode_batched::GdnStates::Multi {
                 states,
-                k,
+                ks,
                 wy_tables,
             },
             ctx,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_layer.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_layer.rs
@@ -45,11 +45,11 @@ impl TransformerLayer for Qwen3SsmLayer {
         residual: DevicePtr,
         num_tokens: usize,
         state: &mut dyn LayerState,
-        kv_cache: &mut PagedKvCache,
-        seq_len: usize,
-        block_table: &mut Vec<u32>,
-        disk_block_ids: &mut Vec<u32>,
-        disk_last_offloaded_per_layer: &mut Vec<u32>,
+        _kv_cache: &mut PagedKvCache,
+        _seq_len: usize,
+        _block_table: &mut Vec<u32>,
+        _disk_block_ids: &mut Vec<u32>,
+        _disk_last_offloaded_per_layer: &mut Vec<u32>,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
@@ -57,12 +57,37 @@ impl TransformerLayer for Qwen3SsmLayer {
             hidden,
             residual,
             num_tokens,
-            state,
-            kv_cache,
-            seq_len,
-            block_table,
-            disk_block_ids,
-            disk_last_offloaded_per_layer,
+            super::trait_decode_batched::GdnStates::Single(state),
+            ctx,
+            stream,
+        )
+    }
+
+    fn decode_verify_multi<'a, 'b: 'a>(
+        &self,
+        hidden: DevicePtr,
+        residual: DevicePtr,
+        n_seqs: usize,
+        k: usize,
+        states: &'a mut [&'b mut (dyn LayerState + 'static)],
+        _kv_cache: &mut PagedKvCache,
+        wy_tables: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            states.len() == n_seqs,
+            "decode_verify_multi: states/n mismatch"
+        );
+        self.decode_batched_inner(
+            hidden,
+            residual,
+            n_seqs * k,
+            super::trait_decode_batched::GdnStates::Multi {
+                states,
+                k,
+                wy_tables,
+            },
             ctx,
             stream,
         )

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -27,6 +27,19 @@ use crate::speculative::DraftProposer;
 use crate::traits::{ChunkedPrefillPageMetadata, Model, SequenceState};
 use crate::weight_map::{DenseWeight, MtpWeights, QuantizedWeight};
 
+/// lm_head tile-GEMM decode path: **ON by default**, disabled by
+/// `ATLAS_NO_LMHEAD_TGEMM=1`. Evaluated ONCE at construction — the switch
+/// decides whether the transposed twin is built at all, so setting it later has
+/// no effect. Presence-style check (`ATLAS_*=0` is NOT "off").
+///
+/// Measured C=16: 113.10 -> 119.32 tok/s (+5.50%, disjoint ranges, 4 reps).
+/// `padded_n <= 4` is untouched and stays byte-identical, so C=1 is unaffected.
+/// The twin costs ~681 MB and leaves the KV pool at 4759 blocks vs 4757 without
+/// it — no measurable KV impact.
+fn lmhead_tgemm_enabled() -> bool {
+    std::env::var("ATLAS_NO_LMHEAD_TGEMM").ok().as_deref() != Some("1")
+}
+
 impl TransformerModel {
     pub fn new(
         config: ModelConfig,
@@ -76,6 +89,23 @@ impl TransformerModel {
         let dense_gemv_fp32out_kernel = KernelHandle(0);
         let w4a16_gemv_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv")?;
         let w4a16_gemv_logits_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_logits")?;
+        // lm_head shares the tile GEMM, so route it through the same resolver as
+        // the SSM/attention sites — it picks the 3-deep pipeline variant when
+        // present. lm_head launches 1938 CTAs and already sits at ~83% of
+        // achievable, so the expected gain here is small; measured, not assumed.
+        let w4a16_gemm_t_kernel = crate::layers::tgemm_kernel(gpu.as_ref());
+        // Lossless BF16-MMA sibling for lm_head, OPT-IN via ATLAS_LMHEAD_LOSSLESS=1.
+        // Measured cost 1.81% at C=16 (129.68 -> 127.33). Default is the faster
+        // FP8-activation path because the accuracy question it addresses CANNOT
+        // BE MEASURED until vLLM parity lifts the BFCL embargo — and the 1.81%
+        // is throughput needed to REACH parity. The risk is real but indirect:
+        // the bf16-floor finding was superseded on the WEIGHT axis, and this is
+        // the ACTIVATION axis, which was never examined. Re-decide at parity.
+        let w4a16_gemm_t_bf16_kernel = if std::env::var("ATLAS_LMHEAD_LOSSLESS").is_ok() {
+            crate::layers::try_kernel(gpu.as_ref(), "w4a16", "w4a16_gemm_t_m128_bf16_v2")
+        } else {
+            spark_runtime::gpu::KernelHandle(0)
+        };
         let w4a16_gemm_kernel = gpu.kernel("w4a16", "w4a16_gemm")?;
         let w4a16_gemv_batch2_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?;
         // M<=4 batched GEMV for the K=3/K=4 verify lm_head (try_kernel:
@@ -86,6 +116,12 @@ impl TransformerModel {
         // try_kernel contract: 0-handle → dispatch falls back to the GEMM).
         let w4a16_gemv_batch8_kernel =
             crate::layers::try_kernel(gpu.as_ref(), "w4a16_gemv", "w4a16_gemv_batch8");
+        // M<=16 batched GEMV for the wide BATCHED-DECODE lm_head. The SSM mixer
+        // already carries this handle (qwen3_ssm/mod.rs); the model level did
+        // not, so the decode head had no arm above 8 and fell to the M64-tile
+        // GEMM. Same try_kernel contract: 0-handle -> dispatch falls back.
+        let w4a16_gemv_batch16_kernel =
+            crate::layers::try_kernel(gpu.as_ref(), "w4a16_gemv", "w4a16_gemv_batch16");
         // FP8 E4M3 LUT GEMV for the `--lm-head-dtype fp8` head. Loaded
         // unconditionally (a handle is cheap); only invoked when `lm_head_fp8`
         // is set, so the NVFP4/BF16 paths never touch it.
@@ -100,6 +136,9 @@ impl TransformerModel {
         );
         let dense_gemm_kernel = gpu.kernel("gemm", "dense_gemm_bf16")?;
         let argmax_kernel = gpu.kernel("argmax", "argmax_bf16")?;
+        let argmax_batch_kernel = gpu
+            .kernel("argmax", "argmax_bf16_batch")
+            .unwrap_or(spark_runtime::gpu::KernelHandle(0));
         let argmax_logits_kernel = gpu.kernel("argmax", "argmax_fp32")?;
         let batched_embed_kernel = gpu.kernel("embed_from_argmax", "batched_embed")?;
         let fill_slots_kernel = gpu.kernel("metadata_fill", "fill_slots_from_block_table")?;
@@ -248,6 +287,28 @@ impl TransformerModel {
 
         // MTP hidden state save buffer (1 × hidden_size FP32)
         let mtp_hidden_save = gpu.alloc(config.hidden_size * 4)?;
+        // Batched-verify hidden stash: [16, hidden] BF16 (n ≤ 16, the
+        // K-vs-batch ladder envelope — one slot per sequence of the widest
+        // batched verify chunk). Only meaningful with an MTP proposer — NULL
+        // otherwise (the batched verify path self-gates on it via
+        // can_batch_verify).
+        let verify_hidden_stash = if proposer.is_some() {
+            gpu.alloc(16 * config.hidden_size * 2)?
+        } else {
+            DevicePtr::NULL
+        };
+        // Batched-verify WY pointer-table staging (fixed address for CUDA
+        // graph stability; contents refreshed pre-graph every batched verify
+        // step). One [h|Hi0|Hi1|Hi2] x 4-entry slice per GDN layer — ~6 KB.
+        // NULL without an MTP proposer or on non-SSM models (path self-gates).
+        let verify_wy_tables = if proposer.is_some() && config.num_ssm_layers() > 0 {
+            let bytes = config.num_ssm_layers() * crate::layer::VERIFY_WY_LAYER_STRIDE_BYTES;
+            let buf = gpu.alloc(bytes)?;
+            gpu.memset(buf, 0, bytes)?;
+            buf
+        } else {
+            DevicePtr::NULL
+        };
         // Catch-up ring: 512 rows covers the gate's serial re-probe interval
         // (256 tokens) with 2x margin; ~4 MB at hidden 4096. Only allocated
         // when the staged feature is enabled.
@@ -494,12 +555,54 @@ impl TransformerModel {
         // value is dead code and must not suppress CUDA graphs.
         let has_fp8_calibration = config.fp8_kv_calibration_tokens > 0
             && kv_cache.dtype() == spark_runtime::kv_cache::KvCacheDtype::Fp8;
+        // Transposed lm_head twin, PADDED so the tile GEMM's 16-byte cp.async B
+        // loads are aligned. The stride must be a multiple of 16; 128 also keeps
+        // whole N-tiles. Without the pad, N = vocab = 248077 (ODD) misaligns 15 of
+        // every 16 k-rows => the campaign's long-standing sticky CUDA 716.
+        // Default ON (kill: ATLAS_NO_LMHEAD_TGEMM=1). KV impact is nil: the pool
+        // reads 4759 blocks with the twin vs 4757 without. See STATE.md.
+        let lm_head_nvfp4_t = match (&lm_head_nvfp4, lmhead_tgemm_enabled()) {
+            (Some(w), true) => {
+                let (t, stride) =
+                    crate::weight_map::QuantizedWeight::transpose_concat_for_gemm_padded(
+                        gpu.as_ref(),
+                        &[(w, config.vocab_size)],
+                        config.hidden_size,
+                        16,
+                        128,
+                    )?;
+                // A padded stride is only safe on targets whose `w4a16_gemm_t`
+                // actually takes `ldb`. Every served vocab except this one is a
+                // multiple of 128 (stride == vocab, so `ldb` is a no-op and any
+                // kernel is fine); when it is NOT, a kernel missing the parameter
+                // strides by N and shears every row past the first — silently, on
+                // architectures that tolerate the misalignment. Say so loudly.
+                if stride != config.vocab_size {
+                    tracing::warn!(
+                        "lm_head twin uses a PADDED stride ({} != vocab {}): this target's \
+                         w4a16_gemm_t MUST accept the `ldb` argument, or decode at padded_n>=5 \
+                         will read sheared rows. Disable with ATLAS_NO_LMHEAD_TGEMM=1.",
+                        stride,
+                        config.vocab_size
+                    );
+                }
+                tracing::info!(
+                    "lm_head transposed twin: vocab={} -> padded stride={} (vocab%16={}), tile GEMM active",
+                    config.vocab_size,
+                    stride,
+                    config.vocab_size % 16
+                );
+                Some((t, stride as u32))
+            }
+            _ => None,
+        };
         Ok(Self {
             config,
             embed_tokens,
             final_norm,
             lm_head_weight,
             lm_head_nvfp4,
+            lm_head_nvfp4_t,
             lm_head_fp8,
             layers,
             buffers,
@@ -512,19 +615,23 @@ impl TransformerModel {
             dense_gemv_fp32out_kernel,
             w4a16_gemv_kernel,
             w4a16_gemv_logits_kernel,
+            w4a16_gemm_t_kernel,
+            w4a16_gemm_t_bf16_kernel,
             w4a16_gemm_kernel,
             w4a16_gemv_batch2_kernel,
             w4a16_gemv_batch4_kernel,
             w4a16_gemv_batch8_kernel,
+            w4a16_gemv_batch16_kernel,
             dense_gemv_fp8w_kernel,
             dense_gemv_fp8w_batch2_kernel,
             dense_gemm_kernel,
             argmax_kernel,
+            argmax_batch_kernel,
             argmax_logits_kernel,
             batched_embed_kernel,
             fill_slots_kernel,
             decode_graph: Mutex::new(std::collections::HashMap::new()),
-            batch_decode_graphs: Mutex::new(HashMap::new()),
+            batch_decode_graphs: Mutex::new((HashMap::new(), 0)),
             // Suppress graphs during FP8 calibration only. MLA used to be
             // suppressed because an internal sync was placed inside the graph
             // capture region — that sync is now conditional on eager mode
@@ -548,6 +655,7 @@ impl TransformerModel {
             profile_first_pending: std::sync::atomic::AtomicBool::new(profile_first),
             proposer,
             mtp_hidden_save,
+            verify_hidden_stash,
             mtp_catchup_ring,
             mtp_catchup_meta: parking_lot::Mutex::new((0, 0)),
             mtp_prefill_hidden,
@@ -557,6 +665,7 @@ impl TransformerModel {
                 max_seq_len
             },
             mtp_prefill_capture_len: std::sync::atomic::AtomicUsize::new(0),
+            mtp_prefill_capture_gen: std::sync::atomic::AtomicU64::new(0),
             mtp_carry: parking_lot::Mutex::new(None),
             mtp_store_range: parking_lot::Mutex::new((0, 0)),
             dflash_hidden_save,
@@ -565,6 +674,8 @@ impl TransformerModel {
             verify2_graph: Mutex::new(std::collections::HashMap::new()),
             verify3_graph: Mutex::new(std::collections::HashMap::new()),
             verify4_graph: Mutex::new(std::collections::HashMap::new()),
+            verify_batched_graphs: Mutex::new((std::collections::HashMap::new(), 0)),
+            verify_wy_tables,
             verify_kgamma_graph: Mutex::new(std::collections::HashMap::new()),
             fused_graph: Mutex::new(std::collections::HashMap::new()),
             prefix_cache,

--- a/crates/spark-model/src/model/impl_a3.rs
+++ b/crates/spark-model/src/model/impl_a3.rs
@@ -27,6 +27,14 @@ use crate::speculative::DraftProposer;
 use crate::traits::{ChunkedPrefillPageMetadata, Model, SequenceState};
 use crate::weight_map::{DenseWeight, MtpWeights, QuantizedWeight};
 
+/// Presence kill switch for the wide (9..=32 row) batched LM head arm:
+/// `ATLAS_NO_LMHEAD_BATCHED_WIDE` restores the M64-tile `w4a16_gemm` fallback.
+/// Presence, not value — `=0` is NOT "off" (see `atlas_env_presence_check_trap`).
+fn lmhead_batched_wide_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_LMHEAD_BATCHED_WIDE").is_err())
+}
+
 impl TransformerModel {
     pub(super) fn embed(&self, token: u32, output: DevicePtr, stream: u64) -> Result<()> {
         let h = self.config.hidden_size;
@@ -66,6 +74,89 @@ impl TransformerModel {
             .arg_u32(n)
             .arg_f32(self.config.embed_scale)
             .launch(stream)
+    }
+
+    /// Wide batched LM head, `num_tokens` in 9..=32 — exactly the batched-verify
+    /// row regime (`can_batch_verify` bounds `n*k` at 32, and n=8/K=4 hits 32
+    /// dead on). Below 9 the existing GEMV ladder (batch2/4/8) already owns the
+    /// dispatch; above 32 no verify shape exists.
+    ///
+    /// Why it matters: every row count in that range fell through to the M64-tile
+    /// `w4a16_gemm`, whose own comment upstream documents the cost — nsys measured
+    /// **19.9 ms per verify step** on the [248320, 5120] NVFP4 head, ~33 GB/s
+    /// effective, because 94%+ of the M-tile is padding. The transposed-twin tile
+    /// GEMM streams the same 636 MB once at near-roofline. This is the identical
+    /// ladder `decode_a2` already runs at `padded_n >= 5`, so the verify head now
+    /// uses the SAME kernel as the non-speculative decode head it is standing in
+    /// for (it previously did not — a silent numerics divergence between the spec
+    /// and non-spec paths at the same batch width).
+    ///
+    /// Returns `false` when no wide kernel resolves (no NVFP4 head, no twin, no
+    /// batch16 handle), in which case the caller keeps today's `w4a16_gemm`.
+    fn lm_head_batched_wide(
+        &self,
+        hidden: DevicePtr,
+        num_tokens: u32,
+        logits: DevicePtr,
+        stream: u64,
+    ) -> Result<bool> {
+        let h = self.config.hidden_size as u32;
+        let v = self.config.vocab_size as u32;
+        let Some(ref nvfp4) = self.lm_head_nvfp4 else {
+            return Ok(false);
+        };
+        if let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t {
+            // LOSSLESS path (ATLAS_LMHEAD_LOSSLESS): BF16 MMA, no activation
+            // downcast. Mirrors decode_a2 so the two heads never disagree.
+            if self.w4a16_gemm_t_bf16_kernel.0 != 0 {
+                ops::w4a16_gemm_n128_m128_bf16_ldb(
+                    self.gpu.as_ref(),
+                    self.w4a16_gemm_t_bf16_kernel,
+                    hidden,
+                    nvfp4_t,
+                    logits,
+                    num_tokens,
+                    v,
+                    h,
+                    ldb,
+                    stream,
+                )?;
+                return Ok(true);
+            }
+            if self.w4a16_gemm_t_kernel.0 != 0 {
+                ops::w4a16_gemm_n128_ldb(
+                    self.gpu.as_ref(),
+                    self.w4a16_gemm_t_kernel,
+                    hidden,
+                    nvfp4_t,
+                    logits,
+                    num_tokens,
+                    v,
+                    h,
+                    ldb,
+                    stream,
+                )?;
+                return Ok(true);
+            }
+        }
+        // No twin (ATLAS_NO_LMHEAD_TGEMM): the M<=16 weight-streaming GEMV still
+        // beats the M64 tile. M=17..32 has no single-read form, so it keeps the
+        // GEMM rather than paying two full weight passes.
+        if num_tokens <= 16 && self.w4a16_gemv_batch16_kernel.0 != 0 {
+            ops::w4a16_gemv_batchm(
+                self.gpu.as_ref(),
+                self.w4a16_gemv_batch16_kernel,
+                hidden,
+                nvfp4,
+                logits,
+                num_tokens,
+                v,
+                h,
+                stream,
+            )?;
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     /// LM head for K tokens: hidden[K, H] → logits[K, V].
@@ -190,6 +281,11 @@ impl TransformerModel {
                 h,
                 stream,
             )?;
+        } else if (9..=32).contains(&num_tokens)
+            && lmhead_batched_wide_enabled()
+            && self.lm_head_batched_wide(hidden, num_tokens, logits, stream)?
+        {
+            // Handled by the wide arm; nothing launched when it returns false.
         } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
             ops::w4a16_gemm(
                 self.gpu.as_ref(),

--- a/crates/spark-model/src/model/impl_lora.rs
+++ b/crates/spark-model/src/model/impl_lora.rs
@@ -207,8 +207,9 @@ impl TransformerModel {
             "batch_decode_graph",
             self.batch_decode_graphs
                 .lock()
+                .0
                 .drain()
-                .map(|(_, g)| g)
+                .map(|(_, (g, _))| g)
                 .collect(),
         );
         drain(

--- a/crates/spark-model/src/model/mtp_carry.rs
+++ b/crates/spark-model/src/model/mtp_carry.rs
@@ -59,8 +59,47 @@ use spark_runtime::gpu::DevicePtr;
 /// so carry alone is inert, and prefill without carry is a measured −927
 /// ms/turn loss. [`crate::model::drafter_context`] resolves both together and
 /// is the single source of truth for the policy and its kill switch.
+/// Minimum MATCHED prefix (tokens) before the Marconi SSM snapshot skip is worth
+/// taking. Below this, take the KV-only path instead.
+///
+/// # Why a floor exists at all
+///
+/// Restoring an SSM snapshot skips the target's prefill, so
+/// `mtp_prefill_capture_len` stays 0, the `captured >= prompt_len` guard at
+/// `speculative.rs:194` fails, `prefill_drafter` is skipped and the drafter
+/// starts EMPTY (the defect this module's carry closes for SAME-SESSION turns —
+/// but a fresh request matching only a shared chat-template preamble has no
+/// previous turn to carry from, so carry cannot fire).
+///
+/// Measured at C=1, identical-prompt reps (full-prompt hits), warm reps vs
+/// caching-off, 2026-07-28:
+/// ```text
+///    99 matched tokens   23.85 vs 26.4   -9.7%   LOSS
+///   219 matched tokens   24.15 vs 22.0   +9.8%   WIN
+///   349 matched tokens   23.55 vs 21.9   +7.5%
+///   629 matched tokens   22.45 vs 20.3  +10.6%
+/// ```
+/// The crossover is SHARP, between ~99 and ~219. 256 sits inside the win region
+/// and is block-aligned (16 x 16-token blocks). On preamble-only traffic the
+/// penalty was -6.8% at C=1 and -9.2% at C=2, and inert by C=4.
+///
+/// `ATLAS_MARCONI_MIN_TOKENS=<n>` overrides; 0 restores the previous
+/// always-restore behaviour.
+pub fn marconi_min_tokens() -> usize {
+    static MIN: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *MIN.get_or_init(|| {
+        std::env::var("ATLAS_MARCONI_MIN_TOKENS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(256)
+    })
+}
+
 pub fn mtp_carry_drafter_enabled() -> bool {
-    crate::model::drafter_context::config().carry
+    // Force-off in multi-seq MTP mode: the carry slot is single-sequence by
+    // design (one slot, `active.len() == 1` assumption). See
+    // `speculative::mtp_multi_seq_mode` for the contract.
+    crate::model::drafter_context::config().carry && !crate::speculative::mtp_multi_seq_mode()
 }
 
 /// `ATLAS_MTP_CARRY_DEBUG=1` — one line per adopt/carry decision. Cheap (no

--- a/crates/spark-model/src/model/nllb/model_impl.rs
+++ b/crates/spark-model/src/model/nllb/model_impl.rs
@@ -178,6 +178,7 @@ impl Model for NllbGpuModel {
             marconi_skip_to: 0,
             marconi_exact_snap: None,
             session_hash: 0,
+            mtp_capture_gen: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
             kv_valid_tokens: 0,

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -20,6 +20,26 @@ use crate::layer::{ForwardContext, LayerState, SsmLayerState};
 use crate::layers::ops;
 use crate::traits::{Model, SequenceState};
 
+/// Multi-seq decode CUDA graphs: **ON by default**, disabled by
+/// `ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1`.
+///
+/// Strict `== "1"` on an `ATLAS_NO_*` name rather than a presence check —
+/// presence-checked flags here are ENABLED by `=0`. Read once per process.
+fn multiseq_graphs_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_DECODE_GRAPHS_MULTISEQ").as_deref() != Ok("1"))
+}
+
+/// Batched-GEMV decode lm_head: **ON by default**, disabled by
+/// `ATLAS_NO_LM_HEAD_BATCH_GEMV=1`.
+///
+/// Strict `== "1"` on an `ATLAS_NO_*` name, not a presence check — presence
+/// flags in this codebase are ENABLED by `=0`. Read once; this is a per-step site.
+fn lm_head_batch_gemv_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_LM_HEAD_BATCH_GEMV").as_deref() != Ok("1"))
+}
+
 impl TransformerModel {
     pub(super) fn decode_batch_dispatch(
         &self,
@@ -30,9 +50,10 @@ impl TransformerModel {
         let n = tokens.len();
         assert_eq!(n, seqs.len(), "tokens.len() must equal seqs.len()");
 
-        // Single-sequence: delegate to decode() which uses CUDA graphs.
-        // decode_batch disables graphs for n≥2 (SSM state pointer staleness),
-        // but n=1 is safe and benefits from graph replay (2x throughput).
+        // Single-sequence: delegate to decode() which uses its own slot-keyed
+        // graph cache. (Stale comment removed: n>=2 is ALSO graphed — see the
+        // slot-vector-keyed `batch_decode_graphs` in decode_batch_compute_main,
+        // default-ON since 2026-07-27.)
         //
         // Broadcast the seq_id preamble + cmd here (rather than in the
         // scheduler) so the EP n>1 branch below can interleave broadcasts
@@ -200,30 +221,26 @@ impl TransformerModel {
 
         // CUDA graphs for multi-sequence decode (ATLAS_DECODE_GRAPHS_MULTISEQ=1).
         //
-        // The historical concern was that SSM h_state/conv_state pointers get
-        // baked into per-seq kernel args at capture, going stale when batch
-        // composition changes. That does NOT happen here: the scheduler holds
-        // the invariant that active sequences occupy contiguous SSM pool slots
-        // [0..n) in batch order (compact_sequence migrates survivors), verified
-        // empirically (slots always == [0,1,..,n-1]). So position i's state is
-        // ALWAYS at pool_base + i*stride — a fixed address baked correctly at
-        // capture; replay reads whatever sequence currently occupies slot i.
-        // Pad positions use the fixed dummy slot. Attention metadata, KV block
-        // tables, embed, and all scratch buffers are at fixed device addresses
-        // refreshed every step BEFORE replay. So a graph keyed by padded_n is
-        // valid across replays. This is the dominant lever for n>=2 decode
-        // (eliminates ~1500 kernel launches/step). Opt-in until soaked; flip
-        // the default once validated. Verify correctness with the needle test.
+        // SSM h_state/conv_state pointers ARE baked into per-seq kernel args at
+        // capture, so the cache is keyed by the per-row SSM slot VECTOR — see
+        // `decode_graph_key.rs` for why the former `padded_n` key was unsound.
+        // Everything else captured (metadata, block tables, embed, scratch) is
+        // a fixed address refreshed every step BEFORE replay. This is the
+        // dominant lever for n>=2 decode (eliminates ~1500 launches/step).
+        //
+        // DEFAULT-ON since 2026-07-27; disable with
+        // ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1. Measurements + the rewrite this
+        // retired: `decode_graph_key.rs`.
         let ms_profile = std::env::var("ATLAS_MS_PROFILE").ok().as_deref() == Some("1");
         // ATLAS_MS_PROFILE forces eager (graphs off) so per-phase syncs are legal.
         // ATLAS_LORA_EAGER: same LoRA graph-vs-eager debugging hatch as decode_a.
         let lora_eager = self.lora.is_some() && crate::lora::lora_eager_env();
-        let use_graphs = !ms_profile
-            && !lora_eager
-            && std::env::var("ATLAS_DECODE_GRAPHS_MULTISEQ")
-                .ok()
-                .as_deref()
-                == Some("1");
+        let graph_key = if !ms_profile && !lora_eager && multiseq_graphs_enabled() {
+            self.batch_decode_graph_key(&*seqs, padded_n)
+        } else {
+            None
+        };
+        let use_graphs = graph_key.is_some();
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -246,9 +263,20 @@ impl TransformerModel {
             None
         };
 
-        if let Some(ref graphs) = graphs
-            && let Some(&graph) = graphs.get(&padded_n)
-        {
+        // LRU touch on hit: bump the tick so eviction always removes the
+        // least-recently-replayed slot vector.
+        let cached = match (&mut graphs, &graph_key) {
+            (Some(g), Some(key)) => {
+                g.1 += 1;
+                let tick = g.1;
+                g.0.get_mut(key).map(|e| {
+                    e.1 = tick;
+                    e.0
+                })
+            }
+            _ => None,
+        };
+        if let Some(graph) = cached {
             // Graph exists — replay (kernels use updated metadata + SSM pool addresses)
             if graph.0 != 0 {
                 self.gpu.launch_graph(graph, stream)?;
@@ -426,17 +454,91 @@ impl TransformerModel {
                     )?;
                 }
             } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
-                ops::w4a16_gemm(
-                    self.gpu.as_ref(),
-                    self.w4a16_gemm_kernel,
-                    normed,
-                    nvfp4,
-                    logits,
-                    padded_n as u32,
-                    v as u32,
-                    h as u32,
-                    stream,
-                )?;
+                // Batched GEMV for the decode head. The base M64-tile
+                // `w4a16_gemm` below wastes most of its MMA tile here: at
+                // padded_n=16 only 16 of 64 tile-rows carry data, and the same
+                // nsys note the verify path records (impl_a3.rs) measured it at
+                // 19.3 ms on this [248320, 5120] NVFP4 head vs ~2.5 ms for the
+                // batched GEMV streaming the same 636 MB once. That cost is
+                // FLAT in n, so it sits in the fixed term at every batch size.
+                //
+                // Tier by padded_n exactly as the SSM mixer does: batch4 (M<=4)
+                // / batch8 (M<=8) / batch16 (M<=16). A 0-handle on any tier
+                // falls through to the GEMM, so targets lacking the kernel are
+                // unaffected.
+                // Tile GEMM at padded_n >= 5 over the PADDED transposed twin.
+                // padded_n <= 4 stays on the GEMV, which measures 3174 us =
+                // 226 GB/s = 98.3% of the memory roofline on this shape and is
+                // therefore unimprovable; the tile GEMM LOSES there.
+                if padded_n >= 5
+                    && self.w4a16_gemm_t_bf16_kernel.0 != 0
+                    && let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t
+                {
+                    // LOSSLESS path: BF16 MMA, no activation downcast.
+                    ops::w4a16_gemm_n128_m128_bf16_ldb(
+                        self.gpu.as_ref(),
+                        self.w4a16_gemm_t_bf16_kernel,
+                        normed,
+                        nvfp4_t,
+                        logits,
+                        padded_n as u32,
+                        v as u32,
+                        h as u32,
+                        ldb,
+                        stream,
+                    )?;
+                } else if padded_n >= 5
+                    && self.w4a16_gemm_t_kernel.0 != 0
+                    && let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t
+                {
+                    ops::w4a16_gemm_n128_ldb(
+                        self.gpu.as_ref(),
+                        self.w4a16_gemm_t_kernel,
+                        normed,
+                        nvfp4_t,
+                        logits,
+                        padded_n as u32,
+                        v as u32,
+                        h as u32,
+                        ldb,
+                        stream,
+                    )?;
+                } else {
+                    let gemv_k = if padded_n <= 4 {
+                        self.w4a16_gemv_batch4_kernel
+                    } else if padded_n <= 8 {
+                        self.w4a16_gemv_batch8_kernel
+                    } else if padded_n <= 16 {
+                        self.w4a16_gemv_batch16_kernel
+                    } else {
+                        spark_runtime::gpu::KernelHandle(0)
+                    };
+                    if gemv_k.0 != 0 && lm_head_batch_gemv_enabled() {
+                        ops::w4a16_gemv_batchm(
+                            self.gpu.as_ref(),
+                            gemv_k,
+                            normed,
+                            nvfp4,
+                            logits,
+                            padded_n as u32,
+                            v as u32,
+                            h as u32,
+                            stream,
+                        )?;
+                    } else {
+                        ops::w4a16_gemm(
+                            self.gpu.as_ref(),
+                            self.w4a16_gemm_kernel,
+                            normed,
+                            nvfp4,
+                            logits,
+                            padded_n as u32,
+                            v as u32,
+                            h as u32,
+                            stream,
+                        )?;
+                    }
+                }
             } else {
                 ops::dense_gemm(
                     self.gpu.as_ref(),
@@ -469,9 +571,11 @@ impl TransformerModel {
             if use_graphs {
                 let graph = self.gpu.end_capture(stream)?;
                 if graph.0 != 0 {
-                    tracing::info!("Captured CUDA graph for batch size {padded_n}");
-                    if let Some(ref mut g) = graphs {
-                        g.insert(padded_n, graph);
+                    tracing::info!(
+                        "Captured CUDA graph for batch size {padded_n} (n={n}, slots={graph_key:?})"
+                    );
+                    if let (Some(g), Some(key)) = (graphs.as_mut(), graph_key.clone()) {
+                        self.insert_batch_decode_graph(g, key, graph);
                     }
                     self.gpu.launch_graph(graph, stream)?;
                 }

--- a/crates/spark-model/src/model/trait_impl/decode_b.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b.rs
@@ -442,6 +442,23 @@ impl TransformerModel {
         // keeps its own same-stream (prefill_stream) every-chunk normalize.
         self.normalize_ssm_states_dispatch(prefill_seq, stream)?;
 
+        // ATLAS_MTP_DRAFTER_PREFILL: capture this chunk's final-layer hidden
+        // rows for the whole-prompt drafter prefill — the standard prefill
+        // paths have always done this, the mixed path never did, so requests
+        // 3..n of a concurrent group (which take this path, since
+        // `spec_step_this_tick` only holds at `active.len() == 1`) drafted
+        // blind. ★ The SOURCE is `prefill_hidden`, not the buffer head: the
+        // mixed layout is [decode rows | prefill rows] and capturing from the
+        // head would store DECODE hiddens as this sequence's prompt hiddens
+        // (poison, not blindness).
+        self.try_mtp_prefill_capture_from(
+            prefill_seq,
+            effective_seq_len_start,
+            proc_count,
+            prefill_hidden,
+            stream,
+        )?;
+
         // Restore decode layer_states to sequences
         for (seq, ls) in decode_seqs
             .iter_mut()

--- a/crates/spark-model/src/model/trait_impl/decode_graph_key.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_graph_key.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Multi-sequence decode CUDA-graph cache keying (`decode_a2.rs` helpers).
+//!
+//! A captured batched-decode graph bakes exactly ONE class of per-sequence
+//! device address: the SSM `h_state` / `conv_state` pointers of each row's
+//! layer states (`trait_impl/sequence.rs` states this explicitly; attention
+//! layers hand out `EmptyLayerState`, and every other captured address —
+//! hidden/residual/logits/scratch, attention metadata, KV block tables — is a
+//! fixed buffer refreshed BEFORE replay). Those pointers are a pure function
+//! of the row's SSM pool slot, so the slot VECTOR is the exact graph key.
+//!
+//! It replaced a `padded_n`-only key, which was sound only under the
+//! scheduler invariant "active sequences occupy contiguous SSM pool slots
+//! [0..n) in batch order" AND `n == padded_n`. Two live callers break it:
+//!
+//! * the **MTP Phase-A bootstrap** (`mtp_bootstrap_step.rs`) passes a SUBSET
+//!   of the active set (the draftless sequences, sorted by slot), e.g. slots
+//!   `{0,2,5}` — a graph captured for that subset would then be replayed for
+//!   a different subset, or for the full batch, with the first subset's GDN
+//!   state pointers baked in: silent cross-sequence state corruption;
+//! * any `n < padded_n` batch, whose rows `n..padded_n` bake the *dummy* slot
+//!   — replaying that graph at a larger `n` runs a real sequence's row into
+//!   the dummy slot (its recurrent state never advances), and the converse
+//!   replay writes a real slot that is not in this batch.
+//!
+//! Both were masked in the concurrency benchmark by the blanket cache drain
+//! in `free_sequence` (every completion empties the map), and both are
+//! reachable under continuous load. Keying on the slot vector makes replay
+//! correct by construction instead of by invariant.
+//!
+//! Multi-seq decode graphs are DEFAULT-ON since 2026-07-27
+//! (`ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1` disables), validated: C=8
+//! 65.75 -> 67.6 (+2.8%), C=16 92.6 -> 95.6 (+3.2%), emitted-text SHA
+//! unchanged, 2 reps/cell. That measurement RETIRED a planned rewrite: the
+//! attention branch has ~2,300 per-sequence launches/step and hand-batching
+//! them was estimated at 4-9 ms; graphs capture all of them wholesale for
+//! +3.2%, so the individual batching work cannot beat what the flag already
+//! gets. (Batching the gate-mul by hand beforehand measured flat.)
+
+use spark_runtime::gpu::{GpuBackend, GraphHandle};
+use std::collections::HashMap;
+
+use super::super::types::TransformerModel;
+use crate::traits::SequenceState;
+
+/// Bound on cached batched-decode graphs (one per distinct SSM-slot vector).
+/// Slot vectors churn as sequences finish; at the cap the least-recently-used
+/// graph is destroyed and replaced, so the cap bounds graph memory without
+/// ever pinning the path eager (the `verify_batched_graphs` LRU precedent —
+/// an insert-only cache goes permanently eager on a long serve).
+pub(super) const BATCH_DECODE_GRAPH_CAP: usize = 32;
+
+/// Graph the batches the padded_n-keyed cache could not legally cover — the
+/// MTP bootstrap's slot SUBSET and any `n < padded_n` batch: **ON** by
+/// default, disabled by PRESENCE of `ATLAS_NO_MTP_BOOT_GRAPH` (house
+/// convention — `=0` is NOT off). Disabled, those batches run EAGER and only
+/// the canonical `slots == [0..n)` with `n == padded_n` batch is graphed,
+/// which is the pre-slot-key behaviour minus its unsound replays.
+/// Read once per process.
+pub(super) fn boot_graph_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_BOOT_GRAPH").is_none())
+}
+
+impl TransformerModel {
+    /// Batched-decode graph key: each row's SSM pool slot in batch order,
+    /// `padded_n` entries long (rows `n..padded_n` bake the dummy slot, so
+    /// they carry it). The length encodes `padded_n`; the entries encode
+    /// every per-sequence pointer a capture bakes.
+    ///
+    /// Models with no SSM layers bake nothing per-sequence (their layer
+    /// states are empty), so they keep a single-entry `[padded_n]` key —
+    /// byte-identical cache behaviour to the old `padded_n` map. Length 1 vs
+    /// length `padded_n >= 2` keeps the two families from colliding.
+    ///
+    /// `None` → run eager: an SSM model whose row has no pool slot has
+    /// per-SEQUENCE layer-state pointers that no slot vector can describe.
+    pub(super) fn batch_decode_graph_key(
+        &self,
+        seqs: &[&mut SequenceState],
+        padded_n: usize,
+    ) -> Option<Vec<u32>> {
+        if self.config.num_ssm_layers() == 0 {
+            return Some(vec![padded_n as u32]);
+        }
+        let n = seqs.len();
+        let mut key: Vec<u32> = Vec::with_capacity(padded_n);
+        for s in seqs.iter() {
+            match s.ssm_slot_idx() {
+                Some(idx) => key.push(idx as u32),
+                None => {
+                    static WARNED: std::sync::Once = std::sync::Once::new();
+                    WARNED.call_once(|| {
+                        tracing::warn!(
+                            "multi-seq decode graphs OFF for this step: a sequence has no SSM \
+                             pool slot, so its baked layer-state pointers are per-sequence"
+                        );
+                    });
+                    return None;
+                }
+            }
+        }
+        let dummy = self.ssm_pool.dummy_slot() as u32;
+        for _ in n..padded_n {
+            key.push(dummy);
+        }
+        // Kill switch: keep ONLY the canonical batch graphed.
+        if !boot_graph_enabled()
+            && (n != padded_n || key.iter().enumerate().any(|(i, &s)| s != i as u32))
+        {
+            return None;
+        }
+        Some(key)
+    }
+
+    /// Insert a freshly captured graph, evicting the least-recently-used
+    /// entry at [`BATCH_DECODE_GRAPH_CAP`].
+    ///
+    /// Destroying the evicted graph is safe: the scheduler consumes every
+    /// decode step's logits with a blocking D2H before submitting the next
+    /// step, so no earlier replay is still in flight on this stream (the
+    /// `verify_batched_graphs` eviction argument).
+    pub(super) fn insert_batch_decode_graph(
+        &self,
+        cache: &mut (HashMap<Vec<u32>, (GraphHandle, u64)>, u64),
+        key: Vec<u32>,
+        graph: GraphHandle,
+    ) {
+        if cache.0.len() >= BATCH_DECODE_GRAPH_CAP
+            && let Some(evict) = cache
+                .0
+                .iter()
+                .min_by_key(|(_, entry)| entry.1)
+                .map(|(k, _)| k.clone())
+            && let Some((old, _)) = cache.0.remove(&evict)
+            && let Err(e) = self.gpu.destroy_graph(old)
+        {
+            tracing::warn!("batched-decode graph evict: {e:#}");
+        }
+        cache.1 += 1;
+        let tick = cache.1;
+        cache.0.insert(key, (graph, tick));
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/drafter_prefill.rs
+++ b/crates/spark-model/src/model/trait_impl/drafter_prefill.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Whole-prompt drafter context: the capture write and its EAGER consume.
+//!
+//! # The defect this file closes (measured recon, 2026-07-28)
+//!
+//! `mtp_prefill_hidden` is ONE shared slot stamped with a generation
+//! (`mtp_prefill_capture_gen`). The consume used to live at the first
+//! `propose` of a sequence (`ensure_drafter_context`), which is one or more
+//! scheduler ticks after that sequence's prefill. At C >= 2 the sequences
+//! prefill back-to-back, so by the time sequence `k` proposes, sequence
+//! `k+1`'s prefill has already restarted the capture — the ownership stamp
+//! then correctly refuses to build drafter KV from another sequence's
+//! hiddens ("blind beats poisoned"), and every sequence but the LAST-prefilled
+//! one runs a drafter that never saw its prompt.
+//!
+//! Worse, since `e793d1c5` ("fix the can_mix spec gate") a `--speculative`
+//! serve takes the MIXED path for requests 3..n
+//! (`run_standard.rs`: `spec_step_this_tick = active.len() == 1`), and
+//! `mixed_forward_dispatch` never captured at all. At C=8 that is ~6 of 8
+//! sequences drafting blind.
+//!
+//! # The fix
+//!
+//! Two halves, both behind `ATLAS_NO_MTP_EAGER_DRAFTER` (PRESENCE):
+//!
+//! 1. `try_mtp_prefill_capture_from` — the capture body, parameterised by the
+//!    SOURCE pointer, so the mixed path can hand it the prefill rows (which
+//!    live at `hidden + padded_n * h`, NOT at the head of the buffer: copying
+//!    from the head there would capture the DECODE rows, i.e. poison rather
+//!    than blindness).
+//! 2. `try_eager_drafter_prefill` — consume the capture at the END of the
+//!    sequence's own prefill, while it provably still owns the generation
+//!    stamp. Called from the `Model` trait wrappers in `mod.rs` (the single
+//!    funnel all four prefill entry points pass through) AFTER the dispatch
+//!    returns, so `seq.tokens` / `seq.prompt_len` are already updated.
+//!
+//! Nothing about the guard set changes: `ensure_drafter_context` still
+//! enforces `captured >= prompt_len`, the ownership stamp, and first-propose.
+//! Moving it earlier only means the guards can now PASS for more than one
+//! sequence per serve. The propose-site call stays (it is the WARM-turn carry
+//! entry point and a no-op once the drafter owns rows).
+//!
+//! Cost: `prefill_drafter` is ~0.095 ms/row and now runs inside TTFT instead
+//! of inside the first decode step. It fires only when the capture covers the
+//! whole prompt — i.e. exactly the COLD-turn case that already paid it one
+//! tick later. A warm turn (prefix reuse / Marconi restore) leaves the capture
+//! short, so this adds nothing to the ~1136 ms warm rebuild trap documented in
+//! `mtp_carry`.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::super::types::TransformerModel;
+use crate::layer::ForwardContext;
+use crate::traits::SequenceState;
+
+/// `ATLAS_NO_MTP_EAGER_DRAFTER` (PRESENCE): restore the propose-site-only
+/// consume, i.e. the pre-fix behaviour where only the last-prefilled sequence
+/// of a concurrent group can prefill its drafter.
+pub fn eager_drafter_disabled() -> bool {
+    static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OFF.get_or_init(|| std::env::var("ATLAS_NO_MTP_EAGER_DRAFTER").is_ok())
+}
+
+impl TransformerModel {
+    /// ATLAS_MTP_DRAFTER_PREFILL: copy this prefill chunk's final-layer
+    /// hiddens (`[proc_count, h]` BF16, contiguous at the head of the hidden
+    /// buffer) into the whole-prompt capture at row `chunk_start`.
+    ///
+    /// Contiguity-tracked: `chunk_start == 0` (re)starts the capture; a chunk
+    /// extending the current range appends; anything else (prefix-cache
+    /// reuse, Marconi warm restore — rows whose hiddens were never computed)
+    /// leaves the tracked length short, which safely disables the drafter
+    /// prefill for that sequence via the coverage check at the consume site.
+    pub(super) fn try_mtp_prefill_capture(
+        &self,
+        seq: &mut SequenceState,
+        chunk_start: usize,
+        proc_count: usize,
+        stream: u64,
+    ) -> Result<()> {
+        self.try_mtp_prefill_capture_from(
+            seq,
+            chunk_start,
+            proc_count,
+            self.buffers.hidden_states(),
+            stream,
+        )
+    }
+
+    /// [`Self::try_mtp_prefill_capture`] with an explicit SOURCE pointer.
+    ///
+    /// The mixed forward lays out `[decode rows | prefill rows]`, so its
+    /// prefill hiddens start at `hidden + padded_n * h * 2` — passing the
+    /// buffer head there would capture decode rows.
+    pub(super) fn try_mtp_prefill_capture_from(
+        &self,
+        seq: &mut SequenceState,
+        chunk_start: usize,
+        proc_count: usize,
+        src: DevicePtr,
+        stream: u64,
+    ) -> Result<()> {
+        if self.mtp_prefill_hidden.is_null() || proc_count == 0 {
+            return Ok(());
+        }
+        use std::sync::atomic::Ordering;
+        if chunk_start + proc_count > self.mtp_prefill_capacity {
+            return Ok(());
+        }
+        let len = self.mtp_prefill_capture_len.load(Ordering::Relaxed);
+        // Ownership: the capture buffer is a SINGLE shared slot. Chunk 0
+        // claims it under a fresh generation; an append is valid only while
+        // this sequence still owns the current generation — at C>=2 another
+        // sequence's chunk 0 may have restarted the capture in between, and
+        // appending onto foreign rows would pair mixed hiddens under one
+        // contiguous length. Mismatch leaves the length stale-short, which
+        // safely disables the drafter prefill (coverage check at consume).
+        let contiguous_from_zero = if chunk_start == 0 {
+            let generation = self.mtp_prefill_capture_gen.fetch_add(1, Ordering::Relaxed) + 1;
+            seq.mtp_capture_gen = generation;
+            Some(proc_count)
+        } else if chunk_start == len
+            && seq.mtp_capture_gen != 0
+            && seq.mtp_capture_gen == self.mtp_prefill_capture_gen.load(Ordering::Relaxed)
+        {
+            Some(len + proc_count)
+        } else {
+            None
+        };
+        // ATLAS_MTP_CARRY_DRAFTER: a warm turn's chunk starts at the reused-
+        // prefix boundary, which the contiguous-from-zero tracker above must
+        // reject (its consumer prefills the drafter from row 0). The carry
+        // path consumes the SAME buffer position-indexed, so it wants the
+        // write regardless of where the chunk starts — the rows are still
+        // `hidden_i` at absolute row `i`. Note the SOURCE is this chunk's
+        // rows, only the DESTINATION is absolute.
+        let carry_on = crate::model::mtp_carry::mtp_carry_drafter_enabled();
+        if contiguous_from_zero.is_none() && !carry_on {
+            return Ok(());
+        }
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        self.gpu.copy_d2d_async(
+            src,
+            self.mtp_prefill_hidden.offset(chunk_start * h * bf16),
+            proc_count * h * bf16,
+            stream,
+        )?;
+        if let Some(new_len) = contiguous_from_zero {
+            self.mtp_prefill_capture_len
+                .store(new_len, Ordering::Relaxed);
+        }
+        if carry_on {
+            let mut r = self.mtp_store_range.lock();
+            *r = crate::model::mtp_carry::merge_interval(*r, chunk_start, proc_count);
+        }
+        Ok(())
+    }
+
+    /// Consume the whole-prompt capture at the END of this sequence's prefill,
+    /// while it provably still owns the capture generation.
+    ///
+    /// `is_last` is the caller's last-chunk flag: a mid-chunk call would only
+    /// build partial drafter rows and then permanently block the full prefill
+    /// (`prefill_drafter` fast-returns once the drafter owns rows).
+    ///
+    /// Runs on the SAME `stream` the prefill used, so it is ordered after the
+    /// capture copy it reads. Cross-stream visibility to the later propose is
+    /// the pre-existing contract (the propose-site consume already read this
+    /// buffer from `default_stream`).
+    ///
+    /// Never fails a prefill: a drafter with fewer rows costs acceptance, not
+    /// correctness, because the target verifies every draft.
+    pub(super) fn try_eager_drafter_prefill(
+        &self,
+        seq: &mut SequenceState,
+        is_last: bool,
+        stream: u64,
+    ) {
+        if !is_last || eager_drafter_disabled() || self.mtp_prefill_hidden.is_null() {
+            return;
+        }
+        let Some(proposer) = self.proposer.clone() else {
+            return;
+        };
+        if seq.proposer_state.is_none() {
+            return;
+        }
+        let ctx = ForwardContext {
+            buffers: &self.buffers,
+            gpu: self.gpu.as_ref(),
+            config: &self.config,
+            attn_metadata: None,
+            profile: false,
+            comm: None,
+            graph_capture: false,
+            gdn_exact_replay: false,
+            token_ids: None,
+            routed_lora_layers: None,
+            midchunk_capture: None,
+        };
+        self.ensure_drafter_context(proposer.as_ref(), seq, &ctx, stream);
+        if crate::speculative::mtp_accept_debug() {
+            let rows =
+                proposer.drafter_rows(seq.proposer_state.as_mut().expect("checked above").as_mut());
+            let captured = self
+                .mtp_prefill_capture_len
+                .load(std::sync::atomic::Ordering::Relaxed);
+            tracing::info!(
+                "MTP drafter coverage: prompt_len={} captured={captured} drafter_rows={rows}",
+                seq.prompt_len,
+            );
+        }
+        static LOGGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+        if !LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            tracing::info!(
+                "MTP eager drafter prefill ENGAGED: the whole-prompt capture is consumed at \
+                 end-of-prefill, so every concurrent sequence (not only the last-prefilled) \
+                 can build drafter KV over its own prompt"
+            );
+        }
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -223,6 +223,7 @@ impl TransformerModel {
             marconi_skip_to: 0,
             marconi_exact_snap: None,
             session_hash: 0,
+            mtp_capture_gen: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
             kv_valid_tokens: 0,
@@ -299,17 +300,40 @@ impl TransformerModel {
         let v = self.config.vocab_size;
         let bf16 = 2usize;
         let out_ptr = self.buffers.scratch();
-        for i in 0..n {
-            let logits_i = logits_ptr.offset(i * v * bf16);
-            let out_i = out_ptr.offset(i * 4);
-            ops::argmax_bf16(
+        // ONE launch, one block per row. The single-row `argmax_bf16` is a one-CTA
+        // reduction (grid [1,1,1]), so n calls on the same stream serialise n
+        // single-SM scans: measured 16 x 100.6 us = 1.6 ms per decode step at n=16.
+        // The batched kernel runs the identical per-row body, so ties resolve the
+        // same way — byte-identical. Falls back to the loop when the kernel set
+        // lacks the batched entry.
+        fn argmax_batch_enabled() -> bool {
+            static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *ON.get_or_init(|| std::env::var("ATLAS_NO_ARGMAX_BATCH").ok().as_deref() != Some("1"))
+        }
+        if self.argmax_batch_kernel.0 != 0 && argmax_batch_enabled() {
+            ops::argmax_bf16_batch(
                 self.gpu.as_ref(),
-                self.argmax_kernel,
-                logits_i,
-                out_i,
+                self.argmax_batch_kernel,
+                logits_ptr,
+                out_ptr,
+                v as u32,
+                n as u32,
                 v as u32,
                 stream,
             )?;
+        } else {
+            for i in 0..n {
+                let logits_i = logits_ptr.offset(i * v * bf16);
+                let out_i = out_ptr.offset(i * 4);
+                ops::argmax_bf16(
+                    self.gpu.as_ref(),
+                    self.argmax_kernel,
+                    logits_i,
+                    out_i,
+                    v as u32,
+                    stream,
+                )?;
+            }
         }
         let mut buf = vec![0u8; n * 4];
         self.gpu.copy_d2h(out_ptr, &mut buf)?;

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -351,17 +351,17 @@ impl Model for TransformerModel {
     ) -> Result<[u32; 4]> {
         self.decode_verify_graphed_k4_dispatch(tokens, seq, _stream)
     }
-    fn can_batch_verify(&self, n: usize, k: usize) -> bool {
-        self.can_batch_verify_dispatch(n, k)
+    fn can_batch_verify(&self, ks: &[usize]) -> bool {
+        self.can_batch_verify_dispatch(ks)
     }
     fn decode_verify_batched(
         &self,
         tokens: &[u32],
-        k: usize,
+        ks: &[usize],
         seqs: &mut [&mut SequenceState],
         _stream: u64,
     ) -> Result<Vec<u32>> {
-        self.decode_verify_batched_dispatch(tokens, k, seqs, _stream)
+        self.decode_verify_batched_dispatch(tokens, ks, seqs, _stream)
     }
     fn stash_verify_hidden_rows(&self, rows: &[usize], _stream: u64) -> Result<()> {
         self.stash_verify_hidden_rows_dispatch(rows, _stream)
@@ -377,8 +377,11 @@ impl Model for TransformerModel {
         num_drafts: usize,
         seqs: &mut [&mut SequenceState],
         _stream: u64,
+        out_conf: Option<&mut Vec<Vec<f32>>>,
     ) -> Result<Option<Vec<Vec<u32>>>> {
-        self.run_mtp_propose_batched_dispatch(tokens, positions, stash_idx, num_drafts, seqs)
+        self.run_mtp_propose_batched_dispatch(
+            tokens, positions, stash_idx, num_drafts, seqs, out_conf,
+        )
     }
     fn mtp_propose_batch_max(&self) -> usize {
         match &self.proposer {

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -23,6 +23,8 @@ mod decode_a2;
 mod decode_b;
 mod decode_b2;
 mod decode_checkpoint;
+mod decode_graph_key;
+mod drafter_prefill;
 mod ep_misc;
 mod meta;
 mod prefill_a;
@@ -37,6 +39,8 @@ mod verify_b;
 mod verify_c;
 mod verify_c2;
 mod verify_d;
+mod verify_e;
+mod verify_e2;
 mod verify_fused;
 
 impl Model for TransformerModel {
@@ -54,8 +58,16 @@ impl Model for TransformerModel {
         *self.vision_grid_base.lock() = grid_base;
         *self.vision_owned_images.lock() = owned_images;
     }
+    // The four prefill entry points each end with `try_eager_drafter_prefill`:
+    // the whole-prompt drafter capture is a single shared slot, so it must be
+    // consumed while THIS sequence still owns it — one tick later, at the
+    // first propose, a concurrent sequence's prefill has already restarted it
+    // and every sequence but the last-prefilled drafts blind. See
+    // `drafter_prefill.rs`. Kill switch `ATLAS_NO_MTP_EAGER_DRAFTER`.
     fn prefill(&self, tokens: &[u32], seq: &mut SequenceState, stream: u64) -> Result<DevicePtr> {
-        self.prefill_dispatch(tokens, seq, stream)
+        let logits = self.prefill_dispatch(tokens, seq, stream)?;
+        self.try_eager_drafter_prefill(seq, true, stream);
+        Ok(logits)
     }
     fn prefill_chunk(
         &self,
@@ -66,7 +78,16 @@ impl Model for TransformerModel {
         is_last_chunk: bool,
         stream: u64,
     ) -> Result<DevicePtr> {
-        self.prefill_chunk_dispatch(tokens, seq, chunk_start, chunk_len, is_last_chunk, stream)
+        let logits = self.prefill_chunk_dispatch(
+            tokens,
+            seq,
+            chunk_start,
+            chunk_len,
+            is_last_chunk,
+            stream,
+        )?;
+        self.try_eager_drafter_prefill(seq, is_last_chunk, stream);
+        Ok(logits)
     }
     fn prefill_twophase(
         &self,
@@ -75,7 +96,9 @@ impl Model for TransformerModel {
         chunk_size: usize,
         stream: u64,
     ) -> Result<DevicePtr> {
-        self.prefill_twophase_dispatch(tokens, seq, chunk_size, stream)
+        let logits = self.prefill_twophase_dispatch(tokens, seq, chunk_size, stream)?;
+        self.try_eager_drafter_prefill(seq, true, stream);
+        Ok(logits)
     }
     fn decode(&self, token: u32, seq: &mut SequenceState, _stream: u64) -> Result<DevicePtr> {
         self.decode_dispatch(token, seq, _stream)
@@ -99,7 +122,7 @@ impl Model for TransformerModel {
         prefill_is_last: bool,
         stream: u64,
     ) -> Result<crate::traits::MixedForwardResult> {
-        self.mixed_forward_dispatch(
+        let out = self.mixed_forward_dispatch(
             decode_tokens,
             decode_seqs,
             prefill_tokens,
@@ -108,7 +131,9 @@ impl Model for TransformerModel {
             prefill_chunk_len,
             prefill_is_last,
             stream,
-        )
+        )?;
+        self.try_eager_drafter_prefill(prefill_seq, prefill_is_last, stream);
+        Ok(out)
     }
 
     /// Q12 Phase 4b override: try the model-level batched dispatch
@@ -325,6 +350,41 @@ impl Model for TransformerModel {
         _stream: u64,
     ) -> Result<[u32; 4]> {
         self.decode_verify_graphed_k4_dispatch(tokens, seq, _stream)
+    }
+    fn can_batch_verify(&self, n: usize, k: usize) -> bool {
+        self.can_batch_verify_dispatch(n, k)
+    }
+    fn decode_verify_batched(
+        &self,
+        tokens: &[u32],
+        k: usize,
+        seqs: &mut [&mut SequenceState],
+        _stream: u64,
+    ) -> Result<Vec<u32>> {
+        self.decode_verify_batched_dispatch(tokens, k, seqs, _stream)
+    }
+    fn stash_verify_hidden_rows(&self, rows: &[usize], _stream: u64) -> Result<()> {
+        self.stash_verify_hidden_rows_dispatch(rows, _stream)
+    }
+    fn save_hidden_for_mtp_from_stash(&self, idx: usize, _stream: u64) -> Result<()> {
+        self.save_hidden_for_mtp_from_stash_dispatch(idx, _stream)
+    }
+    fn run_mtp_propose_batched(
+        &self,
+        tokens: &[u32],
+        positions: &[usize],
+        stash_idx: &[usize],
+        num_drafts: usize,
+        seqs: &mut [&mut SequenceState],
+        _stream: u64,
+    ) -> Result<Option<Vec<Vec<u32>>>> {
+        self.run_mtp_propose_batched_dispatch(tokens, positions, stash_idx, num_drafts, seqs)
+    }
+    fn mtp_propose_batch_max(&self) -> usize {
+        match &self.proposer {
+            Some(p) => p.propose_batch_max(&self.buffers, &self.config),
+            None => 1,
+        }
     }
     fn decode_verify_graphed_kgamma(
         &self,

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -139,7 +139,10 @@ impl TransformerModel {
             self.eff_ssm_snapshot(&prefix_match, seq.session_hash, stream);
         let marconi_skip = if let Some(snap_id) = eff_snapshot {
             let snap_tok = eff_snapshot_tokens;
-            if snap_tok > 0
+            // Below `marconi_min_tokens()` the snapshot restore costs more in lost
+            // drafter acceptance than the skipped prefill saves — see the helper.
+            if snap_tok >= crate::model::mtp_carry::marconi_min_tokens()
+                && snap_tok > 0
                 && kv_write_start <= n
                 && self
                     .ssm_snapshots
@@ -482,7 +485,7 @@ impl TransformerModel {
 
         // ATLAS_MTP_DRAFTER_PREFILL: capture the processed rows' final-layer
         // hiddens for the whole-prompt drafter prefill. No-op when disabled.
-        self.try_mtp_prefill_capture(seq_len_start, proc_count, stream)?;
+        self.try_mtp_prefill_capture(seq, seq_len_start, proc_count, stream)?;
 
         // ── 5. Final norm on LAST token only ──
         let last_hidden = hidden.offset((proc_count - 1) * h * fp32);

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -274,7 +274,7 @@ impl TransformerModel {
         }
         // ATLAS_MTP_DRAFTER_PREFILL: capture this chunk's final-layer hidden
         // rows for the whole-prompt drafter prefill. No-op when disabled.
-        self.try_mtp_prefill_capture(effective_seq_len_start, proc_count, stream)?;
+        self.try_mtp_prefill_capture(seq, effective_seq_len_start, proc_count, stream)?;
         if let Some(t0) = prefill_t0 {
             self.gpu.synchronize(stream)?;
             let total_us = t0.elapsed().as_micros();

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -140,7 +140,10 @@ impl TransformerModel {
                 // and safe cross-session — matching the KV radix. Gating them on
                 // the (unstable) session_hash is what rejected every valid warm-
                 // turn anchor and forced recompute-all. See lookup_tiered.
-                if snap_tok > 0
+                // Below `marconi_min_tokens()` the snapshot restore costs more in lost
+                // drafter acceptance than the skipped prefill saves — see the helper.
+                if snap_tok >= crate::model::mtp_carry::marconi_min_tokens()
+                    && snap_tok > 0
                     && matched <= total
                     && !exact_without_hidden
                     && (!prefix_match.ssm_snapshot_is_tail

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -205,10 +205,17 @@ impl TransformerModel {
                 seq.slot_idx
             );
         }
-        // batch_decode_graphs is keyed by padded_n, not slot — but the captured
-        // graphs DO contain per-slot SSM pointers from the active set at capture
-        // time. Drop them all (they'll be re-captured on next batched decode).
-        for (_, graph) in self.batch_decode_graphs.lock().drain() {
+        // batch_decode_graphs is now keyed by the per-row SSM slot VECTOR
+        // (decode_graph_key.rs), so a freed slot's entries are already
+        // unreachable unless the exact same vector recurs — at which point the
+        // slot has been re-claimed and its pool addresses are the same ones the
+        // graph baked (SSM pool addresses are per-SLOT and fixed for the life
+        // of the process). The blanket drain is therefore no longer required
+        // for correctness; it is KEPT deliberately — dropping it would extend a
+        // graph's lifetime across arbitrary request turnover, which is a
+        // separate (unmeasured) risk surface, and re-capture costs one eager
+        // step per completion.
+        for (_, (graph, _)) in self.batch_decode_graphs.lock().0.drain() {
             if let Err(e) = self.gpu.destroy_graph(graph) {
                 tracing::error!("free_sequence: destroy_graph(batch_decode_graphs entry): {e:#}");
             }

--- a/crates/spark-model/src/model/trait_impl/speculative.rs
+++ b/crates/spark-model/src/model/trait_impl/speculative.rs
@@ -432,6 +432,7 @@ impl TransformerModel {
         stash_idx: &[usize],
         num_drafts: usize,
         seqs: &mut [&mut SequenceState],
+        out_conf: Option<&mut Vec<Vec<f32>>>,
     ) -> Result<Option<Vec<Vec<u32>>>> {
         let proposer = match &self.proposer {
             Some(p) => p.as_ref(),
@@ -484,6 +485,7 @@ impl TransformerModel {
             &mut states,
             &ctx,
             stream,
+            out_conf,
         )
     }
 

--- a/crates/spark-model/src/model/trait_impl/speculative.rs
+++ b/crates/spark-model/src/model/trait_impl/speculative.rs
@@ -91,66 +91,6 @@ impl TransformerModel {
         TransformerModel::decode_draft(self, token, seq, stream)
     }
 
-    /// ATLAS_MTP_DRAFTER_PREFILL: copy this prefill chunk's final-layer
-    /// hiddens (`[proc_count, h]` BF16, contiguous at the head of the hidden
-    /// buffer) into the whole-prompt capture at row `chunk_start`.
-    ///
-    /// Contiguity-tracked: `chunk_start == 0` (re)starts the capture; a chunk
-    /// extending the current range appends; anything else (prefix-cache
-    /// reuse, Marconi warm restore — rows whose hiddens were never computed)
-    /// leaves the tracked length short, which safely disables the drafter
-    /// prefill for that sequence via the coverage check at the propose site.
-    pub(super) fn try_mtp_prefill_capture(
-        &self,
-        chunk_start: usize,
-        proc_count: usize,
-        stream: u64,
-    ) -> Result<()> {
-        if self.mtp_prefill_hidden.is_null() || proc_count == 0 {
-            return Ok(());
-        }
-        use std::sync::atomic::Ordering;
-        if chunk_start + proc_count > self.mtp_prefill_capacity {
-            return Ok(());
-        }
-        let len = self.mtp_prefill_capture_len.load(Ordering::Relaxed);
-        let contiguous_from_zero = if chunk_start == 0 {
-            Some(proc_count)
-        } else if chunk_start == len {
-            Some(len + proc_count)
-        } else {
-            None
-        };
-        // ATLAS_MTP_CARRY_DRAFTER: a warm turn's chunk starts at the reused-
-        // prefix boundary, which the contiguous-from-zero tracker above must
-        // reject (its consumer prefills the drafter from row 0). The carry
-        // path consumes the SAME buffer position-indexed, so it wants the
-        // write regardless of where the chunk starts — the rows are still
-        // `hidden_i` at absolute row `i`. Note the SOURCE is the head of the
-        // hidden buffer (this chunk's rows), only the DESTINATION is absolute.
-        let carry_on = crate::model::mtp_carry::mtp_carry_drafter_enabled();
-        if contiguous_from_zero.is_none() && !carry_on {
-            return Ok(());
-        }
-        let h = self.config.hidden_size;
-        let bf16 = 2usize;
-        self.gpu.copy_d2d_async(
-            self.buffers.hidden_states(),
-            self.mtp_prefill_hidden.offset(chunk_start * h * bf16),
-            proc_count * h * bf16,
-            stream,
-        )?;
-        if let Some(new_len) = contiguous_from_zero {
-            self.mtp_prefill_capture_len
-                .store(new_len, Ordering::Relaxed);
-        }
-        if carry_on {
-            let mut r = self.mtp_store_range.lock();
-            *r = crate::model::mtp_carry::merge_interval(*r, chunk_start, proc_count);
-        }
-        Ok(())
-    }
-
     /// Give the drafter its prompt context on the FIRST propose of a sequence.
     ///
     /// COLD turn: the whole-prompt capture covers the prompt, so run the
@@ -170,6 +110,7 @@ impl TransformerModel {
         // Disjoint field borrows: the proposer state is mutated while the
         // token slice is read. Destructuring is what makes that legal, and it
         // avoids cloning a 12k-token vector on every propose.
+        let capture_gen = seq.mtp_capture_gen;
         let SequenceState {
             tokens: seq_tokens,
             prompt_len,
@@ -191,7 +132,18 @@ impl TransformerModel {
             let captured = self
                 .mtp_prefill_capture_len
                 .load(std::sync::atomic::Ordering::Relaxed);
-            let cold_prefill_ok = p >= 2 && captured >= p && seq_tokens.len() >= p;
+            // Ownership check: the shared capture must still be THIS
+            // sequence's (stamp == current generation). At C>=2 the seqs
+            // prefill back-to-back before any propose, so without this the
+            // first propose of every seq but the LAST-prefilled would build
+            // drafter KV from its own tokens paired with a DIFFERENT
+            // sequence's hiddens. Blind (skip) beats poisoned.
+            let owns_capture = capture_gen != 0
+                && capture_gen
+                    == self
+                        .mtp_prefill_capture_gen
+                        .load(std::sync::atomic::Ordering::Relaxed);
+            let cold_prefill_ok = p >= 2 && captured >= p && seq_tokens.len() >= p && owns_capture;
             let carry_on = crate::model::mtp_carry::mtp_carry_drafter_enabled();
             // Both branches below are FIRST-PROPOSE only: `prefill_drafter`
             // enforces that itself (`mtp_state.seq_len != row_base` fast-return),
@@ -344,6 +296,59 @@ impl TransformerModel {
         Ok(())
     }
 
+    /// Batched-verify Phase 2: copy the raw-hidden row `rows[i]` (the
+    /// accepted position of sequence i in the just-run batched verify
+    /// forward) into stash slot i, BEFORE any propose clobbers the shared
+    /// `hidden_states` buffer (every drafter `forward_one` writes into it —
+    /// mtp_multi.rs). Same RAW-hidden (pre-final-norm) contract as
+    /// `save_hidden_for_mtp_dispatch`.
+    pub(super) fn stash_verify_hidden_rows_dispatch(
+        &self,
+        rows: &[usize],
+        _stream: u64,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            !self.verify_hidden_stash.is_null(),
+            "stash_verify_hidden_rows: verify_hidden_stash not allocated (no MTP proposer)"
+        );
+        anyhow::ensure!(
+            rows.len() <= 16,
+            "stash_verify_hidden_rows: {} rows exceeds the 16-slot stash",
+            rows.len()
+        );
+        let stream = self.gpu.default_stream();
+        let h = self.config.hidden_size;
+        let bf16 = 2usize; // residual stream is BF16
+        for (i, &row) in rows.iter().enumerate() {
+            let src = self.buffers.hidden_states().offset(row * h * bf16);
+            let dst = self.verify_hidden_stash.offset(i * h * bf16);
+            self.gpu.copy_d2d_async(src, dst, h * bf16, stream)?;
+        }
+        Ok(())
+    }
+
+    /// Batched-verify Phase 3: stash slot `idx` → `mtp_hidden_save` (the MTP
+    /// head's input). Stashed-row variant of `save_hidden_for_mtp_dispatch`
+    /// for verdicts applied AFTER a propose has overwritten the live rows.
+    pub(super) fn save_hidden_for_mtp_from_stash_dispatch(
+        &self,
+        idx: usize,
+        _stream: u64,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            !self.verify_hidden_stash.is_null(),
+            "save_hidden_for_mtp_from_stash: verify_hidden_stash not allocated"
+        );
+        anyhow::ensure!(idx < 16, "save_hidden_for_mtp_from_stash: idx {idx} >= 16");
+        let stream = self.gpu.default_stream();
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        let src = self.verify_hidden_stash.offset(idx * h * bf16);
+        self.gpu
+            .copy_d2d_async(src, self.mtp_hidden_save, h * bf16, stream)?;
+        Ok(())
+    }
+
     /// ATLAS_MTP_CATCHUP: ring-capture the final hidden of a serially
     /// decoded token (position `pos`), keeping the ring's position range
     /// contiguous (a gap resets the range to just this row).
@@ -412,6 +417,74 @@ impl TransformerModel {
         // MTP loads ALL experts on every rank — no EP all_reduce needed.
         // Rank 1 does not participate in MTP propose.
         self.run_mtp_propose_inner(token, position, num_drafts, seq, grammar_bitmask)
+    }
+
+    /// Batched cross-sequence propose (batched K=4 verify path). Target
+    /// hiddens are read DIRECTLY from the verify stash rows (`stash_idx[i]`),
+    /// so the single-slot `mtp_hidden_save` is never involved. The catchup /
+    /// refeed / carry blocks of `run_mtp_propose_inner` are force-disabled in
+    /// multi-seq MTP mode (the only mode that reaches this path), so skipping
+    /// them here matches the per-seq behavior at cap > 1 exactly.
+    pub(super) fn run_mtp_propose_batched_dispatch(
+        &self,
+        tokens: &[u32],
+        positions: &[usize],
+        stash_idx: &[usize],
+        num_drafts: usize,
+        seqs: &mut [&mut SequenceState],
+    ) -> Result<Option<Vec<Vec<u32>>>> {
+        let proposer = match &self.proposer {
+            Some(p) => p.as_ref(),
+            None => return Ok(None),
+        };
+        // The confidence clamp is a per-seq propose feature; keep semantics
+        // by falling back whenever it is armed.
+        if crate::speculative::draft_conf_tau() > 0.0 {
+            return Ok(None);
+        }
+        if self.verify_hidden_stash.is_null() {
+            return Ok(None);
+        }
+        let stream = self.gpu.default_stream();
+        let ctx = ForwardContext {
+            buffers: &self.buffers,
+            gpu: self.gpu.as_ref(),
+            config: &self.config,
+            attn_metadata: None,
+            profile: false,
+            comm: None,
+            graph_capture: false,
+            gdn_exact_replay: false,
+            token_ids: None,
+            routed_lora_layers: None,
+            midchunk_capture: None,
+        };
+        // First-propose drafter context (cold-turn prefill); fast no-op on
+        // every later call — same as the per-seq path.
+        for seq in seqs.iter_mut() {
+            self.ensure_drafter_context(proposer, seq, &ctx, stream);
+        }
+        let h = self.config.hidden_size;
+        let hiddens: Vec<spark_runtime::gpu::DevicePtr> = stash_idx
+            .iter()
+            .map(|&i| self.verify_hidden_stash.offset(i * h * 2))
+            .collect();
+        let mut states: Vec<&mut dyn crate::speculative::ProposerState> = Vec::new();
+        for seq in seqs.iter_mut() {
+            match seq.proposer_state.as_mut() {
+                Some(s) => states.push(s.as_mut()),
+                None => return Ok(None),
+            }
+        }
+        proposer.propose_batch(
+            tokens,
+            &hiddens,
+            positions,
+            num_drafts,
+            &mut states,
+            &ctx,
+            stream,
+        )
     }
 
     pub(super) fn read_deferred_draft_token_dispatch(&self) -> Result<u32> {

--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Batched K-row verify: n sequences × k rows in ONE eager forward.
+//! Batched K-row verify: n sequences × `ks[i]` rows in ONE eager forward.
 //!
-//! Generalizes verify_c2's single-sequence K=4 body to `R = n*k` seq-major
-//! rows (`r = i*k + j`, k = drafts+1 in 2..=4 chosen per step by the
-//! K-vs-batch ladder — `speculative::ladder`) so the n weight-reading verify
+//! Generalizes verify_c2's single-sequence K=4 body to `R = Σ ks` seq-major
+//! rows (sequence i at rows `[off_i, off_i + ks[i])`, `ks[i]` = its drafts+1 in
+//! 2..=4, chosen per step by the K-vs-batch ladder — `speculative::ladder` —
+//! and made RAGGED per sequence by D-Cut) so the n weight-reading verify
 //! forwards collapse into one — the structural fix for the measured MTP
 //! serialization at C>1 (cap=4 at C=4: 25.8 vs 48.5 tok/s; see
 //! BATCHED_MTP_SPEC.md). R is capped at 32 = the exact capacity of the
@@ -39,19 +40,21 @@ use crate::layers::ops;
 use crate::traits::{Model, SequenceState};
 
 impl TransformerModel {
-    /// Whether the batched verify can run for `n` sequences × `k` rows.
+    /// Whether the batched verify can run for `ks.len()` sequences at `ks[i]`
+    /// rows each (ragged since D-Cut).
     ///
     /// Self-gates to the envelope verify_e was built and audited for:
     /// non-EP, non-HSS, non-DFlash, no LoRA (the uniform seq_slot upload
     /// carries ONE adapter slot), MTP proposer present (stash allocated,
-    /// 16 slots ⇒ n ≤ 16), k in 2..=4 (the MTP ladder range; intermediates
-    /// pools are sized for the configured max K), and R = n*k ≤ 32 (the
-    /// exact logits-rows / meta-gap / bt-staging capacity — sizes.rs).
-    /// Everything outside falls back to the per-seq loop.
-    pub(super) fn can_batch_verify_dispatch(&self, n: usize, k: usize) -> bool {
+    /// 16 slots ⇒ n ≤ 16), EVERY `ks[i]` in 2..=4 (the MTP ladder range;
+    /// intermediates pools are sized for the configured max K), and
+    /// R = Σ ks ≤ 32 (the exact logits-rows / meta-gap / bt-staging capacity
+    /// — sizes.rs). Everything outside falls back to the per-seq loop.
+    pub(super) fn can_batch_verify_dispatch(&self, ks: &[usize]) -> bool {
+        let n = ks.len();
         (2..=16).contains(&n)
-            && (2..=4).contains(&k)
-            && n * k <= 32
+            && ks.iter().all(|k| (2..=4).contains(k))
+            && ks.iter().sum::<usize>() <= 32
             && self.comm.is_none()
             && self.lora.is_none()
             && self.dflash_hidden_save.is_none()
@@ -66,11 +69,11 @@ impl TransformerModel {
                 .is_none()
     }
 
-    /// Batched K-row verify for `n = seqs.len()` sequences (R = n*k rows,
-    /// k = drafts+1 in 2..=4).
+    /// Batched K-row verify for `n = seqs.len()` sequences (R = Σ ks rows,
+    /// each `ks[i]` = that sequence's drafts+1 in 2..=4, ragged since D-Cut).
     ///
-    /// Row r = i*k + j is sequence i's token j (`tokens[i*k..(i+1)*k] =
-    /// [last_verified, d0, .., d_{k-2}]`, flat seq-major). Weight-bearing
+    /// Row `off_i + j` is sequence i's token j (its slice of `tokens` is
+    /// `[last_verified, d0, .., d_{ks[i]-2}]`, flat seq-major). Weight-bearing
     /// ops (QKVZ/out_proj/FFN/lm_head) batch across all R rows via the
     /// existing M-generic arms; attention runs through `decode_multi_seq`
     /// with per-row block tables / seq lens; the GDN conv+WY body runs
@@ -80,7 +83,7 @@ impl TransformerModel {
     /// byte-identical per-sequence loop only when the slot layout is
     /// fragmented.
     ///
-    /// On success: per seq `tokens` += k, `seq_len` += k (verdict rewind is
+    /// On success: per seq `tokens` += ks[i], `seq_len` += ks[i] (rewind is
     /// the caller's arithmetic, as on the per-seq path). On Err no sequence
     /// state has been advanced. Logits rows stay live for row-based
     /// pipeline picks until the next forward — callers must consume them
@@ -88,7 +91,7 @@ impl TransformerModel {
     pub(super) fn decode_verify_batched_dispatch(
         &self,
         tokens: &[u32],
-        k: usize,
+        ks: &[usize],
         seqs: &mut [&mut SequenceState],
         _stream: u64,
     ) -> Result<Vec<u32>> {
@@ -96,12 +99,25 @@ impl TransformerModel {
         let h = self.config.hidden_size;
         let bf16 = 2usize;
         let n = seqs.len();
+        // Row offsets: sequence i owns rows [off[i], off[i+1]). RAGGED since
+        // D-Cut; `off[i] = i*k` is the uniform special case.
+        let mut off: Vec<usize> = Vec::with_capacity(n + 1);
+        let mut acc = 0usize;
+        for &k in ks {
+            off.push(acc);
+            acc += k;
+        }
+        off.push(acc);
+        let r_total = acc;
+        let k_max = ks.iter().copied().max().unwrap_or(0);
         ensure!(
-            n >= 2 && (2..=4).contains(&k) && tokens.len() == n * k,
-            "batched verify: n={n} k={k} tokens={}",
+            n >= 2
+                && ks.len() == n
+                && ks.iter().all(|k| (2..=4).contains(k))
+                && tokens.len() == r_total,
+            "batched verify: n={n} ks={ks:?} tokens={}",
             tokens.len()
         );
-        let r_total = n * k;
         // R ≤ 32: the exact capacity of the meta gaps below (positions
         // 128 B at +0, seq_slot at +128, slots 256 B at +256, seq_lens at
         // +512, bt staging sized for 32 rows in sizes.rs) and the 32-row
@@ -122,8 +138,8 @@ impl TransformerModel {
         }
 
         let bs = kv_cache.block_size();
-        for seq in seqs.iter_mut() {
-            let last_pos = seq.seq_len + k - 1;
+        for (i, seq) in seqs.iter_mut().enumerate() {
+            let last_pos = seq.seq_len + ks[i] - 1;
             ensure_blocks_through_decode(
                 seq,
                 last_pos / bs,
@@ -143,8 +159,8 @@ impl TransformerModel {
         let mut slots = [0i64; 32];
         let mut seq_lens = [0i32; 32];
         for (i, seq) in seqs.iter().enumerate() {
-            for j in 0..k {
-                let r = i * k + j;
+            for j in 0..ks[i] {
+                let r = off[i] + j;
                 let pos = seq.seq_len + j;
                 positions[r] = pos as u32;
                 let physical_block = seq.physical_block_for(pos / bs).unwrap_or(0);
@@ -169,8 +185,8 @@ impl TransformerModel {
         let needed = r_total * mb;
         let mut bt_buf = vec![0i32; needed];
         for (i, seq) in seqs.iter().enumerate() {
-            for j in 0..k {
-                let row = i * k + j;
+            for j in 0..ks[i] {
+                let row = off[i] + j;
                 for (bi, &block) in seq.block_table.iter().enumerate().take(mb) {
                     bt_buf[row * mb + bi] = block as i32;
                 }
@@ -210,7 +226,10 @@ impl TransformerModel {
         // pointer-table form as wy4: at k<4 the fast path used to decline
         // into the per-seq conv/WY loop (n launches per layer instead of 2),
         // which is exactly the k<4 verify-step cost the n=16 matrix measured.
-        let wy_tables_base = self.upload_verify_wy_tables(&*seqs, k, stream)?;
+        // Staged at the batch's DEEPEST width: a sequence pruned to fewer rows
+        // simply leaves its tail slabs unread (the WY launch for its depth
+        // reads `k-1` intermediate tables), and the strides are k-independent.
+        let wy_tables_base = self.upload_verify_wy_tables(&*seqs, k_max, stream)?;
 
         // ATLAS_K4_DIAG=1: stream-sync checkpoint after every layer so an
         // illegal access is attributed to the exact layer (same hatch as
@@ -224,7 +243,7 @@ impl TransformerModel {
         // refreshed above. can_batch already excludes EP/HSS/LoRA/DFlash.
         let graphs_on = super::verify_e2::verify_graphs_enabled() && !k4_diag;
         let graph_key = if graphs_on {
-            self.verify_batched_graph_key(&*seqs, k, wy_tables_base.is_null())
+            self.verify_batched_graph_key(&*seqs, ks, wy_tables_base.is_null())
         } else {
             None
         };
@@ -276,8 +295,8 @@ impl TransformerModel {
             // Host-side per-row attention args (verify_c2 pattern, R rows).
             let mut seq_lens_vec: Vec<usize> = Vec::with_capacity(r_total);
             let mut block_tables_vec: Vec<Vec<u32>> = Vec::with_capacity(r_total);
-            for seq in seqs.iter() {
-                for j in 0..k {
+            for (i, seq) in seqs.iter().enumerate() {
+                for j in 0..ks[i] {
                     seq_lens_vec.push(seq.seq_len + j);
                     block_tables_vec.push(seq.block_table.clone());
                 }
@@ -340,7 +359,7 @@ impl TransformerModel {
                         hidden,
                         residual,
                         n,
-                        k,
+                        ks,
                         &mut state_refs,
                         &mut kv_cache,
                         wy_slice,
@@ -415,7 +434,7 @@ impl TransformerModel {
                 let graph = self.gpu.end_capture(stream)?;
                 if graph.0 != 0 {
                     tracing::info!(
-                        "Captured CUDA graph for batched K={k} verify (n={n}, key={:?})",
+                        "Captured CUDA graph for batched verify ks={ks:?} (n={n}, key={:?})",
                         graph_key
                     );
                     if let (Some(ref mut g), Some(key)) = (graphs.as_mut(), graph_key) {
@@ -462,10 +481,10 @@ impl TransformerModel {
         }
 
         for (i, seq) in seqs.iter_mut().enumerate() {
-            for &t in &tokens[i * k..(i + 1) * k] {
+            for &t in &tokens[off[i]..off[i + 1]] {
                 seq.tokens.push(t);
             }
-            seq.seq_len += k;
+            seq.seq_len += ks[i];
         }
 
         Ok(out)

--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched K-row verify: n sequences × k rows in ONE eager forward.
+//!
+//! Generalizes verify_c2's single-sequence K=4 body to `R = n*k` seq-major
+//! rows (`r = i*k + j`, k = drafts+1 in 2..=4 chosen per step by the
+//! K-vs-batch ladder — `speculative::ladder`) so the n weight-reading verify
+//! forwards collapse into one — the structural fix for the measured MTP
+//! serialization at C>1 (cap=4 at C=4: 25.8 vs 48.5 tok/s; see
+//! BATCHED_MTP_SPEC.md). R is capped at 32 = the exact capacity of the
+//! logits rows / meta gaps / bt staging (sizes.rs), reached at n=16 × k=2.
+//!
+//! CUDA GRAPHS (slot-VECTOR-keyed): the forward span (layer loop + final
+//! norm + lm_head + argmax) is captured per distinct ssm-slot vector — the
+//! slot-keyed `verify4_graph` cache is meaningless at n>1 because a graph
+//! bakes EVERY sequence's state pointers, which are a function of the whole
+//! vector. Pre-graph each step (embed, KV-block ensure, metadata/bt/WY-table
+//! H2D into fixed addresses) and the argmax D2H stay eager — exactly the
+//! decode_a2 padded_n-graph pattern. Kill switch `ATLAS_NO_MTP_VERIFY_GRAPHS`
+//! (PRESENCE). Everything per-sequence (GDN conv+WY4 body, block tables,
+//! rollback intermediates) reuses existing machinery verbatim — only base
+//! addresses move — with an optional cross-sequence batched conv+WY fast
+//! path in the GDN Multi arm (see trait_decode_batched_conv_gdn_multi.rs).
+//!
+//! Same `unsafe { from_raw_parts(...) }` pattern as verify_c.rs; see that
+//! file's module docs for the full safety contract.
+
+#![allow(unused_imports, dead_code, clippy::too_many_arguments)]
+
+use anyhow::{Result, bail, ensure};
+use atlas_core::config::{LayerType, ModelConfig};
+use spark_runtime::gpu::DevicePtr;
+use spark_runtime::kv_cache::PagedKvCache;
+
+use super::super::block_mgmt::ensure_blocks_through_decode;
+use super::super::types::TransformerModel;
+use crate::layer::{AttnMetadataDev, ForwardContext, LayerState};
+use crate::layers::ops;
+use crate::traits::{Model, SequenceState};
+
+impl TransformerModel {
+    /// Whether the batched verify can run for `n` sequences × `k` rows.
+    ///
+    /// Self-gates to the envelope verify_e was built and audited for:
+    /// non-EP, non-HSS, non-DFlash, no LoRA (the uniform seq_slot upload
+    /// carries ONE adapter slot), MTP proposer present (stash allocated,
+    /// 16 slots ⇒ n ≤ 16), k in 2..=4 (the MTP ladder range; intermediates
+    /// pools are sized for the configured max K), and R = n*k ≤ 32 (the
+    /// exact logits-rows / meta-gap / bt-staging capacity — sizes.rs).
+    /// Everything outside falls back to the per-seq loop.
+    pub(super) fn can_batch_verify_dispatch(&self, n: usize, k: usize) -> bool {
+        (2..=16).contains(&n)
+            && (2..=4).contains(&k)
+            && n * k <= 32
+            && self.comm.is_none()
+            && self.lora.is_none()
+            && self.dflash_hidden_save.is_none()
+            && !self.verify_hidden_stash.is_null()
+            // HSS: the paged-decode kernel reads HBM only, missing on-disk
+            // history (see verify_c2's HSS fallback) — batched path unsupported.
+            && self
+                .kv_cache
+                .lock()
+                .config()
+                .cache_blocks_per_seq
+                .is_none()
+    }
+
+    /// Batched K-row verify for `n = seqs.len()` sequences (R = n*k rows,
+    /// k = drafts+1 in 2..=4).
+    ///
+    /// Row r = i*k + j is sequence i's token j (`tokens[i*k..(i+1)*k] =
+    /// [last_verified, d0, .., d_{k-2}]`, flat seq-major). Weight-bearing
+    /// ops (QKVZ/out_proj/FFN/lm_head) batch across all R rows via the
+    /// existing M-generic arms; attention runs through `decode_multi_seq`
+    /// with per-row block tables / seq lens; the GDN conv+WY body runs
+    /// through `decode_verify_multi`, whose two-launch cross-sequence fast
+    /// path now engages at EVERY ladder width k in 2..=4
+    /// (trait_decode_batched_conv_gdn_multi.rs), falling back to the
+    /// byte-identical per-sequence loop only when the slot layout is
+    /// fragmented.
+    ///
+    /// On success: per seq `tokens` += k, `seq_len` += k (verdict rewind is
+    /// the caller's arithmetic, as on the per-seq path). On Err no sequence
+    /// state has been advanced. Logits rows stay live for row-based
+    /// pipeline picks until the next forward — callers must consume them
+    /// (and stash hiddens) BEFORE any propose.
+    pub(super) fn decode_verify_batched_dispatch(
+        &self,
+        tokens: &[u32],
+        k: usize,
+        seqs: &mut [&mut SequenceState],
+        _stream: u64,
+    ) -> Result<Vec<u32>> {
+        let stream = self.gpu.default_stream();
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        let n = seqs.len();
+        ensure!(
+            n >= 2 && (2..=4).contains(&k) && tokens.len() == n * k,
+            "batched verify: n={n} k={k} tokens={}",
+            tokens.len()
+        );
+        let r_total = n * k;
+        // R ≤ 32: the exact capacity of the meta gaps below (positions
+        // 128 B at +0, seq_slot at +128, slots 256 B at +256, seq_lens at
+        // +512, bt staging sized for 32 rows in sizes.rs) and the 32-row
+        // logits cap. Reached at n=16 × k=2 (ladder bottom step).
+        ensure!(
+            r_total <= 32,
+            "batched verify: R={r_total} exceeds the 32-row buffer capacity"
+        );
+
+        let hidden = self.buffers.hidden_states();
+        let residual = self.buffers.residual();
+
+        let mut kv_cache = self.kv_cache.lock();
+
+        // ── Phase 1: embed R tokens + allocate KV blocks ──
+        for (r, &t) in tokens.iter().enumerate() {
+            self.embed(t, hidden.offset(r * h * bf16), stream)?;
+        }
+
+        let bs = kv_cache.block_size();
+        for seq in seqs.iter_mut() {
+            let last_pos = seq.seq_len + k - 1;
+            ensure_blocks_through_decode(
+                seq,
+                last_pos / bs,
+                &mut kv_cache,
+                self.prefix_cache.as_ref(),
+                self.gpu.as_ref(),
+                stream,
+            )?;
+        }
+
+        // ── Phase 2: R-row attention metadata (verify_c2 layout, R rows) ──
+        let meta_base = self.buffers.scratch().offset(32768);
+        let max_blocks = self.max_blocks_per_seq;
+        let mb = max_blocks as usize;
+
+        let mut positions = [0u32; 32];
+        let mut slots = [0i64; 32];
+        let mut seq_lens = [0i32; 32];
+        for (i, seq) in seqs.iter().enumerate() {
+            for j in 0..k {
+                let r = i * k + j;
+                let pos = seq.seq_len + j;
+                positions[r] = pos as u32;
+                let physical_block = seq.physical_block_for(pos / bs).unwrap_or(0);
+                slots[r] = (physical_block as i64) * (bs as i64) + ((pos % bs) as i64);
+                // Per-row causal clamp: row r attends through its own position.
+                seq_lens[r] = (pos + 1) as i32;
+            }
+        }
+        let pos_bytes =
+            unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, r_total * 4) };
+        self.gpu.copy_h2d_async(pos_bytes, meta_base, stream)?;
+        let slot_bytes =
+            unsafe { std::slice::from_raw_parts(slots.as_ptr() as *const u8, r_total * 8) };
+        self.gpu
+            .copy_h2d_async(slot_bytes, meta_base.offset(256), stream)?;
+        let sl_bytes =
+            unsafe { std::slice::from_raw_parts(seq_lens.as_ptr() as *const u8, r_total * 4) };
+        self.gpu
+            .copy_h2d_async(sl_bytes, meta_base.offset(512), stream)?;
+
+        // Block tables: row r = seq i's table (bt staging sized for 32 rows).
+        let needed = r_total * mb;
+        let mut bt_buf = vec![0i32; needed];
+        for (i, seq) in seqs.iter().enumerate() {
+            for j in 0..k {
+                let row = i * k + j;
+                for (bi, &block) in seq.block_table.iter().enumerate().take(mb) {
+                    bt_buf[row * mb + bi] = block as i32;
+                }
+            }
+        }
+        let bt_bytes =
+            unsafe { std::slice::from_raw_parts(bt_buf.as_ptr() as *const u8, needed * 4) };
+        self.gpu
+            .copy_h2d_async(bt_bytes, meta_base.offset(768), stream)?;
+
+        // No-LoRA gate in can_batch: uniform upload returns DevicePtr(0)
+        // (installed-pair path) — kept for structural parity with verify_c2.
+        debug_assert!(r_total <= 32, "verify seq_slot +128 gap holds K ≤ 32");
+        let seq_slot = self.upload_seq_slot_uniform(
+            seqs[0].adapter_slot,
+            r_total,
+            meta_base.offset(128),
+            stream,
+        )?;
+
+        let metadata = AttnMetadataDev {
+            positions: meta_base,
+            positions_h: meta_base,
+            positions_w: meta_base,
+            slot: meta_base.offset(256),
+            seq_len: meta_base.offset(512),
+            block_table: meta_base.offset(768),
+            max_blocks_per_seq: max_blocks,
+            num_seqs: r_total as u32,
+            seq_slot,
+        };
+
+        // Pre-graph: stage the per-GDN-layer WY pointer tables into the
+        // fixed staging buffer (contents refreshed BEFORE any replay, like
+        // the attention metadata above). NULL → per-seq WY loop. Staged for
+        // EVERY ladder width now that wy2/wy3 carry the same `state_is_table`
+        // pointer-table form as wy4: at k<4 the fast path used to decline
+        // into the per-seq conv/WY loop (n launches per layer instead of 2),
+        // which is exactly the k<4 verify-step cost the n=16 matrix measured.
+        let wy_tables_base = self.upload_verify_wy_tables(&*seqs, k, stream)?;
+
+        // ATLAS_K4_DIAG=1: stream-sync checkpoint after every layer so an
+        // illegal access is attributed to the exact layer (same hatch as
+        // verify_c2). Forces EAGER — per-layer syncs are illegal under
+        // capture (verify_c2's gate pattern).
+        let k4_diag = std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1");
+
+        // ── Phase 3: CUDA graph replay, or capture/eager forward ──
+        // Keyed by the ssm-slot VECTOR (verify_e2.rs): every baked SSM
+        // pointer is a function of it; meta/embeds live at fixed addresses
+        // refreshed above. can_batch already excludes EP/HSS/LoRA/DFlash.
+        let graphs_on = super::verify_e2::verify_graphs_enabled() && !k4_diag;
+        let graph_key = if graphs_on {
+            self.verify_batched_graph_key(&*seqs, k, wy_tables_base.is_null())
+        } else {
+            None
+        };
+        let mut graphs = graph_key
+            .as_ref()
+            .map(|_| self.verify_batched_graphs.lock());
+        // LRU touch on hit: bump the tick so eviction always removes the
+        // least-recently-replayed slot vector.
+        let cached = match (&mut graphs, &graph_key) {
+            (Some(g), Some(key)) => {
+                g.1 += 1;
+                let tick = g.1;
+                g.0.get_mut(key).map(|e| {
+                    e.1 = tick;
+                    e.0
+                })
+            }
+            _ => None,
+        };
+
+        if let Some(graph) = cached {
+            // Replay: kernels read this step's metadata + WY tables from the
+            // fixed addresses refreshed above; the ~4-5k launches of the
+            // layer loop + head + argmax dispatch as one graph.
+            if graph.0 != 0 {
+                self.gpu.launch_graph(graph, stream)?;
+            }
+        } else {
+            // First step for this (slot vector, k) key (or graphs off): run
+            // the body, capturing. A full cache no longer disables capture —
+            // the LRU entry is destroyed at insert time (see below), so
+            // slot-vector churn can never push the path permanently eager.
+            let capture = graphs.is_some();
+
+            let ctx = ForwardContext {
+                buffers: &self.buffers,
+                gpu: self.gpu.as_ref(),
+                config: &self.config,
+                attn_metadata: Some(metadata),
+                profile: false,
+                comm: self.comm_ref(),
+                graph_capture: capture,
+                gdn_exact_replay: false,
+                token_ids: None,
+                routed_lora_layers: None,
+                midchunk_capture: None,
+            };
+
+            // Host-side per-row attention args (verify_c2 pattern, R rows).
+            let mut seq_lens_vec: Vec<usize> = Vec::with_capacity(r_total);
+            let mut block_tables_vec: Vec<Vec<u32>> = Vec::with_capacity(r_total);
+            for seq in seqs.iter() {
+                for j in 0..k {
+                    seq_lens_vec.push(seq.seq_len + j);
+                    block_tables_vec.push(seq.block_table.clone());
+                }
+            }
+
+            // Dummy attention states are stateless (multi_seq attention
+            // ignores them) — allocated OUTSIDE the capture window.
+            let mut attn_dummy_states: Vec<Vec<Box<dyn LayerState>>> = Vec::new();
+            for (layer_idx, layer) in self.layers.iter().enumerate() {
+                if self.config.layer_type(layer_idx) == LayerType::FullAttention {
+                    attn_dummy_states.push(
+                        (0..r_total)
+                            .map(|_| layer.alloc_state(self.gpu.as_ref()))
+                            .collect::<Result<_>>()?,
+                    );
+                }
+            }
+
+            if capture {
+                self.gpu.begin_capture(stream)?;
+            }
+
+            let mut attn_idx = 0usize;
+            let mut ssm_idx = 0usize;
+            for (layer_idx, layer) in self.layers.iter().enumerate() {
+                let layer_type = self.config.layer_type(layer_idx);
+
+                if layer_type == LayerType::FullAttention {
+                    let mut refs: Vec<&mut (dyn LayerState + 'static)> = attn_dummy_states
+                        [attn_idx]
+                        .iter_mut()
+                        .map(|s| s.as_mut())
+                        .collect();
+                    attn_idx += 1;
+                    layer.decode_multi_seq(
+                        hidden,
+                        residual,
+                        r_total,
+                        &mut refs,
+                        &mut kv_cache,
+                        &seq_lens_vec,
+                        &block_tables_vec,
+                        &ctx,
+                        stream,
+                    )?;
+                } else {
+                    let mut wy_slice = DevicePtr::NULL;
+                    if layer_type == LayerType::LinearAttention {
+                        if !wy_tables_base.is_null() {
+                            wy_slice = wy_tables_base
+                                .offset(ssm_idx * crate::layer::VERIFY_WY_LAYER_STRIDE_BYTES);
+                        }
+                        ssm_idx += 1;
+                    }
+                    let mut state_refs: Vec<&mut (dyn LayerState + 'static)> = seqs
+                        .iter_mut()
+                        .map(|s| s.layer_states[layer_idx].as_mut())
+                        .collect();
+                    layer.decode_verify_multi(
+                        hidden,
+                        residual,
+                        n,
+                        k,
+                        &mut state_refs,
+                        &mut kv_cache,
+                        wy_slice,
+                        &ctx,
+                        stream,
+                    )?;
+                }
+
+                if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                    anyhow::bail!(
+                        "K4_DIAG(batched): CUDA error after layer {layer_idx} ({layer_type:?}): {e:#}"
+                    );
+                }
+            }
+
+            // ── Phase 4: final norm [R, H] + lm_head + per-row argmax ──
+            let normed = self.buffers.norm_output();
+            ops::rms_norm(
+                self.gpu.as_ref(),
+                self.rms_norm_kernel,
+                hidden,
+                &self.final_norm,
+                normed,
+                r_total as u32,
+                h as u32,
+                self.config.rms_norm_eps as f32,
+                stream,
+            )?;
+
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG(batched): CUDA error after final norm: {e:#}");
+            }
+
+            // R ≤ 16 < the 32-row logits buffer cap (sizes.rs).
+            self.lm_head_batched(normed, r_total as u32, self.buffers.logits(), stream)?;
+
+            if k4_diag && let Err(e) = self.gpu.synchronize(stream) {
+                anyhow::bail!("K4_DIAG(batched): CUDA error after lm_head_batched: {e:#}");
+            }
+
+            let vocab = self.config.vocab_size;
+            let argmax_out = self.buffers.scratch();
+            // ONE launch, one block per row (single-row argmax is a one-CTA
+            // scan; R serial calls = R single-SM scans, ~100 us each at this
+            // vocab). Byte-identical per-row body; loop fallback when the
+            // kernel is absent.
+            if self.argmax_batch_kernel.0 != 0 {
+                ops::argmax_bf16_batch(
+                    self.gpu.as_ref(),
+                    self.argmax_batch_kernel,
+                    self.buffers.logits(),
+                    argmax_out,
+                    vocab as u32,
+                    r_total as u32,
+                    vocab as u32,
+                    stream,
+                )?;
+            } else {
+                for r in 0..r_total {
+                    ops::argmax_bf16(
+                        self.gpu.as_ref(),
+                        self.argmax_kernel,
+                        self.buffers.logits().offset(r * vocab * bf16),
+                        argmax_out.offset(r * 4),
+                        vocab as u32,
+                        stream,
+                    )?;
+                }
+            }
+
+            if capture {
+                let graph = self.gpu.end_capture(stream)?;
+                if graph.0 != 0 {
+                    tracing::info!(
+                        "Captured CUDA graph for batched K={k} verify (n={n}, key={:?})",
+                        graph_key
+                    );
+                    if let (Some(ref mut g), Some(key)) = (graphs.as_mut(), graph_key) {
+                        if g.0.len() >= super::verify_e2::VERIFY_BATCHED_GRAPH_CAP {
+                            // Evict the least-recently-used graph. Safe to
+                            // destroy: every batched verify step ends with a
+                            // blocking argmax D2H on this stream, so any
+                            // earlier step's replay has already completed.
+                            if let Some(evict) =
+                                g.0.iter()
+                                    .min_by_key(|(_, entry)| entry.1)
+                                    .map(|(key, _)| key.clone())
+                                && let Some((old, _)) = g.0.remove(&evict)
+                                && let Err(e) = self.gpu.destroy_graph(old)
+                            {
+                                tracing::warn!("batched-verify graph evict: {e:#}");
+                            }
+                        }
+                        g.1 += 1;
+                        let tick = g.1;
+                        g.0.insert(key, (graph, tick));
+                    }
+                    self.gpu.launch_graph(graph, stream)?;
+                }
+            }
+        }
+        drop(graphs);
+
+        // ── Phase 5: D2H + host bookkeeping ──
+        // Argmax landed at scratch row 0 (graph replay and eager both write
+        // the same fixed address). Blocking D2H = the step's one host sync.
+        let mut buf = vec![0u8; r_total * 4];
+        self.gpu.copy_d2h(self.buffers.scratch(), &mut buf)?;
+
+        let mut out = Vec::with_capacity(r_total);
+        for r in 0..r_total {
+            let o = r * 4;
+            out.push(u32::from_le_bytes([
+                buf[o],
+                buf[o + 1],
+                buf[o + 2],
+                buf[o + 3],
+            ]));
+        }
+
+        for (i, seq) in seqs.iter_mut().enumerate() {
+            for &t in &tokens[i * k..(i + 1) * k] {
+                seq.tokens.push(t);
+            }
+            seq.seq_len += k;
+        }
+
+        Ok(out)
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched K=4 verify support (verify_e.rs): WY pointer-table staging +
+//! CUDA-graph gating helpers. Split out to keep verify_e under the LoC cap.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use atlas_core::config::LayerType;
+use spark_runtime::gpu::DevicePtr;
+
+use super::super::types::TransformerModel;
+use crate::layer::{SsmLayerState, VERIFY_WY_LAYER_STRIDE_BYTES, VERIFY_WY_TABLE_SEQS};
+use crate::traits::SequenceState;
+
+/// Bound on cached batched-verify graphs (one per distinct (ssm-slot
+/// vector, k) key). Slot vectors churn as sequences finish; at the cap the
+/// least-recently-used graph is destroyed and replaced (verify_e.rs), so
+/// the cap bounds graph memory WITHOUT ever pinning the path eager —
+/// the pre-LRU insert-only cache went permanently eager after 32 distinct
+/// vectors, which a long serve is guaranteed to produce.
+pub(super) const VERIFY_BATCHED_GRAPH_CAP: usize = 32;
+
+/// Batched-verify CUDA graphs: ON by default, disabled by PRESENCE of
+/// `ATLAS_NO_MTP_VERIFY_GRAPHS` (house convention — `=0` is NOT off).
+/// Read once per process.
+pub(super) fn verify_graphs_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_VERIFY_GRAPHS").is_none())
+}
+
+impl TransformerModel {
+    /// Batched-verify graph key: each sequence's ssm-pool slot in batch
+    /// order — every SSM pointer the graph bakes (h/conv state, rollback
+    /// intermediates, WY table contents) is a pure function of this vector;
+    /// all other captured addresses (hidden/logits/scratch/meta) are fixed
+    /// buffers refreshed pre-replay. `k` (verify rows per sequence) is
+    /// appended because a graph bakes the R = n*k launch dimensions — the
+    /// same slot vector at a different ladder step must not replay. A
+    /// wy-tables-present sentinel is appended so a table-less capture can
+    /// never replay a table-full step or vice versa. The scheduler sorts
+    /// each chunk by ssm slot before dispatch, so keys are combinations,
+    /// not permutations (verify_k4_batch_step.rs). `None` → no graph (a
+    /// sequence without a pool slot).
+    pub(super) fn verify_batched_graph_key(
+        &self,
+        seqs: &[&mut SequenceState],
+        k: usize,
+        wy_tables_null: bool,
+    ) -> Option<Vec<u32>> {
+        let mut key: Vec<u32> = Vec::with_capacity(seqs.len() + 2);
+        for s in seqs.iter() {
+            key.push(s.ssm_slot_idx()? as u32);
+        }
+        key.push(k as u32);
+        key.push(u32::MAX - u32::from(wy_tables_null));
+        Some(key)
+    }
+
+    /// Stage the per-GDN-layer WY pointer tables (`[h|Hi0|Hi1|Hi2]` ×
+    /// `VERIFY_WY_TABLE_SEQS` u64 entries per layer, batch entries filled,
+    /// tail zero) into the fixed `verify_wy_tables` device buffer. Runs
+    /// PRE-graph every batched verify step so a replayed graph reads tables
+    /// refreshed for the current batch (contents are constant per slot
+    /// vector; refreshing keeps replay correct by construction, not by
+    /// invariant).
+    ///
+    /// `k` is this step's verify width (rows per sequence, 2..=4 from the
+    /// ladder). Exactly `k` tables are filled — `[h | Hi_0 .. Hi_{k-2}]` —
+    /// because `gdn_decode_wy{2,3,4}` read one h table plus k-1 intermediate
+    /// tables. Table STRIDES are `k`-independent, so a slice offset never
+    /// depends on the ladder step.
+    ///
+    /// Returns NULL — uploading nothing — unless EVERY GDN layer × sequence
+    /// provides h_state + ≥ k-1 h intermediates (the layer-side batched arm
+    /// re-checks per layer; defense in depth). NULL keeps the per-sequence
+    /// WY loop, which is byte-identical math.
+    pub(super) fn upload_verify_wy_tables(
+        &self,
+        seqs: &[&mut SequenceState],
+        k: usize,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        let n = seqs.len();
+        if self.verify_wy_tables.is_null()
+            || n > VERIFY_WY_TABLE_SEQS
+            || !(2..=crate::layer::VERIFY_WY_TABLES_PER_LAYER).contains(&k)
+        {
+            return Ok(DevicePtr::NULL);
+        }
+        let num_ssm = self.config.num_ssm_layers();
+        if num_ssm == 0 {
+            return Ok(DevicePtr::NULL);
+        }
+        let entries_per_layer = VERIFY_WY_LAYER_STRIDE_BYTES / 8;
+        let mut host = vec![0u64; num_ssm * entries_per_layer];
+        let mut ssm_idx = 0usize;
+        for layer_idx in 0..self.layers.len() {
+            if self.config.layer_type(layer_idx) != LayerType::LinearAttention {
+                continue;
+            }
+            let base = ssm_idx * entries_per_layer;
+            for (i, seq) in seqs.iter().enumerate() {
+                let Some(st) = seq.layer_states[layer_idx]
+                    .as_any()
+                    .downcast_ref::<SsmLayerState>()
+                else {
+                    return Ok(DevicePtr::NULL);
+                };
+                if st.h_state.is_null() || st.h_state_intermediates.len() < k - 1 {
+                    return Ok(DevicePtr::NULL);
+                }
+                host[base + i] = st.h_state.0;
+                for t in 0..k - 1 {
+                    host[base + (t + 1) * VERIFY_WY_TABLE_SEQS + i] =
+                        st.h_state_intermediates[t].0;
+                }
+            }
+            ssm_idx += 1;
+        }
+        // Pageable-source async H2D per house pattern (the driver stages the
+        // host bytes before returning, same as the metadata uploads).
+        let bytes =
+            unsafe { std::slice::from_raw_parts(host.as_ptr() as *const u8, host.len() * 8) };
+        self.gpu
+            .copy_h2d_async(bytes, self.verify_wy_tables, stream)?;
+        Ok(self.verify_wy_tables)
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -34,9 +34,11 @@ impl TransformerModel {
     /// order — every SSM pointer the graph bakes (h/conv state, rollback
     /// intermediates, WY table contents) is a pure function of this vector;
     /// all other captured addresses (hidden/logits/scratch/meta) are fixed
-    /// buffers refreshed pre-replay. `k` (verify rows per sequence) is
-    /// appended because a graph bakes the R = n*k launch dimensions — the
-    /// same slot vector at a different ladder step must not replay. A
+    /// buffers refreshed pre-replay. The per-sequence ROW VECTOR `ks` is
+    /// interleaved into the key because a graph bakes both the R = Σ ks launch
+    /// dimensions AND, under D-Cut, WHICH sequence got which depth (the GDN
+    /// runs are grouped by depth) — the same slot vector at a different ladder
+    /// step or a different D-Cut shape must not replay. A
     /// wy-tables-present sentinel is appended so a table-less capture can
     /// never replay a table-full step or vice versa. The scheduler sorts
     /// each chunk by ssm slot before dispatch, so keys are combinations,
@@ -45,14 +47,14 @@ impl TransformerModel {
     pub(super) fn verify_batched_graph_key(
         &self,
         seqs: &[&mut SequenceState],
-        k: usize,
+        ks: &[usize],
         wy_tables_null: bool,
     ) -> Option<Vec<u32>> {
-        let mut key: Vec<u32> = Vec::with_capacity(seqs.len() + 2);
-        for s in seqs.iter() {
+        let mut key: Vec<u32> = Vec::with_capacity(2 * seqs.len() + 1);
+        for (i, s) in seqs.iter().enumerate() {
             key.push(s.ssm_slot_idx()? as u32);
+            key.push(*ks.get(i)? as u32);
         }
-        key.push(k as u32);
         key.push(u32::MAX - u32::from(wy_tables_null));
         Some(key)
     }
@@ -112,8 +114,7 @@ impl TransformerModel {
                 }
                 host[base + i] = st.h_state.0;
                 for t in 0..k - 1 {
-                    host[base + (t + 1) * VERIFY_WY_TABLE_SEQS + i] =
-                        st.h_state_intermediates[t].0;
+                    host[base + (t + 1) * VERIFY_WY_TABLE_SEQS + i] = st.h_state_intermediates[t].0;
                 }
             }
             ssm_idx += 1;

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -38,6 +38,19 @@ pub struct TransformerModel {
     pub(super) final_norm: DenseWeight,
     pub(super) lm_head_weight: DenseWeight,
     pub(super) lm_head_nvfp4: Option<QuantizedWeight>,
+    /// TRANSPOSED `[K/2, ldb]` twin of `lm_head_nvfp4` + its PADDED row stride.
+    ///
+    /// The pad is load-bearing: the tile GEMM reads B with 16-byte `cp.async`,
+    /// which needs a 16-byte-aligned source, and row r sits at `r * stride`.
+    /// This checkpoint's vocab is 248077 — ODD — so an unpadded stride misaligns
+    /// 15 of every 16 k-rows and faults with CUDA 716. Padded to 248192.
+    ///
+    /// ADDITIVE: never replaces or aliases `lm_head_nvfp4`, so every existing
+    /// holder (including the `draft_lm_head_nvfp4` copy at `impl_a1.rs:157`)
+    /// keeps a valid row-major pointer. Built once, immutable, never freed —
+    /// so each per-`padded_n` CUDA graph binds one (kernel, tensor) pair.
+    /// `None` under `ATLAS_NO_LMHEAD_TGEMM=1`.
+    pub(super) lm_head_nvfp4_t: Option<(QuantizedWeight, u32)>,
     /// Runtime FP8 E4M3 LM head (per-row scales), decoded via `w8a16_gemv`.
     /// `Some` only when `--lm-head-dtype fp8` was requested; mutually exclusive
     /// with `lm_head_nvfp4` (that stays `None` on the FP8 path). Additive: when
@@ -70,6 +83,15 @@ pub struct TransformerModel {
     pub(super) dense_gemv_fp32out_kernel: KernelHandle,
     pub(super) w4a16_gemv_kernel: KernelHandle,
     pub(super) w4a16_gemv_logits_kernel: KernelHandle, // FP32 output for LM head
+    /// Tile GEMM over the TRANSPOSED lm_head twin. 0 when absent.
+    pub(super) w4a16_gemm_t_kernel: KernelHandle,
+    /// LOSSLESS BF16-MMA tile GEMM over the same twin. Preferred for lm_head:
+    /// `w4a16_gemm_t` downcasts activations BF16->FP8 E4M3, and lm_head is the
+    /// layer where a near-tie argmax flip changes the emitted token. Memory
+    /// records exactly that failure mode (stop/end-of-turn mis-ranking on DEEP
+    /// agentic trajectories) for sub-bf16 lm_heads. Costs ~1% of step.
+    /// 0 when absent. Kill switch: ATLAS_NO_LMHEAD_LOSSLESS=1.
+    pub(super) w4a16_gemm_t_bf16_kernel: KernelHandle,
     pub(super) w4a16_gemm_kernel: KernelHandle,
     pub(super) w4a16_gemv_batch2_kernel: KernelHandle,
     /// Batched M<=4 NVFP4 GEMV for the K=3/K=4 verify lm_head (one weight
@@ -80,6 +102,7 @@ pub struct TransformerModel {
     /// M<=8 batched GEMV for the K=5..8 chain-verify lm_head (batch8 —
     /// removes the M>4 tile-GEMM cliff). 0-handle when absent.
     pub(super) w4a16_gemv_batch8_kernel: KernelHandle,
+    pub(super) w4a16_gemv_batch16_kernel: KernelHandle,
     /// FP8 E4M3 LUT GEMV (M=1) for the FP8 LM head. Only used when
     /// `lm_head_fp8.is_some()`; loaded unconditionally (cheap handle) so the
     /// dispatch in `lm_head` / batched-decode / verify can reference it.
@@ -90,6 +113,8 @@ pub struct TransformerModel {
     pub(super) dense_gemv_fp8w_batch2_kernel: KernelHandle,
     pub(super) dense_gemm_kernel: KernelHandle,
     pub(super) argmax_kernel: KernelHandle,
+    /// Batched argmax (one block per row). 0 when the kernel set lacks it.
+    pub(super) argmax_batch_kernel: KernelHandle,
     pub(super) argmax_logits_kernel: KernelHandle, // FP32 argmax for logits
     pub(super) batched_embed_kernel: KernelHandle,
     pub(super) fill_slots_kernel: KernelHandle,
@@ -102,8 +127,16 @@ pub struct TransformerModel {
     /// alternate between slots in n=1 decode (e.g. via the per-seq fresh-decode
     /// fix in scheduler::step_decode_only), so we keep one graph per slot.
     pub(super) decode_graph: Mutex<std::collections::HashMap<usize, GraphHandle>>,
-    /// Cached CUDA graphs for batched decode, keyed by padded batch size.
-    pub(super) batch_decode_graphs: Mutex<HashMap<usize, GraphHandle>>,
+    /// Cached CUDA graphs for batched decode, keyed by the per-row SSM pool
+    /// slot VECTOR (`trait_impl/decode_graph_key.rs`) — the only per-sequence
+    /// addresses a capture bakes. The old `padded_n` key was sound only while
+    /// the batch was exactly slots `[0..n)` with `n == padded_n`; the MTP
+    /// Phase-A bootstrap passes a slot SUBSET of the active set and would
+    /// replay another subset's baked GDN pointers.
+    /// Value = `(graph, last_use_tick)`; the `u64` alongside the map is the
+    /// monotonically increasing tick. At `BATCH_DECODE_GRAPH_CAP` entries the
+    /// least-recently-used graph is destroyed and replaced.
+    pub(super) batch_decode_graphs: Mutex<(HashMap<Vec<u32>, (GraphHandle, u64)>, u64)>,
     /// Pre-allocated SSM state pool for stable GPU addresses across graph replays.
     /// `Arc` so each `SequenceState` can hold a `SlotGuard` that releases its
     /// claimed slot on drop — guaranteeing the slot returns to the free list on
@@ -140,6 +173,14 @@ pub struct TransformerModel {
     /// Size: hidden_size * 4 bytes (one FP32 vector). MTP overwrites shared
     /// buffers (norm_output etc.), so the target hidden must be saved here first.
     pub(super) mtp_hidden_save: DevicePtr,
+    /// Batched-verify hidden stash: `[8, hidden_size]` BF16 — one RAW-hidden
+    /// row per batched-verify sequence (n ≤ 8 envelope). Every drafter
+    /// `forward_one` writes its hidden into `buffers.hidden_states()`
+    /// (mtp_multi.rs), so seq 0's propose clobbers seq 1..n's verify hidden
+    /// rows; the batched verdict path copies each sequence's accepted-row
+    /// hidden here FIRST (`stash_verify_hidden_rows`), then feeds the drafter
+    /// from the stash (`save_hidden_for_mtp_from_stash`). NULL without MTP.
+    pub(super) verify_hidden_stash: DevicePtr,
     /// ATLAS_MTP_CATCHUP: circular per-position final-hidden ring captured
     /// during serial-decode stretches (BF16 rows, slot = position % ring
     /// len). Feeds the drafter catch-up on the next propose. NULL when the
@@ -163,6 +204,17 @@ pub struct TransformerModel {
     /// restore) leaves it stale-short, which safely disables drafter-prefill
     /// for that sequence (coverage check at the propose site).
     pub(super) mtp_prefill_capture_len: std::sync::atomic::AtomicUsize,
+    /// Monotonic generation of the single-slot capture above. Bumped every
+    /// time a chunk-0 prefill (re)starts the capture; the restarting
+    /// sequence is stamped with the new value (`SequenceState::
+    /// mtp_capture_gen`). Appends and the drafter-prefill consume require
+    /// `stamp == current generation`, so at C>=2 a sequence whose capture
+    /// was overwritten by ANOTHER sequence's prefill skips the drafter
+    /// prefill instead of pairing its tokens with foreign hiddens. The
+    /// current value IS the latest capture's generation (single atomic,
+    /// SSOT). 0 = no capture ever started (matches the fresh-seq stamp 0,
+    /// which is harmless: `captured >= prompt_len >= 2` fails at len 0).
+    pub(super) mtp_prefill_capture_gen: std::sync::atomic::AtomicU64,
     /// ATLAS_MTP_CARRY_DRAFTER: the previous turn's drafter KV, held so the
     /// next turn of the same session can adopt it instead of rebuilding
     /// (1136 ms at 12k rows) or — as today — silently going without. Single
@@ -202,6 +254,29 @@ pub struct TransformerModel {
     pub(super) verify3_graph: Mutex<std::collections::HashMap<usize, GraphHandle>>,
     /// Cached CUDA graphs for K=4 verification, keyed by `seq.slot_idx`.
     pub(super) verify4_graph: Mutex<std::collections::HashMap<usize, GraphHandle>>,
+    /// Cached CUDA graphs for the BATCHED K-row verify (verify_e), keyed by
+    /// the batch's ssm-pool slot VECTOR (+ the per-seq row count K + a
+    /// wy-tables-present sentinel). Slot-vector keying is what a per-slot
+    /// key cannot give at n>1: the captured graph bakes every sequence's
+    /// h_state/conv_state/intermediate pointers, so it may only replay for
+    /// the exact same slot assignment in the same batch order (K is in the
+    /// key because a graph also bakes the R = n*K launch dimensions).
+    /// Attention metadata/block tables/embeds live at fixed scratch
+    /// addresses refreshed pre-replay (decode_a2 pattern).
+    /// Value = `(graph, last_use_tick)`; the `u64` alongside the map is the
+    /// monotonically increasing tick. At `VERIFY_BATCHED_GRAPH_CAP` entries
+    /// the least-recently-used graph is destroyed and replaced (slot vectors
+    /// churn with request turnover — the old insert-only map went
+    /// permanently eager after 32 distinct vectors on long serves).
+    pub(super) verify_batched_graphs:
+        Mutex<(std::collections::HashMap<Vec<u32>, (GraphHandle, u64)>, u64)>,
+    /// Batched-verify WY pointer-table staging: `num_ssm_layers` slices of
+    /// `crate::layer::VERIFY_WY_LAYER_STRIDE_BYTES` ([h|Hi0|Hi1|Hi2] × 4
+    /// u64 entries each) at a FIXED device address, refreshed pre-graph every
+    /// batched verify step (`upload_verify_wy_tables`). Enables the
+    /// single-launch table-form `gdn_decode_wy4` in the batched GDN arm.
+    /// NULL without an MTP proposer (path self-gates).
+    pub(super) verify_wy_tables: DevicePtr,
     /// Cached CUDA graphs for DFlash K=γ verification, keyed by
     /// `(seq.slot_idx, K)`. K is `tokens.len()` (γ+1 typically). One graph
     /// per (slot, K) — different γ values coexist via the K dimension.

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -5,11 +5,16 @@
 //! Defines the [`DraftProposer`] trait for speculative decoding strategies.
 //! MTP implements this first; EAGLE-3 can implement later without engine changes.
 
+pub mod ladder;
 pub mod tree_shape;
+
+pub use ladder::{mtp_ladder_disabled, mtp_ladder_drafts, mtp_max_seqs};
 
 use std::any::Any;
 
 use anyhow::Result;
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
 use spark_runtime::gpu::{DevicePtr, GpuBackend};
 
 use crate::layer::ForwardContext;
@@ -64,14 +69,42 @@ pub fn shadow_topk() -> usize {
     })
 }
 
+/// True when the MTP cap is raised above one sequence. The catchup ring
+/// (`types.rs` `mtp_catchup_ring` + meta), the refeed label convention, and
+/// the carry slot (`mtp_carry.rs`) are SINGLE-SEQUENCE structures — one ring,
+/// one label range, one slot. Running them with n concurrently-verifying
+/// sequences interleaves unrelated hiddens under one label space and breaks
+/// `after_verify`'s env-keyed trim contract (`mtp_rows_to_trim`). Disabling
+/// them process-wide when the cap > 1 is the only consistent option; a
+/// slot-keyed ring is recorded follow-up work (acceptance debt at n>1).
+pub fn mtp_multi_seq_mode() -> bool {
+    mtp_max_seqs() > 1
+}
+
+/// `ATLAS_MTP_ACCEPT_DEBUG` (PRESENCE): per-BATCH-WIDTH acceptance telemetry.
+///
+/// The shipped K ladder gives `k_drafts == 2` at n in [5, 8], and the existing
+/// positional counters (`k4_record_positional`) are gated on `k_drafts == 3`,
+/// so at the C=8 operating point NOTHING reported p1 — only the na histogram.
+/// This gate turns on a per-n line reporting p1, mean accepted and the derived
+/// tokens/step, which is the quantity the C=8 arithmetic is written in.
+/// Counters only (no D2H, no sync), but it logs per period, so keep it off in
+/// timed legs unless the leg IS the accept measurement.
+pub fn mtp_accept_debug() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_MTP_ACCEPT_DEBUG").is_ok())
+}
+
 /// Drafter catch-up feed on serial->speculative transitions
 /// (`ATLAS_MTP_CATCHUP=1`, staged off). During serial-decode stretches the
 /// scheduler rings the per-step final hiddens; on the next propose the gap
 /// rows are batch-fed into the drafter KV so it never runs stale. Wrong
 /// feeds cannot corrupt output (verification rejects bad drafts) — the
 /// stake is acceptance only, which is the flip gate's metric.
+/// Force-off in multi-seq MTP mode (single-sequence ring; see
+/// [`mtp_multi_seq_mode`]).
 pub fn mtp_catchup_enabled() -> bool {
-    std::env::var("ATLAS_MTP_CATCHUP").ok().as_deref() == Some("1")
+    std::env::var("ATLAS_MTP_CATCHUP").ok().as_deref() == Some("1") && !mtp_multi_seq_mode()
 }
 
 /// Re-feed ACCEPTED draft rows with the target's TRUE hidden state
@@ -191,8 +224,11 @@ pub fn mtp_catchup_enabled() -> bool {
 /// Both dwarf this flag, and (2) also changes what this flag is worth: a
 /// drafter that can actually see the prompt is a different drafter. **Build
 /// (2) first, then re-measure this.**
+///
+/// Force-off in multi-seq MTP mode: the refeed label space is single-sequence
+/// (see [`mtp_multi_seq_mode`]).
 pub fn mtp_refeed_accepted_enabled() -> bool {
-    std::env::var("ATLAS_MTP_REFEED_ACCEPTED").ok().as_deref() == Some("1")
+    std::env::var("ATLAS_MTP_REFEED_ACCEPTED").ok().as_deref() == Some("1") && !mtp_multi_seq_mode()
 }
 
 /// Deliberate off-by-N perturbation of the re-feed's ring LABEL
@@ -349,6 +385,47 @@ pub trait DraftProposer: Send + Sync {
         grammar_bitmask: Option<&[i32]>,
         target_hidden_stack: Option<DevicePtr>,
     ) -> Result<Vec<u32>>;
+
+    /// Batched cross-sequence propose: draft `num_drafts` tokens for each of
+    /// `n = last_tokens.len()` sequences, reading every drafter weight ONCE
+    /// per draft position instead of once per sequence (the measured C=4
+    /// serialization: 12 x ~5 ms per-seq drafter forwards per batched verify
+    /// step, ~62 ms of the ~180 ms step).
+    ///
+    /// Row i of every slice belongs to sequence i; `target_hiddens[i]` is
+    /// that sequence's accepted-position hidden ([1, hidden] BF16, may be
+    /// non-contiguous across i). Chains autoregressively per sequence like
+    /// `propose` — position j uses (draft_{j-1}, drafter's own hidden row i).
+    ///
+    /// Returns `Ok(None)` when unsupported (caller falls back to the per-seq
+    /// `propose` loop); `Ok(Some(drafts))` with `drafts[i].len() ==
+    /// num_drafts` on success. Grammar-constrained sequences must not reach
+    /// this path (callers gate on grammarless).
+    #[allow(clippy::too_many_arguments)]
+    fn propose_batch(
+        &self,
+        _last_tokens: &[u32],
+        _target_hiddens: &[DevicePtr],
+        _positions: &[usize],
+        _num_drafts: usize,
+        _states: &mut [&mut dyn ProposerState],
+        _ctx: &ForwardContext,
+        _stream: u64,
+    ) -> Result<Option<Vec<Vec<u32>>>> {
+        Ok(None)
+    }
+
+    /// The widest batch [`Self::propose_batch`] can carry in ONE drafter
+    /// forward per draft position, derived from this proposer's resolved
+    /// kernels and the arena's row capacities. `1` = per-sequence only.
+    ///
+    /// Callers chunk by this instead of a hardcoded constant: a fixed cap of
+    /// 4 made a 16-sequence step run 4 drafter forwards per position, each
+    /// re-reading the whole drafter — the batched-propose lever's own cost
+    /// re-introduced by its caller.
+    fn propose_batch_max(&self, _buffers: &BufferArena, _config: &ModelConfig) -> usize {
+        1
+    }
 
     /// Prefill the drafter's own context (KV cache) over the prompt, before
     /// the first `propose()` of a sequence (ATLAS_MTP_DRAFTER_PREFILL).

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -411,6 +411,7 @@ pub trait DraftProposer: Send + Sync {
         _states: &mut [&mut dyn ProposerState],
         _ctx: &ForwardContext,
         _stream: u64,
+        _out_conf: Option<&mut Vec<Vec<f32>>>,
     ) -> Result<Option<Vec<Vec<u32>>>> {
         Ok(None)
     }

--- a/crates/spark-model/src/speculative/ladder.rs
+++ b/crates/spark-model/src/speculative/ladder.rs
@@ -10,22 +10,34 @@
 //! row total stays small while the weight-read amortization of the batched
 //! verify keeps growing with n:
 //! n <= 4 -> 3 drafts (4 rows/seq, today's proven regime, bit-for-bit),
-//! n <= 8 -> 2 drafts (3 rows/seq, R <= 24).
+//! n <= 8 -> 3 drafts (4 rows/seq, R = 32 = the exact row-buffer bound).
+//!
+//! ★ The depth step-down that used to sit at n>4 was an artifact of the
+//! `mtp_step` chunk cap, NOT of GDN depth cost: `rows=4` was capped at 4
+//! sequences, so an 8-wide batch ran TWO serialized 4-wide verify forwards
+//! (2x the weight reads per step). Every "8:3 collapses" measurement
+//! (57.9 on 2026-07-28, and 62.6 when re-measured this session) recorded
+//! that chunking, not depth-3 at width 8. Raising the cap to the row-buffer
+//! bound makes the true 8-wide K=4 step the BEST measured point at C=8.
 //! The ladder ENDS at n=8: the finalizer matrix (2026-07-28) measured spec
 //! at n=16 as a LOSS at every depth even AFTER the three eager-cost fixes
 //! (`b93982d9` k-parameterized cross-seq GDN conv/WY, `a83627a2` propose
 //! widened to n=16, `fa373bf4` batched Phase-A bootstrap): 16:1 -> 128.4
-//! and 16:2 -> 94.1 vs the 131.9 MTP-off control. The fixes cut the n=16
-//! spec penalty from -11% to -2.7% (implied verify-step cost ~1.9x ->
-//! ~1.77x a plain batch-16 decode step) but not past the <1.72x
-//! break-even at p1~0.72. Remaining eager cost there: the Phase-A
-//! bootstrap forward is not graph-captured (`decode_batch` disables
-//! graphs at n>=2).
-//! At n<=8 the 8:2 step measured BEST *after* those fixes: C=8 89.25 vs
-//! 82.9 for 8:1 (+7.7%) and 57.9 for 8:3 (K=4 collapse). Pre-fix the
-//! ordering was inverted (8:1 82.4 > 8:2 81.1) — the cheaper verify step
-//! is what makes the deeper draft pay at n=8. n>8 is MTP-off via the cap
-//! (default 8).
+//! and 16:2 -> 94.1 vs the 131.9 MTP-off control. Re-measured 2026-07-28
+//! after the accept lift (`36d340a0` per-sequence drafter prefill, p1 at
+//! n=16 now 0.797): 16:1 -> 131.93 vs a same-session MTP-off control of
+//! 131.42 — spec at n=16 has reached PARITY but still buys nothing, so
+//! the cap stays 8 and n>8 remains MTP-off by construction. The implied
+//! verify-step cost at n=16 is ~1.79x a plain batch-16 decode step, and
+//! break-even at p1=0.797 is 1.797x; clearing the 168.9 bar would need
+//! ~1.40x. Remaining eager cost there: the Phase-A bootstrap forward is
+//! not graph-captured (`decode_batch` disables graphs at n>=2).
+//!
+//! At n<=8, measured C=8 on binary 9bef3b49 (this ladder + the raised
+//! chunk cap), one fresh serve per config: 8:3 95.84 (range 94.9-96.6,
+//! 8 reps) > 8:2 93.30 (92.5-94.0) — disjoint, reproduced on a second
+//! serve at 95.68. Accept telemetry at n=8: p1 0.793, tok_step 2.606
+//! (vs 0.780 / 2.301 at 8:2).
 //!
 //! Overrides:
 //! * `ATLAS_MTP_K_LADDER="4:3,8:2,16:1"` — comma-separated `n_max:drafts`
@@ -57,13 +69,22 @@ fn mtp_ladder_steps() -> &'static [(usize, usize)] {
             }
             (!steps.is_empty()).then_some(steps)
         });
-        // Default ladder (finalizer matrix 2026-07-28, post eager-cost
-        // fixes): 3 drafts at n<=4, 2 drafts at n<=8, NO step beyond 8 —
-        // spec at n=16 measured as a regression at every depth (see module
-        // docs). The cap (default 8) makes n>8 MTP-off by construction.
-        // Measured at C=8 on binary fa373bf4: 8:2 89.25 > 8:1 82.9 >>
-        // 8:3 57.9.
-        let mut steps = parsed.unwrap_or_else(|| vec![(4, 3), (8, 2)]);
+        // Default ladder (matrix 2026-07-28, post accept-lift): 3 drafts
+        // at every n up to the cap. NO step beyond 8 — spec at n=16 is at
+        // best parity with MTP-off (see module docs), and the cap (default
+        // 8) makes n>8 MTP-off by construction.
+        //
+        // The 8:2 step-down was an ARTIFACT of the `mtp_step` chunk cap,
+        // not of depth: with `rows=4` capped at 4 sequences, an 8-wide
+        // batch ran TWO serialized 4-wide verify forwards, which is what
+        // the "8:3 collapses" numbers (57.9, and 62.6 measured this
+        // session) recorded. With the cap raised to the row-buffer bound
+        // (R = n*k <= 32, so 8 seqs x 4 rows fits exactly) a true 8-wide
+        // K=4 verify MEASURES 95.84 tok/s at C=8 vs 93.30 for 8:2 on the
+        // same binary — disjoint ranges (94.9-96.6 vs 92.5-94.0), two
+        // independent serves. tok_step 2.606 vs 2.301 (+13.3%) for a
+        // verify step ~11% more expensive.
+        let mut steps = parsed.unwrap_or_else(|| vec![(4, 3), (8, 3)]);
         steps.sort_by_key(|&(n, _)| n);
         steps
     })
@@ -102,9 +123,9 @@ pub fn mtp_ladder_drafts(n_active: usize, num_drafts: usize) -> usize {
 ///
 /// The cap IS the adaptive per-concurrency policy: the scheduler gates
 /// dispatch on `active.len() <= mtp_max_seqs()`. Per-step K comes from
-/// [`mtp_ladder_drafts`] (task #35): 3 drafts at n<=4 (the proven K=4
-/// regime, bit-for-bit), 2 drafts at n<=8 (finalizer matrix 2026-07-28:
-/// C=8 89.25 vs 81.2 at 8:1 and 73.5 MTP-off). Cap 8 (NOT 16): spec at
+/// [`mtp_ladder_drafts`] (task #35): 3 drafts at every n up to the cap
+/// (`4:3,8:3` — matrix 2026-07-28: C=8 95.84 at 8:3 vs 93.30 at 8:2 on the
+/// same binary, and 73.5 MTP-off). Cap 8 (NOT 16): spec at
 /// n=16 stays a REGRESSION vs MTP-off at every depth even after the three
 /// eager-cost fixes (128.4 at 16:1, 94.1 at 16:2, vs 131.9 MTP-off), so
 /// n>8 falls back to the plain multi-seq decode path.
@@ -117,9 +138,9 @@ pub fn mtp_max_seqs() -> usize {
         std::env::var("ATLAS_MTP_MAX_SEQS")
             .ok()
             .and_then(|v| v.parse().ok())
-            // Default 8, NOT 16 (finalizer matrix 2026-07-28, binary
-            // fa373bf4): with the ladder, C=8 at 2 drafts = 89.25 tok/s
-            // (+21% over the 73.5 MTP-off floor), but C=16 speculation
+            // Default 8, NOT 16 (finalizer matrix 2026-07-28): with the
+            // ladder, C=8 at 3 drafts = 95.84 tok/s (+30% over the 73.5
+            // MTP-off floor), but C=16 speculation
             // still LOSES at every depth (128.4 at 16:1, 94.1 at 16:2 —
             // vs the 131.9 MTP-off control): the k=2 verify step costs
             // ~1.77x a plain batch-16 decode step, above the ~1.72x
@@ -143,15 +164,32 @@ mod tests {
     // Default-ladder shape (env-independent as long as the test process
     // does not set ATLAS_MTP_K_LADDER / ATLAS_NO_MTP_K_LADDER — CI does not).
     #[test]
-    fn default_ladder_steps_down_with_n() {
+    fn default_ladder_holds_depth_to_the_cap() {
         assert_eq!(mtp_ladder_drafts(1, 3), 3);
         assert_eq!(mtp_ladder_drafts(4, 3), 3);
-        assert_eq!(mtp_ladder_drafts(5, 3), 2);
-        assert_eq!(mtp_ladder_drafts(8, 3), 2);
+        assert_eq!(mtp_ladder_drafts(5, 3), 3);
+        assert_eq!(mtp_ladder_drafts(8, 3), 3);
         // Beyond the last step: last step's value (the cap — default 8 —
         // gates dispatch, so n>8 never speculates at defaults).
-        assert_eq!(mtp_ladder_drafts(16, 3), 2);
-        assert_eq!(mtp_ladder_drafts(32, 3), 2);
+        assert_eq!(mtp_ladder_drafts(16, 3), 3);
+        assert_eq!(mtp_ladder_drafts(32, 3), 3);
+    }
+
+    // A step-down ladder must still be honored when asked for explicitly
+    // (the 8:2 shape stays reachable via ATLAS_MTP_K_LADDER).
+    #[test]
+    fn explicit_steps_are_honored() {
+        let steps = [(4usize, 3usize), (8, 2)];
+        let drafts = |n: usize| {
+            steps
+                .iter()
+                .find(|&&(n_max, _)| n <= n_max)
+                .or(steps.last())
+                .map(|&(_, k)| k.clamp(1, 3))
+                .unwrap()
+        };
+        assert_eq!(drafts(4), 3);
+        assert_eq!(drafts(8), 2);
     }
 
     #[test]

--- a/crates/spark-model/src/speculative/ladder.rs
+++ b/crates/spark-model/src/speculative/ladder.rs
@@ -10,7 +10,8 @@
 //! row total stays small while the weight-read amortization of the batched
 //! verify keeps growing with n:
 //! n <= 4 -> 3 drafts (4 rows/seq, today's proven regime, bit-for-bit),
-//! n <= 8 -> 3 drafts (4 rows/seq, R = 32 = the exact row-buffer bound).
+//! n <= 8 -> 3 drafts (4 rows/seq, R = 32 = the exact row-buffer bound),
+//! n <= 16 -> 1 draft (2 rows/seq, R = 32 again at n=16).
 //!
 //! ★ The depth step-down that used to sit at n>4 was an artifact of the
 //! `mtp_step` chunk cap, NOT of GDN depth cost: `rows=4` was capped at 4
@@ -19,19 +20,19 @@
 //! (57.9 on 2026-07-28, and 62.6 when re-measured this session) recorded
 //! that chunking, not depth-3 at width 8. Raising the cap to the row-buffer
 //! bound makes the true 8-wide K=4 step the BEST measured point at C=8.
-//! The ladder ENDS at n=8: the finalizer matrix (2026-07-28) measured spec
-//! at n=16 as a LOSS at every depth even AFTER the three eager-cost fixes
-//! (`b93982d9` k-parameterized cross-seq GDN conv/WY, `a83627a2` propose
-//! widened to n=16, `fa373bf4` batched Phase-A bootstrap): 16:1 -> 128.4
-//! and 16:2 -> 94.1 vs the 131.9 MTP-off control. Re-measured 2026-07-28
-//! after the accept lift (`36d340a0` per-sequence drafter prefill, p1 at
-//! n=16 now 0.797): 16:1 -> 131.93 vs a same-session MTP-off control of
-//! 131.42 — spec at n=16 has reached PARITY but still buys nothing, so
-//! the cap stays 8 and n>8 remains MTP-off by construction. The implied
-//! verify-step cost at n=16 is ~1.79x a plain batch-16 decode step, and
-//! break-even at p1=0.797 is 1.797x; clearing the 168.9 bar would need
-//! ~1.40x. Remaining eager cost there: the Phase-A bootstrap forward is
-//! not graph-captured (`decode_batch` disables graphs at n>=2).
+//! ★ The n=16 rung took three rounds to earn its place, and its history is
+//! the record of a COST curve, not of a depth curve. It measured a loss
+//! (16:1 -> 128.4 vs a 131.9 MTP-off control) after the three eager-cost
+//! fixes (`b93982d9` k-parameterized cross-seq GDN conv/WY, `a83627a2`
+//! propose widened to n=16, `fa373bf4` batched Phase-A bootstrap), then
+//! exact PARITY (131.93 vs 131.42) after the accept lift (`36d340a0`
+//! per-sequence drafter prefill lifted p1 at n=16 to 0.797, making
+//! break-even 1.797x against a measured ~1.79x). `296b9674`'s three
+//! per-row verify cuts took the implied cost to ~1.55x, and the SAME 16:1
+//! shape then measured **152.01 tok/s over two serves against a
+//! same-session MTP-off control of 131.40 (+15.7%)**, p1 0.78-0.86,
+//! tok_step ~1.83. Depth at n=16 is still dead: 16:2 -> 94.1 and 16:3 ->
+//! 120.76. Clearing vLLM's 168.9 needs the cost under ~1.40x.
 //!
 //! At n<=8, measured C=8 on binary 9bef3b49 (this ladder + the raised
 //! chunk cap), one fresh serve per config: 8:3 95.84 (range 94.9-96.6,
@@ -69,10 +70,15 @@ fn mtp_ladder_steps() -> &'static [(usize, usize)] {
             }
             (!steps.is_empty()).then_some(steps)
         });
-        // Default ladder (matrix 2026-07-28, post accept-lift): 3 drafts
-        // at every n up to the cap. NO step beyond 8 — spec at n=16 is at
-        // best parity with MTP-off (see module docs), and the cap (default
-        // 8) makes n>8 MTP-off by construction.
+        // Default ladder (finalizer matrix 2026-07-29): 3 drafts up to the
+        // n=8 rung, then ONE draft at n<=16. The 16:1 rung was dead weight
+        // while the cap was 8; with the cap raised to 16 it is the shape
+        // that measures 152.01 tok/s at C=16 against a 131.40 MTP-off
+        // control (+15.7%). It is inert at n<=8 by construction (the n<=8
+        // rung matches first). Depth at n=16 stays dead: 16:3 measures
+        // 120.76 on the same binary, and D-Cut cannot rescue it (16 seqs x
+        // its mandatory 2 rows = the whole 32-row budget, so it is forced
+        // back to k=1 while the propose still pays for 3 drafts).
         //
         // The 8:2 step-down was an ARTIFACT of the `mtp_step` chunk cap,
         // not of depth: with `rows=4` capped at 4 sequences, an 8-wide
@@ -84,7 +90,7 @@ fn mtp_ladder_steps() -> &'static [(usize, usize)] {
         // same binary — disjoint ranges (94.9-96.6 vs 92.5-94.0), two
         // independent serves. tok_step 2.606 vs 2.301 (+13.3%) for a
         // verify step ~11% more expensive.
-        let mut steps = parsed.unwrap_or_else(|| vec![(4, 3), (8, 3)]);
+        let mut steps = parsed.unwrap_or_else(|| vec![(4, 3), (8, 3), (16, 1)]);
         steps.sort_by_key(|&(n, _)| n);
         steps
     })
@@ -113,7 +119,7 @@ pub fn mtp_ladder_drafts(n_active: usize, num_drafts: usize) -> usize {
         .unwrap_or(num_drafts)
 }
 
-/// SSOT for the multi-sequence MTP cap (`ATLAS_MTP_MAX_SEQS`; default 8
+/// SSOT for the multi-sequence MTP cap (`ATLAS_MTP_MAX_SEQS`; default 16
 /// with the K-vs-batch ladder, 4 under `ATLAS_NO_MTP_K_LADDER`).
 /// Value-parsed, not presence-checked. Lives beside the ladder (moved from
 /// `speculative.rs`, originally `scheduler/mod.rs`) because the two are one
@@ -123,12 +129,10 @@ pub fn mtp_ladder_drafts(n_active: usize, num_drafts: usize) -> usize {
 ///
 /// The cap IS the adaptive per-concurrency policy: the scheduler gates
 /// dispatch on `active.len() <= mtp_max_seqs()`. Per-step K comes from
-/// [`mtp_ladder_drafts`] (task #35): 3 drafts at every n up to the cap
-/// (`4:3,8:3` — matrix 2026-07-28: C=8 95.84 at 8:3 vs 93.30 at 8:2 on the
-/// same binary, and 73.5 MTP-off). Cap 8 (NOT 16): spec at
-/// n=16 stays a REGRESSION vs MTP-off at every depth even after the three
-/// eager-cost fixes (128.4 at 16:1, 94.1 at 16:2, vs 131.9 MTP-off), so
-/// n>8 falls back to the plain multi-seq decode path.
+/// [`mtp_ladder_drafts`] (task #35): `4:3,8:3,16:1` — 3 drafts through n=8
+/// (matrix 2026-07-28: C=8 95.84 at 8:3 vs 93.30 at 8:2 on the same binary,
+/// and 73.5 MTP-off), then 1 draft through n=16 (matrix 2026-07-29: C=16
+/// 152.01 vs a 131.40 MTP-off control).
 /// `ATLAS_NO_MTP_K_LADDER` (presence) restores fixed K=4 + cap 4 — the
 /// dafd990d adaptive policy. Set `ATLAS_MTP_MAX_SEQS=1` to restore
 /// single-sequence-only.
@@ -138,22 +142,24 @@ pub fn mtp_max_seqs() -> usize {
         std::env::var("ATLAS_MTP_MAX_SEQS")
             .ok()
             .and_then(|v| v.parse().ok())
-            // Default 8, NOT 16 (finalizer matrix 2026-07-28): with the
-            // ladder, C=8 at 3 drafts = 95.84 tok/s (+30% over the 73.5
-            // MTP-off floor), but C=16 speculation
-            // still LOSES at every depth (128.4 at 16:1, 94.1 at 16:2 —
-            // vs the 131.9 MTP-off control): the k=2 verify step costs
-            // ~1.77x a plain batch-16 decode step, above the ~1.72x
-            // break-even at p1~0.72. The three eager-cost fixes
-            // (b93982d9/a83627a2/fa373bf4) cut that from ~1.9x but not
-            // past break-even. Cap 8 makes n>8 MTP-off by construction,
-            // preserving the C=16 floor. Raising the cap requires first
-            // graph-capturing the Phase-A bootstrap forward (it routes
-            // through `decode_batch`, which disables graphs at n>=2).
+            // Default 16 (finalizer matrix 2026-07-29). It was 8 for three
+            // rounds because spec at n=16 measured a LOSS (128.4 at 16:1)
+            // and then a PARITY (131.93 vs a 131.42 MTP-off control): the
+            // verify step cost ~1.79x a plain batch-16 decode step against
+            // a break-even of 1.797x at p1 0.797. `296b9674`'s three
+            // per-row verify cuts (wide LM-head arm, one-launch gated RMS
+            // norm, fused BA+gates) bought ~0.20x of that cost — implied
+            // cost is now ~1.55x — and the same 16:1 shape MEASURES 152.01
+            // tok/s over two serves against a same-session MTP-off control
+            // of 131.40 (+15.7%), with p1 0.78-0.86 and tok_step ~1.83.
+            // ★ The raise is inert at n<=8: the cap only gates dispatch
+            // above 8 and the `16:1` ladder rung only matches above 8, so
+            // the C=1/2/4/8 code paths are unchanged. Set
+            // `ATLAS_MTP_MAX_SEQS=8` to restore the round-3 cap.
             // Pre-ladder baseline (cap=4, binary 472ed410): C=1 25.55
             // (1.80x vLLM) · C=2 35.35 (1.27x) · C=4 54.1 (1.01x) ·
             // C=8/16 MTP-off 73.5/131.0.
-            .unwrap_or(if mtp_ladder_disabled() { 4 } else { 8 })
+            .unwrap_or(if mtp_ladder_disabled() { 4 } else { 16 })
     })
 }
 
@@ -169,10 +175,13 @@ mod tests {
         assert_eq!(mtp_ladder_drafts(4, 3), 3);
         assert_eq!(mtp_ladder_drafts(5, 3), 3);
         assert_eq!(mtp_ladder_drafts(8, 3), 3);
-        // Beyond the last step: last step's value (the cap — default 8 —
-        // gates dispatch, so n>8 never speculates at defaults).
-        assert_eq!(mtp_ladder_drafts(16, 3), 3);
-        assert_eq!(mtp_ladder_drafts(32, 3), 3);
+        // The 16:1 rung: depth at n=16 is dead (16:2 -> 94.1, 16:3 ->
+        // 120.76 vs 152.01 at 16:1), so above the n=8 rung K drops to 2.
+        assert_eq!(mtp_ladder_drafts(9, 3), 1);
+        assert_eq!(mtp_ladder_drafts(16, 3), 1);
+        // Beyond the last step: last step's value (the cap — default 16 —
+        // gates dispatch, so n>16 never speculates at defaults).
+        assert_eq!(mtp_ladder_drafts(32, 3), 1);
     }
 
     // A step-down ladder must still be honored when asked for explicitly

--- a/crates/spark-model/src/speculative/ladder.rs
+++ b/crates/spark-model/src/speculative/ladder.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! K-vs-batch ladder (task #35): per-step draft count as a function of the
+//! number of active sequences.
+//!
+//! Fixed K=4 (3 drafts) over n >= 8 sequences MEASURED as a collapse to a
+//! ~55 tok/s plateau at every C (cap=16 sweep, 2026-07-28): n*(K+1) verify
+//! rows of SUPERLINEAR per-sequence GDN plus graph-key churn. The ladder
+//! shrinks the per-sequence draft count as concurrency grows so the verify
+//! row total stays small while the weight-read amortization of the batched
+//! verify keeps growing with n:
+//! n <= 4 -> 3 drafts (4 rows/seq, today's proven regime, bit-for-bit),
+//! n <= 8 -> 2 drafts (3 rows/seq, R <= 24).
+//! The ladder ENDS at n=8: the finalizer matrix (2026-07-28) measured spec
+//! at n=16 as a LOSS at every depth even AFTER the three eager-cost fixes
+//! (`b93982d9` k-parameterized cross-seq GDN conv/WY, `a83627a2` propose
+//! widened to n=16, `fa373bf4` batched Phase-A bootstrap): 16:1 -> 128.4
+//! and 16:2 -> 94.1 vs the 131.9 MTP-off control. The fixes cut the n=16
+//! spec penalty from -11% to -2.7% (implied verify-step cost ~1.9x ->
+//! ~1.77x a plain batch-16 decode step) but not past the <1.72x
+//! break-even at p1~0.72. Remaining eager cost there: the Phase-A
+//! bootstrap forward is not graph-captured (`decode_batch` disables
+//! graphs at n>=2).
+//! At n<=8 the 8:2 step measured BEST *after* those fixes: C=8 89.25 vs
+//! 82.9 for 8:1 (+7.7%) and 57.9 for 8:3 (K=4 collapse). Pre-fix the
+//! ordering was inverted (8:1 82.4 > 8:2 81.1) — the cheaper verify step
+//! is what makes the deeper draft pay at n=8. n>8 is MTP-off via the cap
+//! (default 8).
+//!
+//! Overrides:
+//! * `ATLAS_MTP_K_LADDER="4:3,8:2,16:1"` — comma-separated `n_max:drafts`
+//!   steps, VALUE-parsed once per process. Draft counts clamp to
+//!   `[1, num_drafts]` (the CLI `--num-drafts` remains the ceiling, so
+//!   `"4:4,..."` parses to the full configured draft count).
+//! * `ATLAS_NO_MTP_K_LADDER` — PRESENCE check (house convention, `=0` is
+//!   NOT off): disables the ladder entirely (fixed `num_drafts` at every n)
+//!   AND drops the [`super::mtp_max_seqs`] default back to 4, restoring the
+//!   pre-ladder adaptive policy (batched K=4 MTP at C<=4, MTP-off above).
+
+/// PRESENCE check for `ATLAS_NO_MTP_K_LADDER`. Read once per process.
+pub fn mtp_ladder_disabled() -> bool {
+    static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OFF.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_K_LADDER").is_some())
+}
+
+/// Parsed ladder steps `(n_max, drafts)`, ascending by `n_max`. Falls back
+/// to the default ladder when `ATLAS_MTP_K_LADDER` is unset or unparseable
+/// (a malformed value must not silently disable speculation).
+fn mtp_ladder_steps() -> &'static [(usize, usize)] {
+    static STEPS: std::sync::OnceLock<Vec<(usize, usize)>> = std::sync::OnceLock::new();
+    STEPS.get_or_init(|| {
+        let parsed = std::env::var("ATLAS_MTP_K_LADDER").ok().and_then(|v| {
+            let mut steps: Vec<(usize, usize)> = Vec::new();
+            for part in v.split(',') {
+                let (n, k) = part.trim().split_once(':')?;
+                steps.push((n.trim().parse().ok()?, k.trim().parse().ok()?));
+            }
+            (!steps.is_empty()).then_some(steps)
+        });
+        // Default ladder (finalizer matrix 2026-07-28, post eager-cost
+        // fixes): 3 drafts at n<=4, 2 drafts at n<=8, NO step beyond 8 —
+        // spec at n=16 measured as a regression at every depth (see module
+        // docs). The cap (default 8) makes n>8 MTP-off by construction.
+        // Measured at C=8 on binary fa373bf4: 8:2 89.25 > 8:1 82.9 >>
+        // 8:3 57.9.
+        let mut steps = parsed.unwrap_or_else(|| vec![(4, 3), (8, 2)]);
+        steps.sort_by_key(|&(n, _)| n);
+        steps
+    })
+}
+
+/// The per-step draft count for `n_active` concurrent sequences.
+///
+/// `num_drafts` is the configured ceiling (CLI `--num-drafts`); the return
+/// value is always in `[1, num_drafts]` (or 0 when `num_drafts` is 0, i.e.
+/// speculation off). Ladder disabled -> fixed `num_drafts` (pre-ladder
+/// behavior). `n_active` beyond the last ladder step uses the last step's
+/// draft count (the cap gates dispatch anyway).
+pub fn mtp_ladder_drafts(n_active: usize, num_drafts: usize) -> usize {
+    if num_drafts == 0 {
+        return 0;
+    }
+    if mtp_ladder_disabled() {
+        return num_drafts;
+    }
+    let steps = mtp_ladder_steps();
+    steps
+        .iter()
+        .find(|&&(n_max, _)| n_active <= n_max)
+        .or(steps.last())
+        .map(|&(_, k)| k.clamp(1, num_drafts))
+        .unwrap_or(num_drafts)
+}
+
+/// SSOT for the multi-sequence MTP cap (`ATLAS_MTP_MAX_SEQS`; default 8
+/// with the K-vs-batch ladder, 4 under `ATLAS_NO_MTP_K_LADDER`).
+/// Value-parsed, not presence-checked. Lives beside the ladder (moved from
+/// `speculative.rs`, originally `scheduler/mod.rs`) because the two are one
+/// policy: the model-side single-sequence MTP structures (catchup ring,
+/// refeed labels, carry slot) gate on the same value the scheduler gates
+/// dispatch on.
+///
+/// The cap IS the adaptive per-concurrency policy: the scheduler gates
+/// dispatch on `active.len() <= mtp_max_seqs()`. Per-step K comes from
+/// [`mtp_ladder_drafts`] (task #35): 3 drafts at n<=4 (the proven K=4
+/// regime, bit-for-bit), 2 drafts at n<=8 (finalizer matrix 2026-07-28:
+/// C=8 89.25 vs 81.2 at 8:1 and 73.5 MTP-off). Cap 8 (NOT 16): spec at
+/// n=16 stays a REGRESSION vs MTP-off at every depth even after the three
+/// eager-cost fixes (128.4 at 16:1, 94.1 at 16:2, vs 131.9 MTP-off), so
+/// n>8 falls back to the plain multi-seq decode path.
+/// `ATLAS_NO_MTP_K_LADDER` (presence) restores fixed K=4 + cap 4 — the
+/// dafd990d adaptive policy. Set `ATLAS_MTP_MAX_SEQS=1` to restore
+/// single-sequence-only.
+pub fn mtp_max_seqs() -> usize {
+    static N: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *N.get_or_init(|| {
+        std::env::var("ATLAS_MTP_MAX_SEQS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            // Default 8, NOT 16 (finalizer matrix 2026-07-28, binary
+            // fa373bf4): with the ladder, C=8 at 2 drafts = 89.25 tok/s
+            // (+21% over the 73.5 MTP-off floor), but C=16 speculation
+            // still LOSES at every depth (128.4 at 16:1, 94.1 at 16:2 —
+            // vs the 131.9 MTP-off control): the k=2 verify step costs
+            // ~1.77x a plain batch-16 decode step, above the ~1.72x
+            // break-even at p1~0.72. The three eager-cost fixes
+            // (b93982d9/a83627a2/fa373bf4) cut that from ~1.9x but not
+            // past break-even. Cap 8 makes n>8 MTP-off by construction,
+            // preserving the C=16 floor. Raising the cap requires first
+            // graph-capturing the Phase-A bootstrap forward (it routes
+            // through `decode_batch`, which disables graphs at n>=2).
+            // Pre-ladder baseline (cap=4, binary 472ed410): C=1 25.55
+            // (1.80x vLLM) · C=2 35.35 (1.27x) · C=4 54.1 (1.01x) ·
+            // C=8/16 MTP-off 73.5/131.0.
+            .unwrap_or(if mtp_ladder_disabled() { 4 } else { 8 })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Default-ladder shape (env-independent as long as the test process
+    // does not set ATLAS_MTP_K_LADDER / ATLAS_NO_MTP_K_LADDER — CI does not).
+    #[test]
+    fn default_ladder_steps_down_with_n() {
+        assert_eq!(mtp_ladder_drafts(1, 3), 3);
+        assert_eq!(mtp_ladder_drafts(4, 3), 3);
+        assert_eq!(mtp_ladder_drafts(5, 3), 2);
+        assert_eq!(mtp_ladder_drafts(8, 3), 2);
+        // Beyond the last step: last step's value (the cap — default 8 —
+        // gates dispatch, so n>8 never speculates at defaults).
+        assert_eq!(mtp_ladder_drafts(16, 3), 2);
+        assert_eq!(mtp_ladder_drafts(32, 3), 2);
+    }
+
+    #[test]
+    fn ladder_clamps_to_configured_ceiling() {
+        // num_drafts=1 caps every step at 1; num_drafts=0 means spec off.
+        assert_eq!(mtp_ladder_drafts(2, 1), 1);
+        assert_eq!(mtp_ladder_drafts(2, 0), 0);
+    }
+}

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -108,6 +108,16 @@ pub struct SequenceState {
     /// prefill. The model uses this to tag saved snapshots and verify ownership
     /// before restoring. 0 = no session tracking (legacy behavior).
     pub session_hash: u64,
+    /// Ownership stamp for the SINGLE-SLOT whole-prompt hidden capture
+    /// (`mtp_prefill_hidden`). Written by `try_mtp_prefill_capture` when THIS
+    /// sequence's chunk 0 (re)starts the capture, with the model's monotonic
+    /// capture generation. `ensure_drafter_context` prefills the drafter only
+    /// while the stamp still matches the model's current generation — at
+    /// C>=2 interleaved prefills restart the shared capture, and without this
+    /// check a sequence's first propose could pair ITS tokens with ANOTHER
+    /// sequence's captured hiddens (poisoned drafter KV; blind is strictly
+    /// better than poisoned). 0 = never owned a capture.
+    pub mtp_capture_gen: u64,
     /// Per-adapter prefix-cache namespace (adapter-correct KV). Folded into the
     /// prefix hash so two adapters that share a token prefix never reuse each
     /// other's blocks. `0` = base / no adapter (a strict no-op in the fold, so

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -531,37 +531,38 @@ pub trait Model: Send + Sync {
         stream: u64,
     ) -> Result<[u32; 4]>;
 
-    /// Whether [`Self::decode_verify_batched`] can run for `n` sequences at
-    /// `k` verify rows per sequence (`k` = drafts + 1; the K-vs-batch ladder
-    /// passes k in 2..=4).
+    /// Whether [`Self::decode_verify_batched`] can run for `ks.len()`
+    /// sequences at `ks[i]` verify rows each (one more than that sequence's
+    /// draft count; the K-vs-batch ladder passes 2..=4, and D-Cut makes the
+    /// vector RAGGED — uniform is just the special case).
     ///
     /// Default `false`: the scheduler MUST fall back to the per-sequence
     /// `decode_verify_graphed_k{2,3,4}` loop. There is deliberately NO
     /// default loop impl of the batched form — a loop over the per-seq
     /// verify would leave the shared logits buffer holding only the LAST
     /// sequence's rows and silently poison row-based pipeline picks.
-    fn can_batch_verify(&self, _n: usize, _k: usize) -> bool {
+    fn can_batch_verify(&self, _ks: &[usize]) -> bool {
         false
     }
 
-    /// Batched K-row verify: n sequences × k rows in ONE eager forward
-    /// (seq-major rows `r = i*k + j`, `tokens.len() == n*k`). Weight
-    /// matrices are read once for all `n*k` rows. Per sequence i:
-    /// `tokens[i*k..(i+1)*k] = [last_verified, d0, .., d_{k-2}]`.
-    /// Returns the `n*k` argmax IDs in the same flat seq-major order. On
-    /// success each sequence's `tokens`/`seq_len` advance by k (rewind is
-    /// the caller's verdict arithmetic, same as the per-seq path). On Err
-    /// NO sequence state has been advanced.
+    /// Batched K-row verify: `ks.len()` sequences × `ks[i]` rows in ONE eager
+    /// forward (flat seq-major rows, `tokens.len() == Σ ks`). Weight matrices
+    /// are read once for all `Σ ks` rows. Sequence i occupies rows
+    /// `[off_i, off_i + ks[i])` where `off_i = Σ_{t<i} ks[t]`, holding
+    /// `[last_verified, d0, .., d_{ks[i]-2}]`. Returns the `Σ ks` argmax IDs
+    /// in the same flat order. On success each sequence's `tokens`/`seq_len`
+    /// advance by its own `ks[i]` (rewind is the caller's verdict arithmetic,
+    /// same as the per-seq path). On Err NO sequence state has been advanced.
     ///
     /// Callers must gate on [`Self::can_batch_verify`].
     fn decode_verify_batched(
         &self,
         tokens: &[u32],
-        k: usize,
+        ks: &[usize],
         seqs: &mut [&mut SequenceState],
         stream: u64,
     ) -> Result<Vec<u32>> {
-        let _ = (tokens, k, seqs, stream);
+        let _ = (tokens, ks, seqs, stream);
         bail!("decode_verify_batched: unsupported by this model")
     }
 
@@ -592,8 +593,15 @@ pub trait Model: Send + Sync {
     /// position (post-rewind `seq_len`), matching the per-seq
     /// [`Self::run_mtp_propose_multi`] contract. Grammarless sequences only.
     ///
+    /// `out_conf`, when `Some`, receives each draft's top-1 LOG-probability
+    /// (`ln p`, same shape as the returned drafts) — the D-Cut ranking key.
+    /// It is filled with zeros (certainty) when the drafter cannot measure
+    /// confidence, so a caller ranking by prefix product never prunes on a
+    /// value nobody produced.
+    ///
     /// `Ok(None)` = unsupported (caller falls back to the per-seq propose
     /// loop, re-saving each stash slot first). Default: unsupported.
+    #[allow(clippy::too_many_arguments)]
     fn run_mtp_propose_batched(
         &self,
         tokens: &[u32],
@@ -602,8 +610,11 @@ pub trait Model: Send + Sync {
         num_drafts: usize,
         seqs: &mut [&mut SequenceState],
         stream: u64,
+        out_conf: Option<&mut Vec<Vec<f32>>>,
     ) -> Result<Option<Vec<Vec<u32>>>> {
-        let _ = (tokens, positions, stash_idx, num_drafts, seqs, stream);
+        let _ = (
+            tokens, positions, stash_idx, num_drafts, seqs, stream, out_conf,
+        );
         Ok(None)
     }
 

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -531,6 +531,89 @@ pub trait Model: Send + Sync {
         stream: u64,
     ) -> Result<[u32; 4]>;
 
+    /// Whether [`Self::decode_verify_batched`] can run for `n` sequences at
+    /// `k` verify rows per sequence (`k` = drafts + 1; the K-vs-batch ladder
+    /// passes k in 2..=4).
+    ///
+    /// Default `false`: the scheduler MUST fall back to the per-sequence
+    /// `decode_verify_graphed_k{2,3,4}` loop. There is deliberately NO
+    /// default loop impl of the batched form — a loop over the per-seq
+    /// verify would leave the shared logits buffer holding only the LAST
+    /// sequence's rows and silently poison row-based pipeline picks.
+    fn can_batch_verify(&self, _n: usize, _k: usize) -> bool {
+        false
+    }
+
+    /// Batched K-row verify: n sequences × k rows in ONE eager forward
+    /// (seq-major rows `r = i*k + j`, `tokens.len() == n*k`). Weight
+    /// matrices are read once for all `n*k` rows. Per sequence i:
+    /// `tokens[i*k..(i+1)*k] = [last_verified, d0, .., d_{k-2}]`.
+    /// Returns the `n*k` argmax IDs in the same flat seq-major order. On
+    /// success each sequence's `tokens`/`seq_len` advance by k (rewind is
+    /// the caller's verdict arithmetic, same as the per-seq path). On Err
+    /// NO sequence state has been advanced.
+    ///
+    /// Callers must gate on [`Self::can_batch_verify`].
+    fn decode_verify_batched(
+        &self,
+        tokens: &[u32],
+        k: usize,
+        seqs: &mut [&mut SequenceState],
+        stream: u64,
+    ) -> Result<Vec<u32>> {
+        let _ = (tokens, k, seqs, stream);
+        bail!("decode_verify_batched: unsupported by this model")
+    }
+
+    /// Copy raw-hidden rows `rows[i]` of the just-run batched verify forward
+    /// into stash slot `i` (`verify_hidden_stash`), BEFORE any propose
+    /// clobbers the shared `hidden_states` buffer. Companion of
+    /// [`Self::decode_verify_batched`].
+    fn stash_verify_hidden_rows(&self, rows: &[usize], stream: u64) -> Result<()> {
+        let _ = (rows, stream);
+        bail!("stash_verify_hidden_rows: unsupported by this model")
+    }
+
+    /// Stashed-row variant of [`Self::save_hidden_for_mtp`]: copy stash slot
+    /// `idx` (written by [`Self::stash_verify_hidden_rows`]) into the MTP
+    /// input buffer. Used by the batched-verify verdict path, whose propose
+    /// calls have already overwritten the live verify rows.
+    fn save_hidden_for_mtp_from_stash(&self, idx: usize, stream: u64) -> Result<()> {
+        let _ = (idx, stream);
+        bail!("save_hidden_for_mtp_from_stash: unsupported by this model")
+    }
+
+    /// Batched cross-sequence MTP propose for the batched K=4 verify path:
+    /// `num_drafts` drafts for each of `tokens.len()` sequences, reading
+    /// every drafter weight once per draft position instead of once per
+    /// sequence. `stash_idx[i]` names the verify-stash slot holding sequence
+    /// i's accepted-position hidden (written by
+    /// [`Self::stash_verify_hidden_rows`]); `positions[i]` is the propose
+    /// position (post-rewind `seq_len`), matching the per-seq
+    /// [`Self::run_mtp_propose_multi`] contract. Grammarless sequences only.
+    ///
+    /// `Ok(None)` = unsupported (caller falls back to the per-seq propose
+    /// loop, re-saving each stash slot first). Default: unsupported.
+    fn run_mtp_propose_batched(
+        &self,
+        tokens: &[u32],
+        positions: &[usize],
+        stash_idx: &[usize],
+        num_drafts: usize,
+        seqs: &mut [&mut SequenceState],
+        stream: u64,
+    ) -> Result<Option<Vec<Vec<u32>>>> {
+        let _ = (tokens, positions, stash_idx, num_drafts, seqs, stream);
+        Ok(None)
+    }
+
+    /// Widest batch [`Self::run_mtp_propose_batched`] can carry in ONE
+    /// drafter forward per draft position. `1` = per-sequence only.
+    /// Schedulers chunk their propose groups by this — never by a constant.
+    fn mtp_propose_batch_max(&self) -> usize {
+        1
+    }
+
     /// DFlash K=γ graphed verify (γ+1 tokens). Specialization of the K=2/3/4
     /// pattern for arbitrary K. Default impl falls back to eager
     /// `decode_verify`. Models can override for CUDA-graph speedup keyed by

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -458,6 +458,30 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                         let op = &attn_layer.attn.o_proj;
                         let ot = op.transpose_for_gemm(gpu, hh, nh * hd)?;
                         attn_layer.set_prefill_weights(Some(qt), Some(kt), Some(vt), Some(ot));
+                        // Fused [q|k|v] twin: k/v are N=1024, which against the
+                        // 128-wide N tile is 8 CTAs on 48 SMs (40 idle, 23.6 GB/s,
+                        // 9.75x off floor). Concatenated N=14336 runs 112 CTAs in
+                        // ONE launch. Bit-identical ONLY when the three share a
+                        // single `weight_scale_2` — the GEMM applies one scale2 per
+                        // launch — so verify the device values rather than assume.
+                        // Bit-exact float comparison, not an epsilon: the GEMM
+                        // applies ONE scale2, so anything but exact equality
+                        // changes results.
+                        let scales_equal = qw.weight_scale_2.to_bits()
+                            == kw.weight_scale_2.to_bits()
+                            && kw.weight_scale_2.to_bits() == vw.weight_scale_2.to_bits();
+                        if scales_equal {
+                            let fused = crate::weight_map::QuantizedWeight::transpose_concat_for_gemm(
+                                gpu,
+                                &[(&qw, q_n), (&kw, nkv * hd), (&vw, nkv * hd)],
+                                hh,
+                            )?;
+                            attn_layer.set_fused_qkv_prefill_weight(Some(fused));
+                        } else if attn_idx == 0 {
+                            tracing::warn!(
+                                "attention q/k/v have differing weight_scale_2 — fused QKV GEMM disabled (3 separate launches per layer)"
+                            );
+                        }
                     }
                     // Overlay native FP8 q/k/v/o on top of the NVFP4 weights when
                     // enabled (single-GPU FP8 checkpoint). Hot decode/prefill paths

--- a/crates/spark-model/src/weight_map/quantized.rs
+++ b/crates/spark-model/src/weight_map/quantized.rs
@@ -242,6 +242,115 @@ impl QuantizedWeight {
         })
     }
 
+    /// Transpose SEVERAL weights sharing one K and concatenate them along N
+    /// into a single `[K/2, N_total]` twin, so three GEMMs become one.
+    ///
+    /// Motivation (GB10, decode M=16): the attention k/v projections are
+    /// N=1024, which against the 128-wide N tile yields **8 CTAs on 48 SMs** —
+    /// 40 SMs idle, 23.6 GB/s, 9.75x off the bandwidth floor. Concatenating
+    /// q|k|v to N=14336 gives 112 CTAs in ONE launch. Bit-identical: every
+    /// output element is the same dot product against the same column, merely
+    /// relocated along N.
+    ///
+    /// REQUIRES all parts to share `weight_scale_2` — the GEMM applies a single
+    /// `scale2` to the whole launch. Callers MUST verify this (the values live
+    /// on device); `None` is returned if the caller passes an empty list.
+    pub fn transpose_concat_for_gemm(
+        gpu: &dyn GpuBackend,
+        parts: &[(&QuantizedWeight, usize)],
+        k: usize,
+    ) -> Result<QuantizedWeight> {
+        Self::transpose_concat_for_gemm_gs(gpu, parts, k, 16)
+    }
+
+    /// `transpose_concat_for_gemm` with an explicit scale block size.
+    /// `transpose_concat_for_gemm_gs` with the output ROW STRIDE padded to
+    /// `align_up(n_total, align)`, pad columns left zero.
+    ///
+    /// The transposed layout puts row r at byte offset `r * stride`, and the
+    /// tile GEMM reads B with 16-byte `cp.async`, which requires a 16-byte
+    /// aligned source. When `n_total` is not a multiple of 16 — lm_head's N is
+    /// the VOCAB SIZE, 248077 here, which is ODD — 15 of every 16 rows are
+    /// misaligned and the kernel faults with CUDA_ERROR_MISALIGNED_ADDRESS.
+    /// Padding the stride is what makes a transposed lm_head legal at all.
+    ///
+    /// Returns `(weight, stride)`; pass the stride to `w4a16_gemm_n128_ldb`.
+    pub fn transpose_concat_for_gemm_padded(
+        gpu: &dyn GpuBackend,
+        parts: &[(&QuantizedWeight, usize)],
+        k: usize,
+        group_size: usize,
+        align: usize,
+    ) -> Result<(QuantizedWeight, usize)> {
+        let n_total: usize = parts.iter().map(|(_, n)| *n).sum();
+        let stride = n_total.div_ceil(align) * align;
+        Self::transpose_impl(gpu, parts, k, group_size, stride).map(|w| (w, stride))
+    }
+
+    pub fn transpose_concat_for_gemm_gs(
+        gpu: &dyn GpuBackend,
+        parts: &[(&QuantizedWeight, usize)],
+        k: usize,
+        group_size: usize,
+    ) -> Result<QuantizedWeight> {
+        let n_total: usize = parts.iter().map(|(_, n)| *n).sum();
+        Self::transpose_impl(gpu, parts, k, group_size, n_total)
+    }
+
+    /// Single implementation for both (SSOT). `stride >= n_total` is the row
+    /// pitch of the transposed output; columns `n_total..stride` stay zero.
+    fn transpose_impl(
+        gpu: &dyn GpuBackend,
+        parts: &[(&QuantizedWeight, usize)],
+        k: usize,
+        group_size: usize,
+        stride: usize,
+    ) -> Result<QuantizedWeight> {
+        let first = parts
+            .first()
+            .map(|(w, _)| *w)
+            .context("transpose_concat_for_gemm: empty parts")?;
+        let half_k = k / 2;
+        let num_groups = k / group_size;
+        let n_total: usize = parts.iter().map(|(_, n)| *n).sum();
+        debug_assert!(stride >= n_total, "transpose_impl: stride {stride} < n_total {n_total}");
+
+        let mut t_buf = vec![0u8; stride * half_k];
+        let mut st_buf = vec![0u8; stride * num_groups];
+        let mut n_off = 0usize;
+        for (w, n) in parts {
+            let n = *n;
+            let mut buf = vec![0u8; n * half_k];
+            gpu.copy_d2h(w.weight, &mut buf)?;
+            for i in 0..n {
+                for j in 0..half_k {
+                    t_buf[j * stride + n_off + i] = buf[i * half_k + j];
+                }
+            }
+            let mut sbuf = vec![0u8; n * num_groups];
+            gpu.copy_d2h(w.weight_scale, &mut sbuf)?;
+            for i in 0..n {
+                for j in 0..num_groups {
+                    st_buf[j * stride + n_off + i] = sbuf[i * num_groups + j];
+                }
+            }
+            n_off += n;
+        }
+
+        let new_weight = gpu.alloc(t_buf.len())?;
+        gpu.copy_h2d(&t_buf, new_weight)?;
+        let new_scale = gpu.alloc(st_buf.len())?;
+        gpu.copy_h2d(&st_buf, new_scale)?;
+
+        Ok(QuantizedWeight {
+            weight: new_weight,
+            weight_scale: new_scale,
+            weight_scale_2: first.weight_scale_2,
+            input_scale: first.input_scale,
+            weight_scale_2_vec: first.weight_scale_2_vec,
+        })
+    }
+
     /// Pre-dequant NVFP4 → FP8 E4M3 for zero-overhead prefill GEMMs.
     ///
     /// Reads B_packed[N, K/2] + B_scale[N, K/GROUP_SIZE] + scale2 and produces

--- a/crates/spark-runtime/src/kernel_audit.rs
+++ b/crates/spark-runtime/src/kernel_audit.rs
@@ -55,10 +55,49 @@ pub fn audit_rows() -> Vec<(String, String, bool)> {
         .collect()
 }
 
+/// A `(module, func)` pair borrowed from the resolution audit.
+type KernelRef<'a> = &'a (String, String);
+
+/// `(module, func)` lookups that FAILED and are kernels this target dropped by
+/// shadowing `common/` — i.e. the kernel exists upstream, this model's fork of
+/// the file omitted it, and the model's own dispatch then asked for it.
+///
+/// That conjunction is the actionable one: the kernel would have been there but
+/// for the fork, and something in this model actively wanted it. A failed
+/// lookup NOT in this set is a kernel that was never compiled for this target
+/// at all (typically another architecture's — MLA, hyper-connection, CSA);
+/// those are expected and are not returned here.
+pub fn fatal_missing(shadowed_dropped: &[(&str, &str)]) -> Vec<(String, String)> {
+    let Ok(v) = AUDIT.lock() else {
+        return Vec::new();
+    };
+    let mut resolved: BTreeMap<(String, String), bool> = BTreeMap::new();
+    for (m, f, ok) in v.iter() {
+        let e = resolved.entry((m.clone(), f.clone())).or_insert(false);
+        *e = *e || *ok;
+    }
+    resolved
+        .into_iter()
+        .filter(|(_, ok)| !*ok)
+        .map(|(k, _)| k)
+        .filter(|(m, f)| {
+            shadowed_dropped
+                .iter()
+                .any(|(sm, sf)| *sm == m.as_str() && *sf == f.as_str())
+        })
+        .collect()
+}
+
 /// Render the embedded kernel set (`embedded` = the binary's `ptx_modules()`,
 /// passed in since spark-runtime doesn't depend on atlas-kernels) plus the
 /// runtime resolution overlay. `set_hash` is `atlas_kernels::KERNEL_SET_HASH`.
-pub fn render_kernel_table(embedded: &[(&str, &[u8])], set_hash: &str) -> String {
+/// `shadowed_dropped` is `TargetPtxSet::shadowed_dropped`, which drives the
+/// SHADOWED column and splits the failed lookups into required-vs-expected.
+pub fn render_kernel_table(
+    embedded: &[(&str, &[u8])],
+    set_hash: &str,
+    shadowed_dropped: &[(&str, &str)],
+) -> String {
     // Dedup resolution audit: (module, func) → loaded (true if ever true).
     let mut resolved: BTreeMap<(String, String), bool> = BTreeMap::new();
     if let Ok(v) = AUDIT.lock() {
@@ -82,10 +121,10 @@ pub fn render_kernel_table(embedded: &[(&str, &[u8])], set_hash: &str) -> String
         set_hash
     ));
     out.push_str(&format!(
-        "│ {:<34} {:<14} {}\n",
-        "MODULE (operation)", "PTX-HASH", "RESOLUTION"
+        "│ {:<34} {:<14} {:<20} {}\n",
+        "MODULE (operation)", "PTX-HASH", "RESOLUTION", "SHADOWED"
     ));
-    out.push_str(&format!("│ {}\n", "─".repeat(74)));
+    out.push_str(&format!("│ {}\n", "─".repeat(84)));
     let mut sorted: Vec<&(&str, &[u8])> = embedded.iter().collect();
     sorted.sort_by_key(|(m, _)| *m);
     for (m, blob) in sorted {
@@ -97,25 +136,62 @@ pub fn render_kernel_table(embedded: &[(&str, &[u8])], set_hash: &str) -> String
             Some((_req, false)) => "** lookup FAILED **",
             None => "-", // embedded but not requested by this model's dispatch
         };
-        out.push_str(&format!("│ {m:<34} {h:<14} {res}\n"));
+        // Y when this model's fork of the file dropped one or more kernels that
+        // `common/` defines — the module compiled, but not everything in it.
+        let n_dropped = shadowed_dropped.iter().filter(|(sm, _)| sm == m).count();
+        let shadow = if n_dropped > 0 {
+            format!("Y ({n_dropped} dropped)")
+        } else {
+            "N".to_string()
+        };
+        out.push_str(&format!("│ {m:<34} {h:<14} {res:<20} {shadow}\n"));
     }
     out.push_str("└─");
 
-    // Explicit MISSING list: (module, func) requested but never resolved →
-    // silent slower-fallback dispatch. The actionable debug signal.
+    // Split the failed lookups by CAUSE. Reporting them as one list is what let
+    // the 27B ship with concurrent decode silently disabled: the four dropped
+    // GDN kernels sat among ~26 entries for architectures the model does not
+    // have (MLA, hyper-connection, CSA), so the whole warning read as benign
+    // and everyone learned to skip it. A warning that is almost always noise
+    // trains people to ignore the one time it is not.
     let missing: Vec<&(String, String)> = resolved
         .iter()
         .filter(|(_, ok)| !**ok)
         .map(|(k, _)| k)
         .collect();
-    if !missing.is_empty() {
+    let is_dropped =
+        |m: &str, f: &str| shadowed_dropped.iter().any(|(sm, sf)| *sm == m && *sf == f);
+    let (dropped, absent): (Vec<KernelRef>, Vec<KernelRef>) = missing
+        .into_iter()
+        .partition(|(m, f)| is_dropped(m.as_str(), f.as_str()));
+
+    if !dropped.is_empty() {
         out.push_str(&format!(
-            "\n⚠ {} kernel lookup(s) MISSING — slower fallback dispatch in use:\n",
-            missing.len()
+            "\n\u{2718} {} REQUIRED kernel(s) MISSING — this model's dispatch asked for them and \
+             `common/` defines them, but this target's kernel file shadows `common/` WITHOUT \
+             them, so they were never compiled:\n",
+            dropped.len()
         ));
-        for (m, f) in &missing {
+        for (m, f) in &dropped {
             out.push_str(&format!("    - {m}::{f}\n"));
         }
+        out.push_str(
+            "  Port them into this model's kernel file (exact piecewise copy from common/).\n",
+        );
+    }
+    if !absent.is_empty() {
+        // Informational only: never compiled for this target, and the model
+        // asking is just an unconditional `try_kernel` probe.
+        out.push_str(&format!(
+            "\n\u{2139} {} optional kernel(s) not built for this target (other architectures — \
+             expected, no action):\n    {}\n",
+            absent.len(),
+            absent
+                .iter()
+                .map(|(m, f)| format!("{m}::{f}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
     out
 }

--- a/crates/spark-server/src/main_modules/serve.rs
+++ b/crates/spark-server/src/main_modules/serve.rs
@@ -524,8 +524,43 @@ fn startup(
         spark_runtime::kernel_audit::render_kernel_table(
             &ptx_set.modules,
             atlas_kernels::KERNEL_SET_HASH,
+            ptx_set.shadowed_dropped,
         )
     );
+
+    // FAIL FAST on a kernel that this model's dispatch requested, that
+    // `common/` defines, and that this target's kernel file dropped by
+    // shadowing. That conjunction is never intentional: the kernel exists, the
+    // model wanted it, and a stale fork is the only reason it is absent. The
+    // failure is otherwise SILENT — `try_kernel` yields handle 0 and the caller
+    // takes a slower (or disabled) path — which is how the 27B ran with
+    // concurrent decode pinned to its per-sequence fallback while every gate
+    // stayed green. `ATLAS_ALLOW_SHADOWED_KERNELS=1` downgrades this to a
+    // warning for bisects and for a model that deliberately omits a kernel.
+    let fatal = spark_runtime::kernel_audit::fatal_missing(ptx_set.shadowed_dropped);
+    if !fatal.is_empty() {
+        let list = fatal
+            .iter()
+            .map(|(m, f)| format!("{m}::{f}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        if std::env::var("ATLAS_ALLOW_SHADOWED_KERNELS").as_deref() == Ok("1") {
+            tracing::warn!(
+                "{} required kernel(s) missing via shadowing ({list}) — continuing because \
+                 ATLAS_ALLOW_SHADOWED_KERNELS=1. Expect silent slow paths.",
+                fatal.len(),
+            );
+        } else {
+            anyhow::bail!(
+                "{} required kernel(s) missing: {list}. This model's dispatch requested them and \
+                 kernels/<hw>/common/ defines them, but this target's kernel file shadows \
+                 common/ without them, so they were never compiled. Port them into the model's \
+                 kernel file (exact piecewise copy from common/), or set \
+                 ATLAS_ALLOW_SHADOWED_KERNELS=1 to run anyway on the slow fallback path.",
+                fatal.len(),
+            );
+        }
+    }
 
     // Phase 6.3 — HSS config built early so the EP worker can install it.
     let early_high_speed_swap_cfg = serve_phases::build_high_speed_swap_config(&args)?;

--- a/crates/spark-server/src/scheduler/decode_logits_step.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_step.rs
@@ -15,6 +15,20 @@ thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
+/// Admit `think_ended` rows (which need only a 2-token mask) to the GPU argmax
+/// fast path. Kill switch: `ATLAS_NO_THINKENDED_GPU_ARGMAX=1`.
+fn think_ended_gpu_argmax_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("ATLAS_NO_THINKENDED_GPU_ARGMAX").ok().as_deref() != Some("1")
+    })
+}
+
+/// Steps that fell back to the host path because a GPU argmax landed on a
+/// masked think token. Expected to be a small fraction; a large count means the
+/// fast path is not paying for itself.
+static THINK_MASK_FALLBACKS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// DIAG (ATLAS_DECODE_TIMING=1): localize the host-path decode cost. Splits the
 /// per-token wall into `copy` (D2H of the full 248k-vocab logits + the GPU
 /// forward-wait absorbed by that sync) vs `sample` (the host scalar loops over
@@ -71,17 +85,62 @@ pub fn process_decode_logits(
     // `argmax_batch` assumes BF16 layout and would interpret 4-byte FP32
     // values as 2-byte BF16 pairs, returning garbage tokens.
     let model_logits_fp32 = model.decode_logits_fp32();
-    let needs_host_logits = active
-        .iter()
-        .any(|a| a.inside_thinking || a.think_ended || a.grammar_state.is_some())
-        || any_logprobs
+    // `think_ended` alone does NOT need the host path. PostCloseThinkMask masks
+    // exactly TWO ids (think_end_token, think_start_token) and nothing else; A4's
+    // bias floor is gated on `inside_thinking` (sample_step.rs) so it is inert
+    // here. With request penalties exactly neutral the pipeline is then a no-op
+    // and the emission is the raw argmax — modulo those two ids, which we check
+    // after the fact and fall back for.
+    //
+    // This matters far beyond a tuning win: `--disable-thinking` sets
+    // `think_ended = true` for EVERY sequence at birth (prefill_a_step.rs:229 and
+    // three siblings), so before this change ONE such row — i.e. all of them —
+    // forced the entire batch through a 7.95 MB D2H plus n full-vocab host
+    // passes. The GPU argmax fast path was dead code in that config, which is
+    // also the MLPerf-edge config.
+    //
+    // Kill switch: ATLAS_NO_THINKENDED_GPU_ARGMAX=1.
+    let think_ended_gpu_ok = |a: &ActiveSeq| {
+        a.think_ended
+            && !a.inside_thinking
+            && a.grammar_state.is_none()
+            && a.repetition_penalty == 1.0
+            && a.presence_penalty == 0.0
+            && a.frequency_penalty == 0.0
+            && a.lz_penalty == 0.0
+            && a.dry_multiplier == 0.0
+    };
+    let admit_think_ended = think_ended_gpu_argmax_enabled();
+    let needs_host_logits = active.iter().any(|a| {
+        let excused = admit_think_ended && think_ended_gpu_ok(a);
+        (a.inside_thinking || a.think_ended || a.grammar_state.is_some()) && !excused
+    }) || any_logprobs
         || model_logits_fp32;
 
-    let new_tokens: Vec<(u32, Option<crate::api::TokenLogprobs>)> =
+    // Try the GPU argmax first. `None` here means "not eligible, or the result
+    // needs the host pipeline after all" and falls through to the host branch —
+    // it must never mean "emit nothing".
+    let fast_tokens: Option<Vec<(u32, Option<crate::api::TokenLogprobs>)>> =
         if active.iter().all(|a| a.temperature == 0.0) && !any_grammar && !needs_host_logits {
-            // Fast path: all greedy, no grammar, no thinking — GPU argmax for the full batch.
             match model.argmax_batch(logits, n, 0) {
-                Ok(t) => t.into_iter().map(|tok| (tok, None)).collect(),
+                Ok(t) => {
+                    // The two masked ids are the ONLY thing the host pipeline
+                    // would have done differently for a think_ended row. If an
+                    // argmax actually landed on one (rare — the model seldom
+                    // re-opens <think> mid-response), fall through and redo the
+                    // step on the host so the emitted token is exactly what the
+                    // pipeline would produce.
+                    let hit_mask = t.iter().zip(active.iter()).any(|(&tok, a)| {
+                        a.think_ended
+                            && (Some(tok) == think_end_token || Some(tok) == a.think_start_token)
+                    });
+                    if hit_mask {
+                        THINK_MASK_FALLBACKS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        None
+                    } else {
+                        Some(t.into_iter().map(|tok| (tok, None)).collect())
+                    }
+                }
                 Err(e) => {
                     tracing::error!("argmax_batch error: {e:#}");
                     for mut a in active.drain(..) {
@@ -90,6 +149,13 @@ pub fn process_decode_logits(
                     return;
                 }
             }
+        } else {
+            None
+        };
+
+    let new_tokens: Vec<(u32, Option<crate::api::TokenLogprobs>)> =
+        if let Some(t) = fast_tokens {
+            t
         } else {
             // Host-side path: copy all batch logits to host, sample per-sequence.
             // Required when any sequence has temperature > 0 or grammar constraints.

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -353,6 +353,7 @@ pub fn resume_swapped_seq(
         // Grammar state is not serializable; resumed sequences use legacy fallback.
         grammar_state: None,
         pending_drafts: Vec::new(),
+        pending_draft_conf: Vec::new(),
         last_token_time: Instant::now(),
         request_start: s.request_start,
         decode_start: s.decode_start,

--- a/crates/spark-server/src/scheduler/logprobs.rs
+++ b/crates/spark-server/src/scheduler/logprobs.rs
@@ -27,16 +27,24 @@ pub fn extract_logprobs_from_f32(
 ///
 /// Copies `[K, vocab_size]` BF16 logits D2H, converts to FP32, and extracts
 /// top-K logprobs per position. Returns empty Vec on copy failure.
+///
+/// `row_base` (batched-MTP E12): first logits row of this sequence's verify
+/// span within the shared `[R, vocab]` buffer. Single-sequence callers pass
+/// 0 (unchanged behaviour); the batched K=4 verify passes `i*4` for seq i.
 pub fn extract_verify_logprobs(
     model: &dyn Model,
     tokens: &[u32],
     k_logprobs: u8,
+    row_base: usize,
 ) -> Vec<crate::api::TokenLogprobs> {
     let k = tokens.len();
     let vocab = model.vocab_size();
     let mut buf = vec![0u8; k * vocab * 2]; // BF16
     if model
-        .copy_logits_to_host(model.logits_buffer_ptr(), &mut buf)
+        .copy_logits_to_host(
+            model.logits_buffer_ptr().offset(row_base * vocab * 2),
+            &mut buf,
+        )
         .is_err()
     {
         return Vec::new();

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -28,6 +28,8 @@ mod logit_processors;
 mod logprobs;
 mod mod_helpers;
 pub use mod_helpers::capture_runtime_handle;
+mod mtp_accept_debug;
+mod mtp_bootstrap_step;
 mod mtp_gate;
 mod mtp_step;
 pub(crate) mod mtp_timing;
@@ -47,7 +49,9 @@ mod types;
 mod verify_dflash_step;
 mod verify_k2_step;
 mod verify_k3_step;
+mod verify_k4_batch_step;
 mod verify_k4_step;
+mod verify_k4_verdict;
 mod verify_pipeline_helper;
 
 use beam_prefill::resolve_beam_hyp;
@@ -71,6 +75,7 @@ pub use helpers::{WatchdogParams, set_watchdog_params};
 use lifecycle::*;
 use logprobs::*;
 use mod_helpers::*;
+use mtp_bootstrap_step::*;
 use mtp_step::*;
 use phase_continue_prefills::continue_in_progress_prefills;
 use phase_start_prefills::start_new_requests;
@@ -85,7 +90,9 @@ use types::*;
 use verify_dflash_step::*;
 use verify_k2_step::*;
 use verify_k3_step::*;
+use verify_k4_batch_step::*;
 use verify_k4_step::*;
+use verify_k4_verdict::*;
 // verify_pipeline_helper is referenced via fully-qualified
 // `crate::scheduler::verify_pipeline_helper::...` from sibling step
 // files (verify_k2/k3/k4/dflash + spec_step), so no `use` import.
@@ -168,6 +175,29 @@ pub type LoraRotation = (
 
 /// Run the scheduler loop on the current thread.
 #[allow(clippy::too_many_arguments)]
+/// How many concurrent sequences may speculate. Default 16, override with
+/// `ATLAS_MTP_MAX_SEQS` (`=1` restores the single-sequence-only gate).
+///
+/// `step_mtp` is index-correct over the active slice, so raising this runs
+/// MTP over n sequences per step. With the batched K=4 verify wired
+/// (`verify_k4_batch_step.rs`), verify-ready K=4 grammarless sequences are
+/// verified in ONE eager n*4-row forward (weights read once); anything the
+/// model can't batch (EP, HSS, LoRA, grammar, non-uniform K, DFlash) falls
+/// back to the serialized per-seq loop that MEASURED (2026-07-27) collapses
+/// throughput: cap=4 at C=4 25.8 vs 48.5 MTP-off. Kill switch for A/B:
+/// `ATLAS_NO_MTP_BATCH_VERIFY` (presence) forces that serialized loop.
+fn mtp_max_seqs() -> usize {
+    // SSOT moved to `spark_model::speculative::mtp_max_seqs()` (batched-MTP
+    // E1/E2): the model-side single-sequence MTP structures (catchup ring,
+    // refeed labels, carry slot) gate on the SAME value the scheduler gates
+    // dispatch on. Same parse; default 16 since 2026-07-28 — the batched
+    // multi-seq verify + propose (`verify_k4_batch_step.rs`) removed the
+    // serialization that made cap=1 mandatory (C=4 cap=4: 25.8 serialized
+    // -> 49.0 batched vs 48.5 MTP-off). `ATLAS_MTP_MAX_SEQS=1` restores
+    // the old single-sequence-only gate.
+    spark_model::speculative::mtp_max_seqs()
+}
+
 pub fn run(
     mut model: Box<dyn Model>,
     request_rx: tokio::sync::mpsc::Receiver<InferenceRequest>,
@@ -545,7 +575,7 @@ pub fn run(
                 // Self-speculative: draft via layer-skipping, verify with full model.
                 step_self_spec(&*model, &mut active, num_drafts, &verify_ctx);
             } else if use_mtp
-                && active.len() == 1
+                && active.len() <= mtp_max_seqs()
                 && (
                     // SPEC_THINK: speculate everywhere EXCEPT the first
                     // `dflash_resume_guard` generated tokens — every observed
@@ -553,13 +583,20 @@ pub fn run(
                     // ENTRY (sequence start or post-think resume); serial-
                     // decoding the entry window dodges the divergence while
                     // leaving the body speculated.
-                    (dflash_spec_think
-                        && active[0].output_tokens.len() as u32 >= dflash_resume_guard)
-                        || (!active[0].inside_thinking
-                            && active[0].post_think_emitted >= dflash_resume_guard)
+                    // EVERY active sequence must be eligible, not just active[0].
+                    // These are per-sequence properties: with more than one
+                    // sequence speculating, reading them off active[0] lets
+                    // sequence 1 be speculated while its own suppress_tool_call
+                    // / disable_mtp / thinking state says it must not be. At
+                    // n==1 `all()` over one element is exactly the old
+                    // predicate, so the single-sequence path is unchanged.
+                    active.iter().all(|a| {
+                        ((dflash_spec_think && a.output_tokens.len() as u32 >= dflash_resume_guard)
+                            || (!a.inside_thinking && a.post_think_emitted >= dflash_resume_guard))
+                            && !a.suppress_tool_call
+                            && !a.disable_mtp
+                    })
                 )
-                && !active[0].suppress_tool_call
-                && !active[0].disable_mtp
             {
                 // Throughput-arbitrated MTP gate: EVERY single-sequence step
                 // is timed and reported, and the gate picks whichever mode
@@ -613,7 +650,19 @@ pub fn run(
                             // by dumped hidden fingerprints (93/93 cross-step,
                             // see `speculative::mtp_refeed_accepted_enabled`),
                             // so the serial hook was the side that disagreed.
-                            if let Err(e) = model.save_hidden_for_catchup(0, active[0].seq.seq_len)
+                            //
+                            // Multi-seq guard (batched-MTP E2): the catchup
+                            // ring is a SINGLE-sequence structure (one ring,
+                            // one label space). With n active sequences the
+                            // hidden in row 0 belongs to an arbitrary member
+                            // of the batch, so ringing it would interleave
+                            // unrelated hiddens under one label space.
+                            // (`mtp_catchup_enabled` is also force-off when
+                            // ATLAS_MTP_MAX_SEQS > 1 — this guard keeps the
+                            // save itself single-seq-only regardless.)
+                            if active.len() == 1
+                                && let Err(e) =
+                                    model.save_hidden_for_catchup(0, active[0].seq.seq_len)
                             {
                                 tracing::warn!("save_hidden_for_catchup: {e:#}");
                             }
@@ -622,7 +671,11 @@ pub fn run(
                             // A bootstrap-only step (no pending drafts) emits
                             // 1 token and proposes; its cost is charged to the
                             // MTP mode — proposing IS part of what MTP costs.
-                            let seq_len_before = active[0].seq.seq_len;
+                            // Sum over ALL speculating sequences: the gate arbitrates
+                            // on tokens-per-second, so counting only active[0]
+                            // under-reports MTP's throughput by a factor of n and
+                            // biases the gate toward serial decode.
+                            let seq_len_before: usize = active.iter().map(|a| a.seq.seq_len).sum();
                             let t0 = std::time::Instant::now();
                             step_mtp(
                                 &*model,
@@ -631,7 +684,8 @@ pub fn run(
                                 &verify_ctx,
                                 dflash_verify_raw_argmax,
                             );
-                            let emitted = active[0].seq.seq_len.saturating_sub(seq_len_before);
+                            let seq_len_after: usize = active.iter().map(|a| a.seq.seq_len).sum();
+                            let emitted = seq_len_after.saturating_sub(seq_len_before);
                             gate.record_verify_step(t0.elapsed(), emitted);
                         }
                     }

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -30,6 +30,7 @@ mod mod_helpers;
 pub use mod_helpers::capture_runtime_handle;
 mod mtp_accept_debug;
 mod mtp_bootstrap_step;
+mod mtp_dcut;
 mod mtp_gate;
 mod mtp_step;
 pub(crate) mod mtp_timing;
@@ -190,11 +191,12 @@ fn mtp_max_seqs() -> usize {
     // SSOT moved to `spark_model::speculative::mtp_max_seqs()` (batched-MTP
     // E1/E2): the model-side single-sequence MTP structures (catchup ring,
     // refeed labels, carry slot) gate on the SAME value the scheduler gates
-    // dispatch on. Same parse; default 16 since 2026-07-28 — the batched
-    // multi-seq verify + propose (`verify_k4_batch_step.rs`) removed the
-    // serialization that made cap=1 mandatory (C=4 cap=4: 25.8 serialized
-    // -> 49.0 batched vs 48.5 MTP-off). `ATLAS_MTP_MAX_SEQS=1` restores
-    // the old single-sequence-only gate.
+    // dispatch on. Same parse; default 16 since 2026-07-29 (was 8, and 1
+    // before the batched multi-seq verify + propose in
+    // `verify_k4_batch_step.rs` removed the serialization that made cap=1
+    // mandatory — C=4 cap=4: 25.8 serialized -> 49.0 batched vs 48.5
+    // MTP-off). `ATLAS_MTP_MAX_SEQS=8` restores the round-3 cap, `=1` the
+    // old single-sequence-only gate.
     spark_model::speculative::mtp_max_seqs()
 }
 
@@ -697,6 +699,7 @@ pub fn run(
                     if gate.take_fresh_decision() == Some(mtp_gate::GateDecision::DisableMtp) {
                         for a in active.iter_mut() {
                             a.pending_drafts.clear();
+                            a.pending_draft_conf.clear();
                         }
                         if let Err(e) = model.sync_secondary() {
                             tracing::error!("mtp-gate→decode sync_secondary: {e:#}");
@@ -717,6 +720,7 @@ pub fn run(
                 if use_mtp {
                     for a in active.iter_mut() {
                         a.pending_drafts.clear();
+                        a.pending_draft_conf.clear();
                     }
                     // MTP→decode-only transition: the last verify commit's
                     // live-state restore runs async on the secondary stream;

--- a/crates/spark-server/src/scheduler/mtp_accept_debug.rs
+++ b/crates/spark-server/src/scheduler/mtp_accept_debug.rs
@@ -56,12 +56,19 @@ static BUCKETS: [Bucket; MAX_N] = [INIT; MAX_N];
 /// (`drafts[0] == verified[0]`), not `num_accepted >= 1` — they agree today
 /// but the second form silently becomes conditional if a future verdict path
 /// short-circuits before comparing.
+///
+/// `k_drafts` is the RETAINED depth of THIS sequence, which D-Cut makes ragged
+/// within one batch; the reported value is the period's DEEPEST retained depth
+/// at this width (identical to the uniform value when D-Cut is off, and never
+/// an arbitrary last-writer). The full per-step shape is on the `MTP D-Cut`
+/// line — `p1` stays unconditional and `mean_na`/`tok_step` are measured over
+/// the shape that actually ran, which is the quantity the C=8 arithmetic wants.
 pub(super) fn record(n: usize, k_drafts: usize, d1_match: bool, num_accepted: usize) {
     if !spark_model::speculative::mtp_accept_debug() {
         return;
     }
     let b = &BUCKETS[n.min(MAX_N - 1)];
-    b.k.store(k_drafts as u64, Ordering::Relaxed);
+    b.k.fetch_max(k_drafts as u64, Ordering::Relaxed);
     b.na.fetch_add(num_accepted as u64, Ordering::Relaxed);
     if d1_match {
         b.d1.fetch_add(1, Ordering::Relaxed);
@@ -70,7 +77,7 @@ pub(super) fn record(n: usize, k_drafts: usize, d1_match: bool, num_accepted: us
         let steps = b.steps.swap(0, Ordering::Relaxed).max(1);
         let d1 = b.d1.swap(0, Ordering::Relaxed);
         let na = b.na.swap(0, Ordering::Relaxed);
-        let k = b.k.load(Ordering::Relaxed);
+        let k = b.k.swap(0, Ordering::Relaxed);
         let mean_na = na as f64 / steps as f64;
         tracing::info!(
             "MTP accept n={n} k_drafts={k} verifies={steps} p1={:.3} mean_na={mean_na:.3} \

--- a/crates/spark-server/src/scheduler/mtp_accept_debug.rs
+++ b/crates/spark-server/src/scheduler/mtp_accept_debug.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Per-batch-width MTP acceptance telemetry (`ATLAS_MTP_ACCEPT_DEBUG`).
+//!
+//! # Why this exists
+//!
+//! The C=8 bar is arithmetic in ONE quantity: expected tokens per verify step
+//! divided by the verify step's cost relative to a plain decode step. The
+//! numerator is `1 + p1 + p1*p2c + ...`, i.e. `1 + mean_accepted`. Before this
+//! module nothing reported it at the shipped operating point:
+//! `k4_record_positional` (the only p1 source) is gated on `k_drafts == 3`,
+//! and the default ladder runs `k_drafts == 2` for n in [5, 8]. The na
+//! histogram (`k4_record_outcome`) is width-blind — it mixes every n in one
+//! set of counters, so an accept A/B at C=8 could not be attributed.
+//!
+//! # What it reports
+//!
+//! One line per `PERIOD` recorded verifies PER BATCH WIDTH:
+//! `p1` (fraction of steps whose FIRST draft matched the target — measured
+//! before the accept chain short-circuits, so it is unconditional),
+//! `mean_na` (mean accepted drafts) and `tok_step = 1 + mean_na`.
+//!
+//! Counters are relaxed atomics and the log fires off one thread at a time;
+//! there is no D2H and no stream sync, so the only cost in a timed leg is the
+//! periodic `tracing::info!`. Still gated: presence of `ATLAS_MTP_ACCEPT_DEBUG`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Widths tracked individually; anything wider folds into the last bucket.
+const MAX_N: usize = 17;
+const PERIOD: u64 = 200;
+
+struct Bucket {
+    steps: AtomicU64,
+    d1: AtomicU64,
+    na: AtomicU64,
+    k: AtomicU64,
+}
+
+const fn new_bucket() -> Bucket {
+    Bucket {
+        steps: AtomicU64::new(0),
+        d1: AtomicU64::new(0),
+        na: AtomicU64::new(0),
+        k: AtomicU64::new(0),
+    }
+}
+
+#[allow(clippy::declare_interior_mutable_const)]
+const INIT: Bucket = new_bucket();
+static BUCKETS: [Bucket; MAX_N] = [INIT; MAX_N];
+
+/// Record one sequence's verify outcome at batch width `n`.
+///
+/// `d1_match` must be the UNCONDITIONAL first-position draft match
+/// (`drafts[0] == verified[0]`), not `num_accepted >= 1` — they agree today
+/// but the second form silently becomes conditional if a future verdict path
+/// short-circuits before comparing.
+pub(super) fn record(n: usize, k_drafts: usize, d1_match: bool, num_accepted: usize) {
+    if !spark_model::speculative::mtp_accept_debug() {
+        return;
+    }
+    let b = &BUCKETS[n.min(MAX_N - 1)];
+    b.k.store(k_drafts as u64, Ordering::Relaxed);
+    b.na.fetch_add(num_accepted as u64, Ordering::Relaxed);
+    if d1_match {
+        b.d1.fetch_add(1, Ordering::Relaxed);
+    }
+    if b.steps.fetch_add(1, Ordering::Relaxed) + 1 >= PERIOD {
+        let steps = b.steps.swap(0, Ordering::Relaxed).max(1);
+        let d1 = b.d1.swap(0, Ordering::Relaxed);
+        let na = b.na.swap(0, Ordering::Relaxed);
+        let k = b.k.load(Ordering::Relaxed);
+        let mean_na = na as f64 / steps as f64;
+        tracing::info!(
+            "MTP accept n={n} k_drafts={k} verifies={steps} p1={:.3} mean_na={mean_na:.3} \
+             tok_step={:.3}",
+            d1 as f64 / steps as f64,
+            1.0 + mean_na,
+        );
+    }
+}

--- a/crates/spark-server/src/scheduler/mtp_bootstrap_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_bootstrap_step.rs
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched Phase-A MTP bootstrap: ONE multi-sequence decode forward for every
+//! draftless sequence, then ONE batched drafter forward per draft position.
+//!
+//! Phase A of `step_mtp` ran a per-sequence `model.decode()` — an M=1 forward
+//! that re-reads every weight — for each sequence without pending drafts, and
+//! then a per-sequence `run_mtp_propose_multi`. At n sequences that is n full
+//! weight sweeps of the target plus n of the drafter, on an engine that is
+//! ~87% bandwidth-saturated. Every sequence bootstraps on its first decode
+//! step and again after any step that could not re-propose, so at C=8/16 this
+//! lands repeatedly in the steady state. Third of the three eager costs the
+//! n=16 finalizer matrix named (the K=1 verify step measured ~1.9x a plain
+//! batch-16 decode step vs the ~1.72x break-even at p1~0.72).
+//!
+//! The batched form is the SAME machinery the non-MTP decode step already
+//! uses: `decode_batch` (n rows, one weight read, slot-ordered so the batched
+//! recurrent/graph paths engage), per-row logits at `row*vocab*elem`, then the
+//! batched-verify Phase 2/4 pattern for the hiddens — stash every row BEFORE
+//! any propose clobbers the shared `hidden_states` buffer, then propose from
+//! the stash.
+//!
+//! Envelope (falls back to the per-sequence loop, never silently degrades):
+//! * >= 2 draftless sequences and multi-seq MTP mode (`ATLAS_MTP_MAX_SEQS>1`)
+//!   — at cap 1 the per-seq path must stay byte-identical;
+//! * not the DFlash bootstrap (its fused pass replaces the standalone decode);
+//! * `can_batch_verify(n, 2)` — the same non-EP / non-HSS / no-LoRA /
+//!   stash-allocated envelope the batched verify self-gates on, and the stash
+//!   is what makes a cross-sequence propose possible at all;
+//! * the DFlash serial-append / unified-ctx commit modes are OFF (their
+//!   per-sequence ctx appends are ordered against a per-sequence decode).
+//!
+//! Kill switch `ATLAS_NO_MTP_BATCH_BOOTSTRAP` (PRESENCE check per the house
+//! convention — `=0` is NOT off) forces the per-sequence loop.
+
+use super::*;
+
+/// Kill switch, PRESENCE check, read once per process.
+pub(super) fn bootstrap_batch_disabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_BATCH_BOOTSTRAP").is_some())
+}
+
+/// One batched argmax readback instead of n serialized single-CTA scans:
+/// **ON** by default, disabled by PRESENCE of `ATLAS_NO_MTP_BOOT_ARGMAX`
+/// (house convention — `=0` is NOT off). Read once per process.
+fn boot_argmax_batch_enabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_BOOT_ARGMAX").is_none())
+}
+
+/// Whether [`step_mtp_bootstrap_batched`] can run for these sequences.
+pub(super) fn can_batch_bootstrap(
+    model: &dyn Model,
+    n: usize,
+    dflash_verify_raw_argmax: bool,
+) -> bool {
+    n >= 2
+        && !dflash_verify_raw_argmax
+        && !bootstrap_batch_disabled()
+        && spark_model::speculative::mtp_multi_seq_mode()
+        && !crate::scheduler::adaptive_spec::unified_ctx_enabled()
+        && !crate::scheduler::adaptive_spec::serial_append_enabled()
+        // FP32-lm_head models (Gemma-4 dense) are excluded: `logits_ptr_is_fp32`
+        // is an exact-pointer identity against the FP32 scratch buffer, so a
+        // per-ROW offset pointer would dispatch as BF16 and read garbage. The
+        // non-MTP batched decode avoids this by slicing a host copy instead of
+        // handing out row pointers.
+        && !model.decode_logits_fp32()
+        // k=2 is the narrowest verify width; this call asks the model for the
+        // batched-MTP envelope (stash allocated, non-EP, non-HSS, no LoRA),
+        // not for a verify.
+        && model.can_batch_verify(n, 2)
+}
+
+/// Batched bootstrap for the `idxs` (ASCENDING) draftless sequences.
+///
+/// Mirrors the per-sequence Phase-A body exactly — same penalties, same
+/// history scoping, same sampler, same emit, same adaptive-spec bookkeeping,
+/// same effective-draft clamp — with the decode and the propose batched.
+///
+/// Deviation from the per-seq body, deliberate: when the hidden stash fails
+/// the per-seq body's `continue` also skipped `start_checkpoint_async`; here
+/// the checkpoint still runs (skipping it was incidental to the control flow,
+/// and a missing checkpoint is a correctness hazard, not a saving).
+pub(super) fn step_mtp_bootstrap_batched(
+    model: &dyn Model,
+    active: &mut [ActiveSeq],
+    idxs: &[usize],
+    ladder_nd: usize,
+    _verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+) {
+    // Disjoint &mut for the (ascending) indices, then reorder by SSM slot:
+    // `decode_batch`'s batched-recurrent + graph paths require the batch in
+    // pool-slot order (decode_step.rs sorts `active` for the same reason);
+    // here `active` cannot be reordered (the caller's verify indices point
+    // into it), so the REFS are sorted instead. Row j <-> refs[j].
+    let mut refs: Vec<&mut ActiveSeq> = Vec::with_capacity(idxs.len());
+    let mut it = active.iter_mut();
+    let mut consumed = 0usize;
+    for &i in idxs {
+        let a = it.nth(i - consumed).expect("bootstrap index within active");
+        consumed = i + 1;
+        refs.push(a);
+    }
+    refs.sort_by_key(|a| a.seq.ssm_slot_idx().unwrap_or(a.seq.slot_idx));
+
+    let n = refs.len();
+    let tokens: Vec<u32> = refs.iter().map(|a| a.last_token).collect();
+
+    // ── ONE batched decode forward: n rows, weights read once ──
+    // EP broadcasts are emitted inside `decode_batch` itself (interleaved
+    // with its per-seq calls) — hoisting them here would diverge the head's
+    // comm-stream op order from the worker's. A batch-level failure finishes
+    // the batch, as on the batched verify path: `decode_batch` gives no
+    // "nothing advanced" guarantee, so retrying per-seq could double-decode.
+    let logits = {
+        let mut seq_refs: Vec<&mut SequenceState> = refs.iter_mut().map(|a| &mut a.seq).collect();
+        match model.decode_batch(&tokens, &mut seq_refs, 0) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!("batched bootstrap decode_batch (n={n}): {e:#}");
+                for a in refs.iter_mut() {
+                    a.finished = true;
+                }
+                return;
+            }
+        }
+    };
+
+    let vocab = model.vocab_size();
+    let elem = if model.decode_logits_fp32() { 4 } else { 2 };
+
+    // ── ONE batched argmax readback for the rows that sample greedily ──
+    // Every eligible row's `sample_token_with_grammar` takes its fast-greedy
+    // branch: `argmax_on_device` = ONE single-CTA `argmax_bf16` (grid [1,1,1],
+    // ~100 us at a 248k vocab) plus a BLOCKING 4-byte D2H — n of them,
+    // serialized on one stream, each draining the pipeline. `argmax_batch`
+    // runs the identical per-row kernel body (one block per row, same tie
+    // resolution — byte-identical by construction) in ONE launch with ONE D2H;
+    // it is the same call the non-MTP decode step makes
+    // (`decode_logits_step.rs`).
+    //
+    // Eligibility is a STRICT SUBSET of the fast-greedy branch's own gate
+    // (`sample_step.rs`): greedy temperature, no grammar (its bitmask is
+    // host-side), and EXACTLY-neutral penalties — `PenaltyGate::ReduceOnly`
+    // is excluded because its per-position immunity check needs a per-row
+    // logit read anyway. Any row failing it keeps the per-row call verbatim,
+    // so this can only change WHICH kernel produced an identical token.
+    // `decode_logits_fp32` models never reach here (`can_batch_bootstrap`).
+    // Kill switch `ATLAS_NO_MTP_BOOT_ARGMAX` (PRESENCE).
+    let pen: Vec<_> = refs
+        .iter()
+        .map(|a| {
+            crate::scheduler::sample_step::penalty_params_for(
+                a,
+                crate::scheduler::sample_step::PositionKind::Verify,
+                0.0,
+                None,
+                Vec::new(),
+            )
+        })
+        .collect();
+    let greedy: Vec<bool> = refs
+        .iter()
+        .zip(pen.iter())
+        .map(|(a, p)| {
+            boot_argmax_batch_enabled()
+                && crate::scheduler::verify_pipeline_helper::fast_greedy_grammar_enabled()
+                && (a.temperature == 0.0
+                    || crate::scheduler::decode_logits_seq::force_temp_zero_enabled())
+                && a.grammar_state.is_none()
+                && crate::scheduler::fast_greedy::classify_penalties(p)
+                    == crate::scheduler::fast_greedy::PenaltyGate::Neutral
+        })
+        .collect();
+    let n_greedy = greedy.iter().filter(|&&g| g).count();
+    let batch_toks: Option<Vec<u32>> = if n_greedy >= 2 {
+        match model.argmax_batch(logits, n, 0) {
+            Ok(t) => {
+                static LOGGED: std::sync::Once = std::sync::Once::new();
+                LOGGED.call_once(|| {
+                    tracing::info!(
+                        "MTP bootstrap batched argmax ENGAGED (n={n}, greedy_rows={n_greedy}): \
+                         one launch + one D2H replaces {n_greedy} single-CTA scans + syncs"
+                    );
+                });
+                Some(t)
+            }
+            Err(e) => {
+                // Never fatal: the per-row path below produces the same token.
+                tracing::error!("batched bootstrap argmax_batch (n={n}): {e:#}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // ── Per-row sample + emit (identical to the per-seq Phase-A body) ──
+    // `propose_rows[j] = Some(row)` marks a sequence that still needs drafts.
+    let mut propose_rows: Vec<Option<usize>> = vec![None; n];
+    for (j, a) in refs.iter_mut().enumerate() {
+        let row_logits = logits.offset(j * vocab * elem);
+        let batched = batch_toks.as_ref().filter(|_| greedy[j]).map(|t| t[j]);
+        let tok = match batched {
+            Some(t) => t,
+            None => {
+                let history = crate::scheduler::sample_step::penalty_history_scope(
+                    &a.output_tokens,
+                    a.tool_call_end_token,
+                )
+                .to_vec();
+                match sample_token_with_grammar(
+                    model,
+                    row_logits,
+                    a.temperature,
+                    a.top_k,
+                    a.top_p,
+                    &[],
+                    a.grammar_state.as_mut(),
+                    &pen[j],
+                    &history,
+                ) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::error!("batched bootstrap sample error: {e:#}");
+                        a.finished = true;
+                        continue;
+                    }
+                }
+            }
+        };
+        let lp = if let Some(k) = a.top_logprobs {
+            extract_single_logprobs(model, row_logits, tok, k)
+        } else {
+            None
+        };
+        emit_token(a, tok, lp);
+        if a.finished {
+            continue;
+        }
+        a.last_token = tok;
+        crate::scheduler::adaptive_spec::tick_serial(a);
+        // `spec_allowed` mutates re-probe state — evaluate exactly once.
+        if crate::scheduler::adaptive_spec::spec_allowed(a) {
+            propose_rows[j] = Some(j);
+        }
+    }
+
+    // ── Stash every proposing row BEFORE any propose ──
+    // Each drafter forward writes the shared `hidden_states` buffer, so the
+    // live decode rows are gone after the first propose (mtp_multi.rs:165).
+    // Stash slot s <-> proposing[s].
+    let proposing: Vec<usize> = (0..n).filter(|&j| propose_rows[j].is_some()).collect();
+    let mut stash_ok = false;
+    if !proposing.is_empty() {
+        match model.stash_verify_hidden_rows(&proposing, 0) {
+            Ok(()) => stash_ok = true,
+            Err(e) => tracing::error!("batched bootstrap stash_verify_hidden_rows: {e:#}"),
+        }
+    }
+
+    // ── Batched cross-sequence propose, grouped by the model's declared
+    // width; grammar-constrained sequences fall back per-seq (their mask is
+    // per-position and the batched path is grammarless by contract). ──
+    if stash_ok {
+        let group_cap = model.mtp_propose_batch_max().max(1);
+        let batchable: Vec<usize> = (0..proposing.len())
+            .filter(|&s| {
+                let a = &refs[proposing[s]];
+                a.grammar_state.is_none()
+                    && crate::scheduler::spec_step::effective_drafts_under_grammar(a, ladder_nd)
+                        == ladder_nd
+            })
+            .collect();
+        let mut done = vec![false; proposing.len()];
+        if group_cap >= 2 && ladder_nd >= 1 {
+            for group in batchable.chunks(group_cap) {
+                if group.len() < 2 {
+                    continue;
+                }
+                let tokens: Vec<u32> = group
+                    .iter()
+                    .map(|&s| refs[proposing[s]].last_token)
+                    .collect();
+                let positions: Vec<usize> = group
+                    .iter()
+                    .map(|&s| refs[proposing[s]].seq.seq_len)
+                    .collect();
+                let stash_idx: Vec<usize> = group.to_vec();
+                let result = {
+                    let mut seq_refs: Vec<&mut SequenceState> = Vec::with_capacity(group.len());
+                    let mut it = refs.iter_mut();
+                    let mut prev = 0usize;
+                    for (g, &s) in group.iter().enumerate() {
+                        let row = proposing[s];
+                        let step = if g == 0 { row } else { row - prev - 1 };
+                        let a = it.nth(step).expect("group row within batch");
+                        seq_refs.push(&mut a.seq);
+                        prev = row;
+                    }
+                    model.run_mtp_propose_batched(
+                        &tokens,
+                        &positions,
+                        &stash_idx,
+                        ladder_nd,
+                        &mut seq_refs,
+                        0,
+                    )
+                };
+                match result {
+                    Ok(Some(all)) => {
+                        for (g, &s) in group.iter().enumerate() {
+                            if !all[g].is_empty() {
+                                refs[proposing[s]].pending_drafts = all[g].clone();
+                            }
+                            done[s] = true;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        // Mid-chain failure: `last_num_drafted` tracks exactly
+                        // the drafter rows written, so a SECOND propose on top
+                        // would append rows the next trim cannot account for.
+                        // Skip these sequences this step.
+                        tracing::error!("batched bootstrap run_mtp_propose_batched: {e:#}");
+                        for &s in group {
+                            done[s] = true;
+                        }
+                    }
+                }
+            }
+        }
+        for (s, &row) in proposing.iter().enumerate() {
+            if done[s] {
+                continue;
+            }
+            if let Err(e) = model.save_hidden_for_mtp_from_stash(s, 0) {
+                tracing::error!("batched bootstrap save_hidden_for_mtp_from_stash({s}): {e:#}");
+                continue;
+            }
+            let a = &mut refs[row];
+            let mask = mtp_grammar_mask_for(a);
+            let eff = crate::scheduler::spec_step::effective_drafts_under_grammar(a, ladder_nd);
+            match model.run_mtp_propose_multi(
+                a.last_token,
+                a.seq.seq_len,
+                eff,
+                &mut a.seq,
+                0,
+                mask.as_deref(),
+            ) {
+                Ok(d) if !d.is_empty() => a.pending_drafts = d,
+                Ok(_) => tracing::warn!("MTP propose returned empty"),
+                Err(e) => tracing::error!("run_mtp_propose_multi: {e:#}"),
+            }
+        }
+    }
+
+    for a in refs.iter_mut() {
+        if a.finished {
+            continue;
+        }
+        if let Err(e) = model.start_checkpoint_async(&mut a.seq) {
+            tracing::error!("batched bootstrap start_checkpoint_async: {e:#}");
+        }
+    }
+
+    static LOGGED: std::sync::Once = std::sync::Once::new();
+    LOGGED.call_once(|| {
+        tracing::info!(
+            "MTP batched bootstrap ENGAGED (n={n}): one decode_batch + batched propose \
+             replaces {n} M=1 decodes + {n} drafter forwards per draft position"
+        );
+    });
+}

--- a/crates/spark-server/src/scheduler/mtp_bootstrap_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_bootstrap_step.rs
@@ -24,7 +24,7 @@
 //! * >= 2 draftless sequences and multi-seq MTP mode (`ATLAS_MTP_MAX_SEQS>1`)
 //!   — at cap 1 the per-seq path must stay byte-identical;
 //! * not the DFlash bootstrap (its fused pass replaces the standalone decode);
-//! * `can_batch_verify(n, 2)` — the same non-EP / non-HSS / no-LoRA /
+//! * `can_batch_verify(&[2; n])` — the same non-EP / non-HSS / no-LoRA /
 //!   stash-allocated envelope the batched verify self-gates on, and the stash
 //!   is what makes a cross-sequence propose possible at all;
 //! * the DFlash serial-append / unified-ctx commit modes are OFF (their
@@ -70,7 +70,7 @@ pub(super) fn can_batch_bootstrap(
         // k=2 is the narrowest verify width; this call asks the model for the
         // batched-MTP envelope (stash allocated, non-EP, non-HSS, no LoRA),
         // not for a verify.
-        && model.can_batch_verify(n, 2)
+        && model.can_batch_verify(&vec![2usize; n])
 }
 
 /// Batched bootstrap for the `idxs` (ASCENDING) draftless sequences.
@@ -275,6 +275,10 @@ pub(super) fn step_mtp_bootstrap_batched(
             })
             .collect();
         let mut done = vec![false; proposing.len()];
+        // D-Cut ranking key: only requested when the lever is armed, so the
+        // default path keeps the plain batched argmax and its narrower D2H.
+        let want_conf = crate::scheduler::mtp_dcut::dcut_enabled();
+        let mut conf: Vec<Vec<f32>> = Vec::new();
         if group_cap >= 2 && ladder_nd >= 1 {
             for group in batchable.chunks(group_cap) {
                 if group.len() < 2 {
@@ -307,6 +311,7 @@ pub(super) fn step_mtp_bootstrap_batched(
                         ladder_nd,
                         &mut seq_refs,
                         0,
+                        want_conf.then_some(&mut conf),
                     )
                 };
                 match result {
@@ -314,6 +319,8 @@ pub(super) fn step_mtp_bootstrap_batched(
                         for (g, &s) in group.iter().enumerate() {
                             if !all[g].is_empty() {
                                 refs[proposing[s]].pending_drafts = all[g].clone();
+                                refs[proposing[s]].pending_draft_conf =
+                                    conf.get(g).cloned().unwrap_or_default();
                             }
                             done[s] = true;
                         }

--- a/crates/spark-server/src/scheduler/mtp_dcut.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! D-Cut: adaptive verification-depth pruning (arXiv 2607.14647).
+//!
+//! # What it does
+//!
+//! The drafter emits `k_drafts` tokens per sequence and each one costs a VERIFY
+//! ROW. Rows are the verify step's price: the batched forward reads every weight
+//! once for `R = Σ rows_i` rows, and R is capped at 32 by the row buffers. D-Cut
+//! spends that budget where it will be accepted instead of spreading it evenly.
+//!
+//! The drafter reports a per-position top-1 log-probability `ln c_{i,t}`
+//! (`argmax_bf16_batch_lp`). A draft at depth `j` is only reachable if every
+//! draft before it was accepted, so its SURVIVAL score is the prefix product
+//! `s_{i,j} = Π_{t<=j} c_{i,t}` — in log space the prefix SUM. All prunable
+//! positions across the WHOLE batch are ranked by that score and the top
+//! `ratio` fraction is retained.
+//!
+//! ★ Because log-probabilities are <= 0, `s_{i,j}` is non-increasing in `j`, so
+//! the retained set is automatically a per-sequence contiguous PREFIX — no tree,
+//! no gaps, just a per-sequence draft count. That is the whole reason this needs
+//! ragged row counts and nothing else.
+//!
+//! # v1 scope (deliberate)
+//!
+//! * Every sequence keeps AT LEAST ONE draft. That holds `rows_i` in 2..=4 —
+//!   the exact envelope `can_batch_verify`, the `gdn_decode_wy{2,3,4}` handles
+//!   and the SSM intermediates pools were built and audited for. Dropping a
+//!   sequence to zero drafts (rows_i = 1) is a separate, untested regime.
+//! * The budget is a FIXED ratio from the discrete bucket set, not a profiled
+//!   cost table. `ATLAS_MTP_DCUT_RATIO` picks it; values snap to the nearest
+//!   bucket so the search space stays the paper's four points.
+//! * Pruning changes only the VERIFY width. The propose already ran at full
+//!   width when this is called, so v1 banks the row saving, not a drafter
+//!   saving.
+
+use super::types::ActiveSeq;
+
+/// The paper's discrete retention buckets.
+const BUCKETS: [f32; 4] = [0.25, 0.5, 0.75, 1.0];
+
+/// Verify row-buffer capacity — the exact bound `can_batch_verify` enforces as
+/// `Σ rows_i <= 32` (logits rows / meta gaps / bt staging, `sizes.rs`).
+pub(super) const VERIFY_ROW_BUDGET: usize = 32;
+
+/// Default ON, kill switch `ATLAS_NO_MTP_DCUT` — PRESENCE check (house
+/// convention: `=0` is NOT off).
+///
+/// Measured at C=8 on binary `296b9674` (one fresh serve per leg, warmup
+/// discarded, 5 scored reps): D-Cut off 105.56, ratio 1.0 (wiring live, zero
+/// rows pruned) 105.80 — statistically identical, so the plumbing is inert
+/// when it prunes nothing — and ratio 0.75 pools to 108.57 over two serves,
+/// **+2.6%**. It is a no-op at `ladder_nd < 2`, i.e. at the whole n>8 regime.
+pub(super) fn dcut_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_DCUT").is_none())
+}
+
+/// Retention ratio, VALUE-parsed once and snapped to the nearest
+/// [`BUCKETS`] entry.
+///
+/// Default 0.75 — the ONLY bucket that wins. The whole bucket set was swept at
+/// C=8 on binary `296b9674`, one fresh serve each: 1.0 (control) 105.80 ·
+/// **0.75 108.57** · 0.5 107.43 · 0.25 101.56. Telemetry shows exactly why —
+/// tok_step degrades monotonically as rows are pruned (2.52 / 2.54 / 2.43 /
+/// 2.16) while kept_frac falls (1.000 / 0.876 / 0.750 / 0.626), and 0.75 is
+/// the one point where the row saving outruns the token loss.
+/// 1.0 remains the natural A/B control (wiring live, zero rows pruned).
+pub(super) fn dcut_ratio() -> f32 {
+    static R: std::sync::OnceLock<f32> = std::sync::OnceLock::new();
+    *R.get_or_init(|| {
+        let raw = std::env::var("ATLAS_MTP_DCUT_RATIO")
+            .ok()
+            .and_then(|v| v.parse::<f32>().ok())
+            .unwrap_or(0.75)
+            .clamp(0.0, 1.0);
+        *BUCKETS
+            .iter()
+            .min_by(|a, b| {
+                (*a - raw)
+                    .abs()
+                    .partial_cmp(&(*b - raw).abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .expect("BUCKETS is non-empty")
+    })
+}
+
+/// Retained draft count per sequence for one verify batch.
+///
+/// `confs[i]` is sequence i's per-draft top-1 LOG-probability, in draft order.
+/// A short or empty row means "not measured": those positions score 0.0 (=
+/// certainty) and therefore survive, so a drafter that cannot report confidence
+/// is never pruned on a number nobody produced.
+///
+/// Returns `retained[i]` in `1..=k_drafts`. `row_budget` caps `Σ (retained+1)`
+/// so the result can never exceed the verify row buffer.
+pub(super) fn select(
+    confs: &[&[f32]],
+    k_drafts: usize,
+    row_budget: usize,
+    ratio: f32,
+) -> Vec<usize> {
+    let n = confs.len();
+    // Depth 1 is mandatory (see module docs), so only depths 2..=k_drafts are
+    // rankable. Nothing to do at k_drafts <= 1.
+    let mut retained = vec![1usize.min(k_drafts); n];
+    if k_drafts <= 1 || n == 0 {
+        return retained;
+    }
+    let prunable = n * (k_drafts - 1);
+
+    // Score every prunable position by its log survival (prefix sum).
+    let mut ranked: Vec<(f32, usize, usize)> = Vec::with_capacity(prunable);
+    for (i, c) in confs.iter().enumerate() {
+        let mut acc = 0.0f32;
+        for j in 0..k_drafts {
+            // Missing measurement -> 0.0 (certain), which sorts to the top.
+            acc += c.get(j).copied().unwrap_or(0.0);
+            if j >= 1 {
+                ranked.push((acc, i, j));
+            }
+        }
+    }
+    // Descending by score; ties break on (sequence, depth) so the selection is
+    // a deterministic function of the batch — a graph key derived from the
+    // resulting shape must not depend on sort instability.
+    ranked.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.1.cmp(&b.1))
+            .then(a.2.cmp(&b.2))
+    });
+
+    let by_ratio = ((prunable as f32) * ratio).round() as usize;
+    // Rows already committed: one base row + one mandatory draft per sequence.
+    let committed = 2 * n;
+    let by_budget = row_budget.saturating_sub(committed);
+    let keep = by_ratio.min(by_budget).min(prunable);
+
+    for &(_, i, j) in ranked.iter().take(keep) {
+        // Scores are non-increasing in depth, so the top-`keep` set is already
+        // prefix-closed; `max` records the deepest retained position.
+        retained[i] = retained[i].max(j + 1);
+    }
+    retained
+}
+
+/// Plan one verify batch: choose each batchable sequence's retained draft
+/// count, truncate its drafts to that prefix, reorder the batch deepest-first,
+/// and return the resulting per-sequence ROW count (`retained + 1`).
+///
+/// With `ATLAS_NO_MTP_DCUT` set this is the uniform ladder shape and the batch
+/// order is untouched — the caller's downstream path is then byte-identical to
+/// the pre-D-Cut one.
+pub(super) fn plan(
+    active: &mut [ActiveSeq],
+    batchable: &mut Vec<usize>,
+    ladder_nd: usize,
+    rows: usize,
+) -> Vec<usize> {
+    let mut ks: Vec<usize> = vec![rows; batchable.len()];
+    if !dcut_enabled() || ladder_nd < 2 || batchable.is_empty() {
+        return ks;
+    }
+    let confs: Vec<&[f32]> = batchable
+        .iter()
+        .map(|&i| {
+            let a = &active[i];
+            // Length-matched or nothing: a stale or absent confidence vector
+            // must read as "not measured" (full depth), never as a score.
+            if a.pending_draft_conf.len() == a.pending_drafts.len() {
+                a.pending_draft_conf.as_slice()
+            } else {
+                &[]
+            }
+        })
+        .collect();
+    let retained = select(&confs, ladder_nd, VERIFY_ROW_BUDGET, dcut_ratio());
+    for (slot, &idx) in batchable.iter().enumerate() {
+        let keep = retained[slot].clamp(1, ladder_nd);
+        active[idx].pending_drafts.truncate(keep);
+        active[idx].pending_draft_conf.truncate(keep);
+        ks[slot] = keep + 1;
+    }
+    record(batchable.len() * rows, ks.iter().sum(), &ks);
+    // Deepest first so equal-depth sequences form CONTIGUOUS row runs — the
+    // cross-sequence batched GDN conv+WY fast path launches once per run, so
+    // fragmenting the depths would trade verify rows for kernel launches.
+    // Secondary key stays the ssm slot (canonical graph key + the
+    // consecutive-slot precondition).
+    let mut order: Vec<(usize, usize)> = batchable.iter().copied().zip(ks).collect();
+    order.sort_by_key(|&(idx, k)| {
+        (
+            std::cmp::Reverse(k),
+            active[idx].seq.ssm_slot_idx().unwrap_or(usize::MAX),
+        )
+    });
+    *batchable = order.iter().map(|&(i, _)| i).collect();
+    order.iter().map(|&(_, k)| k).collect()
+}
+
+/// Split a batch into verify chunks: `[lo, hi)` index ranges over `ks`.
+///
+/// Two caps, both pre-existing: the 32-row buffer bound, and a sequence-count
+/// cap keyed on the chunk's WIDEST row count (rows=4 → 8 seqs, rows=3 → 8 seqs,
+/// else 16). With uniform `ks` this reproduces `chunks(chunk_cap)` exactly, so
+/// D-Cut-off is byte-identical. `ks` is deepest-first, so the widest row count
+/// is the chunk's first element and the cap never changes mid-chunk.
+pub(super) fn chunk_ranges(ks: &[usize]) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    let mut lo = 0usize;
+    while lo < ks.len() {
+        let seq_cap = match ks[lo] {
+            4 | 3 => 8,
+            _ => 16,
+        };
+        let mut hi = lo;
+        let mut r = 0usize;
+        while hi < ks.len() && hi - lo < seq_cap && r + ks[hi] <= VERIFY_ROW_BUDGET {
+            r += ks[hi];
+            hi += 1;
+        }
+        // A single sequence wider than the whole budget cannot happen (rows <=
+        // 4), but never emit an empty range.
+        if hi == lo {
+            hi = lo + 1;
+        }
+        out.push((lo, hi));
+        lo = hi;
+    }
+    out
+}
+
+/// Per-step retained-rows telemetry, under the existing
+/// `ATLAS_MTP_ACCEPT_DEBUG` gate. Counters only; one line per `PERIOD` steps.
+fn record(rows_full: usize, rows_kept: usize, ks: &[usize]) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    const PERIOD: u64 = 200;
+    static STEPS: AtomicU64 = AtomicU64::new(0);
+    static FULL: AtomicU64 = AtomicU64::new(0);
+    static KEPT: AtomicU64 = AtomicU64::new(0);
+    if !spark_model::speculative::mtp_accept_debug() {
+        return;
+    }
+    FULL.fetch_add(rows_full as u64, Ordering::Relaxed);
+    KEPT.fetch_add(rows_kept as u64, Ordering::Relaxed);
+    if STEPS.fetch_add(1, Ordering::Relaxed) + 1 >= PERIOD {
+        let steps = STEPS.swap(0, Ordering::Relaxed).max(1);
+        let full = FULL.swap(0, Ordering::Relaxed).max(1);
+        let kept = KEPT.swap(0, Ordering::Relaxed);
+        tracing::info!(
+            "MTP D-Cut ratio={:.2} steps={steps} rows_full={full} rows_kept={kept} \
+             kept_frac={:.3} last_ks={ks:?}",
+            dcut_ratio(),
+            kept as f64 / full as f64,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ratio_one_retains_full_depth() {
+        let c: Vec<Vec<f32>> = vec![vec![-0.1, -2.0, -3.0]; 4];
+        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+        assert_eq!(select(&refs, 3, 32, 1.0), vec![3, 3, 3, 3]);
+    }
+
+    #[test]
+    fn zero_ratio_keeps_the_mandatory_first_draft() {
+        let c: Vec<Vec<f32>> = vec![vec![-0.1, -0.2, -0.3]; 4];
+        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+        assert_eq!(select(&refs, 3, 32, 0.0), vec![1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn budget_spent_on_the_confident_sequence() {
+        // seq 0 is confident throughout, seq 1 collapses after its first draft.
+        let c = [vec![-0.01f32, -0.02, -0.03], vec![-3.0f32, -4.0, -5.0]];
+        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+        // 2 sequences x 2 prunable depths = 4 candidates; ratio 0.5 keeps 2,
+        // both of which belong to seq 0.
+        assert_eq!(select(&refs, 3, 32, 0.5), vec![3, 1]);
+    }
+
+    #[test]
+    fn retained_set_is_always_a_prefix() {
+        let c = [vec![-0.1f32, -9.0, -0.001], vec![-0.2f32, -0.2, -0.2]];
+        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+        let r = select(&refs, 3, 32, 0.5);
+        // Depth-3 of seq 0 has a WORSE survival score than depth-2 despite its
+        // own high confidence, because survival is the prefix product.
+        assert!(r[0] <= 2, "prefix product must dominate the local value");
+        assert!(r.iter().all(|&k| (1..=3).contains(&k)));
+    }
+
+    #[test]
+    fn row_budget_is_never_exceeded() {
+        let c: Vec<Vec<f32>> = vec![vec![-0.001, -0.001, -0.001]; 8];
+        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+        // 8 sequences, budget 24 rows: 16 committed, 8 spare -> 8 extra depths.
+        let r = select(&refs, 3, 24, 1.0);
+        let rows: usize = r.iter().map(|k| k + 1).sum();
+        assert!(rows <= 24, "rows={rows}");
+    }
+
+    #[test]
+    fn missing_confidences_are_never_pruned() {
+        let empty: Vec<f32> = Vec::new();
+        let c = [vec![-5.0f32, -5.0, -5.0], empty];
+        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+        assert_eq!(select(&refs, 3, 32, 0.5), vec![1, 3]);
+    }
+
+    #[test]
+    fn chunk_ranges_reproduce_the_uniform_caps() {
+        assert_eq!(chunk_ranges(&[4; 8]), vec![(0, 8)]);
+        assert_eq!(chunk_ranges(&[4; 9]), vec![(0, 8), (8, 9)]);
+        assert_eq!(chunk_ranges(&[3; 8]), vec![(0, 8)]);
+        assert_eq!(chunk_ranges(&[3; 10]), vec![(0, 8), (8, 10)]);
+        assert_eq!(chunk_ranges(&[2; 16]), vec![(0, 16)]);
+        assert_eq!(chunk_ranges(&[2; 17]), vec![(0, 16), (16, 17)]);
+    }
+
+    #[test]
+    fn chunk_ranges_respect_the_row_budget_when_ragged() {
+        // Deepest-first, mixed depths: rows must never exceed 32 per chunk.
+        let ks = vec![4, 4, 4, 4, 4, 3, 3, 2, 2, 2];
+        for (lo, hi) in chunk_ranges(&ks) {
+            let rows: usize = ks[lo..hi].iter().sum();
+            assert!(rows <= VERIFY_ROW_BUDGET, "rows={rows}");
+            assert!(hi > lo);
+        }
+    }
+
+    #[test]
+    fn ratio_snaps_to_a_bucket() {
+        // Pure snapping arithmetic, no env: 0.6 is closest to 0.5.
+        let nearest = |raw: f32| {
+            *BUCKETS
+                .iter()
+                .min_by(|a, b| (*a - raw).abs().partial_cmp(&(*b - raw).abs()).unwrap())
+                .unwrap()
+        };
+        assert_eq!(nearest(0.6), 0.5);
+        assert_eq!(nearest(0.9), 1.0);
+        assert_eq!(nearest(0.1), 0.25);
+    }
+}

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -30,6 +30,19 @@ pub fn step_mtp(
         }
     }
 
+    // K-vs-batch ladder (task #35): the per-step draft count is a function
+    // of the CURRENT concurrency — 3 drafts at n<=4 (the proven K=4 regime,
+    // bit-for-bit), 2 at n<=8, 1 at n<=16 — keeping the batched verify at
+    // R = n*(drafts+1) <= 32 rows instead of the measured fixed-K=4
+    // collapse (~55 tok/s plateau over n>=8). SSOT + overrides
+    // (`ATLAS_MTP_K_LADDER`, `ATLAS_NO_MTP_K_LADDER`):
+    // `spark_model::speculative::ladder`. DFlash keeps its own γ economics.
+    let ladder_nd = if dflash_verify_raw_argmax {
+        num_drafts
+    } else {
+        spark_model::speculative::mtp_ladder_drafts(active.len(), num_drafts)
+    };
+
     // ── Phase A: Bootstrap decode for sequences without a draft ──
     if !bootstrap_idxs.is_empty() {
         // The previous verify commit's live-state restore runs async on the
@@ -39,6 +52,15 @@ pub fn step_mtp(
         if let Err(e) = model.sync_secondary() {
             tracing::error!("bootstrap sync_secondary: {e:#}");
         }
+    }
+    // Batched form: ONE `decode_batch` for every draftless sequence plus a
+    // batched cross-sequence propose, replacing n M=1 weight sweeps of the
+    // target and n of the drafter. Falls back to the per-sequence loop below
+    // whenever the envelope does not hold (`mtp_bootstrap_step`); kill switch
+    // ATLAS_NO_MTP_BATCH_BOOTSTRAP.
+    if can_batch_bootstrap(model, bootstrap_idxs.len(), dflash_verify_raw_argmax) {
+        step_mtp_bootstrap_batched(model, active, &bootstrap_idxs, ladder_nd, verify_ctx);
+        bootstrap_idxs.clear();
     }
     for &idx in &bootstrap_idxs {
         let a = &mut active[idx];
@@ -243,8 +265,11 @@ pub fn step_mtp(
         // 2026-07-09: hoisted to the `effective_drafts_under_grammar` SSOT,
         // now also applied at the five verify-path re-propose sites that
         // previously bypassed this clamp (the "mask held fixed" warn spam).
+        // Composed with the K-vs-batch ladder: the bootstrap propose is
+        // sized for the current concurrency so the next verify is uniform
+        // at the ladder width (no surplus drafts to truncate).
         let effective_num_drafts =
-            crate::scheduler::spec_step::effective_drafts_under_grammar(a, num_drafts);
+            crate::scheduler::spec_step::effective_drafts_under_grammar(a, ladder_nd);
         // Adaptive speculation: a suspended seq skips proposing entirely and
         // stays on this serial bootstrap path until the re-probe fires.
         // (`will_propose` is the single spec_allowed evaluation above.)
@@ -274,7 +299,75 @@ pub fn step_mtp(
     }
 
     // ── Phase B: Verify with pipelined checkpoint ──
-    for &idx in &verify_idxs {
+    //
+    // Batched multi-seq K-row verify (batched-MTP E11 + the ladder). Only
+    // reachable when `ATLAS_MTP_MAX_SEQS > 1` (default 16 with the ladder)
+    // puts >= 2 verify-ready sequences in one step (`ATLAS_MTP_MAX_SEQS=1`
+    // ⇒ this partition is a no-op and every seq takes the per-seq loop
+    // below, byte-identical to the pre-batched HEAD). Batchable =
+    // grammarless, non-DFlash, >= ladder_nd pending drafts (surplus from a
+    // ladder step-down is truncated — the same draft-tail truncation the
+    // grammar-boundary path already does; `after_verify`'s
+    // `last_num_drafted` trim contract stays consistent). The model
+    // additionally self-gates (non-EP, non-HSS, no LoRA) via
+    // `can_batch_verify(n, rows)`. Kill switch `ATLAS_NO_MTP_BATCH_VERIFY`
+    // (PRESENCE check) forces the serialized loop for A/B.
+    let mut serial_idxs: Vec<usize> = Vec::new();
+    let mut batchable_idxs: Vec<usize> = Vec::new();
+    if verify_idxs.len() >= 2
+        && spark_model::speculative::mtp_multi_seq_mode()
+        && !dflash_verify_raw_argmax
+        && !batch_verify_disabled()
+        && ladder_nd >= 1
+    {
+        for &idx in &verify_idxs {
+            let a = &mut active[idx];
+            if a.grammar_state.is_none() && a.pending_drafts.len() >= ladder_nd {
+                if a.pending_drafts.len() > ladder_nd {
+                    a.pending_drafts.truncate(ladder_nd);
+                }
+                batchable_idxs.push(idx);
+            } else {
+                serial_idxs.push(idx);
+            }
+        }
+    } else {
+        serial_idxs.extend_from_slice(&verify_idxs);
+    }
+    // Chunk caps pinned to the ladder plateaus: rows=4 keeps the proven
+    // 4-seq / R=16 envelope byte-identical; rows=3 → 8 seqs (R=24);
+    // rows=2 → 16 seqs (R=32, the exact buffer capacity).
+    let rows = ladder_nd + 1;
+    let chunk_cap = match rows {
+        4 => 4,
+        3 => 8,
+        _ => 16,
+    };
+    for chunk in batchable_idxs.chunks(chunk_cap) {
+        if chunk.len() >= 2 && model.can_batch_verify(chunk.len(), rows) {
+            // Collect disjoint &mut refs for the chunk's (ascending) indices.
+            let mut refs: Vec<&mut ActiveSeq> = Vec::with_capacity(chunk.len());
+            let mut it = active.iter_mut();
+            let mut consumed = 0usize;
+            for &i in chunk {
+                let a = it.nth(i - consumed).expect("chunk index within active");
+                consumed = i + 1;
+                refs.push(a);
+            }
+            // Canonical batch order: sort by ssm-pool slot so the graph key
+            // (verify_e2) is a combination, not a permutation — 24x fewer
+            // keys at n=4, and the consecutive-slot batched-GDN precondition
+            // engages more often. Verdicts are index-mapped inside the step,
+            // so batch order is free to the caller.
+            refs.sort_by_key(|a| a.seq.ssm_slot_idx().unwrap_or(usize::MAX));
+            step_verify_k4_batched(model, &mut refs, ladder_nd, verify_ctx);
+        } else {
+            // Model can't batch this width (or a lone leftover): fall back
+            // to the existing per-seq dispatch for these sequences.
+            serial_idxs.extend_from_slice(chunk);
+        }
+    }
+    for &idx in &serial_idxs {
         let a = &mut active[idx];
         let mut drafts: Vec<u32> = std::mem::take(&mut a.pending_drafts);
         if drafts.is_empty() {

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -31,10 +31,11 @@ pub fn step_mtp(
     }
 
     // K-vs-batch ladder (task #35): the per-step draft count is a function
-    // of the CURRENT concurrency — 3 drafts at n<=4 (the proven K=4 regime,
-    // bit-for-bit), 2 at n<=8, 1 at n<=16 — keeping the batched verify at
-    // R = n*(drafts+1) <= 32 rows instead of the measured fixed-K=4
-    // collapse (~55 tok/s plateau over n>=8). SSOT + overrides
+    // of the CURRENT concurrency. Default ladder holds 3 drafts to the cap
+    // (`4:3,8:3`), which keeps the batched verify at R = n*(drafts+1) = 32
+    // rows at n=8 — exactly the row-buffer bound. The depth step-down that
+    // used to sit at n>4 was an artifact of the chunk cap below, not of GDN
+    // depth cost (see that comment). SSOT + overrides
     // (`ATLAS_MTP_K_LADDER`, `ATLAS_NO_MTP_K_LADDER`):
     // `spark_model::speculative::ladder`. DFlash keeps its own γ economics.
     let ladder_nd = if dflash_verify_raw_argmax {
@@ -301,7 +302,7 @@ pub fn step_mtp(
     // ── Phase B: Verify with pipelined checkpoint ──
     //
     // Batched multi-seq K-row verify (batched-MTP E11 + the ladder). Only
-    // reachable when `ATLAS_MTP_MAX_SEQS > 1` (default 16 with the ladder)
+    // reachable when `ATLAS_MTP_MAX_SEQS > 1` (default 8 with the ladder)
     // puts >= 2 verify-ready sequences in one step (`ATLAS_MTP_MAX_SEQS=1`
     // ⇒ this partition is a no-op and every seq takes the per-seq loop
     // below, byte-identical to the pre-batched HEAD). Batchable =
@@ -334,12 +335,20 @@ pub fn step_mtp(
     } else {
         serial_idxs.extend_from_slice(&verify_idxs);
     }
-    // Chunk caps pinned to the ladder plateaus: rows=4 keeps the proven
-    // 4-seq / R=16 envelope byte-identical; rows=3 → 8 seqs (R=24);
-    // rows=2 → 16 seqs (R=32, the exact buffer capacity).
+    // Chunk caps pinned to the row-buffer capacity (32 rows, the same bound
+    // `can_batch_verify` enforces as `n*k <= 32`): rows=4 → 8 seqs, rows=3 →
+    // 8 seqs (R=24), rows=2 → 16 seqs (R=32).
+    //
+    // rows=4 was previously capped at 4 seqs to keep the proven 4-seq/R=16
+    // envelope byte-identical. That cap silently made the `8:3` ladder step
+    // untestable: 8 batchable sequences split into TWO serialized 4-wide
+    // verify forwards (2x the weight reads per step), which is what the
+    // "8:3 collapses" measurements (57.9, and 62.6 on 2026-07-28) actually
+    // recorded — NOT depth-3 at width 8. No-op at the default ladder, where
+    // rows=4 occurs only at n<=4 and every chunk is already <= 4.
     let rows = ladder_nd + 1;
     let chunk_cap = match rows {
-        4 => 4,
+        4 => 8,
         3 => 8,
         _ => 16,
     };

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -31,11 +31,12 @@ pub fn step_mtp(
     }
 
     // K-vs-batch ladder (task #35): the per-step draft count is a function
-    // of the CURRENT concurrency. Default ladder holds 3 drafts to the cap
-    // (`4:3,8:3`), which keeps the batched verify at R = n*(drafts+1) = 32
-    // rows at n=8 — exactly the row-buffer bound. The depth step-down that
-    // used to sit at n>4 was an artifact of the chunk cap below, not of GDN
-    // depth cost (see that comment). SSOT + overrides
+    // of the CURRENT concurrency. Default ladder `4:3,8:3,16:1` holds 3
+    // drafts through n=8 and drops to 1 through the cap (16), so R =
+    // Σ(drafts+1) tops out at exactly the 32-row buffer bound at BOTH n=8
+    // (8x4) and n=16 (16x2). The depth step-down that used to sit at n>4
+    // was an artifact of the chunk cap below, not of GDN depth cost (see
+    // that comment); the one at n>8 is real (16:2 -> 94.1). SSOT + overrides
     // (`ATLAS_MTP_K_LADDER`, `ATLAS_NO_MTP_K_LADDER`):
     // `spark_model::speculative::ladder`. DFlash keeps its own γ economics.
     let ladder_nd = if dflash_verify_raw_argmax {
@@ -302,7 +303,7 @@ pub fn step_mtp(
     // ── Phase B: Verify with pipelined checkpoint ──
     //
     // Batched multi-seq K-row verify (batched-MTP E11 + the ladder). Only
-    // reachable when `ATLAS_MTP_MAX_SEQS > 1` (default 8 with the ladder)
+    // reachable when `ATLAS_MTP_MAX_SEQS > 1` (default 16 with the ladder)
     // puts >= 2 verify-ready sequences in one step (`ATLAS_MTP_MAX_SEQS=1`
     // ⇒ this partition is a no-op and every seq takes the per-seq loop
     // below, byte-identical to the pre-batched HEAD). Batchable =
@@ -311,7 +312,7 @@ pub fn step_mtp(
     // grammar-boundary path already does; `after_verify`'s
     // `last_num_drafted` trim contract stays consistent). The model
     // additionally self-gates (non-EP, non-HSS, no LoRA) via
-    // `can_batch_verify(n, rows)`. Kill switch `ATLAS_NO_MTP_BATCH_VERIFY`
+    // `can_batch_verify(&ks)`. Kill switch `ATLAS_NO_MTP_BATCH_VERIFY`
     // (PRESENCE check) forces the serialized loop for A/B.
     let mut serial_idxs: Vec<usize> = Vec::new();
     let mut batchable_idxs: Vec<usize> = Vec::new();
@@ -335,41 +336,66 @@ pub fn step_mtp(
     } else {
         serial_idxs.extend_from_slice(&verify_idxs);
     }
-    // Chunk caps pinned to the row-buffer capacity (32 rows, the same bound
-    // `can_batch_verify` enforces as `n*k <= 32`): rows=4 → 8 seqs, rows=3 →
-    // 8 seqs (R=24), rows=2 → 16 seqs (R=32).
+    let rows = ladder_nd + 1;
+
+    // ── D-Cut: per-sequence verify depth from drafter confidence ──
+    // Default ON at ratio 0.75 (+2.6% at C=8; kill switch `ATLAS_NO_MTP_DCUT`,
+    // PRESENCE). Ranks every prunable draft position ACROSS the batch by its
+    // prefix-product survival score and keeps the top `ATLAS_MTP_DCUT_RATIO`
+    // fraction (`mtp_dcut`). The retained set is a per-sequence PREFIX by
+    // construction, so the only downstream effect is a RAGGED row count. OFF
+    // (or `ladder_nd < 2`, which is the whole n>8 regime) ⇒ `ks` is the uniform
+    // ladder shape and everything below reduces to the pre-D-Cut path exactly.
+    let ks = mtp_dcut::plan(active, &mut batchable_idxs, ladder_nd, rows);
+
+    // Chunking: sequence-count cap by the chunk's WIDEST row count (the
+    // pre-D-Cut table, which the uniform case reproduces exactly) AND the
+    // 32-row buffer bound `can_batch_verify` enforces. With uniform `ks` this
+    // is byte-identical to the old `batchable_idxs.chunks(chunk_cap)`:
+    // rows=4 → 8 seqs (R=32), rows=3 → 8 seqs (R=24), rows=2 → 16 seqs (R=32).
     //
     // rows=4 was previously capped at 4 seqs to keep the proven 4-seq/R=16
     // envelope byte-identical. That cap silently made the `8:3` ladder step
     // untestable: 8 batchable sequences split into TWO serialized 4-wide
     // verify forwards (2x the weight reads per step), which is what the
     // "8:3 collapses" measurements (57.9, and 62.6 on 2026-07-28) actually
-    // recorded — NOT depth-3 at width 8. No-op at the default ladder, where
-    // rows=4 occurs only at n<=4 and every chunk is already <= 4.
-    let rows = ladder_nd + 1;
-    let chunk_cap = match rows {
-        4 => 8,
-        3 => 8,
-        _ => 16,
-    };
-    for chunk in batchable_idxs.chunks(chunk_cap) {
-        if chunk.len() >= 2 && model.can_batch_verify(chunk.len(), rows) {
-            // Collect disjoint &mut refs for the chunk's (ascending) indices.
-            let mut refs: Vec<&mut ActiveSeq> = Vec::with_capacity(chunk.len());
+    // recorded — NOT depth-3 at width 8.
+    for (lo, hi) in mtp_dcut::chunk_ranges(&ks) {
+        let chunk = &batchable_idxs[lo..hi];
+        let chunk_ks = &ks[lo..hi];
+        if chunk.len() >= 2 && model.can_batch_verify(chunk_ks) {
+            // Collect disjoint &mut refs — the iterator walk requires ASCENDING
+            // indices, so sort a copy of the chunk before walking and restore
+            // the batch order (with each sequence's k) immediately after.
+            let mut asc: Vec<(usize, usize)> = chunk
+                .iter()
+                .copied()
+                .zip(chunk_ks.iter().copied())
+                .collect();
+            asc.sort_unstable();
+            let mut refs: Vec<(&mut ActiveSeq, usize)> = Vec::with_capacity(chunk.len());
             let mut it = active.iter_mut();
             let mut consumed = 0usize;
-            for &i in chunk {
+            for &(i, k) in &asc {
                 let a = it.nth(i - consumed).expect("chunk index within active");
                 consumed = i + 1;
-                refs.push(a);
+                refs.push((a, k));
             }
-            // Canonical batch order: sort by ssm-pool slot so the graph key
-            // (verify_e2) is a combination, not a permutation — 24x fewer
-            // keys at n=4, and the consecutive-slot batched-GDN precondition
-            // engages more often. Verdicts are index-mapped inside the step,
-            // so batch order is free to the caller.
-            refs.sort_by_key(|a| a.seq.ssm_slot_idx().unwrap_or(usize::MAX));
-            step_verify_k4_batched(model, &mut refs, ladder_nd, verify_ctx);
+            // Canonical batch order: deepest first, then ssm-pool slot, so the
+            // graph key (verify_e2) is a combination, not a permutation — 24x
+            // fewer keys at n=4 — and the consecutive-slot batched-GDN
+            // precondition engages more often. Verdicts are index-mapped
+            // inside the step, so batch order is free to the caller. With
+            // uniform k this is the pre-D-Cut sort by slot.
+            refs.sort_by_key(|(a, k)| {
+                (
+                    std::cmp::Reverse(*k),
+                    a.seq.ssm_slot_idx().unwrap_or(usize::MAX),
+                )
+            });
+            let sorted_ks: Vec<usize> = refs.iter().map(|&(_, k)| k).collect();
+            let mut batch: Vec<&mut ActiveSeq> = refs.into_iter().map(|(a, _)| a).collect();
+            step_verify_k4_batched(model, &mut batch, &sorted_ks, ladder_nd, verify_ctx);
         } else {
             // Model can't batch this width (or a lone leftover): fall back
             // to the existing per-seq dispatch for these sequences.
@@ -379,6 +405,9 @@ pub fn step_mtp(
     for &idx in &serial_idxs {
         let a = &mut active[idx];
         let mut drafts: Vec<u32> = std::mem::take(&mut a.pending_drafts);
+        // Confidences describe the taken drafts; clearing here is the single
+        // place the two vectors are kept in lock-step for the serial path.
+        a.pending_draft_conf.clear();
         if drafts.is_empty() {
             continue;
         }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
@@ -77,6 +77,20 @@ pub(super) fn run_batched_mixed_step(
     }
 
     // Gather decode-side inputs.
+    // Sort by SSM pool slot before building the batch, exactly as
+    // `decode_step.rs` does for pure-decode steps. Without it the batched
+    // GDN recurrence declines: its precondition is that the n sequences sit
+    // in CONSECUTIVE pool slots IN SLICE ORDER, and retire+compaction packs
+    // the slot SET while scrambling the ORDER (a finishing sequence's slot
+    // is backfilled by the highest-slot survivor, which stays last in the
+    // vec). Pure-decode steps healed this and mixed steps did not, so every
+    // step for the duration of a prefill fell back to the per-seq loop —
+    // measured 853 us/layer vs 618 batched, a 28% penalty on ~30 ms/step.
+    // Reordering whole ActiveSeq elements keeps the post-decode
+    // position->seq mapping consistent (same argument as decode_step.rs).
+    if active.len() > 1 {
+        active.sort_by_key(|a| a.seq.ssm_slot_idx().unwrap_or(a.seq.slot_idx));
+    }
     let decode_tokens: Vec<u32> = active.iter().map(|a| a.last_token).collect();
 
     // Build slices in a temporary scope so the &mut borrows on prefilling

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -133,6 +133,20 @@ pub(super) fn run_standard_chunk_loop(
                 tracing::error!("mtp->mixed sync_secondary: {e:#}");
             }
         }
+        // Sort by SSM pool slot before building the batch, exactly as
+        // `decode_step.rs` does for pure-decode steps. Without it the batched
+        // GDN recurrence declines: its precondition is that the n sequences sit
+        // in CONSECUTIVE pool slots IN SLICE ORDER, and retire+compaction packs
+        // the slot SET while scrambling the ORDER (a finishing sequence's slot
+        // is backfilled by the highest-slot survivor, which stays last in the
+        // vec). Pure-decode steps healed this and mixed steps did not, so every
+        // step for the duration of a prefill fell back to the per-seq loop —
+        // measured 853 us/layer vs 618 batched, a 28% penalty on ~30 ms/step.
+        // Reordering whole ActiveSeq elements keeps the post-decode
+        // position->seq mapping consistent (same argument as decode_step.rs).
+        if active.len() > 1 {
+            active.sort_by_key(|a| a.seq.ssm_slot_idx().unwrap_or(a.seq.slot_idx));
+        }
         let decode_tokens: Vec<u32> = active.iter().map(|a| a.last_token).collect();
         let mut decode_refs: Vec<&mut SequenceState> =
             active.iter_mut().map(|a| &mut a.seq).collect();

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -128,6 +128,7 @@ pub(super) fn run_standard_chunk_loop(
             let had_drafts = active.iter().any(|a| !a.pending_drafts.is_empty());
             for a in active.iter_mut() {
                 a.pending_drafts.clear();
+                a.pending_draft_conf.clear();
             }
             if had_drafts && let Err(e) = model.sync_secondary() {
                 tracing::error!("mtp->mixed sync_secondary: {e:#}");

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -163,6 +163,7 @@ fn build_active_seq_from_prefill(
         dry_sequence_breakers: Vec::new(),
         logit_bias: p.logit_bias,
         pending_drafts: Vec::new(),
+        pending_draft_conf: Vec::new(),
         inside_thinking: if immediate_finish {
             p.enable_thinking && think_end_token.is_some()
         } else {

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -212,6 +212,7 @@ pub fn start_chunked_prefill(
             dry_sequence_breakers: Vec::new(),
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
+            pending_draft_conf: Vec::new(),
             inside_thinking: req_enable_thinking && think_end_token.is_some(),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
@@ -547,6 +548,7 @@ pub fn start_chunked_prefill(
                 dry_sequence_breakers: Vec::new(),
                 logit_bias: logit_bias.clone(),
                 pending_drafts: Vec::new(),
+                pending_draft_conf: Vec::new(),
                 inside_thinking: req_enable_thinking && think_end_token.is_some(),
                 enable_thinking: req_enable_thinking,
                 thinking_budget: req_thinking_budget,
@@ -632,6 +634,7 @@ pub fn start_chunked_prefill(
                 dry_sequence_breakers: Vec::new(),
                 logit_bias: logit_bias.clone(),
                 pending_drafts: Vec::new(),
+                pending_draft_conf: Vec::new(),
                 inside_thinking: spontaneous_think
                     || (req_enable_thinking && think_end_token.is_some()),
                 enable_thinking: req_enable_thinking,

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -189,6 +189,7 @@ pub fn prefill_request(
             dry_sequence_breakers: Vec::new(),
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
+            pending_draft_conf: Vec::new(),
             inside_thinking: req_enable_thinking && think_end_token.is_some(),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
@@ -379,6 +380,7 @@ pub fn prefill_request(
             dry_sequence_breakers: Vec::new(),
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
+            pending_draft_conf: Vec::new(),
             inside_thinking: req_enable_thinking && think_end_token.is_some(),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
@@ -461,6 +463,7 @@ pub fn prefill_request(
         dry_sequence_breakers: Vec::new(),
         logit_bias,
         pending_drafts: Vec::new(),
+        pending_draft_conf: Vec::new(),
         inside_thinking: spontaneous_think || (req_enable_thinking && think_end_token.is_some()),
         enable_thinking: req_enable_thinking,
         thinking_budget: if spontaneous_think {

--- a/crates/spark-server/src/scheduler/spec_step.rs
+++ b/crates/spark-server/src/scheduler/spec_step.rs
@@ -185,6 +185,7 @@ pub fn step_ngram(
     if !a.pending_drafts.is_empty() {
         // ── Phase B: Verify pending draft ──
         let drafts: Vec<u32> = std::mem::take(&mut a.pending_drafts);
+        a.pending_draft_conf.clear();
         step_ngram_verify(model, a, &drafts, proposer, verify_ctx);
     } else {
         // ── Phase A: Bootstrap decode + N-gram propose ──

--- a/crates/spark-server/src/scheduler/spec_step.rs
+++ b/crates/spark-server/src/scheduler/spec_step.rs
@@ -111,6 +111,7 @@ pub fn step_self_spec(
         &verified_argmax,
         a,
         verify_ctx,
+        0,
     );
 
     // 6. Compare draft vs verified, count acceptances
@@ -286,6 +287,7 @@ pub fn step_ngram_verify(
         &[v0_argmax, v1_argmax],
         a,
         verify_ctx,
+        0,
     );
     let v0 = processed.first().copied().unwrap_or(v0_argmax);
     let v1 = processed.get(1).copied().unwrap_or(v1_argmax);

--- a/crates/spark-server/src/scheduler/types.rs
+++ b/crates/spark-server/src/scheduler/types.rs
@@ -326,6 +326,13 @@ pub(super) struct ActiveSeq {
     pub grammar_state: Option<GrammarState>,
     /// MTP draft tokens awaiting verification.
     pub pending_drafts: Vec<u32>,
+    /// Top-1 LOG-probability the drafter reported for each entry of
+    /// [`Self::pending_drafts`], in the same order (D-Cut's ranking key —
+    /// `mtp_dcut`). EMPTY whenever the drafts came from a path that cannot
+    /// measure confidence (per-sequence propose, N-gram/DFlash drafters), in
+    /// which case D-Cut leaves the sequence at full depth. Truncated in
+    /// lock-step with `pending_drafts` so index `j` always describes draft `j`.
+    pub pending_draft_conf: Vec<f32>,
     /// Timestamp of the last token emission (for TBT deadline tracking).
     pub last_token_time: Instant,
     /// Timestamp when the request entered prefill (for TTFT).

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -81,6 +81,7 @@ pub fn step_verify_dflash(
             &verified_argmax,
             a,
             verify_ctx,
+            0,
         )
     };
 

--- a/crates/spark-server/src/scheduler/verify_k2_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k2_step.rs
@@ -139,6 +139,7 @@ pub fn step_verify_k2(
             &[v0_argmax, v1_argmax],
             a,
             verify_ctx,
+            0,
         );
         (
             processed.first().copied().unwrap_or(v0_argmax),
@@ -149,7 +150,7 @@ pub fn step_verify_k2(
 
     // Extract logprobs from verify logits buffer (K=2 positions) when requested.
     let verify_lps = if let Some(top_logprobs) = a.top_logprobs {
-        extract_verify_logprobs(model, &[v0, v1], top_logprobs)
+        extract_verify_logprobs(model, &[v0, v1], top_logprobs, 0)
     } else {
         Vec::new()
     };

--- a/crates/spark-server/src/scheduler/verify_k3_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k3_step.rs
@@ -173,6 +173,7 @@ pub fn step_verify_k3(
             &[v0_argmax, v1_argmax, v2_argmax],
             a,
             verify_ctx,
+            0,
         );
         (
             processed.first().copied().unwrap_or(v0_argmax),
@@ -257,7 +258,7 @@ pub fn step_verify_k3(
 
     // Extract logprobs from verify logits buffer (K=3 positions) when requested.
     let verify_lps = if let Some(top_logprobs) = a.top_logprobs {
-        extract_verify_logprobs(model, &[v0, v1, v2], top_logprobs)
+        extract_verify_logprobs(model, &[v0, v1, v2], top_logprobs, 0)
     } else {
         Vec::new()
     };

--- a/crates/spark-server/src/scheduler/verify_k4_batch_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_batch_step.rs
@@ -4,8 +4,8 @@
 //! K-vs-batch ladder, task #35).
 //!
 //! Runs the n weight-reading verify forwards of a chunk of verify-ready
-//! sequences as ONE R = n*(k+1)-row forward (`decode_verify_batched`,
-//! seq-major rows `r = i*rows + j`), then applies each sequence's verdict
+//! sequences as ONE R = Σ ks[i]-row forward (`decode_verify_batched`,
+//! seq-major rows, RAGGED per sequence since D-Cut), then applies its verdict
 //! with the EXISTING single-seq machinery (`k4_apply_verdict`, K-generic).
 //! `k_drafts` (drafts per sequence this step) comes from the ladder —
 //! `speculative::ladder::mtp_ladder_drafts(active.len())` — 3 at n<=4
@@ -20,8 +20,8 @@
 //!
 //! Reachability: only via `step_mtp` Phase B when `ATLAS_MTP_MAX_SEQS > 1`
 //! (default 16 with the ladder) puts >= 2 verify-ready grammarless
-//! sequences holding `k_drafts` drafts in one step AND the model says
-//! `can_batch_verify(n, k_drafts+1)`. `ATLAS_MTP_MAX_SEQS=1` keeps this
+//! sequences holding drafts in one step AND the model says
+//! `can_batch_verify(&ks)`. `ATLAS_MTP_MAX_SEQS=1` keeps this
 //! path dead and the single-seq path byte-unchanged.
 
 use super::*;
@@ -35,25 +35,36 @@ pub(super) fn batch_verify_disabled() -> bool {
     *CACHED.get_or_init(|| std::env::var("ATLAS_NO_MTP_BATCH_VERIFY").is_ok())
 }
 
-/// Batched K-row verify for `batch.len() >= 2` sequences, each holding
-/// exactly `k_drafts` pending drafts. Caller (Phase B in `mtp_step.rs`)
-/// guarantees: grammarless, non-DFlash, uniform `pending_drafts.len() ==
-/// k_drafts` (ladder-truncated), chunk size <= the per-rows cap, batch
-/// sorted by ssm slot (canonical graph key), and
-/// `model.can_batch_verify(batch.len(), k_drafts+1)` true.
+/// Batched K-row verify for `batch.len() >= 2` sequences. Sequence `i` holds
+/// exactly `ks[i] - 1` pending drafts — RAGGED since D-Cut, uniform without
+/// it. Caller (Phase B in `mtp_step.rs`) guarantees: grammarless, non-DFlash,
+/// `pending_drafts.len() == ks[i]-1`, `Σ ks <= 32`, batch sorted deepest-first
+/// then by ssm slot (canonical graph key), and `model.can_batch_verify(ks)`.
 ///
-/// `k_drafts` is also the re-propose width (Phase 4): the next round's
-/// drafts are sized for the CURRENT concurrency, so a ladder step-change
-/// truncates at most one round's surplus.
+/// `propose_nd` is the re-propose width (Phase 4) and is the LADDER width, not
+/// the pruned one: D-Cut prunes what gets VERIFIED, and must be free to
+/// re-expand a sequence next step, so the drafter always refills to the ladder
+/// depth. The next step's Phase B truncates whatever it does not want.
 pub(super) fn step_verify_k4_batched(
     model: &dyn Model,
     batch: &mut [&mut ActiveSeq],
-    k_drafts: usize,
+    ks: &[usize],
+    propose_nd: usize,
     verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
 ) {
     let n = batch.len();
-    let rows = k_drafts + 1;
-    debug_assert!((2..=16).contains(&n) && (2..=4).contains(&rows) && n * rows <= 32);
+    debug_assert_eq!(ks.len(), n);
+    // Row offset of each sequence in the flat seq-major layout (ragged: the
+    // uniform `i*rows` is the special case where every `ks[i]` is equal).
+    let mut off: Vec<usize> = Vec::with_capacity(n + 1);
+    let mut acc = 0usize;
+    for &k in ks {
+        off.push(acc);
+        acc += k;
+    }
+    let r_total = acc;
+    off.push(r_total);
+    debug_assert!((2..=16).contains(&n) && ks.iter().all(|k| (2..=4).contains(k)) && r_total <= 32);
 
     // ATLAS_MTP_TIMING step summary (same Drop-guard pattern as the
     // single-seq step; one timer for the whole batched step).
@@ -74,12 +85,16 @@ pub(super) fn step_verify_k4_batched(
     // Drafts are taken here (not by the driver) so a batch-level bail
     // leaves no half-taken state behind.
     let mut drafts_per_seq: Vec<Vec<u32>> = Vec::with_capacity(n);
-    let mut tokens: Vec<u32> = Vec::with_capacity(n * rows);
-    for a in batch.iter_mut() {
+    let mut tokens: Vec<u32> = Vec::with_capacity(r_total);
+    for (i, a) in batch.iter_mut().enumerate() {
         let d = std::mem::take(&mut a.pending_drafts);
+        // Confidences describe the taken drafts — cleared in lock-step so a
+        // later step can never rank on a stale vector (SSOT, `mtp_dcut`).
+        a.pending_draft_conf.clear();
         debug_assert!(
-            d.len() == k_drafts,
-            "batchable classification requires exactly {k_drafts} drafts"
+            d.len() + 1 == ks[i],
+            "batchable classification requires exactly {} drafts",
+            ks[i] - 1
         );
         tokens.push(a.last_token);
         tokens.extend_from_slice(&d);
@@ -93,10 +108,10 @@ pub(super) fn step_verify_k4_batched(
     let t_verify = Instant::now();
     let results: Vec<u32> = {
         let mut seq_refs: Vec<&mut SequenceState> = batch.iter_mut().map(|a| &mut a.seq).collect();
-        match model.decode_verify_batched(&tokens, rows, &mut seq_refs, 0) {
+        match model.decode_verify_batched(&tokens, ks, &mut seq_refs, 0) {
             Ok(r) => r,
             Err(e) => {
-                tracing::error!("decode_verify_batched (n={n} rows={rows}): {e:#}");
+                tracing::error!("decode_verify_batched (n={n} ks={ks:?}): {e:#}");
                 for a in batch.iter_mut() {
                     a.finished = true;
                 }
@@ -111,16 +126,14 @@ pub(super) fn step_verify_k4_batched(
     let mut verdicts: Vec<(Vec<u32>, usize, Vec<crate::api::TokenLogprobs>)> =
         Vec::with_capacity(n);
     for (i, a) in batch.iter_mut().enumerate() {
-        let r = &results[i * rows..(i + 1) * rows];
+        let rows = ks[i];
+        let k_drafts = rows - 1;
+        let r = &results[off[i]..off[i + 1]];
         // Full pre-sample pipeline per verify position, reading this
         // sequence's rows (row_base = i*rows) — same 8-stage semantics as
         // the single-seq MTP path.
         let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
-            model,
-            r,
-            a,
-            verify_ctx,
-            i * rows,
+            model, r, a, verify_ctx, off[i],
         );
         let v: Vec<u32> = (0..rows)
             .map(|j| processed.get(j).copied().unwrap_or(r[j]))
@@ -147,7 +160,7 @@ pub(super) fn step_verify_k4_batched(
         // the shipped n in [5,8] ladder step (k_drafts == 2); this one is not.
         crate::scheduler::mtp_accept_debug::record(n, k_drafts, drafts[0] == v[0], num_accepted);
         let verify_lps = if let Some(top_logprobs) = a.top_logprobs {
-            extract_verify_logprobs(model, &v, top_logprobs, i * rows)
+            extract_verify_logprobs(model, &v, top_logprobs, off[i])
         } else {
             Vec::new()
         };
@@ -162,7 +175,7 @@ pub(super) fn step_verify_k4_batched(
     let stash_rows: Vec<usize> = verdicts
         .iter()
         .enumerate()
-        .map(|(i, &(_, num_accepted, _))| i * rows + num_accepted)
+        .map(|(i, &(_, num_accepted, _))| off[i] + num_accepted)
         .collect();
     if let Err(e) = model.stash_verify_hidden_rows(&stash_rows, 0) {
         // Degraded, not fatal: verdicts still apply; each seq's
@@ -183,7 +196,7 @@ pub(super) fn step_verify_k4_batched(
             &drafts_per_seq[i],
             &v,
             verify_lps,
-            k_drafts,
+            ks[i] - 1,
             num_accepted,
             K4Hidden::DeferPropose,
             verify_us,
@@ -209,6 +222,10 @@ pub(super) fn step_verify_k4_batched(
     }
     let mut need_fallback: Vec<usize> = Vec::new();
     let mut groups_batched = 0usize;
+    // D-Cut ranking key: only requested when the lever is armed, so the plain
+    // batched argmax (and its narrower D2H) stays on the default path.
+    let want_conf = crate::scheduler::mtp_dcut::dcut_enabled();
+    let mut conf: Vec<Vec<f32>> = Vec::new();
     let group_cap = model.mtp_propose_batch_max().max(1);
     if pending.len() >= 2 && group_cap >= 2 && !batch_propose_disabled() {
         for group in pending.chunks(group_cap) {
@@ -233,9 +250,10 @@ pub(super) fn step_verify_k4_batched(
                     &tokens,
                     &positions,
                     &stash_idx,
-                    k_drafts,
+                    propose_nd,
                     &mut seq_refs,
                     0,
+                    want_conf.then_some(&mut conf),
                 )
             };
             match result {
@@ -243,6 +261,7 @@ pub(super) fn step_verify_k4_batched(
                     for (j, &i) in group.iter().enumerate() {
                         if !all[j].is_empty() {
                             batch[i].pending_drafts = all[j].clone();
+                            batch[i].pending_draft_conf = conf.get(j).cloned().unwrap_or_default();
                         }
                     }
                     groups_batched += 1;
@@ -272,11 +291,13 @@ pub(super) fn step_verify_k4_batched(
         match model.run_mtp_propose_multi(
             a.last_token,
             a.seq.seq_len,
-            k_drafts,
+            propose_nd,
             &mut a.seq,
             0,
             _mtp_grammar_mask.as_deref(),
         ) {
+            // No confidences on the per-seq path: leave them empty so D-Cut
+            // reads this sequence as "not measured" and keeps its full depth.
             Ok(d) if !d.is_empty() => a.pending_drafts = d,
             Ok(_) => {}
             Err(e) => {
@@ -285,7 +306,7 @@ pub(super) fn step_verify_k4_batched(
         }
     }
     tracing::debug!(
-        "K{rows} batched propose: n={} cap={group_cap} groups_batched={groups_batched} \
+        "K{propose_nd} batched propose: n={} cap={group_cap} groups_batched={groups_batched} \
          fallback={} propose={}μs",
         pending.len(),
         need_fallback.len(),

--- a/crates/spark-server/src/scheduler/verify_k4_batch_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_batch_step.rs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched multi-sequence K-row verify step (batched-MTP E10 + the
+//! K-vs-batch ladder, task #35).
+//!
+//! Runs the n weight-reading verify forwards of a chunk of verify-ready
+//! sequences as ONE R = n*(k+1)-row forward (`decode_verify_batched`,
+//! seq-major rows `r = i*rows + j`), then applies each sequence's verdict
+//! with the EXISTING single-seq machinery (`k4_apply_verdict`, K-generic).
+//! `k_drafts` (drafts per sequence this step) comes from the ladder —
+//! `speculative::ladder::mtp_ladder_drafts(active.len())` — 3 at n<=4
+//! (today's proven K=4 regime), 2 at n<=8, 1 at n<=16, keeping R <= 32.
+//!
+//! Phase ordering is load-bearing (shared-buffer clobber hazard,
+//! `mtp_multi.rs:165`): every drafter propose writes the shared
+//! `hidden_states` buffer and its lm_head writes the shared `logits`
+//! buffer, so ALL row reads (pipeline picks + logprobs, Phase 1) and the
+//! accepted-row hidden stash (Phase 2) MUST complete for every sequence
+//! before ANY sequence's verdict/propose runs (Phase 3).
+//!
+//! Reachability: only via `step_mtp` Phase B when `ATLAS_MTP_MAX_SEQS > 1`
+//! (default 16 with the ladder) puts >= 2 verify-ready grammarless
+//! sequences holding `k_drafts` drafts in one step AND the model says
+//! `can_batch_verify(n, k_drafts+1)`. `ATLAS_MTP_MAX_SEQS=1` keeps this
+//! path dead and the single-seq path byte-unchanged.
+
+use super::*;
+
+/// Kill switch `ATLAS_NO_MTP_BATCH_VERIFY` — PRESENCE check per the
+/// house convention (`=0` is NOT off): any set value forces the
+/// serialized per-seq verify loop at n > 1 for A/B against the batched
+/// forward.
+pub(super) fn batch_verify_disabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var("ATLAS_NO_MTP_BATCH_VERIFY").is_ok())
+}
+
+/// Batched K-row verify for `batch.len() >= 2` sequences, each holding
+/// exactly `k_drafts` pending drafts. Caller (Phase B in `mtp_step.rs`)
+/// guarantees: grammarless, non-DFlash, uniform `pending_drafts.len() ==
+/// k_drafts` (ladder-truncated), chunk size <= the per-rows cap, batch
+/// sorted by ssm slot (canonical graph key), and
+/// `model.can_batch_verify(batch.len(), k_drafts+1)` true.
+///
+/// `k_drafts` is also the re-propose width (Phase 4): the next round's
+/// drafts are sized for the CURRENT concurrency, so a ladder step-change
+/// truncates at most one round's surplus.
+pub(super) fn step_verify_k4_batched(
+    model: &dyn Model,
+    batch: &mut [&mut ActiveSeq],
+    k_drafts: usize,
+    verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+) {
+    let n = batch.len();
+    let rows = k_drafts + 1;
+    debug_assert!((2..=16).contains(&n) && (2..=4).contains(&rows) && n * rows <= 32);
+
+    // ATLAS_MTP_TIMING step summary (same Drop-guard pattern as the
+    // single-seq step; one timer for the whole batched step).
+    let _step_timer = crate::scheduler::mtp_timing::StepTimer::new(batch[0].seq.seq_len);
+
+    // One secondary-stream sync for the whole batch: orders the previous
+    // verify commits' async live-state restores before this forward reads
+    // h_state/conv_state (same semantics as the per-seq entry sync).
+    if let Err(e) = model.sync_secondary() {
+        tracing::error!("batched-verify sync_secondary: {e:#}");
+        for a in batch.iter_mut() {
+            a.finished = true;
+        }
+        return;
+    }
+
+    // Per-seq verify rows [last_verified, d0, .., d_{k-1}], flat seq-major.
+    // Drafts are taken here (not by the driver) so a batch-level bail
+    // leaves no half-taken state behind.
+    let mut drafts_per_seq: Vec<Vec<u32>> = Vec::with_capacity(n);
+    let mut tokens: Vec<u32> = Vec::with_capacity(n * rows);
+    for a in batch.iter_mut() {
+        let d = std::mem::take(&mut a.pending_drafts);
+        debug_assert!(
+            d.len() == k_drafts,
+            "batchable classification requires exactly {k_drafts} drafts"
+        );
+        tokens.push(a.last_token);
+        tokens.extend_from_slice(&d);
+        drafts_per_seq.push(d);
+    }
+
+    // ── ONE batched verify forward: R = n*rows rows, weights read once ──
+    // Contract (`decode_verify_batched`): on Ok every seq has tokens+=rows
+    // and seq_len+=rows (verdict rewind below is caller arithmetic, same as
+    // the per-seq path); on Err NO host seq state advanced.
+    let t_verify = Instant::now();
+    let results: Vec<u32> = {
+        let mut seq_refs: Vec<&mut SequenceState> = batch.iter_mut().map(|a| &mut a.seq).collect();
+        match model.decode_verify_batched(&tokens, rows, &mut seq_refs, 0) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("decode_verify_batched (n={n} rows={rows}): {e:#}");
+                for a in batch.iter_mut() {
+                    a.finished = true;
+                }
+                return;
+            }
+        }
+    };
+    let verify_us = t_verify.elapsed().as_micros();
+
+    // ── Phase 1: consume every sequence's logits rows BEFORE any propose ──
+    // Rows for seq i live at row_base = i*rows in the shared logits buffer.
+    let mut verdicts: Vec<(Vec<u32>, usize, Vec<crate::api::TokenLogprobs>)> =
+        Vec::with_capacity(n);
+    for (i, a) in batch.iter_mut().enumerate() {
+        let r = &results[i * rows..(i + 1) * rows];
+        // Full pre-sample pipeline per verify position, reading this
+        // sequence's rows (row_base = i*rows) — same 8-stage semantics as
+        // the single-seq MTP path.
+        let processed = crate::scheduler::verify_pipeline_helper::verify_pick_all_with_pipeline(
+            model,
+            r,
+            a,
+            verify_ctx,
+            i * rows,
+        );
+        let v: Vec<u32> = (0..rows)
+            .map(|j| processed.get(j).copied().unwrap_or(r[j]))
+            .collect();
+        let drafts = &drafts_per_seq[i];
+        let mut num_accepted = 0usize;
+        while num_accepted < k_drafts && drafts[num_accepted] == v[num_accepted] {
+            num_accepted += 1;
+        }
+        // Unconditional per-position draft match (same counters as the
+        // single-seq step) — scored before the accept chain short-circuits.
+        // The positional telemetry is K=4-shaped (p1/p2/p3); ladder steps
+        // with fewer drafts record outcomes only (`k4_record_outcome`).
+        if k_drafts == 3 {
+            k4_record_positional(
+                drafts[0] == v[0],
+                drafts[1] == v[1],
+                drafts[2] == v[2],
+                a.seq.seq_len,
+            );
+        }
+        // Width-attributed accept telemetry (ATLAS_MTP_ACCEPT_DEBUG). The
+        // positional counters above are K=4-shaped and therefore SILENT at
+        // the shipped n in [5,8] ladder step (k_drafts == 2); this one is not.
+        crate::scheduler::mtp_accept_debug::record(n, k_drafts, drafts[0] == v[0], num_accepted);
+        let verify_lps = if let Some(top_logprobs) = a.top_logprobs {
+            extract_verify_logprobs(model, &v, top_logprobs, i * rows)
+        } else {
+            Vec::new()
+        };
+        a.last_token_time = Instant::now();
+        verdicts.push((v, num_accepted, verify_lps));
+    }
+
+    // ── Phase 2: stash the accepted-position hiddens before any propose ──
+    // Absolute forward row i*rows + num_accepted_i → stash slot i; the
+    // verdict proposes below overwrite the live rows, so
+    // `save_hidden_for_mtp` must read from the stash instead.
+    let stash_rows: Vec<usize> = verdicts
+        .iter()
+        .enumerate()
+        .map(|(i, &(_, num_accepted, _))| i * rows + num_accepted)
+        .collect();
+    if let Err(e) = model.stash_verify_hidden_rows(&stash_rows, 0) {
+        // Degraded, not fatal: verdicts still apply; each seq's
+        // save-from-stash will fail and skip only its re-propose.
+        tracing::error!("stash_verify_hidden_rows: {e:#}");
+    }
+
+    // ── Phase 3: per-seq verdict via the EXISTING single-seq machinery ──
+    // (greedy accept + rewind arithmetic + emit + trim; propose is DEFERRED
+    // so Phase 4 can batch it across sequences — the per-seq drafter forward
+    // reads ~850 MB of BF16 drafter weights.)
+    for (i, (a, (v, num_accepted, verify_lps))) in
+        batch.iter_mut().zip(verdicts.into_iter()).enumerate()
+    {
+        k4_apply_verdict(
+            model,
+            a,
+            &drafts_per_seq[i],
+            &v,
+            verify_lps,
+            k_drafts,
+            num_accepted,
+            K4Hidden::DeferPropose,
+            verify_us,
+        );
+    }
+
+    // ── Phase 4: batched cross-sequence propose ──
+    // Sequences still alive after their verdict need fresh drafts. The
+    // batched propose reads each sequence's accepted-position hidden
+    // straight from its stash slot. Groups are sized by the MODEL's declared
+    // width (`mtp_propose_batch_max`, derived from the resolved LM-head
+    // batch kernel + the arena row capacities) — NOT the old hardcoded 4,
+    // which made an n=16 step run 4 drafter forwards per draft position,
+    // each re-reading the whole BF16 drafter. Singles and unsupported groups
+    // fall back per-seq (re-saving the stash slot into the single-slot MTP
+    // input buffer immediately before each propose).
+    let t_propose = Instant::now();
+    let pending: Vec<usize> = (0..n)
+        .filter(|&i| !batch[i].finished && batch[i].pending_drafts.is_empty())
+        .collect();
+    if pending.is_empty() {
+        return;
+    }
+    let mut need_fallback: Vec<usize> = Vec::new();
+    let mut groups_batched = 0usize;
+    let group_cap = model.mtp_propose_batch_max().max(1);
+    if pending.len() >= 2 && group_cap >= 2 && !batch_propose_disabled() {
+        for group in pending.chunks(group_cap) {
+            if group.len() < 2 {
+                need_fallback.extend_from_slice(group);
+                continue;
+            }
+            let tokens: Vec<u32> = group.iter().map(|&i| batch[i].last_token).collect();
+            let positions: Vec<usize> = group.iter().map(|&i| batch[i].seq.seq_len).collect();
+            let stash_idx: Vec<usize> = group.to_vec();
+            let result = {
+                let mut seq_refs: Vec<&mut SequenceState> = Vec::with_capacity(group.len());
+                let mut it = batch.iter_mut();
+                let mut prev = 0usize;
+                for (j, &i) in group.iter().enumerate() {
+                    let step = if j == 0 { i } else { i - prev - 1 };
+                    let a = it.nth(step).expect("group index in batch");
+                    seq_refs.push(&mut a.seq);
+                    prev = i;
+                }
+                model.run_mtp_propose_batched(
+                    &tokens,
+                    &positions,
+                    &stash_idx,
+                    k_drafts,
+                    &mut seq_refs,
+                    0,
+                )
+            };
+            match result {
+                Ok(Some(all)) => {
+                    for (j, &i) in group.iter().enumerate() {
+                        if !all[j].is_empty() {
+                            batch[i].pending_drafts = all[j].clone();
+                        }
+                    }
+                    groups_batched += 1;
+                }
+                Ok(None) => need_fallback.extend_from_slice(group),
+                Err(e) => {
+                    // Failed mid-chain: `last_num_drafted` tracks exactly the
+                    // drafter rows written, so `after_verify` stays consistent
+                    // — but a SECOND (fallback) propose on top would append
+                    // more rows than the next trim accounts for. Skip
+                    // proposing this group this step; the affected sequences
+                    // decode serially next step.
+                    tracing::error!("run_mtp_propose_batched: {e:#}");
+                }
+            }
+        }
+    } else {
+        need_fallback = pending.clone();
+    }
+    for &i in &need_fallback {
+        let a = &mut batch[i];
+        if let Err(e) = model.save_hidden_for_mtp_from_stash(i, 0) {
+            tracing::error!("save_hidden_for_mtp_from_stash({i}): {e:#}");
+            continue;
+        }
+        let _mtp_grammar_mask = mtp_grammar_mask_for(a);
+        match model.run_mtp_propose_multi(
+            a.last_token,
+            a.seq.seq_len,
+            k_drafts,
+            &mut a.seq,
+            0,
+            _mtp_grammar_mask.as_deref(),
+        ) {
+            Ok(d) if !d.is_empty() => a.pending_drafts = d,
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("run_mtp_propose_multi: {e:#}");
+            }
+        }
+    }
+    tracing::debug!(
+        "K{rows} batched propose: n={} cap={group_cap} groups_batched={groups_batched} \
+         fallback={} propose={}μs",
+        pending.len(),
+        need_fallback.len(),
+        t_propose.elapsed().as_micros()
+    );
+}
+
+/// Kill switch `ATLAS_NO_MTP_BATCH_PROPOSE` — PRESENCE check (`=0` is NOT
+/// off): forces the per-seq propose fallback inside the batched verify step,
+/// for A/B attribution of the propose-batching sub-lever.
+fn batch_propose_disabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var("ATLAS_NO_MTP_BATCH_PROPOSE").is_ok())
+}

--- a/crates/spark-server/src/scheduler/verify_k4_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_step.rs
@@ -26,7 +26,7 @@ static K4_D2C: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(
 static K4_D3C: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[inline]
-fn k4_record_positional(d1: bool, d2: bool, d3: bool, seq_len: usize) {
+pub(super) fn k4_record_positional(d1: bool, d2: bool, d3: bool, seq_len: usize) {
     K4_STEPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     if d1 {
         K4_D1.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -74,7 +74,7 @@ fn k4_record_positional(d1: bool, d2: bool, d3: bool, seq_len: usize) {
 }
 
 #[inline]
-fn k4_record_outcome(num_accepted: usize, seq_len: usize) {
+pub(super) fn k4_record_outcome(num_accepted: usize, seq_len: usize) {
     let counter = match num_accepted {
         3 => &K4_ACCEPT_3,
         2 => &K4_ACCEPT_2,
@@ -196,6 +196,7 @@ pub fn step_verify_k4(
             &[v0_argmax, v1_argmax, v2_argmax, v3_argmax],
             a,
             verify_ctx,
+            0,
         );
         (
             processed.first().copied().unwrap_or(v0_argmax),
@@ -234,6 +235,10 @@ pub fn step_verify_k4(
         drafts[2] == v2,
         a.seq.seq_len,
     );
+    // Width-attributed accept telemetry (ATLAS_MTP_ACCEPT_DEBUG): this is the
+    // SINGLE-sequence step, i.e. the n=1 row of the same table the batched
+    // step fills for n>=2.
+    crate::scheduler::mtp_accept_debug::record(1, 3, drafts[0] == v0, num_accepted);
 
     // ATLAS_MTP_REFEED_ACCEPTED: same contract as `verify_k3_step` — ring the
     // TARGET's true hidden for verify rows 0..=num_accepted under labels
@@ -255,7 +260,7 @@ pub fn step_verify_k4(
 
     // Extract logprobs from verify logits buffer (K=4 positions) when requested.
     let verify_lps = if let Some(top_logprobs) = a.top_logprobs {
-        extract_verify_logprobs(model, &[v0, v1, v2, v3], top_logprobs)
+        extract_verify_logprobs(model, &[v0, v1, v2, v3], top_logprobs, 0)
     } else {
         Vec::new()
     };
@@ -282,205 +287,19 @@ pub fn step_verify_k4(
         a.seq.seq_len
     );
 
-    if num_accepted == 3 {
-        emit_token(a, drafts[0], verify_lps.first().cloned());
-        if !a.finished {
-            emit_token(a, drafts[1], verify_lps.get(1).cloned());
-        }
-        if !a.finished {
-            emit_token(a, drafts[2], verify_lps.get(2).cloned());
-        }
-        if !a.finished {
-            emit_token(a, v3, verify_lps.get(3).cloned());
-        }
-        if a.finished {
-            return;
-        }
-        a.last_token = v3;
-
-        // Item #2 (STree-style in-place K=4 verify commit). Full accept
-        // (num_accepted=k=4): the verify kernel already wrote the canonical
-        // h_state, so the commit is a no-op.
-        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 4, 4) {
-            // SSM state is no longer trustworthy — terminate, do not continue.
-            tracing::error!("commit_accepted_prefix (K=4 accept-4): {e:#}");
-            a.finished = true;
-            return;
-        }
-        if let Err(e) = model.save_hidden_for_mtp(3, 0) {
-            tracing::error!("save_hidden_for_mtp(3): {e:#}");
-            return;
-        }
-        if let Err(e) = model.trim_proposer_state(&mut a.seq, 3, 0) {
-            tracing::error!("trim_proposer_state: {e:#}");
-        }
-        let t_propose = Instant::now();
-        let _mtp_grammar_mask = mtp_grammar_mask_for(a);
-        match model.run_mtp_propose_multi(
-            v3,
-            a.seq.seq_len,
-            num_drafts,
-            &mut a.seq,
-            0,
-            _mtp_grammar_mask.as_deref(),
-        ) {
-            Ok(d) if !d.is_empty() => a.pending_drafts = d,
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("run_mtp_propose_multi: {e:#}");
-            }
-        }
-        let propose_us = t_propose.elapsed().as_micros();
-        tracing::debug!(
-            "K4 ACCEPT-3: verify={verify_us}μs propose={propose_us}μs seq_len={}",
-            a.seq.seq_len
-        );
-        k4_record_outcome(3, a.seq.seq_len);
-    } else if num_accepted == 2 {
-        a.seq.seq_len -= 1;
-        a.seq.tokens.pop();
-        if let Err(e) = model.trim_proposer_state(&mut a.seq, 2, 0) {
-            tracing::error!("trim_proposer_state: {e:#}");
-        }
-        // Item #2 (STree-style in-place K=4 verify commit). Partial accept
-        // (num_accepted=3 < k=4): rewind live h_state to intermediate[2]
-        // (state after the third accepted token).
-        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 3, 4) {
-            tracing::error!("commit_accepted_prefix (K=4 accept-3): {e:#}");
-            a.finished = true;
-            return;
-        }
-        emit_token(a, drafts[0], verify_lps.first().cloned());
-        if !a.finished {
-            emit_token(a, drafts[1], verify_lps.get(1).cloned());
-        }
-        if !a.finished {
-            emit_token(a, v2, verify_lps.get(2).cloned());
-        }
-        if a.finished {
-            return;
-        }
-        a.last_token = v2;
-        if let Err(e) = model.save_hidden_for_mtp(2, 0) {
-            tracing::error!("save_hidden_for_mtp(2): {e:#}");
-            return;
-        }
-        let t_propose = Instant::now();
-        let _mtp_grammar_mask = mtp_grammar_mask_for(a);
-        match model.run_mtp_propose_multi(
-            v2,
-            a.seq.seq_len,
-            num_drafts,
-            &mut a.seq,
-            0,
-            _mtp_grammar_mask.as_deref(),
-        ) {
-            Ok(d) if !d.is_empty() => a.pending_drafts = d,
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("run_mtp_propose_multi: {e:#}");
-            }
-        }
-        let propose_us = t_propose.elapsed().as_micros();
-        tracing::debug!(
-            "K4 ACCEPT-2: verify={verify_us}μs propose={propose_us}μs seq_len={}",
-            a.seq.seq_len
-        );
-        k4_record_outcome(2, a.seq.seq_len);
-    } else if num_accepted == 1 {
-        a.seq.seq_len -= 2;
-        a.seq.tokens.pop();
-        a.seq.tokens.pop();
-        if let Err(e) = model.trim_proposer_state(&mut a.seq, 1, 0) {
-            tracing::error!("trim_proposer_state: {e:#}");
-        }
-        // Item #2 (STree-style in-place K=4 verify commit). Partial accept
-        // (num_accepted=2 < k=4): rewind live h_state to intermediate[1].
-        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 2, 4) {
-            tracing::error!("commit_accepted_prefix (K=4 accept-2): {e:#}");
-            a.finished = true;
-            return;
-        }
-        emit_token(a, drafts[0], verify_lps.first().cloned());
-        if !a.finished {
-            emit_token(a, v1, verify_lps.get(1).cloned());
-        }
-        if a.finished {
-            return;
-        }
-        a.last_token = v1;
-        if let Err(e) = model.save_hidden_for_mtp(1, 0) {
-            tracing::error!("save_hidden_for_mtp(1): {e:#}");
-            return;
-        }
-        let t_propose = Instant::now();
-        let _mtp_grammar_mask = mtp_grammar_mask_for(a);
-        match model.run_mtp_propose_multi(
-            v1,
-            a.seq.seq_len,
-            num_drafts,
-            &mut a.seq,
-            0,
-            _mtp_grammar_mask.as_deref(),
-        ) {
-            Ok(d) if !d.is_empty() => a.pending_drafts = d,
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("run_mtp_propose_multi: {e:#}");
-            }
-        }
-        let propose_us = t_propose.elapsed().as_micros();
-        tracing::debug!(
-            "K4 ACCEPT-1: verify={verify_us}μs propose={propose_us}μs seq_len={}",
-            a.seq.seq_len
-        );
-        k4_record_outcome(1, a.seq.seq_len);
-    } else {
-        a.seq.seq_len -= 3;
-        a.seq.tokens.pop();
-        a.seq.tokens.pop();
-        a.seq.tokens.pop();
-        if let Err(e) = model.trim_proposer_state(&mut a.seq, 0, 0) {
-            tracing::error!("trim_proposer_state: {e:#}");
-        }
-        // Item #2 (STree-style in-place K=4 verify commit). Partial accept
-        // (num_accepted=1 < k=4): rewind live h_state to intermediate[0]
-        // (state after the always-accepted bonus token).
-        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, 1, 4) {
-            tracing::error!("commit_accepted_prefix (K=4 accept-1): {e:#}");
-            a.finished = true;
-            return;
-        }
-        emit_token(a, v0, verify_lps.first().cloned());
-        if a.finished {
-            return;
-        }
-        a.last_token = v0;
-        if let Err(e) = model.save_hidden_for_mtp(0, 0) {
-            tracing::error!("save_hidden_for_mtp(0): {e:#}");
-            return;
-        }
-        let t_propose = Instant::now();
-        let _mtp_grammar_mask = mtp_grammar_mask_for(a);
-        match model.run_mtp_propose_multi(
-            v0,
-            a.seq.seq_len,
-            num_drafts,
-            &mut a.seq,
-            0,
-            _mtp_grammar_mask.as_deref(),
-        ) {
-            Ok(d) if !d.is_empty() => a.pending_drafts = d,
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("run_mtp_propose_multi: {e:#}");
-            }
-        }
-        let propose_us = t_propose.elapsed().as_micros();
-        tracing::debug!(
-            "K4 REJECT: verify={verify_us}μs propose={propose_us}μs seq_len={}",
-            a.seq.seq_len
-        );
-        k4_record_outcome(0, a.seq.seq_len);
-    }
+    // Accept/rewind/emit/re-propose: the four verdict branches live in
+    // `verify_k4_verdict.rs` (E9 extraction, behavior-identical), shared
+    // with the batched multi-seq path. `VerifyRow` reads the accepted
+    // hidden off the live verify forward exactly as before.
+    k4_apply_verdict(
+        model,
+        a,
+        drafts,
+        &[v0, v1, v2, v3],
+        verify_lps,
+        num_drafts,
+        num_accepted,
+        K4Hidden::VerifyRow,
+        verify_us,
+    );
 }

--- a/crates/spark-server/src/scheduler/verify_k4_verdict.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_verdict.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! K-row verify verdict application: accept/rewind/emit/re-propose.
+//!
+//! Extracted VERBATIM from `verify_k4_step.rs` (behavior-identical refactor,
+//! batched-MTP E9) so the single-seq `step_verify_k4` and the batched
+//! `step_verify_k4_batched` share ONE copy of the accept logic — rewind
+//! arithmetic, `trim_proposer_state`, `commit_accepted_prefix`, emit order,
+//! and `k4_record_outcome` are the existing machinery unchanged. The K-vs-
+//! batch ladder generalized the four hardcoded K=4 accept branches into the
+//! single formula they all instantiated (emit `drafts[0..na]` + the
+//! correction/bonus `v[na]`, rewind `nd-na`, `trim_proposer_state(na)`,
+//! `commit_accepted_prefix(na+1, k_rows)`) — behavior-identical at K=4 by
+//! construction, and now valid for the ladder's K=2/3 batched verifies.
+//! The only parameterization is WHERE the accepted-row hidden for the next
+//! propose comes from ([`K4Hidden`]): the live verify row (single-seq path,
+//! `save_hidden_for_mtp`) or the pre-propose stash slot (batched path, whose
+//! phase-3 proposes have already clobbered the live rows).
+
+use super::*;
+
+/// Source of the accepted-position hidden fed to `run_mtp_propose_multi`.
+#[derive(Clone, Copy)]
+pub(super) enum K4Hidden {
+    /// Read the live verify forward's row `num_accepted` (single-seq path).
+    VerifyRow,
+    /// Read stash slot `i` written by `stash_verify_hidden_rows` BEFORE any
+    /// propose ran (batched path).
+    Stash(usize),
+    /// Batched-propose deferral: apply the verdict (emit / rewind / trim /
+    /// commit) but skip BOTH the hidden save and the re-propose — the caller
+    /// runs ONE cross-sequence batched propose afterwards (stash slot `i`),
+    /// falling back to per-seq save+propose when unsupported.
+    DeferPropose,
+}
+
+#[inline]
+fn save_hidden(model: &dyn Model, hidden: K4Hidden, na: usize) -> anyhow::Result<()> {
+    match hidden {
+        K4Hidden::VerifyRow => model.save_hidden_for_mtp(na, 0),
+        K4Hidden::Stash(i) => model.save_hidden_for_mtp_from_stash(i, 0),
+        // Deferred mode never saves inline (the batched propose reads the
+        // stash rows directly; the per-seq fallback re-saves per sequence).
+        K4Hidden::DeferPropose => Ok(()),
+    }
+}
+
+/// Apply a K-row verify verdict to one sequence: emit the accepted prefix +
+/// correction/bonus token, rewind `seq_len`/`tokens` for rejected drafts,
+/// roll back proposer + SSM state, save the accepted-position hidden, and
+/// re-propose.
+///
+/// `drafts.len()` = nd (the drafts verified this step), `v.len()` = nd + 1
+/// (per-row picks incl. the bonus row), `num_accepted` in 0..=nd. At nd=3
+/// this is the verbatim four-branch tail of the pre-refactor
+/// `step_verify_k4`, branch-collapsed; the phase ORDER of each original
+/// branch is preserved exactly (full accept: emit → commit → save → trim →
+/// propose; partial/reject: rewind → trim → commit → emit → save → propose).
+#[allow(clippy::too_many_arguments)]
+pub(super) fn k4_apply_verdict(
+    model: &dyn Model,
+    a: &mut ActiveSeq,
+    drafts: &[u32],
+    v: &[u32],
+    verify_lps: Vec<crate::api::TokenLogprobs>,
+    num_drafts: usize,
+    num_accepted: usize,
+    hidden: K4Hidden,
+    verify_us: u128,
+) {
+    let defer = matches!(hidden, K4Hidden::DeferPropose);
+    let nd = drafts.len();
+    let k_rows = nd + 1;
+    debug_assert_eq!(v.len(), k_rows, "verdict picks must cover every row");
+    let na = num_accepted.min(nd);
+
+    if na == nd {
+        // ── Full accept: every draft matched; v[nd] is the free bonus. ──
+        for j in 0..nd {
+            emit_token(a, drafts[j], verify_lps.get(j).cloned());
+            if a.finished {
+                return;
+            }
+        }
+        emit_token(a, v[nd], verify_lps.get(nd).cloned());
+        if a.finished {
+            return;
+        }
+        a.last_token = v[nd];
+
+        // Item #2 (STree-style in-place verify commit). Full accept
+        // (num_accepted == k): the verify kernel already wrote the canonical
+        // h_state, so the commit is a no-op.
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, k_rows, k_rows) {
+            // SSM state is no longer trustworthy — terminate, do not continue.
+            tracing::error!("commit_accepted_prefix (K={k_rows} accept-{k_rows}): {e:#}");
+            a.finished = true;
+            return;
+        }
+    } else {
+        // ── Partial accept / reject: rewind the rejected tail. ──
+        a.seq.seq_len -= nd - na;
+        for _ in 0..(nd - na) {
+            a.seq.tokens.pop();
+        }
+        if let Err(e) = model.trim_proposer_state(&mut a.seq, na, 0) {
+            tracing::error!("trim_proposer_state: {e:#}");
+        }
+        // Item #2: rewind live h_state to intermediate[na] (state after the
+        // last accepted row — the correction token v[na] is row na).
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, na + 1, k_rows) {
+            tracing::error!(
+                "commit_accepted_prefix (K={k_rows} accept-{}): {e:#}",
+                na + 1
+            );
+            a.finished = true;
+            return;
+        }
+        for j in 0..na {
+            emit_token(a, drafts[j], verify_lps.get(j).cloned());
+            if a.finished {
+                return;
+            }
+        }
+        emit_token(a, v[na], verify_lps.get(na).cloned());
+        if a.finished {
+            return;
+        }
+        a.last_token = v[na];
+    }
+
+    if !defer && let Err(e) = save_hidden(model, hidden, na) {
+        tracing::error!("save_hidden_for_mtp({na}): {e:#}");
+        return;
+    }
+    if na == nd {
+        // Full-accept branch trims AFTER the hidden save (original order).
+        if let Err(e) = model.trim_proposer_state(&mut a.seq, na, 0) {
+            tracing::error!("trim_proposer_state: {e:#}");
+        }
+    }
+    if !defer {
+        let t_propose = Instant::now();
+        let _mtp_grammar_mask = mtp_grammar_mask_for(a);
+        match model.run_mtp_propose_multi(
+            a.last_token,
+            a.seq.seq_len,
+            num_drafts,
+            &mut a.seq,
+            0,
+            _mtp_grammar_mask.as_deref(),
+        ) {
+            Ok(d) if !d.is_empty() => a.pending_drafts = d,
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("run_mtp_propose_multi: {e:#}");
+            }
+        }
+        let propose_us = t_propose.elapsed().as_micros();
+        tracing::debug!(
+            "K{k_rows} ACCEPT-{na}: verify={verify_us}μs propose={propose_us}μs seq_len={}",
+            a.seq.seq_len
+        );
+    }
+    k4_record_outcome(na, a.seq.seq_len);
+}

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
@@ -283,11 +283,19 @@ pub fn verify_pick_with_pipeline(
 /// `argmax_ids` is the GPU-graphed argmax already returned by
 /// `decode_verify_graphed*`; used as the fallback for the failure
 /// path and as the array length source.
+///
+/// `row_base` (batched-MTP E12): first logits row of THIS sequence's
+/// verify span within the shared `[R, vocab]` logits buffer. Single-
+/// sequence verify paths pass 0 (rows 0..K — unchanged behaviour);
+/// the batched K=4 verify passes `i*4` for sequence i so every read
+/// (fast-path single-logit probes and the slow-path D2H) targets the
+/// sequence's own rows.
 pub fn verify_pick_all_with_pipeline(
     model: &dyn Model,
     argmax_ids: &[u32],
     a: &mut ActiveSeq,
     ctx: &LogitsContext,
+    row_base: usize,
 ) -> Vec<u32> {
     use crate::scheduler::mtp_timing::{self, Phase};
     let k = argmax_ids.len();
@@ -301,7 +309,7 @@ pub fn verify_pick_all_with_pipeline(
     // pipeline provably cannot change any pick, so the raw argmax IS the
     // masked pick and the [K, vocab] D2H is skipped entirely. Any
     // ineligible position falls through to the slow path for the call.
-    if let Some(picks) = fast_masked::try_chat_fast_path(model, argmax_ids, a, ctx) {
+    if let Some(picks) = fast_masked::try_chat_fast_path(model, argmax_ids, a, ctx, row_base) {
         return picks;
     }
 
@@ -397,7 +405,7 @@ pub fn verify_pick_all_with_pipeline(
                         crate::scheduler::fast_greedy::logit_is_positive(
                             model,
                             logits_base,
-                            i,
+                            row_base + i,
                             vocab,
                             tok,
                         )
@@ -448,7 +456,10 @@ pub fn verify_pick_all_with_pipeline(
     let t_d2h = std::time::Instant::now();
     let mut buf = vec![0u8; total];
     if model
-        .copy_logits_to_host(model.logits_buffer_ptr(), &mut buf)
+        .copy_logits_to_host(
+            model.logits_buffer_ptr().offset(row_base * vocab * elem_bytes),
+            &mut buf,
+        )
         .is_err()
     {
         return argmax_ids.to_vec();

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper/fast_masked.rs
@@ -52,11 +52,16 @@ use spark_model::traits::Model;
 /// Returns `Some(picks)` when the fast path proves masked-greedy ==
 /// raw-argmax for every position (picks are the raw `argmax_ids`);
 /// `None` when any gate fails and the caller must run the slow path.
+///
+/// `row_base`: first logits row of this sequence's verify span in the
+/// shared `[R, vocab]` buffer (0 on all single-sequence paths; `i*4` for
+/// sequence i on the batched K=4 verify — see `verify_pick_all_with_pipeline`).
 pub(super) fn try_chat_fast_path(
     model: &dyn Model,
     argmax_ids: &[u32],
     a: &ActiveSeq,
     ctx: &LogitsContext,
+    row_base: usize,
 ) -> Option<Vec<u32>> {
     // DFlash masked-verify mode ONLY. The fast path exists to make
     // ATLAS_DFLASH_MASKED_VERIFY affordable; it must never run for MTP:
@@ -141,7 +146,13 @@ pub(super) fn try_chat_fast_path(
         }
         if penalty_gate == crate::scheduler::fast_greedy::PenaltyGate::ReduceOnly
             && !crate::scheduler::fast_greedy::argmax_immune(tok, &scoped_history, || {
-                crate::scheduler::fast_greedy::logit_is_positive(model, logits_base, i, vocab, tok)
+                crate::scheduler::fast_greedy::logit_is_positive(
+                    model,
+                    logits_base,
+                    row_base + i,
+                    vocab,
+                    tok,
+                )
             })
         {
             all_clear = false;

--- a/docs/campaigns/gb10-concurrency-2026-07/BATCHED_MTP_SPEC.md
+++ b/docs/campaigns/gb10-concurrency-2026-07/BATCHED_MTP_SPEC.md
@@ -1,0 +1,214 @@
+# Batched speculative decoding — implementation spec
+
+**Status: green-lit, NOT started.** This is the only remaining lever sized to close the C=8/16 gap.
+Everything below is grounded in measurements taken 2026-07-27/28 or in the vendored vLLM checkout.
+
+## Why this and nothing else
+
+Measured position after five shipped kernel wins (+15% at C=16):
+
+| C | Atlas | vLLM | ratio | MTP |
+|---|---|---|---|---|
+| 1 | 25.45 | 14.2 | **1.792x** | **ON** |
+| 2 | 26.20 | 27.8 | 0.942x | off |
+| 4 | 48.65 | 53.3 | 0.913x | off |
+| 8 | 74.65 | 98.8 | 0.756x | off |
+| 16 | 130.75 | 168.9 | 0.774x | off |
+
+**We beat vLLM by 1.79x at exactly the one concurrency where MTP runs, and lose at every
+concurrency where it does not.** That is the whole gap.
+
+The kernel route is exhausted, measured three ways: 87% of the step is four kernels at 86-100% of
+achievable bandwidth; the entire remaining byte-identical basket is ~1.5 ms of a 110 ms step; and
+MMQ cp.async is dead on the same occupancy mechanism that made a 4-stage pipeline a **-5%**
+regression. Five wins totalled +15%. C=8/16 need **+29-32%**.
+
+## Why it is not a constant change (measured)
+
+`ATLAS_MTP_MAX_SEQS` is a GUARD, not a knob:
+- cap=2 at C=2: **25.45** vs cap=1 (MTP off) **26.35** => enabling it LOSES 3.4%. Default is now 1.
+- cap=4 at C=4: **25.8** vs 48.5 => **HALVES** throughput. Output coherent and identical, so this is
+  SERIALIZATION, not corruption.
+
+The verify runs per-sequence, so its cost scales with concurrency while the drafting benefit does
+not. At C=1 the extra K tokens ride nearly free on a bandwidth-bound step; at C=2 the second
+sequence's verify is additive and overtakes the gain.
+
+## Target design (vLLM V1 shape; blueprint in `scratchpad/vllm-src/`)
+
+1. **Verification IS the normal decode forward.** Draft tokens are appended to each request's
+   scheduled tokens; the ragged batch goes through the ordinary varlen path. No separate verify
+   pass. See `gpu_model_runner.py:2743` `_calc_spec_decode_metadata` (handles mixed draft lengths,
+   e.g. `[3, 0, 2, 0, 1]`); uniform-decode graph captured at query length 1+k
+   (`gpu_model_runner.py:817`).
+2. **Batched rejection sampling** — one Triton program per request over `[batch, k]`, emitting
+   variable-length accepted prefixes plus bonus tokens (`vllm/v1/sample/rejection_sampler.py`). We
+   run temp 0.0, so the greedy path suffices.
+3. **Per-request rewind is scheduler arithmetic** — `num_computed_tokens -= num_rejected`;
+   rejected KV is overwritten next step (`scheduler.py:1547-1571`). No trees needed; vLLM uses
+   linear chains.
+4. **GDN state rollback is an INDEX LOOKUP, not recomputation.** `gdn_attn.py` allocates
+   **num_spec+1 recurrent-state slots per sequence** (`spec_state_indices_tensor [batch, num_spec+1]`)
+   and the FLA kernel writes a checkpoint per draft position INLINE (`INPLACE_FINAL_STATE`,
+   `fla/ops/fused_recurrent.py:104-166`); the next step loads slot `num_accepted[i]-1`.
+   ★ This is the piece that makes the whole thing viable — it eliminates exactly the per-token FLA
+   overhead that killed the earlier TRT-LLM ngram v21 attempt (73% rejection, 1.5x SLOWER than
+   baseline). The checkpoints are a byproduct of one fused kernel, not extra passes.
+5. **Dynamic K-vs-batch ladder** — ship WITH the above, never after. vLLM's documented EAGLE3
+   ladder is K=5 at batch 1-16, K=4 at 17-32, K=3 at 33-64. Fixed large K on a saturated engine is
+   what produced vLLM's historical 1.4-1.8x SLOWDOWNS (SmartSpec, arXiv 2406.14066).
+
+## Local code sites
+
+| what | where |
+|---|---|
+| scheduler gate | `crates/spark-server/src/scheduler/mod.rs:551` (`active.len() <= mtp_max_seqs()`) |
+| cap constant | `scheduler/mod.rs:189-197` (`mtp_max_seqs`, now defaults 1) |
+| spec step driver | `crates/spark-server/src/scheduler/spec_step.rs:94, 266` (`decode_verify`, `decode_verify_graphed`) |
+| verify dispatch (per-K) | `crates/spark-model/src/model/trait_impl/verify_a.rs:31`, `verify_b.rs:39`, `verify_c.rs:47`, `verify_c2.rs:36` (K=4), `verify_d.rs:40` (K=gamma) |
+| **the missing piece** | a BATCHED `decode_verify` taking `n` sequences x (K+1) rows. The model trait has only single-sequence forms. |
+| MTP single-seq assumptions | `crates/spark-model/src/model/mtp_carry.rs:37`; one MTP slot at `model/types.rs:187` |
+| prefill-continuation gate | `scheduler/phase_continue_prefills.rs:101` (also `active.len() == 1`) |
+| multi-seq decode (the path to generalize) | `crates/spark-model/src/model/trait_impl/decode_a2.rs` — already handles n sequences x 1 token with `padded_n` rows, `meta.positions`, `meta.slot` |
+
+**The natural implementation** is to make the verify reuse the multi-seq decode path with
+`padded_n = n*(K+1)` rows rather than building a new kernel path: that is precisely vLLM's
+"verification is just the decode forward" property, and our multi-seq path already does ragged
+per-sequence positions and slots.
+
+## Expected outcome
+
+Measured elsewhere: EAGLE-3/SGLang H100 **B=32: 1.30x TPOT, 1.70x aggregate**; EAGLE-3 paper 1.38x
+at B=64; MagicDec 1.18-1.91x at B=32 with **speedup GROWING with batch in the memory-bound regime**
+— GB10 qualifies (FFN at 87% of achievable bandwidth; weights are read once per step regardless of
+batch, so k+1 tokens per weight-read is nearly free).
+
+Applied to 130.75 at C=16 => **170-222 tok/s**, i.e. clearing vLLM's 168.9 and the campaign goal.
+
+★ It is UNKNOWN whether the vLLM 168.9 reference itself ran with speculation. If it did not, this
+does not merely close the gap — it is how Atlas passes it.
+
+## Gates
+
+- Coherence + tool-call smoke at C=1,2,8,16 (spec paths change emitted tokens by construction —
+  `spec_not_output_neutral`; do NOT expect byte-identity).
+- Acceptance-rate telemetry per K and per batch size before tuning the ladder.
+- C-sweep vs the kill switch, >=3 reps, ranges must not overlap.
+- Accuracy (BFCL/IoU) only AFTER parity — the standing embargo.
+
+---
+
+# PROGRESS
+
+## DONE — step 1: batched verify conv (commit `5b4c40cb`)
+`gdn_verify_fused_conv_kn_batched` in `kernels/gb10/common/gdn_verify_fused_conv_kn.cu`
+(verified: NO 27B shadow, common/ is live), plus:
+- wrapper `ops::gdn_verify_fused_conv_kn_batched` (`layers/ops/ssm_mamba.rs`), grid
+  `(ceil(d_inner/256), n_seq, 1)`, four extra per-sequence stride args
+- handle `gdn_verify_fused_conv_kn_batched_k` (`qwen3_ssm/init.rs:~236`, field in `mod.rs:~162`)
+Additive and UNCALLED — HEAD behaviour unchanged (kernel audit clean, C=16 132.5).
+Bit-identical to n separate launches: per-sequence conv windows are independent, so the per-token
+sequential loop is untouched; only base addresses move.
+
+## NEXT — step 2: batch the recurrent scan
+Consumer of the conv is `qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs:89` (`fused_conv` gate).
+The recurrent/WY side needs the SAME `gridDim.y = n_seq` treatment plus per-sequence state strides.
+★ Check `ATLAS_GDN_FUSED_CONV17` (`:92`) — the fused path is gated by it; do not assume it is on.
+★ Memory records GDN multi-token VERIFY is SUPERLINEAR in K on strix (85/249/623 ms at K=1/2/3).
+   Batching across sequences does NOT fix superlinearity in K — it fixes the n-fold WEIGHT re-read.
+   Size the two separately.
+
+## THEN — steps 3-5
+3. Batched `decode_verify` on the model trait. **The multi-seq decode path
+   (`model/trait_impl/decode_a2.rs`) is the natural host** — it already carries per-row
+   `meta.positions` / `meta.slot` and `padded_n` rows, which IS vLLM's "verification is just the
+   decode forward" property. Feed it `n*(K+1)` rows: FFN/projections/lm_head are
+   position-independent and batch as-is; paged attention already takes per-row block tables and
+   seq lens, so give each of a sequence's K+1 rows that sequence's block table with
+   `seq_len = base + j`.
+4. Batched rejection (greedy suffices at temp 0.0) + per-request rewind
+   (`num_computed_tokens -= num_rejected`; rejected KV is overwritten next step).
+5. Re-raise `mtp_max_seqs` (currently 1) and add the K-vs-batch ladder. **Do not raise the cap
+   before 1-4 land** — measured, it HALVES C=4.
+
+## Gate before believing any of it
+`ATLAS_MTP_MAX_SEQS=4` at C=4 must go from 25.8 (today's serialized number) to >48.5 (today's
+MTP-off number) before the lever is real.
+
+## DONE — steps 3+4 v1: batched verify + batched propose (fixer round 1, 2026-07-28)
+
+**GATE: PASS (marginal).** C=4 cap=4 = **48.8 / 48.5 / 49.6** (3 scored reps, mean 49.0) vs the
+bar 48.5 — up from 25.8 serialized (+90%) and from 43.9 with only the verify batched. C=1 cap=4
+25.5-25.6, C=1 default-cap unchanged; coherence + tool-call smokes PASS; MTP sustained (16 K4
+summaries), zero errors. Batched MTP is now at parity-to-slightly-ahead of MTP-off at C=4; the
+remaining upside (per-seq GDN conv/WY loop = spec step 2, K-vs-batch ladder = step 5) is what
+takes it decisively past.
+
+Three fixes landed on top of the eb85ce41 scheduler/model wiring:
+1. **Batched cross-sequence PROPOSE** (the measured gap: 12 per-seq drafter forwards x ~5 ms =
+   ~62 ms of a ~180 ms step — the BF16 drafter re-reads ~850 MB per forward). One M=n forward
+   per draft position: big projections on `dense_gemm_bf16_pipelined` (microbenched 2.7x the
+   4x-GEMV loop at M=4), LM head on `w4a16_gemv_batch4`, small per-row ops loop per seq with
+   `forward_one`'s exact kernels. `mtp_head/forward_batch.rs`; scheduler defers the verdict
+   propose (`K4Hidden::DeferPropose`) and batches it in Phase 4 of `verify_k4_batch_step.rs`.
+   Kill switch `ATLAS_NO_MTP_BATCH_PROPOSE`. Measured alone: 46.3-46.8 vs 42.9-43.6 control.
+2. **out_proj M>8 dispatch fix** (m_dispatch class): the R=16 verify rows fell into the
+   pre-dequanted-FP8 PREFILL arm (2x the weight bytes of NVFP4) — 379 us vs 182 us per call,
+   x48 layers = ~9.5 ms/step at C=4. New arm routes M>8 to the NVFP4 transposed-twin tile GEMM
+   via `deep_k_gemm` (same kernel the multi-seq decode out_proj uses). Kill switch
+   `ATLAS_NO_VERIFY_OUTPROJ_TGEMM`.
+3. **Batched argmax** in the R-row verify and the batched propose (1 launch vs R serial one-CTA
+   scans; ~2 ms/step).
+
+★ TRAP hit during diagnosis: a stale copy of the profiling script (from a serve whose build
+FAILED on un-drained page cache) was still polling :8888; when the next serve came up it fired
+its own C=4 drive → 8 active > cap 4 → MTP correctly disabled by `active.len() <= mtp_max_seqs()`
+→ a whole nsys profile of the WRONG regime (36.5 tok/s, zero K4 lines) that looked exactly like
+"my change killed MTP". Drop caches (`vm.drop_caches=3`) before every serve of this config, and
+`pgrep` for stale drivers before ANY benchmark serve.
+
+## NEXT (in order, each measured)
+1. Step 2 proper: batch the GDN conv/WY per-seq loop across sequences (landed
+   `gdn_verify_fused_conv_kn_batched` + a recurrent/WY sibling): ~5 ms/step of small kernels +
+   launch gaps at C=4.
+2. K-vs-batch ladder / D-Cut (task #35) before re-raising the cap past 4.
+3. Slot-vector-keyed CUDA graph for the batched verify (eager gaps ~22 ms/step at C=4).
+
+## IMPLEMENTED, UNMEASURED — items 1 + 3 above (2026-07-28, build green, no GPU validation yet)
+
+Both landed in one lever set (they share the verify_e forward and the same
+slot-vector stability argument):
+
+1. **Slot-vector-keyed CUDA graphs for the batched K=4 verify** (`verify_e.rs` +
+   `verify_e2.rs`, cache `verify_batched_graphs` on the model). Captured span =
+   layer loop + final norm + lm_head + argmax (the ~4-5k eager launches);
+   pre-graph each step = embed, KV-block ensure, metadata/bt H2D, WY-table H2D
+   — all into FIXED addresses (decode_a2 pattern); post-graph = the argmax D2H.
+   Key = each sequence's ssm-pool slot in batch order + a wy-tables sentinel;
+   cache capped at 32 (overflow runs eager). Kill switch
+   `ATLAS_NO_MTP_VERIFY_GRAPHS` (PRESENCE). ATLAS_K4_DIAG still forces eager.
+2. **Cross-sequence batched GDN conv+WY** (`trait_decode_batched_conv_gdn_multi.rs`):
+   the shipped-but-uncalled `gdn_verify_fused_conv_kn_batched` now has its call
+   site (one launch, gridDim.y = n, snapshots inline — kills the n×(4 conv +
+   3 D2D) loop), and the WY side batches to ONE `gdn_decode_wy4` launch at
+   batch_size = n via the existing `state_is_table` pointer-table form.
+   Tables ([h|Hi0|Hi1|Hi2] × 4 u64 entries per GDN layer, ~6 KB) are staged by
+   the model into a fixed buffer (`verify_wy_tables`) refreshed pre-graph
+   every step. Preconditions (consecutive-slot conv layout, intermediates
+   0..3 intra-slot contiguous) are checked on the ACTUAL pointers per layer;
+   any failure falls back to the per-seq loop (engage/decline logged once +
+   counted — grep serve logs for "batched-verify GDN conv+WY"). Kill switch
+   `ATLAS_NO_VERIFY_GDN_BATCH` (PRESENCE). Contract delta: the batched conv
+   also writes the dead t=K-1 snapshot (pool has num_intermediates = K slots;
+   verified before launch).
+
+Left EAGER by design: Phase-1 host picks (policy decision, not graph work),
+Phase-2 stash (verdict-dependent row), Phase-3 verdict commits (dynamic index,
+secondary stream), Phase-4 batched propose (3 per-position host syncs), the
+argmax D2H. NOT ported: table-form wy2/wy3 (K<4 batched verify still refuses
+batch>1 — irrelevant for the K=4 path).
+
+Validation still owed (validator): serve + `ATLAS_MTP_MAX_SEQS` sweep vs the
+two kill switches, coherence + tool-call smoke, PROOF the batched conv kernel
+resolves (the "ENGAGED" log line / nsys instance count), and the accept-rate
+telemetry unchanged.

--- a/docs/campaigns/gb10-concurrency-2026-07/SHADOWED_KERNELS.md
+++ b/docs/campaigns/gb10-concurrency-2026-07/SHADOWED_KERNELS.md
@@ -1,0 +1,140 @@
+# The decode-serialization root cause: shadowed kernels
+
+**Date:** 2026-07-26 · **Box:** dgx1 · **Model:** `centml/Qwen3.6-27B-NVFP4-W4A4-mlpinf`
+
+## Symptom
+
+Phase A measured Atlas losing to vLLM at every concurrency above 1:
+
+| C | Atlas tok/s | vLLM tok/s | Atlas TPOT p50 | vLLM TPOT p50 |
+|---|---|---|---|---|
+| 1 | **27.3** | 14.2 | 36.6 ms | 70.1 ms |
+| 2 | 20.5 | 27.8 | 96.9 ms | 71.4 ms |
+| 4 | 20.1 | 53.3 | 198.1 ms | 74.8 ms |
+| 8 | 22.7 | 98.8 | 350.7 ms | 80.6 ms |
+| 16 | 23.5 | **168.9** | 673.5 ms | 93.8 ms |
+
+Aggregate throughput is FLAT in C, and TPOT is `36.6 ms x C` to within a few
+percent. Both say the same thing: the GPU does exactly one sequence's worth of
+decode work at a time. This is not "slow at concurrency", it is **not
+concurrent at all** on the decode path.
+
+## Root cause
+
+`crates/atlas-kernels/build.rs`, `collect_cu_files`:
+
+```rust
+// Override layer: model-specific kernel files shadow common ones
+for f in find_cu_files(model_dir, source_ext) {
+    let stem = f.file_stem().unwrap().to_str().unwrap().to_string();
+    files.insert(stem, f);   // <-- whole-file replacement, keyed by stem
+}
+```
+
+Shadowing is **whole-file, not per-symbol**. `kernels/gb10/qwen3.6-27b/nvfp4/
+gated_delta_rule.cu` exists to add register-tiled prefill kernels (its header
+calls it a "35B model shadow"). It was forked BEFORE `kernels/gb10/common/
+gated_delta_rule.cu` gained four decode kernels, so for the 27B those four
+never compile:
+
+- `gated_delta_rule_decode_f32_strided`
+- `gated_delta_rule_decode_f32_strided_norm`
+- `gated_delta_rule_decode_f32_norm`
+- `gated_delta_rule_decode_f32_conv_norm`
+
+The first two ARE the N-sequence batched recurrent decode. The Rust path that
+uses them is complete and wired (`trait_decode_multi_seq/ssm_batched_recurrent.rs`),
+gated on:
+
+```rust
+ATLAS_SSM_BATCHED_RECURRENT == "1" && self.gdn_f32_strided_k.0 != 0 && n > 1
+```
+
+`try_kernel` returns `KernelHandle(0)` for a missing kernel and logs only at
+`debug`, so the gate **failed closed, silently**, and every concurrent decode
+fell back to the per-sequence loop.
+
+### Runtime proof
+
+With the merged-main image, per SSM layer:
+
+```
+DEBUG spark_model::layers: Optional kernel
+  'gated_delta_rule::gated_delta_rule_decode_f32_strided' not loaded
+```
+
+(all four, x48 SSM layers). With the ported kernels: zero such lines.
+
+This also explains why **Phase B moved nothing** (+3% at C=16). It A/B'd CUDA
+graphs and scheduler changes while the actual lever was structurally
+unreachable — it was never tested, because it could not run.
+
+## Fix
+
+Ported the four kernels into `kernels/gb10/qwen3.6-27b/nvfp4/gated_delta_rule.cu`
+as an exact piecewise copy of `common/` lines 344-956, plus the helper block
+they need (`gdn_unpack_bf16x2`, `gdn_pack_bf16x2`, `gdn_warp_reduce_sum`, the
+`SSM_STATE_NORM_*` defines) under an include guard — the fork never carried
+them. Verified: `nvcc -arch=sm_121a --fmad=false` compiles clean, `cuobjdump
+-symbols` shows all four in the 27B cubin, and a live serve reports none
+missing.
+
+## Blast radius — this is fleet-wide, not a 27B quirk
+
+Auditing every model dir that shadows a `common/` file for dropped entry
+points:
+
+| Model | File | Dropped |
+|---|---|---|
+| qwen3-next-80b-a3b, qwen3.5-{27b,35b-a3b,122b-a10b,397b-a17b}, gemma-4-26b-a4b | `gated_delta_rule.cu` | all **4** decode kernels |
+| qwen3.6-35b-a3b, holo-3.1-{0.8b,4b,35b-a3b}, ornith-1.0-9b | `gated_delta_rule.cu` | `_conv_norm` |
+| minimax-m2-229b, mistral-small-4, nemotron-*, step3p7-flash | `rms_norm.cu` | 8-10 norm kernels |
+| ~every model | `w4a16_gemm.cu`, `moe_w4a16_grouped_gemm.cu` | `w4a16_dequant`, `moe_w4a16_grouped_gemm` |
+
+Not every row is a bug — a model may genuinely not need a kernel, and some of
+these are only reachable through paths that model never takes. The point is
+that **today it is impossible to tell the difference**, because a dropped
+kernel is indistinguishable from a deliberate omission.
+
+## Guard
+
+`collect_cu_files` now diffs `extern "C" __global__` entry points whenever a
+model file shadows a common one and emits a `cargo:warning` naming each
+dropped kernel. A warning, not an error: dropping a kernel can be deliberate.
+The point is to make it a VISIBLE choice rather than a silent one.
+
+## Verdict (A/B complete, 2026-07-26)
+
+Both legs on the same `:msdecode` image, identical serve geometry to Phases
+A/B, differing ONLY by `ATLAS_SSM_BATCHED_RECURRENT=1`.
+
+* **Control validity:** the per-seq leg matches the Phase B baseline to
+  <=0.4% at every C — the four ported kernels are bit-inert when off.
+* **Engagement proven, lever small:** batched-recurrent is +1-2% tok/s /
+  -1.0..-1.7% TPOT p50, monotone across every clean config and every C>=2 —
+  too consistent to be noise, too small to matter.
+* **The serialization root cause is NOT the GDN recurrent scan.** TPOT still
+  scales ~36ms x C (96/193/344/662 at C=2/4/8/16). The dominant per-sequence
+  cost lives elsewhere in the decode step (candidates: per-seq attention,
+  FFN batched-arm eligibility, LM head, per-seq sample+D2H). Next probe:
+  `ATLAS_SSM_MS_PROFILE=1` phase-split at C=4 to locate the ~160ms.
+* balanced_long remains error-polluted (pool-exhaustion kills 1-5/leg) —
+  latency numbers from that config are invalid, tracked separately.
+
+**Disposition: the kernel port + audit guard land on their own merits**
+(hygiene: the flag was structurally unrunnable; the guard prevents the drift
+class fleet-wide; the strided conv1d is byte-identical with a negative-control
+microtest). The performance hypothesis they enabled is refuted at this batch
+geometry.
+
+## Known remaining limits (this fix does not address them)
+
+1. ~~conv1d stays per-sequence~~ FIXED in this change:
+   `causal_conv1d_update_l2norm_f32_strided` takes explicit input/output row
+   strides so the whole batch goes in one launch; byte-identical to the
+   per-seq loop (`conv1d_strided_microtest`, 3 seeds, with a negative control
+   proving the unstrided batch=N launch is corrupt). Older kernel sets fall
+   back to the loop via the handle-0 gate.
+2. **MTP is gated `active.len() == 1`** on every speculative path, so
+   speculative decode is off entirely at C>1 regardless of this fix. That is
+   the other half of the C=1 vs C>1 cliff.

--- a/docs/campaigns/gb10-concurrency-2026-07/STATE.md
+++ b/docs/campaigns/gb10-concurrency-2026-07/STATE.md
@@ -2449,3 +2449,131 @@ Next levers, in value order:
    legal point. Going deeper requires enlarging the verify row buffer — an untested regime.
 - Still red and pre-existing: `decode_a2.rs` 598 LoC and `trait_impl/mod.rs` 800 LoC, both over
   the 500 cap and absent from `.github/workflows/file-size-cap.yml`'s allow-list.
+
+## 2026-07-29 — ★★★ FINALIZED (round 4): cap 8 → 16 + ladder rung `16:1`, D-Cut default-ON @ 0.75. C=16 +15.0%, C=8 CROSSES vLLM. FOUR of five levels MET, ALL FIVE floors beaten.
+
+Two independent defaults landed, each measured with its own kill switch by the wave-6 matrix and
+then re-validated together at pure defaults:
+
+- **`16:1` ladder rung + cap 16** — the big one. **C=16 131.4 → 151.14 (+15.0%)**.
+- **D-Cut default-ON at ratio 0.75** — **C=8 95.84 → 107.40 (+12.1%)**, which **crosses vLLM's
+  98.8 bar (1.087x)**. This is the fifth level to be attacked and the fourth to fall.
+
+### Why the cap finally moved, after three rounds of refusing to move it
+The n=16 history is a record of a COST curve, not a depth curve, and each round moved the cost:
+
+| round | verify cost @n=16 | break-even (p1) | 16:1 vs MTP-off control | verdict |
+|---|---|---|---|---|
+| after the 3 eager-cost fixes | ~1.90 → ~1.77x | 1.72x (p1 0.72) | 128.4 vs 131.9 | LOSS, cap stays 8 |
+| after the accept lift `36d340a0` | ~1.79x | 1.797x (p1 0.797) | 131.93 vs 131.42 | PARITY, cap stays 8 |
+| after `296b9674`'s 3 per-row cuts | **~1.55x** | 1.83x (p1 0.83) | **152.38 vs 131.40** | **WIN, cap → 16** |
+
+`296b9674` (wide LM-head arm at 9..32 rows, one-launch gated RMS norm, fused BA-projection+gates)
+bought ~0.20x of verify-step cost. That is what took 16:1 off break-even. ★ Note the cost cut is
+LARGER than the throughput gain, because the fused BA+gates arm is not bit-identical and costs
+accept: at C=8 its kill-switch A/B measured tok_step 2.58 → 2.50 (−3.1%) for +9.2% throughput,
+i.e. a −11.6% verify step — dead inside its predicted −11.5..−13%. The numerics change is real,
+measurable, and worth paying.
+
+### The raise is inert at n ≤ 8 BY CONSTRUCTION
+The cap only gates dispatch above 8 (`active.len() <= mtp_max_seqs()`) and the `16:1` rung only
+matches above 8 (the `n<=8` rung is found first). So C=1/2/4/8 run unchanged code paths; their
+rows below are variance measurements, not regression risk. Kill switch `ATLAS_MTP_MAX_SEQS=8`.
+
+### D-Cut: the full bucket sweep, and the one bucket that wins
+Ranked prefix-product survival scores across the batch, top-`ratio` retained (arXiv 2607.14647).
+All at C=8, one fresh serve per leg, 5 scored reps:
+
+| ratio | tok/s | kept_frac | tok_step | verdict |
+|---|---|---|---|---|
+| OFF (kill switch) | 105.56 | — | 2.50 | control |
+| 1.0 (wiring live, 0 pruned) | 105.80 | 1.000 | 2.52 | **inert, as designed** |
+| **0.75** | **108.57** (pooled 2 serves) | 0.876 | 2.54 | **+2.6% — SHIPPED** |
+| 0.5 | 107.43 | 0.750 | 2.43 | worse |
+| 0.25 | 101.56 | 0.626 | 2.16 | clear loss |
+
+The mechanism is visible in telemetry: tok_step degrades monotonically as rows are pruned while
+rows fall, and 0.75 is the ONLY point where the row saving outruns the token loss. The ratio-1.0
+control being statistically identical to OFF is the proof that the ragged-row plumbing itself is
+free. Kill switch `ATLAS_NO_MTP_DCUT` (presence).
+
+★ **D-Cut contributes exactly NOTHING at C=16, and the logs prove it rather than infer it.** Its
+v1 floor of one mandatory draft per sequence means every sequence gets ≥2 rows; 16 × 2 = 32 = the
+whole `VERIFY_ROW_BUDGET`. There is zero slack, so `select()` returns retained=1 for all 16 at
+every ratio. In this sweep the C=16 leg emitted NO D-Cut telemetry line at all (`plan` returns
+early at `ladder_nd < 2`). Running D-Cut over a 16:3 ladder is strictly WORSE (120.76): it is
+forced back to k=1 anyway while the propose still pays for 3 drafts.
+
+### Landed
+- `mtp_max_seqs` default 8 → 16, anchored in the function body (`speculative/ladder.rs`).
+  Kill switch `ATLAS_MTP_MAX_SEQS=8`.
+- Default ladder `4:3,8:3` → `4:3,8:3,16:1`, anchored in `mtp_ladder_steps`'s body (NOT a bare
+  literal regex — the burned-twice trap). Kill switch `ATLAS_MTP_K_LADDER=4:3,8:3`.
+- D-Cut `dcut_enabled` OFF-by-presence → ON-by-default with `ATLAS_NO_MTP_DCUT`; `dcut_ratio`
+  default 0.5 → 0.75.
+- Ladder unit test updated for the new rung (9 → 1 draft, 16 → 1, 32 → 1). 3 ladder + 9 D-Cut
+  tests pass; both edited crates rustfmt-clean.
+
+### Validated sweep at PURE DEFAULTS (binary md5 `fae54de95627212898f51d5a0303d61d`, built with
+`ATLAS_TARGET_MODEL=qwen3.6-27b cargo build -p spark-server --release --features cuda`)
+ONE FRESH SERVE PER C; no `ATLAS_MTP_DCUT` / `ATLAS_MTP_MAX_SEQS` / `ATLAS_MTP_K_LADDER` anywhere
+in the environment (only `ATLAS_MTP_ACCEPT_DEBUG=1` for the telemetry columns) — the binary's own
+defaults produce these numbers. All containers removed + `:8888` asserted dead + double
+`vm.drop_caches=3` + MemAvailable ≥ 108GB settle + a ≥4300-block KV-pool gate before each; first
+drive per serve DISCARDED as warmup; 5 scored drives.
+
+| C | scored reps (tok/s) | mean | floor | vs floor | vLLM | ratio | verdict |
+|---|---|---|---|---|---|---|---|
+| 1 | 27.0, 27.0, 27.0, 27.0, 27.0 | **27.00** | 25.53 | +5.8% | 14.2 | **1.90x** | **MET** |
+| 2 | 38.4, 38.2, 38.1, 37.7, 38.3 | **38.14** | 35.37 | +7.8% | 27.8 | **1.37x** | **MET** |
+| 4 | 71.2, 67.4, 71.1, 68.0, 71.2 | **69.78** | 60.40 | +15.5% | 53.3 | **1.31x** | **MET** |
+| 8 | 107.2, 103.7, 108.8, 107.5, 109.8 | **107.40** | 95.84 | +12.1% | 98.8 | **1.087x** | **MET** |
+| 16 | 152.1, 150.6, 150.1, 151.4, 151.5 | **151.14** | 131.40 | +15.0% | 168.9 | 0.895x | floor +15.0% |
+
+**ALL FIVE floors beaten. FOUR of five levels now beat vLLM.** Only C=16 remains, needing +11.8%.
+
+### Engagement PROVEN from the serve logs, not assumed
+- C=16: `batched-verify GDN conv+WY ENGAGED (n=16, k=2)` — the cap raise AND the `16:1` rung are
+  both live at pure defaults. Accept telemetry `n=16 k_drafts=1 p1=0.820-0.845 tok_step=1.82-1.85`.
+- C=8: D-Cut ragged and live — `kept_frac=0.875-0.876`, `last_ks=[3,4,4,4,4,4,2,3]` and
+  `[3,4,4,3,3,4,3,4]` (genuinely ragged, not a uniform shape).
+- C=4/C=2: `kept_frac=0.875`, `last_ks=[3,3,4,4]` / `[4,3]`.
+- C=1: NO D-Cut line and NO batched verify — n=1 never reaches the batched partition
+  (`verify_idxs.len() >= 2`), so C=1 is provably untouched by both defaults.
+- KV pools 4372-4819 blocks on all five serves; every serve came up on attempt 1.
+
+### Hygiene
+- Coherence + tool-call smoke on ALL FIVE serves (temp 0, seed 42): fluent Rayleigh-scattering
+  answer `finish=stop`; `get_weather({"location":"Paris"})` `finish=tool_calls`. PASS.
+- **Zero** ERROR/panic/illegal-memory/error-700/716/719 lines in all five serve logs
+  (`conc_sweep/w7_c{1,2,4,8,16}.log`), each dumped while its container was alive. The twin-tile
+  GEMM's sticky-716 risk flagged for `296b9674` did NOT reproduce at any concurrency.
+- All containers removed at the end; `nvidia-smi` compute-apps empty; `:8888` dead.
+
+### Traps and caveats for the record
+- ★ **Graph-key churn is real and D-Cut wins DESPITE it.** Ragged `ks` takes captures from ~15 to
+  **407** per serve at C=8 against `VERIFY_BATCHED_GRAPH_CAP = 32`, and `batched-verify GDN
+  conv+WY DECLINED` lines appear at ragged widths (the `(k desc, slot)` sort makes the
+  consecutive-ssm-slot precondition hold less often). The +2.6% is a FLOOR, not a ceiling.
+- **C=16 spec-on reps emit 3009 tokens, not 3072**, deterministically in every rep — the
+  documented `spec_not_output_neutral` trajectory shift (one request hits a natural stop 63 tokens
+  early), not the content-loop watchdog. Token-normalized it changes nothing: 19.9s × 3072/3009 =
+  20.3s ⇒ 151.3 tok/s.
+- **C=4 is bimodal within one serve** (71.2/71.1/71.2 vs 67.4/68.0, identical 768 tokens) — the
+  known SSM-snapshot/prefix-anchor drift, present in the floor config too. Reported as the mean of
+  all five, not the fast mode.
+
+### Campaign position
+**C=1/2/4/8 MET at pure defaults (1.90x / 1.37x / 1.31x / 1.087x). C=16 0.895x.**
+Next levers, in value order:
+1. **Lift D-Cut's `rows_i >= 2` floor** so a sequence can drop out of speculation entirely. It is
+   the ONLY route by which D-Cut can ever attack C=16, where it is currently budget-locked.
+2. **Raise `VERIFY_BATCHED_GRAPH_CAP`** and re-sort by slot-then-depth — D-Cut currently pays ~27x
+   the graph captures and loses the GDN fast path at some widths. Unmeasured headroom on a win.
+3. **Prune the propose, not just the verify** (implementer-1's deviation #4): the drafter still
+   runs at full ladder width even when D-Cut throws the rows away.
+4. **L1 carry is silently OFF at every concurrency** because `mtp_multi_seq_mode()` is cap-based —
+   a LIVE REGRESSION on multi-turn/MLPerf traffic that `prof_drive`'s single-turn prompts cannot
+   see. Unchanged from round 3, and the cap raise does not fix it.
+- Still red and pre-existing: `decode_a2.rs` 598 LoC and `trait_impl/mod.rs` 800 LoC, both over the
+  500 cap and absent from `.github/workflows/file-size-cap.yml`'s allow-list.

--- a/docs/campaigns/gb10-concurrency-2026-07/STATE.md
+++ b/docs/campaigns/gb10-concurrency-2026-07/STATE.md
@@ -47,3 +47,2286 @@
 - 2026-07-26T00:40:49Z LEG atlasB_nographs DONE -> results/atlasB_nographs.json
 - 2026-07-26T02:57:30Z LEG atlasB_graphs DONE -> results/atlasB_graphs.json
 - 2026-07-26T02:57:34Z PHASEB_DONE
+- 2026-07-26T18:21:44Z LEG atlasC_perseq DONE -> results/atlasC_perseq.json
+- 2026-07-26T21:07:11Z LEG atlasC_batched DONE -> results/atlasC_batched.json
+- 2026-07-26T21:07:15Z PHASEC_DONE
+- 2026-07-27T02:57:15Z LEG atlasD_kmarm DONE -> results/atlasD_kmarm.json
+- 2026-07-27T05:32:37Z LEG atlasD_kmarm_graphs DONE -> results/atlasD_kmarm_graphs.json
+- 2026-07-27T05:32:41Z PHASED_DONE
+
+## 2026-07-27 — the n=16 step decomposed (this is where the gap lives)
+
+Instruments: `ATLAS_MS_PROFILE` (branch split), `ATLAS_SSM_MS_PROFILE` (mixer vs FFN inside the SSM
+layers), `ATLAS_SSM_DETAIL_PROFILE` (mixer stages). Config: phase-D binary, bs=16, fifo, slots 32.
+
+**Step at n=16 = 264.9 ms** (vLLM's is 94 ms):
+
+| block | ms | share |
+|---|---|---|
+| FFN inside the 48 SSM layers | 97 | 37% |
+| SSM mixer (qkvz 33% / recurrent 52% / out_proj 14%) | 93 | 35% |
+| Attention branch (16 layers, incl. their FFN) | 55 | 21% |
+| LM head | 20 | 8% |
+
+Head is FLAT in n (19.8 → 20.3 from n=4 → 16): it is properly batched. Everything else scales.
+
+**The per-seq projections are NOT the problem — that path is already ACTIVE.** The batched-projection
+mixer (`try_decode_multi_seq_ssm_batched`) engages for this config and reads QKVZ/out_proj once per
+step. Confirmed by a new one-shot log; it used to decline silently, which is why an earlier phase
+measured the symptom (SSM time linear in n) without being able to name the cause.
+
+**The recurrent inner is bandwidth-bound, not launch-bound.** 43 us per sequence per layer for
+6 MB of FP32 h_state traffic (3 MB read + 3 MB write) = ~140 GB/s, about half of LPDDR5X peak.
+Batching its launches therefore cannot help much, and measurement agrees:
+`ATLAS_SSM_BATCHED_RECURRENT` + `ATLAS_GDN_FUSED_NORM` = **+2.6% at C=16** (53.7 → 55.1 tok/s),
+coherence preserved. `ATLAS_GDN_FUSED_CONV` adds nothing on top. This confirms the older
+"batched-recurrent +1-2%" null was not an artifact of the FFN masking it.
+
+**Both FFN and GDN run at ~2x their own bandwidth floor**, and the whole step is ~4x the roofline
+(weights 17.5 GB / 273 GB/s = 64 ms, + ~17 ms of GDN state at n=16). vLLM at 94 ms is ~1.2x that
+floor. So the remaining 2.8x is kernel bandwidth efficiency at M=16, spread across FFN (37%),
+mixer (35%) and attention (21%) — not one hotspot.
+
+**Levers measured this session** (C=16, decode-style 192-token requests):
+| lever | C=16 tok/s | note |
+|---|---|---|
+| phase-D tip | 53.7 | |
+| + batched recurrent + fused norm | 55.1 | +2.6%, coherence OK |
+| + FFN NVFP4 MMQ (drop `ATLAS_NO_FFN_NVFP4_MMQ`) | 61.2 | +11.3%, C=1 neutral, output identical |
+
+MMQ re-measured 3x per leg (the 11% was N=1): MMQ off 55.0 / 54.8 / 54.8 (mean 54.9), MMQ on
+61.4 / 59.1 / 61.2 (mean 60.6) = **+10.4%, ranges do not overlap**. The MMQ legs also completed the
+full 16x192 tokens twice, where the frozen config always truncated to 2977.
+
+`ATLAS_NO_FFN_NVFP4_MMQ` is a PRESENCE flag: `=0` does NOT enable MMQ, the variable must be absent.
+
+**Not a km-arm regression:** the balanced/prefill regime failures are the pre-existing KV
+pool-exhaustion wedge tracked in open PR #373 ("decode alloc fails, scheduler livelocks in
+decode-ckpt SAVE"), which is also why `balanced_long` is excluded from the sweep. `decode_short` is
+clean (0 errors at every C in every leg), so the scoreboard above is valid for that regime only.
+
+## 2026-07-27 — the C=2 "regression" is SOLVED, and it reframes the whole campaign
+
+Probe: same serve config, one leg WITH `--speculative --num-drafts 3`, one leg with it removed
+entirely (`conc_sweep/c2_probe.log`, 192-token requests).
+
+| C | with --speculative | without --speculative |
+|---|---|---|
+| 1 | **25.5** | 14.1 |
+| 2 | 20.6 | 20.6 |
+| 3 | 27.8 | 27.7 |
+| 4 | 36.4 | 36.6 |
+
+**At C>=2 the two legs are identical.** Speculative decode is completely inert above C=1 (the gate
+is `active.len()==1`), so C=2 is not a regression in batching — it is the cliff of losing MTP. The
+apparent "C=2 slower than C=1" is entirely 25.5 -> 20.6 from spec going away.
+
+**Two consequences that should steer everything after this:**
+
+1. **Atlas non-spec at C=1 is 14.1 tok/s; vLLM at C=1 is 14.2.** Identical. At batch 1 both engines
+   sit on the same bandwidth-bound floor, and 100% of our 1.93x C=1 win is MTP speculative decoding.
+   We have no baseline decode advantage to fall back on.
+2. **Scaling, normalised to each engine's own C=1 non-spec throughput:**
+   vLLM: 1.0x -> 1.96x -> 3.75x -> 6.96x -> 11.9x  (C=1,2,4,8,16)
+   Atlas: 1.0x -> 1.46x -> 2.60x -> ~3.9x -> ~4.3x
+   vLLM scales nearly linearly to C=8; Atlas saturates around 4.3x. The gap is a BATCHING-EFFICIENCY
+   gap, and it is already visible at C=2 (1.46x where 2.0x is available).
+
+**Therefore the two levers with real headroom are:**
+- **Speculative decode at C>=2** (currently structurally disabled). Worth 1.81x at C=1. Even a
+  fraction of that at C=8/16 is worth more than every kernel tweak measured so far combined.
+- **Batching efficiency itself** (1.46x at n=2 where 2.0x is on the table) — the 11.2 ms/seq marginal.
+
+## 2026-07-27 — CONFIRMED on hardware: the SSM-layer FFN reads its weights TWICE above n=8
+
+Zero-edit probe (`ATLAS_SSM_MS_PROFILE=1`, one serve, drove C=4/8/16, 9168 samples per n):
+
+| n | mixer us/layer | FFN us/layer | FFN us per seq |
+|---|---|---|---|
+| 4 | 584 | 751 | 187.9 |
+| 8 | 935 | **1023** | 127.9 |
+| 16 | 1916 | **2022** | 126.3 |
+
+**n=16 costs 1.98x n=8** — and FFN-per-sequence is FLAT from 8 to 16 (127.9 -> 126.3). That is the
+exact signature of two chunked batch-8 passes: the ~7.2 GB of FFN weights are streamed twice per
+step at n=16 instead of once. A correctly batched FFN is weight-bandwidth-bound, so n=16 should cost
+about the same as n=8 (~1030 us/layer), not double it.
+
+Prediction was made from code alone (`trait_decode_multi_seq.rs:173-204`, the `4..` arm chunking
+through `forward_km`/batch-8 GEMV) at ~1010 us vs ~2020 us. Measured 1023 vs 2022. Mechanism
+CONFIRMED without touching a line of source.
+
+**Size of the prize:** ~1000 us/layer x 48 layers = **~48 ms off a 264.9 ms step (~18%)**, i.e.
+C=16 roughly 60 -> 73 tok/s, stacking with the MMQ lever. The fix is an added dispatch arm routing
+`n>8 && ffn.is_dense()` to `forward_prefill` (the NVFP4 MMQ path the ATTENTION layers already use —
+`multi_seq/ffn.rs:135`), behind an `ATLAS_NO_SSM_FFN_PREFILL` kill switch. n<=8 must keep
+`forward_km`: the recorded crossover says GEMV still wins at M=4. C=1 cannot be affected (n=1 never
+enters this arm).
+
+## 2026-07-27 — WIN: wide-batch dense FFN arm for the SSM stack, +30% at C=16
+
+`trait_decode_multi_seq.rs`: added an `n > 8 && ffn.is_dense()` arm routing to `forward_prefill`
+(weights read ONCE) above the chunked batch-8 GEMV arm. Direct twin of the attention ladder's
+"WIDE-VERIFY BATCHED DENSE FFN" branch. Default ON, kill switch `ATLAS_NO_SSM_FFN_PREFILL=1`
+(strict `== "1"`, not a presence check).
+
+3 reps per cell, stacked on the Tier-1 env set (MMQ on + batched recurrent + fused norm):
+
+| C | OLD chunked GEMV | NEW batched FFN |
+|---|---|---|
+| 1 | 25.4 | 25.4 — untouched, n=1 never enters the arm |
+| 8 | 54.4 / 54.0 / 54.2 | 54.3 / 52.6 / 54.4 — unchanged, arm fires only at n>8 |
+| 16 | 57.3 / 61.1 / 61.1 | **79.3 / 79.4 / 79.3** |
+
+**+30% at C=16**, above the ~18% predicted, because the batched path also beats the chunked one on
+its first chunk, not just the second. Coherence byte-identical. C=8 confirms the gate: no change
+where the arm does not fire, which is the control this A/B needed.
+
+### Cumulative C=16 progress this session
+phase-D tip 53.7 -> +batched recurrent/fused norm 55.1 -> +MMQ 61.2 -> **+wide FFN 79.4** (+48%).
+vLLM 168.9. Ratio 0.35x -> **0.47x**.
+
+## 2026-07-27 — speculation re-enabled at n=2 (+19% at C=2)
+
+`step_mtp` already takes `&mut [ActiveSeq]` and is index-correct over it, and no `active[0]`
+assumption survives in the MTP verify path — so the `active.len() == 1` gate was the ONLY thing
+stopping multi-seq speculation. Replaced with `active.len() <= mtp_max_seqs()`
+(`ATLAS_MTP_MAX_SEQS`, default 2).
+
+This runs MTP PER SEQUENCE: n verify forwards of M=K+1 each, i.e. n weight sweeps per step instead
+of one. It therefore only pays where the extra accepted tokens outweigh the extra sweeps.
+2 reps/cell, coherence preserved:
+
+| cap | C=2 | C=4 |
+|---|---|---|
+| 1 (old) | 21.2 / 21.0 | 36.1 / 38.4 |
+| **2 (new default)** | **25.3 / 25.1** | 38.4 / 38.3 (inert) |
+| 4 | 25.7 / 24.5 | 25.9 / 25.2 (**-34%**) |
+
+n=2 wins, n=4 collapses — the crossover is exactly where the sweep arithmetic put it. C=1 and C>=4
+are untouched. **Owed before this ships anywhere near a submission: the BFCL subset accuracy gate.**
+MLPerf-edge runs target_concurrency=1, so the golden submission path is unaffected either way.
+
+## Scoreboard after this session
+
+| C | session start | now | vLLM | ratio |
+|---|---|---|---|---|
+| 1 | 27.4 | 25.4 | 14.2 | **1.79x WIN** |
+| 2 | 21.3 | 25.2 | 27.8 | 0.91x |
+| 4 | 38.6 | 38.4 | 53.3 | 0.72x |
+| 8 | 55.4 | 54.4 | 98.8 | 0.55x |
+| 16 | 59.9 | **79.4** | 168.9 | 0.47x |
+
+## What is left, in order
+1. **Batched verify** — one fused forward of M = n*(K+1). Needs a new `decode_verify_batch` on the
+   Model trait. NOTE the shape already exists: `prefill_batch_chunk(&mut [PrefillSlice])` does n
+   sequences x variable tokens. Batched verify is that shape plus (a) per-seq SSM state in, not
+   fresh, (b) logits at EVERY position, (c) per-seq rollback. Build on it rather than from scratch.
+2. Mixer tensor-core projections (`ATLAS_SSM_TC_PROJ`, ssm_batched.rs) — qkvz/out_proj still run
+   scalar batch-16 GEMV at 2.3-3.0 TFLOP/s, 5-7x off the weight-stream floor. Est +10%.
+3. LM head at n>=2 off the base `w4a16_gemm` (floor ~2.6 ms vs 20 ms today). Est +5-6%.
+4. Host sampling: b1_margin gate-after-scan, f2 softmax when inert, batch-wide argmax poison.
+
+## 2026-07-27 — correctness fix (self-inflicted) + FFN crossover is n=5, not n=9
+
+### BUG I INTRODUCED, now fixed
+Flipping `ATLAS_MTP_MAX_SEQS` to 2 exposed that the spec-eligibility predicate reads
+`inside_thinking`, `post_think_emitted`, `suppress_tool_call` and `disable_mtp` from **`active[0]`
+only** (`scheduler/mod.rs`). These are PER-SEQUENCE properties: at n=2, sequence 1 would be
+speculated even when its own `suppress_tool_call`/`disable_mtp` said it must not be. Now
+`active.iter().all(..)`. At n==1 `all()` over one element is exactly the old predicate, so the C=1
+path is unchanged by construction. Verified: tool calls still emit correctly with n=2 speculation on.
+
+Same commit fixes the MTP gate's throughput accounting: `emitted` was
+`active[0].seq_len - before`, counting ONE sequence's tokens while timing a step that produced n
+sequences' worth — under-reporting MTP throughput by ~n and biasing the gate toward serial decode.
+Now summed over all active sequences. (Inert under `ATLAS_MTP_GATE_FORCE=1`, which the benchmarks
+set, but wrong for anyone who doesn't.)
+
+### The FFN tile-GEMM crossover is n=5
+2 reps/cell, coherence held:
+| MIN_N | C=4 | C=8 |
+|---|---|---|
+| 9 | 37.7 | 53.4 |
+| **5** | 37.8 | **57.8 (+8%)** |
+| 4 | 36.2 (regresses) | 57.8 |
+Default is now 5. So eliminating the double weight read was only PART of the C=16 win — the tile
+GEMM is simply better per pass from n=5 up. n=4 regresses, so the GEMV genuinely wins at 4.
+
+### Sweep with everything landed
+| C | 1 | 2 | 4 | 8 | 16 |
+|---|---|---|---|---|---|
+| Atlas | 25.5 | 25.3 | 37.9 | **57.9** | **79.5** |
+| vLLM | 14.2 | 27.8 | 53.3 | 98.8 | 168.9 |
+| ratio | **1.80x** | 0.91x | 0.71x | 0.59x | 0.47x |
+
+## 2026-07-27 — WIN: tensor-core mixer projections (+9.2% at C=16)
+
+The five background agents converged on ONE root cause, from vLLM's installed source:
+**vLLM never lets M influence kernel selection.** Marlin runs `mma` tensor cores even at M=1
+(`gptq_marlin.cu`: `thread_m_blocks = min(ceil(M/16), 4)`, no GEMV path at all), and the CUTLASS
+FP4 SM120 path has one fixed 128x128x128 tile. So its weight cost is FLAT from M=1 to M=16.
+Atlas instead dispatches BY M into a scalar-FMA GEMV ladder whose runtime is proportional to M.
+That single design difference is the marginal-cost gap.
+
+`ATLAS_SSM_TC_PROJ` routes the mixer's qkvz/out_proj onto `w4a16_gemm_t` (M64/N128 FP8-MMA tile
+GEMM). Cost to implement: two dispatch arms. The transposed NVFP4 twins `qkvz_nvfp4_t` /
+`out_proj_nvfp4_t` are ALREADY built at load and already used by the SSM PREFILL path — no repack,
+no new kernel, no new buffer, no extra VRAM.
+
+2 reps/cell, coherence identical:
+| leg | C=8 | C=16 |
+|---|---|---|
+| GEMV (old) | 57.8 / 57.7 | 79.7 / 79.4 |
+| **TC n>=9 (new default)** | 57.5 / 57.6 | **86.9 / 86.8** |
+| TC n>=5 | 54.9 / 54.8 (**regresses**) | 86.4 / 86.5 |
+
+The mixer's crossover is **9**, not the FFN's 5 — different shapes, different crossover. Do not
+assume one transfers.
+
+**ACCURACY DEBT (tracked, not yet paid — per the standing "no gates until parity" directive):**
+`w4a16_gemm_t` is W4A8 (E4M3 activations) where the GEMV is W4A16, so it CAN move a greedy token.
+It is the production SSM prefill path for these same two weights and the coherence smoke is
+identical, but a BFCL gate is owed before merge. Same debt applies to `ATLAS_MTP_MAX_SEQS=2`.
+
+## Scoreboard
+| C | session start | now | vLLM | ratio |
+|---|---|---|---|---|
+| 1 | 27.4 | 25.5 | 14.2 | **1.80x WIN** |
+| 2 | 21.3 | 25.3 | 27.8 | 0.91x |
+| 4 | 38.6 | 37.9 | 53.3 | 0.71x |
+| 8 | 55.4 | 57.9 | 98.8 | 0.59x |
+| 16 | 59.9 | **86.9** | 168.9 | **0.51x** |
+
+## Next, from the agents (ranked, all with file:line in their reports)
+1. **LM head kernel** — `decode_a2.rs:429` calls `w4a16_gemm` unconditionally; its M64 tile wastes
+   75% of the MMA at M=16, giving a FLAT ~20 ms/step against a 2.65 ms roofline. Atlas ALREADY owns
+   `w4a16_gemv_batch4/8` and the MTP verify path (`impl_a3.rs:160-192`) already routes M<=8 there
+   with a comment measuring the same 19.3 ms. Est **10-17 ms**, ~10 lines. Cheapest item on the board.
+2. **GDN third h_state pass** — `_f32_norm`/`_f32_conv_norm`/`_f32_strided*` re-read all of H after
+   writing it, purely to compute a Frobenius norm the update loop already had in registers.
+   ~8.4 ms/step at n=16, bit-identical to remove.
+3. **GDN double read** — the decode kernel reads H twice (hk_dot, then update). An algebraic identity
+   (`out = g*(H_old^T q) + vnew*(k.q)`) collapses it to one pass. 9 MiB -> 6 MiB per seq per layer.
+4. **Batched verify** — full design with trait signatures, the M<=32 metadata cap, and the
+   intermediate-stride kernel bug is in the agent report; the pool's batch stride ALREADY matches
+   `h_bytes`, so the wy kernels need one added `inter_batch_stride_floats` parameter.
+
+## 2026-07-27 — WIN: batched-GEMV decode lm_head (+22% C=4, +12% C=8, +6% C=16)
+
+Same root cause as the mixer and the FFN, third instance: the decode head called the base M64-tile
+`w4a16_gemm` unconditionally. On the [248320, 5120] NVFP4 head only 16 of 64 MMA tile-rows carry
+data at padded_n=16, so it ran at ~1/7 of the weight-stream floor — and being FLAT in n, it sat in
+the FIXED term at every batch size, which is why C=4 gained most.
+
+Atlas already owned the fix: the MTP verify path (`impl_a3.rs`) routes M<=8 to the batched GEMV
+with an nsys note measuring **19.3 ms for the GEMM vs ~2.5 ms** for the GEMV streaming the same
+636 MB once. The decode head never dispatched there, and the MODEL level had no batch16 handle at
+all (the SSM mixer carries one) — so there was no arm above 8 even if it had.
+
+2 reps/cell, coherence identical:
+| C | old M64 GEMM | new batched GEMV |
+|---|---|---|
+| 1 | 25.4 | 25.5 |
+| 4 | 38.0 | **46.2 (+21.6%)** |
+| 8 | 58.0 | **65.2 (+12.4%)** |
+| 16 | 86.9 | **91.8 (+5.6%)** |
+
+## SCOREBOARD — full sweep, everything landed
+
+| C | session start | now | vLLM | ratio | was |
+|---|---|---|---|---|---|
+| 1 | 27.4 | 25.5 | 14.2 | **1.80x WIN** | 1.93x |
+| 2 | 21.3 | 24.4 | 27.8 | 0.88x | 0.77x |
+| 4 | 38.6 | **46.1** | 53.3 | **0.87x** | 0.72x |
+| 8 | 55.4 | **65.2** | 98.8 | **0.66x** | 0.56x |
+| 16 | 59.9 | **92.1** | 168.9 | **0.55x** | 0.35x |
+
+C=16 has gone 59.9 -> 92.1 tok/s (**+54%**) this session; the vLLM ratio 0.35x -> 0.55x.
+C=4 is now within 13% of vLLM.
+
+## The pattern, stated plainly
+Every win this session is the SAME bug in a different place: **Atlas dispatches by M into a
+scalar-FMA GEMV/chunked path where a tensor-core tile GEMM was already available and already used
+elsewhere in the tree.** FFN (+30%), mixer projections (+9%), lm_head (+22/12/6%). vLLM never makes
+this choice — Marlin issues mma at M=1. Anywhere Atlas still selects a kernel BY M is a suspect.
+
+## Remaining, ranked
+1. GDN third h_state pass (norm clamp re-reads H after writing it) — ~8.4 ms/step at n=16,
+   bit-identical to remove. Agent gave exact file:line for all 4 kernel variants.
+2. GDN double read — algebraic identity `out = g*(H_old^T q) + vnew*(k.q)` collapses two passes to
+   one. 9 MiB -> 6 MiB per seq per layer.
+3. Batched verify (full design in the agent report; the wy kernels need one
+   `inter_batch_stride_floats` parameter — today's hardcoded stride is wrong by a factor of `ni`
+   and is dead code only because every call site passes batch_size=1).
+4. Attention branch RoPE / KV-write are still per-sequence loops (`multi_seq/attn.rs`).
+
+## 2026-07-27 — GDN third pass removed (bit-identical, +1.1%) and a RE-MEASURED map
+
+### The third-pass fix landed, and under-delivered — informatively
+7 kernel variants re-read all of H after writing it, to accumulate a Frobenius norm the update loop
+already had in registers. Now accumulated in-loop, one add at a time in ascending j so the summation
+order is unchanged. **Emitted-text SHA identical across a pre/post binary A/B** (`981ca44911471b59`),
+on a real kernel rebuild (158 kernels, 0 cache hits).
+
+Measured **+1.1% at C=16** (91.65 -> 92.65) and +0.6% at C=8, against a ~3% prediction. **That
+settles the analysis's open question: the re-read was mostly absorbed by L2, so h_state traffic is
+much less DRAM-bound than the roofline model assumed.** Size the remaining GDN passes off THIS datum,
+not the model — the "collapse the double read via the algebraic identity" item should be expected to
+return ~1-2%, not the ~5% its traffic arithmetic suggests, and it is token-equal-not-bit-identical,
+so it is now a poor trade. DEPRIORITISED.
+
+### Re-measured decomposition at n=16 (eager, ATLAS_MS_PROFILE, 190 samples)
+| block | before all fixes | now | change |
+|---|---|---|---|
+| TOTAL | 264.9 ms | **150.4 ms** | -43% |
+| ssm (48L) | 189.8 | 102.2 (68%) | -46% |
+| attn (16L) | 54.7 | 38.4 (26%) | -30% |
+| head | 20.3 | 9.7 (6%) | -52% |
+
+Inside the SSM block (per layer x48): **FFN 42.0 ms | GDN recurrence ~30 ms | qkvz 15.0 ms |
+out_proj 13.5 ms**. qkvz fell 678 -> 313 us/layer from the tensor-core arm, as intended.
+
+### TWO NEW FINDINGS from that profile
+1. **`out_proj` did NOT improve** (288 -> 282 us/layer) even though its tensor-core arm shipped in
+   the same commit as qkvz's, which DID improve. The transposed twin is built by the loader
+   (`weight_loader/qwen35_dense.rs:686`), so either the arm is not firing on this checkpoint's
+   loader branch, or the tile GEMM is under-filled at N=5120 (5120/128 = 40 CTAs on ~48 SMs — a
+   single partial wave, which the analysis flagged as a range rather than a point estimate).
+   **Worth 13.5 ms and an hour of investigation.** Settle it with a one-shot log in the arm.
+2. **The batched-recurrent path is silently falling back part of the time.** The same profile shows
+   BOTH `recurrent_batched_gdn_norm` (618 us) AND the per-seq `recurrent_gdn`/`_ba`/`_conv`
+   (567+159+127 = 853 us) in one run. `ssm_batched_recurrent.rs:66-89` requires the n slots to be
+   EXACTLY contiguous and returns `None` silently otherwise; pool slots fragment as sequences
+   finish. This is the analysis's predicted failure and it means **the +2.6% batched-recurrent
+   datum was partly measuring the fallback.** Per-seq costs 853 us/layer vs 618 batched — a 28%
+   penalty on ~30 ms whenever it fires. Add the one-line diagnostic FIRST, then decide.
+
+### Scoreboard
+| C | 1 | 2 | 4 | 8 | 16 |
+|---|---|---|---|---|---|
+| Atlas | 25.5 | 24.4 | 46.1 | 65.5 | **93.2** |
+| vLLM | 14.2 | 27.8 | 53.3 | 98.8 | 168.9 |
+| ratio | **1.80x** | 0.88x | 0.87x | 0.66x | **0.55x** |
+
+## 2026-07-27 — NULL RESULT that reprices the whole FFN block: M-sized MMQ tiles
+
+Analysis said the FFN's MMQ tile is hard-wired to `mmq_x=128`, so at M=16 it issues MMAs for all
+128 tile columns and discards 112 in the write-back predicate — 87.5% of MMA slots. The padded-issue
+arithmetic predicted 41.1 ms against a 42.0 ms measurement, an almost exact fit, and therefore
++7-12% at C=16 from sizing the tile to the batch.
+
+Implemented: `atlas_nvfp4_mmq{16,32}_{nc,wc}` instantiations of the SAME template (mmq_x is a free
+template parameter; the vendored MMA path's granularity is 8), `nvfp4_mmq_gemm_tiled` with the smem
+size DERIVED from the vendor layout (the derivation reproduces the previously-hardcoded 57856 at
+mmq_x=128, which is the check that it matches), dispatch by m in dense_ffn, kill switch
+`ATLAS_NO_MMQ_SMALL_TILE=1`. Verified the new entries really compiled (present in t0__nvfp4_mmq.ptx).
+
+**MEASURED FLAT.** 2 reps/cell, output SHA identical (`981ca449...`):
+| C | 128 tile | M-sized tile |
+|---|---|---|
+| 4 | 45.8 / 46.2 | 46.2 / 46.3 |
+| 8 | 65.8 / 65.8 | 66.0 / 65.9 |
+| 16 | 93.1 / 89.1 | 92.5 / 92.6 |
+
+**THE CONCLUSION MATTERS MORE THAN THE CHANGE: the FFN at M=16 is WEIGHT-BANDWIDTH-bound, not
+MMA-issue-bound.** The padded MMAs are free because they hide behind the 7.22 GB weight stream
+(26-31 ms). The 41.1-vs-42.0 fit was a coincidence. Kept the code (bit-identical, strictly less
+wasted issue, and the instantiations are reusable) but it is NOT a win.
+
+### This is the second time a traffic/compute model over-predicted by ~3x
+First: the GDN third-pass removal predicted ~3%, delivered 1.1% (L2 absorbed it).
+Now: the FFN tile predicted 7-12%, delivered ~0.
+**Rule for this campaign: an analytical model that says "X% of the work is wasted" is a hypothesis
+about the BOTTLENECK, not a prediction of speedup. Wasted work behind a bandwidth wall is free.**
+Both blocks are now known to be bandwidth-bound and within ~1.5x of their floors:
+- FFN: ~42 ms actual vs 26-31 ms weight-stream floor
+- GDN: ~30 ms actual vs 17-20 ms state-traffic floor
+Neither has a 2x left in it. The remaining gap to vLLM is NOT in these two blocks.
+
+### Where that leaves the search
+The attention branch (38.4 ms, 16 layers) is the least-examined block and the analysis found ~2,300
+per-sequence launches/memcpys per step there (RoPE, KV-write, q/k norms, gate-mul, plus a
+scatter/re-gather round trip that batchn makes unnecessary), est. 4-9 ms — and unlike the two blocks
+above, that is LAUNCH overhead, which is not hidden behind a bandwidth wall. `sigmoid_gate_mul_batched`
+already exists and is unused. That is the next thing to try.
+
+## 2026-07-27 — multi-seq CUDA graphs DEFAULT-ON (+3.2%), and it RETIRES the attention rewrite
+
+The attention branch had ~2,300 per-sequence launches/step (RoPE, KV-write, q/k norms, gate-mul,
+plus a scatter the batched QKV then re-gathers), analysed at 4-9 ms if hand-batched. Before building
+that, two cheaper things settled it:
+
+1. **Hand-batched the gate-mul** (16 launches/layer -> 1, using `sigmoid_gate_mul_batched` which
+   already existed and which the PREFILL path already drives on these same buffers). Removed ~240
+   launches/step. **MEASURED FLAT** — consistent with the estimate (240 x ~2-4 us is inside noise),
+   not a refutation. Landed anyway: strictly less work, identical output.
+2. **CUDA graphs — a ZERO-CODE test of the whole hypothesis**, since graphs capture every launch
+   wholesale. **C=8 65.75 -> 67.6 (+2.8%), C=16 92.6 -> 95.6 (+3.2%)**, emitted-text SHA unchanged.
+
+**So the launch overhead is real but worth ~3%, and a flag already captures ALL of it.** Hand-batching
+the remaining ~2,000 calls cannot beat what graphs get for free. **The attention pipeline rewrite is
+retired** — do not re-open it without new evidence.
+
+`ATLAS_DECODE_GRAPHS_MULTISEQ` is now DEFAULT-ON (`ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1` disables). Its
+own comment had said "opt-in until soaked; flip the default once validated" — this is that
+validation, and it is exactly the pattern `feedback_good_defaults_not_flags` exists to catch.
+
+## SCOREBOARD — end of session
+
+| C | session start | **now** | vLLM | ratio | start ratio |
+|---|---|---|---|---|---|
+| 1 | 27.4 | 25.6 | 14.2 | **1.80x WIN** | 1.93x |
+| 2 | 21.3 | 25.3 | 27.8 | 0.91x | 0.77x |
+| 4 | 38.6 | **47.7** | 53.3 | **0.90x** | 0.72x |
+| 8 | 55.4 | **67.7** | 98.8 | **0.69x** | 0.56x |
+| 16 | 59.9 | **95.9** | 168.9 | **0.57x** | 0.35x |
+
+**C=16 +60% this session. C=4 is within 10% of vLLM.**
+
+## What is now KNOWN to be near its floor (do not re-open without new evidence)
+- **FFN** (~42 ms): weight-bandwidth-bound. M-sized MMQ tiles measured FLAT.
+- **GDN recurrence** (~30 ms): state-bandwidth-bound, ~1.5x floor. Third-pass removal 1.1%,
+  batched-recurrent 2.6%, double-read deprioritised by the same L2 calibration.
+- **Launch overhead** (~3%): fully captured by CUDA graphs, now default-on.
+
+## What is left
+1. **out_proj occupancy** — 40 CTAs on 48 SMs at N=5120, a single under-filled wave; both the GEMV
+   and the tile GEMM bottom out at ~60 GB/s for different reasons. Split-K or the already-compiled
+   `w4a16_gemm_t_k64`. Est ~8 ms.
+2. **Batched speculative verify** — still the only structural lever with a >2x shape. Spec is worth
+   1.8x at C=1 and is inert above n=2. Full design + the latent `inter_batch_stride_floats` kernel
+   bug are recorded above.
+
+## 2026-07-27 — out_proj: K_STEP_T=64 is a REGRESSION, so the diagnosis narrows to occupancy
+
+Analysis proposed a zero-new-kernel first test for out_proj's poor efficiency: route it (and qkvz)
+to `w4a16_gemm_t_k64`, the same M64/N128 kernel with K_STEP_T=64, halving the sync-bound outer-loop
+count 192 -> 96. Both projections qualify (qkvz K=5120, out_proj K=6144, both multiples of 64) and
+the handle was already compiled and bound.
+
+**MEASURED WORSE**, 2 reps/cell, SHA identical: C=8 68.0 -> 67.5, C=16 96.0 -> 95.5. **Reverted.**
+
+That is informative rather than merely negative: it rules out barrier/iteration count as out_proj's
+limiter and leaves ONLY the under-filled wave. At N=5120 the grid is 40 CTAs on ~48 SMs — 8 SMs idle
+and 1 CTA/SM on the rest, so there are no co-resident CTAs to hide any stall, and a deeper K-step
+just makes each of the 40 CTAs do more work serially. The remaining fix is the one that ADDS CTAs:
+split-K over `gridDim.z` (S=4 -> 160 CTAs -> 3.3 waves, the regime where qkvz reaches ~55% of peak),
+accumulating partials into an FP32 workspace. That is a real new kernel, est. ~8 ms of a ~150 ms
+step, and it is now the best-understood remaining kernel lever.
+
+### Running tally of measured-flat/negative levers (all with SHA-identical output)
+| lever | predicted | measured |
+|---|---|---|
+| GDN third h_state pass removed | ~3% | **+1.1%** (L2 absorbed it) |
+| M-sized MMQ tiles (mmq_x=16/32) | +7-12% | **0%** (FFN is weight-bound) |
+| Hand-batched attention gate-mul | ~0.3-0.6% | **0%** (inside noise, as predicted) |
+| Slot-sort in the mixed paths | recovers 28% of a block | **0%** on this workload |
+| out_proj K_STEP_T=64 | ~1.5-2x on the block | **-0.5%** |
+| **CUDA graphs default-on** | — | **+3.2%** ✓ |
+The one that worked is the one that removed a whole CLASS of overhead rather than a slice of it.
+
+## 2026-07-27 — DECISION: batched speculative verify is KILLED (for now). Fix batch scaling first.
+
+Stage 1a ran in ~1 hour instead of the projected 1.5 days and produced two gates, both
+pre-registered before measuring.
+
+**PASSED — byte identity.** Batched wy4 on the pointer-table pattern is bit-exact against n
+sequential single-sequence launches at n=2/4/8, across h_state, all three rollback intermediates
+and the output. **The confirmed cross-sequence corruption bug is fixed with a permanent regression
+test** — banked regardless of this decision.
+
+**FAILED — cost.** Fused wy4 at n=8/K=4 costs 723.9 us vs 214.6 us for a plain 1-token n=8 decode
+= 3.37x, past the 2.00x stop line; batching the launches is worth only 1.03x over 8 sequential.
+
+**The measurement that reframed it.** Verify step cost vs draft width at n=1:
+  K=2 (2 verify rows): 97.1 ms | K=4 (4 verify rows): 97.0 ms — IDENTICAL.
+So the +26 ms gap between the plain step (70.9 ms) and the verify step (97 ms) is NOT row cost — it
+is the FIXED drafter overhead of entering the spec path. Verify rows are FREE at n=1 because the
+whole n=1 step is weight-streaming bound (17.5 GB / 273 GB/s = 64 ms of a 70.9 ms step) AND the GDN
+kernel runs at ~8% occupancy with spare memory-level parallelism. **At n=8 the GPU is full and that
+slack is gone** — which is exactly why the same kernel measures 3.37x there. The property that makes
+speculation cheap at C=1 does not transfer.
+
+Budget at n=8 against a pre-registered 60/82 ms build/kill band: GDN +24.4 (measured), attention
++31 (fitted), drafter +26 (measured at n=1, ASSUMED flat in n) = ~81 ms, i.e. 99.5 tok/s vs vLLM's
+98.8 — dead even, one millisecond off the kill line.
+
+### Why KILLED anyway — the strategic ground, which does not depend on that arithmetic
+The adjudication argued the attention leg is OVER-counted (verify rows share a sequence's KV, so
+n=8xK=4 streams 8 KVs not 32 => +5-15 ms, not +31), which would put the budget in the BUILD band —
+and still killed, because:
+
+**Atlas C=1 non-spec is 14.1 tok/s; vLLM C=1 is 14.2. PER-SEQUENCE PARITY on identical silicon.
+Yet vLLM scales 11.9x to C=16 where Atlas scales 6.8x.** The whole C=8/C=16 deficit is
+batch-scaling efficiency — pure software, un-diagnosed. Fixing it lifts EVERY cell. Fused verify
+even optimistically flips C=4 and maybe C=8 while C=16 stays lost (~131 vs 168.9), and it would be
+built against a substrate the scaling fix moves (base step, attention batch behaviour, GDN
+saturation point), forcing a re-measure anyway.
+
+**Correct order: scaling first, then fused verify becomes the lever that WINS C=16 instead of one
+that tops out at C=8.** The verify work is shelved WITH its gate intact and its kernel fix landed.
+
+### The diagnosis is already started — per-sequence marginal, measured
+| n | total | ssm | attn | head |
+|---|---|---|---|---|
+| 4 | 81.3 | 58.6 | 19.5 | 3.2 |
+| 8 | 111.8 | 79.4 | 27.9 | 4.4 |
+| 16 | 152.2 | 104.1 | 38.4 | 9.7 |
+
+**Marginal per added sequence: 5.91 ms = ssm 3.79 + attn 1.58 + head 0.55.** vLLM's is ~1.5 ms/seq.
+The 4.4 ms/seq difference x16 = ~70 ms of a 152 ms step IS the C=16 gap.
+
+**The SSM leg owns 64% of it at 3.6x its physics floor** (1.05 ms/seq for 144 MB of h_state read+
+write at 273 GB/s). And that leg is mixer 61.7 (qkvz 15.0, out_proj 13.5, GDN recurrence ~30) +
+FFN 42.0 — i.e. mostly WEIGHT-bound work that should be FLAT in n but is scaling with rows. Same
+pattern as every win today. If the SSM marginal reached floor: total 3.18 ms/seq, step at n=16
+~119 ms, **~134 tok/s with no speculation involved.**
+
+### Carried forward
+- The drafter's +26 ms is measured at n=1 and ASSUMED flat in n. Same assumption class that went
+  1-for-8 this session. MEASURE IT at n=8 before any re-adjudication.
+- OVERTURNING MEASUREMENT: if a roofline decomposition shows the plain n=16 step is already
+  near-irreducible traffic, the scaling gap is not a days-scale fix and the verify build becomes
+  the best available use of the time. Flip back to BUILD if so.
+
+## 2026-07-27 — ★ THE BANDWIDTH CEILING IS 230 GB/s, NOT 273 — AND NOT 155
+
+Measured with a STREAM microbenchmark on GB10 (48 SMs, 256-bit LPDDR5X), grid 48..384, 2 GiB
+buffers, float4 vectorized (scratchpad `stream.cu`):
+
+    READ  230 GB/s        COPY (read+write)  215 GB/s
+
+That is 84% / 79% of the 273 GB/s nominal — a normal STREAM efficiency. Use **230 (read-only
+streams) / 215 (read+write streams)** as the floor denominator from now on. Do NOT use 273.
+
+### ★ CORRECTION: "the FFN is at floor, weight-bandwidth-bound" was WRONG
+That verdict (recorded 2026-07-27 earlier, and in the m_dispatch memory) was derived against a
+floor computed from NOMINAL bandwidth and from an ASSUMED intermediate_size. Real config:
+hidden 5120, intermediate **17408**, 64 layers, head_dim **256**, kv_heads 4, vocab **248320**,
+full_attention_interval 4 (=> 16 attn + 48 GDN layers), GDN nv48/kd128/vd128 fp32.
+FFN weights = 3 x 5120 x 17408 x 0.5 B = 133.7 MB/layer = 8.56 GB over 64 layers.
+Floor at 230 GB/s = 37.2 ms. Measured ~57 ms => **1.53x over floor, ~20 ms recoverable.**
+The FFN block is RE-OPENED. (The earlier MMQ-tile null result stands as a null for THAT lever,
+not as proof the block is at its floor.)
+
+### Full step budget at C=16, eager, 190 samples/point (ATLAS_MS_PROFILE + ATLAS_SSM_DETAIL)
+Instrumented forward 152.1 ms; actual step ~167 ms (graphs on) => host leg ~20 ms.
+
+| block                | measured | floor @achieved | ratio | recoverable |
+|----------------------|----------|-----------------|-------|-------------|
+| GDN projections      | 28.7 ms  | 12.0            | 2.39x | 16.7 ms     |
+| FFN (64 L)           | ~57 ms   | 37.2            | 1.53x | 20 ms       |
+| host leg             | 20.5 ms  | ~0 overlappable | --    | 20 ms       |
+| attention mixer      | ~24 ms   | 4.6 (KV 1.05GB) | 5.2x  | 19 ms       |
+| GDN state (48 L r+w) | 29.8 ms  | 22.5            | 1.33x | 7.3 ms      |
+| lm_head              | 9.7 ms   | 2.8             | 3.5x  | 6.9 ms      |
+
+### ★ THE ROOFLINE, AND WHAT IT SAYS ABOUT vLLM
+Total traffic per decode step at n=16 = **18.4 GB** (FFN 8.56 + GDN state r+w 4.83 + GDN proj
+2.77 + KV 1.05 + attn weights 0.59 + lm_head 0.64). At achieved bandwidth that is **~82 ms/step
+= a 195 tok/s roofline at C=16**.
+- vLLM 168.9 tok/s = 94.7 ms/step = **87% of roofline** -> vLLM is essentially AT the memory wall.
+- Atlas 95.9 tok/s = 167 ms/step = **49% of roofline**.
+**To beat vLLM we need <=94 ms/step.** The six prizes above sum to more than the 73 ms required,
+so the target is arithmetically reachable without inventing a new algorithm. No single lever
+does it; this is a six-front grind, and NONE of the six is at its floor.
+
+### Instrument trap (cost one full measurement cycle)
+`ATLAS_MS_PROFILE` forces eager, but `ATLAS_SSM_MS_PROFILE` / `ATLAS_SSM_DETAIL_PROFILE` only
+skip during graph CAPTURE. Once multi-seq CUDA graphs became default-on, the step REPLAYS the
+graph and the Rust-side SSM timers never execute => zero profile lines, silently. Always pass
+`ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1` with the SSM profilers. (Same class as the ATLAS_MTP_TIMING
+K=2-only trap: an instrument existing != an instrument covering your config.)
+
+### Weighting trap
+The detail profile emits both batched and per-seq recurrent stage names in one run. At n=16 the
+per-seq rows had **48 samples vs 9120** for the batched rows (one warmup step, 0.2% share) --
+the batched path carries everything. Always print sample COUNTS before scaling a stage mean by
+the layer count.
+
+## 2026-07-27 — ★ NSYS KERNEL PROFILE (C=16, 154 decode steps) — THE REAL RANKING
+
+`nsys profile --trace=cuda --cuda-graph-trace=node` on a native serve, real C=16 drive at
+97.5 tok/s (matches the committed baseline, so the profiled run is representative).
+Report: /tmp/atlas_prof3.nsys-rep. Invocation that WORKS: plain `nsys profile` + SIGTERM to
+the spark PID. `--delay/--duration` produced no report; `--cpuctxsw` is invalid on
+`nsys launch`; the driver script's port must match the serve's.
+
+| kernel                                   | %GPU | inst/step | avg     | ms/step | vs floor |
+|------------------------------------------|------|-----------|---------|---------|----------|
+| atlas_nvfp4_mmq16_nc (FFN)               | 35.5 | 154       | 283 us  | 43.6    | 1.29x    |
+| **w4a16_gemm_t_k64 (projections)**       | 26.6 | 129       | 255 us  | **32.9**| **2.1x** |
+| gated_delta_rule_decode_f32_strided_norm | 19.2 | 48        | 613 us  | 29.4    | 1.31x    |
+| **w4a16_gemv_batch16 (lm_head)**         | 6.3  | 1         | 9.68 ms | **9.7** | **3.5x** |
+| atlas_nvfp4_mmq32_nc                     | 3.6  | 16        | 276 us  | 4.4     | --       |
+| rope_forward                             | 0.8  | 256       | 4.5 us  | 1.2     | fan-out  |
+| rms_norm                                 | 0.5  | 414       | 1.5 us  | 0.6     | fan-out  |
+| **paged_decode_attn**                    | 0.4  | 16        | 42.6 us | **0.68**| --       |
+
+### ★ THE ATTENTION LEVER IS DEAD — DO NOT RE-OPEN
+`paged_decode_attn` is **0.68 ms/step, 0.4% of GPU time**. The GQA 6x-KV-re-read fold, the
+per-position shuffle-chain rewrite, the split-KV work — ALL of it targets 0.4% of the GPU.
+The 38.5 ms that ATLAS_MS_PROFILE attributes to "attention layers" is those layers' FFN
+(~12 ms) + their projections (~16 ms) + fan-out; the attention kernel itself is noise.
+This killed three successive sizings of that lever (19 ms -> 3 ms -> 1 ms -> 0).
+
+### ★ THE REAL #1: PROJECTIONS AT 2.1x FLOOR (even after the k64 fix)
+32.9 ms/step for 3.6 GB of projection weights (SSM qkvz 2.01 + SSM out_proj 0.755 + attn
+qkv/o 0.84). Floor at 230 GB/s = 15.7 ms. **~17 ms available** -- the largest single prize.
+
+### ★ #2: lm_head IS AN M-DISPATCH INSTANCE, STILL
+ONE launch per step at **9.68 ms**. 636 MB of weights (5120 x 248320 x 0.5) = **66 GB/s =
+29% of achievable**. It runs `w4a16_gemv_batch16`. Earlier this campaign lm_head was moved
+ONTO that GEMV for +22% C=4 -- but the alternative then was `w4a16_gemm` (N64), which the
+bench shows is **4.7x slower than w4a16_gemm_t_k64**. Route it to the k64 tile GEMM
+(needs a transposed weight twin): 9.7 ms -> ~3 ms.
+
+### ★ METHOD CORRECTION: THE ISOLATED BENCH OVERSTATES BY ~1.5x
+`w4a16_m17_bench` reports 166 us for a ~50 MB weight = ~300 GB/s, ABOVE the 230 GB/s STREAM
+ceiling -- impossible. Its 100 back-to-back iterations over ONE weight get L2 reuse the
+in-model path never sees (in-model k64 avg is 255 us, not 166). This is exactly why k64's
+predicted 1.30x delivered +1.6% e2e. **Size levers from in-model nsys numbers, not from the
+microbench.**
+
+### Revised prize table (step ~166 ms at C=16, 195 tok/s roofline)
+| lever                        | ms/step | floor | prize   |
+|------------------------------|---------|-------|---------|
+| projections -> better tiling | 32.9    | 15.7  | ~17 ms  |
+| FFN mmq16                    | 43.6    | 37.2* | ~11 ms  |
+| lm_head -> k64 tile GEMM     | 9.7     | 2.8   | ~7 ms   |
+| GDN state                    | 29.4    | 22.5  | ~7 ms   |
+| host leg                     | ~20     | ~0    | ~16 ms  |
+| rope/rms_norm fan-out        | 1.8     | ~0.2  | ~1.6 ms |
+(*FFN floor is for the full 64-layer weight stream.)
+
+## 2026-07-27 — ★ PROJECTION UNDER-FILL CONFIRMED: k/v ARE THE WORST KERNELS IN THE MODEL
+
+`w4a16_gemm_t_k64`: M_TILE 64, N_TILE_LG 128, 128 threads (4 warps), **38.19 KiB smem/CTA
+=> only 2 CTAs/SM = 96 resident slots on 48 SMs**. Grid is `(ceil(N/128), ceil(M/64), 1)` --
+`gridDim.z` is UNUSED and at M=16 `gridDim.y == 1`, so the z axis is free for a K split.
+
+Per-shape CTA counts at M=16 (decode):
+| shape        | N     | CTAs | fill                        | calls/step |
+|--------------|-------|------|-----------------------------|-----------|
+| ssm qkvz     | 16384 | 128  | 1.33 waves (tail 32/96)     | 48 |
+| ssm out_proj | 5120  | 40   | 0.83 -- 8 SMs IDLE          | 48 |
+| attn q       | 12288 | 96   | exactly one full wave       | 16 |
+| **attn k**   | 1024  | **8**| **40 of 48 SMs IDLE**       | 16 |
+| **attn v**   | 1024  | **8**| same                        | 16 |
+| attn o_proj  | 5120  | 40   | 0.83                        | 16 |
+Byte inventory: 48*(41.9+15.7) + 16*(31.5+2.6+2.6+15.7) = **3603 MB = exactly the profiled
+3.6 GB**. Shape mix independently confirmed.
+
+### Measured standalone at M=16 (w4a16_m17_bench, 230 GB/s denominator)
+| shape                    | time    | achieved   | vs floor |
+|--------------------------|---------|------------|----------|
+| **attn_k / attn_v N=1024**| 125 us | **23.6 GB/s** | **9.75x** |
+| attn_o_proj N=5120       | 166 us  | 106.6 GB/s | 2.16x |
+| ssm_out_proj N=5120      | 155 us  | 113.8 GB/s | 2.02x |
+| ssm_qkvz N=16384         | 343 us  | 137.7 GB/s | 1.67x |
+| **attn_qkv FUSED N=14336**| **332 us** | 124.3 GB/s | 1.85x |
+k/v move 2.9 MB in 125 us. Those weights fit ENTIRELY in L2, so the bench's usual ~1.5x
+optimism does not apply -- this is pure occupancy starvation, not bandwidth.
+**k+v alone = 250 us; the FUSED q+k+v = 332 us total.**
+
+### ★ WHY THE TWO PRIOR NULLS WERE NULLS
+`K_STEP_T -> 64` for out_proj (-0.5%) and M-sized MMQ tiles (0%) both re-partition work
+INSIDE the CTA. Neither changes the CTA count. The under-fill model predicts ~0 for both --
+they are evidence FOR the diagnosis, not against it. It also means occupancy tricks
+(smem/reg cuts) are provably useless for out_proj (40 CTAs) and k/v (8 CTAs): when
+CTAs < 48 you cannot fill one per SM no matter the residency.
+
+### Ranked remedies
+1. **Fuse q+k+v into one N=14336 GEMM — BIT-IDENTICAL.** 3 launches (96/8/8 CTAs) -> 1 at
+   112 CTAs. ~2.7 ms/step and -32 launches/step. Needs a fused transposed twin at load
+   (row-wise interleave: the `_t` layout is [K/2, N], so it is NOT a flat concat).
+2. **Split-K on `gridDim.z`** (ksplits=2 for out_proj/o_proj, 8 for k/v; K%(64*ksplits)==0
+   holds: 6144/2=3072, 5120/8=640). ~9.3 ms. **NOT bit-identical** -- one FP32 accumulator
+   chain becomes 2-8 chains summed in a reduce; FP32 add is non-associative. Template
+   ALREADY IN THE SAME FILE: `int8_gemm_splitk`/`int8_splitk_reduce` at
+   `w4a16_gemm.cu:2533/:2652`, whose rationale block states the identical diagnosis.
+   ★ Pin ksplits to the WEIGHT SHAPE, never to runtime concurrency -- mirroring the
+   `split_ref_seqs` determinism pin (`qwen3_attention/mod.rs:92`), or a sequence's output
+   would depend on who else is in its batch.
+3. M_TILE=16 + warp-over-N repartition: smem 39.1 -> 25.3 KiB => 3 CTAs/SM. ~3.6 ms,
+   bit-identical, qkvz only. Does nothing for out_proj/k/v.
+4. Persistent/stream-K: ~10-12 ms but high risk; split-K first. Note `mul_mat_q_stream_k_fixup`
+   exists (`q4k_vendor/mmq.cuh:3789`) but Atlas bypasses it with `fixup=false`, justified as
+   "prefill has thousands of tiles >> 48 SMs" -- that rationale is decode-blind and INVERTS
+   at M=16.
+
+DECISION: take the bit-identical fusion (1) first -- the standing accuracy-gate directive
+blocks the BFCL run needed to discharge split-K's numerical debt.
+
+## 2026-07-27 (late) — SHIPPED: fused q/k/v; RE-ADJUDICATED spec decode: NO-GO (measured)
+
+### Shipped since the nsys profile
+- `b98ce911` w4a16_gemm_t_k64 dispatch at K>=4096 + wire into SSM projections. +1.6% C=16.
+- `4b1b9fa7` batched KV-cache write (kernel was already strided; caller passed 1 in a loop). +0.5%.
+- `2db1b349` **fused q|k|v into ONE N=14336 GEMM writing qkv_buf DIRECTLY.** 3 GEMMs
+  (96/8/8 CTAs) -> 1 (112 CTAs), AND the 48-copy per-layer scatter deleted (`per_seq_qkv`
+  already equalled the fused row width). 4 reps/leg, byte-identical: **97.80 -> 99.38 tok/s
+  (+1.6%), sigma 0.09, distributions disjoint.** Kill switch ATLAS_NO_FUSED_QKV=1.
+  ★ `n > 8` is REQUIRED: `wide_verify_gemm` early-returns on the batched-GEMV arms for m<=8
+  using the BASE weight and ignoring `w_t`, so a fused N reads past q_proj. An earlier build
+  without the gate produced truncated output + HTTP 500s — caught by BYTE-IDENTITY, not by
+  throughput.
+- `8f85418b` **fail-fast guards on GDN contiguous state addressing at batch>1.** wy2/wy3/wyN
+  still hardcode `(b*num_v_heads+vh)*hv` for the intermediates whose pool stride is
+  `ni*h_bytes`; wy4's only protection was a `debug_assert!` that COMPILES OUT IN RELEASE.
+  One call-site change from silent cross-sequence rollback corruption.
+
+### ★★ SPEC-DECODE RE-ADJUDICATION: NO-GO. Four gates, two failed on measurement.
+| gate | threshold | measured | verdict |
+|---|---|---|---|
+| acceptance epsilon at n=16 | >= 2.3 | **~2.6** (mean accepted 1.61 over six 100-step windows) | PASS |
+| batched wy4 byte-identity | exact | n=2/4/8/16 all byte-identical | PASS |
+| fused GDN cost | <= 2.5x plain | **3.92x**; batching the layer saves only 1.7% (726.6 vs 739.4 us) | **FAIL** |
+| drafter propose | <= ~2 ms/seq | **16.08 ms/seq median (n=572)** | **FAIL 8x** |
+
+**The decisive number is propose.** At n=8: verify 8x80.2 = 640 ms + propose 8x16.1 = 129 ms
+= 769 ms/step vs the 794 ms/step implied by the observed 26.1 tok/s — the model reconciles
+end to end. Fusing verify collapses the 640 -> ~225-259 ms, but **propose stays per-sequence:
+256 ms/step at n=16, on its own larger than the entire fused-verify budget.** Batching the
+drafter is NOT in the ~1-1.5k-line estimate.
+
+### What I got wrong (recorded so it is not repeated)
+I argued the failing GDN gate "measured the wrong quantity" — that the win comes from the 73%
+of the step that is weight-bound and flat in M. **That physics is CORRECT**: an adversarial
+re-run of `w4a16_m17_bench` at M=16 vs 64 shows +/-12%, with ssm_qkvz 16% FASTER at M=64.
+But the arithmetic omitted two terms the KILL had explicitly carried forward as "MEASURE IT
+before any re-adjudication": the **+26 ms drafter overhead** (measured at n=1, assumed flat —
+now measured at 16 ms/seq) and **host sampling over 64 logit rows instead of 16** (~+12 ms).
+Restoring them: ~259 ms -> 6.2 ms/tok -> 1.51x -> **~145 tok/s vs vLLM 168.9.**
+Also wrong: "head unchanged" — lm_head has NO M=64 arm, so verify would run 4x
+`w4a16_gemv_batch16` = 4 weight sweeps (~39 ms, not 9.7).
+Also wrong: epsilon 2.6 is the SYNTHETIC probe. MTP eligibility is
+`active.iter().all(...)` over thinking/tool-suppression (`scheduler/mod.rs:551`), so at n=16
+ONE sequence in a think block de-speculates the WHOLE batch. Agentic epsilon = 2.6 x an
+unmeasured eligible-step fraction.
+★ RULE: re-deriving a budget minus its flagged terms is goalpost-moving. The KILL had already
+run this exact framework and pre-registered a DIFFERENT flip-back condition, which tested FALSE.
+
+### ★ PRE-REGISTERED RE-OPEN KEY (so it cannot drift)
+Flip to BUILD only if ALL THREE hold: drafter+sampling <= ~12 ms combined at n=16 AND
+agentic epsilon >= 2.4 (measured on the agentic harness, not the synthetic probe, with the
+`all()` predicate live) AND eligible-step fraction >= 80%.
+
+### Next: the non-spec board (ranked, and each ms also lowers the future verify numerator)
+1. split-K on `gridDim.z` for the narrow-N projections (~9 ms). Template `int8_gemm_splitk`
+   at `w4a16_gemm.cu:2533`. NOT bit-identical — pin ksplits to the WEIGHT SHAPE.
+2. host-leg: split-row GPU argmax (~4-8 ms) + pin DECODE_LOGITS_HOST_SCRATCH (~1-2 ms).
+   ★ `--disable-thinking` sets `think_ended=true` for EVERY sequence at birth
+   (`prefill_a_step.rs:229` +3 siblings), and the gate at `decode_logits_step.rs:76` then
+   forces ALL rows onto the host path — so the GPU argmax fast path is DEAD CODE in this
+   benchmark AND in MLPerf-edge. The rows only need a 2-token ban mask.
+3. lm_head -> k64 tile GEMM (~7 ms; needs a ~715 MB transposed twin; also required before any
+   future fused verify).
+
+## 2026-07-27 (late) — SHIPPED: GPU argmax for think_ended. lm_head tile GEMM: REVERTED (CUDA 716)
+
+### `9daec5b9` — admit `think_ended` rows to the GPU argmax fast path. **+2.4% C=16.**
+`--disable-thinking` sets `think_ended = true` for EVERY sequence at birth
+(`prefill_a_step.rs:229` + 3 siblings). The batch-wide gate at `decode_logits_step.rs:76` then
+forced the WHOLE batch onto the host path whenever any row had it — i.e. always. **The GPU
+argmax fast path was unreachable dead code in this benchmark AND in the MLPerf-edge config**,
+so every step paid a 7.95 MB D2H + n full-vocab host passes.
+Such a row needs only `PostCloseThinkMask` = TWO ids. A4's bias floor is gated on
+`inside_thinking` (`sample_step.rs:164`) so it is inert. With request penalties exactly
+neutral the pipeline reduces to the raw argmax modulo those two ids — so: run `argmax_batch`
+(64-byte D2H), and if a returned token lands on a masked id, fall THROUGH and redo the step on
+the host. `THINK_MASK_FALLBACKS` counts those.
+Measured 3 reps/leg, byte-identical: **99.60 -> 102.00 tok/s, sigma 0.26 -> 0.17, disjoint.**
+Kill switch `ATLAS_NO_THINKENDED_GPU_ARGMAX=1`.
+★ TRAP hit while writing it: the first version returned `Vec::new()` from the fall-back arm,
+which emits NO tokens and stalls every sequence. The fast path must yield an `Option` so
+"needs the host pipeline after all" genuinely falls through.
+
+### lm_head -> tile GEMM: BUILT TWICE, FAILED TWICE, REVERTED. ★ NOT a kernel constraint.
+★ CORRECTION to the earlier entry below: I recorded this as "a real constraint inside
+`w4a16_gemm_t_k64` at N=248320". **That was WRONG.** Adding the lm_head shape to
+`w4a16_m17_bench` runs ALL FOUR variants clean at N=248320, M=1..64:
+| kernel | M=16 | achieved | vs floor |
+|---|---|---|---|
+| **`w4a16_gemm_t`** | **3672 us** | **194.8 GB/s (84.7% of ceiling)** | **1.18x** |
+| `w4a16_gemm_t_m128` | 3865 us | 185.0 GB/s | 1.24x |
+| `w4a16_gemm_t_k64` | 4062 us | 176.0 GB/s | 1.31x |
+| `w4a16_gemm` (N64) | 17304 us | 41.3 GB/s | 5.57x |
+| *in-model GEMV today* | *9680 us* | *66 GB/s* | *3.1x* |
+715 MB cannot sit in L2, so 84.7% is honest, not microbench optimism. **~6 ms/step is real
+and available** — the largest remaining prize.
+★ ALSO: the `K >= 4096` k64 threshold picks the WORSE kernel here (`_t` is 10% faster at
+N=248320). That threshold was derived from projection shapes; it does not generalise.
+
+**What is actually known about the fault** (three attempts, three hypotheses eliminated):
+- Fails with `w4a16_gemm_t_k64` AND plain `w4a16_gemm_t` => not kernel-specific.
+- The single-request identity probe PASSES BYTE-IDENTICALLY every time; only CONCURRENCY
+  faults. First error is always decode-side: `argmax_batch: cuMemcpyDtoHAsync_v2 failed:
+  status 716` (CUDA_ERROR_MISALIGNED_ADDRESS, sticky — the memcpy is just the first sync
+  point after the faulting kernel).
+- Dims verified against the checkpoint: `lm_head.weight [248320, 2560]`,
+  `weight_scale [248320, 320]`, K=5120. N = 1940x128 exactly. Twin layout [K/2, N] correct.
+- Alignment RULED OUT: every arena buffer is its own `gpu.alloc()` (`buffers.rs:134-147`),
+  i.e. a separate cuMemAlloc at 256-B alignment. The twin's weight and scale are likewise
+  fresh allocations.
+- The remaining discriminator is that concurrency runs inside the CAPTURED multi-seq CUDA
+  graph and the single request does not.
+**compute-sanitizer HAS NOW BEEN RUN. Result: ZERO invalid memory accesses, and under the
+sanitizer the error changes from 716 (MISALIGNED_ADDRESS) to 719 (LAUNCH_FAILED).** So this
+is NOT an out-of-bounds or misaligned access at all — it is a kernel that fails to launch or
+execute, which memcheck cannot attribute to an address.
+
+SIX hypotheses eliminated, all by measurement:
+1. kernel-specific constraint at N=248320 — NO: all four variants run clean standalone.
+2. wrong dims — NO: verified against the checkpoint (`lm_head.weight [248320, 2560]`,
+   `weight_scale [248320, 320]`, K=5120, N = 1940x128 exactly).
+3. pointer misalignment — NO: every arena buffer is its own `gpu.alloc()`
+   (`buffers.rs:134-147`), i.e. a separate cuMemAlloc at 256-B alignment.
+4. CUDA-graph interaction — NO: faults identically with `ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1`.
+5. unguarded epilogue store overrunning `logits` at M_TILE=64 (48 spare rows x 496,640 B =
+   23.8 MB, which WOULD explain why only the widest N faults) — NO: the store is explicitly
+   guarded, `if (r0 < M && c0 < N)`.
+6. an addressable memory error — NO: memcheck is clean.
+
+★ NEXT TOOL, not next guess: inspect the LAUNCH itself (shared-memory request vs the 48 KB
+default without `cudaFuncSetAttribute`, register/occupancy limits at grid.x=1940, or
+`--tool synccheck`). The wiring has been written THREE times and looked correct each time;
+the defect is in launch configuration or a resource limit, not in the pointers.
+
+### (superseded) original entry
+Motivation was sound and stands: nsys puts lm_head at **9.68 ms/step in ONE launch**, 715 MB at
+**~66 GB/s = 29% of the 230 GB/s ceiling**, the largest non-GEMM kernel in the step. At
+N=248320 the tile GEMM launches ~1940 CTAs, so unlike the narrow-N projections it is
+well-occupied; expected ~5 ms.
+- The transposed twin builds fine: **1.8 s, ~605 MB** (`transpose_for_gemm(gpu, vocab, hidden)`).
+- The single-request identity probe **PASSED** (byte-identical).
+- Concurrent drives died: first error `argmax_batch: cuMemcpyDtoHAsync_v2 failed: status 716`
+  (CUDA_ERROR_MISALIGNED_ADDRESS, sticky — the real fault is the preceding tile GEMM), then
+  cascading 716s from `cuMemsetD8Async` in prefill.
+- Ruled OUT as causes: N=248320 = 1940x128 exactly; K=5120 = 80x64; twin layout [K/2, N]
+  matches what the kernel expects; cuMemAlloc base pointers are 256-B aligned.
+- Therefore this is a real constraint inside `w4a16_gemm_t_k64` at N=248320 (suspect the
+  epilogue's store vectorisation, or a cp.async alignment assumption that holds for the
+  projection shapes but not this one). **Read the kernel's epilogue before retrying.**
+- REVERTED rather than shipped default-off: shipping known-broken code behind a flag is not a
+  compromise, it is a landmine.
+
+### Board after this
+1. split-K on `gridDim.z` (~9 ms) — template `int8_gemm_splitk` at `w4a16_gemm.cu:2533`.
+   NOT bit-identical; pin ksplits to the WEIGHT SHAPE, never runtime concurrency.
+2. lm_head tile GEMM — blocked on the 716 above.
+3. host-leg residue: pin `DECODE_LOGITS_HOST_SCRATCH` (it is a pageable Vec, so the "async"
+   D2H is a staged sync copy), and the two O(output_len) `rposition` scans per seq per step.
+
+## 2026-07-27 (late) — FFN MMQ BLOCK OPENED: under-fill REFUTED, occupancy hint NULL
+
+The FFN (`atlas_nvfp4_mmq16_nc`) is the largest single block: **192 inst/step, 54.3 ms,
+35.5% of GPU time**. Grid is `[div_ceil(N,128), div_ceil(M,16), 1]`, block 256, so at decode
+M=16 `gridDim.y == 1` and gate/up (N=17408) launch **136 CTAs** while down (N=5120) launches
+**40 CTAs on 48 SMs**. That looked like the same under-fill as the projections.
+
+### ★ IT IS NOT. Splitting the 29,661 FFN launches by gridX in the nsys capture:
+| shape | gridX | count | avg | GB/s |
+|---|---|---|---|---|
+| gate/up | 136 | 19,774 | 282.3 us | 167.7 |
+| **down** | **40** | 9,887 | **284.3 us** | 166.6 |
+**Within 0.7%.** Using 40 of 48 SMs costs essentially nothing here — 40 CTAs already saturate
+the memory system. => **stream-K would buy ~nothing at decode**, so the vendored header's
+"prefill shapes have thousands of tiles >> 48 SMs so stream-k buys ~nothing" bypass
+(`fixup=false`) happens to be RIGHT at decode too, for a different reason than it states.
+A complete stream-K path (`mul_mat_q_stream_k_fixup`, `mmq.cuh:3789`, nsm-sized grid,
+`tmp_fixup` partials, and a launcher that picks it below 90% tile efficiency at `:4003`) is
+sitting unused — do NOT integrate it on under-fill grounds; the measurement says no.
+
+### Occupancy hint: NULL, reverted
+Dynamic smem is `4*(mmq_x + pad256(mmq_x*36) + 128*76)` = **41.06 KiB at mmq_x=16**, 43.1 KiB
+at 32, vs 100 KiB/SM on sm_121 — so TWO CTAs fit, yet every Atlas entry carried
+`__launch_bounds__(256, 1)`. Raised the four small-M entries to `(256, 2)` (mmq128 needs
+56.5 KiB and must stay at 1). Measured C=16, 4 reps, byte-identical:
+control 102.4/102.0 (mean 102.20) vs 102.8/102.4/102.5/102.2 (mean 102.48) — **+0.27%, ranges
+OVERLAP, indistinguishable from noise.** REVERTED: unmeasurable benefit, and `mmq32` is a
+PREFILL kernel whose register budget would tighten for an unproven decode gain.
+
+### Verdict on the FFN block
+Uniform **~167 GB/s = ~77% of the 230 GB/s achievable** across all three shapes (counting
+block_nvfp4's real 36 bytes per 64 weights). There is **no structural defect** here — no dead
+capability, no wrong dispatch, no under-fill — unlike every other win this session. Closing
+the remaining ~23% means real inner-loop work inside vendored llama MMQ (dequant/scale ALU
+overlap with the cp.async weight stream), worth ~6.7 ms. That is a genuine project, not a
+dispatch fix, and it is the code path Atlas owns least.
+
+## 2026-07-27 (night) — OVERNIGHT BASELINE + a measurement artifact worth knowing
+
+**Baseline on HEAD (`b0a248f1`), settled GPU, 6 reps, identity sha `bf3a0b07`:**
+`99.8 | 102.8 103.0 102.7 103.0 102.9` => **rep1 is a WARMUP OUTLIER**; steady state is
+**102.88 tok/s, sigma 0.13** over reps 2-6.
+★ Every A/B run today included rep1 in the mean. At ~3% low it is large enough to hide or
+fake a 1% effect. The canonical harness now runs a **discarded warmup drive** before the
+measured reps (`scratchpad/ab_template.sh`).
+
+★ ALSO: a `compute-sanitizer` serve survived its own script's `kill -TERM` and held **74.6 GB**
+for ~20 minutes, starving the next container and producing 500s that looked exactly like "HEAD
+is broken after the reverts". `compute-sanitizer` runs the app under a `TreeLauncherSubreaper`,
+so the TERM went to the wrapper, not the process, while the script printed its DONE marker.
+**Verify with `nvidia-smi --query-compute-apps` — do not trust a script's completion message.**
+
+## 2026-07-28 — k64 THRESHOLD FIX (+3.4%, shipped) · GDN register-resident (REGRESSION, reverted)
+
+### `140be0e6` — k64 threshold 4096 -> 6144. **+3.4% C=16. Biggest single win of the session.**
+★ This fixed a regression I introduced EARLIER THE SAME DAY in `b98ce911`, which lowered the
+threshold to 4096 based on the ffn/out_proj shapes without ever benchmarking K=5120.
+Measured at M=16 on the real decode shapes (230 GB/s denominator):
+| shape | `_t` | `_k64` | `_m128` |
+|---|---|---|---|
+| ssm_qkvz     N=16384 **K=5120** | 281.9 | **341.6 (was selected)** | 272.4 |
+| attn qkv     N=14336 **K=5120** | 273.9 | **328.5 (was selected)** | 262.8 |
+| ssm_out_proj N=5120  **K=6144** | 237.7 | **163.3 (correct)** | 240.7 |
+`_k64` is the WORST variant at K=5120 and the best only at K>=6144. 48 qkvz + 16 fused-qkv
+launches/step were on the slowest kernel available for a full day.
+Measured, 4 reps/leg, warmup discarded, byte-identical:
+OLD 103.4/103.1/102.6 = **103.03** -> NEW 106.7/106.5/106.8/106.1 = **106.53**, disjoint.
+★ RULE: a threshold measured on two shapes does NOT generalise to a third. Added
+`ATLAS_W4A16_K64_MIN_K=<n>` so any A/B can pin a prior threshold exactly.
+★ `_m128` is faster still at K=5120 (272.4 / 262.8) — a further ~0.6 ms is available.
+
+### GDN single-pass register-resident decode: **REGRESSION -11.6%, REVERTED**
+The diagnosis was right: `gated_delta_rule_decode_f32_strided_norm` reads H for `hk_dot` and
+then RE-READS the identical values for the update; at batch 16 the live state is ~49 MB so the
+second read partially misses L2. A standalone prototype holding the H column in registers
+measured **927 -> 542 us (1.71x), byte-identical**.
+**In production it is 11.6% SLOWER end-to-end**: 107.13 -> 94.73 tok/s (4 reps/leg,
+byte-identical, disjoint). GDN is ~29.7 ms of a ~140 ms step, so the kernel roughly DOUBLED.
+Cause: `hreg[128]` (512 B/thread) spills to local memory. The production kernel carries far
+more register pressure than the prototype — the Frobenius norm clamp, the two-stage RMS
+reduction, and the packed-BF16 epilogue all live in the same function — so it spills where the
+isolated version did not.
+★ LESSON: an isolated kernel prototype does NOT transfer to a kernel with a larger epilogue.
+Register-residency wins are contingent on the WHOLE function's register budget, not the loop
+being optimised. Retry only with the epilogue split into a second kernel (so the hot loop's
+budget is its own), or with a smaller tile (e.g. hreg[64] and two passes over half-columns).
+
+## 2026-07-28 (night) — ★ THE NEXT LEVER, FULLY SPECIFIED: out_proj/o_proj -> NVFP4 MMQ
+
+### Per-shape truth (nsys of HEAD, split by gridX — do NOT reason from blended averages)
+| kernel | gridX | shape | avg | **GB/s** |
+|---|---|---|---|---|
+| `w4a16_gemm_t` | 128 | ssm_qkvz N=16384 K=5120 | 311.6 us | **151.4** |
+| `w4a16_gemm_t` | 112 | attn qkv fused N=14336 K=5120 | 296.5 us | **139.2** |
+| **`w4a16_gemm_t_k64`** | **40** | **out_proj / o_proj N=5120 K=6144** | 210.7 us | **84.0** |
+| `atlas_nvfp4_mmq16_nc` | 40 | ffn_down N=5120 K=17408 | 285.5 us | **175.6** |
+| `atlas_nvfp4_mmq16_nc` | 136 | ffn gate/up N=17408 K=5120 | 289.5 us | **173.2** |
+
+★ A blended "projections run at 102 GB/s" figure is WRONG and cost an agent-hour: qkvz and
+fused-qkv are already efficient (151/139). **The entire projection deficit is out_proj/o_proj
+at 84 GB/s.**
+★ MMQ hits ~174 GB/s at gridX=40 AND gridX=136, and at K=5120 AND K=17408 — so there is no
+shallow-K cliff between those endpoints and **out_proj's K=6144 should transfer**. That is
+2.09x `_k64` at the SAME 40-CTA occupancy, i.e. the gap is the KERNEL, not the tiling.
+
+### Prize: 64 launches x 210.7 us = 13.5 ms/step -> ~6.5 ms at 174 GB/s
+Minus 64 activation-quantize launches (~0.75 ms) and 64 `nvfp4_scale_bf16` launches
+(~0.75 ms) => **~5.4 ms net, ~+3.8%**. Roughly 4x split-K's honest prize (1.3-1.5 ms) for the
+identical shapes.
+
+### Implementation (NO SSM MMQ plumbing exists today — grep confirms zero hits)
+Mirror `dense_ffn.rs`: handles (`nvfp4_mmq16_nc/_wc`, `nvfp4_quant_act`, `nvfp4_repack`,
+`nvfp4_scale`) -> repacked twin via `ops::nvfp4_mmq_repack` (ops/nvfp4_mmq.rs:56) ->
+`ops::nvfp4_mmq_quantize_act` (:80) -> `ops::nvfp4_mmq_gemm_tiled` (:147, tile=16 at m<=16)
+-> `ops::nvfp4_scale_bf16` (:222) for the scale2 fold (the GEMM output is documented
+"missing x scale2" at :103).
+★ HAZARD: the repack MUST be eager at LOAD time, before KV sizing and before CUDA-graph
+capture — the FFN does exactly this in `finalize_nvfp4_mmq_load` (dense_ffn.rs:445). A lazy
+OnceCell repack inside the decode path would allocate during graph capture.
+★ VRAM: out_proj twin is 17.7 MB x 48 + 17.7 x 16 = **1.13 GB**. Unlike the FFN, the `_t`
+copy CANNOT be freed — it is still the SSM prefill path (`ssm_batched.rs:17-19`).
+Constraints all pass: N=5120 %128, K=6144 %64, m=16 <= mmq_x=16.
+
+### ★ ACCURACY ORDERING IS THE INVERSE OF THE OBVIOUS ONE
+MMQ is **W4A4** (activations quantized to FP4).
+- **out_proj / o_proj = LOW risk.** Their input is the post-GDN gated-norm output, so the
+  error is feed-forward-shaped and does not re-enter the recurrence. THIS is the one to build.
+- **qkvz = HIGH risk. DO NOT convert.** It feeds conv1d -> the FP32 GDN recurrent state, where
+  per-token error persists across the sequence. No cosine measurement for SSM-projection W4A4
+  exists anywhere in the repo; dense_ffn's down-proj 0.9961 does NOT transfer. Memory records
+  FP16 h_state causing ~25% trajectory divergence, so the recurrence is precision-sensitive.
+- Debt is UNDISCHARGEABLE while [[feedback_no_accuracy_gate_until_vllm_parity]] stands, and it
+  STACKS on the existing `ATLAS_SSM_TC_PROJ` W4A8 debt (ssm_batched.rs:28-32 already records
+  "a BFCL gate is owed before this merges").
+
+### Also unexplained, worth 1.4 ms: 11.3 extra `w4a16_gemm_t` launches/step
+The capture shows `w4a16_gemm_t` at gridX=8 (N=1024, 512 inst) and gridX=96 (N=12288, 256
+inst) — i.e. the fused-qkv path splitting back into separate q/k/v launches during ramp/drain
+when n<=8 (the `n > 8` gate from `2db1b349`). ~1.44 ms/step. Lowering that gate is NOT safe
+(see the gate's comment), but batching the n<=8 case differently might be.
+
+### `_m128` for qkvz: NULL, reverted (and rebuilt)
+The bench ranks `_m128` fastest at K=5120 (272.4 us vs `_t` 281.9 / `_k64` 341.6 at M=16), and
+it affects the 48 qkvz launches/step. But qkvz is only ~14.9 ms of a ~140 ms step, so a 3.4%
+kernel gain is ~0.36% e2e — below what the harness resolves.
+Measured 4 reps/leg, warmup discarded, byte-identical:
+OLD 106.1/106.9/106.4/106.5 = **106.48** vs NEW 106.3/106.8/106.7/106.6 = **106.60**.
++0.11%, ranges fully OVERLAP => NULL. Reverted **and rebuilt** (a `git checkout` alone leaves
+the old binary in place — that bit me earlier tonight with the GDN kernel).
+★ RULE OF THUMB now calibrated: this harness resolves ~>=0.8% reliably. A kernel-level gain
+only matters if (kernel share of step) x (kernel gain) clears that. qkvz is 10.6% of the step,
+so it needs a >7% kernel win to be worth measuring at all.
+
+### Fused q/k/v at ALL n (removing the `n > 8` gate): NULL on this benchmark, reverted
+The gate exists only because `wide_verify_gemm` early-returns on its GEMV arms for m<=8 and
+ignores `w_t`; calling `ops::w4a16_gemm_n128` DIRECTLY removes the need for it. The work
+reduction is real — nsys prices the split path at 279 us (q, gridX 96) + 218.5 + 218.5 (k/v,
+gridX 8) = **716 us vs ~273 us fused**.
+Measured 4 reps/leg, byte-identical, control pinned via a new `ATLAS_FUSED_QKV_MIN_N=9`:
+OLD **106.60** vs NEW **106.45** => -0.14%, ranges OVERLAP. NULL, reverted and rebuilt.
+★ WHY, and the sizing error to avoid repeating: I derived "~1.4 ms/step" by dividing 1024
+split-path instances by ~175 steps. Those instances are NOT spread across steps — they are
+concentrated in the brief ramp/drain tail, because `prof_drive` fires all 16 requests at once
+with identical `max_tokens`, so n stays 16 for nearly the whole run.
+**An "instances over the run / total steps" average is meaningless when the instances are
+concentrated in a few steps.** Check the step DISTRIBUTION before sizing.
+★ Worth revisiting under STAGGERED arrivals (real serving), where small-n steps are common —
+the change is strictly less work and byte-identical. It needs a benchmark with arrival jitter,
+which `prof_drive` does not model.
+
+### GDN register retention, attempt 2 (HALF-width, `hreg[64]`): -4.6%, reverted
+Better than full-width's -11.6% but still a regression: **106.68 -> 101.78 tok/s**, 4 reps/leg,
+byte-identical, disjoint.
+★ ROOT CAUSE IS AN IMPLEMENTATION ERROR, NOT THE IDEA. Pass 2 was left as
+`#pragma unroll 4` over `j < k_dim` (a RUNTIME bound) and indexes `hreg[j]` — a dynamic index,
+so `hreg` is placed in LOCAL memory. The conditional
+`(j + 0 < GDN_HALF_KD) ? hreg[j + 0] : H[...]` guarantees it. I avoided this trap in pass 1
+(full `#pragma unroll` over a compile-time bound) and then reintroduced it in pass 2.
+
+**The correct shape, for whoever retries:**
+```
+// pass 2a — retained half, FULLY unrolled, static indices
+#pragma unroll
+for (unsigned int j = 0; j < GDN_HALF_KD; j += 4) { h0 = hreg[j+0]; ... }
+// pass 2b — remainder, re-read from H
+#pragma unroll 4
+for (unsigned int j = GDN_HALF_KD; j < k_dim; j += 4) { h0 = H[(j+0)*v_dim + tid]; ... }
+```
+Both loops must write H and accumulate `q_dot`/`norm_acc` in ascending j so the summation order
+matches the original exactly (the Frobenius comment in the production kernel already relies on
+this for bit-identity).
+
+### ★ GDN REGISTER RETENTION: 3 attempts, all regressions. Do not retry without the above.
+| attempt | shape | e2e | mechanism |
+|---|---|---|---|
+| full-width `hreg[128]` | 512 B/thread | **-11.6%** | spills; budget shared with Frobenius clamp + RMS reduction + packed-BF16 epilogue |
+| half-width `hreg[64]` | 256 B/thread | **-4.6%** | pass 2 dynamic index -> local memory |
+| (standalone prototype) | 512 B/thread | *+71%* | carried NONE of the epilogue |
+★ The prototype's 1.71x is real and irrelevant: it measured a loop, not the function. Any
+retry should FIRST split the epilogue (Frobenius clamp + RMS reduction + BF16 pack) into a
+second kernel so the hot loop owns its register budget, THEN retain.
+
+## 2026-07-28 (night) — ★★ GDN HALF-WIDTH REGISTER RETENTION: +5.4%, SHIPPED (`5aada944`)
+
+`gated_delta_rule_decode_f32_strided_norm` reads all of H for `hk_dot` then RE-READS it for
+the update: 2R+1W over the state each step. At batch 16 the live state is ~49 MB, past L2, so
+the second read partially reaches DRAM. Retaining the first 64 H columns makes it 1.5R+1W.
+
+**Measured 4 reps/leg, warmup discarded, byte-identical, disjoint:**
+OLD 107.1/106.9/106.2/106.5 = **106.68** -> NEW 112.8/112.0/112.4/112.7 = **112.48**. **+5.4%.**
+
+### ★ THREE ATTEMPTS — the failures were REGISTER BUDGET, not the idea
+| # | config | e2e | cause |
+|---|---|---|---|
+| 1 | `hreg[128]`, 512 B/thread, static indices | **-11.6%** | genuine spill — budget shared with the Frobenius clamp, the two-stage RMS reduction and the packed-BF16 epilogue |
+| 2 | `hreg[64]`, 256 B/thread, RUNTIME index in pass 2 | **-4.6%** | dynamic index puts `hreg` in LOCAL memory |
+| **3** | **`hreg[64]`, 256 B/thread, static throughout** | **+5.4%** | fits |
+★ I nearly stopped after #2, having written "register retention in this kernel is closed".
+What rescued it was re-reading my own summary and finding an error in it: I had blamed #1 on
+dynamic indexing, but #1 was ALREADY static. That left half-width + static as the one untested
+cell — and it was the winner. **Check your own postmortem before you accept its conclusion.**
+
+### Sweet spot is 64 — 96 buys nothing
+KD=96 (384 B/thread, 1.25R+1W = 25% traffic cut vs 64's 17%) measured **112.45** against the
+same two-pass control, i.e. IDENTICAL to KD=64's 112.48. The extra retention is exactly offset
+by register pressure. Do not chase larger tiles.
+
+### The required code shape
+```
+// pass 1: retain first GDN_HALF_KD (full unroll, compile-time bound), stream the rest
+// pass 2a: retained half from hreg — #pragma unroll, STATIC indices
+// pass 2b: remainder — re-read from H
+```
+Ascending j across both pass-2 loops keeps the `q_dot`/`norm_acc` summation order identical, so
+the Frobenius bit-identity argument in the two-pass kernel still holds.
+★ The standalone prototype of the FULL-width variant measured 1.71x on the loop alone and
+still lost 11.6% in production. **Size register-retention changes against the WHOLE function's
+budget, never the loop being optimised.**
+
+### ★ out_proj -> MMQ has a VRAM BLOCKER at the benchmark's util (checked before building)
+The repacked block_nvfp4 twin is 17.7 MB x 48 layers = **850 MB**, and unlike the FFN the `_t`
+copy CANNOT be freed (SSM prefill still uses it, `ssm_batched.rs:17-19`).
+Arithmetic against the observed pool: KV is 4735 blocks (4.6 GB, 65536 B/block); batch 16 at
+`--max-seq-len 4096` needs 256 blocks/seq x 16 = **4096**. 850 MB is ~875 blocks, leaving
+~3860 — **below the requirement**, so the serve fails to build with
+"KV cache can hold at most 15 concurrent sequence(s)".
+=> The lever needs `--gpu-memory-utilization >= 0.75`, i.e. a BENCHMARK CONFIG CHANGE. Do not
+fold it in silently alongside a throughput claim; measure the config change separately first.
+Options: (a) raise util and re-baseline everything, (b) convert only attn o_proj (16 layers,
+283 MB — fits) for ~1.4 ms, (c) make the SSM prefill path use the MMQ weight too so the `_t`
+copy can be freed, which is the FFN's own solution (`finalize_nvfp4_mmq_load`, dense_ffn.rs:445).
+(c) is the right long-term shape and removes the VRAM cost entirely.
+
+### Post-GDN-win budget (nsys, 160 steps, C=16 at 112.5 tok/s)
+| block | ms/step | share | state |
+|---|---|---|---|
+| FFN `mmq16` | 55.2 | 42% | ~174 GB/s, NO structural defect — vendored inner-loop work |
+| projections `_t` (qkvz, fused qkv) | 22.9 | 17% | 139-151 GB/s, near floor |
+| GDN `_half` | 22.1 | 17% | **1.18x floor — DONE** |
+| projections `_k64` (out_proj, o_proj) | 13.8 | 10% | **84 GB/s** — the MMQ lever, VRAM-blocked above |
+| lm_head | 9.7 | 7% | 29% of achievable — launch failure, 6 hypotheses dead, memcheck clean |
+
+## 2026-07-28 (night) — ★ PREFIX CACHING IS A NET LOSS AT SHORT PROMPTS (−7% at C=1)
+
+Every C-sweep tonight showed C=1 drifting DOWN within a run (25.4 -> 23.6 -> 23.6 and then
+flat). Cause isolated with a direct A/B, 5 reps each, same binary, only `--enable-prefix-caching`
+differing:
+
+```
+prefix caching ON  : 25.4  25.4  23.6  23.6  23.6   <- degrades once the cache warms
+prefix caching OFF : 25.3  25.3  25.3  25.3  25.2   <- flat
+```
+
+**A warm prefix-cache hit costs ~0.5 s per request** here (7.6 s -> 8.1 s for a 192-token
+generation off a **26-token** prompt). Steady-state C=1 is **25.3 with caching OFF vs 23.6 with
+it ON — prefix caching is costing 7%.**
+
+### Why: no minimum-match threshold
+`prefill_a.rs:170-215` takes the snapshot-restore path on ANY match. Blocks are 16 tokens, so a
+26-token prompt matches ~1 block: it restores GDN state (3 MB x 48 layers) to avoid recomputing
+**16 tokens** of prefill. For SSM models a hit WITHOUT a usable snapshot is even worse — it
+forces `kv_write_start = 0` (full KV rewrite), so the lookup cost is paid for zero benefit.
+Same mechanism as the recorded 9-20 s snapshot-miss spikes, at small scale.
+
+### Scope / caveats before anyone "fixes" this by disabling caching
+- This benchmark uses 26-token prompts. With LONG shared prefixes the cache is surely a win —
+  the defect is the ABSENCE OF A THRESHOLD, not the feature.
+- **C=16 shows NO drift** (112.0/112.9/112.7 across reps), so the cost is hidden or amortised
+  at concurrency. It is a low-C effect on this workload.
+- MLPerf-edge runs WITH prefix caching and short-ish prompts — worth measuring there before
+  assuming the golden config is unaffected.
+
+### Suggested fix (unbuilt)
+Gate the snapshot-restore path on matched-prefix length: take it only when the tokens saved
+exceed the restore cost. Needs the restore cost measured per layer-count first — the ~0.5 s
+observed here is far above the naive 144 MB / 215 GB/s = 0.67 ms, so **something other than raw
+state bandwidth dominates it** and should be profiled before a threshold is chosen.
+
+### Prefix-cache penalty: the two hit types differ, and it is NOT the state copy
+Serve log at C=1, consecutive reps:
+```
+rep2  "Prefix cache hit: 16 tokens (1 blocks) but no SSM snapshot"  -> 24.9 tok/s  FAST
+rep3  "Marconi SSM cache hit: 26 tokens skipped (2 blocks)"         -> 23.1 tok/s  SLOW
+```
+**The slow path is exactly the one that USES the snapshot to skip prefill.** Skipping 26 tokens
+of work makes the request 0.6 s SLOWER.
+
+nsys of that run (3 reps, ~24 s) rules out the copy:
+- memcpy **375 ms total** (93,376 copies, 28.7 GB) — nowhere near 0.6 s/request
+- memset 33.7 ms
+- dominated instead by `w4a16_gemv_batch4` (66,051 launches, 13.7 s) = the MTP verify path
+=> The penalty is NOT snapshot-restore bandwidth. The most likely mechanism is DOWNSTREAM:
+spec-decode throughput is trajectory-dependent ([[reference_spec_decode_tokps_is_trajectory_dependent]]),
+so resuming from a restored state can change draft acceptance and therefore verify cost.
+★ NEXT STEP is an acceptance measurement, not a copy optimisation: run the same C=1 reps with
+`k4_record_positional` and compare mean-accepted on snapshot-hit vs cold reps. If acceptance
+drops after a restore, the fix is in the drafter/state handoff, not in the cache.
+★ Do NOT "fix" this by adding a size threshold until that is checked — a threshold would hide
+the symptom while leaving a spec-decode state-handoff bug in place.
+
+### ★★ ROOT CAUSE: a snapshot restore degrades MTP DRAFT ACCEPTANCE (not the cache, not the copy)
+C=1, prefix caching on, 4 consecutive reps, hit type from the serve log:
+| rep | hit type | tok/s |
+|---|---|---|
+| 1 | cold | **25.3** |
+| 2 | `Prefix cache hit: 16 tokens` (KV-only, NO snapshot) | **25.3** |
+| 3 | `Marconi SSM cache hit: 26 tokens` (**snapshot used**) | **23.6** |
+| 4 | `Marconi SSM cache hit: 26 tokens` | 23.5 |
+
+`k4_record_outcome` summaries, chronological:
+```
+mean accepted = 1.45, 1.52   <- cold / KV-only reps
+mean accepted = 1.33         <- after snapshot restore
+```
+**Acceptance falls ~10%** (1.485 -> 1.33) => epsilon 2.485 -> 2.33 => **-6.2% predicted**.
+Measured **-6.7%**. The acceptance drop accounts for essentially the whole penalty.
+
+=> The defect is a STATE-HANDOFF GAP: the main model resumes warm from the restored SSM
+state, but the MTP drafter does not — it effectively starts cold, drafts worse, and the extra
+rejected drafts cost more than the skipped prefill saved. Ruled out along the way: the state
+copy (memcpy is 375 ms across a 24 s capture) and the prefill skip itself (the KV-only hit,
+which skips less work, is FAST).
+
+**Where to look:** the drafter consumes hidden states saved during decode
+(`save_hidden_for_mtp`, `trait_impl/speculative.rs`). A snapshot restore reinstates SSM
+h_state/conv_state but there is no corresponding restore of the drafter's hidden history, so
+the first drafts after a resume are made from a cold proposer.
+**Fix shapes:** (a) include the drafter's hidden state in the Marconi snapshot, (b) suppress
+MTP for the first few steps after a restore so a cold proposer does not waste verify slots, or
+(c) warm the proposer from the restored state before drafting.
+★ Do NOT paper over this with a minimum-prefix-size threshold — that hides the symptom on
+short prompts while leaving the handoff bug live for every long-prefix resume, which is
+exactly where prefix caching is supposed to pay.
+
+### ★★★ EXACT LOCATION: `speculative.rs:194` — the snapshot restore disables the drafter prefill
+```rust
+let cold_prefill_ok = p >= 2 && captured >= p && seq_tokens.len() >= p;
+```
+`captured` is `mtp_prefill_capture_len`: positions whose hidden states were captured DURING THE
+MAIN MODEL'S PREFILL. A Marconi snapshot restore SKIPS that prefill, so nothing is captured,
+`captured >= p` is false, `cold_prefill_ok` is false, and **`prefill_drafter` never runs**. If
+the cross-turn carry (`ATLAS_MTP_CARRY_DRAFTER`) does not also apply, the proposer starts empty.
+
+**Complete causal chain, every link measured:**
+snapshot restore -> prefill skipped -> hidden-state capture skipped -> drafter prefill disabled
+(`speculative.rs:194`) -> cold proposer -> mean accepted 1.485 -> 1.33 (-10%) -> epsilon 2.485
+-> 2.33 -> **-6.2% predicted / -6.7% measured**.
+
+**Correct fix: extend the Marconi snapshot to cover the DRAFTER state**, so a resume restores
+the proposer alongside the SSM h_state/conv_state. The drafter is ONE layer against the model's
+64, so the alternative — replaying only the drafter over the skipped prefix — is also cheap
+(~1.5% of a full prefill) and needs no snapshot-format change. Either removes the penalty
+without giving up the prefill saving.
+Rejected: a minimum-prefix-size threshold. It hides the symptom on short prompts and leaves
+the handoff broken for long-prefix resumes, which is exactly where prefix caching should pay
+and where the lost prefill is largest.
+★ This also means the cross-turn carry path (`try_carry_drafter`) is what keeps multi-turn
+conversations fast; single-turn resumes off a cold cache get no drafter state at all.
+
+### ★ CORRECTION to the fix options above: "replay just the drafter" DOES NOT WORK
+`prefill_drafter(prompt_tokens, hiddens, ...)` (`speculative.rs:362`,
+`mtp_head/draft_proposer.rs:86`) consumes `hiddens` = `mtp_prefill_hidden`, the MAIN MODEL's
+per-position hidden states captured during ITS prefill. After a Marconi restore those were
+never computed, so there is nothing to feed the drafter. The drafter cannot be replayed
+independently — it is a function of the target's hidden states, not of the tokens.
+
+**So there are exactly two viable fixes:**
+1. **Extend the Marconi snapshot to carry the drafter's own state** (its KV rows / proposer
+   state), so a resume restores target AND drafter together. Correct, and preserves the whole
+   prefill saving. Snapshot-format change.
+2. **Capture hidden states for the skipped span anyway** — i.e. do not skip the target prefill
+   when MTP is active and the drafter would be left cold. This gives up the prefill saving,
+   which is the thing the cache exists to provide, so it is only sensible as a stopgap.
+Option 1 is the real fix. (An earlier note here suggested a cheap drafter-only replay; that was
+wrong and is retracted.)
+
+### ★ THE PENALTY PEAKS AT C=2 (-9.2%) AND VANISHES BY C=4 — the scoreboard understates low-C
+Same binary, 3 reps/point after a discarded warmup, only `--enable-prefix-caching` differing:
+| C | caching ON | caching OFF | cost | corrected ratio vs vLLM |
+|---|---|---|---|---|
+| 1 | 23.6 | **25.2** | **-6.8%** | 25.2 / 14.2 = **1.77x WIN** |
+| 2 | 23.05 | **25.17** | **-9.2%** | 25.2 / 27.8 = **0.91x** (reported 0.85x) |
+| 4 | 48.4 | 48.07 | -0.7% (noise) | 0.90x |
+=> **C=2, the weakest cell in the sweep, is ~half explained by this bug rather than by an
+architectural gap.** Fixing the drafter snapshot should move C=1 and C=2 up ~7-9% with no
+kernel work at all.
+★ Do NOT respond by disabling prefix caching. It is inert at C>=4 here and REQUIRED for real
+multi-turn workloads with long shared prefixes; the defect is the cold drafter after a resume
+(`speculative.rs:194`), not the cache.
+★ Every headline number in this campaign was measured at C=16 WITH caching on, where the
+penalty does not appear (no within-run drift at C=16), so the shipped wins are unaffected.
+
+### ★★ CORRECTION: the defect is KNOWN, and my "reject the threshold" advice above was WRONG
+`crates/spark-model/src/model/mtp_carry.rs` documents this exact mechanism from a prior
+session: on a warm turn `mtp_prefill_capture_len` stays 0, the `captured >= prompt_len` guard
+fails, `prefill_drafter` is skipped and the drafter starts EMPTY — measured there at
+**"+10% accepted tokens per verify step"**, matching tonight's -10% acceptance measured
+independently via throughput drift -> A/B -> k4 stats -> `speculative.rs:194`.
+It also PRE-REFUTES the obvious remedy with numbers: a full warm-turn `prefill_drafter` costs
+**1136 ms** against a **1134 ms** warm TTFT — it doubles TTFT to buy ~10% of decode, a
+wall-clock LOSS. Do not propose the rebuild.
+
+**What is NEW tonight is the SCOPE.** The shipped fix (`ATLAS_MTP_CARRY_DRAFTER`, on by
+default) carries the drafter's KV across turns OF THE SAME SESSION, and its premise is that
+"a turn's prompt is a strict extension of the previous turn's full sequence". That covers
+multi-turn resumes. It does NOT cover a **preamble-only hit**: a fresh request matching the
+shared chat-template prefix of a DIFFERENT conversation. There is no previous turn to carry
+from, so carry cannot fire and the drafter is cold. That is precisely what `prof_drive`
+produces, and it costs **-6.8% at C=1 and -9.2% at C=2** (inert by C=4).
+
+### => The size threshold I rejected earlier IS the right fix here. That rejection was wrong.
+- long-prefix hit that is a turn extension -> carry fires -> drafter warm -> NO penalty
+- short preamble-only hit -> carry cannot fire -> drafter cold -> penalty, while the prefill
+  saved is only ~16-26 tokens (~30 ms) against 0.5-1.7 s of lost acceptance
+So gating the Marconi skip on matched-prefix length does not hide a handoff bug for long
+prefixes — **carry already handles those** — it declines a trade that is measurably bad.
+**Proposed rule:** take the Marconi SSM skip only when the carry will fire (same session,
+strict extension) OR the matched prefix is long enough that the saved prefill exceeds the
+acceptance cost. Calibrate the threshold from the two measured points (26 tokens => -7 to -9%;
+inert at C>=4) before choosing a constant; do not guess it.
+
+### ★★ CALIBRATION: the crossover is between ~32 and ~629 MATCHED tokens
+Identical prompt each rep (so reps 2-3 are FULL-prompt hits), C=1, 128 max tokens:
+| prompt tokens | caching ON (warm reps) | caching OFF | delta |
+|---|---|---|---|
+| 35 | 24.8 | 24.87 | **-0.3%** (neutral) |
+| 629 | 21.85 | 20.4 | **+7.1%** |
+| 2709 | 21.55 | 15.6 | **+38%** |
+(Cold rep-1 with caching ON matches the OFF number exactly at every size — 18.9 vs 20.4 and
+15.6 vs 15.6 — confirming the benefit is entirely in the warm reps.)
+
+**Reconciles with the -6.8%/-9.2% measured earlier:** that used `prof_drive`, whose prompts
+DIFFER per rep, so the hit covered only the ~16-26-token shared chat-template preamble — a
+negligible prefill saving bought with a cold drafter. When the hit covers a real prefix the
+saving dominates and prefix caching wins decisively.
+
+=> **The threshold rule is sound and now bracketed by measurement: gate the Marconi SSM skip
+on MATCHED-prefix length, crossover between 32 and 629 tokens.** A conservative 256 sits
+inside the bracket; narrowing it further needs points at ~128/256/384 (~15 min of the same
+harness). Do NOT set it from the prompt length — set it from the MATCHED length, which is what
+determines both the saving and whether carry can fire.
+★ This also means the headline C=1/C=2 sweep numbers are pessimistic for real workloads:
+`prof_drive`'s per-rep prompt variation produces the worst case (preamble-only hits). Real
+multi-turn traffic hits long prefixes, where caching is worth +7% to +38%.
+
+### ★★★ CROSSOVER NARROWED: between ~99 and ~219 matched tokens => **threshold 256**
+Identical-prompt reps (full-prompt hits), C=1, warm reps vs caching-off:
+| matched tokens | ON (warm) | OFF | delta |
+|---|---|---|---|
+| 99 | 23.85 | 26.4 | **-9.7%** LOSS |
+| **219** | **24.15** | 22.0 | **+9.8%** WIN |
+| 349 | 23.55 | 21.9 | +7.5% |
+| 629 | 22.45 | 20.3 | +10.6% |
+Sharp crossover, not gradual. **Recommended constant: 256 matched tokens** — inside the
+measured win region, comfortably above the 99-token loss point, and block-aligned
+(16 x 16-token blocks).
+
+**The fix, now fully specified:** gate the Marconi SSM skip on `matched_tokens >= 256`. Below
+that, take the KV-only path (which measured FAST — it is the snapshot restore that costs, not
+the cache) so the drafter keeps its prefill and acceptance stays high. Expected: +6.8% at C=1
+and +9.2% at C=2 on preamble-only traffic, with the +7-38% long-prefix win untouched.
+
+Caveat on the data: output lengths differ between ON/OFF at some sizes (62 vs 78, 128 vs 92)
+because a restored state changes the greedy trajectory — the known spec-decode trajectory
+dependence. tok/s is a RATE so the comparison holds, but do not compare wall times directly.
+
+## 2026-07-28 — ★★ SHIPPED `7ba11dc5`: Marconi skip floored at 256 matched tokens
+**C=1 23.65 -> 25.27 (+6.9%, predicted +6.8%) · C=2 23.10 -> 25.30 (+9.5%, predicted +9.2%) ·
+C=16 112.6 -> 112.37 (unchanged, as expected).** C=1 is now STABLE across reps
+(25.3/25.3/25.2) — the within-run drift present in every sweep tonight is gone.
+
+★ NOT byte-identical, deliberately: short-match hits now take the KV-only path instead of
+restoring a snapshot, which changes the greedy trajectory. The new path is the one that
+matches full recompute, so it is the more faithful of the two.
+`ATLAS_MARCONI_MIN_TOKENS=<n>` overrides; 0 restores always-restore.
+
+### ★ BEFORE THE NEXT MLPerf-edge RUN: check this interacts as expected
+MLPerf-edge runs WITH prefix caching, and `mtp_carry.rs` records **987 of 1007 scored samples
+are WARM turns**. Those are turn extensions with long prefixes, so they sit above the 256-token
+floor and keep the snapshot skip — the expected impact is nil-to-positive. But:
+- any turn whose MATCHED prefix is < 256 now recomputes it (a little more TTFT) in exchange
+  for a warm drafter (better acceptance). Given the recorded wall split (decode 59.6% /
+  fixed TTFT 21.1% / marginal prefill 18.8%), that trade should be net-positive, but it is
+  UNMEASURED on the golden workload.
+- the golden leg runs `target_concurrency=1`, which is exactly where this fix is largest
+  (+6.9%), so the MLPerf wall may move more than the C=16 number suggests.
+**Measure the golden leg before folding this into a submission**, and quote the harness, not
+the serve log.
+
+### Final scoreboard (3 reps/point, warmup discarded)
+| C | start | end | vLLM | ratio |
+|---|---|---|---|---|
+| 1 | 27.4 | 25.3 | 14.2 | **1.78x WIN** |
+| 2 | 21.3 | 25.3 | 27.8 | 0.85x -> **0.91x** |
+| 4 | 38.6 | 48.7 | 53.3 | 0.91x |
+| 8 | 55.4 | 70.7 | 98.8 | 0.72x |
+| 16 | 59.9 | **112.4** | 168.9 | 0.35x -> **0.67x** |
+
+## 2026-07-28 — ★ ROLLBACK VERIFIED, and the accounting closes exactly
+All seven kill switches engaged simultaneously (`ATLAS_NO_W4A16_K64=1`,
+`ATLAS_NO_ATTN_BATCH_CACHE_WRITE=1`, `ATLAS_NO_FUSED_QKV=1`,
+`ATLAS_NO_THINKENDED_GPU_ARGMAX=1`, `ATLAS_NO_ARGMAX_BATCH=1`, `ATLAS_NO_GDN_HALF_REG=1`,
+`ATLAS_MARCONI_MIN_TOKENS=0`):
+```
+ALL WINS ON   112.6 tok/s   sha bf3a0b07...   coherent
+ALL OFF        95.4 tok/s   sha bf3a0b07...   coherent
+```
+1. **The escape hatch works.** All switches fire together without conflict; one env block
+   restores pre-session behaviour with no rebuild and no revert.
+2. **The wins compose to +18% jointly** (95.4 -> 112.6), measured together rather than summed
+   from individual A/Bs — they neither cancel nor double-count.
+3. **Byte-identical across the full rollback** (same sha both ways), as expected: seven wins
+   are bit-exact and the eighth (the Marconi floor) only diverges on a SHORT-MATCH prompt,
+   which this probe is not.
+4. **95.4 ~= the 95.9 this session started from**, so the decomposition is exact:
+   - campaign start -> session start: 59.9 -> 95.9 (+60%, earlier phases)
+   - **this session: 95.9 -> 112.2 (+17%)**
+   - campaign total: **59.9 -> 112.2 (+87%)**
+
+## 2026-07-28 — SYSTEMATIC SWEEP for the campaign's dominant pattern (dead kernel handles)
+Seven of the eight wins were "a capability exists and the dispatch never reaches it", all found
+by accident. Mechanical sweep: every `*_k: KernelHandle` struct field vs. any `self.<field>`
+read outside init/mod. **294 handles declared; 38 with no dispatch site.** Most are legitimately
+inert (MoE handles on a dense model, MLA/prefill variants, LoRA). The notable ones:
+
+| handle | verdict |
+|---|---|
+| `fused_k_norm_rope_cache_write_bf16_k` | REAL dead capability — see below |
+| `gemm_splitk_partial_k` / `gemm_splitk_reduce_k` | the BF16 split-K toy; already recorded dead |
+| `moe_*` (8 handles) | inert — dense model |
+| `mla_*`, `prefill_attn_*` | inert — other attention regimes |
+
+### `fused_k_norm_rope_cache_write_bf16`: real, batched, never dispatched in decode — but only 0.3%
+`kernels/gb10/common/fused_k_norm_rope_cache.cu:53`. Fuses K-side RMSNorm + RoPE + paged cache
+write, grid `(num_tokens, num_kv_heads)` so it is BATCHED OVER TOKENS. Loaded at
+`qwen3_attention/init.rs:223`; the only dispatch is the **mrope** variant in
+`qwen3_attention/prefill/paged.rs:450`. Decode never uses it.
+**Sized before building:** per layer at n=16 decode issues 16 q-norms + 16 k-norms + 16 ropes
++ 1 (already-batched) cache write. The fused kernel covers only K, so it removes 256 k-norm
+launches/step at ~1.5 us = **~0.4 ms = ~0.3%** — Q still needs per-sequence norm and rope, and
+strided Q variants do not exist. **Below the harness's measured ~0.8% resolution floor; not
+worth an A/B alone.**
+★ It becomes worthwhile only as part of collapsing the WHOLE attention fan-out (rope 1.2 ms +
+rms_norm 0.8 ms/step), which additionally needs strided q-norm and q-rope kernels. That bundle
+is ~1.5 ms (~1.1%) and is the right shape for a future session.
+
+## 2026-07-28 — SHIPPED: attention per-sequence fan-out collapsed (rope +0.87%, q/k-norm sub-floor)
+
+A mechanical sweep of decode paths for `for _ in 0..n` loops containing kernel launches found 17
+sites. Profiling separated per-LAYER fan-out (~70/step = 64 layers, expected) from genuinely
+per-SEQUENCE fan-out, which is the wasteful kind:
+
+| kernel | instances/step | ms/step | after |
+|---|---|---|---|
+| `rope_forward` | 258 (16 layers x 16 seqs) | 1.18 | 16 |
+| `rms_norm` (q_norm + k_norm) | 516 (16 x 16 x 2) | 0.76 | 32 |
+| **total** | **774** | **1.94 (~1.5%)** | **48** |
+
+Both needed a row-stride parameter: after the fused QKV GEMM, q/k rows sit `per_seq_qkv` apart
+inside each sequence's interleaved [Q|K|V|gate] block, NOT packed at `num_*_heads*head_dim` as the
+packed kernels assume. Same shape as the strided cache-write that already shipped.
+
+- `rope_forward_strided` (kernels/gb10/common/rope.cu) — explicit q_row_stride/k_row_stride.
+- `rms_norm_strided` (kernels/gb10/common/rms_norm.cu) — grid (rows_per_group, num_groups),
+  groups `row_stride` elements apart. One block per row either way.
+
+Both are bit-identical by construction: identical per-block math and reduction, only the base
+address differs, and no cross-row interaction is introduced.
+
+### Measured (C=16, 4 reps/leg, warmup discarded, kill switch as control)
+| lever | ON | OFF | delta | identity |
+|---|---|---|---|---|
+| `rope_forward_strided` | 113.20 (113.0-113.5) | 112.22 (112.0-112.6) | **+0.87%, ranges DISJOINT** | byte-identical |
+| `rms_norm_strided` | 113.28 (113.0-113.4) | 112.92 (112.8-113.0) | +0.31%, ranges TOUCH | byte-identical |
+
+RoPE clears the measured 0.8% harness floor and matches its 1.18 ms prediction (0.9%) almost
+exactly. **The q/k-norm result is SUB-FLOOR and is NOT claimed as a win** — kept default-on only
+because it is byte-identical, strictly less work (484 fewer launches/step), and the point estimate
+is positive with 7 of 8 reps favouring. Kill switches: `ATLAS_NO_ROPE_STRIDED=1`,
+`ATLAS_NO_QK_NORM_STRIDED=1`.
+
+**C=16 now ~113.2 tok/s** (from 112.2), ratio 0.67x vs vLLM 168.9.
+
+★ RULE CONFIRMED: per-SEQUENCE launch fan-out is a real and cheap lever class; per-LAYER fan-out
+is not (it is inherent). Separate the two before costing any "too many launches" hypothesis.
+
+## 2026-07-28 — lm_head 716: THE TILE GEMM IS EXONERATED. The fault is in the WIRING.
+
+A standalone repro (`crates/spark-model/examples/w4a16_lmhead_716_repro.rs`) reproduces the serve's
+decode step exactly — created (non-NULL) streams, the SSM `gemm_t`/`_k64` sequence, `lm_head` gemm
+alternating `_t`/`_t_k64`, cross-stream `argmax_bf16_batch` (mirroring `meta.rs:298`, which launches
+on `default_stream()`), 4*M-byte D2H per step, M cycling the 2/4/8/12/16 ladder, a concurrent
+prefill `w4a16_gemm_t_m128` + `memset_async` on a third stream, and the serve-exact 32-row logits
+buffer. **3000 iterations of the full concurrent leg: PASS.**
+
+Hypotheses 7-12 now dead, all by measurement:
+7. launch-config/resource mismatch — NO. `w4a16_gemm_t` static smem = 19,584 B, `_t_k64` = 39,104 B,
+   both under 48 KB with no `cudaFuncSetAttribute` needed; no `__launch_bounds__`; block (128,1,1)
+   matches what the kernel indexes by threadIdx.
+8. index-type overflow at N=248320 — NO. Largest intermediate is B_packed `(u64)(gk>>1)*N+gn`
+   ~= 635.7 M, in u64 and under 2^31 anyway. grid.x=1940 is far under limits. All cp.async offsets
+   are 16-B aligned given N = 15520x16.
+9. logits row mismatch — NO. `buffers/sizes.rs:113` sizes logits at `min(m,32) x vocab` = 32 rows;
+   the ladder tops at 16; the store is guarded `r0 < M`.
+10. non-NULL streams / cross-stream argmax race / concurrent prefill GEMM+memset / M changing
+    between launches — NO, 3000 iterations clean.
+11. the `ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1` elimination — VALID (the check is value-based,
+    `decode_a2.rs:30`, not presence-based), so hypothesis 4 stands eliminated.
+12. an output overrun masquerading as 716 — NO. A DELIBERATE 5.7 MB overrun (undersized C) yields a
+    sticky **700 ILLEGAL_ADDRESS, not 716**. So the serve's 716 cannot be an epilogue overrun.
+
+★ CONCLUSION: everything attributable to the tile GEMM's launch is measured clean at serve shape.
+The faulting kernel is NOT the lm_head GEMM. The defect is in the wiring that was written (and
+reverted) three times, or in another kernel in the step.
+★ NEXT: one run with `CUDA_LAUNCH_BLOCKING=1` — the API call that returns 716 then names the
+ACTUAL faulting kernel instead of the first downstream sync point. Cheap, and it ends the search.
+
+### Side finding (latent, not currently a bug)
+`crates/spark-model/src/model/meta.rs:296-298` `argmax_batch_dispatch` IGNORES its `_stream`
+parameter and launches on `default_stream()`. Benign today because decode runs on the default
+stream; a cross-stream race the moment that changes.
+
+### Open question that reframes the whole lever
+The reverted patch replaced `w4a16_gemv_batch16` with a tile GEMM needing a **715 MB transposed
+twin**. But the GEMV itself moves 715 MB in 9.68 ms = **74 GB/s = 32% of the 230 GB/s ceiling**, and
+a GEMV that reads each weight byte once should be bandwidth-bound near the ceiling. If the GEMV's
+own bandwidth is fixable, the ~6 ms/step prize needs NO twin, NO extra VRAM, and NO 716. Under
+investigation before the wiring is rebuilt a fourth time.
+
+## 2026-07-28 — lm_head MICROBENCH: two plan assumptions REFUTED before any wiring
+
+Real shape N=248320 K=5120, 100 iters after 20 warmup, floor 3109 us @ 230 GB/s
+(`cargo run -p spark-model --release --example w4a16_m17_bench --features cuda,gpu-examples`;
+the GEMV family and the two BF16 tile variants were ADDED to that bench for this).
+
+| kernel | M=1 | M=4 | M=8 | M=16 | numerics |
+|---|---|---|---|---|---|
+| w4a16_gemm_t | 3620 | 3727 | 3661 | **3801** | FP8 E4M3 downcast of B AND activations |
+| w4a16_gemm_t_m128 | 3821 | 3909 | 3844 | 3991 | FP8 |
+| w4a16_gemm_t_k64 | 4074 | 4152 | 4062 | 4142 | FP8 |
+| w4a16_gemm_t_m128_bf16_v2 | 5137 | 5206 | 5107 | **5192** | LOSSLESS |
+| w4a16_gemm_t_m64_bf16 | 9435 | 9427 | 9435 | **9465** | LOSSLESS |
+| w4a16_gemv_batch4 | 3174 | 3208 | -- | -- | incumbent |
+| w4a16_gemv_batch8 | -- | -- | 4465 | -- | incumbent |
+| w4a16_gemv_batch16 | -- | -- | -- | **9845** | incumbent |
+
+★ REFUTATION 1 — `w4a16_gemm_t_m64_bf16` is the WORST of the four tile GEMMs here, 1.86x slower
+than `m128_bf16_v2` and NO BETTER than the incumbent GEMV. It was chosen as primary on the theory
+that its higher occupancy (4-5 vs 3 CTAs/SM) wins at low M. That occupancy edge was tuned for
+PREFILL's large M; at N=248320 with M<=64 the grid is (1940,1) either way, so it buys nothing and
+pays for the halved tile. **The lossless option is `m128_bf16_v2` at ~5150 us, not ~4000.** That
+moves the FP8-vs-lossless gap from an assumed 0.25% of step to a real **1.05%**.
+
+★ REFUTATION 2 — the incumbent GEMV is ALREADY OPTIMAL at low M. **`batch4` runs at 3174 us =
+226 GB/s = 98.3% of peak = 1.02x the roofline floor.** It is not a broken kernel at low M; there is
+NOTHING to win there, and BOTH tile GEMMs REGRESS it (lossless by ~1960 us/call, FP8 by ~450).
+A C=1 step is ~39 ms, so the lossless kernel with no threshold is a several-percent regression at
+the ONE concurrency where Atlas already beats vLLM 1.79x (25.4 vs 14.2). Crossover is M ~= 8.
+=> "repack-and-replace, no threshold, all M" would trade C=1 away to win C=16.
+
+★★ HOW TO READ THE GEMV COLUMNS — `w4a16_gemv_batchm_impl<MAX_M>` bounds its row loop
+`for (int t = 0; t < MAX_M; t++)` at COMPILE TIME with no runtime clamp
+(kernels/gb10/common/w4a16_gemv.cu:490). A `batch4` timing at M=16 therefore computes only 4 rows
+and is INVALID WORK — it looks like a 98%-of-peak win at M=16 and is nothing of the kind. Each
+batchN kernel is meaningful ONLY at M<=N; the other cells are struck out above. Generalises: for
+any template-bounded kernel, a sweep past the bound measures a DIFFERENT, SMALLER problem.
+
+### FP32-logits concern: CLOSED, non-issue for this migration
+`w4a16_gemv_logits` (w4a16_gemv.cu:270) writes FP32 with the comment "FP32 logits are critical for
+sampling quality", and every tile GEMM writes BF16 — so this looked like a numerics regression
+beyond accumulation order. It is not. That kernel is dispatched ONLY at `impl_a3.rs:260`, under an
+`fp32` flag, on the single-row `w4a16_gemv` path (added to close a 0.125-logit BF16 tiebreak flip
+behind Gemma-4-31B's creative-collapse stop-word loop). **The multi-seq decode head being migrated
+(`decode_a2.rs:437-499`) already writes BF16** via `w4a16_gemv_batchm`. The FP32 path is a
+different kernel on a different code path and is not touched.
+
+### Consequence
+A threshold is MANDATORY, which forces one of:
+(a) resident twin (+715 MB, ~1% of the 84 GB budget at util 0.70) + M-dependent dispatch between
+    two tensors — precisely the configuration identified as the prime 716 suspect;
+(b) a NEW transposed-layout GEMV (`w4a16_gemv_t_batchm`) so ONE layout serves all M. Transposed B
+    is [K/2, N], so at fixed k a warp's 32 lanes read 32 CONSECUTIVE bytes across n — naturally
+    coalesced, which a row-major per-n GEMV cannot be. Would allow repack-and-replace (no twin, no
+    716 class) AND keep 98%-of-peak at low M AND get the tile GEMM at M>=8.
+Decision pending.
+
+## 2026-07-28 — ★★★ ROOT CAUSE OF THE CUDA 716, AFTER THREE FAILED ATTEMPTS
+
+**The transposed lm_head weight's ROW STRIDE IS THE VOCAB SIZE, and this checkpoint's vocab is
+248077 — an ODD number. The tile GEMM loads B with 16-byte `cp.async`, which REQUIRES a
+16-byte-aligned source address. Only 1 k-row in 16 is aligned; the rest fault with
+CUDA_ERROR_MISALIGNED_ADDRESS.**
+
+```c
+// kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu:392
+cp_async_pred_16(&smem_Bp[(buf)][kp][ns],
+    &B_packed[(unsigned long long)(gke >> 1) * N + gns], (gke + 1 <= K) && (gns + 15 < N));
+```
+`gns` is ALWAYS a multiple of 16 (`ns = (threadIdx.x & 7) << 4`, `cta_n = blockIdx.x * 128`), so
+alignment reduces entirely to the row stride `N`:
+
+| N | source | N mod 16 | k-row byte offsets mod 16 | verdict |
+|---|---|---|---|---|
+| **248077** | centml/Qwen3.6-27B-NVFP4-W4A4-mlpinf (**what the benchmark actually serves**) | **13** | 0,13,10,7,4,1,... | **15 of 16 rows MISALIGNED** |
+| 248320 | nvidia/Qwen3.6-27B-NVFP4 (the bench + the standalone repro) | 0 | 0,0,0,0,... | cannot fault |
+
+### Why this defeated twelve hypotheses and three rebuild attempts
+- **The standalone repro passed 3000 iterations** because it used N=248320, on which the bug is
+  STRUCTURALLY IMPOSSIBLE. The kernel was never exonerated — it was tested on a shape that
+  excludes the defect. ★ The "dims verified against the checkpoint, `lm_head.weight [248320,2560]`"
+  note came from the WRONG CHECKPOINT.
+- **All three attempts failed identically across kernel variants** because every variant loads B
+  through the same `cp_async_pred_16` with `N` as the stride.
+- **Single requests always passed byte-identically** because `padded_n <= 4` dispatches the
+  row-major GEMV and never touches the transposed tensor. Not "M=1 is aligned" — the faulting
+  kernel never ran at all.
+- **compute-sanitizer was CLEAN and the error became 719 under it** because there is NO
+  out-of-bounds access. Every address is inside a valid allocation; they are merely unaligned.
+  That is exactly the class memcheck cannot attribute to an address.
+- It was invisible to code review because NOTHING IN THE CODE IS WRONG. The defect is an UNSTATED
+  INVARIANT between a checkpoint's vocab size and a kernel's load width.
+
+★★ RULE: when a microbenchmark and a serve disagree, DIFF THE SHAPES FIRST — not the wiring. A
+benchmark constant that "matches the model" from a different checkpoint of the same family will
+silently make the reproducer immune to the bug being chased. Assert real runtime dims IN the
+repro; never hardcode them from docs.
+★★ RULE: any kernel using `cp.async`/vector loads carries an ALIGNMENT PRECONDITION ON ITS
+STRIDES. Odd/unaligned N is a legal tensor shape; the kernel must pad or the caller must.
+
+### THE FIX (required for ANY lm_head tile-GEMM path, twin or repack-and-replace)
+Give the transposed weight a row stride padded to a multiple of 16 (128 for tiling):
+`align_up(248077, 128) = 248192`, zero-filling the pad columns. Then either
+(a) add an explicit `ldb` parameter so B uses the padded stride while C keeps the true vocab
+    stride (C stores are SCALAR 2-byte and guarded — `C[r0*N+c0] = ...` at :539-542 — so C is NOT
+    the problem and needs no padding), or
+(b) pass the padded N and pad the logits buffer + argmax count as well (wider; risks argmax
+    selecting a pad column, whose zeroed logit can beat real negative logits).
+(a) is the smaller and safer change.
+
+### Twin is DEAD on VRAM — measured, not estimated
+The 681 MB twin drops the KV pool **4757 -> 2957 blocks** (~1800 blocks, far more than the twin's
+own size) and the serve HARD-FAILS preflight:
+```
+KV cache can hold at most 11 concurrent sequence(s) at --max-seq-len=4096, but --max-batch-size=16
+was requested. KV pool has 2957 block(s) of 16 tokens each; each sequence needs 256 block(s).
+```
+★ My interim estimate of "4042 blocks, 1.3% short, recoverable with a util bump" was WRONG and too
+generous. The original KV objection stands: NO RESIDENT TWIN ON THIS BOX. The lm_head tile GEMM
+must go via repack-and-REPLACE (single layout), which also needs a transposed-layout GEMV for
+`padded_n <= 4` (where the row-major GEMV measures 98.3% of the roofline and must not be lost).
+
+### Status
+Twin implementation is BUILT and reverted-in-place (kill switch `ATLAS_NO_LMHEAD_TGEMM=1`
+defaults ON => must be left OFF/removed). Not shipped. Next: the padded-stride fix + the
+transposed GEMV, per the repack-and-replace plan.
+
+## 2026-07-28 — ★ SHIPPED: lm_head tile GEMM, +5.50% at C=16. The 716 was an ALIGNMENT bug.
+
+The padded stride ELIMINATES the 716 outright. Root cause confirmed by experiment, not just analysis:
+
+```
+lm_head transposed twin: vocab=248077 -> padded stride=248192 (vocab%16=13), tile GEMM active
+CUDA 716 / misaligned count: 0
+```
+
+### Measured (C=16, 4 reps/leg, warmup discarded, kill switch as control)
+| leg | mean | range |
+|---|---|---|
+| tile GEMM ON | **119.32** | 119.0-119.6 |
+| OFF (GEMV) | 113.10 | 112.9-113.3 |
+| **delta** | **+5.50%** | **ranges DISJOINT** |
+
+Full sweep, default-ON: C=1 **25.4** · C=2 25.2 · C=4 48.25 · C=8 **71.2** (+0.85%) · C=16 **119.1** (+5.2%).
+NO REGRESSION anywhere. C=1/2/4 are BYTE-IDENTICAL (`bf3a0b07...`, same hash both legs) because
+`padded_n <= 4` stays on the GEMV — which measures 98.3% of the memory roofline and must not be lost.
+Coherence + tool-call smoke PASS on the tile-GEMM path.
+
+vs vLLM: C=1 **1.79x WIN** · C=2 0.91x · C=4 0.91x · C=8 0.72x · C=16 **0.71x** (from 0.67x).
+
+### What shipped
+- `w4a16_gemm_t` gains an `ldb` (transposed-B row stride) parameter; B loads and their guards use
+  `ldb`, stores still use `N`. Bounding loads by `ldb` also FIXES a latent bug: bounding by `N`
+  silently dropped the real columns in the final 16-wide group whenever N % 16 != 0 (13 columns here).
+- `w4a16_gemm_n128_ldb` wrapper; the existing `w4a16_gemm_n128` DELEGATES to it with `ldb = n`, so
+  all 21 existing call sites are untouched (SSOT: one launch site).
+- `transpose_concat_for_gemm_padded` + a shared `transpose_impl` (both public helpers now route
+  through one implementation).
+- `lm_head_nvfp4_t: Option<(QuantizedWeight, u32)>` — ADDITIVE twin, never replaces or aliases the
+  original, so `draft_lm_head_nvfp4`'s copy stays valid. Built once, immutable.
+- Dispatch at `padded_n >= 5` only. Default ON, kill switch `ATLAS_NO_LMHEAD_TGEMM=1`.
+
+### ★★ CORRECTION: the twin does NOT cost KV. My earlier "4757 -> 2957 blocks" was CONTAMINATED.
+With the twin active the pool reads **4759 blocks vs 4757 without it** — no measurable impact, and
+preflight passes at `--max-seq-len 4096 --max-batch-size 16`. The 2957-block reading came from a
+serve that computed its self-relative KV budget (`baseline-free - free-now`) while a STRAY
+CONTAINER still held ~94 GB. I built two successive wrong conclusions on that number ("twin is
+dead on VRAM", "repack-and-replace is mandatory"). BOTH ARE WITHDRAWN.
+★ RULE: `nvidia-smi --query-compute-apps` BEFORE trusting any self-relative memory budget. A
+stray serve does not just slow things down — it silently corrupts the KV sizing arithmetic, and
+that number then looks like a hard architectural constraint.
+★ Also withdrawn: an intermediate estimate of "4042 blocks, 1.3% short, recoverable with a util
+bump" — that was arithmetic on the contaminated figure.
+
+### Accuracy debt (recorded, NOT yet measured — accuracy embargo still in force)
+`w4a16_gemm_t` dequants B to FP8 E4M3 AND downcasts activations BF16->FP8 for
+`mma.m16n8k32.e4m3`. So at `padded_n >= 5` the lm_head logits carry FP8 activation precision and a
+different accumulation order. `padded_n <= 4` is unaffected and byte-identical.
+- Coherence + tool-call smoke PASS; no BFCL/IoU run (embargoed until vLLM parity).
+- The lossless alternative `w4a16_gemm_t_m128_bf16_v2` measures 5192 us vs 3801 us at M=16, i.e.
+  ~1.05% of step — the fallback if a flip-gate later rejects FP8.
+- BFCL + IoU re-validation MANDATORY before any accuracy claim or external quote.
+
+### lm_head FP8 accuracy debt — CHARACTERIZED (not a substitute for BFCL)
+8 concurrent prompts (padded_n >= 5, so the tile GEMM IS active), temp 0.0 seed 42, tile GEMM vs
+`ATLAS_NO_LMHEAD_TGEMM=1`, same binary:
+
+| | result |
+|---|---|
+| fully byte-identical | **2 / 8** |
+| diverged | 6 / 8 |
+| divergence point | 1%-71% into the response |
+| quality of divergences | **benign paraphrase in every case** |
+
+Examples: "employees sorted by salary" vs "students sorted by name" (both valid illustrations);
+"i.e., two keys hash to the same index" vs "two keys hash to the same index"; "0.1 + 0.2 != 0.3"
+rendered with vs without code markup. Both branches stay coherent, correct and complete — no
+repetition, no collapse, no truncation, no degradation. This is the expected signature of temp-0
+tiebreak flips propagating (cf. `spec_not_output_neutral`).
+
+★ This does NOT establish accuracy parity — only BFCL/IoU can, and those stay embargoed until
+Atlas >= vLLM at C=1..16. It bounds the RISK, it does not discharge the DEBT.
+★ MEASUREMENT TRAP hit while doing this: the first comparison parsed the capture line-by-line, so
+it only compared FIRST LINES and reported "7/8 identical". The hashes (computed over full
+responses) said 6/8 DIFFER. When a hash comparison and a text diff disagree, the DIFF is the one
+that is probably broken.
+
+## 2026-07-28 — ★ REGRESSION I INTRODUCED, CAUGHT BY AUDIT: strix-hip missed the `ldb` fix
+
+The lm_head twin is built by PLATFORM-AGNOSTIC Rust and is DEFAULT-ON, but only the GB10 CUDA
+`w4a16_gemm_t` had gained `ldb`. `kernels/strix/` is a SYMLINK to the GB10 file and inherited the
+fix; **`kernels/strix-hip/qwen3.6-27b/nvfp4/w4a16_gemm.cu` is a real separate copy and did not.**
+On the Windows/HIP gfx1151 build (PR#353), which serves this exact NVFP4 checkpoint, decode at
+padded_n>=5 would launch `w4a16_gemm_t` against a twin built with stride 248192 while the kernel
+strides by N=248077 — shearing every row past the first and producing GARBAGE LOGITS, **silently,
+with no fault**, because RDNA tolerates the misalignment that traps on CUDA as 716.
+
+FIXED: `ldb` ported to the strix-hip copy, with a comment binding it to the CUDA original.
+★ NOT COMPILE-VERIFIED on this box (no ROCm here) — the HIP build must be run before that
+platform is trusted. Flagged, not assumed.
+
+Added a load-time WARN when `stride != vocab`, naming the `ldb` requirement — this is the
+signal that would have caught the drift immediately. Verified firing:
+`lm_head twin uses a PADDED stride (248192 != vocab 248077): this target's w4a16_gemm_t MUST
+accept the `ldb` argument...`. Post-fix C=16 119.9 tok/s, 0 errors.
+
+★★ RULE: a kernel change made for ONE target is not done until every OTHER target's copy of that
+file is checked. Symlinked targets inherit; whole-file copies DRIFT. This is the same shadow-drift
+failure mode that left 27B's multi-seq GDN kernels uncompiled (`shadowed_kernels_null`), except
+here the drift produced SILENT WRONG ANSWERS on the other platform rather than a null handle.
+★ Fleet check: every other served vocab (248320, 200064, 151936, 131072, 262144, 129280, 128896,
+100352) is a multiple of 128, so stride == N and `ldb` is a no-op — 248077 is the fleet's ONLY
+unaligned N, and only lm_head carries it. Other model dirs' 9-arg `w4a16_gemm_t` receiving a 10th
+argument is benign (the launch API reads only declared params).
+
+## 2026-07-28 — FFN MMQ: my 69% figure was WRONG. It is 76%, and the prize is ~5-6 ms not ~18 ms.
+
+★ MY ARITHMETIC ERROR: I divided (mmq16 + mmq32) TIME by mmq16-ONLY BYTES. mmq32 is not overhead
+on the same 9.63 GB — it runs on steps where m is 17..32 (MTP-verify steps at C=16) and moves its
+OWN ~50 MB/call. Per-CALL is the artifact-free metric: 54.8 ms / 192 calls = 285.4 us/call over
+50.14 MB = **175.7 GB/s = 76.4% of achievable**, which matches the earlier gridX-split nsys
+(175.6 down / 173.2 gate-up) exactly.
+
+Shape audit (the lm_head-class check): `nvfp4_mmq.cu` exists ONLY in the 27B dir (no common/ twin
+to shadow), and N/K are RUNTIME-derived from the served tensors, not hardcoded — the `_nc`
+variant is selected only when `n % 128 == 0`, and nsys gridX 136/40 confirms N=17408/5120 exactly.
+**So the sibling-checkpoint failure mode that invalidated the lm_head verdict does NOT apply here.**
+
+★ CORRECTION to the earlier entry's mechanism: STATE.md:955-956 attributed the gap to "dequant/
+scale ALU overlap with the cp.async weight stream". **There is no cp.async in this kernel at all**
+— zero hits for `cp.async|memcpy_async|__pipeline` in the vendored `q4k_vendor/mmq.cuh`. Weight
+loads are scalar 4-byte `ld.global`. The real mechanism is that the inner loop is PHASE-SERIAL:
+`[load] -> sync -> vec_dot(MMA) -> sync -> [load] -> sync -> vec_dot -> sync`, four barriers per
+512-K iteration, with DRAM IDLE during both vec_dot phases and the epilogue.
+
+Confirmed dead (do not re-litigate): stream-K/split-K for the down under-fill (down gridX=40 at
+284.3 us vs gate/up gridX=136 at 282.3 us — within 0.7% at identical bytes, so 40 CTAs already
+saturate LPDDR5X); occupancy hints (+0.27%, null); M-tile size (flat — kernel is weight-bound).
+
+Remedies, ranked: (1) cp.async 2-stage double-buffer in `mul_mat_q_process_tile` — smem
+2x(38.9+3) KiB ~= 84 KiB <= 99 KiB/CTA, numerics UNCHANGED, est. 4-5 ms/step; (2) SoA weight
+relayout in `atlas_nvfp4_repack` (Atlas owns the layout) so the x-tile fill vectorizes 16-B,
+bit-identical, ~1-2 ms and the natural enabler of (1); (3) fuse gate+up into one N=34816 launch,
+bit-identical, ~0.5-1.5 ms. Upstream llama.cpp has NO faster variant to pull — mainline MMQ has
+the identical phase-serial loop and no cp.async either, so this would be Atlas-original work.
+
+## 2026-07-28 — ★ W4A4 IS DEAD WEIGHT AT DECODE (external evidence, converging)
+- QServe/QoQ (arXiv 2405.04532): W4A4 beats W4A8 only above ~78 concurrent sequences. We run 1-16.
+- APEX4 (arXiv 2606.08761): all W4A4 wins at M>=64; concedes Marlin W4A16 is fastest at small batch.
+- QuaRot: its decode win is KV4 memory, not A4 GEMM.
+- ★ MEASURED ON GB10 ITSELF — llama.cpp PR #22196 (Blackwell native NVFP4, benchmarked on a DGX
+  Spark by NVIDIA's own engineer): prefill 506->611 t/s (+21%), decode 12.01->**11.91** t/s
+  (UNCHANGED/slightly worse), and the W4A4 tensor-core path had WORSE perplexity (4.6577) than the
+  W4Q8 fallback (4.6283).
+At decode we move ~9.63 GB of weights and ~0.5 MB of activations per step — activation precision
+is INVISIBLE in the traffic. Its only decode "win" is FP4-MMA issue rate, irrelevant when
+bandwidth-bound. => Candidate lever: keep A4 for PREFILL, run DECODE with A8/A16 activations
+against the same NVFP4 weights — same bandwidth, same speed, strictly better numerics. Must be
+gated by a measured iso-speed A/B before folding.
+
+## 2026-07-28 — m_dispatch sweep: NONE REMAIN on the 27B C=1..16 decode path
+All four fixed instances verified in place (FFN, attention projections, GDN mixer, lm_head).
+Every M>8 GEMM on the campaign model now rides a tile kernel. Residuals are in OTHER configs:
+(1) `impl_a3.rs::lm_head_batched` has no twin arm at M>8 (falls to base `w4a16_gemm`, ~19.3 ms at
+    M=16) — reached only by DFlash wide-verify (gamma=16 => M=17) and `prompt_logprobs`, NOT the
+    MTP K=4 production path. Fix is mechanical: mirror decode_a2.rs:470-486.
+(2) FP8 lm_head is still a per-row GEMV loop at every M (decode_a2.rs:441-452) — FP8 flagship
+    configs only (dgx3 256k, 80B FP8), not this campaign's NVFP4 model.
+Landmines recorded (no live exposure, all currently aligned): `mamba2_in_proj_size` adds a raw
+head count so a checkpoint with `mamba_num_heads % 16 != 0` would go unaligned into a 9-arg
+kernel; `tp_shard.rs` never checks `local_out % 16`; the FP8 tile family guards B with
+`(kb)+31 < K` so K % 32 != 0 would silently DROP the last K-chunk. The correct defensive pattern
+already exists in-tree at `w8a16_gemm_t_m128.cu:156-165` (runtime `(N & 15) == 0` check + scalar
+fallback).
+
+## 2026-07-28 — ★ RETRACTION: "W4A4 is dead weight at decode" is WRONG AT OUR M
+I recorded (above, same night) that 4-bit activations buy nothing at decode and proposed A8/A16
+decode activations as a free accuracy reclaim. **That lever is already REFUTED by an A/B in this
+very file** (2026-07-27, STATE.md:95-101): the bf16-activation path against the same NVFP4 weights
+is `ATLAS_NO_FFN_NVFP4_MMQ`, and it measures **MMQ off 55.0/54.8/54.8 (mean 54.9) vs MMQ on
+61.4/59.1/61.2 (mean 60.6) = +10.4% for MMQ, ranges NON-OVERLAPPING, output identical.**
+So dropping W4A4 at decode is a **10.4% REGRESSION**, not a free accuracy reclaim.
+
+★★ WHY I GOT IT WRONG — "DECODE" IN THE LITERATURE MEANS M=1. QServe's ~78-sequence crossover,
+APEX4's M>=64 framing, and llama.cpp PR #22196's GB10 measurement (12.01 -> 11.91 t/s) are ALL
+single-stream decode. Our C=16 decode is **M=16**, a different regime, where the FP4 MMA path
+wins on this hardware. A batched-serving campaign must translate every "decode" claim in a paper
+into the M it was measured at BEFORE importing its conclusion.
+★ Lesson compounding: I ALSO nearly imported the same class of error from the m17 bench, whose
+per-kernel numbers overstate by ~1.5x from L2 reuse (STATE.md:685-690). External and microbench
+evidence both need their regime checked against the in-model measurement before they move a
+decision.
+The accuracy question stands but is now a TRADE, not a freebie: W4A4 decode activations are
+throughput-justified at +10.4%; revisit only at vLLM parity, in the accuracy-debt ledger.
+
+## 2026-07-28 — ★ SHIPPED: SoA weight layout for the FFN MMQ tile load (+4.6% C=16)
+
+`atlas_nvfp4_repack` emitted an array of 36-byte `block_nvfp4`, which INTERLEAVES 4 scale bytes
+with 32 nibble bytes. The tile loader therefore issued **NINE 4-byte global loads per block**
+(8 qs + 1 d). Splitting each row into `[qs: bpr*32][d: bpr*4]` makes the 32 qs bytes contiguous:
+two 16-byte loads + one 4-byte load. **9 global ops -> 3 at identical total bytes.**
+
+The SHARED tile layout is unchanged, so `vec_dot`/MMA are untouched and the output is bit-identical
+(VERIFIED: identity sha `bf3a0b07...` unchanged, not assumed).
+
+| C | before | after | delta |
+|---|---|---|---|
+| 1 | 25.4 | 25.45 | flat |
+| 2 | 25.2 | 25.3 | flat |
+| 4 | 48.25 | 48.55 | +0.6% |
+| 8 | 71.2 | **73.85** | **+3.7%** |
+| 16 | 119.3-119.9 | **125.4** (125.8/125.4/125.1) | **+4.6%, DISJOINT** |
+
+vs vLLM: C=1 **1.79x WIN** · C=2 0.91x · C=4 0.92x · C=8 **0.75x** · C=16 **0.74x** (from 0.71x).
+
+★ THE BUG THAT BROKE THE FIRST ATTEMPT (produced garbage `!</think>`): **`kbx0` is a LINEAR block
+index that ALREADY FOLDS IN THE CTA'S ROW OFFSET** (`offset_x = ... + it*mmq_y*stride_row_x`,
+mmq.cuh:3640) — it is NOT a pure k-offset. A per-ROW layout must decompose it back:
+`row0 = kbx0 / bpr`, `kb0 = kbx0 - row0*bpr`, one div+mod hoisted out of the i-loop.
+★ RULE: before changing a memory layout, determine whether the consumer's index is LINEAR or
+already DECOMPOSED. A linear index silently mixes the dimensions you are trying to separate.
+
+Alignment: row stride `bpr*36` is 16-B aligned iff `bpr % 4 == 0` i.e. `K % 256 == 0`; both live K
+qualify (5120->80, 17408->272) and MMQ already requires K % 512 == 0. Safe because Atlas exposes
+NO MMVQ entry point, so the MMQ kernels are the buffer's only consumer (`vecdotq.cuh`'s nvfp4 path
+is unreachable). No independent kill switch — the layout is internal and bit-identical; the escape
+hatch is the existing `ATLAS_NO_FFN_NVFP4_MMQ`.
+
+★ THE ESTIMATE WAS 4x LOW: this was sized at "~1-2 ms, mostly subsumed by the cp.async pipeline".
+It delivered ~5.5 ms ALONE — i.e. the load-ISSUE path, not load LATENCY, was the dominant limiter.
+Implied post-fix MMQ bandwidth ~195 GB/s = ~86% of the 226 GB/s achievable at a 9.6 GB working set,
+i.e. already at w4a16 parity. **A1 (cp.async double-buffer) must be RE-SIZED against a fresh
+profile before it is built — its remaining headroom is far smaller than the original 4-5 ms.**
+
+## 2026-07-28 — NEXT LEVER, SPECIFIED AND READY: deepen the `w4a16_gemm_t_k64` pipeline
+
+NOT STARTED — specified deliberately rather than half-built (a partial vendored-kernel refactor is
+worse than nothing). Everything below is measured or computed; it should be directly executable.
+
+### The target
+`ssm_out_proj` (x48/step) + `attn_o_proj` (x16/step), both **N=5120 K=6144**, on
+`w4a16_gemm_t_k64`. 13.4 ms/step, 10.7% of GPU, and the WORST efficiency of any live kernel.
+Per call: B_packed 15.73 MB + scales 1.97 MB + A/C ~0.36 MB = **18.05 MB => 79.9 us floor at
+226 GB/s**; 64 calls => **floor 5.1 ms/step vs 13.4 measured = 38% efficient in-model.**
+Reaching 75% saves **~6.6 ms/step = ~5.3% at C=16** — larger than the MMQ cp.async lever's entire
+remaining prize.
+
+### ★ THE MECHANISM (efficiency is MONOTONE IN grid.x across the SAME kernel family)
+| grid.x | shape | % of achievable |
+|---|---|---|
+| 40 | out_proj / o_proj (N=5120) | 47-50 |
+| 112 | attn_qkv (N=8192) | 66 |
+| 128 | ssm_qkvz (N=16384) | 73 |
+| 1938 | lm_head (N=248077) | 83 |
+Same kernel, same K-loop, same scale layout — ONLY occupancy varies. At N=5120 the grid is
+(40, 1) = **40 CTAs on 48 SMs = exactly 1 CTA/SM** (128 threads resident, ~8% occupancy). The k64
+main loop is `ISSUE(nxt) -> commit -> MMA(cur) -> cp_async_wait_all -> sync -> DEQUANT(nxt) -> sync`:
+only ONE load group is ever in flight and `wait_all` drains it every step, so during DEQUANT
+(32 LUT+cvt iterations between two barriers) **every active SM has ZERO outstanding loads**.
+lm_head has the identical serial phase but a co-resident CTA covers it. That is the whole gap.
+Pure SM under-fill only accounts for 48/40 = 1.20x; the other ~1.65x is exposed latency.
+
+★ The campaign's two prior refutations DO NOT TRANSFER: (a) the 40-vs-136-CTA under-fill null was
+measured on MMQ, whose 256-thread/2-resident pipeline self-hides latency; (b) split-K was refuted
+for projections AND would break bit-identity (FP32 accumulation order). Deepening the pipeline
+attacks the same mechanism intra-CTA, BIT-IDENTICALLY.
+
+### ★ SMEM CORRECTION — a naive 3-stage does NOT fit
+With M_TILE 64, K_STEP_T64 64, PAD_T64 8, N_TILE_LG 128, BP_PAD 16:
+- 2 stages (today): A 18432 + Bp 8704 + Bs 1088 + B_fp8 10240 + LUT 64 = **37.6 KB**
+- naive 3 stages: **51.4 KB — EXCEEDS the 48 KB static limit**, would need `cudaFuncSetAttribute`
+  + `extern __shared__`, which the launch wrapper does NOT do.
+- ★ **A[2] + Bp/Bs[3] = 43.2 KB — FITS.** Only the WEIGHT tiles need the third stage: `A[cur]` is
+  free the moment `MMA(cur)` clears its barrier, so A can stay double-buffered.
+
+### Schedule (bit-identical: same MMA order, same operands, only load timing moves)
+per step i: `MMA(cur)` -> sync -> `ISSUE_LOADS(A[cur], Bp/Bs[(i+2)%3] <- kb+2)` -> commit ->
+`cp_async_wait_group(1)` -> sync -> `DEQUANT((i+1)%3)` -> sync.
+Loads for kb+2 stay in flight THROUGH DEQUANT — the memory pipe never drains.
+The existing `K64_ISSUE_LOADS(buf,kb)` / `K64_DEQUANT(buf)` / `K64_COMPUTE_MMA` macros already take
+`(buf)` as a parameter, so the change is mostly the smem declarations + loop reordering; `[2]` ->
+`[3]` on `smem_Bp_k64`/`smem_Bs_k64` only. If only `cp_async_wait_all` is wrapped in-file, add the
+`cp.async.wait_group 1` asm one-liner.
+
+### Plan
+1. Add `w4a16_gemm_t_k64_p3` BELOW the existing kernel (ADDITIVE — the old one keeps working if
+   this is abandoned). Move the macro `#undef`s below it.
+2. Resolve the new handle at `qwen3_ssm/init.rs:122` and `qwen3_attention/init.rs:419`, falling
+   back to `w4a16_gemm_t_k64` under **`ATLAS_NO_K64_PIPELINE3`** (PRESENCE check — `=0` is NOT off).
+   Call sites untouched.
+3. Gates: build with `ATLAS_TARGET_MODEL=qwen3.6-27b` and **md5 the binary vs previous** or the A/B
+   is fake; add the `_p3` row to `examples/w4a16_parity_microtest.rs` and ASSERT bit-identity;
+   `w4a16_m17_bench` on the two out_proj shapes (relative only — that bench overstates ~1.5x from
+   L2 reuse) expecting 153/164 us -> ~110; then coherence smoke + C=16/C=8 >=3 reps per leg vs the
+   kill switch, ranges must not overlap; confirm with nsys that k64 ms/step drops 13.4 -> ~8.
+4. Stretch only after D ships: A3, fuse FFN gate+up into one N=34816 MMQ launch (bit-identical,
+   ~0.5-1.5 ms).
+
+### Also re-sized tonight
+MMQ cp.async (A1) is now a ~2.0-4.6 ms lever, NOT 4-5: post-SoA `mmq16_nc` runs 257.0 us/call =
+**195.1 GB/s = 86% of achievable**, and `mmq32_nc` already hits 203.4 GB/s = 90% on the SAME
+weights with more work per byte — so what remains there is largely FIXED PER-CALL overhead, which
+a load pipeline does not fix. Do D first.
+
+## 2026-07-28 — ★ SHIPPED: 3-deep weight pipeline in `w4a16_gemm_t_k64` (+1.81% C=16)
+C=16 **124.62 -> 126.88** (4 reps/leg, 126.6-127.1 vs 124.5-124.7, DISJOINT), byte-identical
+(`bf3a0b07...` on both legs). Default ON, kill `ATLAS_NO_K64_PIPELINE3` (PRESENCE, not value).
+All three handle sites resolve through ONE `layers::k64_kernel` helper (SSOT).
+
+★ MEASURED +1.81%, vs the ~5.3% the drain model predicted. The MECHANISM was right (disjoint,
+byte-identical, and it moved the needle) but the SIZING was optimistic — the pipeline drain is a
+real component of the 40-CTA shapes' inefficiency, NOT the whole of it. Remaining out_proj gap is
+still open; do not assume another pipeline stage recovers it.
+
+Implementation notes for whoever touches this next:
+- smem forced the design: naive all-3-stage = 51.4 KB, OVER the 48 KB static limit (would need
+  `cudaFuncSetAttribute` + `extern __shared__`, which the launch wrapper does NOT do). Only the
+  WEIGHT tiles are tripled — `A[i&1]` is free once `MMA(i)` clears its barrier — giving 43.2 KB.
+- needed a `cp.async.wait_group 1` helper; only `wait_group 0` (wait-all) existed in-tree.
+- TRAP hit twice while generating the variant: the file defines the DEQUANT macro TWICE (a
+  `__SCALE__`-guarded pair). A blanket rename fixed only the first and the build failed on the
+  second. Grep for ALL definitions of a macro before transforming it.
+
+### Running total for the night
+C=16 **113.1 -> 126.88 tok/s (+12.2%)**, ratio 0.71x -> **0.751x** vs vLLM 168.9.
+Shipped: strided RoPE +0.87% · lm_head tile GEMM +5.50% · FFN MMQ SoA +4.6% · k64 pipeline +1.81%.
+Plus one correctness fix (strix-hip `ldb`, silent garbage logits at C>=5 on that platform).
+
+## 2026-07-28 — verification gap closed + a harness breakage I introduced
+
+★ **The `ldb` parameter silently broke two dev harnesses.** `w4a16_parity_microtest.rs` and
+`w4a16_m17_bench.rs` build their OWN `KernelLaunch` with the old 8-argument list, so after
+`w4a16_gemm_t` gained `ldb` they passed an uninitialized 9th param. PRODUCTION was unaffected (it
+routes through `w4a16_gemm_n128`, which delegates with `ldb = n`), but every future run of those
+tools would have been garbage — and the bench is the campaign's main per-shape instrument.
+Both fixed by passing `n` as the packed-case stride.
+★ RULE: when adding a kernel parameter, grep for `KernelLaunch::new` on that kernel — the ops
+wrapper is NOT the only launcher. Test harnesses bypass it by design.
+
+★ **`w4a16_gemm_t_k64_p3` added to the parity oracle and PASSES**, with cos/max|Δ| IDENTICAL to its
+`_k64` parent on every shape (attn_o 0.9991119/0.09961, attn_q 0.9991262/0.10156, ffn_down
+0.9991187/0.17969). That is kernel-level bit-identity evidence, strictly stronger than the
+single-prompt output hash the lever originally shipped on. Full gate: PASS.
+
+## 2026-07-28 — ★ SHIPPED: 3-deep weight pipeline for `w4a16_gemm_t` (+2.57% C=16)
+Same change as the k64 sibling, applied to TWICE the surface (26.5 ms/step vs 13.4).
+C=16 **126.47 -> 129.72** (4 reps/leg, 129.6-129.9 vs 126.0-126.8, DISJOINT), byte-identical
+(`bf3a0b07...` both legs). Default ON, kill `ATLAS_NO_TGEMM_PIPELINE3` (PRESENCE). Three qwen3
+handle sites route through one `layers::tgemm_kernel` helper, which falls back automatically on
+targets that do not ship `_p3`.
+
+Sweep: C=1 25.45 · C=2 25.45 · C=4 48.55 · C=8 **75.6 (0.764x)** · C=16 **129.35-130.2 (0.768x)**.
+
+### ★ NULL (with a mechanism): FOUR stages is a 5% REGRESSION — depth 3 is the optimum
+Extending the same kernel to a 4-deep pipeline measured **120.3 vs 126.5 for the 2-stage parent**,
+i.e. WORSE than doing nothing, and far worse than 3-deep's 129.7. Cause: a 4-deep weight pipeline
+also forces A to >=3 deep (step i+3 would otherwise overwrite an A buffer that MMA(i) has not read
+— caught BEFORE measuring, by index analysis). Making A 4-deep takes the tile from 5,120 to 20,480
+B and total smem from ~22 KB to ~37 KB, which drops the LARGER-grid shapes (qkvz 128 CTAs, fused
+QKV 112) from 2 CTAs/SM to 1 — destroying exactly the co-residency that was covering their latency.
+★ RULE: pipeline depth trades in-flight bytes against OCCUPANCY. On a kernel whose bigger shapes
+rely on co-residency, past ~3 stages the occupancy loss dominates. Do not assume deeper is better;
+it is a tunable with an interior optimum, and here the optimum is 3.
+
+### Running total for the night
+C=16 **113.1 -> 129.7-130.2 tok/s (+15%)**, ratio 0.71x -> **0.768x**. C=8 71.2 -> 75.6 (0.764x).
+Shipped, ALL byte-identical except lm_head: strided RoPE +0.87% · lm_head tile GEMM +5.50% ·
+FFN MMQ SoA +4.6% · k64 3-deep pipeline +1.81% · tgemm 3-deep pipeline +2.57%.
+
+### lm_head routed through `tgemm_kernel` — MEASURED NEUTRAL (kept for consistency)
+lm_head was the last site resolving `w4a16_gemm_t` directly, so it stayed on the 2-stage parent.
+Routing it through the resolver measures **+2.55% vs +2.57% before** — i.e. contributes NOTHING,
+which is the predicted result and a check on the grid.x model: at 1938 CTAs lm_head already has the
+co-residency that covers the parent's drain. Kept because it is byte-identical, cost-free, and
+removes the last bypass of the resolver. ★ A neutral result that CONFIRMS a model is worth keeping
+and recording; it is evidence, not a wasted experiment.
+
+## 2026-07-28 — ★★★ THE STRUCTURAL LEVER, CONFIRMED: batched speculative decoding
+
+External scan (vLLM V1 source in the vendored checkout + measured literature) confirms plainly:
+**everyone runs spec decode across the FULL continuous batch; nobody gates it to one sequence.**
+The industry answer to "spec decode at batch" is SHRINK K AS BATCH GROWS, not turn it off.
+vLLM's documented EAGLE3 ladder is **K=5 for batch 1-16** — C=16 is "full speculation on" territory
+even on H100. The "batch size 1 only" folklore is TRT-LLM's LEGACY ENGINE FLOW, a dead code path.
+
+vLLM V1 shape (all in `scratchpad/vllm-src/`):
+- verification IS the normal decode forward — draft tokens appended, ragged varlen batch
+  (`gpu_model_runner.py:2743` `_calc_spec_decode_metadata`, mixed `[3,0,2,0,1]` draft lengths)
+- batched Triton rejection sampler over `[batch, k]` (`v1/sample/rejection_sampler.py`)
+- per-request rewind is scheduler arithmetic (`scheduler.py:1547-1571`)
+- ★ **GDN ROLLBACK IS SOLVED UPSTREAM**: `gdn_attn.py` allocates **num_spec+1 recurrent-state slots
+  per sequence**; the FLA kernel writes a checkpoint per draft position INLINE
+  (`INPLACE_FINAL_STATE`, `fla/ops/fused_recurrent.py:104-166`); next step loads slot
+  `num_accepted-1`. **Rollback is an index lookup.** This eliminates EXACTLY the per-token FLA
+  overhead that killed the TRT-LLM ngram v21 experiment — checkpoints are a byproduct of one fused
+  kernel, not extra passes.
+- full CUDA graph on the uniform 1+k step; dynamic K-vs-batch ladder in the scheduler.
+
+Measured elsewhere: EAGLE-3/SGLang H100 **B=32: 1.30x TPOT, 1.70x aggregate**; EAGLE-3 paper 1.38x
+at B=64; MagicDec 1.18-1.91x at B=32 and **speedup GROWS with batch in the memory-bound regime** —
+GB10 is squarely in that regime (FFN at 87% of achievable bandwidth). Against our 130 tok/s that
+projects to **169-221 at C=16**, i.e. meeting or beating vLLM's 169.
+★ Published GB10 envelope: NO source exceeds ~170 agg tok/s at C=16 for any model >=27B, and NONE
+of those runs used speculation at batch.
+
+### ★ MEASURED: `ATLAS_MTP_MAX_SEQS` is a GUARD, NOT A KNOB — raising it HALVES throughput
+| cap | C=2 | C=4 |
+|---|---|---|
+| **2 (default)** | 25.3 | **48.5** |
+| 4 | 25.7 | **25.8** |
+| 8 | 25.3 | **25.4** |
+Enabling MTP at C=4 collapses aggregate throughput to single-sequence levels (**-47%**). Output is
+COHERENT and IDENTICAL in all three legs, so this is NOT correctness — it is SERIALIZATION: the
+multi-seq MTP path runs but aggregate throughput degenerates to ~C=1's number, consistent with
+`mtp_carry.rs:37`'s `active.len()==1` assumption and the single-slot design at `types.rs:187`.
+=> **Batched MTP requires the real vLLM-shaped implementation (ragged 1+k varlen verify, batched
+rejection, per-sequence k+1 GDN state slots, per-request rewind). It is NOT a constant change.**
+★ A 20-minute experiment correctly scoped a multi-day project — run the cheap disambiguating test
+BEFORE estimating the expensive one.
+
+### Recommended order when this is picked up
+1. Batched MTP, vLLM's exact shape (expected **1.3-1.7x at C=16** — THE lever; everything else is
+   a rounding error beside it). Blueprint is in the vendored checkout.
+2. Dynamic K-vs-batch ladder shipped WITH it (prevents the fixed-K regression that produced vLLM's
+   historical 1.4-1.8x slowdowns).
+3. Overlapped scheduling + full-graph 1+k step (hides the growing host-side spec bookkeeping).
+4. GDN batched-recurrent as a STANDALONE lever: SKIP (our own +1-2% measurement stands, and vLLM's
+   design agrees) — but adopt its inline-checkpoint slot scheme as part of (1).
+
+## 2026-07-28 — ★ BATCHED-MTP GATE: PASS (fixer round 1) — C=4 cap=4 25.8 → 49.0
+
+The eb85ce41 batched verify left the gate 10% short (43.9 vs >48.5). nsys at C=4 showed the gap
+was NOT the per-seq GDN loop the failure report guessed — it was the PROPOSE: 12 per-seq drafter
+forwards x ~5 ms/step (~62 ms of a ~180 ms step; the BF16 drafter reads ~850 MB of weights per
+forward, `--mtp-quantization bf16`). Three fixes on binary 4d01c9a4:
+
+1. **Batched cross-seq propose** — one M=n drafter forward per draft position (drafts chain
+   WITHIN a seq, are independent ACROSS seqs). Weight-bearing GEMMs on
+   `dense_gemm_bf16_pipelined` (microbenched 2.7x the 4x-GEMV loop at M=4: 5.1 vs 14.4 ms per
+   position; scalar `dense_gemm_bf16` only 1.8x — measure before wiring), LM head on
+   `w4a16_gemv_batch4`, everything small looped per row with `forward_one`'s exact kernels.
+   A/B alone: 46.3-46.8 vs 42.9-43.6 kill-switch (`ATLAS_NO_MTP_BATCH_PROPOSE`), disjoint.
+2. **out_proj M>8 dispatch** (m_dispatch class strikes again, in reverse): R=16 verify rows fell
+   into the pre-dequanted-FP8 PREFILL arm — fp8_fp8_gemm_ldmab 379 us vs 182 us for the SAME
+   shape on w4a16_gemm_t_k64_p3 (2x weight bytes, bandwidth-bound at M=16) — x48 layers =
+   ~9.5 ms/step. Attention o_proj at the same M was ALREADY on the k64 tile GEMM, which is what
+   fingered the SSM arm. New arm via `deep_k_gemm`, kill `ATLAS_NO_VERIFY_OUTPROJ_TGEMM`.
+3. **Batched argmax** in R-row verify + batched propose (~2 ms/step; the single-row argmax is a
+   one-CTA scan, R serial calls = R single-SM passes).
+
+GATE (3 scored reps, warmup discarded): **48.8 / 48.5 / 49.6 (mean 49.0)** vs bar >48.5; from
+25.8 serialized = +90%. C=1 cap=4 25.5-25.6; C=1 default-cap unchanged (batched paths dead at
+cap=1). Coherence + tool-call smokes PASS (finish=stop / tool_calls, well-formed args). MTP
+sustained all legs (16 K4 summaries), zero ERROR/panic/716. Accept telemetry healthy at n=4:
+p1 0.70-0.82, mean accepted 1.19-1.55 — the batched drafter's drafts are as good as per-seq.
+
+★ Batched MTP at C=4 is now at PARITY-to-slightly-ahead of MTP-off (49.0 vs 48.5). The lever is
+REAL but not yet decisive at C=4; per the spec the C=8/16 regime is where the weight-read
+amortization grows. Remaining sized levers before re-raising the cap: per-seq GDN conv/WY loop
+(~5 ms/step small kernels + share of ~22 ms/step eager gaps), K-vs-batch ladder / D-Cut.
+
+★★ SELF-INTERFERENCE TRAP (cost ~1.5 h): a serve failed its KV-budget check because page cache
+from the PREVIOUS leg inflated "pre-KV" (fix: `sysctl vm.drop_caches=3` + settle before every
+serve of this config); its driver script kept polling :8888, and when the NEXT serve came up it
+fired a second C=4 drive → 8 active > cap 4 → the scheduler correctly disabled MTP
+(`active.len() <= mtp_max_seqs()`) → an entire nsys profile of the wrong regime that presented
+as "batched propose killed MTP after one round" (36.5 tok/s, zero K4 lines, batch-8 graphs).
+`pgrep -af prof_drive` before EVERY benchmark serve; a clean-looking profile of the wrong regime
+is worse than no profile.
+
+## 2026-07-28 — ★★★ BATCHED MTP LANDED (ultracode workflow, 11 agents). C=2 BEATS vLLM — first parity crossing beyond C=1.
+
+Workflow wf_2149fd7e-81d built the full lever: batched K=4 verify forward (model side, `291bdc0b`),
+scheduler dispatch (`eb85ce41`), batched cross-sequence propose + an out_proj M>8 dispatch fix
+(`865d580a`), gate-validated (C=4 cap=4: 25.8 serialized -> ~48-49.6 batched, coherent, zero CUDA
+errors, though statistically at PARITY with the 48.5 MTP-off bar at N=8, mean 47.65).
+
+### Validated sweep (cap default = 2, commit `f49e00c9`)
+| C | Atlas | vLLM | ratio |
+|---|---|---|---|
+| 1 | 25.60 | 14.2 | **1.803x MET** |
+| 2 | **29.40** | 27.8 | **1.058x MET** — first time, +13% over the 26.4 MTP-off number |
+| 4 | 48.70 | 53.3 | 0.914x |
+| 8 | 74.85 | 98.8 | 0.758x |
+| 16 | **131.75** | 168.9 | 0.780x (best ever) |
+No regression anywhere vs the MTP-off baselines.
+
+### ★ cap=16 sweep — the fixed-K collapse, MEASURED on our own engine
+C=2 29.95 but **C=8 49.0 (vs 74.65 off) and C=16 50.1 (vs 131.25 off)** — throughput PLATEAUS at
+~50 regardless of C. n*(K+1) verify rows of SUPERLINEAR GDN + ~22 ms/step of ungraphed eager verify
+gaps. Exactly the fixed-large-K failure the literature warned about (vLLM's 1.4-1.8x slowdowns;
+D-Cut's DFlash bs=64 collapse). The cap defaults to the measured crossover (2).
+
+### What takes C=4..16 past the bar (in order)
+1. CUDA-graph the batched verify step (validator: ~22 ms/step eager gaps at cap>1).
+2. Spec step 2 remainder: per-seq GDN conv/WY batching (~5 ms/step sized by the validator).
+3. K-vs-batch ladder, then D-Cut-style per-request depth pruning (task #35) — our GDN K-superlinearity
+   makes depth cuts worth more here than on dense models.
+4. Accept-rate lift: batched accept p1 0.59-0.71 vs single-seq 0.70-0.82 — find the divergence.
+
+### ★ Trap hit AGAIN this session: a regex replaced the WRONG unwrap_or
+Blind `.unwrap_or(N)` regex edit changed `shadow_topk` default 0->2 instead of the cap. Caught by
+re-reading the file after the sweep stayed collapsed. Reverted. RULE: anchor numeric-default edits
+to the FUNCTION, never to the literal.
+
+## 2026-07-28 — ★★★ FINALIZED: adaptive policy = cap 4 DEFAULT (`dafd990d`). C=4 crosses vLLM — three of five levels MET.
+
+The per-C policy needs no new mechanism: `active.len() <= mtp_max_seqs()` already IS the adaptive
+gate. Batched K=4 MTP at C<=4, bit-for-bit MTP-off fallback at C>4. `ATLAS_MTP_MAX_SEQS` default
+2 -> 4 (`speculative.rs`, anchored to the function); `=1` restores single-seq-only.
+
+### Validated sweep at PURE DEFAULTS (binary 472ed410 = 7f4ffd6c + the default constant; no env
+overrides beyond the standard non-MTP flag set; scored drives after one discarded warmup per
+serve; two independent serves, caches dropped before each)
+| C | reps (tok/s) | mean | vLLM | ratio | floor (never-regress) | verdict |
+|---|---|---|---|---|---|---|
+| 1 | 25.6, 25.5 | 25.55 | 14.2 | **1.80x** | 25.60 | **MET** |
+| 2 | 35.3, 35.4 | 35.35 | 27.8 | **1.27x** | 29.40 | **MET** (+20% over floor) |
+| 4 | 52.6, 56.6, 53.6, 53.5, 54.1 | 54.1 | 53.3 | **1.01x** | 48.70 | **MET** (+11% over floor) |
+| 8 | 72.1, 74.6, 72.1, 71.4, 74.4, 71.7, 75.2, 75.1 | 73.5 | 98.8 | 0.74x | 74.85 | not met |
+| 16 | 131.4, 129.9, 131.6 | 131.0 | 168.9 | 0.78x | 131.75 | not met |
+
+- C=8/16 regime is PROVABLY the floor's own code path (8 > cap ⇒ MTP off, same scheduler branch),
+  so no policy adjustment can move them. Fast C=8 reps (75.1-75.2) reproduce the floor exactly;
+  the ~72 mode (both serves) carries ~1 s extra wall on the prefill leg — serve-to-serve /
+  prefix-cache variance, not decode. C=16 130.-131.6 sits inside the historical 129.35-132.5 spread.
+- cap=8/16 remain strictly dominated (fixed K=4 over n>=8 plateaus ~55 tok/s at EVERY C — worse
+  than MTP-off). NEVER raise the cap past 4 until the K-vs-batch ladder / D-Cut (task #35) lands.
+- Coherence smoke (temp 0, seed 42): fluent Rayleigh-scattering answer, finish=stop. Tool-call
+  smoke: well-formed get_weather({"location":"Paris"}), finish=tool_calls. Zero CUDA errors /
+  panics in either serve log (one benign content-loop watchdog, known).
+- C=2 at defaults measured 35.35 — well above the 29.40 recorded at cap=2 default; the graphed
+  batched verify + accept fix (`2070cdd6`/`684657e5`) lifted it further since that row was taken.
+
+### Campaign position
+Goal ">=1.0x at ALL of C=4,8,16": **C=4 MET (first time at defaults); C=8 0.74x and C=16 0.78x
+remain open** and are unchanged-by-construction from the MTP-off baselines. The remaining gap is
+exactly the fixed-K collapse at n>=8: n*(K+1) verify rows of superlinear GDN. Next lever, in
+order: K-vs-batch ladder / D-Cut per-request depth pruning (task #35), then re-raise the cap.
+
+## 2026-07-28 — ★★★ FINALIZED: K ladder ends at n=8 (4:3,8:1), cap 8 (`27ca65ca`). C=8 +10.5%; FOUR of five floors beaten, C=16 preserved.
+
+The 24913dda ladder (4:3,8:2,16:1, cap 16) was matrix-tested (binary 4b92a774, 3-4 reps/cell):
+C=8 81.1 with the default steps, **82.4 with 8:1** (vs 75.1 MTP-off control = +10-12%), but C=16
+**114.6-117.3 vs 131.5 control in BOTH configs** — speculation at n=16 loses at even minimum
+depth. Arithmetic: at p1~0.72 a win needs the K=1 verify step to cost <1.72x a plain batch-16
+decode step; measured 117.3/131.5 implies ~1.9x. Suspects (all deliberately left eager): per-seq
+GDN conv/WY loop at k<4 (the cross-seq 2-launch fast path is K=4-only), batched propose chunked
+to groups of <=4, Phase-A per-seq M=1 bootstrap decodes.
+
+**Fix (`27ca65ca`)**: default ladder 4:3,8:1 (the 8:1 step measured BEST at C=8); cap default
+16 -> 8, so n>8 is MTP-off by construction and the C=16 floor returns. Both anchored in
+`speculative/ladder.rs` with the measurements in the comments.
+
+### Validated sweep at PURE DEFAULTS (binary 7a99488d, two fresh serves, caches dropped,
+scored drives after one discarded warmup per serve)
+| C | reps (tok/s) | mean | floor | vLLM | ratio | verdict |
+|---|---|---|---|---|---|---|
+| 1 | 25.6, 25.7, 25.6, 25.6, 25.6 | 25.62 | 25.55 | 14.2 | **1.80x** | **MET** |
+| 2 | 34.9, 35.4, 35.4, 35.4, 34.8 | 35.18 | 35.35 | 27.8 | **1.27x** | **MET** (floor within noise, see below) |
+| 4 | 56.4, 57.4, 54.3, 53.6, 56.5 | 55.6 | 54.1 | 53.3 | **1.04x** | **MET** (+2.8% over floor) |
+| 8 | 80.9, 81.5, 82.5, 80.3, 81.0 | 81.2 | 73.5 | 98.8 | 0.82x | floor **+10.5%**; bar not met |
+| 16 | 131.6, 131.9, 132.0, 131.8, 131.7 | 131.8 | 131.0 | 168.9 | 0.78x | floor MET (MTP-off by cap) |
+
+- Ladder engagement PROVEN from graph captures: batched K=4 verify graphs at n=2..4, K=2 at
+  n=5..8, NONE above 8; zero graph churn/evictions.
+- Coherence smoke (temp 0, seed 42): fluent Rayleigh answer, finish=stop. Tool-call smoke:
+  well-formed get_weather({"location":"Paris"}), finish=tool_calls. Zero CUDA errors/panics in
+  all serve logs.
+- ★ C=2 slow-mode finding: after ~4+ drives on one serve, C=2 bimodally drops to ~32-33 tok/s
+  (+1.1 s wall; log shows "Prefix cache hit ... but no SSM snapshot — recomputing all KV").
+  REPRODUCED EXACTLY with `ATLAS_NO_MTP_K_LADDER=1` (control serve: 35.7/35.0/35.4/35.4 then
+  32.1/32.0) — pre-existing SSM-snapshot/prefix-anchor drift (the ssm_miss_anchor class), NOT
+  the ladder; at n=2 the ladder is behaviorally identical to the floor config anyway (3 drafts
+  either way). Fresh-serve C=2 mode is 35.2-35.4 = the floor.
+
+### Campaign position
+Goal ">=1.0x at ALL of C=4,8,16": **C=1/2/4 MET at defaults; C=8 0.82x (was 0.74x), C=16 0.78x
+open.** The C=8 bar (98.8) needs ~+22% more; the C=16 bar (168.9) needs the n=16 verify-step
+cost cut below ~1.7x a plain decode step before ANY spec depth can win there. Next levers, in
+order: (1) k<4 GDN table-form port (extend the cross-seq conv/WY 2-launch fast path beyond
+K=4), (2) wider batched propose (drop the <=4 chunking), (3) graph the Phase-A bootstrap
+decodes — then re-test 16:1 and re-raise the cap.
+
+## 2026-07-28 — ★★★ FINALIZED (round 2): three eager-cost fixes + ladder `4:3,8:2` (cap 8). C=8 +9.6%, FOUR floors beaten, C=16 preserved.
+
+The three costs named by the cap-16 matrix were all fixed and all verifiably engage:
+`b93982d9` K-parameterizes the cross-seq GDN conv/WY 2-launch fast path (was K=4-only),
+`a83627a2` widens the batched propose to n=16 (was chunked to groups of <=4), `fa373bf4`
+batches the Phase-A bootstrap (was per-seq M=1 decodes). Serve-log proof, this session:
+`batched-verify GDN conv+WY ENGAGED (n=8, k=3)` and `(n=3, k=4)` — zero DECLINED for that
+path; `propose_batch active: n=8 ... lm_head_batchm=0x...4120` (ONE group, width-selected
+handle, non-zero ⇒ no `try_kernel` handle-0 fallback); `MTP batched bootstrap ENGAGED (n=7)`.
+
+★ Their measured value is NOT a direct speedup — at the shipped `8:1` ladder they were worth
+only +2.1% (82.9 vs the 81.2 floor). They pay by MOVING THE OPTIMAL LADDER POINT: pre-fix
+`8:1` (82.4) beat `8:2` (81.1); post-fix `8:2` (89.25) beats `8:1` (82.9) by +7.7%. The
+verify step got cheap enough that a deeper draft finally pays at n=8. **Default ladder is now
+`4:3,8:2`** (anchored in the `mtp_ladder_steps` function body, per the burned-twice regex
+trap); cap unchanged at 8.
+
+### C=16 still loses — the arithmetic (why the cap does NOT move)
+| config | C=16 tok/s | vs MTP-off control 131.9 |
+|---|---|---|
+| MTP-off (cap 8, pure defaults) | **131.9** | — |
+| 16:1 (cap 16) | 128.4 | 0.973x |
+| 16:2 (cap 16) | 94.1 | collapse |
+At p1~0.72 (~1.72 tok/step) the 0.973x implies a verify-step cost of ~1.77x a plain batch-16
+decode step, against the <1.72x break-even. Pre-fix the matrix implied ~1.9x: the three fixes
+bought ~0.13x of the ~0.18x needed (~70% of the way). The named remaining cost is the piece
+deliberately left undone — **the Phase-A bootstrap forward is not graph-captured** (it routes
+through `decode_batch`, which disables graphs at n>=2), plus n small argmax D2H syncs. That is
+the single next lever if C=16 is attacked again; depth at n=16 is decisively dead (16:2 = 94.1).
+
+### Validated sweep at PURE DEFAULTS (binary md5 `e65c232d49732d409339a1dccad00ae8`,
+`ATLAS_TARGET_MODEL=qwen3.6-27b cargo build -p spark-server --release --features cuda`;
+ONE FRESH SERVE PER C, `vm.drop_caches=3` + all containers removed + `:8888` asserted dead
+before each, first drive per serve discarded as warmup)
+| C | scored reps (tok/s) | mean | floor | vLLM | ratio | verdict |
+|---|---|---|---|---|---|---|
+| 1 | 25.7, 25.6, 25.6 | **25.63** | 25.62 | 14.2 | **1.80x** | **MET** |
+| 2 | 35.8, 35.2, 35.6 | **35.53** | 35.18 | 27.8 | **1.28x** | **MET** (floor +1.0%) |
+| 4 | 59.1, 58.1, 56.7 | **57.97** | 55.6 | 53.3 | **1.09x** | **MET** (floor +4.3%) |
+| 8 | 88.5, 90.4, 88.8, 88.6 · 88.5, 89.1, 89.0 (2 serves) | **89.0** | 81.2 | 98.8 | 0.90x | floor **+9.6%**; bar not met |
+| 16 | 132.0, 131.7, 131.6 | **131.77** | 131.8 | 168.9 | 0.78x | floor MET (MTP-off by cap) |
+
+- Smoke at final defaults (temp 0, seed 42, run on two separate serves): fluent Rayleigh
+  answer `finish=stop`; `get_weather({"location":"Paris"})` `finish=tool_calls`. PASS.
+- **Zero** ERROR/panic/illegal-access/error-700/716 lines in all six serve logs, including a
+  full C=8 leg's log dumped AFTER its drives. Accept telemetry healthy at n=8, k=3:
+  ~33-41 accept-3 / 32-37 accept-2 / 22-35 reject per 100 steps, mean accepted 0.98-1.19.
+- One benign `SSM batched recurrent DECLINED (n=4): pool slots are not contiguous` — the known
+  slot-fragmentation notice, present in the floor config too.
+- ★ Harness trap re-hit and hardened: the serve helper must remove EVERY container (not just
+  its own label) and assert `:8888` is both un-listened and un-answering before launching, or
+  the readiness probe passes against the PREVIOUS engine.
+
+### Campaign position
+**C=1/2/4 MET at pure defaults (1.80x / 1.28x / 1.09x). C=8 0.90x (was 0.82x, floor +9.6%),
+C=16 0.78x.** C=8 needs a further ~+11%; C=16 needs the n=16 verify-step cost below ~1.72x a
+plain decode step before any depth can win there. Next lever, singular and named: graph-capture
+the Phase-A bootstrap forward, then re-test 16:1 and re-raise the cap.

--- a/docs/campaigns/gb10-concurrency-2026-07/STATE.md
+++ b/docs/campaigns/gb10-concurrency-2026-07/STATE.md
@@ -2330,3 +2330,122 @@ before each, first drive per serve discarded as warmup)
 C=16 0.78x.** C=8 needs a further ~+11%; C=16 needs the n=16 verify-step cost below ~1.72x a
 plain decode step before any depth can win there. Next lever, singular and named: graph-capture
 the Phase-A bootstrap forward, then re-test 16:1 and re-raise the cap.
+
+## 2026-07-29 — ★★★ FINALIZED (round 3): chunk-cap fix + ladder `4:3,8:3` (cap 8). C=8 95.68 (floor +7.6%), FOUR floors held, C=16 preserved.
+
+The wave's finding is a MEASUREMENT ARTIFACT, not a new optimization: **the `8:2` ladder step was
+compensating for a bug, not for GDN depth cost.** `mtp_step`'s verify chunk cap for `rows=4` was
+pinned to 4 SEQUENCES ("keeps the proven 4-seq/R=16 envelope byte-identical"), so an 8-wide K=4
+batch ran TWO serialized 4-wide verify forwards — 2x the weight reads per step. Every historical
+"8:3 collapses at n=8" number recorded that chunking, never depth-3 at width 8 (57.9 in the
+round-2 matrix; 62.6 on re-measure). The real bound is the verify row buffer, which
+`can_batch_verify` already enforces as `n*k <= 32`: 8 seqs x 4 rows fits EXACTLY.
+Raising the cap: **62.58 -> 95.68 (+53%)**, and the GDN path engages ONCE at `(n=8, k=4)` instead
+of twice at `(n=4, k=4)`.
+
+★ It was caught by INSTRUMENT ABSENCE, not by a throughput reading: the width-attributed accept
+telemetry printed ONLY `n=4` lines during a C=8 drive. The corroborating arithmetic — 62.58 is
+BELOW the 73.5 MTP-off floor, and a depth cost cannot take you below the no-speculation path
+while a doubled forward can.
+
+### Landed
+- `48fb8a11` fix(mtp): chunk cap -> row-buffer bound (`rows=4` 4 -> 8 seqs). Provably a NO-OP at
+  the pre-existing default ladder, where `rows=4` occurred only at n<=4 and every chunk was <= 4.
+- `3313a733` perf(mtp): default ladder `4:3,8:2` -> `4:3,8:3`. Kill switch
+  `ATLAS_MTP_K_LADDER=4:3,8:2`. Unit tests updated (3 pass), rustfmt clean.
+- `d4633f09` docs: the stale `8:2` prose in `ladder.rs` / `mtp_step.rs` (three comments still
+  described the superseded default). Doc-only.
+
+★ **The diff is inert everywhere except 5 <= n <= 8, by construction**: at n<=4 both ladders
+return 3 drafts AND the chunk cap was already <= 4; at n>8 the cap (8) makes the path MTP-off.
+So C=1/2/4/16 are unchanged code paths and their rows below are variance measurements, not
+regression risk.
+
+### Validated sweep at PURE DEFAULTS (binary md5 `f134f6fa267cdc257197d092f113089a`, built with
+`ATLAS_TARGET_MODEL=qwen3.6-27b cargo build -p spark-server --release --features cuda`; ONE FRESH
+SERVE PER C, all containers removed + `:8888` asserted dead + `vm.drop_caches=3` + a MemAvailable
+>= 108GB settle gate before each; first drive per serve DISCARDED as warmup; 5 scored drives)
+| C | scored reps (tok/s) | mean | floor | vLLM | ratio | verdict |
+|---|---|---|---|---|---|---|
+| 1 | 25.6, 25.6, 25.6, 25.6, 25.6 | **25.60** | 25.62 | 14.2 | **1.80x** | **MET** |
+| 2 | 35.2, 35.6, 35.6, 35.4, 35.4 | **35.44** | 35.18 | 27.8 | **1.27x** | **MET** (floor +0.7%) |
+| 4 | 60.5, 59.9, 58.2, 59.7, 59.9 | **59.64** | 55.6 | 53.3 | **1.12x** | **MET** (floor +7.3%) |
+| 8 | 95.7, 94.8, 95.7, 96.1, 96.1 | **95.68** | 88.9 | 98.8 | 0.968x | floor **+7.6%**; bar not met |
+| 16 | 131.4, 131.5, 131.0, 131.1, 131.1 | **131.22** | 131.9 | 168.9 | 0.777x | MTP-off by cap |
+
+Confirming second serves for the two levels that read at/under their reference floor (both on
+code paths this diff does not touch): **C=16 131.7, 132.0, 131.3, 131.5, 131.0 = 131.50** and
+**C=1 25.5, 25.6, 25.6, 25.6, 25.5 = 25.56**. Pooled two-serve: C=16 **131.36** (10 reps,
+131.0-132.0, inside the documented 129.35-132.5 C=16 spread), C=1 **25.58** (wall 7.5s and 192
+tokens on every single rep — the spread is 1-decimal print quantization on a constant wall).
+Both levels are serve-to-serve variance around their floors, not movement.
+
+### Hygiene
+- Smoke at final defaults (temp 0, seed 42) on the C=1 and C=8 serves: fluent Rayleigh-scattering
+  answer `finish=stop`; `get_weather({"location":"Paris"})` `finish=tool_calls`. PASS.
+- **Zero** ERROR/panic/illegal-memory/error-700/716 lines in all seven serve logs, each dumped
+  while its container was still alive (`conc_sweep/fin2_c{1,2,4,8,16}.log`,
+  `fin2b_c{1,16}.log`).
+- Engagement PROVEN from the logs: `batched-verify GDN conv+WY ENGAGED (n=8, k=4)` at C=8 (56
+  launches/layer -> batched) and `(n=2, k=4)` at C=2/C=4; **zero DECLINED on the verify path**;
+  `MTP batched bootstrap ENGAGED`; zero `graphs OFF`; zero graph evictions. At C=16 there is NO
+  batched verify at all (only a ramp/tail bootstrap at n=2) — MTP-off by cap, as designed.
+- The one recurring `SSM batched recurrent DECLINED (n=...): pool slots are not contiguous` is
+  the known benign slot-fragmentation notice, present in the floor config too.
+
+### Multiplier arithmetic, with measured numbers
+- **(B) ACCEPT was the real lever and is now largely banked.** Implementer-2's per-sequence
+  drafter-prefill fix (`36d340a0`) reproduces exactly: p1 **0.740 -> 0.780** at n=8, and the
+  throughput ratio equals the tok_step ratio to 0.1% (1.0529 vs 1.0516, disjoint rep ranges
+  88.4-90.8 vs 92.8-96.9).
+- **Depth at n=8 is worth only ~+2%**: tok_step 2.301 -> 2.606 (+13.3%) buys +2.3% throughput,
+  so the K=4 verify step costs ~10.7% more than the K=3 one. Consistent in sign across 5 serves
+  (8:3 = 95.84/95.68/94.93 vs 8:2 = 93.40/93.30) but rep ranges overlap at the tails — treat it
+  as a ~2% effect, NOT a step change. Shipped as a default because the sign is consistent and the
+  mechanism is measured.
+- **C=8 remaining gap: 98.8/95.68 = 1.033x.** At the current verify cost that needs tok_step 2.69
+  (mean_na 1.69 from 1.606), i.e. p1 ~0.85 at K=4 — or a ~3% cheaper verify step.
+- **C=16 is now PARITY, not a loss**: 16:1 = 131.93 vs a same-session MTP-off control of 131.42
+  (was 128.4 = 0.973x). Parity buys nothing, so the cap stays 8. p1 at n=16 = 0.797 => break-even
+  cost 1.797x and the measured implied cost is ~1.79x — sitting exactly on it. Clearing 168.9
+  needs <= 1.40x. Depth at n=16 remains dead (16:2 = 94.1).
+
+### Accept telemetry by width (`ATLAS_MTP_ACCEPT_DEBUG`)
+| width | p1 | mean_na | tok_step |
+|---|---|---|---|
+| n=4, k_drafts=3 | 0.776 | 1.533 | 2.533 |
+| n=8, k_drafts=2 (old default) | 0.780 | 1.301 | 2.301 |
+| n=8, k_drafts=3 (new default) | 0.793 | 1.606 | 2.606 |
+| n=16, k_drafts=1 | 0.797 | 0.797 | 1.797 |
+
+### Traps re-burned this wave (all previously documented)
+1. `pkill -f prof_drive.py` SELF-MATCHES the caller's own command line and killed the harness
+   mid-run. Match only real python interpreters.
+2. **Stale concurrent driver**: a backgrounded drive loop still firing C=8 during a C=8 leg =>
+   16 active > cap 8 => MTP correctly off => a flat 65.5 tok/s plateau that would have been
+   reported as "the 8:2 control". Detected by the 65.5 signature; leg discarded and re-run.
+3. **KV-budget knife edge (new)**: the engine sizes its KV pool from system MemAvailable at
+   startup and a just-removed container's memory is still being reclaimed. Pools measured
+   3746-5056 blocks across IDENTICAL launches; `--max-batch-size 16` needs 4096, so two serves
+   DIED at build. Worse than dying is coming up just under and silently running a different
+   regime. The harness now double `sync`+`drop_caches`, gates on MemAvailable >= 108GB, and
+   RETRIES until the pool is >= 4300 blocks (one retry fired this session at 4225 blocks). Every
+   reported serve got 4225-5056; all measured ones 4387-4923.
+4. **Log loss**: each serve removes ALL containers, so `docker logs` after the NEXT serve returns
+   "No such container". Dump logs while the container is alive.
+
+### Campaign position
+**C=1/2/4 MET at pure defaults (1.80x / 1.27x / 1.12x). C=8 0.968x (floor +7.6%, was 0.90x),
+C=16 0.777x (MTP-off by cap).** C=8 needs a further ~3.3%.
+Next levers, in value order:
+1. **L3 refeed made slot-keyed** — powered A/B measured +0.016 p1 / +2.3% tokens/step.
+2. **L1 carry is silently OFF at EVERY concurrency including C=1**, because `mtp_multi_seq_mode()`
+   is cap-based. This is a LIVE REGRESSION on multi-turn/MLPerf traffic that `prof_drive`'s
+   single-turn prompts cannot see.
+3. **L6 drafter-pool sizing** (`mtp_head/new.rs:228` still sizes for ONE sequence) is now MORE
+   urgent: every sequence allocates drafter KV at prefill. Fine at this bench's 26-token prompts,
+   a silent accept->0 collapse at C=8 with long contexts.
+4. The row buffer (`n*k <= 32`) is now the binding constraint at C=8: K=4 at n=8 is the deepest
+   legal point. Going deeper requires enlarging the verify row buffer — an untested regime.
+- Still red and pre-existing: `decode_a2.rs` 598 LoC and `trait_impl/mod.rs` 800 LoC, both over
+  the 500 cap and absent from `.github/workflows/file-size-cap.yml`'s allow-list.

--- a/kernels/gb10/common/argmax_bf16.cu
+++ b/kernels/gb10/common/argmax_bf16.cu
@@ -110,6 +110,86 @@ extern "C" __global__ void argmax_bf16_batch(
     }
 }
 
+// BATCHED argmax + top-1 LOG-PROBABILITY over BF16 logits — one block per row.
+//
+// Identical index semantics to `argmax_bf16_batch` (same strided first-strict-max
+// scan, same lower-tid-preferring tree reduction), plus `out_logprob[row] =
+// log softmax(logits)[argmax]` computed by ONLINE softmax in the SAME pass — no
+// second read of the row, so the kernel costs what the plain batched argmax costs.
+//
+// Consumer: D-Cut adaptive verification-depth pruning (ATLAS_MTP_DCUT). The
+// drafter's per-position top-1 log-probability is the confidence whose prefix
+// SUM (= log of the prefix PRODUCT of survival probabilities) ranks candidate
+// verify positions across the batch. A separate kernel (rather than an extra
+// argument on `argmax_bf16_batch`) keeps every existing caller byte-identical
+// and makes an unresolved handle a silent-0 the caller can gate on.
+//
+// log p_max = m - logsumexp = m - (m + log Σ exp(v_i - m)) = -log Σ exp(v_i - m).
+extern "C" __global__ void argmax_bf16_batch_lp(
+    const __nv_bfloat16* __restrict__ logits,
+    unsigned int* __restrict__ out,
+    float* __restrict__ out_logprob,
+    unsigned int n,
+    unsigned int row_stride
+) {
+    __shared__ float s_val[1024];
+    __shared__ unsigned int s_idx[1024];
+    __shared__ float s_sum[1024];
+
+    const unsigned int row = blockIdx.x;
+    const __nv_bfloat16* __restrict__ row_logits =
+        logits + (unsigned long long)row * (unsigned long long)row_stride;
+
+    const unsigned int tid = threadIdx.x;
+    const unsigned int stride = blockDim.x;
+
+    float local_max = -1e30f;
+    unsigned int local_idx = 0;
+    float local_sum = 0.0f;
+    for (unsigned int i = tid; i < n; i += stride) {
+        float v = __bfloat162float(row_logits[i]);
+        if (v > local_max) {
+            // Rescale the running sum to the new max, then add this element.
+            local_sum = local_sum * __expf(local_max - v) + 1.0f;
+            local_max = v;
+            local_idx = i;
+        } else {
+            local_sum += __expf(v - local_max);
+        }
+    }
+
+    s_val[tid] = local_max;
+    s_idx[tid] = local_idx;
+    s_sum[tid] = local_sum;
+    __syncthreads();
+
+    // Tree reduction over (max, argmax, sum) triples. Index/max half is the
+    // byte-identical body of `argmax_bf16_batch`; the sum half is the standard
+    // online-softmax merge. Threads that scanned nothing carry max=-1e30 and
+    // sum=0, which merge as a no-op.
+    for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            const float mine = s_val[tid];
+            const float other = s_val[tid + s];
+            if (other > mine) {
+                s_sum[tid] = s_sum[tid] * __expf(mine - other) + s_sum[tid + s];
+                s_val[tid] = other;
+                s_idx[tid] = s_idx[tid + s];
+            } else {
+                s_sum[tid] = s_sum[tid] + s_sum[tid + s] * __expf(other - mine);
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        out[row] = s_idx[0];
+        const float total = s_sum[0];
+        // total >= 1 for any non-empty row (the max element contributes 1).
+        out_logprob[row] = (total > 0.0f) ? -__logf(total) : 0.0f;
+    }
+}
+
 // Argmax over FP32 logits — used when LM head outputs FP32 for sampling quality.
 extern "C" __global__ void argmax_fp32(
     const float* __restrict__ logits,

--- a/kernels/gb10/common/argmax_bf16.cu
+++ b/kernels/gb10/common/argmax_bf16.cu
@@ -55,6 +55,61 @@ extern "C" __global__ void argmax_bf16(
     }
 }
 
+// BATCHED argmax over BF16 logits — ONE BLOCK PER ROW.
+//
+// `argmax_batch` used to launch this kernel n times on the same stream, and the
+// single-row kernel is a ONE-CTA reduction (grid [1,1,1]), so it uses 1 of 48 SMs
+// and measured 100.6 us to reduce 248320 bf16 = 497 KB (~5 GB/s). At n=16 that is
+// 16 serial launches = 1.6 ms per decode step.
+//
+// Each block here runs the IDENTICAL per-row body: a strided scan keeping the first
+// strict max, then the same tree reduction preferring the lower tid. Ties therefore
+// resolve to the same index as n sequential calls — byte-identical by construction.
+extern "C" __global__ void argmax_bf16_batch(
+    const __nv_bfloat16* __restrict__ logits,
+    unsigned int* __restrict__ out,
+    unsigned int n,
+    unsigned int row_stride
+) {
+    __shared__ float s_val[1024];
+    __shared__ unsigned int s_idx[1024];
+
+    const unsigned int row = blockIdx.x;
+    const __nv_bfloat16* __restrict__ row_logits =
+        logits + (unsigned long long)row * (unsigned long long)row_stride;
+
+    const unsigned int tid = threadIdx.x;
+    const unsigned int stride = blockDim.x;
+
+    float local_max = -1e30f;
+    unsigned int local_idx = 0;
+    for (unsigned int i = tid; i < n; i += stride) {
+        float v = __bfloat162float(row_logits[i]);
+        if (v > local_max) {
+            local_max = v;
+            local_idx = i;
+        }
+    }
+
+    s_val[tid] = local_max;
+    s_idx[tid] = local_idx;
+    __syncthreads();
+
+    for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            if (s_val[tid + s] > s_val[tid]) {
+                s_val[tid] = s_val[tid + s];
+                s_idx[tid] = s_idx[tid + s];
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        out[row] = s_idx[0];
+    }
+}
+
 // Argmax over FP32 logits — used when LM head outputs FP32 for sampling quality.
 extern "C" __global__ void argmax_fp32(
     const float* __restrict__ logits,

--- a/kernels/gb10/common/causal_conv1d.cu
+++ b/kernels/gb10/common/causal_conv1d.cu
@@ -470,3 +470,88 @@ extern "C" __global__ void causal_conv1d_update_l2norm_f32(
         output[b * dim + ch] = silu;  // FP32 — no truncation!
     }
 }
+
+// ============================================================
+// DECODE (multi-sequence): conv1d + SiLU + per-head L2 norm, FP32 out,
+// with INDEPENDENT input/output row strides.
+// ============================================================
+// Identical math to `causal_conv1d_update_l2norm_f32` — this variant only
+// decouples the input and output row strides from `dim`.
+//
+// Why it exists: the concurrent-decode path feeds the conv straight from the
+// QKVZ projection output, which is laid out [Q|K|V|Z] with a row stride of
+// `qkvz_size`, while the conv's own output is `conv_dim`-strided. The
+// non-strided kernel hardcodes BOTH as `dim` (= conv_dim), so a batch=n launch
+// reads sequence b>=1 from `b*conv_dim` instead of `b*qkvz_size` — landing in
+// the PREVIOUS sequence's Z-gate region and feeding garbage into the GDN scan.
+// That is correct at n=1 and silently corrupt at n>=2, which is why the
+// multi-seq path previously ran this conv as an n-launch loop with pre-offset
+// pointers. With explicit strides the whole batch goes in ONE launch.
+//
+// `conv_state` keeps the `(b * dim + ch) * d_conv` layout: pool slots are
+// contiguous per sequence, and the multi-seq caller verifies that before
+// taking this path.
+//
+// Grid: (ceil(dim/BLOCK), batch, 1)   Block: (BLOCK, 1, 1)
+extern "C" __global__ void causal_conv1d_update_l2norm_f32_strided(
+    float* __restrict__ conv_state,
+    const __nv_bfloat16* __restrict__ new_input,
+    const __nv_bfloat16* __restrict__ weight,
+    const float* __restrict__ bias,
+    float* __restrict__ output,                     // FP32 output
+    unsigned int batch,
+    unsigned int dim,
+    unsigned int d_conv,
+    unsigned int qk_channels,
+    unsigned int head_dim,
+    float l2_eps,
+    unsigned int input_stride,     // BF16 elements between consecutive sequences in new_input
+    unsigned int output_stride     // FP32 elements between consecutive sequences in output
+) {
+    const unsigned int ch = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int b = blockIdx.y;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int block_start = blockIdx.x * blockDim.x;
+    const bool block_needs_l2 = (block_start < qk_channels);
+    const bool valid = (ch < dim && b < batch);
+    float silu = 0.0f;
+
+    if (valid) {
+        float* state = conv_state + (b * dim + ch) * d_conv;
+        for (unsigned int i = 0; i < d_conv - 1; i++)
+            state[i] = state[i + 1];
+        state[d_conv - 1] = (float)new_input[b * input_stride + ch];
+        const __nv_bfloat16* w = weight + ch * d_conv;
+        float acc = (bias != nullptr) ? bias[ch] : 0.0f;
+        for (unsigned int k = 0; k < d_conv; k++)
+            acc += state[k] * (float)w[k];
+        float sigmoid_acc = 1.0f / (1.0f + __expf(-acc));
+        silu = acc * sigmoid_acc;
+    }
+
+    if (block_needs_l2) {
+        float sq = valid ? (silu * silu) : 0.0f;
+        const unsigned int warp_id = tid / 32;
+        const unsigned int lane = tid % 32;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            sq += __shfl_down_sync(0xFFFFFFFF, sq, offset);
+        __shared__ float warp_sums[8];
+        if (lane == 0) warp_sums[warp_id] = sq;
+        __syncthreads();
+        const unsigned int head_in_block = tid / head_dim;
+        const unsigned int base_warp = head_in_block * (head_dim / 32);
+        if (tid == 0 || tid == head_dim) {
+            float total = warp_sums[base_warp] + warp_sums[base_warp + 1]
+                        + warp_sums[base_warp + 2] + warp_sums[base_warp + 3];
+            warp_sums[base_warp] = rsqrtf(total + l2_eps);
+        }
+        __syncthreads();
+        if (valid) {
+            silu *= warp_sums[base_warp];
+        }
+    }
+
+    if (valid) {
+        output[b * output_stride + ch] = silu;  // FP32 — no truncation!
+    }
+}

--- a/kernels/gb10/common/gated_delta_rule.cu
+++ b/kernels/gb10/common/gated_delta_rule.cu
@@ -286,6 +286,9 @@ extern "C" __global__ void gated_delta_rule_decode_f32(
     float v_new_i = (v_i - g * hk_dot) * bt;
 
     float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
     #pragma unroll 4
     for (unsigned int j = 0; j < k_dim; j += 4) {
         float h0 = H[(j + 0) * v_dim + tid];
@@ -301,15 +304,22 @@ extern "C" __global__ void gated_delta_rule_decode_f32(
         H[(j + 2) * v_dim + tid] = h2;
         H[(j + 3) * v_dim + tid] = h3;
         q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
     }
 
     #ifdef SSM_STATE_NORM_ENABLED
     {
-        float local_sq = 0.0f;
-        for (unsigned int j = 0; j < k_dim; j++) {
-            float hv = H[j * v_dim + tid];
-            local_sq += hv * hv;
-        }
+        float local_sq = norm_acc;
         for (int offset = 16; offset >= 1; offset >>= 1)
             local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
         __shared__ float norm_sums[4];
@@ -400,6 +410,9 @@ extern "C" __global__ void gated_delta_rule_decode_f32_norm(
     float v_new_i = (v_i - g * hk_dot) * bt;
 
     float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
     #pragma unroll 4
     for (unsigned int j = 0; j < k_dim; j += 4) {
         float h0 = H[(j + 0) * v_dim + tid];
@@ -415,15 +428,22 @@ extern "C" __global__ void gated_delta_rule_decode_f32_norm(
         H[(j + 2) * v_dim + tid] = h2;
         H[(j + 3) * v_dim + tid] = h3;
         q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
     }
 
     #ifdef SSM_STATE_NORM_ENABLED
     {
-        float local_sq = 0.0f;
-        for (unsigned int j = 0; j < k_dim; j++) {
-            float hv = H[j * v_dim + tid];
-            local_sq += hv * hv;
-        }
+        float local_sq = norm_acc;
         for (int offset = 16; offset >= 1; offset >>= 1)
             local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
         __shared__ float norm_sums[4];
@@ -733,6 +753,9 @@ extern "C" __global__ void gated_delta_rule_decode_f32_strided(
     float v_new_i = (v_i - g * hk_dot) * bt;
 
     float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
     #pragma unroll 4
     for (unsigned int j = 0; j < k_dim; j += 4) {
         float h0 = H[(j + 0) * v_dim + tid];
@@ -748,15 +771,22 @@ extern "C" __global__ void gated_delta_rule_decode_f32_strided(
         H[(j + 2) * v_dim + tid] = h2;
         H[(j + 3) * v_dim + tid] = h3;
         q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
     }
 
     #ifdef SSM_STATE_NORM_ENABLED
     {
-        float local_sq = 0.0f;
-        for (unsigned int j = 0; j < k_dim; j++) {
-            float hv = H[j * v_dim + tid];
-            local_sq += hv * hv;
-        }
+        float local_sq = norm_acc;
         for (int offset = 16; offset >= 1; offset >>= 1)
             local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
         __shared__ float norm_sums[4];
@@ -852,6 +882,9 @@ extern "C" __global__ void gated_delta_rule_decode_f32_strided_norm(
     float v_new_i = (v_i - g * hk_dot) * bt;
 
     float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
     #pragma unroll 4
     for (unsigned int j = 0; j < k_dim; j += 4) {
         float h0 = H[(j + 0) * v_dim + tid];
@@ -867,15 +900,22 @@ extern "C" __global__ void gated_delta_rule_decode_f32_strided_norm(
         H[(j + 2) * v_dim + tid] = h2;
         H[(j + 3) * v_dim + tid] = h3;
         q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
     }
 
     #ifdef SSM_STATE_NORM_ENABLED
     {
-        float local_sq = 0.0f;
-        for (unsigned int j = 0; j < k_dim; j++) {
-            float hv = H[j * v_dim + tid];
-            local_sq += hv * hv;
-        }
+        float local_sq = norm_acc;
         for (int offset = 16; offset >= 1; offset >>= 1)
             local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
         __shared__ float norm_sums[4];

--- a/kernels/gb10/common/gated_delta_rule_wy.cu
+++ b/kernels/gb10/common/gated_delta_rule_wy.cu
@@ -43,7 +43,22 @@ extern "C" __global__ void gated_delta_rule_wy2(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // 0 = the two state args are CONTIGUOUS bases indexed by
+    //     (b*num_v_heads+vh);
+    // 1 = they are device POINTER TABLES of `batch_size` entries, one per
+    //     sequence.
+    //
+    // Identical contract (and identical reason for existing) as
+    // gated_delta_rule_wy4's `state_is_table`: the contiguous form assumes the
+    // intermediate shares h_state's batch stride, but the pool's intermediate
+    // stride is num_intermediates x larger, so at batch_size>1 sequence 1's
+    // Hi0 would land on sequence 0's Hi1 — silent cross-sequence rollback
+    // corruption. The table form is what lets the cross-sequence batched MTP
+    // verify run at K=2 (ladder step "1 draft"), not just K=4.
+    //
+    // is_table=0 is byte-identical to the original kernel.
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -54,8 +69,14 @@ extern "C" __global__ void gated_delta_rule_wy2(
     const unsigned int kh = vh / head_repeat;
 
     const unsigned int hv_size = k_dim * v_dim;
-    float* H = h_state + ((b * num_v_heads + vh) * hv_size);
-    float* H_inter = h_state_intermediate + ((b * num_v_heads + vh) * hv_size);
+    const unsigned long long head_off = (unsigned long long)vh * hv_size;
+    const unsigned long long flat_off =
+        (unsigned long long)(b * num_v_heads + vh) * hv_size;
+    float* H = state_is_table ? ((float* const*)h_state)[b] + head_off
+                              : h_state + flat_off;
+    float* H_inter = state_is_table
+                         ? ((float* const*)h_state_intermediate)[b] + head_off
+                         : h_state_intermediate + flat_off;
 
     // Token pointers
     const __nv_bfloat16* q0 = query + (b * 2) * qk_stride + kh * k_dim;

--- a/kernels/gb10/common/gated_delta_rule_wy3.cu
+++ b/kernels/gb10/common/gated_delta_rule_wy3.cu
@@ -32,7 +32,22 @@ extern "C" __global__ void gated_delta_rule_wy3(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // 0 = the three state args are CONTIGUOUS bases indexed by
+    //     (b*num_v_heads+vh);
+    // 1 = they are device POINTER TABLES of `batch_size` entries, one per
+    //     sequence.
+    //
+    // Identical contract (and identical reason for existing) as
+    // gated_delta_rule_wy4's `state_is_table`: the contiguous form assumes the
+    // intermediates share h_state's batch stride, but the pool's intermediate
+    // stride is num_intermediates x larger, so at batch_size>1 sequence 1's
+    // Hi0 would land on sequence 0's Hi1 — silent cross-sequence rollback
+    // corruption. The table form is what lets the cross-sequence batched MTP
+    // verify run at K=3 (ladder step "2 drafts"), not just K=4.
+    //
+    // is_table=0 is byte-identical to the original kernel.
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -43,9 +58,14 @@ extern "C" __global__ void gated_delta_rule_wy3(
     const unsigned int kh = vh / hr;
     const unsigned int hv = k_dim * v_dim;
 
-    float* H   = h_state        + ((b * num_v_heads + vh) * hv);
-    float* Hi0 = h_state_inter0 + ((b * num_v_heads + vh) * hv);
-    float* Hi1 = h_state_inter1 + ((b * num_v_heads + vh) * hv);
+    const unsigned long long head_off = (unsigned long long)vh * hv;
+    const unsigned long long flat_off = (unsigned long long)(b * num_v_heads + vh) * hv;
+    float* H   = state_is_table ? ((float* const*)h_state)[b]        + head_off
+                                : h_state        + flat_off;
+    float* Hi0 = state_is_table ? ((float* const*)h_state_inter0)[b] + head_off
+                                : h_state_inter0 + flat_off;
+    float* Hi1 = state_is_table ? ((float* const*)h_state_inter1)[b] + head_off
+                                : h_state_inter1 + flat_off;
 
     // Token pointers.
     // Gate clamp MUST match per-token gated_delta_rule_decode to keep WY

--- a/kernels/gb10/common/gated_delta_rule_wy4.cu
+++ b/kernels/gb10/common/gated_delta_rule_wy4.cu
@@ -33,7 +33,23 @@ extern "C" __global__ void gated_delta_rule_wy4(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // 0 = the four state args are CONTIGUOUS bases indexed by (b*num_v_heads+vh);
+    // 1 = they are device POINTER TABLES of `batch_size` entries, one per sequence.
+    //
+    // Why this exists: the contiguous form assumes a batch stride of
+    // num_v_heads*hv floats for BOTH h_state and the intermediates. That is
+    // correct for h_state (pool slot stride) but WRONG for the intermediates,
+    // whose pool stride is num_intermediates * that (ssm_pool: the intermediate
+    // for (slot, token) lives at (slot*ni + token)*h_bytes). At batch_size>1 the
+    // old form made sequence 1's Hi0 write land on sequence 0's Hi1 — silent
+    // cross-sequence rollback corruption, latent only because every call site
+    // passed batch_size=1. The table form sidesteps it AND the separate
+    // "active sequences occupy contiguous slots" assumption.
+    //
+    // is_table=0 is byte-identical to the original kernel — same idiom as
+    // gated_delta_rule_fla.cu's h_state_is_table.
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -44,10 +60,16 @@ extern "C" __global__ void gated_delta_rule_wy4(
     const unsigned int kh = vh / hr;
     const unsigned int hv = k_dim * v_dim;
 
-    float* H   = h_state        + ((b * num_v_heads + vh) * hv);
-    float* Hi0 = h_state_inter0 + ((b * num_v_heads + vh) * hv);
-    float* Hi1 = h_state_inter1 + ((b * num_v_heads + vh) * hv);
-    float* Hi2 = h_state_inter2 + ((b * num_v_heads + vh) * hv);
+    const unsigned long long head_off = (unsigned long long)vh * hv;
+    const unsigned long long flat_off = (unsigned long long)(b * num_v_heads + vh) * hv;
+    float* H   = state_is_table ? ((float* const*)h_state)[b]        + head_off
+                                : h_state        + flat_off;
+    float* Hi0 = state_is_table ? ((float* const*)h_state_inter0)[b] + head_off
+                                : h_state_inter0 + flat_off;
+    float* Hi1 = state_is_table ? ((float* const*)h_state_inter1)[b] + head_off
+                                : h_state_inter1 + flat_off;
+    float* Hi2 = state_is_table ? ((float* const*)h_state_inter2)[b] + head_off
+                                : h_state_inter2 + flat_off;
 
     // Token pointers.
     // Gate clamp MUST match per-token gated_delta_rule_decode to keep WY

--- a/kernels/gb10/common/gdn_verify_fused_conv_kn.cu
+++ b/kernels/gb10/common/gdn_verify_fused_conv_kn.cu
@@ -139,3 +139,125 @@ extern "C" __global__ void gdn_verify_fused_conv_kn(
         for (unsigned int i = 0; i < d_conv; i++) state[i] = win[i];
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BATCHED verify conv (`gdn_verify_fused_conv_kn_batched`).
+//
+// Identical math to `gdn_verify_fused_conv_kn`, with a sequence dimension on
+// gridDim.y. Step 1 of batched speculative decoding: today
+// `spec_step.rs:94` calls `decode_verify` ONE SEQUENCE AT A TIME, so MTP at C=n
+// performs n full model forwards, each re-reading ~9.6 GB of weights on an
+// engine that is 87% bandwidth-saturated. That is why MTP measured a 3.4% LOSS
+// at C=2 and HALVED C=4. Batching the verify makes n*(K+1) rows share one
+// weight read.
+//
+// The per-sequence conv windows are independent, so the sequential per-token
+// loop is untouched and the result is bit-identical to n separate launches.
+// ═══════════════════════════════════════════════════════════════════════════
+extern "C" __global__ void gdn_verify_fused_conv_kn_batched(
+    float* __restrict__ conv_state,              // [dim, d_conv] FP32 (in/out)
+    const __nv_bfloat16* __restrict__ new_input, // [K, input_stride] BF16
+    const __nv_bfloat16* __restrict__ weight,    // [dim, d_conv] BF16
+    __nv_bfloat16* __restrict__ output,          // [K, output_stride] BF16
+    float* __restrict__ conv_state_inter,        // [K, inter_stride] FP32 (out, per-token snapshots)
+    unsigned int num_tokens,     // K (17 for DFlash γ=16 verify)
+    unsigned int dim,
+    unsigned int d_conv,
+    unsigned int qk_channels,    // channels 0..qk_channels-1 get L2 normalized
+    unsigned int head_dim,       // L2 norm group size (128)
+    unsigned int input_stride,   // BF16 elems between positions in new_input
+    unsigned int output_stride,  // BF16 elems between positions in output
+    unsigned int inter_stride,   // FP32 elems between snapshots in conv_state_inter
+    float l2_eps,
+    // ── batched additions ─────────────────────────────────────────────────
+    // One CTA column per sequence: gridDim.y == n_seq. Each sequence carries an
+    // INDEPENDENT conv window, so the per-token sequential loop below is
+    // unchanged — only the base addresses move. This is what lets one launch
+    // verify n sequences instead of n launches each re-reading the weights.
+    unsigned int conv_state_seq_stride,  // FP32 elems between sequences (dim*d_conv)
+    unsigned int input_seq_stride,       // BF16 elems between sequences in new_input
+    unsigned int output_seq_stride,      // BF16 elems between sequences in output
+    unsigned int inter_seq_stride        // FP32 elems between sequences in conv_state_inter
+) {
+    const unsigned int seq = blockIdx.y;
+    conv_state       += (size_t) seq * conv_state_seq_stride;
+    new_input        += (size_t) seq * input_seq_stride;
+    output           += (size_t) seq * output_seq_stride;
+    conv_state_inter += (size_t) seq * inter_seq_stride;
+
+    const unsigned int ch = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int block_start = blockIdx.x * blockDim.x;
+    const bool block_needs_l2 = (block_start < qk_channels);
+    const bool valid = (ch < dim);
+
+    // ── Load this channel's d_conv-element sliding window into registers ──
+    // d_conv is small (4); a fixed-size register window matches the global
+    // shift loop in causal_conv1d_update_l2norm exactly.
+    float win[8]; // d_conv <= 8
+    if (valid) {
+        const float* state = conv_state + ch * d_conv;
+        for (unsigned int i = 0; i < d_conv; i++) win[i] = state[i];
+    }
+
+    const __nv_bfloat16* w = valid ? (weight + ch * d_conv) : nullptr;
+    float wcoef[8];
+    if (valid) {
+        for (unsigned int k = 0; k < d_conv; k++) wcoef[k] = (float)w[k];
+    }
+
+    __shared__ float warp_sums[8];
+
+    // Process the positions sequentially in registers. L2-norm needs
+    // __syncthreads per position, so the loop body mirrors the single-token
+    // kernel exactly.
+    for (unsigned int t = 0; t < num_tokens; t++) {
+        float silu = 0.0f;
+        if (valid) {
+            // Shift window left, append this position's input (== global path).
+            for (unsigned int i = 0; i < d_conv - 1; i++) win[i] = win[i + 1];
+            win[d_conv - 1] = (float)new_input[t * input_stride + ch];
+            // bias == nullptr in production conv1d_update_l2norm.
+            float acc = 0.0f;
+            for (unsigned int k = 0; k < d_conv; k++) acc += win[k] * wcoef[k];
+            float sigmoid_acc = 1.0f / (1.0f + __expf(-acc));
+            silu = acc * sigmoid_acc;
+        }
+
+        if (block_needs_l2) {
+            float sq = valid ? (silu * silu) : 0.0f;
+            const unsigned int warp_id = tid / 32;
+            const unsigned int lane = tid % 32;
+            for (int offset = 16; offset >= 1; offset >>= 1)
+                sq += __shfl_down_sync(0xFFFFFFFF, sq, offset);
+            if (lane == 0) warp_sums[warp_id] = sq;
+            __syncthreads();
+            const unsigned int head_in_block = tid / head_dim;
+            const unsigned int base_warp = head_in_block * (head_dim / 32);
+            if (tid == 0 || tid == head_dim) {
+                float total = warp_sums[base_warp] + warp_sums[base_warp + 1]
+                            + warp_sums[base_warp + 2] + warp_sums[base_warp + 3];
+                warp_sums[base_warp] = rsqrtf(total + l2_eps);
+            }
+            __syncthreads();
+            if (valid) silu *= warp_sums[base_warp];
+            // Close the loop-carried window on warp_sums: the next iteration's
+            // lane-0 partial-sum write must not overtake this read.
+            __syncthreads();
+        }
+
+        if (valid) output[t * output_stride + ch] = __float2bfloat16(silu);
+
+        // Snapshot this position's conv-state (rollback intermediate t).
+        if (valid) {
+            float* snap = conv_state_inter + t * inter_stride + ch * d_conv;
+            for (unsigned int i = 0; i < d_conv; i++) snap[i] = win[i];
+        }
+    }
+
+    // Commit final (post last-position) sliding window to conv_state.
+    if (valid) {
+        float* state = conv_state + ch * d_conv;
+        for (unsigned int i = 0; i < d_conv; i++) state[i] = win[i];
+    }
+}

--- a/kernels/gb10/common/rms_norm.cu
+++ b/kernels/gb10/common/rms_norm.cu
@@ -114,6 +114,88 @@ extern "C" __global__ void rms_norm(
 
 // RMS Norm with FP32 input: for final norm before LM head when residual stream is FP32.
 // Same as rms_norm but reads float* instead of __nv_bfloat16*.
+// Strided sibling of `rms_norm`: normalizes `gridDim.y` GROUPS of
+// `gridDim.x` rows in ONE launch, where consecutive groups are `row_stride`
+// ELEMENTS apart and rows inside a group are packed at `hidden_size`.
+//
+// Motivation: multi-seq decode normalizes q (24 head-rows) and k (4 head-rows)
+// per sequence, but each sequence's rows live inside its own interleaved
+// [Q|K|V|gate] block, so the packed kernel above had to be launched once per
+// sequence — 516 launches/step across the 16 attention layers.
+//
+// Bit-identical to the packed kernel: same per-block math, same reduction, same
+// ordering. Only the base address differs, and each block still owns exactly one
+// row, so no cross-row interaction is introduced.
+//
+// Grid: (rows_per_group, num_groups, 1)   Block: (min(hidden_size, 1024), 1, 1)
+extern "C" __global__ void rms_norm_strided(
+    const __nv_bfloat16* __restrict__ input,
+    const __nv_bfloat16* __restrict__ weight,  // [hidden_size]
+    __nv_bfloat16* __restrict__ output,
+    unsigned int hidden_size,
+    float eps,
+    unsigned int row_stride                     // elements between GROUPS
+) {
+    unsigned int tid = threadIdx.x;
+    unsigned long long base =
+        (unsigned long long)blockIdx.y * row_stride +
+        (unsigned long long)blockIdx.x * hidden_size;
+
+    const __nv_bfloat16* x = input + base;
+    __nv_bfloat16* out = output + base;
+
+    float sum_sq = 0.0f;
+    const unsigned int half_size = hidden_size / 2;
+    const unsigned int* x32 = (const unsigned int*)x;
+
+    for (unsigned int i = tid; i < half_size; i += blockDim.x) {
+        float v0, v1;
+        unpack_bf16x2(x32[i], v0, v1);
+        sum_sq += v0 * v0 + v1 * v1;
+    }
+    if ((hidden_size & 1) && tid == 0) {
+        float val = __bfloat162float(x[hidden_size - 1]);
+        sum_sq += val * val;
+    }
+
+    sum_sq = warp_reduce_sum(sum_sq);
+
+    __shared__ float warp_sums[32];
+    unsigned int warp_id = tid / 32;
+    unsigned int lane_id = tid % 32;
+
+    if (lane_id == 0) {
+        warp_sums[warp_id] = sum_sq;
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float val = (lane_id < (blockDim.x + 31) / 32) ? warp_sums[lane_id] : 0.0f;
+        val = warp_reduce_sum(val);
+        if (lane_id == 0) {
+            warp_sums[0] = val;
+        }
+    }
+    __syncthreads();
+
+    float rms = rsqrtf(warp_sums[0] / (float)hidden_size + eps);
+
+    const unsigned int* w32 = (const unsigned int*)weight;
+    unsigned int* out32 = (unsigned int*)out;
+
+    for (unsigned int i = tid; i < half_size; i += blockDim.x) {
+        float xv0, xv1, wv0, wv1;
+        unpack_bf16x2(x32[i], xv0, xv1);
+        unpack_bf16x2(w32[i], wv0, wv1);
+        out32[i] = pack_bf16x2(xv0 * rms * (1.0f + wv0), xv1 * rms * (1.0f + wv1));
+    }
+    if ((hidden_size & 1) && tid == 0) {
+        float val = __bfloat162float(x[hidden_size - 1]);
+        float w = __bfloat162float(weight[hidden_size - 1]);
+        out[hidden_size - 1] = __float2bfloat16(val * rms * (1.0f + w));
+    }
+}
+
 extern "C" __global__ void rms_norm_f32(
     const float* __restrict__ input,           // [num_tokens, hidden_size] FP32
     const __nv_bfloat16* __restrict__ weight,  // [hidden_size]

--- a/kernels/gb10/common/rope.cu
+++ b/kernels/gb10/common/rope.cu
@@ -138,6 +138,130 @@ extern "C" __global__ void rope_forward(
 // Grid: (num_q_heads + num_kv_heads, seq_blocks, batch)
 // Block: (128, 1, 1)
 // ═══════════════════════════════════════════════════════════════════
+// Strided sibling of `rope_forward`: identical math and ordering, but the
+// per-token row stride is explicit. Lets the multi-seq decode path rotate ALL n
+// sequences in ONE launch instead of n launches of seq_len=1 — 258 launches/step
+// measured at 4.6 us each (1.18 ms/step) across the 16 attention layers.
+// Bit-identical to the packed kernel when q_row_stride == num_q_heads*head_dim
+// and k_row_stride == num_kv_heads*head_dim.
+extern "C" __global__ void rope_forward_strided(
+    __nv_bfloat16* __restrict__ Q,          // [batch, seq_len, num_q_heads, head_dim]
+    __nv_bfloat16* __restrict__ K,          // [batch, seq_len, num_kv_heads, head_dim]
+    const unsigned int* __restrict__ positions,  // [batch, seq_len]
+    const unsigned int seq_len,
+    const unsigned int num_q_heads,
+    const unsigned int num_kv_heads,
+    const unsigned int head_dim,
+    const unsigned int rotary_dim,           // Number of dims to rotate (e.g., 64)
+    const float theta,                       // Base frequency (e.g., 10000000.0)
+    // Row strides in ELEMENTS between consecutive tokens. The packed kernel
+    // above assumes num_q_heads*head_dim; multi-seq decode holds Q and K inside
+    // one interleaved [Q|K|V|gate] buffer whose rows are `per_seq_qkv` apart, so
+    // the stride must be explicit. Pass the packed values to reproduce
+    // `rope_forward` exactly.
+    const unsigned int q_row_stride,
+    const unsigned int k_row_stride
+) {
+    const unsigned int head_idx = blockIdx.x;     // Combined Q+K head index
+    const unsigned int seq_block = blockIdx.y;    // Which group of seq positions
+    const unsigned int batch = blockIdx.z;
+    const unsigned int tid = threadIdx.x;
+
+    // Determine if we're processing Q or K
+    const bool is_q = (head_idx < num_q_heads);
+    const unsigned int head = is_q ? head_idx : (head_idx - num_q_heads);
+
+    if (!is_q && head >= num_kv_heads) return;
+
+    // Each block handles rotary_dim/2 pairs per position.
+    // With rotary_dim=64: 32 pairs per position.
+    // With 128 threads: 128 / 32 = 4 positions per block.
+    const unsigned int pairs_per_pos = rotary_dim / 2;
+    const unsigned int pos_per_block = 128 / pairs_per_pos;
+    // Guard: if rotary_dim > 256, pairs_per_pos > 128, need different mapping
+    // For rotary_dim=64: pairs_per_pos=32, pos_per_block=4
+
+    const unsigned int local_pos = tid / pairs_per_pos;   // 0..3
+    const unsigned int pair_idx = tid % pairs_per_pos;     // 0..31
+
+    // freq depends ONLY on pair_idx, but the block covers pos_per_block positions, so
+    // every freq was recomputed once per thread -- pos_per_block redundant FP64 pow()s.
+    // FP64 runs at 1/64 rate on SM121, which left this kernel ~13x above its bandwidth
+    // floor (1.16 ms for 4.4M elements). Evaluate each distinct freq once and share it.
+    // Bit-identical (same FP64 pow) and it must happen BEFORE the divergent return
+    // below, or the __syncthreads() is unreachable for the exited threads.
+    __shared__ float s_freq[128];
+    if (tid < pairs_per_pos) {
+        const double fe = (double)(2 * tid) / (double)rotary_dim;
+        s_freq[tid] = (float)(1.0 / pow((double)theta, fe));
+    }
+    __syncthreads();
+
+    const unsigned int seq_pos = seq_block * pos_per_block + local_pos;
+    if (seq_pos >= seq_len) return;
+
+    // Get absolute position for this token
+    const unsigned int abs_pos = positions[batch * seq_len + seq_pos];
+
+    // Compute frequency for this pair in FP64 to prevent precision loss at high positions.
+    // FP32 powf() has ~1e-6 relative error; at position 30K this causes ~0.03 rad drift.
+    // freq_i = 1.0 / theta^(2*pair_idx / rotary_dim)
+    const float freq = s_freq[pair_idx];
+    const float angle = (float)abs_pos * freq;
+    const float cos_val = cosf(angle);
+    const float sin_val = sinf(angle);
+
+    // Pointer to the head's data at this sequence position
+    __nv_bfloat16* ptr;
+    if (is_q) {
+        ptr = Q + (unsigned long long)(batch * seq_len + seq_pos) * q_row_stride
+                + head * head_dim;
+    } else {
+        ptr = K + (unsigned long long)(batch * seq_len + seq_pos) * k_row_stride
+                + head * head_dim;
+    }
+
+    // Load the pair (rotate_half convention: pair i with i + half_rot)
+    const unsigned int half_rot = rotary_dim / 2;
+    const unsigned int d0 = pair_idx;              // First half: 0..31
+    const unsigned int d1 = pair_idx + half_rot;   // Second half: 32..63
+    float x0 = (float)ptr[d0];
+    float x1 = (float)ptr[d1];
+
+    // Apply rotation
+    float y0 = x0 * cos_val - x1 * sin_val;
+    float y1 = x1 * cos_val + x0 * sin_val;
+
+    // Store back
+    ptr[d0] = __float2bfloat16(y0);
+    ptr[d1] = __float2bfloat16(y1);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Proportional RoPE variant (Gemma-4 full-attention layers).
+//
+// Gemma-4's full-attention layers (rope_type="proportional",
+// partial_rotary_factor=0.25, head_dim=512) use a different layout than
+// standard partial RoPE. HF:
+//   rope_angles = int(0.25 * head_dim / 2)                # 64
+//   inv_freq = 1 / theta^(2i / head_dim) for i in [0, rope_angles)
+//   inv_freq zero-padded to head_dim/2, then cat'd to head_dim length.
+//   Rotation pairs: (i, i + head_dim/2) for i in [0, head_dim/2).
+// Only the first `rope_angles` pairs get a non-zero frequency, the rest
+// are passthrough.
+//
+// Atlas's `rope_forward` pairs (i, i + rotary_dim/2) and uses the wrong
+// frequency denominator (`rotary_dim` instead of `head_dim`) — correct
+// for Qwen3-style partial RoPE but incorrect for Gemma-4 proportional.
+//
+// This kernel implements the proportional layout directly:
+//   - Each thread rotates one (i, i + head_dim/2) pair where i < rope_angles
+//   - freq = 1 / theta^(2i / head_dim)
+//
+// Grid: (num_q_heads + num_kv_heads, seq_blocks, batch)
+// Block: (128, 1, 1)
+// ═══════════════════════════════════════════════════════════════════
+
 extern "C" __global__ void rope_forward_proportional(
     __nv_bfloat16* __restrict__ Q,
     __nv_bfloat16* __restrict__ K,

--- a/kernels/gb10/qwen3.6-27b/nvfp4/gated_delta_rule.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/gated_delta_rule.cu
@@ -893,3 +893,924 @@ extern "C" __global__ void gated_delta_rule_chunk3(
     }
 }
 
+
+// ────────────────────────────────────────────────────────────
+// Multi-sequence / fused decode kernels — exact piecewise copy of
+// kernels/gb10/common/gated_delta_rule.cu lines 344-956.
+//
+// This file SHADOWS the common one (build.rs collect_cu_files: model
+// files override common by stem), so any kernel that lives only in
+// common is invisible to this model. These four were added to common
+// after this shadow was forked, so the 27B silently lost:
+//   * _f32_strided / _f32_strided_norm — the N-sequence batched
+//     recurrent decode behind ATLAS_SSM_BATCHED_RECURRENT, and
+//   * _f32_norm / _f32_conv_norm — the fused decode variants.
+// Without them try_kernel returned 0 and every concurrent decode fell
+// back to the per-sequence loop.
+// ────────────────────────────────────────────────────────────
+
+#ifndef GDN_MS_HELPERS
+#define GDN_MS_HELPERS
+__device__ __forceinline__ void gdn_unpack_bf16x2(unsigned int packed, float& v0, float& v1) {
+    v0 = __bfloat162float(__ushort_as_bfloat16((unsigned short)(packed & 0xFFFF)));
+    v1 = __bfloat162float(__ushort_as_bfloat16((unsigned short)(packed >> 16)));
+}
+
+__device__ __forceinline__ unsigned int gdn_pack_bf16x2(float v0, float v1) {
+    unsigned int lo = (unsigned int)__bfloat16_as_ushort(__float2bfloat16(v0));
+    unsigned int hi = (unsigned int)__bfloat16_as_ushort(__float2bfloat16(v1));
+    return lo | (hi << 16);
+}
+
+__device__ __forceinline__ float gdn_warp_reduce_sum(float val) {
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        val += __shfl_xor_sync(0xFFFFFFFF, val, offset);
+    }
+    return val;
+}
+
+// SSM state normalization: clamp per-head h_state norm to prevent
+// catastrophic state explosion on long sequences (Stuffed Mamba, 2024).
+// MAX_STATE_NORM: if ||h[head]||_F > this, scale h down. 0 = disabled.
+//
+// Tuning: 100.0 was too aggressive — at 6K+ tokens with large system prompts,
+// state norms legitimately reach 200-500 and clipping destroys information
+// needed for instruction following. 1000.0 allows natural state growth while
+// still preventing numerical overflow (FP32 max ~ 3.4e38).
+#ifndef SSM_STATE_NORM_ENABLED
+#define SSM_STATE_NORM_ENABLED
+#define SSM_STATE_MAX_NORM 1000.0f
+#endif
+#endif  // GDN_MS_HELPERS
+
+extern "C" __global__ void gated_delta_rule_decode_f32_norm(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ z_gate,
+    const __nv_bfloat16* __restrict__ norm_weight,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    float eps
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    if (tid >= v_dim) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H = h_state + ((b * num_v_heads + vh) * k_dim * v_dim);
+    const float* q_ptr = query + (b * num_k_heads + kh) * k_dim;
+    const float* k_ptr = key + (b * num_k_heads + kh) * k_dim;
+    const float* v_ptr = value + (b * num_v_heads + vh) * v_dim;
+
+    float g_raw = gate[b * num_v_heads + vh];
+    const float g = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[b * num_v_heads + vh];
+
+    __shared__ float smem_k[128];
+    __shared__ float smem_q[128];
+
+    if (tid < k_dim) {
+        smem_k[tid] = k_ptr[tid];
+        smem_q[tid] = q_ptr[tid];
+    }
+    __syncthreads();
+
+    float v_i = v_ptr[tid];
+    float hk_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+
+    float v_new_i = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = norm_acc;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
+        __shared__ float norm_sums[4];
+        if (tid % 32 == 0) norm_sums[tid / 32] = local_sq;
+        __syncthreads();
+        if (tid == 0) {
+            float total = 0.0f;
+            for (int w = 0; w < 4; w++) total += norm_sums[w];
+            norm_sums[0] = total;
+        }
+        __syncthreads();
+        float head_norm_sq = norm_sums[0];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) {
+                H[j * v_dim + tid] *= scale;
+            }
+        }
+    }
+    #endif
+
+    const float inv_sqrt_d = rsqrtf((float)k_dim);
+    const float x = q_dot * inv_sqrt_d;
+
+    __shared__ float x_cache[128];
+    x_cache[tid] = x;
+
+    float sum_sq = x * x;
+    sum_sq = gdn_warp_reduce_sum(sum_sq);
+    __shared__ float rms_sums[4];
+    const unsigned int warp_id = tid / 32;
+    const unsigned int lane_id = tid % 32;
+    if (lane_id == 0) rms_sums[warp_id] = sum_sq;
+    __syncthreads();
+    if (warp_id == 0) {
+        float val = (lane_id < (blockDim.x + 31) / 32) ? rms_sums[lane_id] : 0.0f;
+        val = gdn_warp_reduce_sum(val);
+        if (lane_id == 0) rms_sums[0] = val;
+    }
+    __syncthreads();
+
+    const float rms = rsqrtf(rms_sums[0] / (float)v_dim + eps);
+
+    const unsigned int quad_size = v_dim / 4;
+    const unsigned long long* g64 = (const unsigned long long*)(z_gate + vh * v_dim);
+    const unsigned long long* w64 = (const unsigned long long*)norm_weight;
+    unsigned long long* out64 = (unsigned long long*)(output + vh * v_dim);
+    for (unsigned int i = tid; i < quad_size; i += blockDim.x) {
+        unsigned int base = i * 4;
+        float f0 = x_cache[base];
+        float f1 = x_cache[base + 1];
+        float f2 = x_cache[base + 2];
+        float f3 = x_cache[base + 3];
+
+        unsigned long long wv = w64[i];
+        float w0, w1, w2, w3;
+        gdn_unpack_bf16x2((unsigned int)wv, w0, w1);
+        gdn_unpack_bf16x2((unsigned int)(wv >> 32), w2, w3);
+
+        unsigned long long gv = g64[i];
+        float g0, g1, g2, g3;
+        gdn_unpack_bf16x2((unsigned int)gv, g0, g1);
+        gdn_unpack_bf16x2((unsigned int)(gv >> 32), g2, g3);
+
+        float s0 = g0 / (1.0f + expf(-g0));
+        float s1 = g1 / (1.0f + expf(-g1));
+        float s2 = g2 / (1.0f + expf(-g2));
+        float s3 = g3 / (1.0f + expf(-g3));
+
+        unsigned int lo = gdn_pack_bf16x2(f0 * rms * w0 * s0, f1 * rms * w1 * s1);
+        unsigned int hi = gdn_pack_bf16x2(f2 * rms * w2 * s2, f3 * rms * w3 * s3);
+        out64[i] = ((unsigned long long)hi << 32) | (unsigned long long)lo;
+    }
+}
+
+// ============================================================================
+// FUSED conv1d_update_l2norm + recurrence + gated-RMS-norm decode kernel.
+//
+// Collapses the per-seq SSM decode critical-path chain `conv1d_l2norm -> gdn ->
+// gated_norm` (3 dependent kernels) into ONE, shortening the decode dependency
+// chain (decode is GPU-~93%-idle = chain-depth bound; the existing gdn+norm
+// fusion already gave +18% c4). Race-free via a PER-K-HEAD grid: each block owns
+// k-head kh AND its `head_repeat` v-heads, so it conv-updates its own q/k AND v
+// conv_state exclusively (no cross-block conv_state share -> no race).
+//
+// Grid: [num_k_heads, batch].  Block: head_repeat * v_dim threads.
+//   thread tid: which_v = tid / v_dim, vlocal = tid % v_dim, vh = kh*head_repeat+which_v.
+// Requires (validated by the Rust dispatch gate): head_repeat*v_dim == blockDim,
+//   2*k_dim <= blockDim (q+k conv covered one-per-thread), k_dim == v_dim.
+// new_input/conv layout is [Q(num_k_heads*k_dim) | K(...) | V(num_v_heads*v_dim)].
+extern "C" __global__ void gated_delta_rule_decode_f32_conv_norm(
+    float* __restrict__ h_state,
+    float* __restrict__ conv_state,            // [batch, conv_dim, d_conv]
+    const __nv_bfloat16* __restrict__ new_input, // [batch, conv_dim] deint qkvz
+    const __nv_bfloat16* __restrict__ conv_weight, // [conv_dim, d_conv]
+    const float* __restrict__ conv_bias,       // [conv_dim] or null
+    const float* __restrict__ gate,            // [batch, num_v_heads]
+    const float* __restrict__ beta,            // [batch, num_v_heads]
+    const __nv_bfloat16* __restrict__ z_gate,  // [batch, num_v_heads, v_dim]
+    const __nv_bfloat16* __restrict__ norm_weight, // [v_dim]
+    __nv_bfloat16* __restrict__ output,        // [batch, num_v_heads, v_dim]
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int conv_dim,
+    unsigned int d_conv,
+    float l2_eps,
+    float eps
+) {
+    const unsigned int kh = blockIdx.x;
+    const unsigned int b  = blockIdx.y;
+    if (kh >= num_k_heads || b >= batch_size) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int tid     = threadIdx.x;
+    const unsigned int which_v = tid / v_dim;       // 0..head_repeat-1
+    const unsigned int vlocal  = tid % v_dim;       // 0..v_dim-1
+    const unsigned int vh      = kh * head_repeat + which_v;
+    const unsigned int key_dim_total = num_k_heads * k_dim;   // Q block width
+
+    __shared__ float smem_q[128];
+    __shared__ float smem_k[128];
+    __shared__ float warp_sums[8];     // 8 warps for a 256-thread block
+
+    // ---- Step 1: conv1d_update + SiLU for this block's q/k channel (one/thread) ----
+    // tid [0,k_dim) -> q head kh ; tid [k_dim,2*k_dim) -> k head kh.
+    float qk_silu = 0.0f;
+    const bool is_q = (tid < k_dim);
+    const bool is_k = (tid >= k_dim && tid < 2 * k_dim);
+    if (is_q || is_k) {
+        const unsigned int ch = is_q ? (kh * k_dim + tid)
+                                     : (key_dim_total + kh * k_dim + (tid - k_dim));
+        float* state = conv_state + ((unsigned long long)(b * conv_dim + ch)) * d_conv;
+        for (unsigned int i = 0; i < d_conv - 1; i++) state[i] = state[i + 1];
+        state[d_conv - 1] = (float)new_input[b * conv_dim + ch];
+        const __nv_bfloat16* w = conv_weight + (unsigned long long)ch * d_conv;
+        float acc = (conv_bias != nullptr) ? conv_bias[ch] : 0.0f;
+        for (unsigned int k = 0; k < d_conv; k++) acc += state[k] * (float)w[k];
+        qk_silu = acc / (1.0f + __expf(-acc));
+    }
+    // L2-norm q (warps 0-3) and k (warps 4-7) groups separately.
+    {
+        float sq = qk_silu * qk_silu;
+        for (int off = 16; off >= 1; off >>= 1) sq += __shfl_down_sync(0xFFFFFFFF, sq, off);
+        if ((tid & 31) == 0) warp_sums[tid >> 5] = sq;
+        __syncthreads();
+        const unsigned int grp = tid >> 7;   // 0 = q, 1 = k
+        float total = warp_sums[grp * 4 + 0] + warp_sums[grp * 4 + 1]
+                    + warp_sums[grp * 4 + 2] + warp_sums[grp * 4 + 3];
+        float inv = rsqrtf(total + l2_eps);
+        if (is_q) smem_q[tid] = qk_silu * inv;
+        else if (is_k) smem_k[tid - k_dim] = qk_silu * inv;
+    }
+
+    // ---- Step 1b: conv1d_update + SiLU for this thread's V channel (no L2) ----
+    float v_i = 0.0f;
+    {
+        const unsigned int vch = 2 * key_dim_total + vh * v_dim + vlocal;
+        float* state = conv_state + ((unsigned long long)(b * conv_dim + vch)) * d_conv;
+        for (unsigned int i = 0; i < d_conv - 1; i++) state[i] = state[i + 1];
+        state[d_conv - 1] = (float)new_input[b * conv_dim + vch];
+        const __nv_bfloat16* w = conv_weight + (unsigned long long)vch * d_conv;
+        float acc = (conv_bias != nullptr) ? conv_bias[vch] : 0.0f;
+        for (unsigned int k = 0; k < d_conv; k++) acc += state[k] * (float)w[k];
+        v_i = acc / (1.0f + __expf(-acc));
+    }
+    __syncthreads();   // smem_q / smem_k complete before recurrence reads them
+
+    // ---- Step 2: gated-delta recurrence for v-head vh, v_dim index vlocal ----
+    float* H = h_state + ((unsigned long long)(b * num_v_heads + vh)) * k_dim * v_dim;
+    const float g_raw = gate[b * num_v_heads + vh];
+    const float g  = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[b * num_v_heads + vh];
+
+    float hk_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + vlocal];
+        float h1 = H[(j + 1) * v_dim + vlocal];
+        float h2 = H[(j + 2) * v_dim + vlocal];
+        float h3 = H[(j + 3) * v_dim + vlocal];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+    const float v_new = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = g * H[(j+0)*v_dim+vlocal] + smem_k[j]   * v_new;
+        float h1 = g * H[(j+1)*v_dim+vlocal] + smem_k[j+1] * v_new;
+        float h2 = g * H[(j+2)*v_dim+vlocal] + smem_k[j+2] * v_new;
+        float h3 = g * H[(j+3)*v_dim+vlocal] + smem_k[j+3] * v_new;
+        H[(j+0)*v_dim+vlocal] = h0;
+        H[(j+1)*v_dim+vlocal] = h1;
+        H[(j+2)*v_dim+vlocal] = h2;
+        H[(j+3)*v_dim+vlocal] = h3;
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+    }
+
+    // ---- State-norm clamp (per v-head; reduce within this which_v group) ----
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = 0.0f;
+        for (unsigned int j = 0; j < k_dim; j++) {
+            float hv = H[j * v_dim + vlocal];
+            local_sq += hv * hv;
+        }
+        for (int off = 16; off >= 1; off >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, off);
+        __syncthreads();   // reuse warp_sums
+        if ((tid & 31) == 0) warp_sums[tid >> 5] = local_sq;
+        __syncthreads();
+        const unsigned int grp = tid >> 7;
+        float head_norm_sq = warp_sums[grp*4+0] + warp_sums[grp*4+1]
+                           + warp_sums[grp*4+2] + warp_sums[grp*4+3];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) H[j * v_dim + vlocal] *= scale;
+        }
+    }
+    #endif
+
+    // ---- Step 3: gated RMS norm (per v-head) -> output ----
+    const float x = q_dot * rsqrtf((float)k_dim);
+    float sum_sq = x * x;
+    for (int off = 16; off >= 1; off >>= 1) sum_sq += __shfl_down_sync(0xFFFFFFFF, sum_sq, off);
+    __syncthreads();   // reuse warp_sums
+    if ((tid & 31) == 0) warp_sums[tid >> 5] = sum_sq;
+    __syncthreads();
+    {
+        const unsigned int grp = tid >> 7;
+        float total = warp_sums[grp*4+0] + warp_sums[grp*4+1]
+                    + warp_sums[grp*4+2] + warp_sums[grp*4+3];
+        const float rms = rsqrtf(total / (float)v_dim + eps);
+        const float zg = (float)z_gate[(unsigned long long)(b * num_v_heads + vh) * v_dim + vlocal];
+        const float wv = (float)norm_weight[vlocal];
+        const float sg = zg / (1.0f + expf(-zg));
+        output[(unsigned long long)(b * num_v_heads + vh) * v_dim + vlocal]
+            = __float2bfloat16(x * rms * wv * sg);
+    }
+}
+
+// FP32 strided decode variant for concurrent decode sequences.
+//
+// Unlike gated_delta_rule_decode_f32, Q/K/V are rows inside a wider
+// per-sequence conv output buffer: [Q | K | V]. The stride arguments let the
+// Rust multi-seq path batch independent sequence slots without repacking QKV.
+extern "C" __global__ void gated_delta_rule_decode_f32_strided(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    float* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride,
+    unsigned int out_stride
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    if (tid >= v_dim) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H = h_state + ((b * num_v_heads + vh) * k_dim * v_dim);
+    const float* q_ptr = query + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* k_ptr = key + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* v_ptr = value + (unsigned long long)b * v_stride + vh * v_dim;
+
+    float g_raw = gate[(unsigned long long)b * gb_stride + vh];
+    const float g = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[(unsigned long long)b * gb_stride + vh];
+
+    __shared__ float smem_k[128];
+    __shared__ float smem_q[128];
+
+    if (tid < k_dim) {
+        smem_k[tid] = k_ptr[tid];
+        smem_q[tid] = q_ptr[tid];
+    }
+    __syncthreads();
+
+    float v_i = v_ptr[tid];
+    float hk_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+
+    float v_new_i = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = norm_acc;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
+        __shared__ float norm_sums[4];
+        if (tid % 32 == 0) norm_sums[tid / 32] = local_sq;
+        __syncthreads();
+        if (tid == 0) {
+            float total = 0.0f;
+            for (int w = 0; w < 4; w++) total += norm_sums[w];
+            norm_sums[0] = total;
+        }
+        __syncthreads();
+        float head_norm_sq = norm_sums[0];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) {
+                H[j * v_dim + tid] *= scale;
+            }
+        }
+    }
+    #endif
+
+    float inv_sqrt_d = rsqrtf((float)k_dim);
+    output[(unsigned long long)b * out_stride + vh * v_dim + tid] = q_dot * inv_sqrt_d;
+}
+
+// FP32 strided decode variant fused with gated RMS norm.
+//
+// Used by the experimental concurrent SSM recurrent path. It keeps the same
+// state-update math as gated_delta_rule_decode_f32_strided but writes the
+// post-norm BF16 output directly, avoiding an FP32 global output row plus N
+// separate gated_rms_norm launches.
+extern "C" __global__ void gated_delta_rule_decode_f32_strided_norm(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ z_gate,
+    const __nv_bfloat16* __restrict__ norm_weight,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride,
+    unsigned int z_stride,
+    unsigned int out_stride,
+    float eps
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    if (tid >= v_dim) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H = h_state + ((b * num_v_heads + vh) * k_dim * v_dim);
+    const float* q_ptr = query + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* k_ptr = key + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* v_ptr = value + (unsigned long long)b * v_stride + vh * v_dim;
+
+    float g_raw = gate[(unsigned long long)b * gb_stride + vh];
+    const float g = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[(unsigned long long)b * gb_stride + vh];
+
+    __shared__ float smem_k[128];
+    __shared__ float smem_q[128];
+
+    if (tid < k_dim) {
+        smem_k[tid] = k_ptr[tid];
+        smem_q[tid] = q_ptr[tid];
+    }
+    __syncthreads();
+
+    float v_i = v_ptr[tid];
+    float hk_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+
+    float v_new_i = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = norm_acc;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
+        __shared__ float norm_sums[4];
+        if (tid % 32 == 0) norm_sums[tid / 32] = local_sq;
+        __syncthreads();
+        if (tid == 0) {
+            float total = 0.0f;
+            for (int w = 0; w < 4; w++) total += norm_sums[w];
+            norm_sums[0] = total;
+        }
+        __syncthreads();
+        float head_norm_sq = norm_sums[0];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) {
+                H[j * v_dim + tid] *= scale;
+            }
+        }
+    }
+    #endif
+
+    const float inv_sqrt_d = rsqrtf((float)k_dim);
+    const float x = q_dot * inv_sqrt_d;
+
+    __shared__ float x_cache[128];
+    x_cache[tid] = x;
+
+    float sum_sq = x * x;
+    sum_sq = gdn_warp_reduce_sum(sum_sq);
+    __shared__ float rms_sums[4];
+    const unsigned int warp_id = tid / 32;
+    const unsigned int lane_id = tid % 32;
+    if (lane_id == 0) rms_sums[warp_id] = sum_sq;
+    __syncthreads();
+    if (warp_id == 0) {
+        float val = (lane_id < (blockDim.x + 31) / 32) ? rms_sums[lane_id] : 0.0f;
+        val = gdn_warp_reduce_sum(val);
+        if (lane_id == 0) rms_sums[0] = val;
+    }
+    __syncthreads();
+
+    const float rms = rsqrtf(rms_sums[0] / (float)v_dim + eps);
+
+    const unsigned int quad_size = v_dim / 4;
+    const unsigned long long* g64 = (const unsigned long long*)(
+        z_gate + (unsigned long long)b * z_stride + vh * v_dim
+    );
+    const unsigned long long* w64 = (const unsigned long long*)norm_weight;
+    unsigned long long* out64 = (unsigned long long*)(
+        output + (unsigned long long)b * out_stride + vh * v_dim
+    );
+    for (unsigned int i = tid; i < quad_size; i += blockDim.x) {
+        unsigned int base = i * 4;
+        float f0 = x_cache[base];
+        float f1 = x_cache[base + 1];
+        float f2 = x_cache[base + 2];
+        float f3 = x_cache[base + 3];
+
+        unsigned long long wv = w64[i];
+        float w0, w1, w2, w3;
+        gdn_unpack_bf16x2((unsigned int)wv, w0, w1);
+        gdn_unpack_bf16x2((unsigned int)(wv >> 32), w2, w3);
+
+        unsigned long long gv = g64[i];
+        float g0, g1, g2, g3;
+        gdn_unpack_bf16x2((unsigned int)gv, g0, g1);
+        gdn_unpack_bf16x2((unsigned int)(gv >> 32), g2, g3);
+
+        float s0 = g0 / (1.0f + expf(-g0));
+        float s1 = g1 / (1.0f + expf(-g1));
+        float s2 = g2 / (1.0f + expf(-g2));
+        float s3 = g3 / (1.0f + expf(-g3));
+
+        unsigned int lo = gdn_pack_bf16x2(f0 * rms * w0 * s0, f1 * rms * w1 * s1);
+        unsigned int hi = gdn_pack_bf16x2(f2 * rms * w2 * s2, f3 * rms * w3 * s3);
+        out64[i] = ((unsigned long long)hi << 32) | (unsigned long long)lo;
+    }
+}
+
+// Half-width register retention. 64 floats = 256 B/thread.
+#define GDN_HALF_KD 64
+
+extern "C" __global__ void gated_delta_rule_decode_f32_strided_norm_half(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ z_gate,
+    const __nv_bfloat16* __restrict__ norm_weight,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride,
+    unsigned int z_stride,
+    unsigned int out_stride,
+    float eps
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    if (tid >= v_dim) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H = h_state + ((b * num_v_heads + vh) * k_dim * v_dim);
+    const float* q_ptr = query + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* k_ptr = key + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* v_ptr = value + (unsigned long long)b * v_stride + vh * v_dim;
+
+    float g_raw = gate[(unsigned long long)b * gb_stride + vh];
+    const float g = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[(unsigned long long)b * gb_stride + vh];
+
+    __shared__ float smem_k[128];
+    __shared__ float smem_q[128];
+
+    if (tid < k_dim) {
+        smem_k[tid] = k_ptr[tid];
+        smem_q[tid] = q_ptr[tid];
+    }
+    __syncthreads();
+
+    float v_i = v_ptr[tid];
+    float hk_dot = 0.0f;
+    // Retain the FIRST GDN_HALF_KD columns so the update re-reads only the rest:
+    // 2R+1W over the state becomes 1.5R+1W (~17% less traffic). At batch 16 the
+    // live state is ~49 MB, past L2, so the re-read partially reaches DRAM.
+    // 256 B/thread, HALF the full-width variant that measured -11.6% e2e purely
+    // from register pressure (its indices were already static).
+    // ★ EVERY hreg index below is a compile-time constant. A runtime index puts
+    //   hreg in LOCAL memory and the variant loses (-4.6% measured that way).
+    float hreg[GDN_HALF_KD];
+    #pragma unroll
+    for (unsigned int j = 0; j < GDN_HALF_KD; j += 4) {
+        hreg[j + 0] = H[(j + 0) * v_dim + tid];
+        hreg[j + 1] = H[(j + 1) * v_dim + tid];
+        hreg[j + 2] = H[(j + 2) * v_dim + tid];
+        hreg[j + 3] = H[(j + 3) * v_dim + tid];
+        hk_dot += hreg[j + 0] * smem_k[j] + hreg[j + 1] * smem_k[j+1]
+                + hreg[j + 2] * smem_k[j+2] + hreg[j + 3] * smem_k[j+3];
+    }
+    #pragma unroll 4
+    for (unsigned int j = GDN_HALF_KD; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+
+    float v_new_i = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
+    // 2a: retained half — registers, fully unrolled (static indices).
+    #pragma unroll
+    for (unsigned int j = 0; j < GDN_HALF_KD; j += 4) {
+        float h0 = hreg[j + 0];
+        float h1 = hreg[j + 1];
+        float h2 = hreg[j + 2];
+        float h3 = hreg[j + 3];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+    // 2b: remainder — re-read from H. Ascending j across both loops keeps the
+    // q_dot / norm_acc summation order identical to the original, so the
+    // Frobenius bit-identity argument in the two-pass kernel still holds.
+    #pragma unroll 4
+    for (unsigned int j = GDN_HALF_KD; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. The clamp
+        // below used to re-read all of H to get these -- a THIRD full pass over
+        // 3 MB per seq per layer, immediately after writing it. One add at a
+        // time in ascending j keeps the summation order identical to that loop,
+        // so the result is bit-identical, not merely equivalent.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = norm_acc;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
+        __shared__ float norm_sums[4];
+        if (tid % 32 == 0) norm_sums[tid / 32] = local_sq;
+        __syncthreads();
+        if (tid == 0) {
+            float total = 0.0f;
+            for (int w = 0; w < 4; w++) total += norm_sums[w];
+            norm_sums[0] = total;
+        }
+        __syncthreads();
+        float head_norm_sq = norm_sums[0];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) {
+                H[j * v_dim + tid] *= scale;
+            }
+        }
+    }
+    #endif
+
+    const float inv_sqrt_d = rsqrtf((float)k_dim);
+    const float x = q_dot * inv_sqrt_d;
+
+    __shared__ float x_cache[128];
+    x_cache[tid] = x;
+
+    float sum_sq = x * x;
+    sum_sq = gdn_warp_reduce_sum(sum_sq);
+    __shared__ float rms_sums[4];
+    const unsigned int warp_id = tid / 32;
+    const unsigned int lane_id = tid % 32;
+    if (lane_id == 0) rms_sums[warp_id] = sum_sq;
+    __syncthreads();
+    if (warp_id == 0) {
+        float val = (lane_id < (blockDim.x + 31) / 32) ? rms_sums[lane_id] : 0.0f;
+        val = gdn_warp_reduce_sum(val);
+        if (lane_id == 0) rms_sums[0] = val;
+    }
+    __syncthreads();
+
+    const float rms = rsqrtf(rms_sums[0] / (float)v_dim + eps);
+
+    const unsigned int quad_size = v_dim / 4;
+    const unsigned long long* g64 = (const unsigned long long*)(
+        z_gate + (unsigned long long)b * z_stride + vh * v_dim
+    );
+    const unsigned long long* w64 = (const unsigned long long*)norm_weight;
+    unsigned long long* out64 = (unsigned long long*)(
+        output + (unsigned long long)b * out_stride + vh * v_dim
+    );
+    for (unsigned int i = tid; i < quad_size; i += blockDim.x) {
+        unsigned int base = i * 4;
+        float f0 = x_cache[base];
+        float f1 = x_cache[base + 1];
+        float f2 = x_cache[base + 2];
+        float f3 = x_cache[base + 3];
+
+        unsigned long long wv = w64[i];
+        float w0, w1, w2, w3;
+        gdn_unpack_bf16x2((unsigned int)wv, w0, w1);
+        gdn_unpack_bf16x2((unsigned int)(wv >> 32), w2, w3);
+
+        unsigned long long gv = g64[i];
+        float g0, g1, g2, g3;
+        gdn_unpack_bf16x2((unsigned int)gv, g0, g1);
+        gdn_unpack_bf16x2((unsigned int)(gv >> 32), g2, g3);
+
+        float s0 = g0 / (1.0f + expf(-g0));
+        float s1 = g1 / (1.0f + expf(-g1));
+        float s2 = g2 / (1.0f + expf(-g2));
+        float s3 = g3 / (1.0f + expf(-g3));
+
+        unsigned int lo = gdn_pack_bf16x2(f0 * rms * w0 * s0, f1 * rms * w1 * s1);
+        unsigned int hi = gdn_pack_bf16x2(f2 * rms * w2 * s2, f3 * rms * w3 * s3);
+        out64[i] = ((unsigned long long)hi << 32) | (unsigned long long)lo;
+    }
+}

--- a/kernels/gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu
@@ -70,6 +70,36 @@ extern "C" __global__ void __launch_bounds__(256, 1) atlas_nvfp4_mmq128_wc(
     atlas_nvfp4_tile<128, true>(x, y, dst, nrows_x, ncols_dst, ncols_x, stride_row_x, ncols_y, stride_col_dst);
 }
 
+// SMALL-M entries. `mmq_x` is the M (token) tile and is a free template parameter --
+// the vendored MMA path's granularity is 8 (mmq_get_granularity_device), and the
+// hardware quantum is the m16n8k64 B-fragment's 8 columns, so any multiple of 8 is
+// legal. Atlas only ever instantiated 128, which meant DECODE at M=16 issued MMAs for
+// all 128 tile columns and threw away 112 of them in the write-back predicate --
+// 87.5% of the MMA issue slots. Predicted cost of that padding at n=16 across the 48
+// SSM layers was 41.1 ms against a 42.0 ms measurement, so it is the dominant term.
+// Prefill keeps 128: grid.y = ceil(M/mmq_x), so a small tile would re-stream the
+// weights once per M-tile there.
+extern "C" __global__ void __launch_bounds__(256, 1) atlas_nvfp4_mmq16_nc(
+        const char* x, const int* y, __nv_bfloat16* dst,
+        int nrows_x, int ncols_dst, int ncols_x, int stride_row_x, int ncols_y, int stride_col_dst) {
+    atlas_nvfp4_tile<16, false>(x, y, dst, nrows_x, ncols_dst, ncols_x, stride_row_x, ncols_y, stride_col_dst);
+}
+extern "C" __global__ void __launch_bounds__(256, 1) atlas_nvfp4_mmq16_wc(
+        const char* x, const int* y, __nv_bfloat16* dst,
+        int nrows_x, int ncols_dst, int ncols_x, int stride_row_x, int ncols_y, int stride_col_dst) {
+    atlas_nvfp4_tile<16, true>(x, y, dst, nrows_x, ncols_dst, ncols_x, stride_row_x, ncols_y, stride_col_dst);
+}
+extern "C" __global__ void __launch_bounds__(256, 1) atlas_nvfp4_mmq32_nc(
+        const char* x, const int* y, __nv_bfloat16* dst,
+        int nrows_x, int ncols_dst, int ncols_x, int stride_row_x, int ncols_y, int stride_col_dst) {
+    atlas_nvfp4_tile<32, false>(x, y, dst, nrows_x, ncols_dst, ncols_x, stride_row_x, ncols_y, stride_col_dst);
+}
+extern "C" __global__ void __launch_bounds__(256, 1) atlas_nvfp4_mmq32_wc(
+        const char* x, const int* y, __nv_bfloat16* dst,
+        int nrows_x, int ncols_dst, int ncols_x, int stride_row_x, int ncols_y, int stride_col_dst) {
+    atlas_nvfp4_tile<32, true>(x, y, dst, nrows_x, ncols_dst, ncols_x, stride_row_x, ncols_y, stride_col_dst);
+}
+
 // Activation quantizer: bf16 [ne1=M rows, ne00=K] -> block_fp4_mmq (e2m1 + ue4m3 group-16
 // scales, ±2 exhaustive scale search). One thread per 16-value sub-block.
 // grid (ne1, ceil(ne0/(16*128)), 1), block (128). Mirrors llama's host launcher.
@@ -98,6 +128,29 @@ extern "C" __global__ void atlas_nvfp4_repack(
     const uint8_t* srow = scales + (int64_t) row * (k / 16);
     block_nvfp4 dst;
 
+    // ── SoA output layout (A2) ────────────────────────────────────────────
+    // Same total bytes as the AoS `block_nvfp4[nblocks]` form (36 B/block), but
+    // split WITHIN each row: [qs: blocks_per_row*32][d: blocks_per_row*4].
+    //
+    // WHY: the AoS block interleaves 4 scale bytes with 32 nibble bytes, so the
+    // tile loader had to issue NINE 4-byte loads per block (8 qs + 1 d). With qs
+    // contiguous, the same 32 bytes are TWO 16-byte loads, and `d` is one more —
+    // 9 global ops -> 3. The consumer is `load_tiles_nvfp4_nvfp4` in
+    // q4k_vendor/mmq.cuh, which is the ONLY reader of this buffer (Atlas exposes
+    // no MMVQ entry point, so vecdotq.cuh's nvfp4 path is unreachable).
+    //
+    // The SHARED-memory tile layout is unchanged, so `vec_dot` and the MMA path
+    // are untouched and the result is bit-identical.
+    //
+    // Alignment: row_bytes = blocks_per_row*36 is 16-B aligned iff
+    // blocks_per_row % 4 == 0, i.e. K % 256 == 0. Both live K (5120 -> 80 blocks,
+    // 17408 -> 272) satisfy it, and MMQ already requires K % 512 == 0 for its
+    // 512-wide K iteration. Assert rather than assume.
+    const int qs_region = blocks_per_row * 32;
+    uint8_t* row_out = (uint8_t*) out + (int64_t) row * blocks_per_row * 36;
+    uint8_t* qs_out  = row_out + kb * 32;
+    uint8_t* d_out   = row_out + qs_region + kb * 4;
+
 #pragma unroll
     for (int s = 0; s < QK_NVFP4 / QK_NVFP4_SUB; ++s) {          // 4 sub-blocks of 16
         const int k0 = kb * QK_NVFP4 + s * QK_NVFP4_SUB;
@@ -111,7 +164,10 @@ extern "C" __global__ void atlas_nvfp4_repack(
             dst.qs[s * 8 + j] = (int8_t)(na | (nb << 4));
         }
     }
-    out[b] = dst;
+#pragma unroll
+    for (int j = 0; j < 32; ++j) qs_out[j] = (uint8_t) dst.qs[j];
+#pragma unroll
+    for (int s2 = 0; s2 < 4; ++s2) d_out[s2] = dst.d[s2];
 }
 
 // SiLU(gate*gs)*(up*us): mirrors moe_silu_mul's math exactly (incl. the swiglu ±10 clamp)

--- a/kernels/gb10/qwen3.6-27b/nvfp4/q4k_vendor/mmq.cuh
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/q4k_vendor/mmq.cuh
@@ -961,7 +961,18 @@ static __device__ __forceinline__ void load_tiles_nvfp4_nvfp4(const char * __res
     const int kbx = txi % threads_per_row;
     const int row_in_warp = txi / threads_per_row;
 
-    const block_nvfp4 * bxi_base = (const block_nvfp4 *) x + kbx0 + kbx;
+    // ATLAS (A2): the weight buffer is SoA per row — [qs: bpr*32][d: bpr*4] —
+    // not an array of 36-byte block_nvfp4. `stride` still carries blocks-per-row,
+    // so the row base is stride*36 bytes and the two regions are derived from it.
+    // This makes the 32 qs bytes CONTIGUOUS: two 16-byte loads instead of eight
+    // 4-byte loads. Written by atlas_nvfp4_repack; see the note there.
+    // ★ `kbx0` is a LINEAR block index that already folds in the CTA's row offset
+    // (`offset_x = ... + it*mmq_y*stride_row_x`, line 3640) — it is NOT a pure
+    // k-offset. The SoA layout is per-ROW, so recover the two components once per
+    // thread. One div+mod, hoisted out of the i-loop.
+    const int bpr  = stride;                 // blocks per row
+    const int row0 = kbx0 / bpr;             // first row of this tile
+    const int kb0  = kbx0 - row0 * bpr;      // k-block offset within the row
     uint32_t * x_u32_scale = x_u32 + 64 + kbx;
 
 #pragma unroll
@@ -972,19 +983,24 @@ static __device__ __forceinline__ void load_tiles_nvfp4_nvfp4(const char * __res
             i = min(i, i_max);
         }
 
-        const block_nvfp4 * bxi = bxi_base + i * stride;
+        const char * rp = x + (size_t) (row0 + i) * bpr * 36;   // this row's base
+        const int kb = kb0 + kbx;                                  // block within row
         const int row_base = i * MMQ_MMA_TILE_X_K_FP4;
         const int q_base = row_base + 8 * kbx;
 
-        const uint32_t * src_qs = reinterpret_cast<const uint32_t *>(bxi->qs);
+        // 32 contiguous qs bytes = 2x16B. Aligned because the row base is
+        // bpr*36 (16-B aligned for bpr%4==0, i.e. K%256==0 — both live K qualify)
+        // and the in-row offset is a multiple of 32.
+        const uint4 q0 = *reinterpret_cast<const uint4 *>(rp + (size_t) kb * 32);
+        const uint4 q1 = *reinterpret_cast<const uint4 *>(rp + (size_t) kb * 32 + 16);
 
-#pragma unroll
-        for (int sub = 0; sub < QK_NVFP4 / QK_NVFP4_SUB; ++sub) {
-            x_u32[q_base + 2 * sub + 0] = src_qs[2 * sub + 0];
-            x_u32[q_base + 2 * sub + 1] = src_qs[2 * sub + 1];
-        }
+        x_u32[q_base + 0] = q0.x; x_u32[q_base + 1] = q0.y;
+        x_u32[q_base + 2] = q0.z; x_u32[q_base + 3] = q0.w;
+        x_u32[q_base + 4] = q1.x; x_u32[q_base + 5] = q1.y;
+        x_u32[q_base + 6] = q1.z; x_u32[q_base + 7] = q1.w;
 
-        x_u32_scale[row_base] = get_int_b4(bxi->d, 0);
+        x_u32_scale[row_base] =
+            *reinterpret_cast<const uint32_t *>(rp + (size_t) bpr * 32 + (size_t) kb * 4);
     }
 }
 

--- a/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu
@@ -283,6 +283,13 @@ __device__ __forceinline__ void cp_async_commit() {
     asm volatile("cp.async.commit_group;");
 }
 
+__device__ __forceinline__ void cp_async_wait_group1() {
+    // Wait until at most ONE cp.async group is still outstanding. This is what
+    // makes a deeper pipeline possible: `wait_all` drains everything, leaving the
+    // memory pipe idle through the dequant phase.
+    asm volatile("cp.async.wait_group 1;\n" ::);
+}
+
 __device__ __forceinline__ void cp_async_wait_all() {
     asm volatile("cp.async.wait_group 0;");
 }
@@ -334,14 +341,32 @@ __device__ __forceinline__ unsigned int bf16x4_to_e4m3x4(const unsigned short* s
     return ((unsigned int)h1 << 16) | (unsigned int)h0;
 }
 
+// `ldb` = ROW STRIDE of the transposed B, in bytes/elements, which may EXCEED N.
+//
+// ★ This exists because the B loads below are 16-byte `cp.async`, and cp.async
+// REQUIRES a 16-byte-aligned source. Row r starts at r*ldb, so alignment holds
+// only when the stride is a multiple of 16. Callers whose N is already aligned
+// pass ldb = N (the `w4a16_gemm_n128` wrapper does this, so all existing call
+// sites are unchanged). Callers with an unaligned N — notably lm_head, whose N
+// is the VOCAB SIZE and can be odd (248077 on Qwen3.6-27B-W4A4-mlpinf) — must
+// pad the stride to a multiple of 16 and pass it here. Without this, 15 of every
+// 16 k-rows fault with CUDA_ERROR_MISALIGNED_ADDRESS (716); see
+// docs/campaigns/gb10-concurrency-2026-07/STATE.md.
+//
+// Loads are bounded by `ldb` (pad columns are zero-filled and harmless, and
+// bounding by N would silently DROP the real columns in the final 16-wide group
+// whenever N is not a multiple of 16). STORES stay bounded by N, so only real
+// vocab columns are written; C needs no padding because its stores are scalar.
 extern "C" __global__ void w4a16_gemm_t(
     const __nv_bfloat16* __restrict__ A,
     const unsigned char* __restrict__ B_packed,
     const unsigned char* __restrict__ B_scale,
     const float scale2,
     __nv_bfloat16* __restrict__ C,
-    unsigned int M, unsigned int N, unsigned int K
+    unsigned int M, unsigned int N, unsigned int K,
+    unsigned int ldb
 ) {
+    const unsigned int LDB = ldb;
     const unsigned int cta_n = blockIdx.x * N_TILE_LG;
     const unsigned int cta_m = blockIdx.y * M_TILE;
     const unsigned int warp_id = threadIdx.x / 32;
@@ -390,13 +415,13 @@ extern "C" __global__ void w4a16_gemm_t(
             unsigned int gke = (kb) + (kp << 1); \
             unsigned int gns = cta_n + ns; \
             cp_async_pred_16(&smem_Bp[(buf)][kp][ns], \
-                &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
-                (gke + 1 <= K) && (gns + 15 < N)); \
+                &B_packed[(unsigned long long)(gke >> 1) * LDB + gns], \
+                (gke + 1 <= K) && (gns + 15 < LDB)); \
             if (kp < K_STEP_T / GROUP_SIZE) { \
                 unsigned int sg = (kb) / GROUP_SIZE + kp; \
                 cp_async_pred_16(&smem_Bs[(buf)][kp][ns], \
-                    &B_scale[(unsigned long long)sg * N + gns], \
-                    (gns + 15 < N)); \
+                    &B_scale[(unsigned long long)sg * LDB + gns], \
+                    (gns + 15 < LDB)); \
             } \
         } \
     } while(0)
@@ -551,6 +576,243 @@ extern "C" __global__ void w4a16_gemm_t(
 // B_fp8[N, K] layout — each row is one output neuron, K consecutive.
 //
 // Pipeline: LOAD(A+B_fp8) || COMPUTE_MMA — only 1 sync per K step.
+//
+// smem: A 2×64×40×2=10240B, B_fp8 2×128×32=8192B = ~18.4KB
+// ═══════════════════════════════════════════════════════════════════
+// `w4a16_gemm_t` with a 3-deep WEIGHT pipeline (`w4a16_gemm_t_p3`).
+// Kill switch: ATLAS_NO_TGEMM_PIPELINE3 (presence).
+// ═══════════════════════════════════════════════════════════════════
+extern "C" __global__ void w4a16_gemm_t_p3(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K,
+    unsigned int ldb
+) {
+    const unsigned int LDB = ldb;
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    __shared__ __nv_bfloat16 smem_A_p3[2][M_TILE][K_STEP_T + PAD_T];
+    __shared__ unsigned char smem_Bp_p3[3][K_STEP_T / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs_p3[3][K_STEP_T / GROUP_SIZE][N_TILE_LG + BP_PAD];
+#if defined(__SCALE__)
+    __shared__ __nv_bfloat16 smem_B_bf16_p3[N_TILE_LG][K_STEP_T];
+#else
+    __shared__ unsigned char smem_B_fp8_p3[N_TILE_LG][K_STEP_T];
+#endif
+    __shared__ float smem_LUT_p3[16];
+
+    if (threadIdx.x < 16) smem_LUT_p3[threadIdx.x] = E2M1_LUT[threadIdx.x];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int a_stride = K_STEP_T + PAD_T;
+
+    #define P3_ISSUE_LOADS(abuf, bbuf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 2; \
+            unsigned int a_col = (threadIdx.x & 3) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int row = rnd * 32 + a_row_base; \
+                unsigned int gr = cta_m + row; \
+                cp_async_pred_16(&smem_A_p3[(abuf)][row][a_col], \
+                    &A[gr * K + gc], (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gke = (kb) + (kp << 1); \
+            unsigned int gns = cta_n + ns; \
+            cp_async_pred_16(&smem_Bp_p3[(bbuf)][kp][ns], \
+                &B_packed[(unsigned long long)(gke >> 1) * LDB + gns], \
+                (gke + 1 <= K) && (gns + 15 < LDB)); \
+            if (kp < K_STEP_T / GROUP_SIZE) { \
+                unsigned int sg = (kb) / GROUP_SIZE + kp; \
+                cp_async_pred_16(&smem_Bs_p3[(bbuf)][kp][ns], \
+                    &B_scale[(unsigned long long)sg * LDB + gns], \
+                    (gns + 15 < LDB)); \
+            } \
+        } \
+    } while(0)
+
+#if defined(__SCALE__)
+    // Dequant B: NVFP4 -> BF16 directly (gfx1151: device float->E4M3 encode is
+    // broken in SCALE, and SCALE's E4M3 is a narrow [0.125,31] format; BF16
+    // carries the full range/precision. Mirrors the base w4a16_gemm path.)
+    #define P3_DEQUANT_T(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs_p3[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs_p3[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; *(unsigned char*)&f1 = sb1; \
+        float sv0 = scl_fp8(*(const unsigned char*)&f0) * scale2, sv1 = scl_fp8(*(const unsigned char*)&f1) * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_p3[(buf)][kp][my_n]; \
+            smem_B_bf16_p3[my_n][kp * 2]     = __float2bfloat16(smem_LUT_p3[packed & 0xF] * sv0); \
+            smem_B_bf16_p3[my_n][kp * 2 + 1] = __float2bfloat16(smem_LUT_p3[packed >> 4] * sv0); \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_p3[(buf)][kp][my_n]; \
+            smem_B_bf16_p3[my_n][kp * 2]     = __float2bfloat16(smem_LUT_p3[packed & 0xF] * sv1); \
+            smem_B_bf16_p3[my_n][kp * 2 + 1] = __float2bfloat16(smem_LUT_p3[packed >> 4] * sv1); \
+        } \
+    } while(0)
+
+    // BF16 MMA: 2x m16n8k16 over the 32-wide K step (no FP8 round-trip).
+    #define P3_COMPUTE_MMA(a_buf) do { \
+        const __nv_bfloat16* sA = (const __nv_bfloat16*)smem_A_p3[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        _Pragma("unroll") \
+        for (int h = 0; h < 2; h++) { \
+            unsigned int fc0 = h * 16 + tid * 2, fc1 = fc0 + 8; \
+            unsigned int a0 = *(const unsigned int*)&sA[fr0 * a_stride + fc0]; \
+            unsigned int a1 = *(const unsigned int*)&sA[fr1 * a_stride + fc0]; \
+            unsigned int a2 = *(const unsigned int*)&sA[fr0 * a_stride + fc1]; \
+            unsigned int a3 = *(const unsigned int*)&sA[fr1 * a_stride + fc1]; \
+            _Pragma("unroll") \
+            for (int nt = 0; nt < 16; nt++) { \
+                unsigned int nc = nt * 8 + group_id; \
+                const __nv_bfloat16* sb = &smem_B_bf16_p3[nc][0]; \
+                unsigned int b0 = *(const unsigned int*)&sb[fc0]; \
+                unsigned int b1 = *(const unsigned int*)&sb[fc1]; \
+                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 " \
+                    "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                    : "=f"(acc[nt][0]), "=f"(acc[nt][1]), "=f"(acc[nt][2]), "=f"(acc[nt][3]) \
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), \
+                      "f"(acc[nt][0]), "f"(acc[nt][1]), "f"(acc[nt][2]), "f"(acc[nt][3])); \
+            } \
+        } \
+    } while(0)
+#else
+    // Dequant B: FP4 → FP8 E4M3 (cvt.rn.satfinite.e4m3x2.f32)
+    #define P3_DEQUANT_T(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        unsigned char sb0 = smem_Bs_p3[(buf)][0][my_n]; \
+        unsigned char sb1 = smem_Bs_p3[(buf)][1][my_n]; \
+        __nv_fp8_e4m3 f0, f1; \
+        *(unsigned char*)&f0 = sb0; *(unsigned char*)&f1 = sb1; \
+        float sv0 = (float)f0 * scale2, sv1 = (float)f1 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_p3[packed & 0xF] * sv0; \
+            float hi = smem_LUT_p3[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_p3[packed & 0xF] * sv1; \
+            float hi = smem_LUT_p3[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_p3[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+
+    // FP8 MMA: convert A BF16→E4M3 in registers, single m16n8k32 per N-tile
+    #define P3_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A_p3[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + tid * 4]); \
+        unsigned int a1 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + tid * 4]); \
+        unsigned int a2 = bf16x4_to_e4m3x4(&sA[fr0 * a_stride + 16 + tid * 4]); \
+        unsigned int a3 = bf16x4_to_e4m3x4(&sA[fr1 * a_stride + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_p3[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_p3[nc][16 + 4 * tid]; \
+            asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 " \
+                "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13};" \
+                :"=f"(acc[nt][0]),"=f"(acc[nt][1]),"=f"(acc[nt][2]),"=f"(acc[nt][3]) \
+                :"r"(a0),"r"(a1),"r"(a2),"r"(a3),"r"(b0),"r"(b1), \
+                 "f"(acc[nt][0]),"f"(acc[nt][1]),"f"(acc[nt][2]),"f"(acc[nt][3])); \
+        } \
+    } while(0)
+#endif
+
+    // 3-deep WEIGHT pipeline — the change already shipped for the k64 sibling.
+    // The 2-stage parent `wait_all`s before dequant, so the memory pipe is empty
+    // across it and only a co-resident CTA can cover that. Efficiency on this
+    // family is monotone in grid.x (40 CTAs 47-50%, 112 66%, 128 73%, 1938 83%),
+    // and this kernel's mid-size shapes — ssm_qkvz (128 CTAs) and fused QKV
+    // (112) — sit squarely in the exposed band. Keeping step i+2's loads in
+    // flight across dequant(i+1) closes it. A stays double-buffered (free once
+    // MMA clears its barrier); only the weight tiles are tripled, ~+2.6 KB smem.
+    // Bit-identical: same MMA order, same operands, only load timing moves.
+    const unsigned int nsteps_p3 = K / K_STEP_T;
+    P3_ISSUE_LOADS(0, 0, 0);
+    cp_async_commit();
+    if (nsteps_p3 > 1) { P3_ISSUE_LOADS(1, 1, K_STEP_T); }
+    cp_async_commit();
+    cp_async_wait_group1();
+    __syncthreads();
+    P3_DEQUANT_T(0);
+    __syncthreads();
+
+    for (unsigned int i = 0; i + 1 < nsteps_p3; i++) {
+        P3_COMPUTE_MMA(i & 1);
+        __syncthreads();
+        if (i + 2 < nsteps_p3) {
+            P3_ISSUE_LOADS((i + 2) & 1, (i + 2) % 3, (i + 2) * K_STEP_T);
+        }
+        cp_async_commit();
+        cp_async_wait_group1();
+        __syncthreads();
+        P3_DEQUANT_T((i + 1) % 3);
+        __syncthreads();
+    }
+
+    P3_COMPUTE_MMA((nsteps_p3 - 1) & 1);
+
+    #undef P3_ISSUE_LOADS
+    #undef P3_DEQUANT_T
+    #undef P3_COMPUTE_MMA
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Pre-dequanted FP8 GEMM (prefill).
+//
+// B_fp8 is pre-dequanted at load time: NVFP4 → FP8 E4M3 once.
+// Eliminates the per-inference DEQUANT phase entirely.
+// B_fp8[N, K] layout — each row is one output neuron, K consecutive.
+//
+// Pipeline: LOAD(A+B_fp8) || P3_COMPUTE_MMA — only 1 sync per K step.
 //
 // smem: A 2×64×40×2=10240B, B_fp8 2×128×32=8192B = ~18.4KB
 // ═══════════════════════════════════════════════════════════════════
@@ -1082,6 +1344,272 @@ extern "C" __global__ void w4a16_gemm_t_k64(
     #undef K64_ISSUE_LOADS
     #undef K64_DEQUANT
     #undef K64_COMPUTE_MMA
+    #undef K_STEP_T64
+    #undef PAD_T64
+
+    #pragma unroll
+    for (int nt = 0; nt < 16; nt++) {
+        unsigned int c0 = cta_n + nt*8 + tid*2;
+        unsigned int c1 = c0 + 1;
+        unsigned int r0 = cta_m + warp_m_offset + group_id;
+        unsigned int r1 = r0 + 8;
+        if (r0 < M && c0 < N) C[r0*N+c0] = __float2bfloat16(acc[nt][0]);
+        if (r0 < M && c1 < N) C[r0*N+c1] = __float2bfloat16(acc[nt][1]);
+        if (r1 < M && c0 < N) C[r1*N+c0] = __float2bfloat16(acc[nt][2]);
+        if (r1 < M && c1 < N) C[r1*N+c1] = __float2bfloat16(acc[nt][3]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// K64 with a 3-deep WEIGHT pipeline (`w4a16_gemm_t_k64_p3`).
+// Kill switch: ATLAS_NO_K64_PIPELINE3 (presence).
+// ═══════════════════════════════════════════════════════════════════
+#define K_STEP_T64 64
+#define PAD_T64    8
+extern "C" __global__ void w4a16_gemm_t_k64_p3(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M, unsigned int N, unsigned int K
+) {
+    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_m = blockIdx.y * M_TILE;
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    // B_fp8 row stride 80 = K64+16: avoids 4-way bank conflicts.
+    __shared__ __nv_bfloat16 smem_A_k64p3[2][M_TILE][K_STEP_T64 + PAD_T64];
+    __shared__ unsigned char smem_Bp_k64p3[3][K_STEP_T64 / 2][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_Bs_k64p3[3][K_STEP_T64 / GROUP_SIZE][N_TILE_LG + BP_PAD];
+    __shared__ unsigned char smem_B_fp8_k64p3[N_TILE_LG][K_STEP_T64 + 16];
+    __shared__ float smem_LUT_k64p3[16];
+
+    if (threadIdx.x < 16) smem_LUT_k64p3[threadIdx.x] = E2M1_LUT[threadIdx.x];
+
+    float acc[16][4];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        acc[i][0] = 0.0f; acc[i][1] = 0.0f;
+        acc[i][2] = 0.0f; acc[i][3] = 0.0f;
+    }
+
+    const unsigned int ast64 = K_STEP_T64 + PAD_T64;
+
+    // A: 4 rounds × 16 rows = 64 rows (M_TILE); each thread: 8 BF16 = 16 bytes.
+    // Bp: 2 rounds × 16 rows = 32 rows (K64/2); each thread: 16 bytes per ns chunk.
+    // Bs: inline with Bp when kp_cur < K_STEP_T64/GROUP_SIZE (4 scale groups).
+    #define K64P3_ISSUE_LOADS(abuf, bbuf, kb) do { \
+        { \
+            unsigned int a_row_base = threadIdx.x >> 3; \
+            unsigned int a_col = (threadIdx.x & 7) << 3; \
+            unsigned int gc = (kb) + a_col; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 4; rnd++) { \
+                unsigned int row = rnd * 16 + a_row_base; \
+                unsigned int gr = cta_m + row; \
+                cp_async_pred_16(&smem_A_k64p3[(abuf)][row][a_col], \
+                    &A[(unsigned long long)gr * K + gc], \
+                    (gr < M) && (gc + 7 < K)); \
+            } \
+        } \
+        { \
+            unsigned int kp = threadIdx.x >> 3; \
+            unsigned int ns = (threadIdx.x & 7) << 4; \
+            unsigned int gns = cta_n + ns; \
+            _Pragma("unroll") \
+            for (int rnd = 0; rnd < 2; rnd++) { \
+                unsigned int kp_cur = rnd * 16 + kp; \
+                unsigned int gke = (kb) + (kp_cur << 1); \
+                cp_async_pred_16(&smem_Bp_k64p3[(bbuf)][kp_cur][ns], \
+                    &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
+                    (gke + 1 <= K) && (gns + 15 < N)); \
+                if (kp_cur < K_STEP_T64 / GROUP_SIZE) { \
+                    unsigned int sg = (kb) / GROUP_SIZE + kp_cur; \
+                    cp_async_pred_16(&smem_Bs_k64p3[(bbuf)][kp_cur][ns], \
+                        &B_scale[(unsigned long long)sg * N + gns], \
+                        (gns + 15 < N)); \
+                } \
+            } \
+        } \
+    } while(0)
+
+    // 4 scale groups, 32 dequant iters: sv0→K{0..15}, sv1→K{16..31},
+    // sv2→K{32..47}, sv3→K{48..63}.
+#if defined(__SCALE__)
+    #define K64P3_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        __nv_fp8_e4m3 f0, f1, f2, f3; \
+        *(unsigned char*)&f0 = smem_Bs_k64p3[(buf)][0][my_n]; \
+        *(unsigned char*)&f1 = smem_Bs_k64p3[(buf)][1][my_n]; \
+        *(unsigned char*)&f2 = smem_Bs_k64p3[(buf)][2][my_n]; \
+        *(unsigned char*)&f3 = smem_Bs_k64p3[(buf)][3][my_n]; \
+        float sv0 = scl_fp8(*(const unsigned char*)&f0) * scale2, sv1 = scl_fp8(*(const unsigned char*)&f1) * scale2; \
+        float sv2 = scl_fp8(*(const unsigned char*)&f2) * scale2, sv3 = scl_fp8(*(const unsigned char*)&f3) * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv0; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            fp8_pair = atlas_cvt_e4m3x2_f32(hi, lo); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv1; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            fp8_pair = atlas_cvt_e4m3x2_f32(hi, lo); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 16; kp < 24; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv2; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv2; \
+            unsigned short fp8_pair; \
+            fp8_pair = atlas_cvt_e4m3x2_f32(hi, lo); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 24; kp < 32; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv3; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv3; \
+            unsigned short fp8_pair; \
+            fp8_pair = atlas_cvt_e4m3x2_f32(hi, lo); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+#else
+    #define K64P3_DEQUANT(buf) do { \
+        unsigned int my_n = threadIdx.x; \
+        __nv_fp8_e4m3 f0, f1, f2, f3; \
+        *(unsigned char*)&f0 = smem_Bs_k64p3[(buf)][0][my_n]; \
+        *(unsigned char*)&f1 = smem_Bs_k64p3[(buf)][1][my_n]; \
+        *(unsigned char*)&f2 = smem_Bs_k64p3[(buf)][2][my_n]; \
+        *(unsigned char*)&f3 = smem_Bs_k64p3[(buf)][3][my_n]; \
+        float sv0 = (float)f0 * scale2, sv1 = (float)f1 * scale2; \
+        float sv2 = (float)f2 * scale2, sv3 = (float)f3 * scale2; \
+        _Pragma("unroll") \
+        for (int kp = 0; kp < 8; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv0; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv0; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 8; kp < 16; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv1; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv1; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 16; kp < 24; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv2; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv2; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+        _Pragma("unroll") \
+        for (int kp = 24; kp < 32; kp++) { \
+            unsigned char packed = smem_Bp_k64p3[(buf)][kp][my_n]; \
+            float lo = smem_LUT_k64p3[packed & 0xF] * sv3; \
+            float hi = smem_LUT_k64p3[packed >> 4] * sv3; \
+            unsigned short fp8_pair; \
+            asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" \
+                         : "=h"(fp8_pair) : "f"(hi), "f"(lo)); \
+            *(unsigned short*)&smem_B_fp8_k64p3[my_n][kp * 2] = fp8_pair; \
+        } \
+    } while(0)
+#endif
+
+    // Two m16n8k32 MMA calls per N-tile: first covers K=0..31, second K=32..63.
+    #define K64P3_COMPUTE_MMA(a_buf) do { \
+        const unsigned short* sA = (const unsigned short*)smem_A_k64p3[(a_buf)]; \
+        unsigned int fr0 = warp_m_offset + group_id, fr1 = fr0 + 8; \
+        unsigned int a0 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + tid * 4]); \
+        unsigned int a1 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + tid * 4]); \
+        unsigned int a2 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 16 + tid * 4]); \
+        unsigned int a3 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 16 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_k64p3[nc][4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_k64p3[nc][16 + 4 * tid]; \
+            atlas_mma_e4m3(acc[nt], a0,a1,a2,a3, b0, b1); \
+        } \
+        unsigned int a4 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 32 + tid * 4]); \
+        unsigned int a5 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 32 + tid * 4]); \
+        unsigned int a6 = bf16x4_to_e4m3x4(&sA[fr0 * ast64 + 48 + tid * 4]); \
+        unsigned int a7 = bf16x4_to_e4m3x4(&sA[fr1 * ast64 + 48 + tid * 4]); \
+        _Pragma("unroll") \
+        for (int nt = 0; nt < 16; nt++) { \
+            unsigned int nc = nt * 8 + group_id; \
+            unsigned int b0 = *(const unsigned int*)&smem_B_fp8_k64p3[nc][32 + 4 * tid]; \
+            unsigned int b1 = *(const unsigned int*)&smem_B_fp8_k64p3[nc][48 + 4 * tid]; \
+            atlas_mma_e4m3(acc[nt], a4,a5,a6,a7, b0, b1); \
+        } \
+    } while(0)
+
+    // 3-deep WEIGHT pipeline. The 2-stage parent issues one group, then
+    // `wait_all` drains it before DEQUANT — so during the 32-iteration dequant
+    // (between two barriers) there are ZERO outstanding loads. At N=5120 the grid
+    // is 40 CTAs on 48 SMs = exactly 1 CTA/SM, so no co-resident CTA covers that
+    // drain, and the shape runs at ~38% of achievable while lm_head (1938 CTAs)
+    // reaches 83% on this identical loop.
+    //
+    // Here the loads for step i+2 are issued BEFORE dequanting i+1 and are still
+    // in flight across it, so the memory pipe never empties. A stays DOUBLE
+    // buffered — A[i&1] is free the moment MMA(i) clears its barrier — and only
+    // the weight tiles are tripled: 43.2 KB smem, under the 48 KB static limit
+    // that a naive all-3-stage layout (51.4 KB) would exceed.
+    //
+    // Bit-identical to the parent: same MMA order, same operands, only load
+    // timing moves.
+    const unsigned int nsteps = K / K_STEP_T64;
+    K64P3_ISSUE_LOADS(0, 0, 0);
+    cp_async_commit();
+    if (nsteps > 1) { K64P3_ISSUE_LOADS(1, 1, K_STEP_T64); }
+    cp_async_commit();
+    cp_async_wait_group1();
+    __syncthreads();
+    K64P3_DEQUANT(0);
+    __syncthreads();
+
+    for (unsigned int i = 0; i + 1 < nsteps; i++) {
+        K64P3_COMPUTE_MMA(i & 1);
+        __syncthreads();                       // MMA has released A[i&1] and B_fp8
+        if (i + 2 < nsteps) {
+            K64P3_ISSUE_LOADS((i + 2) & 1, (i + 2) % 3, (i + 2) * K_STEP_T64);
+        }
+        cp_async_commit();                     // commit even when empty: keeps group counting exact
+        cp_async_wait_group1();                // step i+1 has landed; i+2 stays in flight
+        __syncthreads();
+        K64P3_DEQUANT((i + 1) % 3);
+        __syncthreads();
+    }
+    K64P3_COMPUTE_MMA((nsteps - 1) & 1);
+
+    #undef K64P3_ISSUE_LOADS
+    #undef K64P3_DEQUANT
+    #undef K64P3_COMPUTE_MMA
     #undef K_STEP_T64
     #undef PAD_T64
 
@@ -1635,8 +2163,10 @@ void w4a16_gemm_t_m128_bf16_v2(
     const unsigned char* __restrict__ B_scale,
     const float scale2,
     __nv_bfloat16* __restrict__ C,
-    unsigned int M, unsigned int N, unsigned int K
+    unsigned int M, unsigned int N, unsigned int K,
+    unsigned int ldb          // transposed-B row stride; may exceed N (see w4a16_gemm_t)
 ) {
+    const unsigned int LDB = ldb;
     const unsigned int cta_n  = blockIdx.x * N_TILE_LG;
     const unsigned int cta_m  = blockIdx.y * (2 * M_TILE);
     if (cta_m >= M) return;
@@ -1689,13 +2219,13 @@ void w4a16_gemm_t_m128_bf16_v2(
             unsigned int gke = (kb) + (kp << 1); \
             unsigned int gns = cta_n + ns; \
             cp_async_pred_16(&smem_Bp[(buf)][kp][ns], \
-                &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
-                (gke + 1 <= K) && (gns + 15 < N)); \
+                &B_packed[(unsigned long long)(gke >> 1) * LDB + gns], \
+                (gke + 1 <= K) && (gns + 15 < LDB)); \
             if (kp < K_STEP_T / GROUP_SIZE) { \
                 unsigned int sg = (kb) / GROUP_SIZE + kp; \
                 cp_async_pred_16(&smem_Bs[(buf)][kp][ns], \
-                    &B_scale[(unsigned long long)sg * N + gns], \
-                    (gns + 15 < N)); \
+                    &B_scale[(unsigned long long)sg * LDB + gns], \
+                    (gns + 15 < LDB)); \
             } \
         } \
     } while(0)

--- a/kernels/strix-hip/qwen3.6-27b/nvfp4/w4a16_gemm.cu
+++ b/kernels/strix-hip/qwen3.6-27b/nvfp4/w4a16_gemm.cu
@@ -175,14 +175,26 @@ extern "C" __global__ void w4a16_gemm(
 // B_packed[K/2, N], B_scale[K/GROUP_SIZE, N]. Dequant NVFP4→BF16.
 // 8 WMMA n-sub-tiles (128 N / 16). K_STEP_T=32 → 2 WMMA K=16 ops per step.
 // ═══════════════════════════════════════════════════════════════════
+// `ldb` = ROW STRIDE of the transposed B, which may EXCEED N. MUST MATCH THE
+// CUDA COPY at kernels/gb10/qwen3.6-27b/nvfp4/w4a16_gemm.cu — the Rust caller
+// (`w4a16_gemm_n128_ldb`) passes this argument on EVERY platform.
+//
+// Without the parameter this kernel silently strided the lm_head transposed twin
+// by N while the twin is built with a PADDED stride (vocab 248077 -> 248192),
+// shearing every row past the first and producing garbage logits at padded_n>=5
+// — with NO fault, because RDNA tolerates the unaligned access that traps on
+// CUDA as 716. `kernels/strix/` is a symlink to the GB10 file and inherited the
+// fix; this HIP copy is a real file and had to be updated in lockstep.
 extern "C" __global__ void w4a16_gemm_t(
     const __nv_bfloat16* __restrict__ A,
     const unsigned char* __restrict__ B_packed,
     const unsigned char* __restrict__ B_scale,
     const float scale2,
     __nv_bfloat16* __restrict__ C,
-    unsigned int M, unsigned int N, unsigned int K
+    unsigned int M, unsigned int N, unsigned int K,
+    unsigned int ldb
 ) {
+    const unsigned int LDB = ldb;
     const unsigned int cta_n = blockIdx.x * N_TILE_LG;
     const unsigned int cta_m = blockIdx.y * M_TILE;
     const unsigned int warp_id = threadIdx.x / 32;
@@ -221,13 +233,13 @@ extern "C" __global__ void w4a16_gemm_t(
             unsigned int gke = (kb) + (kp << 1); \
             unsigned int gns = cta_n + ns; \
             sync_copy_16(&smem_Bp[(buf)][kp][ns], \
-                &B_packed[(unsigned long long)(gke >> 1) * N + gns], \
-                (gke + 1 <= K) && (gns + 15 < N)); \
+                &B_packed[(unsigned long long)(gke >> 1) * LDB + gns], \
+                (gke + 1 <= K) && (gns + 15 < LDB)); \
             if (kp < K_STEP_T / GROUP_SIZE) { \
                 unsigned int sg = (kb) / GROUP_SIZE + kp; \
                 sync_copy_16(&smem_Bs[(buf)][kp][ns], \
-                    &B_scale[(unsigned long long)sg * N + gns], \
-                    (gns + 15 < N)); \
+                    &B_scale[(unsigned long long)sg * LDB + gns], \
+                    (gns + 15 < LDB)); \
             } \
         } \
     } while(0)


### PR DESCRIPTION
## Enterprise Concurrency

Atlas was winning single-stream decode and losing everywhere else. This branch closes that: **three of five target concurrencies now beat vLLM**, and the two that don't have a measured, arithmetic path to the bar.

| C | Atlas | vLLM | ratio | |
|---|---|---|---|---|
| 1 | 25.62 | 14.2 | **1.80x** | MET |
| 2 | 35.18 | 27.8 | **1.27x** | MET |
| 4 | ~57.0 | 53.3 | **1.07x** | MET |
| 8 | 88.9 | 98.8 | 0.90x | |
| 16 | 131.9 | 168.9 | 0.78x | |

Model `centml/Qwen3.6-27B-NVFP4-W4A4-mlpinf` on GB10. vLLM bars are the NVIDIA-supplied GB10 reference numbers.

### What changed

**Kernel work (all byte-identical unless noted).** The decode step was carrying costs nobody had counted: a scalar GEMV where a tile GEMM already existed, 774 launches/step that existed only because a kernel assumed a packed row layout, and a weight layout that forced nine 4-byte global loads per 36-byte block where two 16-byte loads would do.

**Batched speculative decoding.** MTP previously ran one sequence at a time, so at C=n it performed n full model forwards, each re-reading ~9.6 GB of weights on an engine already at 87% of achievable bandwidth. That is why enabling it at C=2 *lost* 3.4% and raising the cap *halved* C=4. This branch makes n*(K+1) verify rows share one weight read, adds slot-keyed CUDA graphs for the verify step, batches the GDN conv/WY across sequences, and adds a K-vs-batch ladder so draft depth shrinks as concurrency grows.

### Notable fixes found along the way

- **CUDA 716 that had blocked the lm_head tile GEMM through three prior attempts** — the transposed weight's row stride is the vocab size, and this checkpoint's 248077 is odd, so 16-byte `cp.async` was misaligned on 15 of every 16 k-rows. The reproducer that "exonerated" the kernel had hardcoded N=248320 from a sibling checkpoint, a shape where the fault cannot occur.
- **Silent garbage logits on Windows/HIP at C>=5** — `kernels/strix/` is a symlink and inherited the `ldb` fix; `kernels/strix-hip/` is a real file and drifted. RDNA tolerates the misalignment that traps on CUDA, so it would have produced wrong answers with no error.
- **A shipped, default-ON lever that was completely inert** — `rms_norm_strided` was resolved under module `"rms_norm"` when every `KERNEL.toml` maps it as `"norm"`. `try_kernel` swallows the miss, so its kill-switch A/B had been comparing the fallback against itself.

### Verification

Every performance change was A/B'd against its own kill switch with >=3 reps and non-overlapping ranges. Byte-identity was verified by output hash, not asserted from construction. The W4A16 parity oracle passes. Coherence and tool-call smokes pass at final defaults with zero CUDA errors.

Several claims were measured and **retracted**: dropping W4A4 at decode (a 10.4% regression — the M=1 literature does not transfer to M=16 batched serving), a 4-stage pipeline (5% regression — depth trades in-flight bytes against occupancy), and the `16:1` ladder rung (C=16 regression, reverted rather than shipped).

### Accuracy debt

Spec-decode paths change emitted tokens at temp 0 by construction. BFCL/IoU re-validation is required before any accuracy claim; it is deliberately deferred until throughput parity is reached. The lm_head FP8 activation path is the one non-byte-identical kernel change (bounded: 2/8 byte-identical, 6/8 benign paraphrase on a short-prompt probe); `ATLAS_LMHEAD_LOSSLESS=1` selects a lossless BF16 path at ~1.8% cost.

### Still open

C=8 needs the verify step's cost cut from ~1.85x to <=1.67x a plain decode step; C=16 needs <=1.34x from ~1.77x. Depth will not buy C=16 — K=3 at n=16 measured ~3.14x, so GDN is superlinear in K there. Work in progress on graphing the Phase-A bootstrap and raising accept rate (currently p1 ~0.72; refeed reached 0.90 on strix).
