### PR TITLE
ci: subscribe the whole suite to merge_group for the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
   push:
     branches: [main, master]
+  # Merge queue: entries are validated on a temporary `gh-readonly-queue/**`
+  # merge-commit, which fires NONE of the above events. A required check that
+  # does not subscribe here is never reported for the queue commit, and the
+  # queue then fails the entry with "required status check not reported".
+  # Every job that is (or becomes) a required check must stay event-agnostic
+  # or run here too. Jobs that are event-gated to `pull_request` and NOT
+  # required (pr-categorize) are advisory only and need not report on queue
+  # commits. release-matrix and pr-benchmark-gate both run under merge_group
+  # deliberately — see their own comments for why.
+  merge_group:
   # Reusable: release.yml gates its (expensive) build matrix on CI passing, so
   # a fmt or clippy failure costs one cheap runner instead of eight toolchain
   # installs. Defined once here; release.yml calls it rather than copying it.
@@ -176,11 +186,14 @@ jobs:
   # second matrix build there.
   release-matrix:
     name: release matrix
-    if: github.event_name == 'pull_request'
+    # Runs for pull_request AND merge_group (queue entry validation on the
+    # temporary gh-readonly-queue/** commit). github.event.number is empty
+    # under merge_group, so the version string falls back to "queue".
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     needs: [fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
     uses: ./.github/workflows/release-build.yml
     with:
-      version: 0.0.0-pr${{ github.event.number }}
+      version: 0.0.0-pr${{ github.event.number || 'queue' }}
       pr_mode: true
       retention_days: 1
 
@@ -483,6 +496,17 @@ jobs:
   pr-benchmark-gate:
     name: PR benchmark gate
     runs-on: ubuntu-latest
+    # Runs under `merge_group` too, deliberately. There the checkout is the
+    # queue's temporary merge commit (latest main + this PR), and the gate
+    # answers "do the committed records still cover the MERGED tree" — which
+    # is exactly the invariant 2026-08-11's double-merge broke: #457 and #461
+    # were each green in isolation, yet #461's perf-path content invalidated
+    # #457's records the moment both were on main. In the queue, a preceding
+    # merge that invalidates this entry's records turns this check red HERE
+    # and the entry is ejected, instead of silently landing a broken main.
+    # Records are keyed by tree (record_still_stands diffs TREES, never
+    # ancestry), so a record taken at the PR's frozen sha covers the queue
+    # commit iff nothing perf-relevant moved on main since the cycle ran.
     # ENFORCING as of this commit. The `continue-on-error: true` that used to
     # sit here was justified by a bootstrap gap — "no bench record is committed
     # yet, and the PR that introduces the gate cannot commit one". That gap is
@@ -496,9 +520,13 @@ jobs:
     # rust-toolchain.toml) — which is the point. Fix it by measuring on a GPU
     # box and committing the record, not by re-adding continue-on-error.
     #
-    # It is deliberately NOT in `release-matrix`'s `needs`, and deliberately
-    # not a required status check on `main`: a missing GPU measurement must
-    # show as red without wedging the image path or the merge button.
+    # It is deliberately NOT in `release-matrix`'s `needs`: a missing GPU
+    # measurement must show as red without wedging the image path. It IS a
+    # required status check on `main` (added with the merge queue): the point
+    # of the queue is that NOTHING lands with an uncovered perf-relevant tree,
+    # so "no record covers this merge-commit" must eject the entry rather than
+    # land a broken main — which is exactly the invariant the 2026-08-11
+    # double-merge broke before this job ran in the queue.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,16 +28,32 @@ on:
   # fork-controlled input executing with the write scopes declared below.
   pull_request_target:
     types: [opened, closed, synchronize]
+  # Merge queue: entries are validated on a temporary gh-readonly-queue/**
+  # merge-commit that fires NONE of the above events, and `CLAAssistant` is a
+  # required check the queue waits for — without this trigger it is never
+  # reported and every entry times out. The queue step below re-proves the
+  # signature verdict for the queued PR. Same safety envelope as the
+  # pull_request_target job, and tighter: it performs NO checkout at all —
+  # the signatures file is read from the cla-signatures branch through the
+  # contents API — and interpolates no event free text into the run body.
+  merge_group:
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     # `issue_comment` fires for plain issues too, where the action's
     # `pulls.get(issue.number)` 404s and reds the job for no reason. Gate on
-    # the `pull_request` key that only PR-backed issues carry.
+    # the `pull_request` key that only PR-backed issues carry. `merge_group`
+    # is handled by the mirror step below, never by the pinned action.
     if: >-
       github.event_name == 'pull_request_target' ||
+      github.event_name == 'merge_group' ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    env:
+      # SSOT for the allowlist: both the pinned action's `allowlist` input
+      # below and the merge-queue mirror step read this one value. Keep it
+      # here, nowhere else.
+      CLA_ALLOWLIST: dependabot[bot],renovate[bot],google-labs-jules[bot],claude[bot],google-labs-jules,claude,AzeezIsh,tbraun96
     # Scoped to what contributor-assistant actually calls (verified against the
     # action source at the pinned sha):
     #   contents      — git refs/commits that persist signatures/version1/cla.json
@@ -54,6 +70,11 @@ jobs:
       actions: write
     steps:
       - name: "CLA Assistant"
+        # The pinned action resolves "the PR" from `github.event.pull_request` /
+        # `context.issue`, which do not exist under `merge_group` — so it runs
+        # only for the two original triggers, and queue commits take the mirror
+        # step below instead.
+        if: github.event_name != 'merge_group'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +85,8 @@ jobs:
           # Maintainer-controlled identities are allowlisted: they own the copyright
           # and have already signed, so gating their own (AI-generated) PRs adds only
           # friction. External first-time contributors are still asked to sign.
-          allowlist: dependabot[bot],renovate[bot],google-labs-jules[bot],claude[bot],google-labs-jules,claude,AzeezIsh,tbraun96
+          # (SSOT: $CLA_ALLOWLIST above — do not re-list these here.)
+          allowlist: ${{ env.CLA_ALLOWLIST }}
           lock-pullrequest-aftermerge: false
           create-file-commit-message: 'chore: setup CLA signatures file'
           signed-commit-message: 'chore: $contributorName signed the CLA in PR #$pullRequestNo'
@@ -82,3 +104,72 @@ jobs:
           # `use-dco-flag: false` regex, which matches the phrase anywhere in a
           # comment and credits it to the COMMENT AUTHOR's committer id only.
           custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'
+
+      # Merge-queue mirror of the step above. The pinned action cannot run on a
+      # queue commit (no pull_request payload, no issue number), but the queue
+      # still needs the SAME check name reported on the merge-commit or the
+      # entry hangs until timeout. This step re-proves the verdict itself:
+      #   contributors of the queued PR ⊆ (allowlist ∪ signedContributors)
+      # Same safety envelope as the pull_request_target path, and tighter: NO
+      # checkout at all — the signatures file is read from the cla-signatures
+      # branch through the contents API (never queue-commit code), and event
+      # text (`head_ref`) arrives via an `env:` binding, never interpolated
+      # into the run body. Both steps live in the one job `CLAAssistant`, so
+      # the required context (the JOB key, not the step name) is reported
+      # identically on both trigger types; the steps are mutually exclusive by
+      # `if`, so exactly one runs per run.
+      - name: "CLA Assistant (merge queue)"
+        if: github.event_name == 'merge_group'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MQ_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+          # Queue branches are GitHub-generated: gh-readonly-queue/<base>/pr-<N>-<sha>.
+          BRANCH="${MQ_HEAD_REF#refs/heads/}"
+          PR_NUM="$(sed -n 's|.*/pr-\([0-9][0-9]*\)-.*|\1|p' <<< "$BRANCH")"
+          if [ -z "$PR_NUM" ]; then
+            echo "::error::cannot derive a PR number from queue branch '$BRANCH'"
+            exit 1
+          fi
+          # ONE identity per commit, extracted EXACTLY as the pinned action
+          # does (graphql.ts extractUserFromCommit: author.user || committer.user
+          # || author || committer, then .login || .name): the GitHub-resolved
+          # AUTHOR login first (commit emails like 38082993+tbraun96@users.noreply
+          # resolve to a login), the raw commit name ONLY when GitHub resolves
+          # no user at all. Collecting all four fields as separate identities
+          # would reject raw names ("Thomas Braun") that the pinned action never
+          # asks about — a mirror stricter than its original is not a mirror.
+          gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUM/commits" \
+            --jq '.[] | [ .author.login?, .committer.login?,
+                          .commit.author.name?, .commit.committer.name? ]
+                    | map(select(. != null and . != "")) | first // empty' \
+            | sort -u > identities.txt
+          # The pinned action drops databaseId 41898282 (github-actions[bot]).
+          grep -vxF 'github-actions[bot]' identities.txt > ids.txt || true
+          # Signed identities from the cla-signatures branch (SSOT: same file
+          # and branch the pinned action writes to). `name` there is the login
+          # of the comment author at signing time.
+          gh api "repos/$GITHUB_REPOSITORY/contents/signatures/version1/cla.json?ref=cla-signatures" \
+            --jq '.content' | base64 -d \
+            | python3 -c 'import json,sys; print("\n".join(s["name"] for s in json.load(sys.stdin)["signedContributors"]))' \
+            > signed.txt
+          # Split the allowlist with tr, NOT unquoted shell expansion:
+          # entries like dependabot[bot] are shell glob patterns and would be
+          # expanded against the cwd if word-split unquoted. Comparison is
+          # case-sensitive exact match, same as checkAllowList.ts (`pattern ===
+          # committer`; wildcard patterns are not in this repo's allowlist).
+          tr ',' '\n' <<< "$CLA_ALLOWLIST" > allow.txt
+          cat allow.txt signed.txt | sort -u > accepted.txt
+          MISSING=()
+          while IFS= read -r id; do
+            [ -z "$id" ] && continue
+            grep -qxF -- "$id" accepted.txt || MISSING+=("$id")
+          done < ids.txt
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::unsigned contributors on PR #$PR_NUM: ${MISSING[*]}"
+            echo "Sign by replying on PR #$PR_NUM: 'I have read the CLA Document and I hereby sign the CLA'"
+            exit 1
+          fi
+          echo "All contributors of PR #$PR_NUM have signed the CLA (or are allowlisted)."

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,13 @@ on:
   pull_request:
   push:
     branches: [main, master]
