### PR TITLE
spark-model: CUDA-graph MTP propose via fused BF16 MoE

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-13-2cb725c874.json
+++ b/.benchmarks/agentic-webserver/2026-08-13-2cb725c874.json
@@ -1,0 +1,77 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "2cb725c874",
+  "recorded_at": 1786650099,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1000"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1000",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2418.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 668.041470206,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 668s ≤ 1000s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=668.04, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 668s ≤ 1000s",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-13-d6e3f98491.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-13-d6e3f98491.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "d6e3f98491",
+  "recorded_at": 1786659330,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 85.34,
+    "overall_accuracy": 84.76,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.76 (floor 83.64) · normalized 85.34 (floor 85.32) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=85.34, overall_accuracy=84.76, samples=1004.00 · Pass: overall 84.76 (floor 83.64) · normalized 85.34 (floor 85.32) · n=1004",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-13-51a448712c.json
+++ b/.benchmarks/bfcl-subset/2026-08-13-51a448712c.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "51a448712c",
+  "recorded_at": 1786648488,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.94,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.94, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "0e13fc150f6f77b21b04f0f48e48dbb43cc7ed633c659bca2ade0c953345d5d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-13-a5d2002e57.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-13-a5d2002e57.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "a5d2002e57",
+  "recorded_at": 1786633366,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "256",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=256",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 1.0,
+    "jittered": 11.0,
+    "rounds": 12.0,
+    "sum_wall_s": 314.696016876,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=1.00, jittered=11.00, rounds=12.00, sum_wall_s=314.70, unmeasured=0.00 · Pass: 1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-13-310067ef0a.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-13-310067ef0a.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "310067ef0a",
+  "recorded_at": 1786633981,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1594.792804,
+    "p90_ms": 4298.763695,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.1% (limit +3.0%) · p90 -0.6% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1594.79, p90_ms=4298.76, samples=36.00 · Pass: median -0.1% (limit +3.0%) · p90 -0.6% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-13-f09a86bf09.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-13-f09a86bf09.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "f09a86bf09",
+  "recorded_at": 1786633755,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1518.416623,
+    "p90_ms": 4316.794238,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.1% (limit +3.0%) · p90 -0.0% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1518.42, p90_ms=4316.79, samples=36.00 · Pass: median -0.1% (limit +3.0%) · p90 -0.0% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -177,7 +177,6 @@ jobs:
             "crates/spark-model/examples/gdn_fla_e2e_gateb.rs"
             "crates/spark-model/src/layers/moe/forward_prefill_fp8.rs"
             "crates/spark-model/src/layers/moe/forward.rs"
