### PR TITLE
perf(verify): canonical depth→slot assignment kills the batched-verify graph-key thrash (266 keys → 3 at n=8)

### DIFF
--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -19,6 +19,12 @@ use crate::traits::SequenceState;
 /// the cap bounds graph memory WITHOUT ever pinning the path eager —
 /// the pre-LRU insert-only cache went permanently eager after 32 distinct
 /// vectors, which a long serve is guaranteed to produce.
+///
+/// The cap is only sane because the key space is bounded: since the
+/// canonical depth→slot assignment (`speculative::verify_key`) a step's key
+/// is (slot set, depth MULTISET), not the arrangement. Keyed on the
+/// arrangement, D-Cut alone produced 266 keys at n=8 against this 32 —
+/// 89% of steps re-captured, 23.2 ms/step of instantiate+destroy.
 pub(super) const VERIFY_BATCHED_GRAPH_CAP: usize = 32;
 
 /// Verify row-buffer capacity R = Σ ks — the exact capacity of the batched
@@ -51,23 +57,32 @@ impl TransformerModel {
     /// runs are grouped by depth) — the same slot vector at a different ladder
     /// step or a different D-Cut shape must not replay. A
     /// wy-tables-present sentinel is appended so a table-less capture can
-    /// never replay a table-full step or vice versa. The scheduler sorts
-    /// each chunk by ssm slot before dispatch, so keys are combinations,
-    /// not permutations (verify_k4_batch_step.rs). `None` → no graph (a
-    /// sequence without a pool slot).
+    /// never replay a table-full step or vice versa.
+    ///
+    /// The scheduler dispatches each chunk in the ONE canonical order
+    /// (`speculative::verify_key::verify_batch_order` — depths descending
+    /// paired with slots ascending), so the key is a pure function of
+    /// (slot set, depth multiset, sentinel): at n=8 the 266 D-Cut
+    /// ARRANGEMENTS that thrashed this 32-entry cache collapse onto the 3
+    /// multisets behind them. Kill switch `ATLAS_NO_CANONICAL_VERIFY_KEY`
+    /// (scheduler side) restores the arrangement-keyed behaviour. Key BYTES
+    /// live in `verify_key` so the ordering rule and the key it produces
+    /// cannot drift apart. `None` → no graph (a sequence without a pool
+    /// slot).
     pub(super) fn verify_batched_graph_key(
         &self,
         seqs: &[&mut SequenceState],
         ks: &[usize],
         wy_tables_null: bool,
     ) -> Option<Vec<u32>> {
-        let mut key: Vec<u32> = Vec::with_capacity(2 * seqs.len() + 1);
+        let mut pairs: Vec<(u32, u32)> = Vec::with_capacity(seqs.len());
         for (i, s) in seqs.iter().enumerate() {
-            key.push(s.ssm_slot_idx()? as u32);
-            key.push(*ks.get(i)? as u32);
+            pairs.push((s.ssm_slot_idx()? as u32, *ks.get(i)? as u32));
         }
-        key.push(u32::MAX - u32::from(wy_tables_null));
-        Some(key)
+        Some(crate::speculative::verify_key::verify_graph_key(
+            &pairs,
+            wy_tables_null,
+        ))
     }
 
     /// Stage the per-GDN-layer WY pointer tables (`[h|Hi0|Hi1|Hi2]` ×

--- a/crates/spark-model/src/speculative.rs
+++ b/crates/spark-model/src/speculative.rs
@@ -7,6 +7,7 @@
 
 pub mod ladder;
 pub mod tree_shape;
+pub mod verify_key;
 
 pub use ladder::{mtp_ladder_disabled, mtp_ladder_drafts, mtp_max_seqs};
 

--- a/crates/spark-model/src/speculative/verify_key.rs
+++ b/crates/spark-model/src/speculative/verify_key.rs
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched-verify graph key: the canonical depth→slot assignment and the key
+//! bytes derived from it. ONE ordering rule, shared by the scheduler that
+//! dispatches the batch (`mtp_dcut::plan`, `mtp_step`) and the model that
+//! builds the CUDA-graph cache key (`verify_e2::verify_batched_graph_key`).
+//!
+//! # The measured defect (nsys + A/B on dgx2, binary `b508679e4`)
+//!
+//! The batched-verify graph cache keys on the per-row `(ssm slot, depth k)`
+//! pairs in batch order, because a capture bakes each row's pool state
+//! addresses AND the depth-run launch structure. D-Cut re-ranks WHICH
+//! sequence gets WHICH depth every step, so the key space was the set of
+//! ARRANGEMENTS of the step's depth multiset over the batch's slots:
+//!
+//! ```text
+//! n=8, the three multisets actually observed:
+//!   8!/(5!·2!·1!) + 8!/(4!·4!) + 8!/(6!·2!) = 168 + 70 + 28 = 266 keys
+//! ```
+//!
+//! against `VERIFY_BATCHED_GRAPH_CAP` = 32. Measured key counts: n=2 → 2,
+//! n=4 → 10, **n=8 → 160-253**, n=16 → 1 (D-Cut is off above width 8). nsys
+//! at C=8: 149 captures in 167 steps (89% of steps), `cuGraphInstantiate` +
+//! `cuGraphExecDestroy` + `cuGraphDestroy` = 23.2 ms/step ≈ 20% of the step;
+//! GPU busy 96.3% → 77.2%. A/B at C=8: control 78.89 tok/s vs 84.35 with
+//! D-Cut off (+6.9%, key count 253 → 1) — and that leg also LOSES the row
+//! pruning, so the thrash alone costs more than 6.9%.
+//!
+//! # The fix: canonical depth→slot assignment
+//!
+//! D-Cut's ranking chooses HOW MANY drafts survive at each depth (the
+//! multiset) — that is where its row saving comes from. It also chooses WHO
+//! gets them, and that half is what multiplies the key space. So the multiset
+//! stays confidence-chosen and the ARRANGEMENT becomes a pure function of the
+//! batch: depths descending are paired with slots ascending. The key is then
+//! determined by (slot set, depth multiset) alone — at n=8 the 266 observed
+//! arrangements collapse to the 3 multisets that produced them (worst case
+//! over all reachable shapes: multisets of size 8 over depths {2,3,4} =
+//! C(10,2) = 45, versus 3^8 = 6561 arrangements).
+//!
+//! ★ The two orderings RECONCILE instead of fighting. The dispatch needs
+//! depths descending (equal depths must form contiguous runs — the batched
+//! conv+WY fast path launches once per run,
+//! `trait_decode_batched_conv_gdn_multi.rs`) and the SSM batched arms need
+//! slots ascending and consecutive in batch order (`ssm_batched_recurrent.rs`,
+//! `decode_step.rs`, `mtp_step.rs`). Under the confidence-chosen arrangement
+//! those two demands are in direct conflict: a ragged batch sorted
+//! deepest-first scrambles the slot order, so each depth run gets an
+//! arbitrary SUBSET of the pool slots and the consecutive-slot precondition
+//! fails. Pairing depths-descending with slots-ascending makes the two orders
+//! THE SAME order, and each depth run then owns a consecutive slot block.
+//!
+//! Correctness: which sequence gets which depth is a pure PERFORMANCE choice.
+//! Every batchable sequence enters the step with exactly `ladder_nd` drafts
+//! (`mtp_step` truncates the surplus), each assigned depth is in
+//! `1..=ladder_nd` drafts, and a verify of a shorter draft prefix is the same
+//! math on fewer rows. Σ rows is unchanged, so the row budget and chunking
+//! are unchanged. What is NOT free to change is the pairing between a batch
+//! POSITION and the slot whose pointers the graph baked there — hence one
+//! ordering rule, used by both the dispatch and the key.
+//!
+//! Kill switch `ATLAS_NO_CANONICAL_VERIFY_KEY` (PRESENCE — house convention,
+//! `=0` is NOT off) restores the pre-canonical behaviour: each sequence keeps
+//! its own confidence-chosen depth and the batch is sorted deepest-first,
+//! ssm-slot second.
+
+/// Canonical assignment ON unless `ATLAS_NO_CANONICAL_VERIFY_KEY` is present.
+/// Read once per process.
+pub fn canonical_verify_key_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_CANONICAL_VERIFY_KEY").is_none())
+}
+
+/// Dispatch ORDER for one verify batch — the permutation only.
+///
+/// `slots[i]` / `ks[i]` describe batch member `i` in the caller's arbitrary
+/// order (`ks[i]` = that member's ROW count, drafts+1). `order[p]` is the
+/// input index dispatched at position `p`.
+///
+/// * `canonical = true` — sort by ssm slot ASCENDING. `ks` is unread: under
+///   the canonical assignment the depths are already descending along that
+///   order, so slot order IS depth order and there is nothing to trade off.
+/// * `canonical = false` — the kill-switch path: deepest first, ssm slot
+///   second (today's behaviour, where the two demands genuinely conflict).
+///
+/// Ties break on input index, so the result is a deterministic function of
+/// the inputs — a graph key must never depend on sort instability. Callers
+/// that build the batch in ascending active-sequence index therefore agree
+/// on the order of slot-less (`usize::MAX`) members.
+///
+/// Idempotent under `canonical = true`, so a chunked caller may re-apply it
+/// to a contiguous sub-range of an already-ordered batch.
+pub fn verify_batch_permutation(slots: &[usize], ks: &[usize], canonical: bool) -> Vec<usize> {
+    debug_assert_eq!(
+        slots.len(),
+        ks.len(),
+        "verify_batch_permutation: slots/ks mismatch"
+    );
+    let n = slots.len().min(ks.len());
+    let mut order: Vec<usize> = (0..n).collect();
+    if canonical {
+        order.sort_by_key(|&i| (slots[i], i));
+    } else {
+        order.sort_by_key(|&i| (std::cmp::Reverse(ks[i]), slots[i], i));
+    }
+    order
+}
+
+/// Order one verify batch AND assign its depths — the planner's entry point
+/// (`mtp_dcut::plan`), the one place a sequence's verify depth is decided.
+///
+/// Returns `(order, depths)` where `order` is [`verify_batch_permutation`]
+/// and `depths[p]` is the row count position `p` verifies.
+///
+/// * `canonical = true` — the depth MULTISET is re-paired onto the ordered
+///   batch, deepest onto the lowest slot. `depths[p]` is therefore NOT
+///   generally `ks[order[p]]`; the multiset is preserved exactly, only the
+///   pairing is re-made. Both dispatch invariants then hold by construction:
+///   slots non-decreasing in `p` (the SSM consecutive-slot precondition) and
+///   depths non-increasing in `p` (the contiguous depth-run precondition).
+/// * `canonical = false` — each member keeps its own depth.
+///
+/// Because a caller must TRUNCATE each sequence's drafts to the depth it was
+/// assigned, this must be called exactly once per batch; downstream stages
+/// that only need the batch in dispatch order use
+/// [`verify_batch_permutation`], which cannot disturb an assignment.
+pub fn verify_batch_order(
+    slots: &[usize],
+    ks: &[usize],
+    canonical: bool,
+) -> (Vec<usize>, Vec<usize>) {
+    let order = verify_batch_permutation(slots, ks, canonical);
+    let depths: Vec<usize> = if canonical {
+        let mut d: Vec<usize> = ks[..order.len()].to_vec();
+        d.sort_unstable_by(|a, b| b.cmp(a));
+        d
+    } else {
+        order.iter().map(|&i| ks[i]).collect()
+    };
+    (order, depths)
+}
+
+/// The batched-verify CUDA-graph cache key for one batch: the `(ssm slot,
+/// row count)` pairs in DISPATCH order, then a wy-tables-present sentinel.
+///
+/// Every SSM pointer a capture bakes (h/conv state, rollback intermediates,
+/// WY table contents) is a pure function of the pair at that batch position,
+/// and the depth-run launch structure is a pure function of the depth
+/// sequence — so the key must carry both, in order. All other captured
+/// addresses (hidden/logits/scratch/meta) are fixed buffers refreshed
+/// pre-replay. The sentinel keeps a table-less capture from ever replaying a
+/// table-full step or vice versa.
+///
+/// Pairs arrive in the order [`verify_batch_order`] produced, so with
+/// canonicalization on the key is a pure function of (slot set, depth
+/// multiset, sentinel) — the whole point of this module.
+pub fn verify_graph_key(pairs: &[(u32, u32)], wy_tables_null: bool) -> Vec<u32> {
+    let mut key: Vec<u32> = Vec::with_capacity(2 * pairs.len() + 1);
+    for &(slot, k) in pairs {
+        key.push(slot);
+        key.push(k);
+    }
+    key.push(u32::MAX - u32::from(wy_tables_null));
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build the key the dispatch would produce for a batch given as
+    /// `(slot, k)` pairs in the scheduler's arbitrary pre-sort order.
+    fn key_for(batch: &[(usize, usize)], canonical: bool) -> Vec<u32> {
+        let slots: Vec<usize> = batch.iter().map(|&(s, _)| s).collect();
+        let ks: Vec<usize> = batch.iter().map(|&(_, k)| k).collect();
+        let (order, depths) = verify_batch_order(&slots, &ks, canonical);
+        let pairs: Vec<(u32, u32)> = order
+            .iter()
+            .zip(&depths)
+            .map(|(&i, &k)| (slots[i] as u32, k as u32))
+            .collect();
+        verify_graph_key(&pairs, false)
+    }
+
+    /// THE DEFECT, pinned. The same depth multiset spread over the same slots
+    /// in different arrangements — exactly what D-Cut re-ranking produces
+    /// step to step — must collapse onto ONE key.
+    #[test]
+    fn same_multiset_different_arrangement_is_one_key() {
+        // Multiset {4,4,3,3} over slots {0,1,2,3}: 4!/(2!·2!) = 6 arrangements.
+        let arrangements: [[(usize, usize); 4]; 6] = [
+            [(0, 4), (1, 4), (2, 3), (3, 3)],
+            [(0, 4), (1, 3), (2, 4), (3, 3)],
+            [(0, 4), (1, 3), (2, 3), (3, 4)],
+            [(0, 3), (1, 4), (2, 4), (3, 3)],
+            [(0, 3), (1, 4), (2, 3), (3, 4)],
+            [(0, 3), (1, 3), (2, 4), (3, 4)],
+        ];
+        let keys: std::collections::HashSet<Vec<u32>> =
+            arrangements.iter().map(|a| key_for(a, true)).collect();
+        assert_eq!(keys.len(), 1, "6 arrangements must collapse to 1 key");
+        // And the ONE key is the canonical pairing: slots ascending, depths
+        // descending.
+        assert_eq!(
+            keys.into_iter().next().unwrap(),
+            vec![0, 4, 1, 4, 2, 3, 3, 3, u32::MAX]
+        );
+    }
+
+    /// The n=8 arithmetic from the module docs, executed: the three depth
+    /// multisets the profile observed produce 266 keys pre-canonicalization
+    /// and 3 after. Generated exhaustively so the count is computed, not
+    /// asserted from a comment.
+    #[test]
+    fn n8_key_space_collapses_266_to_3() {
+        // (count of depth 4, count of 3, count of 2) for each observed shape.
+        let multisets = [(5usize, 2usize, 1usize), (4, 4, 0), (6, 0, 2)];
+        let mut legacy: std::collections::HashSet<Vec<u32>> = Default::default();
+        let mut canon: std::collections::HashSet<Vec<u32>> = Default::default();
+        for &(c4, c3, c2) in &multisets {
+            let mut depths: Vec<usize> = Vec::new();
+            depths.extend(std::iter::repeat_n(4usize, c4));
+            depths.extend(std::iter::repeat_n(3usize, c3));
+            depths.extend(std::iter::repeat_n(2usize, c2));
+            assert_eq!(depths.len(), 8);
+            // Every distinct arrangement of this multiset over slots 0..8.
+            let mut perm: Vec<usize> = (0..8).collect();
+            permute(&mut perm, 0, &mut |p| {
+                let batch: Vec<(usize, usize)> = (0..8).map(|s| (s, depths[p[s]])).collect();
+                legacy.insert(key_for(&batch, false));
+                canon.insert(key_for(&batch, true));
+            });
+        }
+        assert_eq!(legacy.len(), 266, "pre-canonical arrangement count");
+        assert_eq!(canon.len(), 3, "one key per depth multiset");
+    }
+
+    /// Every permutation of `v`, in place.
+    fn permute(v: &mut Vec<usize>, i: usize, f: &mut impl FnMut(&[usize])) {
+        if i == v.len() {
+            f(v);
+            return;
+        }
+        for j in i..v.len() {
+            v.swap(i, j);
+            permute(v, i + 1, f);
+            v.swap(i, j);
+        }
+    }
+
+    /// Different multisets must NOT collide — a graph baked for one depth
+    /// shape replaying against another is the state-poisoning failure mode.
+    #[test]
+    fn different_multisets_have_different_keys() {
+        let a = key_for(&[(0, 4), (1, 4), (2, 3), (3, 3)], true);
+        let b = key_for(&[(0, 4), (1, 3), (2, 3), (3, 3)], true);
+        let c = key_for(&[(0, 4), (1, 4), (2, 4), (3, 3)], true);
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    /// A different SLOT SET at the same depth multiset must also differ: the
+    /// graph bakes those pool addresses.
+    #[test]
+    fn different_slot_sets_have_different_keys() {
+        let a = key_for(&[(0, 4), (1, 3)], true);
+        let b = key_for(&[(0, 4), (2, 3)], true);
+        assert_ne!(a, b);
+    }
+
+    /// The sentinel keeps a table-less capture from replaying a table-full
+    /// step.
+    #[test]
+    fn wy_table_presence_splits_the_key() {
+        let pairs = [(0u32, 4u32), (1, 3)];
+        assert_ne!(
+            verify_graph_key(&pairs, true),
+            verify_graph_key(&pairs, false)
+        );
+    }
+
+    /// The invariants the SSM batched arms depend on, asserted explicitly on
+    /// the canonical order: slots ASCENDING in batch order (the
+    /// consecutive-slot precondition of `ssm_batched_recurrent.rs` and
+    /// `trait_decode_batched_conv_gdn_multi.rs`) and depths NON-INCREASING
+    /// (equal depths form contiguous runs — `decode_batched_inner`'s run
+    /// loop).
+    #[test]
+    fn canonical_order_holds_both_dispatch_invariants() {
+        // Deliberately hostile input: slot order and depth order disagree.
+        let slots = [7usize, 2, 5, 0, 3];
+        let ks = [2usize, 4, 2, 3, 4];
+        let (order, depths) = verify_batch_order(&slots, &ks, true);
+        let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
+        assert!(
+            placed.windows(2).all(|w| w[0] < w[1]),
+            "slots must be ascending in batch order, got {placed:?}"
+        );
+        assert!(
+            depths.windows(2).all(|w| w[0] >= w[1]),
+            "depths must be non-increasing, got {depths:?}"
+        );
+        // The multiset — and therefore Σ rows, the row budget and chunking —
+        // is preserved exactly.
+        let mut before = ks.to_vec();
+        before.sort_unstable();
+        let mut after = depths.clone();
+        after.sort_unstable();
+        assert_eq!(before, after);
+        assert_eq!(placed, vec![0, 2, 3, 5, 7]);
+        assert_eq!(depths, vec![4, 4, 3, 2, 2]);
+    }
+
+    /// Contiguous slots stay contiguous per depth RUN — the precondition the
+    /// two-launch conv+WY fast path actually checks.
+    #[test]
+    fn each_depth_run_owns_a_consecutive_slot_block() {
+        let slots = [0usize, 1, 2, 3, 4, 5, 6, 7];
+        let ks = [2usize, 4, 3, 4, 2, 3, 4, 3];
+        let (order, depths) = verify_batch_order(&slots, &ks, true);
+        let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
+        let mut g0 = 0usize;
+        while g0 < depths.len() {
+            let mut g1 = g0 + 1;
+            while g1 < depths.len() && depths[g1] == depths[g0] {
+                g1 += 1;
+            }
+            assert!(
+                placed[g0..g1].windows(2).all(|w| w[1] == w[0] + 1),
+                "run {g0}..{g1} (k={}) must be consecutive slots, got {:?}",
+                depths[g0],
+                &placed[g0..g1]
+            );
+            g0 = g1;
+        }
+    }
+
+    /// The permutation-only entry point must NEVER re-pair depths — a
+    /// downstream stage re-assigning them could hand a sequence a depth
+    /// deeper than the drafts the planner truncated it to.
+    #[test]
+    fn permutation_leaves_depths_attached_to_their_member() {
+        // An arrangement the canonical planner would never emit (depths
+        // ascending along the slots), to prove the permutation does not
+        // "repair" it.
+        let slots = [7usize, 2, 5, 0];
+        let ks = [4usize, 2, 3, 2];
+        for canonical in [true, false] {
+            let order = verify_batch_permutation(&slots, &ks, canonical);
+            let (_, assigned) = verify_batch_order(&slots, &ks, canonical);
+            let carried: Vec<usize> = order.iter().map(|&i| ks[i]).collect();
+            if canonical {
+                // The planner's entry point DOES re-pair; the permutation
+                // does not. That difference is the point of the split.
+                assert_eq!(carried, vec![2, 2, 3, 4]);
+                assert_eq!(assigned, vec![4, 3, 2, 2]);
+            } else {
+                assert_eq!(carried, assigned);
+            }
+        }
+    }
+
+    /// Idempotence: a chunked caller re-applies the ordering per chunk.
+    #[test]
+    fn canonical_order_is_idempotent() {
+        let slots = [7usize, 2, 5, 0, 3];
+        let ks = [2usize, 4, 2, 3, 4];
+        let (o1, d1) = verify_batch_order(&slots, &ks, true);
+        let s1: Vec<usize> = o1.iter().map(|&i| slots[i]).collect();
+        let (o2, d2) = verify_batch_order(&s1, &d1, true);
+        assert_eq!(o2, (0..s1.len()).collect::<Vec<_>>());
+        assert_eq!(d2, d1);
+    }
+
+    /// Kill switch: the legacy ordering keeps each sequence's own depth, so
+    /// the same multiset in different arrangements yields DIFFERENT keys —
+    /// today's behaviour, restored exactly.
+    #[test]
+    fn kill_switch_restores_the_arrangement_keyed_behaviour() {
+        let a = key_for(&[(0, 4), (1, 4), (2, 3), (3, 3)], false);
+        let b = key_for(&[(0, 3), (1, 3), (2, 4), (3, 4)], false);
+        assert_ne!(a, b, "legacy keys must still separate arrangements");
+        // Legacy order is deepest-first, slot second — each member keeps its
+        // OWN depth.
+        assert_eq!(b, vec![2, 4, 3, 4, 0, 3, 1, 3, u32::MAX]);
+    }
+
+    /// Uniform depths (D-Cut off, above `dcut_width_cap`, or ratio 1.0):
+    /// both arms reduce to "sort by slot", so the whole D-Cut-off regime is
+    /// byte-identical under either setting.
+    #[test]
+    fn uniform_depths_are_identical_under_both_arms() {
+        let slots = [3usize, 1, 2, 0];
+        let ks = [3usize; 4];
+        let canon = verify_batch_order(&slots, &ks, true);
+        let legacy = verify_batch_order(&slots, &ks, false);
+        assert_eq!(canon, legacy);
+        assert_eq!(
+            canon.0.iter().map(|&i| slots[i]).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+    }
+
+    /// Env-independent as long as the test process does not set the kill
+    /// switch (CI does not) — same pattern as `dcut_width_cap`'s default pin.
+    #[test]
+    fn canonical_is_on_by_default() {
+        assert!(canonical_verify_key_enabled());
+    }
+
+    /// Degenerate widths must not panic: the key path runs for every batch
+    /// the scheduler forms.
+    #[test]
+    fn empty_and_single_batches_are_well_formed() {
+        assert_eq!(verify_batch_order(&[], &[], true), (vec![], vec![]));
+        assert_eq!(verify_batch_order(&[5], &[3], true), (vec![0], vec![3]));
+        assert_eq!(verify_graph_key(&[], false), vec![u32::MAX]);
+    }
+}

--- a/crates/spark-server/src/scheduler/mtp_dcut.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut.rs
@@ -185,9 +185,21 @@ pub(super) fn select(
     retained
 }
 
-/// Plan one verify batch: choose each batchable sequence's retained draft
-/// count, truncate its drafts to that prefix, reorder the batch deepest-first,
-/// and return the resulting per-sequence ROW count (`retained + 1`).
+/// Plan one verify batch: choose the retained draft-count MULTISET from the
+/// drafter's confidences, assign it to the batch's ssm slots in the canonical
+/// order, truncate each sequence's drafts to its assigned prefix, and return
+/// the resulting per-sequence ROW count (`retained + 1`) in dispatch order.
+///
+/// ★ The depth→slot ASSIGNMENT is canonical (`verify_key::verify_batch_order`
+/// — depths descending paired with slots ascending), not confidence-ordered.
+/// D-Cut's row saving comes from the multiset, which stays confidence-chosen;
+/// WHO gets which depth was the half that multiplied the batched-verify
+/// CUDA-graph key space (266 arrangements at n=8 against a 32-entry cache →
+/// 89% of steps re-capturing, 23.2 ms/step). It also RECONCILES the batch's
+/// two ordering demands — contiguous equal-depth runs and ascending
+/// consecutive ssm slots — which the confidence-ordered arrangement put in
+/// direct conflict. See `verify_key`'s module docs for the full argument and
+/// the kill switch `ATLAS_NO_CANONICAL_VERIFY_KEY`.
 ///
 /// With `ATLAS_NO_MTP_DCUT` set — or the batch wider than [`dcut_width_cap`]
 /// sequences (the D-Cut-at-depth policy: pruning at the 16:2 rung's n=16
@@ -222,27 +234,42 @@ pub(super) fn plan(
         })
         .collect();
     let retained = select(&confs, ladder_nd, VERIFY_ROW_BUDGET, dcut_ratio());
-    for (slot, &idx) in batchable.iter().enumerate() {
-        let keep = retained[slot].clamp(1, ladder_nd);
-        active[idx].pending_drafts.truncate(keep);
-        active[idx].pending_draft_conf.truncate(keep);
-        ks[slot] = keep + 1;
+    for (pos, r) in retained.iter().enumerate() {
+        ks[pos] = (*r).clamp(1, ladder_nd) + 1;
     }
-    record(batchable.len() * rows, ks.iter().sum(), &ks);
-    // Deepest first so equal-depth sequences form CONTIGUOUS row runs — the
-    // cross-sequence batched GDN conv+WY fast path launches once per run, so
-    // fragmenting the depths would trade verify rows for kernel launches.
-    // Secondary key stays the ssm slot (canonical graph key + the
-    // consecutive-slot precondition).
-    let mut order: Vec<(usize, usize)> = batchable.iter().copied().zip(ks).collect();
-    order.sort_by_key(|&(idx, k)| {
-        (
-            std::cmp::Reverse(k),
-            active[idx].seq.ssm_slot_idx().unwrap_or(usize::MAX),
-        )
-    });
-    *batchable = order.iter().map(|&(i, _)| i).collect();
-    order.iter().map(|&(_, k)| k).collect()
+    // Dispatch order + depth assignment, from the ONE ordering rule shared
+    // with the graph key. Canonical: depths descending onto slots ascending,
+    // so `ks_out[p]` is the multiset's p-th deepest row count, NOT
+    // necessarily the confidence-chosen depth of the sequence placed there.
+    // Kill switch: each sequence keeps its own depth, deepest-first.
+    let slots: Vec<usize> = batchable
+        .iter()
+        .map(|&idx| active[idx].seq.ssm_slot_idx().unwrap_or(usize::MAX))
+        .collect();
+    let (order, ks_out) = spark_model::speculative::verify_key::verify_batch_order(
+        &slots,
+        &ks,
+        spark_model::speculative::verify_key::canonical_verify_key_enabled(),
+    );
+    // Truncate to the ASSIGNED depth. Every batchable sequence entered the
+    // step with exactly `ladder_nd` drafts (`mtp_step` truncates the surplus)
+    // and `ks_out[p] - 1` is in `1..=ladder_nd`, so this is always a prefix
+    // of what the drafter produced — deepening a sequence past its own drafts
+    // is unrepresentable, not merely unlikely.
+    let reordered: Vec<usize> = order.iter().map(|&p| batchable[p]).collect();
+    for (idx, &k) in reordered.iter().zip(&ks_out) {
+        let a = &mut active[*idx];
+        debug_assert!(
+            k >= 2 && k - 1 <= a.pending_drafts.len(),
+            "assigned depth {k} exceeds the {} drafts proposed",
+            a.pending_drafts.len()
+        );
+        a.pending_drafts.truncate(k - 1);
+        a.pending_draft_conf.truncate(k - 1);
+    }
+    record(batchable.len() * rows, ks_out.iter().sum(), &ks_out);
+    *batchable = reordered;
+    ks_out
 }
 
 /// Split a batch into verify chunks: `[lo, hi)` index ranges over `ks`.
@@ -315,132 +342,6 @@ fn record(rows_full: usize, rows_kept: usize, ks: &[usize]) {
         );
     }
 }
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn ratio_one_retains_full_depth() {
-        let c: Vec<Vec<f32>> = vec![vec![-0.1, -2.0, -3.0]; 4];
-        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
-        assert_eq!(select(&refs, 3, 32, 1.0), vec![3, 3, 3, 3]);
-    }
-
-    #[test]
-    fn zero_ratio_keeps_the_mandatory_first_draft() {
-        let c: Vec<Vec<f32>> = vec![vec![-0.1, -0.2, -0.3]; 4];
-        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
-        assert_eq!(select(&refs, 3, 32, 0.0), vec![1, 1, 1, 1]);
-    }
-
-    #[test]
-    fn budget_spent_on_the_confident_sequence() {
-        // seq 0 is confident throughout, seq 1 collapses after its first draft.
-        let c = [vec![-0.01f32, -0.02, -0.03], vec![-3.0f32, -4.0, -5.0]];
-        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
-        // 2 sequences x 2 prunable depths = 4 candidates; ratio 0.5 keeps 2,
-        // both of which belong to seq 0.
-        assert_eq!(select(&refs, 3, 32, 0.5), vec![3, 1]);
-    }
-
-    #[test]
-    fn retained_set_is_always_a_prefix() {
-        let c = [vec![-0.1f32, -9.0, -0.001], vec![-0.2f32, -0.2, -0.2]];
-        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
-        let r = select(&refs, 3, 32, 0.5);
-        // Depth-3 of seq 0 has a WORSE survival score than depth-2 despite its
-        // own high confidence, because survival is the prefix product.
-        assert!(r[0] <= 2, "prefix product must dominate the local value");
-        assert!(r.iter().all(|&k| (1..=3).contains(&k)));
-    }
-
-    #[test]
-    fn row_budget_is_never_exceeded() {
-        let c: Vec<Vec<f32>> = vec![vec![-0.001, -0.001, -0.001]; 8];
-        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
-        // 8 sequences, budget 24 rows: 16 committed, 8 spare -> 8 extra depths.
-        let r = select(&refs, 3, 24, 1.0);
-        let rows: usize = r.iter().map(|k| k + 1).sum();
-        assert!(rows <= 24, "rows={rows}");
-    }
-
-    #[test]
-    fn missing_confidences_are_never_pruned() {
-        let empty: Vec<f32> = Vec::new();
-        let c = [vec![-5.0f32, -5.0, -5.0], empty];
-        let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
-        assert_eq!(select(&refs, 3, 32, 0.5), vec![1, 3]);
-    }
-
-    #[test]
-    fn chunk_ranges_reproduce_the_uniform_caps() {
-        // Every default-ladder-reachable shape is a SINGLE chunk — true under
-        // the old 64-row budget too, so the 96 widening is default-inert.
-        assert_eq!(chunk_ranges(&[4; 8]), vec![(0, 8)]);
-        assert_eq!(chunk_ranges(&[3; 8]), vec![(0, 8)]);
-        // The 16:2 default rung: [3; 16] = 48 rows, one chunk.
-        assert_eq!(chunk_ranges(&[3; 16]), vec![(0, 16)]);
-        assert_eq!(chunk_ranges(&[2; 16]), vec![(0, 16)]);
-        // The 32:1 rung: one chunk up to n=32 (R = 64).
-        assert_eq!(chunk_ranges(&[2; 17]), vec![(0, 17)]);
-        assert_eq!(chunk_ranges(&[2; 32]), vec![(0, 32)]);
-    }
-
-    #[test]
-    fn chunk_ranges_seq_cap_derives_from_the_row_budget() {
-        // Depth above n=8 (env-ladder / ragged-D-Cut shapes) is no longer
-        // serialized into 8-wide chunks: the row budget is the only bound.
-        // rows=3: 96/3 = 32 seqs — 16:2, 24:2 AND 32:2 are each ONE chunk.
-        assert_eq!(chunk_ranges(&[3; 21]), vec![(0, 21)]);
-        assert_eq!(chunk_ranges(&[3; 24]), vec![(0, 24)]);
-        assert_eq!(chunk_ranges(&[3; 32]), vec![(0, 32)]);
-        assert_eq!(chunk_ranges(&[3; 33]), vec![(0, 32), (32, 33)]);
-        // rows=4: 96/4 = 24 seqs.
-        assert_eq!(chunk_ranges(&[4; 9]), vec![(0, 9)]);
-        assert_eq!(chunk_ranges(&[4; 24]), vec![(0, 24)]);
-        assert_eq!(chunk_ranges(&[4; 25]), vec![(0, 24), (24, 25)]);
-        // rows=2: 96/2 = 48 seqs.
-        assert_eq!(chunk_ranges(&[2; 48]), vec![(0, 48)]);
-        assert_eq!(chunk_ranges(&[2; 49]), vec![(0, 48), (48, 49)]);
-        // rows=3 with 10 seqs (the old (0,8),(8,10) split): one chunk now.
-        assert_eq!(chunk_ranges(&[3; 10]), vec![(0, 10)]);
-    }
-
-    #[test]
-    fn chunk_ranges_respect_the_row_budget_when_ragged() {
-        // Deepest-first, mixed depths: rows must never exceed the budget per
-        // chunk.
-        let ks = vec![4, 4, 4, 4, 4, 3, 3, 2, 2, 2];
-        for (lo, hi) in chunk_ranges(&ks) {
-            let rows: usize = ks[lo..hi].iter().sum();
-            assert!(rows <= VERIFY_ROW_BUDGET, "rows={rows}");
-            assert!(hi > lo);
-        }
-    }
-
-    // Env-independent as long as the test process does not set
-    // ATLAS_MTP_DCUT_MAX_SEQS (CI does not) — same pattern as the ladder
-    // default-shape test.
-    #[test]
-    fn dcut_width_cap_default_is_the_measured_win_regime() {
-        // 8 = the C=8 regime where ratio 0.75 measured +2.6%; pruning at the
-        // 16:2 rung's n=16 measured -9% (fixer r2 leg D), so `plan` must
-        // return the uniform shape for any wider batch.
-        assert_eq!(dcut_width_cap(), 8);
-    }
-
-    #[test]
-    fn ratio_snaps_to_a_bucket() {
-        // Pure snapping arithmetic, no env: 0.6 is closest to 0.5.
-        let nearest = |raw: f32| {
-            *BUCKETS
-                .iter()
-                .min_by(|a, b| (*a - raw).abs().partial_cmp(&(*b - raw).abs()).unwrap())
-                .unwrap()
-        };
-        assert_eq!(nearest(0.6), 0.5);
-        assert_eq!(nearest(0.9), 1.0);
-        assert_eq!(nearest(0.1), 0.25);
-    }
-}
+#[path = "mtp_dcut_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (`mtp_dcut`). A sibling file via `#[path]` — the
+//! `ssm_reserve.rs`/`ssm_reserve_tests.rs` idiom — so `mtp_dcut.rs` stays
+//! under the 500-line cap; module position (child of `mtp_dcut`) is
+//! unchanged, so `super::*` paths are untouched.
+use super::*;
+
+#[test]
+fn ratio_one_retains_full_depth() {
+    let c: Vec<Vec<f32>> = vec![vec![-0.1, -2.0, -3.0]; 4];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    assert_eq!(select(&refs, 3, 32, 1.0), vec![3, 3, 3, 3]);
+}
+
+#[test]
+fn zero_ratio_keeps_the_mandatory_first_draft() {
+    let c: Vec<Vec<f32>> = vec![vec![-0.1, -0.2, -0.3]; 4];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    assert_eq!(select(&refs, 3, 32, 0.0), vec![1, 1, 1, 1]);
+}
+
+#[test]
+fn budget_spent_on_the_confident_sequence() {
+    // seq 0 is confident throughout, seq 1 collapses after its first draft.
+    let c = [vec![-0.01f32, -0.02, -0.03], vec![-3.0f32, -4.0, -5.0]];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    // 2 sequences x 2 prunable depths = 4 candidates; ratio 0.5 keeps 2,
+    // both of which belong to seq 0.
+    assert_eq!(select(&refs, 3, 32, 0.5), vec![3, 1]);
+}
+
+#[test]
+fn retained_set_is_always_a_prefix() {
+    let c = [vec![-0.1f32, -9.0, -0.001], vec![-0.2f32, -0.2, -0.2]];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    let r = select(&refs, 3, 32, 0.5);
+    // Depth-3 of seq 0 has a WORSE survival score than depth-2 despite its
+    // own high confidence, because survival is the prefix product.
+    assert!(r[0] <= 2, "prefix product must dominate the local value");
+    assert!(r.iter().all(|&k| (1..=3).contains(&k)));
+}
+
+#[test]
+fn row_budget_is_never_exceeded() {
+    let c: Vec<Vec<f32>> = vec![vec![-0.001, -0.001, -0.001]; 8];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    // 8 sequences, budget 24 rows: 16 committed, 8 spare -> 8 extra depths.
+    let r = select(&refs, 3, 24, 1.0);
+    let rows: usize = r.iter().map(|k| k + 1).sum();
+    assert!(rows <= 24, "rows={rows}");
+}
+
+#[test]
+fn missing_confidences_are_never_pruned() {
+    let empty: Vec<f32> = Vec::new();
+    let c = [vec![-5.0f32, -5.0, -5.0], empty];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    assert_eq!(select(&refs, 3, 32, 0.5), vec![1, 3]);
+}
+
+#[test]
+fn chunk_ranges_reproduce_the_uniform_caps() {
+    // Every default-ladder-reachable shape is a SINGLE chunk — true under
+    // the old 64-row budget too, so the 96 widening is default-inert.
+    assert_eq!(chunk_ranges(&[4; 8]), vec![(0, 8)]);
+    assert_eq!(chunk_ranges(&[3; 8]), vec![(0, 8)]);
+    // The 16:2 default rung: [3; 16] = 48 rows, one chunk.
+    assert_eq!(chunk_ranges(&[3; 16]), vec![(0, 16)]);
+    assert_eq!(chunk_ranges(&[2; 16]), vec![(0, 16)]);
+    // The 32:1 rung: one chunk up to n=32 (R = 64).
+    assert_eq!(chunk_ranges(&[2; 17]), vec![(0, 17)]);
+    assert_eq!(chunk_ranges(&[2; 32]), vec![(0, 32)]);
+}
+
+#[test]
+fn chunk_ranges_seq_cap_derives_from_the_row_budget() {
+    // Depth above n=8 (env-ladder / ragged-D-Cut shapes) is no longer
+    // serialized into 8-wide chunks: the row budget is the only bound.
+    // rows=3: 96/3 = 32 seqs — 16:2, 24:2 AND 32:2 are each ONE chunk.
+    assert_eq!(chunk_ranges(&[3; 21]), vec![(0, 21)]);
+    assert_eq!(chunk_ranges(&[3; 24]), vec![(0, 24)]);
+    assert_eq!(chunk_ranges(&[3; 32]), vec![(0, 32)]);
+    assert_eq!(chunk_ranges(&[3; 33]), vec![(0, 32), (32, 33)]);
+    // rows=4: 96/4 = 24 seqs.
+    assert_eq!(chunk_ranges(&[4; 9]), vec![(0, 9)]);
+    assert_eq!(chunk_ranges(&[4; 24]), vec![(0, 24)]);
+    assert_eq!(chunk_ranges(&[4; 25]), vec![(0, 24), (24, 25)]);
+    // rows=2: 96/2 = 48 seqs.
+    assert_eq!(chunk_ranges(&[2; 48]), vec![(0, 48)]);
+    assert_eq!(chunk_ranges(&[2; 49]), vec![(0, 48), (48, 49)]);
+    // rows=3 with 10 seqs (the old (0,8),(8,10) split): one chunk now.
+    assert_eq!(chunk_ranges(&[3; 10]), vec![(0, 10)]);
+}
+
+#[test]
+fn chunk_ranges_respect_the_row_budget_when_ragged() {
+    // Deepest-first, mixed depths: rows must never exceed the budget per
+    // chunk.
+    let ks = vec![4, 4, 4, 4, 4, 3, 3, 2, 2, 2];
+    for (lo, hi) in chunk_ranges(&ks) {
+        let rows: usize = ks[lo..hi].iter().sum();
+        assert!(rows <= VERIFY_ROW_BUDGET, "rows={rows}");
+        assert!(hi > lo);
+    }
+}
+
+// Env-independent as long as the test process does not set
+// ATLAS_MTP_DCUT_MAX_SEQS (CI does not) — same pattern as the ladder
+// default-shape test.
+#[test]
+fn dcut_width_cap_default_is_the_measured_win_regime() {
+    // 8 = the C=8 regime where ratio 0.75 measured +2.6%; pruning at the
+    // 16:2 rung's n=16 measured -9% (fixer r2 leg D), so `plan` must
+    // return the uniform shape for any wider batch.
+    assert_eq!(dcut_width_cap(), 8);
+}
+
+/// The seam `plan` builds on: the canonical assignment consumes exactly
+/// the multiset `select` produced, so Σ rows — and therefore the row
+/// budget, `chunk_ranges` and the `record` telemetry — is untouched,
+/// while the batch comes out slot-ascending / depth-descending. `plan`
+/// itself needs live `ActiveSeq`s (GPU-backed `SequenceState`); this
+/// pins the arithmetic it delegates.
+#[test]
+fn canonical_assignment_preserves_the_selected_row_total() {
+    use spark_model::speculative::verify_key::verify_batch_order;
+    // A confidence spread that prunes raggedly: seq 0 collapses, seq 3 is
+    // confident throughout.
+    let c = [
+        vec![-0.01f32, -6.0, -7.0],
+        vec![-0.01f32, -0.02, -4.0],
+        vec![-0.01f32, -5.0, -6.0],
+        vec![-0.01f32, -0.02, -0.03],
+    ];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    let retained = select(&refs, 3, VERIFY_ROW_BUDGET, 0.5);
+    let ks: Vec<usize> = retained.iter().map(|r| r + 1).collect();
+    assert!(ks.iter().any(|&k| k != ks[0]), "the case must be ragged");
+    // Pool slots deliberately out of batch order, as they are after
+    // sequences finish and the pool fragments.
+    let slots = [5usize, 0, 7, 2];
+    let (order, depths) = verify_batch_order(&slots, &ks, true);
+    assert_eq!(
+        depths.iter().sum::<usize>(),
+        ks.iter().sum::<usize>(),
+        "Σ rows must survive the re-pairing — the row budget depends on it"
+    );
+    let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
+    assert!(placed.windows(2).all(|w| w[0] < w[1]), "{placed:?}");
+    assert!(depths.windows(2).all(|w| w[0] >= w[1]), "{depths:?}");
+    // Every assigned depth stays inside the audited 2..=4 row envelope
+    // (`can_batch_verify`, `gdn_decode_wy{2,3,4}`).
+    assert!(depths.iter().all(|k| (2..=4).contains(k)));
+    // Chunking sees the same shape it always did.
+    assert_eq!(chunk_ranges(&depths), vec![(0, 4)]);
+}
+
+#[test]
+fn ratio_snaps_to_a_bucket() {
+    // Pure snapping arithmetic, no env: 0.6 is closest to 0.5.
+    let nearest = |raw: f32| {
+        *BUCKETS
+            .iter()
+            .min_by(|a, b| (*a - raw).abs().partial_cmp(&(*b - raw).abs()).unwrap())
+            .unwrap()
+    };
+    assert_eq!(nearest(0.6), 0.5);
+    assert_eq!(nearest(0.9), 1.0);
+    assert_eq!(nearest(0.1), 0.25);
+}

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -414,20 +414,40 @@ pub fn step_mtp(
                 consumed = i + 1;
                 refs.push((a, k));
             }
