### PR TITLE
kernels: dual-issue w4a16_gemv_batch2 (not wired)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -234,6 +234,10 @@ name = "w4a16_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]
+name = "w4a16_batch2_dualissue_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "bf16_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
 

--- a/crates/spark-model/examples/w4a16_batch2_dualissue_microtest.rs
+++ b/crates/spark-model/examples/w4a16_batch2_dualissue_microtest.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! BYTE-parity + optional cold-DRAM timing for `w4a16_gemv_batch2_dualissue`.
+//!
+//! Dual-issue must match template `w4a16_gemv_batch2` (and therefore 2×
+//! `w4a16_gemv`) bit-for-bit. It is not wired to production. Default-on
+//! only after `w4a16_batch2_bw_oracle` with
+//! `ATLAS_GEMV_BATCH2_CANDIDATE=w4a16_gemv_batch2_dualissue:w4a16_gemv_batch2_dualissue`
+//! beats template batch2 by ≥3% on 12288×2048 and 8192×2048.
+//!
+//! Run:
+//!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b \
+//!   ATLAS_TARGET_QUANT=nvfp4 cargo run -p spark-model --release \
+//!     --features cuda,gpu-examples --example w4a16_batch2_dualissue_microtest
+
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+const GROUP_SIZE: usize = 16;
+const SCALE2: f32 = 0.0123_f32;
+const M: usize = 2;
+
+const SHAPES: [(&str, usize, usize); 3] = [
+    ("gdn in_proj  [12288 x 2048]", 12288, 2048),
+    ("attn Q       [ 8192 x 2048]", 8192, 2048),
+    ("gdn out      [ 2048 x 4096]", 2048, 4096),
+];
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (((self.0 >> 11) as f64) / ((1u64 << 53) as f64)) as f32
+    }
+    fn r(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+fn up(g: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let p = g.alloc(bytes.len().max(1))?;
+    g.copy_h2d(bytes, p)?;
+    Ok(p)
+}
+
+fn down(g: &dyn GpuBackend, p: DevicePtr, n_bytes: usize) -> Result<Vec<u8>> {
+    let mut b = vec![0u8; n_bytes];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b)
+}
+
+fn launch(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    w: DevicePtr,
+    ws: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(w)
+        .arg_ptr(ws)
+        .arg_f32(SCALE2)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+fn main() -> Result<()> {
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &backend;
+    let b2 = g.kernel("w4a16_gemv", "w4a16_gemv_batch2");
+    let du = g.kernel("w4a16_gemv_batch2_dualissue", "w4a16_gemv_batch2_dualissue");
+    let (Ok(b2), Ok(du)) = (b2, du) else {
+        println!("batch2 or dualissue kernel absent — SKIP");
+        std::process::exit(2);
+    };
+
+    let mut clean = true;
+    for seed in [1u64, 99, 12345] {
+        let mut rng = Lcg(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xB4B4);
+        for (label, n, k) in SHAPES {
+            let a: Vec<u8> = (0..M * k)
+                .flat_map(|_| bf16::from_f32(rng.r(-1.5, 1.5)).to_bits().to_le_bytes())
+                .collect();
+            let w: Vec<u8> = (0..n * k / 2).map(|_| rng.r(0.0, 256.0) as u8).collect();
+            let ws: Vec<u8> = (0..n * k / GROUP_SIZE)
+                .map(|_| 0x30u8 + (rng.r(0.0, 24.0) as u8))
+                .collect();
+            let a_d = up(g, &a)?;
+            let w_d = up(g, &w)?;
+            let ws_d = up(g, &ws)?;
+            let c_b2 = g.alloc(M * n * 2)?;
+            let c_du = g.alloc(M * n * 2)?;
+            g.memset(c_b2, 0, M * n * 2)?;
+            g.memset(c_du, 0, M * n * 2)?;
+            launch(g, b2, a_d, w_d, ws_d, c_b2, n as u32, k as u32)?;
+            launch(g, du, a_d, w_d, ws_d, c_du, n as u32, k as u32)?;
+            g.synchronize(0)?;
+            let xb = down(g, c_b2, M * n * 2)?;
+            let xd = down(g, c_du, M * n * 2)?;
+            let identical = xb == xd;
+            clean &= identical;
+            println!("seed {seed:>5}  {label}  byte-identical={identical}");
+            g.free(a_d)?;
+            g.free(w_d)?;
+            g.free(ws_d)?;
+            g.free(c_b2)?;
+            g.free(c_du)?;
+        }
+    }
+    if clean {
+        println!("PASS — dualissue is byte-identical to template batch2");
+        Ok(())
+    } else {
+        println!("FAIL — dualissue diverged from template batch2");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -55,6 +55,8 @@ pub use model_stats::ModelStats;
 mod gemm_fp8_prefill;
 #[path = "ops/gemm_quant.rs"]
 mod gemm_quant;
+#[path = "ops/gemv_batch2_dualissue.rs"]
+mod gemv_batch2_dualissue;
 #[path = "ops/gemv_q2.rs"]
 mod gemv_q2;
 #[path = "ops/gemv_q2_vec.rs"]

--- a/crates/spark-model/src/layers/ops/gemv_batch2_dualissue.rs
+++ b/crates/spark-model/src/layers/ops/gemv_batch2_dualissue.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Presence + polarity pins for the dual-issue batch2 experiment.
+//!
+//! The kernel is compiled and microtested. Production dispatch stays on
+//! template `w4a16_gemv_batch2` until the bandwidth oracle passes.
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn gb10_exports_dualissue_kernel() {
+        let p = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../kernels/gb10/common/w4a16_gemv_batch2_dualissue.cu");
+        let src = fs::read_to_string(&p).unwrap();
+        assert!(
+            src.contains("void w4a16_gemv_batch2_dualissue("),
+            "{} missing export",
+            p.display()
+        );
+        assert!(
+            !src.contains("cp.async.ca.shared.global"),
+            "{} must not issue the failed smem mailbox",
+            p.display()
+        );
+        assert!(
+            src.contains("load phase-0 AND phase-1"),
+            "{} must document the dual-issue hoist",
+            p.display()
+        );
+    }
+
+    #[test]
+    fn production_init_still_uses_template_batch2() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let needle = "w4a16_gemv_batch2_dualissue";
+        let mut hits = Vec::new();
+        fn visit(d: &Path, needle: &str, out: &mut Vec<String>) {
+            let Ok(rd) = fs::read_dir(d) else { return };
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    visit(&p, needle, out);
+                } else if p.extension().is_some_and(|x| x == "rs")
+                    && p.file_name()
+                        .is_some_and(|n| n != "gemv_batch2_dualissue.rs")
+                {
+                    let src = fs::read_to_string(&p).unwrap();
+                    if src.contains(needle) {
+                        out.push(p.display().to_string());
+                    }
+                }
+            }
+        }
+        visit(&root, needle, &mut hits);
+        assert!(
+            hits.is_empty(),
+            "do not wire dualissue into production until the oracle passes: {hits:?}"
+        );
+    }
+}

