### PR TITLE
spark-model: host-testable 3% kill-bar for the batch2 oracle

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-14-7f9a542486.json
+++ b/.benchmarks/agentic-webserver/2026-08-14-7f9a542486.json
@@ -1,0 +1,77 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "7f9a542486",
+  "recorded_at": 1786730424,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1000"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1000",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_wall_s": 646.139436559,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · Σwall 646s ≤ 1000s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · followed_directions=10.00, iterations=10.00, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_wall_s=646.14, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · Σwall 646s ≤ 1000s",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-14-66eeb9c70c.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-14-66eeb9c70c.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "66eeb9c70c",
+  "recorded_at": 1786747082,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 85.34,
+    "overall_accuracy": 84.76,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.76 (floor 84.66) · normalized 85.34 (floor 83.32) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=85.34, overall_accuracy=84.76, samples=1004.00 · Pass: overall 84.76 (floor 84.66) · normalized 85.34 (floor 83.32) · n=1004",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-14-b45f44a117.json
+++ b/.benchmarks/bfcl-subset/2026-08-14-b45f44a117.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "b45f44a117",
+  "recorded_at": 1786729473,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.94,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.94, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "0e13fc150f6f77b21b04f0f48e48dbb43cc7ed633c659bca2ade0c953345d5d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-15-5c067d8ee8.json
+++ b/.benchmarks/bfcl-subset/2026-08-15-5c067d8ee8.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "5c067d8ee8",
+  "recorded_at": 1786752238,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 88.94,
+    "overall_accuracy": 87.64,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · normalized_single_turn_score=88.94, overall_accuracy=87.64, samples=995.00 · Pass: overall 87.64 (floor 83.64) · normalized 88.94 (floor 85.32) · n=995",
+  "closure": {
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "0e13fc150f6f77b21b04f0f48e48dbb43cc7ed633c659bca2ade0c953345d5d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-14-97cf7382b5.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-14-97cf7382b5.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "97cf7382b5",
+  "recorded_at": 1786714737,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "256",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=256",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 1.0,
+    "jittered": 11.0,
+    "rounds": 12.0,
+    "sum_wall_s": 315.891041373,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=1.00, jittered=11.00, rounds=12.00, sum_wall_s=315.89, unmeasured=0.00 · Pass: 1 of 12 replays byte-identical, 11 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-14-4a40549418.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-14-4a40549418.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "4a40549418",
+  "recorded_at": 1786715048,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1604.276735,
+    "p90_ms": 4336.526771,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.0% (limit +3.0%) · p90 +0.5% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1604.28, p90_ms=4336.53, samples=36.00 · Pass: median -0.0% (limit +3.0%) · p90 +0.5% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-14-9ed521a029.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-14-9ed521a029.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "9ed521a029",
+  "recorded_at": 1786714932,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.173.02",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "metrics": {
+    "median_ms": 1521.4815609999998,
+    "p90_ms": 4318.477656999999,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 +0.3% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1521.48, p90_ms=4318.48, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 +0.3% (limit +5.0%)",
+  "closure": {
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "93219922b91312e7a82701bbc29bfd390bf04223039b52a108dbb8d652be4135",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    }
+  }
+}

--- a/crates/atlas-plugin/src/benchmarks/bfcl/bfcl_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/bfcl/bfcl_tests.rs
@@ -52,12 +52,16 @@ fn a_changed_percentage_changes_the_draw() {
 }
 
 fn scores(overall: f64, normalized: f64) -> Scores {
+    scores_n(overall, normalized, 995)
+}
+
+fn scores_n(overall: f64, normalized: f64, n: usize) -> Scores {
     Scores {
         overall_accuracy: overall,
         normalized_single_turn_score: normalized,
         category_scores: BTreeMap::new(),
         subset_scores: BTreeMap::new(),
-        total_samples: 995,
+        total_samples: n,
         unmatched_responses: 0,
     }
 }
