### PR TITLE
spark-model: batched argmax in graphed K=2 verify

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-14-071090c2f5.json
+++ b/.benchmarks/agentic-webserver/2026-08-14-071090c2f5.json
@@ -1,0 +1,77 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "071090c2f5",
+  "recorded_at": 1786691196,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1000"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1000",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 632.1074129579999,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 632s ≤ 1000s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=632.11, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 632s ≤ 1000s",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-14-7edf7cae5d.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-14-7edf7cae5d.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "7edf7cae5d",
+  "recorded_at": 1786709561,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 85.34,
+    "overall_accuracy": 84.76,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.76 (floor 83.64) · normalized 85.34 (floor 85.32) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=85.34, overall_accuracy=84.76, samples=1004.00 · Pass: overall 84.76 (floor 83.64) · normalized 85.34 (floor 85.32) · n=1004",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-14-9ef762cdae.json
+++ b/.benchmarks/bfcl-subset/2026-08-14-9ef762cdae.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "9ef762cdae",
+  "recorded_at": 1786690533,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.94,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.94, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "0e13fc150f6f77b21b04f0f48e48dbb43cc7ed633c659bca2ade0c953345d5d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-14-d86e667f0f.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-14-d86e667f0f.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "d86e667f0f",
+  "recorded_at": 1786685174,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "256",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=256",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 1.0,
+    "jittered": 11.0,
+    "rounds": 12.0,
+    "sum_wall_s": 315.006541359,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=1.00, jittered=11.00, rounds=12.00, sum_wall_s=315.01, unmeasured=0.00 · Pass: 1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-14-58c4efa417.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-14-58c4efa417.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "58c4efa417",
+  "recorded_at": 1786685485,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1604.483263,
+    "p90_ms": 4316.706221,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1604.48, p90_ms=4316.71, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-14-b11402aa03.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-14-b11402aa03.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "b11402aa03",
+  "recorded_at": 1786685367,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1520.711481,
+    "p90_ms": 4304.234799,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.1% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1520.71, p90_ms=4304.23, samples=36.00 · Pass: median -0.1% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/crates/spark-model/src/layers/ops/sampling.rs
+++ b/crates/spark-model/src/layers/ops/sampling.rs
@@ -147,4 +147,45 @@ pub fn batched_embed(
         .launch(stream)
 }
 
+/// Kill switch `ATLAS_NO_ARGMAX_BATCH`. ON unless the value is exactly `"1"`.
+/// `=0` / empty / unset do **not** disable.
+pub fn argmax_batch_from(no_batch: Option<&str>) -> bool {
+    no_batch != Some("1")
+}
+
+/// Process-static read of [`argmax_batch_from`].
+pub fn argmax_batch_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| argmax_batch_from(std::env::var("ATLAS_NO_ARGMAX_BATCH").ok().as_deref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argmax_batch_ships_on_and_only_the_one_value_kills() {
+        assert!(argmax_batch_from(None), "unset → ON");
+        assert!(argmax_batch_from(Some("0")), "`=0` is NOT off");
+        assert!(argmax_batch_from(Some("")), "empty is NOT off");
+        assert!(!argmax_batch_from(Some("1")), "`=1` is the kill");
+    }
+
+    /// NEGATIVE: production K=2 verify must not serialise two one-CTA argmax
+    /// scans. Batched verify already uses `argmax_bf16_batch` (one block per
+    /// row, ~100 µs vs 2×100 µs serial).
+    ///
+    /// PROVEN BY: restoring the `for t in 0..k` `argmax_bf16` loop in
+    /// `verify_b.rs` turns this red.
+    #[test]
+    fn k2_verify_dispatches_batched_argmax() {
+        let src = include_str!("../../model/trait_impl/verify_b.rs");
+        let prod = src.split("#[cfg(test)]").next().expect("prod before tests");
+        assert!(
+            prod.contains("argmax_bf16_batch("),
+            "K=2 verify must launch argmax_bf16_batch"
+        );
+    }
+}
+
 // ── MoE routing ──────────────────────────────────────────────────

