### PR TITLE
perf(gdn): batched verify QKVZ reads NVFP4, not the FP8 prefill copy (26.3% of the C=8 step)

### DIFF
--- a/crates/spark-model/src/layers/qwen3_ssm/tests.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/tests.rs
@@ -263,3 +263,107 @@ fn gpu_launch_grids(gpu: &MockGpuBackend) -> Vec<([u32; 3], [u32; 3])> {
         .map(|l| (l.grid, l.block))
         .collect()
 }
+
+// ── Batched decode/verify QKVZ weight-copy dispatch (M>8) ──
+//
+// nsys on b508679e4 (unsloth/Qwen3.8-27B-NVFP4) showed the batched verify
+// QKVZ taking the pre-dequanted FP8 PREFILL copy at every M>8:
+// `fp8_fp8_gemm_ldmab` 42.58 ms/step = 26.3% of the whole step at C=8,
+// +1.762 GB/step (+77.8%) of weight traffic over the NVFP4 twin that sits at
+// the same dispatch site. The decision is a pure function of the row count,
+// which weight copies the layer holds, and the kill switch — so it is pinned
+// here directly rather than through a mock launch, whose one shared kernel
+// handle cannot tell `fp8_gemm_n128` from `w4a16_gemm_t_k64`.
+
+use super::trait_decode_batched::qkvz_verify_nvfp4_wins;
+
+/// Below and AT the threshold the FP8 arm must still win: M<=8 is exactly the
+/// range the weight-streaming NVFP4 GEMVs (`w4a16_gemv_batch2/3/4/8`) cover,
+/// and the FP8 tile GEMM is the measured-better fallback for the shapes that
+/// reach it there. This is the assertion that keeps the fix additive.
+#[test]
+fn qkvz_verify_keeps_fp8_at_and_below_the_threshold() {
+    for m in 1..=8 {
+        assert!(
+            !qkvz_verify_nvfp4_wins(m, true, true, true, false),
+            "M={m} must keep the FP8 arm"
+        );
+    }
+}
+
+/// Above the threshold, with both copies present, the NVFP4 twin wins — the
+/// C=4/8/16 verify widths (R = Σ ks) are all here.
+#[test]
+fn qkvz_verify_takes_nvfp4_above_the_threshold() {
+    for m in [9, 12, 16, 32, 64, 65, 128, 512] {
+        assert!(
+            qkvz_verify_nvfp4_wins(m, true, true, true, false),
+            "M={m} must take the NVFP4 arm"
+        );
+    }
+}
+
+/// The kill switch (`ATLAS_NO_QKVZ_NVFP4_DECODE`) restores the FP8 choice at
+/// every row count — the A/B must be able to reproduce today's behaviour
+/// verbatim, not approximately.
+#[test]
+fn qkvz_verify_kill_switch_restores_the_fp8_arm() {
+    for m in [9, 16, 32, 128, 512] {
+        assert!(
+            !qkvz_verify_nvfp4_wins(m, true, true, true, true),
+            "kill switch must restore the FP8 arm at M={m}"
+        );
+    }
+}
+
+/// No NVFP4 twin (native-FP8-GDN builds, where `qkvz_nvfp4_t` is None): the
+/// arm must decline so the chain reaches the w8a16/FP8 arms it already had.
+/// Diverting to a None weight is the NULL-slot dispatch bug this file's other
+/// tests exist for.
+#[test]
+fn qkvz_verify_declines_without_the_nvfp4_twin() {
+    for m in [9, 32, 512] {
+        assert!(!qkvz_verify_nvfp4_wins(m, true, false, true, false));
+    }
+}
+
+/// No tile GEMM linked for this target (`deep_k_gemm` resolves to a 0 handle):
+/// the arm must decline rather than hand `ms_proj_gemm` a NULL kernel. Launching
+/// a 0 handle is the sticky-context-loss class this dispatcher already carries
+/// three NULL-slot regression tests for.
+#[test]
+fn qkvz_verify_declines_without_a_tile_gemm() {
+    for m in [9, 32, 512] {
+        assert!(!qkvz_verify_nvfp4_wins(m, true, true, false, false));
+    }
+}
+
+/// No pre-dequanted FP8 copy: the predicate must decline even though NVFP4 is
+/// present. This arm exists ONLY to divert the FP8 arm; on builds without that
+/// copy the chain's own NVFP4 arm (`w4a16_gemm_n128_m128_v2` at the wide
+/// DFlash verify) is unmeasured against `ms_proj_gemm` and must not be moved.
+#[test]
+fn qkvz_verify_declines_without_the_fp8_copy() {
+    for m in [9, 17, 32, 512] {
+        assert!(
+            !qkvz_verify_nvfp4_wins(m, false, true, true, false),
+            "M={m}: no FP8 copy means nothing to divert"
+        );
+    }
+}
+
+/// The threshold is SHARED with the out_proj arm — both projections make the
+/// same trade on the same rows. Pins that the QKVZ predicate flips at exactly
+/// the row count out_proj's `num_tokens > VERIFY_TGEMM_MIN_TOKENS` flips at,
+/// so the two cannot drift apart silently.
+#[test]
+fn qkvz_and_out_proj_share_one_threshold() {
+    let flip = (1..=64)
+        .find(|&m| qkvz_verify_nvfp4_wins(m, true, true, true, false))
+        .expect("predicate must turn on somewhere in 1..=64");
+    assert_eq!(
+        flip,
+        super::trait_decode_batched::VERIFY_TGEMM_MIN_TOKENS + 1,
+        "QKVZ must flip at the shared out_proj threshold"
+    );
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched.rs
@@ -37,6 +37,57 @@ fn batched_norm_enabled() -> bool {
     *ON.get_or_init(|| std::env::var("ATLAS_NO_BATCHED_GDN_NORM").is_err())
 }
 
+/// Row count above which the batched decode/verify GDN projections stop taking
+/// the FP8 PREFILL arm (`fp8_gemm_n128` on the single-scale FP8 copy) and read
+/// the NVFP4 twin through a tile GEMM instead. SSOT for both projections —
+/// QKVZ and out_proj make the same trade on the same rows, and the threshold
+/// has the same derivation for both.
+///
+/// DERIVED, not tuned: every weight-streaming NVFP4 GEMV in this dispatcher
+/// (`w4a16_gemv_batch2/3/4`, and `w4a16_gemv_batchm` on the batch8 handle)
+/// caps at M=8, so 8 is the last row count those arms can serve. Above it the
+/// chain reaches the tile GEMMs, and that is exactly where the choice of
+/// weight copy starts to cost bandwidth.
+pub(super) const VERIFY_TGEMM_MIN_TOKENS: usize = 8;
+
+/// Presence kill switch for the NVFP4 QKVZ arm of the batched decode/verify
+/// projection — `ATLAS_NO_QKVZ_NVFP4_DECODE` restores the FP8-prefill-copy
+/// dispatch verbatim. PRESENCE, not value, per house convention (`=0` is NOT
+/// "off"). Read ONCE: this site runs under CUDA-graph capture.
+fn qkvz_nvfp4_decode_off() -> bool {
+    static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OFF.get_or_init(|| std::env::var("ATLAS_NO_QKVZ_NVFP4_DECODE").is_ok())
+}
+
+/// Should the batched decode/verify QKVZ projection read the NVFP4 transposed
+/// twin instead of the single-scale FP8 prefill copy?
+///
+/// PURE (SBIO): every input is a parameter — row count, which weight copies the
+/// layer actually holds, and the already-resolved kill switch — so the dispatch
+/// decision is decidable without a GPU, a layer, or a process-global env read.
+///
+/// `has_fp8_prefill` is a precondition, not a preference: this predicate exists
+/// only to divert the FP8 arm. When that copy is absent the chain's own NVFP4
+/// arms already run and must keep running unchanged.
+///
+/// `has_tile_gemm` is `deep_k_gemm(K).0 != 0` — the terminal handle
+/// `ms_proj_gemm` falls back to. Launching a 0 handle is the NULL-dispatch
+/// class this dispatcher has already been bitten by three times, so the arm
+/// declines rather than assuming a target carries the kernel.
+pub(super) fn qkvz_verify_nvfp4_wins(
+    num_tokens: usize,
+    has_fp8_prefill: bool,
+    has_nvfp4_t: bool,
+    has_tile_gemm: bool,
+    kill_switch: bool,
+) -> bool {
+    !kill_switch
+        && has_fp8_prefill
+        && has_nvfp4_t
+        && has_tile_gemm
+        && num_tokens > VERIFY_TGEMM_MIN_TOKENS
+}
+
 /// GDN-state routing for [`Qwen3SsmLayer::decode_batched_inner`].
 ///
 /// `Single`: today's path — `num_tokens` rows belong to ONE sequence, whose
@@ -339,6 +390,56 @@ impl Qwen3SsmLayer {
                     stream,
                 )?;
             }
