### PR TITLE
fix(ci): cap CodeRAG chunks at 8192 bytes (embedder token limit)

### DIFF
--- a/.github/workflows/coderag.yml
+++ b/.github/workflows/coderag.yml
@@ -102,6 +102,13 @@ jobs:
           # floor sits well above the 5th digit), and test files excluded.
           chunk-lines: '150'
           chunk-overlap: '10'
+          # The embedder rejects inputs over 8192 tokens; dense generated code
+          # (hex tables, LUT headers) can reach ~2 bytes per token, so a
+          # 16 KB chunk overflowed at 8 245 tokens on 2026-08-16. Capping
+          # chunks at 8 192 BYTES guarantees <= 8 192 tokens even at the
+          # 1-byte-per-token worst case. Typical 150-line chunks are ~4.5 KB,
+          # so only outlier lines get truncated.
+          max-chunk-bytes: '8192'
           vector-precision: '5'
           embedding-endpoint: ${{ steps.ssot.outputs.endpoint_base }}
           embedding-model: ${{ steps.ssot.outputs.embed_model }}


### PR DESCRIPTION
Third dispatch failed at batch-embed time: a dense 16 KB chunk tokenized to 8,245 tokens, over the embedder's 8,192-token input cap (only reachable since the 150-line windows landed — 90-line windows never filled the byte cap). 8,192 bytes guarantees <= 8,192 tokens at the 1-byte-per-token worst case; typical chunks are ~4.5 KB so only outliers truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)