### PR TITLE
spark-model: unsuppress CUDA graphs after FP8 KV freeze on mixed-dtype layers

### DIFF
--- a/crates/spark-model/src/layers/fp8_calibration.rs
+++ b/crates/spark-model/src/layers/fp8_calibration.rs
@@ -22,12 +22,38 @@
 use anyhow::Result;
 use parking_lot::Mutex;
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kv_cache::KvCacheDtype;
 
 /// FP8 E4M3 max representable magnitude.
 const FP8_E4M3_MAX: f32 = 448.0;
 
 /// Minimum scale to prevent division by zero or denormalized values.
 const MIN_SCALE: f32 = 1e-12;
+
+/// Whether this KV dtype's write path calls [`Fp8KvCalibration::observe`].
+///
+/// SSOT with `qwen3_attention/decode/write_kv_cache.rs`: only the plain
+/// `KvCacheDtype::Fp8` arm observes. BF16 boundary layers
+/// (`--kv-high-precision-layers auto` on FP8 KV) never observe; attaching a
+/// tracker there leaves `is_calibrating() == true` forever, and
+/// `Iterator::find_map` on that first attention layer pins CUDA graphs eager
+/// for the life of the process.
+pub fn dtype_runs_online_fp8_kv_calibration(kv_dtype: KvCacheDtype) -> bool {
+    matches!(kv_dtype, KvCacheDtype::Fp8)
+}
+
+/// Lift CUDA-graph suppression once every calibrating layer has frozen.
+///
+/// `None` = this layer does not calibrate (SSM, BF16 KV, static scales).
+/// `Some(false)` = still warming. Vacuously true when no layer calibrates.
+/// Must not use `find_map`: a BF16 boundary layer reporting `Some(false)`
+/// would shadow later FP8 layers that already froze.
+pub fn graphs_ready_after_fp8_kv_cal<I>(states: I) -> bool
+where
+    I: IntoIterator<Item = Option<bool>>,
+{
+    states.into_iter().all(|s| s.unwrap_or(true))
+}
 
 /// Mutable calibration state protected by Mutex for Send + Sync.
 struct CalibrationInner {
@@ -321,6 +347,96 @@ mod tests {
             frozen,
             "the frozen scale moved after later observes — pre-freeze KV would \
              now dequantize through a different scale than it was written with"
+        );
+    }
+
+    #[test]
+    fn only_plain_fp8_kv_runs_online_calibration() {
+        use spark_runtime::kv_cache::KvCacheDtype as D;
+        assert!(super::dtype_runs_online_fp8_kv_calibration(D::Fp8));
+        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Bf16));
+        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Nvfp4));
+        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Turbo8));
+        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Fp8KTurbo4V));
+    }
+
+    #[test]
+    fn graphs_ready_vacuous_when_no_calibrator() {
+        assert!(super::graphs_ready_after_fp8_kv_cal([None, None]));
+    }
+
+    #[test]
+    fn graphs_ready_blocked_while_any_calibrator_is_warm() {
+        assert!(!super::graphs_ready_after_fp8_kv_cal([
+            None,
+            Some(false),
+            Some(true)
+        ]));
+    }
+
+    #[test]
+    fn graphs_ready_when_every_calibrator_frozen() {
+        assert!(super::graphs_ready_after_fp8_kv_cal([
+            None,
+            Some(true),
+            Some(true)
+        ]));
+    }
+
+    /// Qwen3.6 `--kv-high-precision-layers auto`: first/last 2 attention
+    /// layers are BF16 (report `None` after we stop attaching a tracker)
+    /// and the FP8 middles freeze on first observe (`Some(true)`).
+    /// `find_map` on a leftover BF16 `Some(false)` would keep graphs off.
+    #[test]
+    fn graphs_ready_ignores_bf16_boundary_layers() {
+        assert!(super::graphs_ready_after_fp8_kv_cal([
+            None,
+            Some(true),
+            Some(true),
+            None
+        ]));
+    }
+
+    #[test]
+    fn attention_init_attaches_calibrator_only_via_dtype_predicate() {
+        let src = include_str!("qwen3_attention/init.rs");
+        assert!(
+            src.contains("dtype_runs_online_fp8_kv_calibration(kv_dtype)"),
+            "init.rs must attach Fp8KvCalibration only when the KV dtype observes"
+        );
+    }
+
+    #[test]
+    fn decode_unsuppress_aggregates_all_layers_not_find_map() {
+        let src = include_str!("../model/trait_impl/decode_a.rs");
+        assert!(
+            src.contains("graphs_ready_after_fp8_kv_cal"),
+            "decode_a must lift graph suppression from every layer's frozen flag"
+        );
+        let frozen_fn = src
+            .split("fn fp8_calibration_frozen")
+            .nth(1)
+            .expect("fp8_calibration_frozen");
+        let body = frozen_fn
+            .split("pub(super) fn decode_dispatch")
+            .next()
+            .unwrap();
+        assert!(
+            !body.contains("find_map"),
+            "find_map lets a BF16 boundary layer's Some(false) shadow frozen FP8 layers"
+        );
+    }
+
+    #[test]
+    fn fused_verify_unsuppress_matches_decode_frozen_flag() {
+        let src = include_str!("../model/trait_impl/verify_fused.rs");
+        assert!(
+            src.contains("fp8_calibration_frozen()"),
+            "fused verify must not wait seq_len > calibration_tokens+10"
+        );
+        assert!(
+            !src.contains("calibration_tokens + 10"),
+            "old token-count gate kept fused verify eager for ~266 tokens"
         );
     }
 }

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -650,13 +650,8 @@ impl Qwen3AttentionLayer {
                 "quantize_bf16_to_nvfp4",
             ),
             fp8_calibration: if fp8_calibration_tokens > 0