+        } else if qkvz_verify_nvfp4_wins(
+            num_tokens,
+            self.qkvz_fp8.is_some(),
+            self.qkvz_nvfp4_t.is_some(),
+            self.deep_k_gemm(h as u32).0 != 0,
+            qkvz_nvfp4_decode_off(),
+        ) && let Some(ref nvfp4_t) = self.qkvz_nvfp4_t
+        {
+            // M > 8 (batched K-token verify, R = Σ ks rows; DFlash wide
+            // verify): the single-scale FP8 PREFILL arm below (`qkvz_fp8`,
+            // built by `bf16_to_fp8` at load) reads 1 byte per element where
+            // the NVFP4 twin reads 0.5625 — on THIS matrix
+            // (N=16384, K=5120) across the 48 GDN layers that is
+            // +1.762 GB/step, +77.8%, on a path already at the LPDDR5X wall.
+            // nsys, binary b508679e4, unsloth/Qwen3.8-27B-NVFP4 at C=8:
+            // `fp8_fp8_gemm_ldmab` 42.58 ms/step = 26.3% of the entire step
+            // over 48 calls, achieving 94.6 GB/s against the 203 GB/s the
+            // shape admits — its 128-row M tile is ~75% padding at the M=32
+            // a C=8 step produces. This is ~90% of the measured 1.56x
+            // GEMM-time regression from C=1 to C=8.
+            //
+            // IDENTICAL defect and identical fix to the out_proj arm below;
+            // that half was found first only because attention `o_proj` was
+            // already on the tile GEMM and fingered it. Route to the NVFP4
+            // transposed twin through `ms_proj_gemm` — the SAME call the
+            // multi-seq decode QKVZ makes on this same weight
+            // (`trait_decode_multi_seq/ssm_batched.rs`), which also picks the
+            // 128-row M tile once N fills the machine and the batch is wide
+            // enough that the 64-row tile would re-stream the weight.
+            //
+            // Numerics: `qkvz_fp8` and `qkvz_nvfp4_t` are BOTH derived from
+            // the one BF16 `qkvz_dense` at load (`qwen35_dense.rs`:
+            // `bf16_to_fp8` and `quantize_to_nvfp4`), so this changes which
+            // lossy copy is read, not what the weight means. NVFP4 is the
+            // copy every OTHER decode arm here already reads (batch2/3/4/8
+            // above, multi-seq decode, single-token decode), so this makes
+            // batched verify agree with the decode it is verifying — the FP8
+            // arm was the odd one out. BF16 activations (vs the FP8 arm's
+            // e4m3 downcast) against a 4-bit weight: not byte-identical.
+            // Kill switch ATLAS_NO_QKVZ_NVFP4_DECODE (PRESENCE check).
+            self.ms_proj_gemm(
+                ctx.gpu,
+                normed,
+                nvfp4_t,
+                proj_dst,
+                num_tokens as u32,
+                qkvz_size as u32,
+                h as u32,
+                stream,
+            )?;
         } else if let Some(fp8) = self.qkvz_fp8 {
             ops::fp8_gemm_n128(
                 ctx.gpu,
@@ -917,7 +1018,7 @@ impl Qwen3SsmLayer {
                     stream,
                 )?;
             }
-        } else if num_tokens > 8
+        } else if num_tokens > VERIFY_TGEMM_MIN_TOKENS
             && let Some(ref nvfp4_t) = self.out_proj_nvfp4_t
             && {
                 // Kill switch, PRESENCE check per house convention (`=0` is NOT
@@ -936,9 +1037,22 @@ impl Qwen3SsmLayer {
             // (`deep_k_gemm`). BF16 activations (vs the FP8 arm's e4m3
             // downcast) — equal-or-better numerics, not byte-identical.
             // Kill switch ATLAS_NO_VERIFY_OUTPROJ_TGEMM (PRESENCE check).
-            ops::w4a16_gemm_n128(
+            //
+            // 2026-08-17: the call now goes through `ms_proj_gemm` rather than
+            // `deep_k_gemm` directly. `ms_proj_gemm` IS `deep_k_gemm` plus the
+            // narrow-N twin test this arm was skipping: at THIS shape
+            // (N=h=5120, K=value_dim=6144) the wide tile launches
+            // ceil(5120/128)=40 CTAs on a 48-SM device, which is precisely the
+            // `k64_n64_wins` case — bit-identical output, measured 1.42x on
+            // the replay bench (see `layers::K64_N64_MAX_WIDE_CTAS`) and
+            // 100 GB/s -> 151 GB/s in the C=8 profile, ~2.9 ms/step. Attention
+            // `o_proj` already applies the same test to the same shape
+            // (`qwen3_attention/trait_impl/multi_seq/qkv.rs`), and the
+            // multi-seq decode out_proj already makes this exact
+            // `ms_proj_gemm` call on this exact weight — so this is one call
+            // site rejoining the other three, not a new rule.
+            self.ms_proj_gemm(
                 ctx.gpu,
-                self.deep_k_gemm(value_dim as u32),
                 normed_out_buf,
                 nvfp4_t,
                 out_proj_buf,

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -235,9 +235,18 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
         let fp8_ssm_prefill = std::env::var_os("ATLAS_NO_GDN_FP8_PREFILL").is_none();
         let bf16_to_fp8_k = if fp8_ssm_prefill {
             tracing::info!(
+                // The old wording — "NVFP4 kept as structural fallback for
+                // decode batch paths" — was DISPROVEN by nsys at C=8
+                // (2026-08-17): the batched verify QKVZ was taking this FP8
+                // copy at every M>8, 26.3% of the step. It is true again only
+                // because that arm now reads NVFP4; say the actual rule so the
+                // log cannot re-drift from the dispatch.
                 "SSM in_proj_qkv + out_proj via native FP8 prefill GEMM \
-                 (BF16 act × FP8 weight via fp8_gemm_n128); NVFP4 kept as \
-                 structural fallback for decode batch paths"
+                 (BF16 act × FP8 weight via fp8_gemm_n128). PREFILL ONLY: \
+                 decode + batched verify read the NVFP4 copy — weight-streaming \
+                 GEMV at M<=8, tile GEMM above it (trait_decode_batched.rs). \
+                 The FP8 copy reaches decode only at M<=8 on a build whose \
+                 batched NVFP4 GEMVs are absent"
             );
             Some(gpu.kernel("w4a16", "bf16_to_fp8")?)
         } else {

--- a/crates/spark-model/src/weight_loader/qwen35_dense/rowwise_fp8.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/rowwise_fp8.rs
@@ -43,8 +43,8 @@
 //! above. So the row-wise weights live in their own fields, the NVFP4 copy is
 //! still built and still serves decode, and prefill is the phase that stops
 //! double-quantising. Mixing precision across phases is already the house
-//! pattern — the native-FP8 SSM arm logs "NVFP4 kept as structural fallback
-//! for decode batch paths".
+//! pattern — the native-FP8 SSM arm logs that its FP8 copy is "PREFILL ONLY"
+//! and that decode + batched verify read the NVFP4 copy.
 //!
 //! A decode-side fix needs a per-row `w8a16_gemv` variant, which does not
 //! exist yet; see `docs/fp8-rowwise-mixed-precision.md`.


### PR DESCRIPTION
## The defect

nsys profile on dgx2, binary `b508679e4`, `unsloth/Qwen3.8-27B-NVFP4`, batched decode/verify path at C=8. The GDN `in_proj_qkvz` matmul is dispatched to the **single-scale FP8 prefill weight copy** (1 B/elt) instead of the **NVFP4 transposed twin** (0.5625 B/elt) that is available at the same dispatch site:

| | measured |
|---|---|
| `fp8_fp8_gemm_ldmab` | **42.58 ms/step, 26.3% of the entire step**, 48 calls/step (one per GDN layer) |
| extra weight traffic | **+1.762 GB/step (+77.8%)** on this matrix (N=16384, K=5120 × 48 layers) vs the NVFP4 copy |
| achieved bandwidth | **94.6 GB/s** vs **203 GB/s** achievable on the shape — its 128-row M tile is ~75% padding at the M=32 a C=8 step produces |

Attribution: this single arm is **~90% of the measured 1.56x GEMM-time regression from C=1 to C=8**, and the per-added-sequence marginal cost it produces (4.28 ms/token/seq vs vLLM's 1.94) is what loses Atlas the C=2..32 concurrency rungs.

## Why out_proj's arm transfers — there is no blocker

The identical defect on the **sibling matrix** was already fixed in this same file on 2026-07-28 (`trait_decode_batched.rs`, out_proj `num_tokens > 8` → `deep_k_gemm`, kill switch `ATLAS_NO_VERIFY_OUTPROJ_TGEMM`; 379 µs → 182 µs per call at M=16, ~9.5 ms/step at C=4 — see `docs/campaigns/gb10-concurrency-2026-07/STATE.md`, fixer round 1).

Reading both sites and the history, out_proj gained the arm and QKVZ did not for a purely **diagnostic** reason, not a technical one: the campaign note says *"Attention o_proj at the same M was ALREADY on the k64 tile GEMM, which is what fingered the SSM arm."* QKVZ has no attention counterpart to compare against, so nobody looked. There is **no shape or scale-layout difference** that blocks it:

- Both `qkvz_nvfp4_t` and `out_proj_nvfp4_t` are transposed NVFP4 twins built at load by the same `QuantizedWeight::transpose_for_gemm`, already consumed by the SSM **prefill** path on these exact weights (`trait_prefill_proj.rs`).
- The **multi-seq DECODE** QKVZ already routes through `ms_proj_gemm(qkvz_nvfp4_t)` at n≥9 (`trait_decode_multi_seq/ssm_batched.rs`). Batched verify was the only QKVZ site still on the FP8 copy.
- QKVZ's N (16384) is wider than out_proj's (5120), which if anything favours the tile GEMM more.

## Design

- New QKVZ arm placed **above** the FP8 arm, at `num_tokens > VERIFY_TGEMM_MIN_TOKENS`, routed through **`ms_proj_gemm`** — the same call multi-seq decode makes on this same weight. `ms_proj_gemm` is `deep_k_gemm` plus two measured refinements it already owns: the 128-row M tile once N fills the machine (measured **27.73 → 16.77 ms/step, −39%** at n=128 on *this* QKVZ shape) and the narrow-N `k64_n64` twin. No new `.cu`, no new buffer, no new VRAM.
- **`VERIFY_TGEMM_MIN_TOKENS = 8`** is now the SSOT for *both* projections — out_proj's literal `> 8` consumes it. **Derived, not tuned**, on the same basis out_proj used: every weight-streaming NVFP4 GEMV in this dispatcher (`w4a16_gemv_batch2/3/4`, `batchm` on the batch8 handle) caps at M=8, so 8 is the last row count those arms can serve, and above it the chain reaches the tile GEMMs where the weight-copy choice starts costing bandwidth. The FP8 arm therefore **keeps every shape where it genuinely wins** (small M).
- The arm is scoped to **divert the FP8 arm only**: `qkvz_fp8.is_some()` is a precondition, so a build without that copy keeps its existing NVFP4 arm (`w4a16_gemm_n128_m128_v2` at the wide DFlash verify), which is unmeasured against `ms_proj_gemm` and must not be moved on a guess. It also declines when `deep_k_gemm(K)` resolves to a 0 handle — this dispatcher has been bitten three times by NULL-slot/0-handle launches (sticky CUDA-700, 503s the whole serve).
- The decision is a **pure function** `qkvz_verify_nvfp4_wins(num_tokens, has_fp8_prefill, has_nvfp4_t, has_tile_gemm, kill_switch)` (SBIO): no env read, no GPU, no layer.

## Kill switch

`ATLAS_NO_QKVZ_NVFP4_DECODE=1` (PRESENCE check per house convention — `=0` is NOT "off", read once because this site runs under CUDA-graph capture) restores today's behaviour **verbatim**: every row count returns to the FP8 arm. Pinned by a test.

## Correctness

This changes **which weight copy is read**, not what the weight means. Both copies are derived from the one BF16 `qkvz_dense` at load (`qwen35_dense.rs`: `quantize_to_nvfp4` and `bf16_to_fp8` off the same tensor), so they are two lossy encodings of the same reference.

**The reference copy is NVFP4** — not because it is more precise (FP8 E4M3 is the higher-precision *weight* encoding) but because it is the copy **every other decode arm already reads**: the M≤8 batched GEMVs directly above in this same chain, the multi-seq decode path, and single-token decode. The FP8 copy is a *prefill* artefact that leaked into one decode arm. After this change, batched verify computes with the same weights as the decode it is verifying — which is the property MTP accept-rate depends on, and which was silently violated at every M>8.

Activation side: the tile GEMM keeps **BF16 activations** where `fp8_gemm_n128` downcasts them to e4m3. So: better activations, coarser weights, not byte-identical. Same trade the out_proj arm made and gated.

## Also in this PR (profile item 4)

GDN `out_proj`'s M>8 arm was calling `deep_k_gemm` directly and thereby **skipping the `k64_n64_wins` test** that attention `o_proj` applies at `qwen3_attention/trait_impl/multi_seq/qkv.rs:651`. Verified as genuinely the same test on the identical shape: **N=5120, K=6144 → ceil(5120/128) = 40 CTAs on a 48-SM device**, which is exactly the case `K64_N64_MAX_WIDE_CTAS` documents (measured 1.42x on the replay bench, bit-identical output). Measured in this profile at **100 GB/s vs 151 GB/s, ~2.9 ms/step (+1.5% at C=8)**.

Fixed by routing that arm through `ms_proj_gemm` as well — which *is* `deep_k_gemm` + that test, and is the exact call the multi-seq decode out_proj already makes on this exact weight. One call site rejoining the other three, not a new rule.

## Log correction

The native-FP8 SSM loader asserted **"NVFP4 kept as structural fallback for decode batch paths"**. The profile disproves that claim for this arm — batched verify QKVZ was taking the FP8 copy at every M>8, 26.3% of the step. The log now states the actual rule (FP8 is PREFILL ONLY; decode + batched verify read NVFP4, GEMV at M≤8 and tile GEMM above it), and `qwen35_dense/rowwise_fp8.rs`, which quoted the old wording, is updated with it.

## Tests

`crates/spark-model/src/layers/qwen3_ssm/tests.rs` — the dispatch decision pinned as a pure function of (num_tokens, available weight copies, env kill switch), following the file's existing dispatch-test pattern:

- FP8 arm still chosen at **every** M in 1..=8 (the additivity assertion)
- NVFP4 arm chosen at M = 9, 12, 16, 32, 64, 65, 128, 512
- kill switch restores the FP8 choice at every row count
- declines with no NVFP4 twin (native-FP8-GDN builds)
- declines with no tile-GEMM handle (never launch a 0 handle)
- declines with no FP8 copy (nothing to divert)
- QKVZ flips at exactly `VERIFY_TGEMM_MIN_TOKENS + 1`, so the two projections cannot drift apart

Asserting the selected kernel *by name* is not available: `MockGpuBackend::kernel()` hands out one shared handle for every kernel, so launch geometry is the only per-launch identity the mock records — and `fp8_gemm_n128` and `w4a16_gemm_t_k64` are not separable that way at these shapes. The pure predicate is asserted directly instead, which is a stronger pin than a geometry match.

## Expected effect — ESTIMATE, not measured

Removes **~31.4 of the 42.6 ms/step** at C=8 (the FP8-vs-NVFP4 byte delta plus the tile-padding recovery; the remainder is work the NVFP4 tile GEMM still has to do).

| rung | estimated | why |
|---|---|---|
| C=4 | **+26%** | M=16, deepest into the ldmab padding |
| C=8 | **+20%** | M=32, the profiled point |
| C=16 | **+25%** | M=64, tile still under-filled, bytes dominate |
| C=32 | diminishing | M=128 begins to fill the ldmab tile |
| C=64 / C=128 | small | M≥128, tile full; only the byte delta remains, and `ms_proj_gemm`'s m128 arm already covers it |

**No rung may regress.** Floors, apples-to-apples vs vLLM+MTP fp8:

`C=1 22.44 · C=2 30.32 · C=4 52.35 · C=8 83.22 · C=16 154.30 · C=32 225.37 · C=64 373.90 · C=128 442.83`

C=1 and C=2 are M≤8 and structurally untouched (the predicate is false there) — any movement at those rungs is noise or a different cause.

## Validation plan (GPU, not run here — this PR is CPU-only work)

1. **Full concurrency ladder** C=1..128 vs the floors above, with the same-session `ATLAS_NO_QKVZ_NVFP4_DECODE=1` kill-switch leg as the control so the A/B is on one binary and one box.
2. **ssm-state-poisoning-gate** — this changes the weights the GDN verify computes with, so the conv/SSM state the verify writes back must still match the sequential path.
3. **decode-floor** gate.
4. **BFCL** on the dense 27B flagship, quoted with its draw (`category_sample_pct` + N + ordered-`sample_id` SHA256) per the repo's BFCL discipline — the weight-copy change can move a greedy token, exactly as the out_proj arm could.
5. Coherence + tool-call smoke before any of the above (a numerically-broken NVFP4 path passes the throughput gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
