### PR TITLE
perf(ssm-verify): batch the per-layer rollback copies into pitched 2-D transfers (96 → 2 launches/seq/step)

### DIFF
--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod impl_lora;
 pub(crate) mod impl_lora_swap;
 pub(crate) mod mtp_carry;
 pub(crate) mod pinned_pack;
+pub(crate) mod ssm_batched_copy;
 pub(crate) mod ssm_pool;
 pub(crate) mod ssm_snapshot;
 pub(crate) mod ssm_snapshot_faultin;

--- a/crates/spark-model/src/model/ssm_batched_copy.rs
+++ b/crates/spark-model/src/model/ssm_batched_copy.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched execution of the SSM verify-state copy sets.
+//!
+//! Every speculative-verify state move — pre-verify checkpoint, full-reject
+//! rollback, partial-accept commit — is the SAME shape: for each of the
+//! model's SSM layers, copy one h blob and one conv blob between two pool
+//! regions. On the 27B hybrid (48 GDN layers) that loop issued **96 eager
+//! `copy_d2d_async` launches per sequence per verify step**, entirely outside
+//! any captured graph; at n=8 sequences a single decode step spent 768
+//! launches on it.
+//!
+//! The blobs are not adjacent within a layer (h and conv live in different
+//! pool families), but the per-layer regions of ONE family are uniformly
+//! strided — [`super::ssm_pool::SsmStatePool`] allocates each family as one
+//! contiguous block and hands out `base + layer * stride` (see
+//! `alloc_layer_pools` there). So the 48 h copies collapse to a single
+//! pitched 2-D copy, and likewise the 48 conv copies:
+//!
+//! | | launches / sequence / step | at n=8 |
+//! |---|---|---|
+//! | per-layer loop | 96 | 768 |
+//! | batched | 2 | 16 |
+//!
+//! **The bytes are identical.** [`copy_plan_as_strided_run`] only collapses a
+//! plan whose rows it can reproduce exactly — same width, same monotone
+//! pitch — and `copy_d2d_2d_async`'s own fallback (and its
+//! `cudaMemcpy2DAsync` implementation) writes row `r` as `width_bytes` from
+//! `src + r*src_pitch` to `dst + r*dst_pitch`, which is row `r` of the plan
+//! by construction. Anything that does not collapse (a fragmented pool, a
+//! ragged plan, a single-layer model) runs the original loop verbatim.
+//!
+//! Kill switch: `ATLAS_NO_BATCHED_SSM_ROLLBACK=1` forces the loop everywhere.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+/// One device-to-device state blob move: `bytes` from `src` to `dst`.
+///
+/// A `Vec<StateCopy>` is the SSOT for "what this rollback does" — both
+/// executors below consume the same plan, so the batched and looped forms
+/// cannot drift apart in which bytes land where.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StateCopy {
+    pub src: DevicePtr,
+    pub dst: DevicePtr,
+    pub bytes: usize,
+}
+
+/// A copy plan that collapses to one pitched 2-D transfer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StridedRun {
+    pub src: DevicePtr,
+    pub src_pitch: usize,
+    pub dst: DevicePtr,
+    pub dst_pitch: usize,
+    pub width_bytes: usize,
+    pub height: usize,
+}
+
+/// Can `plan` be issued as ONE pitched 2-D copy instead of `plan.len()`
+/// separate ones? PURE — this is where the equivalence argument lives, so it
+/// is testable without a GPU.
+///
+/// Requires, and checks, every condition `cudaMemcpy2DAsync` needs to
+/// reproduce the plan row-for-row:
+/// - at least two rows (one row is already one launch — nothing to gain, and
+///   a pitch cannot be derived from a single element);
+/// - every row the same `width_bytes` (a ragged plan is not a 2-D shape);
+/// - a single FORWARD `src_pitch` and `dst_pitch` shared by every consecutive
+///   pair (row `r` must sit at `base + r*pitch`);
+/// - `pitch >= width_bytes` on both sides, so consecutive rows never overlap
+///   — the CUDA precondition, and what makes row order irrelevant.
+///
+/// Returns `None` on anything else; the caller then runs the plan as-is.
+pub(crate) fn copy_plan_as_strided_run(plan: &[StateCopy]) -> Option<StridedRun> {
+    if plan.len() < 2 {
+        return None;
+    }
+    let width_bytes = plan[0].bytes;
+    if width_bytes == 0 || plan.iter().any(|c| c.bytes != width_bytes) {
+        return None;
+    }
+    // Pitches are derived from the first pair and then VERIFIED against every
+    // other pair — `checked_sub` on u64 rejects a descending family outright
+    // (a negative pitch has no `cudaMemcpy2D` representation).
+    let src_pitch = plan[1].src.0.checked_sub(plan[0].src.0)?;
+    let dst_pitch = plan[1].dst.0.checked_sub(plan[0].dst.0)?;
+    if src_pitch < width_bytes as u64 || dst_pitch < width_bytes as u64 {
+        return None;
+    }
+    for (r, c) in plan.iter().enumerate() {
+        let r = r as u64;
+        if c.src.0 != plan[0].src.0 + r * src_pitch || c.dst.0 != plan[0].dst.0 + r * dst_pitch {
+            return None;
+        }
+    }
+    Some(StridedRun {
+        src: plan[0].src,
+        src_pitch: src_pitch as usize,
+        dst: plan[0].dst,
+        dst_pitch: dst_pitch as usize,
+        width_bytes,
+        height: plan.len(),
+    })
+}
+
+/// Kill switch for the batched form: `ATLAS_NO_BATCHED_SSM_ROLLBACK=1`
+/// restores the per-layer `copy_d2d_async` loop everywhere.
+///
+/// PRESENCE check per the house convention (`=0` is NOT off), read once per
+/// process — this predicate sits on the verify path, which runs per sequence
+/// per decode step.
+pub(crate) fn batched_ssm_copy_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_BATCHED_SSM_ROLLBACK").is_none())
+}
+
+/// Issue `plan` on `stream`, batched when it collapses.
+///
+/// `batched` is a PARAMETER, not a flag read, so both polarities are testable
+/// without touching process env or the latching `OnceLock` above (which would
+/// make such tests order-dependent). Production callers pass
+/// [`batched_ssm_copy_enabled`].
+pub(crate) fn run_state_copies_with(
+    gpu: &dyn GpuBackend,
+    plan: &[StateCopy],
+    batched: bool,
+    stream: u64,
+) -> Result<()> {
+    if batched && let Some(run) = copy_plan_as_strided_run(plan) {
+        return gpu.copy_d2d_2d_async(
+            run.src,
+            run.src_pitch,
+            run.dst,
+            run.dst_pitch,
+            run.width_bytes,
+            run.height,
+            stream,
+        );
+    }
+    for c in plan {
+        gpu.copy_d2d_async(c.src, c.dst, c.bytes, stream)?;
+    }
+    Ok(())
+}
+
+/// [`run_state_copies_with`] at the process-wide kill-switch setting.
+pub(crate) fn run_state_copies(
+    gpu: &dyn GpuBackend,
+    plan: &[StateCopy],
+    stream: u64,
+) -> Result<()> {
+    run_state_copies_with(gpu, plan, batched_ssm_copy_enabled(), stream)
+}
+
+/// Issue an h plan and a conv plan back to back.
+///
+/// The two families are issued as separate runs rather than one interleaved
+/// loop because a 2-D copy needs ONE width, and h blobs and conv blobs have
+/// different widths. Re-ordering across the families is sound: they address
+/// DISJOINT pool allocations (`h_*_pools` vs `conv_*_pools` in
+/// [`super::ssm_pool::SsmStatePool`]), so no h copy can read or write a byte
+/// any conv copy touches, and both land on the same stream before any
+/// consumer of either.
+pub(crate) fn run_ssm_state_copies(
+    gpu: &dyn GpuBackend,
+    h_plan: &[StateCopy],
+    conv_plan: &[StateCopy],
+    stream: u64,
+) -> Result<()> {
+    let batched = batched_ssm_copy_enabled();
+    run_state_copies_with(gpu, h_plan, batched, stream)?;
+    run_state_copies_with(gpu, conv_plan, batched, stream)
+}
+
+#[cfg(test)]
+#[path = "ssm_batched_copy_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/ssm_batched_copy_tests.rs
+++ b/crates/spark-model/src/model/ssm_batched_copy_tests.rs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Equivalence pins for the batched SSM verify-state copies.
+//!
+//! The property under test is the one the `ssm-state-poisoning-gate` exists
+//! for: **the same bytes must land in the same slots as the per-layer
+//! `copy_d2d_async` loop**, for every per-sequence rollback depth. So every
+//! test here runs BOTH executors over the SAME plan on two identically-built
+//! mock devices and compares the destination regions byte-for-byte — a test
+//! that only asserted "one launch instead of 48" would pass on a batched form
+//! that copied the wrong rows.
+
+use super::super::ssm_pool::SsmStatePool;
+use super::*;
+use crate::ssm_reserve::SsmRollbackMode;
+use atlas_core::config::{LayerType, ModelConfig};
+use spark_runtime::gpu::{DevicePtr, GpuBackend, mock::MockGpuBackend};
+
+/// The 27B/80B hybrid layer pattern (3 GDN : 1 attention, 48 layers → 36 SSM
+/// layers) at doll-house blob widths, so a test allocates kilobytes instead
+/// of the gigabytes the production head dims imply. The GEOMETRY under test
+/// is the pool's layer/slot/intermediate striding, which is independent of
+/// the blob width; the width only has to be uniform and non-trivial.
+fn tiny_config() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.linear_num_key_heads = 2;
+    c.linear_key_head_dim = 4;
+    c.linear_num_value_heads = 2;
+    c.linear_value_head_dim = 4;
+    c.linear_conv_kernel_dim = 4;
+    c
+}
+
+const MAX_SLOTS: usize = 4;
+const NUM_INTERMEDIATES: usize = 4;
+const NUM_DRAFTS: usize = 3;
+
+fn pool(gpu: &MockGpuBackend) -> SsmStatePool {
+    SsmStatePool::new(
+        &tiny_config(),
+        MAX_SLOTS,
+        true,
+        NUM_INTERMEDIATES,
+        NUM_DRAFTS,
+        false,
+        SsmRollbackMode::Snapshot,
+        gpu,
+    )
+    .unwrap()
+}
+
+/// Distinct, position-encoding fill for every source region, so restoring
+/// from the WRONG layer / slot / token index is visible in the bytes rather
+/// than hidden behind a uniform pattern.
+fn seed(gpu: &MockGpuBackend, p: &SsmStatePool) {
+    for l in 0..p.num_ssm_layers {
+        for s in 0..=p.mtp_slots {
+            let tag = |k: usize| ((l * 131 + s * 17 + k * 7) % 251 + 1) as u8;
+            gpu.copy_h2d(&vec![tag(0); p.h_stored_bytes], p.h_state(l, s))
+                .unwrap();
+            gpu.copy_h2d(&vec![tag(1); p.conv_bytes], p.conv_state(l, s))
+                .unwrap();
+            gpu.copy_h2d(&vec![tag(2); p.h_stored_bytes], p.h_checkpoint(l, s))
+                .unwrap();
+            gpu.copy_h2d(&vec![tag(3); p.conv_bytes], p.conv_checkpoint(l, s))
+                .unwrap();
+            for t in 0..p.h_inter_count(s) {
+                gpu.copy_h2d(
+                    &vec![tag(4 + t); p.h_stored_bytes],
+                    p.h_intermediate(l, s, t),
+                )
+                .unwrap();
+            }
+            for t in 0..p.num_intermediates {
+                gpu.copy_h2d(
+                    &vec![tag(9 + t); p.conv_bytes],
+                    p.conv_intermediate(l, s, t),
+                )
+                .unwrap();
+            }
+        }
+    }
+}
+
+/// The LIVE state of every slot of every layer — the only thing a rollback
+/// is allowed to change, and the thing the two executors must agree on.
+fn live_state(gpu: &MockGpuBackend, p: &SsmStatePool) -> Vec<u8> {
+    let mut out = Vec::new();
+    for l in 0..p.num_ssm_layers {
+        for s in 0..=p.mtp_slots {
+            let mut h = vec![0u8; p.h_stored_bytes];
+            gpu.copy_d2h(p.h_state(l, s), &mut h).unwrap();
+            out.extend_from_slice(&h);
+            let mut c = vec![0u8; p.conv_bytes];
+            gpu.copy_d2h(p.conv_state(l, s), &mut c).unwrap();
+            out.extend_from_slice(&c);
+        }
+    }
+    out
+}
+
+/// The h/conv plans `commit_accepted_prefix_dispatch` builds for one
+/// sequence: `h_intermediate[na-1] → h_state`, same for conv, one row per
+/// SSM layer in ascending layer order.
+fn commit_plans(
+    p: &SsmStatePool,
+    slot: usize,
+    num_accepted: usize,
+) -> (Vec<StateCopy>, Vec<StateCopy>) {
+    let cfg = tiny_config();
+    let conv_bytes = (cfg.linear_num_key_heads * cfg.linear_key_head_dim * 2
+        + cfg.linear_num_value_heads * cfg.linear_value_head_dim)
+        * cfg.linear_conv_kernel_dim
+        * 4;
+    let mut h = Vec::new();
+    let mut c = Vec::new();
+    let mut ssm_layer_idx = 0usize;
+    for i in 0..cfg.num_hidden_layers {
+        if cfg.layer_type(i) != LayerType::LinearAttention {
+            continue;
+        }
+        let idx = num_accepted - 1;
+        h.push(StateCopy {
+            src: p.h_intermediate(ssm_layer_idx, slot, idx),
+            dst: p.h_state(ssm_layer_idx, slot),
+            bytes: p.h_stored_bytes,
+        });
+        c.push(StateCopy {
+            src: p.conv_intermediate(ssm_layer_idx, slot, idx),
+            dst: p.conv_state(ssm_layer_idx, slot),
+            bytes: conv_bytes,
+        });
+        ssm_layer_idx += 1;
+    }
+    (h, c)
+}
+
+/// The full-reject arm of `rollback_ssm_states_dispatch`: restore the
+/// pre-verify checkpoint (`num_accepted == 0`).
+fn reject_plans(p: &SsmStatePool, slot: usize) -> (Vec<StateCopy>, Vec<StateCopy>) {
+    let (mut h, mut c) = commit_plans(p, slot, 1);
+    for (l, row) in h.iter_mut().enumerate() {
+        row.src = p.h_checkpoint(l, slot);
+    }
+    for (l, row) in c.iter_mut().enumerate() {
+        row.src = p.conv_checkpoint(l, slot);
+    }
+    (h, c)
+}
+
+/// Run one plan pair both ways on two identically-built devices and assert
+/// the live state is byte-identical.
+fn assert_equivalent(make_plans: impl Fn(&SsmStatePool) -> (Vec<StateCopy>, Vec<StateCopy>)) {
+    let looped = MockGpuBackend::new();
+    let lp = pool(&looped);
+    seed(&looped, &lp);
+    let (lh, lc) = make_plans(&lp);
+    run_state_copies_with(&looped, &lh, false, 0).unwrap();
+    run_state_copies_with(&looped, &lc, false, 0).unwrap();
+
+    let batched = MockGpuBackend::new();
+    let bp = pool(&batched);
+    seed(&batched, &bp);
+    let (bh, bc) = make_plans(&bp);
+    run_state_copies_with(&batched, &bh, true, 0).unwrap();
+    run_state_copies_with(&batched, &bc, true, 0).unwrap();
+    // Both plans must actually have COLLAPSED, or this whole comparison is
+    // vacuously "the loop equals the loop".
+    assert_eq!(
+        (batched.d2d_count(), batched.d2d_2d_count()),
+        (0, 2),
+        "batched run fell back to the per-layer loop"
+    );
+
+    // The two devices are built by the same deterministic bump allocator, so
+    // the plans are address-identical too — a drift there would mean the
+    // comparison below is comparing different geometries.
+    assert_eq!(lh, bh, "h plan differs between runs");
+    assert_eq!(lc, bc, "conv plan differs between runs");
+
+    let want = live_state(&looped, &lp);
+    let got = live_state(&batched, &bp);
+    assert_eq!(want.len(), got.len());
+    assert!(
+        want == got,
+        "batched rollback wrote different bytes than the per-layer loop"
+    );
+    // And the rollback must actually have DONE something — two no-op
+    // executors would agree byte-for-byte for the wrong reason.
+    let untouched = MockGpuBackend::new();
+    let up = pool(&untouched);
+    seed(&untouched, &up);
+    assert!(
+        want != live_state(&untouched, &up),
+        "live state unchanged — the plan moved nothing"
+    );
+}
+
+#[test]
+fn commit_is_byte_identical_at_every_accepted_depth() {
+    let probe = MockGpuBackend::new();
+    let p = pool(&probe);
+    let k = p.h_inter_count(0);
+    assert!(k >= 2, "fixture must offer more than one rollback depth");
+    // num_accepted == 1 is the shallowest commit (index 0); k is the deepest
+    // representable (index k-1). Both ends plus the interior are covered.
+    for na in 1..=k {
+        assert_equivalent(|pool| commit_plans(pool, 0, na));
+    }
+}
+
+#[test]
+fn full_reject_restore_is_byte_identical() {
+    // `num_accepted == 0`: the checkpoint family is the source, which is a
+    // DIFFERENT pool with a different layer stride from the intermediates.
+    assert_equivalent(|p| reject_plans(p, 0));
+}
+
+#[test]
+fn every_slot_rolls_back_to_its_own_state() {
+    // Slot addressing is where a batched form silently poisons a neighbour:
+    // the h intermediates are TIERED, so slot s's rows are not at `s * k`.
+    let probe = MockGpuBackend::new();
+    let p = pool(&probe);
+    for s in 0..MAX_SLOTS {
+        let k = p.h_inter_count(s);
+        assert!(k >= 1, "slot {s} has no intermediates");
+        assert_equivalent(|pool| commit_plans(pool, s, k));
+    }
+}
+
+#[test]
+fn single_ssm_layer_still_copies_the_right_bytes() {
+    // A one-row plan cannot collapse (no pitch to derive) and must fall
+    // through to the single `copy_d2d_async` — the n=1-layer degenerate case.
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu);
+    seed(&gpu, &p);
+    let (h, _) = commit_plans(&p, 0, 1);
+    let one = [h[0]];
+    assert!(copy_plan_as_strided_run(&one).is_none());
+    run_state_copies_with(&gpu, &one, true, 0).unwrap();
+    assert_eq!(gpu.d2d_count(), 1, "single row = one plain d2d");
+    assert_eq!(gpu.d2d_2d_count(), 0);
+    let mut got = vec![0u8; p.h_stored_bytes];
+    gpu.copy_d2h(p.h_state(0, 0), &mut got).unwrap();
+    let mut want = vec![0u8; p.h_stored_bytes];
+    gpu.copy_d2h(p.h_intermediate(0, 0, 0), &mut want).unwrap();
+    assert_eq!(got, want);
+}
+
+#[test]
+fn batching_collapses_the_layer_loop_to_one_launch() {
+    let gpu = MockGpuBackend::new();
+    let p = pool(&gpu);
+    seed(&gpu, &p);
+    let (h, c) = commit_plans(&p, 0, 1);
+    let layers = p.num_ssm_layers;
+    assert_eq!(h.len(), layers);
+
+    run_ssm_state_copies(&gpu, &h, &c, 0).unwrap();
+    assert_eq!(
+        (gpu.d2d_count(), gpu.d2d_2d_count()),
+        (0, 2),
+        "{layers} h + {layers} conv copies must become 2 pitched launches"
+    );
+
+    // Kill switch: the same plan, unbatched, is the original loop.
+    let off = MockGpuBackend::new();
+    let op = pool(&off);
+    let (oh, oc) = commit_plans(&op, 0, 1);
+    run_state_copies_with(&off, &oh, false, 0).unwrap();
+    run_state_copies_with(&off, &oc, false, 0).unwrap();
+    assert_eq!((off.d2d_count(), off.d2d_2d_count()), (2 * layers, 0));
+}
+
+#[test]
+fn kill_switch_default_is_batched() {
+    // The env var is a PRESENCE check latched in a `OnceLock`; under `cargo
+    // test` (no var set) the production reader must say "batched", or the
+    // optimization is inert in production too.
+    assert!(
+        batched_ssm_copy_enabled(),
+        "ATLAS_NO_BATCHED_SSM_ROLLBACK is set in this environment"
+    );
+}
+
+// ── copy_plan_as_strided_run: the collapse predicate itself ──
+
+fn row(src: u64, dst: u64, bytes: usize) -> StateCopy {
+    StateCopy {
+        src: DevicePtr(src),
+        dst: DevicePtr(dst),
+        bytes,
+    }
+}
+
+#[test]
+fn uniform_plan_collapses_to_its_pitches() {
+    let plan: Vec<StateCopy> = (0..4)
+        .map(|l| row(1000 + l * 64, 9000 + l * 32, 16))
+        .collect();
+    let run = copy_plan_as_strided_run(&plan).expect("uniform plan must collapse");
+    assert_eq!(run.src.0, 1000);
+    assert_eq!(run.dst.0, 9000);
+    assert_eq!(run.src_pitch, 64);
+    assert_eq!(run.dst_pitch, 32);
+    assert_eq!(run.width_bytes, 16);
+    assert_eq!(run.height, 4);
+}
+
+#[test]
+fn a_plan_that_a_2d_copy_cannot_reproduce_is_refused() {
+    let base: Vec<StateCopy> = (0..4)
+        .map(|l| row(1000 + l * 64, 9000 + l * 64, 16))
+        .collect();
+    assert!(copy_plan_as_strided_run(&base).is_some(), "control");
+
+    // Ragged width: no single `width_bytes`.
+    let mut ragged = base.clone();
+    ragged[2].bytes = 8;
+    assert!(copy_plan_as_strided_run(&ragged).is_none());
+
+    // A relocated layer (the fragmented-pool fallback) breaks the src stride.
+    let mut hole = base.clone();
+    hole[2].src = DevicePtr(500_000);
+    assert!(copy_plan_as_strided_run(&hole).is_none());
+
+    // ...and the dst stride, independently.
+    let mut dhole = base.clone();
+    dhole[3].dst = DevicePtr(500_000);
+    assert!(copy_plan_as_strided_run(&dhole).is_none());
+
+    // Descending family: a negative pitch has no 2-D representation.
+    let down: Vec<StateCopy> = (0..4)
+        .map(|l| row(1000 - l * 64, 9000 - l * 64, 16))
+        .collect();
+    assert!(copy_plan_as_strided_run(&down).is_none());
+
+    // Pitch below width: rows would overlap, so the 2-D form is NOT the plan.
+    let tight: Vec<StateCopy> = (0..4)
+        .map(|l| row(1000 + l * 8, 9000 + l * 8, 16))
+        .collect();
+    assert!(copy_plan_as_strided_run(&tight).is_none());
+
+    // Zero-width and empty plans are not 2-D shapes either.
+    assert!(copy_plan_as_strided_run(&[]).is_none());
+    assert!(copy_plan_as_strided_run(&[row(1, 2, 0), row(3, 4, 0)]).is_none());
+}
+
+#[test]
+fn the_collapsed_run_reproduces_the_plan_row_for_row() {
+    // The equivalence argument in one assertion: expanding the 2-D run by its
+    // own definition (`row r = width bytes at base + r*pitch`) must give back
+    // exactly the plan that produced it.
+    let plan: Vec<StateCopy> = (0..7)
+        .map(|l| row(4096 + l * 256, 1_000_000 + l * 128, 96))
+        .collect();
+    let r = copy_plan_as_strided_run(&plan).unwrap();
+    let expanded: Vec<StateCopy> = (0..r.height)
+        .map(|i| StateCopy {
+            src: r.src.offset(i * r.src_pitch),
+            dst: r.dst.offset(i * r.dst_pitch),
+            bytes: r.width_bytes,
+        })
+        .collect();
+    assert_eq!(expanded, plan);
+}

