### PR TITLE
fix(ci): PR telemetry has been crashing on any PR with >100 files

### DIFF
--- a/.github/workflows/pr-telemetry.yml
+++ b/.github/workflows/pr-telemetry.yml
@@ -56,8 +56,27 @@ jobs:
           : > enriched.ndjson
           while read -r pr; do
             number=$(jq -r '.number' <<<"$pr")
-            paths=$(gh api "repos/$REPO/pulls/$number/files?per_page=100" --paginate \
-                      --jq '[.[].filename]' 2>/dev/null || echo '[]')
+            # ★ `--paginate` applies `--jq` PER PAGE, so an array filter emits
+            # ONE ARRAY PER PAGE. At >100 files that is two JSON documents, and
+            # `--argjson` takes exactly one — the whole render died on the first
+            # such PR. It was not hypothetical: #350 has 144 files, and both
+            # scheduled runs on 2026-08-09 aborted here.
+            #
+            # `jq -e .` does NOT catch this (it happily validates a concatenated
+            # stream); only `--argjson` rejects it. So emit newline-delimited
+            # names and assemble ONE array, which is page-count independent.
+            # Guard on gh's EXIT STATUS, not on whether the output is empty:
+            # on a 404 `gh api` prints the error BODY to stdout, so a
+            # length-based check turns `{"message":"Not Found",...}` into a
+            # single bogus "filename" that renders as a real path. (The first
+            # version of this fix did exactly that.)
+            if raw=$(gh api "repos/$REPO/pulls/$number/files?per_page=100" \
+                       --paginate --jq '.[].filename' 2>/dev/null); then
+              paths=$(printf '%s' "$raw" \
+                      | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            else
+              paths='[]'
+            fi
             jq -c --argjson p "$paths" '. + {changed_paths: $p}' <<<"$pr" >> enriched.ndjson
           done < prs.ndjson
           jq -s '.' enriched.ndjson > facts.json


### PR DESCRIPTION
## It has not been working

Both scheduled runs today failed (05:17, 09:01). The tracking comment has never been updated.

The failure was easy to miss: the render step errored, and the post step reported **`skipped`** — which reads as *"nothing to do"*, not *"the thing upstream died"*.

## Root cause

`gh api --paginate --jq '[.[].filename]'` applies the jq filter **per page**, so it emits **one array per page**. Above 100 files that is two JSON documents concatenated, and `--argjson` takes exactly one:

```
jq: invalid JSON text passed to --argjson
```

**#350 has 144 files.** The enrichment loop aborts on the first such PR, so the whole view dies regardless of the other 45.

> ★ `jq -e .` does **not** detect this — it happily validates a concatenated stream. Only `--argjson` rejects it. My first attempt to reproduce used `jq -e .`, concluded the JSON was fine, and was wrong.

## Fix

Emit newline-delimited names and assemble one array with `jq -R -s -c 'split("\n") | map(select(length > 0))'` — page-count independent.

## ★ The first version of this fix was also wrong

It replaced the original `|| echo '[]'` with a `[ -n "$paths" ]` emptiness check. But on a 404, `gh api` prints the **error body to stdout**, so the pipeline produced:

```json
["{\"message\":\"Not Found\",\"documentation_url\":\"...\",\"status\":\"404\"}"]
```

— one bogus "filename" that would render as a real changed path and silently mis-categorize the PR. Guarding on gh's **exit status** (confirmed: `1` on 404) rather than on output length fixes it.

## Verified in both directions

The check the first two attempts lacked:

| case | result |
|---|---|
| #350 (144 files, 2 pages) | **144** paths |
| #999999 (404) | **0** paths — not 1 path made of the error body |

## Not fixed here — both bigger than a workflow patch

- **`PR_TELEMETRY_ISSUE` is unset**, so even a successful render posts nowhere. The workflow correctly refuses to guess an issue number (PCND) and exits 0 saying so. Needs a tracking issue created and the repo variable set — that is repo config, not code.
- **`crates/atlas-governance` (the LatticeDB journey ledger) is an island.** Zero crates depend on it; zero call sites outside its own crate. It compiles and has tests; nothing has ever written an event to it. Wiring it needs a decision about who emits — the CI-side render, or the gate checker.

Touches one file under `.github/workflows/` — zero perf paths, no gate debt.

Co-Authored-By: Atlas <atlas@avarok.net>