--- a/kernels/gb10/common/w4a16_gemv_batch2_dualissue.cu
+++ b/kernels/gb10/common/w4a16_gemv_batch2_dualissue.cu
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// W4A16 GEMV batch2 — dual-issue (no smem mailbox).
+//
+// Same bit-exact FMA order and two-phase virtual-lane remap as
+// `w4a16_gemv_batchm_impl<2>` in w4a16_gemv.cu. The difference is WHEN
+// the packed-weight loads happen:
+//
+//   template batch2:  load phase-0 → compute → load phase-1 → compute
+//   this kernel:      load phase-0 AND phase-1 → compute 0 → compute 1
+//
+// `#497` cp.async tried the same overlap via a shared-memory mailbox and
+// lost (195 vs 227 GB/s on 12288×2048). This path keeps ordinary
+// `ld.global` so there is no commit/wait/alignment tax. Not wired to
+// production. Do not default-on until
+// `w4a16_batch2_bw_oracle` says ≥3% faster than template batch2.
+//
+// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)
+// Signature matches `w4a16_gemv_batch2`.
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+__device__ __forceinline__ float scl_fp8(unsigned char b) {
+    unsigned int s = (b >> 7) & 1u, e = (b >> 3) & 0xFu, m = b & 0x7u;
+    float v;
+    if (e == 0u)
+        v = (float)m * 0.001953125f;
+    else if (e == 15u && m == 7u)
+        v = 0.0f;
+    else
+        v = __uint_as_float(((e + 120u) << 23) | (m << 20));
+    return s ? -v : v;
+}
+#endif
+
+#define BLOCK_SIZE 256
+#define N_PER_BLOCK 4
+#define WARP_SIZE 32
+#define GROUP_SIZE 16
+
+__device__ __constant__ float E2M1_LUT[16] = {
+    0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f};
+
+__device__ __forceinline__ void dualissue_fma_chunk(
+    const __nv_bfloat16* __restrict__ A, unsigned int K, unsigned int kk,
+    unsigned long long packed8, float scale, const float* s_lut, float acc[2])
+{
+    float wl[16];
+#pragma unroll
+    for (int b = 0; b < 8; b++) {
+        unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+        wl[b * 2] = s_lut[byte_val & 0xF];
+        wl[b * 2 + 1] = s_lut[byte_val >> 4];
+    }
+#pragma unroll
+    for (int t = 0; t < 2; t++) {
+        const __nv_bfloat16* At = A + (unsigned long long)t * K;
+        uint4 a_lo = ((const uint4*)At)[kk * 2];
+        uint4 a_hi = ((const uint4*)At)[kk * 2 + 1];
+        const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                    a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+        float part = 0.0f;
+#pragma unroll
+        for (int b = 0; b < 8; b++) {
+            float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
+            part = fmaf(af.x, wl[b * 2], part);
+            part = fmaf(af.y, wl[b * 2 + 1], part);
+        }
+        acc[t] = fmaf(scale, part, acc[t]);
+    }
+}
+
+extern "C" __global__ void w4a16_gemv_batch2_dualissue(
+    const __nv_bfloat16* __restrict__ A, const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale, const float scale2,
+    __nv_bfloat16* __restrict__ C, unsigned int N, unsigned int K)
+{
+    const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
+
+    __shared__ float s_lut[16];
+    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
+    __syncthreads();
+    if (n >= N) return;
+
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int K16 = K / 16;
+    const unsigned int stride = threads_per_out * 2u;
+
+    __shared__ float s_vl[2][N_PER_BLOCK][2 * WARP_SIZE];
+
+    // Hoist the first packed+scale load of BOTH phases before either
+    // compute. On K=2048 each phase is one iteration, so this is the
+    // whole weight stream for this thread.
+    unsigned int kk0 = lane;
+    unsigned int kk1 = lane + threads_per_out;
+    unsigned long long pk0 = 0, pk1 = 0;
+    unsigned char sc0 = 0, sc1 = 0;
+    const bool live0 = kk0 < K16;
+    const bool live1 = kk1 < K16;
+    if (live0) {
+        pk0 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk0 * 8);
+        sc0 = B_scale[(unsigned long long)n * num_groups + kk0];
+    }
+    if (live1) {
+        pk1 = *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk1 * 8);
+        sc1 = B_scale[(unsigned long long)n * num_groups + kk1];
+    }
+
+#pragma unroll 1
+    for (unsigned int phase = 0; phase < 2u; phase++) {
+        float acc[2] = {0.0f, 0.0f};
+        unsigned int kk = (phase == 0u) ? kk0 : kk1;
+        unsigned long long packed8 = (phase == 0u) ? pk0 : pk1;
+        unsigned char scale_byte = (phase == 0u) ? sc0 : sc1;
+        bool live = (phase == 0u) ? live0 : live1;
+
+        while (live) {
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+            float scale = scl_fp8(scale_byte) * scale2;
+#else
+            float scale = (float)fp8 * scale2;
+#endif
+            const unsigned int kk_next = kk + stride;
+            const bool more = kk_next < K16;
+            unsigned long long pk_next = 0;
+            unsigned char sc_next = 0;
+            if (more) {
+                pk_next = *(const unsigned long long*)(
+                    B_packed + (unsigned long long)n * half_K + kk_next * 8);
+                sc_next = B_scale[(unsigned long long)n * num_groups + kk_next];
+            }
+            dualissue_fma_chunk(A, K, kk, packed8, scale, s_lut, acc);
+            if (!more) break;
+            kk = kk_next;
+            packed8 = pk_next;
+            scale_byte = sc_next;
+            live = true;
+        }
+
+#pragma unroll
+        for (int t = 0; t < 2; t++) {
+            const float v = acc[t] + __shfl_xor_sync(0xFFFFFFFF, acc[t], 1);
+            if ((lane & 1u) == 0u) {
+                s_vl[t][local_out][phase * WARP_SIZE + (lane >> 1)] = v;
+            }
+        }
+    }
+    __syncthreads();
+
+    __shared__ float smem[2][N_PER_BLOCK * 2];
+    const unsigned int warp_in_out = lane / WARP_SIZE;
+#pragma unroll
+    for (int t = 0; t < 2; t++) {
+        float a = s_vl[t][local_out][lane];
+#pragma unroll
+        for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+            a += __shfl_down_sync(0xFFFFFFFF, a, offset);
+        }
+        if (lane % WARP_SIZE == 0) smem[t][local_out * 2 + warp_in_out] = a;
+    }
+    __syncthreads();
+
+    if (lane == 0) {
+#pragma unroll
+        for (int t = 0; t < 2; t++) {
+            float r = smem[t][local_out * 2] + smem[t][local_out * 2 + 1];
+            C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Next shot at the leftover `w4a16_gemv_batch2` load-wait after `#497` lost. Template batch2 does `load phase-0 → compute → load phase-1 → compute`. This kernel hoists **both** packed-weight `ld.global`s before compute, then software-pipelines extra K iterations. No `cp.async`, no smem mailbox, same FMA order / virtual-lane remap as `w4a16_gemv_batchm_impl<2>`.

**Not wired to production.** Do not default-on until `w4a16_batch2_bw_oracle` (sibling PR) says ≥3% faster on 12288×2048 and 8192×2048 **and** bit-identical to `w4a16_gemv` × 2.

Depends on / pairs with: the batch2 bandwidth-oracle PR (`cursor/gemv-batch2-bw-oracle-4ece`).

## Why this is not `#497`

`#497` used `cp.async` from the SM into shared memory. On production K=2048 that is one wave per phase — the mailbox cost more than the wait it hid (195 vs 227 GB/s). This path keeps ordinary `ld.global` so there is no commit/wait/alignment tax.

## Test plan

- [x] Host tests: export exists, no `cp.async.ca.shared.global` in the `.cu`, production init must not mention the kernel name
- [x] SPDX + module name = file stem (`gpu.kernel("w4a16_gemv_batch2_dualissue", "w4a16_gemv_batch2_dualissue")`)
- [ ] CI: fmt / clippy / license / typos
- [ ] GPU kill gates (after `:8888` / gate-bake-493-496 is idle — do not steal the bake):

```
ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b ATLAS_TARGET_QUANT=nvfp4 \
  cargo run -p spark-model --release --features cuda,gpu-examples \
  --example w4a16_batch2_dualissue_microtest

ATLAS_GEMV_BATCH2_CANDIDATE=w4a16_gemv_batch2_dualissue:w4a16_gemv_batch2_dualissue \
  cargo run -p spark-model --release --features cuda,gpu-examples \
  --example w4a16_batch2_bw_oracle
```

Default-on is a **follow-up PR** after those numbers, not this one.

## Notes for reviewers

- If the oracle says this is slower, leave it unwired. TMA (third PR) is the next truck only if this does not win.
- Out of scope: `#497` `ATLAS_GEMV_BATCH2_CPASYNC=1`, echolp draw, SW GEMV at K=2, more drafts.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
