### PR TITLE
feat(gate): fill the intent taxonomy + one-time content-pinned invalidation amnesty

### DIFF
--- a/.github/pr-taxonomy.json
+++ b/.github/pr-taxonomy.json
@@ -42,19 +42,19 @@
     "numerics": { "_benches": ["bfcl-subset-echolp"] },
     "loader": { "_benches": ["bfcl-subset-echolp", "ttft-cold-gate"] },
     "tool-calling": { "_benches": ["bfcl-subset-echolp"] },
-    "ssm-state": { "_benches": ["ttft-warm-gate"] },
-    "kv-cache": { "_benches": ["ttft-warm-gate", "ttft-cold-gate"] },
-    "sampling": {}
+    "ssm-state": { "_benches": ["ttft-warm-gate", "ssm-state-poisoning-gate"] },
+    "kv-cache": { "_benches": ["ttft-warm-gate", "ttft-cold-gate", "ssm-state-poisoning-gate"] },
+    "sampling": { "_benches": ["bfcl-subset-echolp", "agentic-webserver"] }
   },
 
   "performance": {
     "_benches": ["agentic-webserver"],
-    "decode": { "_benches": ["bfcl-subset", "ttft-warm-gate"] },
+    "decode": { "_benches": ["bfcl-subset", "ttft-warm-gate", "decode-floor"] },
     "prefill": { "_benches": ["ttft-cold-gate", "ttft-warm-gate"] },
-    "kernel-dispatch": { "_benches": ["bfcl-subset"] },
-    "memory-traffic": { "_benches": ["bfcl-subset", "ttft-warm-gate"] },
-    "scheduling": { "_benches": ["ttft-warm-gate"] },
-    "speculation": { "_benches": ["bfcl-subset"] }
+    "kernel-dispatch": { "_benches": ["bfcl-subset", "decode-floor"] },
+    "memory-traffic": { "_benches": ["bfcl-subset", "ttft-warm-gate", "decode-floor"] },
+    "scheduling": { "_benches": ["ttft-warm-gate", "concurrency-sweep"] },
+    "speculation": { "_benches": ["bfcl-subset", "decode-floor"] }
   },
 
   "capability": {
@@ -62,11 +62,18 @@
     "new-model": { "_benches": ["ttft-cold-gate"] },
     "new-hardware": { "_benches": ["ttft-cold-gate", "ttft-warm-gate"] },
     "quantization": { "_benches": ["bfcl-subset-echolp"] },
-    "adapters": {},
-    "serving-api": {}
+    "adapters": { "_benches": ["bfcl-subset-echolp", "ttft-cold-gate"] },
+    "serving-api": { "_benches": ["concurrency-sweep", "ttft-warm-gate"] }
   },
 
   "infrastructure": {
+    "_doc": [
+      "Deliberately NO _benches anywhere under this root (2026-08-16 fill):",
+      "CI, release and build tooling cannot move an inference number, so this",
+      "emptiness is on purpose, not an omission awaiting a fill. If a change",
+      "here CAN move a number, it is misfiled — it belongs under performance/",
+      "or correctness/ instead."
+    ],
     "ci": {},
     "benchmark-gate": {},
     "release": {},
@@ -75,6 +82,10 @@
   },
 
   "documentation": {
+    "_doc": [
+      "Deliberately NO _benches (2026-08-16 fill): prose cannot move an",
+      "inference number. Empty on purpose, not awaiting entries."
+    ],
     "reference": {},
     "design-record": {}
   },

--- a/crates/atlas-plugin/src/gate/amnesty.rs
+++ b/crates/atlas-plugin/src/gate/amnesty.rs
@@ -5,7 +5,7 @@
 //! # The grant
 //!
 //! `.github/pr-taxonomy.json` and `check.rs` are
-//! [`super::coverage::BOUNDARY_FILES`]: touching either invalidates every
+//! `coverage::BOUNDARY_FILES` entries: touching either invalidates every
 //! standing gate record, at ~4h19m of GPU to re-earn. The 2026-08-16
 //! governance PR has to touch exactly those two files — the taxonomy to fill
 //! its empty `_benches` leaves, `check.rs` to add the hook that consults this
@@ -16,8 +16,8 @@
 //!
 //! # Why content-pinned rather than waived
 //!
-//! Each entry pins the exact blob OID this PR lands. `git rev-parse
-//! <head>:<path>` names the CONTENT of the file at the commit being checked,
+//! Each entry pins the exact blob OID this PR lands. `git rev-parse <head>:<path>`
+//! names the CONTENT of the file at the commit being checked,
 //! so the grant covers precisely the reviewed bytes: the moment anyone edits
 //! either file again, the OID changes and invalidation applies exactly as
 //! before. There is no time window and no path-level waiver to inherit —
