### PR TITLE
site: make the serve-matrix receipt read as a control at rest

### DIFF
--- a/site/src/lib/components/Hero.svelte
+++ b/site/src/lib/components/Hero.svelte
@@ -80,8 +80,12 @@
         aria-haspopup="dialog"
         aria-label="Open the benchmark dashboard"
       >
+        <span class="receipt-chip" aria-hidden="true">⤢ expand</span>
         <Receipt compact={true} />
-        <span class="receipt-open-hint">benchmark dashboard →</span>
+        <span class="receipt-open-hint">
+          <span class="rh-glyph" aria-hidden="true">⤢</span>
+          view the benchmark dashboard
+        </span>
       </button>
     </div>
   </div>

--- a/site/src/styles/dashboard.css
+++ b/site/src/styles/dashboard.css
@@ -6,17 +6,66 @@
    Viewport rules for these components live in mobile.css (its stated SSOT).
    ========================================================================== */
 
-/* ---- hero trigger --------------------------------------------------------- */
+/* ---- hero trigger ---------------------------------------------------------
+   The receipt opens the dashboard, so it must READ as a control at rest —
+   hover-only affordance was invisible to anyone who never hovered it. Three
+   at-rest cues: a corner chip, a standing copper ring, and a real button pill.
+   -------------------------------------------------------------------------- */
+/* The button must track the receipt's own width (app.css `.receipt`, and the
+   per-breakpoint overrides in mobile.css) — otherwise the corner chip anchors
+   to empty grid track beside the receipt instead of to its corner. */
 .receipt-hit {
-  display: block; width: 100%; background: none; border: 0; padding: 0;
+  display: block; width: 100%; max-width: 460px;
+  background: none; border: 0; padding: 0;
   cursor: pointer; text-align: inherit; font: inherit; color: inherit;
+  position: relative;
 }
-.receipt-hit:hover .receipt { box-shadow: var(--shadow-lg), 0 0 0 2px var(--accent-soft); }
+/* Ring is present at REST (1px), not only on hover. */
+.receipt-hit .receipt {
+  box-shadow: var(--shadow-lg), 0 0 0 1.5px rgba(181, 98, 47, 0.38);
+  transition: box-shadow 0.16s ease, transform 0.16s ease;
+}
+.receipt-hit:hover .receipt,
+.receipt-hit:focus-visible .receipt {
+  box-shadow: var(--shadow-lg), 0 0 0 2.5px var(--accent); transform: translateY(-2px);
+}
+.receipt-hit:focus-visible { outline: none; }
+
+/* Corner chip — sits on the receipt's top-right corner, outside its clip. */
+.receipt-chip {
+  position: absolute; top: -0.55rem; right: -0.4rem; z-index: 2;
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  padding: 0.24rem 0.55rem; border-radius: 999px;
+  background: var(--accent); color: #fff;
+  font-family: var(--font-mono); font-size: 0.62rem; font-weight: 800;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  box-shadow: var(--shadow-sm); transition: background 0.16s ease;
+}
+.receipt-hit:hover .receipt-chip,
+.receipt-hit:focus-visible .receipt-chip { background: var(--accent-deep); }
+
+/* Hint reads as a button, not a caption. */
 .receipt-open-hint {
-  display: inline-block; margin-top: 0.6rem; font-family: var(--font-mono);
-  font-size: 0.74rem; font-weight: 700; letter-spacing: 0.08em; color: var(--accent);
+  display: inline-flex; align-items: center; gap: 0.4rem; margin-top: 0.85rem;
+  padding: 0.42rem 0.85rem; border: 1.5px solid var(--accent);
+  border-radius: 8px; background: var(--accent-soft);
+  font-family: var(--font-mono); font-size: 0.74rem; font-weight: 700;
+  letter-spacing: 0.06em; color: var(--accent-deep);
+  transition: background 0.16s ease, color 0.16s ease;
 }
-.receipt-hit:hover .receipt-open-hint { color: var(--accent-deep); text-decoration: underline; }
+.receipt-open-hint .rh-glyph { font-size: 0.85rem; line-height: 1; }
+.receipt-hit:hover .receipt-open-hint,
+.receipt-hit:focus-visible .receipt-open-hint { background: var(--accent); color: #fff; }
+
+/* One-shot attention cue after the receipt finishes "printing". Motion only —
+   every cue above is legible with animation disabled. */
+@media (prefers-reduced-motion: no-preference) {
+  .receipt-chip { animation: chip-cue 1.1s ease-out 0.9s 2 both; }
+}
+@keyframes chip-cue {
+  0%, 100% { transform: scale(1); }
+  35% { transform: scale(1.09); }
+}
 
 /* ---- modal shell ---------------------------------------------------------- */
 .bd-backdrop {

--- a/site/src/styles/mobile.css
+++ b/site/src/styles/mobile.css
@@ -129,7 +129,8 @@ img, svg, video { max-width: 100%; }
   .proof-item { font-size: 0.86rem; }
 
   /* cards and instruments */
-  .verified-grid .receipt, .hero-receipt .receipt { max-width: none; }
+  /* .receipt-hit tracks its receipt so the corner chip stays on the corner. */
+  .verified-grid .receipt, .hero-receipt .receipt, .hero-receipt .receipt-hit { max-width: none; }
   .hw-card { padding: 1.5rem 1.35rem; }
   .news-card, .reach-card, .road-card, .contrib-card { padding: 1.35rem 1.3rem; }
   .method-card { padding: 1.25rem 1.3rem; }


### PR DESCRIPTION
The receipt in the hero opens the benchmark dashboard, but at rest it looked like a static figure — the only affordances were a hover ring and a caption-styled hint. You had to already suspect it was clickable to find out that it was.

### What changes

Three cues that are present **without hovering**:

| cue | before | after |
|---|---|---|
| corner chip | — | copper `⤢ expand` pill on the receipt's top-right corner |
| ring | hover only | standing 1.5px copper ring; hover/focus strengthens it and lifts the card |
| hint line | caption text `benchmark dashboard →` | real button pill `⤢ view the benchmark dashboard`, bordered + tinted; fills on hover/focus |

The chip carries a one-shot scale cue after the receipt's existing print-in animation, guarded by `prefers-reduced-motion: no-preference`. Every cue above is legible with animation disabled — the motion is an accent, not the affordance.

`.receipt-hit` now tracks the receipt's own width (460px, plus the `mobile.css` per-breakpoint override) instead of filling the grid track, so the corner chip anchors to the receipt's corner rather than to empty space beside it.

### Scope

Interactive chrome stays in the `Hero` wrapper — `Receipt.svelte` is also rendered non-interactively by `Verified.svelte` and is not forked. Keyboard path unchanged: `:focus-visible` gets the same treatment as hover, and the decorative glyphs are `aria-hidden` so the button's `aria-label` still reads "Open the benchmark dashboard".

### Verification

- `bun run build` green (Node 20).
- Screenshotted at 1440x900 and 760x1450 with animations disabled: all three cues visible at rest, chip lands on the corner at both widths, no layout shift.