### PR TITLE
telemetry: gitGraph merge-order chart first, one bound for every chart, next steps on each merge

### DIFF
--- a/.github/workflows/pr-telemetry.yml
+++ b/.github/workflows/pr-telemetry.yml
@@ -14,6 +14,12 @@ on:
     # someone opens it, rare enough that a queue of PRs does not generate a
     # notification storm.
     - cron: "17 */4 * * *"
+  push:
+    # Every merge to main lands as a push, so "Recommended next steps" (which
+    # PR to merge next, who must re-gate, what debt the merge left) refreshes
+    # the moment the tree changes instead of up to four hours later. The
+    # concurrency group below already serializes this against the schedule.
+    branches: [main]
   workflow_dispatch:
 
 # One run at a time, and never cancelled mid-flight: the write step reads a

--- a/crates/atlas-plugin/src/gate/telemetry.rs
+++ b/crates/atlas-plugin/src/gate/telemetry.rs
@@ -29,6 +29,11 @@ use std::path::Path;
 
 use super::{codeowners, coverage, taxon};
 
+/// The bounded renderings: recommended order, the gitGraph, next steps.
+#[path = "telemetry_order.rs"]
+pub mod order;
+pub use order::{CHART_PR_BOUND, merge_order};
+
 /// The marker pair that makes the comment rewritable in place.
 ///
 /// Without it the bot would append, and a week of appends is a comment nobody
@@ -126,21 +131,6 @@ pub fn collisions(views: &[PrView]) -> BTreeMap<String, Vec<u64>> {
     by_target
 }
 
-/// A merge order that avoids re-measuring the same target twice in a row.
-///
-/// Deliberately simple, and simple is the point: fewest targets first, ties
-/// broken by PR number. It is a SUGGESTION printed for a human, not a scheduler
-/// — a clever order that nobody can predict is worse than an obvious one, since
-/// the reader has to be able to tell at a glance when it is wrong.
-pub fn merge_order(views: &[PrView]) -> Vec<u64> {
-    let mut ranked: Vec<(usize, bool, u64)> = views
-        .iter()
-        .map(|v| (v.targets.len(), v.whole_repo, v.facts.number))
-        .collect();
-    ranked.sort();
-    ranked.into_iter().map(|(_, _, n)| n).collect()
-}
-
 fn escape(s: &str) -> String {
     s.replace('|', "\\|").replace('\n', " ")
 }
@@ -153,9 +143,6 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
 
     out.push_str(MARKER_START);
     out.push_str("\n## Open-PR telemetry\n\n");
-    out.push_str(
-        "Advisory. Nothing here blocks a merge — the blocking checks live on each PR.\n\n",
-    );
 
     if views.is_empty() {
         out.push_str("_No open pull requests._\n");
@@ -164,12 +151,34 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
         return out;
     }
 
+    // ── The chart, first ──
+    //
+    // The one picture the comment exists for: `main` as a line, the
+    // recommended merge order branching off it. Everything below is the
+    // evidence; the chart is the conclusion, so it leads.
+    out.push_str(&order::render_order_chart(&views));
+    out.push_str(
+        "\nAdvisory. Nothing here blocks a merge — the blocking checks live on each PR.\n",
+    );
+
+    out.push_str(&order::render_next_steps(&views));
+
     // ── PRs, grouped by the hardware they touch ──
-    out.push_str("### Pull requests\n\n");
+    //
+    // Open PRs only. A merged PR's remaining relevance is the debt it left,
+    // which has its own ledger below — repeating it here buried the open work
+    // under history and was most of why the comment grew unreadable.
+    let merged_count = views.iter().filter(|v| v.facts.merged).count();
+    out.push_str("\n### Pull requests\n\n");
+    if merged_count > 0 {
+        out.push_str(&format!(
+            "_{merged_count} merged PR(s) tracked for debt only — see the ledger below._\n\n"
+        ));
+    }
     out.push_str("| PR | category | targets re-opened | codeowners |\n");
     out.push_str("|---|---|---|---|\n");
     let mut grouped: BTreeMap<String, Vec<&PrView>> = BTreeMap::new();
