### PR TITLE
spark-model: default-on fused K=2 GDN verify epilogue

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-14-48185e4649.json
+++ b/.benchmarks/agentic-webserver/2026-08-14-48185e4649.json
@@ -1,0 +1,77 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "48185e4649",
+  "recorded_at": 1786666228,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1000"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1000",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 638.17946369,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 638s ≤ 1000s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=638.18, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 638s ≤ 1000s",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-13-d8b924eca7.json
+++ b/.benchmarks/bfcl-subset/2026-08-13-d8b924eca7.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "d8b924eca7",
+  "recorded_at": 1786665561,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.94,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.94, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "0e13fc150f6f77b21b04f0f48e48dbb43cc7ed633c659bca2ade0c953345d5d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-13-50bc5ce287.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-13-50bc5ce287.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "50bc5ce287",
+  "recorded_at": 1786660190,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "256",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=256",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 1.0,
+    "jittered": 11.0,
+    "rounds": 12.0,
+    "sum_wall_s": 316.090324416,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=1.00, jittered=11.00, rounds=12.00, sum_wall_s=316.09, unmeasured=0.00 · Pass: 1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-13-2c9a350c55.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-13-2c9a350c55.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "2c9a350c55",
+  "recorded_at": 1786660500,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1602.516526,
+    "p90_ms": 4324.178638,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.5% (limit +3.0%) · p90 +0.6% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1602.52, p90_ms=4324.18, samples=36.00 · Pass: median +0.5% (limit +3.0%) · p90 +0.6% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-13-484808f5c7.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-13-484808f5c7.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "484808f5c7",
+  "recorded_at": 1786660383,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1522.414726,
+    "p90_ms": 4312.017491,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.3% (limit +3.0%) · p90 -0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1522.41, p90_ms=4312.02, samples=36.00 · Pass: median +0.3% (limit +3.0%) · p90 -0.1% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/crates/spark-model/examples/gdn_verify_fused_microtest.rs
+++ b/crates/spark-model/examples/gdn_verify_fused_microtest.rs
@@ -400,7 +400,7 @@ struct FusedStage1 {
 /// separate launch), then fused gated-RMS-norm ×2 in one launch.
 ///
 /// Drives `gdn_verify_fused_k2` the same way `decode_batched_conv_gdn` does
-/// under `ATLAS_GDN_FUSED_VERIFY`: the conv phase advances state 0→1 in
+/// on the default-ON fused K=2 path: the conv phase advances state 0→1 in
 /// registers and writes the position-0 conv-state snapshot once; WY2 consumes
 /// its conv output (unchanged); the norm phase produces the gated-norm output.
 fn run_fused_stage1(g: &dyn GpuBackend, ins: &Inputs) -> Result<FusedStage1> {

--- a/crates/spark-model/examples/gdn_verify_fused_microtest.rs
+++ b/crates/spark-model/examples/gdn_verify_fused_microtest.rs
@@ -219,6 +219,7 @@ fn launch_wy2(
         .arg_u32(CONV_DIM as u32) // qk_stride
         .arg_u32(CONV_DIM as u32) // v_stride
         .arg_u32((NV * 2) as u32) // gb_stride
+        .arg_u32(0) // state_is_table=0 (contiguous, batch_size==1)
         .launch(0)
 }
 

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_fused_verify_k2.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_fused_verify_k2.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Default-ON fused K=2 MTP-verify GDN epilogue.
+//!
+//! Production `--num-drafts 1` is K=2 every verify step. Without this path
+//! each of the ~30 SSM layers launches `conv1d_update_l2norm` twice and
+//! `copy_d2d`s the conv-state for rollback. The fused kernels
+//! (`gdn_verify_fused_conv_k2` / `gdn_verify_fused_norm_k2`) fold both
+//! positions into one launch each, snapshot pos-0 inline, and are
+//! byte-identical to the per-token path (`gdn_verify_fused_microtest`,
+//! cos ≥ 0.99999, `--fmad=false`).
+//!
+//! They used to sit behind opt-in `ATLAS_GDN_FUSED_VERIFY=1` (default OFF)
+//! even though the PTX is linked on gb10. That polarity is inverted here:
+//! fused is the shipped path; `ATLAS_NO_GDN_FUSED_VERIFY=1` restores the
+//! two-launch + D2D sequence. `=0` does NOT disable (house `== "1"` kill).
+//! The obsolete opt-in name is ignored (warned once).
+
+/// Kill switch. Strict `== "1"`.
+pub const DISABLE_ENV: &str = "ATLAS_NO_GDN_FUSED_VERIFY";
+
+/// Pre-default opt-in. Presence is warned; never read for behaviour.
+pub const OBSOLETE_ENV: &str = "ATLAS_GDN_FUSED_VERIFY";
+
+/// Pure so the polarity is testable without touching process env (SBIO).
+pub fn gdn_fused_verify_k2_from(no_fused: Option<&str>) -> bool {
+    no_fused != Some("1")
+}
+
+/// Process-static env resolution. Kernels-present is gated at the call site.
+pub fn gdn_fused_verify_k2_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        if std::env::var(OBSOLETE_ENV).is_ok() {
+            tracing::warn!(
+                "{OBSOLETE_ENV} is OBSOLETE and IGNORED — GDN fused K=2 verify \
+                 is ON by default. Remove it; to disable, set {DISABLE_ENV}=1."
+            );
+        }
+        gdn_fused_verify_k2_from(std::env::var(DISABLE_ENV).ok().as_deref())
+    })
+}
+
+/// One-shot serve-log smoking gun. `kernels_present` is the PTX-handle gate.
+pub fn log_fused_k2_once(kernels_present: bool, env_on: bool) {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if kernels_present && env_on {
+            tracing::info!(
+                "GDN fused K=2 verify ENGAGED: one conv1d+L2norm launch + inline \
+                 pos-0 snapshot (was two conv launches + copy_d2d per SSM layer); \
+                 kill switch {DISABLE_ENV}=1"
+            );
+        } else if !kernels_present {
+            tracing::info!(
+                "GDN fused K=2 verify NOT engaged: fused kernels absent (NULL \
+                 handle); per-token conv1d_update_l2norm path in use"
+            );
+        } else {
+            tracing::info!(
+                "GDN fused K=2 verify NOT engaged: {DISABLE_ENV}=1; per-token \
+                 conv1d_update_l2norm path in use"
+            );
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unset must be ON. The old polarity (`ATLAS_GDN_FUSED_VERIFY=1` opt-in)
+    /// would fail this assertion.
+    #[test]
+    fn unset_enables_fused_k2() {
+        assert!(gdn_fused_verify_k2_from(None));
+    }
+
+    #[test]
+    fn kill_switch_exactly_one_disables() {
+        assert!(!gdn_fused_verify_k2_from(Some("1")));
+    }
+
+    /// `ATLAS_NO_*=0` / empty / junk do NOT disable.
+    #[test]
+    fn zero_empty_and_junk_do_not_disable() {
+        for v in ["0", "", "true", "yes", "2", "1 "] {
+            assert!(
+                gdn_fused_verify_k2_from(Some(v)),
+                "{DISABLE_ENV}={v:?} must not disable"
+            );
+        }
+    }
+
+    #[test]
+    fn obsolete_opt_in_is_not_an_input() {
+        assert_eq!(OBSOLETE_ENV, "ATLAS_GDN_FUSED_VERIFY");
+        assert_eq!(DISABLE_ENV, "ATLAS_NO_GDN_FUSED_VERIFY");
+        assert!(gdn_fused_verify_k2_from(None));
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -297,7 +297,7 @@ impl Qwen3SsmLayer {
             // STAGE 1 fused K=2 verify epilogue. Only present in the gb10
             // common PTX module set; NULL on targets lacking the .cu, in which
             // case the num_tokens==2 arm keeps the per-token path even when
-            // ATLAS_GDN_FUSED_VERIFY is set.
+            // the default-ON fused path would otherwise dispatch.
             gdn_verify_fused_conv_k2_k: super::super::try_kernel(
                 gpu,
                 "gdn_verify_fused_k2",

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -234,9 +234,9 @@ pub struct Qwen3SsmLayer {
     gdn_wy3_resident_f16_k: KernelHandle,
     gdn_wy4_f16_k: KernelHandle,
     /// STAGE 1 fused K=2 MTP-verify epilogue: conv1d+L2norm ×2 and
-    /// gated-RMS-norm ×2 each folded into a single launch. Dispatched only
-    /// when the `ATLAS_GDN_FUSED_VERIFY` env flag is set (default OFF); the
-    /// per-token path runs unchanged otherwise. Bit-identical (cos == 1.0).
+    /// gated-RMS-norm ×2 each folded into a single launch. Default ON when
+    /// the kernels are present; kill switch `ATLAS_NO_GDN_FUSED_VERIFY=1`.
+    /// Bit-identical (cos == 1.0).
     gdn_verify_fused_conv_k2_k: KernelHandle,
     gdn_verify_fused_norm_k2_k: KernelHandle,
     /// Fused generic-K verify conv1d+L2norm (one launch for all K positions,
@@ -428,6 +428,7 @@ fn ssm_m128_min_m() -> Option<u32> {
 // ── Sub-files (split for ≤500 LoC) ────────────────────────────────────────
 mod debug;
 pub mod gdn_flags;
+mod gdn_fused_verify_k2;
 mod init;
 mod init_fp8;
 mod init_q2;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -91,17 +91,17 @@ impl Qwen3SsmLayer {
     /// STAGE 1: whether the fused K=2 MTP-verify epilogue (single-launch
     /// conv1d+L2norm and gated-RMS-norm for both draft positions) should run.
     ///
-    /// Opt-in via `ATLAS_GDN_FUSED_VERIFY=1` (default OFF — the per-token path
-    /// runs unchanged) AND only when the fused kernels are present in this
-    /// target's PTX module set (NULL handle on non-gb10 targets). Bit-identical
-    /// to the per-token path (gdn_verify_fused_microtest, cos == 1.0).
+    /// Default ON when the fused kernels are present in this target's PTX
+    /// (NULL handle on non-gb10 targets). Kill switch
+    /// `ATLAS_NO_GDN_FUSED_VERIFY=1` restores the two-launch + `copy_d2d`
+    /// path. Bit-identical to the per-token path
+    /// (`gdn_verify_fused_microtest`, cos == 1.0).
     pub(super) fn fused_verify_k2_enabled(&self) -> bool {
-        self.gdn_verify_fused_conv_k2_k.0 != 0
-            && self.gdn_verify_fused_norm_k2_k.0 != 0
-            && matches!(
-                std::env::var("ATLAS_GDN_FUSED_VERIFY").ok().as_deref(),
-                Some("1")
-            )
+        let kernels =
+            self.gdn_verify_fused_conv_k2_k.0 != 0 && self.gdn_verify_fused_norm_k2_k.0 != 0;
+        let env_on = super::gdn_fused_verify_k2::gdn_fused_verify_k2_enabled();
+        super::gdn_fused_verify_k2::log_fused_k2_once(kernels, env_on);
+        kernels && env_on
     }
 
     /// Select the K=2 verify WY kernel: the register-resident twin


### PR DESCRIPTION
## Summary

Production C=1 K=2 MTP verify was launching `conv1d_update_l2norm` twice plus a conv-state `copy_d2d` on every SSM layer even though the bit-identical fused kernels (`gdn_verify_fused_k2`) were already linked on gb10. This flips the old opt-in `ATLAS_GDN_FUSED_VERIFY=1` (default OFF) to a `ATLAS_NO_GDN_FUSED_VERIFY=1` kill switch so the fused path is the shipped default.

Closes nothing tracked; this is the next GB10 decode bottleneck after #478/#479/#480/#481/#485.

## Bottleneck (evidence, not folklore)

Live `:8888` on `nvidia/Qwen3.6-35B-A3B-NVFP4` with `--speculative --num-drafts 1` (K=2 every verify step):

- Kernel table at boot: `gdn_verify_fused_k2 … used`
- Container env did **not** set `ATLAS_GDN_FUSED_VERIFY=1`
- No log line for fused K=2 on the baseline image — the kernels sat idle
- Contrast: K=17 DFlash fused conv is already default-ON

That extra per-layer work (two conv launches + D2D × ~30 SSM layers) is off the NVFP4 weight-byte roofline and sits inside the graphed ~12 ms `fwd`.

## What changed

- New `gdn_fused_verify_k2.rs`: pure `gdn_fused_verify_k2_from` so polarity is unit-testable without process env. Unset / `=0` / junk → ON; only `ATLAS_NO_GDN_FUSED_VERIFY=1` kills.
- One-shot INFO: `GDN fused K=2 verify ENGAGED … kill switch ATLAS_NO_GDN_FUSED_VERIFY=1`
- Obsolete `ATLAS_GDN_FUSED_VERIFY` is ignored (warned once)
- Call site still requires both fused kernel handles (NULL → per-token path)

## Image proof on :8888

Same flags both sides (`--gpu-memory-utilization 0.50`). Same five prompts, temperature 0. Short 2-token replies are noise; 220-token lifecycle tok/s is the metric.

Baseline image `atlas-gb10:pr-proof-1b906f0` (#478–#481 + #485). After image `atlas-gb10:pr-proof-321128d` layers this binary on that runtime. Git PR is this one commit on `origin/main` (`35c5a46`); the combined proof stack was not pushed.

### Smoking gun

Baseline: **zero** `GDN fused K=2 verify` lines.

After (once, first K=2 verify; no recapture):

```
GDN fused K=2 verify ENGAGED: one conv1d+L2norm launch + inline pos-0 snapshot
  (was two conv launches + copy_d2d per SSM layer); kill switch ATLAS_NO_GDN_FUSED_VERIFY=1
FP8 calibration frozen — re-enabling CUDA graphs
CUDA graph captured successfully for slot=0
Captured CUDA graph for MTP propose (full)
Captured CUDA graph for K=2 verify (slot=0)
```

`destroy_graph` count: **0**. Graph captures: **3** (decode / propose / K=2 verify), each once. K2 accept stayed **80–81%**.

### Before / after (220-token lifecycle)

| Prompt | Answer | Baseline tok/s | After tok/s |
|---|---|---|---|
| What is 2+2? (max_tokens=16) | `4` | noise | noise |
| Capital of France | `Paris` | noise | noise |
| Sky color | `Blue` | noise | noise |
| 220-token BST explanation | coherent | **124.4** (TTFT 117ms, cold) / 128.3 (TTFT 75.6ms, hours-warm) | **124.9** (TTFT 118ms, cold) / 125.3 (TTFT 117ms, 2nd pass) |
| 220-token hash-table collisions | coherent | **126.3** (TTFT 76.1ms) / 126.9 (TTFT 76.8ms) | **126.9** (TTFT 77.0ms) / 126.9 (TTFT 77.7ms) |

Verify `fwd`: **12.0–12.1 ms → 11.82–12.11 ms** (best warm window 11.82). Propose still ~2.16–2.21 ms. Tok/s is noise-floor; the log invariant is capture-once ENGAGED vs never. Remaining `fwd` is NVFP4 active-parameter traffic (~11 ms roofline).

Local tag only (`atlas-gb10:pr-proof-321128d`). Not pushed to `avarok/atlas-gb10:latest`. `:8888` left on the proven image. Rollback: `atlas-pr-proof-1b906f0-keep`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests`
- [x] `bash scripts/check-license-headers.sh`
- [x] Polarity tests: unset/`=0`/junk → ON; `=1` → kill (`cargo test -p spark-model --lib gdn_fused_verify`)
- [x] Image-proven on GB10 `:8888` against `nvidia/Qwen3.6-35B-A3B-NVFP4` (table above)

## Notes for reviewers

- Fused kernels were already compiled, loaded, and microtested byte-identical (`gdn_verify_fused_microtest`, cos ≥ 0.99999, `--fmad=false`). This PR only changes default polarity + the serve-log smoking gun.
- A 2026-07 campaign A/B on a ~43 ms TPOT regime called L1 “dead”. Inside today’s graphed ~12 ms `fwd` the launch/D2D fold is still the right default; tok/s does not move much because graphs already ate launch overhead. Fewer graph nodes + no idle linked kernels.
- `=0` does **not** disable (house `== "1"` kill). Presence-style `ATLAS_NO_GDN_WY2_RESIDENT` is a different convention and is unchanged.
- Do not lower the wy2 resident width gate; C=1 still logs `NOT engaged (n=1 vs min width 16)` on purpose.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md). (facepunch47 is signed)
