### PR TITLE
fix(#328): the inter-tool prose budget default was raised in July — on a constant nothing reads

### DIFF
--- a/crates/atlas-kernels/build_parse_behavior.rs
+++ b/crates/atlas-kernels/build_parse_behavior.rs
@@ -4,6 +4,12 @@
 // (500-LoC cap). Included as a child module of `build_parse`, so `super::`
 // reaches its items and `crate::` reaches build.rs types.
 
+// Shared with `src/lib.rs` (which `mod`s the same file) so the parse
+// default below and `ModelBehavior::default()` are one literal. A build
+// script cannot import the library it builds, and the hand-synced copies
+// this replaces drifted for a month (#328: 384 here vs 3072 lib-side).
+include!("src/behavior_defaults.rs");
+
 /// Parsed `[behavior]` table from a model's MODEL.toml. Field defaults
 /// match `ModelBehavior::default()` so an absent table / absent field is
 /// behavior-neutral.
@@ -89,7 +95,7 @@ impl Default for ParsedBehavior {
             confidence_early_stop: true,
             confidence_run_length: 30,
             fuzzy_repeat_tolerance_div: 12,
-            max_inter_tool_prose: 384,
+            max_inter_tool_prose: DEFAULT_MAX_INTER_TOOL_PROSE,
             max_post_think_content_tokens: 100_000,
             tscg: false,
             disable_tool_grammar: false,
@@ -216,7 +222,7 @@ pub(crate) fn parse_behavior(model_dir: &std::path::Path) -> ParsedBehavior {
         .and_then(|v| v.get("max_inter_tool_prose"))
         .and_then(|v| v.as_integer())
         .map(|v| v as u32)
-        .unwrap_or(384);
+        .unwrap_or(DEFAULT_MAX_INTER_TOOL_PROSE);
     let max_post_think_content_tokens = b
         .and_then(|v| v.get("max_post_think_content_tokens"))
         .and_then(|v| v.as_integer())

--- a/crates/atlas-kernels/src/behavior_defaults.rs
+++ b/crates/atlas-kernels/src/behavior_defaults.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// `[behavior]` defaults that MUST be identical at build time and at run
+// time. This file is a plain-`mod` of `lib.rs` AND `include!`d by the
+// build script (`build_parse_behavior.rs`) — the build script cannot
+// import the library it is building, and keeping two literals in sync by
+// hand is exactly how #328 shipped: P2-1 (2026-07-09) raised the
+// spark-server default to 3072 while the build-time parse default stayed
+// 384, so every model without an explicit MODEL.toml pin kept truncating
+// agentic prose at 384 tokens for another month. One literal, two
+// consumers, no drift. Doc comments here use `//` only: `//!` is illegal
+// at an `include!` site.
+
+/// Default cap on free-text tokens between successive tool calls on a
+/// tool-armed request (`[behavior].max_inter_tool_prose`).
+///
+/// 3072 is the P2-1 value (2026-07-09): 384 was tuned as an
+/// `<invoke>`-dormant-opener wander bound, but agent frontends arm tools
+/// on every turn, so a legitimate plan/analysis turn was guillotined
+/// mid-sentence (#328: Pi.dev, opencode). Repeating wander is caught by
+/// the content-loop + SimHash watchdogs independently; this budget's
+/// residual job is the non-repeating dormant-opener burn, for which 3072
+/// still sits well below a typical `max_tokens`. A model with measured
+/// evidence for a tighter bound pins it in MODEL.toml (see
+/// kernels/strix/qwen3.6-35b-a3b, 2026-06-10). 0 is reserved by the
+/// runtime resolver to mean "guard disabled".
+pub const DEFAULT_MAX_INTER_TOOL_PROSE: u32 = 3072;

--- a/crates/atlas-kernels/src/lib.rs
+++ b/crates/atlas-kernels/src/lib.rs
@@ -18,6 +18,12 @@
 
 use atlas_core::target::KernelTarget;
 
+// Build-time/run-time shared `[behavior]` defaults — also `include!`d by
+// `build_parse_behavior.rs` so the build script's parse defaults cannot
+// drift from `ModelBehavior::default()` (the #328 failure mode).
+mod behavior_defaults;
+pub use behavior_defaults::DEFAULT_MAX_INTER_TOOL_PROSE;
+
 // Auto-generated: per-target PTX constants, ptx_modules() function,
 // and all_ptx_sets() for multi-target builds.
 // NOTE: cargo does NOT track this build-script-generated include! as a
@@ -241,7 +247,8 @@ pub struct ModelBehavior {
     /// mismatches. Default 12 (~8%).
     pub fuzzy_repeat_tolerance_div: u32,
     /// Cap on free-text tokens between successive `<tool_call>` opens in
-    /// `tool_choice=auto`. Default 384. Agentic coding may want larger.
+    /// `tool_choice=auto`. Default [`DEFAULT_MAX_INTER_TOOL_PROSE`]
+    /// (see `behavior_defaults.rs` for the tuning history — #328).
     pub max_inter_tool_prose: u32,
     /// Unconditional per-generation cap on post-`</think>` content tokens
     /// for tool-active requests (grammar attached). Bounds a runaway where
@@ -342,7 +349,7 @@ impl Default for ModelBehavior {
             confidence_early_stop: true,
             confidence_run_length: 30,
             fuzzy_repeat_tolerance_div: 12,
-            max_inter_tool_prose: 384,
+            max_inter_tool_prose: DEFAULT_MAX_INTER_TOOL_PROSE,
             max_post_think_content_tokens: 100_000,
             tscg: false,
             disable_tool_grammar: false,

--- a/crates/atlas-kernels/src/lib_tests.rs
+++ b/crates/atlas-kernels/src/lib_tests.rs
@@ -156,3 +156,19 @@ fn ptx_for_model_lookup() {
         "ptx_for_model('qwen3-next-80b') should find the default target"
     );
 }
+
+#[test]
+fn behavior_default_prose_budget_matches_shared_constant() {
+    // #328: `ModelBehavior::default()` sat at 384 for a month after P2-1
+    // raised the intended default to 3072 in spark-server — production
+    // resolves the budget from THIS struct, so every model without an
+    // explicit MODEL.toml pin kept truncating agent narration at 384
+    // tokens. The default must come from the shared constant (also
+    // `include!`d by the build script) and stay plan-sized.
+    let b = ModelBehavior::default();
+    assert_eq!(b.max_inter_tool_prose, DEFAULT_MAX_INTER_TOOL_PROSE);
+    assert!(
+        b.max_inter_tool_prose >= 2048,
+        "inter-tool prose budget default must fit a plan/analysis turn"
+    );
+}

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -343,6 +343,15 @@ pub struct ServeArgs {
     #[arg(long)]
     pub max_thinking_budget: Option<u32>,
 
+    /// Override MODEL.toml's `[behavior].max_inter_tool_prose` (tokens):
+    /// the cap on free-prose tokens between successive tool calls on a
+    /// tool-armed request, after which the scheduler ends the response
+    /// with finish_reason "length" (#328). 0 disables the guard entirely.
+    /// Precedence (highest wins): this flag → ATLAS_MAX_INTER_TOOL_PROSE
+    /// → MODEL.toml → built-in default (3072).
+    #[arg(long)]
+    pub max_inter_tool_prose: Option<u32>,
+
     /// Override MODEL.toml's `[behavior].disable_tool_grammar`.
     /// When true, the server skips XGrammar structural-tag enforcement on
     /// `tool_choice="auto"` requests; tools are still parsed from output

--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -758,7 +758,10 @@ pub(crate) fn load_model(
     // Per-model watchdog tunables. Built here, before the scheduler thread
     // spawns — the installer this replaces ran from `log_behavior_audit`,
     // which is called well after the spawn.
-    let watchdog_params = crate::scheduler::WatchdogParams::from_behavior(&ptx_set.behavior);
+    let watchdog_params = crate::scheduler::WatchdogParams::from_behavior(
+        &ptx_set.behavior,
+        args.max_inter_tool_prose,
+    );
     // The run's levers. Shared with the dashboard so `/watchdog on|off`
     // toggles this run's flag; the MODEL.toml `[behavior]` value is its
     // starting position.

--- a/crates/spark-server/src/scheduler/decode_logits_content.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_content.rs
@@ -88,6 +88,7 @@ pub fn handle_content_token(
             max = sched.watchdog.max_post_think_content_tokens,
             "post-think content cap exceeded in non-MTP decode path; ending response (tool-active request would otherwise burn to max_tokens)"
         );
+        a.guard_stop = Some(GUARD_STOP_POST_THINK_CAP);
         a.finished = true;
     }
     // think_just_ended is a one-shot: it was set when the prior
@@ -175,6 +176,9 @@ pub fn handle_content_token(
                     CONTENT_LOOP_PERIOD_MIN,
                     CONTENT_LOOP_PERIOD_MAX,
                 );
+                // #328 class: a server cut must name its guard, or
+                // `derive_finish_reason` sees budget left and wires "stop".
+                a.guard_stop = Some(GUARD_STOP_CONTENT_LOOP);
                 a.finished = true;
             }
         }
@@ -219,8 +223,13 @@ pub fn handle_content_token(
                         prose_tokens = a.prose_tokens_since_last_tool,
                         max = max_prose,
                         ?reason,
-                        "Inter-tool prose budget exhausted, ending response (rollback declined)"
+                        "Inter-tool prose budget exhausted, ending response (rollback declined); \
+                         raise via --max-inter-tool-prose / ATLAS_MAX_INTER_TOOL_PROSE / \
+                         MODEL.toml [behavior].max_inter_tool_prose (0 disables)"
                     );
+                    // #328: unnamed, this cut reached Pi.dev as a generic
+                    // max-tokens stop and the WARN above was the only clue.
+                    a.guard_stop = Some(GUARD_STOP_INTER_TOOL_PROSE);
                     a.finished = true;
                 }
             }

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -309,6 +309,7 @@ pub fn emit_token(
                 max = sched.watchdog.max_post_think_content_tokens,
                 "post-think content cap exceeded in MTP/emit path; ending response (tool-active request would otherwise burn to max_tokens)"
             );
+            a.guard_stop = Some(GUARD_STOP_POST_THINK_CAP);
             a.finished = true;
         }
         if !sched.levers.disable_watchdogs
