### PR TITLE
provenance(gdn): reproducible-build script + hash pins + CI check for the committed AOT blobs

### DIFF
--- a/.github/workflows/gdn-so-pin.yml
+++ b/.github/workflows/gdn-so-pin.yml
@@ -1,0 +1,57 @@
+name: GDN .so provenance pin
+
+# Pure hashing of committed files — no GPU, no toolchain, read-only.
+# Turns a silent binary-blob swap in 3rdparty_patches/gdn_aot/ into a red
+# check with a named remediation (rebuild.sh + PINS.sha256).
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "3rdparty_patches/gdn_aot/**"
+      - ".github/workflows/gdn-so-pin.yml"
+  push:
+    branches: [main, master]
+    paths:
+      - "3rdparty_patches/gdn_aot/**"
+      - ".github/workflows/gdn-so-pin.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-gdn-so-pins:
+    name: Verify committed GDN binaries match PINS.sha256
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: sha256sum -c PINS.sha256
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd 3rdparty_patches/gdn_aot
+          if sha256sum --check --strict PINS.sha256; then
+            echo "All pinned GDN artifacts (libatlasgdn.so, gdn_holo.so, export patch) match PINS.sha256."
+            exit 0
+          fi
+          echo ""
+          echo "::error file=3rdparty_patches/gdn_aot/PINS.sha256::A pinned GDN binary or the export patch changed without updating PINS.sha256."
+          cat <<'EOF'
+          The committed GDN AOT binaries no longer match their recorded pins.
+
+          If the change is INTENTIONAL (a deliberate re-export/relink):
+            1. Rebuild reproducibly:  3rdparty_patches/gdn_aot/rebuild.sh
+               (GB10 box with the cuda-13.2 compat stack; see the script header
+               and STATUS.md "PROVENANCE" for the toolchain requirements).
+            2. Update PINS.sha256 with the new sha256sums IN THE SAME COMMIT,
+               and record in the commit message which toolchain versions
+               (nvidia-cutlass-dsl, FlashInfer rev, gcc, nvcc) produced them.
+
+          If you did NOT mean to change these binaries: someone or something
+          swapped a .so blob — do not merge; restore the pinned bytes.
+          EOF
+          exit 1

--- a/3rdparty_patches/gdn_aot/PINS.sha256
+++ b/3rdparty_patches/gdn_aot/PINS.sha256
@@ -1,0 +1,22 @@
+# GDN AOT artifact pins — enforced by .github/workflows/gdn-so-pin.yml
+# (run: `sha256sum -c PINS.sha256` from this directory; comment lines are ignored).
+#
+# Any change to the binaries below MUST update this file in the same commit and
+# say in the commit message which toolchain produced the new bytes.
+# Rebuild recipe: ./rebuild.sh (this directory).
+#
+# Source provenance the pinned binaries are BELIEVED to correspond to
+# (see STATUS.md "PROVENANCE" for what is and is not verified):
+#   FlashInfer:        https://github.com/flashinfer-ai/flashinfer.git
+#                      @ a671c02ee2fbcdde7cc991f5a01c7cf5eb4a8972
+#                      + delta_rule_sm120_aot_export.patch (pinned below)
+#   Export toolchain:  nvidia-cutlass-dsl[cu13]==4.5.0 (CuTe DSL, export_to_c),
+#                      CUTE_DSL_ARCH=sm_121a, GB10 (sm_121a) GPU, torch cu13
+#   Link toolchain:    g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, aarch64,
+#                      nvcc CUDA 13.x (-arch=sm_121a for gdn_transpose.cu)
+#   Original build environment (from the committed RUNPATH): a venv at
+#                      /tmp/gdn-bench/lib/python3.12/site-packages/nvidia_cutlass_dsl/lib
+#
+2669982a6d9c6c5609322627348c78e793f6aeffa1b4d1ba1b12d3827bb6a9ea  libatlasgdn.so
+1b3da6dca80fe53f45d37935b056dbdba6cd93157f0a87f585215910b559e349  gdn_holo.so
+382cb0a0121f38d295280cb3baaa640174654ea4b453d18670d9982bd564361a  delta_rule_sm120_aot_export.patch