+  # Merge queue: entries are validated on a temporary gh-readonly-queue/**
+  # merge-commit that fires none of the events above, and this job is in the
+  # required set the queue waits on — without this trigger it is never
+  # reported and every entry times out. The Codecov upload stays advisory
+  # here exactly as on PRs (continue-on-error + a loud warning): a queue
+  # entry must never hang on Codecov availability.
+  merge_group:
 
 # Least privilege, same as ci.yml: this workflow only reads the repo. The
 # Codecov upload authenticates with a repository upload token (see the upload

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ on:
   # (kernel-only diffs), leaving them permanently "expected" and unmergeable.
   pull_request:
     branches: [main, master]
+  # Merge queue: same reasoning — this job is required, queue commits fire
+  # none of the events above, so report on every entry unfiltered. The deploy
+  # job stays push-only by its own `if`.
+  merge_group:
 
 concurrency:
   group: docs-${{ github.ref }}

--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
   push:
     branches: [main, master]
+  # Merge queue: entries are validated on a temporary gh-readonly-queue/**
+  # merge-commit that fires none of the events above, and this job is in the
+  # required set the queue waits on — without this trigger it is never
+  # reported and every entry times out.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/gdn-so-pin.yml
+++ b/.github/workflows/gdn-so-pin.yml
@@ -8,15 +8,20 @@ permissions:
 
 on:
   workflow_dispatch:
+  # No path filter on pull_request: this check joins the required set, and a
+  # path-filtered required check never reports on PRs outside its paths,
+  # leaving them permanently "expected" and unmergeable. The job is one
+  # sha256sum -c — running it on every PR costs seconds.
   pull_request:
-    paths:
-      - "3rdparty_patches/gdn_aot/**"
-      - ".github/workflows/gdn-so-pin.yml"
   push:
     branches: [main, master]
     paths:
       - "3rdparty_patches/gdn_aot/**"
       - ".github/workflows/gdn-so-pin.yml"
+  # Merge queue: queue commits fire none of the events above, and this check
+  # is required — without this trigger the entry hangs until timeout.
+  # Unfiltered for the same reason as pull_request.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/kernel-compile.yml
+++ b/.github/workflows/kernel-compile.yml
@@ -21,16 +21,22 @@ name: Kernel compile
 # needs a GB10 and stays with the benchmark gates.
 
 on:
+  # No path filter on pull_request: this check joins the required set, and a
+  # path-filtered required check never reports on PRs outside its paths
+  # (non-kernel diffs), leaving them permanently "expected" and unmergeable.
+  # The job is a pure nvcc cross-compile to PTX (no GPU, ~minutes on a hosted
+  # runner), so running it on every PR is the cost of it being a verdict.
   pull_request:
-    paths:
-      - 'kernels/**'
-      - 'crates/atlas-kernels/**'
-      - '.github/workflows/kernel-compile.yml'
   push:
     branches: [main]
     paths:
       - 'kernels/**'
       - 'crates/atlas-kernels/**'
+  # Merge queue: queue commits (temporary gh-readonly-queue/** merge-commits)
+  # fire none of the events above, and this check is required — without this
+  # trigger it is never reported and the entry hangs until the queue's
+  # check timeout ejects it. Unfiltered for the same reason as pull_request.
+  merge_group:
 
 # A second push supersedes the first: this job is minutes long and its only
 # output is pass/fail on the tip.

--- a/.github/workflows/merge-ancestry.yml
+++ b/.github/workflows/merge-ancestry.yml
@@ -38,6 +38,13 @@ on:
   # dispatch run exercises the self-test job; the guard itself needs a PR
   # context and re-runs from the PR's checks tab or on push.
   workflow_dispatch:
+  # Merge queue: only the self-test runs here. The guard job stays PR-only
+  # by its own `if` — a queue merge-commit BY CONSTRUCTION shares history
+  # with its base (it is base-tip + the PR), so the ancestry question the
+  # guard asks cannot fail and cannot even be resolved (there is no
+  # pull_request payload to name the base). The self-test keeps the guard
+  # script honest on every queue commit, same as on every PR.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -535,8 +535,30 @@ jobs:
   dry-run-summary:
     name: dry-run summary
     needs: [validate, build]
+    # This job is the stable aggregation point for the release matrix and a
+    # required check (the per-leg `build <id>` check names are dynamic and
+    # cannot be required individually). A required check that is SKIPPED when
+    # a build fails is never reported at all — in the merge queue the entry
+    # would then hang for the full check_response_timeout instead of being
+    # ejected. So run always, and let the first step convert any upstream
+    # failure into an explicit red. (`needs` still blocks downstream release
+    # jobs exactly as before — a failed dependency blocks as a skip would.)
+    if: always()
     runs-on: ubuntu-24.04
     steps:
+      - name: Fail explicitly if anything upstream failed
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          bad=""
+          [ "$VALIDATE_RESULT" = success ] || bad="validate ($VALIDATE_RESULT)"
+          [ "$BUILD_RESULT" = success ] || bad="${bad:+$bad, }build ($BUILD_RESULT)"
+          if [ -n "$bad" ]; then
+            echo "::error::release matrix upstream failed: $bad"
+            exit 1
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,12 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - 'deny.toml'
+  # Merge queue: `cargo deny` is in the required set the queue waits on, and
+  # queue commits (temporary gh-readonly-queue/** merge-commits) fire none of
+  # the events above. Unfiltered, same as pull_request — a path-filtered
+  # required check never reports on entries outside its paths, and the entry
+  # would hang until the queue's check timeout ejects it.
+  merge_group:
   schedule:
     # Weekly on Monday at 06:00 UTC
     - cron: '0 6 * * 1'

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -7,12 +7,16 @@ on:
       - 'site/**'
       - '.benchmarks/**'
       - '.github/workflows/site.yml'
+  # No path filter on pull_request: this check joins the required set, and a
+  # path-filtered required check never reports on PRs outside its paths,
+  # leaving them permanently "expected" and unmergeable.
   pull_request:
     branches: [main, master]
