### PR TITLE
Batch A: concurrency curve to C=32 + gate candidacy, MoE width gate, #435 scope, cargo-deny cleanup

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-11-e773eb913b.json
+++ b/.benchmarks/agentic-webserver/2026-08-11-e773eb913b.json
@@ -1,0 +1,273 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "e773eb913b",
+  "recorded_at": 1786443827,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1000"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1000",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 847.565055532,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 848s ≤ 1000s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=847.57, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 848s ≤ 1000s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "b1552efe23b0ec06b66490c380ac98579ea9c0c3e60d94fefd4883f91354afee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "5b22e84e174840275b32ab7780baf0fa5afda9b4a523aadea9a304a544159b20",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "6bc7af10860cac65cdb95f73de59b07aa67bd647ad54514109aa6bfc783c1275",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-11-e773eb913b.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-11-e773eb913b.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "e773eb913b",
+  "recorded_at": 1786459197,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.63,
+    "overall_accuracy": 86.35,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.35 (floor 83.64) · normalized 86.63 (floor 85.32) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.63, overall_accuracy=86.35, samples=1004.00 · Pass: overall 86.35 (floor 83.64) · normalized 86.63 (floor 85.32) · n=1004",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "b1552efe23b0ec06b66490c380ac98579ea9c0c3e60d94fefd4883f91354afee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "5b22e84e174840275b32ab7780baf0fa5afda9b4a523aadea9a304a544159b20",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "6bc7af10860cac65cdb95f73de59b07aa67bd647ad54514109aa6bfc783c1275",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-11-e773eb913b.json
+++ b/.benchmarks/bfcl-subset/2026-08-11-e773eb913b.json
@@ -1,0 +1,262 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "e773eb913b",
+  "recorded_at": 1786449101,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.59,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.59, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.59 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "b1552efe23b0ec06b66490c380ac98579ea9c0c3e60d94fefd4883f91354afee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "5b22e84e174840275b32ab7780baf0fa5afda9b4a523aadea9a304a544159b20",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "6bc7af10860cac65cdb95f73de59b07aa67bd647ad54514109aa6bfc783c1275",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-11-e773eb913b.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-11-e773eb913b.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "e773eb913b",
+  "recorded_at": 1786444393,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1657.595929,
+    "p90_ms": 4524.677018,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 +0.4% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1657.60, p90_ms=4524.68, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 +0.4% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "b1552efe23b0ec06b66490c380ac98579ea9c0c3e60d94fefd4883f91354afee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "5b22e84e174840275b32ab7780baf0fa5afda9b4a523aadea9a304a544159b20",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "6bc7af10860cac65cdb95f73de59b07aa67bd647ad54514109aa6bfc783c1275",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-11-e773eb913b.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-11-e773eb913b.json
@@ -1,0 +1,259 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "e773eb913b",
+  "recorded_at": 1786444090,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1580.955419,
+    "p90_ms": 4501.46645,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 +0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1580.96, p90_ms=4501.47, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 +0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "8e0f2a47d5fc0915c3a70187bd2d978e65d1462d0416e3f4aebf7f041d465f69",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "865e73c260a187b329e6fb359961a67cfdad789060e8a6c40ee4803c1538c88a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "3f6fd5ba400db9ee1da6298c1c0f63517c5b4844afebf3d28e2b484717cf0305",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "564a10ad397db89788b499ac3be3aa73b3e54fb770a453cb8516fc565664a60a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3d70ea1aeb59195dd1fb055a07f3e23024256f48d6acca93345308b8c4e5de7d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "ee6456d676d9a557ec801d055ef552643f04073e1b5c7a9b93f572c876b8b896",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "ccdfa93335c650b5c5b9ce6cdea73c229c7aa64f2bdf1894b7e7d29d0feadd98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "2643f804a74d6088200b24c62fcae72d5aa7cc7ab5a8f29dcb8374a4582d84d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "b1552efe23b0ec06b66490c380ac98579ea9c0c3e60d94fefd4883f91354afee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "5b22e84e174840275b32ab7780baf0fa5afda9b4a523aadea9a304a544159b20",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "6bc7af10860cac65cdb95f73de59b07aa67bd647ad54514109aa6bfc783c1275",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2f7e8360eabe718142fc1f5fdf0f791ad1cc876b5fa25efe252ee05fcb7fd44a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "dd3b6b5dcbd6eacb37562f097c744783c648cee272a61e01d8021a5578894113",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "56a153ab066ad0e13f328ba06e74fd8c63dee1c7e613a6421d84b2d4790c5b39",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "41baf5e72f52c8477cffd11da33512ff743023f25a275da25d4710512bf4de6f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aab0a90227718a0917359e47b484f7441cf9d101791acd82ef0e2adf666c0d5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "639ab6356c42fde4239b89d45d956a97c51c59180eae041b138de0583e485885",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "19777839475772bcd23cf526321f9ee6a787ed53e9a6421d796c943030a276ff",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "22b34ee22a9fe2b07cd8c58b3fd23fa2ac7eb31ba0a6aa14442f2958a366f629",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "e8aafbbe8dbcc9b0c14bc70a8f9d85f645c46d50e3605f55d8b290ad05308675",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "f91fdafdc2b40b17aece49212c979496770ad4b1b0ed27498dc24ac009cfe8ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ed551e4b33c9be27433e4a255f7014e44b1485932388182d8b9c92c0865e1933",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/crates/atlas-plugin/src/benchmarks/concurrency.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency.rs
@@ -24,7 +24,7 @@ use crate::result::{
     BenchmarkResult, Cell, CellStyle, Column, LogLine, ResultTable, RunStatus, Stat, Verdict,
 };
 
