### PR TITLE
fix(mtp-telemetry): give every dispatchable batch width its own accept bucket

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/agentic-webserver/2026-08-19-8ce64f6202.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787119536,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2418.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787118813,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 66.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8370292,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7602044,
+      "gpu_compute_apps": [
+        {
+          "pid": 223981,
+          "name": "./target/release/spark",
+          "used_mib": 109189
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787119536,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        }
+      ],
+      "sm_clock_mhz": 2418.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8885924,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7715696,
+      "gpu_compute_apps": [
+        {
+          "pid": 223981,
+          "name": "./target/release/spark",
+          "used_mib": 109215
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 723,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 8.0,
+      "hottest_chassis_delta_c": 10.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +11 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "decode_tps": 33.845406224863865,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 6.173337942721738,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 709.9338634129999,
+    "sum_completion_tokens": 24028.0,
+    "sum_tool_calls": 114.0,
+    "sum_turns": 115.0,
+    "sum_wall_s": 721.1770464570001,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 6.173s/turn ≤ 8.500 · Σwall 721s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=33.85, followed_directions=10.00, iterations=10.00, s_per_turn=6.17, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=709.93, sum_completion_tokens=24028.00, sum_tool_calls=114.00, sum_turns=115.00, sum_wall_s=721.18, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 6.173s/turn ≤ 8.500 · Σwall 721s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-19-8ce64f6202.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787134788,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787125452,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.4
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8829260,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7904580,
+      "gpu_compute_apps": [
+        {
+          "pid": 245423,
+          "name": "./target/release/spark",
+          "used_mib": 109184
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787134787,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.4
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6937324,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 6268388,
+      "gpu_compute_apps": [
+        {
+          "pid": 245423,
+          "name": "./target/release/spark",
+          "used_mib": 109210
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 9335,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": -1.0,
+      "hottest_chassis_delta_c": -2.0999999999999943
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved -2 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.61,
+    "overall_accuracy": 86.25,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.25 (baseline min 86.10) · normalized 86.61 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.61, overall_accuracy=86.25, samples=1004.00 · Pass: overall 86.25 (baseline min 86.10) · normalized 86.61 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/bfcl-subset/2026-08-19-8ce64f6202.json
@@ -1,0 +1,453 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787125422,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787119554,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 78.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 35950036,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7719180,
+      "gpu_compute_apps": [
+        {
+          "pid": 231078,
+          "name": "./target/release/spark",
+          "used_mib": 83652
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787125422,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 35771304,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7904372,
+      "gpu_compute_apps": [
+        {
+          "pid": 231078,
+          "name": "./target/release/spark",
+          "used_mib": 83788
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5868,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": -2.0,
+      "hottest_chassis_delta_c": -3.6999999999999886
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved -4 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/concurrency-sweep/2026-08-19-8ce64f6202.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787118782,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787118580,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 67.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 16195652,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7601120,
+      "gpu_compute_apps": [
+        {
+          "pid": 223814,
+          "name": "./target/release/spark",
+          "used_mib": 102132
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787118782,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 79.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 90.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 90.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 87.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.0
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15276812,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7601788,
+      "gpu_compute_apps": [
+        {
+          "pid": 223814,
+          "name": "./target/release/spark",
+          "used_mib": 102391
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 202,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 12.0,
+      "hottest_chassis_delta_c": 12.399999999999991
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 88.21824672746479,
+    "c16_ttft_p50_ms": 17272.471963,
+    "c1_aggregate_tok_s": 19.284308043108283,
+    "c1_ttft_p50_ms": 1434.004582,
+    "c4_aggregate_tok_s": 49.20259526835076,
+    "c4_ttft_p50_ms": 5044.134011,
+    "c8_aggregate_tok_s": 61.38852805243018,
+    "c8_ttft_p50_ms": 9258.703779,
+    "min_completion_tokens": 316.0,
+    "peak_aggregate_tok_s": 88.21824672746479,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 19.3/16.2 · C4 49.2/33.5 · C8 61.4/50.5 · C16 88.2/72.0 · peak 88.2/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=88.22, c16_ttft_p50_ms=17272.47, c1_aggregate_tok_s=19.28, c1_ttft_p50_ms=1434.00, c4_aggregate_tok_s=49.20, c4_ttft_p50_ms=5044.13, c8_aggregate_tok_s=61.39, c8_ttft_p50_ms=9258.70, min_completion_tokens=316.00, peak_aggregate_tok_s=88.22, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 19.3/16.2 · C4 49.2/33.5 · C8 61.4/50.5 · C16 88.2/72.0 · peak 88.2/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/decode-floor/2026-08-19-8ce64f6202.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787118005,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787117882,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 51.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.5
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15210736,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 11838836,
+      "gpu_compute_apps": [
+        {
+          "pid": 222565,
+          "name": "./target/release/spark",
+          "used_mib": 103156
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787118005,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 82.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 89.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 86.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 89.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.6
+        }
+      ],
+      "sm_clock_mhz": 2444.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15738800,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 11838880,
+      "gpu_compute_apps": [
+        {
+          "pid": 222565,
+          "name": "./target/release/spark",
+          "used_mib": 103160
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 123,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 31.0,
+      "hottest_chassis_delta_c": 32.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +32 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 23.44385379486688
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 23.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=23.44 · Pass: median decode 23.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-19-8ce64f6202.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787118472,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787118358,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 66.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 73.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8285768,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7600392,
+      "gpu_compute_apps": [
+        {
+          "pid": 223501,
+          "name": "./target/release/spark",
+          "used_mib": 109215
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787118472,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 77.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 87.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 87.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.6
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8315536,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7600516,
+      "gpu_compute_apps": [
+        {
+          "pid": 223501,
+          "name": "./target/release/spark",
+          "used_mib": 109241
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 114,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 11.0,
+      "hottest_chassis_delta_c": 13.899999999999991
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +14 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 112.994763182,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=112.99, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-19-8ce64f6202.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787118127,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787118039,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 62.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 71.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.9
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8592288,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7584048,
+      "gpu_compute_apps": [
+        {
+          "pid": 222657,
+          "name": "./target/release/spark",
+          "used_mib": 109130
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787118127,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.7
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8572468,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7584476,
+      "gpu_compute_apps": [
+        {
+          "pid": 222657,
+          "name": "./target/release/spark",
+          "used_mib": 109154
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 88,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 12.0,
+      "hottest_chassis_delta_c": 11.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "median_ms": 1642.9410469999998,
+    "p90_ms": 4488.111806,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "info",
+  "verdict_reason": "no baseline on this box yet — this run is recorded as the baseline",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1642.94, p90_ms=4488.11, samples=36.00 · Info: no baseline on this box yet — this run is recorded as the baseline",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-19-8ce64f6202.json
@@ -3,7 +3,7 @@
   "benchmark_id": "ttft-cold-gate",
   "benchmark_name": "Cold TTFT Regression Gate",
   "git_sha": "8ce64f6202",
-  "recorded_at": 1787118127,
+  "recorded_at": 1787136855,
   "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
   "params": {
     "median_limit_pct": "3",
@@ -37,54 +37,54 @@
   "hardware": {
     "gpu": "NVIDIA GB10",
     "driver": "580.159.03",
-    "sm_clock_mhz": 2476.0,
+    "sm_clock_mhz": 2496.0,
     "source": "nvidia-smi"
   },
   "hardware_state": {
     "sensitivity": "speed",
     "before": {
-      "captured_at": 1787118039,
+      "captured_at": 1787136768,
       "machine": {
         "hostname": "spark-28c2",
         "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
         "gpu": "NVIDIA GB10",
         "driver": "580.159.03"
       },
-      "gpu_temp_c": 62.0,
+      "gpu_temp_c": 51.0,
       "chassis_temps_c": [
         {
           "name": "acpitz",
-          "temp_c": 71.8
+          "temp_c": 56.3
         },
         {
           "name": "acpitz",
-          "temp_c": 62.9
+          "temp_c": 51.6
         },
         {
           "name": "acpitz",
-          "temp_c": 63.8
+          "temp_c": 56.3
         },
         {
           "name": "acpitz",
-          "temp_c": 63.4
+          "temp_c": 51.8
         },
         {
           "name": "acpitz",
-          "temp_c": 71.8
+          "temp_c": 52.8
         },
         {
           "name": "acpitz",
-          "temp_c": 64.9
+          "temp_c": 53.8
         },
         {
           "name": "acpitz",
-          "temp_c": 63.9
+          "temp_c": 52.8
         }
       ],
-      "sm_clock_mhz": 2411.0,
+      "sm_clock_mhz": 2405.0,
       "sm_clock_max_mhz": 3003.0,
       "throttle_counters": {
-        "sw_power_cap_us": 26257227756,
+        "sw_power_cap_us": 26738371597,
         "sw_thermal_us": 0,
         "hw_thermal_us": 0,
         "hw_power_brake_us": 0,
@@ -96,14 +96,14 @@
         "hw_thermal": false,
         "hw_power_brake": false
       },
-      "mem_available_kb": 8592288,
+      "mem_available_kb": 7711012,
       "mem_total_kb": 127600752,
-      "page_cache_kb": 7584048,
+      "page_cache_kb": 6332188,
       "gpu_compute_apps": [
         {
-          "pid": 222657,
+          "pid": 314293,
           "name": "./target/release/spark",
-          "used_mib": 109130
+          "used_mib": 109903
         }
       ],
       "cpu_governor": "performance",
@@ -115,18 +115,22 @@
       ]
     },
     "after": {
-      "captured_at": 1787118127,
+      "captured_at": 1787136855,
       "machine": {
         "hostname": "spark-28c2",
         "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
         "gpu": "NVIDIA GB10",
         "driver": "580.159.03"
       },
-      "gpu_temp_c": 74.0,
+      "gpu_temp_c": 66.0,
       "chassis_temps_c": [
         {
           "name": "acpitz",
-          "temp_c": 83.5
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
         },
         {
           "name": "acpitz",
@@ -134,29 +138,25 @@
         },
         {
           "name": "acpitz",
-          "temp_c": 72.8
+          "temp_c": 61.0
         },
         {
           "name": "acpitz",
-          "temp_c": 72.0
+          "temp_c": 61.8
         },
         {
           "name": "acpitz",
-          "temp_c": 83.5
+          "temp_c": 71.3
         },
         {
           "name": "acpitz",
-          "temp_c": 81.9
-        },
-        {
-          "name": "acpitz",
-          "temp_c": 73.7
+          "temp_c": 63.1
         }
       ],
-      "sm_clock_mhz": 2476.0,
+      "sm_clock_mhz": 2496.0,
       "sm_clock_max_mhz": 3003.0,
       "throttle_counters": {
-        "sw_power_cap_us": 26257227756,
+        "sw_power_cap_us": 26738371597,
         "sw_thermal_us": 0,
         "hw_thermal_us": 0,
         "hw_power_brake_us": 0,
@@ -168,14 +168,14 @@
         "hw_thermal": false,
         "hw_power_brake": false
       },
-      "mem_available_kb": 8572468,
+      "mem_available_kb": 7735904,
       "mem_total_kb": 127600752,
-      "page_cache_kb": 7584476,
+      "page_cache_kb": 6332404,
       "gpu_compute_apps": [
         {
-          "pid": 222657,
+          "pid": 314293,
           "name": "./target/release/spark",
-          "used_mib": 109154
+          "used_mib": 109927
         }
       ],
       "cpu_governor": "performance",
@@ -187,13 +187,13 @@
       ]
     },
     "delta": {
-      "elapsed_s": 88,
+      "elapsed_s": 87,
       "sw_power_cap_us": 0,
       "sw_thermal_us": 0,
       "hw_thermal_us": 0,
       "hw_power_brake_us": 0,
-      "gpu_temp_delta_c": 12.0,
-      "hottest_chassis_delta_c": 11.700000000000003
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 15.400000000000006
     },
     "precheck": {
       "decision": "proceed"
@@ -201,20 +201,20 @@
     "postcheck": {
       "validity": "valid",
       "concerns": [
-        "hottest chassis zone moved +12 °C"
+        "hottest chassis zone moved +15 °C"
       ]
     },
     "perf_class": "gb10@spark-28c2"
   },
   "metrics": {
-    "median_ms": 1642.9410469999998,
-    "p90_ms": 4488.111806,
+    "median_ms": 1620.157991,
+    "p90_ms": 4446.9013589999995,
     "samples": 36.0
   },
   "frame_status": "Completed",
-  "verdict": "info",
-  "verdict_reason": "no baseline on this box yet — this run is recorded as the baseline",
-  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1642.94, p90_ms=4488.11, samples=36.00 · Info: no baseline on this box yet — this run is recorded as the baseline",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.4% (limit +3.0%) · p90 +0.8% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1620.16, p90_ms=4446.90, samples=36.00 · Pass: median +0.4% (limit +3.0%) · p90 +0.8% (limit +5.0%)",
   "closure": {
     "gb10/deepseek-v4-flash/nvfp4": {
       "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",

--- a/.benchmarks/ttft-warm-gate/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-19-8ce64f6202.json
@@ -3,7 +3,7 @@
   "benchmark_id": "ttft-warm-gate",
   "benchmark_name": "Warm TTFT Regression Gate",
   "git_sha": "8ce64f6202",
-  "recorded_at": 1787118327,
+  "recorded_at": 1787137054,
   "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
   "params": {
     "median_limit_pct": "3",
@@ -37,54 +37,54 @@
   "hardware": {
     "gpu": "NVIDIA GB10",
     "driver": "580.159.03",
-    "sm_clock_mhz": 2470.0,
+    "sm_clock_mhz": 2489.0,
     "source": "nvidia-smi"
   },
   "hardware_state": {
     "sensitivity": "speed",
     "before": {
-      "captured_at": 1787118159,
+      "captured_at": 1787136888,
       "machine": {
         "hostname": "spark-28c2",
         "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
         "gpu": "NVIDIA GB10",
         "driver": "580.159.03"
       },
-      "gpu_temp_c": 63.0,
+      "gpu_temp_c": 53.0,
       "chassis_temps_c": [
         {
           "name": "acpitz",
-          "temp_c": 69.8
+          "temp_c": 62.0
         },
         {
           "name": "acpitz",
-          "temp_c": 63.9
+          "temp_c": 53.9
         },
         {
           "name": "acpitz",
-          "temp_c": 69.8
+          "temp_c": 62.0
         },
         {
           "name": "acpitz",
-          "temp_c": 64.0
+          "temp_c": 53.8
         },
         {
           "name": "acpitz",
-          "temp_c": 65.3
+          "temp_c": 54.8
         },
         {
           "name": "acpitz",
-          "temp_c": 65.8
+          "temp_c": 55.8
         },
         {
           "name": "acpitz",
-          "temp_c": 64.9
+          "temp_c": 54.8
         }
       ],
-      "sm_clock_mhz": 2405.0,
+      "sm_clock_mhz": 2411.0,
       "sm_clock_max_mhz": 3003.0,
       "throttle_counters": {
-        "sw_power_cap_us": 26257227756,
+        "sw_power_cap_us": 26738371597,
         "sw_thermal_us": 0,
         "hw_thermal_us": 0,
         "hw_power_brake_us": 0,
@@ -96,14 +96,14 @@
         "hw_thermal": false,
         "hw_power_brake": false
       },
-      "mem_available_kb": 8437208,
+      "mem_available_kb": 8392220,
       "mem_total_kb": 127600752,
-      "page_cache_kb": 7596884,
+      "page_cache_kb": 6332516,
       "gpu_compute_apps": [
         {
-          "pid": 222799,
+          "pid": 315064,
           "name": "./target/release/spark",
-          "used_mib": 109104
+          "used_mib": 109173
         }
       ],
       "cpu_governor": "performance",
@@ -115,22 +115,30 @@
       ]
     },
     "after": {
-      "captured_at": 1787118326,
+      "captured_at": 1787137054,
       "machine": {
         "hostname": "spark-28c2",
         "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
         "gpu": "NVIDIA GB10",
         "driver": "580.159.03"
       },
-      "gpu_temp_c": 77.0,
+      "gpu_temp_c": 66.0,
       "chassis_temps_c": [
         {
           "name": "acpitz",
-          "temp_c": 88.0
+          "temp_c": 75.8
         },
         {
           "name": "acpitz",
-          "temp_c": 74.8
+          "temp_c": 63.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.8
         },
         {
           "name": "acpitz",
@@ -138,25 +146,17 @@
         },
         {
           "name": "acpitz",
-          "temp_c": 75.5
+          "temp_c": 74.4
         },
         {
           "name": "acpitz",
-          "temp_c": 88.0
-        },
-        {
-          "name": "acpitz",
-          "temp_c": 85.1
-        },
-        {
-          "name": "acpitz",
-          "temp_c": 77.4
+          "temp_c": 65.4
         }
       ],
-      "sm_clock_mhz": 2470.0,
+      "sm_clock_mhz": 2489.0,
       "sm_clock_max_mhz": 3003.0,
       "throttle_counters": {
-        "sw_power_cap_us": 26257227756,
+        "sw_power_cap_us": 26738371597,
         "sw_thermal_us": 0,
         "hw_thermal_us": 0,
         "hw_power_brake_us": 0,
@@ -168,14 +168,14 @@
         "hw_thermal": false,
         "hw_power_brake": false
       },
-      "mem_available_kb": 8554060,
+      "mem_available_kb": 8480848,
       "mem_total_kb": 127600752,
-      "page_cache_kb": 7600268,
+      "page_cache_kb": 6332992,
       "gpu_compute_apps": [
         {
-          "pid": 222799,
+          "pid": 315064,
           "name": "./target/release/spark",
-          "used_mib": 109128
+          "used_mib": 109197
         }
       ],
       "cpu_governor": "performance",
@@ -187,13 +187,13 @@
       ]
     },
     "delta": {
-      "elapsed_s": 167,
+      "elapsed_s": 166,
       "sw_power_cap_us": 0,
       "sw_thermal_us": 0,
       "hw_thermal_us": 0,
       "hw_power_brake_us": 0,
-      "gpu_temp_delta_c": 14.0,
-      "hottest_chassis_delta_c": 18.200000000000003
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 13.799999999999997
     },
     "precheck": {
       "decision": "proceed"
@@ -201,20 +201,20 @@
     "postcheck": {
       "validity": "valid",
       "concerns": [
-        "hottest chassis zone moved +18 °C"
+        "hottest chassis zone moved +14 °C"
       ]
     },
     "perf_class": "gb10@spark-28c2"
   },
   "metrics": {
-    "median_ms": 1569.298049,
-    "p90_ms": 4470.058044,
+    "median_ms": 1555.387192,
+    "p90_ms": 4429.158038,
     "samples": 36.0
   },
   "frame_status": "Completed",
-  "verdict": "info",
-  "verdict_reason": "no baseline on this box yet — this run is recorded as the baseline",
-  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1569.30, p90_ms=4470.06, samples=36.00 · Info: no baseline on this box yet — this run is recorded as the baseline",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.2% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1555.39, p90_ms=4429.16, samples=36.00 · Pass: median +0.2% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
   "closure": {
     "gb10/deepseek-v4-flash/nvfp4": {
       "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",

--- a/.benchmarks/ttft-warm-gate/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-19-8ce64f6202.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787118327,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787118159,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 63.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8437208,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7596884,
+      "gpu_compute_apps": [
+        {
+          "pid": 222799,
+          "name": "./target/release/spark",
+          "used_mib": 109104
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787118326,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 77.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 88.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 88.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.4
+        }
+      ],
+      "sm_clock_mhz": 2470.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8554060,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7600268,
+      "gpu_compute_apps": [
+        {
+          "pid": 222799,
+          "name": "./target/release/spark",
+          "used_mib": 109128
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 167,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 18.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +18 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "median_ms": 1569.298049,
+    "p90_ms": 4470.058044,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "info",
+  "verdict_reason": "no baseline on this box yet — this run is recorded as the baseline",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1569.30, p90_ms=4470.06, samples=36.00 · Info: no baseline on this box yet — this run is recorded as the baseline",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/video-fidelity/2026-08-19-8ce64f6202.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787119615,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2496.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787119598,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 48.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 55.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.7
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 37949503866,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32686000,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 22677172,
+      "gpu_compute_apps": [
+        {
+          "pid": 1339931,
+          "name": "./target/release/spark",
+          "used_mib": 83835
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787119615,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 67.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.4
+        }
+      ],
+      "sm_clock_mhz": 2496.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 37949503866,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32769312,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 22677468,
+      "gpu_compute_apps": [
+        {
+          "pid": 1339931,
+          "name": "./target/release/spark",
+          "used_mib": 83845
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 17,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 12.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 755.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1504.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 3004.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=755.00, conc_2_correct=2.00, conc_2_wall_ms=1504.00, conc_4_correct=4.00, conc_4_wall_ms=3004.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-19-8ce64f6202.json
+++ b/.benchmarks/vision-fidelity/2026-08-19-8ce64f6202.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "8ce64f6202",
+  "recorded_at": 1787118561,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787118506,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 64.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8417220,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7600660,
+      "gpu_compute_apps": [
+        {
+          "pid": 223633,
+          "name": "./target/release/spark",
+          "used_mib": 109064
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787118561,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 84.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.4
+        }
+      ],
+      "sm_clock_mhz": 2470.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 26257227756,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8550160,
+      "mem_total_kb": 127600752,
+      "page_cache_kb": 7601020,
+      "gpu_compute_apps": [
+        {
+          "pid": 223633,
+          "name": "./target/release/spark",
+          "used_mib": 109106
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 55,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 11.0,
+      "hottest_chassis_delta_c": 11.299999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +11 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 484.0,
+    "conc_2_wall_ms": 960.0,
+    "conc_4_wall_ms": 1837.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=484.00, conc_2_wall_ms=960.00, conc_4_wall_ms=1837.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/crates/spark-server/src/scheduler/mtp_accept_debug.rs
+++ b/crates/spark-server/src/scheduler/mtp_accept_debug.rs
@@ -27,7 +27,47 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Widths tracked individually; anything wider folds into the last bucket.
-const MAX_N: usize = 17;
+///
+/// MUST cover the MTP dispatch cap ([`spark_model::speculative::mtp_max_seqs`],
+/// default 32) or the fold ALIASES distinct widths onto one bucket. It did:
+/// this was 17 while the cap was raised 16 -> 32 (`69658b873`, 2026-07-30),
+/// so every width in 16..=128 accumulated into bucket 16 and the flush
+/// reported whichever width happened to trip [`PERIOD`]. The `diag_c32`
+/// serve log shows the single bucket flushing as
+/// `n=18/25/26/28/29/30/31/32` inside one run, at a mean p1 of 0.676 —
+/// while a clean n=16 bucket reads 0.77-0.89.
+///
+/// Two consequences, both live and both on the rung controller:
+/// * the n=16 sample [`super::adaptive_rung`] steers the shipped rung from
+///   was a MIXTURE of n=16 and n>16 statistics. n>16 accepts materially
+///   worse, so the mixture biases `p1` (and through it the token ratio)
+///   DOWN, i.e. toward `k=1` — the conservative side;
+/// * a flush tripped by an n>16 caller is handed to `observe(n>16, ..)`,
+///   which the `9..=16` BAND discards outright, so under mixed-width
+///   traffic the n=16 controller silently LOSES ticks it paid for.
+///
+/// Kill switch `ATLAS_MTP_ACCEPT_FOLD_AT_16` (presence — house convention,
+/// `=0` is NOT off) restores the pre-fix fold for an A/B.
+const MAX_N: usize = 33;
+
+/// PRESENCE check for `ATLAS_MTP_ACCEPT_FOLD_AT_16`: restores the pre-fix
+/// bucket fold (every width >= 16 into one bucket) so the correction is
+/// A/B-able against the binary that measured the ladder. Read once per
+/// process.
+fn fold_at_16() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_MTP_ACCEPT_FOLD_AT_16").is_some())
+}
+
+/// The bucket index for batch width `n` — SSOT for [`record`] and for the
+/// aliasing test. Widths above the tracked range fold onto the last bucket.
+fn bucket_idx(n: usize) -> usize {
+    if fold_at_16() {
+        n.min(16)
+    } else {
+        n.min(MAX_N - 1)
+    }
+}
 /// Verifies per flush. A flush is both a log line and one controller tick
 /// for [`super::adaptive_rung`], so it sets the rung's reaction time: 128
 /// verifies = 8 steps at n=16 ~ 1 s, which puts the probe interval (8 ticks)
@@ -96,7 +136,7 @@ static BUCKETS: [Bucket; MAX_N] = [INIT; MAX_N];
 /// telemetry happened to be switched on. The counters are relaxed atomics
 /// with no D2H and no stream sync, so always-on costs nothing measurable.
 pub(super) fn record(n: usize, k_drafts: usize, d1_match: bool, num_accepted: usize) {
-    let b = &BUCKETS[n.min(MAX_N - 1)];
+    let b = &BUCKETS[bucket_idx(n)];
     b.k.fetch_max(k_drafts as u64, Ordering::Relaxed);
     b.na.fetch_add(num_accepted as u64, Ordering::Relaxed);
     if d1_match {
@@ -243,6 +283,48 @@ impl RequestAccept {
 
 #[cfg(test)]
 mod tests {
+
+    // The bucket table must cover the MTP dispatch cap, or distinct widths
+    // alias onto one bucket and `adaptive_rung` steers the n=16 rung from a
+    // mixture of n=16 and n>16 statistics (see the MAX_N doc). Regression
+    // guard for the 2026-07-30 cap raise that MAX_N never followed.
+    #[test]
+    fn bucket_table_covers_the_mtp_dispatch_cap() {
+        assert_eq!(BUCKETS.len(), MAX_N);
+        // The compiled default cap is 32, so 32 must be individually tracked.
+        const { assert!(MAX_N > 32) };
+        // And it must cover whatever cap THIS process is configured for
+        // (CI does not set the override; an operator who raises it past the
+        // table re-introduces the documented fold).
+        if std::env::var_os("ATLAS_MTP_MAX_SEQS").is_none() {
+            assert!(
+                MAX_N > spark_model::speculative::mtp_max_seqs(),
+                "MAX_N {MAX_N} does not cover dispatch cap {}",
+                spark_model::speculative::mtp_max_seqs()
+            );
+        }
+    }
+
+    // Distinct widths must not share a bucket anywhere the scheduler can
+    // dispatch MTP. Asserted on `bucket_idx`, the SSOT `record` indexes
+    // with, so it fails for exactly the widths that aliased before the fix
+    // (17..=32 onto 16). Env-independent: CI sets neither override.
+    #[test]
+    fn widths_up_to_the_cap_do_not_alias() {
+        if std::env::var_os("ATLAS_MTP_ACCEPT_FOLD_AT_16").is_some()
+            || std::env::var_os("ATLAS_MTP_MAX_SEQS").is_some()
+        {
+            return; // the kill switch deliberately restores the fold
+        }
+        for n in 0..=spark_model::speculative::mtp_max_seqs() {
+            assert_eq!(bucket_idx(n), n, "width {n} aliases onto another bucket");
+        }
+        // Beyond the table the documented fold still applies, and it must
+        // stay inside the array.
+        assert_eq!(bucket_idx(1_000), MAX_N - 1);
+        assert!(bucket_idx(usize::MAX) < BUCKETS.len());
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## What

`mtp_accept_debug::MAX_N` was **17** while the MTP dispatch cap was raised 16 → 32 (`69658b873`, 2026-07-30). `record()` indexes `BUCKETS[n.min(MAX_N - 1)]`, so **every width in 16..=128 accumulated into bucket 16**, and the flush line printed whichever width happened to trip `PERIOD`.

Evidence — dgx2 `/home/claude/diag_c32_serve.log`, one serve, 301 flushes:

```
MTP accept n=32 k_drafts=1 verifies=128 p1=0.594 mean_na=0.594 tok_step=1.594 ...
MTP accept n=31 k_drafts=1 verifies=128 p1=0.704 ...
MTP accept n=18 ...  n=25 ...  n=26 ...  n=28 ...  n=29 ...  n=30 ...
```

Those eight "widths" are **one bucket**.

## Why it matters

`adaptive_rung` (BAND `9..=16`) steers the shipped n=16 rung from exactly this flush (`mtp_accept_debug.rs:124` → `adaptive_rung::observe`). Two live consequences:

1. The n=16 sample was a **mixture** of n=16 and n>16 statistics. They accept differently — a clean n=16 bucket reads `p1` 0.77–0.89 (local `serve-calib.log` 51 flushes / `serve-ladder.log` 31 flushes, same checkpoint) against **0.640–0.676 at n=32** across three dgx2 serves. The mixture biases the token ratio **down**, i.e. toward `k=1`.
2. A flush tripped by an n>16 caller is handed to `observe(n>16, …)`, which BAND discards outright — so under mixed-width traffic the n=16 controller **silently loses ticks it already paid for** (a probe costs a measured 1.74 s).

## Change

- `MAX_N` 17 → **33**: one bucket per width `0..=32`, the default `mtp_max_seqs()`.
- Index moves behind `bucket_idx()` — the SSOT the new test asserts on.
- Presence kill switch **`ATLAS_MTP_ACCEPT_FOLD_AT_16`** restores the old fold, so the correction is A/B-able against the binary that measured the ladder.

## Blast radius

Bit-identical for `n <= 15`. At `n` in 16..=32 it changes only **which counter** a verify lands in (and therefore which width the rung controller believes it observed). No verify, propose, sampling or scheduling path is touched. Cost: 16 more `Bucket`s of relaxed atomics, statically allocated.

## Tests

- `bucket_table_covers_the_mtp_dispatch_cap` — pins the table against `mtp_max_seqs()`, so the next cap raise cannot silently re-introduce the fold. This is the regression the 2026-07-30 raise shipped.
- `widths_up_to_the_cap_do_not_alias` — asserts `bucket_idx(n) == n` for every dispatchable width; fails for exactly the widths that aliased before this change (17..=32 onto 16).

## Gates

```
cargo fmt --all -- --check                                   clean
cargo clippy -p spark-server --all-targets                   clean
cargo test -p spark-server --bin spark mtp_accept_debug      5 passed / 0 failed
```
(`ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000`; CPU-only, no GPU leg — dgx2 is mid-benchmark.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1