### PR TITLE
fix(dflash): use drafter target_layer_ids directly (accept +1 row/step on z-lab drafters)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -30,6 +30,10 @@ extend-ignore-identifiers-re = [
 # reads it as a misspelling of `RETURNED`, which it is not.
 RETUNED = "RETUNED"
 retuned = "retuned"
+# `unauthenticate` — used as a verb ("would silently unauthenticate the
+# endpoint") in the model-swap test commentary (#385). Intentional coinage,
+# not a typo of "unauthenticated".
+unauthenticate = "unauthenticate"
 # `nd` — the num-drafts speculative-decode notation (`nd=2`, `nd=3`) used
 # throughout the MTP verify code and docs. Not a typo of "and".
 nd = "nd"

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -124,30 +124,20 @@ pub fn build_model(
     // capture-layer indices from the drafter's `dflash_config.target_layer_ids`
     // so `TransformerModel::new` allocates the 5×hidden_size capture buffer.
     //
-    // HF `output_hidden_states[i]` semantics: index 0 = post-embedding,
-    // index k>=1 = post-layer-(k-1). The drafter's `target_layer_ids`
-    // are interpreted as HF `output_hidden_states` indices (so layer_id=1
-    // means post-layer-0). Atlas captures AFTER `layer.decode()` for the
-    // listed `dflash_capture_layers` index — to match HF semantics we
-    // subtract 1 from each id (clamped at 0). Set
-    // ATLAS_DFLASH_CAPTURE_LAYER_OFFSET=0 to disable this adjustment for
-    // a back-to-back A/B test.
+    // The drafter's `target_layer_ids` are used DIRECTLY as Atlas capture
+    // indices. An earlier implementation subtracted 1 from each id on HF
+    // `output_hidden_states` reasoning; measurement on the z-lab drafters
+    // shows that adjustment feeds the drafter hidden states one layer early
+    // on every capture layer and costs ~1 full accepted row per step (27B
+    // dense MinHeap: mean accept 6.61 direct vs 5.56 shifted; the 2026-07-19
+    // 35B accept hunt found the same).
     if let Some(ref args) = dflash_args
         && let Some(ref sub) = args.drafter_config.dflash_config
     {
-        let offset: i64 = std::env::var("ATLAS_DFLASH_CAPTURE_LAYER_OFFSET")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(-1);
-        config.dflash_capture_layers = sub
-            .target_layer_ids
-            .iter()
-            .map(|&id| (id as i64 + offset).max(0) as usize)
-            .collect();
+        config.dflash_capture_layers = sub.target_layer_ids.clone();
         tracing::info!(
-            "DFlash: target layer capture indices = {:?} (offset={offset} from raw {:?})",
+            "DFlash: target layer capture indices = {:?} (drafter target_layer_ids, used directly)",
             config.dflash_capture_layers,
-            sub.target_layer_ids,
         );
     }
 


### PR DESCRIPTION
## What

Part 1 of 5 of the dense 27B DFlash records series (36.8 tok/s single-stream, +74% over MTP; matrix in the team post).

Uses the drafter's `target_layer_ids` directly as capture-layer indices in `factory/build.rs`. The previous -1 adjustment and its `ATLAS_DFLASH_CAPTURE_LAYER_OFFSET` env override are both deleted (per project direction: measured wins ship as the only path, no switches). One file, net -10 lines.

## Why

This is the single largest accept lever we have measured on the z-lab drafters, and with the current default every DFlash deployment is giving up roughly one accepted row per step until this merges.

- 27B dense, MinHeap workload, same binary, boot-line A/B: **mean accept 6.61 direct vs 5.56 shifted**.
- The 2026-07-19 35B accept investigation independently reached the same conclusion before we understood the mechanism.
- On the 27B records config this default is worth several tok/s on its own.

The -1 was deliberate (aligning to HF `output_hidden_states` indexing so the drafter sees the layer the training pipeline nominally fed it), but at -1 the drafter is fed hidden states one layer early relative to what it actually conditions on best. Whatever the indexing rationale, accept is the ground truth for what the drafter wants.

## Risk

Behavior change is the point: accept goes up on both drafters we can test (27B dense, 35B MoE). The measurement receipts stay in the code comment; re-testing the old behavior is a one-commit revert.
