### PR TITLE
site: map the qwen3.8 recipe family to the Qwen vendor

### DIFF
--- a/site/scripts/gen-models.mjs
+++ b/site/scripts/gen-models.mjs
@@ -114,6 +114,7 @@ function parseRecipe(text) {
 const FAMILY_DISPLAY = {
   'qwen3.5': 'Qwen3.5',
   'qwen3.6': 'Qwen3.6',
+  'qwen3.8': 'Qwen3.8',
   'qwen3-next': 'Qwen3-Next',
   'qwen3-coder-next': 'Qwen3-Coder-Next',
   'qwen3-vl': 'Qwen3-VL',
@@ -138,6 +139,7 @@ function familyDisplay(fam) {
 const VENDOR_OF_FAMILY = {
   'qwen3.5': 'Qwen',
   'qwen3.6': 'Qwen',
+  'qwen3.8': 'Qwen',
   'qwen3-next': 'Qwen',
   'qwen3-coder-next': 'Qwen',
   'qwen3-vl': 'Qwen',


### PR DESCRIPTION
**Unblocks the whole tree.** The site build is currently failing on every PR branched off `main`, including #519 and #514, and the cause has nothing to do with those PRs' contents.

`atlas-recipes` now ships `recipes/qwen3.8/` (merged as atlas-recipes#19 and #20). `gen-models.mjs` hard-exits on an unmapped recipe family by design — *"PCND — no silent default bucket"* — so since that merge, any PR whose site build runs fails with:

```
Unmapped recipe family "qwen3.8" — add it to VENDOR_OF_FAMILY
EXIT=1
```

The guard is working as intended; the maps just had no entry for the new directory.

This is the two-line fix, extracted from #513 so the tree unblocks without waiting on that branch's multi-hour benchmark gate. #513 carries the identical change and will merge as a no-op against this.

Verified against the merged recipes tree: exit 0, and Qwen3.8 renders as its own subfamily under the Qwen vendor (Qwen now 18 recipes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)