### PR TITLE
Six correctness fixes: spec-decode exactness (#435), finish_reason semantics, and a C≥2 serving crash

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-10-525df5e200.json
+++ b/.benchmarks/agentic-webserver/2026-08-10-525df5e200.json
@@ -1,0 +1,273 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "525df5e200",
+  "recorded_at": 1786358609,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1300",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 970.8237472339999,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 971s ≤ 1300s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=970.82, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 971s ≤ 1300s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/agentic-webserver/2026-08-10-a38e9681a3.json
+++ b/.benchmarks/agentic-webserver/2026-08-10-a38e9681a3.json
@@ -1,0 +1,273 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "a38e9681a3",
+  "recorded_at": 1786329281,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1300",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 8.0,
+    "iterations": 10.0,
+    "step:curled": 8.0,
+    "step:ran_server": 8.0,
+    "step:ran_tests": 8.0,
+    "step:tore_down": 8.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 712.8618725910001,
+    "webserver_ok": 9.0
+  },
+  "frame_status": "Completed",
+  "verdict": "FAIL",
+  "verdict_reason": "webserver_ok 9/10 · followed_directions 8/10",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=8.00, iterations=10.00, step:curled=8.00, step:ran_server=8.00, step:ran_tests=8.00, step:tore_down=8.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=712.86, webserver_ok=9.00 · Fail: webserver_ok 9/10 · followed_directions 8/10",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-10-525df5e200.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-10-525df5e200.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "525df5e200",
+  "recorded_at": 1786368467,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.95,
+    "overall_accuracy": 86.55,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.55 (floor 83.64) · normalized 86.95 (floor 85.32) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.95, overall_accuracy=86.55, samples=1004.00 · Pass: overall 86.55 (floor 83.64) · normalized 86.95 (floor 85.32) · n=1004",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-10-525df5e200.json
+++ b/.benchmarks/bfcl-subset/2026-08-10-525df5e200.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "525df5e200",
+  "recorded_at": 1786375350,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.59,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.59, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-10-a38e9681a3.json
+++ b/.benchmarks/bfcl-subset/2026-08-10-a38e9681a3.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "a38e9681a3",
+  "recorded_at": 1786334200,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.59,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.59, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-10-525df5e200.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-10-525df5e200.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "525df5e200",
+  "recorded_at": 1786370773,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1648.915087,
+    "p90_ms": 4541.940850999999,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.5% (limit +3.0%) · p90 +0.8% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1648.92, p90_ms=4541.94, samples=36.00 · Pass: median -0.5% (limit +3.0%) · p90 +0.8% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-10-a38e9681a3.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-10-a38e9681a3.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "a38e9681a3",
+  "recorded_at": 1786329599,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1653.914294,
+    "p90_ms": 4507.542512,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.0% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1653.91, p90_ms=4507.54, samples=36.00 · Pass: median +0.0% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-10-525df5e200.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-10-525df5e200.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "525df5e200",
+  "recorded_at": 1786370656,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1560.545087,
+    "p90_ms": 4494.15044,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.9% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1560.55, p90_ms=4494.15, samples=36.00 · Pass: median -0.9% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-10-a38e9681a3.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-10-a38e9681a3.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "a38e9681a3",
+  "recorded_at": 1786329481,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1572.735478,
+    "p90_ms": 4493.225256,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.0% (limit +3.0%) · p90 -0.6% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1572.74, p90_ms=4493.23, samples=36.00 · Pass: median -0.0% (limit +3.0%) · p90 -0.6% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "ae055e6917e5341cae84de12c4a481bbcd2825fc7659c8429d215e19926db227",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "17bb4dbaf2081bd7c32d1d3269056c498828340e2dbd72d8d01bdbe629bd0d58",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "eda01033d2662cc294959c0fcb7f5bc8101896ac686f0f77f6135ad45bf0fa6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -357,6 +357,14 @@ jobs:
             "crates/spark-model/src/layers/ops/ssm_mamba.rs"
             # 513 LoC — dev-only W4A16 BF16-v2 microbench example.
             "crates/spark-model/examples/w4a16_bf16_v2_microtest.rs"
+            # 584 LoC — dev-only #435 verify-cost microbench example (GPU
+            # required): one sequential alloc→launch→time body whose legs
+            # mirror the exact/WY kernel chains step by step; splitting
+            # fragments the launch order (same rationale as the
+            # int8_gemm_test.rs / w4a16 entries above). Landed over-cap with
+            # the #435 stack; entry added by the first follow-on commit.
+            # Tracking issue owed when this branch gets its PR.
+            "crates/spark-model/examples/x435_ssm_cost.rs"
             # 509 LoC — scheduler type surface.
             "crates/spark-server/src/scheduler/types.rs"
             # 504 LoC — MTP step driver; crossed the cap when the run context

--- a/crates/atlas-kernels/src/lib_tests.rs
+++ b/crates/atlas-kernels/src/lib_tests.rs
@@ -65,6 +65,88 @@ fn all_targets_have_modules() {
     }
 }
 
