### PR TITLE
fix(nemotron): load native FP8 SSM weights — stop the Mamba2 double-quant

### DIFF
--- a/crates/spark-model/examples/w8a16_gemv_numeric.rs
+++ b/crates/spark-model/examples/w8a16_gemv_numeric.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! NUMERIC correctness check for `w8a16_gemv` at the Nemotron-Puzzle SSM shapes.
+//!
+//! The sibling `gemv_fp4_vs_fp8_microtest` is timing-only — it never checks an
+//! output value. That left a real gap: enabling native FP8 for the Puzzle-75B
+//! Mamba2 projections made the model measurably WORSE (correct "Alice" became an
+//! invented "Charlie"), and a bisect pinned it to the DECODE path, i.e. this
+//! kernel — yet the scale value, scale shape, broadcast, kernel indexing, LUT and
+//! call-site argument order all inspect as correct. So test the arithmetic.
+//!
+//! Construction is chosen so the expected answer is exact and obvious:
+//!   A[k]         = 1.0        for all k
+//!   B[n,k]       = 0x38       = 1.0 in E4M3 (sign 0, exp 0111 -> 2^0, mantissa 0)
+//!   block_scale  = S          constant over every block
+//! then  C[n] = sum_k 1.0 * 1.0 * S = K * S  for every n.
+//!
+//! A per-block vs per-row scale-layout mix-up still yields the right answer under
+//! a CONSTANT scale, so the run also repeats with a scale that VARIES per block —
+//! `scale[nb, kb] = 1 + nb + 100*kb` — where the two layouts disagree and the
+//! expected value per row is a closed form: C[n] = 128 * sum_kb (1 + nb + 100*kb).
+//!
+//! Usage: cargo run --release -p spark-model --example w8a16_gemv_numeric -- [N] [K]
+//! Default N=18048 K=4096 (Puzzle SSM in_proj). Also try 4096 8192 (out_proj).
+
+use anyhow::{Result, bail};
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::GpuBackend;
+use spark_runtime::kernel_args::KernelLaunch;
+
+const FP8_BLOCK: usize = 128;
+
+fn bf16_bytes(v: f32) -> [u8; 2] {
+    // Round-to-nearest-even truncation of f32 -> bf16, as the loaders do.
+    let bits = v.to_bits();
+    let rounded = ((bits >> 16) & 1).wrapping_add(0x7fff).wrapping_add(bits);
+    ((rounded >> 16) as u16).to_le_bytes()
+}
+
+fn bf16_to_f32(lo: u8, hi: u8) -> f32 {
+    f32::from_bits(((u16::from_le_bytes([lo, hi])) as u32) << 16)
+}
+
+fn run(gpu: &dyn GpuBackend, stream: u64, n: u32, k: u32, vary: bool) -> Result<()> {
+    let nb = (n as usize).div_ceil(FP8_BLOCK);
+    let kb = (k as usize).div_ceil(FP8_BLOCK);
+
+    // A = all ones (BF16)
+    let a_host: Vec<u8> = (0..k).flat_map(|_| bf16_bytes(1.0)).collect();
+    let a = gpu.alloc(a_host.len())?;
+    gpu.copy_h2d(&a_host, a)?;
+
+    // B = all 0x38 (= 1.0 in E4M3), [N, K] row-major
+    let b_host = vec![0x38u8; (n as usize) * (k as usize)];
+    let b = gpu.alloc(b_host.len())?;
+    gpu.copy_h2d(&b_host, b)?;
+
+    // block_scale [ceil(N/128), ceil(K/128)] FP32, row-major — the layout the
+    // kernel documents and the loader materializes.
+    let mut s_host = Vec::with_capacity(nb * kb * 4);
+    for i in 0..nb {
+        for j in 0..kb {
+            let s = if vary {
+                1.0f32 + i as f32 + 100.0 * j as f32
+            } else {
+                0.00088065f32 // the real Puzzle L0 in_proj weight_scale
+            };
+            s_host.extend_from_slice(&s.to_le_bytes());
+        }
+    }
+    let s = gpu.alloc(s_host.len())?;
+    gpu.copy_h2d(&s_host, s)?;
+
+    let c = gpu.alloc((n as usize) * 2)?;
+    let kern = gpu.kernel("w8a16_gemv", "w8a16_gemv")?;
+    KernelLaunch::new(gpu, kern)
+        .grid([n.div_ceil(4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(b)
+        .arg_ptr(s)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)?;
+    gpu.synchronize(stream)?;
+
+    let mut c_host = vec![0u8; (n as usize) * 2];
+    gpu.copy_d2h(c, &mut c_host)?;
+
+    // Expected, per row n: sum over k of scale[n/128, k/128].
+    // Each k-block contributes min(128, K - kb*128) terms.
+    let expect = |row: usize| -> f32 {
+        let i = row / FP8_BLOCK;
+        (0..kb)
+            .map(|j| {
+                let width = ((k as usize) - j * FP8_BLOCK).min(FP8_BLOCK) as f32;
+                let sv = if vary {
+                    1.0f32 + i as f32 + 100.0 * j as f32
+                } else {
+                    0.00088065f32
+                };
+                sv * width
+            })
+            .sum()
+    };
+
+    let mut worst = 0.0f32;
+    let mut worst_row = 0usize;
+    let mut first_bad: Option<(usize, f32, f32)> = None;
+    for row in 0..(n as usize) {
+        let got = bf16_to_f32(c_host[row * 2], c_host[row * 2 + 1]);
+        let want = expect(row);
+        let rel = if want.abs() > 0.0 {
+            ((got - want) / want).abs()
+        } else {
+            got.abs()
+        };
+        if rel > worst {
+            worst = rel;
+            worst_row = row;
+        }
+        // BF16 carries ~3 decimal digits; 2% covers accumulation order effects.
+        if rel > 0.02 && first_bad.is_none() {
+            first_bad = Some((row, got, want));
+        }
+    }
+
+    let label = if vary {
+        "VARYING block scale"
+    } else {
+        "constant scale"
+    };
+    println!("  {label}: N={n} K={k} blocks=[{nb},{kb}]");
+    println!(
+        "    row0: got={:.6} want={:.6}",
+        bf16_to_f32(c_host[0], c_host[1]),
+        expect(0)
+    );
+    if let Some((row, got, want)) = first_bad {
+        println!("    FAIL first bad row {row}: got={got:.6} want={want:.6}");
+        println!("    worst rel err {:.4} at row {worst_row}", worst);
+    } else {
+        println!("    PASS (worst rel err {:.6} at row {worst_row})", worst);
+    }
+    Ok(())
+}
+
+/// Same construction, for the PREFILL GEMMs. `C[m,n]` must equal `K*S` for every
+/// (m, n) since A is all ones and every weight is 1.0.
+fn run_gemm(gpu: &dyn GpuBackend, stream: u64, which: &str, m: u32, n: u32, k: u32) -> Result<()> {
+    let nb = (n as usize).div_ceil(FP8_BLOCK);
+    let kb = (k as usize).div_ceil(FP8_BLOCK);
+    const S: f32 = 0.00088065;
+
+    // A varies by ROW and the block scale varies by N-BLOCK, so the expected
+    // value depends on BOTH m and n. With all-ones inputs every output element
+    // is identical and a transposed / wrong-stride result is indistinguishable
+    // from a correct one — which is exactly the failure mode being hunted.
+    let a_row = |mi: usize| -> f32 { ((mi % 7) + 1) as f32 };
+    let s_blk = |nbi: usize| -> f32 { S * (1 + (nbi % 5)) as f32 };
+
+    let a_host: Vec<u8> = (0..(m as usize))
+        .flat_map(|mi| (0..(k as usize)).flat_map(move |_| bf16_bytes(a_row(mi))))
+        .collect();
+    let a = gpu.alloc(a_host.len())?;
+    gpu.copy_h2d(&a_host, a)?;
+
+    let b_host = vec![0x38u8; (n as usize) * (k as usize)];
+    let b = gpu.alloc(b_host.len())?;
+    gpu.copy_h2d(&b_host, b)?;
+
+    let mut s_host = Vec::with_capacity(nb * kb * 4);
+    for nbi in 0..nb {
+        for _ in 0..kb {
+            s_host.extend_from_slice(&s_blk(nbi).to_le_bytes());
+        }
+    }
+    let s = gpu.alloc(s_host.len())?;
+    gpu.copy_h2d(&s_host, s)?;
+
+    let c = gpu.alloc((m as usize) * (n as usize) * 2)?;
+    let kern = gpu.kernel(which, which)?;
+    let launch = KernelLaunch::new(gpu, kern);
+    let launch = if which == "w8a16_gemm_pipelined" {
+        launch
+            .grid([n.div_ceil(32), m.div_ceil(128), 1])
+            .block([256, 1, 1])
+    } else {
+        launch
+            .grid([n.div_ceil(64), m.div_ceil(64), 1])
+            .block([128, 1, 1])
+    };
+    launch
+        .arg_ptr(a)
+        .arg_ptr(b)
+        .arg_ptr(s)
+        .arg_ptr(c)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)?;
+    gpu.synchronize(stream)?;
+
+    let mut c_host = vec![0u8; (m as usize) * (n as usize) * 2];
+    gpu.copy_d2h(c, &mut c_host)?;
+    // Row-major [M, N]: C[m,n] = A_row(m) * s_blk(n/128) * K
+    let want_at = |mi: usize, ni: usize| -> f32 { a_row(mi) * s_blk(ni / FP8_BLOCK) * k as f32 };
+    let mut worst = 0.0f32;
+    let mut bad = 0usize;
+    let mut first_bad: Option<(usize, usize, f32, f32)> = None;
+    for mi in 0..(m as usize) {
+        for ni in 0..(n as usize) {
+            let idx = mi * (n as usize) + ni;
+            let got = bf16_to_f32(c_host[idx * 2], c_host[idx * 2 + 1]);
+            let want = want_at(mi, ni);
+            let rel = ((got - want) / want).abs();
+            if rel > worst {
+                worst = rel;
+            }
+            if rel > 0.02 {
+                bad += 1;
+                if first_bad.is_none() {
+                    first_bad = Some((mi, ni, got, want));
+                }
+            }
+        }
+    }
+    println!("  {which}: M={m} N={n} K={k}");
+    println!(
+        "    [0,0] got={:.4} want={:.4} | [1,0] got={:.4} want={:.4} | [0,{}] got={:.4} want={:.4}",
+        bf16_to_f32(c_host[0], c_host[1]),
+        want_at(0, 0),
+        bf16_to_f32(c_host[(n as usize) * 2], c_host[(n as usize) * 2 + 1]),
+        want_at(1, 0),
+        FP8_BLOCK,
+        bf16_to_f32(c_host[FP8_BLOCK * 2], c_host[FP8_BLOCK * 2 + 1]),
+        want_at(0, FP8_BLOCK),
+    );
+    if let Some((mi, ni, got, want)) = first_bad {
+        println!(
+            "    FAIL first bad [{mi},{ni}] got={got:.4} want={want:.4}  bad={bad}/{}",
+            (m as usize) * (n as usize)
+        );
+    } else {
+        println!("    PASS (worst rel {worst:.5})");
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let n: u32 = args.get(1).map(|s| s.parse()).transpose()?.unwrap_or(18048);
+    let k: u32 = args.get(2).map(|s| s.parse()).transpose()?.unwrap_or(4096);
+    if k % 16 != 0 {
+        bail!("w8a16_gemv requires K%16==0");
+    }
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let stream = gpu.default_stream();
+    println!("w8a16_gemv numeric check (DECODE)");
+    run(&gpu, stream, n, k, false)?;
+    run(&gpu, stream, n, k, true)?;
+    println!("w8a16 GEMM numeric check (PREFILL), M=256");
+    run_gemm(&gpu, stream, "w8a16_gemm_pipelined", 256, n, k)?;
+    run_gemm(&gpu, stream, "w8a16_gemm", 256, n, k)?;
+    Ok(())
+}

--- a/crates/spark-model/src/layers/nemotron_mamba2.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2.rs
@@ -171,8 +171,8 @@ impl NemotronMamba2Layer {
     }
 
     /// Set native FP8 weights to skip double-quantization (FP8→BF16→NVFP4).
-    /// When set, decode uses w8a16_gemv and prefill uses w8a16_gemm[_pipelined]
-    /// instead of the NVFP4/W4A4 arms.
+    /// When set, decode uses `w8a16_gemv` and prefill uses `w8a16_gemm` /
+    /// `w8a16_gemm_pipelined` instead of the NVFP4/W4A4 arms.
     ///
     /// Inputs MUST be tagged `WeightQuantFormat::Fp8BlockScaled`: every w8a16
     /// kernel indexes `block_scale[n/128 * k_blocks + k/128]`, so a per-row `[N]`

--- a/crates/spark-model/src/layers/nemotron_mamba2.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2.rs
@@ -19,6 +19,7 @@ use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
 use crate::weight_map::{DenseWeight, Fp8Weight, NemotronSsmWeights, QuantizedWeight};
 
 mod prefill;
+mod prefill_proj;
 mod trait_impl;
 
 #[allow(dead_code)]
@@ -28,6 +29,12 @@ pub struct NemotronMamba2Layer {
     // FP8 native weights (skip double-quantization FP8→BF16→NVFP4)
     in_proj_fp8: Option<Fp8Weight>,
     out_proj_fp8: Option<Fp8Weight>,
+    // Whether PREFILL may use the native FP8 weights above. False in the
+    // `ATLAS_NEMOTRON_NATIVE_FP8_SSM=decode` bisect mode, where the native
+    // weights are installed for decode only and the legacy NVFP4 copies are
+    // still built and used by prefill. Prefill must key off this flag, not off
+    // `in_proj_fp8.is_some()`.
+    native_fp8_prefill: bool,
     // Transposed NVFP4 weights for fast prefill GEMM (FP8 MMA, N128, cp.async)
     in_proj_t: Option<QuantizedWeight>,
     out_proj_t: Option<QuantizedWeight>,
@@ -35,6 +42,14 @@ pub struct NemotronMamba2Layer {
     // Consumed by `fp8_gemm_t`, which has NO dequant phase at all.
     in_proj_pd_fp8: Option<DevicePtr>,
     out_proj_pd_fp8: Option<DevicePtr>,
+    // NATIVE BF16 projections. A mixed-precision checkpoint can leave some
+    // Mamba layers unquantized (Nano-30B: 6 of 23 in_proj/out_proj are BF16
+    // while 17 are NVFP4). Requantizing those to NVFP4 under ONE global scale
+    // is what the FP8 arm above already documents as destroying context
+    // retrieval; keeping them BF16 avoids inventing a quantization the
+    // checkpoint never asked for.
+    in_proj_bf16: Option<DenseWeight>,
+    out_proj_bf16: Option<DenseWeight>,
     // Kernel handles — decode
     rms_norm_residual_k: KernelHandle,
     w4a16_gemv_k: KernelHandle,
@@ -45,10 +60,16 @@ pub struct NemotronMamba2Layer {
     residual_add_k: KernelHandle,
     // Kernel handles — prefill (GEMM + batched kernels)
     w4a16_gemm_k: KernelHandle,
+    // Native FP8 block-scaled prefill GEMM (paired with in_proj_fp8/out_proj_fp8).
+    w8a16_gemm_k: KernelHandle,
+    w8a16_gemm_pipelined_k: KernelHandle,
     w4a16_gemm_t_k: KernelHandle,
     w4a16_gemm_t_m128_k: KernelHandle,
     fp8_gemm_t_k: KernelHandle,
     fp8_fp8_gemm_t_k: KernelHandle,
+    // Native-BF16 projection kernels (paired with in_proj_bf16/out_proj_bf16).
+    dense_gemm_bf16_k: KernelHandle,
+    dense_gemv_bf16_k: KernelHandle,
     bf16_to_fp8_k: KernelHandle,
     w4a4_gemm_k: KernelHandle,
     quantize_nvfp4_k: KernelHandle,
@@ -95,10 +116,13 @@ impl NemotronMamba2Layer {
             ssm,
             in_proj_fp8: None,
             out_proj_fp8: None,
+            native_fp8_prefill: false,
             in_proj_t: None,
             out_proj_t: None,
             in_proj_pd_fp8: None,
             out_proj_pd_fp8: None,
+            in_proj_bf16: None,
+            out_proj_bf16: None,
             rms_norm_residual_k: gpu.kernel("norm", "rms_norm_residual")?,
             w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
             w8a16_gemv_k: super::try_kernel(gpu, "w8a16_gemv", "w8a16_gemv"),
@@ -107,10 +131,18 @@ impl NemotronMamba2Layer {
             gated_rms_norm_k: gpu.kernel("norm", "gated_rms_norm")?,
             residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
             w4a16_gemm_k: gpu.kernel("w4a16", "w4a16_gemm")?,
+            w8a16_gemm_k: super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),
+            w8a16_gemm_pipelined_k: super::try_kernel(
+                gpu,
+                "w8a16_gemm_pipelined",
+                "w8a16_gemm_pipelined",
+            ),
             w4a16_gemm_t_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t"),
             w4a16_gemm_t_m128_k: super::try_kernel(gpu, "w4a16", "w4a16_gemm_t_m128"),
             fp8_gemm_t_k: super::try_kernel(gpu, "w4a16", "fp8_gemm_t_m128_mfast"),
             fp8_fp8_gemm_t_k: super::try_kernel(gpu, "w4a16", "fp8_fp8_gemm_t_m128_mfast"),
+            dense_gemm_bf16_k: super::try_kernel(gpu, "gemm", "dense_gemm_bf16_pipelined"),
+            dense_gemv_bf16_k: super::try_kernel(gpu, "gemv", "dense_gemv_bf16"),
             bf16_to_fp8_k: super::try_kernel(gpu, "w4a16", "bf16_to_fp8"),
             w4a4_gemm_k: super::try_kernel(gpu, "w4a4", "w4a4_gemm_mfast"),
             quantize_nvfp4_k: super::try_kernel(gpu, "quantize_nvfp4", "quantize_bf16_to_nvfp4"),
@@ -139,10 +171,52 @@ impl NemotronMamba2Layer {
     }
 
     /// Set native FP8 weights to skip double-quantization (FP8→BF16→NVFP4).
-    /// When set, decode uses w8a16_gemv (FP8 LUT kernel) instead of w4a16_gemv.
-    pub fn set_fp8_weights(&mut self, in_proj: Option<Fp8Weight>, out_proj: Option<Fp8Weight>) {
+    /// When set, decode uses w8a16_gemv and prefill uses w8a16_gemm[_pipelined]
+    /// instead of the NVFP4/W4A4 arms.
+    ///
+    /// Inputs MUST be tagged `WeightQuantFormat::Fp8BlockScaled`: every w8a16
+    /// kernel indexes `block_scale[n/128 * k_blocks + k/128]`, so a per-row `[N]`
+    /// scale — or the checkpoint's raw 4-byte scalar `weight_scale` — reads far
+    /// past the end of its allocation (illegal address, not wrong numbers). The
+    /// kernel-handle checks are the same contract: once the FP8 weights are
+    /// installed the NVFP4 fallbacks are NULL, so a missing kernel must fail
+    /// here at load, not deref NULL on the first token.
+    ///
+    /// `prefill` selects whether the prefill GEMMs may use these weights. When
+    /// false (`ATLAS_NEMOTRON_NATIVE_FP8_SSM=decode`) only `w8a16_gemv` reads
+    /// them and prefill stays on the legacy NVFP4 / pre-dequantized copies,
+    /// which the loader still builds in that mode.
+    pub fn set_fp8_weights(
+        &mut self,
+        in_proj: Option<Fp8Weight>,
+        out_proj: Option<Fp8Weight>,
+        prefill: bool,
+    ) -> Result<()> {
+        use crate::weight_map::WeightQuantFormat;
+        if let Some(ref w) = in_proj {
+            w.scale_format.expect(
+                WeightQuantFormat::Fp8BlockScaled,
+                "nemotron mamba2 in_proj (w8a16 expects [ceil(N/128),ceil(K/128)] FP32 block scales)",
+            );
+        }
+        if let Some(ref w) = out_proj {
+            w.scale_format.expect(
+                WeightQuantFormat::Fp8BlockScaled,
+                "nemotron mamba2 out_proj (w8a16 expects [ceil(N/128),ceil(K/128)] FP32 block scales)",
+            );
+        }
+        anyhow::ensure!(
+            self.w8a16_gemv_k.0 != 0,
+            "native FP8 SSM requires the w8a16_gemv kernel (decode)"
+        );
+        anyhow::ensure!(
+            !prefill || self.w8a16_gemm_pipelined_k.0 != 0 || self.w8a16_gemm_k.0 != 0,
+            "native FP8 SSM requires w8a16_gemm[_pipelined] (prefill)"
+        );
         self.in_proj_fp8 = in_proj;
         self.out_proj_fp8 = out_proj;
+        self.native_fp8_prefill = prefill;
+        Ok(())
     }
 
     /// Access SSM weights (needed by weight loader for transpose).
@@ -170,6 +244,23 @@ impl NemotronMamba2Layer {
     /// Measured on Puzzle: ablating just that dequant ALU cut a 1k prefill from
     /// 557 ms to 424 ms. Converting the weights once at load time removes it
     /// entirely and lets prefill use `fp8_gemm_t`, which has no dequant phase.
+    /// Install the checkpoint's own BF16 projections, bypassing the NVFP4
+    /// requant entirely. Only valid when BOTH projections are BF16 in the
+    /// checkpoint and the dense kernels resolved; the caller checks that.
+    pub fn set_bf16_weights(&mut self, in_proj: DenseWeight, out_proj: DenseWeight) {
+        self.in_proj_bf16 = Some(in_proj);
+        self.out_proj_bf16 = Some(out_proj);
+    }
+
+    /// Whether this layer can run natively BF16 (weights installed AND both
+    /// dense kernels present).
+    pub fn bf16_native_ready(&self) -> bool {
+        self.in_proj_bf16.is_some()
+            && self.out_proj_bf16.is_some()
+            && self.dense_gemm_bf16_k.0 != 0
+            && self.dense_gemv_bf16_k.0 != 0
+    }
+
     pub fn set_fp8_prefill_weights(&mut self, in_proj: DevicePtr, out_proj: DevicePtr) {
         self.in_proj_pd_fp8 = Some(in_proj);
         self.out_proj_pd_fp8 = Some(out_proj);

--- a/crates/spark-model/src/layers/nemotron_mamba2/prefill.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2/prefill.rs
@@ -76,107 +76,22 @@ impl NemotronMamba2Layer {
             && self.quantize_nvfp4_k.0 != 0
             && ctx.buffers.fp8_act_bytes() >= (n as usize) * self.d_inner.max(h)
             && std::env::var("ATLAS_NO_SSM_W4A4").is_err();
-        if w4a4 {
-            let a4 = ctx.buffers.fp8_act();
-            let a4_sf = a4.offset((n as usize) * h / 2);
-            ops::quantize_bf16_to_nvfp4(
-                ctx.gpu,
-                self.quantize_nvfp4_k,
-                normed,
-                a4,
-                a4_sf,
-                n,
-                h as u32,
-                stream,
-            )?;
-            ops::w4a4_gemm_mfast(
-                ctx.gpu,
-                self.w4a4_gemm_k,
-                a4,
-                a4_sf,
-                &self.ssm.in_proj,
-                proj,
-                n,
-                self.in_proj_size as u32,
-                h as u32,
-                stream,
-            )?;
-        } else if let Some(w_fp8) = self.in_proj_pd_fp8 {
-            // Weights already FP8: no per-K-step dequant, no M-block redundancy.
-            if fp8_a {
-                let a8 = ctx.buffers.fp8_act();
-                ops::bf16_to_fp8(
-                    ctx.gpu,
-                    self.bf16_to_fp8_k,
-                    normed,
-                    a8,
-                    n * h as u32,
-                    stream,
-                )?;
-                ops::fp8_fp8_gemm_m128_mfast(
-                    ctx.gpu,
-                    self.fp8_fp8_gemm_t_k,
-                    a8,
-                    w_fp8,
-                    proj,
-                    n,
-                    self.in_proj_size as u32,
-                    h as u32,
-                    stream,
-                )?;
-            } else {
-                ops::fp8_gemm_m128_mfast(
-                    ctx.gpu,
-                    self.fp8_gemm_t_k,
-                    normed,
-                    w_fp8,
-                    proj,
-                    n,
-                    self.in_proj_size as u32,
-                    h as u32,
-                    stream,
-                )?;
-            }
-        } else if let Some(ref wt) = self.in_proj_t {
-            // Fast path: transposed weights + FP8 MMA (N128, K32, cp.async pipeline)
-            if n > 128 && self.w4a16_gemm_t_m128_k.0 != 0 {
-                ops::w4a16_gemm_n128_m128(
-                    ctx.gpu,
-                    self.w4a16_gemm_t_m128_k,
-                    normed,
-                    wt,
-                    proj,
-                    n,
-                    self.in_proj_size as u32,
-                    h as u32,
-                    stream,
-                )?;
-            } else {
-                ops::w4a16_gemm_n128(
-                    ctx.gpu,
-                    self.w4a16_gemm_t_k,
-                    normed,
-                    wt,
-                    proj,
-                    n,
-                    self.in_proj_size as u32,
-                    h as u32,
-                    stream,
-                )?;
-            }
-        } else {
-            ops::w4a16_gemm(
-                ctx.gpu,
-                self.w4a16_gemm_k,
-                normed,
-                &self.ssm.in_proj,
-                proj,
-                n,
-                self.in_proj_size as u32,
-                h as u32,
-                stream,
-            )?;
-        }
+        // The predequant-FP8 arms below launch `fp8_fp8_gemm_t_m128_mfast` (when
+        // `fp8_a`) or else `fp8_gemm_t_m128_mfast`. Both resolve through
+        // `try_kernel`, which yields a NULL handle instead of failing, and a
+        // per-model `w4a16_gemm.cu` override need not define them — Nano-30B's
+        // exports `fp8_gemm_t`, NOT `fp8_gemm_t_m128_mfast`. Those arms used to be
+        // entered on weight presence ALONE, unlike every sibling arm here, so on
+        // such a checkpoint prefill launched a null handle and died with
+        // CUDA_ERROR_INVALID_HANDLE (400) at layer 0 — the whole model unusable,
+        // no fallback. `fp8_a` already proves its own two kernels resolved, so only
+        // the non-`fp8_a` kernel needs checking. Falling through reaches the
+        // transposed-NVFP4 and plain `w4a16_gemm` arms, which are always present.
+        let pd_fp8_ok = fp8_a || self.fp8_gemm_t_k.0 != 0;
+        // Arm selection (native BF16 → native FP8 → W4A4 → pre-dequant FP8 →
+        // transposed NVFP4 → plain W4A16) lives in `prefill_proj.rs` (500-LoC
+        // cap split); the precedence rationale is documented there.
+        self.prefill_in_proj(normed, proj, n, h, fp8_a, w4a4, pd_fp8_ok, ctx, stream)?;
 
         // ── 3. Conv1d prefill on xBC (WITH bias, fused SiLU) ──
         //    Input: xBC at proj+d_inner, stride=in_proj_size between tokens
@@ -220,6 +135,15 @@ impl NemotronMamba2Layer {
             && self.head_dim.is_multiple_of(ops::SSD_PT as usize)
             && self.state_size.is_multiple_of(8)
             && (self.state_size / 8).is_multiple_of(4)
+            // The scan's dynamic shared memory grows with `state_size` and can
+            // exceed what a block may opt into (sm_121: 101376 B). Over the limit
+            // `cuFuncSetAttribute` fails with CUDA_ERROR_INVALID_VALUE, which
+            // ABORTS the layer rather than degrading — Nemotron Nano-30B
+            // (state_size=128 -> 115968 B) could not serve a single token, while
+            // Puzzle-75B (state_size=96 -> 91392 B) was unaffected, which is why
+            // this went unnoticed. Treat the fit as a precondition of the fast
+            // path; failing it falls through to the sequential scan below.
+            && ops::ssd_scan_fits(self.state_size as u32)
             && std::env::var("ATLAS_NO_SSD").is_err();
 
         if ssd_ok {
@@ -288,7 +212,13 @@ impl NemotronMamba2Layer {
                 self.d_inner as u32,
                 stream,
             )?;
-        } else if self.mamba2_ssm_prefill_persistent_k.0 != 0 {
+        } else if self.mamba2_ssm_prefill_persistent_k.0 != 0
+            // Same-binary A/B against the plain sequential scan below. The
+            // persistent kernel keeps H in shared memory and is only reachable
+            // when the SSD fast path is unavailable — a path no shipped model
+            // took until Nemotron Nano-30B (state_size=128) fell out of SSD.
+            && std::env::var("ATLAS_NO_SSM_PERSISTENT").is_err()
+        {
             ops::mamba2_ssm_prefill_persistent(
                 ctx.gpu,
                 self.mamba2_ssm_prefill_persistent_k,
@@ -365,105 +295,8 @@ impl NemotronMamba2Layer {
 
         // ── 6. out_proj GEMM: [N, d_inner] × [d_inner, h] → [N, h] ──
         let out = ctx.buffers.ssm_qkvz();
-        if w4a4 {
-            let a4 = ctx.buffers.fp8_act();
-            let a4_sf = a4.offset((n as usize) * self.d_inner / 2);
-            ops::quantize_bf16_to_nvfp4(
-                ctx.gpu,
-                self.quantize_nvfp4_k,
-                gated_out,
-                a4,
-                a4_sf,
-                n,
-                self.d_inner as u32,
-                stream,
-            )?;
-            ops::w4a4_gemm_mfast(
-                ctx.gpu,
-                self.w4a4_gemm_k,
-                a4,
-                a4_sf,
-                &self.ssm.out_proj,
-                out,
-                n,
-                h as u32,
-                self.d_inner as u32,
-                stream,
-            )?;
-        } else if let Some(w_fp8) = self.out_proj_pd_fp8 {
-            if fp8_a {
-                let a8 = ctx.buffers.fp8_act();
-                ops::bf16_to_fp8(
-                    ctx.gpu,
-                    self.bf16_to_fp8_k,
-                    gated_out,
-                    a8,
-                    n * self.d_inner as u32,
-                    stream,
-                )?;
-                ops::fp8_fp8_gemm_m128_mfast(
-                    ctx.gpu,
-                    self.fp8_fp8_gemm_t_k,
-                    a8,
-                    w_fp8,
-                    out,
-                    n,
-                    h as u32,
-                    self.d_inner as u32,
-                    stream,
-                )?;
-            } else {
-                ops::fp8_gemm_m128_mfast(
-                    ctx.gpu,
-                    self.fp8_gemm_t_k,
-                    gated_out,
-                    w_fp8,
-                    out,
-                    n,
-                    h as u32,
-                    self.d_inner as u32,
-                    stream,
-                )?;
-            }
-        } else if let Some(ref wt) = self.out_proj_t {
-            if n > 128 && self.w4a16_gemm_t_m128_k.0 != 0 {
-                ops::w4a16_gemm_n128_m128(
-                    ctx.gpu,
-                    self.w4a16_gemm_t_m128_k,
-                    gated_out,
-                    wt,
-                    out,
-                    n,
-                    h as u32,
-                    self.d_inner as u32,
-                    stream,
-                )?;
-            } else {
-                ops::w4a16_gemm_n128(
-                    ctx.gpu,
-                    self.w4a16_gemm_t_k,
-                    gated_out,
-                    wt,
-                    out,
-                    n,
-                    h as u32,
-                    self.d_inner as u32,
-                    stream,
-                )?;
-            }
-        } else {
-            ops::w4a16_gemm(
-                ctx.gpu,
-                self.w4a16_gemm_k,
-                gated_out,
-                &self.ssm.out_proj,
-                out,
-                n,
-                h as u32,
-                self.d_inner as u32,
-                stream,
-            )?;
-        }
+        // Mirrors the in_proj dispatch (see step 2); arms in `prefill_proj.rs`.
+        self.prefill_out_proj(gated_out, out, n, h, fp8_a, w4a4, pd_fp8_ok, ctx, stream)?;
 
         // ── 7. Residual add (N*h elements) ──
         ops::residual_add(

--- a/crates/spark-model/src/layers/nemotron_mamba2/prefill_proj.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2/prefill_proj.rs
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `NemotronMamba2Layer` prefill projection dispatch: the in_proj and out_proj
+//! GEMM arm selection (native BF16 → native FP8 → W4A4 → pre-dequant FP8 →
+//! transposed NVFP4 → plain W4A16). Split from `prefill.rs` (500-LoC cap);
+//! the surrounding scan/conv/norm pipeline stays there.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::NemotronMamba2Layer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+
+impl NemotronMamba2Layer {
+    /// in_proj GEMM: `[N, h] × [h, in_proj_size] → [N, in_proj_size]`.
+    ///
+    /// `fp8_a` / `w4a4` / `pd_fp8_ok` are computed once in `prefill_ssm` (they
+    /// gate both projections identically); see the comments there.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn prefill_in_proj(
+        &self,
+        normed: DevicePtr,
+        proj: DevicePtr,
+        n: u32,
+        h: usize,
+        fp8_a: bool,
+        w4a4: bool,
+        pd_fp8_ok: bool,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
+        // Native FP8 first: when the checkpoint's own block-scaled FP8 weights are
+        // installed, `self.ssm.in_proj` is NULL (no NVFP4 copy was ever built), so
+        // every arm below would fault. This also keeps prefill on the checkpoint's
+        // per-128×128-block scales instead of the single global NVFP4 scale the
+        // legacy load derived across all 73.9M elements.
+        //
+        // `native_fp8_prefill` (not merely the presence of the weights) selects
+        // this arm: in the `decode` bisect mode the FP8 weights are installed
+        // for `w8a16_gemv` while the NVFP4 copies below are still built, and
+        // prefill must keep using those.
+        // NATIVE BF16 first. When installed, the checkpoint's projections were
+        // never quantized, so `ssm.in_proj` is a NULL `QuantizedWeight` and every
+        // arm below would dereference it — this must take precedence.
+        if let Some(ref w) = self.in_proj_bf16 {
+            ops::dense_gemm_bf16_pipelined(
+                ctx.gpu,
+                self.dense_gemm_bf16_k,
+                normed,
+                w,
+                proj,
+                n,
+                self.in_proj_size as u32,
+                h as u32,
+                stream,
+            )?;
+        } else if let Some(fp8w) = self
+            .in_proj_fp8
+            .as_ref()
+            .filter(|_| self.native_fp8_prefill)
+        {
+            if self.w8a16_gemm_pipelined_k.0 != 0 {
+                ops::w8a16_gemm_pipelined(
+                    ctx.gpu,
+                    self.w8a16_gemm_pipelined_k,
+                    normed,
+                    fp8w.weight,
+                    fp8w.row_scale,
+                    proj,
+                    n,
+                    self.in_proj_size as u32,
+                    h as u32,
+                    stream,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "ssm prefill: in_proj w8a16_gemm_pipelined failed (M={n}, N={}): {e}",
+                        self.in_proj_size
+                    )
+                })?;
+            } else {
+                ops::w8a16_gemm(
+                    ctx.gpu,
+                    self.w8a16_gemm_k,
+                    normed,
+                    fp8w.weight,
+                    fp8w.row_scale,
+                    proj,
+                    n,
+                    self.in_proj_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            }
+        } else if w4a4 {
+            let a4 = ctx.buffers.fp8_act();
+            let a4_sf = a4.offset((n as usize) * h / 2);
+            ops::quantize_bf16_to_nvfp4(
+                ctx.gpu,
+                self.quantize_nvfp4_k,
+                normed,
+                a4,
+                a4_sf,
+                n,
+                h as u32,
+                stream,
+            )?;
+            ops::w4a4_gemm_mfast(
+                ctx.gpu,
+                self.w4a4_gemm_k,
+                a4,
+                a4_sf,
+                &self.ssm.in_proj,
+                proj,
+                n,
+                self.in_proj_size as u32,
+                h as u32,
+                stream,
+            )?;
+        } else if let Some(w_fp8) = self.in_proj_pd_fp8.filter(|_| pd_fp8_ok) {
+            // Weights already FP8: no per-K-step dequant, no M-block redundancy.
+            if fp8_a {
+                let a8 = ctx.buffers.fp8_act();
+                ops::bf16_to_fp8(
+                    ctx.gpu,
+                    self.bf16_to_fp8_k,
+                    normed,
+                    a8,
+                    n * h as u32,
+                    stream,
+                )?;
+                ops::fp8_fp8_gemm_m128_mfast(
+                    ctx.gpu,
+                    self.fp8_fp8_gemm_t_k,
+                    a8,
+                    w_fp8,
+                    proj,
+                    n,
+                    self.in_proj_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            } else {
+                ops::fp8_gemm_m128_mfast(
+                    ctx.gpu,
+                    self.fp8_gemm_t_k,
+                    normed,
+                    w_fp8,
+                    proj,
+                    n,
+                    self.in_proj_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            }
+        } else if let Some(ref wt) = self.in_proj_t {
+            // Fast path: transposed weights + FP8 MMA (N128, K32, cp.async pipeline)
+            if n > 128 && self.w4a16_gemm_t_m128_k.0 != 0 {
+                ops::w4a16_gemm_n128_m128(
+                    ctx.gpu,
+                    self.w4a16_gemm_t_m128_k,
+                    normed,
+                    wt,
+                    proj,
+                    n,
+                    self.in_proj_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            } else {
+                ops::w4a16_gemm_n128(
+                    ctx.gpu,
+                    self.w4a16_gemm_t_k,
+                    normed,
+                    wt,
+                    proj,
+                    n,
+                    self.in_proj_size as u32,
+                    h as u32,
+                    stream,
+                )?;
+            }
+        } else {
+            ops::w4a16_gemm(
+                ctx.gpu,
+                self.w4a16_gemm_k,
+                normed,
+                &self.ssm.in_proj,
+                proj,
+                n,
+                self.in_proj_size as u32,
+                h as u32,
+                stream,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// out_proj GEMM: `[N, d_inner] × [d_inner, h] → [N, h]`.
+    /// Mirrors the in_proj dispatch above arm for arm.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn prefill_out_proj(
+        &self,
+        gated_out: DevicePtr,
+        out: DevicePtr,
+        n: u32,
+        h: usize,
+        fp8_a: bool,
+        w4a4: bool,
+        pd_fp8_ok: bool,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
+        if let Some(ref w) = self.out_proj_bf16 {
+            ops::dense_gemm_bf16_pipelined(
+                ctx.gpu,
+                self.dense_gemm_bf16_k,
+                gated_out,
+                w,
+                out,
+                n,
+                h as u32,
+                self.d_inner as u32,
+                stream,
+            )?;
+        } else if let Some(fp8w) = self
+            .out_proj_fp8
+            .as_ref()
+            .filter(|_| self.native_fp8_prefill)
+        {
+            if self.w8a16_gemm_pipelined_k.0 != 0 {
+                ops::w8a16_gemm_pipelined(
+                    ctx.gpu,
+                    self.w8a16_gemm_pipelined_k,
+                    gated_out,
+                    fp8w.weight,
+                    fp8w.row_scale,
+                    out,
+                    n,
+                    h as u32,
+                    self.d_inner as u32,
+                    stream,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "ssm prefill: out_proj w8a16_gemm_pipelined failed (M={n}, N={h}): {e}"
+                    )
+                })?;
+            } else {
+                ops::w8a16_gemm(
+                    ctx.gpu,
+                    self.w8a16_gemm_k,
+                    gated_out,
+                    fp8w.weight,
+                    fp8w.row_scale,
+                    out,
+                    n,
+                    h as u32,
+                    self.d_inner as u32,
+                    stream,
+                )?;
+            }
+        } else if w4a4 {
+            let a4 = ctx.buffers.fp8_act();
+            let a4_sf = a4.offset((n as usize) * self.d_inner / 2);
+            ops::quantize_bf16_to_nvfp4(
+                ctx.gpu,
+                self.quantize_nvfp4_k,
+                gated_out,
+                a4,
+                a4_sf,
+                n,
+                self.d_inner as u32,
+                stream,
+            )?;
+            ops::w4a4_gemm_mfast(
+                ctx.gpu,
+                self.w4a4_gemm_k,
+                a4,
+                a4_sf,
+                &self.ssm.out_proj,
+                out,
+                n,
+                h as u32,
+                self.d_inner as u32,
+                stream,
+            )?;
+        } else if let Some(w_fp8) = self.out_proj_pd_fp8.filter(|_| pd_fp8_ok) {
+            if fp8_a {
+                let a8 = ctx.buffers.fp8_act();
+                ops::bf16_to_fp8(
+                    ctx.gpu,
+                    self.bf16_to_fp8_k,
+                    gated_out,
+                    a8,
+                    n * self.d_inner as u32,
+                    stream,
+                )?;
+                ops::fp8_fp8_gemm_m128_mfast(
+                    ctx.gpu,
+                    self.fp8_fp8_gemm_t_k,
+                    a8,
+                    w_fp8,
+                    out,
+                    n,
+                    h as u32,
+                    self.d_inner as u32,
+                    stream,
+                )?;
+            } else {
+                ops::fp8_gemm_m128_mfast(
+                    ctx.gpu,
+                    self.fp8_gemm_t_k,
+                    gated_out,
+                    w_fp8,
+                    out,
+                    n,
+                    h as u32,
+                    self.d_inner as u32,
+                    stream,
+                )?;
+            }
+        } else if let Some(ref wt) = self.out_proj_t {
+            if n > 128 && self.w4a16_gemm_t_m128_k.0 != 0 {
+                ops::w4a16_gemm_n128_m128(
+                    ctx.gpu,
+                    self.w4a16_gemm_t_m128_k,
+                    gated_out,
+                    wt,
+                    out,
+                    n,
+                    h as u32,
+                    self.d_inner as u32,
+                    stream,
+                )?;
+            } else {
+                ops::w4a16_gemm_n128(
+                    ctx.gpu,
+                    self.w4a16_gemm_t_k,
+                    gated_out,
+                    wt,
+                    out,
+                    n,
+                    h as u32,
+                    self.d_inner as u32,
+                    stream,
+                )?;
+            }
+        } else {
+            ops::w4a16_gemm(
+                ctx.gpu,
+                self.w4a16_gemm_k,
+                gated_out,
+                &self.ssm.out_proj,
+                out,
+                n,
+                h as u32,
+                self.d_inner as u32,
+                stream,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/layers/nemotron_mamba2/trait_impl.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2/trait_impl.rs
@@ -51,7 +51,19 @@ impl TransformerLayer for NemotronMamba2Layer {
         //    Layout: [z(d_inner) | xBC(d_xbc) | dt(num_heads)]
         let proj = ctx.buffers.ssm_qkvz();
         // Use FP8 GEMV if available (skips double-quantization lossy path)
-        if let Some(ref fp8w) = self.in_proj_fp8 {
+        if let Some(ref w) = self.in_proj_bf16 {
+            // Native BF16: `ssm.in_proj` is NULL here (never quantized).
+            ops::dense_gemv(
+                ctx.gpu,
+                self.dense_gemv_bf16_k,
+                normed,
+                w,
+                proj,
+                self.in_proj_size as u32,
+                h as u32,
+                stream,
+            )?;
+        } else if let Some(ref fp8w) = self.in_proj_fp8 {
             ops::w8a16_gemv(
                 ctx.gpu,
                 self.w8a16_gemv_k,
@@ -138,7 +150,18 @@ impl TransformerLayer for NemotronMamba2Layer {
         // by gated_rms_norm above. Writing out_proj to the same buffer creates a
         // write-after-read race that corrupts the gate signal → all-zero output.
         let out = ctx.buffers.qkv_output();
-        if let Some(ref fp8w) = self.out_proj_fp8 {
+        if let Some(ref w) = self.out_proj_bf16 {
+            ops::dense_gemv(
+                ctx.gpu,
+                self.dense_gemv_bf16_k,
+                gated_out,
+                w,
+                out,
+                h as u32,
+                self.d_inner as u32,
+                stream,
+            )?;
+        } else if let Some(ref fp8w) = self.out_proj_fp8 {
             ops::w8a16_gemv(
                 ctx.gpu,
                 self.w8a16_gemv_k,

--- a/crates/spark-model/src/layers/nemotron_moe.rs
+++ b/crates/spark-model/src/layers/nemotron_moe.rs
@@ -45,6 +45,12 @@ pub struct NemotronMoeLayer {
     topk_sigmoid_k: KernelHandle,
     moe_expert_gemv_k: KernelHandle,
     w4a16_gemv_k: KernelHandle,
+    /// Native-FP8 decode GEMV for the shared-expert up_proj (see
+    /// `NemotronMoeWeights::shared_up_fp8`). 0 when unavailable.
+    w8a16_gemv_k: KernelHandle,
+    /// Native-FP8 prefill GEMM for the shared expert. 0 when unavailable.
+    w8a16_gemm_k: KernelHandle,
+    w8a16_gemm_pipelined_k: KernelHandle,
     relu2_down_shared_k: KernelHandle,
     weighted_sum_scale_k: KernelHandle,
     residual_add_k: KernelHandle,
@@ -146,6 +152,13 @@ impl NemotronMoeLayer {
             topk_sigmoid_k: gpu.kernel("moe_topk_sig", "moe_topk_sigmoid")?,
             moe_expert_gemv_k: gpu.kernel("moe_expert_gemv", "moe_expert_gemv")?,
             w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w8a16_gemv_k: super::try_kernel(gpu, "w8a16_gemv", "w8a16_gemv"),
+            w8a16_gemm_k: super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),
+            w8a16_gemm_pipelined_k: super::try_kernel(
+                gpu,
+                "w8a16_gemm_pipelined",
+                "w8a16_gemm_pipelined",
+            ),
             relu2_down_shared_k: gpu.kernel("moe_relu2_fused", "moe_expert_relu2_down_shared")?,
             weighted_sum_scale_k: gpu.kernel("relu2", "moe_weighted_sum_scale")?,
             residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
@@ -212,6 +225,7 @@ impl NemotronMoeLayer {
 
 mod decode_helpers;
 mod prefill_fallback;
+mod prefill_shared_up;
 mod prefill_sorted;
 mod prefill_weights;
 mod ptr_tables;
@@ -308,94 +322,9 @@ impl TransformerLayer for NemotronMoeLayer {
         // Always compute shared expert UP — even when batched path overwrites it later.
         // The batched UP kernel writes shared_up_out for shared blocks, but we need
         // this result for the per-token fallback path AND it's harmless to overwrite.
-        // Native FP4 tensor cores: shared_up consumed in its ORIGINAL NVFP4 form
-        // (no FP8 or transposed copies), activations quantized to NVFP4 in one
-        // pass. Same gates as the SSM W4A4 path; ATLAS_NO_SHARED_W4A4=1 disables.
-        let w4a4 = n >= 512
-            && self.w4a4_gemm_k.0 != 0
-            && self.quantize_nvfp4_k.0 != 0
-            && ctx.buffers.fp8_act_bytes() >= (shared_inter as usize).max(h) * (n as usize)
-            && std::env::var("ATLAS_NO_SHARED_W4A4").is_err();
-        if w4a4 {
-            let a4 = ctx.buffers.fp8_act();
-            let a4_sf = a4.offset((n as usize) * h / 2);
-            ops::quantize_bf16_to_nvfp4(
-                ctx.gpu,
-                self.quantize_nvfp4_k,
-                normed,
-                a4,
-                a4_sf,
-                n,
-                h as u32,
-                stream,
-            )?;
-            ops::w4a4_gemm_mfast(
-                ctx.gpu,
-                self.w4a4_gemm_k,
-                a4,
-                a4_sf,
-                &self.weights.shared_up,
-                shared_up_out_base,
-                n,
-                shared_inter,
-                h as u32,
-                stream,
-            )?;
-        } else if let Some(w_fp8) = self.shared_up_pd_fp8 {
-            ops::fp8_gemm_m128_mfast(
-                ctx.gpu,
-                self.fp8_gemm_m128_k,
-                normed,
-                w_fp8,
-                shared_up_out_base,
-                n,
-                shared_inter,
-                h as u32,
-                stream,
-            )?;
-        } else if let Some(ref sut) = self.shared_up_t {
-            // Same NVFP4 weights, better kernel: w4a16_gemm_t_m128 tiles M at 128
-            // (half the B panel passes of w4a16_gemm_t's 64) and puts M on the fast
-            // grid axis so those passes hit L2. Costs nothing extra -- the transposed
-            // copy already exists -- and needs no FP8 residency.
-            if n > 128 && self.w4a16_gemm_t_m128_k.0 != 0 {
-                ops::w4a16_gemm_n128_m128(
-                    ctx.gpu,
-                    self.w4a16_gemm_t_m128_k,
-                    normed,
-                    sut,
-                    shared_up_out_base,
-                    n,
-                    shared_inter,
-                    h as u32,
-                    stream,
-                )?;
-            } else {
-                ops::w4a16_gemm_n128(
-                    ctx.gpu,
-                    self.w4a16_gemm_t_k,
-                    normed,
-                    sut,
-                    shared_up_out_base,
-                    n,
-                    shared_inter,
-                    h as u32,
-                    stream,
-                )?;
-            }
-        } else {
-            ops::w4a16_gemm(
-                ctx.gpu,
-                self.w4a16_gemm_k,
-                normed,
-                &self.weights.shared_up,
-                shared_up_out_base,
-                n,
-                shared_inter,
-                h as u32,
-                stream,
-            )?;
-        }
+        // Arm selection (native FP8 → W4A4 → pre-dequant FP8 → transposed NVFP4
+        // → plain W4A16) lives in `prefill_shared_up.rs` (500-LoC cap split).
+        self.prefill_shared_up(normed, shared_up_out_base, n, h, shared_inter, ctx, stream)?;
 
         // ── 4. LatentMoE: batched fc1_latent GEMM [N, H] → [N, L] ──
         // Use attn_output as temp buffer (m*max_dim*2, large enough for [N, L]).

--- a/crates/spark-model/src/layers/nemotron_moe/decode_helpers.rs
+++ b/crates/spark-model/src/layers/nemotron_moe/decode_helpers.rs
@@ -139,18 +139,38 @@ impl NemotronMoeLayer {
             stream,
         )?;
 
-        // Shared expert UP
+        // Shared expert UP. Prefer the checkpoint's own FP8 bytes when the loader
+        // kept them (ModelOpt MIXED_PRECISION) instead of the FP8→BF16→NVFP4
+        // requant — the requant is what degrades proper-noun retrieval on Puzzle.
         let shared_up_out = ctx.buffers.ssm_qkvz();
-        ops::w4a16_gemv(
-            ctx.gpu,
-            self.w4a16_gemv_k,
-            normed,
-            &self.weights.shared_up,
-            shared_up_out,
-            shared_inter,
-            h,
-            stream,
-        )?;
+        match self
+            .weights
+            .shared_up_fp8
+            .as_ref()
+            .filter(|_| self.w8a16_gemv_k.0 != 0)
+        {
+            Some(fp8w) => ops::w8a16_gemv(
+                ctx.gpu,
+                self.w8a16_gemv_k,
+                normed,
+                fp8w.weight,
+                fp8w.row_scale,
+                shared_up_out,
+                shared_inter,
+                h,
+                stream,
+            )?,
+            None => ops::w4a16_gemv(
+                ctx.gpu,
+                self.w4a16_gemv_k,
+                normed,
+                &self.weights.shared_up,
+                shared_up_out,
+                shared_inter,
+                h,
+                stream,
+            )?,
+        }
 
         // Fused relu²+down for all experts (routed + shared in one launch)
         let expert_down_out = ctx.buffers.expert_down_out();
@@ -159,8 +179,44 @@ impl NemotronMoeLayer {
         let shared_down_out = ctx.buffers.ssm_deinterleaved();
         let smem = (shared_inter.max(inter) as usize) * 4;
 
+        // Native-FP8 shared down_proj. The fused kernel below only speaks NVFP4
+        // (E2M1 LUT, per-group u8 scale, one f32 scale_2), so rather than teach
+        // it FP8 we compute the shared expert separately out of the checkpoint's
+        // own bytes — relu^2 in place, then the already-proven `w8a16_gemv` —
+        // and drop the fused launch's shared slot. `is_shared` there is
+        // `expert_slot == top_k`, so a grid.y of `top_k` never selects it.
+        let native_shared_down = self
+            .weights
+            .shared_down_fp8
+            .as_ref()
+            .filter(|_| self.w8a16_gemv_k.0 != 0 && self.moe_relu2_elementwise_k.0 != 0);
+        if let Some(fp8w) = native_shared_down {
+            KernelLaunch::new(ctx.gpu, self.moe_relu2_elementwise_k)
+                .grid([div_ceil(shared_inter, 256), 1, 1])
+                .block([256, 1, 1])
+                .arg_ptr(shared_up_out)
+                .arg_u32(shared_inter)
+                .launch(stream)?;
+            ops::w8a16_gemv(
+                ctx.gpu,
+                self.w8a16_gemv_k,
+                shared_up_out,
+                fp8w.weight,
+                fp8w.row_scale,
+                shared_down_out,
+                h,
+                shared_inter,
+                stream,
+            )?;
+        }
+        let fused_slots = if native_shared_down.is_some() {
+            top_k
+        } else {
+            top_k + 1
+        };
+
         KernelLaunch::new(ctx.gpu, self.relu2_down_shared_k)
-            .grid([div_ceil(h, 8), top_k + 1, 1])
+            .grid([div_ceil(h, 8), fused_slots, 1])
             .block([128, 1, 1])
             .shared_mem(smem as u32)
             .arg_ptr(expert_up_out)
@@ -254,18 +310,38 @@ impl NemotronMoeLayer {
             stream,
         )?;
 
-        // 3. Shared expert UP: normed [H] → [shared_inter]
+        // 3. Shared expert UP: normed [H] → [shared_inter]. Prefer the
+        // checkpoint's native FP8 bytes; under native the NVFP4 copy is
+        // `QuantizedWeight::null()` and w4a16_gemv would fault on it.
         let shared_up_out = ctx.buffers.ssm_qkvz();
-        ops::w4a16_gemv(
-            ctx.gpu,
-            self.w4a16_gemv_k,
-            normed,
-            &self.weights.shared_up,
-            shared_up_out,
-            shared_inter,
-            h,
-            stream,
-        )?;
+        match self
+            .weights
+            .shared_up_fp8
+            .as_ref()
+            .filter(|_| self.w8a16_gemv_k.0 != 0)
+        {
+            Some(fp8w) => ops::w8a16_gemv(
+                ctx.gpu,
+                self.w8a16_gemv_k,
+                normed,
+                fp8w.weight,
+                fp8w.row_scale,
+                shared_up_out,
+                shared_inter,
+                h,
+                stream,
+            )?,
+            None => ops::w4a16_gemv(
+                ctx.gpu,
+                self.w4a16_gemv_k,
+                normed,
+                &self.weights.shared_up,
+                shared_up_out,
+                shared_inter,
+                h,
+                stream,
+            )?,
+        }
 
         // 4. Fused relu²+down: routed → [top_k, L], shared → [H]
         //    The kernel supports N != N_shared natively.
@@ -276,8 +352,42 @@ impl NemotronMoeLayer {
         let max_n = h.max(latent);
         let smem = (shared_inter.max(inter) as usize) * 4;
 
+        // LatentMoE is the live path on Puzzle (`hybrid_mamba2_latent_moe_...`),
+        // so it needs the same native-FP8 shared_down substitution as the direct
+        // path: relu^2 in place, `w8a16_gemv` on the checkpoint bytes, and drop
+        // the fused launch's shared slot.
+        let native_shared_down = self
+            .weights
+            .shared_down_fp8
+            .as_ref()
+            .filter(|_| self.w8a16_gemv_k.0 != 0 && self.moe_relu2_elementwise_k.0 != 0);
+        if let Some(fp8w) = native_shared_down {
+            KernelLaunch::new(ctx.gpu, self.moe_relu2_elementwise_k)
+                .grid([div_ceil(shared_inter, 256), 1, 1])
+                .block([256, 1, 1])
+                .arg_ptr(shared_up_out)
+                .arg_u32(shared_inter)
+                .launch(stream)?;
+            ops::w8a16_gemv(
+                ctx.gpu,
+                self.w8a16_gemv_k,
+                shared_up_out,
+                fp8w.weight,
+                fp8w.row_scale,
+                shared_down_out,
+                h,
+                shared_inter,
+                stream,
+            )?;
+        }
+        let fused_slots = if native_shared_down.is_some() {
+            top_k
+        } else {
+            top_k + 1
+        };
+
         KernelLaunch::new(ctx.gpu, self.relu2_down_shared_k)
-            .grid([div_ceil(max_n, 8), top_k + 1, 1])
+            .grid([div_ceil(max_n, 8), fused_slots, 1])
             .block([128, 1, 1])
             .shared_mem(smem as u32)
             .arg_ptr(expert_up_out)

--- a/crates/spark-model/src/layers/nemotron_moe/prefill_fallback.rs
+++ b/crates/spark-model/src/layers/nemotron_moe/prefill_fallback.rs
@@ -99,8 +99,39 @@ impl NemotronMoeLayer {
                 let shared_down_out = ctx.buffers.ssm_deinterleaved();
                 let max_n = (p.h as u32).max(p.latent);
                 let smem = (p.shared_inter.max(p.inter) as usize) * 4;
+                let native_down =
+                    self.weights.shared_down_fp8.as_ref().filter(|_| {
+                        self.w8a16_gemv_k.0 != 0 && self.moe_relu2_elementwise_k.0 != 0
+                    });
+                if let Some(fp8w) = native_down {
+                    // Same substitution as decode: relu^2 in place, then the
+                    // checkpoint's own FP8 bytes through `w8a16_gemv`, and let the
+                    // fused NVFP4 launch below drop its shared slot.
+                    KernelLaunch::new(ctx.gpu, self.moe_relu2_elementwise_k)
+                        .grid([div_ceil(p.shared_inter, 256), 1, 1])
+                        .block([256, 1, 1])
+                        .arg_ptr(token_shared_up)
+                        .arg_u32(p.shared_inter)
+                        .launch(stream)?;
+                    ops::w8a16_gemv(
+                        ctx.gpu,
+                        self.w8a16_gemv_k,
+                        token_shared_up,
+                        fp8w.weight,
+                        fp8w.row_scale,
+                        shared_down_out,
+                        p.h as u32,
+                        p.shared_inter,
+                        stream,
+                    )?;
+                }
+                let fused_slots = if native_down.is_some() {
+                    p.top_k
+                } else {
+                    p.top_k + 1
+                };
                 KernelLaunch::new(ctx.gpu, self.relu2_down_shared_k)
-                    .grid([div_ceil(max_n, 8), p.top_k + 1, 1])
+                    .grid([div_ceil(max_n, 8), fused_slots, 1])
                     .block([128, 1, 1])
                     .shared_mem(smem as u32)
                     .arg_ptr(expert_up_out)
@@ -188,8 +219,39 @@ impl NemotronMoeLayer {
                 let expert_down_out = ctx.buffers.expert_down_out();
                 let shared_down_out = ctx.buffers.ssm_deinterleaved();
                 let smem = (p.shared_inter.max(p.inter) as usize) * 4;
+                let native_down =
+                    self.weights.shared_down_fp8.as_ref().filter(|_| {
+                        self.w8a16_gemv_k.0 != 0 && self.moe_relu2_elementwise_k.0 != 0
+                    });
+                if let Some(fp8w) = native_down {
+                    // Same substitution as decode: relu^2 in place, then the
+                    // checkpoint's own FP8 bytes through `w8a16_gemv`, and let the
+                    // fused NVFP4 launch below drop its shared slot.
+                    KernelLaunch::new(ctx.gpu, self.moe_relu2_elementwise_k)
+                        .grid([div_ceil(p.shared_inter, 256), 1, 1])
+                        .block([256, 1, 1])
+                        .arg_ptr(token_shared_up)
+                        .arg_u32(p.shared_inter)
+                        .launch(stream)?;
+                    ops::w8a16_gemv(
+                        ctx.gpu,
+                        self.w8a16_gemv_k,
+                        token_shared_up,
+                        fp8w.weight,
+                        fp8w.row_scale,
+                        shared_down_out,
+                        p.h as u32,
+                        p.shared_inter,
+                        stream,
+                    )?;
+                }
+                let fused_slots = if native_down.is_some() {
+                    p.top_k
+                } else {
+                    p.top_k + 1
+                };
                 KernelLaunch::new(ctx.gpu, self.relu2_down_shared_k)
-                    .grid([div_ceil(p.h as u32, 8), p.top_k + 1, 1])
+                    .grid([div_ceil(p.h as u32, 8), fused_slots, 1])
                     .block([128, 1, 1])
                     .shared_mem(smem as u32)
                     .arg_ptr(expert_up_out)

--- a/crates/spark-model/src/layers/nemotron_moe/prefill_shared_up.rs
+++ b/crates/spark-model/src/layers/nemotron_moe/prefill_shared_up.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared-expert UP projection dispatch for `NemotronMoeLayer::prefill`
+//! (native FP8 → W4A4 → pre-dequant FP8 → transposed NVFP4 → plain W4A16).
+//! Split from `nemotron_moe.rs` (500-LoC cap).
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::NemotronMoeLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+
+impl NemotronMoeLayer {
+    /// Shared expert UP GEMM: `[N, h] × [h, shared_inter] → [N, shared_inter]`.
+    ///
+    /// Native FP4 tensor cores: shared_up consumed in its ORIGINAL NVFP4 form
+    /// (no FP8 or transposed copies), activations quantized to NVFP4 in one
+    /// pass. Same gates as the SSM W4A4 path; ATLAS_NO_SHARED_W4A4=1 disables.
+    /// Native FP8 wins over w4a4. w4a4 quantizes the ACTIVATIONS to 4 bits as
+    /// well as the weights, and it is the default for every prompt >= 512
+    /// tokens — i.e. every real request — so leaving it ahead of the native
+    /// arm would have kept the worst-precision path on exactly the traffic
+    /// that matters while the native weights sat unused.
+    pub(super) fn prefill_shared_up(
+        &self,
+        normed: DevicePtr,
+        shared_up_out_base: DevicePtr,
+        n: u32,
+        h: usize,
+        shared_inter: u32,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
+        let native_shared_up = self.weights.shared_up_fp8.is_some()
+            && (self.w8a16_gemm_pipelined_k.0 != 0 || self.w8a16_gemm_k.0 != 0);
+        let w4a4 = !native_shared_up
+            && n >= 512
+            && self.w4a4_gemm_k.0 != 0
+            && self.quantize_nvfp4_k.0 != 0
+            && ctx.buffers.fp8_act_bytes() >= (shared_inter as usize).max(h) * (n as usize)
+            && std::env::var("ATLAS_NO_SHARED_W4A4").is_err();
+        if w4a4 {
+            let a4 = ctx.buffers.fp8_act();
+            let a4_sf = a4.offset((n as usize) * h / 2);
+            ops::quantize_bf16_to_nvfp4(
+                ctx.gpu,
+                self.quantize_nvfp4_k,
+                normed,
+                a4,
+                a4_sf,
+                n,
+                h as u32,
+                stream,
+            )?;
+            ops::w4a4_gemm_mfast(
+                ctx.gpu,
+                self.w4a4_gemm_k,
+                a4,
+                a4_sf,
+                &self.weights.shared_up,
+                shared_up_out_base,
+                n,
+                shared_inter,
+                h as u32,
+                stream,
+            )?;
+        } else if let Some(fp8w) = self
+            .weights
+            .shared_up_fp8
+            .as_ref()
+            .filter(|_| self.w8a16_gemm_pipelined_k.0 != 0 || self.w8a16_gemm_k.0 != 0)
+        {
+            // Native FP8 from the checkpoint — no NVFP4 requant, no derived copy.
+            // `w4a4` is suppressed above when this is available (see there).
+            let (kern, pipelined) = if self.w8a16_gemm_pipelined_k.0 != 0 {
+                (self.w8a16_gemm_pipelined_k, true)
+            } else {
+                (self.w8a16_gemm_k, false)
+            };
+            let f = if pipelined {
+                ops::w8a16_gemm_pipelined
+            } else {
+                ops::w8a16_gemm
+            };
+            f(
+                ctx.gpu,
+                kern,
+                normed,
+                fp8w.weight,
+                fp8w.row_scale,
+                shared_up_out_base,
+                n,
+                shared_inter,
+                h as u32,
+                stream,
+            )?;
+        } else if let Some(w_fp8) = self.shared_up_pd_fp8 {
+            ops::fp8_gemm_m128_mfast(
+                ctx.gpu,
+                self.fp8_gemm_m128_k,
+                normed,
+                w_fp8,
+                shared_up_out_base,
+                n,
+                shared_inter,
+                h as u32,
+                stream,
+            )?;
+        } else if let Some(ref sut) = self.shared_up_t {
+            // Same NVFP4 weights, better kernel: w4a16_gemm_t_m128 tiles M at 128
+            // (half the B panel passes of w4a16_gemm_t's 64) and puts M on the fast
+            // grid axis so those passes hit L2. Costs nothing extra -- the transposed
+            // copy already exists -- and needs no FP8 residency.
+            if n > 128 && self.w4a16_gemm_t_m128_k.0 != 0 {
+                ops::w4a16_gemm_n128_m128(
+                    ctx.gpu,
+                    self.w4a16_gemm_t_m128_k,
+                    normed,
+                    sut,
+                    shared_up_out_base,
+                    n,
+                    shared_inter,
+                    h as u32,
+                    stream,
+                )?;
+            } else {
+                ops::w4a16_gemm_n128(
+                    ctx.gpu,
+                    self.w4a16_gemm_t_k,
+                    normed,
+                    sut,
+                    shared_up_out_base,
+                    n,
+                    shared_inter,
+                    h as u32,
+                    stream,
+                )?;
+            }
+        } else {
+            ops::w4a16_gemm(
+                ctx.gpu,
+                self.w4a16_gemm_k,
+                normed,
+                &self.weights.shared_up,
+                shared_up_out_base,
+                n,
+                shared_inter,
+                h as u32,
+                stream,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/layers/nemotron_moe/prefill_sorted.rs
+++ b/crates/spark-model/src/layers/nemotron_moe/prefill_sorted.rs
@@ -94,8 +94,42 @@ impl NemotronMoeLayer {
 
         // 5c. Grouped UP GEMM: [sorted, K_expert] → [sorted, p.inter]
         let expert_up_out = ctx.buffers.expert_up_out();
+        // Defence in depth for the same class of bug: these arena buffers are
+        // reused across requests and nothing else zeroes them, so any row a future
+        // change fails to write would leak the previous request's activations
+        // rather than merely being wrong. `ATLAS_MOE_NO_ZERO_INTERMEDIATES=1` skips.
+        if std::env::var("ATLAS_MOE_NO_ZERO_INTERMEDIATES").is_err() {
+            ctx.gpu.memset_async(
+                expert_up_out,
+                0,
+                (total_expanded as usize) * (p.inter as usize) * 2,
+                stream,
+            )?;
+        }
         let avg_per_expert = (p.num_tokens * p.top_k as usize).div_ceil(ne);
-        let max_m_tiles = (avg_per_expert * 2).div_ceil(64).max(1) as u32;
+        // `max_m_tiles` is the grouped GEMM's grid.y, so it must cover the LARGEST
+        // number of tokens any single expert receives — not an estimate of it.
+        // The old bound was `2 * avg_per_expert`, and routing is content-dependent
+        // and imbalanced: any expert over 2x the average had its extra rows simply
+        // never computed, and those rows kept whatever the PREVIOUS request left in
+        // `expert_up_out`.
+        //
+        // That made temperature-0 output NONDETERMINISTIC. Measured: the same
+        // request at 1429 prompt tokens returned first-token 'Red' 5 times and
+        // 'The' once; with this bound it is stable, and stable at 729/4229/7869/
+        // 12629/16829 too. It also explains replies containing text from no prompt
+        // we sent ("The cat sat on the mat"), which is another request's residue.
+        //
+        // The true per-expert max is only known on device after the sort, so bound
+        // by the worst case — one expert taking every routed token. Blocks past an
+        // expert's real tile count exit immediately, so the cost is launch overhead,
+        // not work. `ATLAS_MOE_MAX_M_TILES_ESTIMATE=1` restores the old bound for an
+        // A/B; it is not safe to serve on.
+        let max_m_tiles = if std::env::var("ATLAS_MOE_MAX_M_TILES_ESTIMATE").is_ok() {
+            (avg_per_expert * 2).div_ceil(64).max(1) as u32
+        } else {
+            (total_expanded as usize).div_ceil(64).max(1) as u32
+        };
         // Native FP4 up GEMM: latent activations quantized to NVFP4 once per layer,
         // expert weights consumed as raw E2M1 + scales (no LUT dequant), relu^2
         // fused. OPT-IN ONLY (ATLAS_MOE_W4A4=1): although the latent is a linear
@@ -142,7 +176,7 @@ impl NemotronMoeLayer {
                 stream,
             )?;
         } else if let Some(ref upt) = self.up_ptrs_t {
-            ops::moe_w4a16_grouped_gemm_ptrtable(
+            ops::moe_w4a16_grouped_gemm_ptrtable_n128(
                 ctx.gpu,
                 self.moe_grouped_gemm_n128_k,
                 expert_input,
@@ -170,7 +204,7 @@ impl NemotronMoeLayer {
             // relu^2 fused into the UP GEMM's store when the epilogue variant is
             // compiled -- saves a full read+write of expert_up_out.
             let fused = self.moe_grouped_gemm_relu2_k.0 != 0;
-            ops::moe_w4a16_grouped_gemm_ptrtable(
+            ops::moe_w4a16_grouped_gemm_ptrtable_n128(
                 ctx.gpu,
                 if fused {
                     self.moe_grouped_gemm_relu2_k
@@ -203,8 +237,16 @@ impl NemotronMoeLayer {
 
         // 5e. Grouped DOWN GEMM: [sorted, p.inter] → [sorted, expert_out_dim]
         let expert_down_out = ctx.buffers.expert_down_out();
+        if std::env::var("ATLAS_MOE_NO_ZERO_INTERMEDIATES").is_err() {
+            ctx.gpu.memset_async(
+                expert_down_out,
+                0,
+                (total_expanded as usize) * (expert_out_dim as usize) * 2,
+                stream,
+            )?;
+        }
         if let Some(ref dpt) = self.down_ptrs_t {
-            ops::moe_w4a16_grouped_gemm_ptrtable(
+            ops::moe_w4a16_grouped_gemm_ptrtable_n128(
                 ctx.gpu,
                 self.moe_grouped_gemm_n128_k,
                 expert_up_out,
@@ -221,7 +263,7 @@ impl NemotronMoeLayer {
                 stream,
             )?;
         } else {
-            ops::moe_w4a16_grouped_gemm_ptrtable(
+            ops::moe_w4a16_grouped_gemm_ptrtable_n128(
                 ctx.gpu,
                 self.moe_grouped_gemm_k,
                 expert_up_out,
@@ -267,12 +309,45 @@ impl NemotronMoeLayer {
         // wide dynamic range -- and quantizing it to FP4 measurably degraded long-
         // prompt outputs (hallucinated MC options, repetition loops) while the
         // normed-input W4A4 GEMMs stayed clean. ATLAS_SHARED_W4A4_DOWN=1 to test.
-        let w4a4_down = p.n >= 512
+        // Native FP8 from the checkpoint beats every arm below: w4a4_down would
+        // quantize relu^2 activations to 4 bits, and `shared_down_pd_fp8` is FP8
+        // re-derived from the NVFP4 requant, i.e. already degraded. Suppress
+        // w4a4_down when the real bytes are available.
+        let native_down = self
+            .weights
+            .shared_down_fp8
+            .as_ref()
+            .filter(|_| self.w8a16_gemm_pipelined_k.0 != 0 || self.w8a16_gemm_k.0 != 0);
+        let w4a4_down = native_down.is_none()
+            && p.n >= 512
             && self.w4a4_gemm_k.0 != 0
             && self.quantize_nvfp4_k.0 != 0
             && ctx.buffers.fp8_act_bytes() >= (p.shared_inter as usize) * (p.n as usize)
             && std::env::var("ATLAS_SHARED_W4A4_DOWN").is_ok();
-        if w4a4_down {
+        if let Some(fp8w) = native_down {
+            let (kern, pipelined) = if self.w8a16_gemm_pipelined_k.0 != 0 {
+                (self.w8a16_gemm_pipelined_k, true)
+            } else {
+                (self.w8a16_gemm_k, false)
+            };
+            let f = if pipelined {
+                ops::w8a16_gemm_pipelined
+            } else {
+                ops::w8a16_gemm
+            };
+            f(
+                ctx.gpu,
+                kern,
+                p.shared_up_out_base,
+                fp8w.weight,
+                fp8w.row_scale,
+                shared_down_out,
+                p.n,
+                p.h as u32,
+                p.shared_inter,
+                stream,
+            )?;
+        } else if w4a4_down {
             let a4 = ctx.buffers.fp8_act();
             let a4_sf = a4.offset((p.n as usize) * (p.shared_inter as usize) / 2);
             ops::quantize_bf16_to_nvfp4(

--- a/crates/spark-model/src/layers/nemotron_moe/prefill_weights.rs
+++ b/crates/spark-model/src/layers/nemotron_moe/prefill_weights.rs
@@ -116,7 +116,11 @@ impl NemotronMoeLayer {
         // 10 runs each, verified on a cold server (not thermal). The SSM copies
         // (4.3 GB, allocated during the load itself) cost nothing measurable, so the
         // two are gated separately. Set ATLAS_SHARED_FP8_PREFILL=1 to take the trade.
-        let fp8_prefill = std::env::var("ATLAS_SHARED_FP8_PREFILL").is_ok();
+        // Under native FP8 the NVFP4 shared weights are `QuantizedWeight::null()`
+        // and every derived copy below is built FROM them, so build nothing.
+        let native_shared =
+            self.weights.shared_up_fp8.is_some() || self.weights.shared_down_fp8.is_some();
+        let fp8_prefill = !native_shared && std::env::var("ATLAS_SHARED_FP8_PREFILL").is_ok();
         if fp8_prefill
             && self.fp8_gemm_m128_k.0 != 0
             && let Ok(pdq_k) = gpu.kernel("w4a16", "predequant_nvfp4_to_fp8")
@@ -132,7 +136,8 @@ impl NemotronMoeLayer {
                 .predequant_to_fp8(gpu, pdq_k, h, shared_inter, 0)
                 .ok();
         }
-        if self.shared_up_pd_fp8.is_none() || self.shared_down_pd_fp8.is_none() {
+        if !native_shared && (self.shared_up_pd_fp8.is_none() || self.shared_down_pd_fp8.is_none())
+        {
             self.shared_up_t = self
                 .weights
                 .shared_up

--- a/crates/spark-model/src/layers/ops/ssm_ssd.rs
+++ b/crates/spark-model/src/layers/ops/ssm_ssd.rs
@@ -85,6 +85,35 @@ pub fn mamba2_ssd_bmm(
         .launch(stream)
 }
 
+/// Largest dynamic shared-memory block a kernel may opt into on the GB10 target.
+/// Measured on the device (sm_121):
+/// `CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = 101376`
+/// (static default is only 49152; per-SM total is 102400).
+pub const MAX_DYNAMIC_SMEM: u32 = 101_376;
+
+/// Dynamic shared memory [`mamba2_ssd_scan`] requests for a given SSM state size.
+/// Grows ~linearly in `state_size`, so a checkpoint with a large SSM state can
+/// exceed [`MAX_DYNAMIC_SMEM`]. Kept next to the launch so the two cannot drift.
+pub fn ssd_scan_smem(state_size: u32) -> u32 {
+    SSD_PT * (state_size + 1) * 4
+        + 2 * SSD_L * state_size * 2
+        + 2 * SSD_L * state_size * 2
+        + 2 * SSD_L * SSD_PT * 2
+        + 2 * SSD_L * 4
+        + 2 * SSD_L * 4
+}
+
+/// Whether the SSD chunked scan physically fits for this `state_size`.
+///
+/// Callers MUST check this before selecting the SSD path: exceeding the limit
+/// makes `cuFuncSetAttribute(MAX_DYNAMIC_SHARED)` fail with
+/// `CUDA_ERROR_INVALID_VALUE`, which aborts the layer instead of degrading.
+/// Measured: Puzzle-75B `state_size=96` -> 91392 (fits); Nemotron Nano-30B
+/// `state_size=128` -> 115968 (does NOT fit, and made the model unservable).
+pub fn ssd_scan_fits(state_size: u32) -> bool {
+    ssd_scan_smem(state_size) <= MAX_DYNAMIC_SMEM
+}
+
 /// K3: fused chunk_state + state_passing + chunk_scan (h0 stays in shared memory,
 /// so the per-chunk `states` tensor vLLM round-trips through DRAM never exists).
 #[allow(clippy::too_many_arguments)]
@@ -115,12 +144,7 @@ pub fn mamba2_ssd_scan(
     // sH[PT][N+1] f32 | double-buffered streaming tiles: sB[2][L][N] |
     // sCM[2][L][N] | sX[2][L][PT] bf16 | sdA[2][L] + sdt[2][L] f32.
     // (sHb and sXt were dropped -- derived on the fly; see the kernel.)
-    let smem = SSD_PT * (state_size + 1) * 4
-        + 2 * SSD_L * state_size * 2
-        + 2 * SSD_L * state_size * 2
-        + 2 * SSD_L * SSD_PT * 2
-        + 2 * SSD_L * 4
-        + 2 * SSD_L * 4;
+    let smem = ssd_scan_smem(state_size);
     KernelLaunch::new(gpu, kernel)
         .grid([num_heads, head_dim / SSD_PT, batch_size])
         .block([512, 1, 1]) // 16 warps, 2 warp-tasks each (see kernel)

--- a/crates/spark-model/src/weight_loader/nemotron.rs
+++ b/crates/spark-model/src/weight_loader/nemotron.rs
@@ -186,6 +186,7 @@ impl ModelWeightLoader for NemotronHWeightLoader {
                         gpu.free(o_old.weight_scale)?;
                         attn.o_proj = o_sharded;
                     }
+                    let mut bf16_o_dense: Option<DenseWeight> = None;
                     let (q_nv, k_nv, v_nv) = if is_nvfp4 {
                         (q_nvfp4, k_nvfp4, v_nvfp4)
                     } else {
@@ -249,44 +250,63 @@ impl ModelWeightLoader for NemotronHWeightLoader {
                             }
                             o_dense.weight = op;
                         }
-                        let q = quantize_to_nvfp4(
-                            &attn.q_proj,
-                            num_heads * hd,
-                            h,
-                            gpu,
-                            absmax_k,
-                            quantize_k,
-                            stream,
-                        )?;
-                        let k = quantize_to_nvfp4(
-                            &attn.k_proj,
-                            kv_heads * hd,
-                            h,
-                            gpu,
-                            absmax_k,
-                            quantize_k,
-                            stream,
-                        )?;
-                        let v = quantize_to_nvfp4(
-                            &attn.v_proj,
-                            kv_heads * hd,
-                            h,
-                            gpu,
-                            absmax_k,
-                            quantize_k,
-                            stream,
-                        )?;
-                        let o = quantize_to_nvfp4(
-                            &o_dense,
-                            h,
-                            num_heads * hd,
-                            gpu,
-                            absmax_k,
-                            quantize_k,
-                            stream,
-                        )?;
-                        attn.o_proj = o;
-                        (Some(q), Some(k), Some(v))
+                        // Keep attention in BF16 when the checkpoint ships it that
+                        // way. ModelOpt left Q/K/V/O unquantized ON PURPOSE here:
+                        // Puzzle is Mamba-dominant with only 9 full-attention
+                        // layers, so those layers carry the long-range retrieval
+                        // and are the last place to spend precision — and at
+                        // ~1.2 GB BF16 they are cheap to keep. Crushing them
+                        // 16-bit -> 4-bit saved ~0.9 GB and degraded exactly what
+                        // they exist for. `ATLAS_NEMOTRON_BF16_ATTN=0` restores
+                        // the old quantize-everything behaviour for an A/B.
+                        let keep_bf16_attn =
+                            std::env::var("ATLAS_NEMOTRON_BF16_ATTN").as_deref() != Ok("0");
+                        if keep_bf16_attn {
+                            tracing::info!(
+                                "L{i} attention: keeping checkpoint BF16 Q/K/V/O (no NVFP4 requant)"
+                            );
+                            bf16_o_dense = Some(o_dense);
+                            (None, None, None)
+                        } else {
+                            let q = quantize_to_nvfp4(
+                                &attn.q_proj,
+                                num_heads * hd,
+                                h,
+                                gpu,
+                                absmax_k,
+                                quantize_k,
+                                stream,
+                            )?;
+                            let k = quantize_to_nvfp4(
+                                &attn.k_proj,
+                                kv_heads * hd,
+                                h,
+                                gpu,
+                                absmax_k,
+                                quantize_k,
+                                stream,
+                            )?;
+                            let v = quantize_to_nvfp4(
+                                &attn.v_proj,
+                                kv_heads * hd,
+                                h,
+                                gpu,
+                                absmax_k,
+                                quantize_k,
+                                stream,
+                            )?;
+                            let o = quantize_to_nvfp4(
+                                &o_dense,
+                                h,
+                                num_heads * hd,
+                                gpu,
+                                absmax_k,
+                                quantize_k,
+                                stream,
+                            )?;
+                            attn.o_proj = o;
+                            (Some(q), Some(k), Some(v))
+                        }
                     };
                     // Transposed Q/K/V/O so prefill uses `w4a16_gemm_t` (FP8 MMA,
                     // N128/K32, cp.async) instead of the base `w4a16_gemm`. Same
@@ -304,7 +324,17 @@ impl ModelWeightLoader for NemotronHWeightLoader {
                     let vt = v_nv
                         .as_ref()
                         .and_then(|w| w.transpose_for_gemm(gpu, kv_dim, h).ok());
-                    let ot = attn.o_proj.transpose_for_gemm(gpu, h, q_dim).ok();
+                    // Keep-BF16 attention leaves `attn.o_proj` as the NULL
+                    // placeholder (`load_nemotron_attention` returns the real
+                    // weight via `o_dense`); transposing it would launch
+                    // `transpose_u8` on a NULL pointer, and the swallowed `.ok()`
+                    // error left the CUDA context poisoned (700 at the next
+                    // module load). Only transpose a real quantized o_proj.
+                    let ot = if attn.o_proj.is_null() {
+                        None
+                    } else {
+                        attn.o_proj.transpose_for_gemm(gpu, h, q_dim).ok()
+                    };
 
                     let mut attn_layer = Qwen3AttentionLayer::new_ungated(
                         norm,
@@ -322,6 +352,10 @@ impl ModelWeightLoader for NemotronHWeightLoader {
                         config.fp8_kv_calibration_tokens,
                         config,
                     )?;
+                    if let Some(od) = bf16_o_dense {
+                        // Dispatch checks `o_dense_bf16` first (see gemma4 loader).
+                        attn_layer.set_o_dense_bf16(od);
+                    }
                     attn_layer.set_prefill_weights(qt, kt, vt, ot);
                     layers.push(Box::new(attn_layer));
                     attn_idx += 1;

--- a/crates/spark-model/src/weight_loader/nemotron/ssm_layer.rs
+++ b/crates/spark-model/src/weight_loader/nemotron/ssm_layer.rs
@@ -4,7 +4,7 @@
 //! FP8 / transposed-NVFP4 prefill weight copies. Split from `nemotron.rs`
 //! (500-LoC cap).
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use atlas_core::config::ModelConfig;
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 use spark_runtime::weights::WeightStore;
@@ -12,8 +12,8 @@ use spark_runtime::weights::WeightStore;
 use super::NemotronHWeightLoader;
 use crate::layers::NemotronMamba2Layer;
 use crate::weight_map::{
-    DenseWeight, NemotronSsmQuant, dense, dequant_fp8_to_bf16_into, load_nemotron_ssm,
-    quantize_to_nvfp4,
+    DenseWeight, NemotronSsmQuant, dense, dequant_fp8_to_bf16_into,
+    load_fp8_block_scaled_as_fp8weight, load_nemotron_ssm, quantize_to_nvfp4,
 };
 
 impl NemotronHWeightLoader {
@@ -34,16 +34,197 @@ impl NemotronHWeightLoader {
     ) -> Result<NemotronMamba2Layer> {
         // Mamba-2 SSM layer (mixed quant: NVFP4, FP8, or BF16)
         let (mut ssm, quant_kind) = load_nemotron_ssm(store, i, gpu, lp)?;
+        let p = format!("{lp}.mixer");
+        // ModelOpt ships this checkpoint's SSM projections as FP8 inside an
+        // otherwise-NVFP4 repo. The legacy path dequantized them to BF16 and
+        // re-quantized to NVFP4 under ONE global scale spanning the whole
+        // [18048, 4096] tensor (measured at load: global_max=0.394531,
+        // scale2=0.00014678 over 73.9M elements). Puzzle is Mamba-dominant —
+        // only 8 attention layers — so these two projections carry the entire
+        // sequence state, and the model answers noun-retrieval questions from
+        // its training prior instead of from context. Native FP8 keeps the
+        // checkpoint's own per-block scales end to end.
+        //
+        // The old "FP8 direct load causes CUDA 700 / mmap pointers may be
+        // invalidated" TODO here was wrong: `WeightStore` holds *device*
+        // pointers (the default fast loader uses O_DIRECT and never mmaps), and
+        // the NVFP4 arm below has always aliased those pointers for the process
+        // lifetime. The two mechanisms that genuinely fault are (1) the NULL
+        // `QuantizedWeight`s `load_nemotron_ssm` returns on the FP8 arm being
+        // dereferenced by the prefill weight copies, and (2) the checkpoint's
+        // 4-byte scalar `weight_scale` being indexed as a [N/128, K/128] matrix
+        // by w8a16. Both are closed below: the prefill copies are hard-gated off
+        // under native, and `load_fp8_block_scaled_as_fp8weight` materializes a
+        // real block-scale buffer. `ATLAS_NEMOTRON_NATIVE_FP8_SSM=0` restores
+        // the legacy path exactly (same-binary A/B).
+        //
+        // DEFAULT ON. The requant is what broke this model, and the effect is
+        // specific: language modelling was never damaged, but retrieval of a
+        // proper noun from context was. Measured on a 977-token story
+        // ("My dog is named Rufus ... mention his name often"):
+        //   legacy requant  — calls the dog "Rover" / "Rex"; the given name
+        //                     appears ZERO times
+        //   native decode   — Rufus x3 / x8, with occasional "Rex"/"Buddy" slips
+        //   native BOTH     — Rufus x6 / x5 / x2 / x2 over four trials, and
+        //                     ZERO substitutions
+        // Short direct questions ("what is my dog called?") passed either way,
+        // which is why this hid for so long: only sustained generation exposes it.
+        //
+        // Safe to default on: the branch requires `quant_kind == Fp8`, and the
+        // only other Nemotron checkpoint served here
+        // (NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4) has no FP8 config group at all,
+        // so the gate cannot fire on it. `=0` restores the legacy path exactly
+        // for a same-binary A/B, and every failure to load native FP8 falls back
+        // to the legacy arm with a warning rather than aborting.
+        //
+        // THREE modes, kept because they bisect decode from prefill — the native
+        // path changes BOTH (`w8a16_gemv` for decode, `w8a16_gemm[_pipelined]`
+        // for prefill), so a single on/off gate cannot say which one moved a
+        // result:
+        //   "0"            — legacy FP8→BF16→NVFP4 everywhere (baseline)
+        //   "decode"       — native decode; legacy NVFP4 requant + prefill
+        //                    copies still built, prefill keeps using them
+        //   unset/"1"/"both" — native FP8 for decode and prefill (no NVFP4 copies)
+        let mode =
+            std::env::var("ATLAS_NEMOTRON_NATIVE_FP8_SSM").unwrap_or_else(|_| "1".to_string());
+        let native_fp8_enabled = matches!(mode.as_str(), "1" | "both" | "decode");
+        // Decode-only mode keeps the legacy NVFP4 weights resident for prefill.
+        let native_prefill_wanted = matches!(mode.as_str(), "1" | "both");
+        // Probe the kernels BEFORE committing to the path: `w8a16_gemm_pipelined`
+        // has silently resolved to handle 0 in a shipped binary before (that is
+        // why `kernel_audit` exists), and a 0 handle must degrade to the legacy
+        // path rather than fault at the first token. Both projections must be
+        // FP8 — a half-native layer would leave one NULL `QuantizedWeight` live.
+        let out_is_fp8 = store.contains(&format!("{p}.out_proj.weight_scale"));
+        let gemv_k = crate::layers::try_kernel(gpu, "w8a16_gemv", "w8a16_gemv");
+        let gemm_pipe_k =
+            crate::layers::try_kernel(gpu, "w8a16_gemm_pipelined", "w8a16_gemm_pipelined");
+        let gemm_k = crate::layers::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm");
+        let native_fp8 = native_fp8_enabled
+            && quant_kind == NemotronSsmQuant::Fp8
+            && out_is_fp8
+            && gemv_k.0 != 0
+            && (gemm_pipe_k.0 != 0 || gemm_k.0 != 0);
+        // NATIVE BF16 — the same argument as native FP8, for the other mixed-
+        // precision case. A ModelOpt checkpoint may leave some Mamba layers
+        // unquantized: Nemotron Nano-30B ships 6 of 23 in_proj/out_proj as plain
+        // BF16 alongside 17 NVFP4 ones. The legacy arm below then DEQUANTIZES
+        // nothing and simply quantizes BF16 -> NVFP4 under ONE global scale, i.e.
+        // it invents a quantization the checkpoint never asked for and destroys
+        // exactly what the FP8 comment above documents: retrieval of a token from
+        // context. Keeping the checkpoint's own BF16 costs ~2x the bytes of those
+        // few layers and no accuracy.
+        // `ATLAS_NEMOTRON_NATIVE_BF16_SSM=0` restores the legacy requant (A/B).
+        let out_is_bf16 = !store.contains(&format!("{p}.out_proj.weight_scale"));
+        let dgemm_k = crate::layers::try_kernel(gpu, "gemm", "dense_gemm_bf16_pipelined");
+        let dgemv_k = crate::layers::try_kernel(gpu, "gemv", "dense_gemv_bf16");
+        let native_bf16 = std::env::var("ATLAS_NEMOTRON_NATIVE_BF16_SSM").as_deref() != Ok("0")
+            && quant_kind == NemotronSsmQuant::Bf16
+            && out_is_bf16
+            && dgemm_k.0 != 0
+            && dgemv_k.0 != 0;
+        if native_fp8_enabled && quant_kind == NemotronSsmQuant::Fp8 && !native_fp8 {
+            static NATIVE_FALLBACK_WARN: std::sync::Once = std::sync::Once::new();
+            NATIVE_FALLBACK_WARN.call_once(|| {
+                tracing::warn!(
+                    "L{i} SSM: native FP8 unavailable (out_proj_fp8={out_is_fp8} \
+                     w8a16_gemv={} w8a16_gemm_pipelined={} w8a16_gemm={}) — falling back \
+                     to the FP8→BF16→NVFP4 double-quant path",
+                    gemv_k.0 != 0,
+                    gemm_pipe_k.0 != 0,
+                    gemm_k.0 != 0,
+                );
+            });
+        }
+        // Native FP8 for prefill only when the native path is live AND the mode
+        // asked for it. In "decode" mode the NVFP4 copies below are built as
+        // usual and prefill keeps using them.
+        let native_prefill = native_fp8 && native_prefill_wanted;
         tracing::info!(
-            "L{i} SSM quant={quant_kind:?} in_proj_size={} d_inner={} h={h}",
+            "L{i} SSM quant={quant_kind:?} native_fp8={native_fp8} native_bf16={native_bf16} \
+             native_prefill={native_prefill} \
+             in_proj_size={} d_inner={} h={h}",
             config.mamba2_in_proj_size(),
             config.mamba2_d_inner(),
         );
-        // TODO: Fix 3 — FP8 direct load causes CUDA 700 (illegal address).
-        // The WeightStore mmap pointers may be invalidated after loading.
-        // For now, keep the double-quant path (FP8→BF16→NVFP4).
-        if quant_kind != NemotronSsmQuant::Nvfp4 {
-            let p = format!("{lp}.mixer");
+        let native = if native_fp8 {
+            let mut in_fp8 =
+                load_fp8_block_scaled_as_fp8weight(store, &format!("{p}.in_proj"), gpu)?;
+            let mut out_fp8 =
+                load_fp8_block_scaled_as_fp8weight(store, &format!("{p}.out_proj"), gpu)?;
+            // OWN the FP8 weight bytes. `load_fp8_block_scaled_as_fp8weight`
+            // ALIASES the `WeightStore` pointer (loaders_fp8.rs `let weight_ptr =
+            // w.ptr`), which is fine for a loader that consumes the bytes during
+            // load — the legacy arm below dequantizes them into a fresh NVFP4
+            // buffer and never looks again. This arm is different: it keeps the
+            // pointer and dereferences it on every token, for the process
+            // lifetime. That is the real content of the old "FP8 direct load
+            // causes CUDA 700 / mmap pointers may be invalidated" TODO.
+            //
+            // Measured: with the alias, `w8a16_gemv` is fed stale bytes and the
+            // model stays fluent while losing its prompt ("Alice is 30. Bob is
+            // 25. Who is older?" -> "Charlie is the oldest."). The kernel itself
+            // is NOT at fault — `examples/w8a16_gemv_numeric` checks it at this
+            // exact shape (N=18048, K=4096) under both a constant and a varying
+            // per-block scale and it is correct to BF16 tolerance.
+            //
+            // Copying costs ~108 MB per SSM layer (in_proj 74 MB + out_proj
+            // 34 MB), ~2.2 GB over the 20 SSM layers — well under the ~6.4 GB of
+            // derived prefill copies this path no longer builds.
+            for w in [&mut in_fp8, &mut out_fp8] {
+                let bytes = (w.n as usize) * (w.k as usize);
+                let owned = gpu.alloc(bytes)?;
+                gpu.copy_d2d(w.weight, owned, bytes)?;
+                w.weight = owned;
+            }
+            if i == 0 {
+                // Prove the bytes the kernel will read ARE the checkpoint's. The
+                // numeric test covers the kernel with synthetic weights, so this
+                // is the one link it cannot check.
+                let mut head = [0u8; 16];
+                gpu.copy_d2h(in_fp8.weight, &mut head)?;
+                tracing::debug!(
+                    "L0 in_proj FP8 head: {}",
+                    head.iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                );
+            }
+            // Shape + alignment contract. `w8a16_gemv.cu` computes K16 = K/16 with
+            // no tail and issues 16-byte uint4 loads of `B + n*K`, so a K that is
+            // not a multiple of 16 reads garbage silently — fail loudly at load
+            // instead (Puzzle is K=4096 / K=8192, both fine).
+            ensure!(
+                in_fp8.n as usize == config.mamba2_in_proj_size() && in_fp8.k as usize == h,
+                "L{i} SSM in_proj FP8 shape [{},{}] != [{},{h}]",
+                in_fp8.n,
+                in_fp8.k,
+                config.mamba2_in_proj_size(),
+            );
+            ensure!(
+                out_fp8.n as usize == h && out_fp8.k as usize == config.mamba2_d_inner(),
+                "L{i} SSM out_proj FP8 shape [{},{}] != [{h},{}]",
+                out_fp8.n,
+                out_fp8.k,
+                config.mamba2_d_inner(),
+            );
+            ensure!(
+                in_fp8.k % 16 == 0 && out_fp8.k % 16 == 0,
+                "L{i} SSM: w8a16 requires K%16==0, got in_proj K={} out_proj K={}",
+                in_fp8.k,
+                out_fp8.k,
+            );
+            Some((in_fp8, out_fp8))
+        } else {
+            None
+        };
+        // Legacy FP8→BF16→NVFP4 requant. Runs whenever prefill is NOT native
+        // (gate unset, or `decode` mode): the prefill arms and every derived
+        // weight copy below read `ssm.in_proj`/`ssm.out_proj`, which
+        // `load_nemotron_ssm` returns as `QuantizedWeight::null()` on the FP8
+        // arm, so they must be materialized here or prefill derefs NULL.
+        if !native_prefill && !native_bf16 && quant_kind != NemotronSsmQuant::Nvfp4 {
             let in_proj_dense = if quant_kind == NemotronSsmQuant::Fp8 {
                 dequant_fp8_to_bf16_into(store, &format!("{p}.in_proj"), gpu, scratch)?
             } else {
@@ -58,8 +239,7 @@ impl NemotronHWeightLoader {
                 quantize_k,
                 stream,
             )?;
-            let out_fp8 = store.contains(&format!("{p}.out_proj.weight_scale"));
-            let out_proj_dense = if out_fp8 {
+            let out_proj_dense = if out_is_fp8 {
                 dequant_fp8_to_bf16_into(store, &format!("{p}.out_proj"), gpu, scratch)?
             } else {
                 dense(store, &format!("{p}.out_proj.weight"))?
@@ -97,8 +277,22 @@ impl NemotronHWeightLoader {
         //     escape hatch via ATLAS_NO_SSM_FP8_PREFILL=1.
         //
         // NVFP4 stays resident either way: decode uses w4a16_gemv.
-        let fp8_prefill = std::env::var("ATLAS_NO_SSM_FP8_PREFILL").is_err();
-        let prefill_t = !fp8_prefill && std::env::var("ATLAS_NO_SSM_PREFILL_T").is_err();
+        //
+        // Both copies are derived FROM `ssm.in_proj`/`ssm.out_proj`, which are
+        // `QuantizedWeight::null()` on the native-FP8 arm — `transpose_for_gemm`
+        // would `copy_d2h` from NULL and `predequant_to_fp8` would launch on a
+        // NULL B. Native prefill goes through w8a16_gemm instead, so neither
+        // copy is built (and ~6.4 GB of derived weights is not allocated).
+        // `native_bf16` joins `native_prefill` here for the same reason: both
+        // leave `ssm.in_proj`/`ssm.out_proj` as NULL `QuantizedWeight`s, and both
+        // derived copies read them (`transpose_for_gemm` copy_d2h's from NULL,
+        // `predequant_to_fp8` launches on a NULL B).
+        let fp8_prefill =
+            !native_prefill && !native_bf16 && std::env::var("ATLAS_NO_SSM_FP8_PREFILL").is_err();
+        let prefill_t = !native_prefill
+            && !native_bf16
+            && !fp8_prefill
+            && std::env::var("ATLAS_NO_SSM_PREFILL_T").is_err();
         let proj_t = if prefill_t {
             let in_t = ssm
                 .in_proj
@@ -126,7 +320,25 @@ impl NemotronHWeightLoader {
         } else {
             None
         };
+        let bf16w = if native_bf16 {
+            Some((
+                dense(store, &format!("{p}.in_proj.weight"))?,
+                dense(store, &format!("{p}.out_proj.weight"))?,
+            ))
+        } else {
+            None
+        };
         let mut layer = NemotronMamba2Layer::new(norm, ssm, config, gpu, i)?;
+        if let Some((in_w, out_w)) = bf16w {
+            layer.set_bf16_weights(in_w, out_w);
+            ensure!(
+                layer.bf16_native_ready(),
+                "L{i} SSM: native BF16 selected but the dense kernels are missing"
+            );
+        }
+        if let Some((in_fp8, out_fp8)) = native {
+            layer.set_fp8_weights(Some(in_fp8), Some(out_fp8), native_prefill)?;
+        }
         if let Some((in_t, out_t)) = proj_t {
             layer.set_prefill_weights(Some(in_t), Some(out_t));
         }

--- a/crates/spark-model/src/weight_map/nemotron.rs
+++ b/crates/spark-model/src/weight_map/nemotron.rs
@@ -58,8 +58,22 @@ pub struct NemotronMoeWeights {
     pub experts: Vec<NemotronExpertWeight>,
     /// Shared expert up_proj: [shared_inter, hidden_size] NVFP4.
     pub shared_up: QuantizedWeight,
+    /// Shared expert up_proj kept as NATIVE FP8 when the checkpoint ships it that
+    /// way (ModelOpt MIXED_PRECISION), instead of the FP8→BF16→NVFP4 requant.
+    /// `Some` only under `ATLAS_NEMOTRON_NATIVE_FP8_SSM`; decode prefers it via
+    /// `w8a16_gemv`. Measured on Puzzle-75B: with the SSM projections already
+    /// native, a 977-token story went from calling the dog "Rover"/"Rex" to
+    /// using the given name "Rufus" 8 times with no substitutions — proper-noun
+    /// retrieval is what the requant was destroying.
+    pub shared_up_fp8: Option<Fp8Weight>,
     /// Shared expert down_proj: [hidden_size, shared_inter] NVFP4.
     pub shared_down: QuantizedWeight,
+    /// Shared expert down_proj kept as NATIVE FP8, same rationale as
+    /// `shared_up_fp8`. Consumed by relu_squared_inplace + `w8a16_gemv` instead
+    /// of the fused `moe_expert_relu2_down_shared` kernel, which only speaks
+    /// NVFP4 — the fused launch simply drops its shared slot (grid.y = top_k)
+    /// when this is present.
+    pub shared_down_fp8: Option<Fp8Weight>,
     /// LatentMoE: fc1 [moe_latent_size, hidden_size] BF16 (dequant from FP8 at load).
     /// Present only for Super 120B (moe_latent_size > 0).
     pub fc1_latent_proj: Option<DenseWeight>,
@@ -226,7 +240,46 @@ pub(crate) fn load_nemotron_moe(
     let shared_up_prefix = format!("{p}.shared_experts.up_proj");
     let shared_up_has_s2 = store.contains(&format!("{shared_up_prefix}.weight_scale_2"));
     let shared_up_has_s = store.contains(&format!("{shared_up_prefix}.weight_scale"));
-    let shared_up = if shared_up_has_s2 {
+    // Native FP8 for the shared-expert up_proj: skip the FP8→BF16→NVFP4 requant
+    // and hand `w8a16_gemv` the checkpoint's own bytes. Same gate as the SSM
+    // projections — both are ModelOpt MIXED_PRECISION tensors in an otherwise
+    // NVFP4 repo, and both were being needlessly re-quantized.
+    //
+    // `shared_down` is NOT converted here: it is consumed inside the fused
+    // `relu2_down_shared` kernel, which takes NVFP4 (packed + scale + scale_2)
+    // arguments, so making it native needs CUDA work rather than a loader change.
+    let native_fp8_mode =
+        std::env::var("ATLAS_NEMOTRON_NATIVE_FP8_SSM").unwrap_or_else(|_| "1".to_string());
+    let want_native_fp8 = matches!(native_fp8_mode.as_str(), "1" | "both" | "decode");
+    let shared_up_fp8 = if want_native_fp8 && !shared_up_has_s2 && shared_up_has_s {
+        match load_fp8_block_scaled_as_fp8weight(store, &shared_up_prefix, gpu) {
+            Ok(mut w) => {
+                // OWN the bytes — the helper aliases the WeightStore pointer, which
+                // is only safe for a loader that consumes them during load. This one
+                // dereferences per-token forever. Aliasing here produced garbage
+                // weights that still ran (see ssm_layer.rs for the same fix).
+                let bytes = (w.n as usize) * (w.k as usize);
+                let owned = gpu.alloc(bytes)?;
+                gpu.copy_d2d(w.weight, owned, bytes)?;
+                w.weight = owned;
+                Some(w)
+            }
+            Err(e) => {
+                tracing::warn!("shared_up native FP8 unavailable ({e}) — using NVFP4 requant");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    // Under native FP8 nothing reads the NVFP4 copy, so do not spend the load
+    // time or the ~2.9 GB building it. Every consumer is gated on
+    // `shared_up_fp8`/`shared_down_fp8` — including the LatentMoE decode path,
+    // which is the live one on Puzzle (`hybrid_mamba2_latent_moe_...`) and was
+    // the site that faulted with CUDA 700 when it was missed.
+    let shared_up = if shared_up_fp8.is_some() {
+        QuantizedWeight::null()
+    } else if shared_up_has_s2 {
         quantized(store, &shared_up_prefix, gpu)?
     } else {
         // FP8 or BF16 — dequant to scratch, then quantize to NVFP4
@@ -253,7 +306,27 @@ pub(crate) fn load_nemotron_moe(
     let shared_down_prefix = format!("{p}.shared_experts.down_proj");
     let shared_down_has_s2 = store.contains(&format!("{shared_down_prefix}.weight_scale_2"));
     let shared_down_has_s = store.contains(&format!("{shared_down_prefix}.weight_scale"));
-    let shared_down = if shared_down_has_s2 {
+    let shared_down_fp8 = if want_native_fp8 && !shared_down_has_s2 && shared_down_has_s {
+        match load_fp8_block_scaled_as_fp8weight(store, &shared_down_prefix, gpu) {
+            Ok(mut w) => {
+                // Own the bytes (the helper aliases the WeightStore pointer).
+                let bytes = (w.n as usize) * (w.k as usize);
+                let owned = gpu.alloc(bytes)?;
+                gpu.copy_d2d(w.weight, owned, bytes)?;
+                w.weight = owned;
+                Some(w)
+            }
+            Err(e) => {
+                tracing::warn!("shared_down native FP8 unavailable ({e}) — using NVFP4 requant");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let shared_down = if shared_down_fp8.is_some() {
+        QuantizedWeight::null()
+    } else if shared_down_has_s2 {
         quantized(store, &shared_down_prefix, gpu)?
     } else {
         let bf16 = if shared_down_has_s {
@@ -374,6 +447,8 @@ pub(crate) fn load_nemotron_moe(
         e_score_correction_bias,
         experts,
         shared_up,
+        shared_up_fp8,
+        shared_down_fp8,
         shared_down,
         fc1_latent_proj,
         fc2_latent_proj,

--- a/kernels/gb10/nemotron-3-nano-30b-a3b/MODEL.toml
+++ b/kernels/gb10/nemotron-3-nano-30b-a3b/MODEL.toml
@@ -58,6 +58,15 @@ dry_multiplier = 0.0      # 2026-06-06: 0.5->0.0; no vendor DRY. Re-gate; if loo
 # <tool_call>-inside-<think> attractor that previously motivated
 # disabling. If Nemotron-H Nano's Think-Satisfy reappears in practice,
 # re-disable per-model here; see project_qwen36_thinking_fix.md.
+# This checkpoint's generation_config.json carries temperature=1.0 AND top_p=1.0
+# — the HF evaluation default, not a serving recipe. WITHOUT this opt-in, core
+# sampling falls through to those values and every preset above (0.6 thinking /
+# 0.7 non-thinking / 0.6 tools, top_p 0.95, top_k 20) is SILENTLY IGNORED, so any
+# client that does not send its own sampling params — opencode does not — decodes
+# completely unfiltered. Same fix and same reasoning as the Puzzle-75B sibling,
+# where it took tool-call pass rate 4/8 -> 7/8 on Holo. Explicit per-request
+# values from the client always win.
+use_sampling_presets_for_core = true
 thinking_in_tools = true
 # Bumped 256 → 1024 in pass-17: fib prompt's reasoning trace needs room to
 # complete (before bump, model hit budget mid-step and force-end-thinking
@@ -70,7 +79,34 @@ max_thinking_budget = 2048
 # matching NVIDIA's shipped `nano_v3` parser) strips the block and returns
 # clean `content`. A tagless thinking-on output (cut off mid-think) is
 # treated as reasoning, never leaked into `content`.
-thinking_default = true
+# Thinking OFF by default. Measured 2026-07-28 with the empty-system-block fix
+# already in place, so this is NOT that bug resurfacing: thinking ON leaks
+# training-corpus text into the answer ("My dog is named Rufus. What is my dog
+# called?" -> "The name you gave is **NAME_1**") and returns EMPTY content on
+# other prompts, exactly the pathology documented on the Puzzle-75B sibling.
+# Thinking OFF answers the same prompts correctly. Clients can still opt in
+# per request with chat_template_kwargs.enable_thinking.
+thinking_default = false
+# `max_thinking_budget` is the SOLE thinking cap — drop Atlas's second,
+# 90%-of-max_tokens clamp, which vLLM has no equivalent of and which
+# force-closes `</think>` mid-reasoning. Same fix as the Puzzle/Laguna
+# siblings.
+cap_thinking_at_max_tokens = false
+
+# This checkpoint's own chat template renders an EMPTY system turn when the
+# request carries no system message: `<|im_start|>system\n<|im_end|>`. That
+# empty turn ALONE degrades the model. Measured 2026-07-28, temperature 0,
+# identical user text, only the system block differing:
+#   empty system block   -> "My dog is named Rufus. What is my dog called?"
+#                           answers "Your dog's name is Rex."
+#   any system text      -> "Rufus"  (correct)
+#   no system block      -> "Rufus"  (correct)
+# The same user text through /v1/completions with no template at all is also
+# correct ("My dog is named Rufus. My dog is called" -> "Rufus"), so this is a
+# TEMPLATE pathology, not numerics: every weight in this checkpoint is consumed
+# in its own dtype (BF16 attention, 12 BF16 + 34 NVFP4 SSM projections, NVFP4
+# MoE) with no requantization anywhere.
+default_system_prompt = "You are a helpful assistant."
 
 # ── Kernel lookups this model may legitimately fail to resolve ──
 # Harvested 2026-08-03 from `spark serve --check-kernels` (9 lookups).

--- a/kernels/gb10/nemotron-labs-3-puzzle-75b-a9b/MODEL.toml
+++ b/kernels/gb10/nemotron-labs-3-puzzle-75b-a9b/MODEL.toml
@@ -46,11 +46,55 @@ dry_multiplier = 0.0
 
 [behavior]
 enable_loop_watchdog = true
+# The model natively emits qwen3_coder XML tool calls
+# (<tool_call><function=NAME><parameter=KEY>…) — its own chat template renders
+# the tool list + call format. Proven vs vLLM (qwen3_xml parser, auto mode): a
+# clean parsed call. `bare_json` forced the wrong JSON shape off-distribution.
 thinking_in_tools = true
 disable_tool_steering = true
-tool_call_parser = "bare_json"
+tool_call_parser = "qwen3_coder"
+# vLLM auto mode is unconstrained; grammar-constraining this XML-native model
+# fights its distribution (garbled args / length). Post-hoc parse recovers it.
+disable_tool_grammar = true
+# fp8 KV corrupts this thinking model's long reasoning context (hallucinated
+# tool schemas / non-sequiturs); bf16 KV keeps it coherent. Matches vLLM.
+default_kv_dtype = "bf16"
+# This checkpoint's generation_config.json carries temperature=1.0 — an
+# evaluation default, not an agentic one. WITHOUT this opt-in core sampling
+# falls through to that 1.0 and the presets above (0.6 tools/thinking, 0.7
+# non-thinking) are silently ignored, so agentic runs decode far hotter than
+# intended. Measured on the Holo sibling: opting in took tool-call pass rate
+# from 4/8 to 7/8 at C=8 and aggregate 53.5 -> 67.9 tok/s, because temperature
+# 1.0 drives repeated empty-argument tool calls. Clients can still override
+# per request; explicit request values always win.
+use_sampling_presets_for_core = true
 max_thinking_budget = 2048
-thinking_default = true
+# `max_thinking_budget` is the SOLE thinking cap — drop Atlas's second,
+# 90%-of-max_tokens clamp, which vLLM has no equivalent of. Measured here: a
+# request with max_tokens=30 logged "Thinking enabled, budget=Some(27)", and
+# when that budget is hit Atlas force-closes `</think>`, leaving the model with
+# no natural continuation. The result is the degeneration this model was
+# reported for — prompt content elided ("My dog is named ...?") and
+# `The user asks: "The user asks: ...` repeat loops. Same fix, same reasoning as
+# the Laguna siblings (see laguna-xs-2.1 MODEL.toml).
+cap_thinking_at_max_tokens = false
+# Thinking OFF by default: this model's thinking mode is broken as invoked, and
+# leaving it on makes the model unusable through any client that does not pass
+# `enable_thinking:false` (opencode does not). Measured 2026-07-28, identical
+# request, only this kwarg differing:
+#   "hello what model are you?"
+#     thinking ON  -> finish=length, EMPTY content (2048 thinking tokens, no answer)
+#     thinking OFF -> "I am Nemotron 3 Super, a language model trained by ... NVIDIA."
+#   "My dog is named Rufus. What is my dog called?"
+#     thinking ON  -> 0/6 correct; emits unrelated reasoning-corpus text
+#                     ("SAMPLE INPUT", "sort a list of people")
+#     thinking OFF -> 6/6 correct
+# Not a budget or watchdog artefact: reproduced at temperature 0 through
+# /v1/completions with no template and no Atlas thinking logic, purely by
+# appending `<think>\n` to the prompt (which the model's OWN template does).
+# `<think>` tokenizes correctly as the single special token id 12, and
+# ATLAS_DISABLE_WATCHDOGS=1 does not help. Clients can still opt in per request.
+thinking_default = false
 
 # ── Kernel lookups this model may legitimately fail to resolve ──
 # Harvested 2026-08-03 from `spark serve --check-kernels` against this

--- a/kernels/gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4/rms_norm.cu
+++ b/kernels/gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4/rms_norm.cu
@@ -324,9 +324,23 @@ extern "C" __global__ void gated_rms_norm(
     unsigned int lane_id = tid % 32;
 
     // ── Per-group sum accumulators (shared memory) ──
-    __shared__ float group_sums[8];
+    // DETERMINISM: this used to be `atomicAdd(&group_sums[grp], warp_sq)`, which
+    // accumulates FLOATS in whatever order the warps happen to arrive. Float
+    // addition is not associative, so the RMS normaliser differed run to run and
+    // the whole model became nondeterministic at temperature 0 — measured on
+    // Puzzle-75B as 2 distinct completions in 10 runs of an IDENTICAL 34-token
+    // prompt (fixed seed, no prefix cache, batch 1, kernel-sync on, graphs off).
+    // Laguna, which does not use this override, was 12/12 identical.
+    //
+    // Fix: give every (group, warp) pair its own slot, then reduce them in a
+    // FIXED order. Same arithmetic, same cost class (one extra pass over
+    // <= 8*32 floats per block), but a reproducible result.
     __shared__ float group_rms[8];
-    if (tid < num_groups) group_sums[tid] = 0.0f;
+    __shared__ float group_warp_sums[8][32];   // [group][warp]
+    const unsigned int warp_id  = tid / 32;
+    const unsigned int num_warps = (blockDim.x + 31u) / 32u;   // <= 32
+    for (unsigned int z = tid; z < 8u * 32u; z += blockDim.x)
+        ((float*)group_warp_sums)[z] = 0.0f;
     __syncthreads();
 
     // ── Pass 1: Compute temp = input * silu(gate), accumulate per-group sum_sq ──
@@ -365,14 +379,20 @@ extern "C" __global__ void gated_rms_norm(
         float warp_sq = warp_reduce_sum(sq);
         if (lane_id == 0) {
             unsigned int grp = i / group_quads;
-            atomicAdd(&group_sums[grp], warp_sq);
+            // Only this warp's lane 0 ever touches [grp][warp_id]; repeat visits
+            // across loop iterations are sequential within the warp. No atomics,
+            // no cross-warp race, so the accumulation order is fixed.
+            group_warp_sums[grp][warp_id] += warp_sq;
         }
     }
     __syncthreads();
 
-    // Compute per-group RMS
+    // Compute per-group RMS. The per-warp partials are summed in ascending warp
+    // order — deterministic, unlike the atomicAdd arrival order it replaces.
     if (tid < num_groups) {
-        group_rms[tid] = rsqrtf(group_sums[tid] / (float)group_size + eps);
+        float s = 0.0f;
+        for (unsigned int w = 0; w < num_warps; ++w) s += group_warp_sums[tid][w];
+        group_rms[tid] = rsqrtf(s / (float)group_size + eps);
     }
     __syncthreads();
 


### PR DESCRIPTION
Bucket **j** of the Laguna-stack delivery plan (#442): Nemotron/Puzzle-75B native-FP8 SSM.

## The bug

ModelOpt ships **NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4** with the Mamba2 `in_proj`/`out_proj` as **block-scaled FP8** inside an otherwise-NVFP4 repo. The loader dequantized those to BF16 and **re-quantized to NVFP4 under one global scale** spanning the whole `[18048, 4096]` tensor (measured at load: `global_max=0.394531`, `scale2=0.00014678` over 73.9M elements). Puzzle is Mamba-dominant — only 8 attention layers — so these projections carry the entire sequence state, and the model answered noun-retrieval questions from its training prior instead of from context.

Measured on a 977-token story ("My dog is named Rufus … mention his name often"):

| path | result |
|---|---|
| legacy requant | "Rover" / "Rex"; the given name appears **zero** times |
| native FP8 (decode+prefill) | Rufus ×6/×5/×2/×2 over four trials, zero substitutions |

## What this does

- **Native FP8 SSM** (`weight_loader/nemotron/ssm_layer.rs`, `layers/nemotron_mamba2*`): loads the checkpoint's own FP8 bytes into an **owned** allocation (the first cut aliased a `WeightStore` pointer and dereferenced it every token — real corruption, fixed and documented in the provenance commits) and runs `w8a16_gemv` (decode) / `w8a16_gemm[_pipelined]` (prefill) with the checkpoint's per-block scales end to end. Kernels are probed before committing to the path; any failure degrades to the legacy arm with a warning.
- **Native BF16 SSM**: Nano-30B leaves 6 of 23 Mamba layers unquantized; the legacy arm invented an NVFP4 quantization for them. Kept in checkpoint BF16 (`dense_gemm_bf16_pipelined`/`dense_gemv_bf16`).
- **Native FP8 shared expert** (`layers/nemotron_moe*`, `weight_map/nemotron.rs`): same argument for Puzzle's shared-expert up/down projections, decode and prefill.
- **BF16 attention kept unquantized** (`weight_loader/nemotron.rs`): Puzzle's 8 attention layers ship BF16 (~1.2 GB); crushing them to NVFP4 saved ~0.9 GB and degraded exactly the retrieval they exist for.
- **Correctness riders from the same investigation** (all in the extracted commit range):
  - `ops/ssm_ssd.rs`: SSD-scan shared-memory **fit check** — Nano-30B (`state_size=128` → 115968 B) exceeds the sm_121 opt-in limit (101376 B) and could not serve a single token; now falls back to the sequential scan instead of aborting.
  - `nemotron_moe/prefill_sorted.rs`: grouped-GEMM **m-tile bound** was an estimate; under-provisioning dropped tokens and leaked a prior request's activations. Bounded by the worst case; intermediates zeroed as defence in depth.
  - `puzzle nvfp4/rms_norm.cu`: **deterministic `gated_rms_norm`** — `atomicAdd` on floats made temperature-0 decode nondeterministic (2 distinct completions in 10 identical runs); replaced with fixed-order per-warp reduction.
- **MODEL.toml behavior fixes** (both Nemotron variants, measured in the provenance commits): sampling-presets opt-in (`generation_config.json` carries eval defaults `temperature=1.0`), thinking off by default (thinking-on leaks training-corpus text / returns empty content), `qwen3_coder` tool parser + no tool grammar for Puzzle, BF16 KV for Puzzle, default system prompt for Nano (its own template renders an empty system turn that alone degrades the model), and `max_thinking_budget` as the sole thinking cap.
- `examples/w8a16_gemv_numeric.rs`: numeric proof for all three w8a16 kernels at the exact Puzzle shapes (N=18048, K=4096).

## Env gates shipped AS-IS (lever conversion is follow-up, per house rules)

| flag | default | purpose |
|---|---|---|
| `ATLAS_NEMOTRON_NATIVE_FP8_SSM` | on (`1`) | `0` = legacy requant (same-binary A/B); `decode` = native decode only (bisects decode from prefill) |
| `ATLAS_NEMOTRON_NATIVE_BF16_SSM` | on | `0` restores the BF16→NVFP4 requant |
| `ATLAS_NEMOTRON_BF16_ATTN` | on | `0` restores quantize-everything attention |
| `ATLAS_SHARED_FP8_PREFILL` | off | pre-dequant FP8 shared-expert prefill arm (pre-existing gate, code moved) |
| `ATLAS_SHARED_W4A4_DOWN` | off | W4A4 shared-expert down arm |
| `ATLAS_NO_SHARED_W4A4` / `ATLAS_NO_SSM_FP8_PREFILL` / `ATLAS_NO_SSM_PREFILL_T` | off | per-arm escape hatches (pre-existing pattern) |
| `ATLAS_NO_SSM_PERSISTENT` | off | A/B: persistent vs plain sequential SSM prefill scan |
| `ATLAS_MOE_MAX_M_TILES_ESTIMATE` | off | restores the old (unsafe) m-tile estimate for A/B only |
| `ATLAS_MOE_NO_ZERO_INTERMEDIATES` | off | skips the defensive zeroing of reused MoE arena buffers |

## Extraction provenance

Cut from `MonumentalSystems/atlas` `integrate/laguna-on-main` against `avarok/main`, commit range `ab446cd7..3cf579a6` (landmark `0806ed88` "own the FP8 SSM weight bytes") plus `ee681272` (native BF16 SSM projections).

**Shared-file hand-carving scope** — the plan flagged `layers/moe/{forward_prefill_routed,init,mod}.rs` as shared with Laguna perf work. Audit result: the only bucket-j commit touching them is `0806ed88`, and its hunks there are **pure rustfmt reflow and a module-declaration reorder of Laguna GGUF code that does not exist on `avarok/main`**. Zero nemotron-substantive hunks exist in those files, so **none were taken** and the files are untouched by this PR. No re-shaping was needed; the nemotron code compiles against upstream's `moe/` as-is.

Three deliberate divergences from the integration tree:
- `puzzle nvfp4/w4a16_gemm.cu`: the integration tree's copy predates upstream's 2026-07-28 `ldb` fix (the merge kept a stale 8-arg `w4a16_gemm_t`); taking it would have silently re-introduced the B-stride bug that `w4a16_gemm_t_ldb_drift_is_exactly_the_known_set` guards. **Upstream's version is kept**; the guard test passes.
- `nemotron_mamba2/prefill.rs` (620 LoC) and `nemotron_moe.rs` (524 LoC) were split sibling-module style (`prefill_proj.rs`, `prefill_shared_up.rs`) to stay under the 500-LoC cap — same code, moved verbatim.
- One functional re-shape, found by the audit below: the keep-BF16 attention path leaves `attn.o_proj` as the NULL placeholder, and `weight_loader/nemotron.rs` unconditionally called `transpose_for_gemm` on it — `transpose_u8` read a NULL pointer, the `.ok()` swallowed the error, and the poisoned context surfaced as `CUDA_ERROR_ILLEGAL_ADDRESS (700)` at the next module load. Reproduced deterministically with `--check-kernels` on GB10 and bisected to `ATLAS_NEMOTRON_BF16_ATTN=1`; now guarded with `is_null()`. (The integration tree carries the same unguarded line; it presumably survives there via unrelated ops-layer differences. Worth a look when the rest of the stack lands.)

## Verification (GB10, `ATLAS_TARGET_MODEL='*'`)

- `cargo check -p spark-server` — clean
- `cargo fmt --check` — clean
- `cargo clippy -p spark-model --no-deps -- -D warnings` — 0 errors
- `cargo test -p spark-model` — **318 passed, 0 failed** (includes the ldb drift guard)
- 500-LoC scan vs `.github/workflows/file-size-cap.yml` — all changed `.rs` files ≤ 486 LoC, no new allow-list entries
- `spark serve --check-kernels` (release build, real checkpoints, default gates):
  - `nemotron-labs-3-puzzle-75b-a9b` — **PASSED**: 141 lookups, 0 unresolved, 4 expected-absent (all pre-existing entries; the new `w8a16_*`/`dense_gemm_bf16_pipelined`/`dense_gemv_bf16` lookups all resolve)
  - `nemotron-3-nano-30b-a3b` — **PASSED**: 142 lookups, 0 unresolved, 9 expected-absent (pre-existing)
  - No new `[expected_absent]` entries needed.

Closes nothing; part of #442.
