### PR TITLE
fix(ci): bump AutoRepoRAG to v0.1.1 (tie-tolerant verify)

### DIFF
--- a/.github/workflows/coderag.yml
+++ b/.github/workflows/coderag.yml
@@ -73,7 +73,7 @@ jobs:
       # ***********************************************************************
       - name: Build corpus (incremental against the published one)
         id: rag
-        uses: Avarok-Cybersecurity/AutoRepoRAG@61101adaa3d2e5937099f9ecb3386a07c7d65670 # v0.1.0
+        uses: Avarok-Cybersecurity/AutoRepoRAG@f35cc9788aab8cd863d6af24a368d4a2fa37be93 # v0.1.1
         with:
           collection: atlas-coderag
           # output-name is a basename: the action writes <name>.jsonl,


### PR DESCRIPTION
First production CodeRAG run embedded all 11,024 chunks successfully, then failed self-retrieval verification on a legitimate cosine-distance-0 tie between byte-identical chunks in different files (ids 8268/7713). AutoRepoRAG v0.1.1 searches 5 hits and accepts the point itself or an identical-text twin — tie path proven with a forced 7-twin fixture and the full local battery. Pin: 61101ad → f35cc97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)