-                && !matches!(
-                    kv_dtype,
-                    KvCacheDtype::Nvfp4
-                        | KvCacheDtype::Turbo4
-                        | KvCacheDtype::Turbo3
-                        | KvCacheDtype::Turbo8
-                ) {
+                && crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype)
+            {
                 Some(Fp8KvCalibration::new(
                     fp8_calibration_tokens,
                     config.fp8_kv_headroom,

--- a/crates/spark-model/src/model/trait_impl/decode_a.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a.rs
@@ -31,15 +31,15 @@ impl TransformerModel {
     /// Whether the online FP8-KV calibration has frozen its scale, model-wide.
     ///
     /// Every calibrating attention layer freezes on ITS first observe within
-    /// the same first forward pass, so the first layer that reports a state
-    /// speaks for all of them. `true` when NO layer runs online calibration —
-    /// there is nothing to wait for, and the graph-suppression gate below is
-    /// additionally guarded by `fp8_kv_calibration_tokens > 0`.
+    /// the same first forward pass. `true` when NO layer runs online
+    /// calibration — there is nothing to wait for, and the graph-suppression
+    /// gate below is additionally guarded by `fp8_kv_calibration_tokens > 0`.
+    /// Aggregation is all-frozen, not `find_map`: a BF16 boundary layer that
+    /// never observes must not shadow later FP8 layers that already froze.
     pub(in crate::model) fn fp8_calibration_frozen(&self) -> bool {
-        self.layers
-            .iter()
-            .find_map(|l| l.fp8_calibration_frozen())
-            .unwrap_or(true)
+        crate::layers::fp8_calibration::graphs_ready_after_fp8_kv_cal(
+            self.layers.iter().map(|l| l.fp8_calibration_frozen()),
+        )
     }
 
     pub(super) fn decode_dispatch(

--- a/crates/spark-model/src/model/trait_impl/verify_fused.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_fused.rs
@@ -187,11 +187,12 @@ impl TransformerModel {
             moe_row_adapter: spark_runtime::gpu::DevicePtr::NULL,
         };
 
-        // FP8 calibration re-enable (mirrors verify_b.rs).
-        if self
-            .suppress_graphs
-            .load(std::sync::atomic::Ordering::Relaxed)
-            && seq.seq_len > self.config.fp8_kv_calibration_tokens + 10
+        // FP8 calibration re-enable (mirrors verify_b.rs / decode_a.rs).
+        if self.config.fp8_kv_calibration_tokens > 0
+            && self
+                .suppress_graphs
+                .load(std::sync::atomic::Ordering::Relaxed)
+            && self.fp8_calibration_frozen()
         {
             self.suppress_graphs
                 .store(false, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
## Summary

`--kv-high-precision-layers auto` leaves the first/last attention layers on BF16 KV. Those layers still got an `Fp8KvCalibration` but never `observe()` (only the FP8 write arm observes), so `is_calibrating` stayed true. Decode then used `find_map` over layers, saw `Some(false)` on layer 0, and kept `suppress_graphs` for the process lifetime.

On this GB10 serve (`nvidia/Qwen3.6-35B-A3B-NVFP4`, `--kv-high-precision-layers auto`, speculative), that meant **zero CUDA graph captures** and serial decode ~49 tok/s. `--fp8-kv-calibration-tokens 0` does not disable calibration: unset is treated as missing and MODEL.toml `256` wins.

This PR:

- Attaches a calibrator only for `KvCacheDtype::Fp8` (`dtype_runs_online_fp8_kv_calibration`).
- Aggregates freeze with `graphs_ready_after_fp8_kv_cal` (every `Some` must be true; `None` skipped) instead of `find_map`.
- Uses the same frozen-flag gate in fused verify (drops the `seq_len > calibration_tokens + 10` heuristic).

Independent of #478 (graph persist). **#478 is a no-op on this serve until this lands** — persist cannot reuse graphs that never capture.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p spark-model --lib layers::fp8_calibration` (9/9)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p spark-model --tests -- -D warnings`
- [x] `bash scripts/check-license-headers.sh`
- [x] GB10 host `spark` (`--no-default-features --features cuda`, `ATLAS_TARGET_MODEL=qwen3.6-35b-a3b`, NVFP4): after this fix, slot-0 decode graph captured once on `2+2`, reused on Paris/sky and two 220-token prompts; K=2 verify captured once. `destroy_graph` stayed 0 with #478. Lifecycle ~123–125 tok/s vs `avarok/atlas-gb10:latest` 98.8 tok/s (latest recaptures every request).

## Notes for reviewers

Do not mix this into #480. This is the reason persist was invisible on Qwen3.6 35B-A3B with HP-auto: mixed-dtype layers, not a graph-cache bug.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).