@@ -46,7 +46,7 @@
 //! # Removal condition
 //!
 //! EMPTY THE TABLE once every required gate has a record newer than
-//! [`AMNESTY_EPOCH`]. At that point the grant protects nothing — every
+//! `AMNESTY_EPOCH`. At that point the grant protects nothing — every
 //! record postdates the grant day and was earned against the amnestied
 //! content. `amnesty_expires_once_every_gate_has_a_fresh_record` fails with
 //! instructions when that day arrives, so the table cannot quietly outlive

--- a/crates/atlas-plugin/src/gate/amnesty.rs
+++ b/crates/atlas-plugin/src/gate/amnesty.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! A one-time, content-pinned amnesty for the 2026-08-16 governance PR.
+//!
+//! # The grant
+//!
+//! `.github/pr-taxonomy.json` and `check.rs` are
+//! [`super::coverage::BOUNDARY_FILES`]: touching either invalidates every
+//! standing gate record, at ~4h19m of GPU to re-earn. The 2026-08-16
+//! governance PR has to touch exactly those two files — the taxonomy to fill
+//! its empty `_benches` leaves, `check.rs` to add the hook that consults this
+//! table — and the user authorized a one-time bypass for that landing alone
+//! ("just this one time", 2026-08-16). This module is that bypass, made
+//! auditable: a table anyone can read, a pin nobody can stretch, a test that
+//! demands its own removal.
+//!
+//! # Why content-pinned rather than waived
+//!
+//! Each entry pins the exact blob OID this PR lands. `git rev-parse
+//! <head>:<path>` names the CONTENT of the file at the commit being checked,
+//! so the grant covers precisely the reviewed bytes: the moment anyone edits
+//! either file again, the OID changes and invalidation applies exactly as
+//! before. There is no time window and no path-level waiver to inherit —
+//! a second edit to the taxonomy pays full price, as it should.
+//!
+//! # Fail-closed
+//!
+//! Every uncertainty is "not excused": a path not in the table, git missing
+//! or failing, an unknown commit, the path absent at `head`, output that is
+//! not a 40-hex OID, an OID that is not the pinned one. A false "not excused"
+//! costs a re-run; a false "excused" would be a shipped regression behind a
+//! green gate — the same asymmetry the rest of the gate is built on.
+//!
+//! # Residual risk, stated plainly
+//!
+//! This file cannot itself be in `BOUNDARY_FILES` without circularity: its
+//! own landing would then invalidate everything it exists to protect. It is
+//! covered only by `GATE_MACHINERY`'s cargo-test rationale, like the rest of
+//! the gate bookkeeping. Compensations: the table's exact contents are pinned
+//! by `the_table_is_exactly_the_2026_08_16_grant` (entry count, paths, OID
+//! format), every application is logged loudly by `check.rs`, CODEOWNERS
+//! review covers the gate directory, and the gate already executes
+//! PR-checkout code — so this adds no new attack class, only a reviewed
+//! two-file exception to one rule.
+//!
+//! # Removal condition
+//!
+//! EMPTY THE TABLE once every required gate has a record newer than
+//! [`AMNESTY_EPOCH`]. At that point the grant protects nothing — every
+//! record postdates the grant day and was earned against the amnestied
+//! content. `amnesty_expires_once_every_gate_has_a_fresh_record` fails with
+//! instructions when that day arrives, so the table cannot quietly outlive
+//! its purpose.
+
+use std::path::Path;
+
+/// One excused path: the file, the exact blob its grant covers, and why.
+#[derive(Debug, Clone, Copy)]
+pub struct AmnestyEntry {
+    pub path: &'static str,
+    /// The 40-hex blob OID of the file AS THIS PR LANDS IT — computed with
+    /// `git rev-parse <head>:<path>` (equivalently `git hash-object <path>`)
+    /// once the content is final, in the pin phase. Until pinned it holds
+    /// `"PENDING"`, which matches no blob and keeps the grant inert.
+    pub head_blob_oid: &'static str,
+    pub grant: &'static str,
+}
+
+/// When the grant was made: end of 2026-08-16 UTC (`1786924800` =
+/// 2026-08-17T00:00:00Z). End of day rather than midnight because the
+/// standing records this amnesty protects were themselves earned earlier on
+/// 2026-08-16 — a record only counts as "fresh" against the grant if it
+/// postdates the whole grant day.
+pub const AMNESTY_EPOCH: u64 = 1_786_924_800;
+
+/// The whole grant. When this table is empty the module is inert.
+pub const ONE_TIME_AMNESTY: [AmnestyEntry; 2] = [
+    AmnestyEntry {
+        path: ".github/pr-taxonomy.json",
+        head_blob_oid: "7d141f58ed5798d0b49aa44817292e049d6a6364",
+        grant: "2026-08-16 one-time, user-authorized: fill the empty _benches leaves \
+                without re-earning every standing record",
+    },
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/gate/check.rs",
+        head_blob_oid: "e85359c10a5dd78526127b3aabd872f5f8623ed4",
+        grant: "2026-08-16 one-time, user-authorized: the amnesty hook itself in \
+                invalidating_paths",
+    },
+];
+
+/// Whether the one-time grant excuses `path` at `head`.
+pub fn excused(root: &Path, head: &str, path: &str) -> bool {
+    excused_by(root, head, path, &ONE_TIME_AMNESTY)
+}
+
+/// [`excused`] against an explicit table, so tests can pin real OIDs.
+///
+/// True iff `path` is in `table` AND the blob at `<head>:<path>` is exactly
+/// the pinned 40-hex OID. Anything else — including any git failure — is
+/// `false`.
+pub fn excused_by(root: &Path, head: &str, path: &str, table: &[AmnestyEntry]) -> bool {
+    let Some(entry) = table.iter().find(|e| e.path == path) else {
+        return false;
+    };
+    let Ok(out) = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", &format!("{head}:{path}")])
+        .stdin(std::process::Stdio::null())
+        .output()
+    else {
+        return false;
+    };
+    if !out.status.success() {
+        return false;
+    }
+    let oid = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    oid.len() == 40 && oid.chars().all(|c| c.is_ascii_hexdigit()) && oid == entry.head_blob_oid
+}