+/// #438: the exact-verify `_snap` twins (#435) ship ONLY in
+/// qwen3.6-27b/nvfp4's shadow set, but `qwen3_ssm::init` issues their three
+/// lookups on EVERY GDN model. The boot gate fails CLOSED on an unresolved
+/// lookup that is not declared `[expected_absent]`, so every GDN target that
+/// does not compile these modules MUST declare them — qwen3.6-35b-a3b was
+/// unservable without this (3 required-unresolved at boot).
+///
+/// Issuer proxy: a target constructs `qwen3_ssm::init` iff it either ships
+/// `gated_delta_rule_wy17` or declares it expected-absent — a GDN target with
+/// NEITHER would already fail its own boot gate on the wy17 lookup, so a
+/// green fleet cannot contain one.
+#[test]
+#[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
+fn exact_verify_snap_lookups_resolve_or_are_declared_on_every_gdn_target() {
+    const PAIRS: [(&str, &str); 3] = [
+        (
+            "gated_delta_rule_snap",
+            "gated_delta_rule_decode_f32_norm_snap",
+        ),
+        (
+            "gated_delta_rule_snap",
+            "gated_delta_rule_decode_f32_strided_norm_snap",
+        ),
+        (
+            "gdn_verify_fused_conv_kn_f32",
+            "gdn_verify_fused_conv_kn_f32",
+        ),
+    ];
+    let ships = |t: &TargetPtxSet, m: &str| t.modules.iter().any(|(name, _)| *name == m);
+    let declares = |t: &TargetPtxSet, m: &str, f: &str| {
+        t.expected_absent
+            .iter()
+            .any(|(em, ef)| *em == m && *ef == f)
+    };
+
+    let mut gdn_targets = 0usize;
+    let mut by_presence = 0usize; // pair resolves because the module is compiled (qwen3.6-27b)
+    let mut by_declaration = 0usize; // pair declared expected-absent (the #438 fix)
+    let mut violations: Vec<String> = Vec::new();
+    for t in available_targets() {
+        let issues_gdn = ships(&t, "gated_delta_rule_wy17")
+            || declares(&t, "gated_delta_rule_wy17", "gated_delta_rule_wy17");
+        if !issues_gdn {
+            continue;
+        }
+        gdn_targets += 1;
+        for (m, f) in PAIRS {
+            if ships(&t, m) {
+                by_presence += 1;
+            } else if declares(&t, m, f) {
+                by_declaration += 1;
+            } else {
+                violations.push(format!(
+                    "{} misses {m}::{f} UNDECLARED — its boot gate will refuse to serve",
+                    t.target
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "GDN targets with undeclared unresolvable snap lookups:\n{}",
+        violations.join("\n")
+    );
+    // Non-vacuity guards: the invariant must have been exercised from BOTH
+    // sides, or a build/staging regression could pass this test silently.
+    assert!(
+        gdn_targets >= 2,
+        "expected at least the 27B and 35B GDN targets, saw {gdn_targets}"
+    );
+    assert!(
+        by_presence >= 3,
+        "qwen3.6-27b must still SHIP all three snap modules — fixing the 35B \
+         by unshipping the 27B is not a fix (pairs resolved by presence: {by_presence})"
+    );
+    assert!(
+        by_declaration >= 3,
+        "at least the 35B must cover all three pairs by declaration \
+         (pairs covered: {by_declaration})"
+    );
+}
+
 #[test]
 #[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
 fn ptx_for_model_lookup() {

--- a/crates/atlas-kernels/tests/kernel_arity.rs
+++ b/crates/atlas-kernels/tests/kernel_arity.rs
@@ -34,17 +34,27 @@ const PINS: &[(&str, &str, usize)] = &[
 ];
 
 /// Targets whose copy of a kernel legitimately differs in arity from the
-/// family pin (only the 27B grew `ldb` on w4a16_gemm_t/_p3; every other
-/// target still ships the 8-param originals).
+/// family pin.
+///
+/// ★ There are none left. This used to carve out `w4a16_gemm_t`/`_p3` for
+/// every target except the 27B, on the grounds that "only the 27B grew
+/// `ldb`". That stopped being true when #429 finished the port: `ldb` is
+/// now on **all 28 `w4a16_gemm.cu` paths** (8 distinct files — `strix/common`
+/// is a symlink into `gb10/common`, and several model dirs symlink their
+/// neighbours), and `w4a16_gemm_t_ldb_drift_is_exactly_the_known_set` pins
+/// that with an EMPTY known-drift list.
+///
+/// Leaving the carve-out behind made this test red on `main` for every
+/// non-27B target — deepseek-v4-flash reported "9 params vs pin 8", which is
+/// the FIXED kernel being measured against the pre-fix expectation. The
+/// stale side was the exception, not the kernels.
+///
+/// The function is kept (rather than deleted) because it is the designated
+/// place for a future legitimate per-target divergence, and because deleting
+/// it would scatter that decision back into the call site.
 fn expected_arity(model: &str, module: &str, kernel: &str, family_pin: usize) -> usize {
-    let is_27b = model.contains("qwen3.6-27b");
-    match (module, kernel) {
-        ("w4a16", "w4a16_gemm_t") | ("w4a16", "w4a16_gemm_t_p3") if !is_27b => 8,
-        _ => {
-            let _ = family_pin;
-            family_pin
-        }
-    }
+    let _ = (model, module, kernel);
+    family_pin
 }
 
 /// Count `.param` declarations of a PTX `.entry` by name.

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -178,6 +178,10 @@ name = "gdn_wy4_batched_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]
+name = "verify_exact_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "gdn_conv_kn_microtest"
 required-features = ["cuda", "gpu-examples"]
 

--- a/crates/spark-model/examples/verify_exact_microtest/main.rs
+++ b/crates/spark-model/examples/verify_exact_microtest/main.rs
@@ -381,7 +381,11 @@ fn run_legacy_wy4(g: &dyn GpuBackend, ks: &Kernels, inp: &Inputs) -> Result<Vec<
 }
 
 fn main() -> Result<()> {
-    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let set = atlas_kernels::ptx_for_model("qwen3.6-27b")
+        .or_else(|| atlas_kernels::ptx_for_config("qwen3_5_text", 5120))
+        .expect("no qwen3.6-27b ptx set");
+    eprintln!("kernel set: {}", set.target.model);
+    let gpu = AtlasCudaBackend::new(0, &set.modules)?;
     let g: &dyn GpuBackend = &gpu;
     let opt = |m: &str, f: &str| g.kernel(m, f).unwrap_or(KernelHandle(0));
     let ks = Kernels {

--- a/crates/spark-model/examples/verify_exact_microtest/main.rs
+++ b/crates/spark-model/examples/verify_exact_microtest/main.rs
@@ -13,8 +13,9 @@
 //! 3. STRIDED (batch=n): per token, one `causal_conv1d_update_l2norm_f32_strided`
 //!    + one `gated_delta_rule_decode_f32_strided_norm_snap` over n sequences —
 //!    each sequence byte-identical to its own golden run.
-//! 4. NEGATIVE CONTROL (the pre-#435 verify, i.e. what `--verify-wy`
-//!    restores): BF16 conv (`causal_conv1d_update_l2norm`) + `gated_delta_rule_wy4`
+//! 4. NEGATIVE CONTROL (the pre-#435 verify — the DEFAULT WY arms; the exact
+//!    chain under test here is the `--exact-verify` OPT-IN):
+//!    BF16 conv (`causal_conv1d_update_l2norm`) + `gated_delta_rule_wy4`
 //!    — the final H MUST DIFFER from golden (measured ~8.6e-4 relL2 on these
 //!    shapes). If it matches, this gate is not exercising the defect and the
 //!    positive legs prove nothing.
@@ -455,7 +456,8 @@ fn main() -> Result<()> {
             all_ok &= ok;
         }
 
-        // NEGATIVE: legacy BF16-conv + wy4 (the --verify-wy path) must differ.
+        // NEGATIVE: legacy BF16-conv + wy4 (the DEFAULT verify path — exact
+        // is the --exact-verify opt-in) must differ.
         let h_legacy = run_legacy_wy4(g, &ks, &inps[0])?;
         let differs = h_legacy != gold.h_after[K - 1];
         println!(

--- a/crates/spark-model/examples/verify_exact_microtest/main.rs
+++ b/crates/spark-model/examples/verify_exact_microtest/main.rs
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Bitwise gate for the exact MTP-verify arm (issue #435 route (a)).
+//!
+//! GOLDEN is the sequential single-token decode chain — per token,
+//! `causal_conv1d_update_l2norm_f32` then `gated_delta_rule_decode_f32_norm`
+//! — with the h/conv state captured after every token. The legs assert:
+//!
+//! 1. SNAP: per-token conv_f32 + `gated_delta_rule_decode_f32_norm_snap`
+//!    (the exact arm's kernel) — final H, final conv_state, normed outputs
+//!    AND every inline h snapshot must be BYTE-IDENTICAL to golden.
+//! 2. FUSED CONV F32: one `gdn_verify_fused_conv_kn_f32` launch (conv rows +
+//!    inline conv snapshots) + per-token snap GDN — byte-identical to golden.
+//! 3. STRIDED (batch=n): per token, one `causal_conv1d_update_l2norm_f32_strided`
+//!    + one `gated_delta_rule_decode_f32_strided_norm_snap` over n sequences —
+//!    each sequence byte-identical to its own golden run.
+//! 4. NEGATIVE CONTROL (the pre-#435 verify, i.e. what `--verify-wy`
+//!    restores): BF16 conv (`causal_conv1d_update_l2norm`) + `gated_delta_rule_wy4`
+//!    — the final H MUST DIFFER from golden (measured ~8.6e-4 relL2 on these
+//!    shapes). If it matches, this gate is not exercising the defect and the
+//!    positive legs prove nothing.
+//!
+//! GPU REQUIRED — this example cannot run in a CPU-only session. Build with
+//! the qwen3.6-27b kernels present (`ATLAS_TARGET_MODEL="*"` or the 27b
+//! target), then:
+//!   cargo run -p spark-model --release --example verify_exact_microtest \
+//!       --features cuda,gpu-examples
+//! Exit codes: 0 = pass, 1 = FAIL, 2 = skipped (snap kernels not in this
+//! build's PTX set — the gate did NOT run).
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::KernelLaunch;
+
+mod strided;
+use strided::run_strided;
+
+// Qwen3.6-27B GDN shapes (issue #435 measurement config).
+pub(crate) const KD: usize = 128;
+pub(crate) const NK: usize = 16;
+pub(crate) const NV: usize = 48;
+pub(crate) const VD: usize = 128;
+pub(crate) const D_CONV: usize = 4;
+pub(crate) const KEY_DIM: usize = NK * KD; // 2048
+pub(crate) const VALUE_DIM: usize = NV * VD; // 6144
+pub(crate) const CONV_DIM: usize = KEY_DIM * 2 + VALUE_DIM; // 10240
+pub(crate) const QK_CH: usize = KEY_DIM * 2; // 4096
+pub(crate) const QKVZ: usize = CONV_DIM + VALUE_DIM; // 16384
+pub(crate) const K: usize = 4; // verify width (num_drafts=3 rung)
+pub(crate) const N: usize = 3; // strided-leg batch
+pub(crate) const H_ELEMS: usize = NV * KD * VD;
+pub(crate) const CONV_ELEMS: usize = CONV_DIM * D_CONV;
+pub(crate) const EPS: f32 = 1e-6;
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.0 >> 11) as f64) / ((1u64 << 53) as f64)
+    }
+    fn r(&mut self, lo: f64, hi: f64) -> f64 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+pub(crate) fn up(g: &dyn GpuBackend, b: &[u8]) -> Result<DevicePtr> {
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(b, p)?;
+    Ok(p)
+}
+fn bf16v(r: &mut Lcg, n: usize, lo: f64, hi: f64) -> Vec<u8> {
+    (0..n)
+        .flat_map(|_| bf16::from_f64(r.r(lo, hi)).to_bits().to_le_bytes())
+        .collect()
+}
+fn f32v(r: &mut Lcg, n: usize, lo: f64, hi: f64) -> Vec<u8> {
+    (0..n)
+        .flat_map(|_| (r.r(lo, hi) as f32).to_le_bytes())
+        .collect()
+}
+pub(crate) fn dn(g: &dyn GpuBackend, p: DevicePtr, n: usize) -> Result<Vec<u8>> {
+    let mut b = vec![0u8; n];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b)
+}
+fn rel_l2(a: &[u8], b: &[u8]) -> f64 {
+    let f = |x: &[u8]| -> Vec<f64> {
+        x.chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]) as f64)
+            .collect()
+    };
+    let (a, b) = (f(a), f(b));
+    let d: f64 = a.iter().zip(&b).map(|(x, y)| (x - y) * (x - y)).sum();
+    let n: f64 = a.iter().map(|x| x * x).sum();
+    (d / (n + 1e-30)).sqrt()
+}
+
+/// Per-sequence inputs; gates hold [gate(NV) | beta(NV)] FP32 per token.
+pub(crate) struct Inputs {
+    pub(crate) deint: Vec<u8>,  // [K, QKVZ] BF16
+    pub(crate) conv0: Vec<u8>,  // [CONV_ELEMS] FP32
+    pub(crate) h0: Vec<u8>,     // [H_ELEMS] FP32
+    pub(crate) gates: Vec<u8>,  // [K, 2*NV] FP32
+    pub(crate) weight: Vec<u8>, // conv weight [CONV_DIM, D_CONV] BF16
+    pub(crate) norm_w: Vec<u8>, // [VD] BF16
+}
+fn gen_inputs(seed: u64) -> Inputs {
+    let mut r = Lcg(seed);
+    Inputs {
+        deint: bf16v(&mut r, K * QKVZ, -0.5, 0.5),
+        conv0: f32v(&mut r, CONV_ELEMS, -0.3, 0.3),
+        h0: f32v(&mut r, H_ELEMS, -0.2, 0.2),
+        gates: f32v(&mut r, K * 2 * NV, 0.05, 0.95),
+        weight: bf16v(&mut r, CONV_ELEMS, -0.3, 0.3),
+        norm_w: bf16v(&mut r, VD, 0.5, 1.5),
+    }
+}
+
+pub(crate) struct Kernels {
+    pub(crate) conv_f32: KernelHandle,
+    pub(crate) conv_bf16: KernelHandle,
+    pub(crate) conv_f32_strided: KernelHandle,
+    pub(crate) f32_norm: KernelHandle,
+    pub(crate) snap: KernelHandle,
+    pub(crate) snap_strided: KernelHandle,
+    pub(crate) fused_conv_f32: KernelHandle,
+    pub(crate) wy4: KernelHandle,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn conv_launch(
+    g: &dyn GpuBackend,
+    k: KernelHandle,
+    state: DevicePtr,
+    input: DevicePtr,
+    weight: DevicePtr,
+    out: DevicePtr,
+) -> Result<()> {
+    KernelLaunch::new(g, k)
+        .grid([CONV_DIM.div_ceil(256) as u32, 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(state)
+        .arg_ptr(input)
+        .arg_ptr(weight)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_ptr(out)
+        .arg_u32(1)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32(D_CONV as u32)
+        .arg_u32(QK_CH as u32)
+        .arg_u32(KD as u32)
+        .arg_f32(EPS)
+        .launch(0)
+}
+
+/// f32_norm / snap launch (batch=1). `h_inter` NULL for the parent kernel or
+/// the last token.
+#[allow(clippy::too_many_arguments)]
+fn gdn_launch(
+    g: &dyn GpuBackend,
+    k: KernelHandle,
+    snap: bool,
+    h: DevicePtr,
+    conv_row: DevicePtr,
+    gate: DevicePtr,
+    z: DevicePtr,
+    norm_w: DevicePtr,
+    out: DevicePtr,
+    h_inter: DevicePtr,
+) -> Result<()> {
+    let mut l = KernelLaunch::new(g, k)
+        .grid([NV as u32, 1, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h)
+        .arg_ptr(conv_row)
+        .arg_ptr(conv_row.offset(KEY_DIM * 4))
+        .arg_ptr(conv_row.offset(KEY_DIM * 2 * 4))
+        .arg_ptr(gate)
+        .arg_ptr(gate.offset(NV * 4))
+        .arg_ptr(z)
+        .arg_ptr(norm_w)
+        .arg_ptr(out)
+        .arg_u32(1)
+        .arg_u32(NK as u32)
+        .arg_u32(NV as u32)
+        .arg_u32(KD as u32)
+        .arg_u32(VD as u32)
+        .arg_f32(EPS);
+    if snap {
+        l = l.arg_ptr(h_inter);
+    }
+    l.launch(0)
+}
+
+struct Golden {
+    h_after: Vec<Vec<u8>>,    // K snapshots of H (post-token)
+    conv_after: Vec<Vec<u8>>, // K snapshots of conv_state
+    normed: Vec<u8>,          // [K, VALUE_DIM] BF16
+}
+
+/// The sequential decode reference: per-token conv_f32 + f32_norm, states
+/// captured after every token (device sync + d2h — slow, and irrelevant:
+/// this is an oracle, not a benchmark).
+fn run_golden(g: &dyn GpuBackend, ks: &Kernels, inp: &Inputs) -> Result<Golden> {
+    let state = up(g, &inp.conv0)?;
+    let h = up(g, &inp.h0)?;
+    let deint = up(g, &inp.deint)?;
+    let gates = up(g, &inp.gates)?;
+    let (w, nw) = (up(g, &inp.weight)?, up(g, &inp.norm_w)?);
+    let conv_rows = g.alloc(K * QKVZ * 4)?;
+    let normed = g.alloc(K * VALUE_DIM * 2)?;
+    let (mut h_after, mut conv_after) = (Vec::new(), Vec::new());
+    for t in 0..K {
+        let row = conv_rows.offset(t * QKVZ * 4);
+        conv_launch(g, ks.conv_f32, state, deint.offset(t * QKVZ * 2), w, row)?;
+        gdn_launch(
+            g,
+            ks.f32_norm,
+            false,
+            h,
+            row,
+            gates.offset(t * 2 * NV * 4),
+            deint.offset((t * QKVZ + CONV_DIM) * 2),
+            nw,
+            normed.offset(t * VALUE_DIM * 2),
+            DevicePtr::NULL,
+        )?;
+        g.synchronize(0)?;
+        h_after.push(dn(g, h, H_ELEMS * 4)?);
+        conv_after.push(dn(g, state, CONV_ELEMS * 4)?);
+    }
+    Ok(Golden {
+        h_after,
+        conv_after,
+        normed: dn(g, normed, K * VALUE_DIM * 2)?,
+    })
+}
+
+/// The exact verify arm: `fused_conv` selects the one-launch FP32 conv with
+/// inline snapshots vs the per-token conv + d2d-free capture; GDN is always
+/// the snap twin. Returns (final h, final conv, normed, h_inters, conv snaps).
+pub(crate) type LegOut = (Vec<u8>, Vec<u8>, Vec<u8>, Vec<Vec<u8>>, Vec<Vec<u8>>);
+fn run_exact(g: &dyn GpuBackend, ks: &Kernels, inp: &Inputs, fused_conv: bool) -> Result<LegOut> {
+    let state = up(g, &inp.conv0)?;
+    let h = up(g, &inp.h0)?;
+    let deint = up(g, &inp.deint)?;
+    let gates = up(g, &inp.gates)?;
+    let (w, nw) = (up(g, &inp.weight)?, up(g, &inp.norm_w)?);
+    let conv_rows = g.alloc(K * QKVZ * 4)?;
+    let normed = g.alloc(K * VALUE_DIM * 2)?;
+    let h_inters: Vec<DevicePtr> = (0..K - 1)
+        .map(|_| g.alloc(H_ELEMS * 4))
+        .collect::<Result<_>>()?;
+    let conv_inters = g.alloc(K * CONV_ELEMS * 4)?; // contiguous, kn layout
+    if fused_conv {
+        KernelLaunch::new(g, ks.fused_conv_f32)
+            .grid([CONV_DIM.div_ceil(256) as u32, 1, 1])
+            .block([256, 1, 1])
+            .arg_ptr(state)
+            .arg_ptr(deint)
+            .arg_ptr(w)
+            .arg_ptr(conv_rows)
+            .arg_ptr(conv_inters)
+            .arg_u32(K as u32)
+            .arg_u32(CONV_DIM as u32)
+            .arg_u32(D_CONV as u32)
+            .arg_u32(QK_CH as u32)
+            .arg_u32(KD as u32)
+            .arg_u32(QKVZ as u32)
+            .arg_u32(QKVZ as u32)
+            .arg_u32(CONV_ELEMS as u32)
+            .arg_f32(EPS)
+            .launch(0)?;
+    }
+    let mut conv_snaps = Vec::new();
+    for t in 0..K {
+        let row = conv_rows.offset(t * QKVZ * 4);
+        if !fused_conv {
+            conv_launch(g, ks.conv_f32, state, deint.offset(t * QKVZ * 2), w, row)?;
+            if t + 1 < K {
+                g.copy_d2d_async(
+                    state,
+                    conv_inters.offset(t * CONV_ELEMS * 4),
+                    CONV_ELEMS * 4,
+                    0,
+                )?;
+            }
+        }
+        let hi = if t + 1 < K {
+            h_inters[t]
+        } else {
+            DevicePtr::NULL
+        };
+        gdn_launch(
+            g,
+            ks.snap,
+            true,
+            h,
+            row,
+            gates.offset(t * 2 * NV * 4),
+            deint.offset((t * QKVZ + CONV_DIM) * 2),
+            nw,
+            normed.offset(t * VALUE_DIM * 2),
+            hi,
+        )?;
+    }
+    g.synchronize(0)?;
+    let mut his = Vec::new();
+    for p in &h_inters {
+        his.push(dn(g, *p, H_ELEMS * 4)?);
+    }
+    for t in 0..K - 1 {
+        conv_snaps.push(dn(
+            g,
+            conv_inters.offset(t * CONV_ELEMS * 4),
+            CONV_ELEMS * 4,
+        )?);
+    }
+    Ok((
+        dn(g, h, H_ELEMS * 4)?,
+        dn(g, state, CONV_ELEMS * 4)?,
+        dn(g, normed, K * VALUE_DIM * 2)?,
+        his,
+        conv_snaps,
+    ))
+}
+
+/// NEGATIVE CONTROL: the pre-#435 K=4 verify (BF16 conv + wy4). Returns the
+/// final H — which must NOT match golden's.
+fn run_legacy_wy4(g: &dyn GpuBackend, ks: &Kernels, inp: &Inputs) -> Result<Vec<u8>> {
+    let state = up(g, &inp.conv0)?;
+    let h = up(g, &inp.h0)?;
+    let deint = up(g, &inp.deint)?;
+    let gates = up(g, &inp.gates)?;
+    let w = up(g, &inp.weight)?;
+    let conv_rows = g.alloc(K * CONV_DIM * 2)?; // BF16, conv_dim stride
+    let gdn_out = g.alloc(K * VALUE_DIM * 2)?;
+    let his: Vec<DevicePtr> = (0..3)
+        .map(|_| g.alloc(H_ELEMS * 4))
+        .collect::<Result<_>>()?;
+    for t in 0..K {
+        conv_launch(
+            g,
+            ks.conv_bf16,
+            state,
+            deint.offset(t * QKVZ * 2),
+            w,
+            conv_rows.offset(t * CONV_DIM * 2),
+        )?;
+    }
+    // gate/beta rows are [gate|beta] at 2*NV stride; wy kernels take base
+    // pointers + gb_stride exactly like production (gb_stride = 2*NV).
+    KernelLaunch::new(g, ks.wy4)
+        .grid([NV as u32, 1, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h)
+        .arg_ptr(conv_rows)
+        .arg_ptr(conv_rows.offset(KEY_DIM * 2))
+        .arg_ptr(conv_rows.offset(KEY_DIM * 2 * 2))
+        .arg_ptr(gates)
+        .arg_ptr(gates.offset(NV * 4))
+        .arg_ptr(gdn_out)
+        .arg_ptr(his[0])
+        .arg_ptr(his[1])
+        .arg_ptr(his[2])
+        .arg_u32(1)
+        .arg_u32(NK as u32)
+        .arg_u32(NV as u32)
+        .arg_u32(KD as u32)
+        .arg_u32(VD as u32)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32(CONV_DIM as u32)
+        .arg_u32((NV * 2) as u32)
+        .arg_u32(0) // state_is_table = contiguous
+        .launch(0)?;
+    g.synchronize(0)?;
+    dn(g, h, H_ELEMS * 4)
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &gpu;
+    let opt = |m: &str, f: &str| g.kernel(m, f).unwrap_or(KernelHandle(0));
+    let ks = Kernels {
+        conv_f32: g.kernel("causal_conv1d", "causal_conv1d_update_l2norm_f32")?,
+        conv_bf16: g.kernel("causal_conv1d", "causal_conv1d_update_l2norm")?,
+        conv_f32_strided: g.kernel("causal_conv1d", "causal_conv1d_update_l2norm_f32_strided")?,
+        f32_norm: g.kernel("gated_delta_rule", "gated_delta_rule_decode_f32_norm")?,
+        snap: opt(
+            "gated_delta_rule_snap",
+            "gated_delta_rule_decode_f32_norm_snap",
+        ),
+        snap_strided: opt(
+            "gated_delta_rule_snap",
+            "gated_delta_rule_decode_f32_strided_norm_snap",
+        ),
+        fused_conv_f32: opt(
+            "gdn_verify_fused_conv_kn_f32",
+            "gdn_verify_fused_conv_kn_f32",
+        ),
+        wy4: g.kernel("gated_delta_rule_wy4", "gated_delta_rule_wy4")?,
+    };
+    if ks.snap.0 == 0 || ks.snap_strided.0 == 0 || ks.fused_conv_f32.0 == 0 {
+        println!(
+            "SKIPPED: snap/fused-f32 kernels not in this build's PTX set — build with \
+             the qwen3.6-27b target (ATLAS_TARGET_MODEL=\"*\"). The bitwise gate did NOT run."
+        );
+        std::process::exit(2);
+    }
+
+    let mut all_ok = true;
+    for seed in [7u64, 4242] {
+        let inp = gen_inputs(seed);
+        let gold = run_golden(g, &ks, &inp)?;
+
+        for (name, fused) in [("snap", false), ("fused_conv_f32", true)] {
+            let (hf, cf, nf, his, csnaps) = run_exact(g, &ks, &inp, fused)?;
+            let mut ok = hf == gold.h_after[K - 1] && cf == gold.conv_after[K - 1];
+            ok &= nf == gold.normed;
+            for t in 0..K - 1 {
+                ok &= his[t] == gold.h_after[t];
+                ok &= csnaps[t] == gold.conv_after[t];
+            }
+            println!(
+                "seed {seed:>5} leg {name:<14}: bitwise={ok}  h relL2={:.3e}",
+                rel_l2(&hf, &gold.h_after[K - 1])
+            );
+            all_ok &= ok;
+        }
+
+        // Strided leg: N sequences, sequence 0 shares `inp`'s weights.
+        let mut inps = vec![inp];
+        for s in 0..N - 1 {
+            let mut i2 = gen_inputs(1000 + s as u64);
+            i2.weight = inps[0].weight.clone();
+            i2.norm_w = inps[0].norm_w.clone();
+            inps.push(i2);
+        }
+        let strided = run_strided(g, &ks, &inps)?;
+        for (i, (hf, cf, nf, his, _)) in strided.iter().enumerate() {
+            let gold_i = run_golden(g, &ks, &inps[i])?;
+            let mut ok = *hf == gold_i.h_after[K - 1] && *cf == gold_i.conv_after[K - 1];
+            ok &= *nf == gold_i.normed;
+            for t in 0..K - 1 {
+                ok &= his[t] == gold_i.h_after[t];
+            }
+            println!("seed {seed:>5} leg strided seq {i}:  bitwise={ok}");
+            all_ok &= ok;
+        }
+
+        // NEGATIVE: legacy BF16-conv + wy4 (the --verify-wy path) must differ.
+        let h_legacy = run_legacy_wy4(g, &ks, &inps[0])?;
+        let differs = h_legacy != gold.h_after[K - 1];
+        println!(
+            "seed {seed:>5} NEGATIVE legacy wy4: differs={differs}  h relL2={:.3e} \
+             (expected ~1e-3; bitwise match here would VOID the gate)",
+            rel_l2(&h_legacy, &gold.h_after[K - 1])
+        );
+        all_ok &= differs;
+    }
+
+    println!(
+        "\n{}",
+        if all_ok {
+            "PASS — exact verify chain is byte-identical to sequential decode; \
+             the legacy WY chain provably is not."
+        } else {
+            "FAIL"
+        }
+    );
+    if !all_ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/crates/spark-model/examples/verify_exact_microtest/strided.rs
+++ b/crates/spark-model/examples/verify_exact_microtest/strided.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Strided (batch = n) leg of the exact-verify bitwise gate — split from
+//! main.rs for the 500-LoC cap. See main.rs for the gate contract.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::kernel_args::KernelLaunch;
+
+use crate::{
+    CONV_DIM, CONV_ELEMS, D_CONV, EPS, H_ELEMS, Inputs, K, KD, KEY_DIM, Kernels, LegOut, NK, NV,
+    QK_CH, QKVZ, VALUE_DIM, VD, dn, up,
+};
+
+/// Strided leg: N sequences, per-token one strided conv + one strided snap
+/// launch. States sit on contiguous fake "pool slots".
+pub(crate) fn run_strided(
+    g: &dyn GpuBackend,
+    ks: &Kernels,
+    inps: &[Inputs],
+) -> Result<Vec<LegOut>> {
+    let n = inps.len();
+    let state = up(
+        g,
+        &inps
+            .iter()
+            .flat_map(|i| i.conv0.clone())
+            .collect::<Vec<u8>>(),
+    )?;
+    let h = up(
+        g,
+        &inps.iter().flat_map(|i| i.h0.clone()).collect::<Vec<u8>>(),
+    )?;
+    // Seq-major rows, exactly the production Multi layout.
+    let mut deint_all = Vec::new();
+    let mut gates_all = Vec::new();
+    for i in inps {
+        deint_all.extend_from_slice(&i.deint);
+        gates_all.extend_from_slice(&i.gates);
+    }
+    let deint = up(g, &deint_all)?;
+    let gates = up(g, &gates_all)?;
+    let (w, nw) = (up(g, &inps[0].weight)?, up(g, &inps[0].norm_w)?);
+    let conv_scratch = g.alloc(n * QKVZ * 4)?;
+    let normed = g.alloc(n * K * VALUE_DIM * 2)?;
+    // h intermediates: per-seq slab of (K-1) dense snapshots, contiguous.
+    let inter_seq_stride = (K - 1) * H_ELEMS * 4;
+    let h_inters = g.alloc(n * inter_seq_stride)?;
+    for t in 0..K {
+        KernelLaunch::new(g, ks.conv_f32_strided)
+            .grid([CONV_DIM.div_ceil(256) as u32, n as u32, 1])
+            .block([256, 1, 1])
+            .arg_ptr(state)
+            .arg_ptr(deint.offset(t * QKVZ * 2))
+            .arg_ptr(w)
+            .arg_ptr(DevicePtr::NULL)
+            .arg_ptr(conv_scratch)
+            .arg_u32(n as u32)
+            .arg_u32(CONV_DIM as u32)
+            .arg_u32(D_CONV as u32)
+            .arg_u32(QK_CH as u32)
+            .arg_u32(KD as u32)
+            .arg_f32(EPS)
+            .arg_u32((K * QKVZ) as u32)
+            .arg_u32(QKVZ as u32)
+            .launch(0)?;
+        let snapshot = t + 1 < K;
+        let (hi, stride) = if snapshot {
+            (
+                h_inters.offset(t * H_ELEMS * 4),
+                (inter_seq_stride / 4) as u64,
+            )
+        } else {
+            (DevicePtr::NULL, 0)
+        };
+        KernelLaunch::new(g, ks.snap_strided)
+            .grid([NV as u32, n as u32, 1])
+            .block([128, 1, 1])
+            .arg_ptr(h)
+            .arg_ptr(conv_scratch)
+            .arg_ptr(conv_scratch.offset(KEY_DIM * 4))
+            .arg_ptr(conv_scratch.offset(KEY_DIM * 2 * 4))
+            .arg_ptr(gates.offset(t * 2 * NV * 4))
+            .arg_ptr(gates.offset((t * 2 * NV + NV) * 4))
+            .arg_ptr(deint.offset((t * QKVZ + CONV_DIM) * 2))
+            .arg_ptr(nw)
+            .arg_ptr(normed.offset(t * VALUE_DIM * 2))
+            .arg_u32(n as u32)
+            .arg_u32(NK as u32)
+            .arg_u32(NV as u32)
+            .arg_u32(KD as u32)
+            .arg_u32(VD as u32)
+            .arg_u32(QKVZ as u32)
+            .arg_u32(QKVZ as u32)
+            .arg_u32((K * NV * 2) as u32)
+            .arg_u32((K * QKVZ) as u32)
+            .arg_u32((K * VALUE_DIM) as u32)
+            .arg_f32(EPS)
+            .arg_ptr(hi)
+            .arg_u64(stride)
+            .launch(0)?;
+    }
+    g.synchronize(0)?;
+    let mut out = Vec::new();
+    for i in 0..n {
+        let mut his = Vec::new();
+        for t in 0..K - 1 {
+            his.push(dn(
+                g,
+                h_inters.offset(i * inter_seq_stride + t * H_ELEMS * 4),
+                H_ELEMS * 4,
+            )?);
+        }
+        out.push((
+            dn(g, h.offset(i * H_ELEMS * 4), H_ELEMS * 4)?,
+            dn(g, state.offset(i * CONV_ELEMS * 4), CONV_ELEMS * 4)?,
+            dn(g, normed.offset(i * K * VALUE_DIM * 2), K * VALUE_DIM * 2)?,
+            his,
+            Vec::new(), // conv snapshots are d2d in production; not re-proven here
+        ));
+    }
+    Ok(out)
+}

--- a/crates/spark-model/examples/x435_ssm_cost.rs
+++ b/crates/spark-model/examples/x435_ssm_cost.rs
@@ -38,6 +38,7 @@ const VD: usize = 128;
 const KEY_DIM: usize = NK * KD; // 2048
 const VALUE_DIM: usize = NV * VD; // 6144
 const CONV_DIM: usize = 2 * KEY_DIM + VALUE_DIM; // 10240
+const QKVZ: usize = CONV_DIM + VALUE_DIM; // 16384 (production deint row)
 const D_CONV: usize = 4;
 const H_NUMEL: usize = NV * KD * VD; // 786432 (3 MiB)
 const CONV_ST: usize = CONV_DIM * D_CONV; // 40960 f32 (160 KiB)
@@ -88,6 +89,7 @@ struct Kit {
     wy2: KernelHandle,
     wy4: KernelHandle,
     grms: KernelHandle,
+    gdn_snap_str: KernelHandle,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -336,14 +338,18 @@ fn main() -> Result<()> {
         wy2: g.kernel("gated_delta_rule_wy", "gated_delta_rule_wy2")?,
         wy4: g.kernel("gated_delta_rule_wy4", "gated_delta_rule_wy4")?,
         grms: g.kernel("norm", "gated_rms_norm")?,
+        gdn_snap_str: g.kernel(
+            "gated_delta_rule_snap",
+            "gated_delta_rule_decode_f32_strided_norm_snap",
+        )?,
     };
     let mut r = Lcg(0xC057);
 
     println!(
-        "K, n, fused_us, exact_us, exact_nod2d_us, delta_pct, conv_b_us, conv_f_us, wy_us, gdnseq_us, d2d_us"
+        "K, n, fused_us, exact_us, exact_nod2d_us, snap_shipped_us, snap_delta_pct, exact_delta_pct, conv_b_us, conv_f_us, wy_us, gdnseq_us, d2d_us"
     );
     for &k in &[2usize, 4] {
-        for &n in &[1usize, 4, 8] {
+        for &n in &[1usize, 4, 8, 16, 32] {
             let b = Bufs {
                 n,
                 k,
@@ -368,6 +374,83 @@ fn main() -> Result<()> {
             let fused = time_arm(g, || fused_arm(g, &kit, &b))?;
             let exact = time_arm(g, || exact_arm(g, &kit, &b, true))?;
             let exact_nod2d = time_arm(g, || exact_arm(g, &kit, &b, false))?;
+            // EXACT-with-inline-snap: the SHIPPED #435 strided arm, launched
+            // exactly as in verify_exact_microtest/strided.rs — per token one
+            // conv_f32_strided + one strided_norm_snap (inline h snapshot for
+            // t<K-1), plus (K-1) conv-state d2d snapshots.
+            let snap_shipped = if n > 1 {
+                let deint = alloc_fill_bf16(g, n * k * QKVZ, &mut r)?;
+                let conv_scratch = g.alloc(n * QKVZ * 4)?;
+                let inter_seq_stride = (k - 1) * H_NUMEL * 4;
+                let h_inters = g.alloc(n * inter_seq_stride)?;
+                Some(time_arm(g, || {
+                    for t in 0..k {
+                        KernelLaunch::new(g, kit.conv_f_str)
+                            .grid([div_ceil(CONV_DIM as u32, 256), n as u32, 1])
+                            .block([256, 1, 1])
+                            .arg_ptr(b.conv_state)
+                            .arg_ptr(deint.offset(t * QKVZ * 2))
+                            .arg_ptr(b.wconv)
+                            .arg_ptr(DevicePtr::NULL)
+                            .arg_ptr(conv_scratch)
+                            .arg_u32(n as u32)
+                            .arg_u32(CONV_DIM as u32)
+                            .arg_u32(D_CONV as u32)
+                            .arg_u32((2 * KEY_DIM) as u32)
+                            .arg_u32(KD as u32)
+                            .arg_f32(1e-6)
+                            .arg_u32((k * QKVZ) as u32)
+                            .arg_u32(QKVZ as u32)
+                            .launch(0)?;
+                        let snapshot = t + 1 < k;
+                        let (hi, stride) = if snapshot {
+                            (
+                                h_inters.offset(t * H_NUMEL * 4),
+                                (inter_seq_stride / 4) as u64,
+                            )
+                        } else {
+                            (DevicePtr::NULL, 0)
+                        };
+                        KernelLaunch::new(g, kit.gdn_snap_str)
+                            .grid([NV as u32, n as u32, 1])
+                            .block([128, 1, 1])
+                            .arg_ptr(b.h)
+                            .arg_ptr(conv_scratch)
+                            .arg_ptr(conv_scratch.offset(KEY_DIM * 4))
+                            .arg_ptr(conv_scratch.offset(2 * KEY_DIM * 4))
+                            .arg_ptr(b.gates.offset(t * 2 * NV * 4))
+                            .arg_ptr(b.gates.offset((t * 2 * NV + NV) * 4))
+                            .arg_ptr(deint.offset((t * QKVZ + CONV_DIM) * 2))
+                            .arg_ptr(b.normw)
+                            .arg_ptr(b.normed.offset(t * VALUE_DIM * 2))
+                            .arg_u32(n as u32)
+                            .arg_u32(NK as u32)
+                            .arg_u32(NV as u32)
+                            .arg_u32(KD as u32)
+                            .arg_u32(VD as u32)
+                            .arg_u32(QKVZ as u32)
+                            .arg_u32(QKVZ as u32)
+                            .arg_u32((k * NV * 2) as u32)
+                            .arg_u32((k * QKVZ) as u32)
+                            .arg_u32((k * VALUE_DIM) as u32)
+                            .arg_f32(1e-6)
+                            .arg_ptr(hi)
+                            .arg_u64(stride)
+                            .launch(0)?;
+                        if snapshot {
+                            g.copy_d2d_async(
+                                b.conv_state,
+                                b.conv_inter.offset(t * n * CONV_ST * 4),
+                                n * CONV_ST * 4,
+                                0,
+                            )?;
+                        }
+                    }
+                    Ok(())
+                })?)
+            } else {
+                None
+            };
             // Components.
             let conv_b_t = time_arm(g, || {
                 for t in 0..k {
@@ -484,8 +567,15 @@ fn main() -> Result<()> {
                 }
                 Ok(())
             })?;
+            let (snap_s, snap_d) = match snap_shipped {
+                Some(s) => (
+                    format!("{s:.1}"),
+                    format!("{:+.1}%", (s - fused) / fused * 100.0),
+                ),
+                None => ("-".into(), "-".into()),
+            };
             println!(
-                "{k}, {n}, {fused:.1}, {exact:.1}, {exact_nod2d:.1}, {:+.1}%, {conv_b_t:.1}, {conv_f_t:.1}, {wy_t:.1}, {gdnseq_t:.1}, {d2d_t:.1}",
+                "{k}, {n}, {fused:.1}, {exact:.1}, {exact_nod2d:.1}, {snap_s}, {snap_d}, {:+.1}%, {conv_b_t:.1}, {conv_f_t:.1}, {wy_t:.1}, {gdnseq_t:.1}, {d2d_t:.1}",
                 (exact - fused) / fused * 100.0
             );
         }

--- a/crates/spark-model/src/engine/tests.rs
+++ b/crates/spark-model/src/engine/tests.rs
@@ -141,40 +141,7 @@ impl Model for MockModel {
     }
 
     fn alloc_sequence(&self) -> Result<SequenceState> {
-        Ok(SequenceState {
-            adapter_id: 0,
-            adapter_slot: -1,          // default: defer to installed active adapter
-            acquired_adapter_slot: -1, // Task #25: no ref held until prefill acquires
-            src_lang_id: 0,
-            tgt_lang_id: 0,
-            num_beams: 1,
-            length_penalty: 1.0,
-            early_stopping: false,
-            tokens: Vec::new(),
-            block_table: Vec::new(),
-            seq_len: 0,
-            layer_states: Vec::new(),
-            proposer_state: None,
-            slot_idx: 0,
-            ssm_slot: None,
-            marconi_skip_to: 0,
-            marconi_exact_snap: None,
-            session_hash: 0,
-            mtp_capture_gen: 0,
-            chunked_prefill_meta: None,
-            cached_prefix_tokens: 0,
-            cached_prefix_blocks: 0,
-            prefix_ref_tokens: Vec::new(),
-            prefix_lookup_applied: false,
-            prefix_lookup_skip: false,
-            kv_valid_tokens: 0,
-            last_decode_ckpt_block: 0,
-            prompt_len: 0,
-            collect_prompt_logprobs: None,
-            prompt_logprobs: Vec::new(),
-            disk_block_ids: Vec::new(),
-            disk_last_offloaded_per_layer: Vec::new(),
-        })
+        Ok(SequenceState::host_only(0))
     }
 
     fn copy_logits_to_host(&self, logits_ptr: DevicePtr, dst: &mut [u8]) -> Result<()> {

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -115,6 +115,8 @@ mod ssm_gdn_a2;
 mod ssm_gdn_b;
 #[path = "ops/ssm_gdn_batched.rs"]
 mod ssm_gdn_batched;
+#[path = "ops/ssm_gdn_snap.rs"]
+mod ssm_gdn_snap;
 #[path = "ops/ssm_mamba.rs"]
 mod ssm_mamba;
 #[path = "ops/ssm_preproc.rs"]
@@ -168,6 +170,7 @@ pub use ssm_gdn_a::*;
 pub use ssm_gdn_a2::*;
 pub use ssm_gdn_b::*;
 pub use ssm_gdn_batched::*;
+pub use ssm_gdn_snap::*;
 pub use ssm_mamba::*;
 pub use ssm_preproc::*;
 pub use ssm_ssd::*;

--- a/crates/spark-model/src/layers/ops/ssm_gdn_snap.rs
+++ b/crates/spark-model/src/layers/ops/ssm_gdn_snap.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Launch wrappers for the exact-verify `_snap` kernel twins (issue #435
+//! route (a)): the fused-norm GDN decode kernels with an inline per-token
+//! h-state rollback snapshot, and the FP32-output fused verify conv.
+//!
+//! All three are OPTIONAL kernels (`try_kernel`, model-shadow staged): the
+//! exact-verify arm falls back to the parent kernel + `copy_d2d_async`
+//! snapshots when a handle is 0 — same bits, more launches.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+use crate::weight_map::DenseWeight;
+
+/// [`super::gdn_decode_f32_norm`] + inline h-state snapshot.
+///
+/// `h_inter` receives the post-update (post-state-norm-clamp) H — the same
+/// bits left in `h_state` — or is skipped when NULL (the final verify
+/// position, whose snapshot index has no reader). Same grid/block and
+/// argument order as the parent, with `h_inter` appended.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_decode_f32_norm_snap(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    h_state: DevicePtr,
+    query: DevicePtr,
+    key: DevicePtr,
+    value: DevicePtr,
+    gate: DevicePtr,
+    beta: DevicePtr,
+    z_gate: DevicePtr,
+    norm_weight: DevicePtr,
+    output: DevicePtr,
+    h_inter: DevicePtr,
+    batch_size: u32,
+    num_k_heads: u32,
+    num_v_heads: u32,
+    k_dim: u32,
+    v_dim: u32,
+    eps: f32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([num_v_heads, batch_size, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h_state)
+        .arg_ptr(query)
+        .arg_ptr(key)
+        .arg_ptr(value)
+        .arg_ptr(gate)
+        .arg_ptr(beta)
+        .arg_ptr(z_gate)
+        .arg_ptr(norm_weight)
+        .arg_ptr(output)
+        .arg_u32(batch_size)
+        .arg_u32(num_k_heads)
+        .arg_u32(num_v_heads)
+        .arg_u32(k_dim)
+        .arg_u32(v_dim)
+        .arg_f32(eps)
+        .arg_ptr(h_inter)
+        .launch(stream)
+}
+
+/// [`super::gdn_decode_f32_strided_norm`] + inline h-state snapshot, for the
+/// batched-verify arm at `batch_size = n` sequences.
+///
+/// `h_inter` is the snapshot base for THIS token position; sequences are
+/// `h_inter_seq_stride` FP32 elements apart (the ssm-pool per-slot
+/// intermediate stride — passed, not inferred, because pool slots are
+/// `num_intermediates` snapshots wide while H itself is dense). NULL skips.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_decode_f32_strided_norm_snap(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    h_state: DevicePtr,
+    query: DevicePtr,
+    key: DevicePtr,
+    value: DevicePtr,
+    gate: DevicePtr,
+    beta: DevicePtr,
+    z_gate: DevicePtr,
+    norm_weight: DevicePtr,
+    output: DevicePtr,
+    h_inter: DevicePtr,
+    h_inter_seq_stride: u64,
+    batch_size: u32,
+    num_k_heads: u32,
+    num_v_heads: u32,
+    k_dim: u32,
+    v_dim: u32,
+    qk_stride: u32,
+    v_stride: u32,
+    gb_stride: u32,
+    z_stride: u32,
+    out_stride: u32,
+    eps: f32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([num_v_heads, batch_size, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h_state)
+        .arg_ptr(query)
+        .arg_ptr(key)
+        .arg_ptr(value)
+        .arg_ptr(gate)
+        .arg_ptr(beta)
+        .arg_ptr(z_gate)
+        .arg_ptr(norm_weight)
+        .arg_ptr(output)
+        .arg_u32(batch_size)
+        .arg_u32(num_k_heads)
+        .arg_u32(num_v_heads)
+        .arg_u32(k_dim)
+        .arg_u32(v_dim)
+        .arg_u32(qk_stride)
+        .arg_u32(v_stride)
+        .arg_u32(gb_stride)
+        .arg_u32(z_stride)
+        .arg_u32(out_stride)
+        .arg_f32(eps)
+        .arg_ptr(h_inter)
+        .arg_u64(h_inter_seq_stride)
+        .launch(stream)
+}
+
+/// FP32-output twin of [`super::gdn_verify_fused_conv_kn`]: one launch for
+/// all K verify positions of conv1d+SiLU+L2norm, FP32 conv rows (what the
+/// sequential-decode-exact GDN chain reads), every per-token conv-state
+/// rollback snapshot written inline. `output_stride` is in FP32 elements.
+///
+/// Kernel: `gdn_verify_fused_conv_kn_f32(conv_state, new_input, weight,
+///          output, conv_state_inter, num_tokens, dim, d_conv, qk_channels,
+///          head_dim, input_stride, output_stride, inter_stride, l2_eps)`
+/// Grid: (ceil(dim/256), 1, 1)  Block: (256, 1, 1)
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_verify_fused_conv_kn_f32(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    conv_state: DevicePtr,
+    new_input: DevicePtr,
+    weight: &DenseWeight,
+    output: DevicePtr,
+    conv_state_inter: DevicePtr,
+    num_tokens: u32,
+    dim: u32,
+    d_conv: u32,
+    qk_channels: u32,
+    head_dim: u32,
+    input_stride: u32,
+    output_stride: u32,
+    inter_stride: u32,
+    l2_eps: f32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(dim, 256), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(conv_state)
+        .arg_ptr(new_input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(output)
+        .arg_ptr(conv_state_inter)
+        .arg_u32(num_tokens)
+        .arg_u32(dim)
+        .arg_u32(d_conv)
+        .arg_u32(qk_channels)
+        .arg_u32(head_dim)
+        .arg_u32(input_stride)
+        .arg_u32(output_stride)
+        .arg_u32(inter_stride)
+        .arg_f32(l2_eps)
+        .launch(stream)
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -38,26 +38,30 @@ pub struct GdnFlags {
     pub fused_norm: bool,
     /// `--ssm-batched-recurrent`: one strided recurrent launch per batch.
     pub batched_recurrent: bool,
-    /// `--verify-wy`: restore the WY-chunkwise / fused BF16-conv MTP-verify
-    /// arms (the pre-#435 behaviour) for A/B. Default OFF: the verify pass
-    /// runs the EXACT per-token chain that is bitwise-equal to sequential
-    /// decode, because spec-on output equality at temp 0 is a correctness
-    /// property, not a tunable (issue #435, PR1).
-    pub verify_wy: bool,
+    /// `--exact-verify`: run the sequential-decode-EXACT per-token MTP-verify
+    /// chain (issue #435 route (a)) instead of the default WY-chunkwise /
+    /// fused BF16-conv arms. OPT-IN, default OFF: by default #435's
+    /// divergence REMAINS — spec-on output is NOT bitwise-equal to spec-off
+    /// at temp 0. The measured decode-step cost of exact (~+22-36% at the
+    /// n=8/16/32 verify rungs) is why; see the flag's help in `serve_args.rs`.
+    pub exact_verify: bool,
 }
 
 impl GdnFlags {
     /// Whether the MTP-verify pass must run the sequential-decode-exact
-    /// conv+GDN chain (issue #435 route (a)).
+    /// conv+GDN chain (issue #435 route (a)). Default FALSE: exact verify is
+    /// opt-in via `--exact-verify`, so with default settings spec-on output
+    /// is NOT bitwise-equal to spec-off (the #435 divergence ships).
     ///
     /// Pure so it is testable without touching the process-global flags cell.
-    /// `verify_wy` opts back into the WY arms; `h_f16` also disables exact
-    /// mode, because an FP16 h-state is a whole-chain numerics change that is
-    /// not bit-comparable to the FP32 reference in the first place, and the
-    /// exact arm's kernels are FP32 readers (reading the FP16 pool through
-    /// them would be silent garbage, not an error).
+    /// `h_f16` forces non-exact even when requested, because an FP16 h-state
+    /// is a whole-chain numerics change that is not bit-comparable to the
+    /// FP32 reference in the first place, and the exact arm's kernels are
+    /// FP32 readers (reading the FP16 pool through them would be silent
+    /// garbage, not an error). CLI validation additionally REJECTS the
+    /// explicit pair, so this clause is defense in depth, not the interface.
     pub fn verify_exact_active(self) -> bool {
-        !self.verify_wy && !self.h_f16
+        self.exact_verify && !self.h_f16
     }
     /// The legacy environment reading, used when the CLI never set anything.
     ///
@@ -71,8 +75,9 @@ impl GdnFlags {
             fused_norm: std::env::var("ATLAS_GDN_FUSED_NORM").as_deref() == Ok("1"),
             batched_recurrent: std::env::var("ATLAS_SSM_BATCHED_RECURRENT").as_deref() == Ok("1"),
             // No legacy environment variable on purpose (house rule: CLI flags
-            // or defaults, no new env knobs). Default = exact verify.
-            verify_wy: false,
+            // or defaults, no new env knobs). Default = the legacy WY arms;
+            // exact verify is CLI-opt-in only (`--exact-verify`).
+            exact_verify: false,
         }
     }
 }
@@ -107,8 +112,10 @@ pub fn ssm_batched_recurrent_enabled() -> bool {
     flags().batched_recurrent
 }
 
-/// `--verify-wy` NOT given (and h-state is FP32): the MTP-verify pass runs
-/// the sequential-decode-exact chain. See [`GdnFlags::verify_exact_active`].
+/// `--exact-verify` given (and h-state is FP32): the MTP-verify pass runs
+/// the sequential-decode-exact chain. FALSE by default — without the flag the
+/// verify pass runs the WY/chunkwise arms and #435's spec-on/spec-off output
+/// divergence remains. See [`GdnFlags::verify_exact_active`].
 pub fn verify_exact_enabled() -> bool {
     flags().verify_exact_active()
 }
@@ -121,17 +128,23 @@ mod tests {
         h_f16: false,
         fused_norm: false,
         batched_recurrent: false,
-        verify_wy: false,
+        exact_verify: false,
     };
 
-    /// POSITIVE: the default flag set (no `--verify-wy`, FP32 h-state) runs
-    /// the exact verify chain — the #435 fix must be ON by default.
+    /// POSITIVE (the default): with no flags the verify pass runs the legacy
+    /// WY/chunkwise arms, NOT the exact chain. Exact verify became OPT-IN
+    /// (every surveyed production engine ships exactness opt-in; its measured
+    /// decode-step cost here is ~+22-36%), so the #435 divergence is the
+    /// documented default behaviour — this test pins that polarity.
     #[test]
-    fn verify_exact_is_the_default() {
-        assert!(BASE.verify_exact_active(), "default must be exact verify");
-        // Orthogonal flags do not disturb the decision.
+    fn legacy_wy_verify_is_the_default() {
         assert!(
-            GdnFlags {
+            !BASE.verify_exact_active(),
+            "default must be the legacy WY arms — exact verify is opt-in"
+        );
+        // Orthogonal flags do not sneak exact mode on.
+        assert!(
+            !GdnFlags {
                 fused_norm: true,
                 batched_recurrent: true,
                 ..BASE
@@ -140,20 +153,47 @@ mod tests {
         );
     }
 
-    /// NEGATIVE: each opt-out disables exact mode on its own — `--verify-wy`
-    /// (the A/B kill switch) and `--ssm-h-dtype f16` (whose FP16 pool the
-    /// exact arm's FP32 kernels must never read).
+    /// POSITIVE (the opt-in): `--exact-verify` selects the exact chain, alone
+    /// and beside the orthogonal GDN flags.
     #[test]
-    fn verify_wy_and_h_f16_each_disable_exact() {
+    fn exact_verify_flag_selects_the_exact_chain() {
         assert!(
-            !GdnFlags {
-                verify_wy: true,
+            GdnFlags {
+                exact_verify: true,
                 ..BASE
             }
             .verify_exact_active()
         );
         assert!(
+            GdnFlags {
+                exact_verify: true,
+                fused_norm: true,
+                batched_recurrent: true,
+                ..BASE
+            }
+            .verify_exact_active()
+        );
+    }
+
+    /// The environment fallback can NEVER turn exact verify on: there is no
+    /// `ATLAS_*` variable for it on purpose (house rule: no new env knobs),
+    /// so a serve that skips `set_from_cli` still defaults to the WY arms.
+    /// Deterministic despite reading the process environment, because only
+    /// the `exact_verify` field is asserted and no variable feeds it.
+    #[test]
+    fn env_fallback_never_enables_exact_verify() {
+        assert!(!GdnFlags::from_env().exact_verify);
+    }
+
+    /// NEGATIVE: an FP16 h-state forces non-exact EVEN WHEN exact was
+    /// requested — the exact arm's FP32 kernels must never read the FP16
+    /// pool. (CLI validation rejects the explicit pair; this is the
+    /// defense-in-depth layer beneath it.)
+    #[test]
+    fn h_f16_forces_non_exact_even_when_requested() {
+        assert!(
             !GdnFlags {
+                exact_verify: true,
                 h_f16: true,
                 ..BASE
             }
@@ -161,7 +201,6 @@ mod tests {
         );
         assert!(
             !GdnFlags {
-                verify_wy: true,
                 h_f16: true,
                 ..BASE
             }

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -38,9 +38,27 @@ pub struct GdnFlags {
     pub fused_norm: bool,
     /// `--ssm-batched-recurrent`: one strided recurrent launch per batch.
     pub batched_recurrent: bool,
+    /// `--verify-wy`: restore the WY-chunkwise / fused BF16-conv MTP-verify
+    /// arms (the pre-#435 behaviour) for A/B. Default OFF: the verify pass
+    /// runs the EXACT per-token chain that is bitwise-equal to sequential
+    /// decode, because spec-on output equality at temp 0 is a correctness
+    /// property, not a tunable (issue #435, PR1).
+    pub verify_wy: bool,
 }
 
 impl GdnFlags {
+    /// Whether the MTP-verify pass must run the sequential-decode-exact
+    /// conv+GDN chain (issue #435 route (a)).
+    ///
+    /// Pure so it is testable without touching the process-global flags cell.
+    /// `verify_wy` opts back into the WY arms; `h_f16` also disables exact
+    /// mode, because an FP16 h-state is a whole-chain numerics change that is
+    /// not bit-comparable to the FP32 reference in the first place, and the
+    /// exact arm's kernels are FP32 readers (reading the FP16 pool through
+    /// them would be silent garbage, not an error).
+    pub fn verify_exact_active(self) -> bool {
+        !self.verify_wy && !self.h_f16
+    }
     /// The legacy environment reading, used when the CLI never set anything.
     ///
     /// `ATLAS_SSM_H_FP16` stays PRESENCE-gated here on purpose: that is how
@@ -52,6 +70,9 @@ impl GdnFlags {
             h_f16: std::env::var("ATLAS_SSM_H_FP16").is_ok(),
             fused_norm: std::env::var("ATLAS_GDN_FUSED_NORM").as_deref() == Ok("1"),
             batched_recurrent: std::env::var("ATLAS_SSM_BATCHED_RECURRENT").as_deref() == Ok("1"),
+            // No legacy environment variable on purpose (house rule: CLI flags
+            // or defaults, no new env knobs). Default = exact verify.
+            verify_wy: false,
         }
     }
 }
@@ -84,4 +105,67 @@ pub fn gdn_fused_norm_enabled() -> bool {
 /// `--ssm-batched-recurrent` (legacy `ATLAS_SSM_BATCHED_RECURRENT=1`).
 pub fn ssm_batched_recurrent_enabled() -> bool {
     flags().batched_recurrent
+}
+
+/// `--verify-wy` NOT given (and h-state is FP32): the MTP-verify pass runs
+/// the sequential-decode-exact chain. See [`GdnFlags::verify_exact_active`].
+pub fn verify_exact_enabled() -> bool {
+    flags().verify_exact_active()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GdnFlags;
+
+    const BASE: GdnFlags = GdnFlags {
+        h_f16: false,
+        fused_norm: false,
+        batched_recurrent: false,
+        verify_wy: false,
+    };
+
+    /// POSITIVE: the default flag set (no `--verify-wy`, FP32 h-state) runs
+    /// the exact verify chain — the #435 fix must be ON by default.
+    #[test]
+    fn verify_exact_is_the_default() {
+        assert!(BASE.verify_exact_active(), "default must be exact verify");
+        // Orthogonal flags do not disturb the decision.
+        assert!(
+            GdnFlags {
+                fused_norm: true,
+                batched_recurrent: true,
+                ..BASE
+            }
+            .verify_exact_active()
+        );
+    }
+
+    /// NEGATIVE: each opt-out disables exact mode on its own — `--verify-wy`
+    /// (the A/B kill switch) and `--ssm-h-dtype f16` (whose FP16 pool the
+    /// exact arm's FP32 kernels must never read).
+    #[test]
+    fn verify_wy_and_h_f16_each_disable_exact() {
+        assert!(
+            !GdnFlags {
+                verify_wy: true,
+                ..BASE
+            }
+            .verify_exact_active()
+        );
+        assert!(
+            !GdnFlags {
+                h_f16: true,
+                ..BASE
+            }
+            .verify_exact_active()
+        );
+        assert!(
+            !GdnFlags {
+                verify_wy: true,
+                h_f16: true,
+                ..BASE
+            }
+            .verify_exact_active()
+        );
+    }
 }

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -310,6 +310,8 @@ impl Qwen3SsmLayer {
             // Exact-verify `_snap` twins (#435): model-shadow staged
             // (qwen3.6-27b/nvfp4), 0 elsewhere — the exact arm then uses the
             // parent kernel + copy_d2d snapshots (same bits, more launches).
+            // Every other GDN target declares these three lookups in its
+            // MODEL.toml [expected_absent] (#438) — the boot gate fails closed.
             gdn_f32_norm_snap_k: super::super::try_kernel(
                 gpu,
                 "gated_delta_rule_snap",
@@ -325,7 +327,8 @@ impl Qwen3SsmLayer {
                 "gdn_verify_fused_conv_kn_f32",
                 "gdn_verify_fused_conv_kn_f32",
             ),
-            // wy17 only present in qwen3.6-35b-a3b's PTX module set; NULL on other targets.
+            // wy17 ships only in qwen3.6-35b-a3b's and qwen3.6-27b's PTX sets;
+            // NULL elsewhere (declared [expected_absent] in those MODEL.tomls).
             // decode_batched(K=17) checks for non-NULL before dispatching the fused path.
             gdn_wy17_k: super::super::try_kernel(
                 gpu,

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -307,6 +307,24 @@ impl Qwen3SsmLayer {
                 "gdn_verify_fused_conv_kn",
                 "gdn_verify_fused_conv_kn_batched",
             ),
+            // Exact-verify `_snap` twins (#435): model-shadow staged
+            // (qwen3.6-27b/nvfp4), 0 elsewhere — the exact arm then uses the
+            // parent kernel + copy_d2d snapshots (same bits, more launches).
+            gdn_f32_norm_snap_k: super::super::try_kernel(
+                gpu,
+                "gated_delta_rule_snap",
+                "gated_delta_rule_decode_f32_norm_snap",
+            ),
+            gdn_f32_strided_norm_snap_k: super::super::try_kernel(
+                gpu,
+                "gated_delta_rule_snap",
+                "gated_delta_rule_decode_f32_strided_norm_snap",
+            ),
+            gdn_verify_fused_conv_kn_f32_k: super::super::try_kernel(
+                gpu,
+                "gdn_verify_fused_conv_kn_f32",
+                "gdn_verify_fused_conv_kn_f32",
+            ),
             // wy17 only present in qwen3.6-35b-a3b's PTX module set; NULL on other targets.
             // decode_batched(K=17) checks for non-NULL before dispatching the fused path.
             gdn_wy17_k: super::super::try_kernel(

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -230,6 +230,15 @@ pub struct Qwen3SsmLayer {
     gdn_verify_fused_conv_kn_k: KernelHandle,
     /// Batched twin (gridDim.y = n_seq) — batched spec decode. 0 when absent.
     gdn_verify_fused_conv_kn_batched_k: KernelHandle,
+    /// Exact-verify `_snap` twins (issue #435 route (a)): the fused-norm
+    /// decode kernels with an inline per-token h-state rollback snapshot, and
+    /// the FP32-output fused verify conv. All OPTIONAL (model-shadow staged,
+    /// currently qwen3.6-27b/nvfp4 only): a 0 handle makes the exact arm fall
+    /// back to the parent kernel + `copy_d2d_async` snapshots — the same
+    /// bits, more launches.
+    gdn_f32_norm_snap_k: KernelHandle,
+    gdn_f32_strided_norm_snap_k: KernelHandle,
+    gdn_verify_fused_conv_kn_f32_k: KernelHandle,
     /// WY-Chunkwise K=17 GDN verify (DFlash γ+1). Only present in
     /// qwen3.6-35b-a3b's PTX module set; NULL handle for other targets,
     /// in which case decode_batched(K=17) falls through to the sequential
@@ -409,7 +418,9 @@ pub(crate) mod ssm_h_fp16;
 mod trait_decode;
 mod trait_decode_batched;
 mod trait_decode_batched_conv_gdn;
+mod trait_decode_batched_conv_gdn_exact;
 mod trait_decode_batched_conv_gdn_multi;
+mod trait_decode_batched_conv_gdn_multi_exact;
 mod trait_decode_batched_conv_gdn_wyn;
 mod trait_decode_multi_seq;
 mod trait_layer;
@@ -423,6 +434,7 @@ mod trait_prefill_recur;
 
 pub use gdn_flags::{
     GdnFlags, gdn_fused_norm_enabled, ssm_batched_recurrent_enabled, ssm_h_fp16_enabled,
+    verify_exact_enabled,
 };
 
 // ── TransformerLayer impl (delegates to per-file inherent _inner methods) ──

--- a/crates/spark-model/src/layers/qwen3_ssm/tests.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/tests.rs
@@ -30,3 +30,230 @@ fn test_ssm_state_allocation_sizes() {
     assert!(!h_state.is_null());
     assert!(!conv_state.is_null());
 }
+
+// ── Batched-verify QKVZ/out_proj dispatch on native-FP8-GDN checkpoints ──
+//
+// Regression tests for the CUDA_ERROR_ILLEGAL_ADDRESS at the FIRST n>=2
+// batched MTP verify (ks=[4,3] ⇒ R=7) on nvidia/Qwen3.6-27B-NVFP4: the
+// qwen35_dense.rs native-FP8 GDN arm leaves the dense/NVFP4 QKVZ and
+// out_proj slots NULL (`qkvz_fp8w`/`out_proj_fp8w` are the only live
+// weights), and `decode_batched_inner`'s fp8w arms stopped at
+// num_tokens <= 4 — so R > 4 fell through to `dense_gemm`/`w4a16_gemm`
+// on the NULL slots, destroying the CUDA context (sticky 700).
+// Localized on hardware via ATLAS_K4_DIAG=1: "CUDA error after GDN phase
+// `2+3:qkvz_proj+deinterleave`".
+
+use crate::layer::TransformerLayer;
+use crate::weight_map::WeightQuantFormat;
+use spark_runtime::buffers::BufferArena;
+
+/// Wire a layer exactly like the qwen35_dense.rs native-FP8 GDN arm:
+/// dense QKVZ slot NULL, out_proj a null QuantizedWeight, no NVFP4 fields;
+/// `with_qkvz_fp8w` / `with_out_fp8w` control the block-scaled FP8 pair.
+fn native_fp8_gdn_layer(
+    gpu: &MockGpuBackend,
+    config: &ModelConfig,
+    with_qkvz_fp8w: bool,
+    with_out_fp8w: bool,
+) -> Qwen3SsmLayer {
+    let h = config.hidden_size;
+    let qkvz_size = config.ssm_qkvz_size();
+    let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+    let dw = |bytes: usize| DenseWeight {
+        weight: gpu.alloc(bytes).unwrap(),
+    };
+    let ssm = SsmWeights {
+        in_proj_qkvz: DenseWeight {
+            weight: DevicePtr::NULL,
+        },
+        in_proj_ba: dw(config.ssm_ba_size() * h * 2),
+        conv1d: dw(
+            (2 * config.linear_num_key_heads * config.linear_key_head_dim + value_dim)
+                * config.linear_conv_kernel_dim
+                * 2,
+        ),
+        a_log: dw(config.linear_num_value_heads * 4),
+        dt_bias: dw(config.linear_num_value_heads * 4),
+        norm: dw(config.linear_value_head_dim * 2),
+        out_proj: QuantizedWeight::null(),
+    };
+    let mut layer = Qwen3SsmLayer::new_sequential(
+        dw(h * 2),
+        ssm,
+        dw(h * 2),
+        FfnComponent::None,
+        None,
+        None,
+        None,
+        config,
+        gpu,
+    )
+    .unwrap();
+    let fp8 = |n: usize, k: usize| Fp8Weight {
+        weight: gpu.alloc(n * k).unwrap(),
+        row_scale: gpu.alloc((n / 128) * (k / 128) * 4).unwrap(),
+        n: n as u32,
+        k: k as u32,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    };
+    layer.set_fp8_decode_weights(
+        with_qkvz_fp8w.then(|| fp8(qkvz_size, h)),
+        with_out_fp8w.then(|| fp8(h, value_dim)),
+    );
+    layer
+}
+
+/// SSM state with `n_inter` pool-style intermediates (enough for K=4).
+fn mk_state(gpu: &MockGpuBackend, layer: &Qwen3SsmLayer, n_inter: usize) -> SsmLayerState {
+    let h_bytes = layer.h_state_bytes;
+    let conv_bytes = layer.conv_state_bytes;
+    // One contiguous slab per family, mirroring the ssm_pool layout.
+    let h_slab = gpu.alloc(h_bytes * n_inter).unwrap();
+    let conv_slab = gpu.alloc(conv_bytes * n_inter).unwrap();
+    SsmLayerState {
+        h_state: gpu.alloc(h_bytes).unwrap(),
+        conv_state: gpu.alloc(conv_bytes).unwrap(),
+        h_state_checkpoint: None,
+        conv_state_checkpoint: None,
+        h_state_intermediates: (0..n_inter).map(|i| h_slab.offset(i * h_bytes)).collect(),
+        conv_state_intermediates: (0..n_inter)
+            .map(|i| conv_slab.offset(i * conv_bytes))
+            .collect(),
+        h_is_f16: false,
+    }
+}
+
+/// Drive the batched verify body at ragged ks through `decode_verify_multi`
+/// (the verify_e.rs entry point) and return the result.
+fn run_batched_verify(
+    gpu: &MockGpuBackend,
+    config: &ModelConfig,
+    layer: &Qwen3SsmLayer,
+    ks: &[usize],
+) -> anyhow::Result<()> {
+    let buffers = BufferArena::new(config, 64, 4096, 16, 32, gpu).unwrap();
+    let dispatch = crate::layers::ops::GemmDispatch::defaults();
+    let derived = crate::layers::ops::DerivedWeights::new();
+    let levers = crate::layers::ops::ModelLevers::defaults();
+    let stats = crate::layers::ops::ModelStats::new();
+    let ctx = ForwardContext {
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        buffers: &buffers,
+        gpu,
+        config,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+    };
+    let kv_config = spark_runtime::kv_cache::KvCacheConfig {
+        block_size: 16,
+        num_kv_heads: 2,
+        head_dim: 128,
+        num_layers: config.num_hidden_layers,
+        dtype: spark_runtime::kv_cache::KvCacheDtype::Bf16,
+        layer_dtypes: vec![],
+        layer_dims: vec![],
+        cache_blocks_per_seq: None,
+    };
+    let mut kv = spark_runtime::kv_cache::PagedKvCache::new(kv_config, 8, gpu).unwrap();
+    let mut states_own: Vec<SsmLayerState> = ks.iter().map(|_| mk_state(gpu, layer, 4)).collect();
+    let mut states: Vec<&mut (dyn LayerState + 'static)> = states_own
+        .iter_mut()
+        .map(|s| s as &mut (dyn LayerState + 'static))
+        .collect();
+    layer.decode_verify_multi(
+        buffers.hidden_states(),
+        buffers.residual(),
+        ks.len(),
+        ks,
+        &mut states,
+        &mut kv,
+        DevicePtr::NULL, // no staged WY tables → per-sequence GDN loop
+        &ctx,
+        0,
+    )
+}
+
+/// POSITIVE: R = 4+3 = 7 on an fp8w-only layer must dispatch the
+/// block-scaled W8A16 GEMM for BOTH projections and succeed. Before the
+/// fix this fell through to `dense_gemm`/`w4a16_gemm` on NULL slots
+/// (device 700 in production; here the fail-fast guards turn it into Err,
+/// so `is_ok` is the load-bearing assertion).
+#[test]
+fn native_fp8_gdn_batched_verify_r7_dispatches_w8a16_gemm() {
+    let config = ModelConfig::qwen3_next_80b_nvfp4();
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_gdn_layer(&gpu, &config, true, true);
+    run_batched_verify(&gpu, &config, &layer, &[4, 3]).unwrap();
+    // Pin the arm identity: w8a16_gemm_pipelined geometry at M=7 —
+    // QKVZ (N=12288): grid [ceil(12288/32)=384, ceil(7/128)=1, 1];
+    // out_proj (N=2048): grid [64, 1, 1]; both block [256,1,1].
+    let launches = (0..gpu.launch_count()).count();
+    assert!(launches > 0);
+    let seen = gpu_launch_grids(&gpu);
+    assert!(
+        seen.contains(&([384, 1, 1], [256, 1, 1])),
+        "QKVZ w8a16_gemm_pipelined launch missing; grids seen: {seen:?}"
+    );
+    assert!(
+        seen.contains(&([64, 1, 1], [256, 1, 1])),
+        "out_proj w8a16_gemm_pipelined launch missing; grids seen: {seen:?}"
+    );
+}
+
+/// POSITIVE (existing behavior guard): uniform R = 2+2 = 4 keeps the
+/// M<=4 `w8a16_gemv_batch4` arm working.
+#[test]
+fn native_fp8_gdn_batched_verify_r4_still_ok() {
+    let config = ModelConfig::qwen3_next_80b_nvfp4();
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_gdn_layer(&gpu, &config, true, true);
+    run_batched_verify(&gpu, &config, &layer, &[2, 2]).unwrap();
+}
+
+/// NEGATIVE: no QKVZ weight in ANY form at R=7 must fail fast with the
+/// dispatch error — never launch `dense_gemm` on the NULL dense slot
+/// (that launch is the production context-killer).
+#[test]
+fn batched_verify_null_qkvz_fails_fast() {
+    let config = ModelConfig::qwen3_next_80b_nvfp4();
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_gdn_layer(&gpu, &config, false, false);
+    let err = run_batched_verify(&gpu, &config, &layer, &[4, 3])
+        .expect_err("NULL QKVZ slot must be refused, not launched");
+    assert!(
+        format!("{err:#}").contains("batched GDN QKVZ dispatch"),
+        "wrong error: {err:#}"
+    );
+}
+
+/// NEGATIVE: QKVZ fp8w present but out_proj missing in every form at R=7
+/// must fail fast on the out_proj guard.
+#[test]
+fn batched_verify_null_out_proj_fails_fast() {
+    let config = ModelConfig::qwen3_next_80b_nvfp4();
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_gdn_layer(&gpu, &config, true, false);
+    let err = run_batched_verify(&gpu, &config, &layer, &[4, 3])
+        .expect_err("null out_proj must be refused, not launched");
+    assert!(
+        format!("{err:#}").contains("batched GDN out_proj dispatch"),
+        "wrong error: {err:#}"
+    );
+}
+
+/// Grid/block pairs of every launch recorded by the mock.
+fn gpu_launch_grids(gpu: &MockGpuBackend) -> Vec<([u32; 3], [u32; 3])> {
+    gpu.launches_snapshot()
+        .into_iter()
+        .map(|l| (l.grid, l.block))
+        .collect()
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -183,6 +183,50 @@ impl Qwen3SsmLayer {
                 h as u32,
                 stream,
             )?;
+        } else if num_tokens > 4
+            && (self.w8a16_gemm_pipelined_k.0 != 0 || self.w8a16_gemm_k.0 != 0)
+            && let Some(ref fp8) = self.qkvz_fp8w
+        {
+            // Batched MTP verify at R = Σ ks > 4 on native-FP8-GDN checkpoints
+            // (e.g. nvidia/Qwen3.6-27B-NVFP4): `qkvz_fp8w` is the ONLY live
+            // QKVZ weight — the dense, NVFP4 and single-scale-FP8 slots are
+            // all NULL/None (qwen35_dense.rs native-FP8 GDN arm) — and the
+            // fp8w arm above stops at 4 because `w8a16_gemv_batch4` is an
+            // M<=4 kernel. Without this arm the dispatch fell through to
+            // `dense_gemm` on the NULL dense slot: CUDA_ERROR_ILLEGAL_ADDRESS
+            // on the FIRST n>=2 batched verify (ks=[4,3] ⇒ R=7), a sticky
+            // context loss that 503s the whole serve. Third instance of this
+            // NULL-slot dispatch-gap class (see the 2..=4 arm's history);
+            // route through the SAME block-scaled W8A16 GEMM the SSM prefill
+            // path uses (`trait_prefill_proj.rs` — pipelined twin preferred,
+            // bit-identical to `w8a16_gemm`).
+            if self.w8a16_gemm_pipelined_k.0 != 0 {
+                ops::w8a16_gemm_pipelined(
+                    ctx.gpu,
+                    self.w8a16_gemm_pipelined_k,
+                    normed,
+                    fp8.weight,
+                    fp8.row_scale,
+                    proj_dst,
+                    k,
+                    qkvz_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            } else {
+                ops::w8a16_gemm(
+                    ctx.gpu,
+                    self.w8a16_gemm_k,
+                    normed,
+                    fp8.weight,
+                    fp8.row_scale,
+                    proj_dst,
+                    k,
+                    qkvz_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            }
         } else if num_tokens == 4 {
             if let Some(ref nvfp4) = self.qkvz_nvfp4 {
                 ops::w4a16_gemv_batchm(
@@ -347,6 +391,20 @@ impl Qwen3SsmLayer {
                 stream,
             )?;
         } else {
+            // Fail fast: launching `dense_gemm` on a NULL weight is a device
+            // ILLEGAL_ADDRESS that destroys the CUDA context for every live
+            // request (sticky 700). A checkpoint whose QKVZ ships only in a
+            // form this dispatch has no arm for must error per-request, not
+            // kill the serve.
+            anyhow::ensure!(
+                !self.ssm.in_proj_qkvz.weight.is_null(),
+                "batched GDN QKVZ dispatch: no usable weight for num_tokens={num_tokens} \
+                 (dense slot NULL; fp8w={}, nvfp4={}, gemm kernels pipelined/base: {:#x}/{:#x})",
+                self.qkvz_fp8w.is_some(),
+                self.qkvz_nvfp4.is_some(),
+                self.w8a16_gemm_pipelined_k.0,
+                self.w8a16_gemm_k.0,
+            );
             ops::dense_gemm(
                 ctx.gpu,
                 self.dense_gemm_k,
@@ -800,12 +858,54 @@ impl Qwen3SsmLayer {
                 value_dim as u32,
                 stream,
             )?;
-        } else if num_tokens > 8 && self.out_proj_nvfp4_t.is_some() && {
-            // Kill switch, PRESENCE check per house convention (`=0` is NOT
-            // off), cached once.
-            static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-            !*OFF.get_or_init(|| std::env::var("ATLAS_NO_VERIFY_OUTPROJ_TGEMM").is_ok())
-        } {
+        } else if num_tokens > 4
+            && (self.w8a16_gemm_pipelined_k.0 != 0 || self.w8a16_gemm_k.0 != 0)
+            && let Some(ref fp8) = self.out_proj_fp8w
+        {
+            // Batched MTP verify at R = Σ ks > 4 on native-FP8-GDN
+            // checkpoints: `out_proj_fp8w` is the ONLY live out_proj weight
+            // (dense/NVFP4 slots NULL — qwen35_dense.rs native-FP8 GDN arm)
+            // and the fp8w arm above stops at 4. Without this arm the
+            // dispatch fell through to `w4a16_gemm` on the null
+            // `ssm.out_proj` — the out_proj half of the same
+            // CUDA_ERROR_ILLEGAL_ADDRESS the QKVZ dispatch above hits first.
+            // Same block-scaled W8A16 GEMM pair as the prefill path.
+            if self.w8a16_gemm_pipelined_k.0 != 0 {
+                ops::w8a16_gemm_pipelined(
+                    ctx.gpu,
+                    self.w8a16_gemm_pipelined_k,
+                    normed_out_buf,
+                    fp8.weight,
+                    fp8.row_scale,
+                    out_proj_buf,
+                    k,
+                    h as u32,
+                    value_dim as u32,
+                    stream,
+                )?;
+            } else {
+                ops::w8a16_gemm(
+                    ctx.gpu,
+                    self.w8a16_gemm_k,
+                    normed_out_buf,
+                    fp8.weight,
+                    fp8.row_scale,
+                    out_proj_buf,
+                    k,
+                    h as u32,
+                    value_dim as u32,
+                    stream,
+                )?;
+            }
+        } else if num_tokens > 8
+            && let Some(ref nvfp4_t) = self.out_proj_nvfp4_t
+            && {
+                // Kill switch, PRESENCE check per house convention (`=0` is NOT
+                // off), cached once.
+                static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+                !*OFF.get_or_init(|| std::env::var("ATLAS_NO_VERIFY_OUTPROJ_TGEMM").is_ok())
+            }
+        {
             // M > 8 (batched K=4 verify, R = n*4 rows; DFlash wide verify):
             // the pre-dequanted FP8 prefill arm below reads 2x the weight
             // bytes of NVFP4 — bandwidth-bound at this M, measured 379 us
@@ -816,7 +916,6 @@ impl Qwen3SsmLayer {
             // (`deep_k_gemm`). BF16 activations (vs the FP8 arm's e4m3
             // downcast) — equal-or-better numerics, not byte-identical.
             // Kill switch ATLAS_NO_VERIFY_OUTPROJ_TGEMM (PRESENCE check).
-            let nvfp4_t = self.out_proj_nvfp4_t.as_ref().unwrap();
             ops::w4a16_gemm_n128(
                 ctx.gpu,
                 self.deep_k_gemm(value_dim as u32),
@@ -904,6 +1003,17 @@ impl Qwen3SsmLayer {
                 )?;
             }
         } else {
+            // Fail fast: a null out_proj here is the same sticky-700 context
+            // killer as the QKVZ dense arm above — refuse per-request instead.
+            anyhow::ensure!(
+                !self.ssm.out_proj.weight.is_null(),
+                "batched GDN out_proj dispatch: no usable weight for num_tokens={num_tokens} \
+                 (quant slot NULL; fp8w={}, dense={}, gemm kernels pipelined/base: {:#x}/{:#x})",
+                self.out_proj_fp8w.is_some(),
+                self.out_proj_dense.is_some(),
+                self.w8a16_gemm_pipelined_k.0,
+                self.w8a16_gemm_k.0,
+            );
             ops::w4a16_gemm(
                 ctx.gpu,
                 self.w4a16_gemm_k,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -502,6 +502,7 @@ impl Qwen3SsmLayer {
                     gates_buf,
                     conv_out_buf,
                     gdn_out_buf,
+                    normed_out: conv_out_buf, // row0 == 0: bases coincide
                     h_bytes,
                     conv_bytes,
                     qkvz_size,
@@ -570,6 +571,10 @@ impl Qwen3SsmLayer {
                         gates_buf: gates_buf.offset(row0 * nv * 2 * fp32),
                         conv_out_buf: conv_out_buf.offset(row0 * conv_dim * bf16),
                         gdn_out_buf: gdn_out_buf.offset(row0 * value_dim * bf16),
+                        // Normed rows stride value_dim from ROW 0 of the
+                        // phase-8/9 buffer — a conv_dim-scaled offset here
+                        // would land the exact arm's output between rows.
+                        normed_out: conv_out_buf.offset(row0 * value_dim * bf16),
                         h_bytes,
                         conv_bytes,
                         qkvz_size,
@@ -622,6 +627,7 @@ impl Qwen3SsmLayer {
                                 gates_buf: gates_buf.offset(r * nv * 2 * fp32),
                                 conv_out_buf: conv_out_buf.offset(r * conv_dim * bf16),
                                 gdn_out_buf: gdn_out_buf.offset(r * value_dim * bf16),
+                                normed_out: conv_out_buf.offset(r * value_dim * bf16),
                                 h_bytes,
                                 conv_bytes,
                                 qkvz_size,
@@ -651,7 +657,13 @@ impl Qwen3SsmLayer {
         // ── 8. Gated RMS norm per token (Z gate at [Q|K|V] offset) ──
         let normed_out_buf = conv_out_buf;
         let z_offset = key_dim * 2 + value_dim; // == conv_dim
-        if num_tokens == 2 && self.fused_verify_k2_enabled() {
+        if super::verify_exact_enabled() {
+            // Issue #435 exact arm (phase 5-7 above): the norm is already
+            // applied inside the per-token chain — the SAME fused/unfused arm
+            // sequential decode uses — and the normed rows are already in
+            // `normed_out_buf` at value_dim BF16 stride. Running any norm
+            // here would re-normalize final output with stale gdn_out data.
+        } else if num_tokens == 2 && self.fused_verify_k2_enabled() {
             // STAGE 1: single-launch gated-RMS-norm for BOTH positions (cos==1.0).
             ops::gdn_verify_fused_norm_k2(
                 ctx.gpu,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -320,6 +320,23 @@ impl Qwen3SsmLayer {
         // must never read (verify_exact_enabled() is false when h_f16 is
         // set). Phase 8 in decode_batched_inner reads the SAME predicate to
         // skip its norm — the exact arm writes the final normed rows itself.
+        //
+        // OWED (default-divergence mitigation, investigated 2026-08-09, not
+        // implemented — needs GPU-validated kernel twins): the DOMINANT #435
+        // term (~8.6e-4 of the total; the chunkwise reordering term is only
+        // ~3.4e-8) is the BF16 conv-output STORE, not the WY algebra. The
+        // arms below consume `causal_conv1d_update_l2norm` /
+        // `gdn_verify_fused_conv_kn` whose only difference from the `_f32`
+        // twins sequential decode prefers (ssm_forward.rs:222) is
+        // `__float2bfloat16(silu)` at the store; that rounding of k/v is then
+        // committed into the FP32 H state by the WY update. Feeding these
+        // arms FP32 conv rows (the `_f32` conv kernels already exist) and
+        // adding FP32-input twins of the WY family (wy2/wy3/wy4 + resident +
+        // strided) would cut the default divergence ~4 orders of magnitude
+        // for ~1% extra traffic — the WY kernels are bandwidth-bound on H
+        // state (~16 MB/layer/step vs ~120 KB of extra conv-row bytes). It
+        // would NOT make spec-on bitwise-equal to spec-off; only
+        // `--exact-verify` does that.
         if super::verify_exact_enabled() {
             return self.decode_batched_conv_gdn_exact(ssm_state, ctx, args);
         }

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -310,14 +310,16 @@ impl Qwen3SsmLayer {
             stream,
         } = *args;
 
-        // ── Issue #435 route (a), DEFAULT: the sequential-decode-exact chain
-        // (bitwise-equal to spec-off decode). All K widths. The WY / fused
-        // BF16-conv arms below survive behind `--verify-wy` for A/B; they are
-        // also the fallback under `--ssm-h-dtype f16`, whose FP16 pool the
-        // exact arm's FP32 kernels must never read (verify_exact_enabled()
-        // is false when h_f16 is set). Phase 8 in decode_batched_inner reads
-        // the SAME predicate to skip its norm — the exact arm writes the
-        // final normed rows itself.
+        // ── Issue #435 route (a), OPT-IN via `--exact-verify`: the
+        // sequential-decode-exact chain (bitwise-equal to spec-off decode).
+        // All K widths. The WY / fused BF16-conv arms below are the DEFAULT —
+        // fast, but NOT bitwise-equal to spec-off (#435's divergence remains
+        // unless the flag is given; measured decode-step cost of exact is
+        // ~+22-36% at the n=8/16/32 rungs). They are also mandatory under
+        // `--ssm-h-dtype f16`, whose FP16 pool the exact arm's FP32 kernels
+        // must never read (verify_exact_enabled() is false when h_f16 is
+        // set). Phase 8 in decode_batched_inner reads the SAME predicate to
+        // skip its norm — the exact arm writes the final normed rows itself.
         if super::verify_exact_enabled() {
             return self.decode_batched_conv_gdn_exact(ssm_state, ctx, args);
         }

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -63,6 +63,13 @@ pub(super) struct ConvGdnArgs {
     pub gates_buf: DevicePtr,
     pub conv_out_buf: DevicePtr,
     pub gdn_out_buf: DevicePtr,
+    /// Final normed-output base for THIS call's rows: the phase-8/9 buffer
+    /// (== conv_out_buf's UN-offset base) advanced by `row0 * value_dim`
+    /// BF16 — NOT by `row0 * conv_dim` like `conv_out_buf`, because phase 9
+    /// reads normed rows at `value_dim` stride from row 0. Only the exact
+    /// verify arm writes through this (its norm runs in-loop); the WY arms
+    /// leave the norm to phase 8, which derives its own destination.
+    pub normed_out: DevicePtr,
     pub h_bytes: usize,
     pub conv_bytes: usize,
     pub qkvz_size: usize,
@@ -285,6 +292,7 @@ impl Qwen3SsmLayer {
             gates_buf,
             conv_out_buf,
             gdn_out_buf,
+            normed_out: _,
             h_bytes,
             conv_bytes,
             qkvz_size,
@@ -301,6 +309,18 @@ impl Qwen3SsmLayer {
             fp32,
             stream,
         } = *args;
+
+        // ── Issue #435 route (a), DEFAULT: the sequential-decode-exact chain
+        // (bitwise-equal to spec-off decode). All K widths. The WY / fused
+        // BF16-conv arms below survive behind `--verify-wy` for A/B; they are
+        // also the fallback under `--ssm-h-dtype f16`, whose FP16 pool the
+        // exact arm's FP32 kernels must never read (verify_exact_enabled()
+        // is false when h_f16 is set). Phase 8 in decode_batched_inner reads
+        // the SAME predicate to skip its norm — the exact arm writes the
+        // final normed rows itself.
+        if super::verify_exact_enabled() {
+            return self.decode_batched_conv_gdn_exact(ssm_state, ctx, args);
+        }
 
         if num_tokens == 4 {
             // ── K=4 fused path: conv1d+L2norm sequential, GDN WY4 ──

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_exact.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_exact.rs
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Exact MTP-verify conv+GDN arm (issue #435 route (a), PR1).
+//! Exact MTP-verify conv+GDN arm (issue #435 route (a)) — OPT-IN via
+//! `--exact-verify`.
 //!
-//! At temp 0, spec-on output must equal spec-off output. The WY/fused verify
-//! arms broke that in two ways: the verify conv ran the BF16-output kernel
-//! where sequential decode runs the FP32 one (h-state relL2 ~8.6e-4 after one
-//! K=4 window — the dominant term), and the WY chunkwise reordering differs
-//! from the recurrent update by ~3.4e-8 — four orders smaller but nonzero,
-//! and an argmax flip only needs a per-logit error above a thin top-2 margin.
+//! By default this arm does NOT run: the verify pass runs the WY/fused
+//! chunkwise arms, so spec-on output is NOT bitwise-equal to spec-off at
+//! temp 0 — #435's divergence remains with default settings, and
+//! `--exact-verify` is the flag that removes it (measured decode-step cost
+//! ~+35% at n=8/K=4, ~+22% at n=16/K=2, ~+36% at n=32/K=2; every surveyed
+//! production engine ships exactness as the same kind of opt-in).
+//!
+//! The WY/fused verify arms diverge in two ways: the verify conv runs the
+//! BF16-output kernel where sequential decode runs the FP32 one (h-state
+//! relL2 ~8.6e-4 after one K=4 window — the dominant term), and the WY
+//! chunkwise reordering differs from the recurrent update by ~3.4e-8 — four
+//! orders smaller but nonzero, and an argmax flip only needs a per-logit
+//! error above a thin top-2 margin.
 //!
 //! This arm runs, per verify token, EXACTLY the kernel chain `ssm_forward`
 //! (the single-token decode reference) runs — same handles, same launch
@@ -30,10 +38,10 @@
 //! phase-8 norm when `verify_exact_enabled()` — both sites read that one
 //! predicate.
 //!
-//! Kill switch: `--verify-wy` restores the WY/fused arms for A/B. Default is
-//! exact, because this is a correctness fix. Every dispatch decision below is
-//! a pure function of (process-static flags, kernel handles, the slot's fixed
-//! intermediate addresses), so it is CUDA-graph-stable.
+//! Kill switch: omit `--exact-verify` (the default) to run the WY/fused arms.
+//! Every dispatch decision below is a pure function of (process-static flags,
+//! kernel handles, the slot's fixed intermediate addresses), so it is
+//! CUDA-graph-stable.
 
 use anyhow::Result;
 use spark_runtime::gpu::DevicePtr;
@@ -159,10 +167,10 @@ impl Qwen3SsmLayer {
         static LOGGED: std::sync::Once = std::sync::Once::new();
         LOGGED.call_once(|| {
             tracing::info!(
-                "EXACT MTP verify ENGAGED (#435 route (a)): per-token sequential-decode \
-                 kernel chain (f32_conv={use_f32_conv}, fused_gdn_norm={fused_gdn_norm}, \
-                 snap_twin={snap}, fused_f32_conv={fused_conv}); WY arms restorable \
-                 with --verify-wy"
+                "EXACT MTP verify ENGAGED (#435 route (a), opt-in --exact-verify): \
+                 per-token sequential-decode kernel chain (f32_conv={use_f32_conv}, \
+                 fused_gdn_norm={fused_gdn_norm}, snap_twin={snap}, \
+                 fused_f32_conv={fused_conv}); omit the flag for the default WY arms"
             );
         });
 

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_exact.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_exact.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exact MTP-verify conv+GDN arm (issue #435 route (a), PR1).
+//!
+//! At temp 0, spec-on output must equal spec-off output. The WY/fused verify
+//! arms broke that in two ways: the verify conv ran the BF16-output kernel
+//! where sequential decode runs the FP32 one (h-state relL2 ~8.6e-4 after one
+//! K=4 window — the dominant term), and the WY chunkwise reordering differs
+//! from the recurrent update by ~3.4e-8 — four orders smaller but nonzero,
+//! and an argmax flip only needs a per-logit error above a thin top-2 margin.
+//!
+//! This arm runs, per verify token, EXACTLY the kernel chain `ssm_forward`
+//! (the single-token decode reference) runs — same handles, same launch
+//! geometry, same argument values — so the h-state, conv-state and normed
+//! output are bitwise what sequential decode would have produced from the
+//! same inputs. Decode dispatch is untouched anywhere in this change, so
+//! spec-OFF is bit-unchanged by construction.
+//!
+//! Rollback snapshots: the `_snap` kernel twin
+//! (`gated_delta_rule_decode_f32_norm_snap`, model-shadow staged) writes the
+//! per-token h-state intermediate inline — the same bits the recurrence just
+//! committed, following the `gdn_verify_fused_conv_kn.cu` /
+//! `gated_delta_rule_wy4.cu` precedent — and the FP32 fused verify conv
+//! (`gdn_verify_fused_conv_kn_f32`) writes the conv snapshots inline. Where
+//! either handle is 0 the arm falls back to the parent kernel plus a
+//! `copy_d2d_async` per token: identical bits, more launches.
+//!
+//! The arm also writes the FINAL gated-RMS-norm output (fused or per-token,
+//! mirroring the decode dispatch), so `decode_batched_inner` must SKIP its
+//! phase-8 norm when `verify_exact_enabled()` — both sites read that one
+//! predicate.
+//!
+//! Kill switch: `--verify-wy` restores the WY/fused arms for A/B. Default is
+//! exact, because this is a correctness fix. Every dispatch decision below is
+//! a pure function of (process-static flags, kernel handles, the slot's fixed
+//! intermediate addresses), so it is CUDA-graph-stable.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::trait_decode_batched_conv_gdn::ConvGdnArgs;
+use super::{Qwen3SsmLayer, SsmLayerState};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+
+/// Byte offsets for verify token `t` in the exact arm's buffers, plus whether
+/// `t` writes rollback intermediates. Pure — stride arithmetic is the failure
+/// mode of this arm, so it is factored out and unit-tested below.
+pub(super) struct ExactRow {
+    /// Into `deinterleaved` (BF16 bytes): token `t`'s [Q|K|V|Z] row.
+    pub qkv_in: usize,
+    /// Into `ssm_conv_out_f32` (bytes): token `t`'s FP32 conv row. Rows are
+    /// `qkvz_size` FP32 elements apart — NOT `conv_dim` — so each row keeps
+    /// its Z-region tail free for the non-fused arm's FP32 GDN output,
+    /// mirroring `ssm_forward`'s single-row layout.
+    pub conv_out_f32: usize,
+    /// Into `ssm_conv_out_f32` (bytes): token `t`'s FP32 GDN output scratch
+    /// (the row's Z-region tail, exactly `value_dim` FP32 elements).
+    pub gdn_out_f32: usize,
+    /// Into `deinterleaved` (BF16 bytes): token `t`'s Z gate.
+    pub z: usize,
+    /// Into `gates_buf` (bytes): token `t`'s gate / beta (FP32).
+    pub gate: usize,
+    pub beta: usize,
+    /// Into the `normed_out` BASE (BF16 bytes): token `t`'s final normed
+    /// output row — the row phase 9 (out_proj) reads. NOTE the base differs
+    /// from `conv_out_buf` for Multi runs (`row0 * value_dim` vs
+    /// `row0 * conv_dim` — see `ConvGdnArgs::normed_out`).
+    pub normed_out: usize,
+    /// Whether token `t` writes h/conv rollback intermediates. The index
+    /// `num_tokens - 1` has NO reader (see the reader enumeration in
+    /// `trait_decode_batched_conv_gdn.rs`), so the last token skips it.
+    pub snapshot: bool,
+}
+
+/// See [`ExactRow`]. `fp32`/`bf16` are element sizes in bytes.
+pub(super) fn exact_row(
+    t: usize,
+    num_tokens: usize,
+    qkvz_size: usize,
+    conv_dim: usize,
+    value_dim: usize,
+    nv: usize,
+) -> ExactRow {
+    let (bf16, fp32) = (2usize, 4usize);
+    let gate = t * nv * 2 * fp32;
+    ExactRow {
+        qkv_in: t * qkvz_size * bf16,
+        conv_out_f32: t * qkvz_size * fp32,
+        gdn_out_f32: t * qkvz_size * fp32 + conv_dim * fp32,
+        z: t * qkvz_size * bf16 + conv_dim * bf16,
+        gate,
+        beta: gate + nv * fp32,
+        normed_out: t * value_dim * bf16,
+        snapshot: t + 1 < num_tokens,
+    }
+}
+
+impl Qwen3SsmLayer {
+    /// The sequential-decode-exact conv+GDN+norm chain over `num_tokens`
+    /// verify positions of ONE sequence. Bitwise contract: after this call,
+    /// `h_state`, `conv_state`, the rollback intermediates 0..K-2 and the
+    /// normed output rows hold exactly the bits `num_tokens` invocations of
+    /// `ssm_forward`'s conv/GDN/norm chain would have produced.
+    pub(super) fn decode_batched_conv_gdn_exact(
+        &self,
+        ssm_state: &mut SsmLayerState,
+        ctx: &ForwardContext,
+        args: &ConvGdnArgs,
+    ) -> Result<()> {
+        let ConvGdnArgs {
+            num_tokens,
+            deinterleaved,
+            gates_buf,
+            conv_out_buf,
+            gdn_out_buf,
+            normed_out,
+            h_bytes,
+            conv_bytes,
+            qkvz_size,
+            conv_dim,
+            key_dim,
+            value_dim,
+            d_conv,
+            qk_ch,
+            nk,
+            nv,
+            kd,
+            vd,
+            bf16,
+            fp32,
+            stream,
+        } = *args;
+        let eps = ctx.config.rms_norm_eps as f32;
+
+        // ── Kernel selection: the SAME decision tree as `ssm_forward` ──
+        let use_f32_conv = self.conv1d_l2norm_f32_k.0 != 0;
+        let use_f32_gdn = self.gdn_f32_k.0 != 0 && self.gated_rms_norm_f32_k.0 != 0;
+        let fused_gdn_norm = use_f32_gdn
+            && self.gdn_f32_norm_k.0 != 0
+            && crate::layers::qwen3_ssm::gdn_fused_norm_enabled();
+        let snap = fused_gdn_norm && self.gdn_f32_norm_snap_k.0 != 0;
+        let f32_conv_base = ctx.buffers.ssm_conv_out_f32();
+
+        // FP32 fused verify conv: one launch for all K positions with the
+        // conv-state snapshots written inline — requires the pool-contiguous
+        // intermediate layout it writes to (always true for ssm_pool slots;
+        // CHECKED, and constant for a given slot ⇒ graph-stable).
+        let conv_inter_base = ssm_state.conv_state_intermediates[0];
+        let fused_conv = use_f32_conv
+            && self.gdn_verify_fused_conv_kn_f32_k.0 != 0
+            && ssm_state
+                .conv_state_intermediates
+                .iter()
+                .take(num_tokens)
+                .enumerate()
+                .all(|(t, p)| p.0 == conv_inter_base.0 + (t * conv_bytes) as u64);
+
+        static LOGGED: std::sync::Once = std::sync::Once::new();
+        LOGGED.call_once(|| {
+            tracing::info!(
+                "EXACT MTP verify ENGAGED (#435 route (a)): per-token sequential-decode \
+                 kernel chain (f32_conv={use_f32_conv}, fused_gdn_norm={fused_gdn_norm}, \
+                 snap_twin={snap}, fused_f32_conv={fused_conv}); WY arms restorable \
+                 with --verify-wy"
+            );
+        });
+
+        if fused_conv {
+            ops::gdn_verify_fused_conv_kn_f32(
+                ctx.gpu,
+                self.gdn_verify_fused_conv_kn_f32_k,
+                ssm_state.conv_state,
+                deinterleaved,
+                &self.ssm.conv1d,
+                f32_conv_base,
+                conv_inter_base,
+                num_tokens as u32,
+                conv_dim as u32,
+                d_conv as u32,
+                qk_ch,
+                kd as u32,
+                qkvz_size as u32, // input stride (BF16 elems between positions)
+                qkvz_size as u32, // output stride (FP32 elems between positions)
+                (conv_bytes / 4) as u32, // snapshot stride (FP32 elems)
+                1e-6,
+                stream,
+            )?;
+        }
+
+        for t in 0..num_tokens {
+            let row = exact_row(t, num_tokens, qkvz_size, conv_dim, value_dim, nv);
+            let qkv_t = deinterleaved.offset(row.qkv_in);
+
+            // ── Conv1d + SiLU + L2 norm (same kernel as ssm_forward) ──
+            let (conv_out_t, conv_elem) = if use_f32_conv {
+                (f32_conv_base.offset(row.conv_out_f32), fp32)
+            } else {
+                (conv_out_buf.offset(t * conv_dim * bf16), bf16)
+            };
+            if !fused_conv {
+                ops::conv1d_update_l2norm(
+                    ctx.gpu,
+                    if use_f32_conv {
+                        self.conv1d_l2norm_f32_k
+                    } else {
+                        self.conv1d_l2norm_k
+                    },
+                    ssm_state.conv_state,
+                    qkv_t,
+                    &self.ssm.conv1d,
+                    conv_out_t,
+                    conv_dim as u32,
+                    d_conv as u32,
+                    1,
+                    qk_ch,
+                    kd as u32,
+                    1e-6,
+                    stream,
+                )?;
+                if row.snapshot {
+                    ctx.gpu.copy_d2d_async(
+                        ssm_state.conv_state,
+                        ssm_state.conv_state_intermediates[t],
+                        conv_bytes,
+                        stream,
+                    )?;
+                }
+            }
+
+            let q_t = conv_out_t;
+            let k_t = conv_out_t.offset(key_dim * conv_elem);
+            let v_t = conv_out_t.offset(key_dim * 2 * conv_elem);
+            let gate_t = gates_buf.offset(row.gate);
+            let beta_t = gates_buf.offset(row.beta);
+            let z_t = deinterleaved.offset(row.z);
+            let normed_t = normed_out.offset(row.normed_out);
+
+            // ── GDN + gated RMS norm (same arm as ssm_forward) ──
+            if fused_gdn_norm {
+                if snap {
+                    // Inline h snapshot: same bits, no d2d.
+                    let h_inter = if row.snapshot {
+                        ssm_state.h_state_intermediates[t]
+                    } else {
+                        DevicePtr::NULL
+                    };
+                    ops::gdn_decode_f32_norm_snap(
+                        ctx.gpu,
+                        self.gdn_f32_norm_snap_k,
+                        ssm_state.h_state,
+                        q_t,
+                        k_t,
+                        v_t,
+                        gate_t,
+                        beta_t,
+                        z_t,
+                        self.ssm.norm.weight,
+                        normed_t,
+                        h_inter,
+                        1,
+                        nk as u32,
+                        nv as u32,
+                        kd as u32,
+                        vd as u32,
+                        eps,
+                        stream,
+                    )?;
+                } else {
+                    ops::gdn_decode_f32_norm(
+                        ctx.gpu,
+                        self.gdn_f32_norm_k,
+                        ssm_state.h_state,
+                        q_t,
+                        k_t,
+                        v_t,
+                        gate_t,
+                        beta_t,
+                        z_t,
+                        self.ssm.norm.weight,
+                        normed_t,
+                        1,
+                        nk as u32,
+                        nv as u32,
+                        kd as u32,
+                        vd as u32,
+                        eps,
+                        stream,
+                    )?;
+                    if row.snapshot {
+                        ctx.gpu.copy_d2d_async(
+                            ssm_state.h_state,
+                            ssm_state.h_state_intermediates[t],
+                            h_bytes,
+                            stream,
+                        )?;
+                    }
+                }
+            } else {
+                // Unfused arm: FP32 GDN + FP32-input gated norm when linked
+                // (ssm_forward's `use_f32_gdn`), BF16 pair otherwise.
+                let (gdn_kernel, norm_kernel, gdn_out_t) = if use_f32_gdn {
+                    (
+                        self.gdn_f32_k,
+                        self.gated_rms_norm_f32_k,
+                        f32_conv_base.offset(row.gdn_out_f32),
+                    )
+                } else {
+                    (
+                        self.gdn_k,
+                        self.gated_rms_norm_k,
+                        gdn_out_buf.offset(t * value_dim * bf16),
+                    )
+                };
+                ops::gdn_decode(
+                    ctx.gpu,
+                    gdn_kernel,
+                    ssm_state.h_state,
+                    q_t,
+                    k_t,
+                    v_t,
+                    gate_t,
+                    beta_t,
+                    gdn_out_t,
+                    1,
+                    nk as u32,
+                    nv as u32,
+                    kd as u32,
+                    vd as u32,
+                    stream,
+                )?;
+                ops::gated_rms_norm(
+                    ctx.gpu,
+                    norm_kernel,
+                    gdn_out_t,
+                    z_t,
+                    &self.ssm.norm,
+                    normed_t,
+                    nv as u32,
+                    vd as u32,
+                    vd as u32,
+                    eps,
+                    vd as u32,
+                    stream,
+                )?;
+                if row.snapshot {
+                    ctx.gpu.copy_d2d_async(
+                        ssm_state.h_state,
+                        ssm_state.h_state_intermediates[t],
+                        h_bytes,
+                        stream,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exact_row;
+
+    // Real 27B GDN shapes: nk=16, nv=48, kd=vd=128, d_conv=4.
+    const QKVZ: usize = 16384; // conv_dim + value_dim
+    const CONV_DIM: usize = 10240; // 2*2048 + 6144
+    const VALUE_DIM: usize = 6144; // 48*128
+    const NV: usize = 48;
+
+    /// POSITIVE: token offsets stride by the ROW sizes of each buffer — qkvz
+    /// rows in `deinterleaved`/`ssm_conv_out_f32`, value_dim rows in the
+    /// normed output, 2*nv FP32 in gates — on the real 27B shapes.
+    #[test]
+    fn exact_row_strides_match_27b_shapes() {
+        let r2 = exact_row(2, 4, QKVZ, CONV_DIM, VALUE_DIM, NV);
+        assert_eq!(r2.qkv_in, 2 * QKVZ * 2, "deinterleaved rows are qkvz BF16");
+        assert_eq!(r2.conv_out_f32, 2 * QKVZ * 4, "f32 conv rows are qkvz FP32");
+        assert_eq!(
+            r2.gdn_out_f32,
+            2 * QKVZ * 4 + CONV_DIM * 4,
+            "f32 gdn scratch is the conv row's Z-region tail"
+        );
+        assert_eq!(r2.z, 2 * QKVZ * 2 + CONV_DIM * 2, "Z sits after [Q|K|V]");
+        assert_eq!(r2.gate, 2 * NV * 2 * 4, "gates rows are [gate|beta] FP32");
+        assert_eq!(r2.beta, r2.gate + NV * 4);
+        assert_eq!(
+            r2.normed_out,
+            2 * VALUE_DIM * 2,
+            "normed rows are value_dim BF16"
+        );
+        // The FP32 GDN scratch must fit inside the row's tail: exactly
+        // value_dim FP32 elements between conv_dim and qkvz_size.
+        assert_eq!(QKVZ - CONV_DIM, VALUE_DIM);
+    }
+
+    /// POSITIVE + NEGATIVE: rollback intermediates are written for tokens
+    /// 0..K-2 and NOT for K-1 (no reader exists for that index — writing it
+    /// is the dead d2d the K=4 arm removed; skipping earlier ones would break
+    /// rollback).
+    #[test]
+    fn exact_row_snapshot_skips_only_last_token() {
+        for k in 2..=8usize {
+            for t in 0..k {
+                let row = exact_row(t, k, QKVZ, CONV_DIM, VALUE_DIM, NV);
+                assert_eq!(
+                    row.snapshot,
+                    t + 1 < k,
+                    "snapshot policy wrong at t={t}, k={k}"
+                );
+            }
+        }
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
@@ -97,6 +97,14 @@ impl Qwen3SsmLayer {
     ) -> Result<bool> {
         let n = states.len();
         let kk = args.num_tokens;
+        // ── Issue #435 route (a), DEFAULT: exact batched verify (strided
+        // sequential-decode chain at batch=n, bitwise-equal to spec-off
+        // decode). Ok(false) → the caller's per-sequence loop, which under
+        // the same predicate runs the per-token exact arm — identical bits.
+        // The WY fast path below survives behind `--verify-wy` for A/B.
+        if super::verify_exact_enabled() {
+            return self.decode_batched_conv_gdn_multi_exact(states, ctx, args);
+        }
         // wy2/wy3/wy4 all carry the `state_is_table` pointer-table form, so
         // every K-vs-batch ladder width takes the two-launch path. The handle
         // is selected here (try_kernel misses are a silent 0 — gate on it,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
@@ -97,11 +97,12 @@ impl Qwen3SsmLayer {
     ) -> Result<bool> {
         let n = states.len();
         let kk = args.num_tokens;
-        // ── Issue #435 route (a), DEFAULT: exact batched verify (strided
-        // sequential-decode chain at batch=n, bitwise-equal to spec-off
-        // decode). Ok(false) → the caller's per-sequence loop, which under
-        // the same predicate runs the per-token exact arm — identical bits.
-        // The WY fast path below survives behind `--verify-wy` for A/B.
+        // ── Issue #435 route (a), OPT-IN via `--exact-verify`: exact batched
+        // verify (strided sequential-decode chain at batch=n, bitwise-equal
+        // to spec-off decode). Ok(false) → the caller's per-sequence loop,
+        // which under the same predicate runs the per-token exact arm —
+        // identical bits. The WY fast path below is the DEFAULT; without the
+        // flag, spec-on output is NOT bitwise-equal to spec-off (#435).
         if super::verify_exact_enabled() {
             return self.decode_batched_conv_gdn_multi_exact(states, ctx, args);
         }

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi_exact.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi_exact.rs
@@ -149,9 +149,10 @@ impl Qwen3SsmLayer {
         static LOGGED: std::sync::Once = std::sync::Once::new();
         LOGGED.call_once(|| {
             tracing::info!(
-                "EXACT batched MTP verify ENGAGED (#435): per-token strided \
-                 conv_f32 + strided fused-norm snap at batch=n (2 launches + n \
-                 conv d2d per position); --verify-wy restores the WY arms"
+                "EXACT batched MTP verify ENGAGED (#435, opt-in --exact-verify): \
+                 per-token strided conv_f32 + strided fused-norm snap at batch=n \
+                 (2 launches + n conv d2d per position); omit the flag for the \
+                 default WY arms"
             );
         });
 

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi_exact.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi_exact.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exact-verify body for the batched (`GdnStates::Multi`) MTP verify
+//! (issue #435 route (a), PR1).
+//!
+//! Per token position `t`, TWO strided launches cover all `n` sequences:
+//!
+//! 1. `causal_conv1d_update_l2norm_f32_strided` at batch = n — the SAME
+//!    kernel the batched-recurrent decode path runs, whose per-sequence math
+//!    is line-for-line the non-strided `causal_conv1d_update_l2norm_f32`
+//!    (strides only move base addresses).
+//! 2. `gated_delta_rule_decode_f32_strided_norm_snap` at batch = n — the
+//!    strided fused-norm decode kernel (again per-sequence identical to the
+//!    single-seq `..._f32_norm`) with the per-token h rollback snapshot
+//!    written inline.
+//!
+//! Both per-sequence bodies are bitwise the single-token decode chain, so
+//! this arm is bitwise-equal to the per-sequence exact loop it accelerates —
+//! and to sequential decode — regardless of whether spec-off decode at C=n
+//! runs the per-sequence (`ssm_forward`) or batched-recurrent strided form.
+//!
+//! Conv rollback snapshots stay `copy_d2d_async` per sequence (n·(K-1)
+//! copies); the h snapshots ride inline in the `_snap` launch.
+//!
+//! `Ok(false)` declines — non-contiguous pool slots, missing kernels
+//! (`_snap` is model-shadow staged), or `--gdn-fused-norm` absent (the
+//! strided twin only exists on the fused-norm arm) — and the caller runs the
+//! per-sequence loop, which under `verify_exact_enabled()` is the per-token
+//! exact arm: byte-identical math, more launches. All decisions are pure
+//! functions of (flags, handles, the slot vector's fixed addresses), so the
+//! outcome is CUDA-graph-stable for a slot-vector-keyed graph.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::trait_decode_batched_conv_gdn::ConvGdnArgs;
+use super::{Qwen3SsmLayer, SsmLayerState};
+use crate::layer::LayerState;
+use crate::layers::ops;
+
+/// Per-sequence device pointers gathered (and validated) before any launch.
+struct ExactMultiSeq {
+    conv_state: DevicePtr,
+    conv_inter: Vec<DevicePtr>,
+}
+
+impl Qwen3SsmLayer {
+    /// Attempt the two-launch-per-token exact batched verify. See the module
+    /// docs; `args` carries the run's base (row-offset) buffers with
+    /// `args.num_tokens = k`.
+    pub(super) fn decode_batched_conv_gdn_multi_exact(
+        &self,
+        states: &mut [&mut (dyn LayerState + 'static)],
+        ctx: &crate::layer::ForwardContext,
+        args: &ConvGdnArgs,
+    ) -> Result<bool> {
+        let n = states.len();
+        let kk = args.num_tokens;
+        let conv_bytes = self.conv_state_bytes;
+        let h_bytes = self.h_state_bytes;
+
+        // The strided fused-norm snap twin is the only batched form of the
+        // exact chain; everything else declines to the per-sequence exact
+        // loop (still exact — see module docs).
+        if n < 2
+            || !crate::layers::qwen3_ssm::gdn_fused_norm_enabled()
+            || self.conv1d_l2norm_f32_strided_k.0 == 0
+            || self.gdn_f32_strided_norm_snap_k.0 == 0
+        {
+            return Ok(false);
+        }
+
+        // ── Preconditions on the ACTUAL pool pointers (never assumed) ──
+        // The strided kernels infer DENSE per-sequence strides for conv_state
+        // (conv_dim·d_conv FP32) and h_state (nv·kd·vd FP32), so both must sit
+        // on consecutive slots; the h intermediates must be intra-slot
+        // contiguous with a UNIFORM cross-sequence stride.
+        let mut seqs: Vec<ExactMultiSeq> = Vec::with_capacity(n);
+        let mut conv_base = DevicePtr::NULL;
+        let mut h_base = DevicePtr::NULL;
+        let mut h_inter_base = DevicePtr::NULL;
+        let mut h_inter_seq_stride = 0u64;
+        for (i, state) in states.iter().enumerate() {
+            let Some(st) = state.as_any().downcast_ref::<SsmLayerState>() else {
+                return Ok(false);
+            };
+            if st.conv_state_intermediates.len() < kk || st.h_state_intermediates.len() < kk {
+                return Ok(false);
+            }
+            let hi0 = st.h_state_intermediates[0];
+            for t in 1..kk {
+                if st.h_state_intermediates[t].0 != hi0.0 + (t * h_bytes) as u64 {
+                    return Ok(false);
+                }
+            }
+            if i == 0 {
+                conv_base = st.conv_state;
+                h_base = st.h_state;
+                h_inter_base = hi0;
+            } else {
+                if st.conv_state.0 != conv_base.0 + (i * conv_bytes) as u64
+                    || st.h_state.0 != h_base.0 + (i * h_bytes) as u64
+                {
+                    return Ok(false);
+                }
+                if i == 1 {
+                    h_inter_seq_stride = hi0.0.wrapping_sub(h_inter_base.0);
+                    // The kernel writes kk-1 dense snapshots per sequence;
+                    // they must not overlap the next sequence's region.
+                    if h_inter_seq_stride < (kk * h_bytes) as u64 {
+                        return Ok(false);
+                    }
+                } else if hi0.0 != h_inter_base.0 + (i as u64) * h_inter_seq_stride {
+                    return Ok(false);
+                }
+            }
+            seqs.push(ExactMultiSeq {
+                conv_state: st.conv_state,
+                conv_inter: st.conv_state_intermediates[..kk].to_vec(),
+            });
+        }
+
+        let ConvGdnArgs {
+            deinterleaved,
+            gates_buf,
+            normed_out,
+            qkvz_size,
+            conv_dim,
+            key_dim,
+            value_dim,
+            d_conv,
+            qk_ch,
+            nk,
+            nv,
+            kd,
+            vd,
+            bf16,
+            fp32,
+            stream,
+            ..
+        } = *args;
+        let eps = ctx.config.rms_norm_eps as f32;
+        // FP32 conv scratch: one row per SEQUENCE at qkvz_size FP32 stride,
+        // reused across token positions (each is consumed by the GDN launch
+        // that follows it on the same stream). n rows ≤ the buffer's n·k-row
+        // capacity by construction.
+        let conv_scratch = ctx.buffers.ssm_conv_out_f32();
+
+        static LOGGED: std::sync::Once = std::sync::Once::new();
+        LOGGED.call_once(|| {
+            tracing::info!(
+                "EXACT batched MTP verify ENGAGED (#435): per-token strided \
+                 conv_f32 + strided fused-norm snap at batch=n (2 launches + n \
+                 conv d2d per position); --verify-wy restores the WY arms"
+            );
+        });
+
+        for t in 0..kk {
+            // ── 1 launch: conv1d+SiLU+L2norm, FP32 out, all n sequences ──
+            ops::conv1d_update_l2norm_strided(
+                ctx.gpu,
+                self.conv1d_l2norm_f32_strided_k,
+                conv_base,
+                deinterleaved.offset(t * qkvz_size * bf16),
+                &self.ssm.conv1d,
+                conv_scratch,
+                conv_dim as u32,
+                d_conv as u32,
+                n as u32,
+                qk_ch,
+                kd as u32,
+                1e-6,
+                (kk * qkvz_size) as u32, // input seq stride (BF16 elems)
+                qkvz_size as u32,        // output seq stride (FP32 elems)
+                stream,
+            )?;
+
+            // ── 1 launch: GDN + gated norm + inline h snapshot, batch = n ──
+            let snapshot = t + 1 < kk;
+            let (h_inter_t, h_inter_stride_elems) = if snapshot {
+                (h_inter_base.offset(t * h_bytes), h_inter_seq_stride / 4)
+            } else {
+                // Index kk-1 has no reader (see the reader enumeration in
+                // trait_decode_batched_conv_gdn.rs) — NULL skips the stores.
+                (DevicePtr::NULL, 0)
+            };
+            let gate_t = gates_buf.offset(t * nv * 2 * fp32);
+            ops::gdn_decode_f32_strided_norm_snap(
+                ctx.gpu,
+                self.gdn_f32_strided_norm_snap_k,
+                h_base,
+                conv_scratch,
+                conv_scratch.offset(key_dim * fp32),
+                conv_scratch.offset(key_dim * 2 * fp32),
+                gate_t,
+                gate_t.offset(nv * fp32),
+                deinterleaved.offset(t * qkvz_size * bf16 + conv_dim * bf16),
+                self.ssm.norm.weight,
+                normed_out.offset(t * value_dim * bf16),
+                h_inter_t,
+                h_inter_stride_elems,
+                n as u32,
+                nk as u32,
+                nv as u32,
+                kd as u32,
+                vd as u32,
+                qkvz_size as u32,        // qk_stride (FP32 conv rows)
+                qkvz_size as u32,        // v_stride
+                (kk * nv * 2) as u32,    // gb_stride (seq-major gate rows)
+                (kk * qkvz_size) as u32, // z_stride (seq-major deint rows)
+                (kk * value_dim) as u32, // out_stride (seq-major normed rows)
+                eps,
+                stream,
+            )?;
+
+            // ── Conv rollback snapshots (d2d per sequence; index kk-1 dead) ──
+            if snapshot {
+                for seq in &seqs {
+                    ctx.gpu.copy_d2d_async(
+                        seq.conv_state,
+                        seq.conv_inter[t],
+                        conv_bytes,
+                        stream,
+                    )?;
+                }
+            }
+        }
+
+        Ok(true)
+    }
+}

--- a/crates/spark-model/src/model/nllb/model_impl.rs
+++ b/crates/spark-model/src/model/nllb/model_impl.rs
@@ -159,40 +159,9 @@ impl Model for NllbGpuModel {
         let slot = self.slots.lock().unwrap().claim();
         let kv = NllbSeqKv::new(self.gpu.as_ref(), self.dec_layers, self.cache_rows, self.d)?;
         self.kv.lock().unwrap().insert(slot, kv);
-        Ok(SequenceState {
-            adapter_id: 0,
-            adapter_slot: -1,
-            acquired_adapter_slot: -1,
-            src_lang_id: 0,
-            tgt_lang_id: 0,
-            num_beams: 1,
-            length_penalty: 1.0,
-            early_stopping: false,
-            tokens: Vec::new(),
-            block_table: Vec::new(),
-            seq_len: 0,
-            layer_states: Vec::new(),
-            proposer_state: None,
-            slot_idx: slot,
-            ssm_slot: None,
-            marconi_skip_to: 0,
-            marconi_exact_snap: None,
-            session_hash: 0,
-            mtp_capture_gen: 0,
-            chunked_prefill_meta: None,
-            cached_prefix_tokens: 0,
-            cached_prefix_blocks: 0,
-            prefix_ref_tokens: Vec::new(),
-            prefix_lookup_applied: false,
-            prefix_lookup_skip: false,
-            kv_valid_tokens: 0,
-            last_decode_ckpt_block: 0,
-            prompt_len: 0,
-            collect_prompt_logprobs: None,
-            prompt_logprobs: Vec::new(),
-            disk_block_ids: Vec::new(),
-            disk_last_offloaded_per_layer: Vec::new(),
-        })
+        // All-defaults host-side state; NLLB's KV lives in `self.kv`,
+        // keyed by `slot` (SSOT for the field defaults: `host_only`).
+        Ok(SequenceState::host_only(slot))
     }
 
     fn free_sequence(&self, seq: &mut SequenceState) -> Result<()> {

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -260,6 +260,54 @@ pub struct SequenceState {
 }
 
 impl SequenceState {
+    /// A detached, host-only sequence state: no GPU resources, no SSM
+    /// slot, no layer states, every counter zeroed. The single source
+    /// for the "empty sequence" field defaults — construction sites
+    /// that own real resources build on top of it instead of repeating
+    /// the full literal (NLLB's `alloc_sequence`, the engine-test
+    /// mock), so a new field gets ONE default site. Also the only way
+    /// for other crates to construct a `SequenceState` at all (e.g.
+    /// the scheduler's lifecycle unit tests): `ssm_slot` is
+    /// crate-private by design.
+    pub fn host_only(slot_idx: usize) -> Self {
+        SequenceState {
+            tokens: Vec::new(),
+            block_table: Vec::new(),
+            seq_len: 0,
+            layer_states: Vec::new(),
+            proposer_state: None,
+            slot_idx,
+            ssm_slot: None,
+            marconi_skip_to: 0,
+            marconi_exact_snap: None,
+            session_hash: 0,
+            mtp_capture_gen: 0,
+            adapter_id: 0,
+            chunked_prefill_meta: None,
+            cached_prefix_tokens: 0,
+            cached_prefix_blocks: 0,
+            prefix_ref_tokens: Vec::new(),
+            prefix_lookup_applied: false,
+            prefix_lookup_skip: false,
+            kv_valid_tokens: 0,
+            last_decode_ckpt_block: 0,
+            prompt_len: 0,
+            disk_block_ids: Vec::new(),
+            disk_last_offloaded_per_layer: Vec::new(),
+            collect_prompt_logprobs: None,
+            prompt_logprobs: Vec::new(),
+            // -1 = defer to the installed active adapter (see field docs).
+            adapter_slot: -1,
+            // -1 = no LoRA slot ref held until prefill acquires (Task #25).
+            acquired_adapter_slot: -1,
+            src_lang_id: 0,
+            tgt_lang_id: 0,
+            num_beams: 1,
+            length_penalty: 1.0,
+            early_stopping: false,
+        }
+    }
+
     /// SSM-pool slot index for this sequence, if it has GDN/SSM (linear-attn)
     /// layers. Used by the scheduler to order the decode batch by slot so the
     /// batched-recurrent SSM + CUDA-graph contiguity invariant holds

--- a/crates/spark-runtime/src/gpu/mock.rs
+++ b/crates/spark-runtime/src/gpu/mock.rs
@@ -89,6 +89,14 @@ impl MockGpuBackend {
     pub fn read_alloc(&self, ptr: DevicePtr) -> Option<Vec<u8>> {
         self.allocs.lock().get(&ptr.0).map(|a| a.data.clone())
     }
+
+    /// Every launch recorded so far, in dispatch order. Lets a test assert
+    /// WHICH kernel shape ran (grid/block signature), not just how many —
+    /// the mock's `kernel()` hands out one shared handle, so geometry is
+    /// the only per-launch identity available.
+    pub fn launches_snapshot(&self) -> Vec<MockLaunch> {
+        self.launches.lock().clone()
+    }
 }
 
 /// Find the allocation containing `ptr` (supports offset pointers).

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -17,6 +17,7 @@ use crate::AppState;
 use crate::ir;
 use crate::tool_parser;
 
+use super::chat_blocking_choice::{build_choice_message, build_logprobs};
 use super::compact::openai_error_response;
 use super::inference_impl::{extract_thinking, strip_stop_sequences};
 use super::inference_types::{GrammarSpec, InferenceRequest};
@@ -221,6 +222,8 @@ pub(super) async fn run_blocking_path(args: BlockingPathArgs) -> super::chat::Ch
         );
         choice.index = choice_idx;
         choice.matched_stop = matched_stop;
+        choice.finish_reason =
+            stop_match_corrected(choice.finish_reason, choice.matched_stop.is_some());
         choice.logprobs = build_logprobs(&state, &response);
         all_choices.push(choice);
     }
@@ -290,195 +293,6 @@ fn decode_response_text(
     }
 }
 
-/// Build the assistant message + finish_reason for one choice. Tool
-/// parsing, validation, content-strip + refusal-classifier all live
-/// here.
-///
-/// Deliberately NOT `async`: it awaits nothing, and marking pure CPU work as
-/// async only hides where that work runs. If it ever grows expensive enough to
-/// matter, that becomes a visible decision to move it to the blocking pool
-/// rather than something already buried inside a future.
-#[allow(clippy::too_many_arguments)]
-fn build_choice_message(
-    state: &AppState,
-    req: &crate::ir::ChatRequest,
-    response: &super::inference_types::InferenceResponse,
-    reasoning_content_i: Option<String>,
-    output_text_i: String,
-    tools_active: bool,
-    cwd_hint: Option<&str>,
-    choice_idx: usize,
-) -> ir::Choice {
-    let _ = response; // currently only used for finish_reason.clone() below
-    // Neutral locals — the wire annotations (URL citations) are derived
-    // at encode time by the surfaces that emit them.
-    let mut reasoning_content = reasoning_content_i;
-    let mut msg_content: Option<String> = Some(output_text_i.clone());
-    let mut msg_tool_calls: Option<Vec<tool_parser::ToolCall>> = None;
-    let mut msg_refusal: Option<String> = None;
-    let mut finish_reason_i = response.finish_reason.clone();
-
-    if tools_active {
-        if std::env::var("ATLAS_LOG_TOOL_RAW").as_deref() == Ok("1") {
-            tracing::info!(
-                target: "atlas::tool_debug",
-                "raw pre-parse output (tools_active, choice {choice_idx}): {output_text_i:?}"
-            );
-        }
-        // F7 (2026-05-26): also scan `reasoning_content_i` for tool calls.
-        // When the model emits a `<tool_call>...</tool_call>` block INSIDE
-        // its `<think>...</think>` reasoning, `decode_response_text` splits
-        // at `</think>` and routes the tool call into reasoning_content,
-        // hiding it from the post-`</think>` parser below — the tool call
-        // is silently dropped (matches vLLM #39055 pattern). When found in
-        // reasoning, hoist the calls back into the assistant message and
-        // scrub the residual XML from the reasoning trace so it isn't
-        // double-emitted to the client.
-        let (hoisted_reasoning, hoisted_tool_calls): (Option<String>, Vec<_>) =
-            if let Some(ref rc) = reasoning_content {
-                let (scrubbed, tcs) = tool_parser::parse_tool_calls(rc);
-                (scrubbed, tcs)
-            } else {
-                (None, Vec::new())
-            };
-        if !hoisted_tool_calls.is_empty() {
-            tracing::info!(
-                "F7: hoisted {} tool-call(s) from inside <think> block (would have been silently dropped)",
-                hoisted_tool_calls.len()
-            );
-            reasoning_content = hoisted_reasoning;
-        }
-        let (content, parsed_tool_calls) = tool_parser::parse_tool_calls(&output_text_i);
-        let mut tool_calls_i = hoisted_tool_calls;
-        tool_calls_i.extend(parsed_tool_calls);
-        if !tool_calls_i.is_empty() {
-            let tools_ref = req.tools.clone();
-            tool_parser::backfill_required_params(&mut tool_calls_i, &tools_ref);
-            if state
-                .tool_call_parser
-                .as_ref()
-                .is_some_and(|p| p.wants_typed_arguments())
-            {
-                tool_parser::coerce_all(&mut tool_calls_i, &tools_ref);
-            }
-            if let Some(cwd) = cwd_hint {
-                tool_parser::normalize_paths(&mut tool_calls_i, cwd);
-            }
-            let validated = tool_parser::validate_tool_calls(tool_calls_i, &tools_ref);
-            if !validated.errors.is_empty() {
-                for err in &validated.errors {
-                    tracing::warn!("Tool call validation error: {err}");
-                }
-            }
-            // Strip orphan tool call XML tags + ```lang fences from content
-            // (Qwen3-Coder pattern: emits markdown narration AND structured
-            // tool_call for the same payload).
-            let content = content.map(|mut c| {
-                for tag in &["</parameter>", "</function>", "</tool_call>", "<tool_call>"] {
-                    c = c.replace(tag, "");
-                }
-                while let Some(start) = c.find("<function=") {
-                    let end = c[start..]
-                        .find('>')
-                        .map(|p| start + p + 1)
-                        .unwrap_or(c.len());
-                    c = format!("{}{}", &c[..start], &c[end..]);
-                }
-                while let Some(start) = c.find("```") {
-                    let after_open = start + 3;
-                    let Some(rel_close) = c[after_open..].find("```") else {
-                        break;
-                    };
-                    let close_end = after_open + rel_close + 3;
-                    c = format!("{}{}", &c[..start], &c[close_end..]);
-                }
-                c.trim().to_string()
-            });
-            msg_content = content;
-            if !validated.valid.is_empty() {
-                for tc in &validated.valid {
-                    let p: String = tc.function.arguments.chars().take(120).collect();
-                    let s = ["", "…"][usize::from(tc.function.arguments.len() > p.len())];
-                    tracing::info!("Tool call: {}({p}{s})", tc.function.name);
-                    crate::metrics::TOOL_CALLS_TOTAL.inc();
-                }
-                msg_tool_calls = Some(validated.valid);
-                // A deadline cut outranks "tool_calls": the turn was
-                // truncated, so a call parsed out of it may be partial and
-                // the client must not treat it as a completed tool turn.
-                if finish_reason_i != ir::FINISH_REASON_TIMEOUT {
-                    finish_reason_i = "tool_calls".to_string();
-                }
-            }
-        }
-    }
-
-    // Refusal classifier: when the model's assistant text opens with
-    // a known refusal pattern AND no tool call fired, populate
-    // `refusal` and null out `content` per the OpenAI spec.
-    if msg_tool_calls.is_none()
-        && let Some(content_text) = msg_content.as_deref()
-        && let Some(refusal_sentence) = crate::refusal::detect(content_text)
-    {
-        msg_refusal = Some(refusal_sentence);
-        msg_content = None;
-    }
-
-    // Validated wire tool calls → IR (arguments are serde-normalized
-    // strings from the parser, so the parse here is lossless).
-    let tool_calls: Vec<ir::message::ToolCall> = msg_tool_calls
-        .unwrap_or_default()
-        .into_iter()
-        .map(|tc| ir::message::ToolCall {
-            id: tc.id,
-            name: tc.function.name,
-            arguments: serde_json::from_str(&tc.function.arguments)
-                .unwrap_or_else(|_| serde_json::Value::Object(Default::default())),
-        })
-        .collect();
-
-    ir::Choice {
-        index: choice_idx,
-        content: msg_content,
-        reasoning: reasoning_content,
-        tool_calls,
-        refusal: msg_refusal,
-        finish_reason: ir::FinishReason::from(finish_reason_i.as_str()),
-        matched_stop: None, // caller fills
-        logprobs: None,     // caller fills
-    }
-}
-
-/// Convert internal logprobs to OpenAI `ChoiceLogprobs` format.
-fn build_logprobs(
-    state: &AppState,
-    response: &super::inference_types::InferenceResponse,
-) -> Option<ir::ChoiceLogprobs> {
-    if response.logprobs.is_empty() {
-        return None;
-    }
-    Some(ir::ChoiceLogprobs {
-        content: response
-            .logprobs
-            .iter()
-            .map(|lp| {
-                let token_str = state.tokenizer.decode(&[lp.token_id]).unwrap_or_default();
-                ir::TokenLogprob {
-                    token: token_str,
-                    logprob: lp.logprob,
-                    top: lp
-                        .top
-                        .iter()
-                        .map(|&(tid, lp_val)| {
-                            (state.tokenizer.decode(&[tid]).unwrap_or_default(), lp_val)
-                        })
-                        .collect(),
-                }
-            })
-            .collect(),
-    })
-}
-
 /// Core finalization: usage assembly, metrics, and the rate-limit
 /// true-up. Returns the canonical response IR — wire encoding (plus
 /// `store:`/`--dump` handling) happens in the per-surface encoders.
@@ -532,4 +346,51 @@ fn finalize_response(
         choices: all_choices,
         usage,
     }))
+}
+
+/// OpenAI contract: a response ended by a client stop sequence is
+/// `finish_reason="stop"`, never `"length"`. The blocking path only
+/// detects multi-token stop strings post-hoc (the suffix strip in the
+/// caller), so this corrects exactly the "length" misreport — EOS
+/// already reports "stop", and "timeout"/"tool_calls" keep outranking a
+/// stop match (same precedence as the streaming resolver in
+/// `chat_stream::handle_done::resolve_wire_finish_reason`).
+fn stop_match_corrected(fr: ir::FinishReason, stop_matched: bool) -> ir::FinishReason {
+    if stop_matched && fr == ir::FinishReason::Length {
+        ir::FinishReason::Stop
+    } else {
+        fr
+    }
+}
+
+#[cfg(test)]
+mod stop_match_corrected_tests {
+    use super::stop_match_corrected;
+    use crate::ir::{FINISH_REASON_TIMEOUT, FinishReason};
+
+    #[test]
+    fn matched_stop_corrects_length_to_stop() {
+        assert_eq!(
+            stop_match_corrected(FinishReason::Length, true),
+            FinishReason::Stop
+        );
+    }
+
+    #[test]
+    fn everything_else_passes_through() {
+        // No match ⇒ a real budget stop stays "length".
+        assert_eq!(
+            stop_match_corrected(FinishReason::Length, false),
+            FinishReason::Length
+        );
+        // A match never rewrites tool_calls or the timeout contract.
+        assert_eq!(
+            stop_match_corrected(FinishReason::ToolCalls, true),
+            FinishReason::ToolCalls
+        );
+        assert_eq!(
+            stop_match_corrected(FinishReason::Other(FINISH_REASON_TIMEOUT.into()), true),
+            FinishReason::Other(FINISH_REASON_TIMEOUT.into())
+        );
+    }
 }

--- a/crates/spark-server/src/api/chat_blocking_choice.rs
+++ b/crates/spark-server/src/api/chat_blocking_choice.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Per-choice assembly for the blocking `/v1/chat/completions` path:
+//! tool-call parse/validate/coerce, refusal classification, and the
+//! logprobs conversion. Exact piecewise copy out of `chat_blocking.rs`
+//! (2026-08-09) to keep that file under the 500 LoC cap; behaviour
+//! unchanged.
+
+#![allow(clippy::too_many_arguments)]
+
+use crate::AppState;
+use crate::ir;
+use crate::tool_parser;
+
+/// Build the assistant message + finish_reason for one choice. Tool
+/// parsing, validation, content-strip + refusal-classifier all live
+/// here.
+///
+/// Deliberately NOT `async`: it awaits nothing, and marking pure CPU work as
+/// async only hides where that work runs. If it ever grows expensive enough to
+/// matter, that becomes a visible decision to move it to the blocking pool
+/// rather than something already buried inside a future.
+pub(super) fn build_choice_message(
+    state: &AppState,
+    req: &crate::ir::ChatRequest,
+    response: &super::inference_types::InferenceResponse,
+    reasoning_content_i: Option<String>,
+    output_text_i: String,
+    tools_active: bool,
+    cwd_hint: Option<&str>,
+    choice_idx: usize,
+) -> ir::Choice {
+    let _ = response; // currently only used for finish_reason.clone() below
+    // Neutral locals — the wire annotations (URL citations) are derived
+    // at encode time by the surfaces that emit them.
+    let mut reasoning_content = reasoning_content_i;
+    let mut msg_content: Option<String> = Some(output_text_i.clone());
+    let mut msg_tool_calls: Option<Vec<tool_parser::ToolCall>> = None;
+    let mut msg_refusal: Option<String> = None;
+    let mut finish_reason_i = response.finish_reason.clone();
+
+    if tools_active {
+        if std::env::var("ATLAS_LOG_TOOL_RAW").as_deref() == Ok("1") {
+            tracing::info!(
+                target: "atlas::tool_debug",
+                "raw pre-parse output (tools_active, choice {choice_idx}): {output_text_i:?}"
+            );
+        }
+        // F7 (2026-05-26): also scan `reasoning_content_i` for tool calls.
+        // When the model emits a `<tool_call>...</tool_call>` block INSIDE
+        // its `<think>...</think>` reasoning, `decode_response_text` splits
+        // at `</think>` and routes the tool call into reasoning_content,
+        // hiding it from the post-`</think>` parser below — the tool call
+        // is silently dropped (matches vLLM #39055 pattern). When found in
+        // reasoning, hoist the calls back into the assistant message and
+        // scrub the residual XML from the reasoning trace so it isn't
+        // double-emitted to the client.
+        let (hoisted_reasoning, hoisted_tool_calls): (Option<String>, Vec<_>) =
+            if let Some(ref rc) = reasoning_content {
+                let (scrubbed, tcs) = tool_parser::parse_tool_calls(rc);
+                (scrubbed, tcs)
+            } else {
+                (None, Vec::new())
+            };
+        if !hoisted_tool_calls.is_empty() {
+            tracing::info!(
+                "F7: hoisted {} tool-call(s) from inside <think> block (would have been silently dropped)",
+                hoisted_tool_calls.len()
+            );
+            reasoning_content = hoisted_reasoning;
+        }
+        let (content, parsed_tool_calls) = tool_parser::parse_tool_calls(&output_text_i);
+        let mut tool_calls_i = hoisted_tool_calls;
+        tool_calls_i.extend(parsed_tool_calls);
+        if !tool_calls_i.is_empty() {
+            let tools_ref = req.tools.clone();
+            tool_parser::backfill_required_params(&mut tool_calls_i, &tools_ref);
+            if state
+                .tool_call_parser
+                .as_ref()
+                .is_some_and(|p| p.wants_typed_arguments())
+            {
+                tool_parser::coerce_all(&mut tool_calls_i, &tools_ref);
+            }
+            if let Some(cwd) = cwd_hint {
+                tool_parser::normalize_paths(&mut tool_calls_i, cwd);
+            }
+            let validated = tool_parser::validate_tool_calls(tool_calls_i, &tools_ref);
+            if !validated.errors.is_empty() {
+                for err in &validated.errors {
+                    tracing::warn!("Tool call validation error: {err}");
+                }
+            }
+            // Strip orphan tool call XML tags + ```lang fences from content
+            // (Qwen3-Coder pattern: emits markdown narration AND structured
+            // tool_call for the same payload).
+            let content = content.map(|mut c| {
+                for tag in &["</parameter>", "</function>", "</tool_call>", "<tool_call>"] {
+                    c = c.replace(tag, "");
+                }
+                while let Some(start) = c.find("<function=") {
+                    let end = c[start..]
+                        .find('>')
+                        .map(|p| start + p + 1)
+                        .unwrap_or(c.len());
+                    c = format!("{}{}", &c[..start], &c[end..]);
+                }
+                while let Some(start) = c.find("```") {
+                    let after_open = start + 3;
+                    let Some(rel_close) = c[after_open..].find("```") else {
+                        break;
+                    };
+                    let close_end = after_open + rel_close + 3;
+                    c = format!("{}{}", &c[..start], &c[close_end..]);
+                }
+                c.trim().to_string()
+            });
+            msg_content = content;
+            if !validated.valid.is_empty() {
+                for tc in &validated.valid {
+                    let p: String = tc.function.arguments.chars().take(120).collect();
+                    let s = ["", "…"][usize::from(tc.function.arguments.len() > p.len())];
+                    tracing::info!("Tool call: {}({p}{s})", tc.function.name);
+                    crate::metrics::TOOL_CALLS_TOTAL.inc();
+                }
+                msg_tool_calls = Some(validated.valid);
+                // A deadline cut outranks "tool_calls": the turn was
+                // truncated, so a call parsed out of it may be partial and
+                // the client must not treat it as a completed tool turn.
+                if finish_reason_i != ir::FINISH_REASON_TIMEOUT {
+                    finish_reason_i = "tool_calls".to_string();
+                }
+            }
+        }
+    }
+
+    // Refusal classifier: when the model's assistant text opens with
+    // a known refusal pattern AND no tool call fired, populate
+    // `refusal` and null out `content` per the OpenAI spec.
+    if msg_tool_calls.is_none()
+        && let Some(content_text) = msg_content.as_deref()
+        && let Some(refusal_sentence) = crate::refusal::detect(content_text)
+    {
+        msg_refusal = Some(refusal_sentence);
+        msg_content = None;
+    }
+
+    // Validated wire tool calls → IR (arguments are serde-normalized
+    // strings from the parser, so the parse here is lossless).
+    let tool_calls: Vec<ir::message::ToolCall> = msg_tool_calls
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tc| ir::message::ToolCall {
+            id: tc.id,
+            name: tc.function.name,
+            arguments: serde_json::from_str(&tc.function.arguments)
+                .unwrap_or_else(|_| serde_json::Value::Object(Default::default())),
+        })
+        .collect();
+
+    ir::Choice {
+        index: choice_idx,
+        content: msg_content,
+        reasoning: reasoning_content,
+        tool_calls,
+        refusal: msg_refusal,
+        finish_reason: ir::FinishReason::from(finish_reason_i.as_str()),
+        matched_stop: None, // caller fills
+        logprobs: None,     // caller fills
+    }
+}
+
+/// Convert internal logprobs to OpenAI `ChoiceLogprobs` format.
+pub(super) fn build_logprobs(
+    state: &AppState,
+    response: &super::inference_types::InferenceResponse,
+) -> Option<ir::ChoiceLogprobs> {
+    if response.logprobs.is_empty() {
+        return None;
+    }
+    Some(ir::ChoiceLogprobs {
+        content: response
+            .logprobs
+            .iter()
+            .map(|lp| {
+                let token_str = state.tokenizer.decode(&[lp.token_id]).unwrap_or_default();
+                ir::TokenLogprob {
+                    token: token_str,
+                    logprob: lp.logprob,
+                    top: lp
+                        .top
+                        .iter()
+                        .map(|&(tid, lp_val)| {
+                            (state.tokenizer.decode(&[tid]).unwrap_or_default(), lp_val)
+                        })
+                        .collect(),
+                }
+            })
+            .collect(),
+    })
+}

--- a/crates/spark-server/src/api/chat_stream/cancel_guard_tests.rs
+++ b/crates/spark-server/src/api/chat_stream/cancel_guard_tests.rs
@@ -30,9 +30,16 @@
 //! property is structural, so the test is too.
 
 /// Files in `chat_stream` that may cancel a stream.
+///
+/// Derived by grepping `spark-server` for a `.store(true` within three lines
+/// of a `cancel_flag`; keep it that way when adding an entry. `state.rs` was
+/// missed on the first pass and its site — `note_stop_string_match` — was
+/// correctly guarded by luck, not by this test. A file omitted here is a
+/// silent hole, which is why `checked` has a floor below.
 const CANCEL_SITE_FILES: &[(&str, &str)] = &[
     ("handle_token.rs", include_str!("handle_token.rs")),
     ("tool_handlers.rs", include_str!("tool_handlers.rs")),
+    ("state.rs", include_str!("state.rs")),
 ];
 
 /// Any one of these, within the window above a `cancel_flag` store, means
@@ -49,10 +56,17 @@ const WINDOW: usize = 25;
 
 /// True when this store is provably unreachable and so cannot mislabel.
 fn is_dead_path(preceding: &str) -> bool {
-    // `tool_retry_enabled` is a `const false`; `PendingRetry` is never
-    // constructed (see state.rs). Kept compiling as documentation of the
-    // retry design, so exempt it explicitly rather than by silence.
-    preceding.contains("pending_retry")
+    // The retry cut in `tool_handlers.rs` is gated behind `tool_retry_enabled`,
+    // a `const false`, so it can never execute. Kept compiling as documentation
+    // of the retry design, so exempt it explicitly rather than by silence.
+    //
+    // ★ Match the ASSIGNMENT, not the bare identifier. The first version of
+    // this test looked for `pending_retry` anywhere in the window, which also
+    // matched the unrelated `pending_retry: None` struct-field initializer in
+    // `state.rs` — silently exempting a live cut site 15 lines below it and
+    // making the whole invariant vacuous for that file. The exemption must be
+    // narrower than the window it is searched in.
+    preceding.contains("pending_retry = Some(")
 }
 
 #[test]
@@ -87,7 +101,7 @@ fn every_cancel_flag_store_names_its_guard() {
     // sites, this test must fail loudly rather than pass over an empty
     // scan and report a green it never earned.
     assert!(
-        checked >= 3,
+        checked >= 4,
         "found only {checked} cancel_flag stores — the scan stopped matching. \
          Fix the detection before trusting a green here."
     );

--- a/crates/spark-server/src/api/chat_stream/cancel_guard_tests.rs
+++ b/crates/spark-server/src/api/chat_stream/cancel_guard_tests.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! THE invariant behind three separate shipped regressions:
+//!
+//! **Every site that flips `cancel_flag` must also name why**, by setting
+//! one of `guard_stop`, `tool_loop_capped`, or `stop_string_matched`.
+//!
+//! A bare `cancel_flag` reaches the scheduler as "generation stopped with
+//! budget left and no guard", which `derive_finish_reason` correctly maps
+//! to `"stop"` — telling the client *the model finished*. For a stream we
+//! truncated mid-doom-loop that is false, and it silently breaks every
+//! client that keys truncation recovery on `"length"`: `openai-python`
+//! raises `LengthFinishReasonError`, aider's continuation fires, Instructor
+//! raises `IncompleteOutputException`, pydantic-ai refuses a half tool call.
+//!
+//! ★ This was found the expensive way. Three separate cut paths shipped
+//! bare, and each was fixed only after a gate failure pointed at it:
+//!   1. scheduler-side guards        (fixed: guard_stop_wire_reason)
+//!   2. stream simhash / token-loop  (fixed: resolve_wire_finish_reason rung)
+//!   3. orphan-suppression streak    (fixed: sets guard_stop at the site)
+//! Fixes 1 and 2 left path 3 bare, and it cost the agentic gate runs 0 and
+//! 7 on three consecutive shas — a failure that looked like a model
+//! regression and was actually a missing field.
+//!
+//! A per-path unit test would not have caught the class: each fix was
+//! locally correct and locally tested. Only an invariant over ALL sites
+//! catches the fourth one, so this test reads the source rather than
+//! exercising behaviour. Precedent in-tree: `coverage_map_tests` asserts
+//! benchmark drivers do not import each other for the same reason — the
+//! property is structural, so the test is too.
+
+/// Files in `chat_stream` that may cancel a stream.
+const CANCEL_SITE_FILES: &[(&str, &str)] = &[
+    ("handle_token.rs", include_str!("handle_token.rs")),
+    ("tool_handlers.rs", include_str!("tool_handlers.rs")),
+];
+
+/// Any one of these, within the window above a `cancel_flag` store, means
+/// the cut is named and will reach the wire as `"length"`.
+const GUARD_MARKERS: &[&str] = &[
+    "guard_stop = Some(",
+    "tool_loop_capped = true",
+    "stop_string_matched = true",
+];
+
+/// How far back to look. The marker is set in the same statement group as
+/// the store in every current site; 25 lines is slack, not licence.
+const WINDOW: usize = 25;
+
+/// True when this store is provably unreachable and so cannot mislabel.
+fn is_dead_path(preceding: &str) -> bool {
+    // `tool_retry_enabled` is a `const false`; `PendingRetry` is never
+    // constructed (see state.rs). Kept compiling as documentation of the
+    // retry design, so exempt it explicitly rather than by silence.
+    preceding.contains("pending_retry")
+}
+
+#[test]
+fn every_cancel_flag_store_names_its_guard() {
+    let mut bare: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for (name, src) in CANCEL_SITE_FILES {
+        let lines: Vec<&str> = src.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if !line.contains(".store(true") {
+                continue;
+            }
+            // Confirm it is the cancel flag and not some other AtomicBool.
+            let lo = i.saturating_sub(3);
+            if !lines[lo..=i].iter().any(|l| l.contains("cancel_flag")) {
+                continue;
+            }
+            checked += 1;
+            let from = i.saturating_sub(WINDOW);
+            let preceding = lines[from..=i].join("\n");
+            if is_dead_path(&preceding) {
+                continue;
+            }
+            if !GUARD_MARKERS.iter().any(|m| preceding.contains(m)) {
+                bare.push(format!("{name}:{}", i + 1));
+            }
+        }
+    }
+
+    // The floor is the negative half: if a refactor moves or renames the
+    // sites, this test must fail loudly rather than pass over an empty
+    // scan and report a green it never earned.
+    assert!(
+        checked >= 3,
+        "found only {checked} cancel_flag stores — the scan stopped matching. \
+         Fix the detection before trusting a green here."
+    );
+
+    assert!(
+        bare.is_empty(),
+        "cancel_flag flipped without naming a guard at: {bare:?}\n\
+         A bare cancel reaches the client as finish_reason \"stop\", claiming \
+         the model finished when it was truncated. Set guard_stop (or \
+         tool_loop_capped / stop_string_matched) at the site so the wire \
+         reason is \"length\"."
+    );
+}
+
+#[test]
+fn the_scan_would_notice_a_bare_store() {
+    // NEGATIVE case: prove the detector fires. Without this, the test
+    // above passes for two reasons — the invariant holding, or the scan
+    // silently matching nothing — and only one of them is good news.
+    let synthetic = "\
+        if streak > MAX {\n\
+        \x20   tracing::warn!(\"ending stream\");\n\
+        \x20   state.loop_watchdog_triggered = true;\n\
+        \x20   state.cancel_flag.store(true, Ordering::Release);\n\
+        }\n";
+    let lines: Vec<&str> = synthetic.lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.contains(".store(true"))
+        .expect("fixture must contain a store");
+    let preceding = lines[..=idx].join("\n");
+    assert!(
+        !GUARD_MARKERS.iter().any(|m| preceding.contains(m)),
+        "the detector failed to flag a store with no guard marker — it \
+         would pass the real invariant test vacuously"
+    );
+    // And the positive half: adding the marker clears it.
+    let fixed = preceding.replace(
+        "state.loop_watchdog_triggered = true;",
+        "state.guard_stop = Some(\"suppress_streak\");",
+    );
+    assert!(GUARD_MARKERS.iter().any(|m| fixed.contains(m)));
+}

--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -186,30 +186,12 @@ pub(super) fn handle_done(
         response_tokens_per_second: tps,
     };
 
-    let fr = if finish_reason == crate::ir::FINISH_REASON_TIMEOUT {
-        // The server-side request deadline cut this response mid-flight.
-        // It outranks every override below: a truncated turn that emitted
-        // a partial tool call would otherwise be reported "tool_calls" and
-        // the client would run a half-parsed call as if it were complete.
-        finish_reason.as_str()
-    } else if state.tool_loop_capped {
-        // A tool-call loop guard (Bug-2 name-run cap, F11 within-dedup,
-        // F5 cross-flush dedup, or F44 perm-fail) forcibly ended the
-        // response. Signal "length" — OpenAI's slot for a truncated
-        // response — so agent clients can break their outer retry
-        // loop. Without this override the response otherwise looks like
-        // a normal "tool_calls" completion (tool calls *were* emitted)
-        // and agents (opencode, etc.) cheerfully run the tools and ask
-        // the model to continue, perpetuating the loop one round at a
-        // time.
-        "length"
-    } else if state.detector.as_ref().is_some_and(|d| d.has_tool_calls())
-        || state.salvaged_tool_call
-    {
-        "tool_calls"
-    } else {
-        finish_reason.as_str()
-    };
+    let fr = resolve_wire_finish_reason(
+        &finish_reason,
+        state.tool_loop_capped,
+        state.detector.as_ref().is_some_and(|d| d.has_tool_calls()) || state.salvaged_tool_call,
+        state.stop_string_matched,
+    );
 
     // Refusal classification.
     let refusal_signal = if state.detector.as_ref().is_none_or(|d| !d.has_tool_calls()) {
@@ -293,4 +275,97 @@ pub(super) fn handle_done(
     }
 
     deltas
+}
+
+/// Stream-layer overrides on top of the scheduler's finish reason.
+/// Pure so the precedence is unit-testable. In order:
+///
+/// 1. `"timeout"` — the server-side request deadline cut this response
+///    mid-flight. It outranks every override below: a truncated turn
+///    that emitted a partial tool call would otherwise be reported
+///    "tool_calls" and the client would run a half-parsed call as if it
+///    were complete.
+/// 2. `tool_loop_capped` → `"length"` — a tool-call loop guard (Bug-2
+///    name-run cap, F11 within-dedup, F5 cross-flush dedup, or F44
+///    perm-fail) forcibly ended the response. Signal "length" — OpenAI's
+///    slot for a truncated response — so agent clients can break their
+///    outer retry loop. Without this override the response otherwise
+///    looks like a normal "tool_calls" completion (tool calls *were*
+///    emitted) and agents (opencode, etc.) cheerfully run the tools and
+///    ask the model to continue, perpetuating the loop one round at a
+///    time. NOTE: this is a deliberate, pre-existing exception to the
+///    scheduler-side invariant that "length" means "budget exhausted";
+///    kept because it is a shipped contract for exactly this doom-loop
+///    class.
+/// 3. parsed/salvaged tool calls → `"tool_calls"`.
+/// 4. `stop_string_matched` → `"stop"` — a client `stop` sequence ended
+///    this response. OpenAI (and vLLM/SGLang/TGI/llama.cpp) report a
+///    stop-sequence stop as "stop"; the scheduler can still say
+///    "length" here when the cooperative cancel landed a step late
+///    (tokens kept decoding with output suppressed and the budget ran
+///    out first).
+/// 5. otherwise the scheduler's reason passes through verbatim.
+fn resolve_wire_finish_reason(
+    scheduler_reason: &str,
+    tool_loop_capped: bool,
+    has_tool_calls: bool,
+    stop_string_matched: bool,
+) -> &str {
+    if scheduler_reason == crate::ir::FINISH_REASON_TIMEOUT {
+        scheduler_reason
+    } else if tool_loop_capped {
+        "length"
+    } else if has_tool_calls {
+        "tool_calls"
+    } else if stop_string_matched {
+        "stop"
+    } else {
+        scheduler_reason
+    }
+}
+
+#[cfg(test)]
+mod wire_finish_reason_tests {
+    use super::resolve_wire_finish_reason;
+    use crate::ir::FINISH_REASON_TIMEOUT;
+
+    #[test]
+    fn stop_string_match_is_stop_not_length() {
+        // The second instance of the "length is a lie" bug: a matched
+        // client stop sequence previously fell through to the
+        // scheduler's reason, which reads "length" whenever the seq
+        // burned to the budget with its output suppressed.
+        assert_eq!(
+            resolve_wire_finish_reason("length", false, false, true),
+            "stop"
+        );
+        // With no match, the scheduler's reason passes through.
+        assert_eq!(
+            resolve_wire_finish_reason("length", false, false, false),
+            "length"
+        );
+        assert_eq!(
+            resolve_wire_finish_reason("stop", false, false, false),
+            "stop"
+        );
+    }
+
+    #[test]
+    fn timeout_and_tool_overrides_keep_their_rank() {
+        // Shipped contracts, unchanged by this wave.
+        assert_eq!(
+            resolve_wire_finish_reason(FINISH_REASON_TIMEOUT, true, true, true),
+            FINISH_REASON_TIMEOUT
+        );
+        assert_eq!(
+            resolve_wire_finish_reason("stop", true, true, true),
+            "length",
+            "tool-loop cap outranks tool_calls and the stop-string match"
+        );
+        assert_eq!(
+            resolve_wire_finish_reason("stop", false, true, true),
+            "tool_calls",
+            "parsed tool calls outrank the stop-string override"
+        );
+    }
 }

--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -191,6 +191,7 @@ pub(super) fn handle_done(
         state.tool_loop_capped,
         state.detector.as_ref().is_some_and(|d| d.has_tool_calls()) || state.salvaged_tool_call,
         state.stop_string_matched,
+        state.guard_stop,
     );
 
     // Refusal classification.
@@ -304,13 +305,29 @@ pub(super) fn handle_done(
 ///    "length" here when the cooperative cancel landed a step late
 ///    (tokens kept decoding with output suppressed and the budget ran
 ///    out first).
-/// 5. otherwise the scheduler's reason passes through verbatim.
-fn resolve_wire_finish_reason(
-    scheduler_reason: &str,
+/// 5. a STREAM-side degeneration guard (`state.guard_stop`: the token
+///    loop watchdog or the simhash semantic-loop trip) → `"length"`,
+///    for the same reason as rule 2 and by the same invariant the
+///    scheduler applies to its own guards.
+///
+///    ★ This rung is why the scheduler-side fix alone was not enough.
+///    Those watchdogs live on the STREAM: they set `state.guard_stop`
+///    and flip `cancel_flag`, but never touch `ActiveSeq::guard_stop`.
+///    The scheduler therefore finalizes with no guard, falls to its
+///    "early finalize, budget left" rule, and says `"stop"` — which
+///    arrives here and passed through verbatim. Measured: after fixing
+///    only the scheduler path, an episode still died at 4 turns having
+///    written one file, its last turn a mid-word repetition splice
+///    labelled `stop`. The stream knew it was a guard cut and simply
+///    never said so.
+/// 6. otherwise the scheduler's reason passes through verbatim.
+fn resolve_wire_finish_reason<'a>(
+    scheduler_reason: &'a str,
     tool_loop_capped: bool,
     has_tool_calls: bool,
     stop_string_matched: bool,
-) -> &str {
+    stream_guard_stop: Option<&'static str>,
+) -> &'a str {
     if scheduler_reason == crate::ir::FINISH_REASON_TIMEOUT {
         scheduler_reason
     } else if tool_loop_capped {
@@ -319,6 +336,12 @@ fn resolve_wire_finish_reason(
         "tool_calls"
     } else if stop_string_matched {
         "stop"
+    } else if stream_guard_stop.is_some() {
+        // A degeneration cut is a truncation: the model was mid-output.
+        // Ordered AFTER tool_calls/stop_string so a guard that trips on
+        // the same step a real tool call or client stop sequence landed
+        // still reports what actually happened.
+        "length"
     } else {
         scheduler_reason
     }
@@ -336,16 +359,58 @@ mod wire_finish_reason_tests {
         // scheduler's reason, which reads "length" whenever the seq
         // burned to the budget with its output suppressed.
         assert_eq!(
-            resolve_wire_finish_reason("length", false, false, true),
+            resolve_wire_finish_reason("length", false, false, true, None),
             "stop"
         );
         // With no match, the scheduler's reason passes through.
         assert_eq!(
-            resolve_wire_finish_reason("length", false, false, false),
+            resolve_wire_finish_reason("length", false, false, false, None),
             "length"
         );
         assert_eq!(
-            resolve_wire_finish_reason("stop", false, false, false),
+            resolve_wire_finish_reason("stop", false, false, false, None),
+            "stop"
+        );
+    }
+
+    #[test]
+    fn stream_side_guard_cut_reports_length() {
+        // POSITIVE. The token-loop / simhash watchdogs live on the STREAM:
+        // they set `state.guard_stop` and flip `cancel_flag`, but never
+        // touch the scheduler's `ActiveSeq::guard_stop`. The scheduler
+        // therefore finalizes with no guard and says "stop". Without this
+        // rung that "stop" reached the client, and the agentic harness
+        // read a mid-repetition truncation as a finished turn.
+        //
+        // ★ Fixing only the scheduler side left this hole: an episode
+        // still died at 4 turns having written one file, its last turn a
+        // mid-word splice labelled `stop`.
+        for guard in ["simhash_semantic_loop", "token_loop_watchdog"] {
+            assert_eq!(
+                resolve_wire_finish_reason("stop", false, false, false, Some(guard)),
+                "length",
+                "guard={guard}"
+            );
+        }
+    }
+
+    #[test]
+    fn stream_guard_does_not_outrank_what_actually_happened() {
+        // NEGATIVE. The guard rung sits BELOW tool_calls and the
+        // stop-string match, so a watchdog tripping on the same step a
+        // real tool call or a client stop sequence landed still reports
+        // the true event rather than claiming truncation.
+        assert_eq!(
+            resolve_wire_finish_reason("stop", false, true, false, Some("token_loop_watchdog")),
+            "tool_calls"
+        );
+        assert_eq!(
+            resolve_wire_finish_reason("stop", false, false, true, Some("token_loop_watchdog")),
+            "stop"
+        );
+        // And with no stream guard the scheduler's reason is untouched.
+        assert_eq!(
+            resolve_wire_finish_reason("stop", false, false, false, None),
             "stop"
         );
     }
@@ -354,16 +419,16 @@ mod wire_finish_reason_tests {
     fn timeout_and_tool_overrides_keep_their_rank() {
         // Shipped contracts, unchanged by this wave.
         assert_eq!(
-            resolve_wire_finish_reason(FINISH_REASON_TIMEOUT, true, true, true),
+            resolve_wire_finish_reason(FINISH_REASON_TIMEOUT, true, true, true, None),
             FINISH_REASON_TIMEOUT
         );
         assert_eq!(
-            resolve_wire_finish_reason("stop", true, true, true),
+            resolve_wire_finish_reason("stop", true, true, true, None),
             "length",
             "tool-loop cap outranks tool_calls and the stop-string match"
         );
         assert_eq!(
-            resolve_wire_finish_reason("stop", false, true, true),
+            resolve_wire_finish_reason("stop", false, true, true, None),
             "tool_calls",
             "parsed tool calls outrank the stop-string override"
         );

--- a/crates/spark-server/src/api/chat_stream/handle_token.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_token.rs
@@ -94,6 +94,23 @@ pub(super) fn handle_token(state: &mut StreamState, ctx: &StreamCtx, tok: u32) -
             );
             state.loop_watchdog_triggered = true;
             state.stop_string_triggered = true;
+            // ★ Name the guard so the wire reason comes out "length".
+            // Without this the scheduler sees a bare `cancel_flag` with
+            // budget left, falls to its early-finalize rule and reports
+            // "stop" — telling the client the model finished, when in
+            // fact we truncated it mid-doom-loop.
+            //
+            // This was the THIRD such path. The scheduler guards and the
+            // simhash/token-loop watchdogs were fixed first; this one
+            // survived both and cost the agentic gate runs 0 and 7 on
+            // three consecutive shas, because the harness's
+            // `was_cut_off()` only nudges on "length".
+            //
+            // ★ Note the harness's OTHER recovery route cannot cover it:
+            // `emitted_unparsed_call` scans the text for `<tool_call>` /
+            // `<function=`, and the sanitizer has already suppressed
+            // exactly those bytes — which is why this streak fired at all.
+            state.guard_stop = Some("suppress_streak");
             state
                 .cancel_flag
                 .store(true, std::sync::atomic::Ordering::Release);

--- a/crates/spark-server/src/api/chat_stream/handle_token.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_token.rs
@@ -430,6 +430,13 @@ fn handle_token_inner(state: &mut StreamState, ctx: &StreamCtx, tok: u32) -> Del
             &mut state.stop_string_emitted_len,
             &mut state.stop_string_triggered,
         );
+        // Entry was gated on `!triggered`, so a flip here is a GENUINE
+        // client stop-sequence match (the watchdog paths set the flag
+        // elsewhere): record it for the wire finish_reason ("stop", per
+        // OpenAI) and cancel generation.
+        if state.stop_string_triggered {
+            state.note_stop_string_match();
+        }
         if delta.is_empty() {
             // Either everything is sitting in the hold-back window
             // (waiting for the next chunk / stream close) or a match

--- a/crates/spark-server/src/api/chat_stream/mod.rs
+++ b/crates/spark-server/src/api/chat_stream/mod.rs
@@ -266,7 +266,20 @@ pub(crate) async fn run_chat_stream(
                 cached_prompt_tokens,
                 guard_stop,
             } => {
-                stream_state.guard_stop = guard_stop;
+                // ★ `.or()`, NOT `=`. This field began life as a scheduler-owned
+                // diagnostic (see state.rs) and the Done frame legitimately
+                // carries the scheduler's `ActiveSeq::guard_stop`. But the
+                // stream-side watchdogs in handle_token.rs also write it, and
+                // they run BEFORE this frame arrives — an unconditional
+                // assignment erased them with the scheduler's `None`.
+                //
+                // That clobber made two shipped fixes completely inert: the
+                // token-loop watchdog set `guard_stop` on the line above its
+                // `cancel_flag` store, and `handle_done` still read `None`.
+                // The adjacent `loop_watchdog_triggered` / `stop_string_triggered`
+                // flags survived, which is the built-in negative control:
+                // only this field was reset.
+                stream_state.guard_stop = stream_state.guard_stop.or(guard_stop);
                 handle_done::handle_done(
                     &mut stream_state,
                     &ctx,

--- a/crates/spark-server/src/api/chat_stream/mod.rs
+++ b/crates/spark-server/src/api/chat_stream/mod.rs
@@ -19,6 +19,8 @@
 //! - `handle_done`  — Done arm (flush, salvage, usage, dump, metrics)
 //! - `handle_error` — Error arm
 
+#[cfg(test)]
+mod cancel_guard_tests;
 mod ctx;
 mod handle_done;
 mod handle_error;

--- a/crates/spark-server/src/api/chat_stream/state.rs
+++ b/crates/spark-server/src/api/chat_stream/state.rs
@@ -49,6 +49,15 @@ pub(super) struct StreamState {
     /// Flips true on first stop-string match or on watchdog/dedup
     /// trip; suppresses further content emissions.
     pub(super) stop_string_triggered: bool,
+    /// True only when a CLIENT `stop` sequence actually matched
+    /// (`apply_stop_string_holdback` hit) — distinct from
+    /// `stop_string_triggered`, which the watchdog/leak guards also
+    /// set as an output-suppression device. Read by `handle_done`: a
+    /// matched stop sequence is wire `finish_reason="stop"` per the
+    /// OpenAI contract, never "length" (the scheduler can still say
+    /// "length" when the cancel landed a step late and the budget ran
+    /// out first). Set via [`StreamState::note_stop_string_match`].
+    pub(super) stop_string_matched: bool,
     /// Sanitiser state: suppressing content while waiting for a
     /// matching `</parameter>` close after an orphan `<parameter=`.
     pub(super) suppressing_param_leak: bool,
@@ -194,6 +203,7 @@ impl StreamState {
             stop_string_emitted_len: 0,
             refusal_scan_buf: String::new(),
             stop_string_triggered: false,
+            stop_string_matched: false,
             suppressing_param_leak: false,
             suppress_streak_tokens: 0,
             inside_envelope: false,
@@ -229,5 +239,42 @@ impl StreamState {
             pending_retry: None,
             pending_token_ids: Vec::new(),
         }
+    }
+
+    /// A client `stop` sequence matched in the emitted text. Records
+    /// the match for `handle_done` (wire `finish_reason="stop"` — see
+    /// `stop_string_matched`) and flips the scheduler's cancel flag so
+    /// generation actually ends at the next decode boundary instead of
+    /// burning suppressed tokens until natural EOS / max_tokens (the
+    /// exact hazard the `cancel_flag` doc in `inference_types.rs`
+    /// describes).
+    pub(super) fn note_stop_string_match(&mut self) {
+        self.stop_string_matched = true;
+        self.cancel_flag
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod stop_string_match_tests {
+    use super::StreamState;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn note_stop_string_match_records_and_cancels() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let mut s = StreamState::new(false, false, flag.clone(), Vec::new());
+        assert!(!s.stop_string_matched, "fresh stream: no match yet");
+        assert!(!flag.load(Ordering::Acquire));
+        s.note_stop_string_match();
+        assert!(
+            s.stop_string_matched,
+            "match must be recorded for handle_done"
+        );
+        assert!(
+            flag.load(Ordering::Acquire),
+            "scheduler cancel flag must flip so generation stops"
+        );
     }
 }

--- a/crates/spark-server/src/api/mod.rs
+++ b/crates/spark-server/src/api/mod.rs
@@ -29,6 +29,7 @@
 
 pub mod chat;
 pub mod chat_blocking;
+mod chat_blocking_choice;
 pub mod chat_phases;
 pub mod chat_stream;
 pub mod chat_stream_dispatch;

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -201,20 +201,34 @@ pub struct ServeArgs {
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub ssm_batched_recurrent: Option<bool>,
 
-    /// Restore the WY-chunkwise / fused BF16-conv MTP-verify arms
-    /// (default: off — the verify pass runs the sequential-decode-EXACT
-    /// per-token chain).
+    /// Bitwise-exact MTP verify — OPT-IN (default: off). By default,
+    /// speculative (spec-on) output is NOT bitwise-equal to non-speculative
+    /// output at temp 0; this flag is what makes it equal (issue #435).
     ///
-    /// Issue #435: at temp 0, spec-on output must equal spec-off output. The
-    /// WY verify arms ran a BF16-output conv where sequential decode runs
-    /// FP32 (h-state relL2 ~8.6e-4 per K=4 window — committed into persistent
-    /// SSM state) plus a ~3.4e-8 chunkwise reordering term. The exact chain
-    /// is the default because output equivalence is a correctness property;
-    /// this flag is the A/B kill switch, not a tuning knob.
+    /// The default verify pass runs the WY-chunkwise / fused BF16-conv arms:
+    /// fast, but their BF16-output conv (h-state relL2 ~8.6e-4 per K=4
+    /// window, committed into persistent SSM state) plus a ~3.4e-8 chunkwise
+    /// reordering term diverge from the sequential-decode reference — an
+    /// argmax flip only needs a per-logit error above a thin top-2 margin.
+    /// With `--exact-verify` the verify pass instead runs, per token, exactly
+    /// the kernel chain sequential decode runs (measured h relL2 = 0.0), at a
+    /// measured decode-step cost of ~+35% at the n=8/K=4 verify rung, ~+22%
+    /// at n=16/K=2 and ~+36% at n=32/K=2 (GDN phase +116%/+63%/+69%).
+    ///
+    /// Opt-in follows every surveyed production engine — vLLM
+    /// (`VLLM_BATCH_INVARIANT=1`), SGLang (`--enable-deterministic-inference`,
+    /// ~34% avg slowdown), TensorRT-LLM and TGI (no exact mode at all) — none
+    /// pays for exactness by default.
+    ///
+    /// Rejected beside `--ssm-h-dtype f16`: the exact arm's kernels are FP32
+    /// readers and must never read the FP16 h-state pool.
+    ///
+    /// Replaces `--verify-wy` (removed, never in a release), which was the
+    /// opt-OUT back when exact was briefly the default.
     ///
     /// No legacy environment variable — new configuration is CLI-only.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
-    pub verify_wy: Option<bool>,
+    pub exact_verify: Option<bool>,
 
     /// Mid-chunk SSM tail capture on the prefill path (default: on).
     ///

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -201,6 +201,21 @@ pub struct ServeArgs {
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub ssm_batched_recurrent: Option<bool>,
 
+    /// Restore the WY-chunkwise / fused BF16-conv MTP-verify arms
+    /// (default: off — the verify pass runs the sequential-decode-EXACT
+    /// per-token chain).
+    ///
+    /// Issue #435: at temp 0, spec-on output must equal spec-off output. The
+    /// WY verify arms ran a BF16-output conv where sequential decode runs
+    /// FP32 (h-state relL2 ~8.6e-4 per K=4 window — committed into persistent
+    /// SSM state) plus a ~3.4e-8 chunkwise reordering term. The exact chain
+    /// is the default because output equivalence is a correctness property;
+    /// this flag is the A/B kill switch, not a tuning knob.
+    ///
+    /// No legacy environment variable — new configuration is CLI-only.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub verify_wy: Option<bool>,
+
     /// Mid-chunk SSM tail capture on the prefill path (default: on).
     ///
     /// Captures GDN recurrent + conv state in-pass at the block-floored

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -92,6 +92,20 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
             "add --gdn-fused-norm, or use --ssm-h-dtype f32",
         ));
     }
+    // #435: the exact-verify arm's kernels are FP32 readers, so an FP16
+    // h-state pool disables it (`GdnFlags::verify_exact_active`). Honouring
+    // `--ssm-h-dtype f16` by SILENTLY ignoring an explicit `--exact-verify`
+    // would ship the very divergence the operator just opted out of — the
+    // exact class of combination this validator exists to refuse.
+    if args.exact_verify == Some(true) && args.ssm_h_dtype.as_deref() == Some("f16") {
+        v.push(Violation::new(
+            "--exact-verify together with --ssm-h-dtype f16",
+            "the exact MTP-verify chain (issue #435) runs FP32-reader kernels and must \
+             never read the FP16 h-state pool, so with f16 the exact request would be \
+             silently dropped and spec-on output would NOT equal spec-off",
+            "drop --ssm-h-dtype f16 (f32 is the default), or drop --exact-verify",
+        ));
+    }
     check_enum(
         &mut v,
         "--mtp-quantization",
@@ -283,214 +297,5 @@ fn format_violations(v: &[Violation]) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-
-    /// Parse a `spark serve ...` command line into `ServeArgs` for testing.
-    fn parse(extra: &[&str]) -> ServeArgs {
-        let mut argv = vec!["spark", "serve", "dummy/model", "--model-name", "dummy"];
-        argv.extend_from_slice(extra);
-        match super::super::Cli::parse_from(argv).command {
-            super::super::Command::Serve(a) => a,
-            super::super::Command::Benchmark(_) => unreachable!("this test parses a serve command"),
-        }
-    }
-
-    #[test]
-    fn defaults_are_valid() {
-        assert!(validate_serve_args(&parse(&[])).is_ok());
-    }
-
-    #[test]
-    fn fp8_calibration_requires_fp8_kv() {
-        let err = validate_serve_args(&parse(&[
-            "--kv-cache-dtype",
-            "bf16",
-            "--fp8-kv-calibration-tokens",
-            "256",
-        ]))
-        .unwrap_err();
-        assert!(err.contains("--fp8-kv-calibration-tokens"));
-        assert!(err.contains("fix:"));
-        // The same flags with an fp8 cache are fine.
-        assert!(
-            validate_serve_args(&parse(&[
-                "--kv-cache-dtype",
-                "fp8",
-                "--fp8-kv-calibration-tokens",
-                "256",
-            ]))
-            .is_ok()
-        );
-    }
-
-    #[test]
-    fn an_absent_lever_flag_parses_as_unspecified() {
-        // `None` is not the same as the default VALUE, and the difference is
-        // load-bearing: publishing a default seals the cell these two flags
-        // write to, which turned `ATLAS_SSM_TAIL_MIDCHUNK=0` and
-        // `ATLAS_MTP_GATE_FORCE=1` into documented, echoed, silent no-ops under
-        // `spark serve`. Absent has to stay absent all the way to
-        // `publish_kernel_flags` for the fallback to be reachable.
-        let a = parse(&[]);
-        assert!(a.ssm_tail_midchunk.is_none(), "ATLAS_SSM_TAIL_MIDCHUNK");
-        assert!(a.mtp_gate.is_none(), "ATLAS_MTP_GATE_FORCE");
-        assert!(a.ssm_h_dtype.is_none(), "ATLAS_SSM_H_FP16");
-        assert!(a.gdn_fused_norm.is_none(), "ATLAS_GDN_FUSED_NORM");
-        assert!(
-            a.ssm_batched_recurrent.is_none(),
-            "ATLAS_SSM_BATCHED_RECURRENT"
-        );
-        // #435: absent must stay absent so publish_kernel_flags does not seal
-        // the GDN cell; the resolved default (exact verify) is asserted in
-        // gdn_flags' own tests.
-        assert!(a.verify_wy.is_none(), "--verify-wy");
-
-        let a = parse(&["--ssm-tail-midchunk", "false", "--mtp-gate", "force"]);
-        assert_eq!(a.ssm_tail_midchunk, Some(false), "given, it still wins");
-        assert_eq!(a.mtp_gate.as_deref(), Some("force"));
-    }
-
-    #[test]
-    fn the_bare_gdn_switches_still_mean_on() {
-        // `Option<bool>` must not turn a presence switch into one that DEMANDS
-        // a value: every recipe and frozen command line writes them bare, and
-        // silently requiring `--gdn-fused-norm true` would break all of them.
-        let a = parse(&["--gdn-fused-norm", "--ssm-batched-recurrent"]);
-        assert_eq!(a.gdn_fused_norm, Some(true));
-        assert_eq!(a.ssm_batched_recurrent, Some(true));
-        // And an explicit off is now expressible, which it was not before.
-        let a = parse(&["--gdn-fused-norm", "false"]);
-        assert_eq!(a.gdn_fused_norm, Some(false));
-        // #435 A/B kill switch follows the same convention: bare means on
-        // (restore the WY arms), explicit false is expressible.
-        let a = parse(&["--verify-wy"]);
-        assert_eq!(a.verify_wy, Some(true));
-        let a = parse(&["--verify-wy", "false"]);
-        assert_eq!(a.verify_wy, Some(false));
-    }
-
-    #[test]
-    fn f16_h_state_still_needs_the_fused_norm_arm() {
-        // Absent counts as off: one GDN flag publishes all three, so
-        // `--ssm-h-dtype f16` alone reaches the FP32-only kernel with an FP16
-        // pool — fluent garbage, not a fault.
-        assert!(validate_serve_args(&parse(&["--ssm-h-dtype", "f16"])).is_err());
-        assert!(
-            validate_serve_args(&parse(&["--ssm-h-dtype", "f16", "--gdn-fused-norm"])).is_ok(),
-            "the supported pairing"
-        );
-        assert!(
-            validate_serve_args(&parse(&[
-                "--ssm-h-dtype",
-                "f16",
-                "--gdn-fused-norm",
-                "false"
-            ]))
-            .is_err(),
-            "and an explicit off is refused just as an absent one is"
-        );
-    }
-
-    #[test]
-    fn a_mistyped_mtp_gate_is_still_caught() {
-        // Making the flag optional must not make its typo check optional.
-        let err = validate_serve_args(&parse(&["--mtp-gate", "always"])).unwrap_err();
-        assert!(err.contains("--mtp-gate"), "{err}");
-        assert!(err.contains("auto, force"), "names the valid values: {err}");
-    }
-
-    #[test]
-    fn require_auth_needs_a_token() {
-        assert!(validate_serve_args(&parse(&["--require-auth"])).is_err());
-        assert!(validate_serve_args(&parse(&["--require-auth", "--auth-token", "sk-x"])).is_ok());
-    }
-
-    #[test]
-    fn num_drafts_needs_speculative() {
-        assert!(validate_serve_args(&parse(&["--num-drafts", "2"])).is_err());
-        assert!(validate_serve_args(&parse(&["--num-drafts", "2", "--speculative"])).is_ok());
-    }
-
-    #[test]
-    fn rank_must_be_below_world_size() {
-        assert!(validate_serve_args(&parse(&["--rank", "2", "--world-size", "2"])).is_err());
-        assert!(validate_serve_args(&parse(&["--rank", "1", "--world-size", "2"])).is_ok());
-    }
-
-    #[test]
-    fn ep_size_cannot_exceed_world_size() {
-        assert!(validate_serve_args(&parse(&["--ep-size", "2"])).is_err());
-        assert!(validate_serve_args(&parse(&["--ep-size", "2", "--world-size", "2"])).is_ok());
-    }
-
-    #[test]
-    fn disable_thinking_conflicts_with_budget() {
-        assert!(
-            validate_serve_args(&parse(&[
-                "--disable-thinking",
-                "--max-thinking-budget",
-                "2048"
-            ]))
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn flagship_recipe_is_accepted() {
-        // The canonical 35B flagship serve recipe (PR #278) passes
-        // `--kv-cache-dtype bf16 --kv-high-precision-layers auto` together —
-        // redundant but valid. The validator must NOT reject it.
-        assert!(
-            validate_serve_args(&parse(&[
-                "--kv-cache-dtype",
-                "bf16",
-                "--lm-head-dtype",
-                "nvfp4",
-                "--kv-high-precision-layers",
-                "auto",
-                "--scheduling-policy",
-                "slai",
-                "--speculative",
-                "--num-drafts",
-                "1",
-                "--mtp-quantization",
-                "bf16",
-                "--enable-prefix-caching",
-            ]))
-            .is_ok()
-        );
-    }
-
-    #[test]
-    fn enum_typos_are_rejected() {
-        let err = validate_serve_args(&parse(&["--scheduling-policy", "fifoo"])).unwrap_err();
-        assert!(err.contains("--scheduling-policy"));
-        assert!(err.contains("fifo, slai"));
-    }
-
-    #[test]
-    fn multiple_violations_all_reported() {
-        let err = validate_serve_args(&parse(&[
-            "--require-auth",
-            "--num-drafts",
-            "3",
-            "--rank",
-            "5",
-            "--world-size",
-            "2",
-        ]))
-        .unwrap_err();
-        assert!(err.contains("[1]"));
-        assert!(err.contains("[2]"));
-        assert!(err.contains("[3]"));
-    }
-
-    #[test]
-    fn gpu_mem_util_range_enforced() {
-        assert!(validate_serve_args(&parse(&["--gpu-memory-utilization", "1.5"])).is_err());
-        assert!(validate_serve_args(&parse(&["--gpu-memory-utilization", "0.0"])).is_err());
-        assert!(validate_serve_args(&parse(&["--gpu-memory-utilization", "0.9"])).is_ok());
-    }
-}
+#[path = "validate_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -342,6 +342,10 @@ mod tests {
             a.ssm_batched_recurrent.is_none(),
             "ATLAS_SSM_BATCHED_RECURRENT"
         );
+        // #435: absent must stay absent so publish_kernel_flags does not seal
+        // the GDN cell; the resolved default (exact verify) is asserted in
+        // gdn_flags' own tests.
+        assert!(a.verify_wy.is_none(), "--verify-wy");
 
         let a = parse(&["--ssm-tail-midchunk", "false", "--mtp-gate", "force"]);
         assert_eq!(a.ssm_tail_midchunk, Some(false), "given, it still wins");
@@ -359,6 +363,12 @@ mod tests {
         // And an explicit off is now expressible, which it was not before.
         let a = parse(&["--gdn-fused-norm", "false"]);
         assert_eq!(a.gdn_fused_norm, Some(false));
+        // #435 A/B kill switch follows the same convention: bare means on
+        // (restore the WY arms), explicit false is expressible.
+        let a = parse(&["--verify-wy"]);
+        assert_eq!(a.verify_wy, Some(true));
+        let a = parse(&["--verify-wy", "false"]);
+        assert_eq!(a.verify_wy, Some(false));
     }
 
     #[test]

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (cross-flag CLI validation). A sibling file via
+//! `#[path]` — the `helpers.rs`/`helpers_tests.rs` idiom — so `validate.rs`
+//! stays under the 500-line cap; module position (child of `validate`) is
+//! unchanged, so `super::*` paths are untouched.
+use super::*;
+use clap::Parser;
+
+/// Parse a `spark serve ...` command line into `ServeArgs` for testing.
+fn parse(extra: &[&str]) -> ServeArgs {
+    let mut argv = vec!["spark", "serve", "dummy/model", "--model-name", "dummy"];
+    argv.extend_from_slice(extra);
+    match super::super::Cli::parse_from(argv).command {
+        super::super::Command::Serve(a) => a,
+        super::super::Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+    }
+}
+
+#[test]
+fn defaults_are_valid() {
+    assert!(validate_serve_args(&parse(&[])).is_ok());
+}
+
+#[test]
+fn fp8_calibration_requires_fp8_kv() {
+    let err = validate_serve_args(&parse(&[
+        "--kv-cache-dtype",
+        "bf16",
+        "--fp8-kv-calibration-tokens",
+        "256",
+    ]))
+    .unwrap_err();
+    assert!(err.contains("--fp8-kv-calibration-tokens"));
+    assert!(err.contains("fix:"));
+    // The same flags with an fp8 cache are fine.
+    assert!(
+        validate_serve_args(&parse(&[
+            "--kv-cache-dtype",
+            "fp8",
+            "--fp8-kv-calibration-tokens",
+            "256",
+        ]))
+        .is_ok()
+    );
+}
+
+#[test]
+fn an_absent_lever_flag_parses_as_unspecified() {
+    // `None` is not the same as the default VALUE, and the difference is
+    // load-bearing: publishing a default seals the cell these two flags
+    // write to, which turned `ATLAS_SSM_TAIL_MIDCHUNK=0` and
+    // `ATLAS_MTP_GATE_FORCE=1` into documented, echoed, silent no-ops under
+    // `spark serve`. Absent has to stay absent all the way to
+    // `publish_kernel_flags` for the fallback to be reachable.
+    let a = parse(&[]);
+    assert!(a.ssm_tail_midchunk.is_none(), "ATLAS_SSM_TAIL_MIDCHUNK");
+    assert!(a.mtp_gate.is_none(), "ATLAS_MTP_GATE_FORCE");
+    assert!(a.ssm_h_dtype.is_none(), "ATLAS_SSM_H_FP16");
+    assert!(a.gdn_fused_norm.is_none(), "ATLAS_GDN_FUSED_NORM");
+    assert!(
+        a.ssm_batched_recurrent.is_none(),
+        "ATLAS_SSM_BATCHED_RECURRENT"
+    );
+    // #435: absent must stay absent so publish_kernel_flags does not seal
+    // the GDN cell; the resolved default (the legacy WY arms — exact verify
+    // is OPT-IN) is asserted in gdn_flags' own tests.
+    assert!(a.exact_verify.is_none(), "--exact-verify");
+
+    let a = parse(&["--ssm-tail-midchunk", "false", "--mtp-gate", "force"]);
+    assert_eq!(a.ssm_tail_midchunk, Some(false), "given, it still wins");
+    assert_eq!(a.mtp_gate.as_deref(), Some("force"));
+}
+
+#[test]
+fn the_bare_gdn_switches_still_mean_on() {
+    // `Option<bool>` must not turn a presence switch into one that DEMANDS
+    // a value: every recipe and frozen command line writes them bare, and
+    // silently requiring `--gdn-fused-norm true` would break all of them.
+    let a = parse(&["--gdn-fused-norm", "--ssm-batched-recurrent"]);
+    assert_eq!(a.gdn_fused_norm, Some(true));
+    assert_eq!(a.ssm_batched_recurrent, Some(true));
+    // And an explicit off is now expressible, which it was not before.
+    let a = parse(&["--gdn-fused-norm", "false"]);
+    assert_eq!(a.gdn_fused_norm, Some(false));
+    // The #435 exact-verify opt-in follows the same convention: bare means
+    // on (select the exact chain), explicit false is expressible.
+    let a = parse(&["--exact-verify"]);
+    assert_eq!(a.exact_verify, Some(true));
+    let a = parse(&["--exact-verify", "false"]);
+    assert_eq!(a.exact_verify, Some(false));
+}
+
+#[test]
+fn exact_verify_refuses_the_f16_h_state() {
+    // #435: the exact arm's kernels are FP32 readers; pairing the opt-in with
+    // an FP16 h-state pool would silently drop the exact request, so the
+    // validator refuses the combination outright.
+    let err = validate_serve_args(&parse(&[
+        "--exact-verify",
+        "--ssm-h-dtype",
+        "f16",
+        "--gdn-fused-norm",
+    ]))
+    .unwrap_err();
+    assert!(err.contains("--exact-verify"), "{err}");
+    // POSITIVE controls: each side alone stays valid.
+    assert!(validate_serve_args(&parse(&["--exact-verify"])).is_ok());
+    assert!(validate_serve_args(&parse(&["--ssm-h-dtype", "f16", "--gdn-fused-norm"])).is_ok());
+    // And an explicit `--exact-verify false` beside f16 is NOT a request for
+    // exact verify, so it must not be refused.
+    assert!(
+        validate_serve_args(&parse(&[
+            "--exact-verify",
+            "false",
+            "--ssm-h-dtype",
+            "f16",
+            "--gdn-fused-norm"
+        ]))
+        .is_ok()
+    );
+}
+
+#[test]
+fn f16_h_state_still_needs_the_fused_norm_arm() {
+    // Absent counts as off: one GDN flag publishes all three, so
+    // `--ssm-h-dtype f16` alone reaches the FP32-only kernel with an FP16
+    // pool — fluent garbage, not a fault.
+    assert!(validate_serve_args(&parse(&["--ssm-h-dtype", "f16"])).is_err());
+    assert!(
+        validate_serve_args(&parse(&["--ssm-h-dtype", "f16", "--gdn-fused-norm"])).is_ok(),
+        "the supported pairing"
+    );
+    assert!(
+        validate_serve_args(&parse(&[
+            "--ssm-h-dtype",
+            "f16",
+            "--gdn-fused-norm",
+            "false"
+        ]))
+        .is_err(),
+        "and an explicit off is refused just as an absent one is"
+    );
+}
+
+#[test]
+fn a_mistyped_mtp_gate_is_still_caught() {
+    // Making the flag optional must not make its typo check optional.
+    let err = validate_serve_args(&parse(&["--mtp-gate", "always"])).unwrap_err();
+    assert!(err.contains("--mtp-gate"), "{err}");
+    assert!(err.contains("auto, force"), "names the valid values: {err}");
+}
+
+#[test]
+fn require_auth_needs_a_token() {
+    assert!(validate_serve_args(&parse(&["--require-auth"])).is_err());
+    assert!(validate_serve_args(&parse(&["--require-auth", "--auth-token", "sk-x"])).is_ok());
+}
+
+#[test]
+fn num_drafts_needs_speculative() {
+    assert!(validate_serve_args(&parse(&["--num-drafts", "2"])).is_err());
+    assert!(validate_serve_args(&parse(&["--num-drafts", "2", "--speculative"])).is_ok());
+}
+
+#[test]
+fn rank_must_be_below_world_size() {
+    assert!(validate_serve_args(&parse(&["--rank", "2", "--world-size", "2"])).is_err());
+    assert!(validate_serve_args(&parse(&["--rank", "1", "--world-size", "2"])).is_ok());
+}
+
+#[test]
+fn ep_size_cannot_exceed_world_size() {
+    assert!(validate_serve_args(&parse(&["--ep-size", "2"])).is_err());
+    assert!(validate_serve_args(&parse(&["--ep-size", "2", "--world-size", "2"])).is_ok());
+}
+
+#[test]
+fn disable_thinking_conflicts_with_budget() {
+    assert!(
+        validate_serve_args(&parse(&[
+            "--disable-thinking",
+            "--max-thinking-budget",
+            "2048"
+        ]))
+        .is_err()
+    );
+}
+
+#[test]
+fn flagship_recipe_is_accepted() {
+    // The canonical 35B flagship serve recipe (PR #278) passes
+    // `--kv-cache-dtype bf16 --kv-high-precision-layers auto` together —
+    // redundant but valid. The validator must NOT reject it.
+    assert!(
+        validate_serve_args(&parse(&[
+            "--kv-cache-dtype",
+            "bf16",
+            "--lm-head-dtype",
+            "nvfp4",
+            "--kv-high-precision-layers",
+            "auto",
+            "--scheduling-policy",
+            "slai",
+            "--speculative",
+            "--num-drafts",
+            "1",
+            "--mtp-quantization",
+            "bf16",
+            "--enable-prefix-caching",
+        ]))
+        .is_ok()
+    );
+}
+
+#[test]
+fn enum_typos_are_rejected() {
+    let err = validate_serve_args(&parse(&["--scheduling-policy", "fifoo"])).unwrap_err();
+    assert!(err.contains("--scheduling-policy"));
+    assert!(err.contains("fifo, slai"));
+}
+
+#[test]
+fn multiple_violations_all_reported() {
+    let err = validate_serve_args(&parse(&[
+        "--require-auth",
+        "--num-drafts",
+        "3",
+        "--rank",
+        "5",
+        "--world-size",
+        "2",
+    ]))
+    .unwrap_err();
+    assert!(err.contains("[1]"));
+    assert!(err.contains("[2]"));
+    assert!(err.contains("[3]"));
+}
+
+#[test]
+fn gpu_mem_util_range_enforced() {
+    assert!(validate_serve_args(&parse(&["--gpu-memory-utilization", "1.5"])).is_err());
+    assert!(validate_serve_args(&parse(&["--gpu-memory-utilization", "0.0"])).is_err());
+    assert!(validate_serve_args(&parse(&["--gpu-memory-utilization", "0.9"])).is_ok());
+}

--- a/crates/spark-server/src/ir/response.rs
+++ b/crates/spark-server/src/ir/response.rs
@@ -87,6 +87,16 @@ pub struct Usage {
 /// stop ("length") and from a natural end ("stop"), or the client
 /// silently loses output with no way to tell. It is carried as
 /// `FinishReason::Other` and round-trips verbatim through `as_wire`.
+///
+/// KNOWN TRADEOFF (2026-08-09): a non-standard `finish_reason` is a
+/// client-compatibility hazard — strictly typed clients hard-fail on
+/// unknown variants (Rust `async-openai` fails deserialization outright,
+/// which is what forced TGI to drop its `eos_token` value; pydantic-ai
+/// raised on OpenRouter's non-standard "error"). "timeout" is kept as a
+/// deliberate, shipped exception because silent truncation is worse; do
+/// NOT add further non-standard values — server-side guard cuts map to
+/// "stop" and carry their detail in the `guard_stop` side-channel (see
+/// `scheduler::lifecycle::guard_stop_wire_reason`).
 pub const FINISH_REASON_TIMEOUT: &str = "timeout";
 
 /// Why generation stopped. `Other` preserves unknown engine reasons

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -43,13 +43,13 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     let gdn_from_cli = args.ssm_h_dtype.is_some()
         || args.gdn_fused_norm.is_some()
         || args.ssm_batched_recurrent.is_some()
-        || args.verify_wy.is_some();
+        || args.exact_verify.is_some();
     if gdn_from_cli {
         let flags = spark_model::layers::qwen3_ssm::GdnFlags {
             h_f16: args.ssm_h_dtype.as_deref() == Some("f16"),
             fused_norm: args.gdn_fused_norm.unwrap_or(false),
             batched_recurrent: args.ssm_batched_recurrent.unwrap_or(false),
-            verify_wy: args.verify_wy.unwrap_or(false),
+            exact_verify: args.exact_verify.unwrap_or(false),
         };
         let in_force = spark_model::layers::qwen3_ssm::gdn_flags::set_from_cli(flags);
         if in_force != flags {
@@ -74,11 +74,13 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     let gdn = spark_model::layers::qwen3_ssm::gdn_flags::flags();
     tracing::info!(
         "kernel flags: ssm_h_dtype={} gdn_fused_norm={} ssm_batched_recurrent={} \
-         verify_wy={} ssm_tail_midchunk={} mtp_gate={}",
+         exact_verify={} ssm_tail_midchunk={} mtp_gate={}",
         if gdn.h_f16 { "f16" } else { "f32" },
         gdn.fused_norm,
         gdn.batched_recurrent,
-        gdn.verify_wy,
+        // The RESOLVED decision (h_f16 forces this off), matching the
+        // "echo what is in force" rule the surrounding fields follow.
+        gdn.verify_exact_active(),
         spark_runtime::ssm_tail_midchunk_enabled(),
         if crate::scheduler::levers::mtp_gate_force() {
             "force"

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -42,12 +42,14 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     // overrides.
     let gdn_from_cli = args.ssm_h_dtype.is_some()
         || args.gdn_fused_norm.is_some()
-        || args.ssm_batched_recurrent.is_some();
+        || args.ssm_batched_recurrent.is_some()
+        || args.verify_wy.is_some();
     if gdn_from_cli {
         let flags = spark_model::layers::qwen3_ssm::GdnFlags {
             h_f16: args.ssm_h_dtype.as_deref() == Some("f16"),
             fused_norm: args.gdn_fused_norm.unwrap_or(false),
             batched_recurrent: args.ssm_batched_recurrent.unwrap_or(false),
+            verify_wy: args.verify_wy.unwrap_or(false),
         };
         let in_force = spark_model::layers::qwen3_ssm::gdn_flags::set_from_cli(flags);
         if in_force != flags {
@@ -72,10 +74,11 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     let gdn = spark_model::layers::qwen3_ssm::gdn_flags::flags();
     tracing::info!(
         "kernel flags: ssm_h_dtype={} gdn_fused_norm={} ssm_batched_recurrent={} \
-         ssm_tail_midchunk={} mtp_gate={}",
+         verify_wy={} ssm_tail_midchunk={} mtp_gate={}",
         if gdn.h_f16 { "f16" } else { "f32" },
         gdn.fused_norm,
         gdn.batched_recurrent,
+        gdn.verify_wy,
         spark_runtime::ssm_tail_midchunk_enabled(),
         if crate::scheduler::levers::mtp_gate_force() {
             "force"

--- a/crates/spark-server/src/scheduler/decode_logits_step.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_step.rs
@@ -361,6 +361,12 @@ pub fn process_decode_logits(
         {
             a.output_tokens.push(tok);
             a.finished = true;
+            // Name the cut. Without this the ladder skips its guard rung,
+            // budget is untouched, and the turn wires as "stop" -- telling
+            // the client the model finished when a guard ended it. Unlike
+            // `<|im_start|>`, this token is NOT eos-registered, so the
+            // `is_eos` rung does not catch it either.
+            a.guard_stop = Some(GUARD_STOP_TOOL_RESPONSE);
             tracing::debug!("<tool_response> hard-stop fired (id={trs}); ending turn");
             continue;
         }

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -19,11 +19,11 @@ pub fn emit_token(
     sched: &crate::scheduler::sched_ctx::SchedCtx,
 ) {
     // Cooperative cancellation from the streaming pipeline. The
-    // stream-side loop guards (Bug-2 name-run cap, F11 within-dedup,
-    // F44 perm-fail, loop-watchdog) flip this flag when they decide
-    // the response should end. Treat it like an EOS: finalise now so
-    // `handle_done` runs with the proper `tool_loop_capped` /
-    // `finish_reason="length"` machinery, instead of letting the
+    // stream-side guards (Bug-2 name-run cap, F11 within-dedup, F44
+    // perm-fail, loop-watchdog, client stop-sequence match) flip this
+    // flag when they decide the response should end. Treat it like an
+    // EOS: finalise now (lifecycle derives "stop" — budget not hit —
+    // and `handle_done`'s overrides refine it) instead of letting the
     // model keep emitting tokens that just get suppressed.
     if let Some(ref f) = a.cancel_flag
         && f.load(std::sync::atomic::Ordering::Acquire)

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -74,6 +74,8 @@ pub fn emit_token(
     {
         a.output_tokens.push(tok);
         a.finished = true;
+        // Name the cut -- MTP twin of the decode_logits_step site.
+        a.guard_stop = Some(GUARD_STOP_TOOL_RESPONSE);
         tracing::debug!("<tool_response> hard-stop fired (id={trs}); ending turn");
         return;
     }

--- a/crates/spark-server/src/scheduler/finish_guard_tests.rs
+++ b/crates/spark-server/src/scheduler/finish_guard_tests.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The scheduler-side half of the cancel-guard invariant.
+//!
+//! **A control-token hard stop must name its guard.** When the scheduler ends a
+//! turn because the model emitted a token it must never emit, that is a SERVER
+//! cut. If the site does not set `a.guard_stop`, `derive_finish_reason` skips
+//! its guard rung, sees budget remaining, and wires `"stop"` — telling the
+//! client the model finished.
+//!
+//! ★ Why this file exists separately from
+//! `api/chat_stream/cancel_guard_tests.rs`: that test scans `cancel_flag`
+//! stores under `api/chat_stream/`, and it was **green** while the
+//! `<tool_response>` hard stop sat bare — because a scheduler guard never
+//! touches `cancel_flag` at all. It sets `finished` directly. Two layers, two
+//! tests; neither covers the other's sites.
+//!
+//! The cost was concrete: the bare hard stop mislabelled a turn, the agentic
+//! harness's `was_cut_off()` (which nudges only on `"length"`) stayed silent,
+//! and a benchmark run ended at 9 turns instead of 32.
+//!
+//! # Scope, deliberately narrow
+//!
+//! This asserts the **hard-stop family** only — the class that shipped broken
+//! twice (`<tool_response>` and its MTP twin). It does NOT try to classify every
+//! `finished = true` in the scheduler. An earlier draft did, by matching words
+//! like "watchdog" in a lookback window, and it flagged nine sites of which most
+//! were comment prose or intentional. A structural test that fires on comments
+//! is worse than no test, because it trains people to ignore it.
+//!
+//! Sites outside this family that may or may not want naming are recorded as
+//! open questions in the PR, not silently changed.
+
+/// Scheduler files carrying control-token hard stops.
+const HARD_STOP_FILES: &[(&str, &str)] = &[
+    (
+        "decode_logits_step.rs",
+        include_str!("decode_logits_step.rs"),
+    ),
+    ("emit_step.rs", include_str!("emit_step.rs")),
+];
+
+/// The log line every hard-stop site emits. This is the anchor: it is emitted
+/// at the site, in the same statement group as the `finished` assignment.
+const HARD_STOP_ANCHOR: &str = "hard-stop fired";
+
+/// Proof the guard named itself.
+const NAMED: &str = "guard_stop = Some(";
+
+/// Hard stops that intentionally wire `"stop"`, with the reason.
+///
+/// `<|im_start|>` is **registered in `eos_tokens`** at startup
+/// (`tokenizer_runtime.rs::im_start_id`), so the site pushes the token and
+/// `derive_finish_reason`'s `is_eos` check succeeds — `"stop"` is correct and
+/// deliberate. Naming a guard there would flip a correct `"stop"` to `"length"`
+/// and reintroduce the exact mislabel that motivated the push
+/// (`"Done: 13 tokens (length) despite max_tokens=8192"`).
+///
+/// `<tool_response>` is NOT eos-registered — an instrumented leg recorded
+/// `is_eos=false` for it — which is precisely why it fell through to `"stop"`
+/// by accident rather than by design. That asymmetry is the whole point of
+/// this exemption list: it is not "which stops we bothered to fix".
+/// ★ Matched against the ANCHOR LINE ONLY — the `tracing!` message emitted at
+/// the site, which names which hard stop fired. Not against the surrounding
+/// window: an earlier draft searched the whole window and was immediately
+/// fooled by a comment in `decode_logits_step.rs` that merely *mentions*
+/// `<|im_start|>` twelve lines above the `<tool_response>` site, silently
+/// exempting the very site this test exists to catch. Prose is not evidence.
+const INTENTIONAL_STOP: &[&str] = &["<|im_start|>"];
+
+/// Lookback/lookahead around the anchor.
+const WINDOW: usize = 12;
+
+fn scan(src: &str) -> (usize, Vec<usize>) {
+    let lines: Vec<&str> = src.lines().collect();
+    let mut sites = 0usize;
+    let mut bare = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if !line.contains(HARD_STOP_ANCHOR) {
+            continue;
+        }
+        let from = i.saturating_sub(WINDOW);
+        let window = lines[from..=i].join("\n");
+        if !window.contains("finished = true") {
+            continue; // an anchor with no finish next to it is not a cut site
+        }
+        if INTENTIONAL_STOP.iter().any(|t| line.contains(t)) {
+            continue;
+        }
+        sites += 1;
+        if !window.contains(NAMED) {
+            bare.push(i + 1);
+        }
+    }
+    (sites, bare)
+}
+
+#[test]
+fn every_control_token_hard_stop_names_its_guard() {
+    let mut total = 0usize;
+    let mut bare: Vec<String> = Vec::new();
+    for (name, src) in HARD_STOP_FILES {
+        let (n, lines) = scan(src);
+        total += n;
+        bare.extend(lines.iter().map(|l| format!("{name}:{l}")));
+    }
+
+    // Floor: the `<tool_response>` stop and its MTP twin. If a rename or move
+    // drops the scan to zero this must fail loudly rather than report a green
+    // it never earned.
+    assert!(
+        total >= 2,
+        "found only {total} non-exempt hard-stop sites — the scan stopped \
+         matching. Fix the detection before trusting a green here."
+    );
+
+    assert!(
+        bare.is_empty(),
+        "a control-token hard stop ended a turn without naming its guard at: \
+         {bare:?}\n\
+         An unnamed guard cut wires finish_reason \"stop\", claiming the model \
+         finished when the server truncated it. Set \
+         `a.guard_stop = Some(GUARD_STOP_*)` at the site, or add the token to \
+         INTENTIONAL_STOP with the reason it is genuinely a natural end."
+    );
+}
+
+#[test]
+fn the_scan_flags_a_bare_stop_and_clears_a_named_one() {
+    // NEGATIVE half: prove the detector fires. Without this the test above
+    // passes for two reasons — the invariant holding, or the scan matching
+    // nothing — and only one is good news.
+    let bare = "\
+        if tok == trs {\n\
+        \x20   a.output_tokens.push(tok);\n\
+        \x20   a.finished = true;\n\
+        \x20   tracing::debug!(\"<tool_response> hard-stop fired (id={trs})\");\n\
+        }\n";
+    let (n, flagged) = scan(bare);
+    assert_eq!(n, 1, "the site should be counted");
+    assert_eq!(flagged, vec![4], "a bare hard stop must be flagged");
+
+    // POSITIVE half: naming it clears the finding.
+    let named = bare.replace(
+        "    a.finished = true;",
+        "    a.finished = true;\n    a.guard_stop = Some(GUARD_STOP_TOOL_RESPONSE);",
+    );
+    let (n, flagged) = scan(&named);
+    assert_eq!(n, 1);
+    assert!(flagged.is_empty(), "a named hard stop must not be flagged");
+}
+
+#[test]
+fn the_intentional_stop_exemption_is_load_bearing_and_narrow() {
+    // `<|im_start|>` must be exempt (it is eos-registered, so "stop" is right)...
+    let im_start = "\
+        if tok == ims {\n\
+        \x20   a.output_tokens.push(tok);\n\
+        \x20   a.finished = true;\n\
+        \x20   tracing::debug!(\"<|im_start|> hard-stop fired (id={ims})\");\n\
+        }\n";
+    let (n, flagged) = scan(im_start);
+    assert_eq!(n, 0, "<|im_start|> must be exempt — it is eos-registered");
+    assert!(flagged.is_empty());
+
+    // ...but the exemption must NOT be so broad it swallows the sibling it
+    // sits next to. This is the guard against "fixing" the test by widening
+    // the exemption until nothing is ever flagged.
+    // Separated by more than WINDOW, as the real sites are — otherwise the
+    // fixture itself would put the exemption inside the sibling's window and
+    // "prove" a narrowness the scan does not have.
+    let gap = "\n".repeat(WINDOW + 2);
+    let both = format!(
+        "{im_start}{gap}if tok == trs {{\n    a.finished = true;\n    \
+         tracing::debug!(\"<tool_response> hard-stop fired\");\n}}\n"
+    );
+    let (n, flagged) = scan(&both);
+    assert_eq!(n, 1, "the <tool_response> site must still be counted");
+    assert_eq!(flagged.len(), 1, "and still flagged when bare");
+}

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -4,35 +4,107 @@
 
 use super::*;
 
+/// THE single mapping from a server-side guard (`ActiveSeq::guard_stop`)
+/// to the wire `finish_reason`. Do not map guard names to wire reasons
+/// anywhere else.
+///
+/// Every non-timeout guard reports `"stop"`: the guard deliberately ended
+/// generation, the token budget was NOT hit, and OpenAI's closed enum
+/// {stop, length, tool_calls, content_filter} has no truer slot. The
+/// guard's NAME still reaches diagnostics unchanged via
+/// `StreamEvent::Done.guard_stop` and the --dump body.
+///
+/// Considered alternative: putting the guard name on the wire the way
+/// vLLM ships "repetition"/"abort". Rejected — typed clients hard-fail on
+/// unknown variants (Rust `async-openai` fails deserialization outright;
+/// pydantic-ai raised on OpenRouter's non-standard "error"), and our one
+/// deliberate exception, `"timeout"`, already carries that documented
+/// risk (see `ir::FINISH_REASON_TIMEOUT`). If a future guard warrants a
+/// distinct wire reason, add its arm HERE with its rationale.
+fn guard_stop_wire_reason(guard: &'static str) -> &'static str {
+    match guard {
+        // Defensive: the deadline guard is intercepted before the
+        // token-derived checks (see `derive_finish_reason`), so this arm
+        // is normally unreachable — kept so the mapping is total.
+        GUARD_STOP_REQUEST_TIMEOUT => crate::ir::FINISH_REASON_TIMEOUT,
+        _ => "stop",
+    }
+}
+
 /// Derive the wire finish reason for a completed sequence.
 ///
-/// A server-side deadline cut outranks the token-derived reasons: the
-/// last token of a truncated response is an ordinary content token, so
-/// the token-derived path would call it "length" and the client could
-/// not tell a truncation from a legitimate max_tokens stop. Pure so the
-/// precedence is unit-testable without a model or a GPU.
+/// INVARIANT: `"length"` means exactly "the token budget was exhausted" —
+/// the `max_tokens` countdown (`remaining == 0`) or the served context
+/// ceiling — decided by `helpers::hard_ceiling_hit`, the same predicate
+/// that force-stops decode. It is NOT a fallback. OpenAI's contract
+/// (mirrored by vLLM/SGLang/TGI/llama.cpp) is that `"length"` tells the
+/// client "raise the limit / continue and retry"; reporting it for a
+/// guard-cut or client-cancelled response sends agent clients (aider,
+/// opencode, hermes-agent) into retries that re-trigger the same cut
+/// (observed live: `Done: 573 tokens (length)` under max_new_tokens=1024).
+///
+/// Precedence:
+///   1. the server-side deadline → `"timeout"` — a truncation must never
+///      be mistaken for a natural stop, even when the last token is EOS;
+///   2. token-derived natural stops (EOS → `"stop"`, tool-call close →
+///      `"tool_calls"`) — what the model actually sampled outranks any
+///      other guard that tripped on the same step;
+///   3. any other guard → `guard_stop_wire_reason` (single mapping above);
+///   4. token budget exhausted → `"length"`;
+///   5. otherwise `"stop"` — an early finalize with budget left and no
+///      guard (client cancel via `cancel_flag`, dropped stream receiver,
+///      server shutdown drain): generation stopped; it did not hit the
+///      budget.
+///
+/// Pure so the precedence is unit-testable without a model or a GPU
+/// (tests in `lifecycle_tests.rs`).
 pub(super) fn derive_finish_reason(
     guard_stop: Option<&'static str>,
     last_tok: Option<u32>,
     eos_tokens: &[u32],
     tool_call_end_token: Option<u32>,
+    remaining: usize,
+    seq_len: usize,
+    max_seq_len: usize,
 ) -> &'static str {
     if guard_stop == Some(GUARD_STOP_REQUEST_TIMEOUT) {
         return crate::ir::FINISH_REASON_TIMEOUT;
     }
-    if last_tok.is_some_and(|t| eos_tokens.contains(&t)) {
-        "stop"
-    } else if last_tok == tool_call_end_token {
-        "tool_calls"
-    } else {
-        "length"
+    if let Some(t) = last_tok {
+        if eos_tokens.contains(&t) {
+            return "stop";
+        }
+        // Guarded on `Some(t)` so an EMPTY output (max_tokens==0 scoring
+        // path) on a model with no tool-call end token configured cannot
+        // satisfy `None == None` and misreport "tool_calls".
+        if Some(t) == tool_call_end_token {
+            return "tool_calls";
+        }
     }
+    if let Some(guard) = guard_stop {
+        return guard_stop_wire_reason(guard);
+    }
+    if hard_ceiling_hit(remaining, seq_len, max_seq_len) {
+        return "length";
+    }
+    "stop"
 }
 
 /// Send final response and free GPU resources for a completed sequence.
-pub fn finish_sequence(model: &dyn Model, a: &mut ActiveSeq) {
-    let last_tok = a.output_tokens.last().copied();
-    let reason = derive_finish_reason(a.guard_stop, last_tok, &a.eos_tokens, a.tool_call_end_token);
+///
+/// `max_seq_len` is the served context ceiling (`sched.limits.max_seq_len`,
+/// 0 = unlimited) — needed so the `"length"` decision reuses the exact
+/// stop predicate from `emit_step`/`decode_logits_step`.
+pub fn finish_sequence(model: &dyn Model, a: &mut ActiveSeq, max_seq_len: usize) {
+    let reason = derive_finish_reason(
+        a.guard_stop,
+        a.output_tokens.last().copied(),
+        &a.eos_tokens,
+        a.tool_call_end_token,
+        a.remaining,
+        a.seq.seq_len,
+        max_seq_len,
+    );
     match &mut a.sink {
         ResponseSink::Streaming(tx) => {
             let ttft_ms = a.decode_start.duration_since(a.request_start).as_secs_f64() * 1000.0;
@@ -383,80 +455,5 @@ pub fn resume_swapped_seq(
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{GUARD_STOP_REQUEST_TIMEOUT, derive_finish_reason};
-    use crate::ir::FINISH_REASON_TIMEOUT;
-
-    const EOS: &[u32] = &[151645];
-    const TOOL_END: Option<u32> = Some(151658);
-
-    #[test]
-    fn timeout_is_not_reported_as_length() {
-        // The regression this wave fixes: a deadline cut lands on an
-        // ordinary content token, so the token-derived path calls it
-        // "length" — indistinguishable from a legitimate max_tokens stop.
-        assert_eq!(
-            derive_finish_reason(None, Some(42), EOS, TOOL_END),
-            "length"
-        );
-        assert_eq!(
-            derive_finish_reason(Some(GUARD_STOP_REQUEST_TIMEOUT), Some(42), EOS, TOOL_END),
-            FINISH_REASON_TIMEOUT
-        );
-    }
-
-    #[test]
-    fn timeout_outranks_eos_and_tool_call_end() {
-        // A deadline can fire on the same step that emits EOS or the
-        // tool-call close; the response is still truncated relative to
-        // what the client asked for, so "timeout" must win.
-        assert_eq!(
-            derive_finish_reason(
-                Some(GUARD_STOP_REQUEST_TIMEOUT),
-                Some(151645),
-                EOS,
-                TOOL_END
-            ),
-            FINISH_REASON_TIMEOUT
-        );
-        assert_eq!(
-            derive_finish_reason(
-                Some(GUARD_STOP_REQUEST_TIMEOUT),
-                Some(151658),
-                EOS,
-                TOOL_END
-            ),
-            FINISH_REASON_TIMEOUT
-        );
-    }
-
-    #[test]
-    fn other_guards_keep_their_token_derived_reason() {
-        // Only the deadline marker remaps. The pre-existing guards
-        // (fuzzy_repetition, tool_envelope_stuck, ...) are surfaced via
-        // `guard_stop` in the dump body and must not change the wire
-        // reason — that is a separate, already-shipped contract.
-        assert_eq!(
-            derive_finish_reason(Some("fuzzy_repetition"), Some(42), EOS, TOOL_END),
-            "length"
-        );
-        assert_eq!(
-            derive_finish_reason(Some("tool_envelope_stuck"), Some(151645), EOS, TOOL_END),
-            "stop"
-        );
-    }
-
-    #[test]
-    fn normal_stops_are_unchanged() {
-        assert_eq!(
-            derive_finish_reason(None, Some(151645), EOS, TOOL_END),
-            "stop"
-        );
-        assert_eq!(
-            derive_finish_reason(None, Some(151658), EOS, TOOL_END),
-            "tool_calls"
-        );
-        assert_eq!(derive_finish_reason(None, Some(7), EOS, TOOL_END), "length");
-    }
-}
+// Tests live in `lifecycle_tests.rs` (sibling module registered in
+// `scheduler/mod.rs`) to keep this file under the 500-line cap.

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -8,40 +8,78 @@ use super::*;
 /// to the wire `finish_reason`. Do not map guard names to wire reasons
 /// anywhere else.
 ///
-/// Every non-timeout guard reports `"stop"`: the guard deliberately ended
-/// generation, the token budget was NOT hit, and OpenAI's closed enum
-/// {stop, length, tool_calls, content_filter} has no truer slot. The
-/// guard's NAME still reaches diagnostics unchanged via
-/// `StreamEvent::Done.guard_stop` and the --dump body.
+/// Every non-timeout guard reports `"length"`: the server ended the
+/// response with the model UNFINISHED. Neither enum slot is literally
+/// true — the budget was not hit either — so the choice is decided by
+/// which lie clients handle safely.
+///
+/// `"stop"` asserts "the model said what it wanted". For a mid-sentence
+/// repetition cut that is affirmatively false, and every client behaviour
+/// keyed on `"stop"` is then the WRONG action: accept, validate, commit,
+/// end the agent run. `"length"` asserts only "incomplete, serving side
+/// cut it, do not treat as final" — true in every part clients act on,
+/// and its handlers are all safe: `openai-python` raises
+/// `LengthFinishReasonError` instead of parsing truncated JSON, aider
+/// skips the auto-commit, Instructor raises `IncompleteOutputException`,
+/// pydantic-ai raises rather than accepting a half tool call.
+///
+/// The failure modes are asymmetric. A false `"length"` costs a bounded,
+/// VISIBLE retry (agents cap them). A false `"stop"` is unbounded and
+/// INVISIBLE: degenerate output silently banked as a finished answer.
+/// Measured — relabelling these guards to `"stop"` cost 2/10 then 6/10
+/// episodes of the agentic gate, because the harness stopped recognising
+/// truncation and ended runs at 3-10 turns instead of the 12-22 a
+/// recovery takes.
+///
+/// This also matches the ecosystem. On every engine WITHOUT a
+/// degeneration guard (SGLang, TGI, llama.cpp, vLLM by default) the same
+/// loop simply runs to the budget and reports `"length"`; our guard is an
+/// early, smarter budget, so `"length"` preserves parity. No engine maps a
+/// quality cut to `"stop"` by design — vLLM minted a distinct value
+/// (`"repetition"`) rather than overload it.
+///
+/// ★ And it removes an internal contradiction: `tool_loop_capped` already
+/// ships `"length"` (see `api::chat_stream::handle_done`) on exactly this
+/// reasoning — `"length"` is the OpenAI-spec slot for "forcibly truncated"
+/// and gives agents a clean hook to break their outer loop. The same
+/// argument covers `fuzzy_repetition`, `tool_envelope_stuck`,
+/// `inter_tool_prose_budget` and the simhash trip.
 ///
 /// Considered alternative: putting the guard name on the wire the way
 /// vLLM ships "repetition"/"abort". Rejected — typed clients hard-fail on
-/// unknown variants (Rust `async-openai` fails deserialization outright;
-/// pydantic-ai raised on OpenRouter's non-standard "error"), and our one
-/// deliberate exception, `"timeout"`, already carries that documented
-/// risk (see `ir::FINISH_REASON_TIMEOUT`). If a future guard warrants a
-/// distinct wire reason, add its arm HERE with its rationale.
+/// unknown enum VALUES (Rust `async-openai` fails deserialization
+/// outright; pydantic-ai raised on OpenRouter's non-standard "error"),
+/// and our one deliberate exception, `"timeout"`, already carries that
+/// documented risk (see `ir::FINISH_REASON_TIMEOUT`). The guard's NAME
+/// reaches diagnostics via `StreamEvent::Done.guard_stop` and the --dump
+/// body; the right home for it on the wire is an extension FIELD (unknown
+/// fields are ignored by every SDK, cf. vLLM's `stop_reason`), which is
+/// follow-up work, not a reason to keep lying in the enum.
 fn guard_stop_wire_reason(guard: &'static str) -> &'static str {
     match guard {
         // Defensive: the deadline guard is intercepted before the
         // token-derived checks (see `derive_finish_reason`), so this arm
         // is normally unreachable — kept so the mapping is total.
         GUARD_STOP_REQUEST_TIMEOUT => crate::ir::FINISH_REASON_TIMEOUT,
-        _ => "stop",
+        _ => "length",
     }
 }
 
 /// Derive the wire finish reason for a completed sequence.
 ///
-/// INVARIANT: `"length"` means exactly "the token budget was exhausted" —
-/// the `max_tokens` countdown (`remaining == 0`) or the served context
-/// ceiling — decided by `helpers::hard_ceiling_hit`, the same predicate
-/// that force-stops decode. It is NOT a fallback. OpenAI's contract
-/// (mirrored by vLLM/SGLang/TGI/llama.cpp) is that `"length"` tells the
-/// client "raise the limit / continue and retry"; reporting it for a
-/// guard-cut or client-cancelled response sends agent clients (aider,
-/// opencode, hermes-agent) into retries that re-trigger the same cut
+/// INVARIANT: `"length"` means "the SERVER ended the response with the
+/// model unfinished" — the token budget was exhausted (`hard_ceiling_hit`:
+/// the `max_tokens` countdown or the served context ceiling) OR a guard
+/// cut it short. `"stop"` means the MODEL finished: it sampled EOS or a
+/// stop sequence. That is the distinction clients act on, and it is the
+/// one worth keeping exact.
+///
+/// It is still NOT a catch-all. The bug this replaced derived `"length"`
+/// from "the last token wasn't EOS", which swept in stop-string matches,
+/// client cancels and early finalizes — none of which are truncations
 /// (observed live: `Done: 573 tokens (length)` under max_new_tokens=1024).
+/// Those now correctly report `"stop"`; only budget exhaustion and guard
+/// cuts report `"length"`.
 ///
 /// Precedence:
 ///   1. the server-side deadline → `"timeout"` — a truncation must never

--- a/crates/spark-server/src/scheduler/lifecycle_tests.rs
+++ b/crates/spark-server/src/scheduler/lifecycle_tests.rs
@@ -96,13 +96,20 @@ fn timeout_unchanged_and_still_outranks_everything() {
 }
 
 #[test]
-fn guard_cuts_report_stop_not_length() {
-    // Replaces `other_guards_keep_their_token_derived_reason`, which
-    // asserted fuzzy_repetition + non-EOS ⇒ "length" — that expectation
-    // ENCODED the bug: the guard deliberately ended generation with
-    // budget left, and "length" told agent clients to raise the limit
-    // and retry into the same guard. Per the OpenAI contract (and
-    // vLLM/SGLang/TGI/llama.cpp), "length" is reserved for the budget.
+fn guard_cuts_report_length_because_the_model_did_not_finish() {
+    // POSITIVE case. A guard cut is a server-side truncation: the model
+    // was still mid-output. `"length"` is the OpenAI-spec slot for
+    // "forcibly truncated" and is what every client's truncation handling
+    // keys on (openai-python `LengthFinishReasonError`, aider's
+    // continuation, Instructor, pydantic-ai).
+    //
+    // ★ This assertion was briefly INVERTED to `"stop"`, and that shipped
+    // a measured regression: the agentic gate fell to 8/10 then 4/10
+    // followed_directions because its `was_cut_off()` stopped firing and
+    // runs ended at 3-10 turns instead of the 12-22 a recovery needs.
+    // `"stop"` claims the model finished; for a mid-sentence repetition
+    // cut that is false, and every client action keyed on it (accept,
+    // validate, commit, end the run) is then wrong. Do not re-invert.
     for guard in [
         "fuzzy_repetition",
         "inter_tool_prose_budget",
@@ -110,12 +117,33 @@ fn guard_cuts_report_stop_not_length() {
         "simhash_semantic_loop",
         "token_loop_watchdog",
     ] {
-        assert_eq!(derive(Some(guard), Some(42), 100), "stop", "guard={guard}");
-        // A guard trip on the exact step the budget ran out keeps the
-        // guard's reason: precedence is deterministic, and "stop" is
-        // the safer signal for agent retry loops.
-        assert_eq!(derive(Some(guard), Some(42), 0), "stop", "guard={guard}");
+        assert_eq!(
+            derive(Some(guard), Some(42), 100),
+            "length",
+            "guard={guard}"
+        );
+        // A guard trip on the exact step the budget ran out is still a
+        // truncation, and both paths agree — precedence is deterministic.
+        assert_eq!(derive(Some(guard), Some(42), 0), "length", "guard={guard}");
     }
+}
+
+#[test]
+fn non_truncating_stops_are_not_relabelled_as_length() {
+    // NEGATIVE case, and the whole point of the original fix: `"length"`
+    // must NOT become a catch-all again. The bug this replaced derived it
+    // from "the last token wasn't EOS", sweeping in early finalizes and
+    // client cancels that are not truncations at all.
+    //
+    // No guard, budget left (client cancel / dropped receiver / drain):
+    // generation stopped, nothing was truncated ⇒ "stop", never "length".
+    assert_eq!(derive(None, Some(42), 100), "stop");
+    // And the timeout guard keeps its own distinct reason rather than
+    // collapsing into the truncation bucket.
+    assert_eq!(
+        derive(Some(GUARD_STOP_REQUEST_TIMEOUT), Some(42), 100),
+        FINISH_REASON_TIMEOUT
+    );
 }
 
 #[test]
@@ -428,6 +456,10 @@ fn call_site_passes_the_real_guard() {
     // `a.guard_stop` reaches the decision.
     let (a, rx) = test_seq(vec![5, 6, 42], 3, Some(GUARD_STOP_REQUEST_TIMEOUT), 10);
     assert_eq!(finish_and_recv(a, rx).finish_reason, FINISH_REASON_TIMEOUT);
+    // And a degeneration guard reaches the response as "length" — the
+    // truncation signal. Asserted at the CALL SITE, not just over the pure
+    // function, because that is where the wire value the client actually
+    // receives is decided.
     let (a, rx) = test_seq(vec![5, 6, 42], 3, Some("fuzzy_repetition"), 10);
-    assert_eq!(finish_and_recv(a, rx).finish_reason, "stop");
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "length");
 }

--- a/crates/spark-server/src/scheduler/lifecycle_tests.rs
+++ b/crates/spark-server/src/scheduler/lifecycle_tests.rs
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for `lifecycle::derive_finish_reason` and `finish_sequence`.
+//!
+//! Split from `lifecycle.rs` for the ≤500-line cap. Two layers:
+//!  * the pure precedence matrix over `derive_finish_reason`;
+//!  * a call-site proof: `finish_sequence` on a REAL `ActiveSeq` with a
+//!    blocking oneshot sink and a stub `Model`, asserting the
+//!    `finish_reason` that actually reaches the response — so a wiring
+//!    bug (wrong field passed for the budget/count) fails a test even
+//!    though the pure function is correct.
+
+use super::lifecycle::{derive_finish_reason, finish_sequence};
+use super::types::{ActiveSeq, GUARD_STOP_REQUEST_TIMEOUT, ResponseSink};
+use super::{DEFAULT_LZ_PENALTY, SsmDecodeRing};
+use crate::api::InferenceResponse;
+use crate::ir::FINISH_REASON_TIMEOUT;
+use anyhow::Result;
+use spark_model::traits::{Model, SequenceState};
+use spark_runtime::gpu::DevicePtr;
+use std::time::Instant;
+
+const EOS: &[u32] = &[151645];
+const TOOL_END: Option<u32> = Some(151658);
+const MAX_SEQ_LEN: usize = 8192;
+
+/// Common-case shorthand: mid-context position (no seqlen ceiling), so
+/// the budget dimension under test is the `remaining` countdown.
+fn derive(guard: Option<&'static str>, last: Option<u32>, remaining: usize) -> &'static str {
+    derive_finish_reason(guard, last, EOS, TOOL_END, remaining, 10, MAX_SEQ_LEN)
+}
+
+#[test]
+fn length_means_budget_exhausted_only() {
+    // max_tokens countdown exhausted on an ordinary content token.
+    assert_eq!(derive(None, Some(42), 0), "length");
+    // Served context ceiling reached with budget left — the other half
+    // of the hard-ceiling stop predicate. OpenAI reports "length" for
+    // the context limit too.
+    assert_eq!(
+        derive_finish_reason(
+            None,
+            Some(42),
+            EOS,
+            TOOL_END,
+            500,
+            MAX_SEQ_LEN - 1,
+            MAX_SEQ_LEN
+        ),
+        "length"
+    );
+}
+
+#[test]
+fn early_stop_one_token_short_of_budget_is_not_length() {
+    // The bug this wave fixes: "length" was the catch-all, so ANY stop
+    // whose last token was not EOS/tool-end claimed the budget was hit
+    // (observed live: `Done: 573 tokens (length)` under
+    // max_new_tokens=1024). One token of budget left ⇒ not "length".
+    let r = derive(None, Some(42), 1);
+    assert_ne!(r, "length");
+    // Early finalize with no guard = client cancel / dropped receiver /
+    // shutdown drain ⇒ "stop" (generation stopped; budget not hit).
+    assert_eq!(r, "stop");
+}
+
+#[test]
+fn normal_stops_are_unchanged() {
+    assert_eq!(derive(None, Some(151645), 100), "stop");
+    assert_eq!(derive(None, Some(151658), 100), "tool_calls");
+}
+
+#[test]
+fn eos_on_the_last_budgeted_token_is_stop_not_length() {
+    // The model finished naturally ON the final budgeted token: the
+    // sampled EOS outranks the exhausted budget (OpenAI parity).
+    assert_eq!(derive(None, Some(151645), 0), "stop");
+}
+
+#[test]
+fn timeout_unchanged_and_still_outranks_everything() {
+    // Shipped contract (2026-08 deadline wave): a deadline cut must be
+    // distinguishable from both a natural stop and a max_tokens stop,
+    // even when the deadline lands on an EOS / tool-close / budget-end
+    // step.
+    for last in [Some(42), Some(151645), Some(151658)] {
+        assert_eq!(
+            derive(Some(GUARD_STOP_REQUEST_TIMEOUT), last, 100),
+            FINISH_REASON_TIMEOUT
+        );
+    }
+    assert_eq!(
+        derive(Some(GUARD_STOP_REQUEST_TIMEOUT), Some(42), 0),
+        FINISH_REASON_TIMEOUT
+    );
+}
+
+#[test]
+fn guard_cuts_report_stop_not_length() {
+    // Replaces `other_guards_keep_their_token_derived_reason`, which
+    // asserted fuzzy_repetition + non-EOS ⇒ "length" — that expectation
+    // ENCODED the bug: the guard deliberately ended generation with
+    // budget left, and "length" told agent clients to raise the limit
+    // and retry into the same guard. Per the OpenAI contract (and
+    // vLLM/SGLang/TGI/llama.cpp), "length" is reserved for the budget.
+    for guard in [
+        "fuzzy_repetition",
+        "inter_tool_prose_budget",
+        "tool_envelope_stuck",
+        "simhash_semantic_loop",
+        "token_loop_watchdog",
+    ] {
+        assert_eq!(derive(Some(guard), Some(42), 100), "stop", "guard={guard}");
+        // A guard trip on the exact step the budget ran out keeps the
+        // guard's reason: precedence is deterministic, and "stop" is
+        // the safer signal for agent retry loops.
+        assert_eq!(derive(Some(guard), Some(42), 0), "stop", "guard={guard}");
+    }
+}
+
+#[test]
+fn token_derived_stops_outrank_non_timeout_guards() {
+    // Preserved from the old test: a guard that fires on the same step
+    // the model sampled EOS / the tool-call close reports what the
+    // model actually did.
+    assert_eq!(
+        derive(Some("tool_envelope_stuck"), Some(151645), 100),
+        "stop"
+    );
+    assert_eq!(
+        derive(Some("fuzzy_repetition"), Some(151658), 100),
+        "tool_calls"
+    );
+}
+
+#[test]
+fn empty_output_edges() {
+    // max_tokens==0 scoring path: empty output, remaining==0 ⇒ "length"
+    // (the budget of zero was exhausted before the first token).
+    assert_eq!(derive(None, None, 0), "length");
+    // Empty output on a model with NO tool-call end token configured
+    // must not satisfy `None == None` and misreport "tool_calls".
+    assert_eq!(
+        derive_finish_reason(None, None, EOS, None, 5, 10, MAX_SEQ_LEN),
+        "stop"
+    );
+}
+
+// ─── Call-site proof: finish_sequence wires the REAL fields ────────────
+
+/// Minimal `Model`: only the paths `finish_sequence` exercises
+/// (`cache_sequence`, `free_sequence`, `ep_broadcast_cmd_for_seq`
+/// default) are live; everything else is unreachable in these tests.
+struct StubModel;
+
+impl Model for StubModel {
+    fn prefill(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn decode(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn prefill_chunk(
+        &self,
+        _t: &[u32],
+        _s: &mut SequenceState,
+        _cs: usize,
+        _cl: usize,
+        _last: bool,
+        _st: u64,
+    ) -> Result<DevicePtr> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn decode_batch(
+        &self,
+        _t: &[u32],
+        _s: &mut [&mut SequenceState],
+        _st: u64,
+    ) -> Result<DevicePtr> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn decode_verify(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<Vec<u32>> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn generate_speculative(
+        &self,
+        _p: &[u32],
+        _params: &spark_runtime::sampler::SamplingParams,
+        _n: usize,
+    ) -> Result<spark_model::engine::GenerateResult> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn decode_verify_graphed(
+        &self,
+        _t: &[u32; 2],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 2]> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn decode_verify_graphed_k3(
+        &self,
+        _t: &[u32; 3],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 3]> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn decode_verify_graphed_k4(
+        &self,
+        _t: &[u32; 4],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 4]> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn run_mtp_propose(
+        &self,
+        _t: u32,
+        _p: usize,
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<Option<u32>> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn run_mtp_propose_multi(
+        &self,
+        _t: u32,
+        _p: usize,
+        _n: usize,
+        _s: &mut SequenceState,
+        _st: u64,
+        _bm: Option<&[i32]>,
+    ) -> Result<Vec<u32>> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn trim_proposer_state(&self, _s: &mut SequenceState, _n: usize, _st: u64) -> Result<()> {
+        Ok(())
+    }
+    fn vocab_size(&self) -> usize {
+        0
+    }
+    fn bind_gpu_to_thread(&self) -> Result<()> {
+        Ok(())
+    }
+    fn alloc_sequence(&self) -> Result<SequenceState> {
+        Ok(SequenceState::host_only(0))
+    }
+    fn copy_logits_to_host(&self, _p: DevicePtr, _d: &mut [u8]) -> Result<()> {
+        Ok(())
+    }
+    fn logits_buffer_ptr(&self) -> DevicePtr {
+        DevicePtr::NULL
+    }
+    fn argmax_on_device(&self, _p: DevicePtr, _st: u64) -> Result<u32> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn argmax_batch(&self, _p: DevicePtr, _n: usize, _st: u64) -> Result<Vec<u32>> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn hidden_after_norm(&self) -> DevicePtr {
+        DevicePtr::NULL
+    }
+    fn checkpoint_ssm_states(&self, _s: &mut SequenceState) -> Result<()> {
+        Ok(())
+    }
+    fn rollback_ssm_states(&self, _s: &mut SequenceState, _n: usize) -> Result<()> {
+        Ok(())
+    }
+    fn has_proposer(&self) -> bool {
+        false
+    }
+    fn has_self_speculative(&self) -> bool {
+        false
+    }
+    fn decode_draft(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        anyhow::bail!("unused in lifecycle tests")
+    }
+    fn cache_sequence(&self, _s: &SequenceState) {}
+    fn free_sequence(&self, _s: &mut SequenceState) -> Result<()> {
+        Ok(())
+    }
+    fn compact_sequence(&self, _s: &mut SequenceState, _slot: usize) -> Result<()> {
+        Ok(())
+    }
+    fn detach_slot_for_reuse(&self, _s: &mut SequenceState) {}
+    fn save_hidden_for_mtp(&self, _i: usize, _st: u64) -> Result<()> {
+        Ok(())
+    }
+}
+
+type RespRx = tokio::sync::oneshot::Receiver<Result<InferenceResponse>>;
+
+/// A real `ActiveSeq` with a blocking oneshot sink. `min_tokens` is
+/// deliberately set to a value DIFFERENT from `remaining` (7) so a
+/// call-site mutation that passes the wrong field flips a test red.
+fn test_seq(
+    output_tokens: Vec<u32>,
+    remaining: usize,
+    guard_stop: Option<&'static str>,
+    seq_len: usize,
+) -> (ActiveSeq, RespRx) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let now = Instant::now();
+    let mut seq = SequenceState::host_only(0);
+    seq.seq_len = seq_len;
+    let a = ActiveSeq {
+        seq,
+        session_hash: 0,
+        last_token: output_tokens.last().copied().unwrap_or(0),
+        output_tokens,
+        remaining,
+        min_tokens: 7,
+        eos_tokens: EOS.to_vec(),
+        finished: true,
+        guard_stop,
+        param_close_pending: 0,
+        sink: ResponseSink::Blocking(Some(tx)),
+        cancel_flag: None,
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        top_n_sigma: 0.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        repetition_penalty_window: 256,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        lz_penalty: DEFAULT_LZ_PENALTY,
+        dry_multiplier: 0.0,
+        dry_base: 0.0,
+        dry_allowed_length: 0,
+        dry_sequence_breakers: Vec::new(),
+        logit_bias: Vec::new(),
+        inside_thinking: false,
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: None,
+        spontaneous_think_budget: 0,
+        thinking_tokens: 0,
+        force_end_thinking: false,
+        think_force_closed: false,
+        sentence_defer_count: 0,
+        consecutive_confident: 0,
+        in_code_fence: false,
+        think_end_token: None,
+        think_start_token: None,
+        think_ended: false,
+        think_just_ended: false,
+        post_think_emitted: 0,
+        spec_adapt: Default::default(),
+        think_skip_count: 0,
+        tool_call_end_token: TOOL_END,
+        require_tool_call: false,
+        tool_request: false,
+        tools_present: false,
+        tool_call_start_token: None,
+        tool_call_opened: false,
+        inside_tool_body: false,
+        tool_call_completed: false,
+        post_completion_tool_opens: 0,
+        tool_body_streak_tokens: 0,
+        inside_parameter_body: false,
+        param_body_chars_emitted: 0,
+        suppress_tool_call: false,
+        disable_mtp: false,
+        content_started: false,
+        content_tokens: 0,
+        prose_tokens_since_last_tool: 0,
+        think_watchdog_fires: 0,
+        rollback_count: 0,
+        ssm_rollback_ring: SsmDecodeRing::new(0),
+        grammar_state: None,
+        pending_drafts: Vec::new(),
+        pending_draft_conf: Vec::new(),
+        last_token_time: now,
+        request_start: now,
+        decode_start: now,
+        seed: None,
+        top_logprobs: None,
+        logprobs_data: Vec::new(),
+        timeout_at: None,
+        adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(0.0),
+        cached_prompt_tokens: 0,
+    };
+    (a, rx)
+}
+
+fn finish_and_recv(mut a: ActiveSeq, mut rx: RespRx) -> InferenceResponse {
+    finish_sequence(&StubModel, &mut a, MAX_SEQ_LEN);
+    rx.try_recv()
+        .expect("finish_sequence must send the blocking response")
+        .expect("response must be Ok")
+}
+
+#[test]
+fn call_site_passes_the_real_budget() {
+    // Budget exhausted ⇒ "length". Red if finish_sequence stops passing
+    // `a.remaining` (e.g. a constant, or the decoy `min_tokens` = 7).
+    let (a, rx) = test_seq(vec![5, 6, 42], 0, None, 10);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "length");
+    // Budget left ⇒ NOT "length" (same decoy: min_tokens=7 ≠ remaining).
+    let (a, rx) = test_seq(vec![5, 6, 42], 7, None, 10);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "stop");
+}
+
+#[test]
+fn call_site_passes_the_real_seq_len() {
+    // Context-ceiling stop with budget left ⇒ "length". Red if the
+    // call site stops passing `a.seq.seq_len` / the served ceiling.
+    let (a, rx) = test_seq(vec![5, 6, 42], 500, None, MAX_SEQ_LEN - 1);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "length");
+}
+
+#[test]
+fn call_site_passes_the_real_last_token_and_eos() {
+    // Red if the call site stops passing `output_tokens.last()` or
+    // `a.eos_tokens`.
+    let (a, rx) = test_seq(vec![5, 6, 151645], 0, None, 10);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "stop");
+    let (a, rx) = test_seq(vec![5, 6, 151658], 3, None, 10);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "tool_calls");
+}
+
+#[test]
+fn call_site_passes_the_real_guard() {
+    // Timeout is the one guard with a distinct wire reason — proves
+    // `a.guard_stop` reaches the decision.
+    let (a, rx) = test_seq(vec![5, 6, 42], 3, Some(GUARD_STOP_REQUEST_TIMEOUT), 10);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, FINISH_REASON_TIMEOUT);
+    let (a, rx) = test_seq(vec![5, 6, 42], 3, Some("fuzzy_repetition"), 10);
+    assert_eq!(finish_and_recv(a, rx).finish_reason, "stop");
+}

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -22,6 +22,8 @@ mod decode_logits_step;
 mod decode_step;
 mod emit_step;
 mod fast_greedy;
+#[cfg(test)]
+mod finish_guard_tests;
 mod helpers;
 mod lifecycle;
 #[cfg(test)]

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -24,6 +24,8 @@ mod emit_step;
 mod fast_greedy;
 mod helpers;
 mod lifecycle;
+#[cfg(test)]
+mod lifecycle_tests;
 mod logit_dump;
 mod logit_processors;
 mod logprobs;
@@ -857,7 +859,7 @@ pub fn run(
         // on this same iteration. Placed here rather than in a decode step
         // because the MTP/speculative path does not run `process_decode_logits`.
         enforce_request_deadlines(&mut active);
-        retire_finished_sequences(&*model, &mut active);
+        retire_finished_sequences(&*model, &mut active, sched.limits.max_seq_len);
         sched.timing.record(mtp_timing::Phase::LoopRetire, t_loop);
 
         // ── Swap-in: resume swapped sequences when blocks free up ──
@@ -939,7 +941,7 @@ pub fn run(
 
     // Drain any remaining active sequences on shutdown.
     for mut a in active {
-        finish_sequence(&*model, &mut a);
+        finish_sequence(&*model, &mut a, sched.limits.max_seq_len);
     }
     if let Some(ref mut spill) = spill_manager {
         for s in swapped {

--- a/crates/spark-server/src/scheduler/mod_helpers.rs
+++ b/crates/spark-server/src/scheduler/mod_helpers.rs
@@ -258,7 +258,11 @@ pub(super) fn enforce_request_deadlines(active: &mut [ActiveSeq]) {
 /// non-contiguous w.r.t. `slot_idx` — pre-allocated slots stay valid
 /// in place across the swap_remove, and the per-slot CUDA graph cache
 /// stays warm because the seq never moved.
-pub(super) fn retire_finished_sequences(model: &dyn Model, active: &mut Vec<ActiveSeq>) {
+pub(super) fn retire_finished_sequences(
+    model: &dyn Model,
+    active: &mut Vec<ActiveSeq>,
+    max_seq_len: usize,
+) {
     if model.ep_protocol_v2() {
         // v2 EP: slots are pre-allocated and kept in place (see doc above);
         // just drop finished seqs, no compaction.
@@ -266,7 +270,7 @@ pub(super) fn retire_finished_sequences(model: &dyn Model, active: &mut Vec<Acti
         while i < active.len() {
             if active[i].finished {
                 let mut a = active.swap_remove(i);
-                finish_sequence(model, &mut a);
+                finish_sequence(model, &mut a, max_seq_len);
             } else {
                 i += 1;
             }
@@ -291,7 +295,7 @@ pub(super) fn retire_finished_sequences(model: &dyn Model, active: &mut Vec<Acti
     let mut survivors: Vec<ActiveSeq> = Vec::with_capacity(active.len());
     for mut a in active.drain(..) {
         if a.finished {
-            finish_sequence(model, &mut a); // RAII guard releases a's own slot
+            finish_sequence(model, &mut a, max_seq_len); // RAII guard releases a's own slot
         } else {
             survivors.push(a);
         }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -216,6 +216,7 @@ pub(super) fn continue_in_progress_prefills(
             think_start_token,
             tool_call_start_token,
             tool_call_end_token,
+            sched.limits.max_seq_len,
         );
         return did_mixed_step;
     }
@@ -249,6 +250,7 @@ pub(super) fn continue_in_progress_prefills(
             think_start_token,
             tool_call_start_token,
             tool_call_end_token,
+            sched.limits.max_seq_len,
         );
         return did_mixed_step;
     }
@@ -362,6 +364,7 @@ pub(super) fn continue_in_progress_prefills(
         think_start_token,
         tool_call_start_token,
         tool_call_end_token,
+        sched.limits.max_seq_len,
     );
 
     did_mixed_step

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -19,6 +19,9 @@ pub(super) fn promote_completed_prefills(
     think_start_token: Option<u32>,
     tool_call_start_token: Option<u32>,
     tool_call_end_token: Option<u32>,
+    // Served context ceiling (`sched.limits.max_seq_len`) — finish_sequence
+    // needs it for the budget-derived `finish_reason` decision.
+    max_seq_len: usize,
 ) {
     // Process in reverse order so swap_remove indices stay valid.
     completed_indices.sort_unstable_by_key(|x| std::cmp::Reverse(x.0));
@@ -95,7 +98,7 @@ pub(super) fn promote_completed_prefills(
             model.decode_rollback_ring_slots(),
         );
         if immediate_finish {
-            finish_sequence(model, &mut a);
+            finish_sequence(model, &mut a, max_seq_len);
         } else {
             active.push(a);
         }

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -263,7 +263,7 @@ pub fn start_chunked_prefill(
             timeout_at: req_timeout_at,
             adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(temperature),
         };
-        finish_sequence(model, &mut a);
+        finish_sequence(model, &mut a, sched.limits.max_seq_len);
         return Ok(StartPrefillResult::Finished);
     }
 
@@ -600,7 +600,7 @@ pub fn start_chunked_prefill(
                 timeout_at: req_timeout_at,
                 adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(temperature),
             };
-            finish_sequence(model, &mut a);
+            finish_sequence(model, &mut a, sched.limits.max_seq_len);
             Ok(StartPrefillResult::Finished)
         } else {
             Ok(StartPrefillResult::Active(ActiveSeq {

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -240,7 +240,7 @@ pub fn prefill_request(
             timeout_at: req_timeout_at,
             adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(temperature),
         };
-        finish_sequence(model, &mut a);
+        finish_sequence(model, &mut a, sched.limits.max_seq_len);
         return Ok(None);
     }
 
@@ -432,7 +432,7 @@ pub fn prefill_request(
             timeout_at: req_timeout_at,
             adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(temperature),
         };
-        finish_sequence(model, &mut a);
+        finish_sequence(model, &mut a, sched.limits.max_seq_len);
         return Ok(None);
     }
 

--- a/crates/spark-server/src/scheduler/types.rs
+++ b/crates/spark-server/src/scheduler/types.rs
@@ -114,6 +114,12 @@ pub(super) struct PrefillInProgress {
 /// last token — see `derive_finish_reason`.
 pub(super) const GUARD_STOP_REQUEST_TIMEOUT: &str = "request_timeout";
 
+/// The `<tool_response>` hard stop fired: the model emitted a control token
+/// it must never generate (post-tool-call runaway). Ending the turn is
+/// correct; naming it is what makes the wire reason `"length"` instead of
+/// `"stop"`, so the client knows the server cut the response short.
+pub(super) const GUARD_STOP_TOOL_RESPONSE: &str = "tool_response_hard_stop";
+
 /// An in-flight sequence participating in batched decode.
 pub(super) struct ActiveSeq {
     pub seq: SequenceState,

--- a/kernels/gb10/holo-3.1-0.8b/MODEL.toml
+++ b/kernels/gb10/holo-3.1-0.8b/MODEL.toml
@@ -155,6 +155,12 @@ atlas_nvfp4_scale_bf16 = "NVFP4 scale handler; gated off with the family."
 
 [expected_absent.gated_delta_rule_wy17]
 gated_delta_rule_wy17 = "wy17 fused decode (K=17) exists only in qwen3.6-35b-a3b's module set; decode_batched checks non-NULL before dispatch (per init.rs)."
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."
 
 # ⚠ HONESTY NOTE on the four gated_delta_rule f16 arms: the FP16-h-state
 # decode arms dispatch these handles UN-PROBED once --ssm-h-dtype f16 is

--- a/kernels/gb10/holo-3.1-35b-a3b/MODEL.toml
+++ b/kernels/gb10/holo-3.1-35b-a3b/MODEL.toml
@@ -172,3 +172,10 @@ the resolved half-register gate is set, and that gate is off by default
 gated_delta_rule_decode_f32_strided_norm_smem = """
 SMEM-staged twin; gated behind ATLAS_GDN_SMEM_STAGE (presence, off by
 default) AND the half-register gate. Not a live path as shipped."""
+
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."

--- a/kernels/gb10/holo-3.1-4b/MODEL.toml
+++ b/kernels/gb10/holo-3.1-4b/MODEL.toml
@@ -156,6 +156,12 @@ atlas_nvfp4_scale_bf16 = "NVFP4 scale handler; gated off with the family."
 
 [expected_absent.gated_delta_rule_wy17]
 gated_delta_rule_wy17 = "wy17 fused decode (K=17) exists only in qwen3.6-35b-a3b's module set; decode_batched checks non-NULL before dispatch (per init.rs)."
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."
 
 # ⚠ HONESTY NOTE on the four gated_delta_rule f16 arms: the FP16-h-state
 # decode arms dispatch these handles UN-PROBED once --ssm-h-dtype f16 is

--- a/kernels/gb10/ornith-1.0-9b/MODEL.toml
+++ b/kernels/gb10/ornith-1.0-9b/MODEL.toml
@@ -154,6 +154,12 @@ atlas_nvfp4_scale_bf16 = "NVFP4 scale handler; gated off with the family."
 
 [expected_absent.gated_delta_rule_wy17]
 gated_delta_rule_wy17 = "wy17 fused decode (K=17) exists only in qwen3.6-35b-a3b's module set; decode_batched checks non-NULL before dispatch (per init.rs)."
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."
 
 # ⚠ HONESTY NOTE on the four gated_delta_rule f16 arms: the FP16-h-state
 # decode arms dispatch these handles UN-PROBED once --ssm-h-dtype f16 is

--- a/kernels/gb10/qwen3-next-80b-a3b/MODEL.toml
+++ b/kernels/gb10/qwen3-next-80b-a3b/MODEL.toml
@@ -111,6 +111,12 @@ gated_delta_rule_wy17 = """
 wy17 fused decode (K=17) exists only in qwen3.6-35b-a3b's PTX module
 set (per the init.rs comment); decode_batched checks non-NULL before
 the fused path and keeps the sequential per-token path otherwise."""
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."
 
 # ⚠ HONESTY NOTE on the four gated_delta_rule f16 arms: the FP16-h-state
 # decode arms dispatch these handles UN-PROBED once --ssm-h-dtype f16 is

--- a/kernels/gb10/qwen3.5-122b-a10b/MODEL.toml
+++ b/kernels/gb10/qwen3.5-122b-a10b/MODEL.toml
@@ -138,6 +138,12 @@ gated_delta_rule_wy17 = """
 wy17 fused decode (K=17) exists only in qwen3.6-35b-a3b's PTX module
 set (per the init.rs comment); decode_batched checks non-NULL before
 the fused path and keeps the sequential per-token path otherwise."""
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."
 
 # ⚠ HONESTY NOTE on the four gated_delta_rule f16 arms: the FP16-h-state
 # decode arms dispatch these handles UN-PROBED once --ssm-h-dtype f16 is

--- a/kernels/gb10/qwen3.5-27b/MODEL.toml
+++ b/kernels/gb10/qwen3.5-27b/MODEL.toml
@@ -113,6 +113,12 @@ gated_delta_rule_wy17 = """
 wy17 fused decode (K=17) exists only in qwen3.6-35b-a3b's PTX module
 set (per the init.rs comment); decode_batched checks non-NULL before
 the fused path and keeps the sequential per-token path otherwise."""
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = "Exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the exact arm probes handle != 0 and falls back to the parent kernel + copy_d2d snapshots (same bits, more launches)."
+gated_delta_rule_decode_f32_strided_norm_snap = "Batched exact-verify snapshot twin (#435/#438), shipped only in qwen3.6-27b/nvfp4; the batched exact form declines on handle 0 and the per-sequence exact loop serves (still exact)."
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = "FP32 fused verify conv for the exact-verify chain (#435/#438), shipped only in qwen3.6-27b/nvfp4; probed handle != 0, absent keeps the per-token conv launches (same bits, more launches)."
 
 [expected_absent.nvfp4_mmq]
 atlas_nvfp4_mmq128_nc = """

--- a/kernels/gb10/qwen3.6-27b/nvfp4/gated_delta_rule_snap.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/gated_delta_rule_snap.cu
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Atlas GDN decode `_snap` twins — issue #435 route (a): make the MTP-verify
+// path BITWISE match sequential decode.
+//
+// These are the fused-norm decode kernels (`gated_delta_rule_decode_f32_norm`
+// and `..._f32_strided_norm`, transcribed verbatim from this model's
+// gated_delta_rule.cu shadow) with ONE addition each: an `h_inter` output
+// pointer. After the recurrent update commits the new H, the same values are
+// ALSO stored to `h_inter` — the per-token rollback snapshot the WY kernels
+// used to write inline and the sequential path produced with a full h-state
+// `copy_d2d` per token. Precedent: `gdn_verify_fused_conv_kn.cu` (17 launches
+// + 17 conv-state D2D copies -> 1 launch writing snapshots inline) and
+// `gated_delta_rule_wy4.cu` (Hi0/Hi1/Hi2 written inline).
+//
+// BIT-EXACTNESS CONTRACT: every float expression, accumulation order, and
+// barrier is IDENTICAL to the parent kernel — the addition is stores of
+// values already in registers, plus (under SSM_STATE_NORM_ENABLED) the same
+// read-scale-store the parent applies to H, applied to the snapshot from the
+// SAME H read. `h_inter == nullptr` skips the snapshot (the t == K-1 launch,
+// whose snapshot index has no reader — see the reader enumeration in
+// trait_decode_batched_conv_gdn.rs). Built with this dir's KERNEL.toml flags
+// (--fmad=false), the same flags the parent compiles under, so codegen
+// matches bit for bit.
+//
+// MODEL-SPECIFIC ON PURPOSE (shadow-first rule): these land in the
+// qwen3.6-27b/nvfp4 dir only. Every other target resolves handle 0 and the
+// exact-verify arm falls back to the parent kernel + an h-state copy_d2d per
+// token — the SAME bits, more launches. Promote to common/ only after the
+// bitwise gate (verify_exact_microtest) passes on every inheriting model.
+
+#include <cuda_bf16.h>
+
+#ifndef GDN_MS_HELPERS
+#define GDN_MS_HELPERS
+__device__ __forceinline__ void gdn_unpack_bf16x2(unsigned int packed, float& v0, float& v1) {
+    v0 = __bfloat162float(__ushort_as_bfloat16((unsigned short)(packed & 0xFFFF)));
+    v1 = __bfloat162float(__ushort_as_bfloat16((unsigned short)(packed >> 16)));
+}
+
+__device__ __forceinline__ unsigned int gdn_pack_bf16x2(float v0, float v1) {
+    unsigned int lo = (unsigned int)__bfloat16_as_ushort(__float2bfloat16(v0));
+    unsigned int hi = (unsigned int)__bfloat16_as_ushort(__float2bfloat16(v1));
+    return lo | (hi << 16);
+}
+
+__device__ __forceinline__ float gdn_warp_reduce_sum(float val) {
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        val += __shfl_xor_sync(0xFFFFFFFF, val, offset);
+    }
+    return val;
+}
+
+// Same state-norm clamp configuration as the parent shadow file. Must stay in
+// lockstep with gated_delta_rule.cu — a differing SSM_STATE_MAX_NORM here
+// would silently break the bitwise contract.
+#ifndef SSM_STATE_NORM_ENABLED
+#define SSM_STATE_NORM_ENABLED
+#define SSM_STATE_MAX_NORM 1000.0f
+#endif
+#endif  // GDN_MS_HELPERS
+
+// `gated_delta_rule_decode_f32_norm` + inline per-token h-state snapshot.
+// h_inter: same [batch, num_v_heads, k_dim, v_dim] FP32 layout as h_state,
+// or nullptr to skip (the final verify position has no rollback reader).
+extern "C" __global__ void gated_delta_rule_decode_f32_norm_snap(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ z_gate,
+    const __nv_bfloat16* __restrict__ norm_weight,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    float eps,
+    float* __restrict__ h_inter
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    if (tid >= v_dim) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H = h_state + ((b * num_v_heads + vh) * k_dim * v_dim);
+    // Snapshot destination for this head; nullptr disables the extra stores.
+    float* HI = (h_inter != nullptr)
+        ? h_inter + ((b * num_v_heads + vh) * k_dim * v_dim)
+        : nullptr;
+    const float* q_ptr = query + (b * num_k_heads + kh) * k_dim;
+    const float* k_ptr = key + (b * num_k_heads + kh) * k_dim;
+    const float* v_ptr = value + (b * num_v_heads + vh) * v_dim;
+
+    float g_raw = gate[b * num_v_heads + vh];
+    const float g = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[b * num_v_heads + vh];
+
+    __shared__ float smem_k[128];
+    __shared__ float smem_q[128];
+
+    if (tid < k_dim) {
+        smem_k[tid] = k_ptr[tid];
+        smem_q[tid] = q_ptr[tid];
+    }
+    __syncthreads();
+
+    float v_i = v_ptr[tid];
+    float hk_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+
+    float v_new_i = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        // SNAP: same register values, second destination. No arithmetic.
+        if (HI != nullptr) {
+            HI[(j + 0) * v_dim + tid] = h0;
+            HI[(j + 1) * v_dim + tid] = h1;
+            HI[(j + 2) * v_dim + tid] = h2;
+            HI[(j + 3) * v_dim + tid] = h3;
+        }
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        // Frobenius accumulation from the registers we just stored. One add at
+        // a time in ascending j keeps the summation order identical to the
+        // parent kernel, so the result is bit-identical.
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = norm_acc;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
+        __shared__ float norm_sums[4];
+        if (tid % 32 == 0) norm_sums[tid / 32] = local_sq;
+        __syncthreads();
+        if (tid == 0) {
+            float total = 0.0f;
+            for (int w = 0; w < 4; w++) total += norm_sums[w];
+            norm_sums[0] = total;
+        }
+        __syncthreads();
+        float head_norm_sq = norm_sums[0];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) {
+                // Same read-scale-store as the parent; the snapshot receives
+                // the SAME post-clamp value from the SAME H read, so a
+                // rollback restores exactly the state the chain carried.
+                float hv = H[j * v_dim + tid] * scale;
+                H[j * v_dim + tid] = hv;
+                if (HI != nullptr) HI[j * v_dim + tid] = hv;
+            }
+        }
+    }
+    #endif
+
+    const float inv_sqrt_d = rsqrtf((float)k_dim);
+    const float x = q_dot * inv_sqrt_d;
+
+    __shared__ float x_cache[128];
+    x_cache[tid] = x;
+
+    float sum_sq = x * x;
+    sum_sq = gdn_warp_reduce_sum(sum_sq);
+    __shared__ float rms_sums[4];
+    const unsigned int warp_id = tid / 32;
+    const unsigned int lane_id = tid % 32;
+    if (lane_id == 0) rms_sums[warp_id] = sum_sq;
+    __syncthreads();
+    if (warp_id == 0) {
+        float val = (lane_id < (blockDim.x + 31) / 32) ? rms_sums[lane_id] : 0.0f;
+        val = gdn_warp_reduce_sum(val);
+        if (lane_id == 0) rms_sums[0] = val;
+    }
+    __syncthreads();
+
+    const float rms = rsqrtf(rms_sums[0] / (float)v_dim + eps);
+
+    const unsigned int quad_size = v_dim / 4;
+    const unsigned long long* g64 = (const unsigned long long*)(z_gate + vh * v_dim);
+    const unsigned long long* w64 = (const unsigned long long*)norm_weight;
+    unsigned long long* out64 = (unsigned long long*)(output + vh * v_dim);
+    for (unsigned int i = tid; i < quad_size; i += blockDim.x) {
+        unsigned int base = i * 4;
+        float f0 = x_cache[base];
+        float f1 = x_cache[base + 1];
+        float f2 = x_cache[base + 2];
+        float f3 = x_cache[base + 3];
+
+        unsigned long long wv = w64[i];
+        float w0, w1, w2, w3;
+        gdn_unpack_bf16x2((unsigned int)wv, w0, w1);
+        gdn_unpack_bf16x2((unsigned int)(wv >> 32), w2, w3);
+
+        unsigned long long gv = g64[i];
+        float g0, g1, g2, g3;
+        gdn_unpack_bf16x2((unsigned int)gv, g0, g1);
+        gdn_unpack_bf16x2((unsigned int)(gv >> 32), g2, g3);
+
+        float s0 = g0 / (1.0f + expf(-g0));
+        float s1 = g1 / (1.0f + expf(-g1));
+        float s2 = g2 / (1.0f + expf(-g2));
+        float s3 = g3 / (1.0f + expf(-g3));
+
+        unsigned int lo = gdn_pack_bf16x2(f0 * rms * w0 * s0, f1 * rms * w1 * s1);
+        unsigned int hi = gdn_pack_bf16x2(f2 * rms * w2 * s2, f3 * rms * w3 * s3);
+        out64[i] = ((unsigned long long)hi << 32) | (unsigned long long)lo;
+    }
+}
+
+// `gated_delta_rule_decode_f32_strided_norm` + inline per-token h-state
+// snapshot, for the batched-verify arm at batch_size = n sequences.
+// h_inter is the snapshot base for THIS token position; sequences are
+// h_inter_seq_stride FP32 elements apart (the ssm-pool per-slot intermediate
+// stride — passed, not inferred, because pool slots are num_intermediates
+// snapshots wide while H itself is dense). nullptr skips the snapshot.
+extern "C" __global__ void gated_delta_rule_decode_f32_strided_norm_snap(
+    float* __restrict__ h_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ z_gate,
+    const __nv_bfloat16* __restrict__ norm_weight,
+    __nv_bfloat16* __restrict__ output,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride,
+    unsigned int z_stride,
+    unsigned int out_stride,
+    float eps,
+    float* __restrict__ h_inter,
+    unsigned long long h_inter_seq_stride
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    if (tid >= v_dim) return;
+
+    const unsigned int head_repeat = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / head_repeat;
+
+    float* H = h_state + ((b * num_v_heads + vh) * k_dim * v_dim);
+    float* HI = (h_inter != nullptr)
+        ? h_inter + (unsigned long long)b * h_inter_seq_stride + vh * k_dim * v_dim
+        : nullptr;
+    const float* q_ptr = query + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* k_ptr = key + (unsigned long long)b * qk_stride + kh * k_dim;
+    const float* v_ptr = value + (unsigned long long)b * v_stride + vh * v_dim;
+
+    float g_raw = gate[(unsigned long long)b * gb_stride + vh];
+    const float g = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+    const float bt = beta[(unsigned long long)b * gb_stride + vh];
+
+    __shared__ float smem_k[128];
+    __shared__ float smem_q[128];
+
+    if (tid < k_dim) {
+        smem_k[tid] = k_ptr[tid];
+        smem_q[tid] = q_ptr[tid];
+    }
+    __syncthreads();
+
+    float v_i = v_ptr[tid];
+    float hk_dot = 0.0f;
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        hk_dot += h0 * smem_k[j] + h1 * smem_k[j+1] + h2 * smem_k[j+2] + h3 * smem_k[j+3];
+    }
+
+    float v_new_i = (v_i - g * hk_dot) * bt;
+
+    float q_dot = 0.0f;
+#ifdef SSM_STATE_NORM_ENABLED
+    float norm_acc = 0.0f;
+#endif
+    #pragma unroll 4
+    for (unsigned int j = 0; j < k_dim; j += 4) {
+        float h0 = H[(j + 0) * v_dim + tid];
+        float h1 = H[(j + 1) * v_dim + tid];
+        float h2 = H[(j + 2) * v_dim + tid];
+        float h3 = H[(j + 3) * v_dim + tid];
+        h0 = g * h0 + smem_k[j]     * v_new_i;
+        h1 = g * h1 + smem_k[j + 1] * v_new_i;
+        h2 = g * h2 + smem_k[j + 2] * v_new_i;
+        h3 = g * h3 + smem_k[j + 3] * v_new_i;
+        H[(j + 0) * v_dim + tid] = h0;
+        H[(j + 1) * v_dim + tid] = h1;
+        H[(j + 2) * v_dim + tid] = h2;
+        H[(j + 3) * v_dim + tid] = h3;
+        // SNAP: same register values, second destination. No arithmetic.
+        if (HI != nullptr) {
+            HI[(j + 0) * v_dim + tid] = h0;
+            HI[(j + 1) * v_dim + tid] = h1;
+            HI[(j + 2) * v_dim + tid] = h2;
+            HI[(j + 3) * v_dim + tid] = h3;
+        }
+        q_dot += h0 * smem_q[j] + h1 * smem_q[j+1] + h2 * smem_q[j+2] + h3 * smem_q[j+3];
+#ifdef SSM_STATE_NORM_ENABLED
+        norm_acc += h0 * h0;
+        norm_acc += h1 * h1;
+        norm_acc += h2 * h2;
+        norm_acc += h3 * h3;
+#endif
+    }
+
+    #ifdef SSM_STATE_NORM_ENABLED
+    {
+        float local_sq = norm_acc;
+        for (int offset = 16; offset >= 1; offset >>= 1)
+            local_sq += __shfl_down_sync(0xFFFFFFFF, local_sq, offset);
+        __shared__ float norm_sums[4];
+        if (tid % 32 == 0) norm_sums[tid / 32] = local_sq;
+        __syncthreads();
+        if (tid == 0) {
+            float total = 0.0f;
+            for (int w = 0; w < 4; w++) total += norm_sums[w];
+            norm_sums[0] = total;
+        }
+        __syncthreads();
+        float head_norm_sq = norm_sums[0];
+        if (head_norm_sq > SSM_STATE_MAX_NORM * SSM_STATE_MAX_NORM) {
+            float scale = SSM_STATE_MAX_NORM * rsqrtf(head_norm_sq);
+            for (unsigned int j = 0; j < k_dim; j++) {
+                float hv = H[j * v_dim + tid] * scale;
+                H[j * v_dim + tid] = hv;
+                if (HI != nullptr) HI[j * v_dim + tid] = hv;
+            }
+        }
+    }
+    #endif
+
+    const float inv_sqrt_d = rsqrtf((float)k_dim);
+    const float x = q_dot * inv_sqrt_d;
+
+    __shared__ float x_cache[128];
+    x_cache[tid] = x;
+
+    float sum_sq = x * x;
+    sum_sq = gdn_warp_reduce_sum(sum_sq);
+    __shared__ float rms_sums[4];
+    const unsigned int warp_id = tid / 32;
+    const unsigned int lane_id = tid % 32;
+    if (lane_id == 0) rms_sums[warp_id] = sum_sq;
+    __syncthreads();
+    if (warp_id == 0) {
+        float val = (lane_id < (blockDim.x + 31) / 32) ? rms_sums[lane_id] : 0.0f;
+        val = gdn_warp_reduce_sum(val);
+        if (lane_id == 0) rms_sums[0] = val;
+    }
+    __syncthreads();
+
+    const float rms = rsqrtf(rms_sums[0] / (float)v_dim + eps);
+
+    const unsigned int quad_size = v_dim / 4;
+    const unsigned long long* g64 = (const unsigned long long*)(
+        z_gate + (unsigned long long)b * z_stride + vh * v_dim
+    );
+    const unsigned long long* w64 = (const unsigned long long*)norm_weight;
+    unsigned long long* out64 = (unsigned long long*)(
+        output + (unsigned long long)b * out_stride + vh * v_dim
+    );
+    for (unsigned int i = tid; i < quad_size; i += blockDim.x) {
+        unsigned int base = i * 4;
+        float f0 = x_cache[base];
+        float f1 = x_cache[base + 1];
+        float f2 = x_cache[base + 2];
+        float f3 = x_cache[base + 3];
+
+        unsigned long long wv = w64[i];
+        float w0, w1, w2, w3;
+        gdn_unpack_bf16x2((unsigned int)wv, w0, w1);
+        gdn_unpack_bf16x2((unsigned int)(wv >> 32), w2, w3);
+
+        unsigned long long gv = g64[i];
+        float g0, g1, g2, g3;
+        gdn_unpack_bf16x2((unsigned int)gv, g0, g1);
+        gdn_unpack_bf16x2((unsigned int)(gv >> 32), g2, g3);
+
+        float s0 = g0 / (1.0f + expf(-g0));
+        float s1 = g1 / (1.0f + expf(-g1));
+        float s2 = g2 / (1.0f + expf(-g2));
+        float s3 = g3 / (1.0f + expf(-g3));
+
+        unsigned int lo = gdn_pack_bf16x2(f0 * rms * w0 * s0, f1 * rms * w1 * s1);
+        unsigned int hi = gdn_pack_bf16x2(f2 * rms * w2 * s2, f3 * rms * w3 * s3);
+        out64[i] = ((unsigned long long)hi << 32) | (unsigned long long)lo;
+    }
+}

--- a/kernels/gb10/qwen3.6-27b/nvfp4/gdn_verify_fused_conv_kn_f32.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/gdn_verify_fused_conv_kn_f32.cu
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// FP32-output twin of `gdn_verify_fused_conv_kn` (issue #435 route (a)).
+//
+// The exact-verify arm must feed the GDN recurrence the SAME conv values the
+// sequential decode path produces — and sequential decode runs the FP32-output
+// conv (`causal_conv1d_update_l2norm_f32`). The BF16 fused verify conv
+// truncates every Q/K/V element before the recurrence, which is the DOMINANT
+// term of the spec-on/spec-off divergence (h-state relL2 ~8.6e-4 after one
+// K=4 window on the 27B GDN shapes). This twin is the common fused kernel
+// with `output` widened to float and the final `__float2bfloat16` removed —
+// accumulation is already FP32 in both, so the FP32 output is FREE.
+//
+// BIT-EXACTNESS: same contract as the parent (see gdn_verify_fused_conv_kn.cu
+// header): built with --fmad=false, conv dot product / SiLU / L2-norm
+// reduction preserve the EXACT accumulation order of
+// `causal_conv1d_update_l2norm_f32`, so per-position outputs are byte-equal
+// to the per-token FP32 conv loop, and the inline conv-state snapshots are
+// byte-equal to the copy_d2d they replace.
+//
+// `output_stride` is in FP32 elements (the parent's is BF16 elements).
+//
+// MODEL-SPECIFIC ON PURPOSE (shadow-first rule): qwen3.6-27b/nvfp4 only for
+// now. Targets without it fall back to the per-token
+// `causal_conv1d_update_l2norm_f32` loop + conv-state copy_d2d — same bits,
+// more launches. Promote to common/ only after the bitwise gate passes on
+// every inheriting model.
+//
+// Grid: (ceil(dim/256), 1, 1)   Block: (256, 1, 1)
+
+#include <cuda_bf16.h>
+
+extern "C" __global__ void gdn_verify_fused_conv_kn_f32(
+    float* __restrict__ conv_state,              // [dim, d_conv] FP32 (in/out)
+    const __nv_bfloat16* __restrict__ new_input, // [K, input_stride] BF16
+    const __nv_bfloat16* __restrict__ weight,    // [dim, d_conv] BF16
+    float* __restrict__ output,                  // [K, output_stride] FP32
+    float* __restrict__ conv_state_inter,        // [K, inter_stride] FP32 (out, per-token snapshots)
+    unsigned int num_tokens,     // K
+    unsigned int dim,
+    unsigned int d_conv,
+    unsigned int qk_channels,    // channels 0..qk_channels-1 get L2 normalized
+    unsigned int head_dim,       // L2 norm group size (128)
+    unsigned int input_stride,   // BF16 elems between positions in new_input
+    unsigned int output_stride,  // FP32 elems between positions in output
+    unsigned int inter_stride,   // FP32 elems between snapshots in conv_state_inter
+    float l2_eps
+) {
+    const unsigned int ch = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int block_start = blockIdx.x * blockDim.x;
+    const bool block_needs_l2 = (block_start < qk_channels);
+    const bool valid = (ch < dim);
+
+    // ── Load this channel's d_conv-element sliding window into registers ──
+    float win[8]; // d_conv <= 8
+    if (valid) {
+        const float* state = conv_state + ch * d_conv;
+        for (unsigned int i = 0; i < d_conv; i++) win[i] = state[i];
+    }
+
+    const __nv_bfloat16* w = valid ? (weight + ch * d_conv) : nullptr;
+    float wcoef[8];
+    if (valid) {
+        for (unsigned int k = 0; k < d_conv; k++) wcoef[k] = (float)w[k];
+    }
+
+    __shared__ float warp_sums[8];
+
+    // Process the positions sequentially in registers. L2-norm needs
+    // __syncthreads per position, so the loop body mirrors the single-token
+    // kernel exactly.
+    for (unsigned int t = 0; t < num_tokens; t++) {
+        float silu = 0.0f;
+        if (valid) {
+            // Shift window left, append this position's input (== global path).
+            for (unsigned int i = 0; i < d_conv - 1; i++) win[i] = win[i + 1];
+            win[d_conv - 1] = (float)new_input[t * input_stride + ch];
+            // bias == nullptr in production conv1d_update_l2norm.
+            float acc = 0.0f;
+            for (unsigned int k = 0; k < d_conv; k++) acc += win[k] * wcoef[k];
+            float sigmoid_acc = 1.0f / (1.0f + __expf(-acc));
+            silu = acc * sigmoid_acc;
+        }
+
+        if (block_needs_l2) {
+            float sq = valid ? (silu * silu) : 0.0f;
+            const unsigned int warp_id = tid / 32;
+            const unsigned int lane = tid % 32;
+            for (int offset = 16; offset >= 1; offset >>= 1)
+                sq += __shfl_down_sync(0xFFFFFFFF, sq, offset);
+            if (lane == 0) warp_sums[warp_id] = sq;
+            __syncthreads();
+            const unsigned int head_in_block = tid / head_dim;
+            const unsigned int base_warp = head_in_block * (head_dim / 32);
+            if (tid == 0 || tid == head_dim) {
+                float total = warp_sums[base_warp] + warp_sums[base_warp + 1]
+                            + warp_sums[base_warp + 2] + warp_sums[base_warp + 3];
+                warp_sums[base_warp] = rsqrtf(total + l2_eps);
+            }
+            __syncthreads();
+            if (valid) silu *= warp_sums[base_warp];
+            // Close the loop-carried window on warp_sums: the next iteration's
+            // lane-0 partial-sum write must not overtake this read.
+            __syncthreads();
+        }
+
+        if (valid) output[t * output_stride + ch] = silu;  // FP32 — no truncation
+
+        // Snapshot this position's conv-state (rollback intermediate t).
+        if (valid) {
+            float* snap = conv_state_inter + t * inter_stride + ch * d_conv;
+            for (unsigned int i = 0; i < d_conv; i++) snap[i] = win[i];
+        }
+    }
+
+    // Commit final (post last-position) sliding window to conv_state.
+    if (valid) {
+        float* state = conv_state + ch * d_conv;
+        for (unsigned int i = 0; i < d_conv; i++) state[i] = win[i];
+    }
+}

--- a/kernels/gb10/qwen3.6-35b-a3b/MODEL.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/MODEL.toml
@@ -381,3 +381,25 @@ the resolved half-register gate is set, and that gate is off by default
 gated_delta_rule_decode_f32_strided_norm_smem = """
 SMEM-staged twin; gated behind ATLAS_GDN_SMEM_STAGE (presence, off by
 default) AND the half-register gate. Not a live path as shipped."""
+
+# #438: the exact-verify `_snap` twins are model-shadow staged in
+# qwen3.6-27b/nvfp4 ONLY (shadow-first; promote to common/ once validated
+# per family). Every dispatch site probes handle != 0, and the whole chain
+# is opt-in via --exact-verify; the fallback stays exact.
+[expected_absent.gated_delta_rule_snap]
+gated_delta_rule_decode_f32_norm_snap = """
+Exact-verify snapshot twin (#435), shipped only in qwen3.6-27b/nvfp4.
+trait_decode_batched_conv_gdn_exact probes handle != 0; absent, the
+exact arm uses the parent gdn_f32_norm kernel + copy_d2d snapshots
+(same bits, more launches)."""
+gated_delta_rule_decode_f32_strided_norm_snap = """
+Batched exact-verify snapshot twin (#435), shipped only in
+qwen3.6-27b/nvfp4. trait_decode_batched_conv_gdn_multi_exact declines
+the batched form on handle 0 and the per-sequence exact loop serves
+(still exact)."""
+
+[expected_absent.gdn_verify_fused_conv_kn_f32]
+gdn_verify_fused_conv_kn_f32 = """
+FP32 fused verify conv for the exact-verify chain (#435), shipped only
+in qwen3.6-27b/nvfp4. Probed handle != 0; absent, the exact chain keeps
+its per-token conv launches (same bits, more launches)."""


### PR DESCRIPTION
Six fixes, stacked so the GPU gates run once rather than six times. Every one is mutation-proven; the two with hardware-observable behaviour were measured on GB10.

## What lands

| commit | fix | proof |
|---|---|---|
| `491c5a41` | **#435** — exact MTP-verify chain; spec-on output equals spec-off at temp 0 | bitwise, h relL2 **0.000e0**, negative control differs at 5.387e-4 |
| `292b5cda` | **`finish_reason="length"`** — three distinct bugs | 12 mutations, 4 of them at the CALL SITE |
| `05ecf2d4` | the #435 bitwise gate was **self-skipping and had never run** | loaded deepseek's kernel set, not the 27B's |
| `bb6b5913` | exact verify is now **opt-in** via `--exact-verify` | 5 mutations |
| `b554a18c` | the investigated-but-**unimplemented** default mitigation, recorded | — |
| `c31a7fe3` | **C≥2 serving crash** — batched verify fell to NULL weights | 4 mutations; 3 clean sweeps C=1..16 |

## The two that matter most

**A server that could not take two concurrent speculative requests.** On `main` today, any C≥2 request pair dies at the first batched MTP verify — `CUDA_ERROR_ILLEGAL_ADDRESS`, sticky context loss, 503s thereafter. Root cause: the 27B-NVFP4 checkpoint loads its 48 GDN layers through the native-FP8 arm, leaving `in_proj_qkvz` NULL and only `qkvz_fp8w` live. The fp8w dispatch was gated `(2..=4).contains(&num_tokens)` because `w8a16_gemv_batch4` is an M≤4 kernel — but batched verify calls that body at `R = Σks`, which is 7 for `ks=[4,3]`. Any R > 4 fell through every arm to `dense_gemm` on the NULL slot.

Single-sequence verify never exceeds R=4. That is exactly why it took two concurrent requests to crash the server.

This is the **third** instance of this NULL-slot dispatch-gap class at the same site (K=2/3 fixed 2026-07-02, K=4 on 2026-07-18, both documented in comments there). The fix adds the missing R>4 arm and `ensure!` guards so a future gap errors per-request instead of destroying the context. The identical gap in the qwen35 MoE FP8 builds is fixed too.

**`finish_reason="length"` was a catch-all.** It was the `else` branch — returned for every non-EOS, non-tool-end stop, never consulting the token budget, though `ActiveSeq` already carried it. OpenAI defines `length` as "the maximum number of tokens specified in the request was reached", and puts stop sequences under `stop`; vLLM, SGLang, TGI and llama.cpp all agree. A false `length` is actively harmful: Aider marks output truncated and skips auto-commit, opencode routes it into a `repairToolCall` retry loop, hermes-agent auto-retries asking the model to continue. Three bugs were found: the catch-all, multi-token stop strings that suppressed output without cancelling, and an empty-output edge that reported `tool_calls` via `None == None`.

`"length"` is now decided by `helpers::hard_ceiling_hit` — the same predicate that force-stops decode — so the reported reason and the actual stop condition cannot drift apart.

## #435 ships opt-in, and the docs say so

Exact verify is proven bitwise but **defaults off**. Every surveyed engine makes exactness opt-in (vLLM `VLLM_BATCH_INVARIANT=1`; SGLang `--enable-deterministic-inference` at 34% avg slowdown). Serve-level cost here measures **+3–4% TPOT at C=1**; the wide-rung figures remain microbenchmark-derived and are labelled as such. The flag help states plainly that with default settings **#435's divergence remains**, and names the flag that removes it.

## Verification

- `cargo test --workspace` **3951 passed, 0 failed**
- clippy `--workspace --tests` clean; `fmt --check` clean
- 500-LoC cap: **0 violations** (checked with the workflow's own 94-entry allow-list)
- C≥2 fix on hardware: three sweeps, zero 700s, C=16/ISL-128 at 66.8 tok/s

## Known limits

- The C≥2 hardware proof was taken on a branch off `main`; the composed stack passes 3951 unit tests and the cherry-pick auto-merged, but the six-commit tree has not itself been served.
- The qwen35 MoE FP8 builds are fixed by the same code but were not hardware-tested.
- Two stream-layer call sites in the finish_reason fix have no unit coverage (they need a full `StreamCtx`).
- The FP32 conv-output-store mitigation for #435 is written up, not implemented (~1%, needs FP32-input twins across ~8 WY kernel files).
- ★ **The gate set cannot see the class of bug fixed here.** All five required legs run at batch size 1–2 without a K=4 ladder, so a C≥2 crash is invisible to every one of them. `concurrency-sweep` exists in the registry bound to no gate; binding it is owed.

Co-Authored-By: Atlas <atlas@avarok.net>