### PR TITLE
feat(fp8-kv): detect checkpoint k/v scales and log the right guidance (#153 item 1)

### DIFF
--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -183,6 +183,15 @@ impl WeightStore {
             .values()
             .any(|w| matches!(w.dtype, WeightDtype::FP8E4M3))
     }
+
+    /// Number of per-layer FP8 KV-cache scale tensors (`*.k_scale`) the
+    /// checkpoint ships. `>0` means the model carries calibrated KV scales, so
+    /// FP8 KV needs no online calibration; `0` means the scales default to 1.0
+    /// (which clips BF16 into E4M3 range), so online calibration or a non-FP8 KV
+    /// dtype is required. Used to log the right guidance at serve time.
+    pub fn fp8_kv_scale_count(&self) -> usize {
+        self.names().filter(|n| n.ends_with(".k_scale")).count()
+    }
 }
 
 /// SBIO IORouter trait for weight loading.
@@ -440,6 +449,45 @@ mod teardown_tests {
         store.release(&gpu).expect("first");
         store.release(&gpu).expect("second");
         assert_eq!(gpu.alloc_count(), 0);
+    }
+
+    /// `fp8_kv_scale_count` counts exactly the `*.k_scale` tensors — one per
+    /// attention layer in checkpoints that ship calibrated FP8 KV scales —
+    /// and ignores `v_scale` (paired 1:1 with `k_scale`, counting both would
+    /// double-report) and lookalike suffixes.
+    #[test]
+    fn fp8_kv_scale_count_counts_only_k_scale_tensors() {
+        let gpu = MockGpuBackend::new();
+        let tensor = || WeightTensor {
+            ptr: gpu.alloc(1024).expect("alloc"),
+            shape: vec![1],
+            dtype: WeightDtype::BF16,
+        };
+        let mut map = HashMap::new();
+        for name in [
+            "model.layers.0.self_attn.k_scale",
+            "model.layers.0.self_attn.v_scale",
+            "model.layers.7.self_attn.k_scale",
+            "model.layers.7.self_attn.v_scale",
+            "model.layers.0.self_attn.q_proj.weight",
+            // Lookalikes that must NOT count: no dot before the suffix, and a
+            // different scale kind entirely.
+            "model.layers.0.self_attn.attnk_scale",
+            "model.layers.0.mlp.weight_scale",
+        ] {
+            map.insert(name.to_string(), tensor());
+        }
+        let store = WeightStore::from_map(map);
+        assert_eq!(store.fp8_kv_scale_count(), 2);
+    }
+
+    /// A checkpoint without shipped KV scales reports zero — the case where
+    /// serve logs the "needs calibration or a non-FP8 KV dtype" warning.
+    #[test]
+    fn fp8_kv_scale_count_zero_without_scales() {
+        let gpu = MockGpuBackend::new();
+        let store = store_with(&gpu, 4);
+        assert_eq!(store.fp8_kv_scale_count(), 0);
     }
 
     /// Reverse order, and one failure does not abandon the rest — the whole

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -292,6 +292,9 @@ pub(crate) use loader::estimate_load_bytes;
 pub(crate) use loader::{check_oom_guard, estimate_has_fp8};
 
 #[cfg(test)]
