### PR TITLE
fix(tui): route Help section keys to the Help section, not the ? overlay

### DIFF
--- a/crates/spark-server/src/tui/app_input.rs
+++ b/crates/spark-server/src/tui/app_input.rs
@@ -46,7 +46,12 @@ impl App {
             return;
         }
         if self.section == Section::Help {
-            self.on_help_overlay_key(key);
+            // `on_help_key` (the SECTION's keys), not `on_help_overlay_key`
+            // (the `?` modal's scroll). They differed by one word and the
+            // wrong one swallowed every character in its `_ =>` arm, so
+            // editing the report title looked like a frozen dashboard:
+            // keystrokes vanished and nothing on screen moved.
+            self.on_help_key(key);
             return;
         }
         // Terminal input.

--- a/crates/spark-server/src/tui/app_input_tests.rs
+++ b/crates/spark-server/src/tui/app_input_tests.rs
@@ -478,3 +478,44 @@ fn ctrl_n_works_while_typing_and_a_plain_n_still_types() {
     assert!(a.chat.transcript.is_empty());
     assert_eq!(a.chat.input, "never", "the unsent draft survives the reset");
 }
+
+/// The report title accepts typing through `App::on_key`.
+///
+/// This is a ROUTING test, and it exists because the unit tests one layer
+/// down could not see the bug: `HelpState::on_key` was always correct, but
+/// `App` never called it. `in_input()` is consulted before the Help arm in
+/// `on_key`, so the moment the title went into edit mode every keystroke was
+/// handed to `on_input_key` -- which sent it to `on_help_overlay_key`, the
+/// `?` modal's scroll handler, whose `_ =>` arm discards the key. Typing did
+/// nothing and nothing on screen moved, which reads as a frozen dashboard.
+#[test]
+fn typing_a_report_title_reaches_the_composer_and_does_not_look_frozen() {
+    let mut a = app();
+    a.jump(Section::Help);
+    a.help.sub = crate::tui::help_state::HelpSub::Report;
+
+    // Enter on the Title row starts editing; the composer now owns the keys.
+    tap(&mut a, KeyCode::Enter);
+    assert!(
+        a.help.is_editing(),
+        "Enter on Title must start editing, else the field can never be filled"
+    );
+
+    for c in "gpu oom".chars() {
+        press(&mut a, c);
+    }
+    assert_eq!(
+        a.help.title, "gpu oom",
+        "every typed character must reach the title buffer"
+    );
+
+    // Backspace edits rather than being swallowed.
+    tap(&mut a, KeyCode::Backspace);
+    assert_eq!(a.help.title, "gpu oo");
+
+    // Esc leaves edit mode and KEEPS the text -- a draft title is the user's
+    // work, and the filter-box "Esc clears" grammar would destroy it.
+    tap(&mut a, KeyCode::Esc);
+    assert!(!a.help.is_editing());
+    assert_eq!(a.help.title, "gpu oo");
+}


### PR DESCRIPTION
**Reported:** editing the title in Help ▸ Report Issue freezes the dashboard.

**Actual:** not a freeze — every keystroke was being thrown away, so nothing moved. `in_input()` is consulted before the `Section::Help` arm in `App::on_key`, so once the title entered edit mode all keys went to `on_input_key`, whose Help branch called `on_help_overlay_key` — the `?` modal's scroll handler. Its `_ =>` arm discards the key and closes an overlay that was not open.

**Origin:** the Help section and the audit branch had each independently defined `App::on_help_key`. Resolving that collision during the stack merge renamed the overlay one, and this call site got renamed along with it because it matched the pattern, not because it meant the overlay. Self-inflicted during #473's conflict resolution.

**Test:** drives `App::on_key`, deliberately — the existing `help_state_tests` sit one layer below the defect and pass against the broken build. Verified by reintroducing the bug (test fails: "every typed character must reach the title buffer") and removing it again.

Also asserts Esc leaves edit mode while **keeping** the draft title, since destroying a user's typing on Esc would be its own bug.

2100 tests pass, fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)