### PR TITLE
fix(gate): close three holes an adversarial review found

### DIFF
--- a/crates/atlas-plugin/src/gate/bench.rs
+++ b/crates/atlas-plugin/src/gate/bench.rs
@@ -118,6 +118,7 @@ pub fn load_all(root: &Path) -> Result<Vec<(taxon::Target, BenchEntry)>> {
                     entry.checkpoint
                 );
             }
+            validate_noise(&path, &entry)?;
             out.push((
                 taxon::Target {
                     hardware: target.hardware.clone(),
@@ -214,3 +215,67 @@ pub fn baseline_for(root: &Path, benchmark_id: &str) -> Result<GateBaseline> {
 #[cfg(test)]
 #[path = "bench_tests.rs"]
 mod bench_tests;
+
+/// The largest slack a `noise` allowance may claim, as a fraction of the bound
+/// it is applied to.
+///
+/// `noise` widens a threshold at compare time (`check::compare`) and had no
+/// upper limit at all. `noise = 1000.0` on a floor of 87.44 turns that gate
+/// green against any record already in the tree — and it reads like a
+/// measurement annotation, not a threshold change, which makes it the most
+/// review-invisible way to defeat the gate. Every value in the tree today is
+/// 0.4 against floors of 83-89, i.e. ~0.46%.
+const MAX_NOISE_FRACTION: f64 = 0.05;
+
+/// `noise` must be a small, non-negative, finite slack — and must never be
+/// applied to an EXACT pin.
+///
+/// The exact-pin rule is the load-bearing half. `min == max` is how the BFCL
+/// draw size is pinned (`samples` = 995 / 1004), and that pin exists precisely
+/// to catch a silently-changed draw — a different category mix moves
+/// `normalized_single_turn_score` by ~1.8 points while leaving
+/// `overall_accuracy` in the same place, which is exactly what makes crossing
+/// draws impossible to spot after the fact. `check::compare` applies `noise` to
+/// the two-sided arm as well, so a `noise` on `samples` would silently disable
+/// the guard.
+fn validate_noise(path: &std::path::Path, entry: &BenchEntry) -> Result<()> {
+    let Some(metrics) = entry.metrics.as_ref() else {
+        return Ok(());
+    };
+    for (name, bound) in metrics {
+        let Some(noise) = bound.noise else { continue };
+        if !noise.is_finite() || noise < 0.0 {
+            bail!(
+                "{}: {} / {} metric {name}: noise must be finite and non-negative, got {noise}",
+                path.display(),
+                entry.gate,
+                entry.checkpoint,
+            );
+        }
+        if bound.min.is_some() && bound.min == bound.max {
+            bail!(
+                "{}: {} / {} metric {name} is an EXACT pin (min == max == {:?}) and carries \
+                 noise {noise}. Noise on a pin disables it — and a pin is used for things like \
+                 the BFCL draw size, where a changed draw is undetectable after the fact.",
+                path.display(),
+                entry.gate,
+                entry.checkpoint,
+                bound.min,
+            );
+        }
+        let magnitude = bound.min.or(bound.max).unwrap_or(0.0).abs();
+        let cap = magnitude * MAX_NOISE_FRACTION;
+        if magnitude > 0.0 && noise > cap {
+            bail!(
+                "{}: {} / {} metric {name}: noise {noise} exceeds {:.0}% of the bound \
+                 ({magnitude}) — that is a threshold change wearing a measurement-noise \
+                 label. Move the bound instead, so the ratchet is visible in review.",
+                path.display(),
+                entry.gate,
+                entry.checkpoint,
+                MAX_NOISE_FRACTION * 100.0,
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/atlas-plugin/src/gate/check.rs
+++ b/crates/atlas-plugin/src/gate/check.rs
@@ -278,6 +278,39 @@ pub fn check_gates(root: &Path, sha: &str) -> BTreeMap<String, GateStatus> {
     out
 }
 
+/// Does this record actually belong to the gate whose directory it sits in?
+///
+/// Records were located by DIRECTORY and their own `benchmark_id` was never
+/// read back. Nothing stopped one gate's record from satisfying another's, and
+/// two of the five gates make that a one-command forgery:
+/// `ttft-warm-gate` and `ttft-cold-gate` share a checkpoint, a hardware key and
+/// their metric names (`median_ms`, `p90_ms`). On `main` today the committed
+/// WARM record reads 1562.58 / 4478.42 against the COLD ceilings of
+/// 1728.27 / 4809.76 — so `cp` one file into the other directory turns the cold
+/// gate green with no cold leg ever run.
+///
+/// That is the worst possible pair to be able to confuse: cold-TTFT is the only
+/// leg that sees a cold-LOAD regression, and #389 — the change this gate was
+/// built alongside — is "GPU-transpose quantized weights at cold load".
+///
+/// It also needs no malice. Both records are produced minutes apart in one
+/// session with near-identical filenames.
+///
+/// Mismatches are SKIPPED, not failed: a stray file in a directory should leave
+/// the gate reading "no covering record" (which is true and actionable), not
+/// manufacture a hard failure from someone else's passing run.
+fn record_is_for(record: &GateRecord, benchmark_id: &str, path: &Path) -> bool {
+    if record.benchmark_id == benchmark_id {
+        return true;
+    }
+    tracing::warn!(
+        "ignoring {}: it is a `{}` record sitting in the `{benchmark_id}` directory",
+        path.display(),
+        record.benchmark_id,
+    );
+    false
+}
+
 fn check_one(root: &Path, benchmark_id: &str, sha: &str) -> GateStatus {
     let Some(gate) = super::coverage::find(benchmark_id) else {
         // Unreachable through `check_gates`, which iterates the coverage table
@@ -298,6 +331,7 @@ fn check_one(root: &Path, benchmark_id: &str, sha: &str) -> GateStatus {
     let mut covered: Option<GateRecord> = None;
     for path in &paths {
         if let Ok(record) = read_record(path)
+            && record_is_for(&record, benchmark_id, path)
             && record_still_stands(root, sha, &record, gate)
         {
             covered = Some(record);

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -76,7 +76,7 @@ pub const PERF_PATHS: [&str; 8] = [
 /// Editing these changes what "invalidates" means. Letting them be excluded
 /// would let a change to the rules escape the rules.
 ///
-/// ★ This list held ONE entry and that was not enough. [`GATE_MACHINERY`]
+/// ★ This list held ONE entry and that was not enough. `GATE_MACHINERY`
 /// excludes the whole `crates/atlas-plugin/src/gate` prefix from every gate,
 /// so a PR editing `check.rs` — `record_covers`, `invalidating_paths`,
 /// `check_record`, `compare` — invalidated nothing, and then reported itself

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -75,7 +75,35 @@ pub const PERF_PATHS: [&str; 8] = [
 ///
 /// Editing these changes what "invalidates" means. Letting them be excluded
 /// would let a change to the rules escape the rules.
-pub const BOUNDARY_FILES: [&str; 1] = ["crates/atlas-plugin/src/gate/coverage.rs"];
+///
+/// ★ This list held ONE entry and that was not enough. [`GATE_MACHINERY`]
+/// excludes the whole `crates/atlas-plugin/src/gate` prefix from every gate,
+/// so a PR editing `check.rs` — `record_covers`, `invalidating_paths`,
+/// `check_record`, `compare` — invalidated nothing, and then reported itself
+/// covered BY ITS OWN NEW LOGIC. `coverage.rs` alone was "a lock whose key is
+/// kept inside it" with the key moved one room over.
+///
+/// It was not theoretical: PR #420 rewrote `record_covers` and the gate listed
+/// only an unrelated `atlas-kernels` file as invalidating. It read red purely
+/// by accident.
+///
+/// The four files here are the ones that decide a verdict. `GATE_MACHINERY`
+/// still covers the rest of the directory — record IO, telemetry rendering,
+/// the CODEOWNERS parser — where the exclusion's argument does hold.
+pub const BOUNDARY_FILES: [&str; 5] = [
+    "crates/atlas-plugin/src/gate/coverage.rs",
+    // `record_covers` / `invalidating_paths` / `check_record` / `compare`:
+    // decides whether a record stands and whether its numbers pass.
+    "crates/atlas-plugin/src/gate/check.rs",
+    // `excuses` / `changed_targets`: decides which invalidating paths are
+    // forgiven by the closure hash.
+    "crates/atlas-plugin/src/gate/closure.rs",
+    // `sources` / `configs` / `affected`: decides which targets a kernel edit
+    // reaches, i.e. the input to `excuses`.
+    "crates/atlas-plugin/src/gate/taxon.rs",
+    // `baseline_for`: decides WHICH thresholds a record is judged against.
+    "crates/atlas-plugin/src/gate/bench.rs",
+];
 
 /// Basenames under `kernels/` that are read by the gate and compiled by nothing.
 ///

--- a/crates/atlas-plugin/src/gate/coverage_map_tests.rs
+++ b/crates/atlas-plugin/src/gate/coverage_map_tests.rs
@@ -312,17 +312,21 @@ fn a_driver_change_invalidates_only_its_own_gate() {
     assert!(!hit.contains(&"agentic-webserver"), "{hit:?}");
 }
 
-/// Gate bookkeeping does not re-open GPU measurements — the change that
+/// Gate BOOKKEEPING does not re-open GPU measurements — the change that
 /// motivated this whole module.
+///
+/// Note what is NOT in this list any more: `check.rs`. See the test below.
 #[test]
-fn gate_machinery_changes_cost_no_gpu_hours() {
+fn gate_bookkeeping_changes_cost_no_gpu_hours() {
     let hit = coverage::invalidated_by([
-        "crates/atlas-plugin/src/gate/check.rs",
         "crates/atlas-plugin/src/gate/record.rs",
+        "crates/atlas-plugin/src/gate/telemetry.rs",
+        "crates/atlas-plugin/src/gate/codeowners.rs",
     ]);
     assert!(
         hit.is_empty(),
-        "gate bookkeeping should not re-open any gate, got {hit:?}"
+        "record IO, telemetry rendering and CODEOWNERS parsing cannot move a \
+         measurement; they should not re-open any gate, got {hit:?}"
     );
 }
 

--- a/crates/atlas-plugin/src/gate/hardening_tests.rs
+++ b/crates/atlas-plugin/src/gate/hardening_tests.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Three holes an adversarial review found, and the rules that close them.
+//!
+//! Each test below fails without its production change. They are grouped
+//! because they share one theme: the gate trusted things it had never checked
+//! — the directory a record sat in, the files that decide a verdict, and the
+//! size of a "measurement noise" allowance.
+
+use super::tests::{tempdir, *};
+use super::*;
+
+// ── 1. A record must belong to the gate whose directory it sits in ──────────
+
+/// `ttft-warm-gate` and `ttft-cold-gate` share a checkpoint, a hardware key
+/// and their metric names. On `main` the committed WARM record reads
+/// 1562.58 / 4478.42 against COLD ceilings of 1728.27 / 4809.76 — so copying
+/// one file into the other directory used to turn the cold gate green with no
+/// cold leg ever run.
+///
+/// Cold-TTFT is the only leg that sees a cold-LOAD regression, and #389 (the
+/// change this gate was built alongside) is "GPU-transpose quantized weights
+/// at cold load" — so this was the worst pair in the suite to be able to
+/// confuse, and it needed no malice: both records are written minutes apart in
+/// one session with near-identical filenames.
+#[test]
+fn a_record_from_another_gate_does_not_satisfy_this_one() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    for id in REQUIRED_GATES {
+        std::fs::create_dir_all(gate_dir(root, id)).unwrap();
+        write_baseline(root, id, &bfcl_baseline());
+    }
+
+    // A perfectly good record — for the WRONG gate.
+    let src = gate_dir(root, "ttft-warm-gate");
+    let dst = gate_dir(root, "ttft-cold-gate");
+    plant(root, "ttft-warm-gate", "abc1234567", 1_785_891_382, "PASS");
+    let planted = std::fs::read_dir(&src)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    std::fs::copy(&planted, dst.join(planted.file_name().unwrap())).unwrap();
+
+    // The copy is present, readable, PASSing, and names a covering commit.
+    assert_eq!(std::fs::read_dir(&dst).unwrap().count(), 1);
+
+    let status = check_gates(root, "abc1234567");
+    assert!(
+        matches!(&status["ttft-cold-gate"], GateStatus::Missing(_)),
+        "a ttft-warm-gate record must not satisfy ttft-cold-gate, got {:?}",
+        status["ttft-cold-gate"]
+    );
+}
+
+// ── 2. The files that decide a verdict are inside the boundary ─────────────
+
+/// ★ The files that DECIDE a verdict are inside the boundary, and re-open
+/// everything.
+///
+/// This inverts what `gate_machinery_changes_cost_no_gpu_hours` used to
+/// assert, deliberately. `GATE_MACHINERY` excludes the whole
+/// `crates/atlas-plugin/src/gate` prefix, and `BOUNDARY_FILES` listed only
+/// `coverage.rs` — so a PR rewriting `record_covers` invalidated NOTHING and
+/// then reported itself covered by its own new logic.
+///
+/// That happened. PR #420 rewrote `record_covers` and the gate named only an
+/// unrelated `atlas-kernels` file as invalidating; it read red by accident,
+/// not by rule.
+///
+/// The exclusion's argument — "it never runs a model, `cargo test` covers it"
+/// — is right about `record.rs` and wrong about `check.rs`: a verdict function
+/// cannot be trusted to certify the commit that changes it, however good the
+/// unit tests are. Cost of the stricter rule: a gate-logic PR owes one gate
+/// run. That is the correct price for editing the thing that decides whether
+/// anything owes a gate run.
+#[test]
+fn verdict_logic_is_inside_the_boundary() {
+    for f in [
+        "crates/atlas-plugin/src/gate/coverage.rs",
+        "crates/atlas-plugin/src/gate/check.rs",
+        "crates/atlas-plugin/src/gate/closure.rs",
+        "crates/atlas-plugin/src/gate/taxon.rs",
+        "crates/atlas-plugin/src/gate/bench.rs",
+    ] {
+        let hit = super::coverage::invalidated_by([f]);
+        assert_eq!(
+            hit.len(),
+            super::coverage::REQUIRED.len(),
+            "{f} decides a verdict and must re-open every gate, got {hit:?}"
+        );
+    }
+}
+
+// ── 3. `noise` is a measurement allowance, not a threshold change ───────────
+
+fn bench_toml(root: &std::path::Path, metrics: &str) -> std::path::PathBuf {
+    let dir = root.join("kernels/gb10/qwen3.6-27b/nvfp4");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        root.join("kernels/gb10/HARDWARE.toml"),
+        "[hardware]\narch = \"sm_121f\"\nvendor = \"nvidia\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("kernels/gb10/qwen3.6-27b/MODEL.toml"), "").unwrap();
+    let p = root.join("kernels/gb10/qwen3.6-27b/BENCH.toml");
+    std::fs::write(
+        &p,
+        format!(
+            "[[benchmarks]]\ngate = \"bfcl-subset\"\nquant = \"nvfp4\"\n\
+             checkpoint = \"x/y\"\nrecipe = \"a/b\"\nstatus = \"measured\"\n\
+             default = true\n{metrics}"
+        ),
+    )
+    .unwrap();
+    p
+}
+
+/// A `noise` big enough to clear any record is a threshold change wearing a
+/// measurement-noise label — and the most review-invisible one available,
+/// because `BENCH.toml` is deliberately exempt from invalidating any gate.
+#[test]
+fn an_absurd_noise_allowance_is_refused() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    bench_toml(
+        root,
+        "[benchmarks.metrics.overall_accuracy]\nmin = 87.44\nnoise = 1000.0\n",
+    );
+    let err = super::bench::load_all(root).unwrap_err().to_string();
+    assert!(err.contains("exceeds"), "{err}");
+}
+
+/// The values actually in the tree (0.4 against floors of 83-89, ~0.46%) must
+/// keep loading — a rule that rejects the status quo is not a rule, it is a
+/// migration.
+#[test]
+fn the_real_noise_values_still_load() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    bench_toml(
+        root,
+        "[benchmarks.metrics.overall_accuracy]\nmin = 87.44\nnoise = 0.4\n",
+    );
+    super::bench::load_all(root).expect("0.4 on an 87.44 floor is real measurement noise");
+}
+
+/// `min == max` is how the BFCL draw size is pinned. `check::compare` applies
+/// noise to the two-sided arm too, so noise on a pin silently disables the one
+/// guard against a changed draw — and a changed draw is undetectable after the
+/// fact, because a different category mix moves `normalized_single_turn_score`
+/// by ~1.8 points while leaving `overall_accuracy` in the same place.
+#[test]
+fn noise_on_an_exact_pin_is_refused() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    bench_toml(
+        root,
+        "[benchmarks.metrics.samples]\nmin = 995.0\nmax = 995.0\nnoise = 1.0\n",
+    );
+    let err = super::bench::load_all(root).unwrap_err().to_string();
+    assert!(err.contains("EXACT pin"), "{err}");
+}
+
+/// Negative and non-finite slack are nonsense; refuse rather than propagate.
+#[test]
+fn negative_noise_is_refused() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    bench_toml(
+        root,
+        "[benchmarks.metrics.overall_accuracy]\nmin = 87.44\nnoise = -5.0\n",
+    );
+    let err = super::bench::load_all(root).unwrap_err().to_string();
+    assert!(err.contains("non-negative"), "{err}");
+}

--- a/crates/atlas-plugin/src/gate/mod.rs
+++ b/crates/atlas-plugin/src/gate/mod.rs
@@ -216,6 +216,11 @@ mod coverage_tests;
 #[path = "coverage_squash_tests.rs"]
 mod coverage_squash_tests;
 
+/// Three holes an adversarial review found. Split for the 500-LoC cap.
+#[cfg(test)]
+#[path = "hardening_tests.rs"]
+mod hardening_tests;
+
 #[cfg(test)]
 #[path = "dirty_tests.rs"]
 mod dirty_tests;


### PR DESCRIPTION
A subagent was told to **break** the gate, not confirm it. It found three ways a PR could report `PASS` on code the gate never measured — plus one finding that reframes all of them. I verified each myself before acting.

## The reframing, first

**`PR benchmark gate` is not a required status check on `main`.** The required contexts are `cargo fmt`, `cargo clippy`, `cargo test`, `typos`, SPDX, ≤500 LoC, CLA. `enforce_admins: false`; the ruleset requires 0 approving reviews.

So this apparatus is a **warning light, not a lock**. Everything below fixes what that light reports. Making it required is a separate decision and not mine to take.

## 1. The coverage rules exempted themselves

`GATE_MACHINERY` excludes the whole `crates/atlas-plugin/src/gate` prefix from every gate, and `BOUNDARY_FILES` listed only `coverage.rs`. So a PR editing `check.rs` — `record_covers`, `invalidating_paths`, `check_record`, `compare` — **invalidated nothing, and then reported itself covered by its own new logic**.

`coverage.rs:25` argues exactly this case for itself, *"a lock whose key is kept inside it"*, and then leaves the key one room over.

Not theoretical: **#420 rewrote `record_covers`** and the gate named only an unrelated `atlas-kernels` file as invalidating. It read red by accident, not by rule.

`BOUNDARY_FILES` now names the four files that decide a verdict — `check.rs`, `closure.rs`, `taxon.rs`, `bench.rs`. `GATE_MACHINERY` still covers the rest of the directory (record IO, telemetry, CODEOWNERS), where its argument does hold.

**Cost:** a gate-logic PR now owes one gate run. That is the correct price for editing the thing that decides whether anything owes a gate run.

## 2. A warm record satisfied the cold gate

`check_one` located records by **directory** and never read `record.benchmark_id` back. `ttft-warm-gate` and `ttft-cold-gate` share a checkpoint, a hardware key, and their metric names:

| | warm record | cold ceiling |
|---|---|---|
| `median_ms` | 1562.58 | max 1728.27 ✅ |
| `p90_ms` | 4478.42 | max 4809.76 ✅ |

`cp` one file between directories and the cold gate goes green with no cold leg ever run. Confirmed live — with the new check reverted, the test reports **`got Pass`**.

The worst possible pair to be able to confuse: cold-TTFT is the only leg that sees a cold-**load** regression, and #389 — the change this gate was built alongside — is *"GPU-transpose quantized weights at cold load"*. And it needs no malice: both records are written minutes apart in one session with near-identical filenames.

Mismatches are **skipped with a warning, not failed** — a stray file should leave the gate reading "no covering record" (true and actionable), not manufacture a hard failure out of someone else's passing run.

## 3. `noise` was uncapped, and applied to exact pins

`noise` widens a threshold at compare time and had no upper limit. `noise = 1000.0` on a floor of 87.44 turns that gate green against records already in the tree — and it reads like a measurement annotation, not a threshold change, which makes it the most review-invisible edit available. `BENCH.toml` is deliberately exempt from invalidating any gate, so nothing re-opens.

Worse: `check::compare` applies noise to the two-sided arm, so noise on an **exact pin** (`min == max`) silently disables it — and that is how the BFCL **draw size** is pinned. A changed draw is undetectable after the fact, because a different category mix moves `normalized_single_turn_score` by ~1.8 points while leaving `overall_accuracy` in the same place.

`validate_noise` now refuses non-finite/negative slack, slack on an exact pin, and slack above **5%** of the bound. Every value in the tree is `0.4` against floors of 83–89 (~0.46%) and still loads — a rule that rejects the status quo is a migration, not a rule.

## Run both ways

Each fix reverted, tests kept:

| revert | test | result |
|---|---|---|
| `benchmark_id` check removed | `a_record_from_another_gate_does_not_satisfy_this_one` | **FAILED** — `got Pass` |
| `BOUNDARY_FILES` back to 1 | `verdict_logic_is_inside_the_boundary` | **FAILED** — `got []` |
| `validate_noise` unwired | 3 of the 5 noise tests | **FAILED** |

`the_real_noise_values_still_load` passes both ways on purpose — it pins that the cap didn't break the tree.

`atlas-plugin`: **413 passed, 0 failed.** fmt + clippy clean, no LoC violations (the two boundary tests moved into `hardening_tests.rs` to keep `coverage_map_tests.rs` at 468).

## Deliberately not done here

Both change repo-wide behaviour and are the owner's call:

- **Making this gate a required check.**
- **Turning off `delete_branch_on_merge`.** 12 of 13 record shas on `main` are reachable only from two still-living PR branches (`pr388-gpu-transpose`, `w55-squash`). Deleting those makes `git diff` fail for every record and re-opens the ADR-0013 outage — on a delay set by when someone tidies branches.

Still open from the same review, not fixed here: recipes live in `atlas-recipes` (a different repo, unpinned and unhashed) while determining every gated number; `docker/` is outside `PERF_PATHS` while carrying `ATLAS_*` env and rebuilding `libatlasgdn.so`; `recorded_at` is self-reported and orders record selection.

Co-Authored-By: Atlas <atlas@avarok.net>