+mod fp8_scale_count_tests;
+
+#[cfg(test)]
 mod from_str_tests {
     use super::WeightDtype;
 
@@ -449,45 +452,6 @@ mod teardown_tests {
         store.release(&gpu).expect("first");
         store.release(&gpu).expect("second");
         assert_eq!(gpu.alloc_count(), 0);
-    }
-
-    /// `fp8_kv_scale_count` counts exactly the `*.k_scale` tensors — one per
-    /// attention layer in checkpoints that ship calibrated FP8 KV scales —
-    /// and ignores `v_scale` (paired 1:1 with `k_scale`, counting both would
-    /// double-report) and lookalike suffixes.
-    #[test]
-    fn fp8_kv_scale_count_counts_only_k_scale_tensors() {
-        let gpu = MockGpuBackend::new();
-        let tensor = || WeightTensor {
-            ptr: gpu.alloc(1024).expect("alloc"),
-            shape: vec![1],
-            dtype: WeightDtype::BF16,
-        };
-        let mut map = HashMap::new();
-        for name in [
-            "model.layers.0.self_attn.k_scale",
-            "model.layers.0.self_attn.v_scale",
-            "model.layers.7.self_attn.k_scale",
-            "model.layers.7.self_attn.v_scale",
-            "model.layers.0.self_attn.q_proj.weight",
-            // Lookalikes that must NOT count: no dot before the suffix, and a
-            // different scale kind entirely.
-            "model.layers.0.self_attn.attnk_scale",
-            "model.layers.0.mlp.weight_scale",
-        ] {
-            map.insert(name.to_string(), tensor());
-        }
-        let store = WeightStore::from_map(map);
-        assert_eq!(store.fp8_kv_scale_count(), 2);
-    }
-
-    /// A checkpoint without shipped KV scales reports zero — the case where
-    /// serve logs the "needs calibration or a non-FP8 KV dtype" warning.
-    #[test]
-    fn fp8_kv_scale_count_zero_without_scales() {
-        let gpu = MockGpuBackend::new();
-        let store = store_with(&gpu, 4);
-        assert_eq!(store.fp8_kv_scale_count(), 0);
     }
 
     /// Reverse order, and one failure does not abandon the rest — the whole

--- a/crates/spark-runtime/src/weights/fp8_scale_count_tests.rs
+++ b/crates/spark-runtime/src/weights/fp8_scale_count_tests.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`WeightStore::fp8_kv_scale_count`]. Sibling file for the
+//! 500-LoC cap.
+
+#[cfg(test)]
+mod tests {
+    use super::super::{WeightDtype, WeightStore, WeightTensor};
+    use crate::gpu::GpuBackend;
+    use crate::gpu::mock::MockGpuBackend;
+    use std::collections::HashMap;
+
+    /// `fp8_kv_scale_count` counts exactly the `*.k_scale` tensors — one per
+    /// attention layer in checkpoints that ship calibrated FP8 KV scales —
+    /// and ignores `v_scale` (paired 1:1 with `k_scale`, counting both would
+    /// double-report) and lookalike suffixes.
+    #[test]
+    fn fp8_kv_scale_count_counts_only_k_scale_tensors() {
+        let gpu = MockGpuBackend::new();
+        let tensor = || WeightTensor {
+            ptr: gpu.alloc(1024).expect("alloc"),
+            shape: vec![1],
+            dtype: WeightDtype::BF16,
+        };
+        let mut map = HashMap::new();
+        for name in [
+            "model.layers.0.self_attn.k_scale",
+            "model.layers.0.self_attn.v_scale",
+            "model.layers.7.self_attn.k_scale",
+            "model.layers.7.self_attn.v_scale",
+            "model.layers.0.self_attn.q_proj.weight",
+            // Lookalikes that must NOT count: no dot before the suffix, and a
+            // different scale kind entirely.
+            "model.layers.0.self_attn.attnk_scale",
+            "model.layers.0.mlp.weight_scale",
+        ] {
+            map.insert(name.to_string(), tensor());
+        }
+        let store = WeightStore::from_map(map);
+        assert_eq!(store.fp8_kv_scale_count(), 2);
+    }
+
+    /// A checkpoint without shipped KV scales reports zero — the case where
+    /// serve logs the "needs calibration or a non-FP8 KV dtype" warning.
+    #[test]
+    fn fp8_kv_scale_count_zero_without_scales() {
+        let gpu = MockGpuBackend::new();
+        let mut map = HashMap::new();
+        for i in 0..4 {
+            map.insert(
+                format!("w{i}"),
+                WeightTensor {
+                    ptr: gpu.alloc(1024).expect("alloc"),
+                    shape: vec![16, 16],
+                    dtype: WeightDtype::BF16,
+                },
+            );
+        }
+        let store = WeightStore::from_map(map);
+        assert_eq!(store.fp8_kv_scale_count(), 0);
+    }
+}

--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -398,7 +398,12 @@ pub(crate) fn load_model(
         kv_dtype,
         layer_dtypes,
         hss_cache_blocks_per_seq,
-    } = serve_phases::resolve_kv_cache_config(&args, &config, ptx_set.behavior.default_kv_dtype)?;
+    } = serve_phases::resolve_kv_cache_config(
+        &args,
+        &config,
+        ptx_set.behavior.default_kv_dtype,
+        store.fp8_kv_scale_count(),
+    )?;
 
     // Fail-fast: every kernel handle the selected --kv-cache-dtype's dispatch
     // arms need must resolve NOW — not at first dispatch after a multi-minute

