### PR TITLE
fix(v4): route E8M0 K3 verify through per-token GS32 path (K=3 twin of #380)

### DIFF
--- a/crates/spark-model/src/layers/moe/forward_k3.rs
+++ b/crates/spark-model/src/layers/moe/forward_k3.rs
@@ -24,6 +24,20 @@ impl MoeLayer {
         if self.bf16_gate_weight_ptrs.is_some() {
             return self.forward_batched(input, 3, ctx, stream);
         }
+        // E8M0 (native MXFP4, per-32 E8M0 scale) routed experts MUST NOT reach
+        // the unified-T batch3 kernel `moe_expert_gate_up_shared_batch3_t`: like
+        // its K=2 twin it is an NVFP4 kernel that hardcodes GROUP_SIZE=16 and
+        // would read `inter·h/16` scale bytes from the correctly-sized
+        // `inter·h/32` E8M0 scale buffer — a 2× over-read →
+        // CUDA_ERROR_ILLEGAL_ADDRESS (it also E4M3-decodes E8M0 scale bytes →
+        // garbage even in-bounds). No E8M0 batch3 kernel exists, so route all 3
+        // verify tokens through the per-token unified-T path (`forward_batched`),
+        // whose `use_t_layout_for_prefill` branch selects the GS32 `_e8m0`
+        // kernel via `e8m0_or` — the same correct path ordinary decode already
+        // uses. Mirrors the K=2 guard at the top of `forward_k2`.
+        if k3_e8m0_needs_per_token(self.experts_scale_kind) {
+            return self.forward_batched(input, 3, ctx, stream);
+        }
 
         let h = ctx.config.hidden_size as u32;
         let inter = ctx.config.moe_intermediate_size as u32;
@@ -344,3 +358,19 @@ impl MoeLayer {
         Ok(())
     }
 }
+
+/// K=3-verify MoE dispatch guard — the K=3 twin of `k2_e8m0_needs_per_token`
+/// (`forward_k2.rs`). E8M0 (native MXFP4, per-32 E8M0 scale) routed experts
+/// MUST take the per-token unified-T path (GS32 `_e8m0` kernel via `e8m0_or`),
+/// NOT the GS16 NVFP4 `moe_expert_gate_up_shared_batch3_t` batch3 kernel: that
+/// kernel reads `inter·h/16` scale bytes from the correctly-sized `inter·h/32`
+/// E8M0 scale buffer — a 2× over-read → CUDA_ERROR_ILLEGAL_ADDRESS.
+/// Pure decision, unit-tested and wired at the top of `forward_k3`.
+pub(crate) fn k3_e8m0_needs_per_token(scale_kind: crate::weight_map::WeightQuantFormat) -> bool {
+    matches!(scale_kind, crate::weight_map::WeightQuantFormat::Mxfp4E8m0)
+}
+
+// Focused dispatch tests live in a sibling file (same pattern as forward_k2).
+#[cfg(test)]
+#[path = "forward_k3_dispatch_tests.rs"]
+mod k3_dispatch_tests;

--- a/crates/spark-model/src/layers/moe/forward_k3_dispatch_tests.rs
+++ b/crates/spark-model/src/layers/moe/forward_k3_dispatch_tests.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Focused dispatch tests for `forward_k3`'s E8M0 guard (`k3_e8m0_needs_per_token`),
+// mirroring forward_k2_dispatch_tests.rs. Included via `#[path]` from forward_k3.rs.
+
+use super::k3_e8m0_needs_per_token;
+use crate::weight_map::WeightQuantFormat;
+
+#[test]
+fn e8m0_takes_per_token_path_not_gs16_batch3() {
+    // Mxfp4E8m0 → per-token unified-T (GS32 _e8m0), never the GS16 batch3_t kernel.
+    assert!(k3_e8m0_needs_per_token(WeightQuantFormat::Mxfp4E8m0));
+}
+
+#[test]
+fn nvfp4_still_takes_batch3_kernel() {
+    // NVFP4 (GS16) is compatible with the batch3_t kernel → stays on it.
+    assert!(!k3_e8m0_needs_per_token(WeightQuantFormat::Nvfp4));
+}
+
+#[test]
+fn bf16_and_fp8_k3_dispatch_unchanged() {
+    // BF16 / FP8 K3 dispatch is decided by earlier gates (bf16_gate_weight_ptrs,
+    // fp8_gate_weight_ptrs) — the E8M0 guard must never divert them.
+    for f in [
+        WeightQuantFormat::Bf16,
+        WeightQuantFormat::Fp8SingleScale,
+        WeightQuantFormat::Fp8PerRow,
+    ] {
+        assert!(!k3_e8m0_needs_per_token(f));
+    }
+}
+
+#[test]
+fn no_e8m0_tensor_reaches_gs16_batch3() {
+    // Exhaustive over the format enum: the ONLY format routed away from the
+    // batch3_t kernel by this guard is Mxfp4E8m0.
+    let all = [
+        WeightQuantFormat::Bf16,
+        WeightQuantFormat::Fp8PerRow,
+        WeightQuantFormat::Fp8BlockScaled,
+        WeightQuantFormat::Fp8SingleScale,
+        WeightQuantFormat::Nvfp4,
+        WeightQuantFormat::Mxfp4E8m0,
+    ];
+    for f in all {
+        assert_eq!(
+            k3_e8m0_needs_per_token(f),
+            f == WeightQuantFormat::Mxfp4E8m0,
+            "only Mxfp4E8m0 diverts to the per-token path"
+        );
+    }
+}
+
+#[test]
+fn e8m0_gs32_scale_alloc_is_half_the_gs16_batch3_kernel_read() {
+    // The hazard the guard prevents — identical arithmetic to the K=2 case
+    // (GROUP_SIZE is per-K-elements, independent of batch width): for any
+    // (h, inter) an E8M0 (GS32) scale buffer is exactly half the GS16
+    // batch3_t kernel's read span → 2× over-read.
+    for (h, inter) in [(4096usize, 2048usize), (2048, 1408), (5120, 1536)] {
+        let e8m0_alloc = inter * (h / 32); // transpose_for_gemm_gs, routed_gs=32
+        let gs16_read = inter * (h / 16); // batch3_t kernel, GROUP_SIZE=16
+        assert_eq!(gs16_read, 2 * e8m0_alloc);
+    }
+}


### PR DESCRIPTION
Follow-up to **#380**, which routed the **K=2** E8M0 verify path through the per-token GS32 kernels. This extends the **same format-aware fallback to K=3 verification**. Nothing else.

## The defect

`forward_k3` selects the unified-T batch3 kernels purely on layout (`use_t_layout_for_decode`), with **no scale-format guard** — structurally identical to the K=2 defect #380 fixed.

`moe_expert_gate_up_shared_batch3_t` is an NVFP4 kernel with a hardcoded `GROUP_SIZE = 16`, and **no `_e8m0` batch3 variant exists**. So `Mxfp4E8m0` routed experts (per-32 E8M0 scales, allocated `inter·h/32` by `transpose_for_gemm_gs`) would have that buffer read at `inter·h/16`:

```
E8M0 alloc (GS32):        inter · h/32
batch3_t kernel reads:    inter · h/16   = 2 × alloc   → CUDA_ERROR_ILLEGAL_ADDRESS
```

`GROUP_SIZE` is per-K-elements and independent of batch width, so the arithmetic is identical to the K=2 case. Even in-bounds the kernel would E4M3-decode E8M0 scale bytes, which is silent garbage.

## The fix

A pure predicate mirroring `k2_e8m0_needs_per_token`, wired at the top of `forward_k3`:

```rust
if k3_e8m0_needs_per_token(self.experts_scale_kind) {
    return self.forward_batched(input, 3, ctx, stream);
}
```

`forward_batched`'s `use_t_layout_for_prefill` branch already selects the GS32 `_e8m0` kernel via `e8m0_or` — the same path ordinary decode uses. **NVFP4, BF16, FP8 and K ≥ 4 dispatch are unchanged**; BF16/FP8 are decided by earlier gates the guard cannot divert.

## Diff

+96 / −0 across 2 files:

| file | change |
|---|---|
| `crates/spark-model/src/layers/moe/forward_k3.rs` | +30 — the guard call, the predicate, the test-module wire |
| `crates/spark-model/src/layers/moe/forward_k3_dispatch_tests.rs` | +66 — new, 5 focused tests |

`forward_k3.rs` ends at 376 lines.

## ⚠️ Validation label: source-proven + unit-tested only. NOT runtime-proven.

Stating this plainly because it matters for how you review it:

- **The fixed path was NOT exercised on-device, and cannot be today.** No current E8M0 checkpoint ships an MTP head, and Atlas **silently disables** speculative decoding when `mtp.0.*` tensors are absent. A "clean speculative run" on such a checkpoint would be vacuous, so none is claimed.
- The defect is therefore established by **source reading plus the scale-buffer arithmetic**, not by a crash-then-fix reproduction.
- What *is* runtime-proven is the **K=2 twin** this mirrors: that one had a real token-14 `CUDA_ERROR_ILLEGAL_ADDRESS` and a fix that cleared it, which is what #380 landed. The K=3 kernel geometry is the same defect with the same arithmetic.
- **This is a latent-defect guard.** It removes a reachable illegal-address path that becomes live the moment an E8M0 checkpoint ships an MTP head.

## Tests run and results

Host: aarch64 GB10, CUDA 13.0, rustc 1.93.1. Built at `f11d1f16`.

| gate | command | result |
|---|---|---|
| formatting | `cargo fmt --all -- --check` | **clean** |
| type check | `cargo check -p spark-model --tests` | **clean**, exit 0 |
| **new K=3 dispatch tests** | `cargo test -p spark-model k3_dispatch` | **5 passed, 0 failed** |
| **K=2 non-regression (#380)** | `cargo test -p spark-model k2_dispatch` | **5 passed, 0 failed** — #380's behaviour is unchanged |
| **full workspace** | `cargo test --workspace` | **2211 passed, 0 failed, 51 ignored, 61 suites** — includes all 5 new tests |
| lints (touched crate) | `cargo clippy -p spark-model --lib --tests` | **clean**, exit 0 |
| diff size | — | **+96**, under the 500-LoC cap |

The five new tests:

1. `e8m0_takes_per_token_path_not_gs16_batch3` — `Mxfp4E8m0` diverts to the per-token path
2. `nvfp4_still_takes_batch3_kernel` — NVFP4 (GS16) stays on `batch3_t`
3. `bf16_and_fp8_k3_dispatch_unchanged` — the guard never diverts BF16/FP8
4. `no_e8m0_tensor_reaches_gs16_batch3` — exhaustive over `WeightQuantFormat`; only `Mxfp4E8m0` diverts
5. `e8m0_gs32_scale_alloc_is_half_the_gs16_batch3_kernel_read` — the `2×` over-read arithmetic, over three `(h, inter)` shapes

**One disclosure on lints:** `cargo clippy --workspace --all-targets` fails on this host with two `manual_is_multiple_of` errors in `crates/spark-model/examples/w4a16_gemv_sw_microtest.rs:74` and `w4a16_bf16_v2_microtest.rs:122`. **These are pre-existing and not from this PR** — I re-ran the same command on unmodified `avarok/main` @ `f11d1f16` and got the identical two errors. Those lines last changed in #229 (2026-07-04), this PR touches no `examples/`, and the lint is new in Rust 1.93. Flagging it rather than leaving you to wonder.

## Explicitly NOT in this PR

- **No performance claim of any kind.** This is a correctness guard on a latent illegal-address path. It is not a throughput change and no tok/s number is asserted or implied.
- **No shared-gate / null-guard change.** The `gate_weight == 0` nullable-shared-gate work is a separate concern on separate files and is deliberately excluded.
- **No diagnostics or timing instrumentation.** No `mtp_timing`, no `ATLAS_K3_DIAG`, no logging changes.
- **No K≥3 performance work**, no MoE layout changes, no scheduler changes.
- **No overlap with #370/#371.** #371 touches `forward_k2.rs` and other `moe/` files but **not** `forward_k3.rs`; #370 touches no `moe/` files. This PR touches only `forward_k3*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