--- a/crates/atlas-plugin/src/gate/amnesty_tests.rs
+++ b/crates/atlas-plugin/src/gate/amnesty_tests.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The one-time 2026-08-16 amnesty must excuse EXACTLY the pinned bytes,
+//! fail closed on everything else, and demand its own removal.
+//!
+//! `the_table_is_exactly_the_2026_08_16_grant` is deliberately RED while the
+//! table holds `"PENDING"` OIDs: the pin phase (compute the landed blob OIDs
+//! with `git hash-object` once content is final) is what turns it green, so
+//! the grant cannot ship half-armed by accident.
+
+use super::amnesty::{AMNESTY_EPOCH, AmnestyEntry, ONE_TIME_AMNESTY, excused, excused_by};
+use super::check::invalidating_paths;
+use super::coverage_tests::{any_gate, scratch_repo};
+use super::tests::tempdir;
+use super::{REQUIRED_GATES, read_record, records_newest_first};
+
+const TAXONOMY: &str = ".github/pr-taxonomy.json";
+
+fn blob_oid(root: &std::path::Path, head: &str, path: &str) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", &format!("{head}:{path}")])
+        .output()
+        .expect("git runs");
+    assert!(out.status.success(), "rev-parse {head}:{path}: {out:?}");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// A test-only entry pinning a real blob. The leak is fine: a handful of
+/// 40-byte strings for the life of the test binary.
+fn entry(path: &'static str, oid: String) -> AmnestyEntry {
+    AmnestyEntry {
+        path,
+        head_blob_oid: Box::leak(oid.into_boxed_str()),
+        grant: "test grant",
+    }
+}
+
+/// The grant's core behaviour: the pinned content is excused AT the commit
+/// that carries it, and a later edit to the same path re-invalidates because
+/// the blob OID moved.
+#[test]
+fn pinned_content_is_excused_and_a_later_edit_reinvalidates() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    scratch_repo::init(root);
+    scratch_repo::commit(root, TAXONOMY, r#"{ "a": {}, "b": {} }"#, "the landing");
+    let landed = scratch_repo::head(root);
+    let table = [entry(TAXONOMY, blob_oid(root, &landed, TAXONOMY))];
+
+    assert!(
+        excused_by(root, &landed, TAXONOMY, &table),
+        "the exact landed bytes must be excused at the landing commit"
+    );
+
+    scratch_repo::commit(
+        root,
+        TAXONOMY,
+        r#"{ "a": {}, "b": {}, "c": {} }"#,
+        "a later edit",
+    );
+    let later = scratch_repo::head(root);
+    assert!(
+        !excused_by(root, &later, TAXONOMY, &table),
+        "an edit after the grant changes the blob OID — the amnesty must not \
+         stretch to cover bytes nobody reviewed"
+    );
+}
+
+/// A path the table does not list is never excused, whatever its content.
+#[test]
+fn an_unlisted_path_is_never_excused() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    scratch_repo::init(root);
+    scratch_repo::commit(root, TAXONOMY, "{}", "taxonomy");
+    scratch_repo::commit(root, "crates/engine.rs", "// code", "engine");
+    let head = scratch_repo::head(root);
+    // The table pins engine.rs's own real OID under the TAXONOMY path name,
+    // so even a colliding-content probe cannot sneak an unlisted path in.
+    let table = [entry(TAXONOMY, blob_oid(root, &head, TAXONOMY))];
+    assert!(
+        !excused_by(root, &head, "crates/engine.rs", &table),
+        "only listed paths participate; content is checked second, not instead"
+    );
+}
+
+/// Every way git can fail must read as "not excused" — never as forgiveness.
+#[test]
+fn git_failure_fails_closed() {
+    // Not a git repository at all.
+    let bare = tempdir::Dir::new();
+    let table = [entry(TAXONOMY, "0".repeat(40))];
+    assert!(
+        !excused_by(bare.path(), "HEAD", TAXONOMY, &table),
+        "no repo means no answer, and no answer must not excuse"
+    );
+
+    // A real repo, but the commit is unknown and the path absent at head.
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    scratch_repo::init(root);
+    let head = scratch_repo::head(root);
+    assert!(
+        !excused_by(root, "ffffffffff", TAXONOMY, &table),
+        "an unknown commit must fail closed"
+    );
+    assert!(
+        !excused_by(root, &head, TAXONOMY, &table),
+        "a path absent at head has no blob to match — fail closed"
+    );
+}
+
+/// ★ The wiring, not just the table: `check.rs::invalidating_paths` really
+/// consults the grant. Content matching no pin must survive the filter and
+/// invalidate; the REAL repo's taxonomy bytes — the only content the live
+/// table can possibly pin — must be dropped from the list exactly when
+/// [`excused`] says they are the grant. While the pin is live this exercises
+/// the excuse arm; after any later taxonomy edit both sides of the
+/// equivalence flip together and it keeps proving the keep arm.
+#[test]
+fn invalidating_paths_drops_exactly_what_the_grant_excuses() {
+    let dir = tempdir::Dir::new();
+    let root = dir.path();
+    scratch_repo::init(root);
+    scratch_repo::commit(root, TAXONOMY, "{}", "baseline");
+    let record_sha = scratch_repo::head(root);
+
+    scratch_repo::commit(root, TAXONOMY, r#"{ "not": "the grant" }"#, "hostile edit");
+    let hostile = scratch_repo::head(root);
+    let kept = invalidating_paths(root, &hostile, &record_sha, &any_gate())
+        .expect("the diff runs in a scratch repo");
+    assert!(
+        kept.iter().any(|p| p == TAXONOMY),
+        "content matching no pin must keep invalidating, got {kept:?}"
+    );
+
+    let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root is two levels above the crate");
+    let real = std::fs::read_to_string(repo.join(TAXONOMY)).expect("the real taxonomy reads");
+    scratch_repo::commit(root, TAXONOMY, &real, "the amnestied landing");
+    let head = scratch_repo::head(root);
+    let after = invalidating_paths(root, &head, &record_sha, &any_gate())
+        .expect("the diff runs in a scratch repo");
+    assert_eq!(
+        !after.iter().any(|p| p == TAXONOMY),
+        excused(root, &head, TAXONOMY),
+        "invalidating_paths must drop the surviving path exactly when the \
+         grant excuses it; the filter and the table may never disagree"
+    );
+}
+
+/// ★ The exact grant, pinned: two entries, these two paths, and OIDs that are
+/// real 40-hex blob names. DELIBERATELY RED while the OIDs read `"PENDING"` —
+/// the pin phase (run `git hash-object <path>` on the final landed content
+/// and write the values into `amnesty.rs`) is what turns it green. An
+/// unpinned grant matches no blob, so shipping this red test is safe; shipping
+/// it silently green with placeholders would not be.
+#[test]
+fn the_table_is_exactly_the_2026_08_16_grant() {
+    let paths: Vec<&str> = ONE_TIME_AMNESTY.iter().map(|e| e.path).collect();
+    assert_eq!(
+        paths,
+        vec![TAXONOMY, "crates/atlas-plugin/src/gate/check.rs"],
+        "the grant is exactly these two boundary files, in this order — \
+         adding a path is a NEW grant and needs its own authorization"
+    );
+    for e in &ONE_TIME_AMNESTY {
+        assert!(
+            e.head_blob_oid.len() == 40 && e.head_blob_oid.chars().all(|c| c.is_ascii_hexdigit()),
+            "{}: head_blob_oid is {:?}, not a 40-hex blob OID — the pin phase \
+             has not run. Compute it with `git hash-object {}` on the final \
+             landed content and write it into gate/amnesty.rs.",
+            e.path,
+            e.head_blob_oid,
+            e.path
+        );
+    }
+}
+
+/// ★ The grant must not outlive its purpose. Once every required gate's
+/// newest committed record postdates [`AMNESTY_EPOCH`], every record was
+/// earned against the amnestied content and the table protects nothing —
+/// this fails until someone empties it.
+#[test]
+#[allow(clippy::const_is_empty)]
+fn amnesty_expires_once_every_gate_has_a_fresh_record() {
+    if ONE_TIME_AMNESTY.is_empty() {
+        return; // The grant has been removed; nothing left to expire.
+    }
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root is two levels above the crate");
+    let stale: Vec<&str> = REQUIRED_GATES
+        .iter()
+        .copied()
+        .filter(|id| {
+            let newest = records_newest_first(root, id)
+                .first()
+                .and_then(|p| read_record(p).ok())
+                .map(|r| r.recorded_at)
+                .unwrap_or(0);
+            newest <= AMNESTY_EPOCH
+        })
+        .collect();
+    assert!(
+        !stale.is_empty(),
+        "every required gate now has a record newer than AMNESTY_EPOCH \
+         (end of 2026-08-16 UTC): the one-time grant has been fully re-earned \
+         and protects nothing. EMPTY THE TABLE in \
+         crates/atlas-plugin/src/gate/amnesty.rs — the amnesty must not \
+         outlive the records it existed to protect."
+    );
+}

--- a/crates/atlas-plugin/src/gate/check.rs
+++ b/crates/atlas-plugin/src/gate/check.rs
@@ -181,6 +181,22 @@ pub fn invalidating_paths(
             .map(str::trim)
             .filter(|p| !p.is_empty())
             .filter(|p| super::coverage::invalidates(gate, p))
+            // ★ The one-time 2026-08-16 amnesty: a surviving path whose blob
+            // at `head` is exactly the grant's pinned content is excused,
+            // loudly. Content-pinned, so any later edit to the file changes
+            // the OID and invalidates as before. See `amnesty.rs` for the
+            // grant, the fail-closed rule, and the removal condition.
+            .filter(|p| {
+                if super::amnesty::excused(root, head, p) {
+                    tracing::warn!(
+                        "amnesty: {p} would re-open {} but its content at {head} is the \
+                         pinned one-time 2026-08-16 grant — excused (see gate/amnesty.rs)",
+                        gate.id
+                    );
+                    return false;
+                }
+                true
+            })
             .map(str::to_string)
             .collect(),
     )

--- a/crates/atlas-plugin/src/gate/mod.rs
+++ b/crates/atlas-plugin/src/gate/mod.rs
@@ -20,6 +20,8 @@
 //!   committed records are checked against this file alone, so the check
 //!   carries no per-box state ([`check`]).
 
+/// The one-time, content-pinned 2026-08-16 invalidation amnesty.
+pub mod amnesty;
 pub mod bench;
 pub mod check;
 pub mod closure;
@@ -239,6 +241,11 @@ mod coverage_squash_tests;
 #[cfg(test)]
 #[path = "hardening_tests.rs"]
 mod hardening_tests;
+
+/// The one-time 2026-08-16 amnesty: pinned grant, fail-closed, expiry.
+#[cfg(test)]
+#[path = "amnesty_tests.rs"]
+mod amnesty_tests;
 
 #[cfg(test)]
 #[path = "dirty_tests.rs"]

--- a/crates/atlas-plugin/src/gate/pr_taxonomy_tests.rs
+++ b/crates/atlas-plugin/src/gate/pr_taxonomy_tests.rs
@@ -89,6 +89,62 @@ fn every_declared_bench_is_a_required_gate() {
     walk(&roots, &known);
 }
 
+/// ★ `unknown` is the abstain arm. If its subtree ever gained `_benches`, a
+/// classifier outage or a 429 could manufacture GPU spend out of nothing —
+/// `required.rs` skips `error`/`abstain` rows for exactly this reason, and
+/// this pins the other half: even a CONFIDENT `unknown` implies no spend.
+#[test]
+fn the_unknown_root_and_its_descendants_carry_no_benches() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let roots = load(&root).unwrap();
+    let unknown = roots
+        .iter()
+        .find(|r| r.name == "unknown")
+        .expect("the tree offers `unknown`");
+    fn walk(node: &Node, trail: &str) {
+        assert!(
+            node.benches.is_empty(),
+            "{trail}/{} carries _benches {:?} — an abstention must never cost GPU",
+            node.name,
+            node.benches
+        );
+        for child in &node.children {
+            walk(child, &format!("{trail}/{}", node.name));
+        }
+    }
+    walk(unknown, "");
+}
+
+/// The 2026-08-16 fill: `correctness/ssm-state` names the gate built for the
+/// Marconi SSM-snapshot poisoning class. Before the fill the ssm-state intent
+/// implied only a warm-TTFT leg — the one gate that polices restored state
+/// directly was unreachable through intent.
+#[test]
+fn ssm_state_intent_implies_the_poison_gate() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let roots = load(&root).unwrap();
+    for path in [
+        vec!["correctness".to_string(), "ssm-state".into()],
+        vec!["correctness".to_string(), "kv-cache".into()],
+    ] {
+        assert!(
+            benches_for(&roots, &path).contains("ssm-state-poisoning-gate"),
+            "{path:?} must imply the poison gate — restored-state bugs are \
+             exactly what these intents describe"
+        );
+    }
+}
+
 // ── ★ The safety property ──────────────────────────────────────────────────
 
 /// **The whole design rests on this.** Descending FURTHER can only grow the

