### PR TITLE
atlas-plugin: pin ssm_cache_slots=256 on BFCL self-start

### DIFF
--- a/crates/atlas-plugin/src/gate/bench.rs
+++ b/crates/atlas-plugin/src/gate/bench.rs
@@ -58,6 +58,17 @@ pub struct BenchEntry {
     pub status: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub note: String,
+    /// Recipe keys self-start applies on every `--pull-request-gate` run.
+    ///
+    /// Empty (and omitted from the TOML) is the normal case: the recipe serves
+    /// exactly as pinned. Non-empty is a gate-local pin the recipe itself
+    /// must not carry — e.g. `ssm_cache_slots = "256"` on BFCL, so a 1004-
+    /// sample serial generate cannot evict its own Marconi snapshots. Values
+    /// are strings, matching `--serve-override KEY=VALUE`. `port` is refused:
+    /// self-start binds a free port and a second opinion would name a listener
+    /// that is not there.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub serve_overrides: BTreeMap<String, String>,
     /// Thresholds. Absent for `unmeasured` — see the module docs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metrics: Option<BTreeMap<String, super::record::Bound>>,
@@ -113,6 +124,15 @@ pub fn load_all(root: &Path) -> Result<Vec<(taxon::Target, BenchEntry)>> {
             if entry.status == "measured" && entry.metrics.is_none() {
                 bail!(
                     "{}: {} / {} claims to be measured but declares no metrics",
+                    path.display(),
+                    entry.gate,
+                    entry.checkpoint
+                );
+            }
+            if entry.serve_overrides.contains_key("port") {
+                bail!(
+                    "{}: {} / {} serve_overrides cannot set `port`: self-start binds \
+                     a free port itself, so a pin here would name a listener that is not there",
                     path.display(),
                     entry.gate,
                     entry.checkpoint
@@ -183,6 +203,7 @@ pub fn baseline_for(root: &Path, benchmark_id: &str) -> Result<GateBaseline> {
                     recipe: entry.recipe.clone(),
                     note: entry.note.clone(),
                     metrics,
+                    serve_overrides: entry.serve_overrides.clone(),
                 },
             )
             .is_some()

--- a/crates/atlas-plugin/src/gate/bench_tests.rs
+++ b/crates/atlas-plugin/src/gate/bench_tests.rs
@@ -281,3 +281,100 @@ min = 85.0
     let all = load_all(&root).unwrap();
     assert_eq!(all.len(), 1, "one entry, not one per quant dir: {all:?}");
 }
+
+/// A `[benchmarks.serve_overrides]` table is the SSOT for a gate-local pin.
+#[test]
+fn serve_overrides_are_assembled_into_the_baseline() {
+    let root = fixture(
+        "serve-overrides",
+        r#"
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "org/A"
+gate = "bfcl-subset"
+default = true
+status = "measured"
+[benchmarks.serve_overrides]
+ssm_cache_slots = "256"
+[benchmarks.metrics.overall_accuracy]
+min = 85.0
+"#,
+    );
+    let baseline = baseline_for(&root, "bfcl-subset").unwrap();
+    let (_, entry) = baseline.resolve("gb10", None).unwrap();
+    assert_eq!(
+        entry
+            .serve_overrides
+            .get("ssm_cache_slots")
+            .map(String::as_str),
+        Some("256")
+    );
+}
+
+/// `port` is owned by self-start. A pin here would name a listener that is not
+/// there, so it is refused at parse rather than dropped later.
+#[test]
+fn a_port_serve_override_is_refused() {
+    let root = fixture(
+        "port-pin",
+        r#"
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "org/A"
+gate = "bfcl-subset"
+default = true
+status = "measured"
+[benchmarks.serve_overrides]
+port = "8888"
+[benchmarks.metrics.overall_accuracy]
+min = 85.0
+"#,
+    );
+    let err = load_all(&root).unwrap_err().to_string();
+    assert!(err.contains("cannot set `port`"), "{err}");
+}
+
+/// The pin must not move the AST floors. Those are the high-water ratchet;
+/// this change is capacity (Marconi pool), not a score lever.
+#[test]
+fn bfcl_self_start_pins_ssm_slots_without_moving_ast_floors() {
+    let root = repo_root();
+    let echolp = baseline_for(&root, "bfcl-subset-echolp").unwrap();
+    let (_, e) = echolp.resolve("gb10", None).unwrap();
+    assert_eq!(e.metrics["overall_accuracy"].min, Some(84.66));
+    assert_eq!(e.metrics["normalized_single_turn_score"].min, Some(83.32));
+    assert_eq!(e.metrics["samples"].min, Some(1004.0));
+    assert_eq!(e.metrics["samples"].max, Some(1004.0));
+    assert_eq!(
+        e.serve_overrides.get("ssm_cache_slots").map(String::as_str),
+        Some("256")
+    );
+
+    let subset = baseline_for(&root, "bfcl-subset").unwrap();
+    let (_, s) = subset.resolve("gb10", None).unwrap();
+    assert_eq!(s.metrics["overall_accuracy"].min, Some(87.44));
+    assert_eq!(s.metrics["normalized_single_turn_score"].min, Some(88.59));
+    assert_eq!(s.metrics["samples"].min, Some(995.0));
+    assert_eq!(s.metrics["samples"].max, Some(995.0));
+    assert_eq!(
+        s.serve_overrides.get("ssm_cache_slots").map(String::as_str),
+        Some("256")
+    );
+
+    let poison = baseline_for(&root, "ssm-state-poisoning-gate").unwrap();
+    let (_, p) = poison.resolve("gb10", None).unwrap();
+    assert_eq!(
+        p.serve_overrides.get("ssm_cache_slots").map(String::as_str),
+        Some("256")
+    );
+
+    for id in ["ttft-warm-gate", "ttft-cold-gate", "agentic-webserver"] {
+        let b = baseline_for(&root, id).unwrap();
+        let (_, e) = b.resolve("gb10", None).unwrap();
+        assert!(
+            e.serve_overrides.is_empty(),
+            "{id} keeps the recipe's default pool: {:?}",
+            e.serve_overrides
+        );
+    }
+}

--- a/crates/atlas-plugin/src/gate/check.rs
+++ b/crates/atlas-plugin/src/gate/check.rs
@@ -77,6 +77,17 @@ pub fn check_record(record: &GateRecord, baseline: &GateBaseline) -> Option<Vec<
         )]);
     }
     let mut problems = Vec::new();
