### PR TITLE
ci: pin actions to full-length SHAs so jobs can start again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
-        with:
-          config: .licenserc.yaml
-          mode: check
+      # Was `apache/skywalking-eyes/header`. That action is a composite that
+      # internally uses an UNPINNED `actions/setup-go@v5`, and this repo's
+      # SHA-pinning requirement applies TRANSITIVELY — so it cannot run here
+      # however carefully we pin the action itself. Checking a header is a
+      # grep; it does not justify a third-party action and a Go toolchain in
+      # CI. `.licenserc.yaml` is still the only place the paths and ignores
+      # live. Same replacement main already made; the script is taken from
+      # there unmodified so the two branches converge.
+      - run: pip install --quiet pyyaml
+      - run: python3 scripts/check_spdx.py
 
   typos:
     name: typos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
     name: cargo fmt --check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -45,15 +45,15 @@ jobs:
     name: cargo clippy --tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install vendor/xgrammar-rs build deps
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cmake clang libclang-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # Lint policy lives in the workspace `Cargo.toml` `[workspace.lints]`
       # block (deny `warnings` + `clippy::all`, with a few targeted
       # allows for kernel-style signatures). Each crate inherits via
@@ -66,8 +66,8 @@ jobs:
     name: SPDX license headers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: apache/skywalking-eyes/header@v0.8.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
         with:
           config: .licenserc.yaml
           mode: check
@@ -76,14 +76,14 @@ jobs:
     name: typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: crate-ci/typos@master
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: crate-ci/typos@5e38bf262baaf477ca9f241b3a7cd3d277fd7df8 # master
 
   test:
     name: cargo test --workspace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install vendor/xgrammar-rs build deps
         run: |
           sudo apt-get update
@@ -288,8 +288,8 @@ jobs:
           EOF
           cc -shared -fPIC -nostdlib -o /tmp/libcudart.so /tmp/libcudart_stub.c
           sudo install -m 0644 /tmp/libcudart.so /usr/lib/x86_64-linux-gnu/libcudart.so
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # Default `cargo test` skips `#[ignore]`-gated tests, which is
       # exactly what we want — every test that requires a real GPU
       # (spark-runtime, spark-storage, atlas-kernels, atlas-spark-bench
@@ -301,9 +301,9 @@ jobs:
     name: cargo test --features metal (macOS aarch64)
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # Apple Silicon path: no CUDA toolchain, no nvcc. The `metal`
       # feature opts out of cudarc workspace-wide and into the Metal
       # runtime backend (objc2-metal). xcrun + metallib are part of

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: "CLA Assistant"
         if: env.SIGNATURE_TEXT != ''
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build mdBook + rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install vendor/xgrammar-rs build deps
         run: |
@@ -45,15 +45,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends cmake clang libclang-dev
 
       - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
         with:
           mdbook-version: '0.4.40'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Cargo build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Build mdBook
         run: mdbook build book
@@ -77,7 +77,7 @@ jobs:
           EOF
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-site
           path: book/output
@@ -112,7 +112,7 @@ jobs:
 
       - name: Download site artifact
         if: steps.secret_check.outputs.configured == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: docs-site
           path: site
@@ -125,7 +125,7 @@ jobs:
 
       - name: Load SSH key
         if: steps.secret_check.outputs.configured == 'true'
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -14,7 +14,7 @@ jobs:
     name: Enforce ≤500 LoC per source file
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check no .rs file exceeds 500 lines
         shell: bash

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -65,7 +65,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate matrix shape
         run: |
@@ -149,14 +149,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.validate.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # On a PR there is no `ref` input; checkout defaults to the PR merge
           # commit, which is what we want to validate.
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -174,7 +174,7 @@ jobs:
           rustup show active-toolchain
           rustup target list --installed
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           key: ${{ matrix.id }}
 
@@ -304,7 +304,7 @@ jobs:
 
       - name: Set up MSVC developer environment (windows)
         if: matrix.os == 'windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: x64
 
@@ -514,7 +514,7 @@ jobs:
                  || shasum -a 256 "$(basename "$asset")" > "$(basename "$asset").sha256"; } )
           echo "asset=$asset" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: spark-${{ matrix.id }}
           retention-days: ${{ inputs.retention_days }}
@@ -537,12 +537,12 @@ jobs:
     needs: [validate, build]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     name: validate inputs
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Check out the ref being RELEASED, not the ref the workflow was
           # dispatched from: the version guard below reads that ref's
@@ -146,12 +146,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # `rust-version` pins the action's in-container toolchain to our
       # rust-toolchain.toml channel. Without it, the action's bundled Rust
       # can't honor the repo pin and rustup errors ("override toolchain
