### PR TITLE
ci: merge-ancestry guard — fail PRs with no merge base (the #452 orphan class)

### DIFF
--- a/.github/workflows/merge-ancestry.yml
+++ b/.github/workflows/merge-ancestry.yml
@@ -1,0 +1,87 @@
+name: Merge ancestry
+
+# A PR can be MERGEABLE and still destroy work. GitHub computes mergeability
+# over TREES, not ancestry: PR #452's head was an ORPHAN — its first commit a
+# repository root carrying a full tree snapshotted before PR #450 merged — so
+# `git merge-base` found nothing, yet the PR displayed mergeable. Squash-
+# merging it would have applied a diff that silently reverted five PRs of
+# engine work, with nothing in the PR UI saying so. It was caught only because
+# a manual `git merge origin/main` refused with "unrelated histories" and that
+# refusal was diagnosed instead of overridden. `strict: true` also blocked it,
+# but only as a side effect (an orphan can never compute as up-to-date), not
+# as a deliberate check. This workflow makes the refusal deliberate and loud.
+#
+# Not a hypothetical here even beyond #452: this repo's history was re-rooted
+# at "Open Source Release", so pre-release branches (e.g. ci/docs-paths-filter,
+# merged as PR #11) genuinely share no ancestor with today's main.
+#
+# Verdicts (logic + rationale live in scripts/check_merge_ancestry.sh, which
+# is unit-tested by scripts/check_merge_ancestry_test.sh — the self-test job):
+#   FAIL  no merge base — head is unrelated to base (the #452 class).
+#   WARN  merely behind — normal for nearly every open PR; `strict: true`
+#         already forces an update before merge, so failing would be noise.
+#   WARN  revert signature — the PR rewinds files to pre-merge-base contents
+#         (a stale snapshot WITH ancestry: mergeable, conflict-free, and it
+#         reverts silently). WARN not FAIL because deliberate revert PRs are
+#         legitimate; the point is that a reviewer sees it in the checks log.
+#
+# Deliberately NOT in the required status checks yet: promoting a brand-new
+# context to required before it has reported on the ~28 open PRs would block
+# the entire queue. Promotion is a follow-up once it has run everywhere.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  # Manually runnable (2026-08-06 Actions-incident lesson, as in ci.yml): a
+  # dispatch run exercises the self-test job; the guard itself needs a PR
+  # context and re-runs from the PR's checks tab or on push.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: PR shares history with its base
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # merge-base needs the FULL commit graph: a shallow clone cannot
+          # distinguish "no common ancestor" from "not deep enough", and a
+          # targeted deepen loop never terminates against a genuine orphan —
+          # only a full graph can PROVE the base is missing. fetch-depth: 0
+          # stays cheap via blob:none (all commits and trees, no file
+          # contents; ancestry and blob-OID comparison never read contents)
+          # and a sparse checkout that materialises only scripts/.
+          fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: scripts
+
+      - name: Check merge ancestry
+        env:
+          # head.sha tracks the PR's latest push. base.sha in the payload is
+          # the base tip at PR CREATION and goes stale, so the base is
+          # resolved from the just-fetched origin/<base.ref> instead.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          BASE_SHA="$(git rev-parse "refs/remotes/origin/${BASE_REF}")"
+          bash scripts/check_merge_ancestry.sh "$BASE_SHA" "$HEAD_SHA" "$BASE_REF"
+
+  self-test:
+    name: Merge-ancestry guard self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Builds scratch repos from nothing (descendant / orphan / behind /
+      # rewind / bogus-sha), so the default shallow checkout is enough. Runs
+      # per-PR so a change to the guard script cannot land with the guard
+      # silently broken.
+      - name: Run guard unit tests
+        run: bash scripts/check_merge_ancestry_test.sh

--- a/scripts/check_merge_ancestry.sh
+++ b/scripts/check_merge_ancestry.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Merge-ancestry guard: refuse PRs whose head shares NO history with the base.
+#
+# Why this exists (PR #452, 2026-08-10): a branch whose first commit was a
+# fresh repository ROOT — a full tree snapshot with no parent — showed up as
+# `mergeable: MERGEABLE`, because GitHub computes mergeability over TREES,
+# not ancestry. The snapshot predated five merged PRs, so squash-merging it
+# would have applied a diff that silently reverted all of them. Nothing in
+# the PR UI said so. `git merge origin/main` refusing with "unrelated
+# histories" was the only tell. This script makes that refusal a deliberate,
+# per-PR, loud check instead of a side effect someone has to diagnose.
+#
+# Usage:
+#   check_merge_ancestry.sh <base_sha> <head_sha> [base_ref]
+#
+# base_ref is only used to render actionable remedy commands (defaults to
+# "main"). Both commits must already be present in the local object store —
+# this script performs NO network I/O; fetching is the caller's job.
+#
+# Exit codes:
+#   0  PASS (possibly with ::warning annotations)
+#   1  FAIL — no merge base: head is unrelated to base (the #452 class)
+#   2  usage / infrastructure error (missing args, commit not present)
+#
+# Env:
+#   ANCESTRY_HISTORY_CAP  How many base-side commits the revert-signature
+#                         scan walks. Default 2000: covers years of history
+#                         here (~a few thousand commits total) while bounding
+#                         worst-case runtime to a few seconds of local tree
+#                         diffs. Purely a scan bound, never a correctness gate.
+set -euo pipefail
+
+BASE_SHA="${1:-}"
+HEAD_SHA="${2:-}"
+BASE_REF="${3:-main}"
+HISTORY_CAP="${ANCESTRY_HISTORY_CAP:-2000}"
+
+if [[ -z "$BASE_SHA" || -z "$HEAD_SHA" ]]; then
+  echo "::error::usage: check_merge_ancestry.sh <base_sha> <head_sha> [base_ref]" >&2
+  exit 2
+fi
+
+for sha in "$BASE_SHA" "$HEAD_SHA"; do
+  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    echo "::error::commit $sha is not present locally — the caller must fetch full history (fetch-depth: 0) before running this check" >&2
+    exit 2
+  fi
+done
+
+# ── Case 1: no merge base — the #452 class. Hard FAIL. ─────────────────────
+# `git merge-base` exits non-zero and prints nothing when the two commits
+# share no ancestor. This is only trustworthy against a FULL commit graph:
+# a shallow clone cannot distinguish "no common ancestor" from "not deep
+# enough", which is why the workflow fetches with fetch-depth: 0.
+merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA" || true)"
+
+if [[ -z "$merge_base" ]]; then
+  short_base="${BASE_SHA:0:12}"
+  short_head="${HEAD_SHA:0:12}"
+  echo "::error::NO MERGE BASE between base $short_base and head $short_head — this branch shares no history with '$BASE_REF'. Merging it would silently revert work already on '$BASE_REF' (see PR #452). Rebuild the branch on the current '$BASE_REF' and re-apply the patch."
+  cat <<EOF
+
+  ✗ NO MERGE BASE: head $HEAD_SHA
+                   base $BASE_SHA ('$BASE_REF')
+
+  git merge-base found no common ancestor: this branch's history starts at
+  its own root commit (an orphan tree snapshot) instead of branching from
+  '$BASE_REF'. GitHub still reports the PR as MERGEABLE because it computes
+  mergeability over trees, not ancestry — but merging (squash included)
+  would apply the snapshot's stale tree against '$BASE_REF' and silently
+  revert every commit that landed after the snapshot was taken. That is
+  exactly what PR #452 would have done to five merged PRs.
+
+  Remedy (what fixed #452) — rebuild on the current base, re-apply the patch:
+
+    git fetch origin $BASE_REF
+    git switch -c my-fix-rebuilt origin/$BASE_REF
+    # re-apply each intended commit as a patch (cherry-pick cannot cross
+    # unrelated histories cleanly; the root commit IS the whole tree):
+    git diff ${short_head}^ $short_head | git apply -3
+    git add -A && git commit
+    git push --force-with-lease origin HEAD:<your-branch>
+
+  Do NOT "fix" this with \`git merge --allow-unrelated-histories\` — merging
+  the stale snapshot is precisely the destruction this check exists to stop.
+EOF
+  exit 1
+fi
+
+# ── Case 2a: merely behind — WARN only, never FAIL. ────────────────────────
+# Nearly every open PR is some commits behind main; with a real merge base a
+# 3-way (or squash) merge preserves base-side work, and branch protection's
+# `strict: true` already forces an update before merge. Failing here would
+# fire on the whole queue and teach people to ignore the check.
+behind="$(git rev-list --count "$merge_base..$BASE_SHA")"
+if [[ "$behind" -gt 0 ]]; then
+  echo "::warning::PR is $behind commit(s) behind its base '$BASE_REF' (merge base ${merge_base:0:12}). Not a failure — branch protection (strict: true) requires an update before merge."
+fi
+
+# ── Case 2b: revert signature — WARN loudly, listing the files. ────────────
+# The dangerous cousin of the orphan: a branch WITH ancestry whose diff
+# rewinds files to a pre-merge-base state (e.g. an old tree committed on top
+# of a current base — mergeable, conflict-free, and it reverts silently).
+# Detection: a file the PR modifies whose head-side blob is byte-identical
+# to a version that existed in the base's history BEFORE the merge base.
+# WARN rather than FAIL because deliberate revert PRs are legitimate; this
+# exists so a reviewer sees "this PR rewinds N files to old contents" in the
+# checks output instead of nothing at all. Blob comparison is by OID, so a
+# blobless (filter=blob:none) clone suffices — no file contents downloaded.
+reverted="$(
+  {
+    # Wanted set: paths the PR modifies, with their head-side blob OIDs.
+    git diff --raw --no-abbrev --no-renames "$merge_base" "$HEAD_SHA"
+    echo "== HISTORY =="
+    # Base-side history: every (path, blob) pair that ever appeared in the
+    # last $HISTORY_CAP commits reachable from the merge base, both sides
+    # of each change so pre-images count too.
+    git log --format='%H' --raw --no-abbrev --no-renames \
+      --max-count="$HISTORY_CAP" "$merge_base"
+  } | awk '
+    /^== HISTORY ==$/ { in_history = 1; next }
+    /^:/ {
+      # :oldmode newmode oldoid newoid status<TAB>path
+      split($0, halves, "\t"); path = halves[2]
+      if (!in_history) {
+        if ($5 == "M") want[path] = $4          # head-side blob OID
+      } else {
+        if ($3 !~ /^0+$/) seen[path "\t" $3] = 1
+        if ($4 !~ /^0+$/) seen[path "\t" $4] = 1
+      }
+    }
+    END {
+      for (path in want)
+        if (seen[path "\t" want[path]]) print path
+    }
+  ' | sort
+)"
+
+if [[ -n "$reverted" ]]; then
+  count="$(wc -l <<<"$reverted")"
+  echo "::warning::REVERT SIGNATURE: this PR rewinds $count file(s) to contents that predate its merge base ${merge_base:0:12} — if that is not a deliberate revert, the branch was built from a stale snapshot of '$BASE_REF'."
+  echo ""
+  echo "  Files reverted to pre-merge-base contents (first 20):"
+  head -n 20 <<<"$reverted" | sed 's/^/    /'
+fi
+
+echo ""
+echo "✓ merge-ancestry: base ${BASE_SHA:0:12} and head ${HEAD_SHA:0:12} share merge base ${merge_base:0:12}."

--- a/scripts/check_merge_ancestry_test.sh
+++ b/scripts/check_merge_ancestry_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Unit tests for scripts/check_merge_ancestry.sh, run against scratch repos
+# built from nothing — no network, no dependence on this repository's own
+# history. Each case reproduces a real PR shape:
+#
+#   (a) normal descendant branch                  -> PASS, no warnings
+#   (b) orphan snapshot branch (the PR #452 shape:
+#       root commit carrying a full stale tree)   -> FAIL exit 1, NO MERGE BASE
+#   (c) merely-behind branch                      -> PASS with behind ::warning
+#   (d) branch that rewinds a file to a
+#       pre-merge-base version                    -> PASS with revert ::warning
+#   (e) bogus sha                                 -> exit 2 (infra error)
+#
+# CI runs this on every PR (see .github/workflows/merge-ancestry.yml) so a
+# change to the guard script cannot land with the guard silently broken.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/check_merge_ancestry.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+asserts=0
+fail() { echo "ASSERT FAILED [$1]: $2" >&2; exit 1; }
+ok() { asserts=$((asserts + 1)); echo "  ok [$1] $2"; }
+
+# ── Fixture repo: main = root A -> B -> C ("engine work") ──────────────────
+repo="$tmp/repo"
+git init -q -b main "$repo"
+cd "$repo"
+git config user.name "Test"
+git config user.email "test@example.com"
+git config commit.gpgsign false
+
+printf 'engine v1\n' > engine.rs
+printf 'lib v1\n' > lib.rs
+git add -A && git commit -qm "A: root"
+sha_a="$(git rev-parse HEAD)"
+
+printf 'engine v2\n' > engine.rs
+git commit -qam "B: engine work 1"
+sha_b="$(git rev-parse HEAD)"
+
+printf 'engine v3\n' > engine.rs
+printf 'lib v2\n' > lib.rs
+git commit -qam "C: engine work 2"
+sha_c="$(git rev-parse HEAD)"
+
+run() { # run <base> <head>; sets rc + out
+  set +e
+  out="$("$SCRIPT" "$1" "$2" main 2>&1)"
+  rc=$?
+  set -e
+}
+
+# ── (a) normal descendant branch off current base tip -> PASS, quiet ───────
+git checkout -qb feat "$sha_c"
+printf 'feature\n' > feature.rs
+git add -A && git commit -qm "feat: new work"
+head_feat="$(git rev-parse HEAD)"
+
+run "$sha_c" "$head_feat"
+[[ $rc -eq 0 ]] || fail a "descendant branch: expected exit 0, got $rc: $out"
+grep -q '✓ merge-ancestry' <<<"$out" || fail a "missing PASS marker: $out"
+grep -q 'NO MERGE BASE' <<<"$out" && fail a "spurious NO MERGE BASE: $out"
+grep -q 'behind its base' <<<"$out" && fail a "spurious behind-warning: $out"
+grep -q 'REVERT SIGNATURE' <<<"$out" && fail a "spurious revert-warning: $out"
+ok a "descendant branch passes cleanly"
+
+# ── (b) orphan snapshot: the exact #452 shape ──────────────────────────────
+# Two commits; the FIRST is a repository root carrying the full tree as it
+# stood at B (i.e. snapshotted before C landed). No ancestry with main.
+git checkout -q "$sha_b"
+git checkout -q --orphan snapshot452   # index/worktree = B's tree, no parent
+git commit -qm "snapshot root (stale tree of B)"
+printf 'the intended fix\n' > fix.rs
+git add -A && git commit -qm "intended fix"
+head_orphan="$(git rev-parse HEAD)"
+git merge-base "$sha_c" "$head_orphan" >/dev/null 2>&1 \
+  && fail b "fixture broken: orphan unexpectedly shares history with main"
+
+run "$sha_c" "$head_orphan"
+[[ $rc -eq 1 ]] || fail b "orphan branch: expected exit 1, got $rc: $out"
+grep -q 'NO MERGE BASE' <<<"$out" || fail b "missing NO MERGE BASE: $out"
+grep -q "$sha_c" <<<"$out" || fail b "message must name the base sha: $out"
+grep -q "$head_orphan" <<<"$out" || fail b "message must name the head sha: $out"
+grep -q 'force-with-lease' <<<"$out" || fail b "message must carry the remedy: $out"
+grep -q 'allow-unrelated-histories' <<<"$out" || fail b "message must warn against --allow-unrelated-histories: $out"
+ok b "orphan snapshot fails with NO MERGE BASE + shas + remedy"
+
+# ── (c) merely-behind branch -> PASS with a behind ::warning ───────────────
+git checkout -qb behind "$sha_b"       # branched before C
+printf 'late feature\n' > late.rs
+git add -A && git commit -qm "behind: new work"
+head_behind="$(git rev-parse HEAD)"
+
+run "$sha_c" "$head_behind"
+[[ $rc -eq 0 ]] || fail c "behind branch: expected exit 0 (WARN not FAIL), got $rc: $out"
+grep -q '::warning::PR is 1 commit(s) behind its base' <<<"$out" \
+  || fail c "missing behind-warning: $out"
+grep -q '✓ merge-ancestry' <<<"$out" || fail c "missing PASS marker: $out"
+ok c "merely-behind branch warns (1 commit) and passes"
+
+# ── (d) revert signature: file rewound to a pre-merge-base version ─────────
+git checkout -qb rewind "$sha_c"
+printf 'engine v1\n' > engine.rs       # byte-identical to engine.rs at A
+git commit -qam "rewind engine.rs to v1"
+head_rewind="$(git rev-parse HEAD)"
+
+run "$sha_c" "$head_rewind"
+[[ $rc -eq 0 ]] || fail d "rewind branch: expected exit 0 (WARN not FAIL), got $rc: $out"
+grep -q '::warning::REVERT SIGNATURE' <<<"$out" || fail d "missing revert-warning: $out"
+grep -q 'engine.rs' <<<"$out" || fail d "revert-warning must list the file: $out"
+ok d "pre-merge-base rewind warns and lists engine.rs"
+
+# ── (e) missing commit -> exit 2 infra error, never a silent pass ──────────
+run "$sha_c" "0000000000000000000000000000000000000001"
+[[ $rc -eq 2 ]] || fail e "bogus head sha: expected exit 2, got $rc: $out"
+grep -q 'not present locally' <<<"$out" || fail e "missing infra-error message: $out"
+ok e "missing commit is an infra error (exit 2)"
+
+echo ""
+echo "ALL $asserts assert groups passed."


### PR DESCRIPTION
## What

A per-PR CI guard for the class of PR that GitHub reports as `mergeable: MERGEABLE` but which would silently destroy work — the #452 incident. #452's branch head was an orphan: two commits, the first a repository root carrying a full tree snapshotted before #450 merged. `git merge-base` found nothing, GitHub still said MERGEABLE (it diffs trees, not ancestry), and squash-merging would have reverted five PRs of engine work with nothing in the UI saying so. It was caught only because a manual `git merge origin/main` refused with "refusing to merge unrelated histories" and that got diagnosed instead of overridden. `strict: true` blocked it too, but only as a side effect. This makes the refusal deliberate, per-PR, and loud.

Not hypothetical beyond #452 either: our history was re-rooted at "Open Source Release", so pre-release branches genuinely share no ancestor with today's main — `ci/docs-paths-filter` (merged back then as #11) trips the check today, which is how I validated it against real history.

## Pieces

- `.github/workflows/merge-ancestry.yml` — two jobs: **`PR shares history with its base`** (the guard) and **`Merge-ancestry guard self-test`** (runs the unit tests per PR so the guard can't be broken silently).
- `scripts/check_merge_ancestry.sh` — all the logic, extracted to a script precisely so it's unit-testable instead of inline YAML shell. No network; exit 0 pass / 1 no-merge-base / 2 infra.
- `scripts/check_merge_ancestry_test.sh` — scratch-repo tests: descendant, orphan (#452 shape: root commit carrying a stale full tree), merely-behind, pre-merge-base rewind, bogus sha.

## FAIL vs WARN — what I decided and why

- **No merge base → FAIL.** Unambiguous; there are zero legitimate instances of a PR with no common ancestor. The failure prints both shas and the remedy that actually fixed #452 (rebuild on current main, `git diff head^ head | git apply -3`, force-with-lease), and explicitly warns against "fixing" it with `--allow-unrelated-histories`.
- **Merely behind (commits reachable from base but not from the merge base) → WARN, never FAIL.** With a real merge base, a 3-way/squash merge *preserves* base-side work — being behind doesn't revert anything by itself. Nearly every one of the ~28 open PRs is behind; failing here would fire on the whole queue, and `strict: true` already forces an update before merge. A check that's red on everything is a check people learn to ignore.
- **The reframed case — "the diff reverts files it never touched" → WARN with a file list.** This is the dangerous cousin the behind-count completely misses: an old tree committed *on top of* current main has a merge base (main itself), is conflict-free, shows 0 behind — and reverts everything silently. Detection: any file the PR modifies whose head-side blob is byte-identical to a version that existed in base history *before* the merge base. It's a WARN, not a FAIL, because deliberate revert PRs are legitimate and "never touched" is intent, which isn't mechanically decidable — the point is a reviewer sees "this PR rewinds N files to old contents" in the checks output instead of nothing. Blob comparison is by OID only, so it costs no content downloads.

## Fetch depth

`fetch-depth: 0` + `filter: blob:none` + `sparse-checkout: scripts`. Full history is not optional: a shallow clone can't distinguish "no common ancestor" from "not deep enough", and a targeted deepen loop **never terminates against a genuine orphan** — only the full commit graph can *prove* the merge base is absent. `blob:none` keeps that cheap (all commits + trees, no file contents; nothing in the check reads contents). Measured in a real blobless clone of this repo: the whole check runs in ~50 ms, including the revert scan over a 108-behind branch with a large diff.

## Test evidence (each case proven RED first)

Every case was broken deliberately, confirmed red with the *specific* assert firing, restored (md5-identical), and confirmed green:

| break | assert that fired |
|---|---|
| no-merge-base branch made to `exit 0` (the world without this guard) | `ASSERT FAILED [b]: orphan branch: expected exit 1, got 0` |
| guard made to always exit 1 (over-strict) | `ASSERT FAILED [a]: descendant branch: expected exit 0, got 1` |
| behind-warning text broken | `ASSERT FAILED [c]: missing behind-warning` |
| revert-signature warning disabled | `ASSERT FAILED [d]: missing revert-warning` |
| commit-existence check removed | `ASSERT FAILED [e]: bogus head sha: expected exit 2, got 1` |

Restored suite: `ALL 5 assert groups passed.` The self-test job re-runs this suite on every PR.

## Deliberately NOT in required status checks

Making a context required before it has ever reported on the ~28 open PRs would mark them all "expected — waiting for status" and block the queue. Promote it as a follow-up once it has run across the open PRs:

```
gh api -X POST repos/Avarok-Cybersecurity/atlas/branches/main/protection/required_status_checks/contexts \
  -f "contexts[]=PR shares history with its base"
```

(Optionally also `-f "contexts[]=Merge-ancestry guard self-test"`.)
