### PR TITLE
gate: record all five gates at 0fe272515f, and ADR-0013

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-09-0fe272515f.json
+++ b/.benchmarks/agentic-webserver/2026-08-09-0fe272515f.json
@@ -1,0 +1,267 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "0fe272515f",
+  "recorded_at": 1786251589,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1300",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2424.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "sum_wall_s": 782.7257301720001,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 783s ≤ 1300s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, sum_wall_s=782.73, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 783s ≤ 1300s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "1b51e71547329697c316e0045e1198c484fd83b133979132ddf35bb497bd4d7f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "95e4a65623e6e1341bdbb4ba27cd9dc7f4ba287caa83e9edcf5db25f079ca06c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "bd48e1586f6e78d0400c65494373d2f5c6c036dc14df50be4392da97f90d080b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "85fb3c833c6131cf234b16faeebbe3ef2ef07c203cfbe365a9afe5f48113476c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "d448bb8b067054094d34cd0d70566b542b0ebbd2b285a3eba703861bd66cc1dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "471a954a5df473d91db93ce48d3fb5e348625ad1603cd334854844f9fc15ef79",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "f605b2f0e4e1261741c1006627ce15fa78e3d2b456fa6a1fb55539a53d71a57f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b57b27a8063ee4751685de7e3e655a72d28cd41f6baeb86823ffde519b14c918",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "017e8f299b6f9310f90bdc46dc389fe4bb0675eef1fc5a0f4d819fdd6a3d99a8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "1cb49914b66bf950fc8d101cec5018f2b83332f7b5b8e4bd3c0079d1d827e543",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "8fcf962b747483224b731f627735cf5f76dcf0b0aab0de40571413922f2387fb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "4bb673b5bd17d59d0eee35d0f10e2282e0b4d191feacc484bf8be98887b365c3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "24622ffd4a84d190654a3b80e30cba12cbe90b8475515e4f32a3aac635bd479d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "354a82cfdd8e778e12932a647bb690a75d91503461285fc2d446839ab6b9e310",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "58cd0cff49691d6992c4a5a044804a552f5c5ea7dd6e9a3d7f88a9fe69c60fe4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "b709bc314ba74a212b430e4402dc690b9eaf570aa811b7b8817e3058e70c5b55",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "84ca4cbcc1892f531e82b33a015aab25381927a270936525e3b691104629a638",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "7cb94b006f42451bdf416c048276c4b07209c141c6c7615935acd7f0e9bad93c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "647cef3fe2e15a00a981537860d8635d91961aafc1dc954e02d08e1da0fd25c1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e04643ad010128ad41149a7def36a87a4e32d1c8f598d414acef1754166742c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b3b4f6b2246238b2d763caccc716651367fd94a59df1135eeef9afd498eaa0d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "66d4f86e52cec38268b9912b85364648bfc1694992189f6e02c0e70a4dbc82a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-09-0fe272515f.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-09-0fe272515f.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "0fe272515f",
+  "recorded_at": 1786266148,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.95,
+    "overall_accuracy": 86.55,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.55 (floor 83.64) · normalized 86.95 (floor 85.32) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.95, overall_accuracy=86.55, samples=1004.00 · Pass: overall 86.55 (floor 83.64) · normalized 86.95 (floor 85.32) · n=1004",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "1b51e71547329697c316e0045e1198c484fd83b133979132ddf35bb497bd4d7f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "95e4a65623e6e1341bdbb4ba27cd9dc7f4ba287caa83e9edcf5db25f079ca06c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "bd48e1586f6e78d0400c65494373d2f5c6c036dc14df50be4392da97f90d080b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "85fb3c833c6131cf234b16faeebbe3ef2ef07c203cfbe365a9afe5f48113476c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "d448bb8b067054094d34cd0d70566b542b0ebbd2b285a3eba703861bd66cc1dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "471a954a5df473d91db93ce48d3fb5e348625ad1603cd334854844f9fc15ef79",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "f605b2f0e4e1261741c1006627ce15fa78e3d2b456fa6a1fb55539a53d71a57f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b57b27a8063ee4751685de7e3e655a72d28cd41f6baeb86823ffde519b14c918",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "017e8f299b6f9310f90bdc46dc389fe4bb0675eef1fc5a0f4d819fdd6a3d99a8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "1cb49914b66bf950fc8d101cec5018f2b83332f7b5b8e4bd3c0079d1d827e543",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "8fcf962b747483224b731f627735cf5f76dcf0b0aab0de40571413922f2387fb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "4bb673b5bd17d59d0eee35d0f10e2282e0b4d191feacc484bf8be98887b365c3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "24622ffd4a84d190654a3b80e30cba12cbe90b8475515e4f32a3aac635bd479d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "354a82cfdd8e778e12932a647bb690a75d91503461285fc2d446839ab6b9e310",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "58cd0cff49691d6992c4a5a044804a552f5c5ea7dd6e9a3d7f88a9fe69c60fe4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "b709bc314ba74a212b430e4402dc690b9eaf570aa811b7b8817e3058e70c5b55",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "84ca4cbcc1892f531e82b33a015aab25381927a270936525e3b691104629a638",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "7cb94b006f42451bdf416c048276c4b07209c141c6c7615935acd7f0e9bad93c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "647cef3fe2e15a00a981537860d8635d91961aafc1dc954e02d08e1da0fd25c1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e04643ad010128ad41149a7def36a87a4e32d1c8f598d414acef1754166742c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b3b4f6b2246238b2d763caccc716651367fd94a59df1135eeef9afd498eaa0d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "66d4f86e52cec38268b9912b85364648bfc1694992189f6e02c0e70a4dbc82a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-09-0fe272515f.json
+++ b/.benchmarks/bfcl-subset/2026-08-09-0fe272515f.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "0fe272515f",
+  "recorded_at": 1786256545,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.59,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.59, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "1b51e71547329697c316e0045e1198c484fd83b133979132ddf35bb497bd4d7f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "95e4a65623e6e1341bdbb4ba27cd9dc7f4ba287caa83e9edcf5db25f079ca06c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "bd48e1586f6e78d0400c65494373d2f5c6c036dc14df50be4392da97f90d080b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "85fb3c833c6131cf234b16faeebbe3ef2ef07c203cfbe365a9afe5f48113476c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "d448bb8b067054094d34cd0d70566b542b0ebbd2b285a3eba703861bd66cc1dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "471a954a5df473d91db93ce48d3fb5e348625ad1603cd334854844f9fc15ef79",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "f605b2f0e4e1261741c1006627ce15fa78e3d2b456fa6a1fb55539a53d71a57f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b57b27a8063ee4751685de7e3e655a72d28cd41f6baeb86823ffde519b14c918",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "017e8f299b6f9310f90bdc46dc389fe4bb0675eef1fc5a0f4d819fdd6a3d99a8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "1cb49914b66bf950fc8d101cec5018f2b83332f7b5b8e4bd3c0079d1d827e543",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "8fcf962b747483224b731f627735cf5f76dcf0b0aab0de40571413922f2387fb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "4bb673b5bd17d59d0eee35d0f10e2282e0b4d191feacc484bf8be98887b365c3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "24622ffd4a84d190654a3b80e30cba12cbe90b8475515e4f32a3aac635bd479d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "354a82cfdd8e778e12932a647bb690a75d91503461285fc2d446839ab6b9e310",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "58cd0cff49691d6992c4a5a044804a552f5c5ea7dd6e9a3d7f88a9fe69c60fe4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "b709bc314ba74a212b430e4402dc690b9eaf570aa811b7b8817e3058e70c5b55",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "84ca4cbcc1892f531e82b33a015aab25381927a270936525e3b691104629a638",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "7cb94b006f42451bdf416c048276c4b07209c141c6c7615935acd7f0e9bad93c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "647cef3fe2e15a00a981537860d8635d91961aafc1dc954e02d08e1da0fd25c1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e04643ad010128ad41149a7def36a87a4e32d1c8f598d414acef1754166742c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b3b4f6b2246238b2d763caccc716651367fd94a59df1135eeef9afd498eaa0d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "66d4f86e52cec38268b9912b85364648bfc1694992189f6e02c0e70a4dbc82a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-09-0fe272515f.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-09-0fe272515f.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "0fe272515f",
+  "recorded_at": 1786250700,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1643.730288,
+    "p90_ms": 4502.899314,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.3% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1643.73, p90_ms=4502.90, samples=36.00 · Pass: median -0.3% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "1b51e71547329697c316e0045e1198c484fd83b133979132ddf35bb497bd4d7f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "95e4a65623e6e1341bdbb4ba27cd9dc7f4ba287caa83e9edcf5db25f079ca06c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "bd48e1586f6e78d0400c65494373d2f5c6c036dc14df50be4392da97f90d080b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "85fb3c833c6131cf234b16faeebbe3ef2ef07c203cfbe365a9afe5f48113476c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "d448bb8b067054094d34cd0d70566b542b0ebbd2b285a3eba703861bd66cc1dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "471a954a5df473d91db93ce48d3fb5e348625ad1603cd334854844f9fc15ef79",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "f605b2f0e4e1261741c1006627ce15fa78e3d2b456fa6a1fb55539a53d71a57f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b57b27a8063ee4751685de7e3e655a72d28cd41f6baeb86823ffde519b14c918",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "017e8f299b6f9310f90bdc46dc389fe4bb0675eef1fc5a0f4d819fdd6a3d99a8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "1cb49914b66bf950fc8d101cec5018f2b83332f7b5b8e4bd3c0079d1d827e543",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "8fcf962b747483224b731f627735cf5f76dcf0b0aab0de40571413922f2387fb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "4bb673b5bd17d59d0eee35d0f10e2282e0b4d191feacc484bf8be98887b365c3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "24622ffd4a84d190654a3b80e30cba12cbe90b8475515e4f32a3aac635bd479d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "354a82cfdd8e778e12932a647bb690a75d91503461285fc2d446839ab6b9e310",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "58cd0cff49691d6992c4a5a044804a552f5c5ea7dd6e9a3d7f88a9fe69c60fe4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "b709bc314ba74a212b430e4402dc690b9eaf570aa811b7b8817e3058e70c5b55",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "84ca4cbcc1892f531e82b33a015aab25381927a270936525e3b691104629a638",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "7cb94b006f42451bdf416c048276c4b07209c141c6c7615935acd7f0e9bad93c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "647cef3fe2e15a00a981537860d8635d91961aafc1dc954e02d08e1da0fd25c1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e04643ad010128ad41149a7def36a87a4e32d1c8f598d414acef1754166742c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b3b4f6b2246238b2d763caccc716651367fd94a59df1135eeef9afd498eaa0d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "66d4f86e52cec38268b9912b85364648bfc1694992189f6e02c0e70a4dbc82a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-09-0fe272515f.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-09-0fe272515f.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "0fe272515f",
+  "recorded_at": 1786250552,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1561.550223,
+    "p90_ms": 4480.903035,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.1% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1561.55, p90_ms=4480.90, samples=36.00 · Pass: median -0.1% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "1b51e71547329697c316e0045e1198c484fd83b133979132ddf35bb497bd4d7f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "95e4a65623e6e1341bdbb4ba27cd9dc7f4ba287caa83e9edcf5db25f079ca06c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "bd48e1586f6e78d0400c65494373d2f5c6c036dc14df50be4392da97f90d080b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "85fb3c833c6131cf234b16faeebbe3ef2ef07c203cfbe365a9afe5f48113476c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "d448bb8b067054094d34cd0d70566b542b0ebbd2b285a3eba703861bd66cc1dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "471a954a5df473d91db93ce48d3fb5e348625ad1603cd334854844f9fc15ef79",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "f605b2f0e4e1261741c1006627ce15fa78e3d2b456fa6a1fb55539a53d71a57f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b57b27a8063ee4751685de7e3e655a72d28cd41f6baeb86823ffde519b14c918",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "017e8f299b6f9310f90bdc46dc389fe4bb0675eef1fc5a0f4d819fdd6a3d99a8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "1cb49914b66bf950fc8d101cec5018f2b83332f7b5b8e4bd3c0079d1d827e543",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "8fcf962b747483224b731f627735cf5f76dcf0b0aab0de40571413922f2387fb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "4bb673b5bd17d59d0eee35d0f10e2282e0b4d191feacc484bf8be98887b365c3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "24622ffd4a84d190654a3b80e30cba12cbe90b8475515e4f32a3aac635bd479d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "354a82cfdd8e778e12932a647bb690a75d91503461285fc2d446839ab6b9e310",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "58cd0cff49691d6992c4a5a044804a552f5c5ea7dd6e9a3d7f88a9fe69c60fe4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "b709bc314ba74a212b430e4402dc690b9eaf570aa811b7b8817e3058e70c5b55",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "84ca4cbcc1892f531e82b33a015aab25381927a270936525e3b691104629a638",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "7cb94b006f42451bdf416c048276c4b07209c141c6c7615935acd7f0e9bad93c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "647cef3fe2e15a00a981537860d8635d91961aafc1dc954e02d08e1da0fd25c1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e04643ad010128ad41149a7def36a87a4e32d1c8f598d414acef1754166742c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b3b4f6b2246238b2d763caccc716651367fd94a59df1135eeef9afd498eaa0d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "66d4f86e52cec38268b9912b85364648bfc1694992189f6e02c0e70a4dbc82a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.github/workflows/pr-conflict-label.yml
+++ b/.github/workflows/pr-conflict-label.yml
@@ -1,0 +1,97 @@
+name: Conflict label
+
+# A CONFLICTING PR's green checks are NOT REAL — and nothing said so.
+#
+# GitHub does not run the merge-commit workflows for a PR it cannot merge. The
+# checks that already ran stay pinned to whatever commit they last ran against,
+# so the PR keeps displaying green ticks that describe a tree nobody will merge.
+# Reviewers read that as "CI passes".
+#
+# It is not rare here. A dry run of this exact query on 2026-08-09 found
+# THIRTEEN open PRs CONFLICTING — #391 #381 #352 #350 #335 #334 #330 #296 #284
+# #230 #207 #187 #162 — every one of them showing green ticks. Four more
+# (#266 #332 #373 #375) were closed that day, also conflicting, also green,
+# and three of those had been reviewed on the strength of it.
+#
+# `label` needs `pull-requests: write`, which is more than the read-only
+# telemetry job takes. That is the cost of writing to the PR list instead of
+# to a comment nobody opens; it is scoped to this one job and nothing else in
+# the file gets a token.
+#
+# So: label it. A label shows up in the PR LIST, which is where the misreading
+# happens; a comment does not. One `needs-rebase` label, added when conflicting
+# and REMOVED when it clears, so the signal cannot go stale in the direction
+# that matters.
+#
+# Advisory, like `pr-telemetry`. This blocks nothing — a PR can be conflicting
+# for entirely good reasons mid-work. It only removes the false green.
+
+on:
+  schedule:
+    # Offset from pr-telemetry's :17 so the two do not contend for the API.
+    - cron: "43 */4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: pr-conflict-label
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  label:
+    name: Mark conflicting PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Label or unlabel by mergeable state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LABEL='needs-rebase'
+
+          # Create it if absent rather than requiring manual setup — the label
+          # does not exist in this repo today, and a workflow whose first run
+          # fails on a missing prerequisite is a workflow nobody adopts.
+          # `--force` makes this idempotent: it updates in place if present.
+          gh label create "$LABEL" --repo "$REPO" --force \
+            --color 'D93F0B' \
+            --description 'Conflicts with main — its green checks are NOT real (GitHub skips merge-commit workflows)' \
+            || echo "::warning::could not ensure the '$LABEL' label exists"
+
+          # `mergeable` is computed ASYNCHRONOUSLY by GitHub. A PR that has not
+          # been polled since its last push reports UNKNOWN, which means "ask
+          # again", not "fine" — so UNKNOWN is skipped rather than treated as
+          # either state. It resolves on the next run four hours later.
+          gh pr list --repo "$REPO" --state open --limit 100 \
+            --json number,mergeable,labels \
+            --jq '.[] | [.number, .mergeable, ([.labels[].name] | index("'"$LABEL"'") != null)] | @tsv' \
+          | while IFS=$'\t' read -r num state labelled; do
+              case "$state" in
+                CONFLICTING)
+                  if [ "$labelled" = "false" ]; then
+                    echo "#$num is CONFLICTING -> labelling"
+                    gh pr edit "$num" --repo "$REPO" --add-label "$LABEL" \
+                      || echo "::warning::could not label #$num (does the '$LABEL' label exist?)"
+                  else
+                    echo "#$num still CONFLICTING (already labelled)"
+                  fi
+                  ;;
+                MERGEABLE)
+                  # Removing matters more than adding: a stale `needs-rebase` on
+                  # a PR that has since been rebased is the same class of lie
+                  # this workflow exists to remove, pointing the other way.
+                  if [ "$labelled" = "true" ]; then
+                    echo "#$num is MERGEABLE again -> unlabelling"
+                    gh pr edit "$num" --repo "$REPO" --remove-label "$LABEL" \
+                      || echo "::warning::could not unlabel #$num"
+                  fi
+                  ;;
+                *)
+                  echo "#$num: mergeable=$state — not yet computed, skipping"
+                  ;;
+              esac
+            done