-            "crates/spark-model/src/layers/mtp_head/forward.rs"
             "crates/spark-model/src/layers/ops/gemm_quant.rs"
             "crates/spark-model/src/layers/ops/moe_expert.rs"
             # 648 LoC — grew via #231 (per-call penalty-history scope) + the

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -282,6 +282,18 @@ pub struct MtpHead {
     argmax_batch_lp_k: KernelHandle,
     /// Drafter-prefill scratch; `None` unless ATLAS_MTP_DRAFTER_PREFILL=1.
     prefill_scratch: Option<MtpPrefillScratch>,
+    /// CUDA graph of the grammarless propose GPU body (full, or pre-MoE
+    /// when generic experts force a split).
+    propose_graph: Mutex<Option<spark_runtime::gpu::GraphHandle>>,
+    /// Post-MoE graph (final norm + lm_head + argmax). Used only when
+    /// [`MtpHead::moe_experts_generic`] is `Some` so MoE stays eager.
+    propose_graph_post: Mutex<Option<spark_runtime::gpu::GraphHandle>>,
+    /// Process-lifetime staging for `target_hidden` so one graph covers
+    /// both `mtp_hidden_save` (draft 0) and `hidden_states()` (later drafts).
+    propose_in_hidden: DevicePtr,
+    /// Device-side BF16 expert dispatch (fused kernels + pointer tables).
+    /// `None` → host loop in `moe_forward_generic` (FP8, missing kernels).
+    bf16_moe_fused: Option<bf16_moe_fused::MtpBf16MoeFused>,
 }
 
 impl MtpHead {
@@ -375,12 +387,15 @@ impl MtpHead {
 }
 
 mod batch_caps;
+mod bf16_moe_fused;
 mod draft_proposer;
 mod forward;
 mod forward_batch;
 mod moe_forward;
 mod new;
 mod prefill;
+mod propose_gpu;
+mod propose_graph;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spark-model/src/layers/mtp_head/bf16_moe_fused.rs
+++ b/crates/spark-model/src/layers/mtp_head/bf16_moe_fused.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Device-side BF16 MoE for the MTP drafter.
+//!
+//! Production Qwen3.6 MTP is BF16 (`--mtp-quantization bf16`). The generic
+//! per-expert loop D2Hs top-k indices and launches ~40 GEMVs with
+//! token-dependent weight pointers — that slice is ~2.3 ms/step on GB10
+//! and cannot live in a CUDA graph. These fused kernels read expert ids
+//! from device memory (same recipe as `MoeLayer`'s BF16 decode path).
+
+use super::{MtpHead, ProjectionWeight};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::DenseWeight;
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+/// Kill switch `ATLAS_NO_MTP_BF16_MOE_FUSED`. ON unless the value is exactly
+/// `"1"`. `=0` / empty / unset do **not** disable.
+pub const DISABLE_ENV: &str = "ATLAS_NO_MTP_BF16_MOE_FUSED";
+
+pub fn mtp_bf16_moe_fused_from(no_fused: Option<&str>) -> bool {
+    no_fused != Some("1")
+}
+
+pub(super) struct MtpBf16MoeFused {
+    gate_ptrs: DevicePtr,
+    up_ptrs: DevicePtr,
+    down_ptrs: DevicePtr,
+    gate_up_k: KernelHandle,
+    silu_down_k: KernelHandle,
+}
+
+impl MtpBf16MoeFused {
+    pub(super) fn try_build(
+        experts: &[(ProjectionWeight, ProjectionWeight, ProjectionWeight)],
+        gpu: &dyn GpuBackend,
+    ) -> Option<Self> {
+        if !mtp_bf16_moe_fused_from(std::env::var(DISABLE_ENV).ok().as_deref()) {
+            tracing::info!("MTP BF16 MoE fused OFF (ATLAS_NO_MTP_BF16_MOE_FUSED=1)");
+            return None;
+        }
+        let gate_up_k = crate::layers::try_kernel(
+            gpu,
+            "moe_shared_expert_fused_bf16",
+            "moe_expert_gate_up_shared_bf16",
+        );
+        let silu_down_k = crate::layers::try_kernel(
+            gpu,
+            "moe_shared_expert_fused_bf16",
+            "moe_expert_silu_down_shared_bf16",
+        );
+        if gate_up_k.0 == 0 || silu_down_k.0 == 0 {
+            tracing::warn!("MTP BF16 MoE fused kernels missing — keeping host expert loop");
+            return None;
+        }
+        let mut gates = Vec::with_capacity(experts.len());
+        let mut ups = Vec::with_capacity(experts.len());
+        let mut downs = Vec::with_capacity(experts.len());
+        for (g, u, d) in experts {
+            gates.push(as_bf16(g)?);
+            ups.push(as_bf16(u)?);
+            downs.push(as_bf16(d)?);
+        }
+        let built = (|| -> Result<Self> {
+            Ok(Self {
+                gate_ptrs: crate::layers::moe::build_bf16_ptr_table(&gates, gpu)?,
+                up_ptrs: crate::layers::moe::build_bf16_ptr_table(&ups, gpu)?,
+                down_ptrs: crate::layers::moe::build_bf16_ptr_table(&downs, gpu)?,
+                gate_up_k,
+                silu_down_k,
+            })
+        })();
+        match built {
+            Ok(v) => {
+                tracing::info!(
+                    "MTP BF16 MoE fused: device-side expert dispatch ({} experts, graphable)",
+                    experts.len()
+                );
+                Some(v)
+            }
+            Err(e) => {
+                tracing::warn!("MTP BF16 MoE fused ptr-table build failed ({e:#}) — host loop");
+                None
+            }
+        }
+    }
+}
+
+fn as_bf16(proj: &ProjectionWeight) -> Option<DenseWeight> {
+    match proj {
+        ProjectionWeight::Bf16(w) => Some(*w),
+        _ => None,
+    }
+}
+
+impl MtpHead {
+    /// Gate → top-k → fused BF16 expert FFN → blend. Zero D2H.
+    pub(super) fn moe_forward_bf16_fused(
+        &self,
+        fused: &MtpBf16MoeFused,
+        input: DevicePtr,
+        ctx: &ForwardContext<'_>,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        let h = ctx.config.hidden_size as u32;
+        let inter = ctx.config.moe_intermediate_size as u32;
+        let num_experts = ctx.config.num_experts as u32;
+        let top_k = ctx.config.num_experts_per_tok as u32;
+
+        let gate_logits = ctx.buffers.gate_logits();
+        ops::dense_gemv(
+            ctx.gpu,
+            self.dense_gemv_k.unwrap(),
+            input,
+            &self.moe_gate,
+            gate_logits,
+            num_experts,
+            h,
+            stream,
+        )?;
+
+        let scratch = ctx.buffers.scratch();
+        let indices_dev = scratch;
+        let weights_dev = scratch.offset(top_k as usize * 4);
+        ops::moe_topk_softmax(
+            ctx.gpu,
+            self.moe_topk_k.unwrap(),
+            gate_logits,
+            indices_dev,
+            weights_dev,
+            num_experts,
+            top_k,
+            ctx.config.norm_topk_prob,
+            stream,
+        )?;
+
+        let (sh_gate, sh_up, sh_down) = self.moe_shared_generic.as_ref().unwrap();
+        let sh_gate_w = as_bf16(sh_gate)
+            .ok_or_else(|| anyhow::anyhow!("MTP fused MoE expected BF16 shared gate"))?;
+        let sh_up_w = as_bf16(sh_up)
+            .ok_or_else(|| anyhow::anyhow!("MTP fused MoE expected BF16 shared up"))?;
+        let sh_down_w = as_bf16(sh_down)
+            .ok_or_else(|| anyhow::anyhow!("MTP fused MoE expected BF16 shared down"))?;
+
+        let expert_gate_out = ctx.buffers.expert_gate_out();
+        let expert_up_out = ctx.buffers.expert_up_out();
+        let expert_down_out = ctx.buffers.expert_down_out();
+        let shared_gate_scratch = ctx.buffers.logits();
+        let shared_up_scratch = ctx.buffers.ssm_qkvz();
+        let shared_out = ctx.buffers.attn_output();
+
+        ops::moe_expert_gate_up_shared_bf16(
+            ctx.gpu,
+            fused.gate_up_k,
+            input,
+            fused.gate_ptrs,
+            expert_gate_out,
+            fused.up_ptrs,
+            expert_up_out,
+            indices_dev,
+            sh_gate_w.weight,
+            shared_gate_scratch,
+            sh_up_w.weight,
+            shared_up_scratch,
+            inter,
+            h,
+            top_k,
+            stream,
+        )?;
+        ops::moe_expert_silu_down_shared_bf16(
+            ctx.gpu,
+            fused.silu_down_k,
+            expert_gate_out,
+            expert_up_out,
+            fused.down_ptrs,
+            expert_down_out,
+            indices_dev,
+            shared_gate_scratch,
+            shared_up_scratch,
+            sh_down_w.weight,
+            shared_out,
+            h,
+            inter,
+            top_k,
+            stream,
+        )?;
+
+        let output = ctx.buffers.moe_output();
+        ops::moe_weighted_sum_blend(
+            ctx.gpu,
+            self.moe_weighted_sum_blend_k.unwrap(),
+            output,
+            expert_down_out,
+            weights_dev,
+            shared_out,
+            input,
+            self.shared_expert_gate.weight,
+            h,
+            top_k,
+            h,
+            stream,
+        )?;
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fused_kill_switch_is_exactly_one() {
+        assert!(mtp_bf16_moe_fused_from(None), "unset → ON");
+        assert!(mtp_bf16_moe_fused_from(Some("0")), "`=0` is NOT off");
+        assert!(mtp_bf16_moe_fused_from(Some("")), "empty is NOT off");
+        assert!(!mtp_bf16_moe_fused_from(Some("1")), "`=1` is the kill");
+    }
+}

--- a/crates/spark-model/src/layers/mtp_head/forward.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward.rs
@@ -5,9 +5,9 @@
 use anyhow::Result;
 use spark_runtime::gpu::DevicePtr;
 
-use super::{MtpHead, MtpProposerState, MtpQuantization, ProjectionWeight};
+use super::propose_graph::{mtp_propose_graph_enabled, propose_graphable};
+use super::{MtpHead, MtpProposerState};
 use crate::layer::ForwardContext;
-use crate::layers::mtp_meta::{MTP_META_OFFSET, pack_mtp_attn_meta};
 use crate::layers::ops;
 
 /// MTP-debug (ATLAS_MTP_DEBUG_NORMS=1): L2 norm of a BF16 GPU buffer, for
@@ -51,455 +51,56 @@ impl MtpHead {
         grammar_bitmask: Option<&[i32]>,
     ) -> Result<u32> {
         let h = ctx.config.hidden_size as u32;
-        let nq = ctx.config.num_attention_heads as u32;
-        let nkv = ctx.config.num_key_value_heads as u32;
-        let hd = ctx.config.head_dim as u32;
-        let eps = ctx.config.rms_norm_eps as f32;
-
-        // 1. Embed token
-        let embed_out = ctx.buffers.ssm_qkvz(); // reuse scratch
         let row_bytes = h as usize * 2;
+
+        // Token-dependent embed source — never baked into a CUDA graph.
+        let embed_out = ctx.buffers.ssm_qkvz();
         let src = self.embed_tokens.weight.offset(token as usize * row_bytes);
         ctx.gpu.copy_d2d_async(src, embed_out, row_bytes, stream)?;
-
-        // 2. RMSNorm embedding and hidden separately
-        let normed_embed = ctx.buffers.ssm_deinterleaved();
-        ops::rms_norm(
-            ctx.gpu,
-            self.rms_norm_k,
-            embed_out,
-            &self.pre_fc_norm_embedding,
-            normed_embed,
-            1,
-            h,
-            eps,
-            stream,
-        )?;
-
-        // The saved hidden is always BF16 (the residual stream is BF16).
-        let normed_hidden = ctx.buffers.ssm_gates();
-        ops::rms_norm(
-            ctx.gpu,
-            self.rms_norm_k,
-            target_hidden,
-            &self.pre_fc_norm_hidden,
-            normed_hidden,
-            1,
-            h,
-            eps,
-            stream,
-        )?;
-
-        // 3. Concatenate: [normed_embed | normed_hidden] → [2*h]
-        let concat_out = ctx.buffers.ssm_ba();
-        ops::bf16_concat(
-            ctx.gpu,
-            self.bf16_concat_k,
-            normed_embed,
-            normed_hidden,
-            concat_out,
-            h,
-            stream,
-        )?;
-
-        if std::env::var("ATLAS_MTP_DEBUG_NORMS").as_deref() == Ok("1") {
-            ctx.gpu.synchronize(stream).ok();
-            tracing::warn!(
-                "MTP_DBG s1-embed ||={:.4} s2-n_embed ||={:.4} s2-n_hidden ||={:.4} s3-concat ||={:.4}",
-                mtp_dbg_l2(ctx.gpu, embed_out, h as usize),
-                mtp_dbg_l2(ctx.gpu, normed_embed, h as usize),
-                mtp_dbg_l2(ctx.gpu, normed_hidden, h as usize),
-                mtp_dbg_l2(ctx.gpu, concat_out, (h * 2) as usize),
-            );
-        }
-
-        // 4. FC projection: [2*h] → [h]
-        let hidden = ctx.buffers.hidden_states();
-        self.gemv(ctx.gpu, concat_out, &self.fc, hidden, h, h * 2, stream)?;
-        if std::env::var("ATLAS_MTP_DEBUG_NORMS").as_deref() == Ok("1") {
-            ctx.gpu.synchronize(stream).ok();
-            tracing::warn!(
-                "MTP_DBG s4-fc_hidden ||={:.4}",
-                mtp_dbg_l2(ctx.gpu, hidden, h as usize)
-            );
-        }
-
-        // 5. Copy hidden to residual for residual stream
-        let residual = ctx.buffers.residual();
+        // Stage hidden into a process-lifetime buffer so one graph covers
+        // both `mtp_hidden_save` (draft 0) and `hidden_states()` (draft >0).
         ctx.gpu
-            .copy_d2d_async(hidden, residual, row_bytes, stream)?;
+            .copy_d2d_async(target_hidden, self.propose_in_hidden, row_bytes, stream)?;
 
-        // 6. Input layernorm
-        let normed = ctx.buffers.norm_output();
-        ops::rms_norm(
-            ctx.gpu,
-            self.rms_norm_k,
-            hidden,
-            &self.input_layernorm,
-            normed,
-            1,
-            h,
-            eps,
-            stream,
-        )?;
+        let kv = self.prepare_propose_kv(state, ctx, position, stream)?;
 
-        // 7. Attention: Q+Gate and K+V projections
-        let q_out = ctx.buffers.qkv_output();
-        let q_dim = nq * hd;
-        let qg_dim = q_dim * 2;
-        let qg_bytes = qg_dim as usize * 2;
-
-        match self.quant {
-            MtpQuantization::Nvfp4 => {
-                // Fused GEMV + deinterleave in one kernel
-                if let ProjectionWeight::Nvfp4(ref w) = self.q_proj {
-                    ops::w4a16_gemv_qg(
-                        ctx.gpu,
-                        self.w4a16_gemv_qg_k,
-                        normed,
-                        w,
-                        q_out,
-                        qg_dim,
-                        h,
-                        nq,
-                        hd,
-                        stream,
-                    )?;
-                }
-            }
-            MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
-                // Separate GEMV + deinterleave kernel
-                self.gemv(ctx.gpu, normed, &self.q_proj, q_out, qg_dim, h, stream)?;
-                ops::deinterleave_qg(
-                    ctx.gpu,
-                    self.deinterleave_qg_k.unwrap(),
-                    q_out,
-                    1,
-                    nq,
-                    hd,
-                    nq * hd * 2,
-                    stream,
-                )?;
-            }
-        }
-        let gate_ptr = q_out.offset(q_dim as usize * 2);
-
-        // K+V projections
-        let k_out = q_out.offset(qg_bytes);
-        let v_out = k_out.offset((nkv * hd) as usize * 2);
-
-        match self.quant {
-            MtpQuantization::Nvfp4 => {
-                if let (ProjectionWeight::Nvfp4(kw), ProjectionWeight::Nvfp4(vw)) =
-                    (&self.k_proj, &self.v_proj)
-                {
-                    ops::w4a16_gemv_dual(
-                        ctx.gpu,
-                        self.w4a16_gemv_dual_k,
-                        normed,
-                        kw,
-                        k_out,
-                        vw,
-                        v_out,
-                        nkv * hd,
-                        h,
-                        stream,
-                    )?;
-                }
-            }
-            MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
-                self.gemv(ctx.gpu, normed, &self.k_proj, k_out, nkv * hd, h, stream)?;
-                self.gemv(ctx.gpu, normed, &self.v_proj, v_out, nkv * hd, h, stream)?;
-            }
-        }
-
-        // Q/K norms
-        ops::rms_norm(
-            ctx.gpu,
-            self.rms_norm_k,
-            q_out,
-            &self.q_norm,
-            q_out,
-            nq,
-            hd,
-            eps,
-            stream,
-        )?;
-        ops::rms_norm(
-            ctx.gpu,
-            self.rms_norm_k,
-            k_out,
-            &self.k_norm,
-            k_out,
-            nkv,
-            hd,
-            eps,
-            stream,
-        )?;
-
-        // 8. Upload attention metadata for MTP KV cache
-        let mut kv_cache = self.kv_cache.lock();
-        let bs = kv_cache.block_size();
-        let blocks_needed = (state.seq_len / bs) + 1;
-        while state.block_table.len() < blocks_needed {
-            state.block_table.push(kv_cache.alloc_block()?);
-        }
-
-        let meta_base = ctx.buffers.scratch().offset(MTP_META_OFFSET); // after target metadata
-        let max_blocks = state.block_table.len() as u32;
-
-        // Batch all metadata into a single H2D copy (saves 3 CUDA API calls).
-        let block_idx = state.block_table[state.seq_len / bs];
-        let global_slot = (block_idx as i64) * (bs as i64) + ((state.seq_len % bs) as i64);
-        let actual_seq_len = (state.seq_len + 1) as i32;
-
-        // The slab grows with the block table, i.e. with the context length, so
-        // the destination bound is the tail of the shared scratch arena past
-        // `MTP_META_OFFSET`. `pack_mtp_attn_meta` refuses up front rather than
-        // letting a long context write past the arena — this call site had no
-        // bound at all before, while its batched twin `propose_batch` did.
-        let meta_buf = pack_mtp_attn_meta(
-            position as u32,
-            global_slot,
-            actual_seq_len,
-            &state.block_table,
-            ctx.buffers.scratch_bytes().saturating_sub(MTP_META_OFFSET),
-        )?;
-        ctx.gpu.copy_h2d_async(&meta_buf, meta_base, stream)?;
-
-        // RoPE
-        ops::rope(
-            ctx.gpu,
-            self.rope_k,
-            q_out,
-            k_out,
-            meta_base, // positions
-            1,
-            nq,
-            nkv,
-            hd,
-            ctx.config.rotary_dim() as u32,
-            ctx.config.rope_theta as f32,
-            stream,
-        )?;
-
-        // Reshape + cache + paged decode. BF16 KV (self.kv_bf16) matches the
-        // main model; the FP8 path's hard-coded unit scales (1.0,1.0) collapse
-        // the MTP attention to a constant on Qwen3.6-A3B → constant draft 0.
-        let kv_stride = nkv * hd;
-        let attn_out = ctx.buffers.attn_output();
-        let inv_sqrt_d = 1.0f32 / (hd as f32).sqrt();
-        if self.kv_bf16 {
-            ops::reshape_and_cache(
-                ctx.gpu,
-                self.reshape_cache_k,
-                k_out,
-                v_out,
-                kv_cache.k_pool_ptr(self.attn_layer_idx),
-                kv_cache.v_pool_ptr(self.attn_layer_idx),
-                meta_base.offset(8), // slot
-                1,                   // num_tokens
-                nkv,
-                hd,
-                bs as u32, // block_size
-                kv_stride,
-                kv_stride,
-                kv_cache.cache_stride() as u64,
-                stream,
-            )?;
-            ops::paged_decode_attn_bf16(
-                ctx.gpu,
-                self.paged_decode_k,
-                q_out,
-                kv_cache.k_pool_ptr(self.attn_layer_idx),
-                kv_cache.v_pool_ptr(self.attn_layer_idx),
-                attn_out,
-                meta_base.offset(256), // block_table
-                meta_base.offset(16),  // seq_len
-                max_blocks,
-                1, // num_seqs
-                nq,
-                nkv,
-                hd,
-                bs as u32, // block_size
-                inv_sqrt_d,
-                nq * hd, // q_stride
-                0,       // sliding_window (full attention)
-                stream,
-            )?;
-        } else {
-            ops::reshape_and_cache_fp8(
-                ctx.gpu,
-                self.reshape_cache_k,
-                k_out,
-                v_out,
-                kv_cache.k_pool_ptr(self.attn_layer_idx),
-                kv_cache.v_pool_ptr(self.attn_layer_idx),
-                meta_base.offset(8), // slot
-                1,
-                nkv,
-                hd,
-                bs as u32,
-                1.0,
-                1.0, // k_scale, v_scale (no pre-computed scales for MTP)
-                kv_stride,
-                kv_stride,
-                kv_cache.cache_stride() as u64,
-                stream,
-            )?;
-            ops::paged_decode_attn_fp8(
-                ctx.gpu,
-                self.paged_decode_k,
-                q_out,
-                kv_cache.k_pool_ptr(self.attn_layer_idx),
-                kv_cache.v_pool_ptr(self.attn_layer_idx),
-                attn_out,
-                meta_base.offset(256), // block_table
-                meta_base.offset(16),  // seq_len
-                max_blocks,
-                1,
-                nq,
-                nkv,
-                hd,
-                bs as u32,
-                inv_sqrt_d,
-                1.0,
-                1.0, // k_scale, v_scale
-                nq * hd,
-                kv_cache.cache_stride() as u64,
-                0,
-                stream,
-            )?;
-        }
-
-        if std::env::var("ATLAS_MTP_DEBUG_NORMS").as_deref() == Ok("1") {
-            ctx.gpu.synchronize(stream).ok();
-            tracing::warn!(
-                "MTP_DBG s7-attn_out(pre-gate) ||={:.4}  gate ||={:.4}",
-                mtp_dbg_l2(ctx.gpu, attn_out, (nq * hd) as usize),
-                mtp_dbg_l2(ctx.gpu, gate_ptr, (nq * hd) as usize)
+        let debug_norms = std::env::var("ATLAS_MTP_DEBUG_NORMS").as_deref() == Ok("1");
+        let graphable = mtp_propose_graph_enabled()
+            && propose_graphable(
+                grammar_bitmask.is_some(),
+                ctx.levers.shadow_topk,
+                crate::speculative::draft_conf_tau(),
+                ctx.profile,
+                debug_norms,
             );
+
+        if graphable {
+            self.replay_or_capture_propose(ctx, stream, &kv)?;
+        } else {
+            self.propose_gpu_to_argmax(ctx, stream, &kv)?;
         }
 
-        // Sigmoid gate: attn_out = attn_out * sigmoid(gate)
-        ops::sigmoid_gate_mul(
-            ctx.gpu,
-            self.sigmoid_gate_mul_k,
-            attn_out,
-            gate_ptr,
-            attn_out,
-            nq * hd,
-            stream,
-        )?;
-
-        // O projection: [nq*hd] → [h]
-        let o_out = ctx.buffers.norm_output();
-        self.gemv(ctx.gpu, attn_out, &self.o_proj, o_out, h, nq * hd, stream)?;
-
-        // 9. Residual + post-attention norm
-        let normed2 = ctx.buffers.norm_output();
-        ops::residual_add_rms_norm(
-            ctx.gpu,
-            self.residual_add_rms_norm_k,
-            hidden,
-            o_out,
-            &self.post_attn_layernorm,
-            normed2,
-            residual,
-            1,
-            h,
-            eps,
-            stream,
-        )?;
-
-        // 10. FFN: dense shortcut for non-MoE MTP heads (Qwen3.6-27B-FP8),
-        //     otherwise routed MoE.
-        let ffn_out = if self.dense_ffn_generic.is_some() {
-            self.dense_ffn_forward_generic(normed2, ctx, stream)?
-        } else {
-            match self.quant {
-                MtpQuantization::Nvfp4 => self
-                    .moe_nvfp4
-                    .as_ref()
-                    .unwrap()
-                    .forward(normed2, ctx, stream)?,
-                MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
-                    self.moe_forward_generic(normed2, ctx, stream)?
-                }
-            }
-        };
-        ops::residual_add(ctx.gpu, self.residual_add_k, hidden, ffn_out, h, stream)?;
-
-        // 11. Final norm
-        let final_normed = ctx.buffers.norm_output();
-        ops::rms_norm(
-            ctx.gpu,
-            self.rms_norm_k,
-            hidden,
-            &self.norm,
-            final_normed,
-            1,
-            h,
-            eps,
-            stream,
-        )?;
-
-        // 12. LM head (shared NVFP4, reduced vocab for faster propose)
         let v = if self.mtp_vocab_size > 0 {
             self.mtp_vocab_size.min(ctx.config.vocab_size as u32)
         } else {
             ctx.config.vocab_size as u32
         };
         let logits = ctx.buffers.logits();
-        ops::w4a16_decode_gemv(
-            ctx.gpu,
-            self.w4a16_gemv_k,
-            self.w4a16_gemv_sw_k,
-            ctx.levers.gemv_sw,
-            final_normed,
-            &self.lm_head_nvfp4,
-            logits,
-            v,
-            h,
-            stream,
-        )?;
+        let final_normed = ctx.buffers.norm_output();
 
-        // MTP-debug (ATLAS_MTP_DEBUG_NORMS=1): localize the constant-0 draft.
-        // A true zero reads as 0.0 regardless of dtype, so these L2 norms
-        // pinpoint the first stage to zero out: input_hidden (save bug) →
-        // final_normed (forward bug) → logits (lm_head bug).
-        if std::env::var("ATLAS_MTP_DEBUG_NORMS").as_deref() == Ok("1") {
+        if debug_norms {
             ctx.gpu.synchronize(stream).ok();
-            let bf16_norm = |p: DevicePtr, n: usize| -> f64 {
-                let mut b = vec![0u8; n * 2];
-                if ctx.gpu.copy_d2h(p, &mut b).is_err() {
-                    return -1.0;
-                }
-                b.chunks_exact(2)
-                    .map(|c| {
-                        let f =
-                            f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16) as f64;
-                        f * f
-                    })
-                    .sum::<f64>()
-                    .sqrt()
-            };
-            // The residual stream is always BF16, so the saved hidden is BF16.
-            let hin = bf16_norm(target_hidden, h as usize);
             tracing::warn!(
                 "MTP_DEBUG_NORMS: ||input_hidden||={:.4} ||final_normed||={:.4} ||logits||={:.4}",
-                hin,
-                bf16_norm(final_normed, h as usize),
-                bf16_norm(logits, v as usize)
+                mtp_dbg_l2(ctx.gpu, target_hidden, h as usize),
+                mtp_dbg_l2(ctx.gpu, final_normed, h as usize),
+                mtp_dbg_l2(ctx.gpu, logits, v as usize),
             );
         }
 
-        // 13a. Drafter chain confidence (ATLAS_MTP_DRAFT_CONF > 0):
-        // observational only — token selection below is untouched. D2H the
-        // BF16 logits (~200 us, the same cost the grammar-masked path pays)
-        // and fold this draft's top-1 softmax prob into the propose-scoped
-        // running MIN (`last_conf_bits`, reset by `propose`). The clamp that
-        // acts on it lives in `run_mtp_propose_inner`.
+        // Drafter chain confidence (ATLAS_MTP_DRAFT_CONF > 0): observational
+        // only. D2H the BF16 logits and fold this draft's top-1 softmax into
+        // `last_conf_bits`. Ineligible for CUDA graphs (see propose_graphable).
         if crate::speculative::draft_conf_tau() > 0.0 {
             let vocab = v as usize;
             let mut bf16_buf = vec![0u8; vocab * 2];
@@ -518,7 +119,7 @@ impl MtpHead {
                     let x = f32::from_bits((hi as u32) << 16);
                     denom += ((x - max) as f64).exp();
                 }
-                let top1 = (1.0 / denom.max(1.0)) as f32; // exp(max-max)=1 over Z
+                let top1 = (1.0 / denom.max(1.0)) as f32;
                 let cur = f32::from_bits(
                     self.last_conf_bits
                         .load(std::sync::atomic::Ordering::Relaxed),
@@ -530,10 +131,6 @@ impl MtpHead {
             }
         }
 
-        // 13b. Shadow top-k (ATLAS_MTP_SHADOW_TOPK=k): observational only.
-        // Logs this position's top-k candidate ids + softmax probs so an
-        // offline join against the verify steps' SHADOW_TGT lines yields
-        // per-depth conditional top-k coverage (tree-spec Phase 0 gate).
         let shadow_k = ctx.levers.shadow_topk;
         if shadow_k > 0 {
             let vocab = v as usize;
@@ -543,8 +140,6 @@ impl MtpHead {
                     let hi = u16::from_le_bytes([bf16_buf[2 * i], bf16_buf[2 * i + 1]]);
                     f32::from_bits((hi as u32) << 16)
                 };
-                // Single pass keeping k maxima (k ≤ 8): insertion into a
-                // small sorted array beats a full-vocab sort at this size.
                 let mut top: Vec<(f32, usize)> = Vec::with_capacity(shadow_k + 1);
                 for i in 0..vocab {
                     let x = at(i);
@@ -554,7 +149,6 @@ impl MtpHead {
                         top.truncate(shadow_k);
                     }
                 }
-                // Softmax denominator over the full vocab (stable: max-shift).
                 let max = top.first().map(|t| t.0).unwrap_or(0.0);
                 let mut denom = 0.0f64;
                 for i in 0..vocab {
@@ -569,34 +163,20 @@ impl MtpHead {
             }
         }
 
-        // 13. Argmax
         let out_ptr = ctx.buffers.scratch();
-
         let token_id = if let Some(bitmask) = grammar_bitmask {
-            // Grammar-masked CPU argmax path.
-            //
-            // D2H the full logits vector (BF16), apply the XGrammar bitmask
-            // (mask off ⇒ -inf), argmax on CPU. This adds ~200μs per draft
-            // vs the GPU argmax, but the unmasked path sees ~0% draft
-            // acceptance inside tool-call JSON — a 200μs overhead beats a
-            // wasted 13.5ms verify step.
-            //
-            // We then H2D the chosen token id into `out_ptr` so the
-            // downstream `embed_from_argmax` kernel can still gather the
-            // embedding from the token table on GPU without a new kernel.
+            // Grammar-masked CPU argmax. D2H the full logits, mask, argmax.
+            // GPU argmax already ran (writes scratch); this overwrites it.
             let vocab = v as usize;
             let mut bf16_buf = vec![0u8; vocab * 2];
             ctx.gpu.copy_d2h(logits, &mut bf16_buf)?;
 
-            // BF16 → f32 conversion. BF16 is the upper 16 bits of an f32.
             let mut f32_logits = vec![0.0f32; vocab];
             for i in 0..vocab {
-                let lo = 0u16;
                 let hi = u16::from_le_bytes([bf16_buf[2 * i], bf16_buf[2 * i + 1]]);
-                f32_logits[i] = f32::from_bits(((hi as u32) << 16) | (lo as u32));
+                f32_logits[i] = f32::from_bits((hi as u32) << 16);
             }
 
-            // Apply mask: bit `tok` set ⇒ allowed; unset ⇒ -inf.
             let mut any_allowed = false;
             for tok in 0..vocab {
                 let word = tok / 32;
@@ -609,14 +189,6 @@ impl MtpHead {
                 }
             }
 
-            // Degenerate case: matcher gave us an empty allowed set. Don't
-            // propose a real draft — return 0 (pad) as a sentinel. The
-            // verifier almost certainly returns a non-zero target token, the
-            // draft gets rejected, and the step falls through to target-only
-            // decode. This is safer than re-emitting `last_token`, which
-            // could be a special token (e.g. `<|im_end|>`) that the verifier
-            // might happen to also pick — duplicating a role-boundary
-            // token would poison the model's own context.
             if !any_allowed {
                 tracing::warn!(
                     "MTP grammar mask allowed zero tokens at pos {position}; \
@@ -624,20 +196,14 @@ impl MtpHead {
                 );
                 0u32
             } else {
-                // CPU argmax over masked logits.
                 let mut best_tok = 0u32;
                 let mut best_val = f32::NEG_INFINITY;
-                for (i, &v) in f32_logits.iter().enumerate() {
-                    if v > best_val {
-                        best_val = v;
+                for (i, &val) in f32_logits.iter().enumerate() {
+                    if val > best_val {
+                        best_val = val;
                         best_tok = i as u32;
                     }
                 }
-
-                // If caller wants the embedding staged on GPU, stage the
-                // chosen token id into `out_ptr` (4 bytes) and reuse the
-                // existing embed_from_argmax kernel — it reads the argmax
-                // result from `out_ptr` and gathers the embedding on GPU.
                 if let Some(embed_target) = draft_embed_target {
                     let tok_bytes = best_tok.to_le_bytes();
                     ctx.gpu.copy_h2d(&tok_bytes, out_ptr)?;
@@ -654,35 +220,25 @@ impl MtpHead {
                 }
                 best_tok
             }
+        } else if let Some(embed_target) = draft_embed_target {
+            ops::embed_from_argmax(
+                ctx.gpu,
+                self.embed_from_argmax_k,
+                out_ptr,
+                self.embed_tokens.weight,
+                embed_target,
+                self.draft_token_id_dev,
+                h,
+                stream,
+            )?;
+            0u32
         } else {
-            ops::argmax_bf16(ctx.gpu, self.argmax_k, logits, out_ptr, v, stream)?;
-            if let Some(embed_target) = draft_embed_target {
-                // GPU-side embedding: write draft embedding to verify input buffer
-                // and token ID to deferred readback buffer. No D2H sync needed.
-                ops::embed_from_argmax(
-                    ctx.gpu,
-                    self.embed_from_argmax_k,
-                    out_ptr,
-                    self.embed_tokens.weight,
-                    embed_target,
-                    self.draft_token_id_dev,
-                    h,
-                    stream,
-                )?;
-                // Return 0 as placeholder — caller reads actual ID later via
-                // read_deferred_draft_token().
-                0u32
-            } else {
-                // Fallback: synchronous D2H readback.
-                let mut buf = [0u8; 4];
-                ctx.gpu.copy_d2h(out_ptr, &mut buf)?;
-                u32::from_le_bytes(buf)
-            }
+            let mut buf = [0u8; 4];
+            ctx.gpu.copy_d2h(out_ptr, &mut buf)?;
+            u32::from_le_bytes(buf)
         };
 
         state.seq_len += 1;
-        // Pair-key bookkeeping (ATLAS_MTP_CATCHUP gap detection): this call
-        // wrote the pair for sequence key `position - 1` at the row above.
         state.last_pair_key = Some(position.saturating_sub(1));
         Ok(token_id)
     }

--- a/crates/spark-model/src/layers/mtp_head/moe_forward.rs
+++ b/crates/spark-model/src/layers/mtp_head/moe_forward.rs
@@ -80,6 +80,9 @@ impl MtpHead {
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<DevicePtr> {
+        if let Some(fused) = self.bf16_moe_fused.as_ref() {
+            return self.moe_forward_bf16_fused(fused, input, ctx, stream);
+        }
         let h = ctx.config.hidden_size as u32;
         let inter = ctx.config.moe_intermediate_size as u32;
         let num_experts = ctx.config.num_experts as u32;

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -346,6 +346,10 @@ impl MtpHead {
             None
         };
 
+        let bf16_moe_fused = moe_experts_generic
+            .as_ref()
+            .and_then(|e| super::bf16_moe_fused::MtpBf16MoeFused::try_build(e, gpu));
+
         Ok(Self {
             pre_fc_norm_embedding: weights.pre_fc_norm_embedding,
             pre_fc_norm_hidden: weights.pre_fc_norm_hidden,
@@ -445,6 +449,10 @@ impl MtpHead {
             propose_meta: gpu.alloc(super::batch_caps::PROPOSE_META_SEQS * propose_meta_stride)?,
             propose_meta_stride,
             prefill_scratch,
+            propose_graph: Mutex::new(None),
+            propose_graph_post: Mutex::new(None),
+            propose_in_hidden: gpu.alloc(h * 2)?,
+            bf16_moe_fused,
         })
     }
 }

--- a/crates/spark-model/src/layers/mtp_head/propose_gpu.rs
+++ b/crates/spark-model/src/layers/mtp_head/propose_gpu.rs
@@ -359,6 +359,10 @@ impl MtpHead {
         } else {
             ctx.config.vocab_size as u32
         };
+        // Base 64-thread GEMV, not the Batch 5 single-warp decode launcher.
+        // SW is an occupancy win on small-N C=1 decode; this lm_head is
+        // N≈1e5 × K=hidden=2048, where the single-warp K-walk is slower.
+        // C=1 decode still uses SW — not this graphable propose slice.
         ops::w4a16_gemv(
             ctx.gpu,
             self.w4a16_gemv_k,
@@ -390,5 +394,28 @@ impl MtpHead {
         self.propose_gpu_pre_moe(ctx, stream, kv)?;
         let ffn_out = self.propose_gpu_ffn(ctx, stream)?;
         self.propose_gpu_post_moe(ctx, stream, ffn_out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// NEGATIVE: the graphable MTP lm_head must not take Batch 5's SW GEMV.
+    /// The single-warp K-walk is slower at K=hidden=2048; production propose
+    /// (2.16 ms) was image-proven on the base 64-thread launch.
+    ///
+    /// PROVEN BY: restoring the SW decode launcher in `propose_gpu_post_moe`
+    /// turns this red.
+    #[test]
+    fn propose_lm_head_does_not_dispatch_sw_gemv() {
+        let src = include_str!("propose_gpu.rs");
+        let prod = src.split("#[cfg(test)]").next().expect("prod before tests");
+        assert!(
+            prod.contains("ops::w4a16_gemv("),
+            "lm_head must launch the base w4a16_gemv"
+        );
+        assert!(
+            !prod.contains("ops::w4a16_decode_gemv("),
+            "SW decode GEMV must not be on the propose lm_head path"
+        );
     }
 }

--- a/crates/spark-model/src/layers/mtp_head/propose_gpu.rs
+++ b/crates/spark-model/src/layers/mtp_head/propose_gpu.rs
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Grammarless MTP propose GPU body (rms_norm through GPU argmax).
+//!
+//! Pointer-stable: embed already lives in `ssm_qkvz`, hidden in
+//! `propose_in_hidden`, attention metadata already on device. Safe to
+//! record inside a CUDA graph.
+
+use super::propose_graph::ProposeKvView;
+use super::{MtpHead, MtpQuantization, ProjectionWeight};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use anyhow::Result;
+
+impl MtpHead {
+    /// Embed/hidden through post-attn norm. Pointer-stable — graphable.
+    pub(super) fn propose_gpu_pre_moe(
+        &self,
+        ctx: &ForwardContext<'_>,
+        stream: u64,
+        kv: &ProposeKvView,
+    ) -> Result<()> {
+        let h = ctx.config.hidden_size as u32;
+        let nq = ctx.config.num_attention_heads as u32;
+        let nkv = ctx.config.num_key_value_heads as u32;
+        let hd = ctx.config.head_dim as u32;
+        let eps = ctx.config.rms_norm_eps as f32;
+        let row_bytes = h as usize * 2;
+        let embed_out = ctx.buffers.ssm_qkvz();
+        let hidden_in = self.propose_in_hidden;
+
+        let normed_embed = ctx.buffers.ssm_deinterleaved();
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            embed_out,
+            &self.pre_fc_norm_embedding,
+            normed_embed,
+            1,
+            h,
+            eps,
+            stream,
+        )?;
+        let normed_hidden = ctx.buffers.ssm_gates();
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            hidden_in,
+            &self.pre_fc_norm_hidden,
+            normed_hidden,
+            1,
+            h,
+            eps,
+            stream,
+        )?;
+
+        let concat_out = ctx.buffers.ssm_ba();
+        ops::bf16_concat(
+            ctx.gpu,
+            self.bf16_concat_k,
+            normed_embed,
+            normed_hidden,
+            concat_out,
+            h,
+            stream,
+        )?;
+
+        let hidden = ctx.buffers.hidden_states();
+        self.gemv(ctx.gpu, concat_out, &self.fc, hidden, h, h * 2, stream)?;
+
+        let residual = ctx.buffers.residual();
+        ctx.gpu
+            .copy_d2d_async(hidden, residual, row_bytes, stream)?;
+
+        let normed = ctx.buffers.norm_output();
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            hidden,
+            &self.input_layernorm,
+            normed,
+            1,
+            h,
+            eps,
+            stream,
+        )?;
+
+        let q_out = ctx.buffers.qkv_output();
+        let q_dim = nq * hd;
+        let qg_dim = q_dim * 2;
+        let qg_bytes = qg_dim as usize * 2;
+
+        match self.quant {
+            MtpQuantization::Nvfp4 => {
+                if let ProjectionWeight::Nvfp4(ref w) = self.q_proj {
+                    ops::w4a16_gemv_qg(
+                        ctx.gpu,
+                        self.w4a16_gemv_qg_k,
+                        normed,
+                        w,
+                        q_out,
+                        qg_dim,
+                        h,
+                        nq,
+                        hd,
+                        stream,
+                    )?;
+                }
+            }
+            MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
+                self.gemv(ctx.gpu, normed, &self.q_proj, q_out, qg_dim, h, stream)?;
+                ops::deinterleave_qg(
+                    ctx.gpu,
+                    self.deinterleave_qg_k.unwrap(),
+                    q_out,
+                    1,
+                    nq,
+                    hd,
+                    nq * hd * 2,
+                    stream,
+                )?;
+            }
+        }
+        let gate_ptr = q_out.offset(q_dim as usize * 2);
+        let k_out = q_out.offset(qg_bytes);
+        let v_out = k_out.offset((nkv * hd) as usize * 2);
+
+        match self.quant {
+            MtpQuantization::Nvfp4 => {
+                if let (ProjectionWeight::Nvfp4(kw), ProjectionWeight::Nvfp4(vw)) =
+                    (&self.k_proj, &self.v_proj)
+                {
+                    ops::w4a16_gemv_dual(
+                        ctx.gpu,
+                        self.w4a16_gemv_dual_k,
+                        normed,
+                        kw,
+                        k_out,
+                        vw,
+                        v_out,
+                        nkv * hd,
+                        h,
+                        stream,
+                    )?;
+                }
+            }
+            MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
+                self.gemv(ctx.gpu, normed, &self.k_proj, k_out, nkv * hd, h, stream)?;
+                self.gemv(ctx.gpu, normed, &self.v_proj, v_out, nkv * hd, h, stream)?;
+            }
+        }
+
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            q_out,
+            &self.q_norm,
+            q_out,
+            nq,
+            hd,
+            eps,
+            stream,
+        )?;
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            k_out,
+            &self.k_norm,
+            k_out,
+            nkv,
+            hd,
+            eps,
+            stream,
+        )?;
+
+        let meta_base = kv.meta_base;
+        ops::rope(
+            ctx.gpu,
+            self.rope_k,
+            q_out,
+            k_out,
+            meta_base,
+            1,
+            nq,
+            nkv,
+            hd,
+            ctx.config.rotary_dim() as u32,
+            ctx.config.rope_theta as f32,
+            stream,
+        )?;
+
+        let kv_stride = nkv * hd;
+        let attn_out = ctx.buffers.attn_output();
+        let inv_sqrt_d = 1.0f32 / (hd as f32).sqrt();
+        if self.kv_bf16 {
+            ops::reshape_and_cache(
+                ctx.gpu,
+                self.reshape_cache_k,
+                k_out,
+                v_out,
+                kv.k_pool,
+                kv.v_pool,
+                meta_base.offset(8),
+                1,
+                nkv,
+                hd,
+                kv.block_size,
+                kv_stride,
+                kv_stride,
+                kv.cache_stride,
+                stream,
+            )?;
+            ops::paged_decode_attn_bf16(
+                ctx.gpu,
+                self.paged_decode_k,
+                q_out,
+                kv.k_pool,
+                kv.v_pool,
+                attn_out,
+                meta_base.offset(256),
+                meta_base.offset(16),
+                kv.max_blocks,
+                1,
+                nq,
+                nkv,
+                hd,
+                kv.block_size,
+                inv_sqrt_d,
+                nq * hd,
+                0,
+                stream,
+            )?;
+        } else {
+            ops::reshape_and_cache_fp8(
+                ctx.gpu,
+                self.reshape_cache_k,
+                k_out,
+                v_out,
+                kv.k_pool,
+                kv.v_pool,
+                meta_base.offset(8),
+                1,
+                nkv,
+                hd,
+                kv.block_size,
+                1.0,
+                1.0,
+                kv_stride,
+                kv_stride,
+                kv.cache_stride,
+                stream,
+            )?;
+            ops::paged_decode_attn_fp8(
+                ctx.gpu,
+                self.paged_decode_k,
+                q_out,
+                kv.k_pool,
+                kv.v_pool,
+                attn_out,
+                meta_base.offset(256),
+                meta_base.offset(16),
+                kv.max_blocks,
+                1,
+                nq,
+                nkv,
+                hd,
+                kv.block_size,
+                inv_sqrt_d,
+                1.0,
+                1.0,
+                nq * hd,
+                kv.cache_stride,
+                0,
+                stream,
+            )?;
+        }
+
+        ops::sigmoid_gate_mul(
+            ctx.gpu,
+            self.sigmoid_gate_mul_k,
+            attn_out,
+            gate_ptr,
+            attn_out,
+            nq * hd,
+            stream,
+        )?;
+
+        let o_out = ctx.buffers.norm_output();
+        self.gemv(ctx.gpu, attn_out, &self.o_proj, o_out, h, nq * hd, stream)?;
+
+        let normed2 = ctx.buffers.norm_output();
+        ops::residual_add_rms_norm(
+            ctx.gpu,
+            self.residual_add_rms_norm_k,
+            hidden,
+            o_out,
+            &self.post_attn_layernorm,
+            normed2,
+            residual,
+            1,
+            h,
+            eps,
+            stream,
+        )?;
+        Ok(())
+    }
+
+    /// MoE / dense FFN. BF16/FP8 generic experts D2H indices and pick
+    /// per-token weight pointers — must stay eager (not inside a graph).
+    pub(super) fn propose_gpu_ffn(
+        &self,
+        ctx: &ForwardContext<'_>,
+        stream: u64,
+    ) -> Result<spark_runtime::gpu::DevicePtr> {
+        let normed2 = ctx.buffers.norm_output();
+        if self.dense_ffn_generic.is_some() {
+            self.dense_ffn_forward_generic(normed2, ctx, stream)
+        } else {
+            match self.quant {
+                MtpQuantization::Nvfp4 => self
+                    .moe_nvfp4
+                    .as_ref()
+                    .unwrap()
+                    .forward(normed2, ctx, stream),
+                MtpQuantization::Fp8 | MtpQuantization::Bf16 => {
+                    self.moe_forward_generic(normed2, ctx, stream)
+                }
+            }
+        }
+    }
+
+    /// Residual + final norm + NVFP4 lm_head + GPU argmax. Pointer-stable.
+    pub(super) fn propose_gpu_post_moe(
+        &self,
+        ctx: &ForwardContext<'_>,
+        stream: u64,
+        ffn_out: spark_runtime::gpu::DevicePtr,
+    ) -> Result<()> {
+        let h = ctx.config.hidden_size as u32;
+        let eps = ctx.config.rms_norm_eps as f32;
+        let hidden = ctx.buffers.hidden_states();
+        ops::residual_add(ctx.gpu, self.residual_add_k, hidden, ffn_out, h, stream)?;
+
+        let final_normed = ctx.buffers.norm_output();
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            hidden,
+            &self.norm,
+            final_normed,
+            1,
+            h,
+            eps,
+            stream,
+        )?;
+
+        let v = if self.mtp_vocab_size > 0 {
+            self.mtp_vocab_size.min(ctx.config.vocab_size as u32)
+        } else {
+            ctx.config.vocab_size as u32
+        };
+        ops::w4a16_gemv(
+            ctx.gpu,
+            self.w4a16_gemv_k,
+            final_normed,
+            &self.lm_head_nvfp4,
+            ctx.buffers.logits(),
+            v,
+            h,
+            stream,
+        )?;
+        ops::argmax_bf16(
+            ctx.gpu,
+            self.argmax_k,
+            ctx.buffers.logits(),
+            ctx.buffers.scratch(),
+            v,
+            stream,
+        )?;
+        Ok(())
+    }
+
+    /// Single-token MTP GPU body ending at `argmax_bf16` into `scratch`.
+    pub(super) fn propose_gpu_to_argmax(
+        &self,
+        ctx: &ForwardContext<'_>,
+        stream: u64,
+        kv: &ProposeKvView,
+    ) -> Result<()> {
+        self.propose_gpu_pre_moe(ctx, stream, kv)?;
+        let ffn_out = self.propose_gpu_ffn(ctx, stream)?;
+        self.propose_gpu_post_moe(ctx, stream, ffn_out)
+    }
+}

--- a/crates/spark-model/src/layers/mtp_head/propose_graph.rs
+++ b/crates/spark-model/src/layers/mtp_head/propose_graph.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! CUDA-graph capture/replay for the grammarless MTP `forward_one` GPU body.
+//!
+//! MTP propose is a single-layer decoder + NVFP4 lm_head. On GB10 that is
+//! ~2.4 ms/step eager — mostly launch overhead, not LPDDR5X weight traffic.
+//! Target verify is already graphed; this module graphs the leftover propose
+//! slice. Token-dependent embed D2D, metadata H2D, and KV block alloc stay
+//! *outside* the graph (varying src pointer / host buffer / CPU).
+//!
+//! BF16/FP8 generic MoE D2Hs expert ids and launches per-token weight
+//! pointers, so it cannot be captured. Production Qwen3.6 MTP is BF16: we
+//! capture a pre-MoE graph and a post-MoE (lm_head) graph around that eager
+//! slice. NVFP4 fused MoE is device-side and captures as one graph.
+
+use super::{MtpHead, MtpProposerState};
+use crate::layer::ForwardContext;
+use crate::layers::mtp_meta::{MTP_META_OFFSET, pack_mtp_attn_meta};
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, GraphHandle};
+
+/// Kill switch `ATLAS_NO_MTP_PROPOSE_GRAPH`. ON unless the value is exactly
+/// `"1"`. `=0` / empty / unset do **not** disable — same `== "1"` reading as
+/// `ATLAS_NO_GEMV_SW`.
+pub const DISABLE_ENV: &str = "ATLAS_NO_MTP_PROPOSE_GRAPH";
+
+pub fn mtp_propose_graph_from(no_graph: Option<&str>) -> bool {
+    no_graph != Some("1")
+}
+
+/// Process-lifetime read of [`DISABLE_ENV`].
+pub fn mtp_propose_graph_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| mtp_propose_graph_from(std::env::var(DISABLE_ENV).ok().as_deref()))
+}
+
+/// Whether this `forward_one` call may enter a CUDA graph.
+///
+/// Ineligible paths D2H inside the GPU body (grammar CPU argmax, debug
+/// norms, draft-conf softmax, shadow top-k). Profile mode syncs after every
+/// kernel. Host-dispatched MoE is still graphable: it runs *between* two
+/// captured slices rather than vetoing capture.
+pub fn propose_graphable(
+    grammar: bool,
+    shadow_topk: usize,
+    draft_conf_tau: f32,
+    profile: bool,
+    debug_norms: bool,
+) -> bool {
+    !grammar && shadow_topk == 0 && draft_conf_tau <= 0.0 && !profile && !debug_norms
+}
+
+pub(super) struct ProposeKvView {
+    pub k_pool: DevicePtr,
+    pub v_pool: DevicePtr,
+    pub cache_stride: u64,
+    pub block_size: u32,
+    pub max_blocks: u32,
+    pub meta_base: DevicePtr,
+}
+
+impl MtpHead {
+    /// KV block alloc + metadata H2D. CPU + host pointer — never captured.
+    pub(super) fn prepare_propose_kv(
+        &self,
+        state: &mut MtpProposerState,
+        ctx: &ForwardContext<'_>,
+        position: usize,
+        stream: u64,
+    ) -> Result<ProposeKvView> {
+        let mut kv_cache = self.kv_cache.lock();
+        let bs = kv_cache.block_size();
+        let blocks_needed = (state.seq_len / bs) + 1;
+        while state.block_table.len() < blocks_needed {
+            state.block_table.push(kv_cache.alloc_block()?);
+        }
+
+        let meta_base = ctx.buffers.scratch().offset(MTP_META_OFFSET);
+        let max_blocks = state.block_table.len() as u32;
+        let block_idx = state.block_table[state.seq_len / bs];
+        let global_slot = (block_idx as i64) * (bs as i64) + ((state.seq_len % bs) as i64);
+        let actual_seq_len = (state.seq_len + 1) as i32;
+        let meta_buf = pack_mtp_attn_meta(
+            position as u32,
+            global_slot,
+            actual_seq_len,
+            &state.block_table,
+            ctx.buffers.scratch_bytes().saturating_sub(MTP_META_OFFSET),
+        )?;
+        ctx.gpu.copy_h2d_async(&meta_buf, meta_base, stream)?;
+
+        Ok(ProposeKvView {
+            k_pool: kv_cache.k_pool_ptr(self.attn_layer_idx),
+            v_pool: kv_cache.v_pool_ptr(self.attn_layer_idx),
+            cache_stride: kv_cache.cache_stride() as u64,
+            block_size: bs as u32,
+            max_blocks,
+            meta_base,
+        })
+    }
+
+    /// True when MoE/FFN kernel pointers are process-lifetime (NVFP4 fused
+    /// or dense FFN) and can live inside the same graph as attention.
+    fn propose_moe_in_graph(&self) -> bool {
+        self.moe_experts_generic.is_none() || self.bf16_moe_fused.is_some()
+    }
+
+    /// Replay cached propose graph(s), or capture them around the GPU body.
+    pub(super) fn replay_or_capture_propose(
+        &self,
+        ctx: &ForwardContext<'_>,
+        stream: u64,
+        kv: &ProposeKvView,
+    ) -> Result<bool> {
+        let graph_ctx = ctx_for_graph(ctx);
+        if self.propose_moe_in_graph() {
+            let mut slot = self.propose_graph.lock();
+            replay_or_capture_body(ctx.gpu, &mut slot, stream, "full", || {
+                self.propose_gpu_to_argmax(&graph_ctx, stream, kv)
+            })?;
+            return Ok(true);
+        }
+
+        let mut pre = self.propose_graph.lock();
+        let mut post = self.propose_graph_post.lock();
+        replay_or_capture_body(ctx.gpu, &mut pre, stream, "pre-MoE", || {
+            self.propose_gpu_pre_moe(&graph_ctx, stream, kv)
+        })?;
+        let ffn_out = self.propose_gpu_ffn(ctx, stream)?;
+        replay_or_capture_body(ctx.gpu, &mut post, stream, "post-MoE", || {
+            self.propose_gpu_post_moe(&graph_ctx, stream, ffn_out)
+        })?;
+        Ok(true)
+    }
+}
+
+fn replay_or_capture_body(
+    gpu: &dyn GpuBackend,
+    slot: &mut Option<GraphHandle>,
+    stream: u64,
+    label: &'static str,
+    mut body: impl FnMut() -> Result<()>,
+) -> Result<()> {
+    if let Some(graph) = *slot
+        && graph.0 != 0
+    {
+        gpu.launch_graph(graph, stream)?;
+        return Ok(());
+    }
+
+    let mut capture_active = false;
+    match gpu.begin_capture(stream) {
+        Ok(()) => capture_active = true,
+        Err(e) => {
+            tracing::warn!(
+                "MTP propose CUDA graph begin_capture failed ({label}, {e:#}) — running eagerly"
+            );
+        }
+    }
+
+    if let Err(e) = body() {
+        if capture_active {
+            gpu.abort_capture_if_active(stream);
+        }
+        return Err(e);
+    }
+    if !capture_active {
+        return Ok(());
+    }
+
+    match gpu.end_capture(stream) {
+        Ok(graph) if graph.0 != 0 => {
+            tracing::info!("Captured CUDA graph for MTP propose ({label})");
+            gpu.launch_graph(graph, stream)?;
+            *slot = Some(graph);
+            Ok(())
+        }
+        Ok(_) => {
+            tracing::warn!(
+                "MTP propose CUDA graph capture returned null handle ({label}) — running eagerly"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            tracing::warn!(
+                "MTP propose CUDA graph end_capture failed ({label}, {e:#}) — \
+                 re-running propose eagerly"
+            );
+            body()
+        }
+    }
+}
+
+fn ctx_for_graph<'a>(ctx: &ForwardContext<'a>) -> ForwardContext<'a> {
+    ForwardContext {
+        buffers: ctx.buffers,
+        gpu: ctx.gpu,
+        config: ctx.config,
+        dispatch: ctx.dispatch,
+        derived: ctx.derived,
+        levers: ctx.levers,
+        stats: ctx.stats,
+        attn_metadata: ctx.attn_metadata,
+        profile: false,
+        comm: ctx.comm,
+        graph_capture: true,
+        gdn_exact_replay: ctx.gdn_exact_replay,
+        token_ids: ctx.token_ids,
+        routed_lora_layers: ctx.routed_lora_layers,
+        midchunk_capture: None,
+        moe_lora_route: ctx.moe_lora_route,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kill_switch_is_exactly_one() {
+        assert!(mtp_propose_graph_from(None), "unset → ON");
+        assert!(mtp_propose_graph_from(Some("0")), "`=0` is NOT off");
+        assert!(mtp_propose_graph_from(Some("")), "empty is NOT off");
+        assert!(!mtp_propose_graph_from(Some("1")), "`=1` is the kill");
+    }
+
+    #[test]
+    fn production_bf16_mtp_is_graphable() {
+        // Qwen3.6-35B-A3B-NVFP4 ships a BF16 MTP head. Host MoE must not veto.
+        assert!(propose_graphable(false, 0, 0.0, false, false));
+    }
+
+    #[test]
+    fn d2h_observability_paths_are_not_graphable() {
+        assert!(!propose_graphable(true, 0, 0.0, false, false));
+        assert!(!propose_graphable(false, 4, 0.0, false, false));
+        assert!(!propose_graphable(false, 0, 0.5, false, false));
+        assert!(!propose_graphable(false, 0, 0.0, true, false));
+        assert!(!propose_graphable(false, 0, 0.0, false, true));
+    }
+}