--- a/crates/atlas-plugin/src/gate/required_tests.rs
+++ b/crates/atlas-plugin/src/gate/required_tests.rs
@@ -57,13 +57,41 @@ fn intent_adds_where_the_paths_are_silent() {
         );
         assert_eq!(
             got.intent_only(),
-            ["agentic-webserver", "bfcl-subset", "ttft-warm-gate"]
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<BTreeSet<String>>(),
-            "{changed}: intent should supply all three, since paths supply none"
+            [
+                "agentic-webserver",
+                "bfcl-subset",
+                "decode-floor",
+                "ttft-warm-gate"
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<BTreeSet<String>>(),
+            "{changed}: intent should supply all four, since paths supply none \
+             (decode-floor joined the leaf in the 2026-08-16 fill)"
         );
     }
+
+    // ★ The promoted gates are reachable through intent too. `concurrency-sweep`
+    // graduated to REQUIRED on 2026-08-15, and the 2026-08-16 fill put it on
+    // `performance/scheduling` — so a diff off the invalidation floor entirely
+    // (docs/) classified as a scheduling change now owes the concurrency curve,
+    // the exact "10% at C=32, flat at C=1" regression paths cannot see.
+    let promoted = required_for(
+        &["docs/adr/0011-ep-batched-decode-optimization.md".to_string()],
+        &[cat("performance/scheduling")],
+        &roots,
+    );
+    assert!(
+        promoted.by_path.is_empty(),
+        "a docs diff must stay off the floor, got {:?}",
+        promoted.by_path
+    );
+    assert!(
+        promoted.intent_only().contains("concurrency-sweep"),
+        "performance/scheduling must add the promoted concurrency-sweep gate; \
+         intent supplied {:?}",
+        promoted.intent_only()
+    );
 }
 
 /// ★ **The mutation four rounds of mutation-testing missed.**

