### PR TITLE
kernels: default-on M=1 w4a16_gemv cp.async prefetch

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -240,3 +240,11 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "w4a16_qg_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "w4a16_gemv_cpasync_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "w4a16_gemv_cpasync_bw_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/w4a16_gemv_cpasync_bw_microtest.rs
+++ b/crates/spark-model/examples/w4a16_gemv_cpasync_bw_microtest.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Cold-DRAM bandwidth microtest: `w4a16_gemv` vs `w4a16_gemv_sw` vs
+//! `w4a16_gemv_cpasync` on Qwen3.6-35B M=1 shapes.
+//!
+//! Exit 0 if cpasync is not slower than base gemv by more than 3% on the
+//! production shapes. Informational GB/s is always printed.
+
+use anyhow::Result;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+use std::time::Instant;
+
+const WARMUP: usize = 8;
+const ITERS: usize = 40;
+const COLD_CYCLE_BYTES: usize = 256 << 20;
+
+const SHAPES: &[(&str, u32, u32)] = &[
+    ("gdn in_proj N=12288 K=2048", 12288, 2048),
+    ("attn Q      N=8192  K=2048", 8192, 2048),
+    ("gdn out     N=2048  K=4096", 2048, 4096),
+];
+
+struct XorShift(u64);
+impl XorShift {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn byte(&mut self) -> u8 {
+        (self.next() >> 32) as u8
+    }
+    fn unit_f32(&mut self) -> f32 {
+        ((self.next() >> 40) as f32) / ((1u64 << 23) as f32) * 2.0 - 1.0
+    }
+}
+
+fn f32_to_bf16_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let rounding = 0x7fff + ((bits >> 16) & 1);
+    ((bits + rounding) >> 16) as u16
+}
+
+fn launch(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    b: DevicePtr,
+    bs: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+    outs: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, outs), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(b)
+        .arg_ptr(bs)
+        .arg_f32(1.0)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+struct Timed {
+    name: &'static str,
+    us: f64,
+    gbps: f64,
+}
+
+fn time_kernel(
+    g: &dyn GpuBackend,
+    name: &'static str,
+    kh: KernelHandle,
+    a: DevicePtr,
+    copies: &[(DevicePtr, DevicePtr)],
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+    outs: u32,
+    weight_bytes: usize,
+) -> Result<Timed> {
+    let go = |i: usize| {
+        launch(
+            g,
+            kh,
+            a,
+            copies[i % copies.len()].0,
+            copies[i % copies.len()].1,
+            c,
+            n,
+            k,
+            outs,
+        )
+    };
+    for i in 0..WARMUP {
+        go(i)?;
+    }
+    g.synchronize(0)?;
+    let t0 = Instant::now();
+    for i in 0..ITERS {
+        go(WARMUP + i)?;
+    }
+    g.synchronize(0)?;
+    let us = t0.elapsed().as_secs_f64() * 1e6 / ITERS as f64;
+    let gbps = weight_bytes as f64 / (us * 1e-6) / 1e9;
+    Ok(Timed { name, us, gbps })
+}
+
+fn main() -> Result<()> {
+    let g0 = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &g0;
+    let peak: f64 = std::env::var("ATLAS_PEAK_GBPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(273.0);
+
+    let m1 = g.kernel("w4a16_gemv", "w4a16_gemv");
+    let sw = g.kernel("w4a16_gemv", "w4a16_gemv_sw");
+    let cp = g.kernel("w4a16_gemv", "w4a16_gemv_cpasync");
+    let (Ok(m1), Ok(sw), Ok(cp)) = (m1, sw, cp) else {
+        eprintln!("w4a16 GEMV kernels absent — SKIP");
+        std::process::exit(2);
+    };
+
+    eprintln!("W4A16 M=1 cp.async cold-DRAM  peak {peak:.0} GB/s, {ITERS} iters\n");
+
+    let mut rng = XorShift(0x9E3779B97F4A7C15);
+    let mut ok = true;
+    for &(label, n, k) in SHAPES {
+        let (n_us, k_us) = (n as usize, k as usize);
+        let packed_bytes = n_us * k_us / 2;
+        let scale_bytes = n_us * k_us / 16;
+        let weight_bytes = packed_bytes + scale_bytes;
+        let copies_n = (COLD_CYCLE_BYTES.div_ceil(weight_bytes)).clamp(1, 16);
+
+        let a_host: Vec<u16> = (0..k_us)
+            .map(|_| f32_to_bf16_bits(rng.unit_f32()))
+            .collect();
+        let b_host: Vec<u8> = (0..packed_bytes).map(|_| rng.byte()).collect();
+        let bs_host: Vec<u8> = (0..scale_bytes)
+            .map(|_| 0x18 + (rng.byte() & 0x0F))
+            .collect();
+
+        let a = g.alloc(k_us * 2)?;
+        let c = g.alloc(n_us * 2)?;
+        let a_bytes: Vec<u8> = a_host.iter().flat_map(|v| v.to_le_bytes()).collect();
+        g.copy_h2d(&a_bytes, a)?;
+        let mut copies = Vec::with_capacity(copies_n);
+        for _ in 0..copies_n {
+            let b = g.alloc(packed_bytes)?;
+            let bs = g.alloc(scale_bytes)?;
+            g.copy_h2d(&b_host, b)?;
+            g.copy_h2d(&bs_host, bs)?;
+            copies.push((b, bs));
+        }
+
+        let floor_us = weight_bytes as f64 / (peak * 1e9) * 1e6;
+        eprintln!(
+            "── {label}  weights {:.2} MB × {copies_n} copies, floor {floor_us:.1} us ──",
+            weight_bytes as f64 / 1e6
+        );
+
+        let t_m1 = time_kernel(g, "gemv M=1", m1, a, &copies, c, n, k, 4, weight_bytes)?;
+        let t_sw = time_kernel(g, "gemv_sw", sw, a, &copies, c, n, k, 8, weight_bytes)?;
+        let t_cp = time_kernel(g, "gemv_cpasync", cp, a, &copies, c, n, k, 4, weight_bytes)?;
+        for t in [&t_m1, &t_sw, &t_cp] {
+            eprintln!(
+                "  {:<16} {:>8.2} us  {:>6.1} GB/s  {:>5.1}% peak  {:>5.2}x floor",
+                t.name,
+                t.us,
+                t.gbps,
+                100.0 * t.gbps / peak,
+                t.us / floor_us,
+            );
+        }
+        let vs = t_cp.us / t_m1.us;
+        eprintln!("  cpasync / gemv = {vs:.3}x   (target <1.0; fail if >1.03)\n");
+        if vs > 1.03 {
+            ok = false;
+        }
+
+        g.free(a)?;
+        g.free(c)?;
+        for (b, bs) in copies {
+            g.free(b)?;
+            g.free(bs)?;
+        }
+    }
+
+    if ok {
+        eprintln!("PASS — cpasync is not a bandwidth regression vs w4a16_gemv");
+        Ok(())
+    } else {
+        eprintln!("FAIL — cpasync is >3% slower than w4a16_gemv on a production shape");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/examples/w4a16_gemv_cpasync_microtest.rs
+++ b/crates/spark-model/examples/w4a16_gemv_cpasync_microtest.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! BYTE-parity oracle for `w4a16_gemv_cpasync` vs current `w4a16_gemv`
+//! (and vs `w4a16_gemv_sw`, which shares `w4a16_gemv_partial`).
+//!
+//! PASS bar is bit_id == 100% on production 35B shapes including hidden=2048.
+//! Exit: 0 all legs byte-identical, 1 any mismatch, 2 kernels absent.
+
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+const GROUP_SIZE: usize = 16;
+const SCALE2: f32 = 0.0123_f32;
+
+const SHAPES: [(&str, usize, usize); 6] = [
+    ("gdn in_proj  [12288 x 2048]", 12288, 2048),
+    ("attn Q       [ 8192 x 2048]", 8192, 2048),
+    ("gdn out_proj [ 2048 x 4096]", 2048, 4096),
+    ("attn o_proj  [ 2048 x 2048]", 2048, 2048),
+    ("N%4!=0 tail  [ 2050 x 2048]", 2050, 2048),
+    ("K-tail       [ 2048 x 2032]", 2048, 2032),
+];
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (((self.0 >> 11) as f64) / ((1u64 << 53) as f64)) as f32
+    }
+    fn r(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+fn up(g: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let p = g.alloc(bytes.len().max(1))?;
+    g.copy_h2d(bytes, p)?;
+    Ok(p)
+}
+
+fn down(g: &dyn GpuBackend, p: DevicePtr, n_bytes: usize) -> Result<Vec<u8>> {
+    let mut b = vec![0u8; n_bytes];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b)
+}
+
+fn worst_delta(a: &[u8], b: &[u8]) -> (usize, f32) {
+    let mut n_diff = 0usize;
+    let mut worst = 0f32;
+    for (x, y) in a.chunks_exact(2).zip(b.chunks_exact(2)) {
+        if x != y {
+            n_diff += 1;
+            let fx = bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32();
+            let fy = bf16::from_bits(u16::from_le_bytes([y[0], y[1]])).to_f32();
+            worst = worst.max((fx - fy).abs());
+        }
+    }
+    (n_diff, worst)
+}
+
+fn launch(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    w: DevicePtr,
+    ws: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+    grid_n: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, grid_n), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(w)
+        .arg_ptr(ws)
+        .arg_f32(SCALE2)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+fn gen_inputs(seed: u64, n: usize, k: usize) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let mut rng = Lcg(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xB4B4);
+    let a = (0..k)
+        .flat_map(|_| bf16::from_f32(rng.r(-1.5, 1.5)).to_bits().to_le_bytes())
+        .collect();
+    let w = (0..n * k / 2).map(|_| rng.r(0.0, 256.0) as u8).collect();
+    let ws = (0..n * k / GROUP_SIZE)
+        .map(|_| 0x30u8 + (rng.r(0.0, 24.0) as u8))
+        .collect();
+    (a, w, ws)
+}
+
+fn report(tag: &str, seed: u64, label: &str, a: &[u8], b: &[u8]) -> bool {
+    let identical = a == b;
+    let (n_diff, worst) = worst_delta(a, b);
+    let bit_id = if a.is_empty() {
+        100.0
+    } else {
+        100.0 * (1.0 - n_diff as f64 / (a.len() / 2) as f64)
+    };
+    println!(
+        "seed {seed:>5}  {label}  {tag:<18} byte-identical={identical:<5} \
+         bit_id={bit_id:>7.3}%  diff_elems={n_diff:<7} max|delta|={worst:.6}"
+    );
+    identical
+}
+
+fn main() -> Result<()> {
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &backend;
+    let m1 = g.kernel("w4a16_gemv", "w4a16_gemv");
+    let sw = g.kernel("w4a16_gemv", "w4a16_gemv_sw");
+    let cp = g.kernel("w4a16_gemv", "w4a16_gemv_cpasync");
+    let (Ok(m1), Ok(sw), Ok(cp)) = (m1, sw, cp) else {
+        println!("w4a16 GEMV cpasync kernels absent — SKIP");
+        std::process::exit(2);
+    };
+
+    let mut clean = true;
+    let mut control_ok = true;
+    for seed in [1u64, 99, 12345] {
+        for (label, n, k) in SHAPES {
+            let (a, w, ws) = gen_inputs(seed, n, k);
+            let a_d = up(g, &a)?;
+            let w_d = up(g, &w)?;
+            let ws_d = up(g, &ws)?;
+            let c_cp = g.alloc(n * 2)?;
+            let c_m1 = g.alloc(n * 2)?;
+            let c_sw = g.alloc(n * 2)?;
+            g.memset(c_cp, 0, n * 2)?;
+            g.memset(c_m1, 0, n * 2)?;
+            g.memset(c_sw, 0, n * 2)?;
+
+            launch(g, cp, a_d, w_d, ws_d, c_cp, n as u32, k as u32, 4)?;
+            launch(g, m1, a_d, w_d, ws_d, c_m1, n as u32, k as u32, 4)?;
+            launch(g, sw, a_d, w_d, ws_d, c_sw, n as u32, k as u32, 8)?;
+            g.synchronize(0)?;
+            let out_cp = down(g, c_cp, n * 2)?;
+            let out_m1 = down(g, c_m1, n * 2)?;
+            let out_sw = down(g, c_sw, n * 2)?;
+            clean &= report("cpasync vs gemv", seed, label, &out_cp, &out_m1);
+            clean &= report("cpasync vs sw  ", seed, label, &out_cp, &out_sw);
+
+            let mut pert = a.clone();
+            pert[2 * 7] ^= 1;
+            let a_pert = up(g, &pert)?;
+            g.memset(c_m1, 0, n * 2)?;
+            launch(g, m1, a_pert, w_d, ws_d, c_m1, n as u32, k as u32, 4)?;
+            g.synchronize(0)?;
+            let differs = down(g, c_m1, n * 2)? != out_cp;
+            control_ok &= differs;
+            println!("seed {seed:>5}  {label}  CONTROL 1-ULP perturbation detected={differs}");
+            g.free(a_pert).ok();
+            for p in [a_d, w_d, ws_d, c_cp, c_m1, c_sw] {
+                g.free(p).ok();
+            }
+        }
+    }
+
+    if !control_ok {
+        println!("FAIL — negative control did not mismatch; harness is VACUOUS.");
+        std::process::exit(1);
+    }
+    if clean {
+        println!(
+            "PASS — w4a16_gemv_cpasync is byte-identical to w4a16_gemv and \
+             w4a16_gemv_sw at every 35B production shape."
+        );
+        Ok(())
+    } else {
+        println!("FAIL — cpasync is NOT byte-identical (do not ship).");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -323,7 +323,7 @@ impl DenseFfnLayer {
         let layer = Self {
             weights,
             activation,
-            w4a16_gemv: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w4a16_gemv_dual: gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_dual")?,
             w4a16_gemv_silu_input: gpu.kernel("w4a16_gemv_fused", "w4a16_gemv_silu_input")?,

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -76,7 +76,7 @@ impl MoeLayer {
             pre_expert_norm: None,
             pre_expert_norm_k: rms_norm_k,
             dense_gemv: gpu.kernel("gemv", "dense_gemv_bf16")?,
-            w4a16_gemv: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw: super::super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w4a16_gemm: gpu.kernel("w4a16", "w4a16_gemm")?,
             dense_gemm: gpu.kernel("gemm", "dense_gemm_bf16")?,

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -373,7 +373,7 @@ impl MtpHead {
             attn_layer_idx: 0,
             rms_norm_k: gpu.kernel("norm", "rms_norm")?,
             rms_norm_residual_k: gpu.kernel("norm", "rms_norm_residual")?,
-            w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_k: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw_k: crate::layers::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             gemv_sw: crate::layers::ops::gemv_sw_from(
                 std::env::var("ATLAS_NO_GEMV_SW").ok().as_deref(),

--- a/crates/spark-model/src/layers/nemotron_mamba2.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2.rs
@@ -126,7 +126,7 @@ impl NemotronMamba2Layer {
             in_proj_bf16: None,
             out_proj_bf16: None,
             rms_norm_residual_k: gpu.kernel("norm", "rms_norm_residual")?,
-            w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_k: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw_k: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w8a16_gemv_k: super::try_kernel(gpu, "w8a16_gemv", "w8a16_gemv"),
             conv1d_update_k: gpu.kernel("causal_conv1d", "causal_conv1d_update")?,

--- a/crates/spark-model/src/layers/nemotron_moe.rs
+++ b/crates/spark-model/src/layers/nemotron_moe.rs
@@ -153,7 +153,7 @@ impl NemotronMoeLayer {
             dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
             topk_sigmoid_k: gpu.kernel("moe_topk_sig", "moe_topk_sigmoid")?,
             moe_expert_gemv_k: gpu.kernel("moe_expert_gemv", "moe_expert_gemv")?,
-            w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_k: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw_k: super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w8a16_gemv_k: super::try_kernel(gpu, "w8a16_gemv", "w8a16_gemv"),
             w8a16_gemm_k: super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -55,6 +55,8 @@ pub use model_stats::ModelStats;
 mod gemm_fp8_prefill;
 #[path = "ops/gemm_quant.rs"]
 mod gemm_quant;
+#[path = "ops/gemv_cpasync.rs"]
+mod gemv_cpasync;
 #[path = "ops/gemv_q2.rs"]
 mod gemv_q2;
 #[path = "ops/gemv_q2_vec.rs"]
@@ -149,6 +151,7 @@ pub use gemm_dense_int8::*;
 pub use gemm_fp4::*;
 pub use gemm_fp8_prefill::*;
 pub use gemm_quant::*;
+pub use gemv_cpasync::*;
 pub use gemv_q2::*;
 pub use gemv_q2_vec::*;
 pub use gemv_sw::*;

--- a/crates/spark-model/src/layers/ops/gemv_cpasync.rs
+++ b/crates/spark-model/src/layers/ops/gemv_cpasync.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Default-ON cp.async `w4a16_gemv_cpasync` dispatch for M=1 NVFP4 GEMV.
+//!
+//! Same grid/block/signature as `w4a16_gemv`. Kill with
+//! `ATLAS_NO_GEMV_CPASYNC=1` (`=0` does **not** disable). Missing kernel
+//! handle falls back to the 64-thread `w4a16_gemv`. Does not touch SW.
+
+use anyhow::Result;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+use std::sync::OnceLock;
+
+/// Kill-switch env var. Presence of the name is not enough — value must be `"1"`.
+pub const DISABLE_ENV: &str = "ATLAS_NO_GEMV_CPASYNC";
+
+const MODULE: &str = "w4a16_gemv";
+const FALLBACK: &str = "w4a16_gemv";
+const CPASYNC: &str = "w4a16_gemv_cpasync";
+
+/// ON unless `ATLAS_NO_GEMV_CPASYNC` is exactly `"1"`.
+pub fn gemv_cpasync_from(val: Option<&str>) -> bool {
+    val != Some("1")
+}
+
+/// Resolve the live M=1 NVFP4 GEMV handle. Default is the cp.async kernel.
+pub fn resolve_w4a16_gemv(gpu: &dyn GpuBackend) -> Result<KernelHandle> {
+    static LOGGED: OnceLock<bool> = OnceLock::new();
+    let on = gemv_cpasync_from(std::env::var(DISABLE_ENV).ok().as_deref());
+    if on {
+        let h = super::super::try_kernel(gpu, MODULE, CPASYNC);
+        if h.0 != 0 {
+            LOGGED.get_or_init(|| {
+                tracing::info!("w4a16_gemv_cpasync ON (kill {DISABLE_ENV}=1)");
+                true
+            });
+            return Ok(h);
+        }
+    }
+    LOGGED.get_or_init(|| {
+        tracing::info!("w4a16_gemv_cpasync OFF (fallback {FALLBACK})");
+        false
+    });
+    gpu.kernel(MODULE, FALLBACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn cpasync_ships_on_and_only_the_one_value_kills() {
+        assert!(gemv_cpasync_from(None), "unset → ON");
+        assert!(gemv_cpasync_from(Some("0")), "`=0` is NOT off");
+        assert!(gemv_cpasync_from(Some("")), "empty is NOT off");
+        assert!(!gemv_cpasync_from(Some("1")), "`=1` is the kill");
+    }
+
+    fn kernel_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../kernels")
+    }
+
+    #[test]
+    fn gb10_gemv_cu_exports_cpasync_and_shares_mac_helper() {
+        let p = kernel_root().join("gb10/common/w4a16_gemv.cu");
+        let src = fs::read_to_string(&p).unwrap();
+        assert!(
+            src.contains("void w4a16_gemv_cpasync("),
+            "{} missing w4a16_gemv_cpasync",
+            p.display()
+        );
+        assert!(
+            src.contains("cp.async.ca.shared.global"),
+            "{}: M=1 cpasync path must issue cp.async",
+            p.display()
+        );
+        assert!(
+            src.contains("w4a16_gemv_mac_chunk("),
+            "{}: base partial and cpasync must share the MAC helper",
+            p.display()
+        );
+        assert!(
+            src.contains("w4a16_gemv_partial("),
+            "{}: keep current w4a16_gemv on the shared partial",
+            p.display()
+        );
+        assert!(
+            src.contains("for (unsigned int super = 0; super < K16; super += 128u)"),
+            "{}: cpasync K-loop must be uniform-trip (syncwarp deadlock)",
+            p.display()
+        );
+    }
+
+    #[test]
+    fn init_sites_use_the_resolver_not_raw_m1() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let needle = format!("gpu.kernel({q}w4a16_gemv{q}, {q}w4a16_gemv{q})", q = '"');
+        let mut offenders = Vec::new();
+        fn visit(d: &Path, needle: &str, out: &mut Vec<String>) {
+            let Ok(rd) = fs::read_dir(d) else { return };
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    visit(&p, needle, out);
+                } else if p.extension().is_some_and(|x| x == "rs") {
+                    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    // Unit/mock tests may look up the fallback kernel by name.
+                    if name.contains("tests") {
+                        continue;
+                    }
+                    let src = fs::read_to_string(&p).unwrap();
+                    if src.contains(needle) {
+                        out.push(p.display().to_string());
+                    }
+                }
+            }
+        }
+        visit(&root, &needle, &mut offenders);
+        assert!(
+            offenders.is_empty(),
+            "use ops::resolve_w4a16_gemv, not raw kernel lookup: {offenders:?}"
+        );
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -229,7 +229,7 @@ impl Qwen3AttentionLayer {
             dense_gemv_batchm_k: gpu
                 .kernel("dense_gemv_bf16_batchm", "dense_gemv_bf16_batchm")
                 .unwrap_or(KernelHandle(0)),
-            w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_k: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw_k: super::super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w8a16_gemv_k: gpu.kernel("w8a16_gemv", "w8a16_gemv")?,
             w8a16_gemm_k: super::super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -58,7 +58,7 @@ impl Qwen3SsmLayer {
             gated_rms_norm_f32_k: super::super::try_kernel(gpu, "norm", "gated_rms_norm_f32_input"),
             dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
             dense_gemv_batch2_k: gpu.kernel("dense_gemv_bf16_batch2", "dense_gemv_bf16_batch2")?,
-            w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_k: crate::layers::ops::resolve_w4a16_gemv(gpu)?,
             w4a16_gemv_sw_k: super::super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w8a16_gemv_k: gpu.kernel("w8a16_gemv", "w8a16_gemv")?,
             w4a16_gemv_qkvz_k: gpu.kernel("w4a16_gemv", "w4a16_gemv_qkvz")?,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -87,7 +87,7 @@ impl TransformerModel {
         // residual stream, which no longer exists, so this stays
         // KernelHandle(0) and the BF16 path is always taken.
         let dense_gemv_fp32out_kernel = KernelHandle(0);
-        let w4a16_gemv_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv")?;
+        let w4a16_gemv_kernel = crate::layers::ops::resolve_w4a16_gemv(gpu.as_ref())?;
         let w4a16_gemv_logits_kernel = gpu.kernel("w4a16_gemv", "w4a16_gemv_logits")?;
         // lm_head shares the tile GEMM, so route it through the same resolver as
         // the SSM/attention sites — it picks the 3-deep pipeline variant when

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -65,6 +65,42 @@ __device__ __constant__ float E2M1_LUT[16] = {
 // SW copy used the older stride-64 sequential `acc += a*w` loop and was 1 ULP
 // lossy vs this pipelined association (GB10 oracle: gdn in_proj / K-tail).
 
+
+// Shared by `w4a16_gemv_partial` and `w4a16_gemv_cpasync` so FMA order cannot
+// drift. `part` is 16 fmaf into a fresh accumulator, then `acc = fmaf(scale, part, acc)`.
+__device__ __forceinline__ float w4a16_gemv_decode_scale(unsigned char scale_byte, float scale2)
+{
+    __nv_fp8_e4m3 fp8;
+    *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+    return scl_fp8(scale_byte) * scale2;
+#else
+    return (float)fp8 * scale2;
+#endif
+}
+
+__device__ __forceinline__ float w4a16_gemv_mac_chunk(
+    const __nv_bfloat16* __restrict__ A,
+    unsigned int kk,
+    unsigned long long packed8,
+    float scale,
+    float acc)
+{
+    uint4 a_lo = ((const uint4*)A)[kk * 2];
+    uint4 a_hi = ((const uint4*)A)[kk * 2 + 1];
+    const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                    a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+    float part = 0.0f;
+    #pragma unroll
+    for (int b = 0; b < 8; b++) {
+        unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+        float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
+        part = fmaf(af.x, E2M1_LUT[byte_val & 0xF], part);
+        part = fmaf(af.y, E2M1_LUT[byte_val >> 4], part);
+    }
+    return fmaf(scale, part, acc);
+}
+
 // One orig-lane's pipelined K16 partial. `orig_lane` is the 64-thread kernel's
 // lane (0..63): k16 = orig_lane*2, stride 128, inner c={0,1} → kk pair.
 __device__ __forceinline__ float w4a16_gemv_partial(
@@ -83,30 +119,12 @@ __device__ __forceinline__ float w4a16_gemv_partial(
             const unsigned int kk = k16 + (unsigned int)c;
             if (kk >= K16) break;
 
-            uint4 a_lo = ((const uint4*)A)[kk * 2];
-            uint4 a_hi = ((const uint4*)A)[kk * 2 + 1];
-            const unsigned int a_raw[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
-                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
             unsigned long long packed8 = *(const unsigned long long*)(
                 B_packed + (unsigned long long)n * half_K + kk * 8);
             unsigned char scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
-            __nv_fp8_e4m3 fp8;
-            *(unsigned char*)&fp8 = scale_byte;
-#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
-            float scale = scl_fp8(scale_byte) * scale2;
-#else
-            float scale = (float)fp8 * scale2;
-#endif
-            float part = 0.0f;
-            #pragma unroll
-            for (int b = 0; b < 8; b++) {
-                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
-                float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&a_raw[b]);
-                part = fmaf(af.x, E2M1_LUT[byte_val & 0xF], part);
-                part = fmaf(af.y, E2M1_LUT[byte_val >> 4], part);
-            }
-            if (c == 0) acc0 = fmaf(scale, part, acc0);
-            else        acc1 = fmaf(scale, part, acc1);
+            float scale = w4a16_gemv_decode_scale(scale_byte, scale2);
+            if (c == 0) acc0 = w4a16_gemv_mac_chunk(A, kk, packed8, scale, acc0);
+            else        acc1 = w4a16_gemv_mac_chunk(A, kk, packed8, scale, acc1);
         }
     }
     return acc0 + acc1;
@@ -151,6 +169,134 @@ extern "C" __global__ void w4a16_gemv(
     }
     __syncthreads();
 
+    if (lane == 0 && n < N) {
+        float result = smem[local_out * 2] + smem[local_out * 2 + 1];
+        C[n] = __float2bfloat16(result);
+    }
+}
+
+
+// ============================================================
+// W4A16 GEMV M=1 — cp.async 2-stage packed-weight prefetch (default ON).
+// ============================================================
+// Bit-identical to `w4a16_gemv`: same `w4a16_gemv_mac_chunk` FMA order, same
+// two-chunk (acc0/acc1) association, same 64-thread / 2-warp smem reduce.
+// Packed weights move through a 2-stage smem buffer so chunk-1 DMA overlaps
+// chunk-0 compute (phase overlap across the already-pipelined pair, not a
+// new intra-K software pipeline). Scale + activations stay gmem.
+// Kill: ATLAS_NO_GEMV_CPASYNC=1. HIP: cp.async degrades to sync copies.
+// Grid: (ceil(N/4),1,1)  Block: (256,1,1) — same as w4a16_gemv.
+
+__device__ __forceinline__ void gemv1_cp_async_8(
+    void* dst_smem, const void* src_gmem, bool pred)
+{
+#if defined(__HIP_PLATFORM_AMD__)
+    if (!pred) return;
+    *reinterpret_cast<unsigned long long*>(dst_smem) =
+        *reinterpret_cast<const unsigned long long*>(src_gmem);
+#else
+    unsigned int dst = __cvta_generic_to_shared(dst_smem);
+    unsigned int n = pred ? 8u : 0u;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 8, %2;"
+                 :: "r"(dst), "l"(src_gmem), "r"(n));
+#endif
+}
+
+__device__ __forceinline__ void gemv1_cp_commit() {
+#if !defined(__HIP_PLATFORM_AMD__)
+    asm volatile("cp.async.commit_group;");
+#endif
+}
+__device__ __forceinline__ void gemv1_cp_wait_one() {
+#if !defined(__HIP_PLATFORM_AMD__)
+    asm volatile("cp.async.wait_group 1;");
+#endif
+}
+__device__ __forceinline__ void gemv1_cp_wait_all() {
+#if !defined(__HIP_PLATFORM_AMD__)
+    asm volatile("cp.async.wait_group 0;");
+#endif
+}
+
+extern "C" __global__ void w4a16_gemv_cpasync(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int K16 = K / 16;
+
+    __shared__ float smem[N_PER_BLOCK * 2];
+    __shared__ __align__(8) unsigned long long smem_pk[2][N_PER_BLOCK][64];
+
+    float acc0 = 0.0f, acc1 = 0.0f;
+    // Uniform trip count (same `super` bound as batch2 cpasync). A
+    // `k16 = lane*2; k16 += 128` loop deadlocks __syncwarp/__syncthreads
+    // because lanes take different iteration counts. N%4!=0 tail threads
+    // still enter so HIP's block barrier is valid.
+    const bool row_live = n < N;
+    for (unsigned int super = 0; super < K16; super += 128u) {
+        const unsigned int k16 = lane * 2u + super;
+        const bool live0 = row_live && k16 < K16;
+        const bool live1 = row_live && (k16 + 1u) < K16;
+        const unsigned char* src0 = live0
+            ? B_packed + (unsigned long long)n * half_K + (unsigned long long)k16 * 8u
+            : B_packed;
+        const unsigned char* src1 = live1
+            ? B_packed + (unsigned long long)n * half_K + (unsigned long long)(k16 + 1u) * 8u
+            : B_packed;
+        gemv1_cp_async_8(&smem_pk[0][local_out][lane], src0, live0);
+        gemv1_cp_commit();
+        gemv1_cp_async_8(&smem_pk[1][local_out][lane], src1, live1);
+        gemv1_cp_commit();
+
+        gemv1_cp_wait_one();
+#if defined(__HIP_PLATFORM_AMD__)
+        __syncthreads();
+#else
+        __syncwarp();
+#endif
+        if (live0) {
+            unsigned char sb = B_scale[(unsigned long long)n * num_groups + k16];
+            acc0 = w4a16_gemv_mac_chunk(
+                A, k16, smem_pk[0][local_out][lane],
+                w4a16_gemv_decode_scale(sb, scale2), acc0);
+        }
+
+        gemv1_cp_wait_all();
+#if defined(__HIP_PLATFORM_AMD__)
+        __syncthreads();
+#else
+        __syncwarp();
+#endif
+        if (live1) {
+            unsigned char sb = B_scale[(unsigned long long)n * num_groups + (k16 + 1u)];
+            acc1 = w4a16_gemv_mac_chunk(
+                A, k16 + 1u, smem_pk[1][local_out][lane],
+                w4a16_gemv_decode_scale(sb, scale2), acc1);
+        }
+    }
+
+    float acc = acc0 + acc1;
+    const unsigned int warp_lane = threadIdx.x % WARP_SIZE;
+    #pragma unroll
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        acc += __shfl_down_sync(0xFFFFFFFF, acc, offset);
+    }
+    if (warp_lane == 0) {
+        unsigned int smem_idx = local_out * 2 + (lane / WARP_SIZE);
+        smem[smem_idx] = acc;
+    }
+    __syncthreads();
     if (lane == 0 && n < N) {
         float result = smem[local_out * 2] + smem[local_out * 2 + 1];
         C[n] = __float2bfloat16(result);


### PR DESCRIPTION
## Summary

Close the leftover M=1 NVFP4 GEMV DRAM gap on GB10 by issuing packed-weight loads through a 2-stage 8-byte `cp.async` smem pipeline. Same idea as #497, but for the 64-thread `w4a16_gemv` used on reject/serial fallback **and** the graphable MTP lm_head (that path stays on base GEMV, not SW).

`w4a16_gemv_cpasync` shares `w4a16_gemv_mac_chunk` / `w4a16_gemv_decode_scale` with `w4a16_gemv_partial`, so FMA order cannot drift vs current `w4a16_gemv` / `w4a16_gemv_sw`. Grid/block/signature match the 64-thread kernel (4 outs/block). **SW GEMV is not touched** and is not ported to K=2.

Default ON. Kill with `ATLAS_NO_GEMV_CPASYNC=1` (`=0` does **not** disable). Missing handle falls back to `w4a16_gemv`.

8-byte `cp.async` only (NVFP4 `K/2` is 8-byte aligned when `K` is a multiple of 16). This avoids #497's 16-byte K-tail gmem-alignment hole. The K-loop uses a uniform `super` trip count so `__syncwarp` / HIP `__syncthreads` cannot deadlock when lanes would otherwise take different iteration counts.

GPU losslessness + cold-DRAM oracles are **pending**: `gate-bake-485-rest` (`agentic-webserver`) currently holds the GPU. Do not ship as default-on until those pass. If cpasync is >3% slower than current M=1 `w4a16_gemv` on the 35B shapes, this flips to opt-in like #497 (`ATLAS_GEMV_CPASYNC=1`) and `:8888` stays on `atlas-gb10:pr-proof-321128d`.

Does not raise `--num-drafts`. Does not restore the old standalone batch2 body. Does not use tile GEMM at M=2. Does not enable grouped MoE at n=2.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests`
- [x] `bash scripts/check-license-headers.sh`
- [x] Unit tests: default-on polarity (`unset`/`=0`/empty → ON; `=1` → kill), kernel exports `cp.async` + shared MAC helper + uniform `super` loop, init sites use `resolve_w4a16_gemv`
- [x] `nvcc --ptx -arch=sm_121a` of `kernels/gb10/common/w4a16_gemv.cu` (exports `w4a16_gemv_cpasync`)
- [ ] GPU losslessness oracle (`w4a16_gemv_cpasync_microtest`) — bit_id == 100% vs `w4a16_gemv` and vs `w4a16_gemv_sw` on GDN in_proj / attn Q / K-tail / N%4≠0
- [ ] GPU cold-DRAM oracle (`w4a16_gemv_cpasync_bw_microtest`) — fail if cpasync is >3% slower than current M=1 GEMV
- [ ] If oracles pass: cherry-pick onto local 321128d, bake `atlas-gb10:pr-proof-<shortsha>`, five temp-0 prompts vs BST 124.6 / hash 126.4 tok/s, leave winner on `:8888`

## Notes for reviewers

- Resolver sites: `dense_ffn`, `moe/init`, `mtp_head/new` (lm_head), `qwen3_attention/init`, `qwen3_ssm/init`, `nemotron_{mamba2,moe}`, `model/impl_a1`. Examples and `moe/mod_tests.rs` still look up the fallback by name.
- `strix` / `strix-hip` `w4a16_gemv.cu` are symlinks to the gb10 copy.
- Combined 321128d stack, if built, stays local/unpushed. Never docker-push `avarok/atlas-gb10:latest`.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).