@@ -168,4 +172,98 @@ fn the_mlperf_floors_are_the_recorded_thresholds() {
     // 86.23 / 87.96 × 0.97, the `mlperf-edge-current` numbers for qwen3.6-27b.
     assert!((MLPERF_FLOOR_OVERALL - 86.23 * 0.97).abs() < 0.01);
     assert!((MLPERF_FLOOR_NORMALIZED - 87.96 * 0.97).abs() < 0.01);
+}
+
+/// The 2026-08-14 35B echolp run: 84.66 / 85.19, n=1004.
+///
+/// That clears the echolp ratchet (84.66 / 83.32) and misses the golden
+/// MLPerf-edge normalized floor (85.32) by 0.13. Scoring echolp against
+/// 85.32 is the bug: the category mix moves normalized by ~1.8 points, so
+/// the two draws are not interchangeable. This test is the pin — a revert
+/// that puts MLPerf-edge floors back on every variant fails it.
+#[test]
+fn echolp_does_not_use_the_mlperf_edge_floors() {
+    let mut echolp = configured(Variant::SubsetEcholp);
+    echolp.scores = Some(scores_n(84.66, 85.19, 1004));
+    let v = echolp.verdict();
+    assert_eq!(v.kind, VerdictKind::Pass, "{}", v.reason);
+    assert!(
+        v.reason.contains("84.66") && v.reason.contains("83.32"),
+        "{}",
+        v.reason
+    );
+    assert!(!v.reason.contains("MLPERF-EDGE"), "{}", v.reason);
+
+    // The same numbers on the golden draw still fail — we did not lower
+    // the 27B bar to make echolp pass.
+    let mut subset = configured(Variant::Subset);
+    subset.scores = Some(scores_n(84.66, 85.19, 995));
+    let v = subset.verdict();
+    assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
+    assert!(
+        v.reason.contains("BELOW THE MLPERF-EDGE FLOOR"),
+        "{}",
+        v.reason
+    );
+}
+
+#[test]
+fn the_echolp_verdict_gates_on_both_echolp_floors() {
+    let mut b = configured(Variant::SubsetEcholp);
+
+    // Just under the overall floor.
+    b.scores = Some(scores_n(84.65, 90.0, 1004));
+    let v = b.verdict();
+    assert_eq!(v.kind, VerdictKind::Fail);
+    assert!(v.reason.contains("BELOW THE ECHOLP FLOOR"), "{}", v.reason);
+    assert!(!v.reason.contains("MLPERF-EDGE"), "{}", v.reason);
+
+    // Overall fine, normalized under its own floor.
+    b.scores = Some(scores_n(90.0, 83.31, 1004));
+    assert_eq!(b.verdict().kind, VerdictKind::Fail);
+
+    // Exactly on both floors passes — the thresholds are inclusive.
+    b.scores = Some(scores_n(
+        ECHOLP_FLOOR_OVERALL,
+        ECHOLP_FLOOR_NORMALIZED,
+        1004,
+    ));
+    assert_eq!(b.verdict().kind, VerdictKind::Pass);
+}
+
+/// The runtime echolp floors are the BENCH.toml ratchet, not a second
+/// invented pair. A silent drift here is how the MLPerf-edge numbers
+/// ended up on the wrong draw.
+#[test]
+fn the_echolp_floors_are_the_committed_ratchet() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root is two levels above the crate");
+    let baseline = crate::gate::read_baseline(root, "bfcl-subset-echolp")
+        .expect("echolp baseline loads from BENCH.toml");
+    for (hw, entry) in &baseline.hardware {
+        for (model, mb) in &entry.models {
+            let overall = mb
+                .metrics
+                .get("overall_accuracy")
+                .unwrap_or_else(|| panic!("{hw}/{model}: echolp baseline has no overall_accuracy"));
+            let normalized = mb
+                .metrics
+                .get("normalized_single_turn_score")
+                .unwrap_or_else(|| {
+                    panic!("{hw}/{model}: echolp baseline has no normalized_single_turn_score")
+                });
+            assert_eq!(
+                overall.min,
+                Some(ECHOLP_FLOOR_OVERALL),
+                "{hw}/{model}: runtime overall floor drifted from BENCH.toml"
+            );
+            assert_eq!(
+                normalized.min,
+                Some(ECHOLP_FLOOR_NORMALIZED),
+                "{hw}/{model}: runtime normalized floor drifted from BENCH.toml"
+            );
+        }
+    }
 }

--- a/crates/atlas-plugin/src/benchmarks/bfcl/mod.rs
+++ b/crates/atlas-plugin/src/benchmarks/bfcl/mod.rs
@@ -40,7 +40,9 @@ use crate::result::{BenchmarkResult, LogLine, RunStatus};
 
 use draw::DrawSpec;
 