--- a/docs/adr/0014-pr-intent-taxonomy-and-the-required-union.md
+++ b/docs/adr/0014-pr-intent-taxonomy-and-the-required-union.md
@@ -104,3 +104,48 @@ unreachable trains people to ignore it.
 - `intent_only()` is retained separately from the union so the telemetry table
   can say *why* a gate is required. Collapsed into one set, "intent added this"
   becomes invisible, which is how the previous coverage gap survived.
+
+## Amendment (2026-08-16): three claims above went stale, and one was never true
+
+Audits during the governance-harvest work (ADR-0015) refuted parts of this
+record. Per this directory's append-only rule the original text stands;
+read it against the following.
+
+**1. "Any code change already invalidates all five gates" was never true.**
+Reason 2 under *What this does NOT buy* claimed the union is vacuous for code
+PRs because `PERF_PATHS` contains a bare `crates`. It does — but
+`GATE_MACHINERY` excludes the whole `crates/atlas-plugin/src/gate` prefix
+from **every** gate, so paths under it invalidate nothing and intent is their
+only source of coverage. The union was live inside `crates/` from day one; it
+was never waiting on the closure-hash narrowing.
+`required_tests::crates_paths_split_into_fully_covered_and_not_covered_at_all`
+pins both halves of the corrected claim.
+
+**2. The `recipes/` "live case" is unreachable from this repository.** This
+repo tracks zero `recipes/` files — they live in the separate `atlas-recipes`
+repo, and `invalidating_paths` diffs *this* one, so a `recipes/` path can
+never appear in the diff the gate filters. The reachable
+off-the-floor classes are `docker/`, `docs/`, `.github/`, `scripts/`,
+`bench/`, `kernels/**/BENCH.toml`, and the excluded `crates/` paths above.
+The tests named in the original text are gone with the claim:
+`the_live_case_is_recipes` became `intent_adds_where_the_paths_are_silent`
+(which pins reachable paths only), and `intent_is_redundant_for_a_crates_change`
+became the split test cited in point 1.
+
+**3. "Five gates" is now ten.** `REQUIRED` grew to ten entries: the vision
+and video fidelity gates, the echolp BFCL draw, the SSM state-poisoning gate,
+and — promoted from candidates on 2026-08-15 once their calibration
+preconditions were met — `decode-floor` and `concurrency-sweep`. Every count
+above should be read against `coverage::REQUIRED`, which is the SSOT.
+
+**4. The empty-`_benches` gap is closed.** The original tree left
+`correctness/sampling`, `capability/adapters` and `capability/serving-api`
+empty and named none of the later gates. The 2026-08-16 fill (ADR-0015)
+populated every leaf that describes something a benchmark measures, and
+pinned the deliberate emptiness of `infrastructure/*`, `documentation/*`
+and `unknown` — with `_doc` notes in the JSON and a test over the `unknown`
+subtree, so an abstention can never manufacture GPU spend.
+
+Unchanged: the union is still advisory (`check_gates` iterates
+`REQUIRED_GATES` unconditionally and the exit code cannot see intent), and
+`_benches` still may only ADD — both by the same doctrine as before.