+    for (k, want) in &entry.serve_overrides {
+        match record.serve_overrides.get(k) {
+            Some(got) if got == want => {}
+            Some(got) => problems.push(format!(
+                "serve override {k}={got} does not match the baseline pin {k}={want}"
+            )),
+            None => problems.push(format!(
+                "serve override {k}={want} is pinned on the baseline but missing from the record"
+            )),
+        }
+    }
     for (name, bound) in &entry.metrics {
         let Some(value) = record.metrics.get(name) else {
             problems.push(format!("{name}: missing from the record"));

--- a/crates/atlas-plugin/src/gate/fixture_baseline.rs
+++ b/crates/atlas-plugin/src/gate/fixture_baseline.rs
@@ -53,6 +53,12 @@ pub(super) fn write_baseline(root: &Path, benchmark_id: &str, baseline: &GateBas
             }
             toml.push_str("status = \"measured\"\n");
             toml.push_str(&format!("note = {}\n", json_str(&model.note)));
+            if !model.serve_overrides.is_empty() {
+                toml.push_str("\n[benchmarks.serve_overrides]\n");
+                for (k, v) in &model.serve_overrides {
+                    toml.push_str(&format!("{k} = {}\n", json_str(v)));
+                }
+            }
             for (name, bound) in &model.metrics {
                 toml.push_str(&format!("\n[benchmarks.metrics.{name}]\n"));
                 if let Some(v) = bound.min {

--- a/crates/atlas-plugin/src/gate/mod.rs
+++ b/crates/atlas-plugin/src/gate/mod.rs
@@ -43,8 +43,8 @@ pub use check::{
     Comparison, GateStatus, check_gates, check_record, compare, record_covers, records_newest_first,
 };
 pub use record::{
-    Bound, GateBaseline, GateRecord, HardwareBaseline, ModelBaseline, date_of, now_secs,
-    read_baseline, read_record, record_path, write_record,
+    Bound, GateBaseline, GateRecord, HardwareBaseline, ModelBaseline, date_of,
+    merge_serve_overrides, now_secs, read_baseline, read_record, record_path, write_record,
 };
 
 /// The five benches whose records must pass for the branch to be gated.

--- a/crates/atlas-plugin/src/gate/override_tests.rs
+++ b/crates/atlas-plugin/src/gate/override_tests.rs
@@ -69,3 +69,113 @@ fn a_run_without_overrides_carries_no_override_provenance() {
     let json = serde_json::to_string(&gate).unwrap();
     assert!(!json.contains("serve_overrides"), "{json}");
 }
+
+/// A copied 16-slot BFCL record cannot cover a 256-slot pin.
+///
+/// BENCH.toml is outside the closure hash, so a pin-only edit would otherwise
+/// leave an old record green. `check_record` demands the pin on the record.
+#[test]
+fn a_record_missing_a_baseline_serve_pin_fails() {
+    let mut baseline = super::tests::bfcl_baseline();
+    let entry = baseline
+        .hardware
+        .get_mut(TEST_HW)
+        .unwrap()
+        .models
+        .get_mut(MODEL)
+        .unwrap();
+    entry
+        .serve_overrides
+        .insert("ssm_cache_slots".into(), "256".into());
+
+    let mut metrics = BTreeMap::new();
+    metrics.insert("overall_accuracy".into(), 90.0);
+    metrics.insert("normalized_single_turn_score".into(), 90.0);
+    metrics.insert("samples".into(), 995.0);
+    let gate = GateRecord::from_run(
+        &run_record(metrics, Verdict::pass("ok")),
+        hw(),
+        SHA.into(),
+        Vec::new(),
+        Some("qwen3.6/qwen3.6-27b-nvfp4-unsloth".into()),
+        Default::default(),
+    )
+    .unwrap();
+    let problems = check_record(&gate, &baseline).expect("must fail");
+    assert!(
+        problems
+            .iter()
+            .any(|p| p.contains("ssm_cache_slots=256") && p.contains("missing")),
+        "{problems:?}"
+    );
+}
+
+#[test]
+fn a_record_with_the_baseline_serve_pin_still_scores_metrics() {
+    let mut baseline = super::tests::bfcl_baseline();
+    let entry = baseline
+        .hardware
+        .get_mut(TEST_HW)
+        .unwrap()
+        .models
+        .get_mut(MODEL)
+        .unwrap();
+    entry
+        .serve_overrides
+        .insert("ssm_cache_slots".into(), "256".into());
+
+    let mut metrics = BTreeMap::new();
+    metrics.insert("overall_accuracy".into(), 90.0);
+    metrics.insert("normalized_single_turn_score".into(), 90.0);
+    metrics.insert("samples".into(), 995.0);
+    let mut overrides = BTreeMap::new();
+    overrides.insert("ssm_cache_slots".into(), "256".into());
+    let gate = GateRecord::from_run(
+        &run_record(metrics, Verdict::pass("ok")),
+        hw(),
+        SHA.into(),
+        Vec::new(),
+        Some("qwen3.6/qwen3.6-27b-nvfp4-unsloth".into()),
+        overrides,
+    )
+    .unwrap();
+    assert_eq!(check_record(&gate, &baseline), None);
+}
+
+#[test]
+fn a_record_with_a_different_pin_value_fails() {
+    let mut baseline = super::tests::bfcl_baseline();
+    let entry = baseline
+        .hardware
+        .get_mut(TEST_HW)
+        .unwrap()
+        .models
+        .get_mut(MODEL)
+        .unwrap();
+    entry
+        .serve_overrides
+        .insert("ssm_cache_slots".into(), "256".into());
+
+    let mut metrics = BTreeMap::new();
+    metrics.insert("overall_accuracy".into(), 90.0);
+    metrics.insert("normalized_single_turn_score".into(), 90.0);
+    metrics.insert("samples".into(), 995.0);
+    let mut overrides = BTreeMap::new();
+    overrides.insert("ssm_cache_slots".into(), "16".into());
+    let gate = GateRecord::from_run(
+        &run_record(metrics, Verdict::pass("ok")),
+        hw(),
+        SHA.into(),
+        Vec::new(),
+        Some("qwen3.6/qwen3.6-27b-nvfp4-unsloth".into()),
+        overrides,
+    )
+    .unwrap();
+    let problems = check_record(&gate, &baseline).expect("must fail");
+    assert!(
+        problems
+            .iter()
+            .any(|p| p.contains("ssm_cache_slots=16") && p.contains("256")),
+        "{problems:?}"
+    );
+}

--- a/crates/atlas-plugin/src/gate/record.rs
+++ b/crates/atlas-plugin/src/gate/record.rs
@@ -115,6 +115,20 @@ pub struct ModelBaseline {
     pub note: String,
     #[serde(default)]
     pub metrics: BTreeMap<String, Bound>,
+    /// Recipe keys self-start applies for this gate. Empty (and omitted) means
+    /// the recipe serves exactly as pinned. See [`super::bench::BenchEntry`].
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub serve_overrides: BTreeMap<String, String>,
+}
+
+/// Baseline pins first; the operator's `--serve-override` wins on a clash.
+pub fn merge_serve_overrides(
+    baseline: BTreeMap<String, String>,
+    requested: BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut out = baseline;
+    out.extend(requested);
+    out
 }
 
 /// Every model measured on one box class, and which one to serve by default.

--- a/crates/atlas-plugin/src/gate/tests.rs
+++ b/crates/atlas-plugin/src/gate/tests.rs
@@ -107,6 +107,7 @@ pub(super) fn baseline_for(model: &str, metrics: BTreeMap<String, Bound>) -> Gat
             recipe: Some("qwen3.6/test-recipe".to_string()),
             note: "MLPerf floor".to_string(),
             metrics,
+            serve_overrides: BTreeMap::new(),
         },
     );
     let mut hardware = BTreeMap::new();

--- a/crates/spark-server/src/cli/bench_selfstart.rs
+++ b/crates/spark-server/src/cli/bench_selfstart.rs
@@ -138,6 +138,8 @@ impl Drop for SelfServed {
 pub(super) struct Resolved {
     pub model: String,
     pub recipe_id: String,
+    /// Gate-local recipe pins from `BENCH.toml` (`[benchmarks.serve_overrides]`).
+    pub serve_overrides: BTreeMap<String, String>,
 }
 
 /// Pick the (model, recipe) a gate run should serve.
@@ -183,7 +185,11 @@ pub(super) fn resolve(
              --url/--model and no --pull-request-gate."
         )
     })?;
-    Ok(Resolved { model, recipe_id })
+    Ok(Resolved {
+        model,
+        recipe_id,
+        serve_overrides: entry.serve_overrides.clone(),
+    })
 }
 
 /// Parse `--serve-override KEY=VALUE` pairs into recipe overrides.