-    for view in &views {
+    for view in views.iter().filter(|v| !v.facts.merged) {
         let key = if view.hardware.is_empty() {
             "host / non-kernel".to_string()
         } else {
@@ -261,29 +270,12 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
              | target | PRs |\n|---|---|\n",
         );
         for (target, prs) in &collisions {
-            let list = prs
-                .iter()
-                .map(|n| format!("#{n}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            out.push_str(&format!("| `{target}` | {list} |\n"));
+            // Cells share the chart's bound: a wall of two hundred refs is as
+            // unreadable as a two-hundred-node chart, and `cap_prs` says how
+            // many were dropped.
+            out.push_str(&format!("| `{target}` | {} |\n", order::cap_prs(prs)));
         }
     }
-
-    // ── Suggested order ──
-    out.push_str("\n### Suggested merge order\n\n```mermaid\ngraph LR\n");
-    let order = merge_order(&views);
-    for (i, number) in order.iter().enumerate() {
-        let view = views.iter().find(|v| v.facts.number == *number);
-        let count = view.map(|v| v.targets.len()).unwrap_or(0);
-        out.push_str(&format!(
-            "  pr{number}[\"#{number}<br/>{count} target(s)\"]\n"
-        ));
-        if i > 0 {
-            out.push_str(&format!("  pr{} --> pr{number}\n", order[i - 1]));
-        }
-    }
-    out.push_str("```\n\nFewest targets first — the cheapest to re-gate if the order changes.\n");
 
     // ── Every target, always ──
     out.push_str(&format!(
@@ -294,17 +286,17 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
     ));
     for target in &all_targets {
         let key = target.to_string();
-        let touching: Vec<String> = views
+        let touching: Vec<u64> = views
             .iter()
             .filter(|v| v.targets.contains(target))
-            .map(|v| format!("#{}", v.facts.number))
+            .map(|v| v.facts.number)
             .collect();
         out.push_str(&format!(
             "| `{key}` | {} |\n",
             if touching.is_empty() {
                 "—".to_string()
             } else {
-                touching.join(", ")
+                order::cap_prs(&touching)
             }
         ));
     }

--- a/crates/atlas-plugin/src/gate/telemetry_order.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_order.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The bounded renderings: the recommended merge order, the gitGraph that
+//! draws it, and the "Recommended next steps" list.
+//!
+//! # Why `gitGraph` and not `graph LR`
+//!
+//! The thing being drawn IS a git timeline: a mainline with each PR branching
+//! off and merging back in the recommended order. `gitGraph` has those
+//! semantics natively — `main` is a real line, every PR is a real branch to
+//! the side, and left-to-right position IS the order. A `graph LR` chain of
+//! boxes has none of that; it was a list wearing a diagram costume.
+//!
+//! # Why everything here is bounded
+//!
+//! A chart with two hundred nodes is not a chart, it is noise that renders —
+//! unreadable and therefore effectively invisible, which is the same defect
+//! class as a check that silently passes. Every per-PR rendering in the
+//! comment shares [`CHART_PR_BOUND`], and every truncation says "showing N of
+//! M" plus what was dropped, so a bounded view can never be mistaken for a
+//! complete one.
+
+use super::PrView;
+
+/// The one bound every chart and per-PR list in the comment shares.
+///
+/// Why 10: GitHub renders comment bodies ~900px wide and scales a mermaid
+/// SVG to fit, and each `gitGraph` branch-and-merge lane costs roughly
+/// 80-100px of track — past ten branches the whole chart shrinks below
+/// legibility, which recreates the unreadable-chart defect the bound exists
+/// to prevent. Ten is also about as many "next" items as a reader acts on.
+/// One constant on purpose: every bounded rendering degrades at the same
+/// point, and changing the budget is a one-line edit here, never a hunt for
+/// magic numbers.
+pub const CHART_PR_BOUND: usize = 10;
+
+/// True when landing either PR disturbs the other: they share a gate target,
+/// so each is measured against a baseline the other will move and whichever
+/// lands second must re-gate. A whole-repo diff re-opens every gate, so it
+/// contends with any PR that has one.
+///
+/// Shared-changed-file overlap (textual conflict risk) is deliberately NOT a
+/// separate clause — it is subsumed: any diff reaching outside `kernels/` is
+/// whole-repo and already contends with everything gated, and two kernel
+/// diffs sharing a file share that file's target.
+fn contend(a: &PrView, b: &PrView) -> bool {
+    let a_gated = a.whole_repo || !a.targets.is_empty();
+    let b_gated = b.whole_repo || !b.targets.is_empty();
+    if (a.whole_repo && b_gated) || (b.whole_repo && a_gated) {
+        return true;
+    }
+    !a.targets.is_disjoint(&b.targets)
+}
+
+/// The PRs a merge order can contain: open and non-draft. A merged PR has
+/// already landed; a draft cannot land. The old order ranked both, which made
+/// the suggestion wrong on its face whenever the feed carried merged PRs.
+fn orderable(views: &[PrView]) -> Vec<&PrView> {
+    views
+        .iter()
+        .filter(|v| !v.facts.merged && !v.facts.draft)
+        .collect()
+}
+
+/// The recommended merge order over open, non-draft PRs.
+///
+/// The rule, in tie-break order — deliberately simple enough that a reader
+/// can tell at a glance when it is wrong:
+/// 1. fewest conflict partners first (see [`contend`]) — landing uncontended
+///    work first invalidates nobody's baseline and defers the contended
+///    cluster to be decided together;
+/// 2. fewest targets re-opened (whole-repo counts as all of them) — the
+///    cheapest to re-gate if the order changes underneath it;
+/// 3. smallest diff by changed-path count — a size proxy;
+/// 4. lowest PR number — oldest first, and it makes the order total, so the
+///    comment does not churn between runs.
+///
+/// What the rule does NOT know (nothing in [`super::PrFacts`] carries it):
+/// whether one PR unblocks another, required-context/check state, review
+/// state, or true git mergeability. Those live on each PR.
+pub fn merge_order(views: &[PrView]) -> Vec<u64> {
+    let open = orderable(views);
+    let mut ranked: Vec<(usize, usize, usize, u64)> = open
+        .iter()
+        .map(|v| {
+            let partners = open
+                .iter()
+                .filter(|o| o.facts.number != v.facts.number && contend(v, o))
+                .count();
+            let breadth = if v.whole_repo {
+                usize::MAX
+            } else {
+                v.targets.len()
+            };
+            (
+                partners,
+                breadth,
+                v.facts.changed_paths.len(),
+                v.facts.number,
+            )
+        })
+        .collect();
+    ranked.sort_unstable();
+    ranked.into_iter().map(|(_, _, _, n)| n).collect()
+}
+
+/// A bounded `#1, #2, … +k more` list. Every per-PR cell in the comment goes
+/// through this so no table cell can grow into an unreadable wall of refs.
+pub fn cap_prs(numbers: &[u64]) -> String {
+    let shown = numbers.len().min(CHART_PR_BOUND);
+    let mut s = numbers[..shown]
+        .iter()
+        .map(|n| format!("#{n}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if numbers.len() > shown {
+        s.push_str(&format!(" … +{} more", numbers.len() - shown));
+    }
+    s
+}
+
+/// The commit label for one PR inside the chart. `gitGraph` delimits ids with
+/// double quotes and has no escape sequence, so quotes fold to apostrophes;
+/// the title is clipped so ten branches stay legible side by side.
+fn commit_label(v: &PrView) -> String {
+    const TITLE_CLIP: usize = 24; // longer labels shrink the whole SVG to fit
+    let clean = v.facts.title.replace('"', "'").replace('\n', " ");
+    let clipped: String = clean.chars().take(TITLE_CLIP).collect();
+    let ellipsis = if clean.chars().count() > TITLE_CLIP {
+        "…"
+    } else {
+        ""
+    };
+    format!("#{} {}{}", v.facts.number, clipped, ellipsis)
+}
+
+/// The chart: `main` as a line, each recommended PR as a branch off it,
+/// merged back in order. Bounded by [`CHART_PR_BOUND`]; the caption always
+/// says "showing N of M", and anything past the bound is named in text so the
+/// truncation is visible, never silent.
+pub fn render_order_chart(views: &[PrView]) -> String {
+    let order = merge_order(views);
+    if order.is_empty() {
+        // No fence at all: an empty gitGraph (a mainline with no branches)
+        // renders as a lone dot, which reads as a broken chart.
+        return "_No open, non-draft PRs to order._\n".to_string();
+    }
+    let shown = order.len().min(CHART_PR_BOUND);
+    let mut out = String::from("```mermaid\ngitGraph\n  commit id: \"main\"\n");
+    for number in &order[..shown] {
+        let v = views
+            .iter()
+            .find(|v| v.facts.number == *number)
+            .expect("order is drawn from these views");
+        out.push_str(&format!(
+            "  branch pr-{number}\n  commit id: \"{}\"\n  checkout main\n  merge pr-{number}\n",
+            commit_label(v)
+        ));
+    }
+    out.push_str("```\n\n");
+    out.push_str(&format!(
+        "Showing {shown} of {} open PRs, left to right in recommended merge order.",
+        order.len()
+    ));
+    if order.len() > shown {
+        out.push_str(&format!(" Not charted: {}.", cap_prs(&order[shown..])));
+    }
+    out.push_str(
+        "\nOrder: fewest conflict partners first (a partner shares a gate target; \
+         a whole-repo diff contends with every gated PR), then fewest targets \
+         re-opened, then smallest diff, then lowest PR number. Drafts and merged \
+         PRs are not ranked.\n",
+    );
+    out
+}
+
+/// "Recommended next steps" — recomputed on every run, and the workflow now
+/// runs on every push to `main`, so this updates the moment a merge lands.
+///
+/// Everything here is derived from changed paths plus the merged flag; the
+/// closing line says out loud what those inputs cannot see, so the section
+/// never pretends to more knowledge than it has.
+pub fn render_next_steps(views: &[PrView]) -> String {
+    let mut out = String::from("\n### Recommended next steps\n\n");
+    let order = merge_order(views);
+    match order.first() {
+        None => out.push_str("- Nothing to merge: no open, non-draft PRs.\n"),
+        Some(head) => {
+            let v = views.iter().find(|v| v.facts.number == *head).unwrap();
+            out.push_str(&format!(
+                "- **Merge next: #{head}** ({}) — least disruptive open PR under the \
+                 order rule above.\n",
+                super::escape(&v.facts.title)
+            ));
+        }
+    }
+
+    // Baselines already moved: open PRs whose targets a merged PR re-opened.
+    let merged: Vec<&PrView> = views.iter().filter(|v| v.facts.merged).collect();
+    let mut regate: Vec<u64> = Vec::new();
+    for v in views.iter().filter(|v| !v.facts.merged) {
+        if merged.iter().any(|m| contend(v, m)) {
+            regate.push(v.facts.number);
+        }
+    }
+    if !regate.is_empty() {
+        out.push_str(&format!(
+            "- **Re-gate before merging:** {} — a merged PR in this window moved a \
+             baseline they were measured against.\n",
+            cap_prs(&regate)
+        ));
+    }
+
+    // Debt a merge left behind: coverage a candidate gate wanted and the code
+    // shipped without. Discharging it is a concrete, derivable next action.
+    let mut owing: Vec<u64> = merged
+        .iter()
+        .filter(|v| !v.promotion_debt.is_empty())
+        .map(|v| v.facts.number)
+        .collect();
+    owing.sort_unstable();
+    if !owing.is_empty() {
+        out.push_str(&format!(
+            "- **Discharge promotion debt:** merged {} shipped without a \
+             promotion-candidate gate (see the debt table below).\n",
+            cap_prs(&owing)
+        ));
+    }
+
+    out.push_str(
+        "\n_Derived only from changed paths and merge state. This section cannot \
+         see check or required-context status, review state, true git \
+         mergeability, or whether one PR unblocks another — those live on each \
+         PR._\n",
+    );
+    out
+}
+
+#[cfg(test)]
+#[path = "telemetry_order_tests.rs"]
+mod telemetry_order_tests;

--- a/crates/atlas-plugin/src/gate/telemetry_order_tests.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_order_tests.rs
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::super::{PrFacts, render, views};
+use super::*;
+
+fn repo_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("workspace layout")
+        .to_path_buf()
+}
+
+fn pr(number: u64, paths: &[&str]) -> PrFacts {
+    PrFacts {
+        number,
+        title: format!("pr {number}"),
+        author: "someone".into(),
+        draft: false,
+        merged: false,
+        changed_paths: paths.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+const FLAGSHIP: &str = "kernels/gb10/qwen3.6-27b/nvfp4/w4a4_gemm.cu";
+const MOE: &str = "kernels/gb10/qwen3.6-35b-a3b/nvfp4/x.cu";
+
+// ---------------------------------------------------------------------------
+// The chart leads, and it is bounded
+// ---------------------------------------------------------------------------
+
+/// ★ The chart is the conclusion; it must be the first thing in the comment,
+/// before the advisory line and before every section.
+#[test]
+fn the_chart_is_the_first_thing_in_the_comment() {
+    let root = repo_root();
+    let body = render(&root, &[pr(1, &[FLAGSHIP]), pr(2, &[MOE])]);
+    let chart = body.find("```mermaid").expect("a chart rendered");
+    assert!(
+        chart < body.find("Advisory.").unwrap(),
+        "chart before advisory"
+    );
+    assert!(
+        chart < body.find("###").unwrap(),
+        "chart before every section"
+    );
+}
+
+/// ★ The bound actually truncates: past CHART_PR_BOUND open PRs, the chart
+/// stops growing instead of shrinking below legibility.
+#[test]
+fn the_chart_is_bounded_to_chart_pr_bound() {
+    let root = repo_root();
+    let prs: Vec<PrFacts> = (101..=112).map(|n| pr(n, &[FLAGSHIP])).collect();
+    let body = render(&root, &prs);
+    assert_eq!(
+        body.matches("  branch pr-").count(),
+        CHART_PR_BOUND,
+        "exactly the bound, not all 12"
+    );
+}
+
+/// ★ Truncation is disclosed, never silent: "showing N of M" plus the names
+/// of what was dropped. A chart that silently drops points is the same defect
+/// class as a check that silently passes.
+#[test]
+fn truncation_is_disclosed_with_showing_n_of_m() {
+    let root = repo_root();
+    let prs: Vec<PrFacts> = (101..=112).map(|n| pr(n, &[FLAGSHIP])).collect();
+    let body = render(&root, &prs);
+    assert!(
+        body.contains("Showing 10 of 12 open PRs"),
+        "the caption must say showing N of M: {body}"
+    );
+    assert!(
+        body.contains("Not charted: #111, #112."),
+        "the dropped PRs must be named: {body}"
+    );
+}
+
+/// The negative arm: under the bound nothing is dropped and the caption says
+/// so — N equals M and no "Not charted" appears.
+#[test]
+fn a_small_input_is_not_truncated() {
+    let root = repo_root();
+    let body = render(&root, &[pr(1, &[FLAGSHIP]), pr(2, &[MOE])]);
+    assert!(body.contains("Showing 2 of 2 open PRs"), "{body}");
+    assert!(!body.contains("Not charted"), "nothing was dropped");
+}
+
+/// ★ Zero orderable PRs must not emit a degenerate diagram (a gitGraph with
+/// no branches renders as a lone dot that reads as broken).
+#[test]
+fn only_merged_prs_yield_a_note_not_a_degenerate_chart() {
+    let root = repo_root();
+    let mut merged = pr(1, &[FLAGSHIP]);
+    merged.merged = true;
+    let body = render(&root, &[merged]);
+    assert!(!body.contains("```mermaid"), "no empty gitGraph: {body}");
+    assert!(body.contains("No open, non-draft PRs to order."), "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// The ordering rule
+// ---------------------------------------------------------------------------
+
+/// Rule leg 1: fewest conflict partners first. #3 contends with nobody, so it
+/// leads even though every PR here re-opens exactly one target.
+#[test]
+fn the_uncontended_pr_is_recommended_first() {
+    let root = repo_root();
+    let v = views(
+        &root,
+        &[pr(1, &[FLAGSHIP]), pr(2, &[FLAGSHIP]), pr(3, &[MOE])],
+    );
+    assert_eq!(merge_order(&v), vec![3, 1, 2]);
+}
+
+/// Rule leg 2: a whole-repo diff re-opens every gate, so it contends with
+/// everything and counts as the widest — it goes last.
+#[test]
+fn a_whole_repo_pr_orders_last() {
+    let root = repo_root();
+    let v = views(
+        &root,
+        &[
+            pr(1, &["crates/spark-model/src/lib.rs"]),
+            pr(2, &[FLAGSHIP]),
+        ],
+    );
+    assert_eq!(
+        merge_order(&v),
+        vec![2, 1],
+        "whole-repo after the narrow PR"
+    );
+}
+
+/// ★ Merged PRs have landed and drafts cannot land; ranking either makes the
+/// suggestion wrong on its face (the old order ranked both).
+#[test]
+fn merged_and_draft_prs_are_not_ranked_or_charted() {
+    let root = repo_root();
+    let mut merged = pr(1, &[FLAGSHIP]);
+    merged.merged = true;
+    let mut draft = pr(2, &[FLAGSHIP]);
+    draft.draft = true;
+    let open = pr(3, &[FLAGSHIP]);
+    let v = views(&root, &[merged.clone(), draft.clone(), open.clone()]);
+    assert_eq!(merge_order(&v), vec![3], "only the open, non-draft PR");
+    let body = render(&root, &[merged, draft, open]);
+    assert!(!body.contains("branch pr-1\n"), "merged not charted");
+    assert!(!body.contains("branch pr-2\n"), "draft not charted");
+    assert!(body.contains("branch pr-3\n"), "open PR charted");
+}
+
+/// Non-kernel diffs are whole-repo, so they contend with everything gated —
+/// including each other. With partners tied, the smaller diff goes first and
+/// the narrow kernel PR still leads on breadth.
+#[test]
+fn whole_repo_prs_contend_and_tie_break_by_size() {
+    let root = repo_root();
+    let v = views(
+        &root,
+        &[
+            pr(1, &["docs/adr/README.md", "docs/adr/0002.md"]),
+            pr(2, &["docs/other.md"]),
+            pr(3, &[MOE]),
+        ],
+    );
+    // All three contend pairwise (two whole-repo diffs, one gated kernel PR),
+    // so partners tie at 2; #3 wins on breadth (1 target vs whole-repo), then
+    // #2's one-path diff precedes #1's two.
+    assert_eq!(merge_order(&v), vec![3, 2, 1]);
+}
+
+// ---------------------------------------------------------------------------
+// The chart's syntax survives hostile input
+// ---------------------------------------------------------------------------
+
+/// gitGraph delimits commit ids with double quotes and has no escape, so a
+/// quote in a PR title must fold to an apostrophe or the diagram dies and
+/// GitHub degrades the whole block to a raw code fence.
+#[test]
+fn a_hostile_title_cannot_break_the_chart() {
+    let root = repo_root();
+    let mut hostile = pr(9, &[FLAGSHIP]);
+    hostile.title = "evil \"quote\"\ninject".into();
+    let body = render(&root, &[hostile]);
+    assert!(
+        body.contains("commit id: \"#9 evil 'quote' inject\""),
+        "quotes folded, newline flattened: {body}"
+    );
+}
+
+/// Long titles are clipped so ten branches stay legible side by side.
+#[test]
+fn a_long_title_is_clipped_in_the_chart() {
+    let root = repo_root();
+    let mut long = pr(9, &[FLAGSHIP]);
+    long.title = "a".repeat(80);
+    let body = render(&root, &[long]);
+    let line = body
+        .lines()
+        .find(|l| l.trim_start().starts_with("commit id: \"#9"))
+        .expect("the commit line rendered");
+    assert!(line.contains('…'), "clip is visible: {line}");
+    assert!(line.len() < 60, "clipped, not 80 chars wide: {line}");
+}
+
+// ---------------------------------------------------------------------------
+// Next steps
+// ---------------------------------------------------------------------------
+
+/// ★ The section is dynamic across a merge: while both PRs are open, the head
+/// of the order is the recommendation; once one merges, the survivor is
+/// flagged for re-gating because its baseline moved.
+#[test]
+fn next_steps_change_when_a_partner_merges() {
+    let root = repo_root();
+    let before = render(&root, &[pr(1, &[FLAGSHIP]), pr(2, &[FLAGSHIP])]);
+    assert!(before.contains("**Merge next: #1**"), "{before}");
+    assert!(
+        !before.contains("Re-gate before merging"),
+        "nothing merged yet, nothing to re-gate: {before}"
+    );
+
+    let mut merged = pr(2, &[FLAGSHIP]);
+    merged.merged = true;
+    let after = render(&root, &[pr(1, &[FLAGSHIP]), merged]);
+    assert!(after.contains("**Merge next: #1**"), "{after}");
+    assert!(
+        after.contains("Re-gate before merging:** #1"),
+        "the merged partner moved #1's baseline: {after}"
+    );
+}
+
+/// A merged PR that shipped without a promotion-candidate gate is a concrete
+/// next action, and the section says so.
+#[test]
+fn next_steps_surface_merged_promotion_debt() {
+    let root = repo_root();
+    let mut merged = pr(7, &["crates/spark-server/src/scheduler/mod.rs"]);
+    merged.merged = true;
+    let body = render(&root, &[pr(1, &[FLAGSHIP]), merged]);
+    assert!(
+        body.contains("Discharge promotion debt:** merged #7"),
+        "the merged debtor must be named: {body}"
+    );
+}
+
+/// ★ Honesty clause: the section must state what its inputs cannot see, so a
+/// reader never mistakes "derived from paths" for "checked CI".
+#[test]
+fn next_steps_admit_what_they_cannot_know() {
+    let root = repo_root();
+    let body = render(&root, &[pr(1, &[FLAGSHIP])]);
+    assert!(
+        body.contains("cannot") && body.contains("required-context"),
+        "the limits must be printed: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The shared bound reaches the table cells
+// ---------------------------------------------------------------------------
+
+/// ★ The same X bounds every per-PR list: a cell with two hundred refs is as
+/// unreadable as a two-hundred-node chart.
+#[test]
+fn cap_prs_caps_at_the_bound_and_discloses_the_rest() {
+    let numbers: Vec<u64> = (1..=12).collect();
+    let capped = cap_prs(&numbers);
+    assert_eq!(capped.matches('#').count(), CHART_PR_BOUND);
+    assert!(capped.ends_with("… +2 more"), "{capped}");
+    assert_eq!(cap_prs(&[1, 2]), "#1, #2", "no noise under the bound");
+}
+
+/// The target table's cells go through the cap, so a shared-kernel storm
+/// cannot turn the table into a wall of refs.
+#[test]
+fn target_table_cells_are_bounded() {
+    let root = repo_root();
+    let prs: Vec<PrFacts> = (101..=112).map(|n| pr(n, &[FLAGSHIP])).collect();
+    let body = render(&root, &prs);
+    let row = body
+        .lines()
+        .find(|l| l.starts_with("| `gb10/qwen3.6-27b/nvfp4` |"))
+        .expect("the flagship target row rendered");
+    assert!(row.contains("+2 more"), "cell capped and disclosed: {row}");
+    assert_eq!(row.matches('#').count(), CHART_PR_BOUND, "{row}");
+}

--- a/crates/atlas-plugin/src/gate/telemetry_tests.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_tests.rs
@@ -211,15 +211,15 @@ fn a_draft_is_marked_as_one() {
     assert!(render(&root, &[facts]).contains("#5 (draft)"));
 }
 
-/// The mermaid block must be well-formed even for a single PR, where there is
-/// no edge to draw.
+/// The mermaid block must be well-formed even for a single PR: a mainline,
+/// exactly one branch, merged back once.
 #[test]
 fn the_mermaid_graph_is_valid_with_one_pr() {
     let root = repo_root();
     let body = render(&root, &[pr(1, &[FLAGSHIP])]);
-    assert!(body.contains("```mermaid\ngraph LR\n"));
-    assert!(body.contains("pr1["));
-    assert!(!body.contains("--> pr1"), "no edge into the only node");
+    assert!(body.contains("```mermaid\ngitGraph\n  commit id: \"main\"\n"));
+    assert_eq!(body.matches("branch pr-1\n").count(), 1);
+    assert_eq!(body.matches("merge pr-1\n").count(), 1);
 }
 
 /// ★ The debt section is rendered even when nothing is owed — that is the


### PR DESCRIPTION
The cross-PR telemetry comment led with tables and buried its one chart at the bottom — a `graph LR` chain with a node for every PR in the feed, merged ones included. Past a couple dozen PRs that's not a chart, it's noise that renders.

## What changed

**The chart leads, and it's a gitGraph now.** `main` is a real line, each recommended PR is a branch off it, merged back left-to-right in the recommended order. That's what the picture was always trying to say; `graph LR` was a list wearing a diagram costume.

**One bound for everything.** `CHART_PR_BOUND = 10` (named constant, rationale in the comment: past ten branches GitHub scales the SVG below legibility, which recreates the unreadable-chart defect the bound exists to prevent). The same constant bounds the chart, the next-steps list, and every per-PR table cell. Truncation is never silent: the caption always says "Showing N of M open PRs" and names what wasn't charted; capped cells say "+k more".

**The order is derivable and printed with the chart:** fewest conflict partners first (a partner shares a gate target; a whole-repo diff contends with every gated PR), then fewest targets re-opened, then smallest diff, then lowest PR number. Merged and draft PRs are no longer ranked — the old order suggested merging already-merged PRs.

**"Recommended next steps"** — merge-next with its reason, who must re-gate because a merged PR moved their baseline, and merged promotion debt to discharge. The workflow now also triggers on `push: branches: [main]`, so the section refreshes the moment a merge lands instead of up to four hours later. The section prints its own limits: it cannot see check/required-context status, review state, true git mergeability, or PR-unblocks-PR dependencies.

**File cap:** telemetry.rs stays at 311 LoC by splitting the bounded renderings into `telemetry_order.rs` (`telemetry::order`, 241 LoC).

## Verification

- Generated gitGraph validated against the official mermaid parser (`@mermaid-js/parser`, the langium parser mermaid v11 itself uses): the bounded 10-branch chart and the single-PR chart both parse; a chart with an unescaped quote is rejected by the same parser — hence titles fold `"` to `'` (gitGraph has no escape sequence).
- 16 new tests + 1 updated, every behavior proven RED first by sabotage (bound removed, caption removed, chart demoted, partners dropped from the sort key, merged/draft filter dropped, quote folding removed, empty-order guard removed, cell cap removed, re-gate and honesty lines removed) — each fired its specific assert, then restored to green.
- `cargo fmt --all -- --check` clean, `clippy --workspace --tests` clean, `cargo test --workspace` 4070 passed / 0 failed.

## Gating

`crates/` is a perf path, so this needs a five-leg gate cycle before merge — none started. Good candidate to batch with other pending crates-only work in one cycle.