### PR TITLE
perf(ssm): make the fp16-SIZED SSM h pool serveable — prefill narrows through an FP32 staging blob

### DIFF
--- a/crates/spark-model/src/layer.rs
+++ b/crates/spark-model/src/layer.rs
@@ -60,16 +60,35 @@ pub struct SsmLayerState {
     pub h_state_intermediates: Vec<DevicePtr>,
     /// Intermediate conv_state snapshots during batched verification.
     pub conv_state_intermediates: Vec<DevicePtr>,
-    /// Storage dtype of `h_state`: `false` = FP32 (the only format prefill
-    /// ever writes), `true` = FP16 packed into the first half of the same
-    /// FP32-sized pool region (`ATLAS_SSM_H_FP16`).
+    /// Storage dtype of `h_state`: `false` = FP32, `true` = FP16
+    /// (`--ssm-h-dtype f16`).
     ///
-    /// This is the single source of truth for the h-state format. The decode
-    /// mixer flips it exactly once per sequence, on the first decode step
-    /// after any FP32 writer touched the slot, so no caller has to know where
-    /// the prefill->decode edge is. It rides through swap-out/swap-in because
-    /// `state_io` mutates these states in place rather than rebuilding them.
+    /// This is the single source of truth for the h-state format. Which edge
+    /// sets it depends on the POOL width:
+    ///
+    /// * FP32-sized pool (stage 1/2, `h_prefill_stage == None`): prefill is
+    ///   the only FP32 writer and writes the slot in place, so the flag
+    ///   starts `false` and the decode mixer
+    ///   (`TransformerModel::ssm_h_to_f16_dispatch`) flips it exactly once
+    ///   per sequence, on the first decode step. No caller has to know where
+    ///   the prefill->decode edge is.
+    /// * f16-SIZED pool (stage 3, `h_prefill_stage == Some`): the slot is
+    ///   physically 2 bytes/element and can NEVER hold FP32, so the flag is
+    ///   `true` from allocation onwards and the decode mixer is a no-op.
+    ///   Prefill's FP32 kernels run over [`Self::h_prefill_stage`] instead.
+    ///
+    /// It rides through swap-out/swap-in because `state_io` mutates these
+    /// states in place rather than rebuilding them.
     pub h_is_f16: bool,
+    /// Stage-3 f16-SIZED pool ONLY (`--ssm-h-dtype f16-pool`): the FP32
+    /// staging blob for THIS sequence's slot, which the GDN prefill widens
+    /// `h_state` into before its FP32 kernels run and narrows back after.
+    ///
+    /// `None` — every configuration before stage 3 — means "the slot IS
+    /// FP32-wide": prefill writes `h_state` in place exactly as it always
+    /// has, and not one byte moves. The same blob is shared by every layer
+    /// of the sequence (see `SsmStatePool::h_prefill_stage`).
+    pub h_prefill_stage: Option<DevicePtr>,
 }
 
 impl LayerState for SsmLayerState {

--- a/crates/spark-model/src/layer/tests.rs
+++ b/crates/spark-model/src/layer/tests.rs
@@ -19,6 +19,7 @@ fn test_ssm_layer_state_downcast() {
         h_state_intermediates: Vec::new(),
         conv_state_intermediates: Vec::new(),
         h_is_f16: false,
+        h_prefill_stage: None,
     });
     let ssm = state.as_any().downcast_ref::<SsmLayerState>().unwrap();
     assert_eq!(ssm.h_state.0, 0x1000);
@@ -35,6 +36,7 @@ fn test_ssm_layer_state_mut() {
         h_state_intermediates: Vec::new(),
         conv_state_intermediates: Vec::new(),
         h_is_f16: false,
+        h_prefill_stage: None,
     });
     let ssm = state.as_any_mut().downcast_mut::<SsmLayerState>().unwrap();
     ssm.h_state = DevicePtr(0x3000);

--- a/crates/spark-model/src/layers/nemotron_mamba2/trait_impl.rs
+++ b/crates/spark-model/src/layers/nemotron_mamba2/trait_impl.rs
@@ -227,6 +227,9 @@ impl TransformerLayer for NemotronMamba2Layer {
             h_state_intermediates: Vec::new(),
             conv_state_intermediates: Vec::new(),
             h_is_f16: false,
+            // Stage-3 narrowing is GDN-only (`ssm_h_fp16_preconditions`
+            // refuses a non-GDN SSM stack), so this state is always FP32-wide.
+            h_prefill_stage: None,
         }))
     }
 }

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -121,11 +121,32 @@ pub fn ssm_h_fp16_enabled() -> bool {
     flags().h_f16
 }
 
-/// Stage 3 of the f16 h-state: h pools SIZED at 2 bytes/element. Today this
-/// can only be true in unit tests — no CLI surface publishes it, and
-/// `ssm_h_fp16_preconditions` refuses it until prefill narrowing lands.
+/// Stage 3 of the f16 h-state: h pools SIZED at 2 bytes/element
+/// (`--ssm-h-dtype f16-pool`). Implies [`ssm_h_fp16_enabled`] — a narrow
+/// pool holding FP32 would be an OOB write, not a mode — which
+/// [`ssm_h_dtype_bits`] guarantees at the one place the value is decoded.
 pub fn ssm_h_f16_pool_enabled() -> bool {
     flags().h_f16_pool
+}
+
+/// SSOT decode of `--ssm-h-dtype` into the two h-state bits it publishes:
+/// `(h_f16, h_f16_pool)`.
+///
+/// Both the CLI validator (which rejects the pairs the mode cannot serve)
+/// and `publish_kernel_flags` (which publishes the cell the kernels
+/// dispatch on) go through THIS, so a validator that accepted one reading
+/// while the kernels took another is not expressible. Anything that is not
+/// exactly `f16` or `f16-pool` — including `f32` and an absent flag — is
+/// FP32; `check_enum` has already rejected unknown spellings by the time
+/// this runs, and defaulting an unknown one to FP32 here is the safe arm
+/// besides.
+pub fn ssm_h_dtype_bits(dtype: Option<&str>) -> (bool, bool) {
+    match dtype {
+        Some("f16") => (true, false),
+        // f16-pool is f16 PLUS the narrow pool: never one without the other.
+        Some("f16-pool") => (true, true),
+        _ => (false, false),
+    }
 }
 
 /// `--gdn-fused-norm` (legacy `ATLAS_GDN_FUSED_NORM=1`).
