### PR TITLE
kernels: cp.async prefetch for w4a16_gemv_batch2 (opt-in)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -240,3 +240,11 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "w4a16_qg_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "w4a16_batch2_cpasync_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "w4a16_batch2_bw_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/w4a16_batch2_bw_microtest.rs
+++ b/crates/spark-model/examples/w4a16_batch2_bw_microtest.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Cold-DRAM bandwidth microtest: `w4a16_gemv_batch2` vs
+//! `w4a16_gemv_batch2_cpasync` on Qwen3.6-35B K=2 shapes.
+//!
+//! Weight copies cycle past L2 so every launch streams from DRAM the way a
+//! real K=2 verify step does. Bandwidth is unique packed+scale bytes / time.
+//! Peak default 273 GB/s (GB10 LPDDR5X). `ATLAS_PEAK_GBPS` overrides.
+//!
+//! Exit 0 if cpasync is not slower than batch2 by more than 3% on the two
+//! production shapes. Informational GB/s is always printed.
+//!
+//! Run:
+//!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b \
+//!   ATLAS_TARGET_QUANT=nvfp4 cargo run -p spark-model --release \
+//!     --features cuda,gpu-examples --example w4a16_batch2_bw_microtest
+
+use anyhow::Result;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+use std::time::Instant;
+
+const WARMUP: usize = 8;
+const ITERS: usize = 40;
+const COLD_CYCLE_BYTES: usize = 256 << 20;
+const M: usize = 2;
+
+const SHAPES: &[(&str, u32, u32)] = &[
+    ("gdn in_proj N=12288 K=2048", 12288, 2048),
+    ("attn Q      N=8192  K=2048", 8192, 2048),
+    ("gdn out     N=2048  K=4096", 2048, 4096),
+];
+
+struct XorShift(u64);
+impl XorShift {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn byte(&mut self) -> u8 {
+        (self.next() >> 32) as u8
+    }
+    fn unit_f32(&mut self) -> f32 {
+        ((self.next() >> 40) as f32) / ((1u64 << 23) as f32) * 2.0 - 1.0
+    }
+}
+
+fn f32_to_bf16_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let rounding = 0x7fff + ((bits >> 16) & 1);
+    ((bits + rounding) >> 16) as u16
+}
+
+fn launch(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    b: DevicePtr,
+    bs: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(b)
+        .arg_ptr(bs)
+        .arg_f32(1.0)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+struct Timed {
+    name: &'static str,
+    us: f64,
+    gbps: f64,
+}
+
+fn time_kernel(
+    g: &dyn GpuBackend,
+    name: &'static str,
+    kh: KernelHandle,
+    a: DevicePtr,
+    copies: &[(DevicePtr, DevicePtr)],
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+    weight_bytes: usize,
+) -> Result<Timed> {
+    let go = |i: usize| {
+        launch(
+            g,
+            kh,
+            a,
+            copies[i % copies.len()].0,
+            copies[i % copies.len()].1,
+            c,
+            n,
+            k,
+        )
+    };
+    for i in 0..WARMUP {
+        go(i)?;
+    }
+    g.synchronize(0)?;
+    let t0 = Instant::now();
+    for i in 0..ITERS {
+        go(WARMUP + i)?;
+    }
+    g.synchronize(0)?;
+    let us = t0.elapsed().as_secs_f64() * 1e6 / ITERS as f64;
+    let gbps = weight_bytes as f64 / (us * 1e-6) / 1e9;
+    Ok(Timed { name, us, gbps })
+}
+
+fn main() -> Result<()> {
+    let g0 = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &g0;
+    let peak: f64 = std::env::var("ATLAS_PEAK_GBPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(273.0);
+
+    let b2 = g.kernel("w4a16_gemv", "w4a16_gemv_batch2");
+    let cp = g.kernel("w4a16_gemv", "w4a16_gemv_batch2_cpasync");
+    let m1 = g.kernel("w4a16_gemv", "w4a16_gemv");
+    let (Ok(b2), Ok(cp), Ok(m1)) = (b2, cp, m1) else {
+        eprintln!("w4a16 GEMV kernels absent — SKIP");
+        std::process::exit(2);
+    };
+
+    eprintln!("W4A16 batch2 cp.async cold-DRAM  peak {peak:.0} GB/s, {ITERS} iters\n");
+
+    let mut rng = XorShift(0x9E3779B97F4A7C15);
+    let mut ok = true;
+    for &(label, n, k) in SHAPES {
+        let (n_us, k_us) = (n as usize, k as usize);
+        let packed_bytes = n_us * k_us / 2;
+        let scale_bytes = n_us * k_us / 16;
+        let weight_bytes = packed_bytes + scale_bytes;
+        let copies_n = (COLD_CYCLE_BYTES.div_ceil(weight_bytes)).clamp(1, 16);
+
+        let a_host: Vec<u16> = (0..M * k_us)
+            .map(|_| f32_to_bf16_bits(rng.unit_f32()))
+            .collect();
+        let b_host: Vec<u8> = (0..packed_bytes).map(|_| rng.byte()).collect();
+        let bs_host: Vec<u8> = (0..scale_bytes)
+            .map(|_| 0x18 + (rng.byte() & 0x0F))
+            .collect();
+
+        let a = g.alloc(M * k_us * 2)?;
+        let c = g.alloc(M * n_us * 2)?;
+        let a_bytes: Vec<u8> = a_host.iter().flat_map(|v| v.to_le_bytes()).collect();
+        g.copy_h2d(&a_bytes, a)?;
+        let mut copies = Vec::with_capacity(copies_n);
+        for _ in 0..copies_n {
+            let b = g.alloc(packed_bytes)?;
+            let bs = g.alloc(scale_bytes)?;
+            g.copy_h2d(&b_host, b)?;
+            g.copy_h2d(&bs_host, bs)?;
+            copies.push((b, bs));
+        }
+
+        let floor_us = weight_bytes as f64 / (peak * 1e9) * 1e6;
+        eprintln!(
+            "── {label}  weights {:.2} MB × {copies_n} copies, floor {floor_us:.1} us ──",
+            weight_bytes as f64 / 1e6
+        );
+
+        let t_m1 = time_kernel(g, "gemv M=1", m1, a, &copies, c, n, k, weight_bytes)?;
+        let t_b2 = time_kernel(g, "batch2", b2, a, &copies, c, n, k, weight_bytes)?;
+        let t_cp = time_kernel(g, "batch2_cpasync", cp, a, &copies, c, n, k, weight_bytes)?;
+        for t in [&t_m1, &t_b2, &t_cp] {
+            eprintln!(
+                "  {:<16} {:>8.2} us  {:>6.1} GB/s  {:>5.1}% peak  {:>5.2}x floor",
+                t.name,
+                t.us,
+                t.gbps,
+                100.0 * t.gbps / peak,
+                t.us / floor_us,
+            );
+        }
+        let vs = t_cp.us / t_b2.us;
+        eprintln!("  cpasync / batch2 = {vs:.3}x   (target <1.0; fail if >1.03)\n");
+        if vs > 1.03 {
+            ok = false;
+        }
+
+        g.free(a)?;
+        g.free(c)?;
+        for (b, bs) in copies {
+            g.free(b)?;
+            g.free(bs)?;
+        }
+    }
+
+    if ok {
+        eprintln!("PASS — cpasync is not a bandwidth regression vs batch2");
+        Ok(())
+    } else {
+        eprintln!("FAIL — cpasync is >3% slower than batch2 on a production shape");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/examples/w4a16_batch2_cpasync_microtest.rs
+++ b/crates/spark-model/examples/w4a16_batch2_cpasync_microtest.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! BYTE-parity oracle for `w4a16_gemv_batch2_cpasync` vs current batch2
+//! (template `w4a16_gemv_batchm_impl<2>`) and vs 2× `w4a16_gemv`.
+//!
+//! PASS bar is bit_id == 100% on production 35B shapes, especially GDN
+//! in_proj 12288×2048 and attn Q 8192×2048. A cosine gate hid the last
+//! FMA-order defect — this compares RAW BF16 bytes.
+//!
+//! Run:
+//!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b \
+//!   ATLAS_TARGET_QUANT=nvfp4 cargo run -p spark-model --release \
+//!     --features cuda,gpu-examples --example w4a16_batch2_cpasync_microtest
+//!
+//! Exit: 0 all legs byte-identical, 1 any mismatch, 2 kernels absent.
+
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+const GROUP_SIZE: usize = 16;
+const SCALE2: f32 = 0.0123_f32;
+const M: usize = 2;
+
+/// Production Qwen3.6-35B-A3B-NVFP4 K=2 shapes + tails that exercise the
+/// two-phase mapping (K=2048 = one superwave; K=4096 = two).
+const SHAPES: [(&str, usize, usize); 6] = [
+    ("gdn in_proj  [12288 x 2048]", 12288, 2048),
+    ("attn Q       [ 8192 x 2048]", 8192, 2048),
+    ("gdn out_proj [ 2048 x 4096]", 2048, 4096),
+    ("attn o_proj  [ 2048 x 2048]", 2048, 2048),
+    ("N%4!=0 tail  [ 2050 x 2048]", 2050, 2048),
+    ("K-tail       [ 2048 x 2032]", 2048, 2032),
+];
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (((self.0 >> 11) as f64) / ((1u64 << 53) as f64)) as f32
+    }
+    fn r(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+fn up(g: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let p = g.alloc(bytes.len().max(1))?;
+    g.copy_h2d(bytes, p)?;
+    Ok(p)
+}
+
+fn down(g: &dyn GpuBackend, p: DevicePtr, n_bytes: usize) -> Result<Vec<u8>> {
+    let mut b = vec![0u8; n_bytes];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b)
+}
+
+fn worst_delta(a: &[u8], b: &[u8]) -> (usize, f32) {
+    let mut n_diff = 0usize;
+    let mut worst = 0f32;
+    for (x, y) in a.chunks_exact(2).zip(b.chunks_exact(2)) {
+        if x != y {
+            n_diff += 1;
+            let fx = bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32();
+            let fy = bf16::from_bits(u16::from_le_bytes([y[0], y[1]])).to_f32();
+            worst = worst.max((fx - fy).abs());
+        }
+    }
+    (n_diff, worst)
+}
+
+fn launch_batch2(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    w: DevicePtr,
+    ws: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(w)
+        .arg_ptr(ws)
+        .arg_f32(SCALE2)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+fn launch_m1(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    w: DevicePtr,
+    ws: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(w)
+        .arg_ptr(ws)
+        .arg_f32(SCALE2)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+fn gen_inputs(seed: u64, n: usize, k: usize) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let mut rng = Lcg(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xB4B4);
+    let a = (0..M * k)
+        .flat_map(|_| bf16::from_f32(rng.r(-1.5, 1.5)).to_bits().to_le_bytes())
+        .collect();
+    let w = (0..n * k / 2).map(|_| rng.r(0.0, 256.0) as u8).collect();
+    let ws = (0..n * k / GROUP_SIZE)
+        .map(|_| 0x30u8 + (rng.r(0.0, 24.0) as u8))
+        .collect();
+    (a, w, ws)
+}
+
+fn report(tag: &str, seed: u64, label: &str, a: &[u8], b: &[u8]) -> bool {
+    let identical = a == b;
+    let (n_diff, worst) = worst_delta(a, b);
+    let bit_id = if a.is_empty() {
+        100.0
+    } else {
+        100.0 * (1.0 - n_diff as f64 / (a.len() / 2) as f64)
+    };
+    println!(
+        "seed {seed:>5}  {label}  {tag:<18} byte-identical={identical:<5} \
+         bit_id={bit_id:>7.3}%  diff_elems={n_diff:<7} max|delta|={worst:.6}"
+    );
+    identical
+}
+
+fn main() -> Result<()> {
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &backend;
+    let m1 = g.kernel("w4a16_gemv", "w4a16_gemv");
+    let b2 = g.kernel("w4a16_gemv", "w4a16_gemv_batch2");
+    let cp = g.kernel("w4a16_gemv", "w4a16_gemv_batch2_cpasync");
+    let (Ok(m1), Ok(b2), Ok(cp)) = (m1, b2, cp) else {
+        println!("w4a16 GEMV batch2/cpasync kernels absent — SKIP");
+        std::process::exit(2);
+    };
+
+    let mut clean = true;
+    let mut control_ok = true;
+    for seed in [1u64, 99, 12345] {
+        for (label, n, k) in SHAPES {
+            let (a, w, ws) = gen_inputs(seed, n, k);
+            let a_d = up(g, &a)?;
+            let w_d = up(g, &w)?;
+            let ws_d = up(g, &ws)?;
+            let c_cp = g.alloc(M * n * 2)?;
+            let c_b2 = g.alloc(M * n * 2)?;
+            let c_m1 = g.alloc(M * n * 2)?;
+            g.memset(c_cp, 0, M * n * 2)?;
+            g.memset(c_b2, 0, M * n * 2)?;
+            g.memset(c_m1, 0, M * n * 2)?;
+
+            launch_batch2(g, cp, a_d, w_d, ws_d, c_cp, n as u32, k as u32)?;
+            launch_batch2(g, b2, a_d, w_d, ws_d, c_b2, n as u32, k as u32)?;
+            for t in 0..M {
+                launch_m1(
+                    g,
+                    m1,
+                    a_d.offset(t * k * 2),
+                    w_d,
+                    ws_d,
+                    c_m1.offset(t * n * 2),
+                    n as u32,
+                    k as u32,
+                )?;
+            }
+            g.synchronize(0)?;
+            let out_cp = down(g, c_cp, M * n * 2)?;
+            let out_b2 = down(g, c_b2, M * n * 2)?;
+            let out_m1 = down(g, c_m1, M * n * 2)?;
+            clean &= report("cpasync vs batch2", seed, label, &out_cp, &out_b2);
+            clean &= report("cpasync vs 2x gemv", seed, label, &out_cp, &out_m1);
+
+            let mut pert = a.clone();
+            pert[2 * (k + 7)] ^= 1;
+            let a_pert = up(g, &pert)?;
+            g.memset(c_b2, 0, M * n * 2)?;
+            launch_batch2(g, b2, a_pert, w_d, ws_d, c_b2, n as u32, k as u32)?;
+            g.synchronize(0)?;
+            let differs = down(g, c_b2, M * n * 2)? != out_cp;
+            control_ok &= differs;
+            println!("seed {seed:>5}  {label}  CONTROL 1-ULP perturbation detected={differs}");
+            g.free(a_pert).ok();
+            for p in [a_d, w_d, ws_d, c_cp, c_b2, c_m1] {
+                g.free(p).ok();
+            }
+        }
+    }
+
+    if !control_ok {
+        println!("FAIL — negative control did not mismatch; harness is VACUOUS.");
+        std::process::exit(1);
+    }
+    if clean {
+        println!(
+            "PASS — w4a16_gemv_batch2_cpasync is byte-identical to batch2 and to \
+             2 x w4a16_gemv at every 35B production shape."
+        );
+        Ok(())
+    } else {
+        println!("FAIL — cpasync is NOT byte-identical (do not ship).");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -335,7 +335,7 @@ impl DenseFfnLayer {
             ),
             w4a16_gemv_dual_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch2")?,
             w4a16_gemv_dual_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
-            w4a16_gemv_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
+            w4a16_gemv_batch2: crate::layers::ops::resolve_w4a16_gemv_batch2(gpu)?,
             w4a16_gemv_batch3: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,
             w4a16_gemv_batch4: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch4"),
             w4a16_gemv_batch8: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch8"),

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -104,7 +104,7 @@ impl MoeLayer {
                 .kernel("moe_fused_batch2", "moe_expert_silu_down_shared_batch2")?,
             moe_weighted_sum_blend_batch2: gpu
                 .kernel("moe_fused_batch2", "moe_weighted_sum_blend_batch2")?,
-            w4a16_gemv_batch2: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
+            w4a16_gemv_batch2: crate::layers::ops::resolve_w4a16_gemv_batch2(gpu)?,
             moe_expert_gate_up_shared_batch3: gpu
                 .kernel("moe_fused_batch3", "moe_expert_gate_up_shared_batch3")?,
             moe_expert_silu_down_shared_batch3: gpu

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -55,6 +55,8 @@ pub use model_stats::ModelStats;
 mod gemm_fp8_prefill;
 #[path = "ops/gemm_quant.rs"]
 mod gemm_quant;
+#[path = "ops/gemv_batch2.rs"]
+mod gemv_batch2;
 #[path = "ops/gemv_q2.rs"]
 mod gemv_q2;
 #[path = "ops/gemv_q2_vec.rs"]
@@ -149,6 +151,7 @@ pub use gemm_dense_int8::*;
 pub use gemm_fp4::*;
 pub use gemm_fp8_prefill::*;
 pub use gemm_quant::*;
+pub use gemv_batch2::*;
 pub use gemv_q2::*;
 pub use gemv_q2_vec::*;
 pub use gemv_sw::*;

--- a/crates/spark-model/src/layers/ops/gemv_batch2.rs
+++ b/crates/spark-model/src/layers/ops/gemv_batch2.rs
@@ -1,36 +1,37 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Default-ON cp.async `w4a16_gemv_batch2_cpasync` dispatch.
+//! Opt-in cp.async `w4a16_gemv_batch2_cpasync` dispatch.
 //!
-//! Same grid/block/signature as `w4a16_gemv_batch2`. Kill with
-//! `ATLAS_NO_GEMV_BATCH2_CPASYNC=1` (`=0` does **not** disable). Missing
-//! kernel handle falls back to the template `w4a16_gemv_batch2`.
+//! Same grid/block/signature as `w4a16_gemv_batch2`. GB10 cold-DRAM was
+//! 5–16% slower than template batch2, so this stays off unless
+//! `ATLAS_GEMV_BATCH2_CPASYNC=1`. Missing kernel handle falls back to
+//! the template `w4a16_gemv_batch2`.
 
 use anyhow::Result;
 use spark_runtime::gpu::{GpuBackend, KernelHandle};
 use std::sync::OnceLock;
 
-/// Kill-switch env var. Presence of the name is not enough — value must be `"1"`.
-pub const DISABLE_ENV: &str = "ATLAS_NO_GEMV_BATCH2_CPASYNC";
+/// Opt-in env var. Presence of the name is not enough — value must be `"1"`.
+pub const ENABLE_ENV: &str = "ATLAS_GEMV_BATCH2_CPASYNC";
 
 const MODULE: &str = "w4a16_gemv";
 const FALLBACK: &str = "w4a16_gemv_batch2";
 const CPASYNC: &str = "w4a16_gemv_batch2_cpasync";
 
-/// ON unless `ATLAS_NO_GEMV_BATCH2_CPASYNC` is exactly `"1"`.
+/// ON only when `ATLAS_GEMV_BATCH2_CPASYNC` is exactly `"1"`.
 pub fn batch2_cpasync_from(val: Option<&str>) -> bool {
-    val != Some("1")
+    val == Some("1")
 }
 
-/// Resolve the live K=2 NVFP4 GEMV handle. Default is the cp.async kernel.
+/// Resolve the live K=2 NVFP4 GEMV handle. Default is template batch2.
 pub fn resolve_w4a16_gemv_batch2(gpu: &dyn GpuBackend) -> Result<KernelHandle> {
     static LOGGED: OnceLock<bool> = OnceLock::new();
-    let on = batch2_cpasync_from(std::env::var(DISABLE_ENV).ok().as_deref());
+    let on = batch2_cpasync_from(std::env::var(ENABLE_ENV).ok().as_deref());
     if on {
         let h = super::super::try_kernel(gpu, MODULE, CPASYNC);
         if h.0 != 0 {
             LOGGED.get_or_init(|| {
-                tracing::info!("w4a16_gemv_batch2_cpasync ON (kill {DISABLE_ENV}=1)");
+                tracing::info!("w4a16_gemv_batch2_cpasync ON ({ENABLE_ENV}=1)");
                 true
             });
             return Ok(h);
@@ -50,11 +51,11 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     #[test]
-    fn cpasync_ships_on_and_only_the_one_value_kills() {
-        assert!(batch2_cpasync_from(None), "unset → ON");
-        assert!(batch2_cpasync_from(Some("0")), "`=0` is NOT off");
-        assert!(batch2_cpasync_from(Some("")), "empty is NOT off");
-        assert!(!batch2_cpasync_from(Some("1")), "`=1` is the kill");
+    fn cpasync_is_opt_in() {
+        assert!(!batch2_cpasync_from(None), "unset → OFF");
+        assert!(!batch2_cpasync_from(Some("0")), "`=0` does not enable");
+        assert!(!batch2_cpasync_from(Some("")), "empty does not enable");
+        assert!(batch2_cpasync_from(Some("1")), "`=1` is the opt-in");
     }
 
     fn kernel_root() -> PathBuf {

--- a/crates/spark-model/src/layers/ops/gemv_batch2.rs
+++ b/crates/spark-model/src/layers/ops/gemv_batch2.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Default-ON cp.async `w4a16_gemv_batch2_cpasync` dispatch.
+//!
+//! Same grid/block/signature as `w4a16_gemv_batch2`. Kill with
+//! `ATLAS_NO_GEMV_BATCH2_CPASYNC=1` (`=0` does **not** disable). Missing
+//! kernel handle falls back to the template `w4a16_gemv_batch2`.
+
+use anyhow::Result;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+use std::sync::OnceLock;
+
+/// Kill-switch env var. Presence of the name is not enough — value must be `"1"`.
+pub const DISABLE_ENV: &str = "ATLAS_NO_GEMV_BATCH2_CPASYNC";
+
+const MODULE: &str = "w4a16_gemv";
+const FALLBACK: &str = "w4a16_gemv_batch2";
+const CPASYNC: &str = "w4a16_gemv_batch2_cpasync";
+
+/// ON unless `ATLAS_NO_GEMV_BATCH2_CPASYNC` is exactly `"1"`.
+pub fn batch2_cpasync_from(val: Option<&str>) -> bool {
+    val != Some("1")
+}
+
+/// Resolve the live K=2 NVFP4 GEMV handle. Default is the cp.async kernel.
+pub fn resolve_w4a16_gemv_batch2(gpu: &dyn GpuBackend) -> Result<KernelHandle> {
+    static LOGGED: OnceLock<bool> = OnceLock::new();
+    let on = batch2_cpasync_from(std::env::var(DISABLE_ENV).ok().as_deref());
+    if on {
+        let h = super::super::try_kernel(gpu, MODULE, CPASYNC);
+        if h.0 != 0 {
+            LOGGED.get_or_init(|| {
+                tracing::info!("w4a16_gemv_batch2_cpasync ON (kill {DISABLE_ENV}=1)");
+                true
+            });
+            return Ok(h);
+        }
+    }
+    LOGGED.get_or_init(|| {
+        tracing::info!("w4a16_gemv_batch2_cpasync OFF (fallback {FALLBACK})");
+        false
+    });
+    gpu.kernel(MODULE, FALLBACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn cpasync_ships_on_and_only_the_one_value_kills() {
+        assert!(batch2_cpasync_from(None), "unset → ON");
+        assert!(batch2_cpasync_from(Some("0")), "`=0` is NOT off");
+        assert!(batch2_cpasync_from(Some("")), "empty is NOT off");
+        assert!(!batch2_cpasync_from(Some("1")), "`=1` is the kill");
+    }
+
+    fn kernel_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../kernels")
+    }
+
+    #[test]
+    fn gb10_gemv_cu_exports_cpasync_kernel_with_cp_async() {
+        let p = kernel_root().join("gb10/common/w4a16_gemv.cu");
+        let src = fs::read_to_string(&p).unwrap();
+        assert!(
+            src.contains("void w4a16_gemv_batch2_cpasync("),
+            "{} missing w4a16_gemv_batch2_cpasync",
+            p.display()
+        );
+        assert!(
+            src.contains("cp.async.ca.shared.global"),
+            "{}: batch2 cpasync path must issue cp.async",
+            p.display()
+        );
+        assert!(
+            src.contains("w4a16_gemv_batchm_fma_chunk<MAX_M>"),
+            "{}: template must call the shared FMA helper",
+            p.display()
+        );
+        assert!(
+            src.contains("w4a16_gemv_batchm_fma_chunk<2>"),
+            "{}: cpasync must share the template FMA helper",
+            p.display()
+        );
+        assert!(
+            src.contains("w4a16_gemv_batchm_impl<2>"),
+            "{}: keep current batch2 as fallback template inst",
+            p.display()
+        );
+    }
+
+    /// NEGATIVE: production init must go through the resolver so the kill
+    /// switch actually selects a kernel. A new `gpu.kernel(..., batch2)` site
+    /// ships the fallback on the default path.
+    #[test]
+    fn init_sites_use_the_resolver_not_raw_batch2() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let needle = format!(
+            "gpu.kernel({q}w4a16_gemv{q}, {q}w4a16_gemv_batch2{q})",
+            q = '"'
+        );
+        let mut offenders = Vec::new();
+        fn visit(d: &Path, needle: &str, out: &mut Vec<String>) {
+            let Ok(rd) = fs::read_dir(d) else { return };
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    visit(&p, needle, out);
+                } else if p.extension().is_some_and(|x| x == "rs") {
+                    let src = fs::read_to_string(&p).unwrap();
+                    if src.contains(needle) {
+                        out.push(p.display().to_string());
+                    }
+                }
+            }
+        }
+        visit(&root, &needle, &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "use ops::resolve_w4a16_gemv_batch2, not raw kernel lookup: {offenders:?}"
+        );
+    }
+}

--- a/crates/spark-model/src/layers/ops/gemv_batch2.rs
+++ b/crates/spark-model/src/layers/ops/gemv_batch2.rs
@@ -90,6 +90,11 @@ mod tests {
             "{}: keep current batch2 as fallback template inst",
             p.display()
         );
+        assert!(
+            src.contains("src16") && src.contains("pair_live"),
+            "{}: 16-byte cp.async must gate on gmem alignment (K-tail)",
+            p.display()
+        );
     }
 
     /// NEGATIVE: production init must go through the resolver so the kill

--- a/crates/spark-model/src/layers/ops/quant_dispatch.rs
+++ b/crates/spark-model/src/layers/ops/quant_dispatch.rs
@@ -133,8 +133,8 @@ pub fn w4a16_gemv(
 /// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)
 ///
 /// Live decode resolves the handle via [`super::gemv_batch2::resolve_w4a16_gemv_batch2`]
-/// (cp.async kernel by default; `ATLAS_NO_GEMV_BATCH2_CPASYNC=1` restores this
-/// template instantiation). The launcher is shared — same grid/args.
+/// (template batch2 by default; `ATLAS_GEMV_BATCH2_CPASYNC=1` selects the
+/// cp.async kernel). The launcher is shared — same grid/args.
 pub fn w4a16_gemv_batch2(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,

--- a/crates/spark-model/src/layers/ops/quant_dispatch.rs
+++ b/crates/spark-model/src/layers/ops/quant_dispatch.rs
@@ -131,6 +131,10 @@ pub fn w4a16_gemv(
 ///
 /// Kernel: `w4a16_gemv_batch2(A, B_packed, B_scale, scale2, C, N, K)`
 /// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)
+///
+/// Live decode resolves the handle via [`super::gemv_batch2::resolve_w4a16_gemv_batch2`]
+/// (cp.async kernel by default; `ATLAS_NO_GEMV_BATCH2_CPASYNC=1` restores this
+/// template instantiation). The launcher is shared — same grid/args.
 pub fn w4a16_gemv_batch2(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -453,7 +453,7 @@ impl Qwen3AttentionLayer {
             ),
             w4a16_gemv_qg_batch2_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_qg_batch2")?,
             w4a16_gemv_dual_batch2_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch2")?,
-            w4a16_gemv_batch2_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
+            w4a16_gemv_batch2_k: crate::layers::ops::resolve_w4a16_gemv_batch2(gpu)?,
             w4a16_gemv_qg_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_qg_batch3")?,
             w4a16_gemv_dual_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_dual_batch3")?,
             w4a16_gemv_batch3_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch3")?,

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -158,7 +158,7 @@ impl Qwen3SsmLayer {
             w4a16_gemm_t_m128_k: gpu.kernel("w4a16", "w4a16_gemm_t_m128")?,
             // 8-warp pipelined M128 (try_kernel: 0 when absent → falls back to m128/n128).
             w4a16_gemm_t_m128_v2_k: super::super::w4a16_v2_kernel(gpu),
-            w4a16_gemv_batch2_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?,
+            w4a16_gemv_batch2_k: crate::layers::ops::resolve_w4a16_gemv_batch2(gpu)?,
             dense_gemm_k: gpu.kernel("gemm", "dense_gemm_bf16")?,
             // try_kernel: 0-handle if absent (gated at dispatch); the pipelined
             // BF16 GEMM lives in the same `gemm` module as dense_gemm_bf16.

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -107,7 +107,7 @@ impl TransformerModel {
             spark_runtime::gpu::KernelHandle(0)
         };
         let w4a16_gemm_kernel = gpu.kernel("w4a16", "w4a16_gemm")?;
-        let w4a16_gemv_batch2_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_batch2")?;
+        let w4a16_gemv_batch2_kernel = crate::layers::ops::resolve_w4a16_gemv_batch2(gpu.as_ref())?;
         // M<=4 batched GEMV for the K=3/K=4 verify lm_head (try_kernel:
         // 0-handle on targets that predate it; dispatch falls back).
         let w4a16_gemv_batch4_kernel =

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -619,11 +619,20 @@ __device__ __forceinline__ void gemv_b2_issue_packed(
         ? B_packed + (unsigned long long)n * half_K + (unsigned long long)kk * 8u
         : B_packed;
     unsigned long long* dst = &smem_pk[buf][local_out][lane];
+    // cp.async 16-byte needs 16-byte-aligned gmem. K/2 % 16 == 8 (K=2032)
+    // puts odd `n` rows at +8; a wide load there is undefined and showed up
+    // as ~50% bit_id on the K-tail oracle. Fall back to 8-byte + odd self-issue.
+    const bool src16 = (((unsigned long long)src) & 15ull) == 0ull;
+    const bool pair_live = live && ((kk ^ 1u) < K16);
     if ((lane & 1u) == 0u) {
-        bool wide = live && (kk + 1u < K16);
+        bool wide = pair_live && src16;
         gemv_cp_async_n(dst, src, wide ? 16u : 8u, live);
-    } else if (live && ((kk ^ 1u) >= K16)) {
-        gemv_cp_async_n(dst, src, 8u, true);
+    } else {
+        const bool covered = pair_live &&
+            (((((unsigned long long)src) - 8ull) & 15ull) == 0ull);
+        if (live && !covered) {
+            gemv_cp_async_n(dst, src, 8u, true);
+        }
     }
 }
 
@@ -670,7 +679,14 @@ extern "C" __global__ void w4a16_gemv_batch2_cpasync(
         gemv_cp_commit();
 
         gemv_cp_wait_one();
+        // Even/odd 16-byte pairing is same-warp; a block barrier here was
+        // serializing 4 output groups and showed up as a 11–20% cold-DRAM
+        // regression vs template batch2.
+#if defined(__HIP_PLATFORM_AMD__)
         __syncthreads();
+#else
+        __syncwarp();
+#endif
         if (n < N && kk0 < K16) {
             unsigned char sb = B_scale[(unsigned long long)n * num_groups + kk0];
             w4a16_gemv_batchm_fma_chunk<2>(
@@ -679,7 +695,11 @@ extern "C" __global__ void w4a16_gemv_batch2_cpasync(
         }
 
         gemv_cp_wait_all();
+#if defined(__HIP_PLATFORM_AMD__)
         __syncthreads();
+#else
+        __syncwarp();
+#endif
         if (n < N && kk1 < K16) {
             unsigned char sb = B_scale[(unsigned long long)n * num_groups + kk1];
             w4a16_gemv_batchm_fma_chunk<2>(

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -556,7 +556,7 @@ extern "C" __global__ void w4a16_gemv_batch2(
 }
 
 // ============================================================
-// W4A16 GEMV batch2 — cp.async 2-stage weight prefetch (default ON).
+// W4A16 GEMV batch2 — cp.async 2-stage weight prefetch (opt-in).
 // ============================================================
 // Bit-identical to `w4a16_gemv_batch2` / `w4a16_gemv_batchm_impl<2>`:
 // same two-phase coalesced K16 mapping, same `w4a16_gemv_batchm_fma_chunk`
@@ -564,7 +564,7 @@ extern "C" __global__ void w4a16_gemv_batch2(
 // smem buffer via cp.async so phase-1 DMA overlaps phase-0 compute.
 // Production Qwen3.6-35B shapes are K=2048 (one wave per phase); larger
 // K walks superwaves of 128 chunks. Scale + activations stay gmem loads
-// (tiny / L1-resident). Kill: ATLAS_NO_GEMV_BATCH2_CPASYNC=1.
+// (tiny / L1-resident). Opt-in: ATLAS_GEMV_BATCH2_CPASYNC=1.
 // HIP: cp.async degrades to synchronous 8/16-byte copies.
 // Grid: (ceil(N/4),1,1)  Block: (256,1,1) — same as batch2.
 

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -391,6 +391,56 @@ extern "C" __global__ void w4a16_gemv_logits(
 //
 // A:[M,K] BF16, B_packed:[N,K/2], B_scale:[N,K/16] FP8-E4M3, scale2 FP32,
 // C:[M,N] BF16. Grid: (ceil(N/4),1,1) Block: (256,1,1).
+
+// Per-chunk MAC shared by `w4a16_gemv_batchm_impl` and the batch2 cp.async
+// kernel. SSOT for FMA order: unpack E2M1, 16 fmaf into `part`, then
+// `acc = fmaf(scale, part, acc)` per row — identical to `w4a16_gemv`.
+template <int MAX_M>
+__device__ __forceinline__ void w4a16_gemv_batchm_fma_chunk(
+    float acc[MAX_M],
+    const __nv_bfloat16* __restrict__ A,
+    unsigned int M, unsigned int K, unsigned int kk,
+    unsigned long long packed8, float scale,
+    const float* s_lut)
+{
+    float wl[16];
+    #pragma unroll
+    for (int b = 0; b < 8; b++) {
+        unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+        wl[b * 2]     = s_lut[byte_val & 0xF];
+        wl[b * 2 + 1] = s_lut[byte_val >> 4];
+    }
+    #pragma unroll
+    for (int t = 0; t < MAX_M; t++) {
+        if ((unsigned int)t >= M) continue;
+        const __nv_bfloat16* At = A + (unsigned long long)t * K;
+        uint4 a_lo = ((const uint4*)At)[kk * 2];
+        uint4 a_hi = ((const uint4*)At)[kk * 2 + 1];
+        const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                    a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+        float part = 0.0f;
+        #pragma unroll
+        for (int b = 0; b < 8; b++) {
+            float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
+            part = fmaf(af.x, wl[b * 2], part);
+            part = fmaf(af.y, wl[b * 2 + 1], part);
+        }
+        acc[t] = fmaf(scale, part, acc[t]);
+    }
+}
+
+__device__ __forceinline__ float w4a16_gemv_decode_scale(
+    unsigned char scale_byte, float scale2)
+{
+    __nv_fp8_e4m3 fp8;
+    *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+    return scl_fp8(scale_byte) * scale2;
+#else
+    return (float)fp8 * scale2;
+#endif
+}
+
 template <int MAX_M>
 __device__ __forceinline__ void w4a16_gemv_batchm_impl(
     const __nv_bfloat16* __restrict__ A,         // [M, K]
@@ -439,44 +489,9 @@ __device__ __forceinline__ void w4a16_gemv_batchm_impl(
             unsigned long long packed8 =
                 *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk * 8);
             unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
-            __nv_fp8_e4m3 fp8;
-            *(unsigned char*)&fp8 = scale_byte;
-#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-            float scale = scl_fp8(scale_byte) * scale2;
-#else
-            float scale = (float)fp8 * scale2;
-#endif
-            // UNSCALED E2M1 values. The group scale stays factored OUT of the
-            // 16-FMA block and is applied once via fmaf(scale, part, acc),
-            // exactly as `w4a16_gemv` does — pre-multiplying it into each
-            // weight is a different FP32 expression.
-            float wl[16];
-            #pragma unroll
-            for (int b = 0; b < 8; b++) {
-                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-                wl[b * 2]     = s_lut[byte_val & 0xF];   // W[2j]   <-> act 2j
-                wl[b * 2 + 1] = s_lut[byte_val >> 4];    // W[2j+1] <-> act 2j+1
-            }
-
-            #pragma unroll
-            for (int t = 0; t < MAX_M; t++) {
-                if ((unsigned int)t >= M) continue;
-                const __nv_bfloat16* At = A + (unsigned long long)t * K;
-                uint4 a_lo = ((const uint4*)At)[kk * 2];
-                uint4 a_hi = ((const uint4*)At)[kk * 2 + 1];
-                const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
-                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
-                // Per-chunk partial in the M=1 kernel's exact FMA order:
-                // TWO separate fmaf per byte, never `part += x*w0 + y*w1`.
-                float part = 0.0f;
-                #pragma unroll
-                for (int b = 0; b < 8; b++) {
-                    float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
-                    part = fmaf(af.x, wl[b * 2], part);
-                    part = fmaf(af.y, wl[b * 2 + 1], part);
-                }
-                acc[t] = fmaf(scale, part, acc[t]);
-            }
+            w4a16_gemv_batchm_fma_chunk<MAX_M>(
+                acc, A, M, K, kk, packed8,
+                w4a16_gemv_decode_scale(scale_byte, scale2), s_lut);
         }
 
         // Threads p and p^1 hold accumulator 0 and 1 of the SAME reference lane
@@ -538,6 +553,175 @@ extern "C" __global__ void w4a16_gemv_batch2(
     unsigned int K
 ) {
     w4a16_gemv_batchm_impl<2>(A, B_packed, B_scale, scale2, C, 2u, N, K);
+}
+
+// ============================================================
+// W4A16 GEMV batch2 — cp.async 2-stage weight prefetch (default ON).
+// ============================================================
+// Bit-identical to `w4a16_gemv_batch2` / `w4a16_gemv_batchm_impl<2>`:
+// same two-phase coalesced K16 mapping, same `w4a16_gemv_batchm_fma_chunk`
+// FMA order. Packed weights (the DRAM stream) move through a 2-stage
+// smem buffer via cp.async so phase-1 DMA overlaps phase-0 compute.
+// Production Qwen3.6-35B shapes are K=2048 (one wave per phase); larger
+// K walks superwaves of 128 chunks. Scale + activations stay gmem loads
+// (tiny / L1-resident). Kill: ATLAS_NO_GEMV_BATCH2_CPASYNC=1.
+// HIP: cp.async degrades to synchronous 8/16-byte copies.
+// Grid: (ceil(N/4),1,1)  Block: (256,1,1) — same as batch2.
+
+__device__ __forceinline__ void gemv_cp_async_n(
+    void* dst_smem, const void* src_gmem, unsigned int nbytes, bool pred)
+{
+#if defined(__HIP_PLATFORM_AMD__)
+    if (!pred) return;
+    if (nbytes == 16u) {
+        *reinterpret_cast<uint4*>(dst_smem) = *reinterpret_cast<const uint4*>(src_gmem);
+    } else {
+        *reinterpret_cast<unsigned long long*>(dst_smem) =
+            *reinterpret_cast<const unsigned long long*>(src_gmem);
+    }
+#else
+    unsigned int dst = __cvta_generic_to_shared(dst_smem);
+    unsigned int n = pred ? nbytes : 0u;
+    if (nbytes == 16u) {
+        asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;"
+                     :: "r"(dst), "l"(src_gmem), "r"(n));
+    } else {
+        asm volatile("cp.async.ca.shared.global [%0], [%1], 8, %2;"
+                     :: "r"(dst), "l"(src_gmem), "r"(n));
+    }
+#endif
+}
+
+__device__ __forceinline__ void gemv_cp_commit() {
+#if !defined(__HIP_PLATFORM_AMD__)
+    asm volatile("cp.async.commit_group;");
+#endif
+}
+__device__ __forceinline__ void gemv_cp_wait_all() {
+#if !defined(__HIP_PLATFORM_AMD__)
+    asm volatile("cp.async.wait_group 0;");
+#endif
+}
+__device__ __forceinline__ void gemv_cp_wait_one() {
+#if !defined(__HIP_PLATFORM_AMD__)
+    asm volatile("cp.async.wait_group 1;");
+#endif
+}
+
+__device__ __forceinline__ void gemv_b2_issue_packed(
+    unsigned long long smem_pk[2][N_PER_BLOCK][64],
+    unsigned int buf, unsigned int local_out, unsigned int lane,
+    unsigned int n, unsigned int N, unsigned int half_K, unsigned int K16,
+    const unsigned char* B_packed, unsigned int kk)
+{
+    const bool live = (n < N) && (kk < K16);
+    const unsigned char* src = live
+        ? B_packed + (unsigned long long)n * half_K + (unsigned long long)kk * 8u
+        : B_packed;
+    unsigned long long* dst = &smem_pk[buf][local_out][lane];
+    if ((lane & 1u) == 0u) {
+        bool wide = live && (kk + 1u < K16);
+        gemv_cp_async_n(dst, src, wide ? 16u : 8u, live);
+    } else if (live && ((kk ^ 1u) >= K16)) {
+        gemv_cp_async_n(dst, src, 8u, true);
+    }
+}
+
+extern "C" __global__ void w4a16_gemv_batch2_cpasync(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
+
+    __shared__ float s_lut[16];
+    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
+    __syncthreads();
+
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int K16 = K / 16;
+
+    __shared__ __align__(16) unsigned long long smem_pk[2][N_PER_BLOCK][64];
+    __shared__ float s_vl[2][N_PER_BLOCK][2 * WARP_SIZE];
+    __shared__ float smem[2][N_PER_BLOCK * 2];
+    float acc0[2], acc1[2];
+    #pragma unroll
+    for (int t = 0; t < 2; t++) { acc0[t] = 0.0f; acc1[t] = 0.0f; }
+
+    // Superwave of 128 K16-chunks = one iteration of each phase. Issue
+    // phase-0 then phase-1 as two cp.async groups so wait_group 1 lets
+    // phase-0 compute overlap phase-1 DMA.
+    for (unsigned int super = 0; super < K16; super += 128u) {
+        const unsigned int kk0 = lane + super;
+        const unsigned int kk1 = lane + super + 64u;
+        gemv_b2_issue_packed(smem_pk, 0, local_out, lane, n, N, half_K, K16,
+                             B_packed, kk0);
+        gemv_cp_commit();
+        gemv_b2_issue_packed(smem_pk, 1, local_out, lane, n, N, half_K, K16,
+                             B_packed, kk1);
+        gemv_cp_commit();
+
+        gemv_cp_wait_one();
+        __syncthreads();
+        if (n < N && kk0 < K16) {
+            unsigned char sb = B_scale[(unsigned long long)n * num_groups + kk0];
+            w4a16_gemv_batchm_fma_chunk<2>(
+                acc0, A, 2u, K, kk0, smem_pk[0][local_out][lane],
+                w4a16_gemv_decode_scale(sb, scale2), s_lut);
+        }
+
+        gemv_cp_wait_all();
+        __syncthreads();
+        if (n < N && kk1 < K16) {
+            unsigned char sb = B_scale[(unsigned long long)n * num_groups + kk1];
+            w4a16_gemv_batchm_fma_chunk<2>(
+                acc1, A, 2u, K, kk1, smem_pk[1][local_out][lane],
+                w4a16_gemv_decode_scale(sb, scale2), s_lut);
+        }
+    }
+
+    if (n < N) {
+        #pragma unroll
+        for (int t = 0; t < 2; t++) {
+            const float v0 = acc0[t] + __shfl_xor_sync(0xFFFFFFFF, acc0[t], 1);
+            const float v1 = acc1[t] + __shfl_xor_sync(0xFFFFFFFF, acc1[t], 1);
+            if ((lane & 1u) == 0u) {
+                s_vl[t][local_out][lane >> 1] = v0;
+                s_vl[t][local_out][WARP_SIZE + (lane >> 1)] = v1;
+            }
+        }
+    }
+    __syncthreads();
+
+    const unsigned int warp_in_out = lane / WARP_SIZE;
+    if (n < N) {
+        #pragma unroll
+        for (int t = 0; t < 2; t++) {
+            float a = s_vl[t][local_out][lane];
+            #pragma unroll
+            for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+                a += __shfl_down_sync(0xFFFFFFFF, a, offset);
+            }
+            if (lane % WARP_SIZE == 0) smem[t][local_out * 2 + warp_in_out] = a;
+        }
+    }
+    __syncthreads();
+
+    if (lane == 0 && n < N) {
+        #pragma unroll
+        for (int t = 0; t < 2; t++) {
+            float r = smem[t][local_out * 2] + smem[t][local_out * 2 + 1];
+            C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+        }
+    }
 }
 
 // M==3 (K=3 spec verify, C=3 multi-seq decode, MoE forward_k3). Same story as


### PR DESCRIPTION
## Summary

Close the leftover K=2 NVFP4 GEMV DRAM gap on GB10 by issuing packed-weight loads through a 2-stage `cp.async` smem pipeline. Graphs already ate launch tax; this is kernel bandwidth, not extra D2D/D2H.

`w4a16_gemv_batch2_cpasync` keeps the current two-phase coalesced K16 mapping and shares `w4a16_gemv_batchm_fma_chunk` with the template, so output is bit-identical to `w4a16_gemv_batch2` / 2× `w4a16_gemv`. The existing `w4a16_gemv_batch2` (`batchm_impl<2>`) stays as the fallback.

**GB10 oracle (2026-08-13): do not ship default-on.** Cold-DRAM cpasync is 5–16% slower than template batch2 (fail the 3% bar). Bit-identity is 100% on every 35B shape after the alignment gate. Default stays template batch2. Opt-in with `ATLAS_GEMV_BATCH2_CPASYNC=1` (`=0` does not enable).

Does not restore the old standalone batch2 body. Does not port SW GEMV to K=2. Does not use tile GEMM at M=2. `:8888` left on `atlas-gb10:pr-proof-321128d`. No image A/B (would lose tok/s). Combined 321128d+#497 stack was not pushed.

## GPU results (GB10)

Losslessness (`w4a16_batch2_cpasync_microtest`), after gating 16-byte `cp.async` on gmem alignment:

| Shape | bit_id vs batch2 | vs 2× `w4a16_gemv` |
|---|---|---|
| GDN in_proj 12288×2048 | 100% | 100% |
| attn Q 8192×2048 | 100% | 100% |
| GDN out_proj 2048×4096 | 100% | 100% |
| attn o_proj 2048×2048 | 100% | 100% |
| N%4≠0 tail 2050×2048 | 100% | 100% |
| K-tail 2048×2032 | 100% (was ~50% before alignment gate) | 100% |

Cold-DRAM (`w4a16_batch2_bw_microtest`, 273 GB/s peak, 40 iters, weight copies cycle past L2):

| Shape | M=1 GEMV | batch2 | cpasync | cpasync/batch2 |
|---|---|---|---|---|
| GDN in_proj 12288×2048 | 74.1 GB/s (191 µs) | **227.3 GB/s (62.3 µs)** | 195.4 GB/s (72.4 µs) | **1.16× slower** |
| attn Q 8192×2048 | 72.1 GB/s | 180.1 GB/s | 170.9 GB/s | 1.05× slower |
| GDN out 2048×4096 | 65.9 GB/s | 176.8 GB/s | 156.0 GB/s | 1.13× slower |

Template batch2 is already 83% of LPDDR5X peak on the big K=2 shape. Staging packed weights through smem + `cp.async` adds tax; it does not close 242→273.

First-oracle K-tail failure was 16-byte `cp.async` from odd-`n` rows when `K/2 % 16 == 8` (undefined). Fixed: wide load only when src is 16-byte aligned; odd lanes self-issue otherwise. Pipeline `__syncthreads` → `__syncwarp` (even/odd pairing is same-warp); that recovered ~3 points and still lost.

## Live `:8888` (winner unchanged)

`atlas-gb10:pr-proof-321128d`, `--speculative --num-drafts 1`, `ATLAS_MTP_TIMING=1`. Five temperature-0 prompts after restore:

| Prompt | Answer | tok/s (server lifecycle) |
|---|---|---|
| 2+2 / Paris / sky | `4` / `Paris` / `Blue` | noise |
| 220-token BST | coherent | **124.6** (TTFT 117ms) |
| 220-token hash | coherent | **126.4** (TTFT 77.5ms) |

Smoking gun (steady 25-step windows on the 220-token requests):

```
fwd=12.00–12.21ms  propose=2.18–2.22ms  TOTAL=14.23–14.51ms
sync=0.00ms  (host bubble ≈ 0)
Captured CUDA graph for MTP propose (full)
Captured CUDA graph for K=2 verify (slot=0)
```

Unique-weight roofline remains ~11 ms. Leftover ~1.0 ms in `fwd` is not a batch2-cpasync win: K=2 weight traffic is already at 227 GB/s, while M=1 `w4a16_gemv` on the same shapes is ~74 GB/s (reject/serial / graphable MTP lm_head). ncu of the live graphed body was not attached — it would stall production `:8888`; the cold-DRAM split above is the kernel-level name of the remaining ms.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p spark-model --lib --tests -- -D warnings`
- [x] `bash scripts/check-license-headers.sh`
- [x] Unit tests: opt-in polarity (`unset`/`=0`/empty → OFF; `=1` → ON), kernel exports `cp.async`, init sites use the resolver, 16-byte path gates on `src16`
- [x] GPU losslessness oracle — bit_id == 100% on GDN in_proj, attn Q, and K-tail
- [x] GPU cold-DRAM bandwidth vs template batch2 — **FAIL to ship default-on** (5–16% slower)
- [x] No `:8888` A/B; production left on `pr-proof-321128d`

```bash
ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b ATLAS_TARGET_QUANT=nvfp4 \
  cargo run -p spark-model --release --features cuda,gpu-examples \
  --example w4a16_batch2_cpasync_microtest

ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b ATLAS_TARGET_QUANT=nvfp4 \
  cargo run -p spark-model --release --features cuda,gpu-examples \
  --example w4a16_batch2_bw_microtest
```

## Notes for reviewers

- Shared FMA helper is a mechanical extract from `w4a16_gemv_batchm_impl` so the cpasync kernel cannot drift from the template's fmaf order.
- Production 35B shapes are K=2048 (one wave per phase). The pipeline issues phase-0 then phase-1 as two `cp.async` groups so `wait_group 1` lets phase-0 compute overlap phase-1 DMA. Larger K walks superwaves of 128 chunks.
- HIP/gfx1151: `cp.async` degrades to synchronous 8/16-byte copies (same file is a symlink).
- Resolver is the SSOT at the five init sites (attention, SSM, dense FFN, MoE, lm_head). Same grid/block/args as batch2, so CUDA graphs capture the new kernel with no launcher change.
- Next bandwidth lever is M=1 `w4a16_gemv` (74 GB/s on these shapes), not another K=2 batch2 prefetch. Do not port SW to K=2 (SW is slower at hidden=2048).

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