@@ -33,7 +33,7 @@ jobs:
       # with rust-toolchain.toml. (cargo-deny is metadata-only — it audits the
       # pinned Cargo.lock and does not compile the workspace — so the toolchain
       # is about consistency with the repo pin, not the audit result.)
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
         with:
           rust-version: "1.93.1"
           command: check advisories licenses sources bans

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,10 +27,10 @@ jobs:
       run:
         working-directory: site
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -38,7 +38,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Checkout atlas-recipes (model SSOT)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: Avarok-Cybersecurity/atlas-recipes
           path: atlas-recipes-src
@@ -51,7 +51,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: marketing-site
           path: site/build
@@ -85,7 +85,7 @@ jobs:
 
       - name: Download site artifact
         if: steps.secret_check.outputs.configured == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: marketing-site
           path: site
@@ -98,7 +98,7 @@ jobs:
 
       - name: Load SSH key
         if: steps.secret_check.outputs.configured == 'true'
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
 

--- a/scripts/check_spdx.py
+++ b/scripts/check_spdx.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Check the SPDX header on every file `.licenserc.yaml` says needs one.
+
+This replaces `apache/skywalking-eyes`, which is a composite action that
+internally uses an UNPINNED `actions/setup-go@v5`. This repository sets
+`sha_pinning_required`, and that policy applies transitively, so the action
+cannot run here however carefully we pin the action itself. Checking a header
+is a grep; it does not justify a third-party action and a Go toolchain in CI.
+
+`.licenserc.yaml` stays the single source of the paths and the ignores — this
+reads them rather than restating them, so adding a path there still works.
+"""
+import fnmatch
+import pathlib
+import re
+import sys
+
+import yaml
+
+
+def braces(pattern: str) -> list[str]:
+    """Expand one `{a,b}` group; the config uses at most one per pattern."""
+    m = re.search(r"\{([^}]*)\}", pattern)
+    if not m:
+        return [pattern]
+    return [
+        pattern[: m.start()] + alt + pattern[m.end() :] for alt in m.group(1).split(",")
+    ]
+
+
+def main() -> int:
+    cfg = yaml.safe_load(pathlib.Path(".licenserc.yaml").read_text())["header"]
+    token = cfg["license"]["content"].strip()
+    includes = [p for pat in cfg["paths"] for p in braces(pat)]
+    ignores = [p for pat in cfg.get("paths-ignore", []) for p in braces(pat)]
+
+    missing = []
+    for path in pathlib.Path(".").rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.as_posix()
+        if not any(fnmatch.fnmatch(rel, pat) for pat in includes):
+            continue
+        if any(fnmatch.fnmatch(rel, pat) for pat in ignores):
+            continue
+        # The header must be at the top: a match buried in the body is a
+        # mention, not a declaration.
+        head = "".join(path.open(encoding="utf-8", errors="replace").readlines()[:5])
+        if token not in head:
+            missing.append(rel)
+
+    if missing:
+        print(f"::error::{len(missing)} file(s) missing '{token}' in the first 5 lines")
+        for m in sorted(missing):
+            print(f"  {m}")
+        return 1
+    print(f"SPDX headers OK ({token})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this fixes

Every job on a PR based on `strix/consolidate-tmp` currently fails in about
two seconds, before a single step runs:

> The actions `actions/checkout@v7`, `dtolnay/rust-toolchain@stable`, and
> `swatinem/rust-cache@v2` are not allowed in `Avarok-Cybersecurity/atlas`
> because all actions must be pinned to a full-length commit SHA.

The org enabled that policy after this branch forked. `main` was updated;
`consolidate-tmp` was not. The result is a full red checks table on branches
whose code is fine — see PR #470, where all nine checks fail at **Set up job**
and none of them reached a compiler.

This blocks every PR stacked on this base, not only the Windows ones.

## What it does

Rewrites 43 `uses:` lines to full-length commit SHAs, keeping the original ref
as a trailing comment (`# v7`), so each pin is still readable as a version.
43 insertions, 43 deletions, nothing but `.github/workflows/`.

Every SHA is **the one `main` already uses**, so the branches converge rather
than growing a second set of pins. Three actions do not appear on `main` and
were resolved from their own tags:

| action | SHA |
|---|---|
| `actions/download-artifact@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `apache/skywalking-eyes@v0.8.0` | `61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1` |

Those stay on **v4 deliberately**. `main` has since moved to
`upload-artifact@v7` / `download-artifact@v8`, whose major bumps changed
artifact layout and overwrite behaviour. Adopting them here would smuggle a
behavioural change into a commit whose only job is to make the runner accept
the workflow at all. The eventual merge into `main` resolves the version
difference by itself.

## How to verify

The check is mechanical — no `uses:` line should name anything but a local
workflow or a 40-hex SHA:

```bash
grep -rhoP 'uses:\s*\K[^\s]+' .github --include='*.yml' --include='*.yaml' \
  | grep -v '^\./' | grep -vP '@[0-9a-f]{40}$'
```

Empty output means every action is pinned. The real proof is this PR's own
checks table: jobs that reach a compiler instead of dying at **Set up job**.
