### PR TITLE
fix(build): un-gate resolve_dumpbin_path so Linux compiles again

### DIFF
--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -670,7 +670,15 @@ fn build_hip_shim(manifest_dir: &std::path::Path, out_dir: &std::path::Path) {
     );
 }
 
-#[cfg(windows)]
+/// Locate MSVC `dumpbin.exe` for the Windows HIP shim's export scan.
+///
+/// NOT `#[cfg(windows)]`, despite only ever running there. Its caller
+/// `build_hip_shim_windows` is selected by `if cfg!(windows)`, which is a
+/// runtime bool — the body is still COMPILED on every platform. Gating this
+/// one out therefore broke the Linux build with
+/// `E0425: cannot find function resolve_dumpbin_path in this scope`.
+/// The body is plain cross-platform std, so compiling it everywhere costs
+/// nothing and the `cfg!` guard keeps it from being called off-Windows.
 fn resolve_dumpbin_path() -> std::path::PathBuf {
     if let Ok(path) = std::env::var("ATLAS_DUMPBIN") {
         let candidate = std::path::PathBuf::from(path);


### PR DESCRIPTION
## The failure

`cargo clippy --tests` and `cargo test --workspace` both fail on this branch:

```
error[E0425]: cannot find function `resolve_dumpbin_path` in this scope
```

## Why

`resolve_dumpbin_path` is marked `#[cfg(windows)]`. Its only caller,
`build_hip_shim_windows`, is selected like this:

```rust
if cfg!(windows) {
    build_hip_shim_windows(manifest_dir, out_dir);
    return;
}
```

`cfg!(...)` is a macro expanding to a **runtime bool** — not `#[cfg(...)]`.
The branch is dead at runtime on Linux, but the body is still **compiled**
there. So the call survives while the callee is gated away, and `build.rs`
fails to compile on every non-Windows host.

## The fix

Remove the attribute. That is the whole change. The function is plain
cross-platform std (`env::var`, `PathBuf::join`, `Path::exists`), so compiling
it everywhere costs nothing, and the existing `cfg!(windows)` guard already
prevents it from ever being *called* off Windows.

`main` does not carry this function at all, so nothing there needs the same
change — this is specific to the shim work on `consolidate-tmp`.

## Why it went unnoticed

Two reasons, and both are worth knowing:

1. **It cannot be reproduced on Windows.** Build scripts are always compiled
   for the **host**, so `#[cfg(windows)]` is unconditionally true when building
   on a Windows box, and the error is unreachable there.
2. **Every CI job that would have caught it was already failing earlier**, at
   *Set up job*, on the unpinned-actions policy (#503). With that unblocked,
   this was the first thing the compiler had to say.

## Verification

`cargo check -p atlas-kernels` and `cargo fmt -p atlas-kernels -- --check` both
pass on Windows. The Linux verdict is this PR's own CI — the only place that
can give one, for the reason above.

Independent of #503; the two touch different files and can merge in either
order. Both are needed before this branch has a green CI.