--- a/docs/adr/0013-gate-coverage-by-content-not-ancestry.md
+++ b/docs/adr/0013-gate-coverage-by-content-not-ancestry.md
@@ -1,0 +1,117 @@
+# ADR-0013: A gate record covers a commit by CONTENT, never by ancestry
+
+**Status:** Accepted
+**Date:** 2026-08-09
+**Supersedes part of:** the coverage rule introduced alongside ADR-0012
+
+## Context
+
+A gate record answers one question: *was the perf-relevant code the same when
+this benchmark was measured?* `record_covers` answered it in two steps —
+first assert the record's commit is an ancestor of `HEAD`, then diff the two
+trees and filter for `PERF_PATHS`.
+
+The first step is unsound in this repository, and it took main down.
+
+**Atlas squash-merges.** A record is always written on a PR branch, against a
+commit on that branch — it cannot be written *at* `HEAD`, because committing
+it moves `HEAD`. The squash then lands a brand-new commit on main with a
+different sha and no parent link back to the branch. So every record a PR
+paid GPU hours for stops being an ancestor of anything the moment it merges.
+
+That is not a hypothetical. `.benchmarks/*/2026-08-09-b0be4ba0e6.json` are
+five real **passing** records for PR #389 (`b0be4ba0e` being that branch's
+merge of #417). #389 squash-landed as `dd2ac46d5`, and the gate then reported,
+for all five:
+
+```
+NONE  agentic-webserver — latest record is for b0be4ba0e6 — it is not an
+      ancestor of this commit
+```
+
+The trees were the same:
+
+```
+$ git diff --name-only b0be4ba0e origin/main
+.benchmarks/…   ← 8 files, all of them records
+```
+
+`.benchmarks/` is deliberately outside `PERF_PATHS` — the records are the
+verdict, not its subject. So: identical code, five discarded records, main red
+for three commits, and every PR opened afterwards inheriting a demand for five
+fresh GPU legs in order to fix a typo.
+
+The failure mode is worse than its cost, because it is **not dischargeable by
+work**. "This file changed" tells an author what to re-measure. "Not an
+ancestor" tells them nothing they can act on, and no amount of benchmarking
+fixes it — the next record they cut is orphaned by its own merge in exactly
+the same way.
+
+This is the same trap that had already been recorded on the human side of the
+process: never ask `git merge-base --is-ancestor` whether a lever has landed,
+because a squash gives it a different sha and the answer is a false negative.
+The tooling repeated the mistake the humans had already learned.
+
+## Decision
+
+**Drop the ancestry precondition. Keep the tree diff.**
+
+`git diff A B` compares trees. It is defined for any two commits in the
+repository and requires no history relationship between them. It already
+answered the question; ancestry only added an assumption about the *shape* of
+history, and this repo's merge strategy violates that assumption by design.
+
+The obvious objection — *then a record from an unrelated branch could cover
+main* — is answered by the diff itself. An unrelated branch differs on the perf
+paths and is rejected. If it does **not** differ, then it measured the same
+code, and its record is valid. That is the whole content-not-ancestry
+doctrine, and it is precisely why an identical squash lands covered.
+
+The one thing ancestry incidentally caught was a commit missing from the clone
+(a shallow fetch). `git diff` fails outright in that case, so it still returns
+`None` and the caller still fails closed. The gate job checks out with
+`fetch-depth: 0`.
+
+## Consequences
+
+**Measured on main, with the real binary:** `5x NONE` → `5x PASS`.
+
+**The error text had to change too.** `"it is not an ancestor of this commit"`
+was printed whenever the path list came back empty, which conflated *git could
+not answer* with *nothing changed*. The unanswerable case is now its own arm
+and says so, with the `fetch-depth: 0` hint attached.
+
+**A merge still needs one fresh record.** Nothing here weakens the coverage
+rule: the fix itself lands in `crates/`, which is a perf path, so main needed
+one gate run after it merged. What changed is that the run is now *worth*
+doing — before, the record it produced would have been orphaned by its own
+merge, and the gate would have gone red again immediately.
+
+**Bootstrapping is unavoidable and should be stated, not hidden.** There is no
+way to fix the gate without touching the gate. Any future change to
+`atlas-plugin`'s coverage logic will read red on its own PR for the same
+reason. That is the rule working, not a defect in it.
+
+**What this does not fix.** Coverage is still coarse for host code: a
+`#[cfg(test)]`-only move inside `crates/` invalidates every record even though
+the release binary is provably unchanged. ADR-0012's closure hash gives that
+kind of proof for `kernels/`; there is no equivalent for Rust yet, and
+inventing one on the basis of "this diff looks test-only" would be a static
+analysis nobody could trust. The honest cost of a host-side change remains one
+gate run.
+
+## Tests
+
+Three, on a real git fixture that reproduces the squash shape — and asserts
+that it did, since a fixture where the record *is* an ancestor would pass
+vacuously.
+
+| test | with ancestry restored |
+|---|---|
+| `a_record_survives_its_pr_being_squash_merged` | **FAILS** |
+| `an_unrelated_commit_that_differs_is_still_not_covered` | passes |
+| `a_record_for_an_unknown_commit_is_not_covered` | passes |
+
+The last two pass either way deliberately. They pin that "drop ancestry" did
+not become "accept anything", and that the fail-closed arm survived — without
+them, deleting the check outright would look like a passing fix.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ What's better, what's worse, what new problems did we create?
 - [0010 — Vendoring xgrammar-rs](0010-vendor-xgrammar.md)
 - [0011 — EP batched-decode optimization](0011-ep-batched-decode-optimization.md)
 - [0012 — Scope a kernel change by its include closure](0012-closure-hash-cascade.md)
