### PR TITLE
perf(decode): give the mixed co-dispatch head the same lm_head ladder

### DIFF
--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -30,16 +30,6 @@ fn multiseq_graphs_enabled() -> bool {
     *ON.get_or_init(|| std::env::var("ATLAS_NO_DECODE_GRAPHS_MULTISEQ").as_deref() != Ok("1"))
 }
 
-/// Batched-GEMV decode lm_head: **ON by default**, disabled by
-/// `ATLAS_NO_LM_HEAD_BATCH_GEMV=1`.
-///
-/// Strict `== "1"` on an `ATLAS_NO_*` name, not a presence check — presence
-/// flags in this codebase are ENABLED by `=0`. Read once; this is a per-step site.
-fn lm_head_batch_gemv_enabled() -> bool {
-    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ON.get_or_init(|| std::env::var("ATLAS_NO_LM_HEAD_BATCH_GEMV").as_deref() != Ok("1"))
-}
-
 impl TransformerModel {
     pub(super) fn decode_batch_dispatch(
         &self,
@@ -457,120 +447,14 @@ impl TransformerModel {
             // ~N×254 MB/step). nvfp4/dense are batched here; FP8 single-scale
             // keeps the per-row path (no batched single-scale FP8 GEMM handle
             // on the model, and Holo's lm_head is NVFP4 anyway).
-            let logits = self.buffers.logits();
-            let v = self.config.vocab_size;
-            if let Some(ref fp8) = self.lm_head_fp8 {
-                for i in 0..padded_n {
-                    ops::dense_gemv_fp8w(
-                        self.gpu.as_ref(),
-                        self.dense_gemv_fp8w_kernel,
-                        normed.offset(i * h * bf16),
-                        fp8,
-                        logits.offset(i * v * bf16),
-                        v as u32,
-                        h as u32,
-                        stream,
-                    )?;
-                }
-            } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
-                // Batched GEMV for the decode head. The base M64-tile
-                // `w4a16_gemm` below wastes most of its MMA tile here: at
-                // padded_n=16 only 16 of 64 tile-rows carry data, and the same
-                // nsys note the verify path records (impl_a3.rs) measured it at
-                // 19.3 ms on this [248320, 5120] NVFP4 head vs ~2.5 ms for the
-                // batched GEMV streaming the same 636 MB once. That cost is
-                // FLAT in n, so it sits in the fixed term at every batch size.
-                //
-                // Tier by padded_n exactly as the SSM mixer does: batch4 (M<=4)
-                // / batch8 (M<=8) / batch16 (M<=16). A 0-handle on any tier
-                // falls through to the GEMM, so targets lacking the kernel are
-                // unaffected.
-                // Tile GEMM at padded_n >= 5 over the PADDED transposed twin.
-                // padded_n <= 4 stays on the GEMV, which measures 3174 us =
-                // 226 GB/s = 98.3% of the memory roofline on this shape and is
-                // therefore unimprovable; the tile GEMM LOSES there.
-                if padded_n >= 5
-                    && self.w4a16_gemm_t_bf16_kernel.0 != 0
-                    && let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t
-                {
-                    // LOSSLESS path: BF16 MMA, no activation downcast.
-                    ops::w4a16_gemm_n128_m128_bf16_ldb(
-                        self.gpu.as_ref(),
-                        self.w4a16_gemm_t_bf16_kernel,
-                        normed,
-                        nvfp4_t,
-                        logits,
-                        padded_n as u32,
-                        v as u32,
-                        h as u32,
-                        ldb,
-                        stream,
-                    )?;
-                } else if padded_n >= 5
-                    && self.w4a16_gemm_t_kernel.0 != 0
-                    && let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t
-                {
-                    ops::w4a16_gemm_n128_ldb(
-                        self.gpu.as_ref(),
-                        self.w4a16_gemm_t_kernel,
-                        normed,
-                        nvfp4_t,
-                        logits,
-                        padded_n as u32,
-                        v as u32,
-                        h as u32,
-                        ldb,
-                        stream,
-                    )?;
-                } else {
-                    let gemv_k = if padded_n <= 4 {
-                        self.w4a16_gemv_batch4_kernel
-                    } else if padded_n <= 8 {
-                        self.w4a16_gemv_batch8_kernel
-                    } else if padded_n <= 16 {
-                        self.w4a16_gemv_batch16_kernel
-                    } else {
-                        spark_runtime::gpu::KernelHandle(0)
-                    };
-                    if gemv_k.0 != 0 && lm_head_batch_gemv_enabled() {
-                        ops::w4a16_gemv_batchm(
-                            self.gpu.as_ref(),
-                            gemv_k,
-                            normed,
-                            nvfp4,
-                            logits,
-                            padded_n as u32,
-                            v as u32,
-                            h as u32,
-                            stream,
-                        )?;
-                    } else {
-                        ops::w4a16_gemm(
-                            self.gpu.as_ref(),
-                            self.w4a16_gemm_kernel,
-                            normed,
-                            nvfp4,
-                            logits,
-                            padded_n as u32,
-                            v as u32,
-                            h as u32,
-                            stream,
-                        )?;
-                    }
-                }
-            } else {
-                ops::dense_gemm(
-                    self.gpu.as_ref(),
-                    self.dense_gemm_kernel,
-                    normed,
-                    &self.lm_head_weight,
-                    logits,
-                    padded_n as u32,
-                    v as u32,
-                    h as u32,
-                    stream,
-                )?;
-            }
+            // The ladder itself lives in `lm_head_batched.rs` — the mixed
+            // co-dispatch head (`decode_b2::mixed_final_norm_lm_head`) calls
+            // the same function, so the two heads cannot pick different
+            // kernels for the same `padded_n`.
+            // The returned pointer is discarded here: this path reports its
+            // logits through `self.decode_logits_ptr()` at the end of the
+            // function, which reads the same buffer.
+            self.lm_head_project_batched(normed, padded_n, h, bf16, stream)?;
             if let Some(t0) = lmhead_t0 {
                 self.gpu.synchronize(stream).ok();
                 let head_us = t0.elapsed().as_micros();

--- a/crates/spark-model/src/model/trait_impl/decode_b2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b2.rs
@@ -55,46 +55,18 @@ impl TransformerModel {
             stream,
         )?;
 
-        let logits = self.buffers.logits();
+        // The SAME ladder the pure-decode head uses (`lm_head_batched.rs`).
+        //
+        // This loop used to run `padded_n` separate `w4a16_gemv` calls, each
+        // streaming the entire vocab weight — ~N x 254 MB/step on a
+        // [248320, 5120] NVFP4 head, on live continuous-batching traffic,
+        // while `decode_a2` had had the batched ladder for weeks. Sharing one
+        // function is what keeps the two heads from picking different kernels
+        // (and therefore different numerics) at the same `padded_n`.
+        //
+        // Site credit: @rsafier, #332.
+        let logits = self.lm_head_project_batched(normed, padded_n, h, bf16, stream)?;
         let v = self.config.vocab_size;
-        for i in 0..padded_n {
-            let normed_i = normed.offset(i * h * bf16);
-            let logits_i = logits.offset(i * v * bf16);
-            if let Some(ref fp8) = self.lm_head_fp8 {
-                ops::dense_gemv_fp8w(
-                    self.gpu.as_ref(),
-                    self.dense_gemv_fp8w_kernel,
-                    normed_i,
-                    fp8,
-                    logits_i,
-                    v as u32,
-                    h as u32,
-                    stream,
-                )?;
-            } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
-                ops::w4a16_gemv(
-                    self.gpu.as_ref(),
-                    self.w4a16_gemv_kernel,
-                    normed_i,
-                    nvfp4,
-                    logits_i,
-                    v as u32,
-                    h as u32,
-                    stream,
-                )?;
-            } else {
-                ops::dense_gemv(
-                    self.gpu.as_ref(),
-                    self.dense_gemv_kernel,
-                    normed_i,
-                    &self.lm_head_weight,
-                    logits_i,
-                    v as u32,
-                    h as u32,
-                    stream,
-                )?;
-            }
-        }
         let decode_logits = logits;
 
         // 7b. Prefill logits: norm last token → 1 GEMV (if is_last)

--- a/crates/spark-model/src/model/trait_impl/lm_head_batched.rs
+++ b/crates/spark-model/src/model/trait_impl/lm_head_batched.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The decode LM head, batched — ONE source of truth for two call sites.
+//!
+//! `decode_a2.rs` (the pure-decode batch) and `decode_b2.rs`
+//! (`mixed_final_norm_lm_head`, the prefill+decode co-dispatch head reached
+//! from `decode_b.rs` via `mixed_forward_dispatch`) both finish a step with
+//! RMS-norm then the vocab projection. They had drifted: `decode_a2` grew the
+//! full ladder while `decode_b2` still looped `padded_n` times through
+//! `ops::w4a16_gemv`, re-reading the whole vocab weight once per row —
+//! ~N x 254 MB/step on live continuous-batching traffic.
+//!
+//! Credit for spotting the site: @rsafier in #332, which fixed it with a bare
+//! default-OFF `batch16`. This lifts `decode_a2`'s ladder instead, so the two
+//! heads cannot diverge NUMERICALLY at the same batch width — two
+//! independently-maintained ladders would be a second source of truth for
+//! which kernel a given `padded_n` lands on, and the first thing to go wrong
+//! would be a silent accuracy difference between the pure-decode and
+//! co-dispatch paths.
+//!
+//! HONESTY: this is a bandwidth-accounting argument, not a measurement. The
+//! mixed path has never been A/B'd. Any throughput claim for it must be gated
+//! spec-OFF or on reversed-order pairs (a single spec-ON pair drifts +/-2%).
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+use super::super::types::TransformerModel;
+use crate::layers::ops;
+
+/// Batched-GEMV decode lm_head: **ON by default**, disabled by
+/// `ATLAS_NO_LM_HEAD_BATCH_GEMV=1`.
+///
+/// Strict `== "1"` on an `ATLAS_NO_*` name, not a presence check — presence
+/// flags in this codebase are ENABLED by `=0`. Read once; this is a per-step
+/// site.
+pub(super) fn lm_head_batch_gemv_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_LM_HEAD_BATCH_GEMV").as_deref() != Ok("1"))
+}
+
+impl TransformerModel {
+    /// Project `normed` [padded_n, H] into `logits` [padded_n, V].
+    ///
+    /// `v` is read from `self.config.vocab_size` rather than passed: it is the
+    /// same number at both call sites and a parameter would be a second place
+    /// for it to be wrong.
+    pub(super) fn lm_head_project_batched(
+        &self,
+        normed: DevicePtr,
+        padded_n: usize,
+        h: usize,
+        bf16: usize,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        let logits = self.buffers.logits();
+        let v = self.config.vocab_size;
+        if let Some(ref fp8) = self.lm_head_fp8 {
+            for i in 0..padded_n {
+                ops::dense_gemv_fp8w(
+                    self.gpu.as_ref(),
+                    self.dense_gemv_fp8w_kernel,
+                    normed.offset(i * h * bf16),
+                    fp8,
+                    logits.offset(i * v * bf16),
+                    v as u32,
+                    h as u32,
+                    stream,
+                )?;
+            }
+        } else if let Some(ref nvfp4) = self.lm_head_nvfp4 {
+            // Batched GEMV for the decode head. The base M64-tile
+            // `w4a16_gemm` below wastes most of its MMA tile here: at
+            // padded_n=16 only 16 of 64 tile-rows carry data, and the same
+            // nsys note the verify path records (impl_a3.rs) measured it at
+            // 19.3 ms on this [248320, 5120] NVFP4 head vs ~2.5 ms for the
+            // batched GEMV streaming the same 636 MB once. That cost is
+            // FLAT in n, so it sits in the fixed term at every batch size.
+            //
+            // Tier by padded_n exactly as the SSM mixer does: batch4 (M<=4)
+            // / batch8 (M<=8) / batch16 (M<=16). A 0-handle on any tier
+            // falls through to the GEMM, so targets lacking the kernel are
+            // unaffected.
+            // Tile GEMM at padded_n >= 5 over the PADDED transposed twin.
+            // padded_n <= 4 stays on the GEMV, which measures 3174 us =
+            // 226 GB/s = 98.3% of the memory roofline on this shape and is
+            // therefore unimprovable; the tile GEMM LOSES there.
+            if padded_n >= 5
+                && self.w4a16_gemm_t_bf16_kernel.0 != 0
+                && let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t
+            {
+                // LOSSLESS path: BF16 MMA, no activation downcast.
+                ops::w4a16_gemm_n128_m128_bf16_ldb(
+                    self.gpu.as_ref(),
+                    self.w4a16_gemm_t_bf16_kernel,
+                    normed,
+                    nvfp4_t,
+                    logits,
+                    padded_n as u32,
+                    v as u32,
+                    h as u32,
+                    ldb,
+                    stream,
+                )?;
+            } else if padded_n >= 5
+                && self.w4a16_gemm_t_kernel.0 != 0
+                && let Some((ref nvfp4_t, ldb)) = self.lm_head_nvfp4_t
+            {
+                ops::w4a16_gemm_n128_ldb(
+                    self.gpu.as_ref(),
+                    self.w4a16_gemm_t_kernel,
+                    normed,
+                    nvfp4_t,
+                    logits,
+                    padded_n as u32,
+                    v as u32,
+                    h as u32,
+                    ldb,
+                    stream,
+                )?;
+            } else {
+                let gemv_k = if padded_n <= 4 {
+                    self.w4a16_gemv_batch4_kernel
+                } else if padded_n <= 8 {
+                    self.w4a16_gemv_batch8_kernel
+                } else if padded_n <= 16 {
+                    self.w4a16_gemv_batch16_kernel
+                } else {
+                    spark_runtime::gpu::KernelHandle(0)
+                };
+                if gemv_k.0 != 0 && lm_head_batch_gemv_enabled() {
+                    ops::w4a16_gemv_batchm(
+                        self.gpu.as_ref(),
+                        gemv_k,
+                        normed,
+                        nvfp4,
+                        logits,
+                        padded_n as u32,
+                        v as u32,
+                        h as u32,
+                        stream,
+                    )?;
+                } else {
+                    ops::w4a16_gemm(
+                        self.gpu.as_ref(),
+                        self.w4a16_gemm_kernel,
+                        normed,
+                        nvfp4,
+                        logits,
+                        padded_n as u32,
+                        v as u32,
+                        h as u32,
+                        stream,
+                    )?;
+                }
+            }
+        } else {
+            ops::dense_gemm(
+                self.gpu.as_ref(),
+                self.dense_gemm_kernel,
+                normed,
+                &self.lm_head_weight,
+                logits,
+                padded_n as u32,
+                v as u32,
+                h as u32,
+                stream,
+            )?;
+        }
+        Ok(logits)
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -26,6 +26,7 @@ mod decode_checkpoint;
 mod decode_graph_key;
 mod drafter_prefill;
 mod ep_misc;
+mod lm_head_batched;
 mod meta;
 mod prefill_a;
 mod prefill_b;


### PR DESCRIPTION
## The gap

`decode_b2::mixed_final_norm_lm_head` — the prefill+decode co-dispatch head, reached from `decode_b.rs` via `mixed_forward_dispatch`, i.e. **live continuous-batching traffic** — still looped `padded_n` times through `ops::w4a16_gemv`, streaming the **entire vocab weight once per row**. On a `[248320, 5120]` NVFP4 head that is ~N × 254 MB/step.

Its sibling `decode_a2` grew the batched ladder weeks ago. The two had simply drifted.

## Credit

**@rsafier found this site**, in #332. That PR pointed at exactly the right line. It fixed it with a bare `batch16` behind a default-OFF env var; this takes a different route.

## Why extract rather than copy

Duplicating the ladder would put "which kernel does `padded_n` land on" in two independently-maintained places. The first thing to go wrong would not be a perf drift — it would be a silent **numerical** difference between the pure-decode and co-dispatch paths at the same batch width, which is worse than the bandwidth bug being fixed.

So `decode_a2`'s block moves to `trait_impl/lm_head_batched.rs` as one `lm_head_project_batched()`, and both heads call it. `v` is read from `self.config.vocab_size` inside rather than passed, so there is no second place for it to be wrong.

Default-**ON** under the existing kill-switch (`ATLAS_NO_LM_HEAD_BATCH_GEMV=1`), inherited unchanged — not a new flag, per the house rule that wins ship as defaults with a kill-switch rather than as opt-in.

Side effect worth having: `decode_a2.rs` drops **617 → 501** LoC.

## Verification

`spark-model`: **311 passed, 0 failed**. fmt + clippy clean, no LoC violations.

## ★ Honesty about the claim

**This is a bandwidth-accounting argument, not a measurement.** Nobody has A/B'd the mixed path and I am not claiming a number.

The gate run this PR owes must be **spec-OFF or on reversed-order pairs** — a single spec-ON pair drifts ±2%, which is wider than any effect worth reporting here.

There is no unit test that proves the win, and I do not think one is possible: the difference is how many times a weight is streamed, which is invisible to any CPU-side oracle. What the tests do prove is that both heads still produce the same dispatch decisions, because there is now only one function making them.

## Deliberately not included

`SequenceState::cached_prefix_blocks` (`traits.rs:140`) is written at three sites and read at **none**. Removing a `pub` field is an API change and does not belong bundled into a perf PR — noted for a separate one.

Co-Authored-By: rsafier <rsafier@users.noreply.github.com>
Co-Authored-By: Atlas <atlas@avarok.net>