@@ -148,7 +169,7 @@ pub fn verify_exact_enabled() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::GdnFlags;
+    use super::{GdnFlags, ssm_h_dtype_bits};
 
     const BASE: GdnFlags = GdnFlags {
         h_f16: false,
@@ -211,7 +232,37 @@ mod tests {
     fn env_fallback_never_enables_exact_verify() {
         assert!(!GdnFlags::from_env().exact_verify);
         // Same rule for the stage-3 pool sizing: no env variable feeds it.
+        // `--ssm-h-dtype f16-pool` is the ONLY way to publish it, so a
+        // legacy `ATLAS_SSM_H_FP16=1` script keeps the FP32-sized pool.
         assert!(!GdnFlags::from_env().h_f16_pool);
+    }
+
+    /// A narrow pool holding FP32 is an out-of-bounds write, not a mode, so
+    /// `h_f16_pool` without `h_f16` must not be expressible from any input.
+    /// This is the ONE decode both the validator and the publisher use, so
+    /// pinning it here pins it for both.
+    #[test]
+    fn the_pool_bit_is_never_set_without_the_dtype_bit() {
+        for spelling in [
+            None,
+            Some("f32"),
+            Some("f16"),
+            Some("f16-pool"),
+            Some(""),
+            Some("F16-POOL"),
+            Some("f16 "),
+        ] {
+            let (h_f16, h_f16_pool) = ssm_h_dtype_bits(spelling);
+            assert!(
+                h_f16 || !h_f16_pool,
+                "{spelling:?} produced a narrow pool with an FP32 h-state"
+            );
+        }
+        assert_eq!(ssm_h_dtype_bits(Some("f16-pool")), (true, true));
+        // Case and whitespace are NOT accepted spellings — `check_enum`
+        // rejects them upstream, and defaulting them to FP32 here is the
+        // safe arm if it ever did not.
+        assert_eq!(ssm_h_dtype_bits(Some("F16-POOL")), (false, false));
     }
 
     /// NEGATIVE: an FP16 h-state forces non-exact EVEN WHEN exact was

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -143,6 +143,16 @@ impl Qwen3SsmLayer {
                 "gated_delta_rule",
                 "gated_delta_rule_decode_f16_norm",
             ),
+            ssm_h_f16_to_f32_k: super::super::try_kernel(
+                gpu,
+                "ssm_h_dtype",
+                "ssm_h_state_f16_to_f32",
+            ),
+            ssm_h_f32_to_f16_k: super::super::try_kernel(
+                gpu,
+                "ssm_h_dtype",
+                "ssm_h_state_f32_to_f16",
+            ),
             ba_gates_k: gpu.kernel("ssm_preprocess", "dense_gemv_ba_gates")?,
             residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
             l2_norm_k: gpu.kernel("norm", "l2_norm_bf16")?,

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -245,6 +245,16 @@ pub struct Qwen3SsmLayer {
     gdn_wy3_f16_k: KernelHandle,
     gdn_wy3_resident_f16_k: KernelHandle,
     gdn_wy4_f16_k: KernelHandle,
+    /// Stage-3 f16-SIZED pool (`--ssm-h-dtype f16-pool`): the two h-state
+    /// width converters (`ssm_h_dtype.cu`). PREFILL uses them as a matched
+    /// pair around its FP32 kernels — widen the narrow slot into the
+    /// sequence's FP32 staging blob, run, narrow back — so unlike the
+    /// decode-side one-shot conversion these launch once per SSM layer per
+    /// prefill pass and are self-cancelling. A 0 handle is a hard error at
+    /// the first prefill, never an FP32 fallback: an FP32 kernel writing a
+    /// 2-byte-sized slot is an OOB write into the neighbouring slot.
+    ssm_h_f16_to_f32_k: KernelHandle,
+    ssm_h_f32_to_f16_k: KernelHandle,
     /// STAGE 1 fused K=2 MTP-verify epilogue: conv1d+L2norm ×2 and
     /// gated-RMS-norm ×2 each folded into a single launch. Dispatched only
     /// when the `ATLAS_GDN_FUSED_VERIFY` env flag is set (default OFF); the
@@ -464,8 +474,8 @@ mod trait_prefill_proj;
 mod trait_prefill_recur;
 
 pub use gdn_flags::{
-    GdnFlags, gdn_fused_norm_enabled, ssm_batched_recurrent_enabled, ssm_h_f16_pool_enabled,
-    ssm_h_fp16_enabled, verify_exact_enabled,
+    GdnFlags, gdn_fused_norm_enabled, ssm_batched_recurrent_enabled, ssm_h_dtype_bits,
+    ssm_h_f16_pool_enabled, ssm_h_fp16_enabled, verify_exact_enabled,
 };
 
 // ── TransformerLayer impl (delegates to per-file inherent _inner methods) ──

--- a/crates/spark-model/src/layers/qwen3_ssm/ssm_h_fp16.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/ssm_h_fp16.rs
@@ -37,8 +37,10 @@
 //! the restore path — always into a prefill — untouched.
 
 use anyhow::{Result, bail};
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 
-use crate::layer::SsmLayerState;
+use super::Qwen3SsmLayer;
+use crate::layer::{ForwardContext, SsmLayerState};
 
 /// Refuse to run an FP16 decode kernel over a state that was never converted.
 ///
@@ -54,4 +56,333 @@ pub(super) fn require_h_f16(state: &SsmLayerState) -> Result<()> {
         );
     }
     Ok(())
+}
+
+// ── Stage 3: the f16-SIZED pool ────────────────────────────────────────────
+//
+// Stage 1/2 above keep the pool FP32-sized because prefill writes the running
+// h-state FP32 IN PLACE through six GDN kernel families. Stage 3
+// (`--ssm-h-dtype f16-pool`) halves the pool instead, and pays for it with a
+// per-slot FP32 STAGING blob (`SsmStatePool::h_prefill_stage`) that prefill
+// runs over:
+//
+//   widen (f16 slot -> FP32 stage) -> the unchanged FP32 kernels -> narrow
+//   (FP32 stage -> f16 slot)
+//
+// so not one prefill kernel changes and the pool holds FP16 at every moment
+// OUTSIDE a layer's prefill call. That last property is the whole invariant:
+// `SsmLayerState::h_is_f16` is then simply `true` for a sequence's entire
+// life, the decode mixer is a no-op, snapshot save always widens, snapshot
+// restore always narrows, and slot zeroing is format-agnostic.
+//
+// ★ Unlike the decode conversion, this pair is SAFE to launch from inside the
+// layer: it is issued once per prefill call and is self-cancelling, so a
+// replay would re-widen the current slot rather than re-narrow an already
+// narrow one. Prefill is not CUDA-graph captured; if it ever is, this pair
+// captures correctly because both halves are inside the captured region.
+//
+// The cost is 1.5 extra DRAM passes over one layer's h per prefill pass
+// (widen reads 2 bytes/elem and writes 4, narrow the reverse): ~3.1 MB per
+// layer per pass on the 27B GDN shape, ~150 MB per 48-layer pass — a few
+// percent of a chunk's prefill time, against halving the per-step per-
+// sequence decode state traffic that dominates concurrency.
+
+/// A prefill pass's h-state pointer, plus what has to happen when it is done.
+///
+/// `Narrowed` carries BOTH ends so [`prefill_h_end`] cannot be handed a
+/// mismatched pair, and so the caller never has to re-derive which pointer
+/// the kernels actually ran over.
+#[derive(Debug)]
+pub(super) enum PrefillH {
+    /// FP32-sized pool: the kernels ran over the slot itself and there is
+    /// nothing to do. Every configuration before stage 3 takes this arm, and
+    /// it moves zero bytes.
+    InPlace(DevicePtr),
+    /// f16-SIZED pool: the kernels ran over `stage`, which must be narrowed
+    /// back into `slot`.
+    Staged { slot: DevicePtr, stage: DevicePtr },
+}
+
+impl PrefillH {
+    /// The pointer the FP32 prefill kernels must be given.
+    pub(super) fn ptr(&self) -> DevicePtr {
+        match self {
+            Self::InPlace(p) => *p,
+            Self::Staged { stage, .. } => *stage,
+        }
+    }
+}
+
+/// Widen this sequence's h slot into its FP32 staging blob, if the pool is
+/// f16-SIZED. Returns the pointer the prefill kernels must run over.
+///
+/// `h_f32_bytes` is the FP32 width of one layer's h blob — the ELEMENT-count
+/// authority (`n = h_f32_bytes / 4`), never a duplicated shape literal.
+pub(super) fn prefill_h_begin(
+    gpu: &dyn GpuBackend,
+    f16_to_f32_k: KernelHandle,
+    state: &SsmLayerState,
+    h_f32_bytes: usize,
+    stream: u64,
+) -> Result<PrefillH> {
+    let Some(stage) = state.h_prefill_stage else {
+        return Ok(PrefillH::InPlace(state.h_state));
+    };
+    if !state.h_is_f16 {
+        bail!(
+            "--ssm-h-dtype f16-pool: prefill reached an SSM layer whose h-state is flagged FP32 \
+             over a 2-byte-sized pool slot. The slot cannot physically hold FP32; \
+             `h_is_f16` must be set at slot allocation under the f16-sized pool."
+        );
+    }
+    if f16_to_f32_k.0 == 0 {
+        bail!(
+            "--ssm-h-dtype f16-pool: ssm_h_dtype::ssm_h_state_f16_to_f32 did not resolve on this \
+             target — refusing to run the FP32 GDN prefill kernels over a 2-byte-sized pool slot \
+             (that is an out-of-bounds write into the neighbouring slot, not a precision loss)."
+        );
+    }
+    crate::layers::ops::ssm_h_state_f16_to_f32(
+        gpu,
+        f16_to_f32_k,
+        state.h_state,
+        stage,
+        (h_f32_bytes / 4) as u64,
+        stream,
+    )?;
+    Ok(PrefillH::Staged {
+        slot: state.h_state,
+        stage,
+    })
+}
+
+/// Narrow the FP32 staging blob back into the h slot. No-op on the
+/// FP32-sized pool.
+///
+/// ★ MUST run on the SAME stream as the prefill kernels — it is ordered
+/// against them by stream order alone, and the staging blob is reused by the
+/// next layer of the same pass.
+pub(super) fn prefill_h_end(
+    gpu: &dyn GpuBackend,
+    f32_to_f16_k: KernelHandle,
+    h: PrefillH,
+    h_f32_bytes: usize,
+    stream: u64,
+) -> Result<()> {
+    let PrefillH::Staged { slot, stage } = h else {
+        return Ok(());
+    };
+    if f32_to_f16_k.0 == 0 {
+        bail!(
+            "--ssm-h-dtype f16-pool: ssm_h_dtype::ssm_h_state_f32_to_f16 did not resolve on this \
+             target — the prefill h-state cannot be narrowed back into its 2-byte-sized slot."
+        );
+    }
+    crate::layers::ops::ssm_h_state_f32_to_f16(
+        gpu,
+        f32_to_f16_k,
+        stage,
+        slot,
+        (h_f32_bytes / 4) as u64,
+        stream,
+    )
+}
+
+impl Qwen3SsmLayer {
+    /// The h pool's per-SLOT byte pitch — `h_state_bytes` on an FP32-sized
+    /// pool, half that under the stage-3 f16-SIZED pool.
+    ///
+    /// SSOT with `SsmStatePool::h_stored_bytes` through
+    /// [`crate::ssm_reserve::ssm_h_stored_bytes`], which is the point: the
+    /// layer's contiguity checks and strided-kernel arguments and the
+    /// allocator cannot disagree about how far apart two slots are.
+    pub(super) fn h_slot_stride_bytes(&self) -> usize {
+        crate::ssm_reserve::ssm_h_stored_bytes(
+            self.h_state_bytes,
+            super::gdn_flags::ssm_h_f16_pool_enabled(),
+        )
+    }
+
+    /// [`Self::prefill_gdn_recurrence`] with the stage-3 h-state width
+    /// conversion wrapped around it (`--ssm-h-dtype f16-pool`).
+    ///
+    /// On an FP32-sized pool (`h_prefill_stage == None` — every config before
+    /// stage 3) this is EXACTLY `prefill_gdn_recurrence(ssm_state.h_state,
+    /// ..)`: `prefill_h_begin` returns the slot pointer unchanged and
+    /// `prefill_h_end` moves nothing. On the f16-SIZED pool it widens the
+    /// 2-byte slot into the sequence's FP32 staging blob, runs the unchanged
+    /// FP32 recurrence over that, and narrows the result back.
+    ///
+    /// ★ On a FAILED recurrence the narrowing is SKIPPED, which leaves the
+    /// slot holding its pre-pass f16 value rather than a partially written
+    /// one. That is the whole reason the staging blob is separate memory:
+    /// under an FP32-sized pool a failed prefill scribbles the slot itself
+    /// and a later snapshot save would cache the scribble.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn prefill_gdn_recurrence_staged(
+        &self,
+        ssm_state: &SsmLayerState,
+        q_ptr: DevicePtr,
+        k_ptr: DevicePtr,
+        v_ptr: DevicePtr,
+        gates_buf: DevicePtr,
+        gdn_out_buf: DevicePtr,
+        k: u32,
+        nk: usize,
+        nv: usize,
+        kd: usize,
+        vd: usize,
+        conv_dim: usize,
+        midcap_idx: Option<usize>,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
+        let h = prefill_h_begin(
+            ctx.gpu,
+            self.ssm_h_f16_to_f32_k,
+            ssm_state,
+            self.h_state_bytes,
+            stream,
+        )?;
+        self.prefill_gdn_recurrence(
+            h.ptr(),
+            q_ptr,
+            k_ptr,
+            v_ptr,
+            gates_buf,
+            gdn_out_buf,
+            k,
+            nk,
+            nv,
+            kd,
+            vd,
+            conv_dim,
+            midcap_idx,
+            ctx,
+            stream,
+        )?;
+        prefill_h_end(
+            ctx.gpu,
+            self.ssm_h_f32_to_f16_k,
+            h,
+            self.h_state_bytes,
+            stream,
+        )
+    }
+}
+
+#[cfg(test)]
+mod prefill_narrowing_tests {
+    use super::*;
+    use spark_runtime::gpu::mock::MockGpuBackend;
+
+    /// One layer's h blob at the 27B GDN shape (48 v-heads × 128 × 128 FP32).
+    const H_F32: usize = 48 * 128 * 128 * 4;
+    const K: KernelHandle = KernelHandle(0xDEAD);
+
+    fn state(stage: Option<DevicePtr>, h_is_f16: bool) -> SsmLayerState {
+        SsmLayerState {
+            h_state: DevicePtr(0x1000),
+            conv_state: DevicePtr(0x2000),
+            h_state_checkpoint: None,
+            conv_state_checkpoint: None,
+            h_state_intermediates: Vec::new(),
+            conv_state_intermediates: Vec::new(),
+            h_is_f16,
+            h_prefill_stage: stage,
+        }
+    }
+
+    /// FLAG OFF is byte-identical: the prefill kernels are handed the slot
+    /// itself and NOT ONE conversion is launched, at either end. This is the
+    /// assertion that protects every currently-serveable config from this
+    /// change — a stray unconditional widen would show up here as a launch.
+    #[test]
+    fn fp32_sized_pool_launches_nothing_and_hands_back_the_slot() {
+        let gpu = MockGpuBackend::new();
+        let st = state(None, false);
+        let h = prefill_h_begin(&gpu, K, &st, H_F32, 0).unwrap();
+        assert_eq!(h.ptr().0, st.h_state.0);
+        assert!(matches!(h, PrefillH::InPlace(_)));
+        prefill_h_end(&gpu, K, h, H_F32, 0).unwrap();
+        assert!(
+            gpu.launches_snapshot().is_empty(),
+            "the FP32-sized pool must not launch a conversion"
+        );
+        // ...and a NULL converter handle is not even consulted, so a target
+        // without `ssm_h_dtype.cu` still serves the default mode.
+        let gpu2 = MockGpuBackend::new();
+        let st2 = state(None, false);
+        let h2 = prefill_h_begin(&gpu2, KernelHandle(0), &st2, H_F32, 0).unwrap();
+        prefill_h_end(&gpu2, KernelHandle(0), h2, H_F32, 0).unwrap();
+        assert!(gpu2.launches_snapshot().is_empty());
+    }
+
+    /// Stage 3: exactly ONE widen on the way in and ONE narrow on the way
+    /// out, the kernels run over the STAGING blob, and both launches carry
+    /// the FP32 element count (`h_bytes / 4`) — not the byte count, and not
+    /// the halved storage width.
+    #[test]
+    fn f16_sized_pool_widens_in_and_narrows_out_over_the_stage() {
+        let gpu = MockGpuBackend::new();
+        let stage = DevicePtr(0x9000);
+        let st = state(Some(stage), true);
+
+        let h = prefill_h_begin(&gpu, K, &st, H_F32, 0).unwrap();
+        assert_eq!(h.ptr().0, stage.0, "the kernels must run over the stage");
+        assert!(matches!(
+            h,
+            PrefillH::Staged { slot, stage: s } if slot.0 == st.h_state.0 && s.0 == stage.0
+        ));
+        let after_begin = gpu.launches_snapshot();
+        assert_eq!(after_begin.len(), 1, "one widen");
+
+        prefill_h_end(&gpu, K, h, H_F32, 0).unwrap();
+        let all = gpu.launches_snapshot();
+        assert_eq!(all.len(), 2, "one widen + one narrow, no more");
+
+        // Geometry: BLOCK 256 over `n = h_bytes / 4` FP32 elements, capped at
+        // 4096 blocks (grid-stride). Both halves convert the SAME element
+        // count — a widen sized off the storage width would halve this.
+        let n = (H_F32 / 4) as u32;
+        assert_eq!(n, 786_432);
+        for l in &all {
+            assert_eq!(l.block, [256, 1, 1]);
+            assert_eq!(l.grid, [n.div_ceil(256).clamp(1, 4096), 1, 1]);
+        }
+    }
+
+    /// A missing converter is a HARD ERROR at both ends, never a silent
+    /// pass-through: pointing an FP32 prefill kernel at a 2-byte-sized slot
+    /// is an out-of-bounds write into the neighbouring sequence, which no
+    /// later check can detect.
+    #[test]
+    fn a_null_converter_refuses_rather_than_running_fp32_over_a_narrow_slot() {
+        let gpu = MockGpuBackend::new();
+        let st = state(Some(DevicePtr(0x9000)), true);
+        let e = prefill_h_begin(&gpu, KernelHandle(0), &st, H_F32, 0).unwrap_err();
+        assert!(e.to_string().contains("ssm_h_state_f16_to_f32"), "{e}");
+        assert!(e.to_string().contains("out-of-bounds"), "{e}");
+        assert!(gpu.launches_snapshot().is_empty());
+
+        let staged = PrefillH::Staged {
+            slot: DevicePtr(0x1000),
+            stage: DevicePtr(0x9000),
+        };
+        let e2 = prefill_h_end(&gpu, KernelHandle(0), staged, H_F32, 0).unwrap_err();
+        assert!(e2.to_string().contains("ssm_h_state_f32_to_f16"), "{e2}");
+    }
+
+    /// The invariant "a staged slot is ALWAYS f16" is checked, not assumed.
+    /// An FP32-flagged state over a narrowed slot means the slot never got
+    /// the f16 tag at allocation, and widening it would read 2x the bytes
+    /// the slot owns.
+    #[test]
+    fn an_fp32_flagged_state_over_a_narrow_slot_is_refused() {
+        let gpu = MockGpuBackend::new();
+        let st = state(Some(DevicePtr(0x9000)), false);
+        let e = prefill_h_begin(&gpu, K, &st, H_F32, 0).unwrap_err();
+        assert!(e.to_string().contains("flagged FP32"), "{e}");
+        assert!(gpu.launches_snapshot().is_empty());
+    }
 }