--- a/crates/spark-model/src/model/ssm_pool.rs
+++ b/crates/spark-model/src/model/ssm_pool.rs
@@ -112,6 +112,48 @@ fn h_inter_layout(counts: &[usize]) -> (Vec<usize>, usize) {
     (offsets, acc)
 }
 
+/// Allocate one zeroed region of `bytes` per SSM layer, PREFERRING a single
+/// contiguous block so `pools[l] == pools[0] + l * bytes`.
+///
+/// The uniform layer stride is what lets the verify-state copy sets collapse
+/// from `2 × num_ssm_layers` eager `copy_d2d_async` launches per sequence to
+/// two pitched 2-D copies (`model::ssm_batched_copy`). Nothing depends on the
+/// stride existing: if the single block cannot be allocated — a fragmented
+/// device, or simply a pool large enough that one VA range is not available
+/// — this falls back to the original per-layer allocations, the strided-run
+/// detector declines, and the copies run as the same per-layer loop they
+/// always did. Bytes allocated, and the addresses every accessor derives, are
+/// identical either way.
+fn alloc_layer_pools(
+    gpu: &dyn GpuBackend,
+    num_ssm_layers: usize,
+    bytes: usize,
+) -> Result<Vec<DevicePtr>> {
+    if num_ssm_layers == 0 || bytes == 0 {
+        return Ok(vec![DevicePtr::NULL; num_ssm_layers]);
+    }
+    if let Some(total) = bytes.checked_mul(num_ssm_layers)
+        && let Ok(base) = gpu.alloc(total)
+    {
+        gpu.memset(base, 0, total)?;
+        return Ok((0..num_ssm_layers)
+            .map(|l| base.offset(l * bytes))
+            .collect());
+    }
+    tracing::warn!(
+        "SSM pool: {num_ssm_layers} × {bytes} B did not fit one contiguous block — \
+         falling back to per-layer allocations (verify-state rollback keeps the \
+         per-layer copy loop)"
+    );
+    let mut pools = Vec::with_capacity(num_ssm_layers);
+    for _ in 0..num_ssm_layers {
+        let p = gpu.alloc(bytes)?;
+        gpu.memset(p, 0, bytes)?;
+        pools.push(p);
+    }
+    Ok(pools)
+}
+
 impl SsmStatePool {
     /// `h_f16_pool` is `gdn_flags::ssm_h_f16_pool_enabled()` at the one
     /// production call site (`impl_a1.rs`) — a parameter, not a flag read,
@@ -143,22 +185,13 @@ impl SsmStatePool {
         // num_ssm_layers` extra GPU memory (~kilobytes per pool).
         let total_slots = max_slots + 1;
 
-        let mut h_state_pools = Vec::with_capacity(num_ssm_layers);
-        let mut conv_state_pools = Vec::with_capacity(num_ssm_layers);
         let mut h_intermediate_pools = Vec::new();
         let mut conv_intermediate_pools = Vec::new();
         let mut h_checkpoint_pools = Vec::new();
         let mut conv_checkpoint_pools = Vec::new();
 
-        for _ in 0..num_ssm_layers {
-            let h_pool = gpu.alloc(total_slots * h_stored_bytes)?;
-            gpu.memset(h_pool, 0, total_slots * h_stored_bytes)?;
-            h_state_pools.push(h_pool);
-
-            let conv_pool = gpu.alloc(total_slots * conv_bytes)?;
-            gpu.memset(conv_pool, 0, total_slots * conv_bytes)?;
-            conv_state_pools.push(conv_pool);
-        }
+        let h_state_pools = alloc_layer_pools(gpu, num_ssm_layers, total_slots * h_stored_bytes)?;
+        let conv_state_pools = alloc_layer_pools(gpu, num_ssm_layers, total_slots * conv_bytes)?;
 
         // MTP verify pools cover only the slots spec dispatch can reach
         // (SSOT: `ssm_reserve::mtp_state_slots` — the same number preflight
@@ -212,40 +245,29 @@ impl SsmStatePool {
         if has_mtp {
             let ni = num_intermediates;
             let mtp_total = mtp_slots + 1;
-            for _ in 0..num_ssm_layers {
-                if !replay {
-                    let h_inter = gpu.alloc(h_inter_total * h_stored_bytes)?;
-                    gpu.memset(h_inter, 0, h_inter_total * h_stored_bytes)?;
-                    h_intermediate_pools.push(h_inter);
-
-                    let conv_inter = gpu.alloc(mtp_total * ni * conv_bytes)?;
-                    gpu.memset(conv_inter, 0, mtp_total * ni * conv_bytes)?;
-                    conv_intermediate_pools.push(conv_inter);
-                } else {
-                    // Replay: verify-window INPUT rows instead of state
-                    // snapshots — (mtp_total slots incl. dummy) × (K-1)
-                    // rows of qkvz+gates per layer. Sized by the same SSOT
-                    // preflight reserves through.
-                    let row = crate::ssm_reserve::ssm_replay_row_bytes(
-                        config.ssm_qkvz_size(),
-                        config.linear_num_value_heads,
-                    );
-                    let ring = crate::ssm_reserve::ssm_replay_ring_bytes(1, row, ni, mtp_total);
-                    let r = gpu.alloc(ring)?;
-                    gpu.memset(r, 0, ring)?;
-                    replay_input_rings.push(r);
-                }
-
-                // 1 checkpoint per slot per layer (BOTH modes: replay's
-                // reconstruction base is exactly this blob).
-                let h_ckpt = gpu.alloc(mtp_total * h_stored_bytes)?;
-                gpu.memset(h_ckpt, 0, mtp_total * h_stored_bytes)?;
-                h_checkpoint_pools.push(h_ckpt);
-
-                let conv_ckpt = gpu.alloc(mtp_total * conv_bytes)?;
-                gpu.memset(conv_ckpt, 0, mtp_total * conv_bytes)?;
-                conv_checkpoint_pools.push(conv_ckpt);
+            if !replay {
+                h_intermediate_pools =
+                    alloc_layer_pools(gpu, num_ssm_layers, h_inter_total * h_stored_bytes)?;
+                conv_intermediate_pools =
+                    alloc_layer_pools(gpu, num_ssm_layers, mtp_total * ni * conv_bytes)?;
+            } else {
+                // Replay: verify-window INPUT rows instead of state
+                // snapshots — (mtp_total slots incl. dummy) × (K-1)
+                // rows of qkvz+gates per layer. Sized by the same SSOT
+                // preflight reserves through.
+                let row = crate::ssm_reserve::ssm_replay_row_bytes(
+                    config.ssm_qkvz_size(),
+                    config.linear_num_value_heads,
+                );
+                let ring = crate::ssm_reserve::ssm_replay_ring_bytes(1, row, ni, mtp_total);
+                replay_input_rings = alloc_layer_pools(gpu, num_ssm_layers, ring)?;
             }
+
+            // 1 checkpoint per slot per layer (BOTH modes: replay's
+            // reconstruction base is exactly this blob).
+            h_checkpoint_pools =
+                alloc_layer_pools(gpu, num_ssm_layers, mtp_total * h_stored_bytes)?;
+            conv_checkpoint_pools = alloc_layer_pools(gpu, num_ssm_layers, mtp_total * conv_bytes)?;
 
             let mtp_mb = num_ssm_layers
                 * (h_inter_total * h_stored_bytes
@@ -834,6 +856,65 @@ mod h_stored_geometry_tests {
             &gpu,
         )
         .unwrap()
+    }
+
+    /// Every pool family is ONE contiguous block with a uniform per-layer
+    /// stride. This is the enabling precondition for the batched verify-state
+    /// rollback (`model::ssm_batched_copy`): without it the 2 × num_ssm_layers
+    /// copy plan cannot collapse to two pitched 2-D transfers and the verify
+    /// path silently keeps its 96-launch-per-sequence loop. Pinned here
+    /// because nothing else would notice the regression — the addresses stay
+    /// correct, only the launch count changes.
+    #[test]
+    fn layer_pools_are_one_contiguous_block_per_family() {
+        let p = pool(false);
+        let families: [(&str, &[DevicePtr], usize); 6] = [
+            (
+                "h_state",
+                &p.h_state_pools,
+                (p.max_slots + 1) * p.h_stored_bytes,
+            ),
+            (
+                "conv_state",
+                &p.conv_state_pools,
+                (p.max_slots + 1) * p.conv_bytes,
+            ),
+            (
+                "h_intermediate",
+                &p.h_intermediate_pools,
+                *p.h_inter_offsets.last().unwrap() * p.h_stored_bytes,
+            ),
+            (
+                "conv_intermediate",
+                &p.conv_intermediate_pools,
+                (p.mtp_slots + 1) * p.num_intermediates * p.conv_bytes,
+            ),
+            (
+                "h_checkpoint",
+                &p.h_checkpoint_pools,
+                (p.mtp_slots + 1) * p.h_stored_bytes,
+            ),
+            (
+                "conv_checkpoint",
+                &p.conv_checkpoint_pools,
+                (p.mtp_slots + 1) * p.conv_bytes,
+            ),
+        ];
+        for (name, pools, stride) in families {
+            assert_eq!(
+                pools.len(),
+                p.num_ssm_layers,
+                "{name}: one region per layer"
+            );
+            assert!(stride > 0, "{name}: degenerate stride");
+            for (l, ptr) in pools.iter().enumerate() {
+                assert_eq!(
+                    ptr.0,
+                    pools[0].0 + (l * stride) as u64,
+                    "{name}: layer {l} is not at base + {l}*{stride}"
+                );
+            }
+        }
     }
 
     /// Replay-scaffold pool geometry: no per-token intermediates, checkpoints

--- a/crates/spark-model/src/model/trait_impl/async_chkpt.rs
+++ b/crates/spark-model/src/model/trait_impl/async_chkpt.rs
@@ -16,6 +16,7 @@ use super::super::block_mgmt::{
     apply_evicted_blocks, ensure_blocks_through_decode, ensure_blocks_through_prefill,
     extract_layer_refs, reuse_prefix_match_disk_ids,
 };
+use super::super::ssm_batched_copy::{StateCopy, run_ssm_state_copies};
 use super::super::ssm_pool::SsmStatePool;
 use super::super::ssm_snapshot::SsmSnapshotPool;
 use super::super::types::{PinnedMetaStaging, TransformerModel};
@@ -32,6 +33,8 @@ impl TransformerModel {
         use crate::layer::SsmLayerState;
 
         let stream = self.secondary_stream;
+        let mut h_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
+        let mut conv_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
         for (i, layer_state) in seq.layer_states.iter_mut().enumerate() {
             if self.config.layer_type(i) == LayerType::LinearAttention {
                 let ssm = layer_state
@@ -56,20 +59,19 @@ impl TransformerModel {
                     ssm.conv_state_checkpoint = Some(self.gpu.alloc(conv_bytes)?);
                 }
 
-                self.gpu.copy_d2d_async(
-                    ssm.h_state,
-                    ssm.h_state_checkpoint.unwrap(),
-                    h_bytes,
-                    stream,
-                )?;
-                self.gpu.copy_d2d_async(
-                    ssm.conv_state,
-                    ssm.conv_state_checkpoint.unwrap(),
-                    conv_bytes,
-                    stream,
-                )?;
+                h_plan.push(StateCopy {
+                    src: ssm.h_state,
+                    dst: ssm.h_state_checkpoint.unwrap(),
+                    bytes: h_bytes,
+                });
+                conv_plan.push(StateCopy {
+                    src: ssm.conv_state,
+                    dst: ssm.conv_state_checkpoint.unwrap(),
+                    bytes: conv_bytes,
+                });
             }
         }
+        run_ssm_state_copies(self.gpu.as_ref(), &h_plan, &conv_plan, stream)?;
         // Record event so default stream can wait (GPU-side, no CPU block).
         self.gpu.record_event(self.secondary_event, stream)?;
         Ok(())
@@ -84,6 +86,17 @@ impl TransformerModel {
 
         let stream = self.secondary_stream;
         let mut ssm_layer_idx = 0usize;
+        // Four plans in the ORIGINAL issue order: rollback h, rollback conv,
+        // then checkpoint h, checkpoint conv. The checkpoint reads the state
+        // the rollback just wrote, and both land on `stream` in that order,
+        // so the read-after-write is ordered exactly as the per-layer loop
+        // ordered it. Re-ordering ACROSS layers within one plan is sound:
+        // layer L's blobs are disjoint from layer M's.
+        let n_ssm = self.ssm_pool.num_ssm_layers;
+        let mut h_back = Vec::with_capacity(n_ssm);
+        let mut conv_back = Vec::with_capacity(n_ssm);
+        let mut h_ckpt = Vec::with_capacity(n_ssm);
+        let mut conv_ckpt = Vec::with_capacity(n_ssm);
 
         for (i, layer_state) in seq.layer_states.iter_mut().enumerate() {
             if self.config.layer_type(i) == LayerType::LinearAttention {
@@ -106,40 +119,58 @@ impl TransformerModel {
                 if num_accepted == 0 {
                     // No tokens accepted: restore from checkpoint (pre-verify state).
                     if let Some(ckpt) = ssm.h_state_checkpoint {
-                        self.gpu
-                            .copy_d2d_async(ckpt, ssm.h_state, h_bytes, stream)?;
+                        h_back.push(StateCopy {
+                            src: ckpt,
+                            dst: ssm.h_state,
+                            bytes: h_bytes,
+                        });
                     }
                     if let Some(ckpt) = ssm.conv_state_checkpoint {
-                        self.gpu
-                            .copy_d2d_async(ckpt, ssm.conv_state, conv_bytes, stream)?;
+                        conv_back.push(StateCopy {
+                            src: ckpt,
+                            dst: ssm.conv_state,
+                            bytes: conv_bytes,
+                        });
                     }
                 } else {
                     // Partial acceptance: restore from intermediate[num_accepted - 1].
                     let slot = seq.slot_idx;
                     let inter_idx = num_accepted - 1;
-                    let h_inter = self.ssm_pool.h_intermediate(ssm_layer_idx, slot, inter_idx);
-                    let conv_inter =
-                        self.ssm_pool
-                            .conv_intermediate(ssm_layer_idx, slot, inter_idx);
-                    self.gpu
-                        .copy_d2d_async(h_inter, ssm.h_state, h_bytes, stream)?;
-                    self.gpu
-                        .copy_d2d_async(conv_inter, ssm.conv_state, conv_bytes, stream)?;
+                    h_back.push(StateCopy {
+                        src: self.ssm_pool.h_intermediate(ssm_layer_idx, slot, inter_idx),
+                        dst: ssm.h_state,
+                        bytes: h_bytes,
+                    });
+                    conv_back.push(StateCopy {
+                        src: self
+                            .ssm_pool
+                            .conv_intermediate(ssm_layer_idx, slot, inter_idx),
+                        dst: ssm.conv_state,
+                        bytes: conv_bytes,
+                    });
                 }
 
                 // Checkpoint the (now rolled-back) state for the next verify.
                 if let Some(ckpt) = ssm.h_state_checkpoint {
-                    self.gpu
-                        .copy_d2d_async(ssm.h_state, ckpt, h_bytes, stream)?;
+                    h_ckpt.push(StateCopy {
+                        src: ssm.h_state,
+                        dst: ckpt,
+                        bytes: h_bytes,
+                    });
                 }
                 if let Some(ckpt) = ssm.conv_state_checkpoint {
-                    self.gpu
-                        .copy_d2d_async(ssm.conv_state, ckpt, conv_bytes, stream)?;
+                    conv_ckpt.push(StateCopy {
+                        src: ssm.conv_state,
+                        dst: ckpt,
+                        bytes: conv_bytes,
+                    });
                 }
 
                 ssm_layer_idx += 1;
             }
         }
+        run_ssm_state_copies(self.gpu.as_ref(), &h_back, &conv_back, stream)?;
+        run_ssm_state_copies(self.gpu.as_ref(), &h_ckpt, &conv_ckpt, stream)?;
         // Record event so default stream can wait (GPU-side, no CPU block).
         self.gpu.record_event(self.secondary_event, stream)?;
         Ok(())
@@ -252,6 +283,12 @@ impl TransformerModel {
 
         let stream = self.secondary_stream;
         let mut ssm_layer_idx = 0usize;
+        // Two plans, not one interleaved loop: h blobs and conv blobs have
+        // different widths, and a pitched 2-D copy carries ONE width. Both
+        // are built in ascending layer order — the same order, and the same
+        // (src, dst, bytes) triples, the per-layer loop issued.
+        let mut h_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
+        let mut conv_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
         for (i, layer_state) in seq.layer_states.iter_mut().enumerate() {
             if self.config.layer_type(i) != LayerType::LinearAttention {
                 continue;
@@ -273,17 +310,22 @@ impl TransformerModel {
             // intermediate (state after token `num_accepted-1`).
             let slot = seq.slot_idx;
             let inter_idx = num_accepted - 1;
-            let h_inter = self.ssm_pool.h_intermediate(ssm_layer_idx, slot, inter_idx);
-            let conv_inter = self
-                .ssm_pool
-                .conv_intermediate(ssm_layer_idx, slot, inter_idx);
-            self.gpu
-                .copy_d2d_async(h_inter, ssm.h_state, h_bytes, stream)?;
-            self.gpu
-                .copy_d2d_async(conv_inter, ssm.conv_state, conv_bytes, stream)?;
+            h_plan.push(StateCopy {
+                src: self.ssm_pool.h_intermediate(ssm_layer_idx, slot, inter_idx),
+                dst: ssm.h_state,
+                bytes: h_bytes,
+            });
+            conv_plan.push(StateCopy {
+                src: self
+                    .ssm_pool
+                    .conv_intermediate(ssm_layer_idx, slot, inter_idx),
+                dst: ssm.conv_state,
+                bytes: conv_bytes,
+            });
 
             ssm_layer_idx += 1;
         }
+        run_ssm_state_copies(self.gpu.as_ref(), &h_plan, &conv_plan, stream)?;
         self.gpu.record_event(self.secondary_event, stream)?;
         Ok(())
     }

--- a/crates/spark-model/src/model/trait_impl/verify_a.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_a.rs
@@ -16,6 +16,7 @@ use super::super::block_mgmt::{
     apply_evicted_blocks, ensure_blocks_through_decode, ensure_blocks_through_prefill,
     extract_layer_refs, reuse_prefix_match_disk_ids,
 };
+use super::super::ssm_batched_copy::{StateCopy, run_ssm_state_copies};
 use super::super::ssm_pool::SsmStatePool;
 use super::super::ssm_snapshot::SsmSnapshotPool;
 use super::super::types::{PinnedMetaStaging, TransformerModel};
@@ -270,6 +271,8 @@ impl TransformerModel {
         use crate::layer::SsmLayerState;
 
         let stream = self.gpu.default_stream();
+        let mut h_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
+        let mut conv_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
         for (i, layer_state) in seq.layer_states.iter_mut().enumerate() {
             if self.config.layer_type(i) == atlas_core::config::LayerType::LinearAttention {
                 let ssm = layer_state
@@ -300,20 +303,19 @@ impl TransformerModel {
                 }
 
                 // D2D copy: state → checkpoint
-                self.gpu.copy_d2d_async(
-                    ssm.h_state,
-                    ssm.h_state_checkpoint.unwrap(),
-                    h_bytes,
-                    stream,
-                )?;
-                self.gpu.copy_d2d_async(
-                    ssm.conv_state,
-                    ssm.conv_state_checkpoint.unwrap(),
-                    conv_bytes,
-                    stream,
-                )?;
+                h_plan.push(StateCopy {
+                    src: ssm.h_state,
+                    dst: ssm.h_state_checkpoint.unwrap(),
+                    bytes: h_bytes,
+                });
+                conv_plan.push(StateCopy {
+                    src: ssm.conv_state,
+                    dst: ssm.conv_state_checkpoint.unwrap(),
+                    bytes: conv_bytes,
+                });
             }
         }
+        run_ssm_state_copies(self.gpu.as_ref(), &h_plan, &conv_plan, stream)?;
         self.gpu.synchronize(stream)?;
         Ok(())
     }
@@ -357,6 +359,8 @@ impl TransformerModel {
         }
 
         let stream = self.gpu.default_stream();
+        let mut h_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
+        let mut conv_plan = Vec::with_capacity(self.ssm_pool.num_ssm_layers);
         for (i, layer_state) in seq.layer_states.iter_mut().enumerate() {
             if self.config.layer_type(i) == atlas_core::config::LayerType::LinearAttention {
                 let ssm = layer_state
@@ -377,28 +381,32 @@ impl TransformerModel {
                 if num_accepted == 0 {
                     // Restore to pre-verification checkpoint
                     if let Some(ckpt) = ssm.h_state_checkpoint {
-                        self.gpu
-                            .copy_d2d_async(ckpt, ssm.h_state, h_bytes, stream)?;
+                        h_plan.push(StateCopy {
+                            src: ckpt,
+                            dst: ssm.h_state,
+                            bytes: h_bytes,
+                        });
                     }
                     if let Some(ckpt) = ssm.conv_state_checkpoint {
-                        self.gpu
-                            .copy_d2d_async(ckpt, ssm.conv_state, conv_bytes, stream)?;
+                        conv_plan.push(StateCopy {
+                            src: ckpt,
+                            dst: ssm.conv_state,
+                            bytes: conv_bytes,
+                        });
                     }
                 } else if num_accepted <= ssm.h_state_intermediates.len() {
                     // Restore to intermediate checkpoint after the last accepted token
                     let idx = num_accepted - 1;
-                    self.gpu.copy_d2d_async(
-                        ssm.h_state_intermediates[idx],
-                        ssm.h_state,
-                        h_bytes,
-                        stream,
-                    )?;
-                    self.gpu.copy_d2d_async(
-                        ssm.conv_state_intermediates[idx],
-                        ssm.conv_state,
-                        conv_bytes,
-                        stream,
-                    )?;
+                    h_plan.push(StateCopy {
+                        src: ssm.h_state_intermediates[idx],
+                        dst: ssm.h_state,
+                        bytes: h_bytes,
+                    });
+                    conv_plan.push(StateCopy {
+                        src: ssm.conv_state_intermediates[idx],
+                        dst: ssm.conv_state,
+                        bytes: conv_bytes,
+                    });
                 } else {
                     // Unreachable: the pre-validation pass above already
                     // bailed for every `num_accepted > intermediates.len()`,
@@ -419,6 +427,11 @@ impl TransformerModel {
                 // and it would otherwise be swallowed by the branch above.
             }
         }
+        // Enqueued only after every layer validated AND planned — the
+        // pre-validation pass above already guarantees no bail can happen
+        // here, and building the plan first makes that structural rather
+        // than argued: a partially-rewound MIXED state is unrepresentable.
+        run_ssm_state_copies(self.gpu.as_ref(), &h_plan, &conv_plan, stream)?;
         // No synchronize needed: rollback copies and subsequent operations
         // are on the same CUDA stream, so ordering is guaranteed.
         Ok(())

--- a/crates/spark-runtime/src/gpu/mock.rs
+++ b/crates/spark-runtime/src/gpu/mock.rs
@@ -25,6 +25,15 @@ pub struct MockGpuBackend {
     syncs: AtomicUsize,
     d2h_blocking: AtomicUsize,
     d2h_async: AtomicUsize,
+    /// `copy_d2d`/`copy_d2d_async` calls — one eager launch each on the real
+    /// backend. The SSM verify rollback issued 2 per SSM layer per sequence
+    /// (96 on the 27B), so this counter is what proves a batched form
+    /// actually batched rather than merely looking different.
+    d2d: AtomicUsize,
+    /// `copy_d2d_2d_async` calls — ONE `cudaMemcpy2DAsync` each on the real
+    /// backend regardless of `height`. Counted apart from `d2d` so a test can
+    /// assert the SHAPE of the transfer, not just the bytes.
+    d2d_2d: AtomicUsize,
     host_pinned_allocs: AtomicUsize,
 }
 
@@ -51,6 +60,8 @@ impl MockGpuBackend {
             syncs: AtomicUsize::new(0),
             d2h_blocking: AtomicUsize::new(0),
             d2h_async: AtomicUsize::new(0),
+            d2d: AtomicUsize::new(0),
+            d2d_2d: AtomicUsize::new(0),
             host_pinned_allocs: AtomicUsize::new(0),
         }
     }
@@ -80,6 +91,18 @@ impl MockGpuBackend {
         self.d2h_async.load(Ordering::Relaxed)
     }
 
+    /// `copy_d2d` + `copy_d2d_async` calls so far — one eager launch each on
+    /// the real backend.
+    pub fn d2d_count(&self) -> usize {
+        self.d2d.load(Ordering::Relaxed)
+    }
+
+    /// `copy_d2d_2d_async` calls so far — one `cudaMemcpy2DAsync` each,
+    /// whatever the row count.
+    pub fn d2d_2d_count(&self) -> usize {
+        self.d2d_2d.load(Ordering::Relaxed)
+    }
+
     /// `alloc_host_pinned` calls — the tripwire for a staging buffer that is
     /// re-allocated per event instead of reused.
     pub fn host_pinned_alloc_count(&self) -> usize {
@@ -88,6 +111,36 @@ impl MockGpuBackend {
 
     pub fn read_alloc(&self, ptr: DevicePtr) -> Option<Vec<u8>> {
         self.allocs.lock().get(&ptr.0).map(|a| a.data.clone())
+    }
+
+    /// `bytes` from `src` to `dst` inside the simulated device memory.
+    ///
+    /// Real byte movement, not a no-op: a D2D that silently succeeds without
+    /// moving anything lets a test "pass" while asserting the destination is
+    /// still zero — the exact shape of a rollback bug this backend exists to
+    /// catch. Source is staged through a temporary so `src` and `dst` may sit
+    /// in the same allocation (the borrow checker would otherwise reject it,
+    /// and the real `cudaMemcpyAsync` accepts it for non-overlapping ranges).
+    fn blit(&self, src: DevicePtr, dst: DevicePtr, bytes: usize) -> Result<()> {
+        if bytes == 0 {
+            return Ok(());
+        }
+        let mut allocs = self.allocs.lock();
+        let staged = {
+            let (offset, alloc) = find_alloc(&allocs, src)
+                .ok_or_else(|| anyhow::anyhow!("copy_d2d: src {src} not allocated"))?;
+            if offset + bytes > alloc.bytes {
+                anyhow::bail!("copy_d2d: src {src} + {bytes} overruns its allocation");
+            }
+            alloc.data[offset..offset + bytes].to_vec()
+        };
+        let (offset, alloc) = find_alloc_mut(&mut allocs, dst)
+            .ok_or_else(|| anyhow::anyhow!("copy_d2d: dst {dst} not allocated"))?;
+        if offset + bytes > alloc.bytes {
+            anyhow::bail!("copy_d2d: dst {dst} + {bytes} overruns its allocation");
+        }
+        alloc.data[offset..offset + bytes].copy_from_slice(&staged);
+        Ok(())
     }
 
     /// Every launch recorded so far, in dispatch order. Lets a test assert
@@ -183,7 +236,53 @@ impl GpuBackend for MockGpuBackend {
         Ok(())
     }
 
-    fn copy_d2d(&self, _src: DevicePtr, _dst: DevicePtr, _bytes: usize) -> Result<()> {
+    fn copy_d2d(&self, src: DevicePtr, dst: DevicePtr, bytes: usize) -> Result<()> {
+        self.d2d.fetch_add(1, Ordering::Relaxed);
+        self.blit(src, dst, bytes)
+    }
+
+    fn copy_d2d_async(
+        &self,
+        src: DevicePtr,
+        dst: DevicePtr,
+        bytes: usize,
+        _stream: u64,
+    ) -> Result<()> {
+        // NOT delegating to `copy_d2d`: the trait default forwards, which
+        // would make the two indistinguishable to `d2d_count` consumers only
+        // by accident. Counted here so both forms land in one counter on
+        // purpose.
+        self.d2d.fetch_add(1, Ordering::Relaxed);
+        self.blit(src, dst, bytes)
+    }
+
+    fn copy_d2d_2d_async(
+        &self,
+        src: DevicePtr,
+        src_pitch: usize,
+        dst: DevicePtr,
+        dst_pitch: usize,
+        width_bytes: usize,
+        height: usize,
+        _stream: u64,
+    ) -> Result<()> {
+        // ONE launch on the real backend (`cudaMemcpy2DAsync`), so ONE tick —
+        // the row loop below is emulation, not dispatch, and must not inflate
+        // `d2d_count` (which exists to prove a batched form batched).
+        self.d2d_2d.fetch_add(1, Ordering::Relaxed);
+        if width_bytes > src_pitch || width_bytes > dst_pitch {
+            anyhow::bail!(
+                "copy_d2d_2d_async: width {width_bytes} exceeds pitch \
+                 (src {src_pitch}, dst {dst_pitch}) — rows would overlap"
+            );
+        }
+        for r in 0..height {
+            self.blit(
+                src.offset(r * src_pitch),
+                dst.offset(r * dst_pitch),
+                width_bytes,
+            )?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Batches the SSM verify-state rollback copies. Target for this PR is `test/ladder-stack`; **the eventual merge target is `main`, via the campaign branch.**

## Measured defect

Atlas's per-added-sequence decode cost is **4.28 ms/token/seq** against vLLM's **1.94 ms** on the same hybrid checkpoint (`unsloth/Qwen3.8-27B-NVFP4`, 48 GDN + 16 attention layers) — which is why Atlas loses the C=4 / C=8 / C=16 concurrency rungs (**81.4 vs 124.5 tok/s at C=8**).

A profiling pass named `rollback_ssm_states_dispatch` and its sibling `commit_accepted_prefix_dispatch` (`crates/spark-model/src/model/trait_impl/verify_a.rs`, `.../async_chkpt.rs`) as a top contributor: **2 eager `copy_d2d_async` per SSM layer per sequence = 96 launches per sequence per verify step** across 48 GDN layers, all *outside* any captured CUDA graph, moving ~102 MB of h-state + ~6 MB of conv state per sequence. At n=8 that is **768 eager launches per decode step**.

## Design chosen, and why

The brief's preferred option (a) was a kernel — one launch per layer, or one overall. On this tree that means a new `.cu` in `kernels/*/common`, an `[expected_absent]` declaration in every MODEL.toml whose hardware set lacks it, a PTX arity pin, and — decisively — **a kernel body that cannot be equivalence-tested on CPU**: `MockGpuBackend::launch` records `(func, grid, block)` and *discards the params*, and never executes anything. For the regression class that has its own dedicated gate, an untestable rewrite is the wrong trade.

The shape the copies actually have admits something better. The plan is a **column**: for each SSM layer, one blob at a fixed offset inside that layer's pool region. Make the per-layer pool regions uniformly strided and the whole column becomes a **single pitched 2-D copy** — for which `GpuBackend` already carries a primitive the CUDA backend implements as one `cudaMemcpy2DAsync`:

```rust
fn copy_d2d_2d_async(&self, src, src_pitch, dst, dst_pitch, width_bytes, height, stream)
```

added for exactly this reason on the per-token Z-copy loop. So:

1. **`SsmStatePool::new` allocates each family as one contiguous block** (`alloc_layer_pools`), handing out `base + l * bytes`. Same total bytes (strictly *less* rounding waste — one cudaMalloc granularity round-up instead of 48), same accessor arithmetic, and no pool is ever freed per-layer anywhere in the tree.
2. **`model::ssm_batched_copy`** turns each dispatch's per-layer loop into a `Vec<StateCopy>` plan and issues it as one pitched 2-D transfer when `copy_plan_as_strided_run` can reproduce it row-for-row.

No kernel, no PTX, no per-target build surface, and it works unchanged on Metal/HIP — their default row loop *is* the old behaviour.

**Options rejected:**

| option | why not |
|---|---|
| (a) descriptor kernel | new `.cu` × build surface across 30 targets + arity pin; and the kernel body is unreachable from any CPU test, so the equivalence argument would rest on inspection alone |
| (b) group sequences by equal `num_accepted` | leaves launches proportional to `num_ssm_layers` (48 per group per step) and needs the verdict loop restructured to see all sequences at once |
| (c) fold into the captured verify graph | keys the graph on `(slot, num_accepted)` → up to `max_slots × K` instantiations; untestable on any backend whose `end_capture` returns a null handle, i.e. everything but CUDA |

## Launch arithmetic

48 GDN layers, *n* = sequences taking a partial accept in the step:

| | launches / sequence / step | as a function of n | n=8 |
|---|---|---|---|
| **before** | 2 × 48 = **96** | **96n** | **768** |
| **after** | **2** | **2n** | **16** |

A **48× reduction, independent of n.** The remaining 2 is irreducible with a 2-D primitive: h blobs and conv blobs have different widths, so each needs its own run; collapsing the third (layer × sequence) axis would need a 3-D copy.

Note this removes the *launch* half of the cost only. The ~102 MB of h-state per sequence is still moved, and at 273 GB/s that read+write is ~0.75 ms/seq of genuine bandwidth. The two halves were comparable in size, so expect roughly half of this path to disappear, not all of it.

## Correctness argument

The bytes are identical, by construction:

- **The plan is the SSOT.** Both executors consume the same `Vec<StateCopy>` (`{src, dst, bytes}`), so the batched and looped forms cannot drift in which bytes land where.
- **`copy_plan_as_strided_run` collapses a plan only when it can reproduce it row-for-row**: one shared `width_bytes`; one *forward* `src_pitch` and `dst_pitch` derived from the first pair and then verified against **every** consecutive pair; `pitch >= width_bytes` on both sides so rows cannot overlap. `checked_sub` rejects a descending family outright (no 2-D representation).
- `cudaMemcpy2DAsync` writes row *r* as `width_bytes` from `src + r*src_pitch` to `dst + r*dst_pitch` — row *r* of the plan. `the_collapsed_run_reproduces_the_plan_row_for_row` asserts that expansion identity directly.
- **Anything that does not collapse runs the original loop verbatim**: a fragmented pool (the `alloc_layer_pools` fallback), a ragged plan, a single-layer model, a descending family.
- **The one behavioural difference is order**: the h family is issued as a block before the conv family instead of interleaved per layer. Sound because the two families address *disjoint* pool allocations. Inside `start_rollback_and_checkpoint_async` the four plans are still issued rollback-before-checkpoint on one stream, preserving both the read-after-write on `h_state` and the read-before-write on the checkpoint blob.
- **`rollback_ssm_states` gets a structural improvement**: copies are now enqueued only after every layer has been validated *and* planned, so the "MIXED state" hazard its pre-validation pass was written to argue away is no longer representable.

### Tests (all CPU, all on the mock backend)

`MockGpuBackend::copy_d2d` was a **hard no-op** returning `Ok(())` — a test could read a destination after a rollback, see zeros, and be written to "pass" against that. It now moves the bytes for real, and counts `d2d` / `d2d_2d` separately (same rationale as the existing `d2h_blocking` / `d2h_async` counters: bytes being right says nothing about the *shape* of a transfer). Test-only crate surface.

| test | pins |
|---|---|
| `commit_is_byte_identical_at_every_accepted_depth` | every depth `1..=k`, byte-for-byte over the whole live state |
| `full_reject_restore_is_byte_identical` | `num_accepted == 0`, whose source is the checkpoint family with a *different* stride |
| `every_slot_rolls_back_to_its_own_state` | slot addressing on the **tiered** h-intermediate layout, where slot *s*'s rows are not at `s*k` |
| `single_ssm_layer_still_copies_the_right_bytes` | the degenerate one-row plan falls through to a plain d2d |
| `batching_collapses_the_layer_loop_to_one_launch` | 2 launches vs 2×36, plus the kill switch restoring 2×36 |
| `a_plan_that_a_2d_copy_cannot_reproduce_is_refused` | ragged width, relocated src row, relocated dst row, descending family, pitch < width, empty, zero-width |
| `layer_pools_are_one_contiguous_block_per_family` | the enabling stride, across all six families — nothing else would notice it regressing, since addresses stay correct and only the launch count changes |

Each equivalence test additionally asserts the batched run **actually collapsed** (`0 d2d, 2 d2d_2d`) and that the live state **actually changed**, so neither half can pass vacuously.

## Kill switch

`ATLAS_NO_BATCHED_SSM_ROLLBACK=1` restores the per-layer `copy_d2d_async` loop everywhere — presence check per the house convention (`=0` is *not* off), read once per process. The decision is threaded as a parameter into `run_state_copies_with`, so both polarities are tested without touching process env or the latching `OnceLock`.

## n=1 is untouched

The n=1 decode program (`decode_a2.rs:65`, `verify_k4_step.rs`) is a separate path and is currently the fastest rung. **Nothing here changes its dispatch** — only the number of launches its state copies take, with the same bytes into the same slots. The C=1 floor below is the guard.

## Validation plan (GPU — none of this ran here; this was a CPU-only change)

**1. C=1..128 ladder, fp8-KV, no-regression floors:**

| C | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 |
|---|---|---|---|---|---|---|---|---|
| floor (tok/s) | 21.74 | 29.04 | 51.55 | 81.42 | 150.41 | 219.97 | 360.02 | 450.12 |

Expect the gain concentrated at **C=4/8/16**, where the launch count scaled with n and the acceptance rate makes partial accepts common. C=1 must not move (it is the floor this PR must not pay for); C=64/128 will move least, since spec dispatch is clamped to `mtp_state_slots` there.

**2. `ssm-state-poisoning-gate`** — the mandatory gate for this regression class. Must be clean. This is the one that would catch a wrong-row 2-D copy in a way the CPU tests cannot (they pin addresses and byte movement; only the GPU pins the real `cudaMemcpy2DAsync`).

**3. decode-floor gate.**

**4. Boot check on a target with the batched form active:** confirm the `SSM pool: … did not fit one contiguous block` warning is **absent** in the serve log. If it fires, the pool fell back to per-layer allocations and this PR is inert on that box — the tok/s would be unchanged and the result would be a false negative, not a regression.

**5. A/B the kill switch on one rung** (`ATLAS_NO_BATCHED_SSM_ROLLBACK=1` vs unset, same box, same seed) to attribute the delta to this change rather than to run-to-run noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