-const SUMMARY: &str = "Latency/throughput curve across concurrency 1 → 16";
+const SUMMARY: &str = "Latency/throughput curve across concurrency 1 → 32";
 pub const METADATA: PluginMetadata = PluginMetadata::atlas(SUMMARY);
 
 pub const DESCRIPTOR: BenchmarkDescriptor = BenchmarkDescriptor {
@@ -34,9 +34,10 @@ pub const DESCRIPTOR: BenchmarkDescriptor = BenchmarkDescriptor {
     detail: "Fires N concurrent streaming requests per (input-length × concurrency) cell and \
              reports client TTFT, TPOT and end-to-end latency as p50/p90/p99, plus the batch's \
              aggregate output throughput. This is the curve the GB10 concurrency campaign is \
-             measured on — C=1 is where Atlas leads, C=16 is the bar.",
-    duration_hint: "~10–30 min",
-    updated: "2026-07-31",
+             measured on — C=1 is where Atlas leads, C=16 is the bar, and C=32 is where \
+             time-to-answer starts inverting in Atlas's favour.",
+    duration_hint: "~15–45 min",
+    updated: "2026-08-11",
     needs_confirmation: false,
     // A latency/throughput curve is meaningful for any served model; there is
     // no threshold here tied to a checkpoint.
@@ -256,7 +257,13 @@ impl Benchmark for ConcurrencySweep {
                 "Concurrency levels",
                 "How many requests are in flight at once, one sweep column each.",
                 ParamKind::IntList { min: 1, max: 256 },
-                ParamValue::IntList(vec![1, 2, 4, 8, 16]),
+                // 32 is the top rung on purpose: it is where the campaign
+                // measured time-to-answer INVERTING in Atlas's favour (C=32
+                // -4.47% vs vLLM, C=128 -10.84%), so a sweep that stops at 16
+                // reports the regime where Atlas trails and omits the one
+                // where it wins. C=64/128 are deliberately NOT default — they
+                // need bs=64 preflight headroom that not every recipe has.
+                ParamValue::IntList(vec![1, 2, 4, 8, 16, 32]),
             ),
             ParamSpec::new(
                 "isls",
@@ -427,8 +434,27 @@ mod tests {
     fn defaults_are_the_campaign_sweep() {
         let b = ConcurrencySweep::default();
         let v = ParamValues::defaults(&b.parameters());
-        assert_eq!(v.int_list("concurrencies").unwrap(), &[1, 2, 4, 8, 16]);
+        // The PARAM DEFAULTS are what actually runs — `configure()` rebuilds
+        // from these, so a descriptor blurb saying "1 → 32" proves nothing on
+        // its own. This assertion is the only thing that pins the sweep.
+        assert_eq!(v.int_list("concurrencies").unwrap(), &[1, 2, 4, 8, 16, 32]);
         assert_eq!(v.usize("osl").unwrap(), 128);
+    }
+
+    /// The top rung must be 32: below it the sweep only covers the regime
+    /// where Atlas trails vLLM, and omits the C=32 inversion that is the
+    /// point of running the curve at all.
+    #[test]
+    fn the_sweep_reaches_the_inversion_rung() {
+        let b = ConcurrencySweep::default();
+        let v = ParamValues::defaults(&b.parameters());
+        let cs = v.int_list("concurrencies").unwrap();
+        assert!(
+            cs.contains(&32),
+            "C=32 missing from the default sweep ({cs:?}) — that is the rung where \
+             time-to-answer inverts (-4.47% vs vLLM); a curve that stops at 16 \
+             reports only the losing regime"
+        );
     }
 
     #[test]

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -231,6 +231,37 @@ const AGENTIC_EXCLUDES: &[Exclusion] = &[
 /// OTHER benchmark drivers, exactly as a required gate would. Its own driver
 /// directory is deliberately NOT here — a change to the detector re-opens the
 /// detector.
+/// The concurrency curve is a LATENCY/THROUGHPUT measurement of the serving
+/// path, so almost nothing is excusable: scheduler, kernels, batching, KV and
+/// sampling all move it. Only the other benchmark DRIVERS are — a driver is
+/// client-side request-issuing code that cannot change how fast the server
+/// answers someone else's requests.
+///
+/// Deliberately NOT excluded, though the TTFT gates exclude them: nothing in
+/// the engine. A change that costs 10% at C=32 while leaving C=1 flat is
+/// exactly the regression this curve exists to catch, and the TTFT gates
+/// measure a single request — they cannot see it.
+const CONCURRENCY_EXCLUDES: &[Exclusion] = &[
+    GATE_MACHINERY,
+    other_driver(
+        "crates/atlas-plugin/src/benchmarks/bfcl",
+        "the BFCL driver cannot change the server's latency/throughput curve",
+    ),
+    other_driver(
+        "crates/atlas-plugin/src/benchmarks/agentic",
+        "the agentic driver cannot change the server's latency/throughput curve",
+    ),
+    other_driver(
+        "crates/atlas-plugin/src/benchmarks/contamination",
+        "the contamination driver cannot change the server's latency/throughput curve",
+    ),
+    other_driver(
+        "crates/atlas-plugin/src/benchmarks/ttft",
+        "the TTFT driver issues single requests client-side; it cannot change how fast the \
+         server answers a batch of 32",
+    ),
+];
+
 const CONTAMINATION_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
     other_driver(
@@ -299,10 +330,34 @@ pub const REQUIRED: [GateCoverage; 5] = [
 /// candidate naming an unregistered id would be a debt row nobody can ever
 /// discharge, which is worse than no row.
 /// `every_promotion_candidate_is_a_registered_benchmark` pins that.
-pub const PROMOTION_CANDIDATES: &[GateCoverage] = &[GateCoverage {
-    id: "cross-contamination",
-    excludes: CONTAMINATION_EXCLUDES,
-}];
+pub const PROMOTION_CANDIDATES: &[GateCoverage] = &[
+    GateCoverage {
+        id: "cross-contamination",
+        excludes: CONTAMINATION_EXCLUDES,
+    },
+    // Promoted out of NOT_REQUIRED 2026-08-11. It was excused as "an
+    // exploratory table with no baseline thresholds" — true when written, and
+    // the reason it cannot go straight to REQUIRED: `check_record` refuses to
+    // let a thresholds-less entry read as PASS ("there is nothing here for
+    // this run to have passed"), so requiring it today would produce a gate no
+    // PR could ever clear.
+    //
+    // Candidate rather than excused, because the concurrency curve is not
+    // exploratory any more: the C=1..32 ladder is the artifact the GB10
+    // campaign is argued from, and C=32 is where time-to-answer INVERTS in
+    // Atlas's favour (-4.47% vs vLLM). A change that quietly costs 10% at
+    // C=32 currently merges with nothing measured and nothing said — the
+    // "listing only what was gated silently converts ungated into unaffected"
+    // shape this list exists to prevent.
+    //
+    // Promotion to REQUIRED needs thresholds, and thresholds need a measured
+    // run on main. This lands the debt row first so the gap is visible while
+    // that run is collected.
+    GateCoverage {
+        id: "concurrency-sweep",
+        excludes: CONCURRENCY_EXCLUDES,
+    },
+];
 
 pub const NOT_REQUIRED: [(&str, &str); 4] = [
     (
@@ -312,7 +367,10 @@ pub const NOT_REQUIRED: [(&str, &str); 4] = [
     ),
     (
         "concurrency-sweep",
-        "an exploratory table, not a pass/fail measurement — it has no baseline thresholds",
+        "not required YET: a promotion candidate (see PROMOTION_CANDIDATES). It cannot be \
+         REQUIRED until it has measured thresholds — check_record refuses to let a \
+         thresholds-less entry read as PASS, so requiring it today would be a gate no PR \
+         could clear",
     ),
     (
         "serve-matrix",

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -234,6 +234,62 @@ pub fn k64_n64_wins(m: u32, n: u32) -> bool {
 /// model's config so it is never issued, or declare it in the target's
 /// MODEL.toml `[expected_absent]` with a reason; the boot gate
 /// (`kernel_audit::classify_failures`) fails closed on anything else.
+/// Minimum rows in flight for the grouped-GEMM MoE decode arm. SSOT for the
+/// SSM stack (`qwen3_ssm::trait_decode_multi_seq`) and the attention layers
+/// (`qwen3_attention::…::multi_seq::ffn`), which must agree — they are the
+/// same trade on the same weights.
+///
+/// The arm reads each routed expert ONCE instead of once per token, so it
+/// wins when there are enough tokens to amortise the expert sort/permute
+/// launch overhead, and loses when there are not. Both ends are measured:
+///
+/// | n | verdict | measurement |
+/// |---|---|---|
+/// | 4 | LOSS | 31 vs 56 tok/s on Holo — the fixed per-layer sort/permute dominates at small N |
+/// | >=16 | WIN | SSM-side alone C=32 172.7 -> 216.2 tok/s (+25%); #415's attention-side extension +7.9% at C=32 / +9.7% at C=64 on Qwen3.6-35B-A3B-NVFP4, paired gsm8k n=200 strict 0.960 vs 0.900 baseline, zero regressions |
+///
+/// 16 is the smallest width measured on the winning side. n=5..15 is
+/// UNMEASURED, not a known win — it sits on the losing side of this gate on
+/// purpose, because the one thing we know about the gap is that the loss at
+/// n=4 is large (-45%) and the win at n=16 is smaller (+25%).
+pub fn moe_grouped_decode_min_rows() -> usize {
+    16
+}
+
+/// Kill switch for the grouped-GEMM MoE decode arm. PRESENCE check per the
+/// house convention (`ATLAS_NO_MOE_GROUPED_DECODE=0` is NOT off), read once
+/// per process — this predicate sits in the decode path, and the `env::var`
+/// it replaces ran on every dispatch for MoE models.
+pub fn moe_grouped_decode_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_MOE_GROUPED_DECODE").is_none())
+}
+
+/// Force the grouped arm BELOW `moe_grouped_decode_min_rows()`. Diagnostic
+/// only — it exists so the n=5..15 gap can be measured without a rebuild, and
+/// it is the same var #415's measurements used, kept working on purpose.
+/// Never a production setting: if forcing wins at a width, move the THRESHOLD.
+pub fn moe_grouped_decode_forced() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_MOE_GROUPED_DECODE").as_deref() == Ok("1"))
+}
+
+/// Whether the grouped-GEMM MoE decode arm should run for `n` rows —
+/// PURE, so both polarities are testable without touching process env or the
+/// `OnceLock`s below (which latch, and would make the tests order-dependent).
+pub fn moe_grouped_decode_decide(n: usize, enabled: bool, forced: bool) -> bool {
+    enabled && (n >= moe_grouped_decode_min_rows() || forced)
+}
+
+/// Whether the grouped-GEMM MoE decode arm should run for `n` rows.
+pub fn moe_grouped_decode_for(n: usize) -> bool {
+    moe_grouped_decode_decide(n, moe_grouped_decode_enabled(), moe_grouped_decode_forced())
+}
+
+#[cfg(test)]
+#[path = "moe_grouped_decode_tests.rs"]
+mod moe_grouped_decode_tests;
+
 #[track_caller]
 pub fn try_kernel(gpu: &dyn GpuBackend, module: &str, func: &str) -> KernelHandle {
     match gpu.kernel(module, func) {

--- a/crates/spark-model/src/layers/moe_grouped_decode_tests.rs
+++ b/crates/spark-model/src/layers/moe_grouped_decode_tests.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The grouped-GEMM MoE decode arm is a WIDTH trade, and the gate that
+//! decides it is the whole fix (#415 follow-up).
+//!
+//! Before this, the arm was gated on `ATLAS_MOE_GROUPED_DECODE=1` alone —
+//! width-blind. That is wrong in both directions and each direction has a
+//! measurement behind it:
+//!
+//! - env set, n=4: ran, and LOSES badly (31 vs 56 tok/s on Holo)
+//! - env unset, n=32: did NOT run, forgoing a measured +25% (SSM-side C=32
+//!   172.7 -> 216.2) and #415's +7.9%/+9.7%
+//!
+//! and since no recipe ever set the variable, the shipped behaviour was the
+//! second one everywhere: the win existed and was never realised.
+//!
+//! Tests target the PURE decider so neither polarity depends on process env
+//! or on `OnceLock` latch order.
+
+use super::{moe_grouped_decode_decide, moe_grouped_decode_min_rows};
+
+/// POSITIVE: at and above the measured-winning width the arm engages.
+///
+/// PROVEN BY: reverting the gate to the width-blind `enabled` test does NOT
+/// turn this red (it engages there too) — which is exactly why the negative
+/// below is the load-bearing one, and why this test alone would have passed
+/// over the old behaviour.
+#[test]
+fn the_grouped_arm_engages_at_and_above_the_measured_width() {
+    let w = moe_grouped_decode_min_rows();
+    assert!(
+        moe_grouped_decode_decide(w, true, false),
+        "n={w} is the smallest width measured on the winning side (+25%); \
+         the arm must engage there"
+    );
+    assert!(
+        moe_grouped_decode_decide(w * 4, true, false),
+        "wider is more favourable, not less — the amortisation only improves"
+    );
+}
+
+/// NEGATIVE: below the measured width the arm must NOT engage.
+///
+/// This is the one that pins the fix. `n=4` is measured at 31 vs 56 tok/s —
+/// a ~45% loss — so an arm that engages there is a regression shipped as a
+/// feature.
+///
+/// PROVEN BY: restoring the old width-blind gate (return `enabled` alone)
+/// turns this RED at n=4 and n=15, while every other assertion in this file
+/// stays green.
+#[test]
+fn the_grouped_arm_stays_off_below_the_measured_width() {
+    for n in [1usize, 2, 4, 8, moe_grouped_decode_min_rows() - 1] {
+        assert!(
+            !moe_grouped_decode_decide(n, true, false),
+            "n={n} is below the measured-winning width; at n=4 this arm is a \
+             ~45% LOSS (31 vs 56 tok/s), and n=5..15 is unmeasured — the gate \
+             must fall to the per-token loop"
+        );
+    }
+}
+
+/// NEGATIVE: the kill switch beats the width, at every width.
+///
+/// Without this, "disabled" could be quietly ignored above the threshold —
+/// the failure mode where a kill switch exists but does not kill.
+#[test]
+fn the_kill_switch_wins_over_any_width() {
+    for n in [1usize, 4, 16, 64, 1024] {
+        assert!(
+            !moe_grouped_decode_decide(n, false, false),
+            "kill switch set: the arm must not engage at n={n} regardless of width"
+        );
+        assert!(
+            !moe_grouped_decode_decide(n, false, true),
+            "kill switch must also beat the diagnostic force at n={n}, or the \
+             two knobs contradict each other"
+        );
+    }
+}
+
+/// POSITIVE: the diagnostic force reaches BELOW the threshold — that is its
+/// only purpose (measuring the unmeasured n=5..15 gap without a rebuild).
+///
+/// PROVEN BY: dropping `|| forced` from the decider turns this red, which is
+/// what would silently strand #415's original measurement recipe.
+#[test]
+fn the_force_override_reaches_below_the_threshold() {
+    assert!(
+        moe_grouped_decode_decide(4, true, true),
+        "ATLAS_MOE_GROUPED_DECODE=1 exists so a below-threshold width can be \
+         measured; if it cannot reach n=4 it cannot measure the loss it was \
+         used to find"
+    );
+}
+
+/// The threshold is the smallest MEASURED winning width, not a round number.
+///
+/// Pinned because the comment justifying 16 cites a specific measurement
+/// (SSM-side C=32 +25%, #415 attention-side +7.9%/+9.7%); moving the constant
+/// without a new measurement should require editing this assertion and
+/// noticing why.
+#[test]
+fn the_threshold_is_the_measured_width() {
+    assert_eq!(
+        moe_grouped_decode_min_rows(),
+        16,
+        "16 is the smallest width measured on the winning side; changing it \
+         needs a measurement, not a preference"
+    );
+}

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/ffn.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/ffn.rs
@@ -133,8 +133,7 @@ impl Qwen3AttentionLayer {
                 stream,
             )?;
         } else if !force_seq_ffn
-            && (self.ffn.is_dense()
-                || std::env::var("ATLAS_MOE_GROUPED_DECODE").ok().as_deref() == Some("1"))
+            && (self.ffn.is_dense() || crate::layers::moe_grouped_decode_for(n))
         {
             // TASK-167 (gx10): mirror the SSM-side ATLAS_MOE_GROUPED_DECODE arm
             // for the attention layers' MoE — at large n the per-token loop

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -40,10 +40,16 @@ pub struct GdnFlags {
     pub batched_recurrent: bool,
     /// `--exact-verify`: run the sequential-decode-EXACT per-token MTP-verify
     /// chain (issue #435 route (a)) instead of the default WY-chunkwise /
-    /// fused BF16-conv arms. OPT-IN, default OFF: by default #435's
-    /// divergence REMAINS — spec-on output is NOT bitwise-equal to spec-off
-    /// at temp 0. The measured decode-step cost of exact (~+22-36% at the
-    /// n=8/16/32 verify rungs) is why; see the flag's help in `serve_args.rs`.
+    /// fused BF16-conv arms. OPT-IN, default OFF; the measured decode-step
+    /// cost (~+22-36% at the n=8/16/32 verify rungs) is why.
+    ///
+    /// SCOPE: this makes the GDN/SSM verify chain exact. It does NOT deliver
+    /// end-to-end spec-on == spec-off, because every FFN and attention
+    /// projection dispatches on ROW COUNT (verify K=4 takes
+    /// `w4a16_gemv_batch4`, decode takes `w4a16_gemv`) and those separate
+    /// implementations round differently — ~5e-5 of lanes by 1 ULP, on every
+    /// shape measured (#459). Closing that needs single-row routing for the
+    /// whole verify forward, which is future work.
     pub exact_verify: bool,
 }
 

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq.rs
@@ -303,7 +303,7 @@ impl Qwen3SsmLayer {
                 // The launch-overhead fix at small N remains CUDA graphs for
                 // n>=2, not MoE batching (graphs capture these per-token
                 // launches for free).
-                if std::env::var("ATLAS_MOE_GROUPED_DECODE").ok().as_deref() == Some("1") {
+                if crate::layers::moe_grouped_decode_for(n) {
                     // Grouped-GEMM MoE over all N tokens (each expert read once).
                     // Only sensible under CUDA graphs, where the sort/permute
                     // launch overhead that made this a loss is captured for free.

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq.rs
@@ -278,12 +278,31 @@ impl Qwen3SsmLayer {
             _ => {
                 // Per-token MoE: each seq's forward() writes moe_output[0];
                 // consume it immediately with a per-seq residual add before
-                // the next iteration overwrites it. NOTE: the batched
-                // grouped-GEMM (forward_prefill) was measured SLOWER here on
-                // Holo (c4 31 vs 56 tok/s) — the expert sort/permute fixed
-                // overhead per layer dominates at small N. The real fix for
-                // this launch overhead is CUDA graphs for n>=2, not MoE
-                // batching (graphs capture these per-token launches for free).
+                // the next iteration overwrites it.
+                //
+                // WIDTH-DEPENDENT, and the two measurements below disagree only
+                // because they were taken at different n — read both before
+                // concluding anything about the grouped arm:
+                //
+                //   n=4    grouped-GEMM (forward_prefill) is SLOWER on Holo,
+                //          c4 31 vs 56 tok/s — the expert sort/permute fixed
+                //          overhead per layer dominates at small N.
+                //   n>=16  grouped-GEMM WINS: SSM-side flag alone measured
+                //          C=32 172.7 -> 216.2 tok/s (+25%), and #415's
+                //          attention-side extension adds +7.9% at C=32 /
+                //          +9.7% at C=64 on Qwen3.6-35B-A3B-NVFP4 (paired
+                //          gsm8k n=200 gate: strict 0.960 vs 0.900 baseline).
+                //
+                // So the flag below is not a loss waiting to be removed; it is
+                // a narrow-N loss and a wide-N win, currently opt-in at every
+                // width. Flipping the default for n>=16 is the open question
+                // (#415 raised it); no recipe sets the variable today, so the
+                // wide-N win is measured but not realised in any shipped
+                // config.
+                //
+                // The launch-overhead fix at small N remains CUDA graphs for
+                // n>=2, not MoE batching (graphs capture these per-token
+                // launches for free).
                 if std::env::var("ATLAS_MOE_GROUPED_DECODE").ok().as_deref() == Some("1") {
                     // Grouped-GEMM MoE over all N tokens (each expert read once).
                     // Only sensible under CUDA graphs, where the sort/permute

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -201,9 +201,28 @@ pub struct ServeArgs {
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub ssm_batched_recurrent: Option<bool>,
 
-    /// Bitwise-exact MTP verify — OPT-IN (default: off). By default,
-    /// speculative (spec-on) output is NOT bitwise-equal to non-speculative
-    /// output at temp 0; this flag is what makes it equal (issue #435).
+    /// Sequential-decode-exact GDN/SSM verify chain — OPT-IN (default: off).
+    ///
+    /// SCOPE, and it is narrower than this flag once claimed: it makes the
+    /// GDN/SSM verify chain exact. It does NOT make speculative output
+    /// bitwise-equal to non-speculative output end to end, and setting it
+    /// will not give you a reproducible spec-on serve.
+    ///
+    /// Why not (measured on GB10, issue #459): every FFN and attention
+    /// projection is computed by a kernel selected on ROW COUNT. A token
+    /// through K=4 verify takes `w4a16_gemv_batch4`; the same token through
+    /// sequential decode takes `w4a16_gemv`. Those are separate
+    /// implementations and they round differently — ~5e-5 of output lanes
+    /// differ by exactly 1 ULP in BF16, on every projection shape measured
+    /// (qkv/o, ffn gate/up, ffn down). Across 64 layers that is ample to flip
+    /// a thin top-2 argmax, and it is entirely outside the chain this flag
+    /// makes exact, so no amount of SSM exactness closes it.
+    ///
+    /// FUTURE WORK: route every verify token through the same single-row
+    /// kernels sequential decode uses — FFN gate/up/down, attention QKV and
+    /// out_proj — which is what the exact arm already does for the GDN chain,
+    /// extended to the rest of the forward. That, not this flag alone, is
+    /// what end-to-end spec-on == spec-off would require.
     ///
     /// The default verify pass runs the WY-chunkwise / fused BF16-conv arms:
     /// fast, but their BF16-output conv (h-state relL2 ~8.6e-4 per K=4
@@ -211,9 +230,11 @@ pub struct ServeArgs {
     /// reordering term diverge from the sequential-decode reference — an
     /// argmax flip only needs a per-logit error above a thin top-2 margin.
     /// With `--exact-verify` the verify pass instead runs, per token, exactly
-    /// the kernel chain sequential decode runs (measured h relL2 = 0.0), at a
-    /// measured decode-step cost of ~+35% at the n=8/K=4 verify rung, ~+22%
-    /// at n=16/K=2 and ~+36% at n=32/K=2 (GDN phase +116%/+63%/+69%).
+    /// the GDN/SSM kernel chain sequential decode runs (measured h relL2 =
+    /// 0.0), at a measured decode-step cost of ~+35% at the n=8/K=4 verify
+    /// rung, ~+22% at n=16/K=2 and ~+36% at n=32/K=2 (GDN phase
+    /// +116%/+63%/+69%). Those two divergence terms are what this closes —
+    /// the projection-kernel term described above is not among them.
     ///
     /// Opt-in follows every surveyed production engine — vLLM
     /// (`VLLM_BATCH_INVARIANT=1`), SGLang (`--enable-deterministic-inference`,

--- a/kernels/gb10/qwen3.6-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-27b/BENCH.toml
@@ -55,3 +55,26 @@ noise = 0.4
 [benchmarks.metrics.samples]
 min = 995
 max = 995
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "unsloth/Qwen3.6-27B-NVFP4"
+gate = "concurrency-sweep"
+recipe = "qwen3.6/qwen3.6-27b-nvfp4-unsloth"
+default = true
+status = "unmeasured"
+note = """\
+The DENSE half of the concurrency curve. Declared here so the intent is on \
+record for both architectures: the C=1..32 latency/throughput ladder is \
+measured on dense AND MoE, because they do not share a decode path — the \
+dense FFN batches over all rows via forward_prefill while a 256-expert MoE \
+takes the grouped-GEMM arm, and a regression can hit one without touching \
+the other. A curve measured on one model cannot speak for the other.
+
+NO [benchmarks.metrics] TABLE ON PURPOSE. concurrency-sweep is a promotion \
+candidate, not a required gate, and it has never been run on main at C=32. \
+A guessed threshold a run could clear would report PASS for something nobody \
+measured — the exact failure this file's header warns about. Thresholds land \
+here after the first measured run, and that run is what promotes the bench \
+from PROMOTION_CANDIDATES to REQUIRED.\
+"""

--- a/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
@@ -149,3 +149,22 @@ max = 1647.98
 
 [benchmarks.metrics.p90_ms]
 max = 4814.44
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "Qwen/Qwen3.6-35B-A3B-FP8"
+gate = "concurrency-sweep"
+recipe = "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head"
+default = true
+status = "unmeasured"
+note = """\
+The MoE half of the concurrency curve — the sibling of the dense entry in \
+qwen3.6-27b/BENCH.toml, and the reason both exist. The MoE decode path takes \
+the grouped-GEMM expert arm above the width gate (n >= 16, layers/mod.rs \
+moe_grouped_decode_min_rows) where the dense path never does, so C=16 and \
+C=32 exercise code on this model that the dense sweep cannot reach at any \
+concurrency.
+
+NO [benchmarks.metrics] TABLE ON PURPOSE — see the dense entry. Unmeasured \
+means unmeasured; thresholds follow the first run on main.\
+"""


### PR DESCRIPTION
One gate cycle for five changes that all touch `crates/` and would otherwise
cost a cycle each. #404 was dropped from this batch — see the end.

## Concurrency curve (the ask: a standard concurrency bench that goes to 32)

**Sweep 1,2,4,8,16 → 1,2,4,8,16,32.** C=32 is where time-to-answer INVERTS in
Atlas's favour (-4.47% vs vLLM; C=128 -10.84%), so the old curve reported only
the regime where Atlas trails and omitted the one where it wins. C=64/128 stay
off the default: they need bs=64 preflight headroom not every recipe has.

**`concurrency-sweep` moves NOT_REQUIRED → PROMOTION_CANDIDATES.** It cannot go
straight to REQUIRED and that is not an oversight: `check_record` refuses to
let a thresholds-less entry read as PASS (*"there is nothing here for this run
to have passed"*), so requiring it today would be a gate no PR could ever
clear. Promotion needs measured thresholds; those need a run on main. This
lands the debt row so the gap is visible while that run is collected.

**Declared for BOTH architectures**, because they do not share a decode path:
the dense FFN batches every row through `forward_prefill`, while a 256-expert
MoE takes the grouped-GEMM arm above the width gate. C=16/32 exercise MoE code
the dense sweep cannot reach at any concurrency. Both entries are
`status = "unmeasured"` with NO metrics table — a guessed threshold a run
could clear would report PASS for something nobody measured.

## MoE grouped decode: width gate replaces the env var

The arm was gated on `ATLAS_MOE_GROUPED_DECODE=1` — width-blind, wrong in both
directions, and no recipe ever set it:

| | before | after |
|---|---|---|
| n=4, var set | ran, **-45%** (31 vs 56 tok/s) | falls to the per-token loop |
| n=32, var unset | did not run, forgoing **+25%** and #415's +7.9%/+9.7% | runs |

Now default-on at n >= 16 (smallest width measured on the winning side).
n=5..15 sits on the OFF side deliberately — unmeasured, and the known loss at
n=4 is larger than the known win at n=16. `moe_grouped_decode_min_rows()` is
SSOT for both call sites. `ATLAS_NO_MOE_GROUPED_DECODE` is the kill switch;
`ATLAS_MOE_GROUPED_DECODE=1` survives as a diagnostic force below the
threshold so #415's measurement recipe still works. Removes a `std::env::var`
from the decode path.

Five tests on a PURE decider (no env, no OnceLock ordering). The negative is
load-bearing and proven: restoring the width-blind gate turns
`the_grouped_arm_stays_off_below_the_measured_width` RED while the other four
stay green — the positives alone would have passed over the old bug.

## #435: `--exact-verify`'s promise narrowed to what it delivers

Its help said the flag makes spec-on output bitwise-equal to spec-off.
Measured on GB10 (#459), that is false: the arm IS entered (instrumented, both
polarities) and makes the GDN/SSM chain exact, but every FFN and attention
projection dispatches on ROW COUNT — verify K=4 takes `w4a16_gemv_batch4`,
decode takes `w4a16_gemv`, and those round differently (~5e-5 of lanes by 1
ULP, on every shape measured, 8 seeds each). Help now states the scope and
records single-row routing across the whole verify forward as future work.

## Also

`deny.toml` advisory cleanup from #391. Its typo hunk conflicted with main,
which already had the same fix more grammatically; resolved to main.

## Dropped: #404

It is **superseded by main**. Both solve "keep batched QKVZ/out_proj engaged
above n=16", but main routes to the tile-GEMM twins (one launch, any M) via
`tc_wide_ok`/`ssm_tc_proj_min_n`, while #404 chunks into <=16-row tiles using
the GEMV family (ceil(n/16) launches). main has 7 references to that
machinery; #404 has zero, and its base predates it. Rather than hand-resolve
three conflict hunks of someone else's perf work into the older design, it is
left for its author. Detail posted on the PR.

## Verification

`cargo fmt` clean · `cargo clippy --workspace --tests` clean · **4091 tests
passed, 0 failed** · all touched files under the 500-LoC cap or allow-listed ·
gate checker confirms the required set is still 5.

All five gates re-open (`coverage.rs` is a BOUNDARY_FILE) — that is the cycle
this batch exists to pay once.