--- a/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
@@ -173,6 +173,9 @@ pub(crate) fn resolve_kv_cache_config(
     args: &cli::ServeArgs,
     config: &ModelConfig,
     behavior_default_kv_dtype: &str,
+    // Count of `*.k_scale` tensors in the checkpoint (0 = no shipped FP8 KV
+    // scales). Drives the FP8-KV guidance log below.
+    fp8_kv_scale_count: usize,
 ) -> Result<KvCacheConfig> {
     // Resolution rules:
     //   1. No MODEL.toml override        → use args.kv_cache_dtype as-is.
@@ -207,23 +210,43 @@ pub(crate) fn resolve_kv_cache_config(
     };
     let kv_dtype: spark_runtime::kv_cache::KvCacheDtype = effective_kv_dtype_str.parse()?;
     if kv_dtype == spark_runtime::kv_cache::KvCacheDtype::Fp8 {
+        let has_ckpt_scales = fp8_kv_scale_count > 0;
         if config.fp8_kv_calibration_tokens > 0 {
+            if has_ckpt_scales {
+                // The model already ships calibrated scales; online calibration
+                // would override them with a looser first-observe estimate.
+                tracing::info!(
+                    "FP8 KV online calibration is ON, but this checkpoint already ships {} \
+                     per-layer k_scale/v_scale tensors (full-data calibrated, tighter than a \
+                     runtime estimate). Prefer --fp8-kv-calibration-tokens 0 to use them directly.",
+                    fp8_kv_scale_count,
+                );
+            } else {
+                tracing::info!(
+                    "FP8 KV cache with online calibration (checkpoint ships no k/v scales): \
+                     freezing per-tensor scales on the first observed tokens.{}",
+                    if args.fp8_kv_calibration_tokens == 0 {
+                        " (auto-enabled from MODEL.toml)"
+                    } else {
+                        ""
+                    },
+                );
+            }
+        } else if has_ckpt_scales {
+            // The common, correct case for NVFP4 checkpoints that ship KV scales
+            // (e.g. Laguna-S-2.1): no calibration needed, and it is the tightest
+            // option. NOT a warning.
             tracing::info!(
-                "FP8 KV cache with online calibration: tracking max |K|/|V| during \
-                 first {} tokens to compute per-tensor scales.{}",
-                config.fp8_kv_calibration_tokens,
-                if args.fp8_kv_calibration_tokens == 0 {
-                    " (auto-enabled from MODEL.toml)"
-                } else {
-                    ""
-                },
+                "FP8 KV cache using {} per-layer k_scale/v_scale tensors from the checkpoint — \
+                 no calibration needed.",
+                fp8_kv_scale_count,
             );
         } else {
             tracing::warn!(
-                "FP8 KV cache selected. This requires calibrated k_scale/v_scale in the model \
-                 checkpoint. Without scales (default=1.0), BF16 values are silently clipped to \
-                 E4M3 range [-448, 448], destroying dynamic range. Use --fp8-kv-calibration-tokens 256 \
-                 for online calibration, or --kv-cache-dtype nvfp4/bf16 if your model lacks k/v scales."
+                "FP8 KV cache selected but the checkpoint ships NO k_scale/v_scale tensors \
+                 (defaulting to 1.0, which silently clips BF16 into E4M3 range [-448, 448] and \
+                 destroys dynamic range). Enable --fp8-kv-calibration-tokens 256 for online \
+                 calibration, or use --kv-cache-dtype nvfp4/bf16."
             );
         }
     }


### PR DESCRIPTION
Split out of #372 per review — this commit shared nothing with the calibration fix there, so it gets its own PR. Implements proposal item 1 of #153.

**Detection + logging only. No behavior change, no new flags or env vars.**

## Problem

The FP8 KV serve log WARNed whenever online calibration was off ("requires calibrated k_scale/v_scale ... Without scales (default=1.0) ... clips"), even when the checkpoint already ships real per-layer scales — misleadingly pushing users toward online calibration they don't need, and which is looser than the shipped full-data-calibrated scales.

## Change

`WeightStore::fp8_kv_scale_count()` counts the checkpoint's `*.k_scale` tensors (`k_scale`/`v_scale` ship as 1:1 pairs, so counting one side avoids double-reporting). `resolve_kv_cache_config` takes the count and branches the FP8 KV guidance on presence:

| Checkpoint scales | Calibration | Log |
|---|---|---|
| shipped | off | INFO: "FP8 KV cache using N per-layer k_scale/v_scale tensors from the checkpoint — no calibration needed." (the common NVFP4 case) |
| shipped | on | INFO: calibration is ON but the checkpoint ships N calibrated scale pairs (tighter than a runtime first-observe estimate) — prefer `--fp8-kv-calibration-tokens 0` |
| none | off | WARN (unchanged in substance): no k/v scales, default=1.0 silently clips BF16 into E4M3 range — enable `--fp8-kv-calibration-tokens 256` or use `--kv-cache-dtype nvfp4/bf16` |
| none | on | INFO: online calibration appropriate — freezing per-tensor scales on the first observed tokens |

The last case's text is also updated to match the hardened calibration behavior (scales freeze on the first observed tokens, not "during first N tokens").

## Tests

Unit tests on the counting helper (MockGpuBackend, no GPU): counts only `.k_scale` suffixes, ignores `v_scale` pairs and lookalike names (`attnk_scale`, `weight_scale`); returns 0 for scale-free checkpoints.

`cargo fmt`, `clippy -D warnings`, and `cargo test` for spark-runtime + spark-server all pass.