@@ -332,6 +333,8 @@ pub fn emit_token(
                 CONTENT_LOOP_PERIOD_MIN,
                 CONTENT_LOOP_PERIOD_MAX,
             );
+            // #328 class: name the cut or it wires "stop" (see types.rs).
+            a.guard_stop = Some(GUARD_STOP_CONTENT_LOOP);
             a.finished = true;
         }
 
@@ -365,9 +368,11 @@ pub fn emit_token(
                     max = max_prose,
                     output_len = a.output_tokens.len(),
                     "Inter-tool prose budget exhausted in MTP/emit path; ending response \
-                     (no tool call after budget — would otherwise burn to max_tokens)."
+                     (no tool call after budget — would otherwise burn to max_tokens); \
+                     raise via --max-inter-tool-prose / ATLAS_MAX_INTER_TOOL_PROSE / \
+                     MODEL.toml [behavior].max_inter_tool_prose (0 disables)"
                 );
-                a.guard_stop = Some("inter_tool_prose_budget");
+                a.guard_stop = Some(GUARD_STOP_INTER_TOOL_PROSE);
                 a.finished = true;
             }
         }

--- a/crates/spark-server/src/scheduler/finish_guard_tests.rs
+++ b/crates/spark-server/src/scheduler/finish_guard_tests.rs
@@ -204,7 +204,11 @@ fn every_finish_site_is_a_recorded_decision() {
     //
     // Named — decode_logits_step: `<tool_response>`, think-skip watchdog,
     // fuzzy_repetition. emit_step: `<tool_response>`, think-skip watchdog,
-    // inter_tool_prose_budget, tool_envelope_stuck.
+    // post_think_content_cap, content_loop_watchdog, inter_tool_prose_budget,
+    // tool_envelope_stuck. decode_logits_content (#328): post_think_content_cap,
+    // content_loop_watchdog (rollback-declined), inter_tool_prose_budget
+    // (rollback-declined — the cut Pi.dev received as a generic max-tokens
+    // stop while the only truthful record was a server-side WARN line).
     // Unnamed remainder (deliberate): natural stops — the model sampled EOS,
     // the token budget / context ceiling hit, the cooperative cancel flag,
     // and `<|im_start|>` (eos-registered; see INTENTIONAL_STOP above for
@@ -216,7 +220,13 @@ fn every_finish_site_is_a_recorded_decision() {
             11,
             3,
         ),
-        ("emit_step.rs", include_str!("emit_step.rs"), 11, 4),
+        ("emit_step.rs", include_str!("emit_step.rs"), 11, 6),
+        (
+            "decode_logits_content.rs",
+            include_str!("decode_logits_content.rs"),
+            3,
+            3,
+        ),
     ];
     for (name, src, want_total, want_named) in LEDGER {
         let (total, named) = scan_finish_ledger(src);

--- a/crates/spark-server/src/scheduler/helpers.rs
+++ b/crates/spark-server/src/scheduler/helpers.rs
@@ -315,7 +315,9 @@ pub struct WatchdogParams {
     /// mismatches. Default 12 (~8%).
     pub fuzzy_repeat_tolerance_div: usize,
     /// Cap on free-text tokens between successive `<tool_call>` opens in
-    /// `tool_choice=auto`. Default 384 (`MAX_INTER_TOOL_PROSE`).
+    /// `tool_choice=auto`. Default [`MAX_INTER_TOOL_PROSE`]; `u32::MAX`
+    /// here means an operator disabled the guard (see
+    /// [`resolve_max_inter_tool_prose`]).
     pub max_inter_tool_prose: u32,
     /// Unconditional per-generation cap on post-`</think>` content tokens
     /// for tool-active requests. Default 100_000
@@ -381,7 +383,10 @@ impl WatchdogParams {
         DEFAULT_WATCHDOG_PARAMS.fuzzy_repeat_tolerance_div;
 
     /// Resolve this model's watchdog tunables from its MODEL.toml
-    /// `[behavior]` table, applying the one env override that outranks it.
+    /// `[behavior]` table, then the overrides that outrank it.
+    ///
+    /// `max_inter_tool_prose_cli` is `--max-inter-tool-prose` (#328); see
+    /// [`resolve_max_inter_tool_prose`] for the precedence chain.
     ///
     /// Was a `OnceLock` plus a `set_watchdog_params` installer. Two problems,
     /// both fixed by building the value where it is known and carrying it:
@@ -390,7 +395,10 @@ impl WatchdogParams {
     /// `log_behavior_audit`, which serve calls *after* it spawns the
     /// scheduler thread — the reader's `unwrap_or(&DEFAULT)` was the only
     /// reason that ordering was survivable.
-    pub fn from_behavior(b: &atlas_kernels::ModelBehavior) -> Self {
+    pub fn from_behavior(
+        b: &atlas_kernels::ModelBehavior,
+        max_inter_tool_prose_cli: Option<u32>,
+    ) -> Self {
         let mut p = Self {
             think_loop_min_repeats: b.think_loop_min_repeats as usize,
             think_loop_scan_window: b.think_loop_scan_window as usize,
@@ -411,15 +419,44 @@ impl WatchdogParams {
         // 6-turn session died writing an API plan at 385 tokens. The REPEATING
         // wander is already caught by the content-loop + SimHash watchdogs
         // independently; this budget's residual job is only the non-repeating
-        // dormant-opener burn. Env wins over MODEL.toml.
-        if let Some(v) = std::env::var("ATLAS_MAX_INTER_TOOL_PROSE")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-        {
-            p.max_inter_tool_prose = v;
-        }
+        // dormant-opener burn.
+        let env = match std::env::var("ATLAS_MAX_INTER_TOOL_PROSE") {
+            Ok(v) => match v.parse::<u32>() {
+                Ok(n) => Some(n),
+                Err(_) => {
+                    // A set-but-unparseable override is a config error, not
+                    // an absent one — silently keeping the model default here
+                    // is how a truncation "fix" fails to apply (#328 class).
+                    tracing::warn!(
+                        value = %v,
+                        "ATLAS_MAX_INTER_TOOL_PROSE is set but not a u32; ignoring it"
+                    );
+                    None
+                }
+            },
+            Err(_) => None,
+        };
+        p.max_inter_tool_prose =
+            resolve_max_inter_tool_prose(p.max_inter_tool_prose, env, max_inter_tool_prose_cli);
         p
     }
+}
+
+/// Resolve the effective inter-tool prose budget (#328).
+///
+/// Precedence, highest wins: `--max-inter-tool-prose` (CLI, typed per
+/// launch next to the model) → `ATLAS_MAX_INTER_TOOL_PROSE` (env) →
+/// MODEL.toml `[behavior].max_inter_tool_prose` → the shared default
+/// (`atlas_kernels::DEFAULT_MAX_INTER_TOOL_PROSE`, already folded into
+/// `toml` by the build-time parse).
+///
+/// 0 means "guard disabled" and maps to `u32::MAX`: the check sites fire
+/// on `prose_tokens > max`, so a literal 0 would end every tool-armed
+/// response at its FIRST content token — the exact opposite of what an
+/// operator writing 0 is asking for.
+pub fn resolve_max_inter_tool_prose(toml: u32, env: Option<u32>, cli: Option<u32>) -> u32 {
+    let v = cli.or(env).unwrap_or(toml);
+    if v == 0 { u32::MAX } else { v }
 }
 
 // The three vocabulary masks that lived here as `OnceLock<Arc<[bool]>>` plus a
@@ -436,12 +473,14 @@ impl WatchdogParams {
 /// in `auto` mode (grammar.rs:461-462) sets `at_least_one=false`
 /// and `stop_after_first=false`, so `is_terminated()` stays false
 /// forever after the first tool call — the model can emit
-/// prose↔tool↔prose↔tool indefinitely. 384 tokens is enough for
-/// three normal "I'll now do X" paragraphs of agentic narrative;
-/// anything beyond is the failure mode (re-narrating the plan
-/// rather than executing it). Counted across non-thinking,
+/// prose↔tool↔prose↔tool indefinitely. Counted across non-thinking,
 /// non-tool-body tokens only.
-pub const MAX_INTER_TOOL_PROSE: u32 = 3072;
+///
+/// Aliases the atlas-kernels default rather than restating it: P2-1
+/// raised this constant to 3072 while the kernels-side default (the one
+/// `from_behavior` actually reads for every model) stayed 384, so the
+/// "fixed" budget kept amputating agent narration for a month (#328).
+pub const MAX_INTER_TOOL_PROSE: u32 = atlas_kernels::DEFAULT_MAX_INTER_TOOL_PROSE;
 
 /// F1 (2026-06-02): unconditional per-generation cap on post-`</think>`
 /// content tokens for tool-active requests (`grammar_state.is_some()`).
@@ -739,6 +778,8 @@ mod thinking_loop_tests;
 
 #[cfg(test)]
 mod inter_tool_prose_tests {
+    use super::{WatchdogParams, resolve_max_inter_tool_prose};
+
     #[test]
     fn default_prose_budget_is_plan_friendly() {
         // Regression: 384 amputated legitimate plan turns (2026-07-09).
@@ -748,6 +789,48 @@ mod inter_tool_prose_tests {
                 "inter-tool prose budget must fit a typical plan/analysis turn"
             );
         };
+    }
+
+    #[test]
+    fn resolved_default_budget_is_plan_friendly() {
+        // #328: the const assert above was green for a month while every
+        // served model got 384 — production reads the KERNELS-side default
+        // through `from_behavior`, not the constant. Assert the RESOLVED
+        // value, i.e. what `handle_content_token` actually compares against.
+        let p = WatchdogParams::from_behavior(&atlas_kernels::ModelBehavior::default(), None);
+        assert!(
+            p.max_inter_tool_prose >= 2048,
+            "resolved inter-tool prose budget must fit a plan/analysis turn \
+             (got {}) — the build-time and lib defaults have drifted",
+            p.max_inter_tool_prose
+        );
+    }
+
+    #[test]
+    fn prose_budget_precedence_is_cli_env_toml() {
+        // MODEL.toml value stands alone.
+        assert_eq!(resolve_max_inter_tool_prose(384, None, None), 384);
+        // Env outranks MODEL.toml (P2-1 contract, unchanged).
+        assert_eq!(resolve_max_inter_tool_prose(384, Some(8192), None), 8192);
+        // CLI outranks both — it is typed per launch next to the model.
+        assert_eq!(
+            resolve_max_inter_tool_prose(384, Some(8192), Some(4096)),
+            4096
+        );
+        assert_eq!(resolve_max_inter_tool_prose(384, None, Some(4096)), 4096);
+    }
+
+    #[test]
+    fn prose_budget_zero_disables_instead_of_instant_firing() {
+        // The check sites fire on `prose_tokens > max`, so a literal 0 would
+        // truncate every tool-armed response at its first content token.
+        // 0 must mean "guard off" from every source.
+        assert_eq!(resolve_max_inter_tool_prose(0, None, None), u32::MAX);
+        assert_eq!(resolve_max_inter_tool_prose(384, Some(0), None), u32::MAX);
+        assert_eq!(
+            resolve_max_inter_tool_prose(384, Some(8192), Some(0)),
+            u32::MAX
+        );
     }
 }
 

--- a/crates/spark-server/src/scheduler/types.rs
+++ b/crates/spark-server/src/scheduler/types.rs
@@ -135,6 +135,24 @@ pub(super) const GUARD_STOP_TOOL_RESPONSE: &str = "tool_response_hard_stop";
 /// — naming a guard THERE would reintroduce the opposite mislabel.
 pub(super) const GUARD_STOP_THINK_SKIP: &str = "think_skip_watchdog";
 
+/// The inter-tool prose budget ended the turn (#328). Both decode paths
+/// (non-MTP `decode_logits_content` fallback and MTP `emit_step`) must
+/// stamp this: unnamed, the non-MTP cut fell through every rung of
+/// `derive_finish_reason` and wired `"stop"` — the client banked a
+/// mid-sentence truncation as a finished answer, while its only clue was
+/// a server-side WARN line. Named, the wire reason is `"length"` and the
+/// guard name reaches `StreamEvent::Done.guard_stop` and the --dump body.
+pub(super) const GUARD_STOP_INTER_TOOL_PROSE: &str = "inter_tool_prose_budget";
+
+/// The content-loop watchdog hard-stopped (rollback declined or the MTP
+/// mirror, which cannot roll back). Same honesty contract as above: a
+/// degeneration cut is a SERVER truncation and must say so.
+pub(super) const GUARD_STOP_CONTENT_LOOP: &str = "content_loop_watchdog";
+
+/// The F1 post-`</think>` content cap ended a tool-active response.
+/// It is an early, smarter `max_tokens` — report it as one (`"length"`).
+pub(super) const GUARD_STOP_POST_THINK_CAP: &str = "post_think_content_cap";
+
 /// An in-flight sequence participating in batched decode.
 pub(super) struct ActiveSeq {
     pub seq: SequenceState,


### PR DESCRIPTION
Fixes #328.

## What the user sees

Agent frontends (Pi.dev, and anything that arms tools every turn) get truncated responses with a misleading client-side error:

```
Inter-tool prose budget exhausted, ending response (rollback declined)
prose_tokens=385 max=384 reason=StreamUnsafe
```

Reproduced across `Qwen3.6-35B-A3B-NVFP4`, Qwen3.5/3.6 variants and `Qwen3-Coder-Next-FP8`, and **re-confirmed by the reporter on the 2026-08-13 image** built from current main.

## Root cause — a fix that landed on a dead constant

The budget bounds free prose between tool calls: under `tool_choice="auto"` the grammar never self-terminates, so a wandering model can burn the whole `max_tokens`. Past the budget Atlas tries `rollback_to_boundary` to re-steer; for **streaming** requests rollback is always declined (`StreamUnsafe` — SSE deltas already flushed cannot be retracted), so it hard-stops.

**P2-1 (`c598b5387`, 2026-07-09) already diagnosed this** — "384 amputated legitimate plan turns" — and raised the default 384 → 3072. It raised the wrong copy:

- `WatchdogParams::from_behavior` **always overwrites** the `spark-server` constant with the atlas-kernels `ModelBehavior` value (`helpers.rs:439`)
- that value's default — in `lib.rs` *and* in the build-time MODEL.toml parse — stayed **384**
- only `gb10/qwen3.6-35b-a3b` got a MODEL.toml pin; the reporter's models set none
- **P2-1's regression test asserted the dead constant**, so it stayed green through the whole regression

## Unblock today, no upgrade needed

`ATLAS_MAX_INTER_TOOL_PROSE` already works on the shipped image — it was simply undocumented, absent from `--help`, and unmentioned in the warning:

```
docker run -e ATLAS_MAX_INTER_TOOL_PROSE=8192 …
```

## The fix

1. **One default, not three.** New `crates/atlas-kernels/src/behavior_defaults.rs`, `mod`-ed by `lib.rs` and `include!`-d by the build script, so the three formerly hand-synced literals are a single constant at **3072**. Explicit MODEL.toml pins (holo/ornith 384, strix with its measured rationale) are deliberately untouched.
2. **`--max-inter-tool-prose` serve flag**, precedence CLI → env → MODEL.toml → default, resolved in one pure tested function. **0 disables** the guard — previously 0 would have ended every response at its first content token. A malformed env value warns instead of silently doing nothing.
3. **Honesty about the truncation.** The non-MTP rollback-declined path — the reporter's exact log line — set `finished` without naming a guard, so `derive_finish_reason` produced `"stop"`: the response claimed to be *complete*. All watchdog cuts now stamp `GUARD_STOP_INTER_TOOL_PROSE` / `_CONTENT_LOOP` / `_POST_THINK_CAP` and wire `finish_reason="length"`, so a client can tell truncation from completion. The guard name reaches `StreamEvent::Done.guard_stop` and `--dump`; the WARN now names all three knobs. (Surfacing the guard name as a response extension field stays the documented follow-up in `lifecycle.rs` — a novel `finish_reason` enum value would break typed clients.)

The guard itself stays. It prevents a real runaway; it just should never have been unsizeable.

## Tests

Both regression tests were **verified to fail on pre-fix code**: the resolved default through `from_behavior` (the assertion P2-1 should have made), and kernels-default == constant. Plus precedence, 0-disable, and `decode_logits_content.rs` added to the finish-site ledger.

4613 workspace tests pass; fmt and clippy clean.

## Merge caveat

Raising the effective default 384 → 3072 touches the **unpinned `gb10/qwen3.6-27b` MLPerf model**. Gates B/D should run before merge — this changes how much prose that model may emit between tool calls, which is exactly what BFCL measures. Nothing was run on GPU for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)