@@ -226,8 +232,9 @@ pub(super) fn parse_serve_overrides(pairs: &[String]) -> Result<BTreeMap<String,
 /// box's config to serve.
 ///
 /// `overrides` are recipe keys the operator changed on the command line. They
-/// are returned in [`SelfServed::overrides`] so the gate record can name the
-/// config that actually ran rather than the recipe it started from.
+/// are merged on top of any `[benchmarks.serve_overrides]` pin from the
+/// baseline (operator wins a clash) and returned in [`SelfServed::overrides`]
+/// so the gate record names the config that actually ran.
 pub async fn serve_for(
     benchmark_id: &str,
     hardware: Option<&str>,
@@ -235,7 +242,11 @@ pub async fn serve_for(
 ) -> Result<SelfServed> {
     let root = super::bench_run::repo_root()?;
     let baseline = gate::read_baseline(&root, benchmark_id)?;
-    let Resolved { model, recipe_id } = resolve(&baseline, benchmark_id, hardware)?;
+    let Resolved {
+        model,
+        recipe_id,
+        serve_overrides: baseline_overrides,
+    } = resolve(&baseline, benchmark_id, hardware)?;
 
     let store = atlas_plugin::ArtifactStore::discover()?;
     let index = crate::recipe::fetch::cached(store.root());
@@ -266,7 +277,7 @@ pub async fn serve_for(
     }
 
     let port = atlas_plugin::benchmarks::agentic::score::free_port()?;
-    let requested = overrides;
+    let requested = gate::merge_serve_overrides(baseline_overrides, overrides);
     let mut overrides = requested.clone();
     overrides.insert("port".to_string(), port.to_string());
     let serve_args = recipe.serve_args(&overrides).with_context(|| {

--- a/crates/spark-server/src/cli/bench_selfstart_tests.rs
+++ b/crates/spark-server/src/cli/bench_selfstart_tests.rs
@@ -30,6 +30,7 @@ fn baseline(entries: &[(&str, &str, Option<&str>)]) -> GateBaseline {
                 recipe: recipe.map(str::to_string),
                 note: String::new(),
                 metrics: BTreeMap::new(),
+                serve_overrides: BTreeMap::new(),
             },
         );
     }
@@ -327,4 +328,41 @@ fn a_repeated_key_takes_the_last_value() {
 #[test]
 fn no_overrides_is_empty_not_an_error() {
     assert!(parse_serve_overrides(&[]).unwrap().is_empty());
+}
+
+/// Baseline pins land on the resolved serve, and a CLI clash takes the operator.
+#[test]
+fn baseline_pins_are_applied_and_the_operator_wins_a_clash() {
+    let baseline = BTreeMap::from([
+        ("ssm_cache_slots".into(), "256".into()),
+        ("kv_cache_dtype".into(), "bf16".into()),
+    ]);
+    let requested = BTreeMap::from([("kv_cache_dtype".into(), "fp8".into())]);
+    let merged = atlas_plugin::gate::merge_serve_overrides(baseline, requested);
+    assert_eq!(
+        merged.get("ssm_cache_slots").map(String::as_str),
+        Some("256")
+    );
+    assert_eq!(
+        merged.get("kv_cache_dtype").map(String::as_str),
+        Some("fp8")
+    );
+}
+
+#[test]
+fn resolve_carries_baseline_serve_overrides() {
+    let mut b = baseline(&[("gb10", "m", Some("r"))]);
+    b.hardware
+        .get_mut("gb10")
+        .unwrap()
+        .models
+        .get_mut("m")
+        .unwrap()
+        .serve_overrides
+        .insert("ssm_cache_slots".into(), "256".into());
+    let r = resolve(&b, "bfcl-subset", None).expect("resolved");
+    assert_eq!(
+        r.serve_overrides.get("ssm_cache_slots").map(String::as_str),
+        Some("256")
+    );
 }

--- a/kernels/gb10/qwen3.6-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-27b/BENCH.toml
@@ -42,7 +42,12 @@ against these numbers — see bfcl-subset-echolp. History: 2026-07-13 prestack b
 de6153f3 87.34/88.59 (normalized high-water); 2026-08-03 PR #388 Gate D 87.74/89.43 n=995. \
 The draw is PINNED at n=995: a score from a different draw is not comparable to these \
 thresholds, and the sample count is the only thing that reveals it after the fact, so it is \
-gated exactly rather than merely recorded."""
+gated exactly rather than merely recorded. Self-start pins ssm_cache_slots=256 (same \
+override the poison gate already uses) so a 995-sample serial generate cannot evict its own \
+Marconi snapshots. That is capacity, not a score lever — the AST floors below are unchanged."""
+
+[benchmarks.serve_overrides]
+ssm_cache_slots = "256"
 
 [benchmarks.metrics.normalized_single_turn_score]
 min = 88.59

--- a/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
@@ -100,7 +100,13 @@ purely from category mix. History: 2026-07-10 main-438ed09 84.66/83.32 (high-wat
 pr369 de6153f3 83.96/81.96; 2026-08-03 PR #388 Gate B 84.26/82.15 n=1004. The draw is PINNED \
 at n=1004: a score from a different draw is not comparable to these thresholds, and the \
 sample count is the only thing that reveals it after the fact, so it is gated exactly rather \
-than merely recorded."""
+than merely recorded. Self-start pins ssm_cache_slots=256 (same override the poison gate \
+already uses) so a 1004-sample serial generate cannot evict its own Marconi snapshots. The \
+flagship recipe leaves the pool at its default 16; that is capacity, not a score lever — \
+the AST floors below are unchanged."""
+
+[benchmarks.serve_overrides]
+ssm_cache_slots = "256"
 
 [benchmarks.metrics.normalized_single_turn_score]
 min = 83.32
@@ -197,19 +203,22 @@ so the gate carries margin past that.
 not a perf gate (identical philosophy to the agentic Σwall). Generous pending \
 the first recorded run; ratchet after measurement, never to the best.
 
-Serves with `--serve-override ssm_cache_slots=256` (the flagship recipe's \
-pinned value; recorded in the gate record's serve_overrides). The bf16head \
-recipe leaves the Marconi snapshot pool at its default 16, which evicts \
-under this multi-turn load — replays then restore from DRIFTING anchors \
-(different replay geometry, legitimately different output), which is \
-pool-churn noise, not the poisoned-restore-content class this gate polices. \
-Pinning the pool tests restore CONTENT without the noise. Same footing as \
-the agentic gate's norm.rs: normalize known bookkeeping variance so the \
-measurement is repeatable, never hide signal. The first unpinned run on \
-main (2026-08-12, sha 7dd4cc33bc) proved the churn: replays 2-12 diverged \
-with restore anchors drifting 992→1040→1088→1152 and 33 'no SSM snapshot — \
-recomputing' events in the serve log.\
+Self-start applies `[benchmarks.serve_overrides] ssm_cache_slots = "256"` \
+(the flagship recipe's pinned value; recorded in the gate record's \
+serve_overrides). The bf16head recipe leaves the Marconi snapshot pool at \
+its default 16, which evicts under this multi-turn load — replays then \
+restore from DRIFTING anchors (different replay geometry, legitimately \
+different output), which is pool-churn noise, not the poisoned-restore-content \
+class this gate polices. Pinning the pool tests restore CONTENT without the \
+noise. Same footing as the agentic gate's norm.rs: normalize known bookkeeping \
+variance so the measurement is repeatable, never hide signal. The first \
+unpinned run on main (2026-08-12, sha 7dd4cc33bc) proved the churn: replays \
+2-12 diverged with restore anchors drifting 992→1040→1088→1152 and 33 \
+'no SSM snapshot — recomputing' events in the serve log.\
 """
+
+[benchmarks.serve_overrides]
+ssm_cache_slots = "256"
 
 [benchmarks.metrics.rounds]
 min = 12.0


### PR DESCRIPTION
## Summary

BFCL self-start now applies `--serve-override ssm_cache_slots=256` from `BENCH.toml`, the same pin the poison gate already uses on the CLI. The flagship recipe leaves the Marconi snapshot pool at its default 16, so a 995/1004-sample serial generate evicts its own intermediates (KV hash can still hit; the SSM slot is gone). That is capacity, not a score lever.

`[benchmarks.serve_overrides]` is the SSOT. Self-start merges those pins, then the operator's `--serve-override` (operator wins a clash). `check_record` refuses a record that is missing the pin, so an old 16-slot BFCL PASS cannot be copied onto this SHA.

AST floors are unchanged and locked by test:

- `bfcl-subset-echolp`: 84.66 / 83.32, n=1004
- `bfcl-subset`: 87.44 / 88.59, n=995

Poison gets the same machine-readable pin (it already documented the CLI flag). TTFT and agentic keep the recipe default.

Does not start a GPU bake. #509 is still running echolp on the 16-slot recipe; this PR rebakes after those records land. Do not copy old records.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-plugin -p spark-server --tests -- -D warnings`
- [x] `bash scripts/check-license-headers.sh`
- [x] `cargo test -p atlas-plugin --lib gate::` (195 passed), including pin parse, AST-floor lock, and `check_record` refusing a missing/wrong pin
- [x] `cargo test -p spark-server --bin spark bench_selfstart` (23 passed), including merge (operator wins) and resolve carrying the pin
- [ ] GPU re-bake of BFCL (and any other gate this `crates/` + boundary-file diff invalidates) after #509 records are on that branch — not started

## Notes for reviewers

- Follow-up to the #509 bake discussion: prefix hits are thrown away when the 16-slot pool evicts; this pin is the same override poison already uses.
- Later, if wanted: C=4–8 generate after a C=1 vs C=4 score lock. Not this PR.
- `BENCH.toml` stays outside the closure hash. The new `check_record` pin check is what stops a BENCH.toml-only edit from leaving an old record green.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).