### PR TITLE
fix(site): tell the truth when the daily model allowance runs out

### DIFF
--- a/site/e2e/chat-quota.spec.js
+++ b/site/e2e/chat-quota.spec.js
@@ -1,0 +1,109 @@
+// =============================================================================
+// The daily free-model allowance is not a momentary rate limit. It has a known
+// reset, retrying cannot clear it, and the remedy is a different model — so it
+// gets its own card, its own (absent) retry policy, and a one-click switch to
+// the paid twin. These tests pin all three.
+// =============================================================================
+import { test, expect } from '@playwright/test';
+import {
+  OR_EMBEDDINGS,
+  OR_RERANK,
+  OR_CHAT,
+  embeddingsHandler,
+  rerankHandler,
+  dailyQuota429Handler,
+  freeQuotaPaidOkHandler,
+  QUOTA_RESET_AT
+} from './fixtures/openrouter.js';
+import {
+  META,
+  routeCorpus,
+  openChat,
+  waitReady,
+  withKey,
+  askQuestion
+} from './fixtures/chat-helpers.js';
+
+const FREE_MODEL = 'nvidia/nemotron-3-ultra-550b-a55b:free';
+const PAID_MODEL = 'nvidia/nemotron-3-ultra-550b-a55b';
+
+async function routeRetrieval(context) {
+  await context.route(OR_EMBEDDINGS, embeddingsHandler({ dim: META.dim }));
+  await context.route(OR_RERANK, rerankHandler());
+}
+
+test.describe('@quota daily allowance', () => {
+  test('a spent daily allowance shows the quota card with its reset, and never retries', async ({
+    page,
+    context
+  }) => {
+    await routeCorpus(context);
+    await routeRetrieval(context);
+    const attempts = [];
+    await context.route(OR_CHAT, dailyQuota429Handler({ log: attempts }));
+
+    await withKey(page);
+    await page.goto('/');
+    await openChat(page);
+    await waitReady(page);
+    // Shrink the backoff: if the engine wrongly retried, this test would still
+    // finish fast and the attempt count below would catch the mistake.
+    await page.evaluate(() => window.__atlasChatSetRetryBaseMs(1));
+
+    await askQuestion(page, 'how does the scheduler batch decode?');
+
+    const card = page.locator('.cc-error[role="alert"]');
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    await expect(card.locator('.cc-error-tag')).toHaveText('daily limit reached');
+    // The momentary-rate copy must never appear here: waiting seconds is a lie.
+    await expect(card.locator('.cc-error-body')).not.toContainText('catching their breath');
+
+    const expected = new Date(QUOTA_RESET_AT).toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit'
+    });
+    await expect(card.locator('.cc-error-reset')).toContainText(expected);
+
+    expect(attempts.length).toBe(1); // no backoff loop on a per-day cap
+  });
+
+  test('the paid-model button re-asks on the paid twin and persists the choice', async ({
+    page,
+    context
+  }) => {
+    await routeCorpus(context);
+    await routeRetrieval(context);
+    const calls = [];
+    await context.route(
+      OR_CHAT,
+      freeQuotaPaidOkHandler('The scheduler batches decode in `batch.rs` [1].', { log: calls })
+    );
+
+    await withKey(page);
+    await page.goto('/');
+    await openChat(page);
+    await waitReady(page);
+    await page.evaluate(() => window.__atlasChatSetRetryBaseMs(1));
+
+    await askQuestion(page, 'how does the scheduler batch decode?');
+    const card = page.locator('.cc-error[role="alert"]');
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    expect(calls[0].model).toBe(FREE_MODEL);
+
+    await card.locator('.cc-error-paid').click();
+
+    // The answer now arrives, and it came from the paid twin.
+    await expect(page.locator('.cm-card .cm-body').last()).toContainText('batch.rs', {
+      timeout: 20_000
+    });
+    expect(calls[calls.length - 1].model).toBe(PAID_MODEL);
+    await expect(page.locator('.cc-model-id')).toHaveText(PAID_MODEL);
+
+    // The choice survives a reload, and can be handed back to the free default.
+    await page.reload();
+    await openChat(page);
+    await expect(page.locator('.cc-model-id')).toHaveText(PAID_MODEL);
+    await page.locator('.cc-model-reset').click();
+    await expect(page.locator('.cc-model-id')).toHaveText(FREE_MODEL);
+  });
+});

