### PR TITLE
docker: copy tests/fixtures into the build context (quick-speed-bench include_str!)

### DIFF
--- a/docker/gb10/Dockerfile
+++ b/docker/gb10/Dockerfile
@@ -34,6 +34,11 @@ COPY crates/ crates/
 COPY vendor/ vendor/
 COPY kernels/ kernels/
 COPY jinja-templates/ jinja-templates/
+# quick-speed-bench (atlas-plugin) include_str!'s its ISL prompt fixtures from
+# tests/fixtures — without this line the release build fails in-container
+# ("couldn't read ../../tests/fixtures/bench_prompt_128.txt") while every
+# full-tree local build succeeds. Copy just the fixtures, not all of tests/.
+COPY tests/fixtures/ tests/fixtures/
 
 ENV ATLAS_TARGET_HW=gb10
 ENV ATLAS_TARGET_MODEL=*


### PR DESCRIPTION
One-line fix: the in-container release build fails because quick-speed-bench include_str!'s tests/fixtures/bench_prompt_*.txt and the Dockerfile never copies tests/. Found by the first post-#519 dockerhub build. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)