### PR TITLE
build: make the kernel build say which hardware it picked

### DIFF
--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -181,7 +181,13 @@ fn main() {
 
     assert!(
         !targets.is_empty(),
-        "No kernel targets resolved. Check ATLAS_TARGET_* env vars."
+        "{}",
+        build_diagnose::no_targets(
+            &workspace_root.join("kernels"),
+            &env::var("ATLAS_TARGET_HW").unwrap_or_else(|_| build_diagnose::DEFAULT_HW.into()),
+            &env::var("ATLAS_TARGET_MODEL").unwrap_or_else(|_| "*".into()),
+            &env::var("ATLAS_TARGET_QUANT").unwrap_or_else(|_| "nvfp4".into()),
+        )
     );
 
     // ── Resolve compute target (compiler) from HARDWARE.toml vendor ──
@@ -189,7 +195,7 @@ fn main() {
     // Apple (xcrun→metallib), Intel (icpx→SPIR-V). Only NVIDIA is implemented.
     let hw_dir = workspace_root
         .join("kernels")
-        .join(env::var("ATLAS_TARGET_HW").unwrap_or_else(|_| "gb10".into()));
+        .join(env::var("ATLAS_TARGET_HW").unwrap_or_else(|_| build_diagnose::DEFAULT_HW.into()));
     let hw_toml_path = hw_dir.join("HARDWARE.toml");
     let hw_toml: toml::Value = {
         let content = std::fs::read_to_string(&hw_toml_path)
@@ -962,16 +968,24 @@ fn build_hip_shim_windows(manifest_dir: &std::path::Path, out_dir: &std::path::P
 
 /// Resolve all compilation targets from env vars, expanding wildcards.
 fn resolve_targets(workspace_root: &std::path::Path) -> Vec<Target> {
-    let hw = env::var("ATLAS_TARGET_HW").unwrap_or_else(|_| "gb10".into());
+    let kernels_root = workspace_root.join("kernels");
+
+    let hw = env::var("ATLAS_TARGET_HW").unwrap_or_else(|_| build_diagnose::DEFAULT_HW.into());
     let model_spec = env::var("ATLAS_TARGET_MODEL").unwrap_or_else(|_| "*".into());
     let quant_spec = env::var("ATLAS_TARGET_QUANT").unwrap_or_else(|_| "nvfp4".into());
 
-    let hw_dir = workspace_root.join("kernels").join(&hw);
+    let hw_dir = kernels_root.join(&hw);
     assert!(
         hw_dir.is_dir(),
-        "Hardware kernel directory not found: {}",
-        hw_dir.display()
+        "{}",
+        build_diagnose::unknown_hw(&kernels_root, &hw)
     );
+
+    // Nothing else in the build names the hardware it chose. Say it here,
+    // before any of it can fail somewhere that never mentions the env var —
+    // but AFTER the target is known to exist, so a rejected target is not
+    // also announced as the one being built.
+    build_diagnose::warn_if_defaulted(&kernels_root, &hw, &model_spec, &quant_spec);
 
     // Parse HARDWARE.toml (shared across all models for this hw)
     let hw_toml_path = hw_dir.join("HARDWARE.toml");
@@ -1007,7 +1021,7 @@ fn resolve_targets(workspace_root: &std::path::Path) -> Vec<Target> {
     for model in &models {
         let model_dir = hw_dir.join(model);
         if !model_dir.is_dir() {
-            panic!("Model kernel directory not found: {}", model_dir.display());
+            panic!("{}", build_diagnose::unknown_model(&hw_dir, &hw, model));
         }
 
         // Expand quant wildcard
@@ -1226,6 +1240,9 @@ use build_codegen::generate_target_ptx_rs;
 #[path = "build_target.rs"]
 mod build_target;
 use build_target::resolve_compute_target;
+
+#[path = "build_diagnose.rs"]
+mod build_diagnose;
 // Force recompilation 1775404930
 
 /// Every `(module, kernel)` this target's model-specific files drop relative to

--- a/crates/atlas-kernels/build_diagnose.rs
+++ b/crates/atlas-kernels/build_diagnose.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Diagnostics for hardware-target selection.
+//
+// `ATLAS_TARGET_HW` selects which `kernels/<hw>/` tree gets compiled, and it
+// defaults to `gb10` — an NVIDIA GB10 target. That default is right for the
+// machines this repo was born on and silently wrong everywhere else: someone
+// on an AMD box who runs the documented `cargo build --release -p spark-server`
+// builds NVIDIA kernels, and finds out somewhere deep in nvcc, in an error
+// that never mentions the env var that actually chose their hardware.
+//
+// The required triple is currently spelled out only in workflow comments and
+// porting docs. Nothing in the build tells you it exists. Everything here
+// exists to make the build say so itself.
+//
+// These functions run on the failure path and inside panic messages, so they
+// are strictly best-effort: they never panic, and a missing or malformed
+// HARDWARE.toml degrades to a less specific message rather than replacing the
+// user's real error with one of ours.
+
+use std::path::Path;
+use std::sync::Once;
+
+/// Hardware target compiled when `ATLAS_TARGET_HW` is unset.
+pub const DEFAULT_HW: &str = "gb10";
+
+/// Read `vendor = "..."` out of a HARDWARE.toml by hand.
+///
+/// Deliberately not a TOML parse: this is used to build panic messages, so it
+/// must not itself fail on a file that is malformed — which is exactly the
+/// situation some of these messages are reporting.
+fn vendor_of(hw_dir: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(hw_dir.join("HARDWARE.toml")).ok()?;
+    text.lines()
+        .map(str::trim)
+        .find_map(|l| l.strip_prefix("vendor"))
+        .and_then(|rest| rest.trim_start().strip_prefix('='))
+        .map(|v| v.trim().trim_matches('"').to_string())
+}
+
+/// Immediate subdirectories of `dir`, sorted, ignoring anything unreadable.
+fn subdirs(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = entries
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    out.sort();
+    out
+}
+
+/// Hardware targets that exist, as `name (vendor)`.
+pub fn available_hw(kernels_root: &Path) -> Vec<String> {
+    subdirs(kernels_root)
+        .into_iter()
+        .filter(|name| kernels_root.join(name).join("HARDWARE.toml").is_file())
+        .map(|name| match vendor_of(&kernels_root.join(&name)) {
+            Some(v) => format!("{name} ({v})"),
+            None => name,
+        })
+        .collect()
+}
+
+/// Models under a hardware target: subdirs carrying a MODEL.toml.
+pub fn available_models(hw_dir: &Path) -> Vec<String> {
+    subdirs(hw_dir)
+        .into_iter()
+        .filter(|d| hw_dir.join(d).join("MODEL.toml").is_file())
+        .collect()
+}
+
+fn or_none(items: Vec<String>) -> String {
+    if items.is_empty() {
+        "(none found)".to_string()
+    } else {
+        items.join(", ")
+    }
+}
+
+/// One ready-to-paste invocation per hardware target that actually exists.
+///
+/// Every line is built from real directory names, so anything listed here is
+/// known to resolve. Listing all of them rather than picking one avoids
+/// teaching an AMD user the Metal incantation just because `metal` happens to
+/// sort first.
+fn examples(kernels_root: &Path) -> String {
+    let lines: Vec<String> = subdirs(kernels_root)
+        .into_iter()
+        .filter(|h| kernels_root.join(h).join("HARDWARE.toml").is_file())
+        .map(|hw| {
+            let hw_dir = kernels_root.join(&hw);
+            let model = available_models(&hw_dir)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| "<model>".to_string());
+            let quant = subdirs(&hw_dir.join(&model))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| "<quant>".to_string());
+            format!("   ATLAS_TARGET_HW={hw} ATLAS_TARGET_MODEL={model} ATLAS_TARGET_QUANT={quant} cargo build --release -p spark-server")
+        })
+        .collect();
+    if lines.is_empty() {
+        "   (no kernels/<hw>/HARDWARE.toml found - is this a full checkout?)".to_string()
+    } else {
+        lines.join("\n")
+    }
+}
+
+/// Panic text for an `ATLAS_TARGET_HW` naming no `kernels/<hw>/` directory.
+pub fn unknown_hw(kernels_root: &Path, hw: &str) -> String {
+    format!(
+        "\n\
+         ATLAS_TARGET_HW={hw} selects kernels/{hw}/, which does not exist.\n\
+         \n\
+         Available hardware targets: {}\n\
+         \n\
+         Build a target that exists:\n{}\n",
+        or_none(available_hw(kernels_root)),
+        examples(kernels_root),
+    )
+}
+
+/// Panic text for an `ATLAS_TARGET_MODEL` with no directory under this target.
+pub fn unknown_model(hw_dir: &Path, hw: &str, model: &str) -> String {
+    format!(
+        "\n\
+         ATLAS_TARGET_MODEL={model} selects kernels/{hw}/{model}/, which does not exist.\n\
+         \n\
+         Models available for {hw}: {}\n",
+        or_none(available_models(hw_dir)),
+    )
+}
+
+/// Panic text for a target selection that resolved to nothing at all.
+pub fn no_targets(kernels_root: &Path, hw: &str, model: &str, quant: &str) -> String {
+    format!(
+        "\n\
+         No kernel targets resolved for ATLAS_TARGET_HW={hw} \
+         ATLAS_TARGET_MODEL={model} ATLAS_TARGET_QUANT={quant}.\n\
+         \n\
+         Models available for {hw}: {}\n\
+         \n\
+         Build a target that exists:\n{}\n",
+        or_none(available_models(&kernels_root.join(hw))),
+        examples(kernels_root),
+    )
+}
+
+/// Say out loud what is being built whenever any of the triple was implicit.
+///
+/// The `/atlas-release` skill states the rule this serves: "no stage runs on an
+/// implicit default... a bare `cargo build` is a bug, not a shortcut". The
+/// build could not previously say which hardware it picked, so the rule was
+/// unenforceable from inside it.
+///
+/// A `cargo:warning=` rather than a hard error, for two reasons: changing or
+/// requiring the value would break every existing NVIDIA build, and the
+/// problem was never the default itself — it is that the default was
+/// invisible. Emitted once even though resolution reads these from more than
+/// one place.
+pub fn warn_if_defaulted(kernels_root: &Path, hw: &str, model: &str, quant: &str) {
+    static ONCE: Once = Once::new();
+
+    let implicit: Vec<&str> = [
+        ("ATLAS_TARGET_HW", hw),
+        ("ATLAS_TARGET_MODEL", model),
+        ("ATLAS_TARGET_QUANT", quant),
+    ]
+    .iter()
+    .filter(|(var, _)| std::env::var_os(var).is_none())
+    .map(|(var, _)| *var)
+    .collect();
+
+    if implicit.is_empty() {
+        return;
+    }
+
+    // "a, b and c" rather than join(" and "), which produces "a and b and c".
+    let unset = match implicit.split_last() {
+        Some((last, [])) => (*last).to_string(),
+        Some((last, rest)) => format!("{} and {last}", rest.join(", ")),
+        None => unreachable!("empty case returned above"),
+    };
+
+    ONCE.call_once(|| {
+        let vendor = vendor_of(&kernels_root.join(hw)).unwrap_or_else(|| "unknown vendor".into());
+        println!(
+            "cargo:warning=Building kernels for {hw} ({vendor}), model={model}, quant={quant} \
+             - {unset} not set. Hardware targets available: {}. Set all three explicitly \
+             to choose.",
+            or_none(available_hw(kernels_root)),
+        );
+    });
+}


### PR DESCRIPTION
## The problem

`ATLAS_TARGET_HW` chooses which `kernels/<hw>/` tree gets compiled, and it
defaults to `gb10` — an NVIDIA target. **Nothing in the build says so.**

Someone on an AMD box who runs the documented

```bash
cargo build --release -p spark-server
```

builds NVIDIA kernels, and finds out somewhere deep in nvcc, in an error that
never mentions the variable that actually chose their hardware. The required
`ATLAS_TARGET_HW` / `MODEL` / `QUANT` triple is currently written down only in
workflow comments and porting docs — the build itself has never mentioned it.

The `/atlas-release` skill already names this exact footgun: *"no stage runs on
an implicit default… a bare `cargo build` is a bug, not a shortcut."* That rule
was unenforceable from inside the build, because the build could not report
what it had chosen.

## Before / after

Unknown hardware target — before:

```
Hardware kernel directory not found: /repo/kernels/rocm
```

After:

```
ATLAS_TARGET_HW=rocm selects kernels/rocm/, which does not exist.

Available hardware targets: gb10 (nvidia), metal (apple), strix (amd), strix-hip (hip)

Build a target that exists:
   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=deepseek-v4-flash ATLAS_TARGET_QUANT=nvfp4 cargo build --release -p spark-server
   ATLAS_TARGET_HW=metal ATLAS_TARGET_MODEL=nllb-200-3.3b ATLAS_TARGET_QUANT=bf16 cargo build --release -p spark-server
   ATLAS_TARGET_HW=strix ATLAS_TARGET_MODEL=qwen3.6-27b ATLAS_TARGET_QUANT=nvfp4 cargo build --release -p spark-server
   ATLAS_TARGET_HW=strix-hip ATLAS_TARGET_MODEL=qwen3.6-27b ATLAS_TARGET_QUANT=nvfp4 cargo build --release -p spark-server
```

Every line is generated from real directory names, so anything listed is known
to resolve. **All** targets are listed rather than one being picked, because
picking meant teaching an AMD user the Metal incantation on the grounds that
`metal` sorts before `strix`.

Same treatment for an unknown model (lists the models that do exist), and for a
selection that resolves to no targets at all — which previously said only
`Check ATLAS_TARGET_* env vars`.

When any of the triple is implicit, the build now names the whole effective
selection instead of choosing in silence:

```
cargo:warning=Building kernels for gb10 (nvidia), model=*, quant=nvfp4
- ATLAS_TARGET_HW, ATLAS_TARGET_MODEL and ATLAS_TARGET_QUANT not set.
Hardware targets available: ... Set all three explicitly to choose.
```

A **warning, not an error**: requiring the variables would break every existing
NVIDIA build, and the problem was never the default — it is that the default was
invisible. It fires *after* the target is validated, so a rejected target is not
also announced as the one being built.

## Notes for review

- New code is in `build_diagnose.rs`, following the existing
  `#[path = "build_*.rs"] mod` idiom, rather than growing `build.rs` — that file
  is 1204 lines and only clears the 500-LoC cap by allow-list.
- These functions run on the failure path and **inside panic messages**, so they
  never panic themselves. `HARDWARE.toml` is scanned by hand for `vendor` rather
  than TOML-parsed, precisely because some of these messages are reporting a
  malformed one; unreadable directories degrade to a less specific message
  instead of replacing the user's real error with ours.
- The `gb10` default now has one definition (`build_diagnose::DEFAULT_HW`)
  instead of being spelled out at two call sites.

## Verification

Run against the real `kernels/` tree, through real cargo, on the pinned 1.93.1:

- `ATLAS_TARGET_HW=rocm cargo check -p atlas-kernels` → the message above,
  exit 101, and **no** spurious "building rocm" warning
- `ATLAS_SKIP_BUILD=1 cargo check -p atlas-kernels` → clean, exit 0
- `cargo clippy -p atlas-kernels` → clean
- `cargo fmt -p atlas-kernels -- --check` → clean

Each message was also rendered standalone against the real directory tree, so
the model/quant values shown above are the ones the code actually produces, not
hand-written examples.