--- a/site/e2e/fixtures/openrouter.js
+++ b/site/e2e/fixtures/openrouter.js
@@ -193,6 +193,52 @@ export function http429Handler({ log } = {}) {
   };
 }
 
+// The daily free-model allowance, verified against the live API on
+// 2026-08-16. Distinct from a momentary 429 in exactly one way that matters:
+// metadata.limit_source names a per-day source and carries the reset stamp.
+export const QUOTA_RESET_AT = 1786924800000;
+
+/** Factory: HTTP 429 for a spent per-day free-model allowance. */
+export function dailyQuota429Handler({ log, resetAt = QUOTA_RESET_AT } = {}) {
+  return async (route) => {
+    if (await handlePreflight(route)) return;
+    log?.push(route.request().postDataJSON());
+    await route.fulfill(
+      json(
+        {
+          error: {
+            message: 'Rate limit exceeded: free-models-per-day-high-balance. ',
+            code: 429,
+            metadata: {
+              headers: {
+                'X-RateLimit-Limit': '1000',
+                'X-RateLimit-Remaining': '0',
+                'X-RateLimit-Reset': String(resetAt)
+              },
+              limit_source: 'openrouter_free_tier_daily',
+              remedy_hint: 'Wait for the daily reset, or purchase credits.'
+            }
+          }
+        },
+        429
+      )
+    );
+  };
+}
+
+/**
+ * Factory: quota-limit the ":free" model while the paid twin answers normally,
+ * so the "switch to the paid model" remedy can be exercised end to end.
+ */
+export function freeQuotaPaidOkHandler(answer, { log } = {}) {
+  const quota = dailyQuota429Handler({ log });
+  const ok = chatHandler(answer, { log });
+  return async (route) => {
+    const model = route.request().postDataJSON()?.model ?? '';
+    return model.endsWith(':free') ? quota(route) : ok(route);
+  };
+}
+
 /**
  * Factory: the OpenRouter quirk — HTTP 200 whose body is an error envelope
  * (transient upstream saturation). The engine must treat it as retryable.

--- a/site/src/lib/chat/config.js
+++ b/site/src/lib/chat/config.js
@@ -44,6 +44,11 @@ export const WASM_PREFETCH_CACHE = 'atlas-lattice-wasm';
 // --- storage -----------------------------------------------------------------
 // localStorage key holding the visitor's OpenRouter API key.
 export const LS_OPENROUTER_KEY = 'atlas-openrouter-key';
+// The visitor may point the answer model somewhere else, e.g. at the paid twin
+// of the default when their free daily allowance is spent. Retrieval models are
+// deliberately NOT overridable: the embedder has no paid endpoint at all, and a
+// different embedder would not match the vectors the corpus was built with.
+export const LS_CHAT_MODEL = 'atlas-openrouter-chat-model';
 // OPFS file name for the decompressed corpus, keyed by corpus commit SHA.
 export const latticeFileName = (sha) => 'lattice-db-' + sha + '.jsonl';
 // Matches files produced by latticeFileName(); capture group 1 is the SHA.

--- a/site/src/lib/chat/openrouter.js
+++ b/site/src/lib/chat/openrouter.js
@@ -17,11 +17,42 @@ import {
 
 /** Error that knows whether retrying could plausibly help. */
 export class OpenRouterError extends Error {
-  constructor(message, transient) {
+  constructor(message, transient, { quota = false, resetAt = null } = {}) {
     super(message);
     this.name = 'OpenRouterError';
     this.transient = transient;
+    // A per-day allowance that no amount of backoff will clear before its
+    // reset, as opposed to a provider being momentarily saturated.
+    this.quota = quota;
+    this.resetAt = resetAt;
   }
+}
+
+// OpenRouter returns 429 for two very different situations. A saturated
+// provider clears in seconds, so it is worth retrying. A per-day free-model
+// allowance does not clear until its reset stamp, so retrying only burns time
+// and then lies to the reader about what went wrong. The daily case announces
+// itself through metadata.limit_source (e.g. "openrouter_free_tier_daily") or
+// the message text (e.g. "Rate limit exceeded: free-models-per-day-…").
+const DAILY_LIMIT_TEXT = /free-models-per-day|per-?day|daily/i;
+
+function dailyQuota(errorBody, response) {
+  const meta = errorBody?.metadata ?? {};
+  const source = String(meta.limit_source ?? '');
+  const message = String(errorBody?.message ?? '');
+  if (!DAILY_LIMIT_TEXT.test(source) && !DAILY_LIMIT_TEXT.test(message)) return null;
+
+  const stamp = meta.headers?.['X-RateLimit-Reset'] ?? response?.headers?.get?.('X-RateLimit-Reset');
+  const resetAt = Number(stamp);
+  return { resetAt: Number.isFinite(resetAt) && resetAt > 0 ? resetAt : null };
+}
+
+/** Non-retryable, carries the reset stamp so the UI can name a real time. */
+function quotaError(what, message, quota) {
+  return new OpenRouterError(`${what} failed: ${message}`, false, {
+    quota: true,
+    resetAt: quota.resetAt
+  });
 }
 
 const headersFor = (apiKey) => ({
@@ -44,6 +75,15 @@ async function parseResponse(response, what) {
   const raw = await response.text();
 
   if (!response.ok) {
+    let body = null;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      /* not JSON — fall through to the generic message below */
+    }
+    const quota = response.status === 429 ? dailyQuota(body?.error, response) : null;
+    if (quota) throw quotaError(what, body.error.message ?? 'daily limit reached', quota);
+
     throw new OpenRouterError(
       `${what} failed: ${response.status} - ${raw}`,
       response.status === 429 || response.status >= 500
@@ -61,6 +101,8 @@ async function parseResponse(response, what) {
   if (maybeError) {
     const code = maybeError.code ?? 0;
     const message = maybeError.message ?? 'unknown error';
+    const quota = dailyQuota(maybeError, response);
+    if (quota) throw quotaError(what, message, quota);
     throw new OpenRouterError(
       `${what} failed${code ? ` (${code})` : ''}: ${message}`,
       code === 429 || code >= 500 || /ResourceExhausted|rate.?limit|overloaded/i.test(message)
@@ -187,6 +229,8 @@ async function readSseStream(bodyStream, emit) {
 
         if (chunk.error) {
           const message = chunk.error.message ?? 'unknown error';
+          const quota = dailyQuota(chunk.error, null);
+          if (quota) throw quotaError('Chat request', message, quota);
           throw new OpenRouterError(
             `Chat request failed: ${message}`,
             chunk.error.code === 429 ||

--- a/site/src/lib/chat/rag.js
+++ b/site/src/lib/chat/rag.js
@@ -51,7 +51,7 @@ function systemPrompt(repo, commit, context) {
  *   streamed thinking/answer tokens, forwarded verbatim from openrouter.chat
  * @returns {Promise<{answer: string, sources: Array<object>}>}
  */
-export async function askCodebase(question, history, { apiKey, corpus, onPhase, onDelta }) {
+export async function askCodebase(question, history, { apiKey, corpus, onPhase, onDelta, chatModel }) {
   onPhase?.('retrieving');
 
   const vector = await getEmbedding(question, apiKey);
@@ -121,7 +121,7 @@ export async function askCodebase(question, history, { apiKey, corpus, onPhase, 
     [...history, { role: 'user', content: question }],
     systemPrompt(corpus.repo, corpus.commit, context),
     apiKey,
-    { onDelta }
+    { onDelta, model: chatModel }
   );
 
   return { answer, sources };

--- a/site/src/lib/chat/state.svelte.js
+++ b/site/src/lib/chat/state.svelte.js
@@ -12,7 +12,9 @@ import {
   CORPUS_GZ_URL,
   CORPUS_META_URL,
   UPSERT_BATCH,
-  LS_OPENROUTER_KEY
+  LS_OPENROUTER_KEY,
+  LS_CHAT_MODEL,
+  CHAT_MODEL
 } from './config.js';
 import { initWasm, createCorpusCollection, upsertBatch, idleYield } from './lattice.js';
 import { getCachedCorpus, createCorpusWriter, pruneStale, listCached } from './opfs.js';
@@ -23,8 +25,9 @@ export const chat = $state({
   progress: { loadedBytes: 0, totalBytes: 0, indexed: 0, totalPoints: 0 },
   corpus: null, // { commit, files, chunks, dim, generatedAt, repo }
   offline: false, // serving a cached corpus because the manifest fetch failed
-  error: null, // { kind: 'wasm'|'manifest'|'corpus'|'decompress'|'rate'|'key', message }
+  error: null, // { kind: 'wasm'|'manifest'|'corpus'|'decompress'|'rate'|'quota'|'key', message, resetAt? }
   keyState: 'missing', // 'missing'|'set'
+  chatModel: CHAT_MODEL, // answer model, overridable by the visitor
   msgPhase: null, // null|'retrieving'|'reranking'|'thinking'|'writing'
   // In-flight streamed message, non-null only while ask() runs. The UI renders
   // its growing texts per animation frame; reasoningMs is stamped when the
@@ -34,6 +37,29 @@ export const chat = $state({
 
 if (browser) {
   chat.keyState = localStorage.getItem(LS_OPENROUTER_KEY) ? 'set' : 'missing';
+  chat.chatModel = localStorage.getItem(LS_CHAT_MODEL) || CHAT_MODEL;
+}
+
+// --- answer model ------------------------------------------------------------
+
+/**
+ * Point the answer model somewhere else. Spending a visitor's credits is their
+ * decision alone, so nothing here is ever called automatically — only from an
+ * explicit click.
+ */
+export function setChatModel(model) {
+  if (!browser) return;
+  const trimmed = String(model ?? '').trim();
+  if (!trimmed) return;
+  localStorage.setItem(LS_CHAT_MODEL, trimmed);
+  chat.chatModel = trimmed;
+  if (chat.error?.kind === 'quota') chat.error = null;
+}
+
+export function resetChatModel() {
+  if (!browser) return;
+  localStorage.removeItem(LS_CHAT_MODEL);
+  chat.chatModel = CHAT_MODEL;
 }
 
 // --- key management ----------------------------------------------------------
@@ -466,18 +492,23 @@ export async function ask(question, history = []) {
     const result = await askCodebase(question, history, {
       apiKey,
       corpus: chat.corpus,
+      chatModel: chat.chatModel,
       onPhase: (phase) => {
         chat.msgPhase = phase;
       },
       onDelta
     });
-    if (chat.error?.kind === 'rate' || chat.error?.kind === 'key') chat.error = null;
+    if (['rate', 'quota', 'key'].includes(chat.error?.kind)) chat.error = null;
     const reasoningMs =
       chat.stream?.reasoningMs || (thinkStart ? performance.now() - thinkStart : 0);
     return { ...result, reasoning: reasoningAll, reasoningMs };
   } catch (err) {
     const msg = String(err?.message ?? err);
-    if (/\b401\b|\b403\b|invalid.{0,20}key|no auth/i.test(msg)) failAsk('key', err);
+    // A spent daily allowance is not a momentary rate limit: it has a known
+    // reset and its own remedy, so it must never wear the "try again in a few
+    // seconds" copy.
+    if (err?.quota) failAsk('quota', err, { resetAt: err.resetAt ?? null });
+    else if (/\b401\b|\b403\b|invalid.{0,20}key|no auth/i.test(msg)) failAsk('key', err);
     else if (/dimensions but this corpus/.test(msg)) failAsk('corpus', err);
     else failAsk('rate', err);
     throw err;
@@ -490,6 +521,10 @@ export async function ask(question, history = []) {
 
 // Chat-time errors must not knock the machine out of 'ready' — the corpus is
 // still indexed and usable; only the message failed.
-function failAsk(kind, err) {
-  chat.error = { kind, message: err?.message ? String(err.message) : String(err) };
+function failAsk(kind, err, extra = {}) {
+  chat.error = {
+    kind,
+    message: err?.message ? String(err.message) : String(err),
+    ...extra
+  };
 }

--- a/site/src/lib/components/CodeChat.svelte
+++ b/site/src/lib/components/CodeChat.svelte
@@ -4,7 +4,9 @@
   // aria, scroll lock, Escape) plus a real focus trap and focus return since
   // this dialog holds form controls. All engine state comes from
   // chat/state.svelte.js (the contract SSOT), this component never fetches.
-  import { chat, ensureReady, abortLoad, setKey, clearKey, ask } from '../chat/state.svelte.js';
+  import {
+    chat, ensureReady, abortLoad, setKey, clearKey, ask, setChatModel, resetChatModel
+  } from '../chat/state.svelte.js';
   import ChatMessage from './ChatMessage.svelte';
   import { codeChat } from '$lib/data.js';
 
@@ -33,6 +35,20 @@
   // component only ever mounts in the browser (lazy import on click).
   const sourcesOpen =
     typeof window === 'undefined' ? true : !window.matchMedia('(max-width: 860px)').matches;
+
+  // A spent daily allowance names a real reset time, and the same model without
+  // the ":free" suffix is usually available on credits. Both are shown only
+  // when they actually apply.
+  const resetLabel = $derived(
+    askError?.resetAt
+      ? new Date(askError.resetAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+      : ''
+  );
+  const FREE = ':free';
+  const paidModel = $derived(
+    chat.chatModel.endsWith(FREE) ? chat.chatModel.slice(0, -FREE.length) : ''
+  );
+  const modelIsDefault = $derived(chat.chatModel.endsWith(FREE));
 
   // The in-flight streamed card takes over from the pending line as soon as
   // the first thinking or answer token lands.
@@ -182,7 +198,9 @@
     } catch {
       const k = chat.error?.kind;
       askError = {
-        kind: k === 'rate' || k === 'key' ? k : 'generic',
+        kind: ['rate', 'quota', 'key'].includes(k) ? k : 'generic',
+        // A per-day cap knows when it lifts; the card names that time.
+        resetAt: k === 'quota' ? (chat.error?.resetAt ?? null) : null,
         // Engine-crafted diagnostics (e.g. the embedding-dim mismatch) are
         // written for humans — surface them instead of the generic copy.
         detail: k === 'corpus' ? chat.error?.message : null
@@ -213,6 +231,15 @@
       lastQuestion,
       messages.slice(0, -1).map((m) => ({ role: m.role, content: m.text }))
     );
+  }
+
+  // Spending the visitor's credits is their call, so this only ever runs from
+  // an explicit click on the quota card.
+  function usePaidModel() {
+    if (!paidModel) return;
+    setChatModel(paidModel);
+    askError = null;
+    retryAsk();
   }
 
   function chipPick(q) {
@@ -354,9 +381,19 @@
           <div class="cc-error" role="alert">
             <span class="cc-error-tag">{codeChat.errors[askError.kind].tag}</span>
             <p class="cc-error-body">{askError.detail ?? codeChat.errors[askError.kind].body}</p>
-            <button type="button" class="cc-error-retry" onclick={retryAsk}>
-              {codeChat.errors[askError.kind].retry}
-            </button>
+            {#if askError.kind === 'quota' && resetLabel}
+              <p class="cc-error-reset">{codeChat.errors.quota.reset} {resetLabel}.</p>
+            {/if}
+            <div class="cc-error-actions">
+              {#if askError.kind === 'quota' && paidModel}
+                <button type="button" class="cc-error-paid" onclick={usePaidModel}>
+                  {codeChat.errors.quota.paid}
+                </button>
+              {/if}
+              <button type="button" class="cc-error-retry" onclick={retryAsk}>
+                {codeChat.errors[askError.kind].retry}
+              </button>
+            </div>
           </div>
         {/if}
       </div>
@@ -390,6 +427,15 @@
         <span class="cc-connected"><span class="dot" aria-hidden="true"></span>{codeChat.key.connectedTag}</span>
         <span class="cc-keyrow-note">{codeChat.key.connectedNote}</span>
         <button type="button" class="cc-keyrow-swap" onclick={swapKey}>{codeChat.key.change}</button>
+        <span class="cc-model" title={chat.chatModel}>
+          <span class="cc-model-label">{codeChat.model.label}</span>
+          <span class="cc-model-id">{chat.chatModel}</span>
+          {#if !modelIsDefault}
+            <button type="button" class="cc-model-reset" onclick={resetChatModel}>
+              {codeChat.model.reset}
+            </button>
+          {/if}
+        </span>
       </div>
     {/if}
 

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -488,6 +488,11 @@ export const codeChat = {
   sourcesOne: 'source',
   sourcesMany: 'sources',
   loadFail: 'The chat window did not load, maybe the network blinked. Close and try again.',
+  model: {
+    label: 'answer model',
+    reset: 'back to free'
+  },
+
   errors: {
     wasm: {
       tag: 'engine fault',
@@ -512,6 +517,13 @@ export const codeChat = {
     rate: {
       tag: 'rate limited',
       body: 'The free OpenRouter models are catching their breath. Give it a few seconds.',
+      retry: 'ask again'
+    },
+    quota: {
+      tag: 'daily limit reached',
+      body: 'Your OpenRouter key has spent its free model allowance for today. Retrieval still runs locally so the corpus stays loaded and ready.',
+      reset: 'The free pool refills at',
+      paid: 'switch to the paid model and spend my own credits',
       retry: 'ask again'
     },
     key: {

--- a/site/src/styles/chat.css
+++ b/site/src/styles/chat.css
@@ -233,6 +233,39 @@
 }
 .cc-error-retry:hover { background: var(--accent); color: #fff; }
 
+/* A spent daily allowance names its reset and offers the paid twin. The paid
+   action leads because it is the only one that helps before the reset. */
+.cc-error-reset {
+  font-family: var(--font-mono); font-size: 0.74rem; color: var(--t3);
+  margin-top: 0.4rem; font-variant-numeric: tabular-nums;
+}
+.cc-error-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; }
+.cc-error-paid {
+  margin-top: 0.6rem; padding: 0.4rem 0.85rem; cursor: pointer;
+  font-family: var(--font-mono); font-size: 0.72rem; font-weight: 700;
+  color: #fff; background: var(--accent);
+  border: 1px solid var(--accent-deep); border-radius: 6px;
+  transition: background 0.15s;
+}
+.cc-error-paid:hover { background: var(--accent-deep); }
+
+/* ---- answer model chip ----------------------------------------------------- */
+.cc-model {
+  display: inline-flex; align-items: center; gap: 0.4rem; min-width: 0;
+  font-family: var(--font-mono); font-size: 0.68rem; color: var(--t3);
+}
+.cc-model-label { text-transform: uppercase; letter-spacing: 0.08em; }
+.cc-model-id {
+  color: var(--t2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 15rem;
+}
+.cc-model-reset {
+  cursor: pointer; font-family: var(--font-mono); font-size: 0.66rem; font-weight: 700;
+  color: var(--accent); background: none; border: none; padding: 0;
+  text-decoration: underline; text-underline-offset: 2px;
+}
+.cc-model-reset:hover { color: var(--accent-deep); }
+
 /* ---- key entry (a pending receipt) ---------------------------------------- */
 .cc-key {
   margin: 0 1.5rem 0.9rem; padding: 0.85rem 1rem; position: relative; z-index: 1;


### PR DESCRIPTION
## Diagnosis

Probed live against OpenRouter with a real key: `/embeddings` and `/rerank` return **200** (retrieval is fine), only `/chat/completions` returns **429** with `limit_source: openrouter_free_tier_daily`, `X-RateLimit-Remaining: 0` of 1000. The daily free-model pool was spent — largely by the day's corpus builds, which draw from the same account.

The bug is ours: every 429 was classified as momentary, so this got three futile retries and then "The free OpenRouter models are catching their breath. Give it a few seconds." — advice that cannot come true before the reset.

## Fix

- Daily caps are detected via `metadata.limit_source` / message text at all three classification sites (HTTP error, 200-with-error-body, mid-stream SSE chunk), raised as a **non-retryable** `quota` error carrying the `X-RateLimit-Reset` stamp.
- New quota card names the actual reset time and states that retrieval still works locally.
- One-click switch to the paid twin of the answer model (the same id minus `:free`, verified working while the free pool was empty), persisted in localStorage with a way back. **Never automatic** — it spends the visitor's own credits.
- Retrieval models stay pinned to `:free`; the embedder has no paid endpoint (404) and a different embedder would not match the corpus vectors.

## Tests

New `e2e/chat-quota.spec.js`: quota card renders with the real reset time and **exactly one attempt** (no retry loop); the paid button re-asks against the stripped model id and the choice survives a reload. Full suite **39 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)