### PR TITLE
docker/gb10: unbreak Dockerfile.builder (reimplements #396/#397/#398, CLA-blocked)

### DIFF
--- a/docker/gb10/Dockerfile.builder
+++ b/docker/gb10/Dockerfile.builder
@@ -37,6 +37,7 @@ ARG CUTLASS_DSL_VER
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
       curl ca-certificates build-essential pkg-config git cmake libclang-dev \
+      libibverbs-dev libnccl2 libnccl-dev \
       python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
@@ -60,11 +61,12 @@ RUN git clone --filter=blob:none https://github.com/flashinfer-ai/flashinfer.git
     git -C ${FLASHINFER_HOME} submodule update --init --depth 1 3rdparty/cccl
 
 # CuTe-DSL runtime for the GDN AOT kernel (provides libcute_dsl_runtime.so).
-# Discover its location and expose it on the linker/loader path.
+# Discover its location and expose it on the linker/loader path. Since 4.5.0 the
+# .so lives in nvidia_cutlass_dsl/lib/ — a SIBLING of python_packages/cutlass —
+# so a glob relative to the `cutlass` module can never find it; search the pip
+# prefix instead.
 RUN pip3 install --no-cache-dir --break-system-packages "nvidia-cutlass-dsl[cu13]==${CUTLASS_DSL_VER}" && \
-    CUTE_RT=$(python3 -c "import importlib.util,os,glob; \
-      base=os.path.dirname(importlib.util.find_spec('cutlass').origin); \
-      print(next(iter(glob.glob(base+'/**/libcute_dsl_runtime.so', recursive=True)), ''))") && \
+    CUTE_RT=$(find /usr/local/lib /usr/lib -name libcute_dsl_runtime.so 2>/dev/null | head -1) && \
     test -n "$CUTE_RT" && ln -sf "$CUTE_RT" /usr/local/lib/libcute_dsl_runtime.so && \
     echo "cute runtime: $CUTE_RT"
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/compat:${LD_LIBRARY_PATH}
@@ -86,7 +88,10 @@ ENV ATLAS_TARGET_QUANT=*
 # Native FP4 GEMM + cuBLASLt BF16 prefill projections on by default (matches prod).
 ENV ATLAS_CUTLASS_NVFP4_GEMM=1
 
-RUN cargo build --release -p spark-server
+# CUDARC_CUDA_VERSION=13000: the vendored cudarc 0.19.2 tops out at 13.1 in its
+# nvcc-version table, so `nvcc --version` (13.2) panics without the pin. Same
+# value every CI workflow pins.
+RUN CUDARC_CUDA_VERSION=13000 cargo build --release -p spark-server
 
 # Re-link the GDN AOT shared lib from committed artifacts (gdn_holo_0.o is the
 # AOT-exported bf16 kernel; gdn_transpose.o is the k<->v state transpose). No


### PR DESCRIPTION
Reimplements three fixes from @eisbaw (#396, #397, #398) which are all correct but stuck on the CLAassistant check. Thanks Mark — all three were real breakages, and each is verified below against the pinned `nvidia/cuda:13.2.0-devel-ubuntu24.04` base. He is credited via `Co-authored-by` on the commit. The originals stay open for the CLA conversation; this exists so the builder works in the meantime.

**#397 — CuTe-DSL runtime discovery (broken today).** With `nvidia-cutlass-dsl==4.5.0`, `find_spec('cutlass')` resolves to `.../nvidia_cutlass_dsl/python_packages/cutlass/__init__.py`, while the runtime lands at `.../nvidia_cutlass_dsl/lib/libcute_dsl_runtime.so` — a sibling of `python_packages`, so the module-relative recursive glob returns empty and `test -n "$CUTE_RT"` fails the build. Verified in a throwaway container: the current expression prints `''`, `find /usr/local/lib /usr/lib -name libcute_dsl_runtime.so` prints the real path (exactly one match in the image).

**#398 — `CUDARC_CUDA_VERSION=13000` (broken today).** The vendored cudarc 0.19.2 uses `cuda-version-from-build-system`; its supported-version table tops out at 13.1, so parsing `nvcc --version` (release 13.2) panics: `Unsupported cuda toolkit version: '13.2'` (vendor/cudarc/build.rs:138). Reproduced with an nvcc shim printing the 13.2.51 banner; `CUDARC_CUDA_VERSION=13000` makes the identical check pass, and it's the same value every CI workflow pins.

**#396 — RDMA/NCCL dev packages (broken today, adopted minus one package).** The devel base image ships no libibverbs, no NCCL, no `/usr/include/infiniband`. atlas-rdma unconditionally compiles `rdma_shim.c` against `<infiniband/verbs.h>` and links `-libverbs` (deliberately no probing — build.rs says fail loudly), and spark-server's default `nccl` feature links `-lnccl`. Verified in-container: compile and link both fail without the packages and pass after `libibverbs-dev libnccl2 libnccl-dev`. I dropped `librdmacm-dev` from the original list: nothing in the workspace compiles or links against rdmacm (the shim includes only `infiniband/verbs.h`), so it would be an unused dependency in a file whose whole point is pinning exactly what the build needs.