### PR TITLE
test(site): give the live answer assertions room for a reasoning model

### DIFF
--- a/site/e2e/chat-live.spec.js
+++ b/site/e2e/chat-live.spec.js
@@ -39,9 +39,11 @@ test.describe('@live real corpus', () => {
     await page.locator('.cc-ask').click();
     const card = page.locator('.cm-card');
     await expect(card).toBeVisible({ timeout: 120_000 });
-    await expect(card.locator('.cm-body')).not.toBeEmpty();
+    // The card appears with the thinking trace alone; .cm-body only exists once
+    // answer tokens start, and a reasoning model can think for tens of seconds.
+    await expect(card.locator('.cm-body')).not.toBeEmpty({ timeout: 180_000 });
     // Free-tier models can rate-limit; sources are the part the site controls.
-    await expect(card.locator('.cm-src').first()).toBeVisible();
+    await expect(card.locator('.cm-src').first()).toBeVisible({ timeout: 120_000 });
     expect(await card.locator('.cm-src').first().getAttribute('href')).toMatch(
       /^https:\/\/github\.com\/Avarok-Cybersecurity\/atlas\/blob\/[0-9a-f]{40}\/.+#L\d+-L\d+$/
     );


### PR DESCRIPTION
Verified against production with a real key: the corpus loads, the model reasons for ~12.6 s, then streams an answer citing `scheduler/mod_helpers.rs:141-273` with three real sources. The only failure was this spec asserting on `.cm-body` with the default 10 s timeout, while that element does not exist until the first answer token arrives. Both @live tests pass with the wider windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)