--- a/crates/spark-model/src/layers/qwen3_ssm/tests.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/tests.rs
@@ -120,6 +120,7 @@ fn mk_state(gpu: &MockGpuBackend, layer: &Qwen3SsmLayer, n_inter: usize) -> SsmL
             .map(|i| conv_slab.offset(i * conv_bytes))
             .collect(),
         h_is_f16: false,
+        h_prefill_stage: None,
     }
 }
 

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -539,7 +539,11 @@ impl Qwen3SsmLayer {
         // Reuse ssm_qkvz buffer for conv output (safe: deinterleave is done)
         let conv_out_buf = ctx.buffers.ssm_qkvz();
         let gdn_out_buf = ctx.buffers.attn_output();
-        let h_bytes = self.h_state_bytes;
+        // POOL PITCH, not the FP32 width: every consumer of
+        // `ConvGdnArgs::h_bytes` uses it to stride or byte-copy pool h
+        // regions, all of which narrow under the f16-SIZED pool. Identical to
+        // `h_state_bytes` on an FP32-sized pool, so this is a no-op there.
+        let h_bytes = self.h_slot_stride_bytes();
         let conv_bytes = self.conv_state_bytes;
 
         match gdn {

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -70,6 +70,11 @@ pub(super) struct ConvGdnArgs {
     /// verify arm writes through this (its norm runs in-loop); the WY arms
     /// leave the norm to phase 8, which derives its own destination.
     pub normed_out: DevicePtr,
+    /// The h pool's BYTE PITCH — `Qwen3SsmLayer::h_slot_stride_bytes()`, not
+    /// the FP32 `h_state_bytes`. Every reader below strides or byte-copies
+    /// pool h memory with it (per-token intermediates, slot-to-slot bases),
+    /// and under the f16-SIZED pool those regions are 2 bytes/element. An
+    /// FP32 value here would overrun the neighbouring slot rather than fail.
     pub h_bytes: usize,
     pub conv_bytes: usize,
     pub qkvz_size: usize,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched_recurrent.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_multi_seq/ssm_batched_recurrent.rs
@@ -99,7 +99,8 @@ impl Qwen3SsmLayer {
                     h_base = ssm_state.h_state;
                     conv_base = ssm_state.conv_state;
                 } else {
-                    contiguous &= ssm_state.h_state.0 == h_base.0 + (i * self.h_state_bytes) as u64;
+                    contiguous &=
+                        ssm_state.h_state.0 == h_base.0 + (i * self.h_slot_stride_bytes()) as u64;
                     contiguous &=
                         ssm_state.conv_state.0 == conv_base.0 + (i * self.conv_state_bytes) as u64;
                 }
@@ -119,7 +120,7 @@ impl Qwen3SsmLayer {
                     let mut delta = 0i64;
                     for i in 1..n {
                         if let Some(st) = states[i].as_any_mut().downcast_mut::<SsmLayerState>() {
-                            let want = h_base.0 + (i * self.h_state_bytes) as u64;
+                            let want = h_base.0 + (i * self.h_slot_stride_bytes()) as u64;
                             if st.h_state.0 != want {
                                 broke_at = i;
                                 delta = st.h_state.0 as i64 - want as i64;
@@ -133,7 +134,7 @@ impl Qwen3SsmLayer {
                          expects it. The per-seq loop costs ~28% more on this block. Slots \
                          fragment as sequences finish, so this is expected to recur; count is \
                          logged at debug on every occurrence.",
-                        delta / self.h_state_bytes.max(1) as i64
+                        delta / self.h_slot_stride_bytes().max(1) as i64
                     );
                 });
                 tracing::debug!("SSM batched recurrent fallback #{n_fb} (n={n})");
@@ -270,10 +271,13 @@ impl Qwen3SsmLayer {
                     // The FP16 pool has exactly one legal reader; the FP32 arms
                     // above are unreachable in this mode (preflight refuses the
                     // flag for any env combination that could route to one).
-                    // ★ `h_state_bytes` is the FP32-SIZED pool slot stride, so
-                    // in __half elements the per-sequence stride is
-                    // `h_state_bytes / 2` — twice the dense FP16 footprint the
-                    // FP32 kernel is allowed to infer from the head dims.
+                    // ★ The stride is the POOL SLOT PITCH in __half
+                    // elements, which is NOT inferable from the head dims:
+                    // on an FP32-sized pool (stage 1/2) slots are
+                    // `h_state_bytes` apart, i.e. TWICE the dense FP16
+                    // footprint; under the stage-3 f16-SIZED pool they are
+                    // `h_state_bytes / 2` apart, i.e. exactly dense.
+                    // `h_slot_stride_bytes` is the SSOT for which.
                     ops::gdn_decode_f16_strided_norm(
                         ctx.gpu,
                         self.gdn_f16_strided_norm_half_k,
@@ -296,7 +300,7 @@ impl Qwen3SsmLayer {
                         gate_stride,
                         qkvz_size as u32,
                         value_dim as u32,
-                        (self.h_state_bytes / 2) as u64,
+                        (self.h_slot_stride_bytes() / 2) as u64,
                         eps,
                         stream,
                     )?;

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill.rs
@@ -299,8 +299,8 @@ impl Qwen3SsmLayer {
 
         // Recurrence kernel dispatch hoisted to trait_prefill_recur.rs to
         // keep this file under the 500 LoC cap; behavior identical.
-        self.prefill_gdn_recurrence(
-            ssm_state.h_state,
+        self.prefill_gdn_recurrence_staged(
+            ssm_state,
             q_ptr,
             k_ptr,
             v_ptr,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_gdn.rs
@@ -12,6 +12,14 @@ mod batched;
 // encodes.
 
 impl Qwen3SsmLayer {
+    /// Two-phase (whole-prompt) GDN prefill.
+    ///
+    /// Splits into the h-state width wrapper and the kernel ladder so the
+    /// ladder can keep its nine `return ops::...` early exits: under the
+    /// stage-3 f16-SIZED pool the narrowing has to run on EVERY one of them,
+    /// which a per-arm epilogue could not guarantee. See
+    /// `Qwen3SsmLayer::prefill_gdn_recurrence_staged` for the same pattern on
+    /// the chunked path, and `ssm_h_fp16` for why the pair is safe here.
     pub(super) fn prefill_gdn_full_inner(
         &self,
         state: &mut dyn LayerState,
@@ -23,7 +31,31 @@ impl Qwen3SsmLayer {
             .as_any_mut()
             .downcast_mut::<SsmLayerState>()
             .ok_or_else(|| anyhow::anyhow!("Expected SsmLayerState"))?;
+        let h = super::ssm_h_fp16::prefill_h_begin(
+            ctx.gpu,
+            self.ssm_h_f16_to_f32_k,
+            ssm_state,
+            self.h_state_bytes,
+            stream,
+        )?;
+        self.prefill_gdn_full_over(h.ptr(), gdn_bufs, ctx, stream)?;
+        super::ssm_h_fp16::prefill_h_end(
+            ctx.gpu,
+            self.ssm_h_f32_to_f16_k,
+            h,
+            self.h_state_bytes,
+            stream,
+        )
+    }
 
+    /// The GDN kernel ladder, over an explicitly supplied FP32 h-state.
+    fn prefill_gdn_full_over(
+        &self,
+        h_state: DevicePtr,
+        gdn_bufs: &GdnPrefillBuffers,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
         let nk = ctx.config.linear_num_key_heads;
         let kd = ctx.config.linear_key_head_dim;
         let nv = ctx.config.linear_num_value_heads;
@@ -69,7 +101,7 @@ impl Qwen3SsmLayer {
             return ops::gdn_prefill_split4(
                 ctx.gpu,
                 self.gdn_prefill_split4_k,
-                ssm_state.h_state,
+                h_state,
                 q_ptr,
                 k_ptr,
                 v_ptr,
@@ -108,7 +140,7 @@ impl Qwen3SsmLayer {
                 gdn_bufs.qkv,
                 gdn_bufs.gate_beta,
                 gdn_bufs.output,
-                ssm_state.h_state,
+                h_state,
                 scale,
                 total,
                 nk as u32,
@@ -144,7 +176,7 @@ impl Qwen3SsmLayer {
                 self.gdn_prefill_fla_chunk_delta_h_k,
                 self.gdn_prefill_fla_chunk_delta_h_tc_vblock_k,
                 self.gdn_prefill_fla_chunk_fwd_o_k,
-                ssm_state.h_state,
+                h_state,
                 q_ptr,
                 k_ptr,
                 v_ptr,
@@ -186,7 +218,7 @@ impl Qwen3SsmLayer {
             ops::gdn_prefill_persistent_smem(
                 ctx.gpu,
                 self.gdn_prefill_wy32_k,
-                ssm_state.h_state,
+                h_state,
                 q_ptr,
                 k_ptr,
                 v_ptr,
@@ -222,7 +254,7 @@ impl Qwen3SsmLayer {
                     ops::gdn_prefill_persistent(
                         ctx.gpu,
                         self.gdn_prefill_persistent_k,
-                        ssm_state.h_state,
+                        h_state,
                         q_chunk,
                         k_chunk,
                         v_chunk,
@@ -244,7 +276,7 @@ impl Qwen3SsmLayer {
                     ops::gdn_prefill_split4(
                         ctx.gpu,
                         self.gdn_prefill_split4_k,
-                        ssm_state.h_state,
+                        h_state,
                         q_chunk,
                         k_chunk,
                         v_chunk,
@@ -270,7 +302,7 @@ impl Qwen3SsmLayer {
             ops::gdn_prefill_persistent_smem(
                 ctx.gpu,
                 self.gdn_prefill_persistent_wy4_k,
-                ssm_state.h_state,
+                h_state,
                 q_ptr,
                 k_ptr,
                 v_ptr,
@@ -293,7 +325,7 @@ impl Qwen3SsmLayer {
             ops::gdn_prefill_persistent(
                 ctx.gpu,
                 self.gdn_prefill_persistent_k,
-                ssm_state.h_state,
+                h_state,
                 q_ptr,
                 k_ptr,
                 v_ptr,
@@ -315,7 +347,7 @@ impl Qwen3SsmLayer {
             ops::gdn_prefill_split4(
                 ctx.gpu,
                 self.gdn_prefill_split4_k,
-                ssm_state.h_state,
+                h_state,
                 q_ptr,
                 k_ptr,
                 v_ptr,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_phase3.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_phase3.rs
@@ -102,6 +102,9 @@ impl Qwen3SsmLayer {
             h_state_intermediates: Vec::new(),
             conv_state_intermediates: Vec::new(),
             h_is_f16: false,
+            // `Layer::alloc_state` is the NON-pooled fallback — it owns a
+            // private FP32 `h_state_bytes` blob, so there is nothing to widen.
+            h_prefill_stage: None,
         }))
     }
 }

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -553,6 +553,8 @@ impl TransformerModel {
             .unwrap_or(KernelHandle(0));
         let ssm_h_f32_to_f16_k =
             crate::layers::try_kernel(gpu.as_ref(), "ssm_h_dtype", "ssm_h_state_f32_to_f16");
+        let ssm_h_f16_to_f32_k =
+            crate::layers::try_kernel(gpu.as_ref(), "ssm_h_dtype", "ssm_h_state_f16_to_f32");
 
         // Logit softcapping (Gemma-4: cap=30.0). Only load if model uses it.
         let logit_softcap_kernel = if config.final_logit_softcapping > 0.0 {
@@ -790,6 +792,7 @@ impl TransformerModel {
             ssm_state_norm_kernel: ssm_norm_k,
             ssm_state_norm_f16_kernel: ssm_norm_f16_k,
             ssm_h_f32_to_f16_kernel: ssm_h_f32_to_f16_k,
+            ssm_h_f16_to_f32_kernel: ssm_h_f16_to_f32_k,
             ssm_h_f16_scratch: std::sync::OnceLock::new(),
             ssm_norm_ptrs_buf: ssm_norm_ptrs,
             moe_row_adapter_buf,

--- a/crates/spark-model/src/model/ssm_pool.rs
+++ b/crates/spark-model/src/model/ssm_pool.rs
@@ -49,6 +49,15 @@ pub(crate) struct SsmStatePool {
     /// allocate, offset and copy by. Equals `h_bytes` except under the
     /// stage-3 f16-SIZED pool (`ssm_reserve::ssm_h_stored_bytes`).
     pub(super) h_stored_bytes: usize,
+    /// Stage-3 f16-SIZED pool ONLY: one FP32 h-state staging blob per slot,
+    /// laid out `[total_slots] × h_bytes` in a single allocation. `None`
+    /// under an FP32-sized pool, where prefill writes the slot in place.
+    ///
+    /// Shared across LAYERS on purpose — see
+    /// [`crate::ssm_reserve::ssm_h_prefill_stage_bytes`] for why one blob per
+    /// slot is sufficient and why per-slot (rather than per-co-dispatched-
+    /// sequence) is the sizing that needs no width assumption.
+    pub(super) h_prefill_stage_pool: Option<DevicePtr>,
     pub(super) conv_bytes: usize,
     /// Number of CLAIMABLE slots (excludes the reserved dummy slot at
     /// index `max_slots`). All claim_slot/release_slot operations work
@@ -159,6 +168,28 @@ impl SsmStatePool {
             gpu.memset(conv_pool, 0, total_slots * conv_bytes)?;
             conv_state_pools.push(conv_pool);
         }
+
+        // Stage-3 f16-SIZED pool: the FP32 prefill staging arena. Allocated
+        // ONLY when the h slots actually narrowed — an FP32-sized pool needs
+        // no staging and must not pay for it (flag-off is byte-identical).
+        let h_prefill_stage_pool = {
+            let bytes = crate::ssm_reserve::ssm_h_prefill_stage_bytes(
+                total_slots,
+                h_bytes,
+                h_stored_bytes < h_bytes,
+            );
+            if bytes == 0 {
+                None
+            } else {
+                let p = gpu.alloc(bytes)?;
+                gpu.memset(p, 0, bytes)?;
+                tracing::info!(
+                    "SSM f16-sized h pool: FP32 prefill staging arena {} MB ({total_slots} slots × {h_bytes} B)",
+                    bytes / (1024 * 1024)
+                );
+                Some(p)
+            }
+        };
 
         // MTP verify pools cover only the slots spec dispatch can reach
         // (SSOT: `ssm_reserve::mtp_state_slots` — the same number preflight
@@ -294,6 +325,7 @@ impl SsmStatePool {
             conv_checkpoint_pools,
             h_bytes,
             h_stored_bytes,
+            h_prefill_stage_pool,
             conv_bytes,
             max_slots,
             mtp_slots,
@@ -409,6 +441,17 @@ impl SsmStatePool {
 
     pub(super) fn h_state(&self, ssm_layer_idx: usize, slot: usize) -> DevicePtr {
         self.h_state_pools[ssm_layer_idx].offset(slot * self.h_stored_bytes)
+    }
+
+    /// This slot's FP32 prefill staging blob (stage-3 f16-SIZED pool only).
+    ///
+    /// `None` under an FP32-sized pool — the ONLY signal the prefill path
+    /// needs to know that it must widen/narrow, and the reason flag-off
+    /// prefill is byte-identical (there is nothing to convert through).
+    /// Layer-independent by construction: see the field's doc.
+    pub(super) fn h_prefill_stage(&self, slot: usize) -> Option<DevicePtr> {
+        self.h_prefill_stage_pool
+            .map(|p| p.offset(slot * self.h_bytes))
     }
 
     pub(super) fn conv_state(&self, ssm_layer_idx: usize, slot: usize) -> DevicePtr {
@@ -819,13 +862,17 @@ mod h_stored_geometry_tests {
     use atlas_core::config::ModelConfig;
     use spark_runtime::gpu::mock::MockGpuBackend;
 
+    /// Claimable slots in the test pool (the pool allocates `SLOTS + 1`,
+    /// the extra one being the padding dummy).
+    const SLOTS: usize = 4;
+
     /// Build the pool on the mock backend (only `alloc`/`memset` are hit).
     fn pool(h_f16_pool: bool) -> SsmStatePool {
         let config = ModelConfig::qwen3_next_80b_nvfp4();
         let gpu = MockGpuBackend::new();
         SsmStatePool::new(
             &config,
-            4,
+            SLOTS,
             true,
             4,
             3,
@@ -913,6 +960,45 @@ mod h_stored_geometry_tests {
         assert_eq!(p16.h_bytes, p32.h_bytes);
         assert_eq!(p16.h_stored_bytes * 2, p16.h_bytes);
     }
+
+    /// The FP32 prefill staging arena exists ONLY under the narrowed pool,
+    /// is FP32-wide (never `h_stored_bytes` — staging the FP32 kernels write
+    /// is the entire point), and strides ONE blob per SLOT, not per slot per
+    /// layer. A per-layer arena would be `num_ssm_layers ×` bigger and would
+    /// eat the win this mode exists for, so the stride is pinned, not
+    /// assumed.
+    #[test]
+    fn prefill_staging_is_one_fp32_blob_per_slot_and_only_when_narrowed() {
+        // Flag off: not allocated, and every slot answers `None` — the
+        // signal the prefill path takes its historical in-place arm on.
+        let p32 = pool(false);
+        assert!(p32.h_prefill_stage_pool.is_none());
+        assert!(p32.h_prefill_stage(0).is_none());
+        assert!(p32.h_prefill_stage(SLOTS - 1).is_none());
+
+        let p16 = pool(true);
+        assert!(p16.h_prefill_stage_pool.is_some());
+        let s0 = p16.h_prefill_stage(0).expect("narrowed pool stages");
+        let s1 = p16.h_prefill_stage(1).expect("narrowed pool stages");
+        // FP32 pitch — twice the (narrowed) slot pitch it feeds.
+        assert_eq!(s1.0 - s0.0, p16.h_bytes as u64);
+        assert_eq!(s1.0 - s0.0, 2 * p16.h_stored_bytes as u64);
+        // The dummy slot is staged too: `SsmStatePool::new` allocates
+        // `max_slots + 1` blobs, so `dummy_slot()` is addressable rather
+        // than one blob past the end.
+        let dummy = p16.h_prefill_stage(p16.dummy_slot()).unwrap();
+        assert_eq!(dummy.0 - s0.0, (p16.dummy_slot() * p16.h_bytes) as u64);
+
+        // SSOT with the preflight reserve: same function, same numbers.
+        assert_eq!(
+            crate::ssm_reserve::ssm_h_prefill_stage_bytes(SLOTS + 1, p16.h_bytes, true),
+            (SLOTS + 1) * p16.h_bytes
+        );
+        assert_eq!(
+            crate::ssm_reserve::ssm_h_prefill_stage_bytes(SLOTS + 1, p16.h_bytes, false),
+            0
+        );
+    }
 }
 
 #[cfg(test)]
@@ -933,6 +1019,7 @@ mod slot_guard_tests {
             conv_checkpoint_pools: Vec::new(),
             h_bytes: 0,
             h_stored_bytes: 0,
+            h_prefill_stage_pool: None,
             conv_bytes: 0,
             max_slots,
             mtp_slots: 0,

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -400,6 +400,11 @@ impl TransformerModel {
                             // tag them with the active mode so the decode mixer
                             // does not re-convert scratch on every single step.
                             h_is_f16: crate::layers::qwen3_ssm::ssm_h_fp16_enabled(),
+                            // Decode-only rows: never prefilled. Carried
+                            // anyway so the dummy slot's geometry matches a
+                            // real one and a stray prefill over it stages
+                            // rather than overruns.
+                            h_prefill_stage: self.ssm_pool.h_prefill_stage(dummy_ssm_slot),
                         }));
                         ssm_idx += 1;
                     } else {

--- a/crates/spark-model/src/model/trait_impl/decode_b/build_states.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_b/build_states.rs
@@ -73,6 +73,10 @@ impl TransformerModel {
                         // them with the active mode so the decode mixer does
                         // not re-convert scratch on every single step.
                         h_is_f16: crate::layers::qwen3_ssm::ssm_h_fp16_enabled(),
+                        // Decode-only rows: never prefilled. Carried anyway so
+                        // the dummy slot's geometry matches a real one and a
+                        // stray prefill over it stages rather than overruns.
+                        h_prefill_stage: self.ssm_pool.h_prefill_stage(dummy_ssm_slot),
                     }));
                     ssm_idx += 1;
                 } else {

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -269,6 +269,9 @@ impl TransformerModel {
         let mut layer_states: Vec<Box<dyn LayerState>> = Vec::with_capacity(self.layers.len());
         for (i, layer) in self.layers.iter().enumerate() {
             if self.config.layer_type(i) == LayerType::LinearAttention {
+                // Layer-independent (one FP32 staging blob per SLOT), so it is
+                // the same pointer for every SSM layer of this sequence.
+                let stage = self.ssm_pool.h_prefill_stage(slot);
                 let mut ssm_state = SsmLayerState {
                     h_state: self.ssm_pool.h_state(ssm_layer_idx, slot),
                     conv_state: self.ssm_pool.conv_state(ssm_layer_idx, slot),
@@ -277,9 +280,16 @@ impl TransformerModel {
                     h_state_intermediates: Vec::new(),
                     conv_state_intermediates: Vec::new(),
                     // A freshly allocated slot has just been zeroed, and zero
-                    // is zero in both formats — but prefill writes it as FP32,
-                    // so FP32 is the truth until the decode mixer converts.
-                    h_is_f16: false,
+                    // is zero in both formats. Which format it then HOLDS is
+                    // decided by the pool width, not by the phase: under the
+                    // stage-3 f16-SIZED pool the slot is physically 2
+                    // bytes/element and prefill stages its FP32 work
+                    // elsewhere, so the slot is FP16 from here on and the
+                    // decode mixer has nothing to do. Under an FP32-sized
+                    // pool prefill writes FP32 in place and FP32 is the truth
+                    // until the mixer converts.
+                    h_is_f16: stage.is_some(),
+                    h_prefill_stage: stage,
                 };
 
                 if has_mtp {

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batched_layer.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batched_layer.rs
@@ -186,6 +186,10 @@ impl TransformerModel {
                 ctx,
                 stream,
             )?;
+            // Stage-3 f16-SIZED pool: the table pointed at FP32 staging blobs
+            // (`stage_h_state_ptrs` widened into them); narrow them back now
+            // that the kernel has run. No-op on an FP32-sized pool.
+            self.narrow_h_state_stages(layer_idx, seqs, stream)?;
         } else {
             // Ragged lengths: try ONE varlen batched FLA call (cu_seqlens) — fills
             // chunk_delta_h's 32→32N CTAs — and fall back to the per-request loop
@@ -214,6 +218,10 @@ impl TransformerModel {
                 stream,
             )?;
             // Varlen FLA ran the whole GDN → Phase 3 continues below. Else loop.
+            if did_varlen {
+                // Stage-3: same epilogue as the uniform arm above.
+                self.narrow_h_state_stages(layer_idx, seqs, stream)?;
+            }
             if !did_varlen {
                 let nk = ctx.config.linear_num_key_heads;
                 let kd = ctx.config.linear_key_head_dim;

--- a/crates/spark-model/src/model/trait_impl/prefill_b/h_state_ptrs.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/h_state_ptrs.rs
@@ -15,6 +15,19 @@
 //! buffer, after the BatchedAttnMetadata layout (which uses the front of
 //! scratch). The h_state_ptrs array is small (`batch_size × 8` bytes ≤ 64 B
 //! for typical N≤8) so this is cheap.
+//!
+//! ── Stage-3 f16-SIZED pool (`--ssm-h-dtype f16-pool`) ──
+//!
+//! The batched GDN kernels take a `float* const*` table, so the widen/narrow
+//! pair the single-stream ladder wraps around itself (see
+//! `layers::qwen3_ssm::ssm_h_fp16`) has to happen HERE instead — the table
+//! must point at each sequence's FP32 staging blob, not at its 2-byte-sized
+//! pool slot. [`TransformerModel::stage_h_state_ptrs`] widens as it stages
+//! and [`TransformerModel::narrow_h_state_stages`] is the matching epilogue;
+//! they are a PAIR and the caller must run the second one on every path the
+//! table was actually consumed by. On an FP32-sized pool both are byte-for-
+//! byte what they always were: the table carries slot pointers and the
+//! epilogue moves nothing.
 
 #![allow(unused_imports, dead_code, clippy::too_many_arguments)]
 
@@ -58,7 +71,31 @@ impl TransformerModel {
                          SSM batched dispatch)"
                     )
                 })?;
-            h_ptrs.push(ssm_state.h_state.0);
+            // Stage-3: the table entry is the FP32 STAGING blob, widened
+            // from the narrow slot right here. `None` (FP32-sized pool) keeps
+            // the historical behaviour exactly — the slot pointer itself,
+            // and no conversion launched.
+            match ssm_state.h_prefill_stage {
+                None => h_ptrs.push(ssm_state.h_state.0),
+                Some(stage) => {
+                    if self.ssm_h_f16_to_f32_kernel.0 == 0 {
+                        anyhow::bail!(
+                            "--ssm-h-dtype f16-pool: ssm_h_dtype::ssm_h_state_f16_to_f32 did \
+                             not resolve — refusing to point the batched GDN prefill kernels \
+                             at 2-byte-sized pool slots they would write as FP32"
+                        );
+                    }
+                    crate::layers::ops::ssm_h_state_f16_to_f32(
+                        self.gpu.as_ref(),
+                        self.ssm_h_f16_to_f32_kernel,
+                        ssm_state.h_state,
+                        stage,
+                        (self.ssm_pool.h_bytes / 4) as u64,
+                        stream,
+                    )?;
+                    h_ptrs.push(stage.0);
+                }
+            }
         }
 
         let dst = self.buffers.scratch().offset(scratch_offset_bytes);
@@ -73,5 +110,59 @@ impl TransformerModel {
         };
         self.gpu.copy_h2d_async(bytes, dst, stream)?;
         Ok(dst)
+    }
+
+    /// Epilogue of [`Self::stage_h_state_ptrs`]: narrow each stream's FP32
+    /// staging blob back into its 2-byte-sized pool slot (stage-3 f16-SIZED
+    /// pool). No-op — not one launch — on an FP32-sized pool.
+    ///
+    /// ★ Call it only when the batched GDN kernel actually RAN. Skipping it
+    /// after a failure leaves every slot holding its pre-pass f16 value,
+    /// which is the recoverable state; the VARLEN fallback loop must skip it
+    /// too, because that loop routes through the single-stream ladder, which
+    /// widens and narrows each sequence itself.
+    pub(in crate::model) fn narrow_h_state_stages(
+        &self,
+        layer_idx: usize,
+        seqs: &mut [&mut SequenceState],
+        stream: u64,
+    ) -> Result<()> {
+        if self.ssm_pool.h_prefill_stage_pool.is_none() {
+            return Ok(());
+        }
+        for (i, seq) in seqs.iter_mut().enumerate() {
+            let ssm_state = seq.layer_states[layer_idx]
+                .as_any_mut()
+                .downcast_mut::<SsmLayerState>()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "narrow_h_state_stages: stream {i} layer {layer_idx} is not an \
+                         SsmLayerState"
+                    )
+                })?;
+            let Some(stage) = ssm_state.h_prefill_stage else {
+                anyhow::bail!(
+                    "narrow_h_state_stages: stream {i} layer {layer_idx} has no FP32 staging \
+                     blob under an f16-sized h pool — its slot cannot hold the FP32 the \
+                     batched GDN kernel just wrote"
+                );
+            };
+            if self.ssm_h_f32_to_f16_kernel.0 == 0 {
+                anyhow::bail!(
+                    "--ssm-h-dtype f16-pool: ssm_h_dtype::ssm_h_state_f32_to_f16 did not \
+                     resolve — the batched prefill h-state cannot be narrowed back into its \
+                     2-byte-sized slot"
+                );
+            }
+            crate::layers::ops::ssm_h_state_f32_to_f16(
+                self.gpu.as_ref(),
+                self.ssm_h_f32_to_f16_kernel,
+                stage,
+                ssm_state.h_state,
+                (self.ssm_pool.h_bytes / 4) as u64,
+                stream,
+            )?;
+        }
+        Ok(())
     }
 }

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -205,6 +205,7 @@ impl TransformerModel {
             if let Some(ssm) = state.as_any_mut().downcast_mut::<SsmLayerState>() {
                 ssm.h_state = DevicePtr(0);
                 ssm.conv_state = DevicePtr(0);
+                ssm.h_prefill_stage = None;
                 ssm.h_state_checkpoint = None;
                 ssm.conv_state_checkpoint = None;
                 ssm.h_state_intermediates.clear();
@@ -336,6 +337,14 @@ impl TransformerModel {
                 if let Some(ssm) = state.as_any_mut().downcast_mut::<SsmLayerState>() {
                     ssm.h_state = self.ssm_pool.h_state(ssm_layer_idx, new_slot);
                     ssm.conv_state = self.ssm_pool.conv_state(ssm_layer_idx, new_slot);
+                    // Stage-3 f16-SIZED pool: the FP32 prefill staging blob is
+                    // per-SLOT, so compaction must repoint it for the same
+                    // reason the checkpoint/intermediate families below are
+                    // repointed — the old slot becomes reallocatable, and a
+                    // continuation chunk staging through the new occupant's
+                    // blob is cross-sequence corruption. `None` stays `None`
+                    // (FP32-sized pool: no staging exists).
+                    ssm.h_prefill_stage = self.ssm_pool.h_prefill_stage(new_slot);
                     if has_mtp {
                         if ssm.h_state_checkpoint.is_some() {
                             ssm.h_state_checkpoint =

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -403,6 +403,11 @@ pub struct TransformerModel {
     pub(super) ssm_norm_ptrs_buf: DevicePtr,
     /// One-shot FP32 -> FP16 h-state converter (`ATLAS_SSM_H_FP16`).
     pub(super) ssm_h_f32_to_f16_kernel: KernelHandle,
+    /// Its widening inverse. Used ONLY by the stage-3 f16-SIZED pool
+    /// (`--ssm-h-dtype f16-pool`) on the BATCHED prefill path, whose GDN
+    /// kernels take a device pointer TABLE and so cannot be wrapped inside
+    /// the layer the way the single-stream ladder is. Zero otherwise.
+    pub(super) ssm_h_f16_to_f32_kernel: KernelHandle,
     /// Staging buffer for it, one layer wide (`h_bytes / 2`). The conversion is
     /// a narrowing compaction and CANNOT be done in place: thread `2i`'s write
     /// lands inside thread `i`'s read with nothing ordering them. Allocated

--- a/crates/spark-model/src/ssm_reserve.rs
+++ b/crates/spark-model/src/ssm_reserve.rs
@@ -252,6 +252,40 @@ pub fn ssm_h_stored_bytes(h_f32_bytes: usize, f16_pool: bool) -> usize {
     }
 }
 
+/// FP32 h-state PREFILL STAGING bytes (stage 3 of `--ssm-h-dtype f16`).
+///
+/// Under the f16-SIZED pool a slot's h region is 2 bytes/element, but every
+/// GDN prefill kernel family reads and writes the running h-state as FP32 in
+/// place — over a 2-byte slot that is an overrun into the neighbouring slot.
+/// Stage 3 therefore gives each pool slot ONE FP32 staging blob, and the
+/// layer widens the slot into it before its FP32 kernels run and narrows it
+/// back after (`ssm_h_fp16::prefill_h_begin` / `prefill_h_end`).
+///
+/// ★ ONE blob per SLOT, **not** per slot per layer. The staging blob is live
+/// only for the duration of one SSM layer's prefill call: the layers of a
+/// pass are issued in order on a single stream, each narrowing back before
+/// the next widens, so layer L+1 reuses layer L's blob. Sizing it per slot
+/// (rather than per concurrently-prefilling sequence) is what makes that
+/// safe without knowing the co-dispatch width: a sequence owns exactly one
+/// slot for its whole life, so two sequences can never share a blob.
+///
+/// `h_layer_f32_bytes` is ONE layer's FP32 h blob (`ssm_h_state_bytes()`) —
+/// NOT the across-layers per-seq total the pool-reserve terms use. Zero when
+/// the pool is FP32-sized: prefill then writes the slot in place as it
+/// always has, and no staging exists to reserve.
+///
+/// SSOT for both `SsmStatePool::new` (which allocates it, passing
+/// `max_slots + 1` for the dummy slot) and the preflight reserve (which
+/// passes `max_batch_size`, matching its standing convention of not
+/// counting the dummy — the CUDA headroom term absorbs it).
+pub fn ssm_h_prefill_stage_bytes(slots: usize, h_layer_f32_bytes: usize, f16_pool: bool) -> usize {
+    if f16_pool {
+        slots * h_layer_f32_bytes
+    } else {
+        0
+    }
+}
+
 /// SSM state-pool reserve bytes for the pre-load preflight — MUST mirror
 /// what `SsmStatePool::new` allocates (modulo the +1 dummy slot per pool,
 /// which preflight has never counted; the CUDA headroom term absorbs it):

--- a/crates/spark-model/src/ssm_reserve_tests.rs
+++ b/crates/spark-model/src/ssm_reserve_tests.rs
@@ -329,6 +329,54 @@ fn f16_pool_sizing_pinned_and_flag_off_untouched() {
     );
 }
 
+/// ONE layer's FP32 h blob — what the prefill staging arena is sized by.
+/// `H_BLOB` is the across-layers per-seq total, so dividing by the 48 GDN
+/// layers is the only place these two widths may be related.
+const H_LAYER: usize = H_BLOB / 48;
+
+#[test]
+fn prefill_staging_costs_one_fp32_layer_blob_per_slot() {
+    // Flag off: ZERO, at every batch size. Nothing is allocated and nothing
+    // is reserved, which is what makes the FP32-sized pool byte-identical.
+    for bs in [1usize, 32, 64, 128] {
+        assert_eq!(ssm_h_prefill_stage_bytes(bs, H_LAYER, false), 0);
+    }
+    // Stage 3: one FP32 layer blob per slot. NOT per slot per layer — that
+    // would be `48 ×` this and would consume three quarters of the win.
+    assert_eq!(H_LAYER, 3_145_728);
+    assert_eq!(ssm_h_prefill_stage_bytes(128, H_LAYER, true), 402_653_184); // 384 MiB
+    assert_eq!(ssm_h_prefill_stage_bytes(32, H_LAYER, true), 100_663_296);
+    assert!(ssm_h_prefill_stage_bytes(128, H_LAYER, true) * 48 == 48 * 402_653_184);
+}
+
+/// The NET pool win at the reference shape, staging arena included — the
+/// number the PR quotes. Pinned because a per-layer staging arena (the
+/// tempting simplification) would turn a 9 GiB win into a 9 GiB loss, and
+/// nothing else in the suite would notice.
+#[test]
+fn f16_pool_net_win_is_the_h_saving_minus_the_staging_arena() {
+    // SERVEABLE configuration today: spec OFF (the MTP verify arms still
+    // address the h intermediate/checkpoint pools at the FP32 pitch, so
+    // `--speculative` is refused beside `--ssm-h-dtype f16-pool`).
+    let fp32 = tiered_pool_bytes(128, false);
+    let narrowed = tiered_pool_bytes_f16(128, false);
+    assert_eq!(fp32, 128 * BLOB); // 20_333_985_792 — 18.94 GiB
+    assert_eq!(narrowed, 10_670_309_376); //  9.94 GiB
+    let stage = ssm_h_prefill_stage_bytes(128, H_LAYER, true);
+    assert_eq!(fp32 - narrowed, 9_663_676_416); // 9.00 GiB of h
+    assert_eq!(fp32 - narrowed - stage, 9_261_023_232); // 8.63 GiB net
+    // The staging arena is 4.2% of what it buys back. Pinned as a RATIO so
+    // the assertion survives a shape change and still fails a design change.
+    assert!(stage * 20 < fp32 - narrowed, "staging must stay marginal");
+
+    // Spec ON (refused at serve; this pins the allocator arithmetic for when
+    // the verify strides land): the same arena, against a 14.62 GiB saving.
+    assert_eq!(
+        tiered_pool_bytes(128, true) - tiered_pool_bytes_f16(128, true) - stage,
+        15_300_820_992 // 14.25 GiB net
+    );
+}
+
 /// Replay-mode helper at the reference shape.
 fn replay_pool_bytes(bs: usize, spec_on: bool) -> usize {
     ssm_pool_reserve_bytes(

--- a/crates/spark-server/src/cli/flag_values.rs
+++ b/crates/spark-server/src/cli/flag_values.rs
@@ -26,7 +26,7 @@
 pub(crate) const LM_HEAD_DTYPES: &[&str] = &["default", "bf16", "nvfp4", "fp8"];
 pub(crate) const MTP_QUANTS: &[&str] = &["bf16", "fp8", "nvfp4"];
 pub(crate) const SCHEDULING_POLICIES: &[&str] = &["fifo", "slai"];
-pub(crate) const SSM_H_DTYPES: &[&str] = &["f32", "f16"];
+pub(crate) const SSM_H_DTYPES: &[&str] = &["f32", "f16", "f16-pool"];
 pub(crate) const MTP_GATES: &[&str] = &["auto", "force"];
 pub(crate) const TOOL_CALL_PARSERS: &[&str] = &[
     "hermes",

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -180,7 +180,8 @@ pub struct ServeArgs {
     // discoverable in `--help` and visible in `ps`. The environment variables
     // remain honoured as a fallback so existing scripts keep working; the flag
     // WINS when both are given.
-    /// Storage dtype for the GDN decode h-state: `f32` (default) or `f16`.
+    /// Storage dtype for the GDN decode h-state: `f32` (default), `f16`, or
+    /// `f16-pool`.
     ///
     /// The decode scan is pure state traffic — it runs at ~90% of GB10's
     /// row-strided ceiling — so halving the state footprint halves its time:
@@ -193,9 +194,37 @@ pub struct ServeArgs {
     /// vanishes at C=64. Choose it per workload — which is precisely why it is
     /// a flag and not a default.
     ///
-    /// Legacy: `ATLAS_SSM_H_FP16` (presence) selects f16 when NONE of the three
-    /// GDN flags is given. `GdnFlags` is published as one cell, so any of them
-    /// takes the whole decision away from the environment; `warn_shadowed_env`
+    /// `f16-pool` is `f16` PLUS h pools that are SIZED at 2 bytes/element
+    /// rather than merely holding FP16 in the first half of an FP32-sized
+    /// slot. That is where the memory win is — the h-state is ~95% of a
+    /// 151.5 MiB per-sequence state blob, so the bs=128 SSM reserve on the
+    /// 27B drops from 36.7 GiB to ~25.6 GiB and the per-sequence per-step
+    /// state traffic that sets the marginal cost of a concurrent sequence
+    /// halves with it. Prefill keeps its unchanged FP32 kernels: they run
+    /// over a per-slot FP32 staging blob (`max_batch_size × one layer's h
+    /// blob`, ~256 MB at bs=128 on the 27B) which the layer widens into and
+    /// narrows back, so the pool holds FP16 at every moment outside a layer's
+    /// prefill call.
+    ///
+    /// NOT compatible with `--speculative`: the MTP verify arms still stride
+    /// and byte-copy the h intermediate/checkpoint pools at the FP32 width,
+    /// which over a narrowed pool overruns into the neighbouring slot instead
+    /// of failing. Refused at parse time.
+    ///
+    /// ★ NUMERICS. `f16-pool` puts the FP16 state on the PREFILL recurrence's
+    /// chunk boundaries as well as on decode, and a reduced-precision
+    /// recurrence accumulates rounding COHERENTLY (vLLM's fp16 mamba cache
+    /// needed stochastic rounding for exactly this; there is no published
+    /// fp8-recurrent-state accuracy study). Rounding here is
+    /// round-to-nearest-even. Default OFF, in no gate recipe, and no number
+    /// measured under it may be published without passing
+    /// `ssm-state-poisoning-gate`, `decode-floor`, `bfcl-subset` and the
+    /// agentic gate.
+    ///
+    /// Legacy: `ATLAS_SSM_H_FP16` (presence) selects f16 — never f16-pool,
+    /// which has no environment spelling — when NONE of the three GDN flags
+    /// is given. `GdnFlags` is published as one cell, so any of them takes
+    /// the whole decision away from the environment; `warn_shadowed_env`
     /// says so when that happens rather than leaving it to be discovered in a
     /// benchmark number.
     #[arg(long)]

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -73,13 +73,35 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
     // `!= Some(true)`, not `== Some(false)`: an ABSENT `--gdn-fused-norm` beside
     // an explicit `--ssm-h-dtype f16` publishes fused_norm OFF (the three GDN
     // flags are one cell), so absent is just as dangerous here as explicit off.
-    if args.ssm_h_dtype.as_deref() == Some("f16") && args.gdn_fused_norm != Some(true) {
+    // SSOT with what the server PUBLISHES: `f16-pool` is `f16` plus the narrow
+    // pool, so every f16 rule below has to bind on it too. Reading the pair off
+    // `ssm_h_dtype_bits` rather than matching the string twice is what stops a
+    // new spelling from silently escaping these checks.
+    // `.0` only: every rule here binds on "the h-state is FP16", which
+    // `f16-pool` also is. Nothing below is specific to the pool WIDTH — the
+    // narrowing is transparent to the flag combinations.
+    let h_f16 = spark_model::layers::qwen3_ssm::ssm_h_dtype_bits(args.ssm_h_dtype.as_deref()).0;
+    if h_f16 && args.gdn_fused_norm != Some(true) {
         v.push(Violation::new(
             "--ssm-h-dtype f16 without --gdn-fused-norm",
             "the FP16 h-state twins exist only on the fused-norm decode arm; the unfused \
              arms (gated_delta_rule_decode, ..._decode_f32_strided) are FP32-only and \
              would read the FP16 pool as FP32 — fluent garbage, not an error",
             "add --gdn-fused-norm, or use --ssm-h-dtype f32",
+        ));
+    }
+    // DFlash verifies gamma+1 = 17 rows, which lands on `gated_delta_rule_wy17`
+    // — the one WY family with no FP16 h-state twin AND an explicit
+    // FP32-element intermediate stride. Both halves read an FP16 h-state as
+    // FP32: fluent garbage, not an error. Applies to plain `f16` as well as
+    // `f16-pool`, hence `h_f16`.
+    if h_f16 && args.dflash {
+        v.push(Violation::new(
+            "--dflash together with --ssm-h-dtype f16",
+            "the DFlash verify width (gamma + 1 = 17) dispatches gated_delta_rule_wy17, \
+             which has no FP16 h-state twin and strides the h intermediates in FP32 \
+             elements — an FP32 kernel over an FP16 h-state emits fluent garbage",
+            "drop --dflash, or use --ssm-h-dtype f32",
         ));
     }
 
@@ -104,7 +126,7 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
     // `--ssm-h-dtype f16` by SILENTLY ignoring an explicit `--exact-verify`
     // would ship the very divergence the operator just opted out of — the
     // exact class of combination this validator exists to refuse.
-    if args.exact_verify == Some(true) && args.ssm_h_dtype.as_deref() == Some("f16") {
+    if args.exact_verify == Some(true) && h_f16 {
         v.push(Violation::new(
             "--exact-verify together with --ssm-h-dtype f16",
             "the exact MTP-verify chain (issue #435) runs FP32-reader kernels and must \

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -293,3 +293,64 @@ fn model_toml_backed_flags_distinguish_omitted_from_explicit() {
     // `default_value_t = 0` could not express.
     assert_eq!(explicit.fp8_kv_calibration_tokens, Some(0));
 }
+
+#[test]
+fn f16_pool_is_a_published_dtype_and_inherits_every_f16_rule() {
+    use spark_model::layers::qwen3_ssm::ssm_h_dtype_bits;
+
+    // SSOT: the validator and `publish_kernel_flags` decode through the SAME
+    // function, so a spelling accepted here publishes exactly these bits.
+    assert_eq!(ssm_h_dtype_bits(None), (false, false));
+    assert_eq!(ssm_h_dtype_bits(Some("f32")), (false, false));
+    assert_eq!(ssm_h_dtype_bits(Some("f16")), (true, false));
+    // f16-pool is f16 PLUS the narrow pool — never the pool without the bits,
+    // which would be an FP32 write into a 2-byte-sized slot.
+    assert_eq!(ssm_h_dtype_bits(Some("f16-pool")), (true, true));
+
+    // Accepted by the enum check, and serveable with the fused-norm arm.
+    assert!(
+        validate_serve_args(&parse(&["--ssm-h-dtype", "f16-pool", "--gdn-fused-norm"])).is_ok(),
+        "the supported stage-3 pairing"
+    );
+    // Every f16 rule binds on it too, because it IS f16.
+    assert!(validate_serve_args(&parse(&["--ssm-h-dtype", "f16-pool"])).is_err());
+    assert!(
+        validate_serve_args(&parse(&[
+            "--exact-verify",
+            "--ssm-h-dtype",
+            "f16-pool",
+            "--gdn-fused-norm",
+        ]))
+        .is_err()
+    );
+    // An unknown spelling is still rejected by the enum check, and decodes to
+    // FP32 rather than to something half-enabled.
+    assert!(validate_serve_args(&parse(&["--ssm-h-dtype", "f16pool"])).is_err());
+    assert_eq!(ssm_h_dtype_bits(Some("f16pool")), (false, false));
+}
+
+#[test]
+fn dflash_refuses_the_f16_h_state() {
+    // gamma+1 = 17 verify rows dispatch `gated_delta_rule_wy17`: FP32-only,
+    // and the one WY family with an explicit FP32-element intermediate
+    // stride. Over an FP16 h-state that is fluent garbage, not a fault —
+    // the same class the `--num-drafts > 3` preflight refusal exists for.
+    for dtype in ["f16", "f16-pool"] {
+        let err = validate_serve_args(&parse(&[
+            "--dflash",
+            "--ssm-h-dtype",
+            dtype,
+            "--gdn-fused-norm",
+        ]))
+        .unwrap_err();
+        assert!(err.contains("--dflash"), "{dtype}: {err}");
+    }
+    // POSITIVE controls: each side alone stays valid.
+    assert!(validate_serve_args(&parse(&["--dflash"])).is_ok());
+    assert!(validate_serve_args(&parse(&["--ssm-h-dtype", "f16", "--gdn-fused-norm"])).is_ok());
+    // f32 (the default) is unaffected.
+    assert!(
+        validate_serve_args(&parse(&["--dflash", "--ssm-h-dtype", "f32"])).is_ok(),
+        "the FP32 h-state has always been DFlash's supported pairing"
+    );
+}

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -45,13 +45,14 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
         || args.ssm_batched_recurrent.is_some()
         || args.exact_verify.is_some();
     if gdn_from_cli {
+        // SSOT decode (`gdn_flags::ssm_h_dtype_bits`) — the SAME function
+        // `validate_serve_args` rejects on, so the validator cannot approve a
+        // reading the kernels do not share. `f16-pool` publishes BOTH bits.
+        let (h_f16, h_f16_pool) =
+            spark_model::layers::qwen3_ssm::ssm_h_dtype_bits(args.ssm_h_dtype.as_deref());
         let flags = spark_model::layers::qwen3_ssm::GdnFlags {
-            h_f16: args.ssm_h_dtype.as_deref() == Some("f16"),
-            // Stage 3 (f16-SIZED pools) has NO CLI surface yet: the sizing
-            // plumbing exists and is unit-tested parameter-side, but prefill
-            // still writes the h-state FP32 in place, so no serve config may
-            // publish it. `ssm_h_fp16_preconditions` refuses it besides.
-            h_f16_pool: false,
+            h_f16,
+            h_f16_pool,
             fused_norm: args.gdn_fused_norm.unwrap_or(false),
             batched_recurrent: args.ssm_batched_recurrent.unwrap_or(false),
             exact_verify: args.exact_verify.unwrap_or(false),

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -8,6 +8,9 @@ use atlas_core::config::ModelConfig;
 
 use crate::cli;
 
+mod ssm_h_fp16;
+use ssm_h_fp16::ssm_h_fp16_preconditions;
+
 pub(crate) struct ReservePreflight {
     pub(crate) inference_reserve: usize,
     pub(crate) buffer_arena_bytes: usize,
@@ -40,6 +43,17 @@ pub(crate) fn preflight_reserve(
     // (`verify_slot_h_intermediates`); DFlash pools are γ-sized and do not
     // follow the MTP ladder, so they reserve uniform full width — mirroring
     // `SsmStatePool::new`'s `num_intermediates != num_drafts + 1` condition.
+    // Stage-3 f16-SIZED pool: the FP32 prefill staging arena, ONE blob per
+    // slot (shared across layers — see `ssm_h_prefill_stage_bytes`). A
+    // separate term for the same reason the replay ring is: it is sized by a
+    // SINGLE layer's h blob, not by the across-layers per-seq total every
+    // other term here uses. Zero on an FP32-sized pool. `max_batch_size`, not
+    // `+1`: this preflight has never counted the pools' dummy slot.
+    let ssm_h_stage_bytes = spark_model::ssm_reserve::ssm_h_prefill_stage_bytes(
+        args.max_batch_size,
+        h_state_bytes,
+        spark_model::layers::qwen3_ssm::ssm_h_f16_pool_enabled(),
+    );
     let ssm_pool_bytes = spark_model::ssm_reserve::ssm_pool_reserve_bytes(
         args.max_batch_size,
         config.num_ssm_layers() * h_state_bytes,
@@ -173,13 +187,17 @@ pub(crate) fn preflight_reserve(
             0
         }
     };
-    let inference_reserve: usize =
-        ssm_pool_bytes + ssm_replay_ring + ssm_snapshot_bytes + gdn_two_phase_bytes + cuda_headroom;
+    let inference_reserve: usize = ssm_pool_bytes
+        + ssm_h_stage_bytes
+        + ssm_replay_ring
+        + ssm_snapshot_bytes
+        + gdn_two_phase_bytes
+        + cuda_headroom;
     let total_reserve = inference_reserve + buffer_arena_bytes;
     if total_reserve > free_mem {
         let need_gb = total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
         let free_gb = free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
-        let fixed = ssm_pool_bytes + ssm_snapshot_bytes + cuda_headroom;
+        let fixed = ssm_pool_bytes + ssm_h_stage_bytes + ssm_snapshot_bytes + cuda_headroom;
         let budget_for_seq_term = free_mem.saturating_sub(fixed) / 2;
         let per_tok_bytes = {
             let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
@@ -384,103 +402,6 @@ pub(crate) fn post_load_memory_audit(
         estimated_free as f64 / (1024.0 * 1024.0 * 1024.0),
         actual_free as f64 / (1024.0 * 1024.0 * 1024.0),
         inference_reserve / (1024 * 1024),
-    );
-    Ok(())
-}
-
-/// `ATLAS_SSM_H_FP16` refuses rather than degrades.
-///
-/// The flag narrows the GDN h-state to FP16. Stage 1 shipped twins of the two
-/// NON-speculative decode kernels — `gated_delta_rule_decode_f16_strided_norm_half`
-/// (batched) and `..._f16_norm` (per-sequence, taken at n == 1 and whenever
-/// pool slots fragment out of slice order). Stage 2 adds twins of the MTP
-/// verify path — `gated_delta_rule_wy{2,3,4}_f16` plus the register-resident
-/// `wy{2,3}_resident_f16` — so the state stays FP16 through a verify step and
-/// the flag composes with `--speculative`. That matters because the ladder's
-/// low and middle rungs are all spec-ON, so before stage 2 they could not use
-/// the lever at all.
-///
-/// Every remaining h-state reader is still FP32, and an FP32 kernel pointed at
-/// an FP16 pool produces fluent garbage rather than an error — so the
-/// unsupported configurations are rejected here, at boot, instead of being
-/// discovered in a benchmark.
-///
-/// Sizing is untouched: the pool stays FP32-sized (prefill still writes FP32)
-/// and the FP16 state occupies the first half of the same region, so no
-/// reserve arithmetic above depends on the flag.
-fn ssm_h_fp16_preconditions(args: &cli::ServeArgs, config: &ModelConfig) -> Result<()> {
-    // SSOT: the same resolution the kernels dispatch on — `--ssm-h-dtype`,
-    // falling back to `ATLAS_SSM_H_FP16`. This check used to decode the
-    // environment independently, which is how a preflight could pass on a
-    // reading the kernels did not share.
-    if !spark_model::layers::qwen3_ssm::ssm_h_fp16_enabled() || config.num_ssm_layers() == 0 {
-        return Ok(());
-    }
-    // Stage 3 of the f16 h-state (f16-SIZED pools): the h pools would be SIZED at
-    // 2 bytes/element, but prefill still writes the h-state FP32 IN PLACE
-    // through the six GDN prefill kernel families (trait_prefill_gdn.rs /
-    // trait_prefill_recur.rs) — over a 2-byte slot that is an overrun into
-    // the neighboring slot, and a Marconi restore would land f16 under an
-    // FP32 prefill continuation. No CLI surface publishes the mode; this
-    // guards any non-CLI flag publication until prefill narrowing lands.
-    if spark_model::layers::qwen3_ssm::ssm_h_f16_pool_enabled() {
-        anyhow::bail!(
-            "the f16-SIZED SSM h pool (stage 3 of ssm-h-dtype f16) is not serveable yet: \
-             prefill writes the h-state FP32 in place, which would overrun the 2-byte-sized \
-             pool slots. The sizing plumbing (pool allocation, preflight reserve, \
-             byte-copiers) is in place and tested; prefill narrowing is the remaining \
-             work. Use --ssm-h-dtype f16 (FP32-sized pool) until then."
-        );
-    }
-    // STAGE 2 lifted the blanket refusal on `--speculative`: the MTP verify
-    // path's WY kernels now have FP16 h-state twins
-    // (`gated_delta_rule_wy{2,3,4}_f16` and the register-resident
-    // `wy{2,3}_resident_f16`), so the h-state stays FP16 end-to-end through a
-    // verify step. What is still refused is any configuration that can reach a
-    // K with NO twin, because the fallback is an FP32 kernel over an FP16 pool
-    // — which does not fault, it emits fluent garbage.
-    //
-    // The reachable K is bounded by the draft count: the ladder's draft count
-    // is capped by `--num-drafts`, and K = drafts + 1 rows per sequence. Twins
-    // exist for K = 2, 3, 4, so up to 3 drafts is supported. Above that the
-    // width lands on the wyN (K=5..8) or wy17 DFlash arms, which are FP32-only.
-    if args.self_speculative || args.ngram_speculative {
-        anyhow::bail!(
-            "--ssm-h-dtype f16 supports --speculative (MTP) only. The self-speculative and \
-             ngram-speculative verify paths still write the h-state as FP32, and an FP32 \
-             kernel over an FP16 pool produces fluent garbage rather than an error. Run \
-             without --self-speculative/--ngram-speculative, or use --ssm-h-dtype f32."
-        );
-    }
-    if args.speculative && args.resolved_num_drafts() > 3 {
-        anyhow::bail!(
-            "--ssm-h-dtype f16 supports up to 3 drafts (K <= 4 verify rows); --num-drafts is \
-             {}. Wider verify widths dispatch the wyN (K=5..8) / wy17 arms, which have no \
-             FP16 h-state twin. Lower --num-drafts to 3, or use --ssm-h-dtype f32.",
-            args.resolved_num_drafts()
-        );
-    }
-    if !spark_model::layers::qwen3_ssm::gdn_fused_norm_enabled() {
-        anyhow::bail!(
-            "--ssm-h-dtype f16 requires --gdn-fused-norm — the non-fused decode arms \
-             (gated_delta_rule_decode, ..._decode_f32_strided) have no FP16 twin in stage 1."
-        );
-    }
-    if std::env::var("ATLAS_GDN_FUSED_CONV").ok().as_deref() == Some("1") {
-        anyhow::bail!(
-            "--ssm-h-dtype f16 is incompatible with ATLAS_GDN_FUSED_CONV=1 —              gated_delta_rule_decode_f32_conv_norm has no FP16 twin in stage 1."
-        );
-    }
-    if config.linear_key_head_dim != 128 || config.linear_value_head_dim != 128 {
-        anyhow::bail!(
-            "--ssm-h-dtype f16 needs linear head dims 128/128 (the FP16 twins size their shared              memory for k_dim == 128); this model is {}/{}",
-            config.linear_key_head_dim,
-            config.linear_value_head_dim
-        );
-    }
-    tracing::info!(
-        "--ssm-h-dtype f16: GDN h-state stored FP16 during decode AND MTP verify (pool stays \
-         FP32-sized; prefill unchanged). Scan replica at n=128: 183 -> 84 ms/step."
     );
     Ok(())
 }

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/ssm_h_fp16.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/ssm_h_fp16.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `--ssm-h-dtype f16` / `f16-pool` boot preconditions.
+//!
+//! A sibling of `preflight.rs` (which is at the 500-line cap): this is the
+//! one self-contained refusal list in it, and it is the list that grows every
+//! time a stage of the FP16 h-state lands.
+
+use anyhow::Result;
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+/// `ATLAS_SSM_H_FP16` refuses rather than degrades.
+///
+/// The flag narrows the GDN h-state to FP16. Stage 1 shipped twins of the two
+/// NON-speculative decode kernels — `gated_delta_rule_decode_f16_strided_norm_half`
+/// (batched) and `..._f16_norm` (per-sequence, taken at n == 1 and whenever
+/// pool slots fragment out of slice order). Stage 2 adds twins of the MTP
+/// verify path — `gated_delta_rule_wy{2,3,4}_f16` plus the register-resident
+/// `wy{2,3}_resident_f16` — so the state stays FP16 through a verify step and
+/// the flag composes with `--speculative`. That matters because the ladder's
+/// low and middle rungs are all spec-ON, so before stage 2 they could not use
+/// the lever at all.
+///
+/// Every remaining h-state reader is still FP32, and an FP32 kernel pointed at
+/// an FP16 pool produces fluent garbage rather than an error — so the
+/// unsupported configurations are rejected here, at boot, instead of being
+/// discovered in a benchmark.
+///
+/// Stage 3 (`--ssm-h-dtype f16-pool`) is where SIZING changes: every h pool
+/// is allocated at 2 bytes/element, and prefill — whose six GDN kernel
+/// families are FP32 writers and stay that way — runs over a per-slot FP32
+/// STAGING blob that the layer widens into and narrows back
+/// (`spark_model::layers::qwen3_ssm::ssm_h_fp16`). The refusal list below is
+/// UNCHANGED by that, because the narrowing is transparent to every
+/// combination in it: what makes a kernel unsafe here is reading FP16 bits
+/// as FP32, not how wide the slot holding them is.
+pub(super) fn ssm_h_fp16_preconditions(args: &cli::ServeArgs, config: &ModelConfig) -> Result<()> {
+    // SSOT: the same resolution the kernels dispatch on — `--ssm-h-dtype`,
+    // falling back to `ATLAS_SSM_H_FP16`. This check used to decode the
+    // environment independently, which is how a preflight could pass on a
+    // reading the kernels did not share.
+    if !spark_model::layers::qwen3_ssm::ssm_h_fp16_enabled() || config.num_ssm_layers() == 0 {
+        return Ok(());
+    }
+    // ── `--dflash` (γ=17) ──
+    //
+    // DFlash dispatches the verify chain at γ+1 = 17 rows, which lands on
+    // `gated_delta_rule_wy17` — an FP32-only kernel with no FP16 h-state twin,
+    // AND the one WY family that takes an explicit FP32-element intermediate
+    // stride. Both halves are wrong over an FP16 h-state, and neither faults:
+    // the same fluent-garbage failure the `--num-drafts > 3` refusal below
+    // exists for. It applies to stage 1/2 f16 as much as to the f16-SIZED
+    // pool, which is why it sits above the stage-3 branch.
+    if args.dflash {
+        anyhow::bail!(
+            "--ssm-h-dtype f16 is incompatible with --dflash: the DFlash verify width \
+             (gamma + 1 = 17) dispatches gated_delta_rule_wy17, which has no FP16 h-state \
+             twin and strides the h intermediates in FP32 elements. An FP32 kernel over an \
+             FP16 h-state emits fluent garbage rather than an error. Drop --dflash, or use \
+             --ssm-h-dtype f32."
+        );
+    }
+    // STAGE 2 lifted the blanket refusal on `--speculative`: the MTP verify
+    // path's WY kernels now have FP16 h-state twins
+    // (`gated_delta_rule_wy{2,3,4}_f16` and the register-resident
+    // `wy{2,3}_resident_f16`), so the h-state stays FP16 end-to-end through a
+    // verify step. What is still refused is any configuration that can reach a
+    // K with NO twin, because the fallback is an FP32 kernel over an FP16 pool
+    // — which does not fault, it emits fluent garbage.
+    //
+    // The reachable K is bounded by the draft count: the ladder's draft count
+    // is capped by `--num-drafts`, and K = drafts + 1 rows per sequence. Twins
+    // exist for K = 2, 3, 4, so up to 3 drafts is supported. Above that the
+    // width lands on the wyN (K=5..8) or wy17 DFlash arms, which are FP32-only.
+    if args.self_speculative || args.ngram_speculative {
+        anyhow::bail!(
+            "--ssm-h-dtype f16 supports --speculative (MTP) only. The self-speculative and \
+             ngram-speculative verify paths still write the h-state as FP32, and an FP32 \
+             kernel over an FP16 pool produces fluent garbage rather than an error. Run \
+             without --self-speculative/--ngram-speculative, or use --ssm-h-dtype f32."
+        );
+    }
+    if args.speculative && args.resolved_num_drafts() > 3 {
+        anyhow::bail!(
+            "--ssm-h-dtype f16 supports up to 3 drafts (K <= 4 verify rows); --num-drafts is \
+             {}. Wider verify widths dispatch the wyN (K=5..8) / wy17 arms, which have no \
+             FP16 h-state twin. Lower --num-drafts to 3, or use --ssm-h-dtype f32.",
+            args.resolved_num_drafts()
+        );
+    }
+    if !spark_model::layers::qwen3_ssm::gdn_fused_norm_enabled() {
+        anyhow::bail!(
+            "--ssm-h-dtype f16 requires --gdn-fused-norm — the non-fused decode arms \
+             (gated_delta_rule_decode, ..._decode_f32_strided) have no FP16 twin in stage 1."
+        );
+    }
+    if std::env::var("ATLAS_GDN_FUSED_CONV").ok().as_deref() == Some("1") {
+        anyhow::bail!(
+            "--ssm-h-dtype f16 is incompatible with ATLAS_GDN_FUSED_CONV=1 —              gated_delta_rule_decode_f32_conv_norm has no FP16 twin in stage 1."
+        );
+    }
+    if config.linear_key_head_dim != 128 || config.linear_value_head_dim != 128 {
+        anyhow::bail!(
+            "--ssm-h-dtype f16 needs linear head dims 128/128 (the FP16 twins size their shared              memory for k_dim == 128); this model is {}/{}",
+            config.linear_key_head_dim,
+            config.linear_value_head_dim
+        );
+    }
+    if spark_model::layers::qwen3_ssm::ssm_h_f16_pool_enabled() {
+        tracing::info!(
+            "--ssm-h-dtype f16-pool: GDN h-state stored FP16 AND every h pool SIZED at 2 \
+             bytes/element. Prefill runs its unchanged FP32 kernels over a per-slot FP32 \
+             staging blob and narrows back, so the pool holds FP16 at all times. NUMERICS: \
+             the recurrence now carries FP16 state across prefill chunk boundaries as well \
+             as decode steps, with round-to-nearest-even and no stochastic rounding — do NOT \
+             publish a number from this mode without ssm-state-poisoning-gate, decode-floor, \
+             bfcl-subset and the agentic gate."
+        );
+    } else {
+        tracing::info!(
+            "--ssm-h-dtype f16: GDN h-state stored FP16 during decode AND MTP verify (pool \
+             stays FP32-sized; prefill unchanged). Scan replica at n=128: 183 -> 84 ms/step."
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Why

On `unsloth/Qwen3.8-27B-NVFP4` (48 GDN/Mamba + 16 attention layers) Atlas's decode carries **~102 MB of recurrent SSM h-state per sequence per step**. That per-sequence traffic is the dominant marginal cost of adding a concurrent sequence: Atlas pays **4.28 ms/token/seq against vLLM's 1.94 ms** on the same checkpoint, which is why Atlas currently loses the C=4/8/16 rungs (81.4 vs 124.5 tok/s at C=8). The h-state is **95% of every 151.5 MiB state blob**, and it is stored FP32.

`--ssm-h-dtype f16` already keeps the state FP16 through decode and MTP verify, but **the pool was still FP32-SIZED**, so it bought the decode-kernel win and none of the memory. #3 (`66794ddfc`) landed the sizing plumbing — `ssm_reserve::ssm_h_stored_bytes`, `SsmStatePool::h_stored_bytes` through every h allocation/offset, dtype-keyed byte-copiers, the Marconi restore-narrowing path — and then **refused the mode at boot**, because prefill writes the running h-state FP32 **in place** through six GDN kernel families and there was no copy site to convert on.

This PR makes the copy site and lifts the refusal.

## Design

Three options were on the table; the choice and the reasons are recorded in the commit message.

**(a) — CHOSEN. A per-slot FP32 staging blob.** Every pool slot gets one FP32 h blob. The layer widens the narrow slot into it before its FP32 kernels run and narrows it back after. Prefill's kernels are **untouched** — what changes is where they write. The conversion pair already exists (`kernels/gb10/common/ssm_h_dtype.cu`, both directions, out-of-place, which the narrowing needs anyway), prefill is not CUDA-graph captured, and the pair is self-cancelling, so — unlike the decode-side one-shot conversion, which had to be hoisted out of the graph — it is safe to launch from inside the layer.

**(b) — REJECTED. f16 twins of the prefill kernels.** ~10 live kernels across `split4` / `persistent{,_wy4}` / `wy64` / FLA `chunk_delta_h` and their batched twins; ~20 counting linked-but-unreferenced variants, several duplicated per model directory. The repo's dtype-variant pattern is hand-duplicated whole kernels (no templating on the dtype axis), so this is ~20 new `.cu` files. Unbounded, and un-validatable CPU-only.

**(c) — applied only where it is still needed:** the `--dflash` refusal below.

### The invariant the staging blob buys

**The pool holds FP16 at every moment outside a layer's prefill call.** `SsmLayerState::h_is_f16` therefore becomes simply `true` for a sequence's whole life under this mode, which collapses four edges at once:

- the decode mixer (`ssm_h_to_f16_dispatch`) becomes a no-op;
- Marconi snapshot **save** always takes its widening arm — the prefill leaf save, the mid-chunk pre-pass save and the non-last-chunk checkpoint save now all flow through it, so a warm restore's narrowing twin is consistent with the pool dtype;
- slot zeroing stays format-agnostic (zero is zero in both);
- the *"Marconi-restore `h_is_f16` propagation into an f16 prefill continuation"* gap from #3's remaining list closes with no special case.

### Sizing

`ssm_reserve::ssm_h_prefill_stage_bytes(slots, h_layer_f32_bytes, f16_pool)` is the SSOT, and both `SsmStatePool::new` and the preflight reserve go through it.

**One blob per SLOT, not per slot per layer.** The blob is live only inside one layer's prefill call, and the layers of a pass are issued in order on one stream, so layer L+1 reuses layer L's. Sizing it per slot (rather than per co-dispatched sequence) is what makes that safe with no assumption about the co-dispatch width — a sequence owns exactly one slot for its whole life. A per-layer arena would be 48x bigger and would turn the win into a loss; a unit test pins the ratio so that mistake fails loudly.

### Where the conversion is wired

| path | site |
|---|---|
| chunked single-stream | `prefill_gdn_recurrence_staged` wraps the existing recurrence ladder |
| two-phase whole-prompt | `prefill_gdn_full_inner` split from the kernel ladder, so the narrowing runs on **all nine** of its early `return ops::...` exits |
| batched co-dispatch | takes a `float* const*` table, so it converts model-side: `stage_h_state_ptrs` widens as it stages, `narrow_h_state_stages` is the matching epilogue (both uniform and varlen-FLA arms; the varlen *fallback* loop routes through the single-stream ladder and is skipped) |

A **failed** pass skips the narrowing, leaving the slot at its last valid f16 value — which is the point of staging in separate memory: under an FP32-sized pool a failed prefill scribbles the slot itself and a later snapshot save caches the scribble.

Slot-pitch fixes the narrow pool exposes, all routed through `h_slot_stride_bytes()` -> `ssm_reserve::ssm_h_stored_bytes` so layer and allocator cannot disagree: `ssm_batched_recurrent`'s contiguity check and its `h_seq_stride` (the FP16 decode kernel's per-sequence stride is the **pool pitch in halves**, not inferable from head dims), and `ConvGdnArgs::h_bytes`, which every consumer uses as a pool byte pitch.

## What is and is not serveable after this change

**Serveable:** `--ssm-h-dtype f16-pool --gdn-fused-norm`, with or without `--speculative --num-drafts <= 3`. That is a one-word swap in the ladder recipe.

The MTP verify strides were audited exhaustively against exactly that combination and **the live FP32-pitch set is empty**: the `gated_delta_rule_wy{2,3,4}_f16` kernels and their resident twins take **no stride argument at all** — they derive their own offsets in `__half` elements from per-slot base pointers, and the wrappers hard-`ensure!` table addressing at n>1. Every FP32-pitch site that remains is behind `verify_exact_active()` (hard-wired `exact_verify && !h_f16`, so false whenever f16 is set) or K>=5 (already refused). `ConvGdnArgs::h_bytes` is fixed anyway: a no-op today, correct for whatever K-arm touches it next.

**Refused, loudly, with the reason named** — unchanged from `f16` except the last:

| refused | why |
|---|---|
| without `--gdn-fused-norm` | the unfused decode arms are FP32-only |
| `--self-speculative` / `--ngram-speculative` | their verify paths write h as FP32 |
| `--speculative` with `--num-drafts > 3` | K>=5 lands on `wyN`/`wy17`, no f16 twin |
| `--exact-verify` | FP32-reader chain |
| `ATLAS_GDN_FUSED_CONV=1` | no f16 twin |
| head dims != 128/128 | the f16 twins size smem for k_dim == 128 |
| **`--dflash` (NEW)** | gamma+1 = 17 dispatches `gated_delta_rule_wy17` — the one WY family with **no f16 twin AND** an explicit FP32-element intermediate stride |

The `--dflash` refusal is a **pre-existing stage-1/2 hole**, not a stage-3 one: `--ssm-h-dtype f16 --dflash` has always read FP16 bits through an FP32 kernel, which is fluent garbage rather than a fault. It was simply never checked. No gate recipe pairs them (the ladder runs `--speculative --num-drafts 3`), so nothing that runs today changes.

**Not attempted:** f16 twins of the prefill or `wyN`/`wy17` kernels; stochastic rounding.

## NUMERICS — the headline risk

A reduced-precision recurrence accumulates rounding **coherently**, not as independent noise. vLLM's fp16 mamba cache required stochastic rounding for exactly this reason, and there is no published fp8-recurrent-state accuracy study. This PR puts the FP16 state on the **prefill** recurrence's chunk boundaries as well as on decode, so it widens the exposure relative to stage 1/2.

Rounding here is round-to-nearest-even (`__float2half`). **A stochastic-rounding converter behind a further flag is deliberately follow-up, not built here** — it is a second `.cu` entry point plus a per-call RNG seed, and adding it unvalidated would be one more untested surface on an already untested one.

Accordingly:

- the flag stays **default OFF**;
- **gate recipes are unchanged** — no recipe carries it;
- **enabling it for any published number requires passing `ssm-state-poisoning-gate`, `decode-floor`, `bfcl-subset` and the agentic gate first.** The boot log and `--ssm-h-dtype`'s `--help` both say so, in those words.

## Expected payoff

h-state pool bytes halve — h is 95% of a 151.5 MiB blob — cutting both the per-sequence per-step state traffic (the 4.28 ms/seq marginal) and the reserve. Allocator arithmetic, 27B, bs=128, pinned by unit test:

| | FP32-sized | f16-sized | staging arena | net |
|---|---|---|---|---|
| spec OFF (base pool) | 20_333_985_792 (18.94 GiB) | 10_670_309_376 (9.94 GiB) | 402_653_184 (384 MiB) | **8.63 GiB back** |
| spec ON, K=4 (tiered) | 33_671_872_512 | 17_968_398_336 (16.73 GiB) | 402_653_184 | **14.25 GiB back** |

At the concurrency profile's Marconi 32->8 that moves the bs=128 SSM reserve from **36.7 GiB to ~22.5 GiB**, staging arena included — freeing ~14 GiB for KV. The staging arena is 4.2% of what it buys back.

**These are sizing numbers, computed and test-pinned. No throughput number is claimed: nothing here has run on a GPU.**

## Flag-off is byte-identical

Pinned, not asserted in prose: no staging arena is allocated, `h_prefill_stage` is `None` everywhere, `h_stored_bytes == h_bytes`, and `prefill_h_begin`/`prefill_h_end` launch **nothing** and hand back the slot pointer — checked on the mock backend, including that a NULL converter handle is not even consulted, so a target without `ssm_h_dtype.cu` still serves the default mode.

## Tests

Extended, not forked. The reserve numbers were already test-pinned, so the staging term joins that suite.

- **Reserve:** staging term is zero at every batch size flag-off; one FP32 layer blob per slot flag-on; the net win table above; the arena pinned as a **ratio** so a per-layer arena fails.
- **Pool geometry** (mock backend): the arena exists only when narrowed, strides at the FP32 pitch (= 2x the slot pitch it feeds), covers the dummy slot, and agrees with the preflight SSOT.
- **Conversion round-trip** (mock backend, as far as the harness allows — its `kernel()` hands out one shared handle and `copy_d2d` is a no-op, so this is launch-count/geometry, not numerics): exactly one widen in and one narrow out, over the stage, both carrying the FP32 element count `h_bytes/4` = 786_432, block [256,1,1].
- **Refusals:** both NULL-handle bails, an FP32-flagged state over a narrow slot, and `h_f16_pool` without `h_f16` being unrepresentable from any input spelling.
- **CLI:** `f16-pool` accepted with `--gdn-fused-norm` / rejected without; `--exact-verify` refuses it; `f16pool` (no hyphen) rejected by the enum check *and* decoding to FP32 rather than something half-enabled; the `--dflash` refusal for both f16 spellings with positive controls on each side alone and on `--dflash --ssm-h-dtype f32`.

Gates (`ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000` exported, not command-prefixed): `cargo fmt --all -- --check` clean; `cargo clippy --workspace --tests` clean; `check-license-headers.sh` 2232 valid / 0 invalid; `cargo test --workspace` 74 suites, 0 failures; file-size cap 0 violations (`preflight.rs` was at the cap, so `ssm_h_fp16_preconditions` moved to `preflight/ssm_h_fp16.rs`, 515 -> 407 LoC).

## Validation plan — required before any number from this mode is quoted

Nothing here has run on a GPU. Recommended order, cheapest discriminator first:

1. **Flag-off regression** — serve the ladder recipe unchanged (`--ssm-h-dtype f16`) and confirm byte-identical output vs `bd543ebc4`. This is the one leg that gates the merge itself; everything below gates *using* the new mode.
2. **`ssm-state-poisoning-gate`** with `--ssm-h-dtype f16-pool --gdn-fused-norm`. This is the discriminator for the whole design: it is what catches a missed narrow/widen edge, and a coherent-rounding drift, before either can look like a throughput result.
3. **C2 pre-flight smoke** (dense-27B NVFP4 tool-call + coherence, seconds) — catches numerically-broken output that the long gates pass right over.
4. **decode-floor** at C=1.
5. **`bfcl-subset` (ST-995)** on the dense 27B flagship, recorded with its `category_sample_pct`, N, and the ordered-`sample_id` SHA256 beside it — a BFCL number without its draw is meaningless, and the floors are 83.64/85.32.
6. **Agentic gate** (35B flagship, N=10 `webserver_ok`, 10/10 + 10/10 `followed_directions`, sum(wall) <= 1000 s).
7. **Ladder floors** (fp8, must not regress): C=1 21.74, C=2 29.04, C=4 51.55, C=8 81.42, C=16 150.41, C=32 219.97, C=64 360.02, C=128 450.12.
8. **Warm-TTFT guard** (median <=3% / p90 <=5% vs a same-box main control leg) — this diff touches the prefill path, and the widen/narrow pair costs ~1.5 extra DRAM passes over one layer's h per prefill pass (~150 MB per 48-layer pass on the 27B). That cost is real and should be *measured*, not assumed marginal.

Target for this branch is `test/ladder-stack`; the eventual target is `main` via the campaign branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
