### PR TITLE
feat(bench): MLPerf agentic-inference leg — scorer ported with executed-upstream parity fixtures, unrunnable until MLCommons publishes the dataset

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/agentic-webserver/2026-08-19-80c9eb5069.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787146299,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787145520,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.4
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7112436,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4564796,
+      "gpu_compute_apps": [
+        {
+          "pid": 1487349,
+          "name": "./target/release/spark",
+          "used_mib": 109245
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787146298,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 67.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.1
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6588788,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4782680,
+      "gpu_compute_apps": [
+        {
+          "pid": 1487349,
+          "name": "./target/release/spark",
+          "used_mib": 109271
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 778,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 12.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "decode_tps": 33.440589444627875,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 6.806946957707965,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 769.1850062210001,
+    "sum_completion_tokens": 25722.0,
+    "sum_tool_calls": 106.0,
+    "sum_turns": 113.0,
+    "sum_wall_s": 776.9101176280001,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 6.807s/turn ≤ 8.500 · Σwall 777s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=33.44, followed_directions=10.00, iterations=10.00, s_per_turn=6.81, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=769.19, sum_completion_tokens=25722.00, sum_tool_calls=106.00, sum_turns=113.00, sum_wall_s=776.91, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 6.807s/turn ≤ 8.500 · Σwall 777s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/agentic-webserver/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/agentic-webserver/2026-08-19-867aa9a75f.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787123512,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787122793,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7067084,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1778804,
+      "gpu_compute_apps": [
+        {
+          "pid": 1380720,
+          "name": "./target/release/spark",
+          "used_mib": 109217
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787123512,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 67.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 74.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.6
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6901008,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2703708,
+      "gpu_compute_apps": [
+        {
+          "pid": 1380720,
+          "name": "./target/release/spark",
+          "used_mib": 109243
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 719,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 12.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "decode_tps": 33.65700332858681,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 6.8210743789519235,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 709.391735411,
+    "sum_completion_tokens": 23876.0,
+    "sum_tool_calls": 99.0,
+    "sum_turns": 104.0,
+    "sum_wall_s": 716.934829843,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 6.821s/turn ≤ 8.500 · Σwall 717s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=33.66, followed_directions=10.00, iterations=10.00, s_per_turn=6.82, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=709.39, sum_completion_tokens=23876.00, sum_tool_calls=99.00, sum_turns=104.00, sum_wall_s=716.93, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 6.821s/turn ≤ 8.500 · Σwall 717s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-19-80c9eb5069.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787154178,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787144774,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 44.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 51.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 44.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 29566078770,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7863116,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 6270184,
+      "gpu_compute_apps": [
+        {
+          "pid": 356275,
+          "name": "./target/release/spark",
+          "used_mib": 110224
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787154178,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.5
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 29566078770,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5905740,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 4757448,
+      "gpu_compute_apps": [
+        {
+          "pid": 356275,
+          "name": "./target/release/spark",
+          "used_mib": 110250
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 9404,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 16.0,
+      "hottest_chassis_delta_c": 17.099999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.77,
+    "overall_accuracy": 86.35,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.35 (baseline min 86.10) · normalized 86.77 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.77, overall_accuracy=86.35, samples=1004.00 · Pass: overall 86.35 (baseline min 86.10) · normalized 86.77 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-19-9077c352f9.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-19-9077c352f9.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "9077c352f9",
+  "recorded_at": 1787142889,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787133368,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 58.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 65.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 39915445348,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6934336,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2990568,
+      "gpu_compute_apps": [
+        {
+          "pid": 1425877,
+          "name": "./target/release/spark",
+          "used_mib": 109100
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787142889,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.5
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 39915445348,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6028016,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3639940,
+      "gpu_compute_apps": [
+        {
+          "pid": 1425877,
+          "name": "./target/release/spark",
+          "used_mib": 109126
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 9521,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": -2.0,
+      "hottest_chassis_delta_c": 4.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +4 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.61,
+    "overall_accuracy": 86.25,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.25 (baseline min 86.10) · normalized 86.61 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.61, overall_accuracy=86.25, samples=1004.00 · Pass: overall 86.25 (baseline min 86.10) · normalized 86.61 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/bfcl-subset/2026-08-19-80c9eb5069.json
@@ -1,0 +1,453 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787150525,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787144756,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 50.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.9
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 3031741117,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34337780,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4728104,
+      "gpu_compute_apps": [
+        {
+          "pid": 22163,
+          "name": "./target/release/spark",
+          "used_mib": 84937
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787150525,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 69.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 77.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 3031741117,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34362068,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4845248,
+      "gpu_compute_apps": [
+        {
+          "pid": 22163,
+          "name": "./target/release/spark",
+          "used_mib": 85073
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5769,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 20.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +21 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-19-9077c352f9.json
+++ b/.benchmarks/bfcl-subset/2026-08-19-9077c352f9.json
@@ -1,0 +1,453 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "9077c352f9",
+  "recorded_at": 1787133299,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787127326,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 46.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 52.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 39915445348,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34101228,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2748800,
+      "gpu_compute_apps": [
+        {
+          "pid": 1403787,
+          "name": "./target/release/spark",
+          "used_mib": 83445
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787133299,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 78.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.1
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 39915445348,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34365104,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2990280,
+      "gpu_compute_apps": [
+        {
+          "pid": 1403787,
+          "name": "./target/release/spark",
+          "used_mib": 83581
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5973,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 24.0,
+      "hottest_chassis_delta_c": 25.4
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +25 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/concurrency-sweep/2026-08-19-80c9eb5069.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787145451,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787145223,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15033928,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4563508,
+      "gpu_compute_apps": [
+        {
+          "pid": 1486196,
+          "name": "./target/release/spark",
+          "used_mib": 101814
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787145451,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 78.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 84.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.3
+        }
+      ],
+      "sm_clock_mhz": 2450.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14888700,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4564500,
+      "gpu_compute_apps": [
+        {
+          "pid": 1486196,
+          "name": "./target/release/spark",
+          "used_mib": 101975
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 228,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 24.0,
+      "hottest_chassis_delta_c": 17.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +18 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 88.36287644707936,
+    "c16_ttft_p50_ms": 16886.997906,
+    "c1_aggregate_tok_s": 18.75751807992355,
+    "c1_ttft_p50_ms": 1430.920223,
+    "c4_aggregate_tok_s": 43.92928763315659,
+    "c4_ttft_p50_ms": 3729.0726259999997,
+    "c8_aggregate_tok_s": 59.04246032392395,
+    "c8_ttft_p50_ms": 9107.031323,
+    "min_completion_tokens": 296.0,
+    "peak_aggregate_tok_s": 88.36287644707936,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 18.8/16.2 · C4 43.9/33.5 · C8 59.0/50.5 · C16 88.4/72.0 · peak 88.4/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=88.36, c16_ttft_p50_ms=16887.00, c1_aggregate_tok_s=18.76, c1_ttft_p50_ms=1430.92, c4_aggregate_tok_s=43.93, c4_ttft_p50_ms=3729.07, c8_aggregate_tok_s=59.04, c8_ttft_p50_ms=9107.03, min_completion_tokens=296.00, peak_aggregate_tok_s=88.36, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 18.8/16.2 · C4 43.9/33.5 · C8 59.0/50.5 · C16 88.4/72.0 · peak 88.4/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/concurrency-sweep/2026-08-19-867aa9a75f.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787122723,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787122515,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 60.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14737976,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1773900,
+      "gpu_compute_apps": [
+        {
+          "pid": 1379648,
+          "name": "./target/release/spark",
+          "used_mib": 102372
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787122723,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 77.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 85.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.0
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13955420,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1777912,
+      "gpu_compute_apps": [
+        {
+          "pid": 1379648,
+          "name": "./target/release/spark",
+          "used_mib": 102614
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 208,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 23.0,
+      "hottest_chassis_delta_c": 24.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +25 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 85.95811761614455,
+    "c16_ttft_p50_ms": 16893.803949999998,
+    "c1_aggregate_tok_s": 18.762973897969424,
+    "c1_ttft_p50_ms": 1429.392878,
+    "c4_aggregate_tok_s": 48.49425298083977,
+    "c4_ttft_p50_ms": 4977.38139,
+    "c8_aggregate_tok_s": 59.21791602444548,
+    "c8_ttft_p50_ms": 9116.487164,
+    "min_completion_tokens": 320.0,
+    "peak_aggregate_tok_s": 85.95811761614455,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 18.8/16.2 · C4 48.5/33.5 · C8 59.2/50.5 · C16 86.0/72.0 · peak 86.0/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=85.96, c16_ttft_p50_ms=16893.80, c1_aggregate_tok_s=18.76, c1_ttft_p50_ms=1429.39, c4_aggregate_tok_s=48.49, c4_ttft_p50_ms=4977.38, c8_aggregate_tok_s=59.22, c8_ttft_p50_ms=9116.49, min_completion_tokens=320.00, peak_aggregate_tok_s=85.96, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 18.8/16.2 · C4 48.5/33.5 · C8 59.2/50.5 · C16 86.0/72.0 · peak 86.0/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/decode-floor/2026-08-19-80c9eb5069.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787144373,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787144246,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 47.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 58.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.2
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15225896,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 9498400,
+      "gpu_compute_apps": [
+        {
+          "pid": 1480477,
+          "name": "./target/release/spark",
+          "used_mib": 101586
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787144373,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 81.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 90.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 90.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.4
+        }
+      ],
+      "sm_clock_mhz": 2424.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15926276,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 9498756,
+      "gpu_compute_apps": [
+        {
+          "pid": 1480477,
+          "name": "./target/release/spark",
+          "used_mib": 101590
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 127,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 34.0,
+      "hottest_chassis_delta_c": 31.500000000000007
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +32 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.64703611250279
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 22.6 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=22.65 · Pass: median decode 22.6 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/decode-floor/2026-08-19-867aa9a75f.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787121666,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787121539,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 65.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.3
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15567356,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1667984,
+      "gpu_compute_apps": [
+        {
+          "pid": 1369780,
+          "name": "./target/release/spark",
+          "used_mib": 101574
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787121666,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 82.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 91.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 91.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 16073376,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1693432,
+      "gpu_compute_apps": [
+        {
+          "pid": 1369780,
+          "name": "./target/release/spark",
+          "used_mib": 101578
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 127,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 28.0,
+      "hottest_chassis_delta_c": 26.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +26 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.557397346496604
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 22.6 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=22.56 · Pass: median decode 22.6 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-19-80c9eb5069.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787144958,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787144844,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 65.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6641184,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5031052,
+      "gpu_compute_apps": [
+        {
+          "pid": 1483274,
+          "name": "./target/release/spark",
+          "used_mib": 109327
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787144958,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 72.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 79.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.3
+        }
+      ],
+      "sm_clock_mhz": 2444.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7151308,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4531644,
+      "gpu_compute_apps": [
+        {
+          "pid": 1483274,
+          "name": "./target/release/spark",
+          "used_mib": 109353
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 114,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 13.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +14 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 114.011469568,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=114.01, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-19-867aa9a75f.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787122247,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787122132,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6978300,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1734512,
+      "gpu_compute_apps": [
+        {
+          "pid": 1377354,
+          "name": "./target/release/spark",
+          "used_mib": 109318
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787122247,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 72.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 78.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.1
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7086124,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1736696,
+      "gpu_compute_apps": [
+        {
+          "pid": 1377354,
+          "name": "./target/release/spark",
+          "used_mib": 109344
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 115,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 16.0,
+      "hottest_chassis_delta_c": 12.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +13 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 114.002256728,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=114.00, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-19-80c9eb5069.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787144532,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787144444,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 52.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.4
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7079956,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5023368,
+      "gpu_compute_apps": [
+        {
+          "pid": 1481190,
+          "name": "./target/release/spark",
+          "used_mib": 109287
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787144531,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 71.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 79.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6662424,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5026568,
+      "gpu_compute_apps": [
+        {
+          "pid": 1481190,
+          "name": "./target/release/spark",
+          "used_mib": 109311
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 87,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 17.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1638.9360069999998,
+    "p90_ms": 4494.592192,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.4% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1638.94, p90_ms=4494.59, samples=36.00 · Pass: median -0.4% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-19-867aa9a75f.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787121824,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787121736,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7329792,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1698560,
+      "gpu_compute_apps": [
+        {
+          "pid": 1375795,
+          "name": "./target/release/spark",
+          "used_mib": 109329
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787121824,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 72.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 80.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7321956,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1710804,
+      "gpu_compute_apps": [
+        {
+          "pid": 1375795,
+          "name": "./target/release/spark",
+          "used_mib": 109353
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 88,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 18.0,
+      "hottest_chassis_delta_c": 18.60000000000001
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +19 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1645.8116380000001,
+    "p90_ms": 4502.554276,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.5% (limit +3.0%) · p90 +0.4% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1645.81, p90_ms=4502.55, samples=36.00 · Pass: median +0.5% (limit +3.0%) · p90 +0.4% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-19-80c9eb5069.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787144770,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787144602,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 60.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6558992,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5028180,
+      "gpu_compute_apps": [
+        {
+          "pid": 1482269,
+          "name": "./target/release/spark",
+          "used_mib": 109459
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787144770,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 73.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 81.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.2
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6468000,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5029056,
+      "gpu_compute_apps": [
+        {
+          "pid": 1482269,
+          "name": "./target/release/spark",
+          "used_mib": 109483
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 168,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 20.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +21 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1568.131946,
+    "p90_ms": 4514.970089,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.3% (limit +3.0%) · p90 +0.9% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1568.13, p90_ms=4514.97, samples=36.00 · Pass: median +0.3% (limit +3.0%) · p90 +0.9% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-19-867aa9a75f.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787122061,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787121894,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7027844,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1728492,
+      "gpu_compute_apps": [
+        {
+          "pid": 1376416,
+          "name": "./target/release/spark",
+          "used_mib": 109264
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787122061,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 76.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 81.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7192828,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1733136,
+      "gpu_compute_apps": [
+        {
+          "pid": 1376416,
+          "name": "./target/release/spark",
+          "used_mib": 109288
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 167,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 21.0,
+      "hottest_chassis_delta_c": 18.6
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +19 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1564.1731009999999,
+    "p90_ms": 4476.083796,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.0% (limit +3.0%) · p90 -0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1564.17, p90_ms=4476.08, samples=36.00 · Pass: median -0.0% (limit +3.0%) · p90 -0.1% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/video-fidelity/2026-08-19-80c9eb5069.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787145163,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787145146,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 64.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34149560,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4562464,
+      "gpu_compute_apps": [
+        {
+          "pid": 1485360,
+          "name": "./target/release/spark",
+          "used_mib": 83824
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787145163,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 75.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34021256,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4562856,
+      "gpu_compute_apps": [
+        {
+          "pid": 1485360,
+          "name": "./target/release/spark",
+          "used_mib": 83834
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 17,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 11.099999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +11 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 761.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1510.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 3018.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=761.00, conc_2_correct=2.00, conc_2_wall_ms=1510.00, conc_4_correct=4.00, conc_4_wall_ms=3018.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/video-fidelity/2026-08-19-867aa9a75f.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787122452,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787122435,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34165140,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1762168,
+      "gpu_compute_apps": [
+        {
+          "pid": 1378781,
+          "name": "./target/release/spark",
+          "used_mib": 82951
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787122452,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 75.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.4
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34238244,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1771776,
+      "gpu_compute_apps": [
+        {
+          "pid": 1378781,
+          "name": "./target/release/spark",
+          "used_mib": 82961
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 17,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 8.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +8 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 755.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1509.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 3020.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=755.00, conc_2_correct=2.00, conc_2_wall_ms=1509.00, conc_4_correct=4.00, conc_4_wall_ms=3020.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-19-80c9eb5069.json
+++ b/.benchmarks/vision-fidelity/2026-08-19-80c9eb5069.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "80c9eb5069",
+  "recorded_at": 1787145086,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787145030,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7084276,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4533032,
+      "gpu_compute_apps": [
+        {
+          "pid": 1484815,
+          "name": "./target/release/spark",
+          "used_mib": 109209
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787145085,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.2
+        }
+      ],
+      "sm_clock_mhz": 2470.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 40384664375,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7196592,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4533952,
+      "gpu_compute_apps": [
+        {
+          "pid": 1484815,
+          "name": "./target/release/spark",
+          "used_mib": 109249
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 55,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 15.100000000000009
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +15 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 479.0,
+    "conc_2_wall_ms": 940.0,
+    "conc_4_wall_ms": 1809.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=479.00, conc_2_wall_ms=940.00, conc_4_wall_ms=1809.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-19-867aa9a75f.json
+++ b/.benchmarks/vision-fidelity/2026-08-19-867aa9a75f.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "867aa9a75f",
+  "recorded_at": 1787122373,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787122318,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 64.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7003244,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1738284,
+      "gpu_compute_apps": [
+        {
+          "pid": 1378085,
+          "name": "./target/release/spark",
+          "used_mib": 109319
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787122373,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 69.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.7
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 38540430750,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7024904,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1739924,
+      "gpu_compute_apps": [
+        {
+          "pid": 1378085,
+          "name": "./target/release/spark",
+          "used_mib": 109354
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 55,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 11.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 482.0,
+    "conc_2_wall_ms": 961.0,
+    "conc_4_wall_ms": 1811.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=482.00, conc_2_wall_ms=961.00, conc_4_wall_ms=1811.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml",
  "tracing",

--- a/crates/atlas-plugin/Cargo.toml
+++ b/crates/atlas-plugin/Cargo.toml
@@ -19,6 +19,9 @@ atlas-closure = { path = "../atlas-closure" }
 # BENCH.toml — a model's benchmarks and thresholds, beside the model.
 toml = "0.8"
 anyhow = { workspace = true }
+# Full-file dataset hashing + draw fingerprints for the MLPerf agentic leg —
+# the same workspace pin atlas-closure already uses, so nothing new is vendored.
+sha2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/atlas-plugin/assets/mlperf-agentic/gen_parity_fixtures.py
+++ b/crates/atlas-plugin/assets/mlperf-agentic/gen_parity_fixtures.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Generate parity_fixtures.json from the UPSTREAM MLPerf inline scorer.
+
+The Rust port in `benchmarks/mlperf_agentic/scoring.rs` re-implements
+`AgenticInferenceInlineScorer` (mlcommons/endpoints, commit 7935df4,
+`src/inference_endpoint/evaluation/scoring.py`). A port can diverge silently —
+one regex flag, one alias entry — and a diverged scorer produces numbers that
+look like MLPerf inline accuracy and are not. So the expected values in the
+fixture file are never typed by hand: this script EXECUTES the upstream class
+(its source sliced out verbatim, no retyping) over the case list below and
+records what it returns. The Rust tests then assert the port agrees on every
+case, including one generated case per alias-table entry and per shell wrapper,
+so the whole ~60-entry table is pinned rather than spot-checked.
+
+Not run at build or provision time. Re-run only when deliberately tracking an
+upstream scorer change, then commit the regenerated JSON with the new commit id:
+
+    python3 gen_parity_fixtures.py \
+        --scoring-py <endpoints-checkout>/src/inference_endpoint/evaluation/scoring.py \
+        --upstream-commit <sha> \
+        --out parity_fixtures.json
+"""
+
+import argparse
+import json
+import re  # noqa: F401 — used by the exec'd upstream source
+from collections import Counter
+from pathlib import Path
+from typing import Any, ClassVar  # noqa: F401 — used by the exec'd upstream source
+
+
+def load_upstream(scoring_py: Path):
+    """Exec the upstream class body verbatim inside a stub-based shim.
+
+    Only the pure comparison members are exercised (`_model_intent`,
+    `_ground_truth_intents`, `_bash_actions`, the class-level regexes and
+    tables); the heavyweight members (events.jsonl IO, pandas) are defined but
+    never called, so their imports can be stubbed.
+    """
+    src = scoring_py.read_text()
+    start = src.index("class AgenticInferenceInlineScorer")
+    end = src.index("class ", src.index("\n", start + 1))
+    while not src[end:].startswith("class LiveCodeBenchScorer"):
+        end = src.index("class ", end + 1)
+    block = src[start:end]
+    header_end = block.index("\n")
+    block = "class Upstream:" + block[header_end:]
+
+    import os  # noqa: F401 — annotation on upstream __init__
+
+    namespace = {
+        "re": re,
+        "json": json,
+        "Counter": Counter,
+        "ClassVar": ClassVar,
+        "Any": Any,
+        "os": __import__("os"),
+        # Stubs for names that appear only in annotations / uncalled bodies.
+        "Scorer": object,
+        "Dataset": object,
+        "Extractor": object,
+        "AgenticInferenceDataset": object,
+        "defaultdict": dict,
+        "logger": None,
+    }
+    exec(compile(block, str(scoring_py), "exec"), namespace)  # noqa: S102
+    cls = namespace["Upstream"]
+    return cls, cls.__new__(cls)
+
+
+# ── Case lists ───────────────────────────────────────────────────────────────
+# Each case is an assistant-turn dict exactly as the scorer receives it. The
+# comments record which upstream behaviour the case pins, including the
+# ambiguous corners a porter would plausibly get wrong.
+
+INTENT_CASES = [
+    # The documented happy path.
+    {"content": "intent: I042"},
+    # Explicit form is preferred, reasoning_content searched before content.
+    {"reasoning_content": "intent: I001", "content": "intent: I002"},
+    # ★ The explicit pass runs over BOTH fields before the bare fallback runs
+    # over either: an explicit match in content beats a bare token in
+    # reasoning_content, even though reasoning_content is listed first.
+    {"reasoning_content": "thinking about I111", "content": "final intent: I222"},
+    # Explicit regex is IGNORECASE and the result is upper-cased.
+    {"content": "Intent: i042"},
+    # \s* between the colon and the code; Python \s is unicode-aware, so
+    # NBSP (U+00A0) counts as whitespace here.
+    {"content": "intent: I042"},
+    # ★ No space is allowed before the colon and \b guards "intent", so the
+    # EXPLICIT pattern fails on both of these — but the bare fallback still
+    # finds the I042 token, so they score anyway. A port that only implements
+    # the explicit pattern would return None here and diverge.
+    {"content": "intent : I042"},
+    {"content": "reintent: I042"},
+    # \b after the third digit: a fourth digit kills the explicit match, AND
+    # the bare fallback ("I0425" has no boundary after digit three either).
+    {"content": "intent: I0425"},
+    # Bare fallback: LAST bare token wins.
+    {"content": "maybe I100, no, I200"},
+    # ★ Bare fallback is case-SENSITIVE (no IGNORECASE on _BARE_INTENT_RE):
+    # a lowercase bare code matches nothing.
+    {"content": "maybe i123"},
+    # \b before bare I: "AI123" is one word, no match.
+    {"content": "the AI123 model"},
+    # Bare needs exactly three digits with a boundary after.
+    {"content": "I12 and I1234"},
+    # Missing/None fields fall through without error.
+    {"content": None},
+    {},
+    # Non-string content is skipped, reasoning still searched.
+    {"content": 7, "reasoning_content": "intent: I300"},
+]
+
+GT_INTENT_CASES = [
+    # Docstring example: lowercase upper-cased, None dropped.
+    {"intent_codes": ["i001", "I002", None]},
+    # Empty string dropped; non-list is no ground truth at all.
+    {"intent_codes": ["", "I003"]},
+    {"intent_codes": "I001"},
+    {"intent_codes": None},
+    {},
+]
+
+BASH_CASES = [
+    # Upstream docstring example: env assignment + abs path + version alias.
+    {"cmd": "CUDA_VISIBLE_DEVICES=0 /usr/bin/python3 -m pytest"},
+    # Pipes split stages; every stage's executable is normalized.
+    {"cmd": "cat foo.py | grep bar | wc -l"},
+    # `||` splits once (alternation order: \|\| before \|), `;` and newlines too.
+    {"cmd": "make build || make clean; ls\nfind . -name x"},
+    # ★ Executables NOT in the alias table vanish from the multiset entirely —
+    # `echo` contributes nothing, on either side of the IoU.
+    {"cmd": 'echo "done" && grep -r pattern src'},
+    # Quoted spans are stripped BEFORE splitting: the | inside quotes is not a
+    # separator, and quoted text cannot smuggle in an executable.
+    {"cmd": 'grep "a | b" file.txt'},
+    # Double-quote escapes: the escaped quote does not close the span.
+    {"cmd": 'grep "say \\"hi\\" | there" f && ls'},
+    # Backtick spans are stripped too.
+    {"cmd": "diff `ls` other"},
+    # Unterminated quote: no span matches, the quote char stays in the text.
+    {"cmd": "grep 'unterminated && ls"},
+    # Wrapper + env-assignment stripping is iterative and order-free.
+    {"cmd": "sudo env FOO=1 time make test"},
+    # An env-assignment-only stage contributes nothing.
+    {"cmd": "FOO=1"},
+    # `.` aliases to source; `./script.sh` basenames to script.sh → dropped.
+    {"cmd": ". ./venv/bin/activate && ./run.sh"},
+    # Version-suffix stripping: one trailing .N group...
+    {"cmd": "python3.11 setup.py"},
+    # ...and the regex takes at most two trailing groups in one match.
+    {"cmd": "python3.1.2.3 x"},
+    # ★ A single `&` is NOT a separator upstream (the regex has no bare &):
+    # "sleep 5 &" keeps `&` as a token and `sleep` is not in the alias table.
+    {"cmd": "sleep 5 & wait"},
+    # Uppercase executables are lowercased before the table lookup.
+    {"cmd": "GREP pattern file"},
+    # "command" key preferred; empty string falls through to "cmd".
+    {"command": "git status"},
+    {"command": "", "cmd": "git diff"},
+    # Repeats are preserved — this is a multiset, not a set.
+    {"cmd": "grep a f1; grep b f2; grep c f3"},
+]
+
+# (gt_actions_cmd, model_turn) pairs scored end to end, IoU semantics included.
+TURN_CASES = [
+    # Multiset IoU: gt {python, pytest}, model {python} → 1/2.
+    {
+        "domain": "coding",
+        "gt": {"tool_calls": [{"function": {"name": "bash", "arguments": {"cmd": "python x.py && pytest"}}}]},
+        "model": {"tool_calls": [{"function": {"name": "bash", "arguments": {"cmd": "python y.py"}}}]},
+    },
+    # Duplicates count: gt {grep×2}, model {grep×1} → 1/2.
+    {
+        "domain": "coding",
+        "gt": {"tool_calls": [{"function": {"name": "bash", "arguments": {"cmd": "grep a; grep b"}}}]},
+        "model": {"tool_calls": [{"function": {"name": "bash", "arguments": {"cmd": "grep a"}}}]},
+    },
+    # Model produced no bash calls at all → 0, denominator intact.
+    {
+        "domain": "coding",
+        "gt": {"tool_calls": [{"function": {"name": "bash", "arguments": {"cmd": "make"}}}]},
+        "model": {"content": "I would run make here."},
+    },
+    # Non-bash tool calls are invisible to the scorer.
+    {
+        "domain": "coding",
+        "gt": {"tool_calls": [{"function": {"name": "bash", "arguments": {"cmd": "ls"}}}]},
+        "model": {"tool_calls": [{"function": {"name": "edit_file", "arguments": {"cmd": "ls"}}}]},
+    },
+    # Arguments arrive as a JSON STRING over the wire; malformed JSON in one
+    # call skips that call, not the turn.
+    {
+        "domain": "coding",
+        "gt": {"tool_calls": [{"function": {"name": "bash", "arguments": '{"cmd": "git log"}'}}]},
+        "model": {
+            "tool_calls": [
+                {"function": {"name": "bash", "arguments": "{not json"}},
+                {"function": {"name": "bash", "arguments": '{"cmd": "git show"}'}},
+            ]
+        },
+    },
+    # Workflow: binary membership, gt codes upper-cased.
+    {"domain": "workflow", "gt": {"intent_codes": ["i042"]}, "model": {"content": "intent: I042"}},
+    {"domain": "workflow", "gt": {"intent_codes": ["I001", "I002"]}, "model": {"content": "intent: I003"}},
+    # Workflow with no extractable intent → None ∉ codes → 0.
+    {"domain": "workflow", "gt": {"intent_codes": ["I001"]}, "model": {"content": "no code here"}},
+]
+
+DOMAIN_CASES = [
+    "sim_001",
+    "sim_12345",
+    "sim_",          # \d+ requires at least one digit
+    "sim_1x",        # $ anchor: trailing junk is coding
+    "Sim_001",       # case-sensitive
+    "xsim_001",      # ^ anchor
+    "django__django-12345",
+    "task_991",
+]
+
+
+def coding_turn_score(obj, gt_turn, model_turn):
+    """The exact IoU expression from upstream score()."""
+    gt_counts = Counter(obj._bash_actions(gt_turn))
+    model_counts = Counter(obj._bash_actions(model_turn))
+    union = sum((gt_counts | model_counts).values())
+    return sum((gt_counts & model_counts).values()) / union
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scoring-py", required=True, type=Path)
+    ap.add_argument("--upstream-commit", required=True)
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    cls, obj = load_upstream(args.scoring_py)
+
+    def bash_turn(case):
+        return {"tool_calls": [{"function": {"name": "bash", "arguments": dict(case)}}]}
+
+    out = {
+        "upstream_commit": args.upstream_commit,
+        "upstream_file": "src/inference_endpoint/evaluation/scoring.py",
+        "upstream_class": "AgenticInferenceInlineScorer",
+        "intent_cases": [
+            {"turn": t, "expected": obj._model_intent(t)} for t in INTENT_CASES
+        ],
+        "gt_intent_cases": [
+            {"turn": t, "expected": sorted(obj._ground_truth_intents(t))}
+            for t in GT_INTENT_CASES
+        ],
+        "bash_cases": [
+            {"arguments": c, "expected": obj._bash_actions(bash_turn(c))}
+            for c in BASH_CASES
+        ],
+        # One case per alias entry and per wrapper: the WHOLE table is pinned,
+        # generated from the upstream dict itself so nothing is retyped.
+        "alias_cases": [
+            {"arguments": {"cmd": f"{key} --arg"}, "expected": obj._bash_actions(bash_turn({"cmd": f"{key} --arg"}))}
+            for key in cls._EXECUTABLE_ALIASES
+        ],
+        "wrapper_cases": [
+            {"arguments": {"cmd": f"{w} ls -la"}, "expected": obj._bash_actions(bash_turn({"cmd": f"{w} ls -la"}))}
+            for w in sorted(cls._SHELL_WRAPPERS)
+        ],
+        "turn_cases": [
+            {
+                **case,
+                "expected": (
+                    (1.0 if obj._model_intent(case["model"]) in obj._ground_truth_intents(case["gt"]) else 0.0)
+                    if case["domain"] == "workflow"
+                    else coding_turn_score(obj, case["gt"], case["model"])
+                ),
+            }
+            for case in TURN_CASES
+        ],
+        "domain_cases": [
+            {"conversation_id": cid, "workflow": bool(cls._WORKFLOW_CONVERSATION_RE.match(cid))}
+            for cid in DOMAIN_CASES
+        ],
+    }
+    args.out.write_text(json.dumps(out, indent=2) + "\n")
+    print(f"wrote {args.out} ({len(out['alias_cases'])} alias cases)")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/atlas-plugin/assets/mlperf-agentic/parity_fixtures.json
+++ b/crates/atlas-plugin/assets/mlperf-agentic/parity_fixtures.json
@@ -1,0 +1,1012 @@
+{
+  "upstream_commit": "7935df4",
+  "upstream_file": "src/inference_endpoint/evaluation/scoring.py",
+  "upstream_class": "AgenticInferenceInlineScorer",
+  "intent_cases": [
+    {
+      "turn": {
+        "content": "intent: I042"
+      },
+      "expected": "I042"
+    },
+    {
+      "turn": {
+        "reasoning_content": "intent: I001",
+        "content": "intent: I002"
+      },
+      "expected": "I001"
+    },
+    {
+      "turn": {
+        "reasoning_content": "thinking about I111",
+        "content": "final intent: I222"
+      },
+      "expected": "I222"
+    },
+    {
+      "turn": {
+        "content": "Intent: i042"
+      },
+      "expected": "I042"
+    },
+    {
+      "turn": {
+        "content": "intent:\u00a0I042"
+      },
+      "expected": "I042"
+    },
+    {
+      "turn": {
+        "content": "intent : I042"
+      },
+      "expected": "I042"
+    },
+    {
+      "turn": {
+        "content": "reintent: I042"
+      },
+      "expected": "I042"
+    },
+    {
+      "turn": {
+        "content": "intent: I0425"
+      },
+      "expected": null
+    },
+    {
+      "turn": {
+        "content": "maybe I100, no, I200"
+      },
+      "expected": "I200"
+    },
+    {
+      "turn": {
+        "content": "maybe i123"
+      },
+      "expected": null
+    },
+    {
+      "turn": {
+        "content": "the AI123 model"
+      },
+      "expected": null
+    },
+    {
+      "turn": {
+        "content": "I12 and I1234"
+      },
+      "expected": null
+    },
+    {
+      "turn": {
+        "content": null
+      },
+      "expected": null
+    },
+    {
+      "turn": {},
+      "expected": null
+    },
+    {
+      "turn": {
+        "content": 7,
+        "reasoning_content": "intent: I300"
+      },
+      "expected": "I300"
+    }
+  ],
+  "gt_intent_cases": [
+    {
+      "turn": {
+        "intent_codes": [
+          "i001",
+          "I002",
+          null
+        ]
+      },
+      "expected": [
+        "I001",
+        "I002"
+      ]
+    },
+    {
+      "turn": {
+        "intent_codes": [
+          "",
+          "I003"
+        ]
+      },
+      "expected": [
+        "I003"
+      ]
+    },
+    {
+      "turn": {
+        "intent_codes": "I001"
+      },
+      "expected": []
+    },
+    {
+      "turn": {
+        "intent_codes": null
+      },
+      "expected": []
+    },
+    {
+      "turn": {},
+      "expected": []
+    }
+  ],
+  "bash_cases": [
+    {
+      "arguments": {
+        "cmd": "CUDA_VISIBLE_DEVICES=0 /usr/bin/python3 -m pytest"
+      },
+      "expected": [
+        "python"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "cat foo.py | grep bar | wc -l"
+      },
+      "expected": [
+        "cat",
+        "grep",
+        "wc"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "make build || make clean; ls\nfind . -name x"
+      },
+      "expected": [
+        "make",
+        "make",
+        "ls",
+        "find"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "echo \"done\" && grep -r pattern src"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "grep \"a | b\" file.txt"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "grep \"say \\\"hi\\\" | there\" f && ls"
+      },
+      "expected": [
+        "grep",
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "diff `ls` other"
+      },
+      "expected": [
+        "diff"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "grep 'unterminated && ls"
+      },
+      "expected": [
+        "grep",
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "sudo env FOO=1 time make test"
+      },
+      "expected": [
+        "make"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "FOO=1"
+      },
+      "expected": []
+    },
+    {
+      "arguments": {
+        "cmd": ". ./venv/bin/activate && ./run.sh"
+      },
+      "expected": [
+        "source"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "python3.11 setup.py"
+      },
+      "expected": [
+        "python"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "python3.1.2.3 x"
+      },
+      "expected": []
+    },
+    {
+      "arguments": {
+        "cmd": "sleep 5 & wait"
+      },
+      "expected": []
+    },
+    {
+      "arguments": {
+        "cmd": "GREP pattern file"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "command": "git status"
+      },
+      "expected": [
+        "git"
+      ]
+    },
+    {
+      "arguments": {
+        "command": "",
+        "cmd": "git diff"
+      },
+      "expected": [
+        "git"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "grep a f1; grep b f2; grep c f3"
+      },
+      "expected": [
+        "grep",
+        "grep",
+        "grep"
+      ]
+    }
+  ],
+  "alias_cases": [
+    {
+      "arguments": {
+        "cmd": "python --arg"
+      },
+      "expected": [
+        "python"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "python2 --arg"
+      },
+      "expected": [
+        "python"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "python3 --arg"
+      },
+      "expected": [
+        "python"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "py --arg"
+      },
+      "expected": [
+        "python"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "pip --arg"
+      },
+      "expected": [
+        "pip"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "pip3 --arg"
+      },
+      "expected": [
+        "pip"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "pytest --arg"
+      },
+      "expected": [
+        "pytest"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "pylint --arg"
+      },
+      "expected": [
+        "pylint"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "sphinx-build --arg"
+      },
+      "expected": [
+        "sphinx"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "sphinx-quickstart --arg"
+      },
+      "expected": [
+        "sphinx"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "cython --arg"
+      },
+      "expected": [
+        "cython"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "make --arg"
+      },
+      "expected": [
+        "make"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "conda --arg"
+      },
+      "expected": [
+        "conda"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "cat --arg"
+      },
+      "expected": [
+        "cat"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "head --arg"
+      },
+      "expected": [
+        "head"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "tail --arg"
+      },
+      "expected": [
+        "tail"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "less --arg"
+      },
+      "expected": [
+        "cat"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "more --arg"
+      },
+      "expected": [
+        "cat"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "wc --arg"
+      },
+      "expected": [
+        "wc"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "diff --arg"
+      },
+      "expected": [
+        "diff"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "grep --arg"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "egrep --arg"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "fgrep --arg"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "rg --arg"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "ag --arg"
+      },
+      "expected": [
+        "grep"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "sed --arg"
+      },
+      "expected": [
+        "sed"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "awk --arg"
+      },
+      "expected": [
+        "awk"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "gawk --arg"
+      },
+      "expected": [
+        "awk"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "tr --arg"
+      },
+      "expected": [
+        "tr"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "sort --arg"
+      },
+      "expected": [
+        "sort"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "uniq --arg"
+      },
+      "expected": [
+        "uniq"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "cut --arg"
+      },
+      "expected": [
+        "cut"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "find --arg"
+      },
+      "expected": [
+        "find"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "ls --arg"
+      },
+      "expected": [
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "locate --arg"
+      },
+      "expected": [
+        "find"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "xargs --arg"
+      },
+      "expected": [
+        "xargs"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "cp --arg"
+      },
+      "expected": [
+        "cp"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "mv --arg"
+      },
+      "expected": [
+        "mv"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "rm --arg"
+      },
+      "expected": [
+        "rm"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "mkdir --arg"
+      },
+      "expected": [
+        "mkdir"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "touch --arg"
+      },
+      "expected": [
+        "touch"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "tee --arg"
+      },
+      "expected": [
+        "tee"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "source --arg"
+      },
+      "expected": [
+        "source"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": ". --arg"
+      },
+      "expected": [
+        "source"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "which --arg"
+      },
+      "expected": [
+        "which"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "alias --arg"
+      },
+      "expected": [
+        "alias"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "unset --arg"
+      },
+      "expected": [
+        "unset"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "export --arg"
+      },
+      "expected": [
+        "export"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "git --arg"
+      },
+      "expected": [
+        "git"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "curl --arg"
+      },
+      "expected": [
+        "curl"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "wget --arg"
+      },
+      "expected": [
+        "curl"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "true --arg"
+      },
+      "expected": [
+        "true"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "false --arg"
+      },
+      "expected": [
+        "false"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "timeout --arg"
+      },
+      "expected": [
+        "timeout"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "date --arg"
+      },
+      "expected": [
+        "date"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "apt-get --arg"
+      },
+      "expected": [
+        "apt"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "apt --arg"
+      },
+      "expected": [
+        "apt"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "yum --arg"
+      },
+      "expected": [
+        "yum"
+      ]
+    }
+  ],
+  "wrapper_cases": [
+    {
+      "arguments": {
+        "cmd": "command ls -la"
+      },
+      "expected": [
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "env ls -la"
+      },
+      "expected": [
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "exec ls -la"
+      },
+      "expected": [
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "nice ls -la"
+      },
+      "expected": [
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "sudo ls -la"
+      },
+      "expected": [
+        "ls"
+      ]
+    },
+    {
+      "arguments": {
+        "cmd": "time ls -la"
+      },
+      "expected": [
+        "ls"
+      ]
+    }
+  ],
+  "turn_cases": [
+    {
+      "domain": "coding",
+      "gt": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": {
+                "cmd": "python x.py && pytest"
+              }
+            }
+          }
+        ]
+      },
+      "model": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": {
+                "cmd": "python y.py"
+              }
+            }
+          }
+        ]
+      },
+      "expected": 0.5
+    },
+    {
+      "domain": "coding",
+      "gt": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": {
+                "cmd": "grep a; grep b"
+              }
+            }
+          }
+        ]
+      },
+      "model": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": {
+                "cmd": "grep a"
+              }
+            }
+          }
+        ]
+      },
+      "expected": 0.5
+    },
+    {
+      "domain": "coding",
+      "gt": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": {
+                "cmd": "make"
+              }
+            }
+          }
+        ]
+      },
+      "model": {
+        "content": "I would run make here."
+      },
+      "expected": 0.0
+    },
+    {
+      "domain": "coding",
+      "gt": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": {
+                "cmd": "ls"
+              }
+            }
+          }
+        ]
+      },
+      "model": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "edit_file",
+              "arguments": {
+                "cmd": "ls"
+              }
+            }
+          }
+        ]
+      },
+      "expected": 0.0
+    },
+    {
+      "domain": "coding",
+      "gt": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": "{\"cmd\": \"git log\"}"
+            }
+          }
+        ]
+      },
+      "model": {
+        "tool_calls": [
+          {
+            "function": {
+              "name": "bash",
+              "arguments": "{not json"
+            }
+          },
+          {
+            "function": {
+              "name": "bash",
+              "arguments": "{\"cmd\": \"git show\"}"
+            }
+          }
+        ]
+      },
+      "expected": 1.0
+    },
+    {
+      "domain": "workflow",
+      "gt": {
+        "intent_codes": [
+          "i042"
+        ]
+      },
+      "model": {
+        "content": "intent: I042"
+      },
+      "expected": 1.0
+    },
+    {
+      "domain": "workflow",
+      "gt": {
+        "intent_codes": [
+          "I001",
+          "I002"
+        ]
+      },
+      "model": {
+        "content": "intent: I003"
+      },
+      "expected": 0.0
+    },
+    {
+      "domain": "workflow",
+      "gt": {
+        "intent_codes": [
+          "I001"
+        ]
+      },
+      "model": {
+        "content": "no code here"
+      },
+      "expected": 0.0
+    }
+  ],
+  "domain_cases": [
+    {
+      "conversation_id": "sim_001",
+      "workflow": true
+    },
+    {
+      "conversation_id": "sim_12345",
+      "workflow": true
+    },
+    {
+      "conversation_id": "sim_",
+      "workflow": false
+    },
+    {
+      "conversation_id": "sim_1x",
+      "workflow": false
+    },
+    {
+      "conversation_id": "Sim_001",
+      "workflow": false
+    },
+    {
+      "conversation_id": "xsim_001",
+      "workflow": false
+    },
+    {
+      "conversation_id": "django__django-12345",
+      "workflow": false
+    },
+    {
+      "conversation_id": "task_991",
+      "workflow": false
+    }
+  ]
+}

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/dataset.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/dataset.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The MLPerf Agentic Inference trajectory file: flat JSONL, one row per
+//! message, rows per conversation contiguous and turn-ordered from 1.
+//!
+//! This is a port of the upstream loader semantics
+//! (`AgenticInferenceDataset._build_conversation_metadata` and its
+//! validators, mlcommons/endpoints@7935df4) against the format the upstream
+//! README documents. It is written to the DOCUMENTED format because the
+//! official dataset itself does not exist yet — MLCommons' README says it
+//! "can be downloaded from MLCommons storage (link TBD)". Until that file
+//! ships, this loader is exercised only by its tests; nothing here has met
+//! real data, and the first calibration run may surface format corners the
+//! documentation does not.
+//!
+//! # Teacher forcing is the whole design
+//!
+//! The prompt for client turn N is the RECORDED history (system prompt +
+//! recorded user/tool/assistant rows, including recorded `reasoning_content`
+//! and `tool_calls`) plus the current client message, prebuilt here at load
+//! time. The model's own output is scored but never fed into later turns —
+//! so a run's per-turn context lengths are a pure function of the dataset,
+//! which is what makes a pinned draw comparable across engines at all.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+use super::scoring::{Domain, domain_of};
+
+/// One client turn: what is sent, and the recorded assistant row that scores it.
+#[derive(Clone, Debug)]
+pub struct ClientTurn {
+    /// The client row's turn number — the key the scorer joins on.
+    pub turn: i64,
+    /// Prebuilt prompt: system + recorded history + this client message.
+    pub messages: Vec<Value>,
+    /// The recorded assistant row that immediately follows this client row,
+    /// raw. `None` for a trailing client row with no assistant after it.
+    pub ground_truth: Option<Value>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Conversation {
+    pub id: String,
+    pub domain: Domain,
+    /// Tool schemas from the conversation's first `user` row, sent with every
+    /// request (upstream propagates them the same way).
+    pub tools: Option<Value>,
+    pub client_turns: Vec<ClientTurn>,
+}
+
+/// How many whole trajectories to take per domain, FIRST-K in file order —
+/// deterministic and RNG-free, like the BFCL draw. `0` means all of that
+/// domain. Partial conversations are never drawn: under teacher forcing a
+/// half trajectory silently shifts every remaining turn's context length.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DrawSpec {
+    pub coding: usize,
+    pub workflow: usize,
+}
+
+impl DrawSpec {
+    pub fn all() -> Self {
+        Self {
+            coding: 0,
+            workflow: 0,
+        }
+    }
+}
+
+/// Load the trajectory file and apply the draw.
+pub fn load(path: &Path, spec: &DrawSpec) -> Result<Vec<Conversation>> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let conversations = parse(&text)?;
+    let mut taken = Vec::new();
+    let (mut coding_taken, mut workflow_taken) = (0usize, 0usize);
+    for conv in conversations {
+        let (count, limit) = match conv.domain {
+            Domain::Coding => (&mut coding_taken, spec.coding),
+            Domain::Workflow => (&mut workflow_taken, spec.workflow),
+        };
+        if limit == 0 || *count < limit {
+            *count += 1;
+            taken.push(conv);
+        }
+    }
+    if taken.is_empty() {
+        bail!("the draw selected no trajectories");
+    }
+    Ok(taken)
+}
+
+/// The draw fingerprint: SHA256 over the ordered drawn conversation ids and
+/// their client-turn counts. Two runs with equal fingerprints replayed the
+/// same prompts in the same order; a differing fingerprint means the numbers
+/// are not comparable, whatever the sample counts say. This is the content
+/// identity the BFCL legs never had (their provisioning digest is computed
+/// and then dropped), recorded here into the gate record itself.
+pub fn draw_fingerprint(conversations: &[Conversation]) -> String {
+    let mut digest = Sha256::new();
+    for conv in conversations {
+        digest.update(conv.id.as_bytes());
+        digest.update(b"\n");
+        digest.update(conv.client_turns.len().to_string().as_bytes());
+        digest.update(b"\n");
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn parse(text: &str) -> Result<Vec<Conversation>> {
+    // Group contiguous rows by conversation, enforcing the upstream
+    // validators: non-empty printable-ASCII ids, contiguity, turns exactly
+    // 1..=N, and the user/assistant/tool role grammar.
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: std::collections::BTreeMap<String, Vec<Map<String, Value>>> =
+        Default::default();
+    let mut seen_closed: BTreeSet<String> = BTreeSet::new();
+    let mut last_id: Option<String> = None;
+
+    for (i, line) in text.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let row: Map<String, Value> =
+            serde_json::from_str(line).with_context(|| format!("line {}: malformed row", i + 1))?;
+        let id = match row.get("conversation_id") {
+            Some(Value::String(s)) if !s.is_empty() => s.clone(),
+            other => bail!(
+                "line {}: conversation_id must be a non-empty string, got {}",
+                i + 1,
+                other
+                    .map(Value::to_string)
+                    .unwrap_or_else(|| "nothing".into())
+            ),
+        };
+        if id.bytes().any(|b| !(32..=126).contains(&b)) {
+            bail!(
+                "line {}: conversation_id {id:?} has non-printable or non-ASCII characters",
+                i + 1
+            );
+        }
+        if last_id.as_ref() != Some(&id) {
+            if seen_closed.contains(&id) {
+                bail!(
+                    "rows for conversation {id:?} are not consecutive — the loader takes the \
+                     first K per domain in file order, so interleaving would silently change \
+                     which trajectories a draw selects"
+                );
+            }
+            if let Some(prev) = last_id.replace(id.clone()) {
+                seen_closed.insert(prev);
+            }
+            order.push(id.clone());
+        }
+        groups.entry(id).or_default().push(row);
+    }
+
+    let mut out = Vec::new();
+    for id in order {
+        let rows = groups.remove(&id).expect("grouped above");
+        out.push(build_conversation(id, rows)?);
+    }
+    if out.is_empty() {
+        bail!("the trajectory file holds no rows");
+    }
+    Ok(out)
+}
+
+fn turn_of(row: &Map<String, Value>) -> Result<i64> {
+    row.get("turn")
+        .and_then(Value::as_i64)
+        .context("row is missing an integer 'turn'")
+}
+
+fn build_conversation(id: String, mut rows: Vec<Map<String, Value>>) -> Result<Conversation> {
+    for row in &rows {
+        turn_of(row).with_context(|| format!("conversation {id:?}"))?;
+    }
+    rows.sort_by_key(|r| turn_of(r).expect("checked above"));
+    let turns: Vec<i64> = rows.iter().map(|r| turn_of(r).unwrap()).collect();
+    if turns.iter().enumerate().any(|(i, &t)| t != i as i64 + 1) {
+        bail!(
+            "conversation {id:?}: turn numbers must be exactly 1..={}, got {turns:?}",
+            rows.len()
+        );
+    }
+    validate_roles(&id, &rows)?;
+
+    let system = rows
+        .iter()
+        .find_map(|r| {
+            r.get("system")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+        })
+        .map(str::to_string);
+    let tools = rows
+        .iter()
+        .find(|r| r.get("role").and_then(Value::as_str) == Some("user"))
+        .and_then(|r| r.get("tools"))
+        .filter(|t| !t.is_null())
+        .cloned();
+
+    // Single pass in turn order, carrying the running history — the port of
+    // upstream `_build_conversation_metadata`. Client rows snapshot
+    // (history + current) BEFORE extending; assistant rows only extend.
+    let mut history: Vec<Value> = Vec::new();
+    if let Some(system) = &system {
+        history.push(json!({"role": "system", "content": system}));
+    }
+    let mut client_turns: Vec<ClientTurn> = Vec::new();
+    for (i, row) in rows.iter().enumerate() {
+        let role = row.get("role").and_then(Value::as_str).unwrap_or_default();
+        let row_msgs = format_row(&id, row)?;
+        if role == "user" || role == "tool" {
+            let mut messages = history.clone();
+            messages.extend(row_msgs.iter().cloned());
+            // The scorer's ground-truth pairing: the assistant row that
+            // immediately follows this client row in turn order.
+            let ground_truth = rows.get(i + 1).and_then(|next| {
+                (next.get("role").and_then(Value::as_str) == Some("assistant"))
+                    .then(|| Value::Object(next.clone()))
+            });
+            client_turns.push(ClientTurn {
+                turn: turn_of(row).unwrap(),
+                messages,
+                ground_truth,
+            });
+        }
+        history.extend(row_msgs);
+    }
+
+    Ok(Conversation {
+        domain: domain_of(&id),
+        id,
+        tools,
+        client_turns,
+    })
+}
+
+/// Format one row into OpenAI message(s): `tool_results` rows expand to one
+/// tool message per result; everything else passes the recorded fields
+/// through, with `content: null` filled in on tool-calling assistant rows.
+fn format_row(id: &str, row: &Map<String, Value>) -> Result<Vec<Value>> {
+    if let Some(results) = row.get("tool_results").and_then(Value::as_array)
+        && !results.is_empty()
+    {
+        let mut msgs = Vec::new();
+        for (i, result) in results.iter().enumerate() {
+            let (Some(tool_call_id), Some(content)) =
+                (result.get("tool_call_id"), result.get("content"))
+            else {
+                bail!(
+                    "conversation {id:?} turn {}: tool_results[{i}] needs tool_call_id and content",
+                    turn_of(row).unwrap_or_default()
+                );
+            };
+            msgs.push(json!({
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": content,
+            }));
+        }
+        return Ok(msgs);
+    }
+    let mut msg = Map::new();
+    for key in [
+        "role",
+        "content",
+        "name",
+        "tool_calls",
+        "tool_results",
+        "reasoning_content",
+    ] {
+        if let Some(v) = row.get(key).filter(|v| !v.is_null()) {
+            msg.insert(key.to_string(), v.clone());
+        }
+    }
+    if msg.get("role").and_then(Value::as_str) == Some("assistant")
+        && msg.contains_key("tool_calls")
+        && !msg.contains_key("content")
+    {
+        msg.insert("content".into(), Value::Null);
+    }
+    Ok(if msg.contains_key("role") {
+        vec![Value::Object(msg)]
+    } else {
+        Vec::new()
+    })
+}
+
+/// The upstream role grammar: a conversation starts with `user`; `user` is
+/// answered by `assistant`; `assistant` is followed by `tool` or `user`;
+/// `tool` by `assistant` or `user`. A `tool` row must follow an assistant
+/// that made tool calls, and must carry a non-empty `tool_results` list.
+fn validate_roles(id: &str, rows: &[Map<String, Value>]) -> Result<()> {
+    let mut state = "start";
+    let mut prev_assistant_had_tool_calls = false;
+    for row in rows {
+        let role = row
+            .get("role")
+            .and_then(Value::as_str)
+            .with_context(|| format!("conversation {id:?}: row without a role"))?;
+        let valid: &[&str] = match state {
+            "start" => &["user"],
+            "user" => &["assistant"],
+            "assistant" => &["tool", "user"],
+            "tool" => &["assistant", "user"],
+            _ => unreachable!(),
+        };
+        if !valid.contains(&role) {
+            bail!(
+                "conversation {id:?} turn {}: got role {role:?} after {state:?}",
+                turn_of(row).unwrap_or_default()
+            );
+        }
+        if role == "tool" {
+            if state == "assistant" && !prev_assistant_had_tool_calls {
+                bail!(
+                    "conversation {id:?} turn {}: a tool row must follow an assistant row \
+                     with non-empty tool_calls",
+                    turn_of(row).unwrap_or_default()
+                );
+            }
+            if row
+                .get("tool_results")
+                .and_then(Value::as_array)
+                .is_none_or(|r| r.is_empty())
+            {
+                bail!(
+                    "conversation {id:?} turn {}: tool rows need a non-empty tool_results list",
+                    turn_of(row).unwrap_or_default()
+                );
+            }
+        }
+        if role == "assistant" {
+            prev_assistant_had_tool_calls = row
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .is_some_and(|c| !c.is_empty());
+        }
+        state = match role {
+            "user" => "user",
+            "assistant" => "assistant",
+            _ => "tool",
+        };
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "dataset_tests.rs"]
+mod tests;

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/dataset_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/dataset_tests.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Loader tests against the DOCUMENTED trajectory format (upstream README +
+//! `AgenticInferenceDataset` semantics at 7935df4). No real dataset exists to
+//! test against, so these prove the port of the documented behaviour — the
+//! first calibration run is where reality gets a vote.
+
+use serde_json::{Value, json};
+
+use super::*;
+use crate::benchmarks::mlperf_agentic::scoring::Domain;
+
+fn write(name: &str, rows: &[Value]) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "atlas-mlperf-ds-{name}-{}.jsonl",
+        std::process::id()
+    ));
+    let text: String = rows.iter().map(|r| format!("{r}\n")).collect();
+    std::fs::write(&p, text).unwrap();
+    p
+}
+
+/// A well-formed coding conversation exercising every message shape: system,
+/// tool_calls with no content, tool_results expansion, plain assistant.
+fn coding_rows(id: &str) -> Vec<Value> {
+    vec![
+        json!({"conversation_id": id, "turn": 1, "role": "user", "system": "be an agent",
+               "content": "fix the bug", "tools": [{"type": "function"}]}),
+        json!({"conversation_id": id, "turn": 2, "role": "assistant", "reasoning_content": "look first",
+               "tool_calls": [{"id": "c1", "function": {"name": "bash", "arguments": {"cmd": "grep -r bug src"}}}]}),
+        json!({"conversation_id": id, "turn": 3, "role": "tool",
+               "tool_results": [{"tool_call_id": "c1", "content": "src/x.py: bug"}], "delay_seconds": 1.5}),
+        json!({"conversation_id": id, "turn": 4, "role": "assistant",
+               "tool_calls": [{"id": "c2", "function": {"name": "bash", "arguments": {"cmd": "python fix.py"}}}]}),
+    ]
+}
+
+fn workflow_rows(id: &str) -> Vec<Value> {
+    vec![
+        json!({"conversation_id": id, "turn": 1, "role": "user", "system": "support bot", "content": "where is my order"}),
+        json!({"conversation_id": id, "turn": 2, "role": "assistant", "content": "intent: I042", "intent_codes": ["I042"]}),
+    ]
+}
+
+#[test]
+fn prebuilt_messages_are_teacher_forced_snapshots() {
+    let p = write("snap", &coding_rows("proj-1"));
+    let convs = load(&p, &DrawSpec::all()).unwrap();
+    assert_eq!(convs.len(), 1);
+    let c = &convs[0];
+    assert_eq!(c.domain, Domain::Coding);
+    assert_eq!(c.client_turns.len(), 2, "turns 1 (user) and 3 (tool)");
+
+    // Turn 1: system + the user row.
+    let t1 = &c.client_turns[0];
+    assert_eq!(t1.turn, 1);
+    assert_eq!(t1.messages.len(), 2);
+    assert_eq!(t1.messages[0]["role"], "system");
+    assert_eq!(t1.messages[0]["content"], "be an agent");
+    assert_eq!(t1.messages[1]["role"], "user");
+    // The dataset-level fields do not leak into the prompt.
+    assert!(t1.messages[1].get("system").is_none());
+    assert!(t1.messages[1].get("tools").is_none());
+
+    // Turn 3: system + user + RECORDED assistant (content: null filled in) +
+    // the tool_results expanded to a tool message.
+    let t3 = &c.client_turns[1];
+    assert_eq!(t3.turn, 3);
+    assert_eq!(t3.messages.len(), 4);
+    let assistant = &t3.messages[2];
+    assert_eq!(assistant["role"], "assistant");
+    assert!(
+        assistant["content"].is_null(),
+        "tool-calling assistant gets content: null"
+    );
+    assert_eq!(assistant["reasoning_content"], "look first");
+    let tool = &t3.messages[3];
+    assert_eq!(tool["role"], "tool");
+    assert_eq!(tool["tool_call_id"], "c1");
+    assert_eq!(tool["content"], "src/x.py: bug");
+
+    // Ground truth: the immediately-following assistant row, raw.
+    assert_eq!(t1.ground_truth.as_ref().unwrap()["turn"], 2);
+    assert_eq!(t3.ground_truth.as_ref().unwrap()["turn"], 4);
+
+    // Tools come from the first user row.
+    assert!(c.tools.is_some());
+}
+
+#[test]
+fn a_trailing_client_turn_has_no_ground_truth() {
+    let mut rows = workflow_rows("sim_001");
+    rows.push(
+        json!({"conversation_id": "sim_001", "turn": 3, "role": "user", "content": "thanks"}),
+    );
+    let p = write("trailing", &rows);
+    let convs = load(&p, &DrawSpec::all()).unwrap();
+    assert_eq!(convs[0].domain, Domain::Workflow);
+    let turns = &convs[0].client_turns;
+    assert_eq!(turns.len(), 2);
+    assert!(turns[0].ground_truth.is_some());
+    assert!(turns[1].ground_truth.is_none());
+}
+
+#[test]
+fn the_draw_takes_the_first_k_per_domain_in_file_order() {
+    let mut rows = Vec::new();
+    for id in ["proj-a", "proj-b", "proj-c"] {
+        rows.extend(coding_rows(id));
+    }
+    for id in ["sim_001", "sim_002"] {
+        rows.extend(workflow_rows(id));
+    }
+    let p = write("draw", &rows);
+    let convs = load(
+        &p,
+        &DrawSpec {
+            coding: 2,
+            workflow: 1,
+        },
+    )
+    .unwrap();
+    let ids: Vec<&str> = convs.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["proj-a", "proj-b", "sim_001"],
+        "head(K), not a sample"
+    );
+
+    // 0 takes everything.
+    assert_eq!(load(&p, &DrawSpec::all()).unwrap().len(), 5);
+}
+
+#[test]
+fn the_fingerprint_tracks_draw_content_and_order() {
+    let mut rows = coding_rows("proj-a");
+    rows.extend(coding_rows("proj-b"));
+    rows.extend(workflow_rows("sim_001"));
+    let p = write("fp", &rows);
+    let both = load(&p, &DrawSpec::all()).unwrap();
+    let same = load(
+        &p,
+        &DrawSpec {
+            coding: 2,
+            workflow: 1,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        draw_fingerprint(&both),
+        draw_fingerprint(&same),
+        "equal draws, equal identity"
+    );
+
+    let smaller = load(
+        &p,
+        &DrawSpec {
+            coding: 1,
+            workflow: 1,
+        },
+    )
+    .unwrap();
+    assert_ne!(
+        draw_fingerprint(&both),
+        draw_fingerprint(&smaller),
+        "a different draw must never fingerprint the same"
+    );
+    assert_eq!(draw_fingerprint(&both).len(), 64, "full sha256 hex");
+}
+
+#[test]
+fn interleaved_conversations_are_refused() {
+    let a = coding_rows("proj-a");
+    let b = coding_rows("proj-b");
+    let rows = vec![a[0].clone(), b[0].clone(), a[1].clone()];
+    let p = write("interleave", &rows);
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("not consecutive"), "{err}");
+}
+
+#[test]
+fn turn_numbers_must_be_exactly_one_to_n() {
+    let mut rows = workflow_rows("sim_001");
+    rows[1]["turn"] = json!(5);
+    let p = write("turns", &rows);
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("turn numbers must be exactly"), "{err}");
+}
+
+#[test]
+fn the_role_grammar_is_enforced() {
+    // assistant first.
+    let p = write(
+        "grammar1",
+        &[json!({"conversation_id": "c", "turn": 1, "role": "assistant", "content": "hi"})],
+    );
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("after \"start\""), "{err}");
+
+    // tool row without a tool-calling assistant before it.
+    let p = write(
+        "grammar2",
+        &[
+            json!({"conversation_id": "c", "turn": 1, "role": "user", "content": "hi"}),
+            json!({"conversation_id": "c", "turn": 2, "role": "assistant", "content": "plain"}),
+            json!({"conversation_id": "c", "turn": 3, "role": "tool",
+                   "tool_results": [{"tool_call_id": "x", "content": "y"}]}),
+        ],
+    );
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("non-empty tool_calls"), "{err}");
+
+    // tool row without results.
+    let mut rows = coding_rows("proj-a");
+    rows[2] = json!({"conversation_id": "proj-a", "turn": 3, "role": "tool"});
+    let p = write("grammar3", &rows);
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("non-empty tool_results"), "{err}");
+}
+
+#[test]
+fn conversation_ids_must_be_printable_ascii_strings() {
+    let p = write(
+        "ids",
+        &[json!({"conversation_id": "sim_00\u{e9}", "turn": 1, "role": "user", "content": "x"})],
+    );
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("non-printable or non-ASCII"), "{err}");
+
+    let p = write(
+        "ids2",
+        &[json!({"turn": 1, "role": "user", "content": "x"})],
+    );
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("non-empty string"), "{err}");
+}
+
+#[test]
+fn a_malformed_line_names_its_line_number() {
+    let p = write("bad", &coding_rows("proj-a"));
+    let mut text = std::fs::read_to_string(&p).unwrap();
+    text.push_str("{not json}\n");
+    std::fs::write(&p, text).unwrap();
+    let err = load(&p, &DrawSpec::all()).unwrap_err().to_string();
+    assert!(err.contains("line 5"), "{err}");
+}

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/descriptors.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/descriptors.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The registered MLPerf Agentic Inference descriptor.
+//!
+//! One leg, not the two the eventual shape calls for: `mlperf-agentic-subset`
+//! is the pinned-draw merge-gate candidate. The full 613-trajectory official
+//! pass (`mlperf-agentic-full`) is NOT registered yet on purpose — its draw,
+//! concurrency shape and wall time can only be sized from a calibration run,
+//! and no calibration can happen until MLCommons publishes the dataset.
+//! Registering a leg whose parameters are guesses would pin the guesses.
+
+use super::MlperfAgentic;
+use crate::benchmark::BenchmarkDescriptor;
+use crate::hardware::Sensitivity;
+use crate::metadata::PluginMetadata;
+
+const SUBSET_SUMMARY: &str =
+    "MLPerf Agentic Inference replay, inline-scored — UNRUNNABLE: dataset unpublished";
+pub const SUBSET_METADATA: PluginMetadata = PluginMetadata::atlas(SUBSET_SUMMARY);
+
+pub const SUBSET_DESCRIPTOR: BenchmarkDescriptor = BenchmarkDescriptor {
+    id: "mlperf-agentic-subset",
+    name: "MLPerf agentic (subset)",
+    summary: SUBSET_SUMMARY,
+    detail: "Teacher-forced multi-turn replay of the MLPerf Agentic Inference dataset \
+             (mlcommons/endpoints@7935df4): recorded trajectories are replayed single-stream \
+             under the official immutable sampling params (temp 1.0, top_k 20, top_p 0.95, \
+             presence 1.5, max 8192, preserve_thinking) plus a pinned seed, and scored \
+             in-process by a fixture-verified port of the upstream inline scorer — workflow \
+             intent-code match plus coding bash-executable multiset IoU. \
+             ★ CANNOT RUN TODAY: the official dataset is unpublished (\"MLCommons storage, \
+             link TBD\") and this leg refuses proxies, so it fails loudly at provisioning \
+             until the file ships. No baseline exists; the first measured run on main \
+             becomes one. Reports inline accuracy + OSL only — the SWE-bench Verified leg \
+             of the official three-part gate is a separate live-agent workflow, not a leg.",
+    duration_hint: "unrunnable — dataset TBD",
+    updated: "2026-08-13",
+    needs_confirmation: false,
+    intended_for: Some(crate::benchmark::ModelExpectation {
+        families: &["qwen3.6-35b-a3b"],
+        note: "MLCommons specifies Qwen/Qwen3.6-35B-A3B (BF16); Atlas serves the official \
+               FP8 sibling, which is rules-legal quantization but NOT the named checkpoint \
+               — every number needs that caveat until the three-part accuracy gate is \
+               cleared. Kimi K2.6 (1T) does not fit a GB10.",
+    }),
+    // No baseline exists yet — the detail above says so explicitly ("the first
+    // measured run on main becomes one"), and a threshold param with nothing to
+    // substitute from would pin a guess.
+    threshold_params: &[],
+    // CORRECTNESS, same reasoning as the BFCL legs: this scores intent-code
+    // match and bash-executable IoU, and reports OSL rather than a rate. There
+    // is no timing number here for a thermal or clock excursion to reach, so
+    // gating it on machine state would stop accuracy work for a reason that
+    // cannot affect the result.
+    sensitivity: Sensitivity::Correctness,
+    ctor: || Box::new(MlperfAgentic::new()),
+};

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/mlperf_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/mlperf_tests.rs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::json;
+
+use super::*;
+use crate::artifacts::ArtifactStore;
+use crate::plugin::TargetEndpoint;
+
+fn handle(root: &str) -> (PluginHandle, std::path::PathBuf) {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::mem::forget(rx);
+    let dir = std::env::temp_dir().join(format!("atlas-mlperf-{root}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        PluginHandle::new(
+            1,
+            TargetEndpoint::local(8888, "test-model"),
+            ArtifactStore::with_root(&dir),
+            tx,
+            Arc::new(AtomicBool::new(false)),
+        ),
+        dir,
+    )
+}
+
+/// The single most load-bearing behaviour while the dataset does not exist:
+/// provisioning fails LOUDLY, naming the missing artifact, the TBD upstream
+/// status, and the no-proxy rule — never an empty run and never a 0.0.
+#[test]
+fn an_absent_dataset_fails_provisioning_with_the_specific_story() {
+    let (h, _dir) = handle("absent");
+    let err = provision::ensure(h.artifacts(), &h, "")
+        .unwrap_err()
+        .to_string();
+    for needle in [
+        "dataset.jsonl",
+        "NOT yet published",
+        "link TBD",
+        "mlcommons/endpoints@7935df4",
+        "refuses to substitute a proxy",
+        "613 trajectories",
+    ] {
+        assert!(
+            err.contains(needle),
+            "error must mention {needle:?}:\n{err}"
+        );
+    }
+}
+
+#[test]
+fn a_present_dataset_is_hashed_and_a_wrong_pin_refuses_to_run() {
+    let (h, dir) = handle("pin");
+    let plugin_dir = h.artifacts().plugin_dir(provision::PLUGIN_ID).unwrap();
+    std::fs::write(plugin_dir.join("dataset.jsonl"), b"{}\n").unwrap();
+
+    let a = provision::ensure(h.artifacts(), &h, "").unwrap();
+    assert_eq!(a.file_sha256.len(), 64);
+    assert!(plugin_dir.join("dataset_summary.json").is_file());
+
+    // The right pin passes (case-insensitively), the wrong one refuses.
+    provision::ensure(h.artifacts(), &h, &a.file_sha256.to_uppercase()).unwrap();
+    let err = provision::ensure(h.artifacts(), &h, "deadbeef")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("does not match its pin"), "{err}");
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+/// The request carries the official immutable sampling set plus the seed and
+/// NOTHING else. Pinned by exact key set: the upstream rules forbid adding
+/// sampling params, and the repo's own doctrine forbids a temperature knob
+/// here — a temp-0 run would look comparable to the MLPerf thresholds and
+/// not be.
+#[test]
+fn the_request_body_is_the_official_immutable_set_plus_seed() {
+    let messages = vec![json!({"role": "user", "content": "hi"})];
+    let tools = json!([{"type": "function"}]);
+    let body = request_body("m", &messages, Some(&tools), 42);
+    let mut keys: Vec<&str> = body
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec![
+            "chat_template_kwargs",
+            "max_tokens",
+            "messages",
+            "model",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+            "stream",
+            "temperature",
+            "tools",
+            "top_k",
+            "top_p",
+        ]
+    );
+    assert_eq!(body["temperature"], 1.0);
+    assert_eq!(body["top_k"], 20);
+    assert_eq!(body["top_p"], 0.95);
+    assert_eq!(body["repetition_penalty"], 1.0);
+    assert_eq!(body["presence_penalty"], 1.5);
+    assert_eq!(body["max_tokens"], 8192);
+    assert_eq!(body["seed"], 42);
+    assert_eq!(
+        body["chat_template_kwargs"],
+        json!({"preserve_thinking": true})
+    );
+
+    // No tools → no tools key, not tools: null.
+    let body = request_body("m", &messages, None, 42);
+    assert!(body.get("tools").is_none());
+}
+
+/// No temperature (or any sampling) parameter is exposed — verified against
+/// the live spec list so a later param addition trips this test and forces
+/// the conversation.
+#[test]
+fn sampling_is_not_parameterizable() {
+    let b = MlperfAgentic::new();
+    for spec in b.parameters() {
+        for forbidden in [
+            "temperature",
+            "top_p",
+            "top_k",
+            "penalty",
+            "max_new",
+            "max_tokens",
+        ] {
+            assert!(
+                !spec.key.contains(forbidden),
+                "{} must not be a parameter on this leg",
+                spec.key
+            );
+        }
+    }
+}
+
+#[test]
+fn model_turns_mirror_the_upstream_message_shape() {
+    let mut outcome = http::ChatOutcome {
+        text: "done".into(),
+        reasoning: "thinking".into(),
+        ..Default::default()
+    };
+    let turn = model_turn(&outcome);
+    assert_eq!(turn["role"], "assistant");
+    assert_eq!(turn["content"], "done");
+    assert_eq!(turn["reasoning_content"], "thinking");
+    assert!(turn["tool_calls"].is_null(), "no calls is null, not []");
+
+    outcome.tool_calls = vec![crate::http::ToolCall {
+        id: "c1".into(),
+        name: "bash".into(),
+        arguments: r#"{"cmd": "ls"}"#.into(),
+    }];
+    let turn = model_turn(&outcome);
+    assert_eq!(turn["tool_calls"][0]["function"]["name"], "bash");
+    // Arguments stay the raw streamed string; the scorer parses them itself.
+    assert_eq!(
+        turn["tool_calls"][0]["function"]["arguments"],
+        r#"{"cmd": "ls"}"#
+    );
+    assert_eq!(scoring::bash_actions(&turn), vec!["ls".to_string()]);
+}
+
+#[test]
+fn aggregation_follows_the_upstream_denominator_semantics() {
+    let t = |domain, score: Option<f64>, missing, tokens| TurnRecord {
+        conversation_id: "c".into(),
+        turn: 1,
+        domain,
+        score,
+        missing,
+        completion_tokens: tokens,
+        model: json!({}),
+    };
+    // Two scored coding turns (one a missing-output 0), one scored workflow
+    // turn, one excluded turn.
+    let turns = vec![
+        t(Domain::Coding, Some(0.5), false, 100),
+        t(Domain::Coding, Some(0.0), true, 0),
+        t(Domain::Workflow, Some(1.0), false, 60),
+        t(Domain::Coding, None, false, 40),
+    ];
+    let s = report::aggregate(&turns).unwrap();
+    assert_eq!(s.turns_scored, 3);
+    assert_eq!(s.turns_excluded, 1);
+    assert_eq!(s.turns_missing, 1);
+    assert!((s.inline - 0.5).abs() < 1e-9, "mean of 0.5, 0.0, 1.0");
+    assert_eq!(s.coding.unwrap(), (0.25, 2));
+    assert_eq!(s.workflow.unwrap(), (1.0, 1));
+    // OSL is over turns that produced output (3 of 4), missing excluded.
+    assert!((s.osl_per_turn_mean - (200.0 / 3.0)).abs() < 1e-9);
+
+    // Nothing scorable → None, which the phase machine turns into a refusal,
+    // never a 0.0 score.
+    assert!(report::aggregate(&[t(Domain::Coding, None, false, 10)]).is_none());
+}
+
+#[test]
+fn the_descriptor_says_it_cannot_run_and_defaults_validate() {
+    assert_eq!(SUBSET_DESCRIPTOR.id, "mlperf-agentic-subset");
+    for text in [SUBSET_DESCRIPTOR.summary, SUBSET_DESCRIPTOR.detail] {
+        assert!(
+            text.to_lowercase().contains("unrunnable") || text.contains("CANNOT RUN"),
+            "a reader must not mistake this for a measured leg: {text}"
+        );
+    }
+    assert!(
+        SUBSET_DESCRIPTOR.detail.contains("SWE-bench"),
+        "the missing official leg is named"
+    );
+    let b = MlperfAgentic::new();
+    let values = ParamValues::defaults(&b.parameters());
+    values.validate_against(&b.parameters()).unwrap();
+}
+
+/// The verdict can never be PASS: there is no baseline for it to have passed.
+#[test]
+fn the_verdict_is_info_and_names_the_unmeasured_state() {
+    let mut b = MlperfAgentic::new();
+    let v = b.verdict();
+    assert_eq!(v.kind, crate::result::VerdictKind::Info);
+
+    b.turns.push(TurnRecord {
+        conversation_id: "sim_001".into(),
+        turn: 1,
+        domain: Domain::Workflow,
+        score: Some(1.0),
+        missing: false,
+        completion_tokens: 10,
+        model: json!({}),
+    });
+    b.scores = report::aggregate(&b.turns);
+    let v = b.verdict();
+    assert_eq!(
+        v.kind,
+        crate::result::VerdictKind::Info,
+        "perfect scores still do not PASS"
+    );
+    assert!(v.reason.contains("UNMEASURED"), "{}", v.reason);
+    assert!(v.reason.contains("NOT this draw's floors"), "{}", v.reason);
+}
+
+/// The fingerprint written to the terminal frame reaches the gate record —
+/// the whole point of the additive `dataset_fingerprint` field.
+#[test]
+fn the_dataset_fingerprint_survives_into_a_gate_record() {
+    let mut frame = crate::result::BenchmarkResult::completed("done", Duration::from_secs(1));
+    frame.metrics.insert("inline_accuracy".into(), 50.0);
+    frame.dataset_fingerprint = Some("file-sha256:aa;draw-sha256:bb".into());
+    let record = crate::history::RunRecord {
+        schema: 1,
+        run_id: "r".into(),
+        benchmark_id: "mlperf-agentic-subset".into(),
+        benchmark_name: "MLPerf agentic (subset)".into(),
+        recorded_at: 1,
+        target_url: "http://localhost:1".into(),
+        target_model: "m".into(),
+        params: Default::default(),
+        source: crate::history::RunSource::Cli,
+        atlas_version: "test".into(),
+        frame,
+    };
+    let gate = crate::gate::GateRecord::from_run(
+        &record,
+        crate::hardware::Hardware::default(),
+        "abc123".into(),
+        Vec::new(),
+        None,
+        Default::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        gate.dataset_fingerprint.as_deref(),
+        Some("file-sha256:aa;draw-sha256:bb")
+    );
+    // And it round-trips the record file format.
+    let json = serde_json::to_string(&gate).unwrap();
+    let back: crate::gate::GateRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.dataset_fingerprint, gate.dataset_fingerprint);
+    // Older records without the field still parse.
+    let stripped = json.replace(
+        ",\"dataset_fingerprint\":\"file-sha256:aa;draw-sha256:bb\"",
+        "",
+    );
+    let old: crate::gate::GateRecord = serde_json::from_str(&stripped).unwrap();
+    assert_eq!(old.dataset_fingerprint, None);
+}

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/mod.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/mod.rs
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! MLPerf Agentic Inference (datacenter) — teacher-forced replay + inline
+//! scoring, registered **unrunnable-but-ready**.
+//!
+//! Upstream: mlcommons/endpoints@7935df4, `examples/10_Agentic_Inference`.
+//! 613 recorded trajectories (500 Workato customer-support workflow, 113
+//! DeepSWE agentic coding; 30,335 client turns) are replayed against an
+//! OpenAI-compatible endpoint: the prompt for each client turn is the
+//! RECORDED history plus the current client message, so the model's output is
+//! scored but never fed forward. Scoring is the inline scorer's two rules —
+//! workflow intent-code match, coding bash-executable multiset IoU — ported
+//! in [`scoring`] and pinned by fixtures generated from the upstream class.
+//!
+//! # Why this leg cannot run yet, and what that must mean
+//!
+//! The official dataset is UNPUBLISHED: upstream ships an empty `datasets/`
+//! directory and a README pointing at "MLCommons storage (link TBD)". So this
+//! leg has never been run, scored, or timed. Everything downstream honours
+//! that: provisioning fails loudly naming the missing artifact (never a 0.0
+//! from an empty denominator — the vacuous-PASS class the SSM gate work fixed
+//! once already), the BENCH.toml entry is `status = "unmeasured"` with no
+//! thresholds, coverage lists it in `NOT_REQUIRED` with the reason, and the
+//! verdict is always `info`. No proxy dataset, ever: this repo's own BFCL
+//! history (the 2026-08-02 re-score) is the proof that a score from a
+//! different draw is not a score.
+//!
+//! # Sampling is official and deliberately not a knob
+//!
+//! Official runs pin temp 1.0 / top_k 20 / top_p 0.95 / repetition 1.0 /
+//! presence 1.5 / max_new_tokens 8192 / `preserve_thinking: true`, and forbid
+//! adding or removing sampling params. This leg sends exactly that set plus a
+//! pinned `seed` (MLPerf specifies none, so a seed adds no violation for an
+//! internal gate — and without one, temp-1.0 makes this the repo's first
+//! stochastic accuracy leg; variance is a calibration question, N4 in the
+//! design). Temperature is NOT exposed as a parameter: a temp-0 run would
+//! produce numbers that look comparable to the MLPerf thresholds and are not.
+//!
+//! # Known residuals before a first real run (all blocked on the dataset)
+//!
+//! * **KV salting** (`enable_salt`, blake2b-4-hex around the system prompt):
+//!   not implemented — it needs a blake2 dependency and it only shapes cache
+//!   reuse, not scores; wire it with the calibration work.
+//! * **Tool delays** (`inject_tool_delay`): recorded format supported, delays
+//!   not injected — dead wall-clock in a regression gate; official-conformance
+//!   full runs need them.
+//! * **Context exclusion rule**: trajectories whose peak prompt exceeds the
+//!   served context need a deterministic exclusion rule computed with the
+//!   served tokenizer (GB10 will not serve the 262k upstream context).
+//! * **Engine conformance** (`preserve_thinking` template behaviour, history
+//!   `reasoning_content`/`tool_calls` rendering, top_k/presence support).
+//! * The **SWE-bench Verified leg** (200 live mini-swe-agent rollouts +
+//!   Docker) is a separate workflow, not a benchmark leg; without it no run
+//!   here is a valid official submission and every report must say so.
+
+pub mod dataset;
+pub mod provision;
+pub mod scoring;
+
+mod descriptors;
+mod report;
+
+pub use descriptors::{SUBSET_DESCRIPTOR, SUBSET_METADATA};
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+use crate::benchmark::{Benchmark, BenchmarkDescriptor};
+use crate::benchmarks::one_line;
+use crate::http;
+use crate::metadata::PluginMetadata;
+use crate::params::{ParamKind, ParamSpec, ParamValue, ParamValues};
+use crate::plugin::{Plugin, PluginHandle};
+use crate::result::{BenchmarkResult, LogLine, RunStatus};
+
+use dataset::{Conversation, DrawSpec};
+use scoring::Domain;
+
+/// The official immutable sampling set for Qwen3.6-35B-A3B, verbatim from the
+/// upstream README ("Submitters must not modify the sampling parameters or
+/// thinking flags"). One constant each so the request builder cannot drift
+/// from the doc above.
+const TEMPERATURE: f64 = 1.0;
+const TOP_K: i64 = 20;
+const TOP_P: f64 = 0.95;
+const REPETITION_PENALTY: f64 = 1.0;
+const PRESENCE_PENALTY: f64 = 1.5;
+const MAX_NEW_TOKENS: i64 = 8192;
+
+/// The `expected_sha256` value that means "no pin". A named sentinel rather
+/// than an empty string because `ParamKind::Text` refuses empty values — and
+/// because an operator reading the params pane should see the unpinned state
+/// spelled out, not a blank.
+const UNPINNED: &str = "unpinned";
+
+/// One replayed client turn, kept for aggregation and the responses artifact.
+pub(crate) struct TurnRecord {
+    conversation_id: String,
+    turn: i64,
+    domain: Domain,
+    /// `None` when the recorded ground truth had nothing to score (excluded
+    /// from the denominator); `Some(0.0)` when the model failed to answer a
+    /// scorable turn (in the denominator) — upstream's exact semantics.
+    score: Option<f64>,
+    missing: bool,
+    completion_tokens: usize,
+    /// The model turn as the scorer saw it, for rescoring.
+    model: Value,
+}
+
+enum Phase {
+    Provision,
+    Replay,
+    Score,
+    Done,
+}
+
+pub struct MlperfAgentic {
+    handle: Option<PluginHandle>,
+    phase: Phase,
+    artifacts: Option<provision::Artifacts>,
+    conversations: Vec<Conversation>,
+    /// Flattened (conversation, client-turn) replay order — single-stream,
+    /// sequential, like every other Atlas accuracy leg. Concurrency (and the
+    /// official Pareto shape) is a full-leg question for after calibration.
+    schedule: Vec<(usize, usize)>,
+    cursor: usize,
+    turns: Vec<TurnRecord>,
+    scores: Option<report::Scores>,
+    /// `file-sha256:…;draw-sha256:…` — recorded on the terminal frame and
+    /// carried into the gate record.
+    fingerprint: Option<String>,
+    // Parameters.
+    spec: DrawSpec,
+    seed: i64,
+    expected_sha256: String,
+    request_timeout: Duration,
+    started: Option<Instant>,
+    replay_started: Option<Instant>,
+    replay_wall: Option<Duration>,
+}
+
+impl Default for MlperfAgentic {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MlperfAgentic {
+    pub fn new() -> Self {
+        Self {
+            handle: None,
+            phase: Phase::Provision,
+            artifacts: None,
+            conversations: Vec::new(),
+            schedule: Vec::new(),
+            cursor: 0,
+            turns: Vec::new(),
+            scores: None,
+            fingerprint: None,
+            spec: DrawSpec::all(),
+            seed: 42,
+            expected_sha256: String::new(),
+            request_timeout: Duration::from_secs(600),
+            started: None,
+            replay_started: None,
+            replay_wall: None,
+        }
+    }
+
+    fn handle(&self) -> Result<&PluginHandle> {
+        self.handle.as_ref().context("benchmark was not loaded")
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.started.map(|s| s.elapsed()).unwrap_or_default()
+    }
+
+    async fn replay_one(&mut self) -> Result<()> {
+        let handle = self.handle()?.clone();
+        let (conv_idx, turn_idx) = self.schedule[self.cursor];
+        let conv = &self.conversations[conv_idx];
+        let client_turn = &conv.client_turns[turn_idx];
+        let body = request_body(
+            &handle.target().model,
+            &client_turn.messages,
+            conv.tools.as_ref(),
+            self.seed,
+        );
+        let outcome = http::chat_stream(handle.target(), &body, self.request_timeout).await;
+        let (model, missing, completion_tokens) = match outcome {
+            Ok(o) => {
+                let tokens = o.completion_tokens;
+                (model_turn(&o), false, tokens)
+            }
+            Err(e) => {
+                // Upstream keeps failed turns in the denominator at 0; so
+                // does this — and logs them, so a run degraded by transport
+                // errors is visible rather than only mysteriously low.
+                handle.warn(one_line(format!(
+                    "{} turn {}: {e:#}",
+                    conv.id, client_turn.turn
+                )));
+                (json!({"role": "assistant"}), true, 0)
+            }
+        };
+        let (score, domain) = match &client_turn.ground_truth {
+            Some(gt) if scoring::has_ground_truth(conv.domain, gt) => (
+                Some(scoring::score_turn(conv.domain, gt, &model)),
+                conv.domain,
+            ),
+            _ => (None, conv.domain),
+        };
+        self.turns.push(TurnRecord {
+            conversation_id: conv.id.clone(),
+            turn: client_turn.turn,
+            domain,
+            score,
+            missing,
+            completion_tokens,
+            model,
+        });
+        self.cursor += 1;
+        Ok(())
+    }
+
+    /// Write the per-turn artifact beside the dataset so a scorer change can
+    /// re-score a finished run without re-generating it.
+    fn write_responses(&self) -> Result<()> {
+        let artifacts = self.artifacts.as_ref().context("not provisioned")?;
+        let path = artifacts.dir.join("responses.jsonl");
+        let mut text = String::new();
+        for t in &self.turns {
+            text.push_str(&serde_json::to_string(&json!({
+                "conversation_id": t.conversation_id,
+                "turn": t.turn,
+                "domain": match t.domain { Domain::Coding => "coding", Domain::Workflow => "workflow" },
+                "score": t.score,
+                "missing": t.missing,
+                "completion_tokens": t.completion_tokens,
+                "model": t.model,
+            }))?);
+            text.push('\n');
+        }
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))
+    }
+}
+
+/// The request for one client turn: the official immutable sampling set, the
+/// prebuilt teacher-forced messages, the conversation's tools, and a pinned
+/// seed. NOTHING else — the upstream rules forbid extra sampling params, and
+/// a test pins the exact key set so one cannot be added in passing.
+fn request_body(model: &str, messages: &[Value], tools: Option<&Value>, seed: i64) -> Value {
+    let mut body = json!({
+        "model": model,
+        "stream": true,
+        "messages": messages,
+        "temperature": TEMPERATURE,
+        "top_k": TOP_K,
+        "top_p": TOP_P,
+        "repetition_penalty": REPETITION_PENALTY,
+        "presence_penalty": PRESENCE_PENALTY,
+        "max_tokens": MAX_NEW_TOKENS,
+        "seed": seed,
+        "chat_template_kwargs": {"preserve_thinking": true},
+    });
+    if let Some(tools) = tools {
+        body["tools"] = tools.clone();
+    }
+    body
+}
+
+/// The assistant turn as the scorer expects it, mirroring upstream's
+/// `as_message_parts()` assembly: `tool_calls` is `null` (not `[]`) when the
+/// model made none, and arguments stay the raw streamed string.
+fn model_turn(outcome: &http::ChatOutcome) -> Value {
+    let tool_calls: Vec<Value> = outcome
+        .tool_calls
+        .iter()
+        .map(|c| json!({"function": {"name": c.name, "arguments": c.arguments}}))
+        .collect();
+    json!({
+        "role": "assistant",
+        "content": outcome.text,
+        "reasoning_content": outcome.reasoning,
+        "tool_calls": if tool_calls.is_empty() { Value::Null } else { Value::Array(tool_calls) },
+    })
+}
+
+impl Plugin for MlperfAgentic {
+    fn metadata(&self) -> &'static PluginMetadata {
+        &SUBSET_METADATA
+    }
+
+    fn load(&mut self, handle: PluginHandle) -> impl Future<Output = Result<()>> + Send {
+        self.started = Some(Instant::now());
+        self.handle = Some(handle.clone());
+        async move {
+            // This is where an absent dataset stops the run — loudly, naming
+            // the artifact and the TBD upstream URL. See provision.rs.
+            let artifacts = provision::ensure(handle.artifacts(), &handle, &self.expected_sha256)?;
+            self.artifacts = Some(artifacts);
+            Ok(())
+        }
+    }
+}
+
+impl Benchmark for MlperfAgentic {
+    fn descriptor(&self) -> &'static BenchmarkDescriptor {
+        &SUBSET_DESCRIPTOR
+    }
+
+    fn parameters(&self) -> Vec<ParamSpec> {
+        vec![
+            ParamSpec::new(
+                "coding_trajectories",
+                "Coding trajectories",
+                "First-K coding conversations in file order; 0 takes all. The pinned draw is \
+                 a calibration output — until one exists, there is nothing to default to.",
+                ParamKind::Int {
+                    min: 0,
+                    max: 100_000,
+                },
+                ParamValue::Int(0),
+            ),
+            ParamSpec::new(
+                "workflow_trajectories",
+                "Workflow trajectories",
+                "First-K workflow (sim_*) conversations in file order; 0 takes all.",
+                ParamKind::Int {
+                    min: 0,
+                    max: 100_000,
+                },
+                ParamValue::Int(0),
+            ),
+            ParamSpec::new(
+                "seed",
+                "Seed",
+                "Pinned sampling seed. MLPerf specifies none (temp-1.0 is nondeterministic \
+                 by design); a seed narrows internal run-to-run variance without touching \
+                 the immutable sampling set.",
+                ParamKind::Int {
+                    min: 0,
+                    max: i64::MAX,
+                },
+                ParamValue::Int(42),
+            ),
+            ParamSpec::new(
+                "expected_sha256",
+                "Dataset SHA256 pin",
+                "Refuse to run unless the dataset hashes to this. The literal \"unpinned\" \
+                 means record-only — the only honest default while the official file is \
+                 unpublished; pin it the day the file ships.",
+                ParamKind::Text,
+                ParamValue::Text(String::from(UNPINNED)),
+            ),
+            ParamSpec::new(
+                "request_timeout_s",
+                "Request timeout",
+                "Seconds before one turn is abandoned and scored 0. The official client \
+                 allows 14400 per turn; a merge gate wants a bound that fails fast.",
+                ParamKind::Int {
+                    min: 10,
+                    max: 14_400,
+                },
+                ParamValue::Int(600),
+            ),
+        ]
+    }
+
+    fn configure(&mut self, values: &ParamValues) -> Result<()> {
+        let specs = self.parameters();
+        values.validate_against(&specs)?;
+        self.spec = DrawSpec {
+            coding: values.usize("coding_trajectories")?,
+            workflow: values.usize("workflow_trajectories")?,
+        };
+        self.seed = values.int("seed")?;
+        let pin = values.text("expected_sha256")?.trim();
+        self.expected_sha256 = if pin.eq_ignore_ascii_case(UNPINNED) {
+            String::new()
+        } else {
+            pin.to_string()
+        };
+        self.request_timeout = Duration::from_secs(values.usize("request_timeout_s")? as u64);
+        self.phase = Phase::Provision;
+        self.cursor = 0;
+        self.conversations.clear();
+        self.schedule.clear();
+        self.turns.clear();
+        self.scores = None;
+        self.fingerprint = None;
+        self.replay_started = None;
+        self.replay_wall = None;
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<BenchmarkResult> {
+        let handle = self.handle()?.clone();
+        handle.check_cancelled()?;
+        match self.phase {
+            Phase::Provision => {
+                http::probe(handle.target(), Duration::from_secs(10))
+                    .await
+                    .context("endpoint probe failed — check the target URL and port")?;
+                let artifacts = self.artifacts.clone().context("not provisioned")?;
+                self.conversations = dataset::load(&artifacts.dataset, &self.spec)?;
+                self.schedule = self
+                    .conversations
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(c, conv)| (0..conv.client_turns.len()).map(move |t| (c, t)))
+                    .collect();
+                let draw = dataset::draw_fingerprint(&self.conversations);
+                self.fingerprint = Some(format!(
+                    "file-sha256:{};draw-sha256:{draw}",
+                    artifacts.file_sha256
+                ));
+                self.phase = Phase::Replay;
+                self.replay_started = Some(Instant::now());
+                Ok(BenchmarkResult::running("draw", self.elapsed())
+                    .with_progress(0, self.schedule.len() as u64)
+                    .log_line(LogLine::info(format!(
+                        "drew {} trajectories ({} client turns) · draw fingerprint {}",
+                        self.conversations.len(),
+                        self.schedule.len(),
+                        &draw[..12],
+                    ))))
+            }
+            Phase::Replay => {
+                let total = self.schedule.len() as u64;
+                if self.cursor >= self.schedule.len() {
+                    self.replay_wall = self.replay_started.map(|s| s.elapsed());
+                    self.phase = Phase::Score;
+                    handle.status("scoring");
+                    return Ok(BenchmarkResult::running("scoring", self.elapsed())
+                        .with_progress(total, total)
+                        .with_summary(self.summary()));
+                }
+                let (conv_idx, _) = self.schedule[self.cursor];
+                let conv_id = self.conversations[conv_idx].id.clone();
+                self.replay_one().await?;
+                let done = self.cursor as u64;
+                handle.progress(done, total);
+                handle.status(format!("{conv_id} · {done}/{total}"));
+                Ok(BenchmarkResult::running(conv_id, self.elapsed())
+                    .with_progress(done, total)
+                    .with_summary(self.summary()))
+            }
+            Phase::Score => {
+                let Some(scores) = report::aggregate(&self.turns) else {
+                    // Refusing, not reporting 0.0: a denominator of zero means
+                    // the draw held no scorable ground truth, and a zero score
+                    // from no data is the vacuous result this leg must never
+                    // emit.
+                    bail!(
+                        "no turn in the draw carried scorable ground truth — refusing to \
+                         report a score from an empty denominator"
+                    );
+                };
+                self.write_responses()?;
+                self.scores = Some(scores);
+                self.phase = Phase::Done;
+                let total = self.schedule.len() as u64;
+                let mut frame = BenchmarkResult {
+                    status: RunStatus::Completed,
+                    ..BenchmarkResult::running("done", self.elapsed())
+                }
+                .with_progress(total, total)
+                .with_summary(self.summary())
+                .with_metrics(self.metrics())
+                .with_verdict(self.verdict());
+                frame.dataset_fingerprint = self.fingerprint.clone();
+                if let Some(t) = self.table() {
+                    frame = frame.with_table(t);
+                }
+                Ok(frame)
+            }
+            Phase::Done => bail!("next() was called after the run finished"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "mlperf_tests.rs"]
+mod tests;

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/provision.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/provision.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `~/.atlas/artifacts/mlperf-agentic` — the official trajectory file, which
+//! DOES NOT EXIST YET anywhere in the world this code can reach.
+//!
+//! Unlike every other provisioner in this tree, this one cannot download its
+//! artifact: mlcommons/endpoints@7935df4 ships an empty `datasets/` directory
+//! and its README says the official dataset "can be downloaded from MLCommons
+//! storage (link TBD)". There is no URL, no license, no auth story. So this
+//! module does the two things that ARE possible today:
+//!
+//! * fail loudly and specifically when the file is absent — a leg that
+//!   reported 0.0 because it had no data would be the vacuous-PASS class the
+//!   SSM gate work already had to fix once, and
+//! * when an operator has placed the published file here, verify it by
+//!   full-file SHA256 before anything reads it — closing, for this leg, the
+//!   gap where BFCL computes a dataset digest during provisioning and then
+//!   drops it.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::artifacts::ArtifactStore;
+use crate::plugin::PluginHandle;
+
+pub const PLUGIN_ID: &str = "mlperf-agentic";
+
+/// Where the upstream repo says the dataset will eventually come from,
+/// verbatim, so the error below stays quotable when someone greps for it.
+pub const UPSTREAM_DATASET_STATUS: &str = "mlcommons/endpoints@7935df4 examples/10_Agentic_Inference/README.md: \"The official \
+     MLPerf dataset can be downloaded from MLCommons storage (link TBD)\"";
+
+#[derive(Clone, Debug)]
+pub struct Artifacts {
+    pub dir: PathBuf,
+    pub dataset: PathBuf,
+    /// Full-file SHA256 of `dataset`, hex. Recorded into the run summary and
+    /// the gate record's dataset fingerprint.
+    pub file_sha256: String,
+}
+
+/// Locate and verify the dataset. `expected_sha256` is the pin: empty means
+/// "record only" — the honest state while no official file exists to pin —
+/// and non-empty means the file must hash to exactly that.
+pub fn ensure(
+    store: &ArtifactStore,
+    handle: &PluginHandle,
+    expected_sha256: &str,
+) -> Result<Artifacts> {
+    let dir = store.plugin_dir(PLUGIN_ID)?;
+    let dataset = dir.join("dataset.jsonl");
+    if !dataset.is_file() {
+        // The whole failure mode this leg must not have is "ran anyway":
+        // no proxy dataset, no reconstruction from the upstream DeepSWE /
+        // Workato sources, no empty-denominator zero score. A score from a
+        // different draw is not comparable to anything, and calling one
+        // "MLPerf" would be exactly the failure this repo's BENCH notes exist
+        // to prevent.
+        bail!(
+            "the MLPerf Agentic Inference dataset is not provisioned: {} does not exist.\n\
+             The official dataset (613 trajectories: 500 Workato workflow + 113 DeepSWE \
+             coding, 30,335 client turns) is NOT yet published — {}. There is no download \
+             URL, license, or auth story to automate, and this leg deliberately refuses to \
+             substitute a proxy or reconstructed dataset: a score from a different draw is \
+             comparable to nothing, however official it looks.\n\
+             When MLCommons publishes the file: place it at the path above, record its \
+             SHA256 as this leg's expected_sha256 parameter (and in BENCH.toml), and run \
+             the calibration protocol in the BENCH.toml note before trusting any number.",
+            dataset.display(),
+            UPSTREAM_DATASET_STATUS,
+        );
+    }
+
+    let (file_sha256, bytes) = sha256_file(&dataset)?;
+    if !expected_sha256.is_empty() && !expected_sha256.eq_ignore_ascii_case(&file_sha256) {
+        bail!(
+            "{} does not match its pin: sha256 {file_sha256} ({bytes} bytes), expected \
+             {expected_sha256}. A replay of the wrong file scores against the wrong ground \
+             truth; refusing to run.",
+            dataset.display()
+        );
+    }
+    handle.info(format!(
+        "dataset {} — {bytes} bytes, sha256 {file_sha256}{}",
+        dataset.display(),
+        if expected_sha256.is_empty() {
+            " (UNPINNED: no expected_sha256 — record-only until the official file ships)"
+        } else {
+            " (pin verified)"
+        }
+    ));
+    std::fs::write(
+        dir.join("dataset_summary.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "file_sha256": file_sha256,
+            "bytes": bytes,
+        }))? + "\n",
+    )?;
+    Ok(Artifacts {
+        dir,
+        dataset,
+        file_sha256,
+    })
+}
+
+/// Hex SHA256 and byte count of a file, streamed — the official file is a
+/// whole replay corpus and has no business living in memory twice.
+fn sha256_file(path: &Path) -> Result<(String, u64)> {
+    use sha2::{Digest, Sha256};
+    let mut file =
+        std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let mut digest = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut total = 0u64;
+    loop {
+        let n = file
+            .read(&mut buf)
+            .with_context(|| format!("reading {}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        total += n as u64;
+        digest.update(&buf[..n]);
+    }
+    Ok((format!("{:x}", digest.finalize()), total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(name: &str) -> PathBuf {
+        let d =
+            std::env::temp_dir().join(format!("atlas-mlperf-prov-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn sha256_matches_a_known_vector() {
+        let dir = tmp("sha");
+        let p = dir.join("f");
+        std::fs::write(&p, b"abc").unwrap();
+        let (sha, n) = sha256_file(&p).unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(
+            sha,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    // The absent-dataset failure itself (message names the path, the TBD
+    // upstream status, and the no-proxy rule) is pinned in mod.rs's tests,
+    // where a PluginHandle exists to call ensure() with.
+}

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/report.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/report.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Presentation and aggregation for the MLPerf agentic leg.
+//!
+//! Deliberately UNLIKE `bfcl::report`, which hardcodes MLPerf-edge floors and
+//! renders PASS/FAIL against them: this leg has no floors to enforce. The
+//! official dataset is unpublished, so no run has ever been measured, so any
+//! floor written here would be invented — and an invented floor a run can
+//! clear reports PASS for something nobody measured. The verdict is therefore
+//! always `info`, and the MLPerf full-dataset thresholds (inline ≥ 55.86%,
+//! OSL 355–434, SWE-bench ≥ 67.5%) appear in text as CONTEXT only. The first
+//! measured run on main becomes the baseline, exactly like the echolp gate's
+//! history; PASS/FAIL then comes from BENCH.toml via the gate check, not from
+//! this file.
+
+use std::collections::BTreeMap;
+
+use crate::result::{Cell, CellStyle, Column, ResultTable, Stat, Verdict};
+
+use super::scoring::Domain;
+use super::{MlperfAgentic, TurnRecord};
+
+/// Aggregated inline scores, upstream semantics: mean over scored turns,
+/// per-domain sub-scores, missing outputs at 0 in the denominator.
+#[derive(Clone, Debug, Default)]
+pub(super) struct Scores {
+    /// Overall mean over scored turns, in [0,1].
+    pub inline: f64,
+    /// (mean, scored-turn count) per domain, present only if any were scored.
+    pub coding: Option<(f64, usize)>,
+    pub workflow: Option<(f64, usize)>,
+    pub turns_scored: usize,
+    /// Issued turns whose ground truth had nothing to score — excluded from
+    /// the denominator, exactly as upstream lists them.
+    pub turns_excluded: usize,
+    /// Issued, scorable, but no model output — scored 0, IN the denominator.
+    pub turns_missing: usize,
+    pub output_tokens: usize,
+    /// Mean output tokens per turn that produced output — the OSL axis.
+    pub osl_per_turn_mean: f64,
+}
+
+/// Fold per-turn records into the run's scores. `None` when nothing was
+/// scorable — the caller must treat that as a failed run, never as 0.0.
+pub(super) fn aggregate(turns: &[TurnRecord]) -> Option<Scores> {
+    let mut s = Scores::default();
+    let (mut total, mut by_domain) = (0.0f64, BTreeMap::<&str, (f64, usize)>::new());
+    let mut turns_with_output = 0usize;
+    for t in turns {
+        if t.missing {
+            s.turns_missing += 1;
+        } else {
+            turns_with_output += 1;
+            s.output_tokens += t.completion_tokens;
+        }
+        let Some(score) = t.score else {
+            s.turns_excluded += 1;
+            continue;
+        };
+        s.turns_scored += 1;
+        total += score;
+        let key = match t.domain {
+            Domain::Coding => "coding",
+            Domain::Workflow => "workflow",
+        };
+        let e = by_domain.entry(key).or_default();
+        e.0 += score;
+        e.1 += 1;
+    }
+    if s.turns_scored == 0 {
+        return None;
+    }
+    s.inline = total / s.turns_scored as f64;
+    s.coding = by_domain
+        .get("coding")
+        .map(|(sum, n)| (sum / *n as f64, *n));
+    s.workflow = by_domain
+        .get("workflow")
+        .map(|(sum, n)| (sum / *n as f64, *n));
+    s.osl_per_turn_mean = if turns_with_output > 0 {
+        s.output_tokens as f64 / turns_with_output as f64
+    } else {
+        0.0
+    };
+    Some(s)
+}
+
+impl MlperfAgentic {
+    pub(super) fn table(&self) -> Option<ResultTable> {
+        let s = self.scores.as_ref()?;
+        let mut t = ResultTable::new(
+            "INLINE ACCURACY BY DOMAIN",
+            vec![
+                Column::left("Domain", 12),
+                Column::right("turns", 8),
+                Column::right("score %", 9),
+            ],
+        );
+        for (name, entry) in [("coding", &s.coding), ("workflow", &s.workflow)] {
+            if let Some((mean, n)) = entry {
+                t.push(vec![
+                    Cell::new(name),
+                    Cell::new(n.to_string()),
+                    Cell::styled(format!("{:.2}", mean * 100.0), CellStyle::Accent),
+                ]);
+            }
+        }
+        Some(t)
+    }
+
+    pub(super) fn summary(&self) -> Vec<Stat> {
+        match &self.scores {
+            Some(s) => vec![
+                Stat::new("Inline accuracy", format!("{:.2}", s.inline * 100.0), "%")
+                    .with_style(CellStyle::Accent),
+                Stat::new("OSL / turn", format!("{:.1}", s.osl_per_turn_mean), "tok"),
+                Stat::new("Turns scored", s.turns_scored.to_string(), ""),
+                Stat::new("Missing", s.turns_missing.to_string(), "").with_style(
+                    if s.turns_missing == 0 {
+                        CellStyle::Good
+                    } else {
+                        CellStyle::Warn
+                    },
+                ),
+            ],
+            None => vec![
+                Stat::new(
+                    "Turns",
+                    format!("{}/{}", self.cursor, self.schedule.len()),
+                    "",
+                ),
+                Stat::new("Trajectories", self.conversations.len().to_string(), ""),
+            ],
+        }
+    }
+
+    pub(super) fn metrics(&self) -> BTreeMap<String, f64> {
+        let Some(s) = &self.scores else {
+            return BTreeMap::new();
+        };
+        let mut m = BTreeMap::new();
+        m.insert("inline_accuracy".into(), s.inline * 100.0);
+        if let Some((mean, _)) = s.coding {
+            m.insert("coding_iou".into(), mean * 100.0);
+        }
+        if let Some((mean, _)) = s.workflow {
+            m.insert("workflow_intent_acc".into(), mean * 100.0);
+        }
+        m.insert("osl_per_turn_mean".into(), s.osl_per_turn_mean);
+        m.insert("trajectories".into(), self.conversations.len() as f64);
+        m.insert("turns_scored".into(), s.turns_scored as f64);
+        m.insert("turns_excluded".into(), s.turns_excluded as f64);
+        m.insert("turns_missing".into(), s.turns_missing as f64);
+        if let Some(wall) = self.replay_wall {
+            m.insert("wall_s".into(), wall.as_secs_f64());
+            if wall.as_secs_f64() > 0.0 {
+                m.insert(
+                    "output_tok_s".into(),
+                    s.output_tokens as f64 / wall.as_secs_f64(),
+                );
+            }
+        }
+        m
+    }
+
+    /// Always `info`, never PASS — see the module doc. When a measured
+    /// baseline eventually lands in BENCH.toml, requiring this gate will also
+    /// need a decided verdict rule, because `check.rs` demands a PASS verdict
+    /// from required gates; that decision belongs to whoever runs the first
+    /// calibration, not to code written before any run existed.
+    pub(super) fn verdict(&self) -> Verdict {
+        let Some(s) = &self.scores else {
+            return Verdict::info("not scored");
+        };
+        let fmt = |e: &Option<(f64, usize)>| match e {
+            Some((mean, n)) => format!("{:.2}% (n={n})", mean * 100.0),
+            None => "—".to_string(),
+        };
+        Verdict::info(format!(
+            "inline {:.2}% · coding {} · workflow {} · OSL/turn {:.1} · UNMEASURED LEG: no \
+             committed baseline exists; MLPerf's 55.86% / 355–434 OSL are full-dataset \
+             temp-1.0 thresholds and are NOT this draw's floors. The first measured run on \
+             main becomes the baseline.",
+            s.inline * 100.0,
+            fmt(&s.coding),
+            fmt(&s.workflow),
+            s.osl_per_turn_mean,
+        ))
+    }
+}

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/scoring.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/scoring.rs
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Rust port of the MLPerf Agentic Inference inline scorer's comparison rules.
+//!
+//! Source: `AgenticInferenceInlineScorer` in mlcommons/endpoints@**7935df4**,
+//! `src/inference_endpoint/evaluation/scoring.py`. Two rules and nothing else:
+//!
+//! * **Workflow** (`^sim_\d+$` conversation ids): 1.0 iff the intent code
+//!   extracted from the model's text is in the ground truth's `intent_codes`.
+//! * **Coding** (everything else): multiset IoU over normalized bash
+//!   executables from `bash` tool calls.
+//!
+//! # Parity is proven, not assumed
+//!
+//! Every function here is pinned by `assets/mlperf-agentic/parity_fixtures.json`,
+//! whose expected values were produced by EXECUTING the upstream class at the
+//! commit above (see `gen_parity_fixtures.py` beside it) — including one case
+//! per alias-table entry and per shell wrapper, so the whole table is pinned
+//! rather than spot-checked. That matters because several upstream behaviours
+//! are not what a reasonable porter would guess: `"reintent: I042"` still
+//! scores (the bare-token fallback rescues it), unknown executables vanish
+//! from BOTH sides of the IoU, and a lone `&` is not a command separator.
+//! A port that guessed those wrong would emit numbers that look like MLPerf
+//! inline accuracy and are not.
+//!
+//! # Known, deliberate divergences (all degenerate inputs)
+//!
+//! * Python's `\s` also matches `\x1c`-`\x1f`; [`char::is_whitespace`] does
+//!   not. Affects only control characters between `intent:` and the code.
+//! * Python's `\\.` in the double-quote pattern does not match
+//!   backslash-newline (no DOTALL); this port treats any backslash-escaped
+//!   character as escaped. Affects only a backslash at end-of-line inside an
+//!   unterminated double quote.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+/// Which scoring rule applies, decided by conversation id exactly as upstream:
+/// `^sim_\d+$` is workflow, anything else is coding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Domain {
+    Workflow,
+    Coding,
+}
+
+pub fn domain_of(conversation_id: &str) -> Domain {
+    match conversation_id.strip_prefix("sim_") {
+        Some(rest) if !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()) => {
+            Domain::Workflow
+        }
+        _ => Domain::Coding,
+    }
+}
+
+/// Upstream `_EXECUTABLE_ALIASES`, copied verbatim (58 entries, declaration
+/// order preserved). Executables NOT in this table are dropped from the
+/// multiset entirely — they are invisible to the IoU, on both sides.
+const EXECUTABLE_ALIASES: [(&str, &str); 58] = [
+    ("python", "python"),
+    ("python2", "python"),
+    ("python3", "python"),
+    ("py", "python"),
+    ("pip", "pip"),
+    ("pip3", "pip"),
+    ("pytest", "pytest"),
+    ("pylint", "pylint"),
+    ("sphinx-build", "sphinx"),
+    ("sphinx-quickstart", "sphinx"),
+    ("cython", "cython"),
+    ("make", "make"),
+    ("conda", "conda"),
+    ("cat", "cat"),
+    ("head", "head"),
+    ("tail", "tail"),
+    ("less", "cat"),
+    ("more", "cat"),
+    ("wc", "wc"),
+    ("diff", "diff"),
+    ("grep", "grep"),
+    ("egrep", "grep"),
+    ("fgrep", "grep"),
+    ("rg", "grep"),
+    ("ag", "grep"),
+    ("sed", "sed"),
+    ("awk", "awk"),
+    ("gawk", "awk"),
+    ("tr", "tr"),
+    ("sort", "sort"),
+    ("uniq", "uniq"),
+    ("cut", "cut"),
+    ("find", "find"),
+    ("ls", "ls"),
+    ("locate", "find"),
+    ("xargs", "xargs"),
+    ("cp", "cp"),
+    ("mv", "mv"),
+    ("rm", "rm"),
+    ("mkdir", "mkdir"),
+    ("touch", "touch"),
+    ("tee", "tee"),
+    ("source", "source"),
+    (".", "source"),
+    ("which", "which"),
+    ("alias", "alias"),
+    ("unset", "unset"),
+    ("export", "export"),
+    ("git", "git"),
+    ("curl", "curl"),
+    ("wget", "curl"),
+    ("true", "true"),
+    ("false", "false"),
+    ("timeout", "timeout"),
+    ("date", "date"),
+    ("apt-get", "apt"),
+    ("apt", "apt"),
+    ("yum", "yum"),
+];
+
+/// Upstream `_SHELL_WRAPPERS`: tokens stripped from the front of a stage
+/// before the executable is read.
+const SHELL_WRAPPERS: [&str; 6] = ["env", "time", "nice", "sudo", "exec", "command"];
+
+#[cfg(test)]
+pub(super) fn alias_table() -> &'static [(&'static str, &'static str)] {
+    &EXECUTABLE_ALIASES
+}
+
+/// Ground-truth intent codes from an expected assistant turn: strings from
+/// `intent_codes`, upper-cased, empty and non-string entries dropped. An
+/// empty set means the turn has no workflow ground truth and is excluded
+/// from the denominator.
+pub fn ground_truth_intents(turn: &Value) -> Vec<String> {
+    let Some(codes) = turn.get("intent_codes").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = codes
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_uppercase)
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// The model's intent code: the explicit `intent: I123` form searched over
+/// `reasoning_content` then `content` FIRST — the explicit pass covers both
+/// fields before the fallback runs over either — then the LAST bare `I123`
+/// token as fallback. The explicit form is case-insensitive and upper-cased;
+/// the bare fallback is case-sensitive (upstream compiles it without
+/// IGNORECASE, deliberately or not — encoded in the fixtures either way).
+pub fn model_intent(turn: &Value) -> Option<String> {
+    let fields = ["reasoning_content", "content"];
+    for field in fields {
+        if let Some(text) = turn.get(field).and_then(Value::as_str)
+            && let Some(code) = explicit_intent(text)
+        {
+            return Some(code);
+        }
+    }
+    for field in fields {
+        if let Some(text) = turn.get(field).and_then(Value::as_str)
+            && let Some(code) = last_bare_intent(text)
+        {
+            return Some(code);
+        }
+    }
+    None
+}
+
+/// Python's `\w` for the `\b` boundaries: alphanumerics plus underscore.
+fn is_word(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// `\bintent:\s*(I\d{3})\b`, IGNORECASE, first match.
+fn explicit_intent(text: &str) -> Option<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let n = chars.len();
+    for start in 0..n {
+        if start > 0 && is_word(chars[start - 1]) {
+            continue;
+        }
+        let keyword = "intent:";
+        if start + keyword.len() > n
+            || !chars[start..start + keyword.len()]
+                .iter()
+                .zip(keyword.chars())
+                .all(|(&c, k)| c.to_ascii_lowercase() == k)
+        {
+            continue;
+        }
+        let mut i = start + keyword.len();
+        while i < n && chars[i].is_whitespace() {
+            i += 1;
+        }
+        if let Some(code) = intent_code_at(&chars, i) {
+            return Some(code);
+        }
+    }
+    None
+}
+
+/// `\bI(\d{3})\b` (case-sensitive), LAST match.
+fn last_bare_intent(text: &str) -> Option<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut last = None;
+    for start in 0..chars.len() {
+        if chars[start] != 'I' || (start > 0 && is_word(chars[start - 1])) {
+            continue;
+        }
+        if let Some(code) = intent_code_at(&chars, start) {
+            last = Some(code);
+        }
+    }
+    last
+}
+
+/// `[Ii]\d{3}` at `i` with a word boundary after the third digit, upper-cased.
+fn intent_code_at(chars: &[char], i: usize) -> Option<String> {
+    if i + 4 > chars.len()
+        || !matches!(chars[i], 'I' | 'i')
+        || !chars[i + 1..i + 4].iter().all(|c| c.is_ascii_digit())
+        || chars.get(i + 4).copied().is_some_and(is_word)
+    {
+        return None;
+    }
+    Some(format!("I{}{}{}", chars[i + 1], chars[i + 2], chars[i + 3]))
+}
+
+/// Normalized bash executables from a turn's tool calls, upstream
+/// `_bash_actions`: only `function.name == "bash"` calls count; arguments may
+/// be an object or a JSON string (malformed JSON skips that call);
+/// `command` is preferred over `cmd` with Python truthiness (an empty
+/// `command` falls through). Per command: quoted spans stripped, split on
+/// `||` / `|` / `&&` / `;` / newline, leading env assignments and shell
+/// wrappers dropped, executable basenamed, lowercased,
+/// version-suffix-stripped and mapped through the alias table.
+pub fn bash_actions(turn: &Value) -> Vec<String> {
+    let Some(calls) = turn.get("tool_calls").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut actions = Vec::new();
+    for call in calls {
+        let Some(function) = call.get("function").filter(|f| f.is_object()) else {
+            continue;
+        };
+        if function.get("name").and_then(Value::as_str) != Some("bash") {
+            continue;
+        }
+        let arguments = match function.get("arguments") {
+            Some(Value::String(raw)) => match serde_json::from_str::<Value>(raw) {
+                Ok(parsed) => parsed,
+                Err(_) => continue,
+            },
+            Some(v) => v.clone(),
+            None => continue,
+        };
+        if !arguments.is_object() {
+            continue;
+        }
+        // `args.get("command") or args.get("cmd")`: Python truthiness, so an
+        // empty or null `command` falls through to `cmd`.
+        let command = [arguments.get("command"), arguments.get("cmd")]
+            .into_iter()
+            .flatten()
+            .find(|v| py_truthy(v));
+        let Some(command) = command.and_then(Value::as_str) else {
+            continue;
+        };
+        collect_stage_actions(command, &mut actions);
+    }
+    actions
+}
+
+/// Python truthiness for a JSON value, as `or` sees it.
+fn py_truthy(v: &Value) -> bool {
+    match v {
+        Value::Null => false,
+        Value::Bool(b) => *b,
+        Value::Number(n) => n.as_f64() != Some(0.0),
+        Value::String(s) => !s.is_empty(),
+        Value::Array(a) => !a.is_empty(),
+        Value::Object(o) => !o.is_empty(),
+    }
+}
+
+fn collect_stage_actions(command: &str, actions: &mut Vec<String>) {
+    let unquoted = strip_quoted_spans(command);
+    for stage in split_separators(&unquoted) {
+        let mut tokens = stage.split_whitespace();
+        let executable = loop {
+            match tokens.next() {
+                None => break None,
+                Some(t) if is_env_assignment(t) || SHELL_WRAPPERS.contains(&t) => continue,
+                Some(t) => break Some(t),
+            }
+        };
+        let Some(executable) = executable else {
+            continue;
+        };
+        let base = executable
+            .rsplit('/')
+            .next()
+            .unwrap_or(executable)
+            .to_lowercase();
+        let stripped = strip_version_suffix(&base);
+        if let Some((_, alias)) = EXECUTABLE_ALIASES.iter().find(|(k, _)| *k == stripped) {
+            actions.push((*alias).to_string());
+        }
+    }
+}
+
+/// Upstream `_QUOTED_RE.sub(" ", command)`: `'…'`, `"…"` (with backslash
+/// escapes) and `` `…` `` spans each replaced by one space. An unterminated
+/// quote matches nothing and the quote character stays in the text.
+fn strip_quoted_spans(command: &str) -> String {
+    let chars: Vec<char> = command.chars().collect();
+    let mut out = String::with_capacity(command.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        let close = match c {
+            '\'' | '`' => chars[i + 1..]
+                .iter()
+                .position(|&x| x == c)
+                .map(|p| i + 1 + p),
+            '"' => {
+                let mut j = i + 1;
+                loop {
+                    match chars.get(j) {
+                        None => break None,
+                        Some('\\') => j += 2,
+                        Some('"') => break Some(j),
+                        Some(_) => j += 1,
+                    }
+                }
+            }
+            _ => None,
+        };
+        match close {
+            Some(j) => {
+                out.push(' ');
+                i = j + 1;
+            }
+            None => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Upstream `_COMMAND_SEPARATOR_RE.split`: `||`, `|`, `&&`, `;`, newline.
+/// A lone `&` is deliberately NOT a separator — upstream's regex has none.
+fn split_separators(text: &str) -> Vec<String> {
+    let mut stages = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let two = (chars[i], chars.get(i + 1).copied());
+        match two {
+            ('|', Some('|')) | ('&', Some('&')) => {
+                stages.push(std::mem::take(&mut current));
+                i += 2;
+            }
+            ('|' | ';' | '\n', _) => {
+                stages.push(std::mem::take(&mut current));
+                i += 1;
+            }
+            (c, _) => {
+                current.push(c);
+                i += 1;
+            }
+        }
+    }
+    stages.push(current);
+    stages
+}
+
+/// Upstream `_ENV_ASSIGNMENT_RE`: `^[A-Za-z_][A-Za-z0-9_]*=`.
+fn is_env_assignment(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    if bytes.is_empty() || !(bytes[0].is_ascii_alphabetic() || bytes[0] == b'_') {
+        return false;
+    }
+    bytes[1..]
+        .iter()
+        .position(|&b| !(b.is_ascii_alphanumeric() || b == b'_'))
+        .is_some_and(|p| bytes[1 + p] == b'=')
+}
+
+/// Upstream `_PY_VERSION_SUFFIX_RE.sub("", …)`: `\.\d+(\.\d+)?$`, leftmost
+/// match — i.e. at most the last TWO trailing `.N` groups come off in one
+/// match ("python3.11" → "python3", "python3.1.2.3" → "python3.1").
+fn strip_version_suffix(name: &str) -> &str {
+    let bytes = name.as_bytes();
+    'outer: for start in 0..bytes.len() {
+        if bytes[start] != b'.' {
+            continue;
+        }
+        let mut i = start + 1;
+        for groups_left in [true, false] {
+            let digits_start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            if i == digits_start {
+                continue 'outer;
+            }
+            if i == bytes.len() {
+                return &name[..start];
+            }
+            if !groups_left || bytes[i] != b'.' {
+                continue 'outer;
+            }
+            i += 1;
+        }
+    }
+    name
+}
+
+/// One turn's score. `gt_turn` must be scorable (see [`has_ground_truth`]);
+/// a model turn that produced nothing scores 0 and STAYS in the denominator —
+/// that is the upstream failure semantics, and dropping such turns instead is
+/// exactly the denominator trick the 2026-08-02 BFCL re-score caught.
+pub fn score_turn(domain: Domain, gt_turn: &Value, model_turn: &Value) -> f64 {
+    match domain {
+        Domain::Workflow => {
+            let gt = ground_truth_intents(gt_turn);
+            match model_intent(model_turn) {
+                Some(code) if gt.contains(&code) => 1.0,
+                _ => 0.0,
+            }
+        }
+        Domain::Coding => multiset_iou(&bash_actions(gt_turn), &bash_actions(model_turn)),
+    }
+}
+
+/// Whether an expected assistant turn carries scorable ground truth. Turns
+/// without it are EXCLUDED from the denominator (upstream lists them as
+/// `excluded_turns`), unlike issued-but-unanswered turns, which stay at 0.
+pub fn has_ground_truth(domain: Domain, gt_turn: &Value) -> bool {
+    match domain {
+        Domain::Workflow => !ground_truth_intents(gt_turn).is_empty(),
+        Domain::Coding => !bash_actions(gt_turn).is_empty(),
+    }
+}
+
+/// `sum(gt ∩ model) / sum(gt ∪ model)` over action counts. The caller
+/// guarantees `gt` is non-empty, so the union cannot be zero.
+pub fn multiset_iou(gt: &[String], model: &[String]) -> f64 {
+    let mut counts: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+    for a in gt {
+        counts.entry(a).or_default().0 += 1;
+    }
+    for a in model {
+        counts.entry(a).or_default().1 += 1;
+    }
+    let (mut intersection, mut union) = (0usize, 0usize);
+    for (g, m) in counts.values() {
+        intersection += g.min(m);
+        union += g.max(m);
+    }
+    intersection as f64 / union as f64
+}
+
+#[cfg(test)]
+#[path = "scoring_tests.rs"]
+mod tests;

--- a/crates/atlas-plugin/src/benchmarks/mlperf_agentic/scoring_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/mlperf_agentic/scoring_tests.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Upstream-parity tests for the inline-scorer port.
+//!
+//! The expected values in `parity_fixtures.json` were produced by EXECUTING
+//! `AgenticInferenceInlineScorer` at mlcommons/endpoints@7935df4 over the case
+//! list in `gen_parity_fixtures.py` — nothing in the fixture file was typed by
+//! hand. These tests therefore prove agreement with the upstream scorer on
+//! every pinned case, which is the only parity claim a port can honestly make
+//! while the official dataset (and hence an end-to-end cross-check against the
+//! official client) does not exist.
+
+use serde_json::Value;
+
+use super::*;
+
+const FIXTURES: &str = include_str!("../../../assets/mlperf-agentic/parity_fixtures.json");
+
+fn fixtures() -> Value {
+    serde_json::from_str(FIXTURES).expect("parity_fixtures.json parses")
+}
+
+fn cases<'a>(fixtures: &'a Value, key: &str) -> &'a Vec<Value> {
+    fixtures
+        .get(key)
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("fixture set {key} missing"))
+}
+
+/// The fixtures must state which upstream commit produced them; a regenerated
+/// file with a new commit id fails here until this pin is consciously moved.
+#[test]
+fn fixtures_are_pinned_to_the_recorded_upstream_commit() {
+    let f = fixtures();
+    assert_eq!(f["upstream_commit"], "7935df4");
+    assert_eq!(f["upstream_class"], "AgenticInferenceInlineScorer");
+}
+
+#[test]
+fn model_intent_matches_upstream_on_every_case() {
+    let f = fixtures();
+    for case in cases(&f, "intent_cases") {
+        let got = model_intent(&case["turn"]);
+        let want = case["expected"].as_str().map(str::to_string);
+        assert_eq!(got, want, "turn {}", case["turn"]);
+    }
+}
+
+#[test]
+fn ground_truth_intents_match_upstream_on_every_case() {
+    let f = fixtures();
+    for case in cases(&f, "gt_intent_cases") {
+        let got = ground_truth_intents(&case["turn"]);
+        let want: Vec<String> = case["expected"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(got, want, "turn {}", case["turn"]);
+    }
+}
+
+fn as_bash_turn(arguments: &Value) -> Value {
+    serde_json::json!({
+        "tool_calls": [{"function": {"name": "bash", "arguments": arguments}}]
+    })
+}
+
+fn assert_bash_cases(f: &Value, key: &str) {
+    for case in cases(f, key) {
+        let got = bash_actions(&as_bash_turn(&case["arguments"]));
+        let want: Vec<String> = case["expected"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(got, want, "arguments {}", case["arguments"]);
+    }
+}
+
+#[test]
+fn bash_actions_match_upstream_on_every_case() {
+    assert_bash_cases(&fixtures(), "bash_cases");
+}
+
+/// One generated case per upstream alias entry: the whole table is pinned,
+/// not spot-checked.
+#[test]
+fn every_alias_table_entry_matches_upstream() {
+    assert_bash_cases(&fixtures(), "alias_cases");
+}
+
+#[test]
+fn every_shell_wrapper_matches_upstream() {
+    assert_bash_cases(&fixtures(), "wrapper_cases");
+}
+
+/// The port's table must hold EXACTLY the upstream keys — the per-entry cases
+/// above cannot see an entry this port added that upstream does not have.
+#[test]
+fn the_alias_table_has_exactly_the_upstream_keys() {
+    let f = fixtures();
+    let upstream_keys: std::collections::BTreeSet<String> = cases(&f, "alias_cases")
+        .iter()
+        .map(|c| {
+            let cmd = c["arguments"]["cmd"].as_str().unwrap();
+            cmd.strip_suffix(" --arg").unwrap().to_string()
+        })
+        .collect();
+    let port_keys: std::collections::BTreeSet<String> = alias_table()
+        .iter()
+        .map(|entry| entry.0.to_string())
+        .collect();
+    assert_eq!(port_keys, upstream_keys);
+    assert_eq!(
+        alias_table().len(),
+        58,
+        "no duplicate keys hiding in the table"
+    );
+}
+
+#[test]
+fn turn_scores_match_upstream_on_every_case() {
+    let f = fixtures();
+    for case in cases(&f, "turn_cases") {
+        let domain = match case["domain"].as_str().unwrap() {
+            "workflow" => Domain::Workflow,
+            _ => Domain::Coding,
+        };
+        let got = score_turn(domain, &case["gt"], &case["model"]);
+        let want = case["expected"].as_f64().unwrap();
+        assert!(
+            (got - want).abs() < 1e-9,
+            "domain {domain:?}: got {got}, upstream {want} (gt {}, model {})",
+            case["gt"],
+            case["model"]
+        );
+    }
+}
+
+#[test]
+fn domain_matches_upstream_on_every_case() {
+    let f = fixtures();
+    for case in cases(&f, "domain_cases") {
+        let id = case["conversation_id"].as_str().unwrap();
+        let want = if case["workflow"].as_bool().unwrap() {
+            Domain::Workflow
+        } else {
+            Domain::Coding
+        };
+        assert_eq!(domain_of(id), want, "{id}");
+    }
+}
+
+/// Denominator semantics, from the upstream `score()` body rather than a
+/// fixture (they need a whole events pipeline to exercise upstream): a ground
+/// truth with no scorable content is EXCLUDED; an issued turn whose model
+/// output is missing scores 0 and STAYS.
+#[test]
+fn unscorable_ground_truth_is_excluded_but_missing_output_scores_zero() {
+    let no_gt = serde_json::json!({"content": "just prose"});
+    assert!(!has_ground_truth(Domain::Coding, &no_gt));
+    assert!(!has_ground_truth(Domain::Workflow, &no_gt));
+
+    let gt = as_bash_turn(&serde_json::json!({"cmd": "make"}));
+    assert!(has_ground_truth(Domain::Coding, &gt));
+    // The "missing output" model turn upstream synthesizes is a bare
+    // assistant role with no fields.
+    let missing = serde_json::json!({"role": "assistant"});
+    assert_eq!(score_turn(Domain::Coding, &gt, &missing), 0.0);
+
+    let wf_gt = serde_json::json!({"intent_codes": ["I001"]});
+    assert!(has_ground_truth(Domain::Workflow, &wf_gt));
+    assert_eq!(score_turn(Domain::Workflow, &wf_gt, &missing), 0.0);
+}
+
+#[test]
+fn multiset_iou_counts_duplicates_on_both_sides() {
+    let g = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    assert_eq!(multiset_iou(&g(&["grep", "grep"]), &g(&["grep"])), 0.5);
+    assert_eq!(
+        multiset_iou(&g(&["make"]), &g(&["make", "make", "make"])),
+        1.0 / 3.0
+    );
+    assert_eq!(multiset_iou(&g(&["ls"]), &g(&[])), 0.0);
+    assert_eq!(multiset_iou(&g(&["ls"]), &g(&["ls"])), 1.0);
+}

--- a/crates/atlas-plugin/src/benchmarks/mod.rs
+++ b/crates/atlas-plugin/src/benchmarks/mod.rs
@@ -14,6 +14,7 @@ pub mod concurrency;
 pub mod contamination;
 pub mod decode_floor;
 pub mod media_integrity;
+pub mod mlperf_agentic;
 pub mod quick_speed;
 pub mod serve_matrix;
 pub mod ssm_poison;

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -506,7 +506,7 @@ pub const PROMOTION_CANDIDATES: &[GateCoverage] = &[GateCoverage {
     excludes: CONTAMINATION_EXCLUDES,
 }];
 
-pub const NOT_REQUIRED: [(&str, &str); 4] = [
+pub const NOT_REQUIRED: [(&str, &str); 5] = [
     (
         "quick-speed-bench",
         "a single-user speed probe with no thresholds and no baseline — a MEASUREMENT tool, \
@@ -527,6 +527,15 @@ pub const NOT_REQUIRED: [(&str, &str); 4] = [
         "not required YET: a promotion candidate (see PROMOTION_CANDIDATES) run on release cuts \
          and recorded as debt until it has proven itself; a fresh gate that fails on day one \
          would train people to override it",
+    ),
+    (
+        "mlperf-agentic-subset",
+        "not RUNNABLE yet: the official MLPerf Agentic Inference dataset is unpublished \
+         upstream (mlcommons/endpoints@7935df4: \"MLCommons storage (link TBD)\"), so the leg \
+         cannot be run, scored, or timed, and it refuses proxy datasets on purpose. Not a \
+         promotion candidate either — a candidate accrues debt rows, and debt nobody can \
+         discharge is worse than no row. Promote only after the dataset ships and a \
+         calibration run sizes a <2 h draw",
     ),
 ];
 

--- a/crates/atlas-plugin/src/gate/record.rs
+++ b/crates/atlas-plugin/src/gate/record.rs
@@ -79,6 +79,16 @@ pub struct GateRecord {
     pub hardware_state: Option<crate::hardware::HardwareStateReport>,
     /// Raw headline numbers, keyed by stable metric name.
     pub metrics: BTreeMap<String, f64>,
+    /// Content identity of the dataset the run scored against, from the
+    /// terminal frame (e.g. `file-sha256:…;draw-sha256:…`). Additive and
+    /// optional — schema stays 1, older records simply lack it. It exists
+    /// because `metrics` is f64-only: an exact `samples`/`trajectories` pin
+    /// catches a draw whose SIZE drifted, and nothing before this could catch
+    /// a draw whose CONTENT did. BFCL computes exactly this digest during
+    /// provisioning and drops it; the MLPerf agentic leg is the first to
+    /// record it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_fingerprint: Option<String>,
     /// The run's terminal status. A `Failed` frame never passes the gate,
     /// whatever its numbers look like.
     pub frame_status: RunStatus,
@@ -470,6 +480,7 @@ impl GateRecord {
             // idle box instead of the one that did the work.
             hardware_state: frame.hardware_state.clone(),
             metrics: frame.metrics.clone(),
+            dataset_fingerprint: frame.dataset_fingerprint.clone(),
             frame_status: frame.status,
             verdict,
             verdict_reason,

--- a/crates/atlas-plugin/src/history_tests.rs
+++ b/crates/atlas-plugin/src/history_tests.rs
@@ -49,6 +49,7 @@ fn frame(phase: &str) -> BenchmarkResult {
         table: None,
         verdict: Some(Verdict::pass("all good")),
         metrics: std::collections::BTreeMap::new(),
+        dataset_fingerprint: None,
         log: Vec::new(),
         elapsed: std::time::Duration::from_secs(1),
         hardware_state: None,

--- a/crates/atlas-plugin/src/registry.rs
+++ b/crates/atlas-plugin/src/registry.rs
@@ -4,8 +4,8 @@
 
 use crate::benchmark::BenchmarkDescriptor;
 use crate::benchmarks::{
-    agentic, bfcl, concurrency, contamination, decode_floor, quick_speed, serve_matrix, ssm_poison,
-    ttft, video, vision,
+    agentic, bfcl, concurrency, contamination, decode_floor, mlperf_agentic, quick_speed,
+    serve_matrix, ssm_poison, ttft, video, vision,
 };
 
 /// Every benchmark, list order. Cheapest and most-run first.
@@ -45,6 +45,9 @@ const ALL: &[&BenchmarkDescriptor] = &[
     &bfcl::SUBSET_DESCRIPTOR,
     &bfcl::SUBSET_ECHOLP_DESCRIPTOR,
     &bfcl::FULL_DESCRIPTOR,
+    // Unrunnable until MLCommons publishes its dataset; listed after the BFCL
+    // legs it will eventually sit beside so the pane shows it exists.
+    &mlperf_agentic::SUBSET_DESCRIPTOR,
     // Last: the only one that REPLACES the model the box is serving, so it is
     // the one an operator should have to travel furthest to start by accident.
     &serve_matrix::DESCRIPTOR,

--- a/crates/atlas-plugin/src/result.rs
+++ b/crates/atlas-plugin/src/result.rs
@@ -250,6 +250,15 @@ pub struct BenchmarkResult {
     /// box, and no reader should be able to confuse the two.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hardware_state: Option<crate::hardware::HardwareStateReport>,
+    /// Content identity of the dataset the run scored against, when the
+    /// benchmark has one (e.g. `file-sha256:…;draw-sha256:…` for the MLPerf
+    /// agentic leg). Carried into the gate record: the metrics map is
+    /// f64-only, so without this a record can pin a draw's SIZE but not its
+    /// CONTENT — and two same-size draws of different content are exactly the
+    /// incomparable pair the BFCL notes warn about. `None` for benchmarks
+    /// without a dataset; absent from older persisted frames.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_fingerprint: Option<String>,
 }
 
 impl BenchmarkResult {
@@ -265,6 +274,7 @@ impl BenchmarkResult {
             log: Vec::new(),
             elapsed,
             hardware_state: None,
+            dataset_fingerprint: None,
         }
     }
 

--- a/crates/spark-server/src/tui/bench_keys.rs
+++ b/crates/spark-server/src/tui/bench_keys.rs
@@ -59,6 +59,21 @@ impl BenchState {
             }
             // A finished run stays reachable after you navigate away from it.
             KeyCode::Char('v') if self.frame.is_some() => self.view = View::Run,
+            // The pair the help overlay advertises globally. The list scrolls
+            // by keeping the selection in view, so first/last ARE top/bottom.
+            KeyCode::Char('g') | KeyCode::Home if n > 0 => self.select(0),
+            KeyCode::Char('G') | KeyCode::End if n > 0 => self.select(n - 1),
+            // Paged by the renderer-published viewport and clamped at both
+            // ends; `select` re-clamps, so a stale page size from a resize
+            // cannot walk the selection off the registry.
+            KeyCode::PageDown if n > 0 => {
+                let page = self.suite_page.get().max(1);
+                self.select((self.selected + page).min(n - 1));
+            }
+            KeyCode::PageUp => {
+                let page = self.suite_page.get().max(1);
+                self.select(self.selected.saturating_sub(page));
+            }
             _ => {}
         }
         Outcome::None
@@ -275,3 +290,7 @@ impl BenchState {
 #[cfg(test)]
 #[path = "bench_keys_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "bench_keys_more_tests.rs"]
+mod more_tests;

--- a/crates/spark-server/src/tui/bench_keys_more_tests.rs
+++ b/crates/spark-server/src/tui/bench_keys_more_tests.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The Suite list's scroll keys, in their own mount to keep
+//! `bench_keys_tests.rs` under the 500-LoC cap.
+//!
+//! Every key here clamps at both ends: an unclamped selection banks presses
+//! the display quietly ignores, paid back one dead key at a time — the same
+//! failure the results-table scroll had before its ceiling was published.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::*;
+use crate::tui::app::BenchSub;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::from(code)
+}
+
+/// No executor and no target: these keys move a selection, nothing more.
+fn state() -> BenchState {
+    let mut s = BenchState::default();
+    s.select(0);
+    s
+}
+
+fn press(s: &mut BenchState, code: KeyCode) {
+    assert!(
+        matches!(s.on_key(key(code), BenchSub::Suite), Outcome::None),
+        "a scroll key never toasts"
+    );
+}
+
+#[test]
+fn g_and_home_jump_to_the_first_benchmark_and_clamp_there() {
+    let n = atlas_plugin::registry::all().len();
+    let mut s = state();
+    s.select(n - 1);
+    press(&mut s, KeyCode::Char('g'));
+    assert_eq!(s.selected, 0);
+    press(&mut s, KeyCode::Char('k'));
+    assert_eq!(s.selected, 0, "k at the top must not bank a press");
+
+    let mut s = state();
+    s.select(n - 1);
+    press(&mut s, KeyCode::Home);
+    assert_eq!(s.selected, 0, "Home is g");
+}
+
+#[test]
+fn shift_g_and_end_jump_to_the_last_benchmark_and_clamp_there() {
+    let n = atlas_plugin::registry::all().len();
+    let mut s = state();
+    press(&mut s, KeyCode::Char('G'));
+    assert_eq!(s.selected, n - 1);
+    press(&mut s, KeyCode::Char('j'));
+    assert_eq!(s.selected, n - 1, "j at the bottom must not bank a press");
+
+    let mut s = state();
+    press(&mut s, KeyCode::End);
+    assert_eq!(s.selected, n - 1, "End is G");
+}
+
+#[test]
+fn page_keys_move_by_the_renderer_published_viewport() {
+    let n = atlas_plugin::registry::all().len();
+    assert!(n > 4, "paging is only meaningful past one 80x24 screen");
+    let mut s = state();
+    s.suite_page.set(4);
+    press(&mut s, KeyCode::PageDown);
+    assert_eq!(s.selected, 4, "one page is what one frame held");
+    press(&mut s, KeyCode::PageUp);
+    assert_eq!(s.selected, 0);
+}
+
+#[test]
+fn page_keys_clamp_at_both_ends() {
+    let n = atlas_plugin::registry::all().len();
+    let mut s = state();
+    // A page larger than the registry: the terminal grew mid-session.
+    s.suite_page.set(n + 3);
+    press(&mut s, KeyCode::PageDown);
+    assert_eq!(s.selected, n - 1, "PageDown stops at the last entry");
+    press(&mut s, KeyCode::PageDown);
+    assert_eq!(s.selected, n - 1, "a press at the end is not banked");
+    press(&mut s, KeyCode::PageUp);
+    assert_eq!(s.selected, 0, "PageUp stops at the first entry");
+    press(&mut s, KeyCode::PageUp);
+    assert_eq!(s.selected, 0, "a press at the top is not banked");
+}
+
+#[test]
+fn paging_before_the_first_render_still_moves() {
+    // The published page starts at zero; PageDown on a dashboard that has
+    // not drawn a frame yet must still advance by one entry, not freeze.
+    let mut s = state();
+    assert_eq!(s.suite_page.get(), 0);
+    press(&mut s, KeyCode::PageDown);
+    assert_eq!(s.selected, 1);
+}
+
+#[test]
+fn the_scroll_keys_stay_in_the_list() {
+    // They move the selection; none of them may open a form as a side
+    // effect, or paging to survey the suite would keep leaving it.
+    let mut s = state();
+    for code in [
+        KeyCode::Char('G'),
+        KeyCode::PageUp,
+        KeyCode::PageDown,
+        KeyCode::Char('g'),
+        KeyCode::End,
+        KeyCode::Home,
+    ] {
+        press(&mut s, code);
+        assert_eq!(s.view, View::List, "{code:?} left the list");
+    }
+}

--- a/crates/spark-server/src/tui/bench_keys_tests.rs
+++ b/crates/spark-server/src/tui/bench_keys_tests.rs
@@ -88,6 +88,7 @@ fn a_finished_run_stays_reachable_after_navigating_away() {
         verdict: None,
         metrics: std::collections::BTreeMap::new(),
         log: Vec::new(),
+        dataset_fingerprint: None,
         elapsed: std::time::Duration::from_secs(1),
         hardware_state: None,
     });
@@ -394,6 +395,7 @@ fn record() -> atlas_plugin::RunRecord {
             verdict: None,
             metrics: std::collections::BTreeMap::new(),
             log: Vec::new(),
+            dataset_fingerprint: None,
             elapsed: std::time::Duration::from_secs(1),
             hardware_state: None,
         },

--- a/crates/spark-server/src/tui/bench_state.rs
+++ b/crates/spark-server/src/tui/bench_state.rs
@@ -103,6 +103,12 @@ pub struct BenchState {
     /// clamped, and coming back cost as many dead keys as had been spent.
     pub table_scroll_max: std::cell::Cell<usize>,
     pub history_table_scroll_max: std::cell::Cell<usize>,
+    /// Entries one Suite-list page holds, published by the renderer — the
+    /// same contract as the ceilings above, because only `draw_list` knows
+    /// the viewport height and the row density it chose. PgUp/PgDn page the
+    /// selection by this; a hardcoded stride either dead-ends short of the
+    /// last benchmark on a short terminal or overshoots on a tall one.
+    pub suite_page: std::cell::Cell<usize>,
 
     pub history: Vec<atlas_plugin::RunRecord>,
     pub history_row: usize,

--- a/crates/spark-server/src/tui/bench_state_tests.rs
+++ b/crates/spark-server/src/tui/bench_state_tests.rs
@@ -240,6 +240,7 @@ fn a_run_persisted_by_the_dashboard_is_readable_by_the_cli() {
         verdict: Some(atlas_plugin::Verdict::pass("fine")),
         metrics: std::collections::BTreeMap::new(),
         log: Vec::new(),
+        dataset_fingerprint: None,
         elapsed: std::time::Duration::from_secs(3),
         hardware_state: None,
     };
@@ -294,6 +295,7 @@ fn a_run_is_recorded_once_even_if_the_terminal_frame_repeats() {
         verdict: None,
         metrics: std::collections::BTreeMap::new(),
         log: Vec::new(),
+        dataset_fingerprint: None,
         elapsed: std::time::Duration::from_secs(1),
         hardware_state: None,
     };

--- a/crates/spark-server/src/tui/render/bench/list.rs
+++ b/crates/spark-server/src/tui/render/bench/list.rs
@@ -24,25 +24,58 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_list(f: &mut Frame, app: &App, area: Rect) {
+    let all = atlas_plugin::registry::all();
+    let n = all.len();
     let block = panel("SUITE ─".into(), true);
     let inner = block.inner(area);
-    f.render_widget(block, area);
 
     // ★ Scroll offset, in ENTRIES rather than lines: each benchmark occupies
-    // ROWS_PER_ENTRY rows, so an 80x24 terminal shows about four of them.
+    // rows_per_entry rows, so an 80x24 terminal shows about four of them.
     // Without this the list always rendered from index 0 and `j` past the
     // fourth moved a cursor nobody could see -- the detail pane changing was
     // the only clue. Both sibling lists (bench/history.rs, library/list.rs)
     // already compute one.
-    const ROWS_PER_ENTRY: usize = 4;
-    let visible = (inner.height as usize / ROWS_PER_ENTRY).max(1);
-    let offset = app.bench.selected.saturating_sub(visible.saturating_sub(1));
+    //
+    // Density adapts before the list clips: the blank separator is the first
+    // row spent. At 160x48 the four-row layout holds ten entries, so the
+    // eleventh registered benchmark rendered nowhere at default selection —
+    // a leg that registered cleanly but never draws is indistinguishable
+    // from one that does not exist.
+    const ROOMY: usize = 4;
+    const COMPACT: usize = 3;
+    let rows_per_entry = if n * ROOMY <= inner.height as usize {
+        ROOMY
+    } else {
+        COMPACT
+    };
+    let visible = (inner.height as usize / rows_per_entry).max(1);
+    // Clamped to the last full page, not merely derived from the selection:
+    // an unclamped offset is the class the scroll audit kept finding.
+    let offset = app
+        .bench
+        .selected
+        .saturating_sub(visible.saturating_sub(1))
+        .min(n.saturating_sub(visible));
+    // Published for PgUp/PgDn — the `log_scroll_max` contract: only this
+    // function knows how many entries one page holds.
+    app.bench.suite_page.set(visible);
+
+    // Position indicator only when clipped, `library/modal.rs`'s
+    // bottom-border idiom. Plain dim text: the numbers are the signal, so
+    // NO_COLOR loses nothing.
+    let block = if n > visible {
+        let last = (offset + visible).min(n);
+        block.title_bottom(Span::styled(
+            format!("─ {}-{last} of {n} ─", offset + 1),
+            theme::dim(),
+        ))
+    } else {
+        block
+    };
+    f.render_widget(block, area);
+
     let mut lines: Vec<Line> = Vec::new();
-    for (i, descriptor) in atlas_plugin::registry::all()
-        .iter()
-        .enumerate()
-        .skip(offset)
-    {
+    for (i, descriptor) in all.iter().enumerate().skip(offset) {
         let selected = i == app.bench.selected;
         let running = app.bench.running_id == Some(descriptor.id) && app.bench.is_running();
         let marker = if running {
@@ -83,10 +116,16 @@ fn draw_list(f: &mut Frame, app: &App, area: Rect) {
                 Span::raw("")
             },
         ]));
-        lines.push(Line::default());
+        if rows_per_entry == ROOMY {
+            lines.push(Line::default());
+        }
     }
     f.render_widget(Paragraph::new(lines), inner);
 }
+
+#[cfg(test)]
+#[path = "list_tests.rs"]
+mod tests;
 
 fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
     let Some(descriptor) = app.bench.descriptor() else {

--- a/crates/spark-server/src/tui/render/bench/list_tests.rs
+++ b/crates/spark-server/src/tui/render/bench/list_tests.rs
@@ -13,6 +13,23 @@ use crate::tui::app::{App, Section};
 use crate::tui::bench_state::View;
 use crate::tui::render::harness::{has, screen};
 
+/// A terminal tall enough to hold the whole registry on one page.
+///
+/// Derived, not hardcoded: the suite grows, and a fixed `160x48` silently
+/// stopped holding it once `mlperf-agentic-subset` joined the decode-floor /
+/// quick-speed / media-integrity additions — both tests below started failing
+/// on a registry change that had nothing to do with them.
+///
+/// A list entry is NOT one row (measured: 31 rows gave a 7-entry page, 45 rows
+/// gave 12 — about 2.8 rows apiece once the summary line and spacing are
+/// counted), so the height has to scale with `n`, not merely clear a fixed
+/// chrome. `3n + 20` keeps the page strictly larger than the registry with
+/// room to spare, and grows correctly as entries are added.
+fn tall_enough() -> u16 {
+    let n = atlas_plugin::registry::all().len();
+    u16::try_from(n * 3 + 20).expect("fits a u16 terminal")
+}
+
 fn list_app(selected: usize) -> App {
     let mut a = crate::tui::render::tests::app();
     a.section = Section::Benchmarks;
@@ -52,9 +69,10 @@ fn the_clip_indicator_appears_only_when_the_list_is_clipped() {
             .any(|r| r.contains("─ 1-") && r.contains(&format!("of {n} ─"))),
         "clipped list must name its window:\n{rows:#?}"
     );
-    // 160x48 holds every entry (`render_tests` asserts the names); an
-    // indicator over an unclipped list would claim a fold that is not there.
-    let rows = screen(&list_app(0), 160, 48);
+    // A registry-sized terminal holds every entry (`render_tests` asserts the
+    // names); an indicator over an unclipped list would claim a fold that is
+    // not there.
+    let rows = screen(&list_app(0), 160, tall_enough());
     assert!(
         !has(&rows, &format!("of {n} ─")),
         "unclipped list must not draw an indicator:\n{rows:#?}"
@@ -112,10 +130,13 @@ fn the_renderer_publishes_the_page_size_for_the_key_handler() {
         page < n,
         "80x24 is clipped, so one page is less than the suite"
     );
-    screen(&a, 160, 48);
+    let tall = tall_enough();
+    screen(&a, 160, tall);
     assert!(
         a.bench.suite_page.get() >= n,
-        "160x48 holds the whole suite on one page"
+        "a terminal sized from the registry ({n} entries, {tall} rows) holds \
+         the whole suite on one page; got {}",
+        a.bench.suite_page.get()
     );
 }
 

--- a/crates/spark-server/src/tui/render/bench/list_tests.rs
+++ b/crates/spark-server/src/tui/render/bench/list_tests.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The Suite list's windowing: reachability, the clip indicator, clamping.
+//!
+//! In its own mount rather than `bench_tests.rs` to stay under the 500-LoC
+//! cap. These exist because the eleventh registered benchmark rendered
+//! nowhere: the list drew four rows per entry from a selection-anchored
+//! offset with no indicator that anything lay below the fold, so
+//! `mlperf-agentic-subset` registering pushed Serve Matrix silently off a
+//! 160x48 terminal.
+
+use crate::tui::app::{App, Section};
+use crate::tui::bench_state::View;
+use crate::tui::render::harness::{has, screen};
+
+fn list_app(selected: usize) -> App {
+    let mut a = crate::tui::render::tests::app();
+    a.section = Section::Benchmarks;
+    a.bench.view = View::List;
+    a.bench.selected = selected;
+    a
+}
+
+/// The one guarantee the 160x48 all-names assertion cannot give: it holds
+/// for ANY registry size, so the leg after next cannot be invisible either.
+#[test]
+fn every_registered_benchmark_is_reachable_by_scrolling() {
+    // 24 rows clip the suite, so reaching an entry means the offset followed
+    // the selection there. 120 columns, not 80: names are only guaranteed
+    // unclipped horizontally on a wide terminal (`render_tests` states the
+    // same rule for 160), and this test is about the vertical fold.
+    let all = atlas_plugin::registry::all();
+    for (i, descriptor) in all.iter().enumerate() {
+        let rows = screen(&list_app(i), 120, 24);
+        assert!(
+            has(&rows, descriptor.name),
+            "{} unreachable at 120x24:\n{rows:#?}",
+            descriptor.name
+        );
+    }
+}
+
+#[test]
+fn the_clip_indicator_appears_only_when_the_list_is_clipped() {
+    let n = atlas_plugin::registry::all().len();
+    // 80x24 cannot hold the whole suite: the bottom border must say where
+    // the window sits, starting at entry 1. Both halves on one row, so the
+    // footer's own "1-7 jump" cannot satisfy this by accident.
+    let rows = screen(&list_app(0), 80, 24);
+    assert!(
+        rows.iter()
+            .any(|r| r.contains("─ 1-") && r.contains(&format!("of {n} ─"))),
+        "clipped list must name its window:\n{rows:#?}"
+    );
+    // 160x48 holds every entry (`render_tests` asserts the names); an
+    // indicator over an unclipped list would claim a fold that is not there.
+    let rows = screen(&list_app(0), 160, 48);
+    assert!(
+        !has(&rows, &format!("of {n} ─")),
+        "unclipped list must not draw an indicator:\n{rows:#?}"
+    );
+}
+
+#[test]
+fn the_indicator_tracks_the_selection_to_the_bottom() {
+    let n = atlas_plugin::registry::all().len();
+    let rows = screen(&list_app(n - 1), 80, 24);
+    assert!(
+        has(&rows, &format!("-{n} of {n} ─")),
+        "with the last entry selected the window must end at {n}:\n{rows:#?}"
+    );
+}
+
+#[test]
+fn the_offset_is_clamped_at_both_ends() {
+    // A selection past the registry — a stale index after the registry
+    // shrinks — must show the last page, not scroll into blank space below
+    // the real entries.
+    let all = atlas_plugin::registry::all();
+    let rows = screen(&list_app(all.len() + 40), 80, 24);
+    assert!(
+        has(&rows, all[all.len() - 1].name),
+        "an over-large selection clamps to the last page:\n{rows:#?}"
+    );
+    // And the top of the list comes back exactly, not one entry short.
+    let rows = screen(&list_app(0), 80, 24);
+    assert!(has(&rows, all[0].name), "{rows:#?}");
+}
+
+#[test]
+fn compaction_keeps_the_summary_and_duration_on_every_entry() {
+    // Fitting more entries by dropping the separator row, never by dropping
+    // the rows that say what a benchmark does and how long it takes.
+    let all = atlas_plugin::registry::all();
+    let rows = screen(&list_app(0), 80, 24);
+    assert!(
+        has(&rows, all[0].duration_hint),
+        "the duration line survives the compact layout:\n{rows:#?}"
+    );
+}
+
+#[test]
+fn the_renderer_publishes_the_page_size_for_the_key_handler() {
+    // The `log_scroll_max` contract: PgUp/PgDn page by whatever one frame
+    // actually held, so the stride is never a guess about the terminal.
+    let n = atlas_plugin::registry::all().len();
+    let a = list_app(0);
+    screen(&a, 80, 24);
+    let page = a.bench.suite_page.get();
+    assert!(page > 0, "a viewport of zero would freeze the page keys");
+    assert!(
+        page < n,
+        "80x24 is clipped, so one page is less than the suite"
+    );
+    screen(&a, 160, 48);
+    assert!(
+        a.bench.suite_page.get() >= n,
+        "160x48 holds the whole suite on one page"
+    );
+}
+
+#[test]
+fn the_list_survives_a_12x4_terminal() {
+    // The floor the rest of the suite is exercised at. Nothing readable
+    // fits; the assertion is that the windowing math holds — `visible`
+    // floored at one entry, the offset clamp — instead of panicking.
+    let n = atlas_plugin::registry::all().len();
+    for selected in [0, n - 1] {
+        let rows = screen(&list_app(selected), 12, 4);
+        assert_eq!(rows.len(), 4, "selected {selected}");
+    }
+}

--- a/crates/spark-server/src/tui/render/hints.rs
+++ b/crates/spark-server/src/tui/render/hints.rs
@@ -103,10 +103,14 @@ pub(super) fn bench_hints(app: &App) -> &'static str {
         return "j/k run · PgUp/PgDn table · ⇥ Suite↔History · ? help";
     }
     match (app.bench.view, app.bench.editing) {
+        // PgUp/PgDn named for the same reason the History footer names it:
+        // it is the one binding here a user cannot guess.
         (View::List, _) if app.bench.frame.is_some() => {
-            "j/k select · ⏎ configure · v last run · ⇥ Suite↔History · ? help"
+            "j/k select · PgUp/PgDn page · ⏎ configure · v last run · ⇥ Suite↔History · ? help"
         }
-        (View::List, _) => "j/k select · ⏎ configure · ⇥ Suite↔History · 1-7 jump · ? help",
+        (View::List, _) => {
+            "j/k select · PgUp/PgDn page · ⏎ configure · ⇥ Suite↔History · 1-7 jump · ? help"
+        }
         (View::Variants, _) => "j/k variant · ⏎ choose model · Esc back · ? help",
         (View::Params, true) => "⏎ commit · Esc cancel",
         (View::Params, false) => "j/k move · ⏎ edit · d defaults · p probe · s START · Esc back",

--- a/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
@@ -232,6 +232,51 @@ means unmeasured; thresholds follow the first run on main.\
 [[benchmarks]]
 quant = "nvfp4"
 checkpoint = "Qwen/Qwen3.6-35B-A3B-FP8"
+gate = "mlperf-agentic-subset"
+recipe = "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head"
+default = true
+status = "unmeasured"
+note = """\
+MLPerf Agentic Inference (datacenter) subset leg -- REGISTERED UNRUNNABLE, NEVER MEASURED. \
+The official dataset (613 trajectories, 500 Workato workflow + 113 DeepSWE coding) is \
+unpublished as of 2026-08-13: mlcommons/endpoints@7935df4 ships an empty datasets/ dir and \
+its README says "MLCommons storage (link TBD)". No run has ever happened, so there are NO \
+metrics here and none may be guessed in. The scorer is a Rust port of the upstream inline \
+scorer at that same commit, pinned by executed-upstream parity fixtures \
+(crates/atlas-plugin/assets/mlperf-agentic/parity_fixtures.json). || CHECKPOINT CAVEAT: \
+MLCommons specifies Qwen/Qwen3.6-35B-A3B (BF16). This entry serves the official FP8 \
+sibling -- rules-legal quantization under MLPerf closed-division 8.1, but NOT the named \
+checkpoint, and its accuracy validity is unproven until the official three-part gate is \
+cleared. || CONTEXT, NEVER FLOORS: MLPerf's own thresholds for this model are inline \
+accuracy >= 55.86 pct, OSL per-turn mean 355-434 tokens, SWE-bench Verified >= 67.5 pct \
+(200 instances). They are FULL-DATASET, temp-1.0, official-client numbers; this subset \
+draw on an FP8 checkpoint with a pinned seed is a different distribution, so writing any \
+of them as a floor here would gate against a number nobody measured. The first measured \
+run on frozen main becomes the baseline, exactly like the echolp gate's history. || \
+SAMPLING IS IMMUTABLE AND STOCHASTIC: official params are temp 1.0 / top_k 20 / top_p \
+0.95 / repetition 1.0 / presence 1.5 / max_new_tokens 8192 / preserve_thinking true, and \
+submitters may not add or remove any. Every other accuracy gate in this file runs temp 0; \
+this leg is therefore the repo's first stochastic gate candidate. The leg pins seed 42 \
+(MLPerf specifies no seed, so this adds no violation) but a seeded temp-1.0 run is still \
+not bitwise reproducible across engines -- the calibration protocol must quantify the \
+spread before any floor is written, and if the noise cannot fit the 5 pct schema cap the \
+draw is too small or the gate must average repeats. || BEFORE FIRST MEASUREMENT, in \
+order: (1) dataset ships -> record its full-file SHA256 as expected_sha256 here and in \
+the leg params; (2) calibration run on frozen main (generous draw) measures s/turn, OSL, \
+per-domain spread, and the context-exclusion set for the served max_seq_len; (3) freeze \
+the first-K draw + its draw fingerprint (recorded in the gate record's \
+dataset_fingerprint field); (4) >= 3 repeats size the noise; (5) only then write \
+status = "measured" floors. || NOT COVERED BY THIS LEG regardless of dataset: the \
+SWE-bench Verified leg (live mini-swe-agent + Docker service; a workflow, not a leg -- \
+without it no result is a valid official submission and every report must say "inline + \
+OSL only"); KV salting (enable_salt, blake2b -- needs a dep, wire at calibration); tool \
+delays; the official concurrency/Pareto scenario shape (per-user vs per-system tok/s \
+curve via the upstream client, which is the right tool for any official submission run).\
+"""
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "Qwen/Qwen3.6-35B-A3B-FP8"
 gate = "ssm-state-poisoning-gate"
 recipe = "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head"
 default = true


### PR DESCRIPTION
Adds the MLPerf datacenter agentic-inference benchmark as an Atlas leg, built as far as it can honestly be built today.

## Status: unrunnable, on purpose

**MLCommons has not published the dataset.** Verified at upstream `mlcommons/endpoints@7935df4`: `datasets/` is empty and the README says the data "can be downloaded from MLCommons storage (**link TBD**)". No URL, no licence, no auth story.

So this leg ships `status = "unmeasured"`, `NOT_REQUIRED`, **no metric floors**, and its verdict is always `info`. It is not a gate and must not be treated as one until a real measurement exists.

Explicitly **not** done, because each would have been a fabrication: no proxy dataset, no draw reconstructed from the upstream DeepSWE/Workato sources, no invented floors, and no 0.0 score when data is missing — `load()` refuses with the exact missing path, the "613 trajectories… NOT yet published" fact, and the verbatim upstream citation. A leg reporting 0.0 for lack of data is the vacuous-PASS class we just removed from the SSM gate.

## What is real and tested here

**The scorer, with parity proven by execution rather than assertion.** `assets/mlperf-agentic/gen_parity_fixtures.py` slices upstream's scorer class out of `scoring.py` verbatim, **executes it**, and emits 110 fixture cases — nothing hand-typed. Coverage: 15 intent, 5 ground-truth-intent, 18 bash, **58 alias cases (one per upstream table entry, plus set-equality so a table entry we invent is caught)**, 6 wrappers, 8 end-to-end turn scores, 8 domain ids.

Generation caught two behaviours predicted wrong *before* any Rust was written: `"reintent: I042"` and `"intent : I042"` still score (the bare-token fallback rescues what the explicit `\b` kills), and `python3.1.2.3` normalizes to nothing. Encoded ambiguities are tests, not comments: the bare fallback is case-**sensitive** while the explicit form is not; unknown executables vanish from **both** sides of the IoU; a lone `&` is not a separator. Two knowingly-accepted divergences from Python (`\s` matching `\x1c`–`\x1f`; backslash-newline in unterminated double quotes) are documented in the module header.

**Loader/provisioner** against the documented trajectory format — teacher-forced history, `tool_results` expansion, role grammar, contiguity — with streamed full-file SHA256 and a deterministic first-K-per-domain draw.

**Draw fingerprinting** (`c861672f3`, additive `dataset_fingerprint: Option<String>` on `BenchmarkResult` and `GateRecord`; serde default + skip, schema stays 1, round-trip test proves old records parse). This closes a real gap found while reading: Atlas computes a dataset digest during provisioning today **and throws it away** — no draw fingerprint is recorded anywhere, which is what makes "is this score from the same draw?" unanswerable after the fact. Isolated in its own first commit so it can be dropped independently.

## Facts worth knowing before anyone quotes a number from this

- **Reference model is `Qwen/Qwen3.6-35B-A3B` (BF16)**; we serve the official FP8 sibling. Closed division permits quantization (inference_rules §8.1), but validity depends on clearing all three thresholds — until then our numbers are not comparable to reference BF16.
- **Official scale is ~12–30h on one GB10** (the OSL band pins 10.8–13.2M output tokens over 613 trajectories). It cannot be a sub-2-hour merge gate unsubsetted; a ~2,000-turn subset projects to ~45–90min, but only a calibration run can size it honestly.
- **Temperature is immutable at 1.0** — this would be the repo's first stochastic gate, against a ±0.4-band culture. That is a decision, not a detail.
- MLPerf's 55.86% inline / 355–434 OSL / 67.5% SWE-bench appear in the BENCH note as **context, never as our floors**.
- The **SWE-bench Verified leg** (Docker + 200 live mini-swe-agent rollouts) is a workflow, not a leg — without it no run is a valid official submission.

## Two traps that could not be closed in code

1. Drop *any* file at `~/.atlas/artifacts/mlperf-agentic/dataset.jsonl` and the leg will run it. The unpinned-SHA warning and the refusal doctrine are the only guards until a real pin exists.
2. Promoting to REQUIRED later needs a decided verdict rule: `check.rs:427` demands a PASS verdict and this leg deliberately never emits one. Flagged in `report.rs` for whoever owns calibration.

575 atlas-plugin tests pass; fmt and clippy clean; `spark-server` still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)