--- a/docs/adr/0015-governance-harvest-and-the-one-time-amnesty.md
+++ b/docs/adr/0015-governance-harvest-and-the-one-time-amnesty.md
@@ -1,0 +1,110 @@
+# ADR-0015: The governance harvest, and a one-time content-pinned amnesty
+
+**Status:** Accepted
+**Date:** 2026-08-16
+**Builds on:** ADR-0013 (coverage by content), ADR-0014 (intent taxonomy)
+
+## Context
+
+ADR-0014 shipped half a mechanism. The intent taxonomy, the descending
+classifier, the grow-only ledger and `required_for = by_path ∪ by_intent` all
+exist — and the intent half has been identically empty since the day it
+landed, because nothing ever moves a PR's ledger lines from the CI artifact
+into `governance/` on the default branch. `by_intent ≡ ∅`, forever, and the
+categorizer's output gates nothing.
+
+Fixing that means three changes, and one of them is expensive. The harvest
+workflow and the `--pr` glue are off every invalidation path. But the
+taxonomy's empty `_benches` leaves — `correctness/sampling`,
+`capability/adapters`, `capability/serving-api`, and no leaf anywhere naming
+the gates promoted on 2026-08-15 (`decode-floor`, `concurrency-sweep`) or the
+SSM poison gate — live in `.github/pr-taxonomy.json`, which is a
+`BOUNDARY_FILES` entry. So is `check.rs`, which any wiring must touch. A diff
+touching either invalidates **every** standing gate record: ~4h19m of GPU to
+re-earn ten gates, for an edit that only ever ADDS required benchmarks.
+
+That cost is deliberate (coverage.rs says so in as many words: "a cheap edit
+that quietly weakens the gate is worse than an expensive one that cannot").
+But this particular edit strengthens the gate, every standing record was
+freshly earned on 2026-08-16, and the owner authorized a bypass for this
+landing alone — "just this one time".
+
+## Decision
+
+### 1. The taxonomy fill
+
+Every empty leaf that describes something a benchmark measures gets
+`_benches`; the promoted 2026-08-15 gates become reachable through intent
+(`performance/decode` → `decode-floor`, `performance/scheduling` →
+`concurrency-sweep`, and so on); `correctness/ssm-state` and
+`correctness/kv-cache` gain `ssm-state-poisoning-gate`. `infrastructure/*`
+and `documentation/*` stay empty **with `_doc` notes saying it is on
+purpose** — tooling and prose cannot move an inference number.
+`unknown` stays empty and a test pins its whole subtree, so an abstention can
+never manufacture GPU spend.
+
+### 2. A one-time, content-pinned amnesty — not a waiver
+
+Rejected first, with the reasons on record:
+
+- **Closure-hash refresh** (ADR-0012's rung): inapplicable — these are not
+  `kernels/` paths, and no device-code hash can speak for a policy file.
+- **Re-blessing the records** (rewriting their shas to the landing commit):
+  forges provenance; every record would claim a commit it never measured.
+- **Two-phase landing** (land the fill, then re-earn under it): the tree diff
+  is history-independent, so records earned before the fill are invalidated
+  by it no matter which order the commits land in.
+
+Chosen: `crates/atlas-plugin/src/gate/amnesty.rs`, a table of exactly two
+entries — `.github/pr-taxonomy.json` and `check.rs`, the two boundary files
+this PR must touch — each pinning the **blob OID of the file as this PR lands
+it**. `check.rs::invalidating_paths` drops a surviving path only when
+`git rev-parse <head>:<path>` returns exactly the pinned 40-hex OID, and logs
+a warning naming the path and the grant every time it does. Everything else —
+an unlisted path, a later edit (different OID), any git failure — invalidates
+exactly as before. The grant covers the reviewed bytes and nothing else:
+there is no time window, no path-level waiver, and the second edit to either
+file pays full price.
+
+The two-entry shape is itself deliberate: the fill avoids touching
+`coverage.rs`, `required.rs` or any other boundary file precisely so the
+table cannot grow past the two files the change cannot avoid.
+
+### 3. Self-limiting, self-expiring
+
+- `the_table_is_exactly_the_2026_08_16_grant` pins the entry count, the two
+  paths, and that the OIDs are real 40-hex blob names — it ships RED against
+  placeholder OIDs, forcing the pin phase before the grant can arm.
+- `amnesty_expires_once_every_gate_has_a_fresh_record` reads the real
+  `.benchmarks/` tree and FAILS with removal instructions once every required
+  gate's newest record postdates `AMNESTY_EPOCH` (end of 2026-08-16 UTC). The
+  table cannot quietly outlive its purpose.
+- Acceptance is empirical, both directions: gate-check on the landing branch
+  prints PASS for all ten gates with the amnesty log lines visible, and with
+  the table emptied all ten go Missing — proving the amnesty is live rather
+  than vacuous.
+
+## Residual risk, stated plainly
+
+`amnesty.rs` cannot live in `BOUNDARY_FILES` without circularity — its own
+landing would invalidate everything it exists to protect. It is therefore
+covered only by `GATE_MACHINERY`'s cargo-test rationale, like the rest of the
+gate bookkeeping. A future PR could widen the table with an ordinary
+gate-directory edit. Compensations, none of them new machinery: the
+pinned-table test makes that widening a visible test edit; every application
+is logged in the gate output; CODEOWNERS review covers the gate directory;
+and the gate already executes PR-checkout code, so a malicious PR could
+always lie to itself — the merge queue's re-check on main is the backstop
+either way. This is a reviewed two-file exception, not a new attack class.
+
+## Consequences
+
+- The intent half of ADR-0014 can finally carry data: the fill makes the
+  promoted and poison gates reachable through intent, and the harvest
+  workflow (landing separately) starts producing the abstain-rate evidence
+  the enforcement decision was deferred on.
+- Standing records survive a strengthening-only boundary edit, once, on the
+  record, with the bypass reviewable in the diff rather than performed
+  out-of-band.
+- The amnesty's removal is a test failure away from mandatory — the cheapest
+  kind of institutional memory.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,3 +54,4 @@ What's better, what's worse, what new problems did we create?
 - [0012 — Scope a kernel change by its include closure](0012-closure-hash-cascade.md)
 - [0013 — A gate record covers a commit by content, never by ancestry](0013-gate-coverage-by-content-not-ancestry.md)
 - [0014 — PR intent is a descending tree, and it may only ADD benchmarks](0014-pr-intent-taxonomy-and-the-required-union.md)
+- [0015 — The governance harvest, and a one-time content-pinned amnesty](0015-governance-harvest-and-the-one-time-amnesty.md)


### PR DESCRIPTION
## What

1. **Taxonomy fill**: every meaningful leaf in `.github/pr-taxonomy.json` now declares `_benches` (decode-floor and concurrency-sweep became nameable after their 2026-08-15 promotion). `infrastructure/*` and `documentation/*` are *deliberately* empty with `_doc` notes; `unknown` stays bare and is now pinned by test so an abstain can never manufacture GPU spend.
2. **One-time amnesty** (`gate/amnesty.rs`): editing `pr-taxonomy.json` (a BOUNDARY_FILE) would normally invalidate all 10 standing benchmark records (~4h19m GPU to re-earn). This PR carries a content-pinned excuse table — exactly two entries, pinned to the blob OIDs of the files this PR lands (`7d141f58…` taxonomy, `e85359c1…` check.rs). Any later edit to either file changes its OID and re-invalidates normally.

## Why the amnesty is safe

- Fail-closed: any git error or OID mismatch → normal invalidation.
- Self-limiting: excuses only the exact landed bytes.
- Self-expiring: `amnesty_expires_once_every_gate_has_a_fresh_record` fails with "empty the table" once every gate has a post-epoch record.
- Pinned: `the_table_is_exactly_the_2026_08_16_grant` makes any extension a loud diff.
- Logged: every gate-check run prints one warn line per excused path.
- ADR-0015 records the grant, residual risk, and removal condition; ADR-0014's stale claims are amended.

## Verification

- `cargo test -p atlas-plugin`: **713 passed, 0 failed** (6 amnesty tests incl. a wiring test that proves the filter placement inside `invalidating_paths`).
- Acceptance both directions: gate-check at this HEAD → **PASS ×10** with amnesty lines visible; with the table temporarily emptied → all 10 Missing (amnesty is live, not vacuous).
- `cargo fmt --check`, `clippy --lib --tests` clean; check.rs stays under the 500-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)