-    paths:
-      - 'site/**'
-      - '.benchmarks/**'
-      - '.github/workflows/site.yml'
+  # Merge queue: queue commits fire none of the events above, and this check
+  # is required — without this trigger the entry hangs until timeout.
+  # Unfiltered for the same reason as pull_request. The deploy job stays
+  # push/schedule-only by its own `if`.
+  merge_group:
   # Daily rebuild so the dashboard picks up gate records that landed on
   # branches whose PRs have not merged yet (gen-gates.mjs walks all heads).
   schedule:

--- a/.github/workflows/tui-threading.yml
+++ b/.github/workflows/tui-threading.yml
@@ -33,16 +33,20 @@ on:
   # can only be started by an event you do not control is a check you cannot
   # get a verdict from when you most need it.
   workflow_dispatch:
+  # No path filter on pull_request: this check joins the required set, and a
+  # path-filtered required check never reports on PRs outside its paths,
+  # leaving them permanently "expected" and unmergeable. The job is one grep
+  # over two directories — running it on every PR costs seconds.
   pull_request:
-    paths:
-      - 'crates/spark-server/src/tui/**'
-      - 'crates/spark-server/src/recipe/**'
-      - '.github/workflows/tui-threading.yml'
   push:
     branches: [main]
     paths:
       - 'crates/spark-server/src/tui/**'
       - 'crates/spark-server/src/recipe/**'
+  # Merge queue: queue commits fire none of the events above, and this check
+  # is required — without this trigger the entry hangs until timeout.
+  # Unfiltered for the same reason as pull_request.
+  merge_group:
 
 jobs:
   no-blocking-on-the-render-thread:


### PR DESCRIPTION
## What

Subscribes every CI workflow in the suite to the `merge_group` event so the **entire suite** can gate the merge queue (ruleset 20705100, currently `evaluate`).

## Why

The queue validates entries on a temporary `gh-readonly-queue/<base>/pr-<N>-<sha>` merge-commit. That commit fires **none** of `pull_request`, `push`, or `pull_request_target` — so any required check whose workflow doesn't subscribe to `merge_group` is never reported on it, and the entry hangs until `check_response_timeout` (120 min) and is ejected.

This PR closes that gap for every workflow that carries a verdict job, and removes the path filters from the four workflows that must run on *every* entry to become required (the wedge security.yml already documents: a path-filtered required check never reports outside its paths).

## Details

| workflow | change |
|---|---|
| ci.yml | `merge_group` trigger; release-matrix adapted (`pr-queue` version fallback); pr-benchmark-gate runs in queue deliberately ("do records cover the MERGED tree" — the invariant the 08-11 double-merge broke) |
| cla.yml | merge_group mirror step: pinned contributor-assistant action can't resolve a PR from a queue commit, so the step re-proves `contributors ⊆ allowlist ∪ signatures` via contents API (no checkout, no event free text). Identity extraction replicates the action's graphql.ts exactly. Allowlist SSOT in one env var. |
| coverage / docs / file-size-cap / security | `merge_group` added (unfiltered) |
| kernel-compile / gdn-so-pin / tui-threading / site | `merge_group` added, `pull_request` path filter removed |
| merge-ancestry | `merge_group` runs self-test only; guard stays PR-gated |

**Deliberately not required**: CodeQL default-setup (can't subscribe to merge_group), pr-categorize + merge-ancestry guard (attacker-controlled input must stay advisory).

## Follow-ups (separate changes, in order)

1. Land this PR through normal CI
2. Expand the required-status-check set to the whole suite (`cargo deny`, `cargo llvm-cov`, `Build mdBook + rustdoc`, `nvcc -> PTX`, `Enforce ≤500 LoC` is already there, `Build SvelteKit site`, TUI threading, GDN pins, `release matrix / dry-run summary`, merge-ancestry self-test)
3. Flip ruleset 20705100 `evaluate` → `active`
4. Cycle Batch 4 (#464) through the queue once its records land

**Principles Applied:**
- SSOT: allowlist defined once (`CLA_ALLOWLIST` env), read by both CLA steps
- PCND: no implicit defaults — mirror step fails fast if the queue branch shape is unrecognized