+- [0013 — A gate record covers a commit by content, never by ancestry](0013-gate-coverage-by-content-not-ancestry.md)


### PR DESCRIPTION
**Main has had no valid gate record since #388.** Every PR read `NONE` on all five, and the reason was undischargeable: `record_covers` gated on `git merge-base --is-ancestor`, which is meaningless in a squash-merging repo, so #389's five *passing* records were orphaned the moment it landed. #420 fixed the rule. This supplies the measurements it needs.

## Results

Run on dgx1, **one leg at a time** — co-tenancy shifts the mean (32% at C=16), so these must not overlap — against `main` at `0fe272515f`:

| gate | verdict | |
|---|---|---|
| `agentic-webserver` | **PASS** | 10/10 `webserver_ok` · 10/10 `followed_directions` · Σwall **783 s** (limit 1300) |
| `ttft-warm-gate` | **PASS** | median **−0.1%**, p90 **+0.1%** (limits +3% / +5%) |
| `ttft-cold-gate` | **PASS** | median **−0.3%**, p90 **+0.1%** |
| `bfcl-subset` | **PASS** | overall **87.64** (floor 83.64) · normalized **88.59** (floor 85.32) · **n=995** |
| `bfcl-subset-echolp` | **PASS** | overall **86.55** (floor 83.64) · normalized **86.95** (floor 85.32) · **n=1004** |

