### PR TITLE
sampling: let a model declare its own min_p

### DIFF
--- a/crates/atlas-kernels/build.rs
+++ b/crates/atlas-kernels/build.rs
@@ -23,6 +23,9 @@ struct SamplingCat {
     // over the recent token window. 0.0 = disabled. 0.2 is the SGLang
     // reference value; lossless on AIME/GPQA at that strength.
     lz_penalty: f32,
+    // Model-declared min-p. None = MODEL.toml is silent, so the server's
+    // --default-min-p stands (see SamplingCategory in src/lib.rs).
+    min_p: Option<f32>,
 }
 
 impl Default for SamplingCat {
@@ -38,6 +41,7 @@ impl Default for SamplingCat {
             dry_base: 1.75,
             dry_allowed_length: 2,
             lz_penalty: 0.0,
+            min_p: None,
         }
     }
 }

--- a/crates/atlas-kernels/build_codegen.rs
+++ b/crates/atlas-kernels/build_codegen.rs
@@ -131,7 +131,7 @@ pub(super) fn generate_target_ptx_rs(
         };
         let fmt_cat = |c: &SamplingCat| -> String {
             format!(
-                "SamplingCategory {{ temperature: {:.2}, top_p: {:.2}, top_k: {}, presence_penalty: {:.2}, frequency_penalty: {:.2}, repetition_penalty: {:.2}, dry_multiplier: {:.2}, dry_base: {:.2}, dry_allowed_length: {}, lz_penalty: {:.2} }}",
+                "SamplingCategory {{ temperature: {:.2}, top_p: {:.2}, top_k: {}, presence_penalty: {:.2}, frequency_penalty: {:.2}, repetition_penalty: {:.2}, dry_multiplier: {:.2}, dry_base: {:.2}, dry_allowed_length: {}, lz_penalty: {:.2}, min_p: {} }}",
                 c.temperature,
                 c.top_p,
                 c.top_k,
@@ -142,6 +142,10 @@ pub(super) fn generate_target_ptx_rs(
                 c.dry_base,
                 c.dry_allowed_length,
                 c.lz_penalty,
+                match c.min_p {
+                    Some(v) => format!("Some({v:.4})"),
+                    None => "None".to_string(),
+                },
             )
         };
         g.push_str(&format!(

--- a/crates/atlas-kernels/build_parse.rs
+++ b/crates/atlas-kernels/build_parse.rs
@@ -204,6 +204,9 @@ pub(super) fn parse_sampling_presets(
                     .get("lz_penalty")
                     .and_then(|t| t.as_float())
                     .unwrap_or(0.0) as f32,
+                // NO unwrap_or: an absent min_p must stay None so the
+                // server's --default-min-p keeps owning the field.
+                min_p: v.get("min_p").and_then(|t| t.as_float()).map(|p| p as f32),
             },
             None => SamplingCat::default(),
         }

--- a/crates/atlas-kernels/src/lib.rs
+++ b/crates/atlas-kernels/src/lib.rs
@@ -95,6 +95,21 @@ pub struct SamplingCategory {
     /// `presence_penalty` regression. 0.0 = disabled. SGLang reference
     /// strength = 0.2 (lossless on AIME/GPQA).
     pub lz_penalty: f32,
+    /// Model-declared min-p, or `None` when MODEL.toml is silent.
+    ///
+    /// `Option`, not `f32`, because absence and `0.0` mean opposite things
+    /// here. The server ships `--default-min-p 0.08` and every request that
+    /// does not name min_p takes it, so a model whose card specifies
+    /// `min_p = 0` had no way to say so: `[behavior].min_p_floor` only ever
+    /// RAISES min_p (`min_p.max(floor)`), and the preset did not carry the
+    /// value at all. A plain `f32` defaulting to 0.0 would silently strip the
+    /// 0.08 floor from every model that has a `[sampling.*]` table, which is
+    /// the opposite regression.
+    ///
+    /// `Some(x)` outranks the CLI default and is outranked by
+    /// `generation_config.json` — the same precedence temperature/top_k/top_p
+    /// already follow. `None` preserves the CLI-owned behaviour exactly.
+    pub min_p: Option<f32>,
 }
 
 /// Model-specific sampling presets loaded from MODEL.toml `[sampling.*]`.
@@ -123,6 +138,7 @@ impl Default for SamplingPresets {
             dry_base: 1.75,
             dry_allowed_length: 2,
             lz_penalty: 0.0,
+            min_p: None,
         };
         let tools_cat = SamplingCategory {
             temperature: 0.6,
@@ -135,6 +151,7 @@ impl Default for SamplingPresets {
             dry_base: 1.75,
             dry_allowed_length: 2,
             lz_penalty: 0.0,
+            min_p: None,
         };
         Self {
             thinking_text: default_cat,

--- a/crates/spark-server/src/main_modules/serve_phases/runtime.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/runtime.rs
@@ -82,12 +82,22 @@ pub(crate) fn load_sampling_defaults(
 /// Pure per-field resolution: a field present in `generation_config.json` is
 /// honored verbatim (a config that legitimately asks for `temperature=0` gets
 /// it); an ABSENT field backfills from the model's curated MODEL.toml
-/// `[sampling.non_thinking]` preset (temperature/top_k/top_p) or the CLI
-/// defaults (top_n_sigma/min_p, which the preset does not carry). No
-/// hard-coded constants: the old `0.6 / 20 / 0.95` literals duplicated — and
-/// could drift from — the preset that already drives the penalties, and a
-/// missing config must not silently mean "someone's idea of typical" when the
-/// model ships its own numbers.
+/// `[sampling.non_thinking]` preset (temperature/top_k/top_p/min_p) or the CLI
+/// defaults. No hard-coded constants: the old `0.6 / 20 / 0.95` literals
+/// duplicated — and could drift from — the preset that already drives the
+/// penalties, and a missing config must not silently mean "someone's idea of
+/// typical" when the model ships its own numbers.
+///
+/// `min_p` is three-tier because the preset carries it only when MODEL.toml
+/// says so: config → preset (`Some`) → `--default-min-p`. A model card that
+/// specifies `min_p = 0` previously had no way to express it — the server's
+/// 0.08 default reached every request regardless, and `[behavior].min_p_floor`
+/// can only raise min_p, never pin it. A preset that stays silent (`None`)
+/// leaves the CLI default owning the field exactly as before.
+///
+/// `top_n_sigma` remains CLI-only: it is not carried by any model card we
+/// serve, and it is separately suspected of being a no-op on several targets,
+/// so giving it a MODEL.toml voice would advertise a knob that does nothing.
 pub(crate) fn resolve_sampling_defaults(
     gen_cfg: Option<&serde_json::Value>,
     args: &cli::ServeArgs,
@@ -112,6 +122,7 @@ pub(crate) fn resolve_sampling_defaults(
     let min_p = gen_cfg
         .and_then(|v| v.get("min_p")?.as_f64())
         .map(|p| p as f32)
+        .or(preset.min_p)
         .unwrap_or(args.default_min_p);
     SamplingDefaults {
         temperature,
@@ -392,6 +403,7 @@ mod sampling_defaults_tests {
             dry_base: 1.75,
             dry_allowed_length: 2,
             lz_penalty: 0.0,
+            min_p: None,
         }
     }
 
@@ -437,10 +449,35 @@ mod sampling_defaults_tests {
 
     #[test]
     fn sigma_and_min_p_fall_back_to_cli_args() {
-        // These two are CLI-owned (#388): the preset does not carry them.
+        // top_n_sigma is CLI-owned outright; min_p is CLI-owned only while
+        // the preset stays silent (`min_p: None`), which `preset()` is.
         let a = args();
         let d = resolve_sampling_defaults(None, &a, &preset());
         assert_eq!(d.top_n_sigma, a.default_top_n_sigma);
         assert_eq!(d.min_p, a.default_min_p);
+    }
+
+    #[test]
+    fn model_declared_min_p_zero_beats_the_cli_default() {
+        // The reason this field exists. A card that specifies min_p = 0 must
+        // get 0, not the server's 0.08 — and 0.0 is exactly the value a
+        // non-Option field could not distinguish from "unset".
+        let a = args();
+        assert!(a.default_min_p > 0.0, "guard: CLI default must be nonzero");
+        let mut p = preset();
+        p.min_p = Some(0.0);
+        let d = resolve_sampling_defaults(None, &a, &p);
+        assert_eq!(d.min_p, 0.0, "model preset must win over --default-min-p");
+    }
+
+    #[test]
+    fn generation_config_still_outranks_a_declared_min_p() {
+        // Same precedence as temperature/top_k/top_p: the checkpoint's own
+        // generation_config.json is the most specific source and wins.
+        let cfg = serde_json::json!({"min_p": 0.31});
+        let mut p = preset();
+        p.min_p = Some(0.0);
+        let d = resolve_sampling_defaults(Some(&cfg), &args(), &p);
+        assert_eq!(d.min_p, 0.31);
     }
 }


### PR DESCRIPTION
A model card that specifies `min_p = 0` had no way to say so.

The server ships `--default-min-p 0.08` and every request that does not name min_p takes it. `[behavior].min_p_floor` only ever *raises* min_p (`min_p.max(floor)`), so it cannot pin one to zero. And the `[sampling.*]` preset did not carry the field at all — `resolve_sampling_defaults` said so in its own doc comment:

> an ABSENT field backfills from the model's curated MODEL.toml `[sampling.non_thinking]` preset (temperature/top_k/top_p) or the CLI defaults (top_n_sigma/min_p, **which the preset does not carry**).

So for this one field the value reaching the sampler was the operator's, not the model's, and no MODEL.toml edit could change that.

## Why it matters

Not hypothetical. **min_p is live** — measured on Nemotron-3.5-Lightning-30B at temperature 1.6, `min_p = 0.95` collapsed 8 samples to a single distinct output against 8/8 distinct at `0.0`. And two checkpoints in flight publish `min_p = 0` on their cards: Qwen3.8-27B (thinking *and* instruct modes) and Lightning. Both would silently serve at 0.08.

## Shape

`SamplingCategory.min_p` is `Option<f32>`, not `f32`, because **absence and `0.0` mean opposite things here**. A plain `f32` defaulting to 0.0 would silently strip the 0.08 floor from every model that has a `[sampling.*]` table — the opposite regression, and a quiet one.

Precedence becomes the same three-tier rule temperature/top_k/top_p already follow:

```
generation_config.json  →  MODEL.toml preset (Some)  →  --default-min-p
```

`None` leaves the CLI default owning the field exactly as before, so **no existing model changes behaviour**.

## `top_n_sigma` deliberately left alone

The same doc comment groups the two, but they are not in the same position. No model card we serve carries `top_n_sigma`, and it is separately suspected of being a **no-op**: on Lightning, sigma `0.0` / `0.2` / `0.5` all produced 8/8 distinct outputs at temperature 1.6, where a restrictive `0.2` should have collapsed diversity the way `min_p = 0.95` did. Advertising a MODEL.toml knob that does nothing would be worse than leaving it CLI-only. Worth chasing separately.

## Verification

Three unit tests on `resolve_sampling_defaults`, plus two checks that the tests themselves are worth something:

- **Negative control** — deleting only the `.or(preset.min_p)` line while keeping the field fails the new test with `left: 0.08 / right: 0.0`. Restoring it passes. So the test is not vacuous.
- **End to end** — injecting `min_p = 0.0` into a real MODEL.toml `[sampling.non_thinking]` and rebuilding emits exactly **one** `min_p: Some(0.0000)` in the generated target table, with every other target still `min_p: None`. Parser → codegen → runtime all carry it, and absence stays absence.

`cargo check --workspace --tests` and `clippy` clean, **4619 tests pass**, all five touched files under the 500-LoC cap (`lib.rs` 486, `runtime.rs` 483).

**No MODEL.toml is changed here.** This adds the capability; the models that need it declare it in their own PRs.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
