### PR TITLE
fix(windows): make the native-HIP build run out of the box on Strix Halo (gfx1151, runtime-verified)

### DIFF
--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -670,6 +670,33 @@ fn build_hip_shim(manifest_dir: &std::path::Path, out_dir: &std::path::Path) {
     );
 }
 
+#[cfg(windows)]
+fn resolve_dumpbin_path() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("ATLAS_DUMPBIN") {
+        let candidate = std::path::PathBuf::from(path);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    if let Ok(vctools_dir) = std::env::var("VCToolsInstallDir") {
+        let base = std::path::Path::new(&vctools_dir).join("bin");
+        for (host, target) in [
+            ("Hostx64", "x64"),
+            ("Hostx86", "x86"),
+            ("Hostx64", "x86"),
+            ("Hostx86", "x64"),
+        ] {
+            let candidate = base.join(host).join(target).join("dumpbin.exe");
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
+    std::path::PathBuf::from("dumpbin.exe")
+}
+
 /// Windows native-HIP runtime shim. Builds ONE `cuda.dll` from the real cu*
 /// (libcuda_hip_shim.cpp) and cudart (libcudart_hip_shim.cpp) HIP mappings plus
 /// the cuBLASLt stub, linked against `amdhip64.lib`, and generates its import
@@ -718,13 +745,20 @@ fn build_hip_shim_windows(manifest_dir: &std::path::Path, out_dir: &std::path::P
     // `SECTn ... External | <name>`; undefined imports (the hip* the shim calls)
     // are `UNDEF` and start with `hip`, so filtering on `External`, not `UNDEF`,
     // and a `cu` name prefix keeps exactly cu*/cudart/cublasLt.
+    let dumpbin = resolve_dumpbin_path();
     let mut exports = Vec::new();
     for obj in &objs {
-        let out = std::process::Command::new("dumpbin")
+        let out = std::process::Command::new(&dumpbin)
             .arg("/SYMBOLS")
             .arg(obj)
             .output()
-            .unwrap_or_else(|e| panic!("dumpbin /SYMBOLS failed on {} ({e})", obj.display()));
+            .unwrap_or_else(|e| {
+                panic!(
+                    "dumpbin /SYMBOLS failed on {} using {} ({e})",
+                    obj.display(),
+                    dumpbin.display()
+                )
+            });
         for line in String::from_utf8_lossy(&out.stdout).lines() {
             if line.contains("External")
                 && !line.contains("UNDEF")

--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -279,6 +279,7 @@ fn main() {
             target.model,
             target.quant,
         );
+        assert_sources_are_not_symlink_stubs(&cu_files);
 
         // Gather work for this target (no compilation yet — that runs
         // in parallel after the full work plan is built).
@@ -805,22 +806,86 @@ fn build_hip_shim_windows(manifest_dir: &std::path::Path, out_dir: &std::path::P
             .unwrap_or_else(|e| panic!("copy import lib -> {lib}: {e}"));
     }
 
-    // 5. Stage the HIP runtime DLL for packaging. On Windows it is versioned
-    // (amdhip64_6.dll, not amdhip64.dll), so glob `amdhip64*.dll` under the SDK
-    // bin. If absent (a driverless CI runner may ship only the import lib), it
-    // is not fatal: amdhip64 is an AMD-driver component present on any real AMD
-    // Windows host, so the shipped shim resolves it there. Informational, not a
-    // warning, so a green build is not noisy.
+    // 5. Stage the HIP runtime DLLs for packaging. On Windows they are versioned
+    // (amdhip64_6.dll, not amdhip64.dll), so glob by prefix under the SDK bin.
+    //
+    // Staging amdhip64 ALONE is not enough, and the "it is an AMD-driver
+    // component, present on any real AMD Windows host" reasoning is a trap.
+    // amdhip64_6.dll loads its code-object compiler by plain name, and Windows
+    // resolves that against the whole search path -- so on a machine whose
+    // driver dropped an older amd_comgr_2.dll in System32, HIP binds the STALE
+    // comgr and every hipModuleLoadData fails as `CUDA_ERROR_OUT_OF_MEMORY`.
+    // That is a wildly misleading error: it looks like a KV-cache sizing bug and
+    // sends you tuning --gpu-memory-utilization for hours. Measured on a
+    // Ryzen AI MAX+ 395 / gfx1151 box: System32 amd_comgr_2.dll 109 MB (no
+    // version resource) vs ROCm 6.4's 115.55 MB.
+    //
+    // So stage the full set the runtime actually pulls in. Bundling them beside
+    // spark.exe wins because the executable's own directory precedes System32 in
+    // the default DLL search order.
+    const HIP_RUNTIME_PREFIXES: [&str; 4] = [
+        "amdhip64",         // the HIP runtime itself
+        "amd_comgr",        // code-object manager -- the one that gets shadowed
+        "hiprtc-builtins",  // must precede "hiprtc" below only for readability
+        "hiprtc",           // runtime compilation, pulled in by comgr
+    ];
     let mut staged_runtime = false;
+    let mut staged_names: Vec<String> = Vec::new();
     if let Ok(entries) = std::fs::read_dir(hip_root.join("bin")) {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if name.starts_with("amdhip64") && name.ends_with(".dll") {
+            if name.ends_with(".dll")
+                && HIP_RUNTIME_PREFIXES.iter().any(|p| name.starts_with(p))
+            {
                 std::fs::copy(entry.path(), out_dir.join(&*name))
                     .unwrap_or_else(|e| panic!("stage {name}: {e}"));
+                staged_names.push(name.to_string());
                 staged_runtime = true;
             }
+        }
+    }
+    if staged_runtime {
+        staged_names.sort();
+        println!(
+            "cargo:warning=atlas-kernels: staged HIP runtime DLLs for packaging: {}",
+            staged_names.join(", ")
+        );
+    }
+
+    // 5b. Also drop the runtime DLLs NEXT TO THE BUILT BINARY.
+    //
+    // Staging into OUT_DIR only serves the packaging step. A developer who runs
+    // `cargo build && target\...\release\spark.exe` gets an exe with no
+    // nvcuda.dll beside it, so cudarc's dlopen falls back to whatever is on the
+    // system path -- which on an AMD box is the driver's amdhip64 bound to a
+    // stale System32 comgr, i.e. the fake-OOM above. Worse, a rebuilt cuda.dll
+    // silently goes unused because a previous copy is already sitting there.
+    //
+    // OUT_DIR is <target>/<triple>/<profile>/build/<pkg>-<hash>/out, so the
+    // profile dir (where the exe lands) is three ancestors up. Best-effort:
+    // never fail the build over this, since the layout is a cargo implementation
+    // detail rather than a guarantee.
+    if let Some(profile_dir) = out_dir.ancestors().nth(3) {
+        let mut copied = Vec::new();
+        let mut to_copy = staged_names.clone();
+        to_copy.push("cuda.dll".to_string());
+        to_copy.push("nvcuda.dll".to_string());
+        for name in &to_copy {
+            let src = out_dir.join(name);
+            if !src.exists() {
+                continue;
+            }
+            if std::fs::copy(&src, profile_dir.join(name)).is_ok() {
+                copied.push(name.clone());
+            }
+        }
+        if !copied.is_empty() {
+            println!(
+                "cargo:warning=atlas-kernels: copied {} runtime DLL(s) next to the binary in {}",
+                copied.len(),
+                profile_dir.display()
+            );
         }
     }
     if !staged_runtime {
@@ -1027,6 +1092,59 @@ mod build_parse;
 use build_parse::{
     parse_behavior, parse_dflash, parse_kernel_toml, parse_model_types, parse_sampling_presets,
 };
+
+/// Fail with an actionable message if any "kernel source" is really an
+/// unmaterialised git symlink.
+///
+/// `kernels/` leans on symlinks (strix-hip -> strix -> gb10), and Git for
+/// Windows defaults to `core.symlinks=false`, which checks each one out as a
+/// small TEXT FILE whose entire content is the link target path. A default
+/// Windows clone therefore substitutes a few hundred path strings for real
+/// sources. The compiler's complaint about those points at the compiler and
+/// tells you nothing about the clone, so diagnose it here instead.
+fn assert_sources_are_not_symlink_stubs(files: &[std::path::PathBuf]) {
+    let mut stubs = Vec::new();
+    for f in files {
+        // A real kernel is never this small; a link target path always is.
+        match std::fs::metadata(f) {
+            Ok(m) if m.len() < 512 => {}
+            _ => continue,
+        }
+        let Ok(text) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        let t = text.trim();
+        let is_stub = !t.is_empty()
+            && !t.contains('\n')
+            && !t.contains(['{', '}', ';'])
+            && (t.contains('/') || t.contains('\\'))
+            && (t.ends_with(".cu") || t.ends_with(".cuh") || t.ends_with(".h"));
+        if is_stub {
+            stubs.push(format!("  {}  ->  {t}", f.display()));
+        }
+    }
+    if stubs.is_empty() {
+        return;
+    }
+    let shown: Vec<_> = stubs.iter().take(5).cloned().collect();
+    panic!(
+        "{} kernel source(s) are unmaterialised git symlinks -- they contain a path, not code:\n\
+         {}{}\n\n\
+         This is a Windows clone with core.symlinks=false. Fix the clone, not the build:\n\
+         \x20 git config core.symlinks true\n\
+         \x20 git checkout -- kernels/\n\
+         (Developer Mode or an elevated shell is needed for Windows to create symlinks.)\n\
+         Re-cloning with `git clone -c core.symlinks=true ...` works too. Note the links\n\
+         CHAIN (strix-hip -> strix -> gb10), so materialise them target-first.",
+        stubs.len(),
+        shown.join("\n"),
+        if stubs.len() > shown.len() {
+            format!("\n  ... and {} more", stubs.len() - shown.len())
+        } else {
+            String::new()
+        },
+    );
+}
 
 /// Collect kernel-source files with shadowing: common dir provides the
 /// base set, model-specific dir can override individual files by matching

--- a/crates/atlas-kernels/hip/compat/atlas_hip_win_shims.h
+++ b/crates/atlas-kernels/hip/compat/atlas_hip_win_shims.h
@@ -58,7 +58,10 @@ __device__ __forceinline__ int __any_sync(unsigned long long, int pred) { return
 __device__ __forceinline__ int __all_sync(unsigned long long, int pred) { return __all(pred); }
 
 // CUDA returns a 32-bit lane mask; AMD wavefronts are 64-wide, so __ballot(1)
-// (the full active-lane mask) is the faithful analogue.
+// (the full active-lane mask) is the faithful analogue. Newer Windows HIP SDKs
+// already provide __activemask(), so only define the fallback when needed.
+#if !defined(HIP_VERSION_MAJOR) || (HIP_VERSION_MAJOR < 7) || defined(HIP_DISABLE_WARP_SYNC_BUILTINS)
 __device__ __forceinline__ unsigned long long __activemask() { return __ballot(1); }
+#endif
 
 #endif  // __HIP_PLATFORM_AMD__ || __HIP__

--- a/crates/atlas-kernels/hip/libcuda_hip_shim.cpp
+++ b/crates/atlas-kernels/hip/libcuda_hip_shim.cpp
@@ -12,8 +12,42 @@
 //   checks success and formats via cuGetErrorString (mapped to hipGetErrorString).
 #include <hip/hip_runtime.h>
 #include <cstring>
+#include <mutex>
+#include <unordered_map>
 
 typedef unsigned long long CUdeviceptr;
+
+// Windows device-memory accounting.
+//
+// hipMemGetInfo is BROKEN on the Windows HIP runtime: it returns
+// hipErrorInvalidValue ("invalid argument") standalone, and reports free==0
+// under a live context. Atlas sizes its KV cache from cuMemGetInfo, so a bogus
+// 0-free makes serve fail with "No memory left for KV cache" even with tens of
+// GB genuinely available (measured: 64 GB allocatable via a hipMalloc ladder).
+//
+// So track what we hand out and synthesise a truthful answer when HIP won't
+// give one. Only engages when hipMemGetInfo actually fails or returns zeros,
+// so Linux/ROCm behaviour is byte-identical to before.
+static std::mutex g_mem_mu;
+static std::unordered_map<void *, size_t> g_mem_sizes;
+static size_t g_mem_used = 0;
+
+static void atlas_track_alloc(void *p, size_t n) {
+    if (!p) return;
+    std::lock_guard<std::mutex> lk(g_mem_mu);
+    g_mem_sizes[p] = n;
+    g_mem_used += n;
+}
+
+static void atlas_track_free(void *p) {
+    if (!p) return;
+    std::lock_guard<std::mutex> lk(g_mem_mu);
+    auto it = g_mem_sizes.find(p);
+    if (it == g_mem_sizes.end()) return;
+    g_mem_used = (g_mem_used > it->second) ? g_mem_used - it->second : 0;
+    g_mem_sizes.erase(it);
+}
+
 extern "C" {
 
 // ── init / context ────────────────────────────────────────────────────
@@ -28,13 +62,44 @@ int cuGetErrorName(int err, const char** s)   { *s = hipGetErrorName((hipError_t
 int cuGetErrorString(int err, const char** s) { *s = hipGetErrorString((hipError_t)err); return 0; }
 
 // ── memory ────────────────────────────────────────────────────────────
-int cuMemAlloc_v2(CUdeviceptr* dptr, size_t n)      { return hipMalloc((void**)dptr, n); }
-int cuMemFree_v2(CUdeviceptr dptr)                  { return hipFree((void*)dptr); }
+int cuMemAlloc_v2(CUdeviceptr* dptr, size_t n)      {
+    int r = hipMalloc((void**)dptr, n);
+    if (r == hipSuccess && dptr) atlas_track_alloc((void*)*dptr, n);
+    return r;
+}
+int cuMemFree_v2(CUdeviceptr dptr)                  {
+    atlas_track_free((void*)dptr);
+    return hipFree((void*)dptr);
+}
 int cuMemAllocHost_v2(void** pp, size_t n)          { return hipHostMalloc(pp, n, 0); }
 int cuMemFreeHost(void* p)                          { return hipHostFree(p); }
 int cuMemAllocManaged(CUdeviceptr* dptr, size_t n, unsigned flags)
-                                                    { return hipMallocManaged((void**)dptr, n, flags); }
-int cuMemGetInfo_v2(size_t* free, size_t* total)    { return hipMemGetInfo(free, total); }
+                                                    {
+    int r = hipMallocManaged((void**)dptr, n, flags);
+    if (r == hipSuccess && dptr) atlas_track_alloc((void*)*dptr, n);
+    return r;
+}
+// See the g_mem_used comment above: fall back to totalGlobalMem minus tracked
+// allocations whenever hipMemGetInfo errors or hands back a zero.
+int cuMemGetInfo_v2(size_t* free, size_t* total)    {
+    size_t f = 0, t = 0;
+    hipError_t e = hipMemGetInfo(&f, &t);
+    if (e == hipSuccess && t != 0 && f != 0) {
+        if (free)  *free  = f;
+        if (total) *total = t;
+        return hipSuccess;
+    }
+    int dev = 0;
+    if (hipGetDevice(&dev) != hipSuccess) return (int)e;
+    hipDeviceProp_t prop;
+    if (hipGetDeviceProperties(&prop, dev) != hipSuccess) return (int)e;
+    size_t used;
+    { std::lock_guard<std::mutex> lk(g_mem_mu); used = g_mem_used; }
+    const size_t tot = prop.totalGlobalMem;
+    if (total) *total = tot;
+    if (free)  *free  = (used < tot) ? (tot - used) : 0;
+    return hipSuccess;
+}
 
 int cuMemcpyHtoDAsync_v2(CUdeviceptr dst, const void* src, size_t n, void* s)
                               { return hipMemcpyHtoDAsync((hipDeviceptr_t)dst, (void*)src, n, (hipStream_t)s); }

--- a/crates/spark-server/src/main_modules/serve_phases/weights.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/weights.rs
@@ -37,6 +37,25 @@ pub(crate) fn load_weight_store(
     let mult = quant_multiplier(config);
     let use_fast_load =
         !args.no_fast_load && std::env::var("ATLAS_FAST_LOAD").ok().as_deref() != Some("0");
+
+    // The fast loader needs O_DIRECT / posix_fadvise, which Windows does not
+    // have. It is ON by default, so a Windows user who passes nothing special
+    // hits a hard error before a single weight loads -- and the flag that fixes
+    // it (`--no-fast-load`) is not mentioned in the porting guide. Degrade to
+    // the standard loader with a warning instead: slower, but it starts, and
+    // nobody has to discover a Unix-only default to run the server at all.
+    #[cfg(not(unix))]
+    let use_fast_load = {
+        if use_fast_load {
+            tracing::warn!(
+                "Fast weight loader is Unix-only (needs O_DIRECT / posix_fadvise); \
+                 falling back to the standard loader on this host. Pass --no-fast-load \
+                 to silence this."
+            );
+        }
+        false
+    };
+
     let store = if use_fast_load {
         #[cfg(unix)]
         {

--- a/crates/spark-server/src/scheduler/decode_logits_step.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_step.rs
@@ -718,11 +718,30 @@ pub fn process_decode_logits(
             }
 
             // Check request timeout.
+            //
+            // `timeout_at` is stamped at ARRIVAL in the API layer, but
+            // `request_start` is stamped at PREFILL — different origins. A
+            // request can therefore burn its entire budget waiting in the
+            // scheduler queue and trip this on its very first decode step.
+            // The old message reported only `request_start.elapsed()`, which
+            // renders as "Request timeout after 8.4s" against a 300 s budget
+            // and sends the reader looking at decode instead of at queue
+            // depth. Report the overrun and the tokens actually produced:
+            // `output_tokens=1` is the signature of a deadline that expired
+            // before decode ever began, and is otherwise invisible because
+            // the response goes back as a normal `finish_reason="length"`.
             if !a.finished
                 && let Some(deadline) = a.timeout_at
-                && Instant::now() >= deadline
+                && now >= deadline
             {
-                tracing::warn!("Request timeout after {:?}", a.request_start.elapsed());
+                tracing::warn!(
+                    output_tokens = a.output_tokens.len(),
+                    since_prefill_s = a.request_start.elapsed().as_secs_f64(),
+                    overdue_s = now.saturating_duration_since(deadline).as_secs_f64(),
+                    "Request timeout: deadline expired (stamped at arrival, so it \
+                     includes time queued before prefill); truncating output"
+                );
+                a.guard_stop = Some("request_timeout");
                 a.finished = true;
             }
         }

--- a/docs/porting/STRIX_WINDOWS_HIP.md
+++ b/docs/porting/STRIX_WINDOWS_HIP.md
@@ -4,13 +4,47 @@ Windows AMD is the **native-HIP** path (`ATLAS_TARGET_HW=strix-hip`, hipcc, gfx1
 SCALE — Atlas's other AMD toolchain — is Linux-only, so HIP is the only conceivable
 Windows AMD target.
 
-> **Status: COMPILE-VERIFIED, RUNTIME UNVERIFIED.**
-> Every claim below about *building* is checked by CI on a hosted `windows-2022`
-> runner. Nothing below about *running* has been executed on Windows — there is no
-> Windows AMD machine in the fleet. Treat the serve section as a starting point to
-> be corrected by the first person who runs it, not as a reproduction recipe.
-> The Linux numbers in [`STRIX_NVFP4_MLPERF.md`](STRIX_NVFP4_MLPERF.md) do **not**
-> transfer; see "Why the Linux numbers won't reproduce" below.
+> **Status: RUNTIME-VERIFIED** on a Framework Desktop (Ryzen AI MAX+ 395 /
+> Radeon 8060S, gfx1151, Windows 11) serving `nvidia/Qwen3.6-27B-NVFP4`,
+> 2026-08-13. Clean build to a served token in ~93 s; BFCL v3 seeded 196-entry
+> subset **165/196 (84.2%)**.
+> The Linux numbers in [`STRIX_NVFP4_MLPERF.md`](STRIX_NVFP4_MLPERF.md) still do
+> **not** transfer; see "Why the Linux numbers won't reproduce" below.
+
+## OK, how do I test it?
+
+**You do not need to build anything.** Grab the prebuilt zip CI already publishes,
+point one variable at it, run one script:
+
+```powershell
+# 1. Download `spark-windows-x86_64-amd-hip` from any green run of the release
+#    matrix and unzip it. KEEP THE DLLs BESIDE spark.exe -- cudarc dlopens
+#    nvcuda.dll from the exe's own directory, and that DLL imports amdhip64_6.dll.
+
+# 2. Weights (~21 GB):
+hf download nvidia/Qwen3.6-27B-NVFP4 --local-dir "$env:USERPROFILE\models\Qwen3.6-27B-NVFP4"
+
+# 3. Serve + smoke test:
+$env:ATLAS_BIN = "C:\path\to\unzipped\spark.exe"
+powershell -ExecutionPolicy Bypass -File scripts\strix-windows\first_run.ps1
+```
+
+That is the whole thing. You need the AMD driver and the weights — no MSVC, no HIP
+SDK, no Rust, no clone. The script checks the box, starts the server with the
+verified configuration, fires a completion at it, and writes the answer to
+`first_run_smoke.log` beside the exe:
+
+```
+SMOKE OK  finish=length  tokens=63
+TEXT: The three primary colors are **Red**, **Yellow**, and **Blue**. ...
+```
+
+If you got that, the port works on your hardware. `-Phase check` audits the box
+and changes nothing, if you want to look before you leap.
+
+**Building from source instead?** Leave `ATLAS_BIN` unset and the same script
+checks the toolchain, repairs the kernel symlinks a Windows clone breaks, builds,
+and serves. Everything it does is spelled out below.
 
 ## What CI proves
 
@@ -77,7 +111,9 @@ with `dry_run=true` (which is how run `30241443396` above was produced, and need
 no PR). Unzip; **keep the DLLs beside `spark.exe`** — `cudarc` `dlopen`s
 `nvcuda.dll` from the exe's directory, and that DLL imports `amdhip64_6.dll`.
 
-To build it yourself you need the Windows HIP SDK and MSVC on PATH:
+To build it yourself you need the Windows HIP SDK and MSVC on PATH.
+`scripts/strix-windows/first_run.ps1` does all of the below plus the symlink
+repair; the raw commands are here for reference:
 
 ```powershell
 $env:ATLAS_TARGET_HW    = "strix-hip"
@@ -95,25 +131,65 @@ panics resolving it. Build from **PowerShell, not Git Bash**: under bash on
 Windows, Git's `/usr/bin` precedes MSVC on PATH and rustc invokes the coreutils
 `link.exe` instead of the MSVC linker.
 
-## Running it — UNVERIFIED
+## Running it — VERIFIED
 
 Hardware: a Strix Halo (Radeon 8060S, gfx1151) box on Windows 11 with a current
 AMD Adrenalin driver. Model: `nvidia/Qwen3.6-27B-NVFP4`.
 
-Start from the Linux serve line in `STRIX_NVFP4_MLPERF.md` and drop the Linux-only
-parts (`LD_LIBRARY_PATH` is unnecessary — the DLLs sit beside the exe):
+`scripts/strix-windows/first_run.ps1` runs exactly this; the values are reproduced
+here so the reasoning has somewhere to live. **Three of them changed once this was
+run on real hardware** — the pre-runtime guesses are called out inline, because
+each one produces a failure that points somewhere else.
 
 ```powershell
 $env:ATLAS_W4A16_DP4A = "1"; $env:ATLAS_FORCE_GLOBAL_GDN = "1"; $env:ATLAS_W4A16_VARIANT = "v1"
-$env:ATLAS_KV_EXTERNAL_RESERVE_GB = "6"
-$env:ATLAS_SSM_TAIL_MIDCHUNK = "1"; $env:ATLAS_SSM_TAIL_PROTECT = "1"
+$env:ATLAS_KV_EXTERNAL_RESERVE_GB = "0"   # was 6 -- see below, 6 oversizes the KV pool
+$env:ATLAS_SSM_TAIL_MIDCHUNK = "0"        # was 1 -- see below, 1 corrupts shared prefixes
+$env:ATLAS_SSM_TAIL_PROTECT = "1"; $env:ATLAS_SSM_TAIL_LEASE_TTL = "128"
 $env:ATLAS_MTP_GATE_REPROBE = "64"
 .\spark.exe serve <snapshot> --model-name nvidia/Qwen3.6-27B-NVFP4 --port 8081 `
-  --max-seq-len 65536 --gpu-memory-utilization 0.35 --kv-cache-dtype bf16 `
+  --max-seq-len 65536 --gpu-memory-utilization 0.80 --kv-cache-dtype bf16 `
   --max-batch-size 1 --speculative --num-drafts 2 --mtp-quantization bf16 `
   --mtp-vocab 100000 --disable-tool-grammar true --enable-prefix-caching `
   --ssm-cache-slots 64 --ssm-checkpoint-interval 16 --disable-thinking
 ```
+
+**`ATLAS_KV_EXTERNAL_RESERVE_GB` must be 0, not 6.** `hipMemGetInfo` is broken on
+Windows HIP — `hipErrorInvalidValue` standalone, `free == 0` under a live context —
+so `cuMemGetInfo_v2` now synthesises a truthful figure from tracked allocations.
+That tracker reports Atlas-own bytes only, so `build.rs`'s co-tenant *discount*
+double-counts and oversizes the KV pool: with 6 it allocated 11.3 GB of KV and
+then died on a later 24 MB alloc. `0` fails `build.rs`'s `.filter(|gb| gb > 0.0)`
+and falls through to the AUTO path (`baseline_free - free_now`), which is right
+given the fixed shim.
+
+**`ATLAS_SSM_TAIL_MIDCHUNK` must be 0, not 1.** Mid-chunk tail capture corrupts
+*cross-request* SSM prefix reuse — the regression `scripts/mlperf-edge/ab_midchunk.sh`
+already documents. Requests sharing a system-prompt prefix reuse each other's tail
+snapshot; observed here as empty 1-token completions on 12/12 `live_multiple`
+entries. It is a strict-`"0"` opt-out, **not** a presence flag: absent, or any
+other value, leaves it ON.
+
+**`--gpu-memory-utilization 0.80`, not 0.35.** It is a fraction of the total the
+driver *reports* (76.9 GB), but the measured allocatable ceiling is ~63 GB, so it
+cannot go much past 0.83. 0.80 gives a 61.5 GB budget: 40.3 GB pre-KV + 15.7 GB
+reserve → 5.4 GB of KV = **89,232 tokens**.
+
+Two more things a first run needs, neither of them obvious:
+
+- **`--no-fast-load` used to be mandatory.** The fast weight loader needs
+  `O_DIRECT`/`posix_fadvise`, is ON by default, and hard-errored on a non-Unix host
+  before a single weight loaded. It now warns and falls back, so the flag is
+  optional — passing it just silences the warning.
+- **A Windows clone breaks `kernels/`.** 219 entries there are git symlinks that
+  *chain* (`strix-hip → strix → gb10`), and Git for Windows defaults to
+  `core.symlinks=false`, checking each out as a ~32 byte text file containing the
+  link target path. `build.rs` now stops the build and names `core.symlinks`
+  instead of letting hipcc complain about source it can't parse; the script
+  repairs them from the git object store. Cloning with `-c core.symlinks=true`
+  needs Developer Mode or an elevated shell and fails *silently* when it doesn't
+  take. Once repaired, those 219 files show as modified in `git status` forever —
+  real content where git expects a link blob. **Never commit them.**
 
 The Linux doc's `ATLAS_MTP_DRAFTER_PREFILL=1` and `ATLAS_MTP_CARRY_DRAFTER=1` are
 both **dropped on purpose**: `drafter_context` now ships prefill and carry ON by
@@ -122,17 +198,39 @@ A/B against it, is `ATLAS_NO_MTP_DRAFTER_CONTEXT=1` (turns off both).
 
 ### The memory model is the thing most likely to bite
 
-On Linux the GPU pool is APU GTT (~60 GB of the 128 GB) and it grows on demand.
-On Windows it is WDDM: `hipMalloc` sees the **Variable Graphics Memory** carve-out
-you set in Adrenalin / BIOS, and it does **not** grow. Set VGM high *before*
-serving; `--gpu-memory-utilization` is a fraction of what the driver exposes, so
-the Linux value of 0.35 means something different here.
+**The VGM warning this section used to carry did not reproduce.** On the Framework
+Desktop, ~64 GB was allocatable with **no BIOS or Adrenalin tuning at all** —
+default settings, 128 GB of system RAM. Anyone reading the old advice would have
+gone hunting through firmware for a carve-out that was never the problem. What
+*is* true:
 
-There is also **no safety net**. When a weight allocation fails, Atlas falls back
+- `hipInfo` reports **76.87 GB** exposed, but a `hipMalloc` ladder finds the real
+  ceiling at **~63 GB**. `--gpu-memory-utilization` is a fraction of the number the
+  driver *reports*, not of the number it will honour — hence 0.80, not 0.35, and
+  not much above 0.83.
+- Measured: at 11.3 GB of KV the process reached 63.3 GB tracked and `hipMalloc`
+  started failing. ~5 GB of KV keeps peak near 57 GB with real margin.
+
+There is still **no safety net**. When a weight allocation fails, Atlas falls back
 to managed/UVM memory (`load_fns.rs:130`, whose log line literally says "paged via
 Linux swap"). That path calls `hipMallocManaged`, which AMD does not support on
-Windows — so on Windows a too-small carve-out is a **hard error**, not a slow
-degrade. If you see `cuMemAllocManaged failed`, the fix is more VGM, not more swap.
+Windows — so a too-small budget is a **hard error**, not a slow degrade. If you
+see `cuMemAllocManaged failed`, lower `--gpu-memory-utilization`.
+
+### The DLL trap that costs the most time
+
+`amdhip64_6.dll` loads its code-object manager **by plain name**. On a host whose
+driver left an older `amd_comgr_2.dll` in System32, HIP binds the stale one and
+*every* `hipModuleLoadData` fails as **`CUDA_ERROR_OUT_OF_MEMORY`** — which reads
+as a KV-sizing bug and sends you tuning `--gpu-memory-utilization` for hours.
+Measured here: System32's copy 109 MB with no version resource, against ROCm 6.4's
+115.55 MB.
+
+The build now stages `amd_comgr*`, `hiprtc*` and `hiprtc-builtins*` alongside
+`amdhip64`, **and copies them next to the built binary** — `OUT_DIR` staging only
+served the packaging step, so `cargo build` followed by running the exe still
+picked up whatever was on the system path. If you unzip the CI artifact, keep the
+whole folder together for the same reason.
 
 ### Why the Linux numbers won't reproduce
 
@@ -145,19 +243,41 @@ Do not expect the 7108 s / 25 tok/s Linux figures.
   launches per token), which is the workload shape most exposed to per-launch
   overhead.
 
-**Measure launch overhead first.** If it is bad, no amount of kernel tuning
-recovers it, and that result is worth knowing before anyone invests further.
+**Still the right thing to measure next.** The 2026-08-13 run establishes that the
+port is correct and usable (84.2% accuracy, ~25 s/entry at batch 1) but does not
+isolate per-launch overhead from everything else in that number. Nobody should
+invest in kernel tuning on this target before that split exists.
 
-## What to report
+## What the first run answered
 
-Most useful first:
+The five questions this section used to ask, answered on 2026-08-13:
 
-1. Does `spark.exe` start and load all kernels? Expect **97** (see above).
-   Fewer means kernels silently failed to resolve at load time.
-2. Does it produce coherent output for a plain prompt? (Garbage output with a
-   clean startup is the NVFP4-corruption signature, not a crash.)
-3. `nvidia-smi`-equivalent: what does Adrenalin report for VGM, and what
-   `--gpu-memory-utilization` actually fits?
-4. TTFT and TPOT for a short prompt, so we can size the WDDM launch-overhead gap.
-5. Any `cuMemAllocManaged failed` / missing-DLL / missing-symbol error verbatim —
-   the shim exports 76 symbols and a missing one is a one-line fix.
+1. **Does it start and load all kernels?** Yes — **97**, matching CI and the Linux
+   tree.
+2. **Coherent output?** Yes. No NVFP4-corruption signature. BFCL v3 seeded
+   196-entry subset scores **165/196 (84.2%)** — `simple` and `multiple` 0.967,
+   `live_parallel` 0.625 lowest. Not comparable to the porting doc's 89.22, which
+   is v4 on a different 167-sample subset; `bfcl-eval` ships v3 data.
+3. **VGM / utilization?** No VGM tuning was needed; see the memory section above.
+   `0.80` fits, `0.35` needlessly starves the KV pool.
+4. **TTFT / TPOT?** ~25 s per BFCL entry end to end at `--max-batch-size 1`. The
+   WDDM launch-overhead gap is real but did not stop the port from being usable —
+   worth a dedicated measurement, still open.
+5. **Errors?** No missing symbols; the 76-export shim was complete. The failures
+   worth knowing are the ones above, plus the three filed separately.
+
+## If you are running a benchmark
+
+`bfcl-eval`'s local/OSS path hardcodes `ThreadPoolExecutor(max_workers=100)`
+(`base_oss_handler.py:222`) and **ignores `--num-threads`**, which is honoured only
+on the hosted-API path. Against `--max-batch-size 1` that is 100-way concurrency,
+and the queue passes the 300 s request deadline about five minutes in. Because
+Atlas stamps `timeout_at` at *arrival* but `request_start` at *prefill*, those
+requests expire **while queued**, die on their first decode step, and come back as
+**1 token with `finish_reason: "length"`** — indistinguishable from a legitimate
+`max_tokens` stop. Every one scores as a wrong answer and nothing retries.
+
+That invalidated a full 5-hour run at 75.5%. Pinning concurrency to 1 took request
+timeouts from 1126/1294 to **0** and the score to 84.2%. Check the serve log for
+`Request timeout` before trusting any number off this box; the behavioural half is
+filed as #482.

--- a/scripts/strix-windows/first_run.ps1
+++ b/scripts/strix-windows/first_run.ps1
@@ -73,6 +73,15 @@ $BindHost = if ($env:ATLAS_BIND) { $env:ATLAS_BIND } else { '127.0.0.1' }
 # nothing to build, so the binary's own directory takes the place of target/ and
 # the toolchain checks are skipped -- a tester needs the driver and weights only.
 $Prebuilt = [bool]$env:ATLAS_BIN
+
+# Which toolchain pieces this invocation actually needs. Only compiling requires
+# MSVC / hipcc / Rust; serving an existing binary requires none of them, and
+# demanding them anyway is how a "just run it" path turns into a yak shave.
+# 'check' counts as needing them: with ATLAS_BIN unset it means "can this box
+# build and run Atlas?", which is the question someone auditing before they start
+# is actually asking. '-Phase serve' on an existing binary does not.
+$NeedsBuild = (-not $Prebuilt) -and ($Phase -in @('all', 'build', 'check'))
+
 if ($Prebuilt) {
     if (-not (Test-Path $env:ATLAS_BIN)) { throw "ATLAS_BIN does not exist: $env:ATLAS_BIN" }
     $ReleaseDir = Split-Path (Resolve-Path $env:ATLAS_BIN).Path -Parent
@@ -114,13 +123,15 @@ function Phase-Check {
     # VCToolsInstallDir is not only for cl.exe: atlas-kernels/build.rs uses it to
     # locate dumpbin.exe, which generates the HIP shim's export .def. Without
     # dumpbin the shim builds but exports nothing, and cudarc finds no symbols.
-    $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-    if (Test-Path $vsw) {
-        $script:VsPath = & $vsw -products * -latest -format value -property installationPath
-        if ($script:VsPath -and (Test-Path (Join-Path $script:VsPath 'VC\Auxiliary\Build\vcvars64.bat'))) {
-            Ok "MSVC: $script:VsPath"
-        } else { Bad "vswhere found no VC toolset. Install the 'Desktop development with C++' workload." }
-    } else { Bad 'MSVC Build Tools not installed (no vswhere.exe).' }
+    if ($NeedsBuild) {
+        $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (Test-Path $vsw) {
+            $script:VsPath = & $vsw -products * -latest -format value -property installationPath
+            if ($script:VsPath -and (Test-Path (Join-Path $script:VsPath 'VC\Auxiliary\Build\vcvars64.bat'))) {
+                Ok "MSVC: $script:VsPath"
+            } else { Bad "vswhere found no VC toolset. Install the 'Desktop development with C++' workload." }
+        } else { Bad 'MSVC Build Tools not installed (no vswhere.exe).' }
+    }
 
     if (-not $env:HIP_PATH) {
         $rocm = Get-ChildItem 'C:\Program Files\AMD\ROCm' -Directory -ErrorAction SilentlyContinue |
@@ -131,21 +142,53 @@ function Phase-Check {
         $h = Join-Path $env:HIP_PATH 'bin\hipcc.bin.exe'
         if (-not (Test-Path $h)) { $h = Join-Path $env:HIP_PATH 'bin\hipcc.exe' }
         if (Test-Path $h) { $script:Hipcc = $h; Ok "HIP SDK: $env:HIP_PATH" }
-        else { Bad "hipcc not found under $env:HIP_PATH\bin" }
-    } else { Bad 'Windows HIP SDK not found under C:\Program Files\AMD\ROCm' }
-
-    # `cargo` is normally a rustup shim: it resolves on PATH and then refuses to
-    # run when no default toolchain is set. Make it produce a real version.
-    if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
-        $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+        elseif ($NeedsBuild) { Bad "hipcc not found under $env:HIP_PATH\bin" }
+    } elseif ($NeedsBuild) {
+        Bad 'Windows HIP SDK not found under C:\Program Files\AMD\ROCm'
     }
-    if (Get-Command cargo -ErrorAction SilentlyContinue) {
-        $ErrorActionPreference = 'Continue'
-        $v = (cargo --version 2>$null | Select-Object -First 1); $rc = $LASTEXITCODE
-        $ErrorActionPreference = 'Stop'
-        if ($rc -eq 0 -and $v) { Ok "rust: $v" }
-        else { Bad 'cargo is on PATH but will not run. Fix with: rustup default stable' }
-    } else { Bad 'Rust not installed (https://rustup.rs).' }
+    # Serving needs no SDK at all -- the runtime DLLs sit beside the exe.
+
+    # Rust is only needed to COMPILE. Serving an already-built spark.exe must not
+    # require a working toolchain -- gating it on one turns "run the server" into
+    # "fix your rustup first" for no reason.
+    if ($NeedsBuild) {
+        # `cargo` is normally a rustup shim: it resolves on PATH and then refuses
+        # to run when no default toolchain is set, so check it actually runs.
+        if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+            $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+        }
+        if (Get-Command cargo -ErrorAction SilentlyContinue) {
+            # Probe from INSIDE the repo. rust-toolchain.toml pins the channel
+            # (1.93.1) and there is deliberately no global rustup default, so
+            # `cargo --version` run from anywhere else fails with "could not
+            # choose a version of cargo" and rustup helpfully suggests
+            # `rustup default stable` -- which is the wrong fix here, and
+            # installs a toolchain the build will not use.
+            #
+            # Push-Location alone is NOT enough: it moves PowerShell's own
+            # location but leaves [Environment]::CurrentDirectory where the shell
+            # started, and that is the working directory a spawned rustup
+            # inherits and searches upward from for rust-toolchain.toml. Without
+            # the explicit sync this check fails for anyone who launches the
+            # script from outside the repo -- i.e. exactly the copy-paste case.
+            $ErrorActionPreference = 'Continue'
+            $prevCwd = [Environment]::CurrentDirectory
+            Push-Location $RepoRoot
+            [Environment]::CurrentDirectory = (Get-Location).Path
+            # Let the command run to completion and read $LASTEXITCODE before
+            # touching the output. Piping straight into `Select-Object -First 1`
+            # stops the pipeline as soon as one object arrives, which terminates
+            # the native process early and leaves a bogus exit code behind.
+            $out = cargo --version 2>$null
+            $rc = $LASTEXITCODE
+            $v = ($out | Select-Object -First 1)
+            Pop-Location
+            [Environment]::CurrentDirectory = $prevCwd
+            $ErrorActionPreference = 'Stop'
+            if ($rc -eq 0 -and $v) { Ok "rust: $v" }
+            else { Bad "cargo will not run in $RepoRoot -- is rust-toolchain.toml's channel installed? Try: rustup toolchain install" }
+        } else { Bad 'Rust not installed (https://rustup.rs).' }
+    }
 
     Check-Gpu
 

--- a/scripts/strix-windows/first_run.ps1
+++ b/scripts/strix-windows/first_run.ps1
@@ -1,0 +1,401 @@
+# First run of Atlas on Strix Halo (gfx1151) under Windows, native HIP.
+#
+# This is the ONE entry point for docs/porting/STRIX_WINDOWS_HIP.md.
+#
+# TWO WAYS TO USE IT
+#
+#   1. JUST TEST IT (no toolchain, no build, ~5 min + download)
+#      Grab the prebuilt `spark-windows-x86_64-amd-hip` zip from any green run of
+#      the release matrix, unzip it KEEPING THE DLLs BESIDE spark.exe, then:
+#
+#        $env:ATLAS_BIN = "C:\path\to\unzipped\spark.exe"
+#        powershell -ExecutionPolicy Bypass -File scripts\strix-windows\first_run.ps1
+#
+#      With ATLAS_BIN set this skips the toolchain check, the symlink repair and
+#      the build entirely -- it only needs the AMD driver and the weights. This is
+#      the answer to "OK, how do I test it?".
+#
+#   2. BUILD IT FROM SOURCE (contributors)
+#      Leave ATLAS_BIN unset and it checks the toolchain, repairs the kernel
+#      symlinks a Windows clone breaks, builds, then serves:
+#
+#        powershell -ExecutionPolicy Bypass -File scripts\strix-windows\first_run.ps1
+#
+# Either way it ends by serving `nvidia/Qwen3.6-27B-NVFP4` and firing a smoke
+# request at it, so a successful run prints a real completion.
+#
+# The serve flags and env below are the RUNTIME-VERIFIED config from the
+# 2026-08-13 bring-up (BFCL v3 subset 165/196). Three of them differ deliberately
+# from the pre-runtime values the porting doc used to carry -- see the comments at
+# each one before changing it.
+#
+# MUST run from PowerShell, NOT Git Bash: under bash, Git's /usr/bin precedes MSVC
+# on PATH and rustc invokes the coreutils `link.exe` instead of the MSVC linker.
+#
+# Every phase is idempotent -- re-run after a failure and it resumes.
+#
+# Optional (all have working defaults):
+#   ATLAS_BIN        prebuilt spark.exe. Set it to skip straight to serving.
+#   ATLAS_REPO       repo root.        Default: the checkout this script lives in.
+#   ATLAS_MODEL_DIR  weights snapshot. Default: $env:USERPROFILE\models\Qwen3.6-27B-NVFP4
+#   HIP_PATH         HIP SDK root.     Default: newest under C:\Program Files\AMD\ROCm
+#   ATLAS_GPU_UTIL   --gpu-memory-utilization. Default 0.80. Read the note in Serve
+#                    before raising it; it is a fraction of a total the driver
+#                    reports but will not honour.
+#   ATLAS_PORT       serve port.       Default 8081.
+#   ATLAS_BIND       serve host.       Default 127.0.0.1.
+#
+# Parameters:
+#   -Phase   all (default) | check | symlinks | build | serve
+#   -NoSmokeTest   skip the post-startup completion probe.
+#
+# Example:
+#   powershell -ExecutionPolicy Bypass -File scripts\strix-windows\first_run.ps1 -Phase check
+[CmdletBinding()]
+param(
+    [ValidateSet('all', 'check', 'symlinks', 'build', 'serve')]
+    [string]$Phase = 'all',
+    [switch]$NoSmokeTest
+)
+$ErrorActionPreference = 'Stop'
+
+# Default the repo root to the checkout this script lives in, so the script works
+# from any working directory and from a moved clone.
+$RepoRoot = if ($env:ATLAS_REPO) { $env:ATLAS_REPO }
+            else { (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path }
+$ModelDir = if ($env:ATLAS_MODEL_DIR) { $env:ATLAS_MODEL_DIR }
+            else { "$env:USERPROFILE\models\Qwen3.6-27B-NVFP4" }
+$GpuUtil  = if ($env:ATLAS_GPU_UTIL) { $env:ATLAS_GPU_UTIL } else { '0.80' }
+$Port     = if ($env:ATLAS_PORT) { $env:ATLAS_PORT } else { '8081' }
+$BindHost = if ($env:ATLAS_BIND) { $env:ATLAS_BIND } else { '127.0.0.1' }
+
+# ATLAS_BIN points at a prebuilt spark.exe (the CI zip). When it is set there is
+# nothing to build, so the binary's own directory takes the place of target/ and
+# the toolchain checks are skipped -- a tester needs the driver and weights only.
+$Prebuilt = [bool]$env:ATLAS_BIN
+if ($Prebuilt) {
+    if (-not (Test-Path $env:ATLAS_BIN)) { throw "ATLAS_BIN does not exist: $env:ATLAS_BIN" }
+    $ReleaseDir = Split-Path (Resolve-Path $env:ATLAS_BIN).Path -Parent
+} else {
+    $ReleaseDir = Join-Path $RepoRoot 'target\x86_64-pc-windows-msvc\release'
+}
+
+$fails = @()
+function Ok   ($m) { Write-Host "  [ ok ] $m" -ForegroundColor Green }
+function Warn ($m) { Write-Host "  [warn] $m" -ForegroundColor Yellow }
+function Bad  ($m) { Write-Host "  [FAIL] $m" -ForegroundColor Red; $script:fails += $m }
+function Head ($m) { Write-Host ""; Write-Host "=== $m ===" -ForegroundColor Cyan }
+
+# ---------------------------------------------------------------------------
+function Phase-Check {
+    Head 'Preflight'
+
+    if ($env:MSYSTEM) { Bad 'Running under MSYS/Git Bash. Use a plain PowerShell window.' }
+
+    # Prebuilt path: nothing gets compiled, so MSVC / Rust / hipcc are all
+    # irrelevant. Check only what running actually needs -- the exe, the DLLs
+    # that must sit beside it, and the GPU.
+    if ($Prebuilt) {
+        Ok "prebuilt binary: $env:ATLAS_BIN"
+        # cudarc dlopens nvcuda.dll from the exe's OWN directory, and that DLL
+        # imports amdhip64_6.dll. Unzipping the exe on its own, or copying it
+        # somewhere tidy and leaving the DLLs behind, fails at cuInit with a
+        # missing-module error that does not name the DLL.
+        foreach ($d in @('nvcuda.dll', 'cuda.dll', 'amdhip64_6.dll')) {
+            if (Test-Path (Join-Path $ReleaseDir $d)) { Ok "  $d beside the exe" }
+            else { Bad "$d is NOT beside spark.exe -- keep the whole unzipped folder together" }
+        }
+        Check-Gpu
+        if ($fails.Count) { Write-Host ''; Write-Host 'Preflight failed.' -ForegroundColor Red; exit 1 }
+        Ok 'preflight clean'
+        return
+    }
+
+    # VCToolsInstallDir is not only for cl.exe: atlas-kernels/build.rs uses it to
+    # locate dumpbin.exe, which generates the HIP shim's export .def. Without
+    # dumpbin the shim builds but exports nothing, and cudarc finds no symbols.
+    $vsw = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vsw) {
+        $script:VsPath = & $vsw -products * -latest -format value -property installationPath
+        if ($script:VsPath -and (Test-Path (Join-Path $script:VsPath 'VC\Auxiliary\Build\vcvars64.bat'))) {
+            Ok "MSVC: $script:VsPath"
+        } else { Bad "vswhere found no VC toolset. Install the 'Desktop development with C++' workload." }
+    } else { Bad 'MSVC Build Tools not installed (no vswhere.exe).' }
+
+    if (-not $env:HIP_PATH) {
+        $rocm = Get-ChildItem 'C:\Program Files\AMD\ROCm' -Directory -ErrorAction SilentlyContinue |
+                Sort-Object Name -Descending | Select-Object -First 1
+        if ($rocm) { $env:HIP_PATH = $rocm.FullName }
+    }
+    if ($env:HIP_PATH -and (Test-Path $env:HIP_PATH)) {
+        $h = Join-Path $env:HIP_PATH 'bin\hipcc.bin.exe'
+        if (-not (Test-Path $h)) { $h = Join-Path $env:HIP_PATH 'bin\hipcc.exe' }
+        if (Test-Path $h) { $script:Hipcc = $h; Ok "HIP SDK: $env:HIP_PATH" }
+        else { Bad "hipcc not found under $env:HIP_PATH\bin" }
+    } else { Bad 'Windows HIP SDK not found under C:\Program Files\AMD\ROCm' }
+
+    # `cargo` is normally a rustup shim: it resolves on PATH and then refuses to
+    # run when no default toolchain is set. Make it produce a real version.
+    if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+        $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+    }
+    if (Get-Command cargo -ErrorAction SilentlyContinue) {
+        $ErrorActionPreference = 'Continue'
+        $v = (cargo --version 2>$null | Select-Object -First 1); $rc = $LASTEXITCODE
+        $ErrorActionPreference = 'Stop'
+        if ($rc -eq 0 -and $v) { Ok "rust: $v" }
+        else { Bad 'cargo is on PATH but will not run. Fix with: rustup default stable' }
+    } else { Bad 'Rust not installed (https://rustup.rs).' }
+
+    Check-Gpu
+
+    if ($fails.Count) { Write-Host ''; Write-Host 'Preflight failed.' -ForegroundColor Red; exit 1 }
+    Ok 'preflight clean'
+}
+
+# The kernels here are gfx1151. Another AMD part builds and loads fine right up
+# until it looks for a matching code object, so name it now rather than later.
+# hipInfo only exists with the HIP SDK installed, which a prebuilt-zip tester has
+# no reason to have -- fall back to the adapter name from the driver.
+function Check-Gpu {
+    $hipInfo = if ($env:HIP_PATH) { Join-Path $env:HIP_PATH 'bin\hipInfo.exe' } else { $null }
+    if ($hipInfo -and (Test-Path $hipInfo)) {
+        $gfx = & $hipInfo 2>$null | Select-String 'gcnArchName:\s*(\S+)' |
+               ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1
+        if ($gfx -eq 'gfx1151') { Ok 'GPU: gfx1151 (Strix Halo)'; return }
+        elseif ($gfx) { Warn "GPU reports '$gfx', not gfx1151 -- this tree ships gfx1151 kernels."; return }
+    }
+    $amd = Get-CimInstance Win32_VideoController -ErrorAction SilentlyContinue |
+           Where-Object { $_.Name -match 'AMD|Radeon' } | Select-Object -First 1
+    if ($amd) {
+        if ($amd.Name -match '8060S|Strix|AI MAX') { Ok "GPU: $($amd.Name)" }
+        else { Warn "GPU is '$($amd.Name)' -- expected a Strix Halo part (Radeon 8060S); kernels are gfx1151." }
+    } else { Warn 'No AMD adapter found. Is the Adrenalin driver installed?' }
+}
+
+# ---------------------------------------------------------------------------
+# kernels/ leans on git symlinks that CHAIN (strix-hip/foo.cu -> ../../strix/foo.cu
+# -> ../../gb10/foo.cu). Git for Windows defaults to core.symlinks=false and checks
+# each one out as a ~32 byte TEXT FILE containing the link target path, so hipcc is
+# handed a few hundred path strings where kernel sources should be. build.rs stops
+# the build and names core.symlinks when it sees one, but detecting is not fixing.
+#
+# Cloning with `-c core.symlinks=true` needs Developer Mode or an elevated shell and
+# fails silently when it does not take, so repair from the git object store instead:
+# that is correct no matter what state the working tree is in, and is re-runnable.
+function Phase-Symlinks {
+    Head 'Kernel symlinks'
+    Push-Location $RepoRoot
+    try {
+        $links = @{}
+        foreach ($line in (git ls-files -s kernels/)) {
+            if ($line -match '^120000 ([0-9a-f]{40}) \d+\s+(.+)$') {
+                $links[$matches[2]] = (git cat-file blob $matches[1])
+            }
+        }
+        if ($links.Count -eq 0) { Ok 'no symlink entries under kernels/'; return }
+
+        $written = 0; $ok = 0; $failed = @()
+        foreach ($link in $links.Keys) {
+            # Follow the chain to a path that is not itself a link entry. A
+            # single-hop resolve just leaves a stub pointing at another stub.
+            $cur = $link; $hops = 0
+            while ($links.ContainsKey($cur)) {
+                $dir = Split-Path $cur -Parent
+                $joined = if ($dir) { "$dir/$($links[$cur])" } else { $links[$cur] }
+                $parts = New-Object System.Collections.Generic.List[string]
+                foreach ($p in $joined -split '[\\/]+') {
+                    if ($p -eq '.' -or $p -eq '') { continue }
+                    elseif ($p -eq '..') { if ($parts.Count) { $parts.RemoveAt($parts.Count - 1) } }
+                    else { $parts.Add($p) }
+                }
+                $cur = ($parts -join '/')
+                if (++$hops -gt 10) { break }
+            }
+            if ($links.ContainsKey($cur)) { $failed += "$link (cycle)"; continue }
+
+            # Content comes from the index, not the working tree: on a broken clone
+            # the destination may itself still be a stub.
+            $sha = (git ls-files -s -- $cur) -replace '^\d+ ([0-9a-f]{40}).*$', '$1'
+            if ($sha -notmatch '^[0-9a-f]{40}$') { $failed += "$link -> $cur (no blob)"; continue }
+
+            # LF, UTF-8, no BOM, matching what git stores. Set-Content/Out-File
+            # would write CRLF and a BOM and leave all of them permanently dirty.
+            $bytes = (New-Object System.Text.UTF8Encoding($false)).GetBytes(
+                        (@(git cat-file blob $sha) -join "`n") + "`n")
+            $dest = Join-Path $RepoRoot ($link -replace '/', '\')
+            if ((Test-Path $dest) -and
+                ([System.IO.File]::ReadAllBytes($dest).Length -eq $bytes.Length) -and
+                (-not (Compare-Object ([System.IO.File]::ReadAllBytes($dest)) $bytes -SyncWindow 0))) {
+                $ok++; continue
+            }
+            [System.IO.File]::WriteAllBytes($dest, $bytes)
+            $written++
+        }
+        if ($failed.Count) { $failed | ForEach-Object { Bad "symlink: $_" }; throw 'symlink repair failed' }
+        Ok "$written materialised, $ok already correct (of $($links.Count))"
+        Warn "these now show as modified in 'git status' -- real content where git expects a link blob. Do NOT commit them."
+    } finally { Pop-Location }
+}
+
+# ---------------------------------------------------------------------------
+function Phase-Build {
+    Head 'Build'
+
+    # A running server holds an exclusive lock on spark.exe, so the build does all
+    # the work and then dies at the final link with "failed to remove file ...
+    # Access is denied. (os error 5)", which names neither the server nor the lock.
+    $running = Get-Process -Name spark -ErrorAction SilentlyContinue
+    if ($running) { throw "spark.exe is running (pid $($running.Id -join ',')) and locks the build output. Stop it first." }
+
+    $vcvars = Join-Path $script:VsPath 'VC\Auxiliary\Build\vcvars64.bat'
+    cmd /c "`"$vcvars`" >nul 2>&1 && set" | ForEach-Object {
+        if ($_ -match '^([^=]+)=(.*)$') { Set-Item -Path "env:$($matches[1])" -Value $matches[2] }
+    }
+    $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+    $env:ATLAS_HIPCC = $script:Hipcc
+
+    # MODEL and QUANT are MANDATORY: the default target is a qwen3-next-80b kernel
+    # dir that does not exist under strix-hip, and build.rs panics resolving it.
+    $env:ATLAS_TARGET_HW     = 'strix-hip'
+    $env:ATLAS_TARGET_MODEL  = 'qwen3.6-27b'
+    $env:ATLAS_TARGET_QUANT  = 'nvfp4'
+    $env:CUDARC_CUDA_VERSION = '12080'
+
+    Push-Location $RepoRoot
+    try {
+        # cargo writes ordinary progress ("Compiling foo v1.2.3") to STDERR. Under
+        # PowerShell 5.1 with ErrorActionPreference=Stop every stderr line from a
+        # native exe becomes a terminating NativeCommandError, which aborts the
+        # build on its first crate. Gate on the exit code instead.
+        $ErrorActionPreference = 'Continue'
+        # --no-default-features --features cuda avoids pulling in nccl, which does
+        # not link on a single-GPU box.
+        cargo build --release -p spark-server --target x86_64-pc-windows-msvc `
+            --no-default-features --features cuda
+        $code = $LASTEXITCODE
+        $ErrorActionPreference = 'Stop'
+        if ($code -ne 0) { throw "cargo build failed ($code)" }
+    } finally { Pop-Location }
+
+    Ok "built $ReleaseDir\spark.exe"
+
+    # 97 is the number to check -- main alone builds 91. A lower count means
+    # kernels silently failed to resolve.
+    #
+    # amdhip64_6.dll loads its code-object manager by PLAIN NAME, so if a driver
+    # install left an older amd_comgr_2.dll in System32, HIP binds the stale one
+    # and every hipModuleLoadData fails as CUDA_ERROR_OUT_OF_MEMORY -- which reads
+    # as a KV-sizing bug and sends you tuning --gpu-memory-utilization for hours.
+    # The build stages the ROCm copies beside the exe; confirm the size.
+    foreach ($d in @('amdhip64_6.dll', 'amd_comgr_2.dll')) {
+        $p = Join-Path $ReleaseDir $d
+        if (Test-Path $p) { Ok ("staged {0} ({1:N1} MB)" -f $d, ((Get-Item $p).Length / 1MB)) }
+        else { Warn "$d not staged beside spark.exe -- serve may bind a stale system copy" }
+    }
+}
+
+# ---------------------------------------------------------------------------
+function Phase-Serve {
+    Head 'Serve'
+    $exe = if ($Prebuilt) { (Resolve-Path $env:ATLAS_BIN).Path } else { Join-Path $ReleaseDir 'spark.exe' }
+    if (-not (Test-Path $exe)) { throw "spark.exe not found -- run -Phase build first, or set ATLAS_BIN to a prebuilt one" }
+    if (-not (Test-Path $ModelDir)) {
+        throw "no weights at $ModelDir. Fetch with: hf download nvidia/Qwen3.6-27B-NVFP4 --local-dir `"$ModelDir`""
+    }
+
+    # cudarc dlopens nvcuda.dll from the EXE's directory, and that DLL imports
+    # amdhip64_6.dll -- so run from there.
+    Set-Location $ReleaseDir
+    $env:PATH = "$ReleaseDir;$env:HIP_PATH\bin;$env:PATH"
+
+    $env:ATLAS_W4A16_DP4A         = '1'
+    $env:ATLAS_FORCE_GLOBAL_GDN   = '1'
+    $env:ATLAS_W4A16_VARIANT      = 'v1'
+    $env:ATLAS_SSM_TAIL_PROTECT   = '1'
+    $env:ATLAS_SSM_TAIL_LEASE_TTL = '128'
+    $env:ATLAS_MTP_GATE_REPROBE   = '64'
+
+    # 0, NOT the 6 this doc carried before runtime. cuMemGetInfo_v2 now synthesises
+    # a truthful free figure from tracked allocations, and that tracker reports
+    # Atlas-own bytes only -- so build.rs's co-tenant discount double-counts and
+    # oversizes the KV pool (it allocated 11.3 GB of KV, then died on a later 24 MB
+    # alloc). 0 fails build.rs's `.filter(|gb| gb > 0.0)` and falls through to the
+    # AUTO path (baseline_free - free_now), which is correct given the fixed shim.
+    $env:ATLAS_KV_EXTERNAL_RESERVE_GB = '0'
+
+    # 0, NOT 1. Mid-chunk tail capture corrupts CROSS-REQUEST SSM prefix reuse:
+    # BFCL single-turn requests share a system-prompt prefix and reuse each other's
+    # tail snapshot -> garbled tool calls. Observed here as empty 1-token
+    # completions on 12/12 live_multiple entries. This is a strict-"0" opt-out, NOT
+    # a presence flag -- absent, or any other value, leaves it ON.
+    $env:ATLAS_SSM_TAIL_MIDCHUNK = '0'
+
+    if (-not $NoSmokeTest) {
+        # The server owns this console until Ctrl-C, so probe from a detached
+        # process. Log lands beside the exe (inside target/ for a source build,
+        # which is gitignored).
+        #
+        # The probe writes its OWN file rather than being launched with
+        # `Start-Process -RedirectStandardOutput`. That switch reassigns the
+        # parent's standard handles, and when this script's stdout is itself
+        # redirected -- which is exactly what happens when you tee a first run to
+        # a log -- everything the SERVER prints afterwards is silently swallowed.
+        # The server runs fine and looks dead, which is the worst failure to hand
+        # someone testing a port for the first time.
+        $smokeLog = Join-Path $ReleaseDir 'first_run_smoke.log'
+        $probe = Join-Path $env:TEMP 'atlas_first_run_smoke.ps1'
+        @"
+`$out = '$smokeLog'
+`$u = 'http://${BindHost}:$Port'
+`$dl = (Get-Date).AddMinutes(15)
+while ((Get-Date) -lt `$dl) {
+    try { Invoke-WebRequest -Uri "`$u/v1/models" -TimeoutSec 3 -UseBasicParsing | Out-Null; break }
+    catch { Start-Sleep -Seconds 5 }
+}
+`$b = @{ model='nvidia/Qwen3.6-27B-NVFP4'
+        prompt="<|im_start|>user``nName three primary colors.<|im_end|>``n<|im_start|>assistant``n"
+        max_tokens=64; temperature=0.001 } | ConvertTo-Json -Compress
+try {
+    `$r = Invoke-RestMethod -Uri "`$u/v1/completions" -Method Post -ContentType 'application/json' -Body `$b -TimeoutSec 300
+    @("SMOKE OK  finish=`$(`$r.choices[0].finish_reason)  tokens=`$(`$r.usage.completion_tokens)",
+      "TEXT: `$(`$r.choices[0].text.Trim())") | Out-File -FilePath `$out -Encoding ascii
+} catch { "SMOKE FAILED: `$_" | Out-File -FilePath `$out -Encoding ascii }
+"@ | Out-File -FilePath $probe -Encoding ascii
+        if (Test-Path $smokeLog) { Remove-Item $smokeLog -Force -ErrorAction SilentlyContinue }
+        Start-Process powershell -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File',$probe) `
+            -WindowStyle Hidden
+        Write-Host "  smoke result -> $smokeLog"
+    }
+
+    Write-Host "  serving on http://${BindHost}:$Port  (Ctrl-C to stop)"
+    Write-Host ''
+    $ErrorActionPreference = 'Continue'
+
+    # --gpu-memory-utilization is a fraction of the total the driver REPORTS
+    # (76.9 GB here) but the real allocatable ceiling measured ~63 GB, so this
+    # cannot go much past 0.83. 0.80 -> 61.5 GB budget: 40.3 GB pre-KV + 15.7 GB
+    # reserve -> 5.4 GB KV = 89232 tokens. The Linux 0.35 does not apply.
+    #
+    # --no-fast-load is no longer required (the Unix-only O_DIRECT loader now warns
+    # and falls back instead of hard-erroring); passing it just silences the warning.
+    & $exe serve $ModelDir `
+        --no-fast-load `
+        --model-name nvidia/Qwen3.6-27B-NVFP4 --host $BindHost --port $Port `
+        --max-seq-len 65536 --gpu-memory-utilization $GpuUtil --kv-cache-dtype bf16 `
+        --max-batch-size 1 --speculative --num-drafts 2 --mtp-quantization bf16 `
+        --mtp-vocab 100000 --disable-tool-grammar true --enable-prefix-caching `
+        --ssm-cache-slots 64 --ssm-checkpoint-interval 16 --disable-thinking
+}
+
+switch ($Phase) {
+    'check'    { Phase-Check }
+    'symlinks' { Phase-Symlinks }
+    'build'    { if ($Prebuilt) { throw 'ATLAS_BIN is set, so there is nothing to build. Unset it to build from source.' }
+                 Phase-Check; Phase-Build }
+    'serve'    { Phase-Check; Phase-Serve }
+    # With a prebuilt binary there is no source to repair and nothing to compile,
+    # so "all" is just check + serve.
+    'all'      { if ($Prebuilt) { Phase-Check; Phase-Serve }
+                 else { Phase-Check; Phase-Symlinks; Phase-Build; Phase-Serve } }
+}


### PR DESCRIPTION
## Summary

`docs/porting/STRIX_WINDOWS_HIP.md` is upfront that the Windows native-HIP path
is **COMPILE-VERIFIED, RUNTIME UNVERIFIED** ("there is no Windows AMD machine in
the fleet"). This is the runtime follow-up, from an actual gfx1151 Windows box:
a Framework Desktop (Ryzen AI MAX+ 395 / Radeon 8060S), Windows 11, serving
`nvidia/Qwen3.6-27B-NVFP4`.

The port itself was sound — the shim mappings and the 64-bit mask widen are
correct, and the model runs. But four things stopped a first run from working,
and each one failed in a way that pointed somewhere other than the cause. Two of
them cost hours of misdiagnosis, so the fixes are as much about the error you get
as the behaviour.

Serve now comes up and answers in ~93 s from a clean `cargo build`, with no
manual steps.

## What was wrong

**1. `hipMemGetInfo` is broken on Windows HIP** — returns `hipErrorInvalidValue`
standalone, and reports `free == 0` under a live context. Atlas sizes its KV
cache from `cuMemGetInfo`, so serve aborts with `No memory left for KV cache` on
a box with ~64 GB genuinely allocatable (measured with a `hipMalloc` ladder).
`cuMemGetInfo_v2` now tracks what the shim hands out and synthesises a truthful
answer when HIP won't give one. It only engages when `hipMemGetInfo` actually
fails or returns zeros, so **Linux/ROCm behaviour is unchanged**. Helpers are
`static` and don't start with `cu`, so the dumpbin-derived export list still
comes out at 76.

**2. Only `amdhip64` was staged.** `amdhip64_6.dll` loads its code-object manager
by plain name, so on a host whose driver left an older `amd_comgr_2.dll` in
System32, HIP binds the stale comgr and *every* `hipModuleLoadData` fails as
`CUDA_ERROR_OUT_OF_MEMORY`. That error reads as a KV-sizing bug and sends you
tuning `--gpu-memory-utilization` for hours. Measured here: System32
`amd_comgr_2.dll` 109 MB with no version resource, vs ROCm 6.4's 115.55 MB.
Now stages `amd_comgr*`, `hiprtc*`, `hiprtc-builtins*` too — **and copies them
next to the built binary**, since OUT_DIR staging only served the packaging step
(`cargo build` then running the exe still picked up whatever was on the system
path, and a rebuilt `cuda.dll` went unused because an older copy was already
sitting beside the exe).

**3. 219 unmaterialised symlinks.** `kernels/` leans on symlinks
(`strix-hip -> strix -> gb10`) and Git for Windows defaults to
`core.symlinks=false`, checking each one out as a ~32 byte text file containing
the link target path. The build now fails early naming `core.symlinks` and the
fact that the links *chain*, instead of letting the compiler complain about
source it can't parse.

**4. `--no-fast-load` was mandatory but undocumented.** The fast loader needs
`O_DIRECT`/`posix_fadvise`, is ON by default, and hard-errors on a non-Unix host
before a single weight loads. Now warns and falls back to the standard loader.

**5. The request-timeout warning reported the wrong clock** (added after the
first four; diagnostic only, no behaviour change). `timeout_at` is stamped at
ARRIVAL but `request_start` at PREFILL, so a 300 s budget consumed entirely by
queue wait printed as `Request timeout after 8.4s` — which reads as a slow
generation. The part that mattered wasn't in the message: those requests die on
their *first* decode step having produced one token, and go back to the client as
a normal `finish_reason="length"`. The warning now reports `output_tokens`,
`since_prefill_s` and `overdue_s`, and sets `guard_stop = "request_timeout"`.
This cost me a full 5-hour benchmark run that scored 1-token completions as wrong
answers; the behavioural half is #482.

## Making it runnable by someone else

`docs/porting/STRIX_WINDOWS_HIP.md` asked to be "corrected by the first person who
runs it". This does that, and adds `scripts/strix-windows/first_run.ps1` so that
correction is executable rather than a list of things to remember.

**"OK, how do I test it?" now needs no toolchain at all.** CI already publishes a
prebuilt `spark-windows-x86_64-amd-hip` zip, so:

```powershell
$env:ATLAS_BIN = "C:\path\to\unzipped\spark.exe"
powershell -ExecutionPolicy Bypass -File scripts\strix-windows\first_run.ps1
```

checks the box, serves with the verified config, fires a completion and writes the
answer to `first_run_smoke.log`. Driver and weights only — no MSVC, no HIP SDK, no
Rust, no clone. Unset `ATLAS_BIN` and the same script builds from source,
repairing the 219 chained kernel symlinks first. `-Phase check` audits and changes
nothing.

Three values in the doc were wrong in ways that fail somewhere other than the
cause, and are corrected inline with the reasoning:

| | doc said | actually | why it matters |
|---|---|---|---|
| `ATLAS_KV_EXTERNAL_RESERVE_GB` | `6` | **`0`** | double-counts against the fixed shim; oversized the KV pool to 11.3 GB, then died on a later 24 MB alloc |
| `ATLAS_SSM_TAIL_MIDCHUNK` | `1` | **`0`** | corrupts cross-request SSM prefix reuse; empty 1-token completions on 12/12 `live_multiple` |
| `--gpu-memory-utilization` | `0.35` | **`0.80`** | 0.35 needlessly starves KV; ceiling ~0.83 because the fraction is against a reported 76.9 GB the driver won't honour past ~63 GB |

The doc's WDDM/VGM warning is replaced rather than kept: it did **not** reproduce —
~64 GB was allocatable with no BIOS or Adrenalin tuning, so the old text sent
readers hunting through firmware for something that was never the problem.

## Verification

Each change was verified on the box, not just compiled:

| change | how it was verified |
|---|---|
| `cuMemGetInfo_v2` | serve reports `76.7 GB free` → `35.85 GB` after weights; KV sizes correctly and the OOM watchdog no longer trips |
| DLL staging | wiped every DLL from the target dir, rebuilt, confirmed the build places all 7 including `amd_comgr_2.dll` at 115.5 MB (the ROCm one) |
| symlink guard | wrote a synthetic 37-byte stub into `kernels/strix-hip/common/`, confirmed the build stops with the `core.symlinks` message, removed it |
| fast-load fallback | ran serve **without** `--no-fast-load`; warns and loads all 2194 weight tensors instead of aborting |
| timeout warning | ran with `--request-timeout 1` so the deadline expires during prefill: warning fires with `output_tokens=1 since_prefill_s=3.84 overdue_s=2.84` and the response returns `finish_reason=length` with a 1-token empty body — the production failure in miniature |

Full clean build + serve + a 196-entry BFCL v3 single-turn run on this hardware:
**165/196 = 84.2%** weighted (`simple` 0.967, `multiple` 0.967, `live_parallel`
0.625), 82 min, zero request timeouts. Not comparable to the porting doc's 89.22
— that's v4 on a different 167-sample subset and `bfcl-eval` ships v3 data.

## Notes for maintainers

- The doc's WDDM/VGM memory warning did **not** reproduce here — 64 GB was
  allocatable with no BIOS tuning. Worth revisiting that section.
- Once (1) is in, `ATLAS_KV_EXTERNAL_RESERVE_GB` should be **0** on Windows, not
  the doc's `6`: with honest accounting that value is a co-tenant *discount* that
  double-counts and oversizes the KV pool until a later allocation fails.
- `--gpu-memory-utilization` is a fraction of a total the driver will not honour
  (reports 76.9 GB; ~63 GB actually allocatable). `0.80` works here. Deriving the
  budget from measured-allocatable would be a real improvement but is a
  behavioural change, so it's deliberately **not** in this PR.

Three further issues found on this box are filed separately, since they are
runtime behaviour rather than build/first-run: #471 (`--disable-thinking`
silently ignored on `/v1/completions`), #472 (`ATLAS_SSM_TAIL_MIDCHUNK=1`
corrupts shared-prefix BFCL runs — the regression
`scripts/mlperf-edge/ab_midchunk.sh` already documents), and #482 (a request
whose deadline expires while queued is prefilled anyway and returned as a
1-token `finish_reason="length"`, which no eval harness can distinguish from a
legitimate `max_tokens` stop).

Happy to run anything else on this hardware — it's a permanent Windows/gfx1151
target now, which is exactly what the porting doc says the fleet lacks.
