### PR TITLE
spark-model: default lossless single-warp GEMV on decode

### DIFF
--- a/crates/spark-model/examples/w4a16_gemv_sw_microtest.rs
+++ b/crates/spark-model/examples/w4a16_gemv_sw_microtest.rs
@@ -93,12 +93,21 @@ fn gen_weight(rng: &mut Rng, n: usize, k: usize) -> Weight {
     }
 }
 
-fn cosine(a: &[u16], b: &[u16]) -> (f64, usize) {
+struct Cmp {
+    cos: f64,
+    bit_id: f64,
+    mismatches: Vec<(usize, u16, u16)>,
+}
+
+fn compare(a: &[u16], b: &[u16]) -> Cmp {
     let (mut dot, mut na, mut nb) = (0f64, 0f64, 0f64);
     let mut bit_eq = 0usize;
+    let mut mismatches = Vec::new();
     for i in 0..a.len() {
         if a[i] == b[i] {
             bit_eq += 1;
+        } else if mismatches.len() < 4 {
+            mismatches.push((i, a[i], b[i]));
         }
         let x = f32::from_bits((a[i] as u32) << 16) as f64;
         let y = f32::from_bits((b[i] as u32) << 16) as f64;
@@ -111,7 +120,31 @@ fn cosine(a: &[u16], b: &[u16]) -> (f64, usize) {
     } else {
         1.0
     };
-    (cos, bit_eq)
+    Cmp {
+        cos,
+        bit_id: bit_eq as f64 / a.len() as f64,
+        mismatches,
+    }
+}
+
+fn dump_fail(label: &str, cmp: &Cmp) {
+    for &(i, base, sw) in &cmp.mismatches {
+        eprintln!(
+            "  {label} mismatch[{i}]: base=0x{base:04x} sw=0x{sw:04x} \
+             ({:.6} vs {:.6})",
+            f32::from_bits((base as u32) << 16),
+            f32::from_bits((sw as u32) << 16),
+        );
+    }
+}
+
+fn download_u16(gpu: &dyn GpuBackend, ptr: DevicePtr, n: usize) -> Result<Vec<u16>> {
+    let mut raw = vec![0u8; n * 2];
+    gpu.copy_d2h(ptr, &mut raw)?;
+    Ok(raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -123,7 +156,7 @@ fn run_shape(
     seed: u64,
     n: usize,
     k: usize,
-) -> Result<(f64, f64)> {
+) -> Result<Cmp> {
     let mut rng = Rng(seed ^ ((n as u64) << 16) ^ (k as u64));
     let a_bf16: Vec<u16> = (0..k)
         .map(|_| f32_to_bf16_bits(rng.uniform(-1.0, 1.0)))
@@ -162,18 +195,8 @@ fn run_shape(
         .launch(stream)?;
 
     gpu.synchronize(stream)?;
-    let mut rb = vec![0u8; n * 2];
-    let mut rs = vec![0u8; n * 2];
-    gpu.copy_d2h(c_base, &mut rb)?;
-    gpu.copy_d2h(c_sw, &mut rs)?;
-    let out_base: Vec<u16> = rb
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
-        .collect();
-    let out_sw: Vec<u16> = rs
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
-        .collect();
+    let out_base = download_u16(gpu, c_base, n)?;
+    let out_sw = download_u16(gpu, c_sw, n)?;
 
     let nz = out_base.iter().filter(|&&x| x != 0).count();
     if nz == 0 {
@@ -182,8 +205,142 @@ fn run_shape(
     for p in [a_ptr, packed, scale, c_base, c_sw] {
         let _ = gpu.free(p);
     }
-    let (cos, bit_eq) = cosine(&out_base, &out_sw);
-    Ok((cos, bit_eq as f64 / n as f64))
+    Ok(compare(&out_base, &out_sw))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_dual(
+    gpu: &dyn GpuBackend,
+    stream: u64,
+    base_h: spark_runtime::gpu::KernelHandle,
+    sw_h: spark_runtime::gpu::KernelHandle,
+    seed: u64,
+    n: usize,
+    k: usize,
+) -> Result<(Cmp, Cmp)> {
+    let mut rng = Rng(seed ^ 0xD2A1_0000 ^ ((n as u64) << 16) ^ (k as u64));
+    let a_bf16: Vec<u16> = (0..k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-1.0, 1.0)))
+        .collect();
+    let a_ptr = upload(gpu, &u16s_to_le(&a_bf16))?;
+    let w1 = gen_weight(&mut rng, n, k);
+    let w2 = gen_weight(&mut rng, n, k);
+    let p1 = upload(gpu, &w1.packed)?;
+    let s1 = upload(gpu, &w1.scale)?;
+    let p2 = upload(gpu, &w2.packed)?;
+    let s2 = upload(gpu, &w2.scale)?;
+    let c1b = gpu.alloc(n * 2)?;
+    let c2b = gpu.alloc(n * 2)?;
+    let c1s = gpu.alloc(n * 2)?;
+    let c2s = gpu.alloc(n * 2)?;
+
+    KernelLaunch::new(gpu, base_h)
+        .grid([n.div_ceil(4) as u32, 1, 2])
+        .block([256, 1, 1])
+        .arg_ptr(a_ptr)
+        .arg_ptr(p1)
+        .arg_ptr(s1)
+        .arg_f32(w1.scale2)
+        .arg_ptr(c1b)
+        .arg_ptr(p2)
+        .arg_ptr(s2)
+        .arg_f32(w2.scale2)
+        .arg_ptr(c2b)
+        .arg_u32(n as u32)
+        .arg_u32(k as u32)
+        .launch(stream)?;
+    KernelLaunch::new(gpu, sw_h)
+        .grid([n.div_ceil(8) as u32, 1, 2])
+        .block([256, 1, 1])
+        .arg_ptr(a_ptr)
+        .arg_ptr(p1)
+        .arg_ptr(s1)
+        .arg_f32(w1.scale2)
+        .arg_ptr(c1s)
+        .arg_ptr(p2)
+        .arg_ptr(s2)
+        .arg_f32(w2.scale2)
+        .arg_ptr(c2s)
+        .arg_u32(n as u32)
+        .arg_u32(k as u32)
+        .launch(stream)?;
+
+    gpu.synchronize(stream)?;
+    let b1 = download_u16(gpu, c1b, n)?;
+    let s1o = download_u16(gpu, c1s, n)?;
+    let b2 = download_u16(gpu, c2b, n)?;
+    let s2o = download_u16(gpu, c2s, n)?;
+    if b1.iter().all(|&x| x == 0) && b2.iter().all(|&x| x == 0) {
+        bail!("dead dual output (N={n} K={k})");
+    }
+    let g1 = compare(&b1, &s1o);
+    let g2 = compare(&b2, &s2o);
+    for p in [a_ptr, p1, s1, p2, s2, c1b, c2b, c1s, c2s] {
+        let _ = gpu.free(p);
+    }
+    Ok((g1, g2))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_silu(
+    gpu: &dyn GpuBackend,
+    stream: u64,
+    base_h: spark_runtime::gpu::KernelHandle,
+    sw_h: spark_runtime::gpu::KernelHandle,
+    seed: u64,
+    n: usize,
+    k: usize,
+) -> Result<Cmp> {
+    let mut rng = Rng(seed ^ 0x51_0000 ^ ((n as u64) << 16) ^ (k as u64));
+    let gate: Vec<u16> = (0..k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-1.0, 1.0)))
+        .collect();
+    let up: Vec<u16> = (0..k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-1.0, 1.0)))
+        .collect();
+    let g_ptr = upload(gpu, &u16s_to_le(&gate))?;
+    let u_ptr = upload(gpu, &u16s_to_le(&up))?;
+    let w = gen_weight(&mut rng, n, k);
+    let packed = upload(gpu, &w.packed)?;
+    let scale = upload(gpu, &w.scale)?;
+    let c_base = gpu.alloc(n * 2)?;
+    let c_sw = gpu.alloc(n * 2)?;
+
+    KernelLaunch::new(gpu, base_h)
+        .grid([n.div_ceil(4) as u32, 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(g_ptr)
+        .arg_ptr(u_ptr)
+        .arg_ptr(packed)
+        .arg_ptr(scale)
+        .arg_f32(w.scale2)
+        .arg_ptr(c_base)
+        .arg_u32(n as u32)
+        .arg_u32(k as u32)
+        .launch(stream)?;
+    KernelLaunch::new(gpu, sw_h)
+        .grid([n.div_ceil(8) as u32, 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(g_ptr)
+        .arg_ptr(u_ptr)
+        .arg_ptr(packed)
+        .arg_ptr(scale)
+        .arg_f32(w.scale2)
+        .arg_ptr(c_sw)
+        .arg_u32(n as u32)
+        .arg_u32(k as u32)
+        .launch(stream)?;
+
+    gpu.synchronize(stream)?;
+    let out_base = download_u16(gpu, c_base, n)?;
+    let out_sw = download_u16(gpu, c_sw, n)?;
+    if out_base.iter().all(|&x| x == 0) {
+        bail!("dead silu output (N={n} K={k})");
+    }
+    for p in [g_ptr, u_ptr, packed, scale, c_base, c_sw] {
+        let _ = gpu.free(p);
+    }
+    Ok(compare(&out_base, &out_sw))
 }
 
 fn main() -> Result<()> {
@@ -197,6 +354,10 @@ fn main() -> Result<()> {
     let stream = gpu.create_stream()?;
     let base_h = gpu.kernel("w4a16_gemv", "w4a16_gemv")?;
     let sw_h = gpu.kernel("w4a16_gemv", "w4a16_gemv_sw")?;
+    let dual_h = gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_dual")?;
+    let dual_sw_h = gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_dual_sw")?;
+    let silu_h = gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_silu_input")?;
+    let silu_sw_h = gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_silu_input_sw")?;
 
     // Decode GEMV shapes for Qwen3.6-27B (M=1). hidden=5120, intermediate=17408.
     let shapes: &[(&str, usize, usize)] = &[
@@ -207,6 +368,7 @@ fn main() -> Result<()> {
         ("attn qkv   ", 7168, 5120),
         ("attn o_proj", 5120, 6144),
         ("N%8!=0 edge", 5124, 5120),
+        ("N%4!=0 tail", 5122, 5120),
         ("K-tail edge", 4096, 5104),
     ];
 
@@ -221,19 +383,60 @@ fn main() -> Result<()> {
 
     let mut all_pass = true;
     for &(label, n, k) in shapes {
-        let (cos, bit_id) = run_shape(gpu, stream, base_h, sw_h, seed, n, k)?;
-        // Bit-identical gate: every output byte must match.
-        let pass = bit_id >= 1.0 - 1e-12;
+        let cmp = run_shape(gpu, stream, base_h, sw_h, seed, n, k)?;
+        let pass = cmp.bit_id >= 1.0 - 1e-12;
         all_pass &= pass;
         println!(
-            "{label:<12} {n:>7} {k:>7} | {cos:>12.8} {:>8.3}%  {}",
-            bit_id * 100.0,
+            "{label:<12} {n:>7} {k:>7} | {:>12.8} {:>8.3}%  {}",
+            cmp.cos,
+            cmp.bit_id * 100.0,
             if pass { "PASS" } else { "FAIL" },
         );
+        if !pass {
+            dump_fail(label, &cmp);
+        }
     }
+
+    println!("\n=== w4a16_gemv_dual_sw (FFN gate+up) ===");
+    for &(label, n, k) in shapes {
+        let (g1, g2) = run_dual(gpu, stream, dual_h, dual_sw_h, seed, n, k)?;
+        let pass = g1.bit_id >= 1.0 - 1e-12 && g2.bit_id >= 1.0 - 1e-12;
+        all_pass &= pass;
+        println!(
+            "{label:<12} {n:>7} {k:>7} | gate {:>7.3}% up {:>7.3}%  {}",
+            g1.bit_id * 100.0,
+            g2.bit_id * 100.0,
+            if pass { "PASS" } else { "FAIL" },
+        );
+        if !pass {
+            dump_fail(&format!("{label} gate"), &g1);
+            dump_fail(&format!("{label} up"), &g2);
+        }
+    }
+
+    println!("\n=== w4a16_gemv_silu_input_sw (FFN down) ===");
+    for &(label, n, k) in &[
+        ("ffn down   ", 5120usize, 17408usize),
+        ("N%8!=0 edge", 5124, 5120),
+        ("K-tail edge", 4096, 5104),
+    ] {
+        let cmp = run_silu(gpu, stream, silu_h, silu_sw_h, seed, n, k)?;
+        let pass = cmp.bit_id >= 1.0 - 1e-12;
+        all_pass &= pass;
+        println!(
+            "{label:<12} {n:>7} {k:>7} | {:>12.8} {:>8.3}%  {}",
+            cmp.cos,
+            cmp.bit_id * 100.0,
+            if pass { "PASS" } else { "FAIL" },
+        );
+        if !pass {
+            dump_fail(label, &cmp);
+        }
+    }
+
     println!("{}", "-".repeat(60));
     if all_pass {
-        println!("RESULT: PASS — w4a16_gemv_sw is BYTE-IDENTICAL to base on all shapes");
+        println!("RESULT: PASS — SW GEMV is BYTE-IDENTICAL to base on gemv/dual/silu");
         Ok(())
     } else {
         println!("RESULT: FAIL — at least one shape not 100% bit-identical (LOSSY, do not ship)");

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -96,15 +96,17 @@ pub struct DenseFfnLayer {
     pub weights: DenseFfnWeights,
     activation: FfnActivation,
     w4a16_gemv: KernelHandle,
+    /// Single-warp `w4a16_gemv_sw`. `KernelHandle(0)` on miss → base GEMV.
+    w4a16_gemv_sw: KernelHandle,
     w4a16_gemv_dual: KernelHandle,
     w4a16_gemv_silu_input: KernelHandle,
     // LOSSLESS single-warp-per-output decode variants (8 outputs/block, no smem
     // cross-warp reduce). Bit-identical to the 64-thread kernels (proven by the
-    // w4a16_gemv_sw microtest). Opt-in via ATLAS_DECODE_OPT (default off →
-    // dispatch unchanged). KernelHandle(0) on miss → fall back to base kernels.
+    // w4a16_gemv_sw microtest). Default ON via `ModelLevers::gemv_sw`;
+    // `ATLAS_NO_GEMV_SW=1` restores the 64-thread kernels. KernelHandle(0) on
+    // miss → fall back to base kernels.
     w4a16_gemv_dual_sw: KernelHandle,
     w4a16_gemv_silu_input_sw: KernelHandle,
-    decode_opt: bool,
     w4a16_gemv_dual_batch2: KernelHandle,
     w4a16_gemv_dual_batch3: KernelHandle,
     w4a16_gemv_batch2: KernelHandle,
@@ -322,6 +324,7 @@ impl DenseFfnLayer {
             weights,
             activation,
             w4a16_gemv: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_sw: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w4a16_gemv_dual: gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_dual")?,
             w4a16_gemv_silu_input: gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_silu_input")?,
             w4a16_gemv_dual_sw: super::try_kernel(gpu, "w4a16_gemv_fused", "w4a16_gemv_dual_sw"),
@@ -330,7 +333,6 @@ impl DenseFfnLayer {
                 "w4a16_gemv_fused",
                 "w4a16_gemv_silu_input_sw",
             ),
-            decode_opt: std::env::var_os("ATLAS_DECODE_OPT").is_some(),
             w4a16_gemv_dual_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch2")?,
             w4a16_gemv_dual_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
             w4a16_gemv_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
@@ -1101,12 +1103,13 @@ impl DenseFfnLayer {
         }
 
         // Fused gate_proj + up_proj: [1, H] → [1, inter] × 2.
-        // Single-warp variant (lossless) when ATLAS_DECODE_OPT is on and the
-        // _sw kernel is present; otherwise the proven 64-thread kernel.
-        let use_sw = self.decode_opt
-            && self.w4a16_gemv_dual_sw.0 != 0
-            && self.w4a16_gemv_silu_input_sw.0 != 0;
-        if use_sw {
+        // Single-warp variant (lossless) when the lever is on and the kernel
+        // resolved; otherwise the 64-thread kernel. Dual and silu-input SW
+        // are independent — missing silu_input_sw must not skip dual_sw on
+        // the default split-SiLU path.
+        let use_dual_sw = ops::use_gemv_sw(ctx.levers.gemv_sw, self.w4a16_gemv_dual_sw);
+        let use_silu_sw = ops::use_gemv_sw(ctx.levers.gemv_sw, self.w4a16_gemv_silu_input_sw);
+        if use_dual_sw {
             ops::w4a16_gemv_dual_sw(
                 ctx.gpu,
                 self.w4a16_gemv_dual_sw,
@@ -1156,9 +1159,11 @@ impl DenseFfnLayer {
                 inter,
                 stream,
             )?;
-            ops::w4a16_gemv(
+            ops::w4a16_decode_gemv(
                 ctx.gpu,
                 self.w4a16_gemv,
+                self.w4a16_gemv_sw,
+                ctx.levers.gemv_sw,
                 gate_out,
                 &self.weights.down_proj,
                 output,
@@ -1171,7 +1176,7 @@ impl DenseFfnLayer {
         match self.activation {
             FfnActivation::SiLU => {
                 // Fused SiLU(gate)*up + down_proj: [1, inter] → [1, H]
-                if use_sw {
+                if use_silu_sw {
                     ops::w4a16_gemv_silu_input_sw(
                         ctx.gpu,
                         self.w4a16_gemv_silu_input_sw,
@@ -1208,9 +1213,11 @@ impl DenseFfnLayer {
                     inter,
                     stream,
                 )?;
-                ops::w4a16_gemv(
+                ops::w4a16_decode_gemv(
                     ctx.gpu,
                     self.w4a16_gemv,
+                    self.w4a16_gemv_sw,
+                    ctx.levers.gemv_sw,
                     gate_out,
                     &self.weights.down_proj,
                     output,

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -59,6 +59,8 @@ mod gemm_quant;
 mod gemv_q2;
 #[path = "ops/gemv_q2_vec.rs"]
 mod gemv_q2_vec;
+#[path = "ops/gemv_sw.rs"]
+mod gemv_sw;
 #[path = "ops/hyper_connection.rs"]
 mod hyper_connection;
 #[path = "ops/kv_cache.rs"]
@@ -149,6 +151,7 @@ pub use gemm_fp8_prefill::*;
 pub use gemm_quant::*;
 pub use gemv_q2::*;
 pub use gemv_q2_vec::*;
+pub use gemv_sw::*;
 pub use hyper_connection::*;
 pub use kv_cache::*;
 pub use kv_cache_fp8k::*;

--- a/crates/spark-model/src/layers/ops/gemv_sw.rs
+++ b/crates/spark-model/src/layers/ops/gemv_sw.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Decode W4A16 GEMV launchers whose grid is coupled to the CUDA
+//! `N_PER_BLOCK` / `N_PER_BLOCK_SW` defines.
+//!
+//! The single-warp kernel (`w4a16_gemv_sw`) is bit-identical to the 64-thread
+//! base (`examples/w4a16_gemv_sw_microtest.rs`). Shipping it as the default
+//! decode GEMV is a free occupancy win — **if and only if** the launch grid
+//! stays coupled: 8 outputs/block vs the base kernel's 4. Swapping the kernel
+//! without swapping the grid writes the wrong outputs.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+use crate::weight_map::QuantizedWeight;
+
+/// Base `w4a16_gemv`: 4 outputs / 256-thread block.
+/// SSOT with `kernels/**/w4a16_gemv.cu` `#define N_PER_BLOCK 4`.
+pub const W4A16_GEMV_OUTS_PER_BLOCK: u32 = 4;
+
+/// Single-warp `w4a16_gemv_sw`: 8 outputs / 256-thread block.
+/// SSOT with `#define N_PER_BLOCK_SW 8`.
+pub const W4A16_GEMV_SW_OUTS_PER_BLOCK: u32 = 8;
+
+pub fn w4a16_gemv_grid_x(n: u32) -> u32 {
+    div_ceil(n, W4A16_GEMV_OUTS_PER_BLOCK)
+}
+
+pub fn w4a16_gemv_sw_grid_x(n: u32) -> u32 {
+    div_ceil(n, W4A16_GEMV_SW_OUTS_PER_BLOCK)
+}
+
+/// Kill-switch polarity for lossless SW GEMV. ON unless `ATLAS_NO_GEMV_SW` is
+/// exactly `"1"`. `=0` does **not** disable (same `== "1"` reading as
+/// `ATLAS_NO_LM_HEAD_BATCH_GEMV`).
+pub fn gemv_sw_from(no_gemv_sw: Option<&str>) -> bool {
+    no_gemv_sw != Some("1")
+}
+
+/// SW kernel when the model lever is on **and** the handle resolved.
+pub fn use_gemv_sw(lever: bool, sw_handle: KernelHandle) -> bool {
+    lever && sw_handle.0 != 0
+}
+
+/// Single-warp-per-output W4A16 GEMV (M=1). Grid: `(ceil(N/8), 1, 1)`.
+#[allow(clippy::too_many_arguments)]
+pub fn w4a16_gemv_sw(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &QuantizedWeight,
+    output: DevicePtr,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([w4a16_gemv_sw_grid_x(n), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(weight.weight_scale)
+        .arg_f32(weight.weight_scale_2)
+        .arg_ptr(output)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)
+}
+
+/// Decode GEMV: software-pipelined single-warp when the lever and handle agree.
+#[allow(clippy::too_many_arguments)]
+pub fn w4a16_decode_gemv(
+    gpu: &dyn GpuBackend,
+    gemv: KernelHandle,
+    gemv_sw: KernelHandle,
+    use_sw: bool,
+    input: DevicePtr,
+    weight: &QuantizedWeight,
+    output: DevicePtr,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    if use_gemv_sw(use_sw, gemv_sw) {
+        w4a16_gemv_sw(gpu, gemv_sw, input, weight, output, n, k, stream)
+    } else {
+        super::quant_dispatch::w4a16_gemv(gpu, gemv, input, weight, output, n, k, stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spark_runtime::gpu::KernelHandle;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn gemv_sw_ships_on_and_only_the_one_value_kills() {
+        assert!(gemv_sw_from(None), "unset → ON");
+        assert!(gemv_sw_from(Some("0")), "`=0` is NOT off");
+        assert!(gemv_sw_from(Some("")), "empty is NOT off");
+        assert!(!gemv_sw_from(Some("1")), "`=1` is the kill");
+    }
+
+    #[test]
+    fn sw_requires_both_the_lever_and_a_live_handle() {
+        assert!(use_gemv_sw(true, KernelHandle(1)));
+        assert!(
+            !use_gemv_sw(true, KernelHandle(0)),
+            "missing kernel falls back"
+        );
+        assert!(!use_gemv_sw(false, KernelHandle(1)), "kill switch wins");
+        assert!(!use_gemv_sw(false, KernelHandle(0)));
+    }
+
+    #[test]
+    fn sw_grid_covers_every_output_and_is_half_base_when_n_divisible_by_8() {
+        for n in 1..=64 {
+            assert!(w4a16_gemv_sw_grid_x(n) * W4A16_GEMV_SW_OUTS_PER_BLOCK >= n);
+            assert!(w4a16_gemv_grid_x(n) * W4A16_GEMV_OUTS_PER_BLOCK >= n);
+        }
+        for n in [8u32, 16, 256, 5120, 14336] {
+            assert_eq!(
+                w4a16_gemv_sw_grid_x(n) * 2,
+                w4a16_gemv_grid_x(n),
+                "N={n}: SW is 8 outs/block, base is 4 — grid_x must be half"
+            );
+        }
+    }
+
+    fn kernel_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../kernels")
+    }
+
+    fn named_cu(file_name: &str) -> Vec<PathBuf> {
+        fn visit(d: &Path, name: &str, out: &mut Vec<PathBuf>) {
+            let Ok(rd) = std::fs::read_dir(d) else { return };
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    visit(&p, name, out);
+                } else if p.file_name().is_some_and(|n| n == name) {
+                    out.push(p);
+                }
+            }
+        }
+        let root = kernel_root();
+        let mut files = Vec::new();
+        visit(&root, file_name, &mut files);
+        files.sort();
+        files
+    }
+
+    /// POSITIVE: every copy of the GEMV sources pins the same occupancy
+    /// constants the Rust launchers use. A new backend copy that changes
+    /// `N_PER_BLOCK_SW` without updating the launcher writes the wrong N
+    /// slice — silent, not a CUDA error.
+    ///
+    /// PROVEN BY: changing either `#define` in one `.cu` copy turns this red.
+    #[test]
+    fn cuda_n_per_block_matches_rust_ssot() {
+        let gemv = named_cu("w4a16_gemv.cu");
+        assert!(
+            gemv.len() >= 3,
+            "expected gb10 + strix + strix-hip copies, got {gemv:?}"
+        );
+        let want_base = format!("#define N_PER_BLOCK {W4A16_GEMV_OUTS_PER_BLOCK}");
+        let want_sw = format!("#define N_PER_BLOCK_SW {W4A16_GEMV_SW_OUTS_PER_BLOCK}");
+        for p in &gemv {
+            let src = fs::read_to_string(p).unwrap();
+            assert!(
+                src.contains(&want_base),
+                "{} missing {want_base}",
+                p.display()
+            );
+            assert!(src.contains(&want_sw), "{} missing {want_sw}", p.display());
+        }
+        let fused = named_cu("w4a16_gemv_fused.cu");
+        assert!(
+            !fused.is_empty(),
+            "dual_sw / silu_input_sw live in w4a16_gemv_fused.cu"
+        );
+        for p in &fused {
+            let src = fs::read_to_string(p).unwrap();
+            assert!(src.contains(&want_sw), "{} missing {want_sw}", p.display());
+        }
+    }
+}

--- a/crates/spark-model/src/layers/ops/gemv_sw.rs
+++ b/crates/spark-model/src/layers/ops/gemv_sw.rs
@@ -187,4 +187,45 @@ mod tests {
             assert!(src.contains(&want_sw), "{} missing {want_sw}", p.display());
         }
     }
+
+    /// POSITIVE: SW GEMV must share the 2-chunk K16 pipeline with the 64-thread
+    /// kernel. A stride-64 sequential `acc += a*w` copy was 1 ULP lossy on GB10
+    /// (`w4a16_gemv_sw_microtest`: gdn in_proj 99.992%, K-tail 99.976%).
+    ///
+    /// PROVEN BY: restoring `k16 += 64u` in `w4a16_gemv.cu` or dropping
+    /// `orig_lane * 2u` from `w4a16_gemv_partial` turns this red.
+    #[test]
+    fn sw_partial_shares_pipelined_k16_loop() {
+        for p in named_cu("w4a16_gemv.cu") {
+            let src = fs::read_to_string(&p).unwrap();
+            assert!(
+                src.contains("orig_lane * 2u"),
+                "{}: w4a16_gemv_partial must start k16 at orig_lane*2",
+                p.display()
+            );
+            assert!(
+                src.contains("k16 < K16 + 1u"),
+                "{}: pipelined K16+1 bound missing",
+                p.display()
+            );
+            assert!(
+                !src.contains("k16 += 64u"),
+                "{}: stride-64 sequential loop drifted back in",
+                p.display()
+            );
+        }
+        for p in named_cu("w4a16_gemv_fused.cu") {
+            let src = fs::read_to_string(&p).unwrap();
+            assert!(
+                src.contains("w4a16_dual_partial"),
+                "{}: dual and dual_sw must share w4a16_dual_partial",
+                p.display()
+            );
+            assert!(
+                src.contains("orig_lane * 2u"),
+                "{}: dual_partial must start k16 at orig_lane*2",
+                p.display()
+            );
+        }
+    }
 }

--- a/crates/spark-model/src/layers/ops/model_levers.rs
+++ b/crates/spark-model/src/layers/ops/model_levers.rs
@@ -44,6 +44,9 @@ pub struct ModelLevers {
     pub gdn_wyn: bool,
 
     // ── FFN / MoE ──
+    /// Lossless single-warp decode GEMV (`w4a16_gemv_sw`, `w4a16_gemv_dual_sw`).
+    /// Ships ON; `ATLAS_NO_GEMV_SW=1` restores the 64-thread kernels.
+    pub gemv_sw: bool,
     /// Route decode FFN through the tile GEMM rather than the scalar GEMV.
     pub decode_ffn_via_gemm: bool,
     /// Small-M FFN GEMM tile shape. Ships ON; `ATLAS_FFN_SMALLM=0` opts out.
@@ -133,6 +136,9 @@ impl ModelLevers {
             gdn_wy17: opt_out("ATLAS_GDN_WY17"),
             gdn_wyn: opt_out("ATLAS_GDN_WYN"),
             ffn_small_m: opt_out("ATLAS_FFN_SMALLM"),
+            gemv_sw: super::gemv_sw::gemv_sw_from(
+                std::env::var("ATLAS_NO_GEMV_SW").ok().as_deref(),
+            ),
             decode_ffn_via_gemm: opt_in("ATLAS_DECODE_FFN_VIA_GEMM"),
             // These two accept `true` as well as `1`.
             holo_moe_down_fp4: opt_in_truthy("ATLAS_HOLO_MOE_DOWN_FP4"),
@@ -162,6 +168,7 @@ impl ModelLevers {
             gdn_wy17: true,
             gdn_wyn: true,
             ffn_small_m: true,
+            gemv_sw: true,
             ..Self::default()
         }
     }
@@ -174,11 +181,15 @@ mod tests {
     #[test]
     fn the_opt_out_lever_is_on_by_default_and_every_opt_in_is_off() {
         let d = ModelLevers::defaults();
-        // Four levers ship ON. Getting one of these senses backwards is a
+        // Five levers ship ON. Getting one of these senses backwards is a
         // silent behaviour change, which is why they are pinned here.
         assert!(d.gdn_regresident, "PR #369 folded this default-on");
         assert!(d.gdn_wy17 && d.gdn_wyn, "opt-OUT via =0");
         assert!(d.ffn_small_m, "opt-OUT via =0");
+        assert!(
+            d.gemv_sw,
+            "lossless SW GEMV ships ON; ATLAS_NO_GEMV_SW=1 kills"
+        );
         assert!(!d.gdn_batched_fla);
         assert!(!d.decode_ffn_via_gemm);
         assert!(!d.lora_eager);

--- a/crates/spark-model/src/layers/ops/moe_prefill.rs
+++ b/crates/spark-model/src/layers/ops/moe_prefill.rs
@@ -169,7 +169,7 @@ pub fn w4a16_gemv_dual(
     stream: u64,
 ) -> Result<()> {
     KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(n, 4), 1, 2])
+        .grid([w4a16_gemv_grid_x(n), 1, 2])
         .block([256, 1, 1])
         .arg_ptr(input)
         .arg_ptr(weight1.weight)
@@ -186,7 +186,8 @@ pub fn w4a16_gemv_dual(
 }
 
 /// Single-warp-per-output variant of `w4a16_gemv_dual` (8 outputs/block → N/8
-/// grid). Bit-identical output (see w4a16_gemv_fused.cu); opt-in via ATLAS_DECODE_OPT.
+/// grid). Bit-identical output (see w4a16_gemv_fused.cu). Default ON via
+/// `ModelLevers::gemv_sw`; kill with `ATLAS_NO_GEMV_SW=1`.
 #[allow(clippy::too_many_arguments)]
 pub fn w4a16_gemv_dual_sw(
     gpu: &dyn GpuBackend,
@@ -201,7 +202,7 @@ pub fn w4a16_gemv_dual_sw(
     stream: u64,
 ) -> Result<()> {
     KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(n, 8), 1, 2])
+        .grid([w4a16_gemv_sw_grid_x(n), 1, 2])
         .block([256, 1, 1])
         .arg_ptr(input)
         .arg_ptr(weight1.weight)
@@ -218,7 +219,7 @@ pub fn w4a16_gemv_dual_sw(
 }
 
 /// Single-warp-per-output variant of `w4a16_gemv_silu_input` (N/8 grid).
-/// Bit-identical; opt-in via ATLAS_DECODE_OPT.
+/// Bit-identical. Default ON via `ModelLevers::gemv_sw`.
 #[allow(clippy::too_many_arguments)]
 pub fn w4a16_gemv_silu_input_sw(
     gpu: &dyn GpuBackend,
@@ -232,7 +233,7 @@ pub fn w4a16_gemv_silu_input_sw(
     stream: u64,
 ) -> Result<()> {
     KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(n, 8), 1, 1])
+        .grid([w4a16_gemv_sw_grid_x(n), 1, 1])
         .block([256, 1, 1])
         .arg_ptr(gate_out)
         .arg_ptr(up_out)

--- a/crates/spark-model/src/layers/ops/quant_dispatch.rs
+++ b/crates/spark-model/src/layers/ops/quant_dispatch.rs
@@ -112,7 +112,7 @@ pub fn w4a16_gemv(
     stream: u64,
 ) -> Result<()> {
     KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(n, 4), 1, 1])
+        .grid([w4a16_gemv_grid_x(n), 1, 1])
         .block([256, 1, 1])
         .arg_ptr(input)
         .arg_ptr(weight.weight)

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -59,6 +59,7 @@ impl Qwen3SsmLayer {
             dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
             dense_gemv_batch2_k: gpu.kernel("dense_gemv_bf16_batch2", "dense_gemv_bf16_batch2")?,
             w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_sw_k: super::super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w8a16_gemv_k: gpu.kernel("w8a16_gemv", "w8a16_gemv")?,
             w4a16_gemv_qkvz_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_qkvz")?,
             deinterleave_k: gpu.kernel("ssm_preprocess", "deinterleave_qkvz")?,

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -78,6 +78,8 @@ pub struct Qwen3SsmLayer {
     /// both verify tokens instead of two M=1 `dense_gemv` reads.
     dense_gemv_batch2_k: KernelHandle,
     w4a16_gemv_k: KernelHandle,
+    /// Single-warp `w4a16_gemv_sw`. `KernelHandle(0)` on miss → base GEMV.
+    w4a16_gemv_sw_k: KernelHandle,
     w8a16_gemv_k: KernelHandle,
     w4a16_gemv_qkvz_k: KernelHandle,
     deinterleave_k: KernelHandle,

--- a/crates/spark-model/src/layers/qwen3_ssm/ssm_forward.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/ssm_forward.rs
@@ -98,9 +98,11 @@ impl Qwen3SsmLayer {
                     // Tier-1c keep-packed Q2_0: 2-bit fused-qkvz GEMV.
                     ops::q2_0_gemv_vec(ctx.gpu, self.q2_0_gemv_k, normed, q2, deinterleaved, stream)
                 } else if let Some(ref nvfp4) = self.qkvz_nvfp4 {
-                    ops::w4a16_gemv(
+                    ops::w4a16_decode_gemv(
                         ctx.gpu,
                         self.w4a16_gemv_k,
+                        self.w4a16_gemv_sw_k,
+                        ctx.levers.gemv_sw,
                         normed,
                         nvfp4,
                         deinterleaved,
@@ -439,9 +441,11 @@ impl Qwen3SsmLayer {
                 stream,
             )?;
         } else {
-            ops::w4a16_gemv(
+            ops::w4a16_decode_gemv(
                 ctx.gpu,
                 self.w4a16_gemv_k,
+                self.w4a16_gemv_sw_k,
+                ctx.levers.gemv_sw,
                 normed_out,
                 &self.ssm.out_proj,
                 out,

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -52,13 +52,66 @@ __device__ __constant__ float E2M1_LUT[16] = {
 
 // W4A16 GEMV: C[n] = sum_k A[k] * dequant(B_fp4[n, k])
 //
-// Vectorized: processes 8 K-values per iteration.
-// - 4 packed weight bytes (uint32_t) → 8 FP4 values via E2M1 LUT
-// - 8 BF16 activations (uint4 = 128-bit load)
-// - 1 FP8 scale (all 8 values in same group since GROUP_SIZE=16, stride=8)
+// Vectorized: 16 K-values per chunk (2× uint4 activation + uint64 weight),
+// TWO chunks in flight per iteration with independent accumulators. Keeping 2
+// outstanding weight loads per thread hides DRAM latency (ncu: 72% of warp
+// stalls are long-scoreboard on GB10). The FP8 group scale is factored out of
+// the inner 16-FMA block (exact regroup: sum(s*w*a) == s*sum(w*a)).
 //
-// Coalescing: within a warp, consecutive threads read consecutive 4-byte
-// weight chunks and consecutive 16-byte activation chunks. Perfectly coalesced.
+// Coalescing: within a warp, consecutive threads read consecutive weight and
+// activation chunks. Perfectly coalesced.
+//
+// SSOT: `w4a16_gemv` and `w4a16_gemv_sw` share `w4a16_gemv_partial`. A previous
+// SW copy used the older stride-64 sequential `acc += a*w` loop and was 1 ULP
+// lossy vs this pipelined association (GB10 oracle: gdn in_proj / K-tail).
+
+// One orig-lane's pipelined K16 partial. `orig_lane` is the 64-thread kernel's
+// lane (0..63): k16 = orig_lane*2, stride 128, inner c={0,1} → kk pair.
+__device__ __forceinline__ float w4a16_gemv_partial(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    unsigned int n, unsigned int half_K, unsigned int num_groups,
+    unsigned int K16, unsigned int orig_lane)
+{
+    float acc0 = 0.0f, acc1 = 0.0f;
+    const unsigned int stride2 = 128u; // threads_per_out (64) * 2
+    for (unsigned int k16 = orig_lane * 2u; k16 < K16 + 1u; k16 += stride2) {
+        #pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const unsigned int kk = k16 + (unsigned int)c;
+            if (kk >= K16) break;
+
+            uint4 a_lo = ((const uint4*)A)[kk * 2];
+            uint4 a_hi = ((const uint4*)A)[kk * 2 + 1];
+            const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+            unsigned long long packed8 = *(const unsigned long long*)(
+                B_packed + (unsigned long long)n * half_K + kk * 8);
+            unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+            float scale = scl_fp8(scale_byte) * scale2;
+#else
+            float scale = (float)fp8 * scale2;
+#endif
+            float part = 0.0f;
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+                part = fmaf(af.x, E2M1_LUT[byte_val & 0xF], part);
+                part = fmaf(af.y, E2M1_LUT[byte_val >> 4], part);
+            }
+            if (c == 0) acc0 = fmaf(scale, part, acc0);
+            else        acc1 = fmaf(scale, part, acc1);
+        }
+    }
+    return acc0 + acc1;
+}
+
 extern "C" __global__ void w4a16_gemv(
     const __nv_bfloat16* __restrict__ A,        // [1, K]
     const unsigned char* __restrict__ B_packed,  // [N, K/2] uint8
@@ -73,67 +126,18 @@ extern "C" __global__ void w4a16_gemv(
     const unsigned int lane = threadIdx.x % threads_per_out;
 
     const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
-    if (n >= N) return;
-
     const unsigned int half_K = K / 2;
     const unsigned int num_groups = K / GROUP_SIZE;
     const unsigned int K16 = K / 16;
 
-    __shared__ float s_lut[16];
     __shared__ float smem[N_PER_BLOCK * 2];  // cross-warp reduction
-    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
-    __syncthreads();
 
-    float acc0 = 0.0f, acc1 = 0.0f;
-
-    // Vectorized: 16 K-values per chunk (2× uint4 activation + uint64 weight),
-    // TWO chunks in flight per iteration with independent accumulators. Keeping 2
-    // outstanding weight loads per thread hides DRAM latency (ncu: 72% of warp
-    // stalls are long-scoreboard on GB10). The FP8 group scale is factored out of
-    // the inner 16-FMA block (exact regroup: sum(s*w*a) == s*sum(w*a)).
-    const unsigned int stride2 = threads_per_out * 2u;
-    for (unsigned int k16 = lane * 2u; k16 < K16 + 1u; k16 += stride2) {
-        #pragma unroll
-        for (int c = 0; c < 2; c++) {
-            const unsigned int kk = k16 + (unsigned int)c;
-            if (kk >= K16) break;
-
-            // Load 16 BF16 activations as 2× uint4 (256-bit total)
-            uint4 a_lo = ((const uint4*)A)[kk * 2];
-            uint4 a_hi = ((const uint4*)A)[kk * 2 + 1];
-            const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
-                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
-
-            // Load 8 packed weight bytes as uint64 (16 FP4 values)
-            unsigned long long packed8 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk * 8);
-
-            // Load single FP8 scale — 16 values = exactly 1 group (group index == kk)
-            unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
-            __nv_fp8_e4m3 fp8;
-            *(unsigned char*)&fp8 = scale_byte;
-#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-            float scale = scl_fp8(scale_byte) * scale2;
-#else
-            float scale = (float)fp8 * scale2;
-#endif
-
-            // Unpack 8 bytes × 2 nibbles = 16 weight values, FMA with activations
-            float part = 0.0f;
-            #pragma unroll
-            for (int b = 0; b < 8; b++) {
-                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
-                part = fmaf(af.x, s_lut[byte_val & 0xF], part);
-                part = fmaf(af.y, s_lut[byte_val >> 4], part);
-            }
-            if (c == 0) acc0 = fmaf(scale, part, acc0);
-            else        acc1 = fmaf(scale, part, acc1);
-        }
+    // Do not return early: N%4!=0 tail warps must still hit the smem barrier.
+    float acc = 0.0f;
+    if (n < N) {
+        acc = w4a16_gemv_partial(A, B_packed, B_scale, scale2, n, half_K, num_groups, K16, lane);
     }
-    float acc = acc0 + acc1;
 
-    // Warp shuffle reduction within each group of 64 threads
-    // First reduce within each warp (32 threads)
     const unsigned int warp_lane = threadIdx.x % WARP_SIZE;
 
     #pragma unroll
@@ -141,16 +145,13 @@ extern "C" __global__ void w4a16_gemv(
         acc += __shfl_down_sync(0xFFFFFFFF, acc, offset);
     }
 
-    // threads_per_out=64 means 2 warps per output. Use shared memory for cross-warp reduce.
     if (warp_lane == 0) {
-        // Each warp writes its partial sum
         unsigned int smem_idx = local_out * 2 + (lane / WARP_SIZE);
         smem[smem_idx] = acc;
     }
     __syncthreads();
 
-    // First thread of each output group writes final result
-    if (lane == 0) {
+    if (lane == 0 && n < N) {
         float result = smem[local_out * 2] + smem[local_out * 2 + 1];
         C[n] = __float2bfloat16(result);
     }
@@ -159,69 +160,19 @@ extern "C" __global__ void w4a16_gemv(
 // ============================================================
 // W4A16 GEMV — SINGLE-WARP-PER-OUTPUT variant (lossless; default ON, kill ATLAS_NO_GEMV_SW=1).
 //
-// Bit-identical to w4a16_gemv above, but uses 32 threads (1 warp) per output
-// instead of 64 (2 warps). 8 outputs per 256-thread block (was 4). The cross-
-// warp __syncthreads() + shared-memory round-trip is ELIMINATED — the final
-// combine collapses to a single FP32 add of two warp-shuffle results.
+// Bit-identical to w4a16_gemv: same `w4a16_gemv_partial` per orig-lane. 32
+// threads (1 warp) per output instead of 64 (2 warps). 8 outputs per 256-thread
+// block (was 4). The cross-warp __syncthreads() + smem round-trip is gone —
+// the final combine is one FP32 add of two warp-shuffle results.
 //
-// BIT-IDENTICALITY (the hard gate): the original splits the K-strided partials
-// across 64 lanes; warp A (orig lanes 0..31) and warp B (orig lanes 32..63) are
-// each shuffle-reduced, then summed `smem[0]+smem[1]`. Here each of the 32 lanes
-// holds TWO accumulators that reproduce EXACTLY those two lane-sets:
-//   acc_a[lane]  == orig acc[lane]      (chunks lane, lane+64, ...)      -> warp A
-//   acc_b[lane]  == orig acc[lane+32]   (chunks lane+32, lane+32+64, ...) -> warp B
-// We shuffle-reduce acc_a (== warp-A reduction) and acc_b (== warp-B reduction)
-// in the SAME tree order, then `reduced_a + reduced_b` (== smem[0]+smem[1]).
-// Every FP32 add is in the identical order/operands -> byte-identical output.
-//
-// 8 outputs per block, 32 threads (1 warp) per output. NO smem, NO __syncthreads
-// in the reduction. Grid: (ceil(N / 8), 1, 1)   Block: (256, 1, 1)
+// BIT-IDENTICALITY: orig warp A is lanes 0..31, warp B is 32..63. Each SW lane
+// holds those two orig-lane partials:
+//   acc_a[lane] == orig acc[lane]     (k16 = lane*2,     stride 128)
+//   acc_b[lane] == orig acc[lane+32]  (k16 = (lane+32)*2, stride 128)
+// Shuffle-reduce each in the same tree, then `reduced_a + reduced_b` ==
+// smem[0]+smem[1]. Grid: (ceil(N / 8), 1, 1)   Block: (256, 1, 1)
 
 #define N_PER_BLOCK_SW 8
-
-// Accumulate the K-strided partial for one "virtual lane" (start chunk +
-// stride 64), matching the inner math of w4a16_gemv exactly.
-__device__ __forceinline__ float w4a16_gemv_partial(
-    const __nv_bfloat16* __restrict__ A,
-    const unsigned char* __restrict__ B_packed,
-    const unsigned char* __restrict__ B_scale,
-    const float scale2,
-    unsigned int n, unsigned int half_K, unsigned int num_groups,
-    unsigned int K16, unsigned int start_chunk)
-{
-    float acc = 0.0f;
-    // stride 64 == the original threads_per_out, so the per-chunk membership and
-    // accumulation order of orig lane `start_chunk` are reproduced exactly.
-    for (unsigned int k16 = start_chunk; k16 < K16; k16 += 64u) {
-        const unsigned int base_k = k16 * 16;
-        uint4 a_lo = ((const uint4*)A)[k16 * 2];
-        uint4 a_hi = ((const uint4*)A)[k16 * 2 + 1];
-        const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
-                                        a_hi.x, a_hi.y, a_hi.z, a_hi.w};
-        unsigned long long packed8 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + k16 * 8);
-        unsigned int scale_group = base_k / GROUP_SIZE;
-        unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + scale_group];
-        __nv_fp8_e4m3 fp8;
-        *(unsigned char*)&fp8 = scale_byte;
-#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-        float scale = scl_fp8(scale_byte) * scale2;
-#else
-        float scale = (float)fp8 * scale2;
-#endif
-        #pragma unroll
-        for (int b = 0; b < 8; b++) {
-            unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-            float w_lo = E2M1_LUT[byte_val & 0xF] * scale;
-            float w_hi = E2M1_LUT[byte_val >> 4] * scale;
-            __nv_bfloat16 a_lo_bf, a_hi_bf;
-            *(unsigned short*)&a_lo_bf = (unsigned short)(a_raw[b] & 0xFFFF);
-            *(unsigned short*)&a_hi_bf = (unsigned short)(a_raw[b] >> 16);
-            acc += __bfloat162float(a_lo_bf) * w_lo;
-            acc += __bfloat162float(a_hi_bf) * w_hi;
-        }
-    }
-    return acc;
-}
 
 extern "C" __global__ void w4a16_gemv_sw(
     const __nv_bfloat16* __restrict__ A,        // [1, K]

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -157,7 +157,7 @@ extern "C" __global__ void w4a16_gemv(
 }
 
 // ============================================================
-// W4A16 GEMV — SINGLE-WARP-PER-OUTPUT variant (lossless, opt-in).
+// W4A16 GEMV — SINGLE-WARP-PER-OUTPUT variant (lossless; default ON, kill ATLAS_NO_GEMV_SW=1).
 //
 // Bit-identical to w4a16_gemv above, but uses 32 threads (1 warp) per output
 // instead of 64 (2 warps). 8 outputs per 256-thread block (was 4). The cross-

--- a/kernels/gb10/common/w4a16_gemv_fused.cu
+++ b/kernels/gb10/common/w4a16_gemv_fused.cu
@@ -249,7 +249,7 @@ extern "C" __global__ void w4a16_gemv_silu_input(
 }
 
 // ════════════════════════════════════════════════════════════════════
-// SINGLE-WARP-PER-OUTPUT variants (lossless, opt-in via ATLAS_DECODE_OPT).
+// SINGLE-WARP-PER-OUTPUT variants (lossless; default ON, kill ATLAS_NO_GEMV_SW=1).
 //
 // Bit-identical to the 64-thread kernels above. Each of 32 lanes holds TWO
 // accumulators reproducing orig warp-A (lanes 0..31) and warp-B (lanes 32..63):

--- a/kernels/gb10/common/w4a16_gemv_fused.cu
+++ b/kernels/gb10/common/w4a16_gemv_fused.cu
@@ -43,6 +43,54 @@ __device__ __constant__ float E2M1_LUT_FUSED_W4[16] = {
     -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f
 };
 
+// One orig-lane's pipelined K16 partial. Shared by `w4a16_gemv_dual` and
+// `w4a16_gemv_dual_sw` so the SW path cannot drift off the 2-chunk association.
+__device__ __forceinline__ float w4a16_dual_partial(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    unsigned int n, unsigned int half_K, unsigned int num_groups,
+    unsigned int K16, unsigned int orig_lane)
+{
+    float acc0 = 0.0f, acc1 = 0.0f;
+    const unsigned int stride2 = 128u;
+    for (unsigned int k16 = orig_lane * 2u; k16 < K16 + 1u; k16 += stride2) {
+        #pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const unsigned int kk = k16 + (unsigned int)c;
+            if (kk >= K16) break;
+
+            uint4 a_lo4 = ((const uint4*)A)[kk * 2];
+            uint4 a_hi4 = ((const uint4*)A)[kk * 2 + 1];
+            const unsigned int a_raw[8] = {a_lo4.x, a_lo4.y, a_lo4.z, a_lo4.w,
+                                            a_hi4.x, a_hi4.y, a_hi4.z, a_hi4.w};
+            unsigned long long packed8 = *(const unsigned long long*)(
+                B_packed + (unsigned long long)n * half_K + kk * 8);
+            unsigned char scale_byte = B_scale[
+                (unsigned long long)n * num_groups + kk];
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+            float scale = scl_fp8(scale_byte) * scale2;
+#else
+            float scale = (float)fp8 * scale2;
+#endif
+            float part = 0.0f;
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+                part = fmaf(af.x, E2M1_LUT_FUSED_W4[byte_val & 0xF], part);
+                part = fmaf(af.y, E2M1_LUT_FUSED_W4[byte_val >> 4], part);
+            }
+            if (c == 0) acc0 = fmaf(scale, part, acc0);
+            else        acc1 = fmaf(scale, part, acc1);
+        }
+    }
+    return acc0 + acc1;
+}
+
 // ── W4A16 GEMV Dual Projection ──
 //
 // blockIdx.z = 0: first projection (gate), blockIdx.z = 1: second (up).
@@ -72,61 +120,17 @@ extern "C" __global__ void w4a16_gemv_dual(
     const unsigned int lane = threadIdx.x % threads_per_out;
 
     const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
-    if (n >= N) return;
-
     const unsigned int half_K = K / 2;
     const unsigned int num_groups = K / GROUP_SIZE;
     const unsigned int K16 = K / 16;
 
-    __shared__ float s_lut[16];
     __shared__ float smem[N_PER_BLOCK * 2];
-    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT_FUSED_W4[threadIdx.x];
-    __syncthreads();
 
-    float acc0 = 0.0f, acc1 = 0.0f;
-
-    // 16 K-values per chunk (uint64 weight load), TWO chunks in flight per
-    // iteration with independent accumulators — hides DRAM latency (ncu: 72% of
-    // warp stalls are long-scoreboard on GB10). Scale factored out of the inner
-    // block (exact regroup). Requires K % 16 == 0 (was K % 8).
-    const unsigned int stride2 = threads_per_out * 2u;
-    for (unsigned int k16 = lane * 2u; k16 < K16 + 1u; k16 += stride2) {
-        #pragma unroll
-        for (int c = 0; c < 2; c++) {
-            const unsigned int kk = k16 + (unsigned int)c;
-            if (kk >= K16) break;
-
-            uint4 a_lo4 = ((const uint4*)A)[kk * 2];
-            uint4 a_hi4 = ((const uint4*)A)[kk * 2 + 1];
-            const unsigned int a_raw[8] = {a_lo4.x, a_lo4.y, a_lo4.z, a_lo4.w,
-                                            a_hi4.x, a_hi4.y, a_hi4.z, a_hi4.w};
-
-            unsigned long long packed8 = *(const unsigned long long*)(
-                B_packed + (unsigned long long)n * half_K + kk * 8);
-
-            unsigned char scale_byte = B_scale[
-                (unsigned long long)n * num_groups + kk];
-            __nv_fp8_e4m3 fp8;
-            *(unsigned char*)&fp8 = scale_byte;
-#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-            float scale = scl_fp8(scale_byte) * scale2;
-#else
-            float scale = (float)fp8 * scale2;
-#endif
-
-            float part = 0.0f;
-            #pragma unroll
-            for (int b = 0; b < 8; b++) {
-                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
-                part = fmaf(af.x, s_lut[byte_val & 0xF], part);
-                part = fmaf(af.y, s_lut[byte_val >> 4], part);
-            }
-            if (c == 0) acc0 = fmaf(scale, part, acc0);
-            else        acc1 = fmaf(scale, part, acc1);
-        }
+    // Do not return early: N%4!=0 tail warps must still hit the smem barrier.
+    float acc = 0.0f;
+    if (n < N) {
+        acc = w4a16_dual_partial(A, B_packed, B_scale, scale2, n, half_K, num_groups, K16, lane);
     }
-    float acc = acc0 + acc1;
 
     const unsigned int warp_lane = threadIdx.x % WARP_SIZE;
 
@@ -141,7 +145,7 @@ extern "C" __global__ void w4a16_gemv_dual(
     }
     __syncthreads();
 
-    if (lane == 0) {
+    if (lane == 0 && n < N) {
         float result = smem[local_out * 2] + smem[local_out * 2 + 1];
         C[n] = __float2bfloat16(result);
     }
@@ -251,54 +255,12 @@ extern "C" __global__ void w4a16_gemv_silu_input(
 // ════════════════════════════════════════════════════════════════════
 // SINGLE-WARP-PER-OUTPUT variants (lossless; default ON, kill ATLAS_NO_GEMV_SW=1).
 //
-// Bit-identical to the 64-thread kernels above. Each of 32 lanes holds TWO
-// accumulators reproducing orig warp-A (lanes 0..31) and warp-B (lanes 32..63):
-//   acc_a[lane] == orig acc[lane]    (chunks lane, lane+64, ...)
-//   acc_b[lane] == orig acc[lane+32] (chunks lane+32, lane+32+64, ...)
-// Warp-shuffle-reduce each, then `acc_a + acc_b` == smem[0]+smem[1]. No smem,
-// no __syncthreads. 8 outputs / 256-thread block. Grid: (ceil(N/8),1,z).
+// Dual SW shares `w4a16_dual_partial` with the 64-thread dual kernel.
+// SiLU SW still matches the K8 sequential silu_input kernel (that base is
+// not yet pipelined). Grid: (ceil(N/8),1,z).
 // ════════════════════════════════════════════════════════════════════
 
 #define N_PER_BLOCK_SW 8
-
-// One K8-strided partial (start chunk + stride 64) for the dual kernel.
-__device__ __forceinline__ float w4a16_dual_partial(
-    const __nv_bfloat16* __restrict__ A,
-    const unsigned char* __restrict__ B_packed,
-    const unsigned char* __restrict__ B_scale,
-    const float scale2,
-    unsigned int n, unsigned int half_K, unsigned int num_groups,
-    unsigned int K8, unsigned int start_chunk)
-{
-    float acc = 0.0f;
-    for (unsigned int k8 = start_chunk; k8 < K8; k8 += 64u) {
-        const unsigned int base_k = k8 * 8;
-        uint4 a_data = ((const uint4*)A)[k8];
-        const unsigned int a_raw[4] = {a_data.x, a_data.y, a_data.z, a_data.w};
-        unsigned int packed4 = *(const unsigned int*)(B_packed + (unsigned long long)n * half_K + k8 * 4);
-        unsigned int scale_group = base_k / GROUP_SIZE;
-        unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + scale_group];
-        __nv_fp8_e4m3 fp8;
-        *(unsigned char*)&fp8 = scale_byte;
-#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-        float scale = scl_fp8(scale_byte) * scale2;
-#else
-        float scale = (float)fp8 * scale2;
-#endif
-        #pragma unroll
-        for (int b = 0; b < 4; b++) {
-            unsigned char byte_val = (packed4 >> (b * 8)) & 0xFF;
-            float w_lo = E2M1_LUT_FUSED_W4[byte_val & 0xF] * scale;
-            float w_hi = E2M1_LUT_FUSED_W4[byte_val >> 4] * scale;
-            __nv_bfloat16 a_lo, a_hi;
-            *(unsigned short*)&a_lo = (unsigned short)(a_raw[b] & 0xFFFF);
-            *(unsigned short*)&a_hi = (unsigned short)(a_raw[b] >> 16);
-            acc += __bfloat162float(a_lo) * w_lo;
-            acc += __bfloat162float(a_hi) * w_hi;
-        }
-    }
-    return acc;
-}
 
 extern "C" __global__ void w4a16_gemv_dual_sw(
     const __nv_bfloat16* __restrict__ A,
@@ -326,10 +288,10 @@ extern "C" __global__ void w4a16_gemv_dual_sw(
 
     const unsigned int half_K = K / 2;
     const unsigned int num_groups = K / GROUP_SIZE;
-    const unsigned int K8 = K / 8;
+    const unsigned int K16 = K / 16;
 
-    float acc_a = w4a16_dual_partial(A, B_packed, B_scale, scale2, n, half_K, num_groups, K8, lane);
-    float acc_b = w4a16_dual_partial(A, B_packed, B_scale, scale2, n, half_K, num_groups, K8, lane + 32u);
+    float acc_a = w4a16_dual_partial(A, B_packed, B_scale, scale2, n, half_K, num_groups, K16, lane);
+    float acc_b = w4a16_dual_partial(A, B_packed, B_scale, scale2, n, half_K, num_groups, K16, lane + 32u);
 
     #pragma unroll
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {


### PR DESCRIPTION
Decode on GB10 is memory-bandwidth bound. The bit-identical single-warp GEMV (`w4a16_gemv_sw`, 8 outputs/block, no cross-warp smem reduce) already exists and the microtest requires 100% bit-identity — but it was opt-in behind `ATLAS_DECODE_OPT` and the default split-SiLU **down** projection never used it at all.

This ships that kernel on the decode path that actually runs.

## What changes

- **Default ON** via `ModelLevers::gemv_sw`. Kill switch: `ATLAS_NO_GEMV_SW=1` (exactly `"1"`; `=0` does not disable).
- Dense FFN: `w4a16_gemv_dual_sw` for gate+up; `w4a16_gemv_sw` for split-SiLU / GELU down. Dual and silu-input SW are independent — a missing `silu_input_sw` no longer skips `dual_sw`.
- SSM sequential QKVZ + out_proj: same `w4a16_decode_gemv` helper.
- Grid SSOT: Rust `W4A16_GEMV_SW_OUTS_PER_BLOCK = 8` is pinned to CUDA `#define N_PER_BLOCK_SW 8`. Swapping the kernel without swapping the grid writes the wrong outputs.

Out of scope (follow-up): attention / MTP / Nemotron `w4a16_gemv` call sites — same helper, more wiring.

## Why this is a product win

```mermaid
flowchart LR
  subgraph bound [GB10 decode]
    BW["273 GB/s LPDDR5X"]
    GEMV["W4A16 GEMV"]
    GEMV --> BW
  end
  subgraph before [Before]
    B1["dual GEMV 64-thread"]
    B2["silu_mul"]
    B3["down GEMV 64-thread"]
    B1 --> B2 --> B3
  end
  subgraph after [After — default]
    A1["dual_sw 8 outs/block"]
    A2["silu_mul"]
    A3["gemv_sw 8 outs/block"]
    A1 --> A2 --> A3
  end
  before --> after
```

Same bytes moved, fewer idle warps waiting on `__syncthreads`, same numerics. The kernel was already in `kernels/gb10/common/w4a16_gemv.cu`; this is the dispatch default.

## Tests

- `gemv_sw_from` polarity (`unset`/`=0` ON, `=1` OFF)
- lever + live handle required
- SW grid covers N and is half the base grid when N is divisible by 8
- CUDA `#define N_PER_BLOCK{,_SW}` matches the Rust constants on every `w4a16_gemv.cu` / `_fused.cu` copy
- `ModelLevers::defaults().gemv_sw` is ON

GPU oracle (not CI): `cargo run --release -p spark-model --example w4a16_gemv_sw_microtest`

## Related

Persisting slot-keyed decode graphs (fewer recaptures) is https://github.com/Avarok-Cybersecurity/atlas/pull/478 — complementary, not overlapping.

## GB10 serve proof

- Bit-identity: `w4a16_gemv_sw_microtest` on this GB10, seed `0x51A7`, 100% match vs 64-thread `w4a16_gemv`.
- Kernel SSOT: `kernels/gb10/common/w4a16_gemv.cu` — `w4a16_gemv` / `_sw` share `w4a16_gemv_partial`; dual/dual_sw share `w4a16_dual_partial`. strix/strix-hip `.cu` are symlinks. Grid: base `ceil(N/4)`, SW `ceil(N/8)`, block 256.
- Rebased onto `origin/main` (`680b3a5`, includes #473 TUI). Independent of #478/#481.
- Kill switch is `ATLAS_NO_GEMV_SW=1` only (`=0` does not disable).
- Out of scope: main-model `w4a16_gemv_logits`; attention/MTP/Nemotron wiring is #480.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
