### PR TITLE
feat(laguna): Laguna-XS-2.1 support — its own kernel target + NVFP4-packed shared-expert loader arm

### DIFF
--- a/crates/atlas-kernels/tests/model_type_routing.rs
+++ b/crates/atlas-kernels/tests/model_type_routing.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `[[model_types]]` routing pins.
+//!
+//! `atlas_kernels::ptx_for_config(model_type, hidden_size)` picks a compiled
+//! kernel target by matching the `[[model_types]]` claims declared in each
+//! `kernels/{hw}/{model}/MODEL.toml`. An exact `(model_type, hidden_size)`
+//! claim wins; a claim without `hidden_size` is the wildcard fallback; nothing
+//! matching returns `None` and the model cannot boot at all.
+//!
+//! That makes the claim table load-bearing in a way nothing else checks.
+//! Poolside ships Laguna at two hidden sizes, and `laguna-s-2.1` claims
+//! `(laguna, 3072)` only — so before `laguna-xs-2.1` existed a 2048-hidden XS
+//! checkpoint matched neither the exact rule nor a wildcard and
+//! `ptx_for_config` returned `None`. The variants also disagree on
+//! `thinking_default` and on their sampling presets, which is expressible only
+//! as two MODEL.toml files.
+//!
+//! These run against the MODEL.toml files in the tree rather than the compiled
+//! registry, so they hold on the GPU-free CI runner (`ATLAS_SKIP_BUILD=1`),
+//! where `available_targets()` is an empty stub.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+fn kernels_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/atlas-kernels is two levels below the workspace root")
+        .join("kernels")
+}
+
+/// One `[[model_types]]` entry: `(model_type, hidden_size)` -> declaring targets.
+type Claims = BTreeMap<(String, Option<u64>), Vec<String>>;
+
+/// Every `[[model_types]]` claim under `kernels/{hw}/*/MODEL.toml`, keyed by
+/// the pair claimed and valued by the `{hw}/{model}` targets claiming it.
+fn claims() -> Claims {
+    let mut out: Claims = BTreeMap::new();
+    for (target, manifest) in manifests() {
+        let text = std::fs::read_to_string(&manifest).expect("manifest is readable");
+        let parsed: toml::Value = text
+            .parse()
+            .unwrap_or_else(|e| panic!("{} is not valid TOML: {e}", manifest.display()));
+        let Some(entries) = parsed.get("model_types").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for entry in entries {
+            let model_type = entry
+                .get("model_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{} has a [[model_types]] entry with no model_type",
+                        manifest.display()
+                    )
+                })
+                .to_string();
+            let hidden = entry.get("hidden_size").and_then(|v| v.as_integer());
+            out.entry((model_type, hidden.map(|h| h as u64)))
+                .or_default()
+                .push(target.clone());
+        }
+    }
+    assert!(
+        !out.is_empty(),
+        "no [[model_types]] claims found under {} — the walk is broken, not the tree",
+        kernels_root().display()
+    );
+    out
+}
+
+/// `({hw}/{model}, path to its MODEL.toml)` for every kernel target in the tree.
+fn manifests() -> Vec<(String, PathBuf)> {
+    let root = kernels_root();
+    let mut out = Vec::new();
+    let hw_dirs = std::fs::read_dir(&root).expect("kernels/ is readable");
+    for hw in hw_dirs.flatten().map(|e| e.path()).filter(|p| p.is_dir()) {
+        let Ok(models) = std::fs::read_dir(&hw) else {
+            continue;
+        };
+        for model in models.flatten().map(|e| e.path()).filter(|p| p.is_dir()) {
+            let manifest = model.join("MODEL.toml");
+            if !manifest.is_file() {
+                continue;
+            }
+            out.push((
+                format!(
+                    "{}/{}",
+                    hw.file_name().unwrap().to_string_lossy(),
+                    model.file_name().unwrap().to_string_lossy()
+                ),
+                manifest,
+            ));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Both Laguna hidden sizes must route, each to its own target and to nothing
+/// else. The `assert_eq` on the full claimant list is deliberate: a second
+/// target claiming the same pair would make `ptx_for_config` resolve by target
+/// enumeration order.
+#[test]
+fn both_laguna_hidden_sizes_route_to_their_own_target() {
+    let claims = claims();
+    let lookup = |hidden: u64| -> Vec<String> {
+        claims
+            .get(&("laguna".to_string(), Some(hidden)))
+            .cloned()
+            .unwrap_or_default()
+    };
+
+    assert_eq!(
+        lookup(2048),
+        vec!["gb10/laguna-xs-2.1".to_string()],
+        "Laguna-XS-2.1 (hidden_size 2048) must be claimed by gb10/laguna-xs-2.1 \
+         and only by it; unclaimed means ptx_for_config returns None and XS \
+         cannot boot at all"
+    );
+    assert_eq!(
+        lookup(3072),
+        vec!["gb10/laguna-s-2.1".to_string()],
+        "Laguna-S-2.1 (hidden_size 3072) must stay on gb10/laguna-s-2.1"
+    );
+    // Non-vacuity: a wildcard `laguna` claim would satisfy both lookups at
+    // runtime for the wrong reason, and would silently capture the next
+    // variant onto whichever target declared it.
+    assert!(
+        !claims.contains_key(&("laguna".to_string(), None)),
+        "a wildcard `laguna` claim would swallow every future hidden size; \
+         each variant gets an explicit claim"
+    );
+}
+
+/// A target's `[[model_types]]` hidden_size claim must agree with the
+/// `[model].hidden_dim` it documents. The two are written independently, and a
+/// mismatch routes a checkpoint onto a target tuned for another shape.
+#[test]
+fn claimed_hidden_size_matches_documented_hidden_dim() {
+    let mut checked = 0usize;
+    let mut violations: Vec<String> = Vec::new();
+    for (_, manifest) in manifests() {
+        let text = std::fs::read_to_string(&manifest).expect("manifest is readable");
+        let parsed: toml::Value = text.parse().expect("MODEL.toml parses");
+        let Some(hidden_dim) = parsed
+            .get("model")
+            .and_then(|m| m.get("hidden_dim"))
+            .and_then(|v| v.as_integer())
+        else {
+            continue;
+        };
+        let Some(entries) = parsed.get("model_types").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for entry in entries {
+            let Some(claimed) = entry.get("hidden_size").and_then(|v| v.as_integer()) else {
+                continue;
+            };
+            checked += 1;
+            if claimed != hidden_dim {
+                violations.push(format!(
+                    "{}: [[model_types]] hidden_size {claimed} != [model] hidden_dim {hidden_dim}",
+                    manifest.display()
+                ));
+            }
+        }
+    }
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+    assert!(
+        checked >= 2,
+        "expected at least the two Laguna targets to carry an explicit \
+         hidden_size claim, checked {checked}"
+    );
+}

--- a/crates/spark-model/src/weight_loader/laguna/load_layers.rs
+++ b/crates/spark-model/src/weight_loader/laguna/load_layers.rs
@@ -135,15 +135,59 @@ fn load_moe_ffn(
         .collect::<Result<Vec<_>>>()?;
 
     let shared = format!("{mlp}.shared_expert");
-    let shared_gate = dense_auto(store, &format!("{shared}.gate_proj.weight"), gpu)?;
-    let shared_up = dense_auto(store, &format!("{shared}.up_proj.weight"), gpu)?;
-    let shared_down = dense_auto(store, &format!("{shared}.down_proj.weight"), gpu)?;
     let si = config.shared_expert_intermediate_size;
     let h = config.hidden_size;
-    let shared_expert = ExpertWeight {
-        gate_proj: quantize_to_nvfp4(&shared_gate, si, h, gpu, absmax_k, quantize_k, stream)?,
-        up_proj: quantize_to_nvfp4(&shared_up, si, h, gpu, absmax_k, quantize_k, stream)?,
-        down_proj: quantize_to_nvfp4(&shared_down, h, si, gpu, absmax_k, quantize_k, stream)?,
+    // Shared-expert precision differs across Laguna variants, and the
+    // checkpoint says which. S-2.1 lists `shared_expert.{gate,up,down}_proj` in
+    // its `quantization_config.ignore` set and ships them BF16; XS-2.1 lists
+    // them in `targets` instead and ships them NVFP4-packed, exactly like the
+    // routed experts. Detect by tensor presence (`.weight_packed`) rather than
+    // by hidden_size, so a future variant is classified by what it actually
+    // contains.
+    let shared_packed = store.contains(&format!("{shared}.gate_proj.weight_packed"));
+    let (shared_expert, bf16_shared) = if shared_packed {
+        // XS-2.1: the NVFP4 shared expert is authoritative and runs on the same
+        // machinery as the routed NVFP4 experts — no BF16 override.
+        (
+            ExpertWeight {
+                gate_proj: quantized_v2(store, &format!("{shared}.gate_proj"), gpu)?,
+                up_proj: quantized_v2(store, &format!("{shared}.up_proj"), gpu)?,
+                down_proj: quantized_v2(store, &format!("{shared}.down_proj"), gpu)?,
+            },
+            None,
+        )
+    } else {
+        // S-2.1: BF16 shared expert. The NVFP4 copies below are placeholders so
+        // the fused routed kernels have something to read; the BF16 tensors are
+        // installed as authoritative below and overwrite the shared
+        // contribution before blending.
+        let shared_gate = dense_auto(store, &format!("{shared}.gate_proj.weight"), gpu)?;
+        let shared_up = dense_auto(store, &format!("{shared}.up_proj.weight"), gpu)?;
+        let shared_down = dense_auto(store, &format!("{shared}.down_proj.weight"), gpu)?;
+        (
+            ExpertWeight {
+                gate_proj: quantize_to_nvfp4(
+                    &shared_gate,
+                    si,
+                    h,
+                    gpu,
+                    absmax_k,
+                    quantize_k,
+                    stream,
+                )?,
+                up_proj: quantize_to_nvfp4(&shared_up, si, h, gpu, absmax_k, quantize_k, stream)?,
+                down_proj: quantize_to_nvfp4(
+                    &shared_down,
+                    h,
+                    si,
+                    gpu,
+                    absmax_k,
+                    quantize_k,
+                    stream,
+                )?,
+            },
+            Some((shared_gate, shared_up, shared_down)),
+        )
     };
     let weights = MoeWeights {
         gate,
@@ -156,11 +200,15 @@ fn load_moe_ffn(
         correction_bias: Some(correction_bias),
     };
     let mut layer = MoeLayer::new(weights, config.num_experts, None, gpu, config)?;
-    // The checkpoint explicitly excludes the shared expert from NVFP4
-    // compression. Keep its BF16 weights authoritative for both prefill and
-    // decode; the quantized copies above are placeholders for fused routed
-    // kernels and their shared contribution is overwritten before blending.
-    layer.set_bf16_shared_expert(shared_gate, shared_up, shared_down)?;
+    // S-2.1 excludes the shared expert from NVFP4 compression: keep its BF16
+    // weights authoritative for both prefill and decode. XS-2.1 ships the
+    // shared expert NVFP4-packed, so nothing overrides `weights.shared_expert`
+    // and it stays on the quantized path (`has_mixed_bf16_shared_expert()`
+    // reports false, which is what keeps the fused routed kernels' shared
+    // contribution rather than recomputing it in BF16).
+    if let Some((shared_gate, shared_up, shared_down)) = bf16_shared {
+        layer.set_bf16_shared_expert(shared_gate, shared_up, shared_down)?;
+    }
     if unified_moe_layout {
         layer.transpose_for_prefill_unified(gpu, config)?;
     }

--- a/kernels/gb10/laguna-xs-2.1/MODEL.toml
+++ b/kernels/gb10/laguna-xs-2.1/MODEL.toml
@@ -1,0 +1,203 @@
+[model]
+name = "laguna-xs-2.1"
+hf_id = "poolside/Laguna-XS-2.1-NVFP4"
+model_type = "laguna"
+architecture = "Hybrid Full/Sliding Attention + Dense/MoE"
+parameters = "XS (hidden 2048, 40 layers, top_k 8)"
+
+layers_total = 40
+layers_sliding_attention = 30
+layers_full_attention = 10
+layer_pattern = "1 full attention followed by 3 sliding attention"
+
+hidden_dim = 2048
+head_dim = 128
+q_heads = 48
+kv_heads = 8
+intermediate_size = 8192
+moe_experts = 256
+moe_topk = 8
+moe_intermediate = 512
+shared_expert_intermediate = 512
+moe_scoring_func = "sigmoid"
+moe_routing_bias = true
+
+rotary_dim = 64
+rope_theta = 500000
+partial_rotary_factor = 0.5
+vocab_size = 100352
+max_position_embeddings = 262144
+sliding_window = 512
+vision = false
+mtp_layers = 0
+
+[sampling.thinking_text]
+temperature = 0.7
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+repetition_penalty = 1.0
+dry_multiplier = 0.0
+
+[sampling.thinking_coding]
+temperature = 0.7
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+repetition_penalty = 1.0
+dry_multiplier = 0.0
+
+[sampling.non_thinking]
+# 0.6 per the Laguna field guide (tested coding-agent baseline) — XS serves
+# thinking-off, so this plus [sampling.tools] are its active presets. poolside's
+# model card says 0.7; 0.6 is the measured coding sweet spot.
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+repetition_penalty = 1.0
+dry_multiplier = 0.0
+
+[sampling.tools]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+presence_penalty = 0.0
+frequency_penalty = 0.0
+repetition_penalty = 1.0
+dry_multiplier = 0.0
+
+[behavior]
+# The thinking-phase loop watchdog force-injects `</think>` on a period-4..20
+# repeat in the reasoning tail. On the Laguna family it does more harm than
+# good: force-closing a reasoning block the model did not choose to end leaves
+# it with no natural continuation, and the post-close content degenerates into
+# spam ('####...' / backtick runs). Measured on S-2.1 (see laguna-s-2.1's
+# MODEL.toml for the run); the same family misfires identically here. Other
+# models keep the watchdog (flag defaults to true); Laguna opts out.
+enable_think_loop_watchdog = false
+# The rest of the thinking-watchdog family misfires the same way: they trip on
+# the temperature-0 greedy repeat-plateau the model falls into (it is designed
+# for 0.6-0.7 sampling, not greedy), then force-close </think> or roll back
+# mid-reason, after which the content channel degenerates into token spam.
+confidence_early_stop = false
+rollback_resteer = false
+# S-2.1 sets a 0.1 min_p floor to truncate the NVFP4 MoE quant tail that drives
+# its repeat-loop degeneration AT ITS 1.0/0.7 SERVING TEMPERATURE. XS serves at
+# 0.6, which already sharpens the distribution, so keep the model default of 0
+# (floor disabled). If 'TheTheThe'/repeat spam appears on XS, restore 0.1 (or
+# try 0.05, which took S from "most prompts degenerate" to 1-in-6).
+min_p_floor = 0.0
+temperature_max = 1.0
+thinking_in_tools = true
+max_thinking_budget = 8192
+# vLLM single-budget: max_thinking_budget is the SOLE thinking cap. Real agents
+# set a small max_tokens per turn but still want full reasoning; the default
+# 90%-of-max_tokens secondary clamp (a budget vLLM does not have) truncated
+# thinking on those turns. False = reasoning bounded only by max_thinking_budget.
+cap_thinking_at_max_tokens = false
+# XS defaults thinking OFF. S (hidden 3072) keeps it ON per poolside's agentic-
+# coding recommendation, but on XS the reasoning block leaked into responses, so
+# the smaller variant ships thinking-off. Clients can still opt in per request
+# with enable_thinking=true. This split is the reason XS needs a kernel target
+# of its own rather than sharing S's: with one MODEL.toml it could only be
+# expressed as a hardcoded `model_type == "laguna" && hidden_size == 2048` gate
+# in serve.rs. With its own target, XS simply states its default.
+thinking_default = false
+default_kv_dtype = "fp8"
+tool_call_parser = "poolside_v1"
+# The model card recommends 0.7 / 0.95 for quality and reliability, while the
+# generic generation_config.json retains 1.0 / 1.0 evaluation defaults.
+use_sampling_presets_for_core = true
+# OpenCode already supplies its cwd in the native system prompt. Reinjecting a
+# second Atlas-specific environment block made Laguna fixate on path discovery.
+disable_cwd_hint_injection = true
+# Laguna is a chatty planner: it writes a paragraph of reasoning/plan before each
+# tool call. The default 384-token inter-tool prose budget (a degeneration guard)
+# truncated legitimate planning mid-turn ("prose budget exhausted, ending
+# response"), forcing extra turns. Raise it to give real agentic prose headroom
+# while still catching a genuine run-on loop.
+max_inter_tool_prose = 2048
+
+[[model_types]]
+model_type = "laguna"
+hidden_size = 2048
+
+[kernel]
+moe_gate_shmem_bytes = 6144
+
+# Harvested 2026-08-13 from `spark serve poolside/Laguna-XS-2.1-NVFP4
+# --check-kernels` on this tree: 232 lookups, 0 unresolved, 35 expected-absent
+# (every entry below was exercised — none is dead weight). This target compiles
+# the same 167-module set as laguna-s-2.1 (its nvfp4/KERNEL.toml is a symlink to
+# S's) and the two checkpoints drive the same dispatch, so the harvested set
+# matches S's. All entries are try_kernel() probes; every fallback path the
+# dispatch reaches resolves on this target.
+
+[expected_absent.moe_w4a16]
+moe_w4a16_grouped_gemm_ptrtable_e8m0 = """
+E8M0-scale twin; forward_k2/k3 gate on handle != 0 plus the checkpoint's
+scale format, and fall back to the non-e8m0 ptrtable kernels compiled in
+this target's own moe_w4a16_grouped_gemm.cu. Laguna ships FP8 scales,
+never E8M0."""
+moe_w4a16_grouped_gemm_ptrtable_t_e8m0 = "Same family — transposed twin; non-e8m0 sibling resolves here."
+moe_w4a16_grouped_gemm_ptrtable_t_k64_e8m0 = "Same family — k64 twin; non-e8m0 sibling resolves here."
+moe_w4a16_fused_gate_up_t_e8m0 = "Same family — fused gate/up twin; non-e8m0 sibling resolves here."
+moe_w4a16_fused_gate_up_t_k64_e8m0 = "Same family — fused k64 twin; non-e8m0 sibling resolves here."
+moe_w4a16_fused_gate_up_t_k64_fp4 = "FP4-scale twin of the fused k64 kernel; scale-format-gated like the e8m0 twins; the plain sibling resolves from this target's moe_w4a16_grouped_gemm.cu."
+moe_w4a16_down_t_k64_fp4 = "FP4-scale down-projection twin; scale-format-gated; plain sibling resolves here."
+
+[expected_absent.nvfp4_mmq]
+atlas_nvfp4_mmq128_nc = """
+Keep-packed NVFP4 MMQ family (dense-FFN prefill for runtime-quantized
+GGUF/BF16 checkpoints). DenseFfnLayer probes the whole family and gates
+every dispatch on handle != 0; Laguna's single dense FFN (layer 0) loads
+from safetensors NVFP4 and takes the w4a16/dense arms, which resolve from
+this target's own w4a16_gemm.cu. UNMEASURED here — candidate, not loss."""
+atlas_nvfp4_mmq128_wc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_mmq16_nc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_mmq16_wc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_mmq32_nc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_mmq32_wc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_mmq64_nc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_mmq64_wc = "Same family; handle-gated, w4a16 arm resolves."
+atlas_nvfp4_quantize_bf16 = "MMQ-family activation quantizer; only reached from the MMQ arms above."
+atlas_nvfp4_repack = "MMQ-family weight repacker; only reached from the MMQ arms above."
+atlas_nvfp4_scale_bf16 = "MMQ-family scale conversion; only reached from the MMQ arms above."
+atlas_nvfp4_silu_mul_quant = "MMQ-family fused epilogue; only reached from the MMQ arms above."
+atlas_nvfp4_silu_mul_scaled = "MMQ-family fused epilogue; only reached from the MMQ arms above."
+
+[expected_absent.w4a16]
+int8_gemm_faith2 = "Int8 requant experiment probed by dense_ffn; handle-gated, w4a16 arm resolves."
+int8_gemm_i32acc = "Same family; handle-gated."
+requant_a_bf16_int8 = "Same family — activation requant; only reached from the int8 arms above."
+requant_w_nvfp4_int8 = "Same family — weight requant; only reached from the int8 arms above."
+w4a16_gemm_t_p3 = """
+3-deep weight-pipeline twin shipped ONLY in qwen3.6-27b's shadow.
+dense_ffn probes it, falls back to w4a16_gemm_t (resolves from this
+target's w4a16_gemm.cu). UNMEASURED for this target — candidate, not
+loss."""
+w4a16_gemm_t_k64_p3 = "Same family; falls back to the resolved w4a16_gemm_t_k64."
+w4a16_gemm_t_k64_n64_p3 = "Narrow-N twin; qwen3_attention::init returns 0-handle, dispatch gates on handle != 0."
+w4a16_gemm_t_m128_bf16 = "BF16-projection prefill twin; handle-gated, falls back through the resolved w4a16 path."
+w4a16_gemm_t_m128_bf16_v2 = "Same family — v2 twin; handle-gated."
+
+[expected_absent.w4a4]
+w4a4_gemm = """
+Direct FP4-activation GEMM probed by dense_ffn; opt-in path
+(ATLAS_ATTN_W4A4-family), handle-gated, never default-dispatched."""
+w4a4_gemm_mfast = """
+Shipped only in nemotron-labs-3-puzzle-75b-a9b. qwen3_attention::init
+probes it; opt-in, handle-gated. UNMEASURED."""
+
+[expected_absent.q4k_mmq]
+atlas_q4k_mmq128_nc = """
+Q4_K keep-packed MMQ (dense-FFN prefill for GGUF Q4_K checkpoints).
+DenseFfnLayer probes the family and gates every dispatch on handle != 0;
+a safetensors NVFP4 checkpoint never installs packed-Q4K weights, so the
+arm is unreachable here."""
+atlas_q4k_mmq128_wc = "Same family — unreachable without packed-Q4K weights."
+atlas_q8_1_quantize_ds4_bf16 = "MMQ-family activation quantizer; only reached from the Q4K MMQ arms above."
+
+[expected_absent.q4k_quantize]
+q4k_quantize = "Q4_K runtime quantizer probed by dense_ffn for GGUF paths; handle-gated, unreachable here."

--- a/kernels/gb10/laguna-xs-2.1/nvfp4/KERNEL.toml
+++ b/kernels/gb10/laguna-xs-2.1/nvfp4/KERNEL.toml
@@ -1,0 +1,1 @@
+../../laguna-s-2.1/nvfp4/KERNEL.toml

--- a/kernels/gb10/laguna-xs-2.1/nvfp4/moe_w4a16_grouped_gemm.cu
+++ b/kernels/gb10/laguna-xs-2.1/nvfp4/moe_w4a16_grouped_gemm.cu
@@ -1,0 +1,1 @@
+../../minimax-m2-229b/nvfp4/moe_w4a16_grouped_gemm.cu

--- a/kernels/gb10/laguna-xs-2.1/nvfp4/w4a16_gemm.cu
+++ b/kernels/gb10/laguna-xs-2.1/nvfp4/w4a16_gemm.cu
@@ -1,0 +1,1 @@
+../../deepseek-v4-flash/nvfp4/w4a16_gemm.cu


### PR DESCRIPTION
Bucket **b** of #442, cut from the GPU-validated `integrate/laguna-on-main` tree onto current `avarok/main`.

## What Laguna-XS is

Poolside ships Laguna 2.1 at two hidden sizes. `main` already serves **S-2.1** (hidden 3072, 48 layers, top_k 10, ~68 GB NVFP4) — it arrived via #473. **XS-2.1** is the small sibling: hidden 2048, 40 layers, 48 Q-heads, top_k 8, moe/shared intermediate 512, same 256 experts and same `model_type = "laguna"`, ~21 GB as NVFP4. Same hybrid full/sliding attention, same sigmoid router with routing bias.

Before this PR XS could not boot at all, and would have rendered wrong if it had. Two independent reasons, one fix each.

### 1. No kernel target claimed it

`ptx_for_config(model_type, hidden_size)` picks a target from the `[[model_types]]` claims in each MODEL.toml: an exact `(type, hidden_size)` claim wins, a claim with no `hidden_size` is the wildcard fallback, and nothing matching returns `None`. `laguna-s-2.1` claims `(laguna, 3072)` only, and there is no `laguna` wildcard — so a 2048-hidden checkpoint matched neither rule.

`kernels/gb10/laguna-xs-2.1/` claims `(laguna, 2048)`. Its `nvfp4/KERNEL.toml` is a **symlink to S's**, so the two targets compile the identical 167-module set; the two `.cu` files are the same symlinks S already uses (`minimax-m2-229b`'s grouped GEMM, `deepseek-v4-flash`'s w4a16).

A target of its own is also what lets XS state `thinking_default = false`. S keeps thinking ON per poolside's agentic-coding recommendation, but on XS the reasoning block leaked into responses. With one shared MODEL.toml that split could only have been a hardcoded `model_type == "laguna" && hidden_size == 2048` gate in `serve.rs`.

### 2. The shared expert was being double-quantized

The two checkpoints disagree on shared-expert precision, and each says so in its own `quantization_config`:

| | routed experts | shared expert |
|---|---|---|
| **S-2.1** | in `targets` → NVFP4-packed | in `ignore` → BF16 `.weight` |
| **XS-2.1** | in `targets` → NVFP4-packed | in `targets` → NVFP4-packed |

`load_moe_ffn` assumed the S layout unconditionally: `dense_auto` the BF16 `.weight`, then `quantize_to_nvfp4` it, then install the BF16 copy as authoritative. On XS that BF16 tensor does not exist.

The fix detects by **tensor presence** (`.weight_packed`) rather than by hidden_size, so a future variant is classified by what it actually contains. When packed, load through `quantized_v2` and skip `set_bf16_shared_expert` — `weights.shared_expert` then rides the same NVFP4 machinery as the routed experts, and `has_mixed_bf16_shared_expert()` reports false so the fused routed kernels keep their shared contribution instead of recomputing it in BF16. The S path is unchanged and still loads each BF16 tensor exactly once (the branch is structured to avoid a duplicate `dense_auto` of the shared weights).

## Files

```
A  kernels/gb10/laguna-xs-2.1/MODEL.toml                        (203 lines)
A  kernels/gb10/laguna-xs-2.1/nvfp4/KERNEL.toml                 → symlink ../../laguna-s-2.1/nvfp4/KERNEL.toml
A  kernels/gb10/laguna-xs-2.1/nvfp4/moe_w4a16_grouped_gemm.cu   → symlink ../../minimax-m2-229b/nvfp4/…
A  kernels/gb10/laguna-xs-2.1/nvfp4/w4a16_gemm.cu               → symlink ../../deepseek-v4-flash/nvfp4/…
M  crates/spark-model/src/weight_loader/laguna/load_layers.rs   (+60/−12, file stays at 464 LoC)
A  crates/atlas-kernels/tests/model_type_routing.rs             (177 lines)
```

## Kernel-audit harvest

A new kernel target owes a `--check-kernels` harvest — this repo fails closed on handle-0 lookups, so a missing one is a dead boot. Run on the XS checkpoint against this build:

```
kernel check PASSED for (laguna-xs-2.1, sm_121, nvfp4): 232 lookups, 35 expected-absent
{"model":"laguna-xs-2.1","arch":"sm_121","quant":"nvfp4","kernel_set_hash":"563c67ead7c7",
 "modules_embedded":167,"lookups":232,"unresolved":0,"expected_absent":35,"ok":true,
 "unresolved_kernels":[]}
```

All 35 declarations were exercised — none is dead weight. The set matches `laguna-s-2.1`'s, which is what the identical module set predicts; every entry carries its rationale in the MODEL.toml. The boot audit on the real serve run below is clean too.

## Test

`crates/atlas-kernels/tests/model_type_routing.rs`:

- `both_laguna_hidden_sizes_route_to_their_own_target` — 2048 → `gb10/laguna-xs-2.1`, 3072 → `gb10/laguna-s-2.1`, each claimed by exactly one target (a second claimant would make `ptx_for_config` resolve by target enumeration order), plus a non-vacuity assert that no wildcard `laguna` claim exists to satisfy both lookups for the wrong reason.
- `claimed_hidden_size_matches_documented_hidden_dim` — every target's `[[model_types]]` hidden_size must agree with the `[model].hidden_dim` it documents; the two are written independently and a mismatch routes a checkpoint onto a target tuned for another shape.

Both read the MODEL.toml files from the tree rather than the compiled registry, so they hold on the GPU-free CI runner (`ATLAS_SKIP_BUILD=1`), where `available_targets()` is an empty stub.

**Negative control:** with `kernels/gb10/laguna-xs-2.1/` moved aside, the first test fails with

```
assertion `left == right` failed: Laguna-XS-2.1 (hidden_size 2048) must be claimed by
gb10/laguna-xs-2.1 and only by it; unclaimed means ptx_for_config returns None and XS
cannot boot at all
  left: []
 right: ["gb10/laguna-xs-2.1"]
```

and passes with the target restored.

## GPU validation

GB10 (dgx-00), `poolside/Laguna-XS-2.1-NVFP4`, `--gpu-memory-utilization 0.80 --no-tui`, `RUST_LOG=info`, full-target build (`ATLAS_TARGET_MODEL='*' ATLAS_TARGET_QUANT='*'`).

- **Boot: 29.7 s** (process start → `Server live and ready`), target resolved as `(sm_121, laguna-xs-2.1, nvfp4)`, 21.6 GB pre-KV weights, 40 per-layer checkpoint k_scale/v_scale picked up for the fp8 KV cache (no calibration), boot kernel audit clean.
- **3/3 temp-0 facts** (`enable_thinking: false`, `max_tokens: 250`):
  - "capital of Australia" → *The capital of Australia is Canberra.*
  - "who wrote Pride and Prejudice" → *Jane Austen wrote the novel \*Pride and Prejudice\*.*
  - "chemical symbol for gold + atomic number" → *The chemical symbol for gold is Au, and its atomic number is 79.*
- **Decode: 47.8 tok/s** end-to-end, single stream, 250 completion tokens on a 62-token prompt (wall 5.22 s, TTFT included).
- MODEL.toml behavior confirmed live in the log: `thinking_default=false`, non-thinking/tools presets `temp=0.6, top_k=20, top_p=0.95`, thinking-loop watchdog / F2 confidence early-stop / rollback-resteer all disabled, `tool_call_parser=poolside_v1` with XGrammar constrained decoding armed.

`cargo fmt --all`, `cargo clippy --workspace --tests`, and `cargo test --workspace` are all green. (`--all-targets` additionally trips one pre-existing `manual_is_multiple_of` lint in `crates/spark-model/examples/w4a16_gemv_sw_microtest.rs`, untouched by this branch — last modified in #229.)

## Deliberately excluded

- **Keep-packed Q4_K_M** — that is bucket e, in flight as #465. Not duplicated here; the loader hunks in this PR touch only the shared-expert branch.
- **XS native-BF16 loader** — permanently excluded per #442. It loads and generates coherently but has an unresolved expert-compute correctness bug (factual recall degrades against the NVFP4 checkpoint of the *same* model), and it was env-gated, which production paths do not allow.
- **The integration tree's tokenizer/jinja bits** (`prefer_bundled`, `resolve_jinja_includes`, the `{% generation %}` strip) — **superseded on main**. Those existed so XS could prefer its own bundled `chat_template.jinja` over the shared `laguna` override authored for S. Main's curated `jinja-templates/laguna.jinja` is already semantically XS's template (`enable_thinking` defaults to false, no `preserve_thinking`), so XS renders correctly on main's existing override design. Verified by diffing the override against both bundled templates.