-pub use report::{MLPERF_FLOOR_NORMALIZED, MLPERF_FLOOR_OVERALL};
+pub use report::{
+    ECHOLP_FLOOR_NORMALIZED, ECHOLP_FLOOR_OVERALL, MLPERF_FLOOR_NORMALIZED, MLPERF_FLOOR_OVERALL,
+};
 
 mod descriptors;
 pub use descriptors::{

--- a/crates/atlas-plugin/src/benchmarks/bfcl/report.rs
+++ b/crates/atlas-plugin/src/benchmarks/bfcl/report.rs
@@ -3,20 +3,55 @@
 //! How a BFCL run is presented, and what makes it pass.
 //!
 //! Split out of the state machine so the run logic and the reporting can each
-//! be read on their own — and because the MLPerf floors belong next to the
-//! verdict that enforces them, not buried in a phase loop.
+//! be read on their own — and because the floors belong next to the verdict
+//! that enforces them, not buried in a phase loop. The floors are
+//! per-variant: scoring the echolp draw against the golden MLPerf-edge
+//! numbers is the bug this split exists to prevent.
 
 use std::collections::BTreeMap;
 
-use super::Bfcl;
+use super::{Bfcl, Variant};
 use crate::benchmarks::bfcl::draw;
 use crate::result::{Cell, CellStyle, Column, ResultTable, Stat, Verdict};
 
 /// MLPerf-edge `qwen3.6-27b` thresholds: the golden llama.cpp Q4_K_M reference
 /// (86.23 / 87.96) x the 0.97 factor. Below these is a submission failure, not
 /// a routine regression, so the verdict says so in those words.
+///
+/// These apply to the golden n=995 draw (`bfcl-subset` / `bfcl-full`) only.
 pub const MLPERF_FLOOR_OVERALL: f64 = 83.64;
 pub const MLPERF_FLOOR_NORMALIZED: f64 = 85.32;
+
+/// Echolp-draw floors: the 35B high-water ratchet (84.66 / 83.32). Locked to
+/// `kernels/gb10/qwen3.6-35b-a3b/BENCH.toml` by test. Do not use the
+/// MLPerf-edge pair — the category mix moves normalized by ~1.8 points.
+pub const ECHOLP_FLOOR_OVERALL: f64 = 84.66;
+pub const ECHOLP_FLOOR_NORMALIZED: f64 = 83.32;
+
+/// The two accuracy floors a variant's runtime verdict applies, and the name
+/// the fail reason prints so a crossed-draw miss is readable.
+pub(super) struct ScoreFloors {
+    pub overall: f64,
+    pub normalized: f64,
+    pub name: &'static str,
+}
+
+impl Variant {
+    pub(super) fn score_floors(self) -> ScoreFloors {
+        match self {
+            Self::Subset | Self::Full => ScoreFloors {
+                overall: MLPERF_FLOOR_OVERALL,
+                normalized: MLPERF_FLOOR_NORMALIZED,
+                name: "MLPERF-EDGE",
+            },
+            Self::SubsetEcholp => ScoreFloors {
+                overall: ECHOLP_FLOOR_OVERALL,
+                normalized: ECHOLP_FLOOR_NORMALIZED,
+                name: "ECHOLP",
+            },
+        }
+    }
+}
 
 impl Bfcl {
     pub(super) fn table(&self) -> Option<ResultTable> {
@@ -58,24 +93,27 @@ impl Bfcl {
 
     pub(super) fn summary(&self) -> Vec<Stat> {
         match &self.scores {
-            Some(s) => vec![
-                Stat::new(
-                    "Overall accuracy",
-                    format!("{:.2}", s.overall_accuracy),
-                    "%",
-                )
-                .with_style(floor_style(s.overall_accuracy, MLPERF_FLOOR_OVERALL)),
-                Stat::new(
-                    "Normalized single-turn",
-                    format!("{:.2}", s.normalized_single_turn_score),
-                    "%",
-                )
-                .with_style(floor_style(
-                    s.normalized_single_turn_score,
-                    MLPERF_FLOOR_NORMALIZED,
-                )),
-                Stat::new("Samples", s.total_samples.to_string(), ""),
-            ],
+            Some(s) => {
+                let floors = self.variant.score_floors();
+                vec![
+                    Stat::new(
+                        "Overall accuracy",
+                        format!("{:.2}", s.overall_accuracy),
+                        "%",
+                    )
+                    .with_style(floor_style(s.overall_accuracy, floors.overall)),
+                    Stat::new(
+                        "Normalized single-turn",
+                        format!("{:.2}", s.normalized_single_turn_score),
+                        "%",
+                    )
+                    .with_style(floor_style(
+                        s.normalized_single_turn_score,
+                        floors.normalized,
+                    )),
+                    Stat::new("Samples", s.total_samples.to_string(), ""),
+                ]
+            }
             None => vec![
                 Stat::new(
                     "Samples",
@@ -107,17 +145,21 @@ impl Bfcl {
         let Some(s) = &self.scores else {
             return Verdict::info("not scored");
         };
-        let overall_ok = s.overall_accuracy >= MLPERF_FLOOR_OVERALL;
-        let normalized_ok = s.normalized_single_turn_score >= MLPERF_FLOOR_NORMALIZED;
+        let floors = self.variant.score_floors();
+        let overall_ok = s.overall_accuracy >= floors.overall;
+        let normalized_ok = s.normalized_single_turn_score >= floors.normalized;
         let detail = format!(
-            "overall {:.2} (floor {MLPERF_FLOOR_OVERALL}) · normalized {:.2} (floor \
-             {MLPERF_FLOOR_NORMALIZED}) · n={}",
-            s.overall_accuracy, s.normalized_single_turn_score, s.total_samples
+            "overall {:.2} (floor {}) · normalized {:.2} (floor {}) · n={}",
+            s.overall_accuracy,
+            floors.overall,
+            s.normalized_single_turn_score,
+            floors.normalized,
+            s.total_samples
         );
         if overall_ok && normalized_ok {
             Verdict::pass(detail)
         } else {
-            Verdict::fail(format!("BELOW THE MLPERF-EDGE FLOOR — {detail}"))
+            Verdict::fail(format!("BELOW THE {} FLOOR — {detail}", floors.name))
         }
     }
 }

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -234,6 +234,10 @@ name = "w4a16_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]
+name = "w4a16_batch2_bw_oracle"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "bf16_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
 

--- a/crates/spark-model/examples/w4a16_batch2_bw_oracle.rs
+++ b/crates/spark-model/examples/w4a16_batch2_bw_oracle.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Cold-DRAM bandwidth oracle for `w4a16_gemv_batch2` and one optional
+//! candidate kernel.
+//!
+//! This is the kill-gate for prefetch experiments. `#497` cp.async lost
+//! here (195 vs 227 GB/s on GDN in_proj 12288×2048). A candidate that is
+//! >3% slower than template batch2 on a production shape must not default-on.
+//!
+//! Weight copies cycle past L2 so every launch streams from DRAM the way a
+//! real K=2 verify step does. GB/s is packed+scale bytes / GPU time.
+//!
+//! Env:
+//!   ATLAS_GEMV_BATCH2_CANDIDATE  module:kernel (default none — baseline only)
+//!   ATLAS_STREAM_GBPS            STREAM read ceiling (default 230)
+//!   ATLAS_PEAK_GBPS              datasheet peak (default 273)
+//!
+//! Exit 0 if no candidate, or candidate is not >3% slower.
+//! Exit 1 if candidate loses the 3% bar.
+//! Exit 2 if template batch2 is absent.
+//!
+//! Run:
+//!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.6-35b-a3b \
+//!   ATLAS_TARGET_QUANT=nvfp4 cargo run -p spark-model --release \
+//!     --features cuda,gpu-examples --example w4a16_batch2_bw_oracle
+
+use anyhow::Result;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+use std::time::Instant;
+
+const WARMUP: usize = 8;
+const ITERS: usize = 40;
+const COLD_CYCLE_BYTES: usize = 256 << 20;
+const M: usize = 2;
+const FAIL_SLOWER: f64 = 1.03;
+
+const SHAPES: &[(&str, u32, u32)] = &[
+    ("gdn in_proj N=12288 K=2048", 12288, 2048),
+    ("attn Q      N=8192  K=2048", 8192, 2048),
+    ("gdn out     N=2048  K=4096", 2048, 4096),
+];
+
+struct XorShift(u64);
+impl XorShift {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn byte(&mut self) -> u8 {
+        (self.next() >> 32) as u8
+    }
+    fn unit_f32(&mut self) -> f32 {
+        ((self.next() >> 40) as f32) / ((1u64 << 23) as f32) * 2.0 - 1.0
+    }
+}
+
+fn f32_to_bf16_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let rounding = 0x7fff + ((bits >> 16) & 1);
+    ((bits + rounding) >> 16) as u16
+}
+
+fn parse_candidate(spec: &str) -> Option<(&str, &str)> {
+    let (module, kernel) = spec.split_once(':')?;
+    if module.is_empty() || kernel.is_empty() {
+        return None;
+    }
+    Some((module, kernel))
+}
+
+fn launch(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    b: DevicePtr,
+    bs: DevicePtr,
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(b)
+        .arg_ptr(bs)
+        .arg_f32(1.0)
+        .arg_ptr(c)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(0)
+}
+
+struct Timed {
+    name: String,
+    us: f64,
+    gbps: f64,
+}
+
+fn time_kernel(
+    g: &dyn GpuBackend,
+    name: &str,
+    kh: KernelHandle,
+    a: DevicePtr,
+    copies: &[(DevicePtr, DevicePtr)],
+    c: DevicePtr,
+    n: u32,
+    k: u32,
+    weight_bytes: usize,
+) -> Result<Timed> {
+    let go = |i: usize| {
+        launch(
+            g,
+            kh,
+            a,
+            copies[i % copies.len()].0,
+            copies[i % copies.len()].1,
+            c,
+            n,
+            k,
+        )
+    };
+    for i in 0..WARMUP {
+        go(i)?;
+    }
+    g.synchronize(0)?;
+    let t0 = Instant::now();
+    for i in 0..ITERS {
+        go(WARMUP + i)?;
+    }
+    g.synchronize(0)?;
+    let us = t0.elapsed().as_secs_f64() * 1e6 / ITERS as f64;
+    let gbps = weight_bytes as f64 / (us * 1e-6) / 1e9;
+    Ok(Timed {
+        name: name.to_string(),
+        us,
+        gbps,
+    })
+}
+
+fn main() -> Result<()> {
+    let g0 = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &g0;
+    let peak: f64 = std::env::var("ATLAS_PEAK_GBPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(273.0);
+    let stream_bw: f64 = std::env::var("ATLAS_STREAM_GBPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(230.0);
+
+    let Ok(b2) = g.kernel("w4a16_gemv", "w4a16_gemv_batch2") else {
+        eprintln!("w4a16_gemv_batch2 absent — SKIP");
+        std::process::exit(2);
+    };
+    let cand_spec = std::env::var("ATLAS_GEMV_BATCH2_CANDIDATE").ok();
+    let cand = cand_spec
+        .as_deref()
+        .and_then(parse_candidate)
+        .and_then(|(m, k)| g.kernel(m, k).ok().map(|h| (format!("{m}:{k}"), h)));
+
+    eprintln!(
+        "W4A16 batch2 cold-DRAM oracle  STREAM {stream_bw:.0}  peak {peak:.0}  {ITERS} iters"
+    );
+    if let Some((name, _)) = &cand {
+        eprintln!("candidate {name}");
+    } else {
+        eprintln!("no candidate (baseline only — set ATLAS_GEMV_BATCH2_CANDIDATE=module:kernel)");
+    }
+    eprintln!();
+
+    let mut rng = XorShift(0x9E3779B97F4A7C15);
+    let mut ok = true;
+    for &(label, n, k) in SHAPES {
+        let (n_us, k_us) = (n as usize, k as usize);
+        let packed_bytes = n_us * k_us / 2;
+        let scale_bytes = n_us * k_us / 16;
+        let weight_bytes = packed_bytes + scale_bytes;
+        let copies_n = (COLD_CYCLE_BYTES.div_ceil(weight_bytes)).clamp(1, 16);
+
+        let a_host: Vec<u16> = (0..M * k_us)
+            .map(|_| f32_to_bf16_bits(rng.unit_f32()))
+            .collect();
+        let b_host: Vec<u8> = (0..packed_bytes).map(|_| rng.byte()).collect();
+        let bs_host: Vec<u8> = (0..scale_bytes)
+            .map(|_| 0x18 + (rng.byte() & 0x0F))
+            .collect();
+
+        let a = g.alloc(M * k_us * 2)?;
+        let c = g.alloc(M * n_us * 2)?;
+        let a_bytes: Vec<u8> = a_host.iter().flat_map(|v| v.to_le_bytes()).collect();
+        g.copy_h2d(&a_bytes, a)?;
+        let mut copies = Vec::with_capacity(copies_n);
+        for _ in 0..copies_n {
+            let b = g.alloc(packed_bytes)?;
+            let bs = g.alloc(scale_bytes)?;
+            g.copy_h2d(&b_host, b)?;
+            g.copy_h2d(&bs_host, bs)?;
+            copies.push((b, bs));
+        }
+
+        let floor_us = weight_bytes as f64 / (stream_bw * 1e9) * 1e6;
+        eprintln!(
+            "── {label}  weights {:.2} MB × {copies_n} copies, STREAM floor {floor_us:.1} us ──",
+            weight_bytes as f64 / 1e6
+        );
+
+        let t_b2 = time_kernel(g, "batch2", b2, a, &copies, c, n, k, weight_bytes)?;
+        eprintln!(
+            "  {:<28} {:>8.2} us  {:>6.1} GB/s  {:>5.1}% STREAM  {:>5.1}% peak",
+            t_b2.name,
+            t_b2.us,
+            t_b2.gbps,
+            100.0 * t_b2.gbps / stream_bw,
+            100.0 * t_b2.gbps / peak,
+        );
+        if let Some((name, kh)) = &cand {
+            let t_c = time_kernel(g, name, *kh, a, &copies, c, n, k, weight_bytes)?;
+            let vs = t_c.us / t_b2.us;
+            eprintln!(
+                "  {:<28} {:>8.2} us  {:>6.1} GB/s  {:>5.1}% STREAM  {:>5.1}% peak",
+                t_c.name,
+                t_c.us,
+                t_c.gbps,
+                100.0 * t_c.gbps / stream_bw,
+                100.0 * t_c.gbps / peak,
+            );
+            eprintln!("  candidate / batch2 = {vs:.3}x   (fail if >{FAIL_SLOWER})");
+            if vs > FAIL_SLOWER {
+                ok = false;
+            }
+        }
+        eprintln!();
+
+        g.free(a)?;
+        g.free(c)?;
+        for (b, bs) in copies {
+            g.free(b)?;
+            g.free(bs)?;
+        }
+    }
+
+    if cand.is_none() {
+        eprintln!("PASS — baseline recorded (no candidate)");
+        return Ok(());
+    }
+    if ok {
+        eprintln!("PASS — candidate is not a >3% regression vs batch2");
+        Ok(())
+    } else {
+        eprintln!("FAIL — candidate is >3% slower than batch2 on a production shape");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/examples/w4a16_batch2_bw_oracle.rs
+++ b/crates/spark-model/examples/w4a16_batch2_bw_oracle.rs
@@ -24,6 +24,10 @@
 //!     --features cuda,gpu-examples --example w4a16_batch2_bw_oracle
 
 use anyhow::Result;
+use spark_model::layers::ops::gemv_batch2_oracle::{
+    FAIL_SLOWER, OracleVerdict, PEAK_GBPS_DEFAULT, STREAM_GBPS_DEFAULT, gbps_from, parse_candidate,
+    verdict,
+};
 use spark_runtime::cuda_backend::AtlasCudaBackend;
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
@@ -33,7 +37,6 @@ const WARMUP: usize = 8;
 const ITERS: usize = 40;
 const COLD_CYCLE_BYTES: usize = 256 << 20;
 const M: usize = 2;
-const FAIL_SLOWER: f64 = 1.03;
 
 const SHAPES: &[(&str, u32, u32)] = &[
     ("gdn in_proj N=12288 K=2048", 12288, 2048),
@@ -63,14 +66,6 @@ fn f32_to_bf16_bits(v: f32) -> u16 {
     let bits = v.to_bits();
     let rounding = 0x7fff + ((bits >> 16) & 1);
     ((bits + rounding) >> 16) as u16
-}
-
-fn parse_candidate(spec: &str) -> Option<(&str, &str)> {
-    let (module, kernel) = spec.split_once(':')?;
-    if module.is_empty() || kernel.is_empty() {
-        return None;
-    }
-    Some((module, kernel))
 }
 
 fn launch(
@@ -146,14 +141,14 @@ fn time_kernel(
 fn main() -> Result<()> {
     let g0 = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
     let g: &dyn GpuBackend = &g0;
-    let peak: f64 = std::env::var("ATLAS_PEAK_GBPS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(273.0);
-    let stream_bw: f64 = std::env::var("ATLAS_STREAM_GBPS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(230.0);
+    let peak = gbps_from(
+        std::env::var("ATLAS_PEAK_GBPS").ok().as_deref(),
+        PEAK_GBPS_DEFAULT,
+    );
+    let stream_bw = gbps_from(
+        std::env::var("ATLAS_STREAM_GBPS").ok().as_deref(),
+        STREAM_GBPS_DEFAULT,
+    );
 
     let Ok(b2) = g.kernel("w4a16_gemv", "w4a16_gemv_batch2") else {
         eprintln!("w4a16_gemv_batch2 absent — SKIP");
@@ -223,6 +218,7 @@ fn main() -> Result<()> {
         if let Some((name, kh)) = &cand {
             let t_c = time_kernel(g, name, *kh, a, &copies, c, n, k, weight_bytes)?;
             let vs = t_c.us / t_b2.us;
+            let shape = verdict(t_c.us, t_b2.us);
             eprintln!(
                 "  {:<28} {:>8.2} us  {:>6.1} GB/s  {:>5.1}% STREAM  {:>5.1}% peak",
                 t_c.name,
@@ -231,8 +227,8 @@ fn main() -> Result<()> {
                 100.0 * t_c.gbps / stream_bw,
                 100.0 * t_c.gbps / peak,
             );
-            eprintln!("  candidate / batch2 = {vs:.3}x   (fail if >{FAIL_SLOWER})");
-            if vs > FAIL_SLOWER {
+            eprintln!("  candidate / batch2 = {vs:.3}x   {shape:?}   (fail if >{FAIL_SLOWER})");
+            if shape == OracleVerdict::Fail {
                 ok = false;
             }
         }

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -55,6 +55,8 @@ pub use model_stats::ModelStats;
 mod gemm_fp8_prefill;
 #[path = "ops/gemm_quant.rs"]
 mod gemm_quant;
+#[path = "ops/gemv_batch2_oracle.rs"]
+pub mod gemv_batch2_oracle;
 #[path = "ops/gemv_q2.rs"]
 mod gemv_q2;
 #[path = "ops/gemv_q2_vec.rs"]

--- a/crates/spark-model/src/layers/ops/gemv_batch2_oracle.rs
+++ b/crates/spark-model/src/layers/ops/gemv_batch2_oracle.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Kill-bar for `w4a16_gemv_batch2` prefetch candidates.
+//!
+//! SSOT for the 3% regression / 3% win thresholds the cold-DRAM oracle
+//! prints. GPU timing stays in the example; this module is host-testable
+//! so a candidate PR cannot silently change the bar.
+
+/// STREAM read ceiling on this GB10 (GB/s). Override with `ATLAS_STREAM_GBPS`.
+pub const STREAM_GBPS_DEFAULT: f64 = 230.0;
+/// Datasheet LPDDR5X peak (GB/s). Override with `ATLAS_PEAK_GBPS`.
+pub const PEAK_GBPS_DEFAULT: f64 = 273.0;
+/// `candidate_us / batch2_us` above this is a regression. Do not default-on.
+pub const FAIL_SLOWER: f64 = 1.03;
+/// `batch2_us / candidate_us` at or above this is a win. Default-on still
+/// requires bit-identity in a separate microtest.
+pub const WIN_FASTER: f64 = 1.03;
+
+/// Parse `ATLAS_GEMV_BATCH2_CANDIDATE=module:kernel`. Empty sides are reject.
+pub fn parse_candidate(spec: &str) -> Option<(&str, &str)> {
+    let (module, kernel) = spec.split_once(':')?;
+    if module.is_empty() || kernel.is_empty() {
+        return None;
+    }
+    Some((module, kernel))
+}
+
+/// Parse a positive GB/s override. Junk / zero / absent → `default`.
+pub fn gbps_from(raw: Option<&str>, default: f64) -> f64 {
+    raw.and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0)
+        .unwrap_or(default)
+}
+
+/// Per-shape verdict from two GPU wall times (same units).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OracleVerdict {
+    /// ≥3% faster than template batch2.
+    Win,
+    /// Within ±3%.
+    Neutral,
+    /// >3% slower. The example exits 1.
+    Fail,
+}
+
+pub fn verdict(candidate_us: f64, batch2_us: f64) -> OracleVerdict {
+    if !candidate_us.is_finite()
+        || !batch2_us.is_finite()
+        || candidate_us <= 0.0
+        || batch2_us <= 0.0
+    {
+        return OracleVerdict::Fail;
+    }
+    let vs = candidate_us / batch2_us;
+    if vs > FAIL_SLOWER {
+        OracleVerdict::Fail
+    } else if batch2_us / candidate_us >= WIN_FASTER {
+        OracleVerdict::Win
+    } else {
+        OracleVerdict::Neutral
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_candidate_requires_both_sides() {
+        assert_eq!(
+            parse_candidate("w4a16_gemv_batch2_dualissue:w4a16_gemv_batch2_dualissue"),
+            Some(("w4a16_gemv_batch2_dualissue", "w4a16_gemv_batch2_dualissue"))
+        );
+        assert_eq!(parse_candidate(""), None);
+        assert_eq!(parse_candidate("nocolon"), None);
+        assert_eq!(parse_candidate(":kernel"), None);
+        assert_eq!(parse_candidate("module:"), None);
+    }
+
+    #[test]
+    fn gbps_from_rejects_junk_and_non_positive() {
+        assert_eq!(gbps_from(None, STREAM_GBPS_DEFAULT), STREAM_GBPS_DEFAULT);
+        assert_eq!(
+            gbps_from(Some(""), STREAM_GBPS_DEFAULT),
+            STREAM_GBPS_DEFAULT
+        );
+        assert_eq!(
+            gbps_from(Some("abc"), STREAM_GBPS_DEFAULT),
+            STREAM_GBPS_DEFAULT
+        );
+        assert_eq!(
+            gbps_from(Some("0"), STREAM_GBPS_DEFAULT),
+            STREAM_GBPS_DEFAULT
+        );
+        assert_eq!(
+            gbps_from(Some("-1"), STREAM_GBPS_DEFAULT),
+            STREAM_GBPS_DEFAULT
+        );
+        assert_eq!(gbps_from(Some("240"), STREAM_GBPS_DEFAULT), 240.0);
+        assert_eq!(gbps_from(Some("273"), PEAK_GBPS_DEFAULT), 273.0);
+    }
+
+    #[test]
+    fn verdict_497_in_proj_is_fail() {
+        // Published #497 cold-DRAM: 72.4 us cpasync vs 62.3 us batch2.
+        assert_eq!(verdict(72.4, 62.3), OracleVerdict::Fail);
+    }
+
+    #[test]
+    fn verdict_exact_3pct_slower_is_neutral() {
+        assert_eq!(verdict(62.3 * FAIL_SLOWER, 62.3), OracleVerdict::Neutral);
+    }
+
+    #[test]
+    fn verdict_just_over_3pct_slower_is_fail() {
+        assert_eq!(verdict(62.3 * 1.031, 62.3), OracleVerdict::Fail);
+    }
+
+    #[test]
+    fn verdict_exact_3pct_faster_is_win() {
+        assert_eq!(verdict(62.3 / WIN_FASTER, 62.3), OracleVerdict::Win);
+    }
+
+    #[test]
+    fn verdict_tie_is_neutral() {
+        assert_eq!(verdict(62.3, 62.3), OracleVerdict::Neutral);
+    }
+
+    #[test]
+    fn verdict_non_finite_or_non_positive_is_fail() {
+        assert_eq!(verdict(f64::NAN, 62.3), OracleVerdict::Fail);
+        assert_eq!(verdict(62.3, 0.0), OracleVerdict::Fail);
+        assert_eq!(verdict(-1.0, 62.3), OracleVerdict::Fail);
+    }
+}

--- a/docs/campaigns/gb10-batch2-rhythm-2026-08/README.md
+++ b/docs/campaigns/gb10-batch2-rhythm-2026-08/README.md
@@ -26,6 +26,10 @@ Oracles must print both. The kill bar is vs **template batch2**, not vs 273.
 2. **Dual-issue** — hoist phase-1 `ld.global` before phase-0 compute. No smem mailbox.
 3. **TMA** — hardware copy engine. Only after (1) exists and (2) is not enough.
 
-Do not default-on (2) or (3) until the oracle says the candidate is ≥3%
-faster than template batch2 on both `12288×2048` and `8192×2048`, and
-bit-identical to `w4a16_gemv` × 2.
+Do not default-on (2) or (3) until the oracle prints `Win` (≥3% faster)
+on both `12288×2048` and `8192×2048`, and a separate microtest is
+bit-identical to `w4a16_gemv` × 2. `Fail` (>3% slower) is a hard no;
+`Neutral` is not a default-on.
+
+The 3% bar lives in `spark_model::layers::ops::gemv_batch2_oracle` so a
+candidate PR cannot silently move it.

--- a/docs/campaigns/gb10-batch2-rhythm-2026-08/README.md
+++ b/docs/campaigns/gb10-batch2-rhythm-2026-08/README.md
@@ -10,8 +10,31 @@ shared-memory `cp.async` mailbox lost on this box.
 
 | Attempt | Result on GDN `in_proj` 12288×2048 |
 |---|---|
-| template `w4a16_gemv_batch2` | **227 GB/s** |
+| template `w4a16_gemv_batch2` (2026-08-13, #497) | **227 GB/s** |
+| template `w4a16_gemv_batch2` (2026-08-14, this oracle) | **224.2 GB/s** (63.14 us, 97.5% STREAM) |
 | `#497` `w4a16_gemv_batch2_cpasync` | **195 GB/s** (1.16× slower) |
+
+2026-08-14 baseline (`w4a16_batch2_bw_oracle`, 40 iters, cold DRAM):
+
+| Shape | us | GB/s | % STREAM 230 | % peak 273 |
+|---|---|---|---|---|
+| GDN in_proj 12288×2048 | 63.14 | 224.2 | 97.5% | 82.1% |
+| attn Q 8192×2048 | 42.91 | 219.9 | 95.6% | 80.6% |
+| GDN out 2048×4096 | 23.91 | 197.4 | 85.8% | 72.3% |
+
+in_proj is already 97.5% of STREAM. A candidate needs ≥3% vs batch2 to `Win`; that shape has ~2.5% headroom to the measured ceiling.
+
+## Dual-issue (#500) — measured, leave unwired
+
+Two cold-DRAM runs on this box (candidate not in the committed tree; `.cu` copied for the oracle only):
+
+| Shape | Run 1 vs batch2 | Run 2 vs batch2 | Verdict |
+|---|---|---|---|
+| GDN in_proj 12288×2048 | 0.983× (228 vs 224 GB/s) | 0.985× (226 vs 223) | Neutral |
+| attn Q 8192×2048 | 0.989× | 0.971× | Neutral |
+| GDN out 2048×4096 | 0.721× (batch2 noisy 138 GB/s) | 0.958× (194 vs 186) | Win on the small shape only |
+
+Default-on needs `Win` on **both** 12288×2048 and 8192×2048. Dual-issue does not. TMA (#501) is optional, not next.
 
 `#497` stays opt-in. `ATLAS_GEMV_BATCH2_CPASYNC=1` is not a fix.
 

--- a/docs/campaigns/gb10-batch2-rhythm-2026-08/README.md
+++ b/docs/campaigns/gb10-batch2-rhythm-2026-08/README.md
@@ -1,0 +1,31 @@
+# GB10 batch2 rhythm (2026-08)
+
+K=2 verify streams NVFP4 weights through `w4a16_gemv_batch2`. The bytes
+are already minimal (one pass, 4-bit packed). The leftover time is
+**load latency**: ncu shows ~72% long-scoreboard stalls. Production
+Qwen3.6-35B projections are K=2048 — one wave per phase — so a
+shared-memory `cp.async` mailbox lost on this box.
+
+## Already tried (do not merge as default)
+
+| Attempt | Result on GDN `in_proj` 12288×2048 |
+|---|---|
+| template `w4a16_gemv_batch2` | **227 GB/s** |
+| `#497` `w4a16_gemv_batch2_cpasync` | **195 GB/s** (1.16× slower) |
+
+`#497` stays opt-in. `ATLAS_GEMV_BATCH2_CPASYNC=1` is not a fix.
+
+## Denominator
+
+Datasheet LPDDR5X is 273 GB/s. STREAM read on this GB10 is **~230 GB/s**.
+Oracles must print both. The kill bar is vs **template batch2**, not vs 273.
+
+## PR split
+
+1. **Oracle** — cold-DRAM GB/s, STREAM-230, 3% kill bar, candidate kernel name.
+2. **Dual-issue** — hoist phase-1 `ld.global` before phase-0 compute. No smem mailbox.
+3. **TMA** — hardware copy engine. Only after (1) exists and (2) is not enough.
+
+Do not default-on (2) or (3) until the oracle says the candidate is ≥3%
+faster than template batch2 on both `12288×2048` and `8192×2048`, and
+bit-identical to `w4a16_gemv` × 2.


### PR DESCRIPTION
## Summary

Continues #499. The cold-DRAM oracle example is unchanged in what it measures; the 3% kill-bar, candidate parse, and STREAM/peak defaults now live in `spark_model::layers::ops::gemv_batch2_oracle` so CI can lock them without a GPU.

This is still not a kernel change and not a default-on. Do not set `ATLAS_GEMV_BATCH2_CPASYNC=1`.

Also fixes a pre-existing harness bug that blocked the last gate: `Bfcl::verdict()` applied the 27B golden-draw MLPerf-edge bar (83.64 / **85.32**) to every variant, including the 35B echolp draw. Echolp now uses its own ratchet (84.66 / 83.32), locked to `BENCH.toml`. Subset still uses the MLPerf-edge floors — those were not lowered.

`report.rs` is on the BFCL invalidation set, so both BFCL records from earlier today no longer cover HEAD. Echolp then subset are re-running on GB10. The other four gates still cover (a BFCL driver change cannot move them).

Closes nothing. Campaign notes: `docs/campaigns/gb10-batch2-rhythm-2026-08/README.md`.

## GPU baseline (GB10, 2026-08-14)

`:8888` stopped for the run. Template `w4a16_gemv_batch2`, 40 iters, weight copies cycle past L2:

| Shape | us | GB/s | % STREAM 230 | % peak 273 |
|---|---|---|---|---|
| GDN in_proj 12288×2048 | 63.14 | **224.2** | 97.5% | 82.1% |
| attn Q 8192×2048 | 42.91 | **219.9** | 95.6% | 80.6% |
| GDN out 2048×4096 | 23.91 | **197.4** | 85.8% | 72.3% |

`PASS — baseline recorded (no candidate)`. in_proj is already 97.5% of STREAM.

## Dual-issue (#500) — Neutral, leave unwired

Oracle ran with `ATLAS_GEMV_BATCH2_CANDIDATE=w4a16_gemv_batch2_dualissue:w4a16_gemv_batch2_dualissue` (`.cu` not committed):

| Shape | vs batch2 (run 2) | Verdict |
|---|---|---|
| GDN in_proj 12288×2048 | 0.985× | Neutral |
| attn Q 8192×2048 | 0.971× | Neutral |
| GDN out 2048×4096 | 0.958× | Win (not a default-on shape) |

Default-on needs Win on both 12288×2048 and 8192×2048. Dual-issue does not. TMA (#501) is optional, not next.

## PR gates (bake 2026-08-14)

| Gate | Result |
|---|---|
| ssm-state-poisoning-gate | PASS at `97cf7382b5` (still covers) |
| ttft-warm-gate | PASS at `9ed521a029` (still covers) |
| ttft-cold-gate | PASS at `4a40549418` (still covers) |
| agentic-webserver | PASS 10/10 · 10/10 · Σwall 646s at `7f9a542486` (still covers) |
| bfcl-subset (27B) | Earlier PASS 87.64 / 88.94 n=995 at `b45f44a117` — **invalidated** by the verdict fix; re-running |
| bfcl-subset-echolp | Earlier 84.66 / 85.19 n=1004 cleared the echolp ratchet; runtime stamped FAIL on 85.32. Fix is in `66eeb9c`. **Re-running** so the record's own verdict is PASS |

`:8888` is parked for the BFCL re-bake (`KEEP_NAME=atlas-pr-proof-321128d-499oracle-keep`) and will be restored when it finishes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] host tests `gemv_batch2_oracle` 8/8
- [x] clippy -p spark-model --tests
- [x] license headers
- [x] GPU baseline + dual-issue candidate
- [x] BFCL unit tests: echolp 84.66/85.19 PASSES; same numbers on subset still FAIL; floors locked to BENCH.toml
- [ ] Six REQUIRED PR gates (4/6 still cover; both BFCL legs re-running after the verdict fix)

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).