### PR TITLE
fix(tui): downloads, toasts, progress UI, network memory, log scroll

### DIFF
--- a/crates/spark-server/src/model_download/hf.rs
+++ b/crates/spark-server/src/model_download/hf.rs
@@ -116,6 +116,30 @@ fn get(
     }
 }
 
+/// [`get`], retrying anonymously when the token is refused.
+///
+/// A stale or revoked token makes the Hub answer 401 for PUBLIC repos too, so
+/// one bad line in `~/.cache/huggingface/token` turned every download into an
+/// instant "requires credentials" failure. Public models need no credentials
+/// at all; the retry costs one request and only ever runs on a 401/403 that
+/// was about to be fatal anyway. A genuinely gated repo fails the anonymous
+/// retry with the same class of status, and the ORIGINAL error is reported —
+/// `had_token: true` is what routes the reader to the licence hint rather
+/// than the "set HF_TOKEN" one.
+fn get_or_anon(
+    url: &str,
+    token: Option<&str>,
+    range_from: Option<u64>,
+) -> Result<ureq::http::Response<ureq::Body>, (u16, anyhow::Error)> {
+    match get(url, token, range_from) {
+        Err((s @ (401 | 403), e)) if token.is_some() => match get(url, None, range_from) {
+            Ok(r) => Ok(r),
+            Err(_) => Err((s, e)),
+        },
+        other => other,
+    }
+}
+
 /// The repo's current `main` revision sha, and every file in it.
 pub fn repo_info(
     repo: &str,
@@ -123,7 +147,7 @@ pub fn repo_info(
 ) -> Result<(String, Vec<RemoteFile>), DownloadError> {
     let had = tok.is_some();
     let url = format!("{HOST}/api/models/{repo}");
-    let body = match get(&url, tok, None) {
+    let body = match get_or_anon(&url, tok, None) {
         Ok(r) => r
             .into_body()
             .read_to_string()
@@ -161,7 +185,7 @@ pub fn repo_info(
 /// a percentage, which is degraded but never blocking.
 pub fn sizes(repo: &str, revision: &str, tok: Option<&str>) -> Vec<(String, u64)> {
     let url = format!("{HOST}/api/models/{repo}/tree/{revision}?recursive=1");
-    let Ok(r) = get(&url, tok, None) else {
+    let Ok(r) = get_or_anon(&url, tok, None) else {
         return Vec::new();
     };
     let Ok(body) = r.into_body().read_to_string() else {
@@ -217,7 +241,7 @@ pub fn fetch_file(
     let have = std::fs::metadata(&part).map(|m| m.len()).unwrap_or(0);
 
     let url = format!("{HOST}/{repo}/resolve/{revision}/{name}");
-    let resp = match get(&url, tok, (have > 0).then_some(have)) {
+    let resp = match get_or_anon(&url, tok, (have > 0).then_some(have)) {
         Ok(r) => r,
         Err((0, e)) => return Err(DownloadError::Offline(e.to_string())),
         Err((s, _)) => return Err(classify(repo, s, had)),

--- a/crates/spark-server/src/model_download/net_tests.rs
+++ b/crates/spark-server/src/model_download/net_tests.rs
@@ -156,8 +156,16 @@ fn a_stale_token_still_resolves_and_fetches_a_public_repo() {
     let c = Cache::new("staletoken");
     let dest = c.0.join("config.json");
     let cancel = std::sync::atomic::AtomicBool::new(false);
-    let done = hf::fetch_file(repo, &revision, "config.json", &dest, bad, &cancel, &mut |_| {})
-        .expect("public files must survive a bad token");
+    let done = hf::fetch_file(
+        repo,
+        &revision,
+        "config.json",
+        &dest,
+        bad,
+        &cancel,
+        &mut |_| {},
+    )
+    .expect("public files must survive a bad token");
     assert!(done);
     assert!(dest.exists());
 }

--- a/crates/spark-server/src/model_download/net_tests.rs
+++ b/crates/spark-server/src/model_download/net_tests.rs
@@ -136,3 +136,28 @@ fn a_gated_repo_is_reported_as_gated_and_not_as_a_network_fault() {
     );
     assert!(!dest.exists(), "nothing should have been written");
 }
+
+/// A stale token must not lock the user out of PUBLIC models. HF answers 401
+/// to an invalid `Authorization` header even on repos that need none, so
+/// before the anonymous retry existed, one bad line in
+/// `~/.cache/huggingface/token` made every download fail on arrival with
+/// "requires credentials".
+#[test]
+#[ignore = "network"]
+fn a_stale_token_still_resolves_and_fetches_a_public_repo() {
+    let repo = "hf-internal-testing/tiny-random-gpt2";
+    let bad = Some("hf_thistokenisdefinitelynotvalid");
+
+    let (revision, files) =
+        hf::repo_info(repo, bad).expect("public metadata must survive a bad token");
+    assert!(!revision.is_empty());
+    assert!(!files.is_empty());
+
+    let c = Cache::new("staletoken");
+    let dest = c.0.join("config.json");
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+    let done = hf::fetch_file(repo, &revision, "config.json", &dest, bad, &cancel, &mut |_| {})
+        .expect("public files must survive a bad token");
+    assert!(done);
+    assert!(dest.exists());
+}

--- a/crates/spark-server/src/tui/app.rs
+++ b/crates/spark-server/src/tui/app.rs
@@ -210,9 +210,14 @@ impl App {
     pub fn on_tick(&mut self) {
         self.tick += 1;
         self.progress.ease_tick();
-        // Info toasts auto-dismiss after 5s; errors persist.
-        self.toasts
-            .retain(|t| t.error || t.at.elapsed().as_secs() < 5);
+        // Info toasts auto-dismiss after 5s. Errors get longer — they carry a
+        // hint the reader has to act on — but they still leave: an error kept
+        // forever parks itself over the content, and with the 3-toast cap it
+        // eventually crowds out every message that follows it.
+        self.toasts.retain(|t| {
+            let ttl = if t.error { 12 } else { 5 };
+            t.at.elapsed().as_secs() < ttl
+        });
         // A launch that failed after its thread started must not leave the
         // dashboard showing a load. The checklist was reset and the pill set
         // to LOADING the moment the thread spawned; if the swap then refused

--- a/crates/spark-server/src/tui/app.rs
+++ b/crates/spark-server/src/tui/app.rs
@@ -210,14 +210,10 @@ impl App {
     pub fn on_tick(&mut self) {
         self.tick += 1;
         self.progress.ease_tick();
-        // Info toasts auto-dismiss after 5s. Errors get longer — they carry a
-        // hint the reader has to act on — but they still leave: an error kept
-        // forever parks itself over the content, and with the 3-toast cap it
-        // eventually crowds out every message that follows it.
-        self.toasts.retain(|t| {
-            let ttl = if t.error { 12 } else { 5 };
-            t.at.elapsed().as_secs() < ttl
-        });
+        // Info toasts auto-dismiss at 5s, errors at 12s — never forever: under
+        // the 3-toast render cap a permanent error crowds out what follows.
+        self.toasts
+            .retain(|t| t.at.elapsed().as_secs() < if t.error { 12 } else { 5 });
         // A launch that failed after its thread started must not leave the
         // dashboard showing a load. The checklist was reset and the pill set
         // to LOADING the moment the thread spawned; if the swap then refused

--- a/crates/spark-server/src/tui/app_tests.rs
+++ b/crates/spark-server/src/tui/app_tests.rs
@@ -323,3 +323,26 @@ fn scrolling_stops_at_the_limits_instead_of_running_away() {
     }
     assert_eq!(a.chat.scroll, Some(4), "clamped at the oldest message");
 }
+
+/// Errors linger longer than info — they carry the hint the reader has to act
+/// on — but they must still leave. "Errors persist" was the old rule, and a
+/// download that failed once parked its toast over the corner forever; with
+/// the 3-toast cap, three of them silenced every message that followed.
+#[test]
+fn error_toasts_outlive_info_toasts_but_still_leave() {
+    use clap::Parser;
+    let mut a = App::new(crate::cli::ServeArgs::parse_from(["spark", "some/model"]));
+    a.toast("plain note", false);
+    a.toast("something failed", true);
+    let aged = Instant::now() - std::time::Duration::from_secs(6);
+    for t in &mut a.toasts {
+        t.at = aged;
+    }
+    a.on_tick();
+    assert_eq!(a.toasts.len(), 1, "at 6s the info toast is gone");
+    assert!(a.toasts[0].error);
+
+    a.toasts[0].at = Instant::now() - std::time::Duration::from_secs(13);
+    a.on_tick();
+    assert!(a.toasts.is_empty(), "at 13s the error leaves too");
+}

--- a/crates/spark-server/src/tui/download_state.rs
+++ b/crates/spark-server/src/tui/download_state.rs
@@ -119,6 +119,23 @@ impl DownloadState {
         let mut settled = None;
         if let Some(job) = self.job.as_mut() {
             let msgs: Vec<DownloadMsg> = job.handle.rx.try_iter().collect();
+            // A worker that died without a terminal message — a panic, since
+            // `run`'s Err path sends `Failed` — must still settle the job.
+            // Left tracked, `is_downloading` stays true forever and every
+            // later `d` is refused with "already downloading", which reads as
+            // downloads being broken outright.
+            if msgs.is_empty()
+                && matches!(
+                    job.handle.rx.try_recv(),
+                    Err(std::sync::mpsc::TryRecvError::Disconnected)
+                )
+            {
+                settled = Some(Settled::Stopped(job.repo.clone()));
+                self.last_message = Some((
+                    format!("{} download stopped unexpectedly — press d to resume", job.repo),
+                    true,
+                ));
+            }
             for msg in msgs {
                 match msg {
                     DownloadMsg::Planned {

--- a/crates/spark-server/src/tui/download_state.rs
+++ b/crates/spark-server/src/tui/download_state.rs
@@ -132,7 +132,10 @@ impl DownloadState {
             {
                 settled = Some(Settled::Stopped(job.repo.clone()));
                 self.last_message = Some((
-                    format!("{} download stopped unexpectedly — press d to resume", job.repo),
+                    format!(
+                        "{} download stopped unexpectedly — press d to resume",
+                        job.repo
+                    ),
                     true,
                 ));
             }

--- a/crates/spark-server/src/tui/download_state.rs
+++ b/crates/spark-server/src/tui/download_state.rs
@@ -118,26 +118,23 @@ impl DownloadState {
     pub fn pump(&mut self) -> Option<Settled> {
         let mut settled = None;
         if let Some(job) = self.job.as_mut() {
-            let msgs: Vec<DownloadMsg> = job.handle.rx.try_iter().collect();
-            // A worker that died without a terminal message — a panic, since
-            // `run`'s Err path sends `Failed` — must still settle the job.
-            // Left tracked, `is_downloading` stays true forever and every
-            // later `d` is refused with "already downloading", which reads as
-            // downloads being broken outright.
-            if msgs.is_empty()
-                && matches!(
-                    job.handle.rx.try_recv(),
-                    Err(std::sync::mpsc::TryRecvError::Disconnected)
-                )
-            {
-                settled = Some(Settled::Stopped(job.repo.clone()));
-                self.last_message = Some((
-                    format!(
-                        "{} download stopped unexpectedly — press d to resume",
-                        job.repo
-                    ),
-                    true,
-                ));
+            // Drained one message at a time, so a disconnect can only be seen
+            // AFTER everything the worker managed to send. The first version
+            // used `try_iter` plus a second `try_recv` as a liveness probe —
+            // and a terminal message sent between the two was consumed by the
+            // probe and dropped, reporting a finished download as "stopped
+            // unexpectedly".
+            let mut msgs = Vec::new();
+            let mut disconnected = false;
+            loop {
+                match job.handle.rx.try_recv() {
+                    Ok(m) => msgs.push(m),
+                    Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
             }
             for msg in msgs {
                 match msg {
@@ -181,6 +178,21 @@ impl DownloadState {
                         self.last_message = Some((describe(&job.repo, &e), true));
                     }
                 }
+            }
+            // A worker that died WITHOUT a terminal message — a panic, since
+            // `run`'s Err path sends `Failed` — must still settle the job.
+            // Left tracked, `is_downloading` stays true forever and every
+            // later `d` is refused with "already downloading", which reads as
+            // downloads being broken outright.
+            if settled.is_none() && disconnected {
+                settled = Some(Settled::Stopped(job.repo.clone()));
+                self.last_message = Some((
+                    format!(
+                        "{} download stopped unexpectedly — press d to resume",
+                        job.repo
+                    ),
+                    true,
+                ));
             }
         }
         if settled.is_some() {

--- a/crates/spark-server/src/tui/render/library/library_tests.rs
+++ b/crates/spark-server/src/tui/render/library/library_tests.rs
@@ -82,13 +82,27 @@ fn downloading(done: u64, total: u64) -> App {
     a
 }
 
+/// The rows cut down to the LIST pane's columns.
+///
+/// The detail pane now carries the download's full story at every width, so an
+/// assertion about what the ROW sheds has to stop looking at the columns to
+/// its right or the detail pane satisfies it.
+fn list_pane(rows: &[String], screen_w: u16) -> Vec<String> {
+    let chrome =
+        crate::tui::render::Chrome::of(ratatui::layout::Size::new(screen_w, 40));
+    // Sidebar, then the 1-cell glow ring, then 46% of the content is the list.
+    let content_w = screen_w - chrome.sidebar_w - 2;
+    let end = (chrome.sidebar_w + 1 + content_w * 46 / 100) as usize;
+    rows.iter().map(|r| r.chars().take(end).collect()).collect()
+}
+
 #[test]
 fn the_progress_line_sheds_fields_from_the_right_as_the_pane_narrows() {
     // The bar and the percentage answer "is this still moving", so they are
     // the last things to go; the rate and the file counter are the first.
     let a = downloading(4_000_000_000, 34_900_000_000);
 
-    let cramped = screen(&a, 120, 40);
+    let cramped = list_pane(&screen(&a, 120, 40), 120);
     assert!(
         has(&cramped, " 11%"),
         "the percentage survives:\n{cramped:#?}"
@@ -108,8 +122,46 @@ fn the_progress_line_sheds_fields_from_the_right_as_the_pane_narrows() {
     // the 28.8 GB still to go by the rate got a time 7% short.
     assert!(has(&roomy, "92 MB/s"), "{roomy:#?}");
 
-    let wide = screen(&a, 280, 40);
+    let wide = list_pane(&screen(&a, 280, 40), 280);
     assert!(has(&wide, "file 3/85"), "{wide:#?}");
+}
+
+/// The screen row holding this model's LIST entry — the one place the inline
+/// dot may appear. The header's status pill also draws a "●", so a whole-
+/// screen scan cannot tell the two apart.
+fn model_row(rows: &[String], id: &str) -> String {
+    rows.iter()
+        .find(|r| r.contains(id))
+        .cloned()
+        .unwrap_or_default()
+}
+
+#[test]
+fn a_running_download_owns_the_detail_pane_and_marks_its_row_with_a_dot() {
+    let a = downloading(4_000_000_000, 34_900_000_000);
+    let rows = screen(&a, 120, 40);
+    // The detail pane's bar section, present even at widths where the row
+    // line has shed everything but the bar.
+    assert!(has(&rows, "DOWNLOADING"), "{rows:#?}");
+    assert!(has(&rows, "3.7 GB / 32.5 GB"), "{rows:#?}");
+    assert!(has(&rows, "92 MB/s"), "{rows:#?}");
+    assert!(has(&rows, "file 3/85"), "{rows:#?}");
+    // The inline dot after the model name on the row itself.
+    let row = model_row(&rows, "atlas-render-tests/no-such-model");
+    assert!(
+        row.contains("●"),
+        "the row glows while its download runs: {row:?}"
+    );
+}
+
+#[test]
+fn a_model_not_downloading_draws_no_dot_and_no_download_section() {
+    let a = flagship();
+    let rows = screen(&a, 200, 40);
+    assert!(!has(&rows, "DOWNLOADING"), "{rows:#?}");
+    let id = a.lib.visible()[0].model.clone();
+    let row = model_row(&rows, &id);
+    assert!(!row.contains("●"), "{row:?}");
 }
 
 #[test]

--- a/crates/spark-server/src/tui/render/library/library_tests.rs
+++ b/crates/spark-server/src/tui/render/library/library_tests.rs
@@ -88,8 +88,7 @@ fn downloading(done: u64, total: u64) -> App {
 /// assertion about what the ROW sheds has to stop looking at the columns to
 /// its right or the detail pane satisfies it.
 fn list_pane(rows: &[String], screen_w: u16) -> Vec<String> {
-    let chrome =
-        crate::tui::render::Chrome::of(ratatui::layout::Size::new(screen_w, 40));
+    let chrome = crate::tui::render::Chrome::of(ratatui::layout::Size::new(screen_w, 40));
     // Sidebar, then the 1-cell glow ring, then 46% of the content is the list.
     let content_w = screen_w - chrome.sidebar_w - 2;
     let end = (chrome.sidebar_w + 1 + content_w * 46 / 100) as usize;

--- a/crates/spark-server/src/tui/render/library/list.rs
+++ b/crates/spark-server/src/tui/render/library/list.rs
@@ -8,7 +8,7 @@ use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use super::super::{panel, wrap};
+use super::super::{gradient_bar, panel, wrap};
 use crate::tui::app::App;
 use crate::tui::data::catalogue::Entry;
 use crate::tui::theme;
@@ -143,11 +143,21 @@ fn draw_list(f: &mut Frame, app: &App, area: Rect) {
         } else {
             theme::text()
         };
-        let mut head = Line::from(vec![
-            bar,
-            mark,
-            Span::styled(entry.model.clone(), name_style),
-        ]);
+        let mut head_spans = vec![bar, mark, Span::styled(entry.model.clone(), name_style)];
+        // A live download marks its row inline, right after the name: the row
+        // is what the eye tracks in a list, and the glyph column alone is easy
+        // to miss. It glows — bold and dim alternating on the tick — because a
+        // static dot next to a stalled job and one next to a moving job would
+        // look identical.
+        if app.download.is_downloading(&entry.model) {
+            let glow = if (app.tick / 4).is_multiple_of(2) {
+                theme::warn().add_modifier(Modifier::BOLD)
+            } else {
+                theme::warn().add_modifier(Modifier::DIM)
+            };
+            head_spans.push(Span::styled(" ●", glow));
+        }
+        let mut head = Line::from(head_spans);
         if selected {
             head = head.style(theme::selected());
         }
@@ -275,6 +285,61 @@ fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
             " weights are not in the local cache",
             theme::warn(),
         )));
+    }
+
+    // The download this model is in the middle of, as a real bar. The list
+    // row's one-line progress survives narrow panes; this pane has the width
+    // to answer "how far along, how fast, which file" in full.
+    if let Some(job) = app.download.job.as_ref().filter(|j| j.repo == entry.model) {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(" DOWNLOADING", theme::dim())));
+        let bar_w = inner.width.saturating_sub(12).clamp(8, 36);
+        let mut bar = vec![Span::raw("  ")];
+        match job.fraction() {
+            Some(frac) => {
+                bar.extend(gradient_bar(frac, bar_w).spans);
+                bar.push(Span::styled(
+                    format!(" {:>3.0}%", frac * 100.0),
+                    theme::text().add_modifier(Modifier::BOLD),
+                ));
+            }
+            // No sizes from the Hub: motion instead of a bar stuck at zero,
+            // same rule as the list row.
+            None => {
+                let phase = (app.tick as usize / 2) % theme::SPINNER.len();
+                bar.push(Span::styled(theme::SPINNER[phase], theme::brand_cyan()));
+                bar.push(Span::styled(" resolving…", theme::text2()));
+            }
+        }
+        lines.push(Line::from(bar));
+        if job.total > 0 {
+            let mut detail = vec![Span::styled(
+                format!(
+                    "  {} / {}",
+                    crate::tui::format::bytes(job.done),
+                    crate::tui::format::bytes(job.total)
+                ),
+                theme::text2(),
+            )];
+            // No rate while stopping: it is the one field that implies the
+            // bytes are still moving, and the user just asked them not to.
+            if job.rate_bps > 0.0 && !job.cancelling {
+                detail.push(Span::styled(
+                    format!("  {}", crate::tui::format::rate(job.rate_bps)),
+                    theme::dim(),
+                ));
+            }
+            lines.push(Line::from(detail));
+        }
+        if let Some((i, of, name)) = &job.file {
+            lines.push(Line::from(Span::styled(
+                format!("  file {i}/{of}  {name}"),
+                theme::dim(),
+            )));
+        }
+        if job.cancelling {
+            lines.push(Line::from(Span::styled("  stopping…", theme::warn())));
+        }
     }
 
     lines.push(Line::from(""));

--- a/crates/spark-server/src/tui/render/main_tab.rs
+++ b/crates/spark-server/src/tui/render/main_tab.rs
@@ -273,8 +273,19 @@ fn draw_logs(f: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let want = inner.height as usize + app.log_scroll.unwrap_or(0);
-    let mut lines: Vec<Line> = log_ring::tail(want.max(64))
+    // Headroom past the current offset, so the ceiling published below always
+    // sits ahead of the scroll. The fetch used to stop at exactly
+    // `height + offset` (floored at 64), so the ceiling could never exceed
+    // what one frame happened to hold — scrolling up jammed ~64 lines in
+    // while the ring held thousands. The offset only moves a few lines
+    // between frames and each frame re-fetches from the new offset, so a
+    // margin of one ring-page keeps the ceiling ahead of the fastest scroll
+    // without cloning and wrapping the whole 10k-line ring at 10 Hz — and
+    // while FOLLOWING, the margin stays small: it exists only so the first
+    // wheel-up has a nonzero ceiling to move into.
+    let headroom = if app.log_scroll.is_some() { 512 } else { 64 };
+    let want = inner.height as usize + app.log_scroll.unwrap_or(0) + headroom;
+    let mut lines: Vec<Line> = log_ring::tail(want)
         .into_iter()
         .filter(|l| {
             app.log_filter.is_empty()

--- a/crates/spark-server/src/tui/render/main_tab.rs
+++ b/crates/spark-server/src/tui/render/main_tab.rs
@@ -7,7 +7,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Paragraph, Row, Sparkline, Table};
+use ratatui::widgets::{Paragraph, Sparkline};
 
 use super::{gradient_bar, panel};
 use crate::tui::app::App;
@@ -377,97 +377,6 @@ fn wrap_line(line: Line<'static>, width: usize) -> Vec<Line<'static>> {
         out.push(Line::from(row));
     }
     out
-}
-
-pub fn draw_kernels(f: &mut Frame, app: &App, area: Rect) {
-    let Some(model) = &app.kernels else {
-        let block = panel("KERNELS ─ waiting for startup ─".into(), false);
-        f.render_widget(
-            Paragraph::new(Span::styled(
-                "  kernel audit runs at model load…",
-                theme::dim(),
-            ))
-            .block(block),
-            area,
-        );
-        return;
-    };
-    // Only the ACTIONABLE class alarms; expected-absent is declared with a reason.
-    let missing = &model.missing_required;
-    let mut constraints = vec![Constraint::Min(6)];
-    if !missing.is_empty() {
-        constraints.insert(0, Constraint::Length(missing.len().min(6) as u16 + 2));
-    }
-    let rows_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(constraints)
-        .split(area);
-    let mut idx = 0;
-    if !missing.is_empty() {
-        let n = missing.len();
-        let title = format!(
-            "⚠ {n} UNRESOLVED ─ {} EXPECTED-ABSENT ─",
-            model.missing_expected.len()
-        );
-        let block = panel(title, false).border_style(theme::warn());
-        let lines: Vec<Line> = missing
-            .iter()
-            .take(6)
-            .map(|m| {
-                Line::from(Span::styled(
-                    format!("  {}::{}  at {}", m.module, m.func, m.site),
-                    theme::warn(),
-                ))
-            })
-            .collect();
-        f.render_widget(Paragraph::new(lines).block(block), rows_layout[idx]);
-        idx += 1;
-    }
-    let filtered: Vec<_> = model
-        .rows
-        .iter()
-        .filter(|r| app.kernel_filter.is_empty() || r.module.contains(&app.kernel_filter))
-        .collect();
-    // Two rows of chrome (header + border) come off the visible count; the
-    // ceiling is what remains once a full screen is showing.
-    let kernel_view = rows_layout[idx].height.saturating_sub(3) as usize;
-    app.kernel_scroll_max
-        .set(filtered.len().saturating_sub(kernel_view));
-    let title = format!("KERNELS ─ {} modules ─", filtered.len());
-    let header = Row::new(vec!["MODULE", "PTX-HASH", "RESOLUTION"])
-        .style(theme::text2().add_modifier(Modifier::BOLD));
-    let table_rows: Vec<Row> = filtered
-        .iter()
-        .skip(app.kernel_scroll)
-        .map(|r| {
-            let (res, style) = match r.resolution {
-                Some(true) => ("used", theme::brand_cyan()),
-                Some(false) => ("** lookup FAILED **", theme::error()),
-                None => ("-", theme::dim()),
-            };
-            let row_style = if r.resolution.is_none() {
-                theme::dim()
-            } else {
-                theme::text()
-            };
-            Row::new(vec![
-                Span::styled(r.module.clone(), row_style),
-                Span::styled(r.ptx_hash.clone(), theme::dim()),
-                Span::styled(res, style),
-            ])
-        })
-        .collect();
-    let table = Table::new(
-        table_rows,
-        [
-            Constraint::Length(34),
-            Constraint::Length(14),
-            Constraint::Min(10),
-        ],
-    )
-    .header(header)
-    .block(panel(title, true));
-    f.render_widget(table, rows_layout[idx]);
 }
 
 fn middle_truncate(s: &str, max: usize) -> String {

--- a/crates/spark-server/src/tui/render/main_tab_kernels.rs
+++ b/crates/spark-server/src/tui/render/main_tab_kernels.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Main ▸ Kernels: the per-module kernel audit table.
+//!
+//! Split from `main_tab.rs` at the 500-LoC cap — a coherent unit on its own:
+//! everything here renders the audit a model LOAD populates (`App::kernels`),
+//! and nothing else in the Main tab reads it. Its tests stay in
+//! `main_tab_tests.rs`, which drives the whole section through `render::draw`.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Row, Table};
+
+use super::panel;
+use crate::tui::app::App;
+use crate::tui::theme;
+
+pub(super) fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let Some(model) = &app.kernels else {
+        let block = panel("KERNELS ─ waiting for startup ─".into(), false);
+        f.render_widget(
+            Paragraph::new(Span::styled(
+                "  kernel audit runs at model load…",
+                theme::dim(),
+            ))
+            .block(block),
+            area,
+        );
+        return;
+    };
+    // Only the ACTIONABLE class alarms; expected-absent is declared with a reason.
+    let missing = &model.missing_required;
+    let mut constraints = vec![Constraint::Min(6)];
+    if !missing.is_empty() {
+        constraints.insert(0, Constraint::Length(missing.len().min(6) as u16 + 2));
+    }
+    let rows_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(area);
+    let mut idx = 0;
+    if !missing.is_empty() {
+        let n = missing.len();
+        let title = format!(
+            "⚠ {n} UNRESOLVED ─ {} EXPECTED-ABSENT ─",
+            model.missing_expected.len()
+        );
+        let block = panel(title, false).border_style(theme::warn());
+        let lines: Vec<Line> = missing
+            .iter()
+            .take(6)
+            .map(|m| {
+                Line::from(Span::styled(
+                    format!("  {}::{}  at {}", m.module, m.func, m.site),
+                    theme::warn(),
+                ))
+            })
+            .collect();
+        f.render_widget(Paragraph::new(lines).block(block), rows_layout[idx]);
+        idx += 1;
+    }
+    let filtered: Vec<_> = model
+        .rows
+        .iter()
+        .filter(|r| app.kernel_filter.is_empty() || r.module.contains(&app.kernel_filter))
+        .collect();
+    // Two rows of chrome (header + border) come off the visible count; the
+    // ceiling is what remains once a full screen is showing.
+    let kernel_view = rows_layout[idx].height.saturating_sub(3) as usize;
+    app.kernel_scroll_max
+        .set(filtered.len().saturating_sub(kernel_view));
+    let title = format!("KERNELS ─ {} modules ─", filtered.len());
+    let header = Row::new(vec!["MODULE", "PTX-HASH", "RESOLUTION"])
+        .style(theme::text2().add_modifier(Modifier::BOLD));
+    let table_rows: Vec<Row> = filtered
+        .iter()
+        .skip(app.kernel_scroll)
+        .map(|r| {
+            let (res, style) = match r.resolution {
+                Some(true) => ("used", theme::brand_cyan()),
+                Some(false) => ("** lookup FAILED **", theme::error()),
+                None => ("-", theme::dim()),
+            };
+            let row_style = if r.resolution.is_none() {
+                theme::dim()
+            } else {
+                theme::text()
+            };
+            Row::new(vec![
+                Span::styled(r.module.clone(), row_style),
+                Span::styled(r.ptx_hash.clone(), theme::dim()),
+                Span::styled(res, style),
+            ])
+        })
+        .collect();
+    let table = Table::new(
+        table_rows,
+        [
+            Constraint::Length(34),
+            Constraint::Length(14),
+            Constraint::Min(10),
+        ],
+    )
+    .header(header)
+    .block(panel(title, true));
+    f.render_widget(table, rows_layout[idx]);
+}

--- a/crates/spark-server/src/tui/render/mod.rs
+++ b/crates/spark-server/src/tui/render/mod.rs
@@ -8,6 +8,7 @@ mod chat_lines;
 mod header;
 mod library;
 mod main_tab;
+mod main_tab_kernels;
 mod network_tab;
 mod overlay;
 mod stats_tab;
@@ -108,7 +109,7 @@ pub fn draw(f: &mut Frame, app: &App) {
     match app.section {
         Section::Main => match app.main_sub {
             MainSub::Overview => main_tab::draw(f, app, content),
-            MainSub::Kernels => main_tab::draw_kernels(f, app, content),
+            MainSub::Kernels => main_tab_kernels::draw(f, app, content),
         },
         Section::Stats => stats_tab::draw(f, app, content),
         Section::Network => network_tab::draw(f, app, content),

--- a/crates/spark-server/src/tui/render/network_tab.rs
+++ b/crates/spark-server/src/tui/render/network_tab.rs
@@ -41,16 +41,29 @@ fn card_lines(app: &App, rank: usize) -> Vec<Line<'static>> {
             "NVIDIA GB10 · local".to_string(),
             theme::text2(),
         )));
-        let used = s.atlas_used_gb;
-        let total = s.gpu_total_gb.max(0.001);
-        let w = 18usize;
-        let filled = ((used / total).clamp(0.0, 1.0) * w as f64) as usize;
-        let bar: String = "█".repeat(filled) + &"░".repeat(w - filled);
-        lines.push(Line::from(vec![
-            Span::styled("mem ", theme::dim()),
-            Span::styled(bar, theme::brand_cyan()),
-            Span::styled(format!(" {used:.0}/{total:.0} GB"), theme::text2()),
-        ]));
+        // System memory, not the GPU accessors: those stay 0.0 until a model
+        // has loaded and NVML answers, which drew "0/0 GB" on every idle boot.
+        // On unified-memory hardware /proc/meminfo is the whole truth anyway,
+        // and it answers whether or not a model is up. The format is
+        // used/total-of-the-system; "—" when the read is unavailable, because
+        // this pane never fakes a measurement.
+        let total = s.host_total_gb;
+        if total > 0.0 {
+            let used = (total - s.host_avail_gb).max(0.0);
+            let w = 18usize;
+            let filled = ((used / total).clamp(0.0, 1.0) * w as f64) as usize;
+            let bar: String = "█".repeat(filled) + &"░".repeat(w - filled);
+            lines.push(Line::from(vec![
+                Span::styled("mem ", theme::dim()),
+                Span::styled(bar, theme::brand_cyan()),
+                Span::styled(format!(" {used:.0}/{total:.0} GB"), theme::text2()),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::styled("mem ", theme::dim()),
+                Span::styled("—", theme::dim()),
+            ]));
+        }
         lines.push(Line::from(Span::styled(
             format!("{}:{}", app.args.bind, app.args.port),
             theme::text2(),

--- a/crates/spark-server/src/tui/render/network_tab_tests.rs
+++ b/crates/spark-server/src/tui/render/network_tab_tests.rs
@@ -22,17 +22,28 @@ fn net(world: usize, tp: usize, ep: usize) -> App {
 #[test]
 fn a_single_node_deployment_gets_a_centrepiece_rather_than_an_empty_screen() {
     let mut a = net(1, 1, 1);
-    a.stats.atlas_used_gb = 57.0;
-    a.stats.gpu_total_gb = 119.7;
+    // The card reports SYSTEM memory (used/total), from /proc/meminfo: the
+    // GPU accessors are 0.0 until a model loads, and this card must not read
+    // "0/0 GB" on an idle boot.
+    a.stats.host_total_gb = 119.7;
+    a.stats.host_avail_gb = 62.7;
     let rows = screen(&a, 160, 48);
     assert!(has(&rows, "rank 0 · HEAD"), "{rows:#?}");
     assert!(has(&rows, "NVIDIA GB10 · local"));
     assert!(
         has(&rows, "57/120 GB"),
-        "the memory bar is labelled:\n{rows:#?}"
+        "the memory bar is used/total-system:\n{rows:#?}"
     );
     assert!(has(&rows, "tp 1 · ep 1 · world 1 — all local"));
     assert!(has(&rows, "❯❯❯"), "the stage chevrons flank the card");
+}
+
+#[test]
+fn an_unreadable_meminfo_draws_a_dash_rather_than_a_zero() {
+    // 0/0 was the bug this line replaced; the honest fallback is no number.
+    let rows = screen(&net(1, 1, 1), 160, 48);
+    assert!(has(&rows, "mem —"), "{rows:#?}");
+    assert!(!has(&rows, "0/0 GB"), "{rows:#?}");
 }
 
 #[test]


### PR DESCRIPTION
Fixes the five dashboard bugs reported this week:

1. **Downloads failed on arrival with an error toast** when a stale HF token was present. The Hub answers 401 for public repos on any invalid Authorization header, so the client now retries anonymously on 401/403. Gated repos still classify exactly as before.
2. **Error toasts persisted forever.** They now auto-dismiss at 12s (info stays 5s). Also settled a related wedge: a download worker dying without a terminal message left the job tracked forever, refusing every later download with "already downloading".
3. **Download progress now renders in both panes**: a gradient bar with bytes, rate, and file counter in the detail pane, and a pulsing yellow dot inline after the model name on the list row.
4. **Network tab memory read 0/0** until a model loaded (GPU accessors). It now reports used/total system RAM from /proc/meminfo, dash when unreadable.
5. **Main tab log scrolling jammed ~64 lines up**: the renderer fetched only what one frame held and published a ceiling from that. It now fetches ahead of the offset, so scrollback reaches the whole 10k line ring.

731 tui + 34 model_download + 112 app unit tests pass. Two ignored network tests (stale-token fallback, failure settling) pass live. Verified interactively on GB10: resume, stop/resume round trip, toast expiry, memory line, deep scrollback.
