### PR TITLE
perf(ssm): keep batched QKVZ/out_proj engaged for n>16 NVFP4 decode (≤16-row tiling) — C=32 aggregate +36% on GB10

### DIFF
--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched.rs
@@ -35,7 +35,7 @@ impl Qwen3SsmLayer {
         // (batch4/16, M<=16). Either amortizes the QKVZ/out_proj weight read
         // across the n seqs; otherwise the per-seq loop re-streams it n times.
         let qkvz_ok = (self.qkvz_nvfp4.is_none() && self.w8a16_gemm_k.0 != 0)
-            || (self.qkvz_nvfp4.is_some() && self.w4a16_gemv_batch4_k.0 != 0 && n <= 16);
+            || (self.qkvz_nvfp4.is_some() && self.w4a16_gemv_batch4_k.0 != 0);
         let out_ok = self.out_proj_fp8w.is_some()
             || self.out_proj_dense.is_some()
             || self.qkvz_nvfp4.is_some();
@@ -179,17 +179,25 @@ impl Qwen3SsmLayer {
         } else if let Some(ref nvfp4) = self.qkvz_nvfp4 {
             // FP4 batched QKVZ: ONE NVFP4 weight pass for all n seqs
             // (sequential layout writes the deinterleaved buffer directly).
-            ops::w4a16_gemv_batchm(
-                ctx.gpu,
-                fp4_gemv_batch_k,
-                normed_base,
-                nvfp4,
-                deinterleaved,
-                n as u32,
-                qkvz_size as u32,
-                h as u32,
-                stream,
-            )?;
+            // TASK-160 (gx10): tile n>16 into <=16-row chunks so the batched
+            // path (weights read ceil(n/16)x) survives decode batches >16
+            // instead of disengaging to the per-seq loop (weights read n x).
+            let mut c0 = 0usize;
+            while c0 < n {
+                let m = (n - c0).min(16);
+                ops::w4a16_gemv_batchm(
+                    ctx.gpu,
+                    fp4_gemv_batch_k,
+                    normed_base.offset(c0 * h * bf16),
+                    nvfp4,
+                    deinterleaved.offset(c0 * qkvz_size * bf16),
+                    m as u32,
+                    qkvz_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+                c0 += m;
+            }
         } else {
             ops::dense_gemm(
                 ctx.gpu,
@@ -297,17 +305,22 @@ impl Qwen3SsmLayer {
             // FP4 batched out_proj: ONE NVFP4 weight pass for all n seqs.
             // (qkvz_nvfp4.is_some() ⇒ the NVFP4 SSM build, where ssm.out_proj
             // is the NVFP4 weight the per-seq path also uses via w4a16_gemv.)
-            ops::w4a16_gemv_batchm(
-                ctx.gpu,
-                fp4_gemv_batch_k,
-                normed_out_base,
-                &self.ssm.out_proj,
-                ssm_out_base,
-                n as u32,
-                h as u32,
-                value_dim as u32,
-                stream,
-            )?;
+            let mut c0 = 0usize;
+            while c0 < n {
+                let m = (n - c0).min(16);
+                ops::w4a16_gemv_batchm(
+                    ctx.gpu,
+                    fp4_gemv_batch_k,
+                    normed_out_base.offset(c0 * value_dim * bf16),
+                    &self.ssm.out_proj,
+                    ssm_out_base.offset(c0 * h * bf16),
+                    m as u32,
+                    h as u32,
+                    value_dim as u32,
+                    stream,
+                )?;
+                c0 += m;
+            }
         }
         detail_step!("out_proj");
 


### PR DESCRIPTION
## What

The NVFP4 arm of `try_decode_multi_seq_ssm_batched` gates on `n <= 16` (`ssm_batched.rs`). Above that, the whole batched SSM path returns `false` and every GDN layer falls back to the per-seq loop — the QKVZ and out_proj weights get re-streamed once per sequence, which un-does exactly the amortization this path exists for.

This PR relaxes the eligibility gate and tiles the two batched GEMVs (QKVZ in_proj, out_proj) into ≤16-row chunks of the existing `w4a16_gemv_batch16` kernel: weights read `ceil(n/16)`× instead of `n`×. For `n <= 16` the call is bit-for-bit the same single dispatch as before (one chunk, unchanged kernel selection). The recurrent inner and both norm ends are untouched; chunk offsets use the same per-row strides the recurrent inner already indexes with (`h`, `qkvz_size`, `value_dim` × bf16).

## Measured (GB10 / DGX Spark, sm_121a, CUDA 13.2, built from source)

`spark serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 --port 8888 --lm-head-dtype nvfp4 --max-batch-size 32`, 256-tok non-stream requests, distinct sequences, coherence-checked, same-session A/B vs `main` @ `3e5115e8`:

| aggregate tok/s | C=8 | C=16 | C=32 |
|---|---|---|---|
| main | 155.92 | 164.35 | **130.84** ← cliff |
| main + this PR | 162.77* | 163.47 | **178.07** (+36%) |

Single-session parity: 96.24 vs 96.40 median. (*C=8 rung is noisy across all our runs, 156–173.)

Composes with #332 and the `ATLAS_GDN_FUSED_NORM=1 ATLAS_SSM_BATCHED_RECURRENT=1` pair: **190 tok/s aggregate at C=32, 188 at C=64** (batch-32 waves) on the same setup — vs ~151 stock best.

## Notes / limits

- NVFP4 path only; the w8a16/dense arms already had no `n <= 16` limit (GEMM).
- `--max-batch-size 64` with real >32-row batches hits a separate pre-existing kernel limit (`CUDA_ERROR_ILLEGAL_ADDRESS`, grid=[64,9,2]) — out of scope here; batch 32 is the validated ceiling for this path.
- Validated on the 35B MoE only; a 27B-dense run would be a good maintainer cross-check.
- Found while profiling open PRs on GB10; the same cliff reproduces with #332's lm_head batched-GEMV (its `n<=16` gate is the right call — at n=32 the plain GEMM lm_head outperforms tiled GEMV, 178 vs 173 in our runs).

Developed and benchmarked with AI assistance (Claude Code); measurements are from real hardware runs as described.