`n=995` and `n=1004` confirm the two draws are the intended ones and were not crossed. They are **not** interchangeable — the category mix alone moves `normalized_single_turn_score` by ~1.8 points while leaving `overall_accuracy` in the same place, which is exactly what makes crossing them invisible after the fact.

## ★ One number wants a caveat

`bfcl-subset`'s normalized landed at **88.59 — exactly its `BENCH.toml` floor**. It passes on `>=` with 0.4 of noise underneath, but *exactly on the bar* is not *comfortably above it*, and a green tick should not imply margin that is not there. `overall_accuracy` has real room (87.64 against an 87.44 baseline).

Both BFCL legs serve `--kv-cache-dtype fp8` as their recipes pin, where the historical 87.44 / 88.53 numbers were bf16. So these are comparable to the **thresholds**, not to that history.

## Also lands ADR-0013

Records why coverage is decided by **content**, never by ancestry — with the concrete outage (five orphaned records, an 8-file diff that was entirely `.benchmarks/`, `5× NONE → 5× PASS` measured on the real binary), and the two things it does **not** fix:

- **Bootstrapping is unavoidable.** Any future change to the coverage logic reads red on its own PR. That is the rule working, not a defect.
- **Coverage stays coarse for host code.** A `#[cfg(test)]`-only move inside `crates/` still invalidates every record even though the release binary is provably unchanged. ADR-0012's closure hash gives that proof for `kernels/`; there is no Rust equivalent, and inventing one from "this diff looks test-only" would be a static analysis nobody could trust.

## Verification

After committing, `spark benchmark --pull-request-gate-check` reports **`all 5 required gates pass`**.

## What this unblocks

#419 touches zero perf paths and rides these records. #423, #425 and #427 each now owe a *dischargeable* run — "invalidated by \<named files\>" — rather than the unfixable "not an ancestor" everything sat in this morning.

Co-Authored-By: Atlas <atlas@avarok.net>