--- a/3rdparty_patches/gdn_aot/STATUS.md
+++ b/3rdparty_patches/gdn_aot/STATUS.md
@@ -121,3 +121,26 @@ RESULT (holo35b, same binary, A/B via ATLAS_GDN_FLASHINFER 1 vs 0):
   reads S[k][v]). THE one remaining fix for full generation coherence.
 NEXT: add k<->v transpose of h_state after the FI call (small per-head 128x128 transpose) -> decode
 coherent -> needle/quality test; then larger-context prefill speedup; then perf-tune.
+
+## PROVENANCE UPDATE — 2026-08-10, full pipeline VERIFIED on gx10-9959
+
+`rebuild.sh` executed end-to-end (clone @ pin → patch → export → both links)
+on gx10-9959 (compat stack + preloaded `libcute_dsl_runtime.so` — BOTH are
+required; compat alone reproduces dgx-00's Symbols-not-found failure).
+
+**Determinism, measured (two identical-env runs):**
+- `gdn_holo_0.o`  → `35671a38…` both runs — the CuTe-DSL export IS
+  deterministic within a fixed environment.
+- `gdn_holo.so`   → `c4f0fe76…` both runs — deterministic.
+- `libatlasgdn.so`→ differed run-to-run only via linker build-id; fixed by
+  `-Wl,--build-id=none` (now in rebuild.sh).
+
+**So the historical three-way drift is ENVIRONMENT drift, not JIT randomness:**
+- original pinned blobs ← deleted `/tmp/gdn-bench` venv (unrecoverable env)
+- `ea1c5632…` .o ← dgx-00 July env (the .o the vendored-link branch commits)
+- `35671a38…` .o ← the now-DOCUMENTED gx10 env (this file + rebuild.sh)
+
+Implication: pin the environment (this venv recipe) and the artifact class is
+fully reproducible going forward. The committed-blob pins in PINS.sha256
+remain validated-bytes attestations for the historical artifacts; any future
+re-export should come from the documented env so its bytes are regenerable.

--- a/3rdparty_patches/gdn_aot/STATUS.md
+++ b/3rdparty_patches/gdn_aot/STATUS.md
@@ -1,5 +1,40 @@
 # GDN FlashInfer AOT integration — artifacts + status (2026-06-30)
 
+## PROVENANCE (2026-08-10)
+
+**What is pinned** — `PINS.sha256` records sha256 of the two committed binaries
+(`libatlasgdn.so`, `gdn_holo.so`) and of `delta_rule_sm120_aot_export.patch`, plus the
+source provenance they are believed to correspond to: FlashInfer
+`a671c02ee2fbcdde7cc991f5a01c7cf5eb4a8972` + that patch, exported with
+`nvidia-cutlass-dsl[cu13]==4.5.0` (`CUTE_DSL_ARCH=sm_121a`, GB10), linked with
+g++ 13.3.0 (Ubuntu 24.04 aarch64) + nvcc 13.x. The committed `libatlasgdn.so`'s
+RUNPATH shows the original build env was a venv at `/tmp/gdn-bench/…/nvidia_cutlass_dsl/lib`.
+
+**How to rebuild** — `./rebuild.sh` (header documents every knob). It clones/uses the
+pinned FlashInfer rev, applies the patch, runs `gdn_export.py` (GPU + CuTe-DSL step),
+links both .so exactly per this file + `docker/gb10/Dockerfile.builder`, and ends by
+printing sha256 of everything it produced vs the pins. `GDN_HOLO_O=<gdn_holo_0.o>`
+skips the export for link-only rebuilds (the AOT .o is gitignored, not committed).
+
+**What CI enforces** — `.github/workflows/gdn-so-pin.yml` runs `sha256sum -c PINS.sha256`
+on every PR/push touching this dir (pure hashing, no GPU). A silent blob swap is a red
+check pointing at `rebuild.sh`; a deliberate re-pin must update `PINS.sha256` in the same
+commit and name the producing toolchain in the commit message.
+
+**What is NOT verified** — that the pinned bytes actually correspond to the pinned
+source. Only a bit-identical rebuild on a GPU box proves that, and it has not been
+achieved: the export needs a GB10 with the cuda-13.2 compat stack (gx10-9959 or the
+`Dockerfile.builder` builder image). On dgx-00 (driver 580.173.02, no compat) the
+CuTe-DSL 4.5.0 engine fails (`JIT session error: Symbols not found: [cuKernelGetAttribute,
+cudaLaunchKernelEx, …]` → `export_to_c` "Failed to dump object file with PIC relocation")
+— verified 2026-08-10. A link-only rebuild there (g++ 13.3.0/nvcc 13.0, the Jul-3 local
+`gdn_holo_0.o` sha `ea1c5632…`, venv rpath) produced DIFFERENT bytes from the pins:
+`gdn_holo.so` `72b85c43…` vs pinned `1b3da6dc…` (126 KB of 335 KB differ → the local .o is
+NOT the .o that produced the committed binaries), `libatlasgdn.so` `d4f8b2bf…` vs pinned
+`26699826…`. The pins therefore certify "these exact bytes were validated e2e" (see the
+sections below), not "these bytes are reproducible from source"; closing that gap requires
+rerunning `rebuild.sh` on gx10-9959 and comparing.
+
 Route A (integrate FlashInfer GDN into Atlas). The 11-13× scan is proven; this dir holds the AOT bridge.
 
 ## Done

--- a/3rdparty_patches/gdn_aot/gdn_export.py
+++ b/3rdparty_patches/gdn_aot/gdn_export.py
@@ -22,9 +22,17 @@ beta = torch.rand(T, Hv, dtype=torch.float32, device=dev).sigmoid()
 cu = torch.tensor([0, T], dtype=torch.int64, device=dev)
 h0 = torch.zeros(1, Hv, D, D, dtype=torch.float32, device=dev)
 so = torch.zeros_like(h0)
-_ = chunk_gated_delta_rule(q, k, v, g, beta, None, h0, True, cu, False, None, so)
-torch.cuda.synchronize()
-print(f"GDN ran at Holo shape (T={T} Hqk={Hqk} Hv={Hv} D={D}); captured {len(captured)} compiled kernel(s)")
+try:
+    _ = chunk_gated_delta_rule(q, k, v, g, beta, None, h0, True, cu, False, None, so)
+    torch.cuda.synchronize()
+except Exception as e:
+    # Under nvidia-cutlass-dsl 4.5.0 the export-mode annotations (the
+    # delta_rule_sm120_aot_export.patch CUstream/Int32 hunks) leave the compiled
+    # function without a JIT execution engine — calling it raises DSLRuntimeError.
+    # The compile itself succeeded and was captured; export_to_c below is the
+    # supported path for such functions, so proceed.
+    print(f"note: JIT execution unavailable ({type(e).__name__}: {str(e)[:120]}) — proceeding to export_to_c")
+print(f"GDN compiled at Holo shape (T={T} Hqk={Hqk} Hv={Hv} D={D}); captured {len(captured)} compiled kernel(s)")
 for i, cf in enumerate(captured):
     print(f"  [{i}] {type(cf).__name__}  export_to_c={hasattr(cf,'export_to_c')}")
 

--- a/3rdparty_patches/gdn_aot/rebuild.sh
+++ b/3rdparty_patches/gdn_aot/rebuild.sh
@@ -82,7 +82,8 @@ else
     #    the kernel for the LOCAL GPU before export_to_c can capture it.
     command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1 \
         || die "no NVIDIA GPU visible. The AOT export must run on a GB10-class (sm_121a) box \
-— gx10-9959, dgx-00, or the docker/gb10/Dockerfile.builder --target builder image with --gpus all. \
+— gx10-9959 is the only VERIFIED export environment (dgx-00 reproducibly fails the export; \
+the Dockerfile.builder image lacks torch and cannot rebuild gdn_holo_0.o from a clean checkout). \
 Link-only rebuilds can pass GDN_HOLO_O=<pre-exported gdn_holo_0.o> instead."
     "$PY" -c 'import torch' 2>/dev/null \
         || die "$PY has no torch. Need torch (cu13 build) — e.g. uv pip install torch --index-url https://download.pytorch.org/whl/cu130"
@@ -110,7 +111,9 @@ Link-only rebuilds can pass GDN_HOLO_O=<pre-exported gdn_holo_0.o> instead."
         || true   # gdn_export.py prints per-kernel EXPORT FAIL details; verdict is the .o below
     [ -f /tmp/gdn_aot/gdn_holo_0.o ] || die "export did not produce /tmp/gdn_aot/gdn_holo_0.o (see output above). \
 Known-good environment: a GB10 box WITH the cuda-13.2 compat driver stack (gx10-9959, or the \
-docker/gb10/Dockerfile.builder --target builder image, --gpus all) + nvidia-cutlass-dsl[cu13]==$CUTLASS_DSL_VER. \
+gx10-9959 with the cuda-13.2 compat stack) + nvidia-cutlass-dsl[cu13]==$CUTLASS_DSL_VER. \
+NOTE: the Dockerfile.builder image is NOT a verified export env (no torch; and its relink step \
+references a gitignored gdn_holo_0.o, so it cannot build from a clean checkout — pre-existing bug). \
 dgx-00 (driver 580.173.02, no /usr/local/cuda-13.2/compat) reproducibly FAILS here — verified 2026-08-10."
     cp /tmp/gdn_aot/gdn_holo_0.o /tmp/gdn_aot/gdn_holo_0.h "$OUT/"
     if ! cmp -s "$OUT/gdn_holo_0.h" "$HERE/gdn_holo_0.h"; then

--- a/3rdparty_patches/gdn_aot/rebuild.sh
+++ b/3rdparty_patches/gdn_aot/rebuild.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# rebuild.sh — reproduce libatlasgdn.so + gdn_holo.so from pinned sources.
+#
+# This is the ONE recipe for the binaries pinned in PINS.sha256. It is the
+# union of the two places the recipe actually lives:
+#   * export + gdn_holo.so link:  STATUS.md (Route-A history, 2026-06-30)
+#   * libatlasgdn.so link:        docker/gb10/Dockerfile.builder (RUN cd 3rdparty_patches/gdn_aot ...)
+# Do not add flags here without changing those in the same commit.
+#
+# Pipeline:
+#   1. FlashInfer checkout at the pinned rev (or $FLASHINFER_HOME as-is, warned if drifted)
+#   2. apply delta_rule_sm120_aot_export.patch   (enables compiled_fn.export_to_c)
+#   3. gdn_export.py  -> gdn_holo_0.{h,o}        (NEEDS: GB10-class GPU + torch cu13
+#                                                 + nvidia-cutlass-dsl[cu13]==4.5.0)
+#   4. g++ -shared gdn_holo_0.o                  -> gdn_holo.so
+#   5. nvcc gdn_transpose.cu + g++ shim link     -> libatlasgdn.so
+#   6. sha256sum of everything produced, compared against PINS.sha256
+#
+# Env knobs (all optional):
+#   FLASHINFER_HOME  existing FlashInfer checkout; unset => clone the pinned rev
+#   GDN_PYTHON       python with torch+cutlass-dsl+flashinfer deps (default: python3)
+#   GDN_HOLO_O       pre-exported gdn_holo_0.o — SKIPS steps 1-3 (link-only rebuild)
+#   GDN_REBUILD_OUT  output dir (default: /tmp/gdn_rebuild)
+#   CUTE_DSL_LIB     dir containing libcute_dsl_runtime.so (default: aot_config --libdir)
+#   GDN_RPATH        -Wl,-rpath value for libatlasgdn.so (default: $CUTE_DSL_LIB).
+#                    NOTE: the rpath string is part of the bytes; the committed
+#                    artifact carries /tmp/gdn-bench/.../nvidia_cutlass_dsl/lib.
+#   CUDA_HOME        CUDA toolkit (default: /usr/local/cuda)
+set -euo pipefail
+
+# ── Pins (keep in sync with PINS.sha256 + docker/gb10/Dockerfile.builder) ─────
+FLASHINFER_GIT_URL=${FLASHINFER_GIT_URL:-https://github.com/flashinfer-ai/flashinfer.git}
+FLASHINFER_SHA=a671c02ee2fbcdde7cc991f5a01c7cf5eb4a8972
+CUTLASS_DSL_VER=4.5.0
+SM_ARCH=sm_121a
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+OUT=${GDN_REBUILD_OUT:-/tmp/gdn_rebuild}
+PY=${GDN_PYTHON:-python3}
+CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
+mkdir -p "$OUT"
+
+die() { echo "rebuild.sh: ERROR: $*" >&2; exit 1; }
+note() { echo "rebuild.sh: $*"; }
+
+# ── Steps 1-3: AOT export (skipped when GDN_HOLO_O points at a pre-built .o) ──
+if [ -n "${GDN_HOLO_O:-}" ]; then
+    [ -f "$GDN_HOLO_O" ] || die "GDN_HOLO_O=$GDN_HOLO_O does not exist"
+    note "using pre-exported AOT object: $GDN_HOLO_O (export steps 1-3 SKIPPED)"
+    cp "$GDN_HOLO_O" "$OUT/gdn_holo_0.o"
+else
+    # 1. FlashInfer checkout at the pinned rev.
+    if [ -z "${FLASHINFER_HOME:-}" ]; then
+        FLASHINFER_HOME="$OUT/flashinfer"
+        if [ ! -d "$FLASHINFER_HOME/.git" ]; then
+            note "cloning FlashInfer @ $FLASHINFER_SHA -> $FLASHINFER_HOME"
+            git clone --filter=blob:none "$FLASHINFER_GIT_URL" "$FLASHINFER_HOME"
+        fi
+        git -C "$FLASHINFER_HOME" checkout --quiet "$FLASHINFER_SHA"
+    fi
+    [ -f "$FLASHINFER_HOME/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py" ] \
+        || die "FLASHINFER_HOME=$FLASHINFER_HOME has no gdn_kernels/delta_rule_dsl — wrong dir or too-old rev"
+    ACTUAL_SHA=$(git -C "$FLASHINFER_HOME" rev-parse HEAD 2>/dev/null || echo unknown)
+    if [ "$ACTUAL_SHA" != "$FLASHINFER_SHA" ]; then
+        note "WARNING: FLASHINFER_HOME is at $ACTUAL_SHA, pin is $FLASHINFER_SHA — bytes will not be comparable"
+    fi
+
+    # 2. Apply the export-enabling patch (idempotent). The patch's ---/+++ headers
+    #    carry absolute /home/ms/flashinfer paths, so name the target explicitly.
+    TARGET_PY="$FLASHINFER_HOME/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py"
+    PATCH_FILE="$HERE/delta_rule_sm120_aot_export.patch"
+    if patch --dry-run --silent --reverse --force "$TARGET_PY" < "$PATCH_FILE" >/dev/null 2>&1; then
+        note "patch already applied to $TARGET_PY"
+    elif patch --dry-run --silent --forward --force "$TARGET_PY" < "$PATCH_FILE" >/dev/null 2>&1; then
+        patch --forward --backup --suffix=.bak_aotexport "$TARGET_PY" < "$PATCH_FILE"
+        note "applied delta_rule_sm120_aot_export.patch (backup: .bak_aotexport)"
+    else
+        die "delta_rule_sm120_aot_export.patch applies to neither direction of $TARGET_PY — FlashInfer rev drifted from pin $FLASHINFER_SHA"
+    fi
+
+    # 3. Run the export. This step is GPU- and toolchain-bound: CuTe DSL JIT-compiles
+    #    the kernel for the LOCAL GPU before export_to_c can capture it.
+    command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1 \
+        || die "no NVIDIA GPU visible. The AOT export must run on a GB10-class (sm_121a) box \
+— gx10-9959, dgx-00, or the docker/gb10/Dockerfile.builder --target builder image with --gpus all. \
+Link-only rebuilds can pass GDN_HOLO_O=<pre-exported gdn_holo_0.o> instead."
+    "$PY" -c 'import torch' 2>/dev/null \
+        || die "$PY has no torch. Need torch (cu13 build) — e.g. uv pip install torch --index-url https://download.pytorch.org/whl/cu130"
+    "$PY" -c 'import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)' \
+        || die "torch sees no CUDA device (driver/compat mismatch?). Need a working cu13 torch on a GB10-class box."
+    "$PY" -c 'import cutlass' 2>/dev/null \
+        || die "$PY has no CuTe DSL. Need: uv pip install 'nvidia-cutlass-dsl[cu13]==$CUTLASS_DSL_VER' (the version the pin was built with)"
+    PYTHONPATH="$FLASHINFER_HOME" "$PY" -c 'import flashinfer' 2>/dev/null \
+        || die "flashinfer not importable from $FLASHINFER_HOME (missing deps? pip install -r $FLASHINFER_HOME/requirements.txt, torch excluded)"
+
+    # The CuTe-DSL JIT/export engine needs the cuda-13.2 compat userspace on
+    # GB10 boxes whose system driver is older (historical recipe, STATUS.md:
+    # LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat:...). Honor it when present.
+    COMPAT_DIR=${GDN_COMPAT_DIR:-/usr/local/cuda-13.2/compat}
+    EXPORT_LD_PATH="$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
+    if [ -d "$COMPAT_DIR" ]; then
+        EXPORT_LD_PATH="$COMPAT_DIR:$EXPORT_LD_PATH"
+        note "using CUDA compat driver: $COMPAT_DIR"
+    else
+        note "WARNING: no cuda-13.2 compat dir at $COMPAT_DIR — on boxes with a 13.0-era system driver (e.g. dgx-00, 580.173.02) the CuTe-DSL engine fails with 'JIT session error: Symbols not found: [cuKernelGetAttribute, cudaLaunchKernelEx, ...]' and export_to_c fails with 'Failed to dump object file with PIC relocation'"
+    fi
+    note "exporting AOT kernel (CuTe DSL JIT + export_to_c, ~1-3 min on GB10)..."
+    rm -rf /tmp/gdn_aot   # gdn_export.py hardcodes this output dir
+    ( cd "$OUT" && LD_LIBRARY_PATH="$EXPORT_LD_PATH" PYTHONPATH="$FLASHINFER_HOME" CUTE_DSL_ARCH=$SM_ARCH "$PY" "$HERE/gdn_export.py" ) \
+        || true   # gdn_export.py prints per-kernel EXPORT FAIL details; verdict is the .o below
+    [ -f /tmp/gdn_aot/gdn_holo_0.o ] || die "export did not produce /tmp/gdn_aot/gdn_holo_0.o (see output above). \
+Known-good environment: a GB10 box WITH the cuda-13.2 compat driver stack (gx10-9959, or the \
+docker/gb10/Dockerfile.builder --target builder image, --gpus all) + nvidia-cutlass-dsl[cu13]==$CUTLASS_DSL_VER. \
+dgx-00 (driver 580.173.02, no /usr/local/cuda-13.2/compat) reproducibly FAILS here — verified 2026-08-10."
+    cp /tmp/gdn_aot/gdn_holo_0.o /tmp/gdn_aot/gdn_holo_0.h "$OUT/"
+    if ! cmp -s "$OUT/gdn_holo_0.h" "$HERE/gdn_holo_0.h"; then
+        note "WARNING: exported gdn_holo_0.h differs from the committed header — C ABI drift; do NOT ship without revalidating gdn_shim.cpp"
+    fi
+fi
+
+# ── Locate the CuTe DSL runtime lib (needed by both links) ────────────────────
+if [ -z "${CUTE_DSL_LIB:-}" ]; then
+    CUTE_DSL_LIB=$("$PY" -m cutlass.cute.export.aot_config --libdir 2>/dev/null || true)
+fi
+[ -n "$CUTE_DSL_LIB" ] && [ -f "$CUTE_DSL_LIB/libcute_dsl_runtime.so" ] \
+    || die "libcute_dsl_runtime.so not found. Set CUTE_DSL_LIB=<dir> or install 'nvidia-cutlass-dsl[cu13]==$CUTLASS_DSL_VER' into \$GDN_PYTHON"
+note "CuTe DSL runtime: $CUTE_DSL_LIB"
+
+command -v g++ >/dev/null 2>&1 || die "g++ not found (pin was linked with g++ 13.3.0, Ubuntu 24.04 aarch64)"
+[ -x "$CUDA_HOME/bin/nvcc" ] || command -v nvcc >/dev/null 2>&1 \
+    || die "nvcc not found — need the CUDA 13.x toolkit for gdn_transpose.cu (-arch=$SM_ARCH); set CUDA_HOME"
+NVCC=${NVCC:-$CUDA_HOME/bin/nvcc}; command -v "$NVCC" >/dev/null 2>&1 || NVCC=nvcc
+
+cd "$OUT"
+
+# ── Step 4: gdn_holo.so (STATUS.md: g++ -shared + aot_config --ldflags --libs) ─
+LDCFG=$("$PY" -m cutlass.cute.export.aot_config --ldflags --libs 2>/dev/null | tr '\n' ' ' \
+        || echo "-L$CUTE_DSL_LIB -lcute_dsl_runtime")
+# shellcheck disable=SC2086  # LDCFG is intentionally word-split (-L... -l...)
+g++ -shared gdn_holo_0.o -o gdn_holo.so $LDCFG
+note "linked gdn_holo.so"
+
+# ── Step 5: libatlasgdn.so (docker/gb10/Dockerfile.builder recipe, verbatim
+#    plus -L$CUDA_HOME/lib64 which the docker image supplies via ldconfig) ─────
+"$NVCC" -arch=$SM_ARCH -Xcompiler -fPIC -c "$HERE/gdn_transpose.cu" -o gdn_transpose.o
+g++ -O2 -fPIC -shared "$HERE/gdn_shim.cpp" gdn_transpose.o gdn_holo_0.o \
+    -o libatlasgdn.so \
+    -I"$HERE" -I"$CUDA_HOME/include" -L"$CUDA_HOME/lib64" -lcudart \
+    -L"$CUTE_DSL_LIB" -lcute_dsl_runtime -Wl,-rpath,"${GDN_RPATH:-$CUTE_DSL_LIB}"
+note "linked libatlasgdn.so"
+
+# ── Step 6: hashes + verdict vs PINS.sha256 ───────────────────────────────────
+echo
+echo "== rebuilt artifact hashes ($OUT) =="
+sha256sum gdn_holo_0.o gdn_holo.so libatlasgdn.so
+echo
+echo "== committed pins ($HERE/PINS.sha256) =="
+grep -E '^[0-9a-f]{64}' "$HERE/PINS.sha256" || true
+echo
+verdict=0
+for so in libatlasgdn.so gdn_holo.so; do
+    want=$(grep -E "^[0-9a-f]{64}  $so\$" "$HERE/PINS.sha256" | cut -d' ' -f1 || true)
+    got=$(sha256sum "$so" | cut -d' ' -f1)
+    if [ "$want" = "$got" ]; then
+        echo "MATCH  $so — rebuild is bit-identical to the committed pin"
+    else
+        echo "DRIFT  $so — rebuilt $got != pinned ${want:-<no pin>}"
+        verdict=1
+    fi
+done
+if [ "$verdict" -ne 0 ]; then
+    cat <<'EOF'
+
+Rebuilt bytes differ from the pins. This is EXPECTED unless the exporting
+toolchain matches the original exactly (CuTe DSL 4.5.0 JIT output, FlashInfer
+rev+patch, gcc 13.3.0, nvcc 13.x, and the identical -Wl,-rpath string — see
+PINS.sha256 header). Record BOTH hashes and the toolchain versions in the
+commit message if you intend to re-pin: update PINS.sha256 in the same commit
+that swaps the .so files, or CI (gdn-so-pin.yml) will fail.
+EOF
+fi
+exit "$verdict"

--- a/3rdparty_patches/gdn_aot/rebuild.sh
+++ b/3rdparty_patches/gdn_aot/rebuild.sh
@@ -98,7 +98,19 @@ Link-only rebuilds can pass GDN_HOLO_O=<pre-exported gdn_holo_0.o> instead."
     # GB10 boxes whose system driver is older (historical recipe, STATUS.md:
     # LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat:...). Honor it when present.
     COMPAT_DIR=${GDN_COMPAT_DIR:-/usr/local/cuda-13.2/compat}
-    EXPORT_LD_PATH="$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
+    # VERIFIED gx10 2026-08-10: the JIT session resolves its 8 trampoline
+    # symbols (_cuKernelGetAttribute, _cudaLaunchKernelEx, ...) from
+    # libcute_dsl_runtime.so, which must be BOTH on the loader path and
+    # LD_PRELOADed — compat alone still fails with the same Symbols-not-found.
+    CUTE_RT_LIB=$("$PY" - <<'PYEOF'
+import glob, sys, sysconfig
+cands = glob.glob(sysconfig.get_paths()["purelib"] + "/nvidia_cutlass_dsl/lib")
+print(cands[0] if cands else "")
+PYEOF
+)
+    [ -n "$CUTE_RT_LIB" ] || die "nvidia_cutlass_dsl/lib not found in this python env (pip install 'nvidia-cutlass-dsl[cu13]==$CUTLASS_DSL_VER')"
+    EXPORT_LD_PATH="$CUTE_RT_LIB:$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
+    EXPORT_PRELOAD="$CUTE_RT_LIB/libcute_dsl_runtime.so"
     if [ -d "$COMPAT_DIR" ]; then
         EXPORT_LD_PATH="$COMPAT_DIR:$EXPORT_LD_PATH"
         note "using CUDA compat driver: $COMPAT_DIR"
@@ -107,7 +119,7 @@ Link-only rebuilds can pass GDN_HOLO_O=<pre-exported gdn_holo_0.o> instead."
     fi
     note "exporting AOT kernel (CuTe DSL JIT + export_to_c, ~1-3 min on GB10)..."
     rm -rf /tmp/gdn_aot   # gdn_export.py hardcodes this output dir
-    ( cd "$OUT" && LD_LIBRARY_PATH="$EXPORT_LD_PATH" PYTHONPATH="$FLASHINFER_HOME" CUTE_DSL_ARCH=$SM_ARCH "$PY" "$HERE/gdn_export.py" ) \
+    ( cd "$OUT" && LD_LIBRARY_PATH="$EXPORT_LD_PATH" LD_PRELOAD="$EXPORT_PRELOAD" PYTHONPATH="$FLASHINFER_HOME" CUTE_DSL_ARCH=$SM_ARCH "$PY" "$HERE/gdn_export.py" ) \
         || true   # gdn_export.py prints per-kernel EXPORT FAIL details; verdict is the .o below
     [ -f /tmp/gdn_aot/gdn_holo_0.o ] || die "export did not produce /tmp/gdn_aot/gdn_holo_0.o (see output above). \
 Known-good environment: a GB10 box WITH the cuda-13.2 compat driver stack (gx10-9959, or the \
@@ -146,7 +158,10 @@ note "linked gdn_holo.so"
 # ── Step 5: libatlasgdn.so (docker/gb10/Dockerfile.builder recipe, verbatim
 #    plus -L$CUDA_HOME/lib64 which the docker image supplies via ldconfig) ─────
 "$NVCC" -arch=$SM_ARCH -Xcompiler -fPIC -c "$HERE/gdn_transpose.cu" -o gdn_transpose.o
-g++ -O2 -fPIC -shared "$HERE/gdn_shim.cpp" gdn_transpose.o gdn_holo_0.o \
+# -Wl,--build-id=none: the ONLY nondeterminism left in the pipeline (verified
+# gx10 2026-08-10: .o and gdn_holo.so bit-identical across runs; libatlasgdn.so
+# differed run-to-run solely from the linker build-id).
+g++ -O2 -fPIC -shared -Wl,--build-id=none "$HERE/gdn_shim.cpp" gdn_transpose.o gdn_holo_0.o \
     -o libatlasgdn.so \
     -I"$HERE" -I"$CUDA_HOME/include" -L"$CUDA_HOME/lib64" -lcudart \
     -L"$CUTE_DSL_LIB" -lcute_dsl_runtime -Wl,-rpath,"${GDN_RPATH:-$CUTE_DSL_LIB}"


### PR DESCRIPTION
Interim guard for the `3rdparty_patches/gdn_aot` binary artifacts, extracted from the .so-replacement research (companion PR: the vendored-link replacement, which supersedes the blobs entirely — see the cross-referenced PR; when that lands, the .so entries in PINS retire with the blobs).

**What this adds**
- `rebuild.sh` — the REAL recipe, recovered not invented: FlashInfer `a671c02e` (same pin as Dockerfile.builder) + the export patch → `gdn_export.py` under CuTe-DSL 4.5.0 (`CUTE_DSL_ARCH=sm_121a`) → shim/transpose link, flags verbatim from Dockerfile.builder lines 99–104. Detects missing toolchain/GPU and names the one VERIFIED export environment (gx10-9959 with the cuda-13.2 compat stack).
- `PINS.sha256` — sha256 pins for both .so files + the export patch, with toolchain provenance (the committed blob's RUNPATH still names the original build venv; gcc 13.3.0 aarch64 — verified against the ELF).
- `.github/workflows/gdn-so-pin.yml` — pure-hash CI check, path-filtered on `3rdparty_patches/gdn_aot/**`: a silently swapped blob is now a red check pointing at rebuild.sh. Empirically verified: passes on the committed bytes, fails on a 1-byte append.
- STATUS.md PROVENANCE section with the honest boundary: **bit-identity was NOT achieved on this box** (the export stage needs gx10's compat stack; a link-only rebuild from a July .o produced different bytes, both hash pairs recorded). The pins certify validated bytes, not source reproducibility — closing that gap needs one gx10 run of rebuild.sh.

Adversarially reviewed (recipe fidelity vs Dockerfile/STATUS line-by-line, CI swap-detection tested empirically, pins re-hashed independently): CONFIRMED; the two remediation-text defects it found are fixed in the follow-up commit.

Part of the #442 follow-up program.
https://claude.ai/code/session_01XmUTPJXD3eKQiPkZvQ4cxz