### PR TITLE
fix(v4): route E8M0 K2 verify through per-token GS32 path

### DIFF
--- a/crates/spark-model/src/layers/moe/forward_k2.rs
+++ b/crates/spark-model/src/layers/moe/forward_k2.rs
@@ -34,6 +34,19 @@ impl MoeLayer {
         if self.bf16_gate_weight_ptrs.is_some() && !use_bf16_batch2 {
             return self.forward_batched(input, 2, ctx, stream);
         }
+        // E8M0 (native MXFP4, per-32 E8M0 scale) routed experts MUST NOT reach the
+        // unified-T batch2 kernel `moe_expert_gate_up_shared_batch2_t`: it is an
+        // NVFP4 kernel that hardcodes GROUP_SIZE=16 and would read `inter·h/16`
+        // scale bytes from the correctly-sized `inter·h/32` E8M0 scale buffer — a
+        // 2× over-read → CUDA_ERROR_ILLEGAL_ADDRESS (it also E4M3-decodes E8M0
+        // scale bytes → garbage even in-bounds). No E8M0 batch2 kernel exists, so
+        // route both verify tokens through the per-token unified-T path
+        // (`forward_batched`), whose `use_t_layout_for_prefill` branch selects the
+        // GS32 `_e8m0` kernel via `e8m0_or` — the same correct path ordinary decode
+        // already uses. Mirrors the BF16 fallback above.
+        if k2_e8m0_needs_per_token(self.experts_scale_kind) {
+            return self.forward_batched(input, 2, ctx, stream);
+        }
 
         let h = ctx.config.hidden_size as u32;
         let inter = ctx.config.moe_intermediate_size as u32;
@@ -468,5 +481,79 @@ impl MoeLayer {
         }
 
         Ok(())
+    }
+}
+
+/// K=2-verify MoE dispatch guard. E8M0 (native MXFP4, per-32 E8M0 scale) routed
+/// experts MUST take the per-token unified-T path (GS32 `_e8m0` kernel via
+/// `e8m0_or`), NOT the GS16 NVFP4 `moe_expert_gate_up_shared_batch2_t` batch2
+/// kernel: that kernel reads `inter·h/16` scale bytes from the correctly-sized
+/// `inter·h/32` E8M0 scale buffer — a 2× over-read → CUDA_ERROR_ILLEGAL_ADDRESS
+/// (and E4M3-decodes E8M0 scale bytes → garbage even in-bounds). Pure decision,
+/// unit-tested and wired at the top of `forward_k2`.
+pub(crate) fn k2_e8m0_needs_per_token(scale_kind: crate::weight_map::WeightQuantFormat) -> bool {
+    matches!(scale_kind, crate::weight_map::WeightQuantFormat::Mxfp4E8m0)
+}
+
+#[cfg(test)]
+mod k2_dispatch_tests {
+    use super::k2_e8m0_needs_per_token;
+    use crate::weight_map::WeightQuantFormat;
+
+    #[test]
+    fn e8m0_takes_per_token_path_not_gs16_batch2() {
+        // Mxfp4E8m0 → per-token unified-T (GS32 _e8m0), never the GS16 batch2_t kernel.
+        assert!(k2_e8m0_needs_per_token(WeightQuantFormat::Mxfp4E8m0));
+    }
+
+    #[test]
+    fn nvfp4_still_takes_batch2_kernel() {
+        // NVFP4 (GS16) is compatible with the batch2_t kernel → stays on it.
+        assert!(!k2_e8m0_needs_per_token(WeightQuantFormat::Nvfp4));
+    }
+
+    #[test]
+    fn bf16_and_fp8_dispatch_unchanged() {
+        // BF16 / FP8 K2 dispatch is decided by earlier gates (bf16_gate_weight_ptrs,
+        // fp8_gate_weight_ptrs) — the E8M0 guard must never divert them.
+        for f in [
+            WeightQuantFormat::Bf16,
+            WeightQuantFormat::Fp8SingleScale,
+            WeightQuantFormat::Fp8PerRow,
+        ] {
+            assert!(!k2_e8m0_needs_per_token(f));
+        }
+    }
+
+    #[test]
+    fn no_e8m0_tensor_reaches_gs16_batch2() {
+        // Exhaustive over the format enum: the ONLY format routed away from the
+        // batch2_t kernel by this guard is Mxfp4E8m0.
+        let all = [
+            WeightQuantFormat::Bf16,
+            WeightQuantFormat::Fp8PerRow,
+            WeightQuantFormat::Fp8BlockScaled,
+            WeightQuantFormat::Fp8SingleScale,
+            WeightQuantFormat::Nvfp4,
+            WeightQuantFormat::Mxfp4E8m0,
+        ];
+        for f in all {
+            assert_eq!(
+                k2_e8m0_needs_per_token(f),
+                f == WeightQuantFormat::Mxfp4E8m0,
+                "only Mxfp4E8m0 diverts to the per-token path"
+            );
+        }
+    }
+
+    #[test]
+    fn e8m0_gs32_scale_alloc_is_half_the_gs16_kernel_read() {
+        // The hazard the guard prevents: for any (h, inter) an E8M0 (GS32) scale
+        // buffer is exactly half the GS16 kernel's read span → 2× over-read.
+        for (h, inter) in [(4096usize, 2048usize), (2048, 1408), (5120, 1536)] {
+            let e8m0_alloc = inter * (h / 32); // transpose_for_gemm_gs, routed_gs=32
+            let gs16_read = inter * (h / 16); // batch2_t kernel, GROUP_SIZE=16
+            assert_eq!(gs16_read, 2 * e8m0_alloc);
+        }
     }
 }