### PR DESCRIPTION
## Summary

MTP propose ran eager every decode step (~2.37 ms, ~16% of the step) because BF16 MTP MoE D2Hs top-k expert ids and launches per-token weight pointers — a path that cannot live in one CUDA graph. This PR fuses that MoE onto device-side expert dispatch so the whole propose body (attn + FFN + fused MoE + lm_head) can capture once and replay.

Closes nothing tracked; this is the next GB10 decode bottleneck after #478/#479/#480/#481.

**Rebased 2026-08-13:** merged `origin/main` (Batch 5 / #490). The only conflict was `mtp_head/forward.rs` — Batch 5 had wired lossless SW GEMV into the old 689-line eager body; this PR had already split that file. Resolution: keep the graph-split dispatcher (245 LoC) and keep the **base** 64-thread GEMV on the graphable MTP lm_head (SW is slower at K=hidden=2048; production propose 2.16 ms was proven on the base kernel). No force-push.

## Bottleneck (evidence, not folklore)

Production `:8888` on `nvidia/Qwen3.6-35B-A3B-NVFP4` with `--speculative --num-drafts 1`:

```
MTP head: quant=Bf16
MTP verify timing: fwd=12.0–12.1ms  propose=2.33–2.40ms  TOTAL=14.3–14.6ms
```

Verify was already graphed. Propose was not. `--mtp-quantization` defaults to bf16 even on this NVFP4 target. Generic BF16 MoE is host-dispatch and vetoed a single graph until the fused kernels landed.

## What changed

- Device-side pointer tables + fused kernels `moe_expert_gate_up_shared_bf16` / `moe_expert_silu_down_shared_bf16`.
- CUDA-graph MTP propose (full body) after KV/meta H2D. Kill switches: `ATLAS_NO_MTP_PROPOSE_GRAPH=1`, `ATLAS_NO_MTP_BF16_MOE_FUSED=1` (`=0` does **not** disable).
- Split `forward.rs` (now 245 LoC; removed from the file-size allow-list).
- Grammar / debug / confidence / shadow paths stay eager.
- After Batch 5: MTP `gemv()` can use SW for NVFP4 C=1 projections; the graphable lm_head stays on base `w4a16_gemv`.

## Image proof on :8888

Same flags both sides (`--gpu-memory-utilization 0.50`). Same five prompts, temperature 0. Short 2-token replies are noise; 220-token lifecycle tok/s is the metric.

Baseline image `atlas-gb10:pr-proof`. After image `atlas-gb10:pr-proof-1b906f0`.

### Smoking gun (once, no recapture)

```
MTP BF16 MoE fused: device-side expert dispatch (256 experts, graphable)
FP8 calibration frozen — re-enabling CUDA graphs
CUDA graph captured successfully for slot=0
Captured CUDA graph for MTP propose (full)
Captured CUDA graph for K=2 verify (slot=0)
```

No `destroy_graph` on later requests. K2 accept stayed **80%**.

### Before / after (220-token)

| Prompt | Answer | Baseline tok/s | After tok/s |
|---|---|---|---|
| What is 2+2? (max_tokens=16) | `4` | noise | noise |
| Capital of France | `Paris` | noise | noise |
| Sky color | `Blue` | noise | noise |
| 220-token BST explanation | coherent | **123.4** (TTFT 117ms) | **124.4** (TTFT 117ms) |
| 220-token hash-table collisions | coherent | **125.2** (TTFT 77.5ms) | **126.3** (TTFT 76.1ms) |

Propose phase: **2.33–2.40 ms → 2.16–2.22 ms**. Verify `fwd` still ~12.1 ms. Remaining propose time is fused-expert + NVFP4 lm_head weight traffic, not launch overhead.

Local tag only (`atlas-gb10:pr-proof-1b906f0`). Not pushed to `avarok/atlas-gb10:latest`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Kill-switch polarity tests for `ATLAS_NO_MTP_PROPOSE_GRAPH` and `ATLAS_NO_MTP_BF16_MOE_FUSED`
- [x] Graphable vs grammar/debug/conf/shadow unit tests
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests`
- [x] `bash scripts/check-license-headers.sh`
- [x] Image-proven on GB10 `:8888` against `nvidia/Qwen3.6-35B-A3B-NVFP4` (table above)
- [x] Re-checked after merging Batch 5: fmt / workspace clippy / license / unit tests
- [x] Follow-up: graphable MTP lm_head stays on base GEMV (not SW)

## Notes for reviewers

- First attempt (graph the body, leave host MoE outside) captured `pre-MoE`/`post-MoE` and moved **zero** milliseconds — MoE *was* the 2.4 ms.
- Fused MoE is MTP-head only; target-model MoE is unchanged.
- `:8888` left on the proven local image. Rollback containers: `atlas-pr-proof-keep`, `atlas-latest-keep`.
- PR benchmark gate will be red until a GPU box commits a record covering this merged tree (Batch 5 + this PR).

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md). (facepunch47 is signed)