### PR TITLE
fix(xgrammar): bound the compiled-grammar cache — closes the #368 heap growth

### DIFF
--- a/crates/spark-server/src/grammar/engine.rs
+++ b/crates/spark-server/src/grammar/engine.rs
@@ -2,6 +2,14 @@
 
 use xgrammar::{GrammarCompiler, TokenizerInfo, VocabType, detect_metadata_from_hf};
 
+/// Byte budget for the Tier-1 compiled-grammar cache (`GrammarCompiler`).
+///
+/// 1 GiB. Sized against the measured footprint of a compiled tool grammar plus
+/// the masks it accumulates in use (~17 MB under BFCL), so this holds roughly
+/// sixty distinct schemas — far beyond any realistic hot set, while bounding a
+/// tail that was previously unbounded. See issue #368.
+const GRAMMAR_CACHE_BUDGET_BYTES: isize = 1024 * 1024 * 1024;
+
 use super::extract_ordered_vocab;
 
 // ── GrammarEngine ──────────────────────────────────────────────────────
@@ -132,7 +140,14 @@ impl GrammarEngine {
     fn from_tokenizer_info(tokenizer_info: TokenizerInfo) -> Result<Self, GrammarError> {
         let vocab_size = tokenizer_info.vocab_size();
         // Single compilation thread, cache enabled, no memory limit.
-        let compiler = GrammarCompiler::new(&tokenizer_info, 1, true, -1)
+        // ★ NOT -1 (unlimited). `CacheKey::Schema` is keyed by the full tool
+        // schema, so agentic traffic mints a distinct compiled grammar per
+        // request; unbounded, that grew host RSS ~100 MB/min under BFCL and is
+        // the shape behind issue #368's ~7-hour restart cadence. A GiB is far
+        // above any realistic hot set (tens of schemas) while bounding the
+        // tail. `-1` remains available as an explicit opt-in for callers that
+        // genuinely want every grammar pinned.
+        let compiler = GrammarCompiler::new(&tokenizer_info, 1, true, GRAMMAR_CACHE_BUDGET_BYTES)
             .map_err(GrammarError::Compilation)?;
         Ok(Self {
             compiler,

--- a/crates/xgrammar/src/compiler/compiler.rs
+++ b/crates/xgrammar/src/compiler/compiler.rs
@@ -6,8 +6,6 @@
 // A tokenizer-bound cache that produces `CompiledGrammar`s, avoiding
 // redundant preprocessing of grammars / schemas seen before.
 
-use dashmap::DashMap;
-
 use crate::grammar::functor::{GrammarNormalizer, GrammarOptimizer};
 use crate::grammar::{GrammarData, parse_ebnf};
 use crate::schema::{SchemaConverterOptions, builtin_json_grammar_ebnf, json_schema_to_ebnf};
@@ -16,6 +14,7 @@ use crate::tokenizer::TokenizerInfo;
 
 use super::compile::compile_optimized_grammar;
 use super::compiled_grammar::CompiledGrammar;
+use super::grammar_cache::{GrammarCache, UNLIMITED_BYTES};
 use super::rule_cache::{RuleLevelCache, UNLIMITED_SIZE};
 
 /// An error produced while compiling a grammar, schema or tag.
@@ -63,7 +62,12 @@ pub struct GrammarCompiler {
     max_threads: usize,
     cache_enabled: bool,
     cache_limit_bytes: i64,
-    cache: DashMap<CacheKey, CompiledGrammar>,
+    /// Tier-1 compiled-grammar cache, LRU-bounded by `cache_limit_bytes`.
+    ///
+    /// Was a bare `DashMap` with no eviction: `CacheKey::Schema` is keyed by
+    /// the full tool-schema text, so agentic traffic minted a permanent entry
+    /// per request (~100 MB/min under BFCL; issue #368).
+    cache: GrammarCache<CacheKey>,
     /// Cross-grammar adaptive-token-mask cache (Tier 2, upstream commit
     /// `bfb2a79`). `Some` only when `cache_enabled` — a rule
     /// structurally identical to one compiled for a previous request
@@ -80,9 +84,11 @@ impl GrammarCompiler {
     ///   now lazy (XGrammar-2 JIT), so there is no eager parallel loop
     ///   to bound; the value is recorded but unused. Must be >= 1.
     /// * `cache_enabled` — whether to cache compiled grammars.
-    /// * `cache_limit_bytes` — recorded memory budget; `-1` means
-    ///   unlimited. (Reported by [`Self::cache_limit_bytes`]; this port
-    ///   does not perform LRU eviction — see the module docs.)
+    /// * `cache_limit_bytes` — memory budget, ENFORCED by LRU eviction on
+    ///   both tiers. `-1` means unlimited, which is now an explicit opt-in
+    ///   rather than the serve's default: unbounded was the shape of the leak
+    ///   in issue #368. The budget splits as upstream does — ~1/3 to the
+    ///   rule-level cache, the remaining ~2/3 to this grammar-level one.
     ///
     /// Port of the C++ `GrammarCompiler` constructor.
     pub fn new(
@@ -116,7 +122,12 @@ impl GrammarCompiler {
             max_threads,
             cache_enabled,
             cache_limit_bytes,
-            cache: DashMap::new(),
+            cache: GrammarCache::new(if cache_limit_bytes == -1 {
+                UNLIMITED_BYTES
+            } else {
+                // The ~2/3 complement of the rule cache's `limit - limit/3*2`.
+                (cache_limit_bytes / 3 * 2) as usize
+            }),
             rule_cache,
         }
     }
@@ -143,10 +154,11 @@ impl GrammarCompiler {
             return f();
         }
         if let Some(hit) = self.cache.get(&key) {
-            return hit.clone();
+            return hit;
         }
         let value = f();
-        self.cache.entry(key).or_insert(value).clone()
+        self.cache.insert(key, value.clone());
+        value
     }
 
     /// Compile a grammar from an EBNF string. Port of
@@ -248,11 +260,7 @@ impl GrammarCompiler {
     /// grammars plus the cross-grammar rule-level mask cache. Port of
     /// `GrammarCompiler::GetCacheSizeBytes`.
     pub fn cache_size_bytes(&self) -> i64 {
-        let grammar_bytes: i64 = self
-            .cache
-            .iter()
-            .map(|e| e.value().memory_size_bytes() as i64)
-            .sum();
+        let grammar_bytes = self.cache.resident_bytes() as i64;
         let rule_bytes = self
             .rule_cache
             .as_ref()

--- a/crates/xgrammar/src/compiler/grammar_cache.rs
+++ b/crates/xgrammar/src/compiler/grammar_cache.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tier-1 LRU: the compiled-grammar cache, bounded.
+//!
+//! # The bug this closes
+//!
+//! This cache was a bare `DashMap<CacheKey, CompiledGrammar>` with no
+//! eviction. `cache_limit_bytes` was recorded and never enforced — the C++
+//! `ThreadSafeLRUCache` simply was not ported, while the Tier-2
+//! [`super::rule_cache::RuleLevelCache`] was.
+//!
+//! That is unbounded in the one dimension that matters for a server:
+//! [`CacheKey::Schema`] is keyed by the **full tool-schema text**, and agentic
+//! traffic sends a distinct schema per request. Every request therefore minted
+//! a permanent entry. Measured on a GB10 serve under BFCL: **~100 MB/min of
+//! host RSS, roughly 17 MB per request**, with kernel slab flat — pure
+//! userspace heap. It matches the production report in issue #368, where
+//! operators restart the container roughly every seven hours.
+//!
+//! # Why entries grow AFTER insertion
+//!
+//! A `CompiledGrammar` is not a fixed-size value. Each one owns a
+//! `mask_cache: Mutex<AHashMap<ParserState, Arc<AdaptiveTokenMask>>>` that
+//! fills lazily as that grammar is *used* (XGrammar-2 JIT). So an entry's
+//! footprint is a moving target, and a size captured at insert time
+//! understates it — often by orders of magnitude, since a freshly compiled
+//! grammar has an empty mask cache.
+//!
+//! This is why the budget is re-measured on each insert rather than
+//! accumulated incrementally, using the existing
+//! [`CompiledGrammar::memory_size_bytes`] (which already sums the grammar plus
+//! whatever masks are live): the sum of what is actually resident now is the
+//! only honest number. Inserts happen on a cache MISS, which by construction
+//! is the rare path, so an O(entries) walk there is not on the hot path.
+//!
+//! Dropping a grammar drops its mask cache with it, which is what makes
+//! bounding Tier 1 sufficient to bound both.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use super::compiled_grammar::CompiledGrammar;
+
+/// Pass as the budget for no bound.
+pub const UNLIMITED_BYTES: usize = usize::MAX;
+
+struct Entry<K> {
+    key: K,
+    value: CompiledGrammar,
+}
+
+struct Inner<K> {
+    /// Key -> index into `lru`. `lru[0]` is least-recently-used.
+    index: HashMap<K, usize>,
+    lru: Vec<Entry<K>>,
+}
+
+/// An LRU-bounded cache of compiled grammars.
+///
+/// Cheap to clone; state is shared through an `Arc`, matching
+/// [`super::rule_cache::RuleLevelCache`].
+pub struct GrammarCache<K> {
+    max_bytes: usize,
+    inner: Arc<Mutex<Inner<K>>>,
+}
+
+impl<K> Clone for GrammarCache<K> {
+    fn clone(&self) -> Self {
+        Self {
+            max_bytes: self.max_bytes,
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<K: std::hash::Hash + Eq + Clone> GrammarCache<K> {
+    pub fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            inner: Arc::new(Mutex::new(Inner {
+                index: HashMap::new(),
+                lru: Vec::new(),
+            })),
+        }
+    }
+
+    /// Cached grammar for `key`, marking it most-recently-used on a hit.
+    pub fn get(&self, key: &K) -> Option<CompiledGrammar> {
+        let mut inner = self.inner.lock().expect("grammar cache mutex poisoned");
+        let idx = *inner.index.get(key)?;
+        Self::touch(&mut inner, idx);
+        Some(inner.lru[inner.lru.len() - 1].value.clone())
+    }
+
+    /// Drop every entry. Port target for `GrammarCompiler::ClearCache`.
+    pub fn clear(&self) {
+        let mut inner = self.inner.lock().expect("grammar cache mutex poisoned");
+        inner.index.clear();
+        inner.lru.clear();
+    }
+
+    /// Bytes currently resident, re-measured across live entries.
+    pub fn resident_bytes(&self) -> usize {
+        let inner = self.inner.lock().expect("grammar cache mutex poisoned");
+        inner.lru.iter().map(|e| e.value.memory_size_bytes()).sum()
+    }
+
+    /// Insert `value` under `key`, evicting least-recently-used entries until
+    /// the total fits the budget.
+    ///
+    /// The new entry is ALWAYS retained, even if it alone exceeds the budget:
+    /// the caller is about to use it, and evicting the grammar a live request
+    /// depends on would turn a memory bound into a correctness problem. An
+    /// oversized entry is instead evicted by the next insert, once it is no
+    /// longer the most recent.
+    pub fn insert(&self, key: K, value: CompiledGrammar) {
+        let mut inner = self.inner.lock().expect("grammar cache mutex poisoned");
+        if let Some(&idx) = inner.index.get(&key) {
+            Self::touch(&mut inner, idx);
+            return;
+        }
+
+        let slot = inner.lru.len();
+        inner.index.insert(key.clone(), slot);
+        inner.lru.push(Entry { key, value });
+
+        if self.max_bytes == UNLIMITED_BYTES {
+            return;
+        }
+        // Re-measured, not accumulated: entries grow after insertion as their
+        // mask caches fill (see the module docs).
+        let mut total: usize = inner.lru.iter().map(|e| e.value.memory_size_bytes()).sum();
+        while total > self.max_bytes && inner.lru.len() > 1 {
+            let evicted = inner.lru.remove(0);
+            total = total.saturating_sub(evicted.value.memory_size_bytes());
+            inner.index.remove(&evicted.key);
+            // Removing index 0 shifts every later index down by one.
+            for v in inner.index.values_mut() {
+                *v -= 1;
+            }
+        }
+    }
+
+    /// Move `idx` to the back (most-recently-used).
+    fn touch(inner: &mut Inner<K>, idx: usize) {
+        let last = inner.lru.len() - 1;
+        if idx == last {
+            return;
+        }
+        let entry = inner.lru.remove(idx);
+        inner.lru.push(entry);
+        // Everything after `idx` shifted down one; the moved entry is last.
+        for v in inner.index.values_mut() {
+            if *v > idx {
+                *v -= 1;
+            }
+        }
+        let key = inner.lru[last].key.clone();
+        inner.index.insert(key, last);
+    }
+}
+
+#[cfg(test)]
+#[path = "grammar_cache_tests.rs"]
+mod grammar_cache_tests;

--- a/crates/xgrammar/src/compiler/grammar_cache_tests.rs
+++ b/crates/xgrammar/src/compiler/grammar_cache_tests.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The cache exists to be BOUNDED, so most of these assert eviction happens
+//! rather than that lookups work.
+
+/// A stand-in with a controllable footprint. `CompiledGrammar` needs a real
+/// tokenizer and grammar to build, which would make these tests a compilation
+/// harness rather than a cache harness.
+mod fake {
+    pub struct Sized(pub usize);
+    impl Sized {
+        pub fn memory_size_bytes(&self) -> usize {
+            self.0
+        }
+    }
+}
+
+/// Mirrors `GrammarCache` over the stand-in so the eviction policy itself is
+/// under test. Kept in lockstep with the real `insert` by
+/// `the_policy_mirrors_the_real_insert` below.
+struct TestCache {
+    max_bytes: usize,
+    lru: Vec<(u32, fake::Sized)>,
+}
+
+impl TestCache {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            lru: Vec::new(),
+        }
+    }
+    fn insert(&mut self, key: u32, size: usize) {
+        if let Some(i) = self.lru.iter().position(|(k, _)| *k == key) {
+            let e = self.lru.remove(i);
+            self.lru.push(e);
+            return;
+        }
+        self.lru.push((key, fake::Sized(size)));
+        if self.max_bytes == usize::MAX {
+            return;
+        }
+        let mut total: usize = self.lru.iter().map(|(_, v)| v.memory_size_bytes()).sum();
+        while total > self.max_bytes && self.lru.len() > 1 {
+            let (_, v) = self.lru.remove(0);
+            total = total.saturating_sub(v.memory_size_bytes());
+        }
+    }
+    fn keys(&self) -> Vec<u32> {
+        self.lru.iter().map(|(k, _)| *k).collect()
+    }
+    fn get(&mut self, key: u32) -> bool {
+        match self.lru.iter().position(|(k, _)| *k == key) {
+            Some(i) => {
+                let e = self.lru.remove(i);
+                self.lru.push(e);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// ★ The bug: without a bound, distinct keys accumulate forever. This is the
+/// BFCL shape — a new tool schema on every request.
+#[test]
+fn distinct_keys_do_not_accumulate_without_bound() {
+    let mut c = TestCache::new(1000);
+    for k in 0..100 {
+        c.insert(k, 100);
+    }
+    assert!(
+        c.keys().len() <= 10,
+        "bounded to the budget, got {}",
+        c.keys().len()
+    );
+}
+
+#[test]
+fn unlimited_really_is_unlimited() {
+    let mut c = TestCache::new(usize::MAX);
+    for k in 0..50 {
+        c.insert(k, 1_000_000);
+    }
+    assert_eq!(c.keys().len(), 50, "-1 stays an explicit opt-out");
+}
+
+/// Least-recently-USED, not least-recently-inserted: a re-read must protect
+/// an entry from the next eviction.
+#[test]
+fn a_recent_read_protects_an_entry_from_eviction() {
+    let mut c = TestCache::new(300);
+    c.insert(1, 100);
+    c.insert(2, 100);
+    c.insert(3, 100);
+    assert!(c.get(1), "1 is resident"); // 1 becomes most-recent
+    c.insert(4, 100); // evicts the now-oldest, which is 2
+    let keys = c.keys();
+    assert!(keys.contains(&1), "the re-read entry survived: {keys:?}");
+    assert!(!keys.contains(&2), "the genuinely-oldest went: {keys:?}");
+}
+
+/// ★ The newest entry is never evicted, even when it alone busts the budget:
+/// a live request is about to use it, so evicting it would trade a memory
+/// bound for a correctness bug.
+#[test]
+fn an_oversized_newest_entry_is_retained() {
+    let mut c = TestCache::new(100);
+    c.insert(1, 10_000);
+    assert_eq!(c.keys(), vec![1]);
+    // ...and it is evicted by the NEXT insert, once it is no longer newest.
+    c.insert(2, 10);
+    assert_eq!(
+        c.keys(),
+        vec![2],
+        "the oversized entry left once superseded"
+    );
+}
+
+#[test]
+fn reinserting_a_present_key_refreshes_rather_than_duplicates() {
+    let mut c = TestCache::new(1000);
+    c.insert(1, 100);
+    c.insert(2, 100);
+    c.insert(1, 100);
+    assert_eq!(
+        c.keys(),
+        vec![2, 1],
+        "1 moved to most-recent, not duplicated"
+    );
+}
+
+/// The real cache must agree with the policy modelled above. If `insert`
+/// changes shape, this is the test that should fail.
+#[test]
+fn the_policy_mirrors_the_real_insert() {
+    let src = include_str!("grammar_cache.rs");
+    assert!(
+        src.contains("while total > self.max_bytes && inner.lru.len() > 1"),
+        "the real eviction loop changed shape — update TestCache to match"
+    );
+    assert!(
+        src.contains("if self.max_bytes == UNLIMITED_BYTES"),
+        "the unlimited short-circuit changed shape"
+    );
+}

--- a/crates/xgrammar/src/compiler/mod.rs
+++ b/crates/xgrammar/src/compiler/mod.rs
@@ -43,8 +43,8 @@
 // SIMPLIFICATIONS vs C++
 // ----------------------
 //  * The grammar-level cache is a `dashmap` keyed by the request
-//    parameters; it has no LRU byte-budget eviction (the C++
-//    `ThreadSafeLRUCache`). `cache_limit_bytes` is recorded and
+//    parameters, LRU-bounded by `cache_limit_bytes` (the C++
+//    `ThreadSafeLRUCache` equivalent, added after issue #368: it was
 //    reported but not enforced — entries are kept until `clear_cache`.
 //  * `compile_structural_tag` delegates the tag-JSON -> `GrammarData`
 //    conversion to the W5 `src/structural_tag/` module.
@@ -65,6 +65,7 @@ mod compile;
 mod compiled_grammar;
 mod compiler;
 mod decompose;
+mod grammar_cache;
 mod mask;
 mod mask_gen;
 mod rule_cache;


### PR DESCRIPTION
Closes the heap-growth half of #368. rsafier's #374 fixed the `atlas_requests_active` gauge; this is the separate defect underneath it, and it is the one that costs operators a restart every ~7 hours.

## Root cause

`crates/xgrammar/src/compiler/compiler.rs` held the Tier-1 compiled-grammar cache as a bare `DashMap<CacheKey, CompiledGrammar>` with **no eviction**. `cache_limit_bytes` was recorded and never enforced — the C++ `ThreadSafeLRUCache` was not ported, while the Tier-2 `RuleLevelCache` was. `compiler/mod.rs` said so outright:

> it has no LRU byte-budget eviction (the C++ `ThreadSafeLRUCache`). `cache_limit_bytes` is recorded and [not enforced]

That is unbounded in the dimension that matters for a server. `CacheKey::Schema` is keyed by the **full tool-schema text**, and agentic traffic sends a distinct schema on nearly every request, so every request minted a permanent entry.

## Evidence

Measured on a GB10 serve under BFCL, process identified:

| | t0 | t+120s |
|---|---|---|
| `spark` RSS | 1,493,732 KB | 1,698,296 KB |
| `MemAvailable` | 6205 MB | 6056 MB |
| Slab / SUnreclaim / PageTables | 2807088 / 1974356 / 40680 kB | 2806820 / 1974088 / 40616 kB |

**~100 MB/min, ~17 MB/request.** Kernel memory flat → userspace heap. `atlas_requests_active` sat at 1 while `requests_total` advanced, so this is not the gauge defect.

Corroborating: the same teardown sweep reports **1,479** unreleased allocations after the 27B BFCL leg and **33,110** after the 35B one — a 22× spread tracking how many distinct grammars each workload compiles.

Operationally it made a 3.5 h accuracy benchmark unable to finish on a box that started with ~8 GB of headroom.

## The fix

`GrammarCache` — byte budget, LRU list, evict-until-fits — mirroring the Tier-2 cache already in this crate. Two details are specific to this tier and are why it is not a copy:

- **Entries grow after insertion.** A `CompiledGrammar` owns a `mask_cache` filled lazily as that grammar is *used* (XGrammar-2 JIT), so a size captured at insert time understates it by orders of magnitude — a freshly compiled grammar has an empty mask cache. The budget is re-measured across live entries on each insert, using the existing `memory_size_bytes()`. Inserts happen only on a cache miss, so that walk is never on the hot path.
- **The newest entry is never evicted**, even if it alone exceeds the budget. The caller is about to use it; dropping it would trade a memory bound for a correctness bug. It leaves on the next insert, once superseded.

Dropping a grammar drops its mask cache with it, which is what makes bounding this tier sufficient to bound both.

## Behaviour change

`grammar/engine.rs` passed `-1` (unlimited). It now passes a **1 GiB** budget — roughly 60 distinct schemas at the measured footprint, far above any realistic hot set. `-1` remains available as an explicit opt-in for callers that genuinely want every grammar pinned.

## Risk

Evicting a genuinely hot schema forces a recompile, so **warm TTFT is the gate to watch**. Gates are being run on this branch; results will be posted here before merge.

## Tests

`grammar_cache_tests.rs`: unbounded accumulation is bounded; `-1` stays unlimited; a recent *read* protects an entry (least-recently-**used**, not inserted); an oversized newest entry is retained then evicted once superseded; re-inserting a present key refreshes rather than duplicates. Plus a guard that fails if the real eviction loop changes shape without the modelled policy following it.

822 xgrammar + full workspace green; clippy 0; fmt clean.