--- a/crates/spark-model/src/layers/moe/forward_k2.rs
+++ b/crates/spark-model/src/layers/moe/forward_k2.rs
@@ -488,72 +488,13 @@ impl MoeLayer {
 /// experts MUST take the per-token unified-T path (GS32 `_e8m0` kernel via
 /// `e8m0_or`), NOT the GS16 NVFP4 `moe_expert_gate_up_shared_batch2_t` batch2
 /// kernel: that kernel reads `inter·h/16` scale bytes from the correctly-sized
-/// `inter·h/32` E8M0 scale buffer — a 2× over-read → CUDA_ERROR_ILLEGAL_ADDRESS
-/// (and E4M3-decodes E8M0 scale bytes → garbage even in-bounds). Pure decision,
-/// unit-tested and wired at the top of `forward_k2`.
+/// `inter·h/32` E8M0 scale buffer — a 2× over-read → CUDA_ERROR_ILLEGAL_ADDRESS.
+/// Pure decision, unit-tested and wired at the top of `forward_k2`.
 pub(crate) fn k2_e8m0_needs_per_token(scale_kind: crate::weight_map::WeightQuantFormat) -> bool {
     matches!(scale_kind, crate::weight_map::WeightQuantFormat::Mxfp4E8m0)
 }
 
+// Focused dispatch tests live in a sibling file to keep this file ≤500 LoC.
 #[cfg(test)]
-mod k2_dispatch_tests {
-    use super::k2_e8m0_needs_per_token;
-    use crate::weight_map::WeightQuantFormat;
-
-    #[test]
-    fn e8m0_takes_per_token_path_not_gs16_batch2() {
-        // Mxfp4E8m0 → per-token unified-T (GS32 _e8m0), never the GS16 batch2_t kernel.
-        assert!(k2_e8m0_needs_per_token(WeightQuantFormat::Mxfp4E8m0));
-    }
-
-    #[test]
-    fn nvfp4_still_takes_batch2_kernel() {
-        // NVFP4 (GS16) is compatible with the batch2_t kernel → stays on it.
-        assert!(!k2_e8m0_needs_per_token(WeightQuantFormat::Nvfp4));
-    }
-
-    #[test]
-    fn bf16_and_fp8_dispatch_unchanged() {
-        // BF16 / FP8 K2 dispatch is decided by earlier gates (bf16_gate_weight_ptrs,
-        // fp8_gate_weight_ptrs) — the E8M0 guard must never divert them.
-        for f in [
-            WeightQuantFormat::Bf16,
-            WeightQuantFormat::Fp8SingleScale,
-            WeightQuantFormat::Fp8PerRow,
-        ] {
-            assert!(!k2_e8m0_needs_per_token(f));
-        }
-    }
-
-    #[test]
-    fn no_e8m0_tensor_reaches_gs16_batch2() {
-        // Exhaustive over the format enum: the ONLY format routed away from the
-        // batch2_t kernel by this guard is Mxfp4E8m0.
-        let all = [
-            WeightQuantFormat::Bf16,
-            WeightQuantFormat::Fp8PerRow,
-            WeightQuantFormat::Fp8BlockScaled,
-            WeightQuantFormat::Fp8SingleScale,
-            WeightQuantFormat::Nvfp4,
-            WeightQuantFormat::Mxfp4E8m0,
-        ];
-        for f in all {
-            assert_eq!(
-                k2_e8m0_needs_per_token(f),
-                f == WeightQuantFormat::Mxfp4E8m0,
-                "only Mxfp4E8m0 diverts to the per-token path"
-            );
-        }
-    }
-
-    #[test]
-    fn e8m0_gs32_scale_alloc_is_half_the_gs16_kernel_read() {
-        // The hazard the guard prevents: for any (h, inter) an E8M0 (GS32) scale
-        // buffer is exactly half the GS16 kernel's read span → 2× over-read.
-        for (h, inter) in [(4096usize, 2048usize), (2048, 1408), (5120, 1536)] {
-            let e8m0_alloc = inter * (h / 32); // transpose_for_gemm_gs, routed_gs=32
-            let gs16_read = inter * (h / 16); // batch2_t kernel, GROUP_SIZE=16
-            assert_eq!(gs16_read, 2 * e8m0_alloc);
-        }
-    }
-}
+#[path = "forward_k2_dispatch_tests.rs"]
+mod k2_dispatch_tests;

--- a/crates/spark-model/src/layers/moe/forward_k2_dispatch_tests.rs
+++ b/crates/spark-model/src/layers/moe/forward_k2_dispatch_tests.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Focused dispatch tests for `forward_k2`'s E8M0 guard (`k2_e8m0_needs_per_token`).
+// Included via `#[path]` from forward_k2.rs to keep that file ≤500 LoC.
+
+use super::k2_e8m0_needs_per_token;
+use crate::weight_map::WeightQuantFormat;
+
+#[test]
+fn e8m0_takes_per_token_path_not_gs16_batch2() {
+    // Mxfp4E8m0 → per-token unified-T (GS32 _e8m0), never the GS16 batch2_t kernel.
+    assert!(k2_e8m0_needs_per_token(WeightQuantFormat::Mxfp4E8m0));
+}
+
+#[test]
+fn nvfp4_still_takes_batch2_kernel() {
+    // NVFP4 (GS16) is compatible with the batch2_t kernel → stays on it.
+    assert!(!k2_e8m0_needs_per_token(WeightQuantFormat::Nvfp4));
+}
+
+#[test]
+fn bf16_and_fp8_dispatch_unchanged() {
+    // BF16 / FP8 K2 dispatch is decided by earlier gates (bf16_gate_weight_ptrs,
+    // fp8_gate_weight_ptrs) — the E8M0 guard must never divert them.
+    for f in [
+        WeightQuantFormat::Bf16,
+        WeightQuantFormat::Fp8SingleScale,
+        WeightQuantFormat::Fp8PerRow,
+    ] {
+        assert!(!k2_e8m0_needs_per_token(f));
+    }
+}
+
+#[test]
+fn no_e8m0_tensor_reaches_gs16_batch2() {
+    // Exhaustive over the format enum: the ONLY format routed away from the
+    // batch2_t kernel by this guard is Mxfp4E8m0.
+    let all = [
+        WeightQuantFormat::Bf16,
+        WeightQuantFormat::Fp8PerRow,
+        WeightQuantFormat::Fp8BlockScaled,
+        WeightQuantFormat::Fp8SingleScale,
+        WeightQuantFormat::Nvfp4,
+        WeightQuantFormat::Mxfp4E8m0,
+    ];
+    for f in all {
+        assert_eq!(
+            k2_e8m0_needs_per_token(f),
+            f == WeightQuantFormat::Mxfp4E8m0,
+            "only Mxfp4E8m0 diverts to the per-token path"
+        );
+    }
+}
+
+#[test]
+fn e8m0_gs32_scale_alloc_is_half_the_gs16_kernel_read() {
+    // The hazard the guard prevents: for any (h, inter) an E8M0 (GS32) scale
+    // buffer is exactly half the GS16 kernel's read span → 2× over-read.
+    for (h, inter) in [(4096usize, 2048usize), (2048, 1408), (5120, 1536)] {
+        let e8m0_alloc = inter * (h / 32); // transpose_for_gemm_gs, routed_gs=32
+        let gs16_read = inter * (h / 16); // batch2_t kernel, GROUP_SIZE=16
+        assert_eq!(gs16_read, 2 * e8m0_alloc);
+    }
+}


### PR DESCRIPTION
## Summary

DeepSeek V4 K2 verification could dispatch `Mxfp4E8m0` routed experts through the unified-layout batch-2 MoE kernel.

That kernel is specialized for GS16/NVFP4 scales, while E8M0 routed experts use GS32 scales. As a result, the kernel read twice the allocated E8M0 scale span and decoded the scale format incorrectly, causing token-dependent CUDA illegal-address failures during K2 verification.

This change routes E8M0 K2 verification through the existing per-token GS32 E8M0 decode path, mirroring the existing BF16 fallback. No new CUDA kernel is introduced.

## Root cause

For `h=4096` and `inter=2048`:

- E8M0 scale allocation: `inter * h / 32 = 262144` bytes
- GS16 batch-2 kernel read: `inter * h / 16 = 524288` bytes

The GS16 kernel therefore read 2× the valid E8M0 scale allocation. Concretely, `forward_k2` dispatched E8M0 experts to `moe_expert_gate_up_shared_batch2_t`, which hardcodes `GROUP_SIZE=16` and decodes scale bytes as FP8-E4M3; E8M0 routed experts are per-32 with E8M0-encoded scales. `transpose_for_gemm_gs` sizes the scale buffer correctly at `inter·(h/32)`, but the kernel indexes `inter·(h/16)` scale rows, over-reading every E8M0 expert's scale allocation. The fault surfaces token-dependently — the over-read only traps when a routed expert's buffer sits at a pool/page edge.

## Scope

- E8M0 K2 verification dispatch only
- GS16/NVFP4 batch-2 behavior unchanged
- BF16 behavior unchanged
- ordinary decode unchanged
- no scheduler, proposer or checkpoint-layout changes
- no native DSpark drafter code
- **K=3 is not part of this PR.** The K=3 twin of this dispatch fix exists but is held for a follow-up.

## Validation

**Static**

- 5 focused dispatch tests pass (`cargo test -p spark-model k2_dispatch`)
- the exhaustive test prevents E8M0 from reaching the GS16 batch-2 kernel

**Runtime — two separate runs, stated separately**

1. **Causal crash→fix proof (lane build, TP=2/EP=2, unified layout, MTP `--speculative`).** A reproducible
   token-14 `CUDA_ERROR_ILLEGAL_ADDRESS` in E8M0 K2 verification disappears with this change: HTTP 200,
   coherent output, and under `ATLAS_DEBUG_SYNC_KERNELS=1` zero `moe_expert_gate_up_shared_batch2_t`
   launches and zero illegal-address faults. **This is the evidence that the fix works, and it was taken on
   the originating lane build, not on `main`.**

2. **Clean-branch gate (`main` + this fix).** This run established **spec-OFF non-regression only** —
   output byte-identical to the pre-change run. It did **not** exercise the corrected dispatch path:
   the checkpoint used carried no `mtp.0` tensors, so speculation was **silently disabled** and K2 verify
   never ran. An earlier revision of this description implied a broader clean-branch gate than the evidence
   supports; that is what this amendment corrects.

**Why the clean-branch run could not cover it**

`main` does not support TP>1 for `deepseek_v4` (`crates/spark-model/src/weight_loader/deepseek_v4.rs`,
`supports_tp() -> false`, MQA `num_key_value_heads=1`), so the TP=2 topology on which the crash was found
cannot be instantiated on `main` as it stands. Reviewers should expect to reproduce (1) on a TP>1-capable
branch, and (2) on `main`.

## Reviewer summary

The fix itself is proven by the token-14 crash→fix reproduction. On `main` the corrected path is currently
unreachable, so `main`-side evidence is limited to spec-OFF non-regression. Both facts are stated above
rather than merged into a single claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

_Description amended 2026-07-30 to separate the lane-build crash→fix proof from the clean-branch spec-OFF
non-regression run, to record that speculation was silently disabled in the latter (checkpoint lacked
`mtp.0` tensors), and to state that K=3 is not in this PR. No source, commits or CI were changed._