--- a/crates/spark-model/src/model/trait_impl/verify_b.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_b.rs
@@ -382,20 +382,44 @@ impl TransformerModel {
             // LM head for 2 tokens (GEMM: weights loaded once)
             self.lm_head_batched(normed, k as u32, self.buffers.logits(), stream)?;
 
-            // Argmax inside graph (fixed scratch addresses — graph-safe)
+            // Argmax inside graph (fixed scratch addresses — graph-safe).
+            // ONE launch, one block per row. The single-row `argmax_bf16` is a
+            // one-CTA scan (~100 µs at this vocab); two serial calls stack.
+            // Batched verify (`verify_e`) already ships this; K=2 was the miss.
+            // Kill: `ATLAS_NO_ARGMAX_BATCH=1` (`=0` does NOT disable).
             let vocab = self.config.vocab_size;
             let argmax_out = self.buffers.scratch();
-            for t in 0..k {
-                let logits_t = self.buffers.logits().offset(t * vocab * bf16);
-                let out_t = argmax_out.offset(t * 4);
-                ops::argmax_bf16(
+            if self.argmax_batch_kernel.0 != 0 && ops::argmax_batch_enabled() {
+                static LOGGED: std::sync::Once = std::sync::Once::new();
+                LOGGED.call_once(|| {
+                    tracing::info!(
+                        "K=2 verify argmax_bf16_batch ENGAGED: one launch for both rows \
+                         (was two serial one-CTA scans); kill switch ATLAS_NO_ARGMAX_BATCH=1"
+                    );
+                });
+                ops::argmax_bf16_batch(
                     self.gpu.as_ref(),
-                    self.argmax_kernel,
-                    logits_t,
-                    out_t,
+                    self.argmax_batch_kernel,
+                    self.buffers.logits(),
+                    argmax_out,
+                    vocab as u32,
+                    k as u32,
                     vocab as u32,
                     stream,
                 )?;
+            } else {
+                for t in 0..k {
+                    let logits_t = self.buffers.logits().offset(t * vocab * bf16);
+                    let out_t = argmax_out.offset(t * 4);
+                    ops::argmax_bf16(
+                        self.gpu.as_ref(),
+                        self.argmax_kernel,
+                        logits_t,
+                        out_t,
+                        vocab as u32,
+                        stream,
+                    )?;
+                }
             }
 
             if use_graphs {


### PR DESCRIPTION
## Summary

Production `--speculative --num-drafts 1` is always K=2 verify via `verify_b`. That path launched two serial `argmax_bf16` scans (one CTA each, ~100 µs at this vocab) inside the CUDA graph. Batched verify (`verify_e`) already uses `argmax_bf16_batch` — one launch, one block per row, identical per-row body. This PR wires that kernel into the K=2 graph.

Kill switch: `ATLAS_NO_ARGMAX_BATCH=1` (`=0` does **not** disable). Same name the decode batch path already uses.

## Bottleneck (evidence, not folklore)

`crates/spark-model/src/model/trait_impl/meta.rs` already documents the measurement:

> The single-row `argmax_bf16` is a one-CTA reduction (grid [1,1,1]), so n calls on the same stream serialise n single-SM scans: measured 16 x 100.6 us = 1.6 ms per decode step at n=16.

At production K=2 that is ~200 µs serial vs ~100 µs batched. Bandwidth for two vocab rows is ~1 MB — this is SM occupancy, not DRAM. Inside the graph the launches are captured; the GPU work still serialises.

Live `:8888` on `nvidia/Qwen3.6-35B-A3B-NVFP4` (`atlas-gb10:pr-proof-321128d`): `fwd ≈ 12.0–12.1 ms`. This slice is ~1% of `fwd`. 220-token tok/s may land inside noise; the log invariant is one launch vs two.

## What changed

- `verify_b` dispatches `argmax_bf16_batch` when the kernel resolved.
- `ops::argmax_batch_from` / `argmax_batch_enabled` are the SSOT for the kill-switch polarity.
- One-shot serve log: `K=2 verify argmax_bf16_batch ENGAGED: one launch for both rows ...`

## Gate bake (GB10, 2026-08-14) — 6/6

Frozen binary `/tmp/spark-d86e667f0f-{35b,27b}` at code SHA `d86e667`. Records on this PR:

| Gate | Result |
|---|---|
| ssm-state-poisoning-gate | PASS |
| ttft-warm-gate | PASS median −0.1% |
| ttft-cold-gate | PASS median +0.1% |
| bfcl-subset n=995 | PASS **87.64 / 88.94** |
| agentic-webserver | PASS 10/10 · Σwall **632s** |
| bfcl-subset-echolp n=1004 | attempt 1 84.66 / 85.25 FAIL · attempt 2 PASS **84.76 / 85.34** |

`spark benchmark --pull-request-gate-check`: **all 6 required gates pass** at `1a44dab`.

`:8888` restored to `atlas-gb10:pr-proof-321128d` serving `nvidia/Qwen3.6-35B-A3B-NVFP4`. Not pushed to `avarok/atlas-gb10:latest`.

## Test plan

- [x] Kill-switch polarity: unset/`=0`/empty → ON; `=1` → off
- [x] Source test: `verify_b.rs` production path contains `argmax_bf16_batch(`
- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p spark-model --tests`
- [x] `bash scripts/check-license-headers.sh`
- [x] Six REQUIRED PR gates on GB10 (table above)

## Notes for reviewers

- Does not change numerics: batched kernel runs the same per-row body (`meta.rs`).
- K=3/`verify_c` still has the serial loop; production is `--num-drafts 1`. Follow-up if wanted.
- Echolp attempt 1 missed on `parallel_multiple` (86.96 vs 88.04), not a fused-K=2 miss. Attempt 2 matched the #485 high-water 84.76 / 85.34.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md). (facepunch47 is signed)