-            // Canonical batch order: deepest first, then ssm-pool slot, so the
-            // graph key (verify_e2) is a combination, not a permutation — 24x
-            // fewer keys at n=4 — and the consecutive-slot batched-GDN
-            // precondition engages more often. Verdicts are index-mapped
-            // inside the step, so batch order is free to the caller. With
-            // uniform k this is the pre-D-Cut sort by slot.
-            refs.sort_by_key(|(a, k)| {
-                (
-                    std::cmp::Reverse(*k),
-                    a.seq.ssm_slot_idx().unwrap_or(usize::MAX),
-                )
-            });
-            let sorted_ks: Vec<usize> = refs.iter().map(|&(_, k)| k).collect();
-            let mut batch: Vec<&mut ActiveSeq> = refs.into_iter().map(|(a, _)| a).collect();
+            // Canonical batch order, from the ONE ordering rule shared with
+            // the graph key (`verify_key`): ssm slots ascending, which under
+            // the canonical depth assignment is ALSO deepest-first, so the
+            // key is a function of the depth MULTISET rather than its
+            // arrangement (266 keys → 3 at n=8) and each depth run owns a
+            // consecutive slot block for the batched-GDN precondition.
+            // Idempotent on `plan`'s already-canonical order; it still runs
+            // because `plan` returns the batch UNORDERED whenever D-Cut
+            // declines, and that uniform-`k` case is the pre-D-Cut sort by
+            // slot. PERMUTATION ONLY — depths stay attached to the sequence
+            // `plan` truncated for (`verify_k4_batch_step` pins
+            // `drafts + 1 == ks[i]`). Verdicts are index-mapped inside the
+            // step, so batch order is free to the caller.
+            let chunk_slots: Vec<usize> = refs
+                .iter()
+                .map(|(a, _)| a.seq.ssm_slot_idx().unwrap_or(usize::MAX))
+                .collect();
+            let chunk_depths: Vec<usize> = refs.iter().map(|&(_, k)| k).collect();
+            let order = spark_model::speculative::verify_key::verify_batch_permutation(
+                &chunk_slots,
+                &chunk_depths,
+                spark_model::speculative::verify_key::canonical_verify_key_enabled(),
+            );
+            let sorted_ks: Vec<usize> = order.iter().map(|&p| chunk_depths[p]).collect();
+            let mut slotted: Vec<Option<&mut ActiveSeq>> =
+                refs.into_iter().map(|(a, _)| Some(a)).collect();
+            let mut batch: Vec<&mut ActiveSeq> = order
+                .iter()
+                .map(|&p| {
+                    slotted[p]
+                        .take()
+                        .expect("verify_batch_permutation is a permutation")
+                })
+                .collect();
             step_verify_k4_batched(model, &mut batch, sched, &sorted_ks, ladder_nd, verify_ctx);
         } else {
             // Model can't batch this width (or a lone leftover): fall back


### PR DESCRIPTION
## The defect

The batched-verify CUDA-graph cache thrashes at mid concurrency.

`verify_batched_graph_key` (`crates/spark-model/src/model/trait_impl/verify_e2.rs`) builds the key by interleaving each sequence's **draft depth `k`** with its **ssm-pool slot id** — it must, because a capture bakes each row's pool state addresses *and* the depth-run launch structure. D-Cut (default ON, ratio 0.75, active only at width ≤ 8 — `crates/spark-server/src/scheduler/mtp_dcut.rs`) re-ranks WHICH slot gets WHICH depth every single step. So the key space was the set of **arrangements** of the step's depth multiset over the batch's slots:

```
n=8, the three multisets actually observed:
  8!/(5!·2!·1!) + 8!/(4!·4!) + 8!/(6!·2!) = 168 + 70 + 28 = 266 keys
```

against `VERIFY_BATCHED_GRAPH_CAP = 32`.

**Measured key counts:** n=2 → 2, n=4 → 10, **n=8 → 160-253**, n=16 → 1 (D-Cut is off above width 8).

**nsys (dgx2, binary `b508679e4`):** C=1 has **zero** graph captures in 266 steps; C=8 has **149 captures in 167 steps (89% of steps)**, costing `cuGraphInstantiateWithFlags` 15.38 + `cuGraphExecDestroy` 5.25 + `cuGraphDestroy` 2.40 = **23.2 ms/step — 20% of the entire step**. GPU busy falls 96.3% → 77.2%.

**A/B at C=8** (osl 512, 2 reps, fresh serve per leg): control 78.89 tok/s; `ATLAS_MTP_DCUT_RATIO=1.0` (D-Cut off) **84.35 tok/s, +6.9%**, key count 253 → 1. That leg *also* loses D-Cut's row pruning, so the thrash alone costs more than 6.9%.

Related: D-Cut's recorded +2.6% win was measured on binary `296b9674`, **before this graph key existed**. With the current key, D-Cut is net-negative.

## Key-space arithmetic, before → after

| rung | before (arrangements) | after (multisets) |
|---|---|---|
| n=2 | 2 | **1** |
| n=4 | 10 | **2** |
| n=8 | 266 (160-253 observed) | **3** |
| n≥16 | 1 (D-Cut off) | 1 |

The n=8 → 3 is not an estimate: `ladder_nd = 3`, ratio 0.75 ⇒ `keep = round(16 × 0.75) = 12` of 16 prunable positions ⇒ Σ retained = 20 over 8 sequences with `retained ∈ {1,2,3}`, which admits exactly three multisets — `(a,b,c) = (0,4,4), (1,2,5), (2,0,6)` — and those are precisely the (5,2,1) / (4,4,0) / (6,0,2) depth shapes the profile observed. A test enumerates all 8! placements of each and **computes** both counts (266 and 3). Steady-state cache pressure across every rung is now ~6 keys against a cap of 32.

## Design, and why

**Option 1 — canonicalize the depth→slot assignment.** D-Cut's ranking decides two things: HOW MANY drafts survive at each depth (the multiset — where the row saving comes from) and WHO gets them (the arrangement — what multiplies the key space). The multiset stays confidence-chosen; the arrangement becomes a pure function of the batch: **depths descending paired with slots ascending**. The key is then determined by (slot set, depth multiset). D-Cut's row pruning is retained in full.

**Why not option 2** (key on the multiset, depth as data): the GDN conv+WY kernels take the per-row depth as *baked launch structure* — `gdn_decode_wy{2,3,4}` handles are selected per depth run — and conv/rollback pointers are baked directly rather than read from the WY pointer tables. Making depth a data input is a kernel change, not a key change.

**Why not option 3** (raise the cap to ≥ 288): it caches the thrash instead of removing it. 288 instantiated exec graphs of a 40-layer, ~4-5k-launch forward is hundreds of MB of driver-side graph memory on a box where the KV cache already competes for it — and the *first* visit to each of 266 keys still pays a capture, so at C=8 the cold-miss rate is the cost, not the eviction rate.

### ★ The two orderings reconcile instead of fighting

The dispatch needs **depths descending** (equal depths must form contiguous runs — the batched conv+WY fast path launches once per run, `trait_decode_batched_conv_gdn_multi.rs`). The SSM batched arms need **slots ascending and consecutive in batch order** (`ssm_batched_recurrent.rs:93-106`, sorted for by `decode_step.rs:33` and `mtp_step.rs`).

Under the confidence-chosen arrangement these are in direct conflict: a ragged batch sorted deepest-first scrambles the slot order, so every depth run gets an arbitrary *subset* of the pool slots and the consecutive-slot precondition fails — the two-launch fast path has been declining on ragged D-Cut steps. Pairing depths-descending with slots-ascending makes the two orders **the same order**, and each depth run then owns a consecutive slot block. That is a second win on top of the capture saving; it is **not** claimed as a number here.

## Row-order correctness argument

Which sequence gets which depth is a pure **performance** choice:

* Every batchable sequence enters the step with exactly `ladder_nd` drafts (`mtp_step` truncates the surplus *before* D-Cut runs).
* Every assigned depth is in `1..=ladder_nd` drafts, so the truncation is always a prefix of what the drafter actually produced — deepening a sequence past its own drafts is unrepresentable, not merely unlikely.
* Verifying a shorter draft prefix is the same math on fewer rows. **Σ rows is unchanged**, so `VERIFY_ROW_BUDGET`, `chunk_ranges` and the D-Cut telemetry are untouched (pinned by a test).

What is **not** free to change is the pairing between a batch POSITION and the slot whose pointers the graph baked there. So there is exactly **one** ordering rule (`spark_model::speculative::verify_key`) and every stage uses it, with the seam deliberately split so a downstream stage cannot disturb an assignment:

* `mtp_dcut::plan` → `verify_batch_order` (order **and** assignment) and truncates each sequence's drafts to the depth it was assigned. The single place a verify depth is decided.
* `mtp_step` → `verify_batch_permutation` (**order only**). Re-assigning depths at that seam could hand a sequence a depth deeper than its own drafts; `verify_k4_batch_step` pins `drafts + 1 == ks[i]`.
* `verify_e2::verify_batched_graph_key` → `verify_key::verify_graph_key` for the key bytes, so the ordering rule and the key it produces cannot drift apart.

**Every other consumer of row order was audited** and is index-mapped or order-independent: `chunk_ranges`/`ks` alignment, the disjoint-`&mut` walk (sorts a copy, restores order), `upload_verify_wy_tables` (entry `i` = seq `i`, sliced per depth run by `g0`), `decode_verify_batched_dispatch`'s `off[]`/metadata/bt fill, `graph_borrow`'s prefix match, and the proposer's `last_num_drafted` (set at propose time, already independent of D-Cut truncation).

### Default-inert outside the defect

Uniform `ks` — D-Cut off, ratio 1.0, `ladder_nd < 2`, or width > `dcut_width_cap` (8) — makes both arms reduce to "sort by ssm slot", byte-identical to today. C=1, C≥16 and every D-Cut-off configuration are untouched **by construction**, pinned by a test.

## Kill switch

`ATLAS_NO_CANONICAL_VERIFY_KEY` (PRESENCE — house convention, `=0` is NOT off) restores today's behaviour exactly: each sequence keeps its own confidence-chosen depth and the batch sorts deepest-first, ssm-slot second.

## Tests (13 in `verify_key`, 1 at the D-Cut seam — all pure/CPU)

* `same_multiset_different_arrangement_is_one_key` — the defect, pinned.
* `n8_key_space_collapses_266_to_3` — enumerates every placement of the three observed multisets and **computes** both counts.
* `different_multisets_have_different_keys` / `different_slot_sets_have_different_keys` / `wy_table_presence_splits_the_key` — a graph must never replay against a shape it was not baked for.
* `canonical_order_holds_both_dispatch_invariants` and `each_depth_run_owns_a_consecutive_slot_block` — the SSM contiguity / depth-run invariants asserted **explicitly**.
* `permutation_leaves_depths_attached_to_their_member` — the plan/dispatch seam split.
* `canonical_order_is_idempotent` — chunked callers re-apply per chunk.
* `kill_switch_restores_the_arrangement_keyed_behaviour`.
* `uniform_depths_are_identical_under_both_arms` — the default-inert claim.
* `canonical_assignment_preserves_the_selected_row_total` — Σ rows and the audited 2..=4 row envelope survive the re-pairing; `chunk_ranges` sees the same shape.

`mtp_dcut.rs`'s tests move to a sibling `mtp_dcut_tests.rs` via `#[path]` (the `ssm_reserve.rs` idiom) so the file stays under the 500-line cap: 446 → 347.

## Graph borrow (PR #536) — noted, scope NOT expanded

The profile measured **0 borrows at n=8**. A borrow needs a *wider* captured key whose extra baked slots are all currently **free**; at a steady C=8 every pool slot is claimed, so no wider key can ever be tail-valid. That is structural, not a tunable — and with the canonical key the n=8 cache now holds ~3 keys and hits essentially always, so borrowing is not the mechanism that rung needs. No change made.

## Validation plan

* **Gates run here (CPU):** `cargo fmt --all -- --check` clean; `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests` clean; license headers 2236 valid / 0 invalid; `cargo test -p spark-model --lib` 604 passed / 0 failed; `cargo test -p spark-server --bins` 2289 passed / 0 failed / 12 ignored.
* **ssm-state-poisoning-gate** — mandatory. This patch changes which sequence's SSM state is advanced how far on the batched verify path; the gate exists for exactly this class.
* **Decode-floor ladder** — must not regress: C=1 22.44, C=2 30.32, C=4 52.35, C=8 83.22, C=16 154.30, C=32 225.37, C=64 373.90, C=128 442.83.
* **Targeted A/B at C=8**, fresh serve per leg, with `ATLAS_MTP_ACCEPT_DEBUG` on to read `last_ks` and confirm the key count collapses (`grep "Captured CUDA graph for batched verify"` should fall from ~89% of steps to a handful of lines per serve).
* **Kill-switch leg** (`ATLAS_NO_CANONICAL_VERIFY_KEY=1`) to confirm the old behaviour is recoverable and that the delta is attributable to this change.

## Expected effect (to be measured — not claimed)

**+6.9% at C=8** from removing the thrash (via the D-Cut-off proxy), likely more since D-Cut's row pruning is retained. **~+1% at C=4** (captures are only 6% of steps there). **No effect at C≥16** (D-Cut is off) or **C=1** (single-seq path).

## D-Cut re-tuning

Recommended **after** this lands, not in this PR. The 0.75 bucket was chosen on binary `296b9674` — before the graph key existed — so every bucket in that sweep (1.0 / 0.75 / 0.5 / 0.25) was measured through a different, thrashing cost model, and the ratio that shed the fewest *arrangements* was rewarded as much as the one that shed the right *rows*. With the key stabilized, re-sweep the four buckets at C=8 on the post-merge binary; 0.5 in particular deserves a fresh look, since its measured penalty (107.43 vs 108.57) is smaller than the capture noise it was measured through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
