### PR TITLE
perf: attack the n>=2 verify fixed cost — cache the WY stage, hoist the env reads, and make the two real suspects measurable

### DIFF
--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
@@ -69,6 +69,36 @@ fn first_for_k(mask: &std::sync::atomic::AtomicU32, k: usize) -> bool {
     (mask.fetch_or(bit, std::sync::atomic::Ordering::Relaxed) & bit) == 0
 }
 
+/// Periodic engaged-vs-declined RATE at INFO, under the existing
+/// `ATLAS_MTP_ACCEPT_DEBUG` gate (checked FIRST — a default serve pays one
+/// `OnceLock` load and nothing else).
+///
+/// The per-`k` first-occurrence lines above prove WHICH widths ever took
+/// each arm; they say nothing about how often. That distinction is the whole
+/// question when the batched verify carries a per-step cost the n==1 path
+/// does not: a declined call runs `n*(2k-1)` launches per GDN layer instead
+/// of 2 (768 vs 96 at n=2, k=4 over 48 GDN layers), so a decline RATE is a
+/// millisecond-scale term while a single decline is noise.
+fn record_multi_rate(n: usize, kk: usize) {
+    use std::sync::atomic::Ordering;
+    const PERIOD: u64 = 2048;
+    static SINCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    if !crate::speculative::mtp_accept_debug() {
+        return;
+    }
+    if SINCE.fetch_add(1, Ordering::Relaxed) + 1 >= PERIOD {
+        SINCE.store(0, Ordering::Relaxed);
+        let ok = BATCHED_OK.load(Ordering::Relaxed);
+        let fb = FALLBACK.load(Ordering::Relaxed);
+        tracing::info!(
+            "batched-verify GDN conv+WY [last n={n} k={kk}]: engaged={ok} declined={fb} \
+             declined_frac={:.3} (a declined call is {} launches/layer, not 2)",
+            fb as f64 / (ok + fb).max(1) as f64,
+            n * (kk + kk - 1),
+        );
+    }
+}
+
 /// Kill switch, PRESENCE check (`=0` is NOT off), read once per process.
 fn verify_gdn_batch_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -310,6 +340,7 @@ impl Qwen3SsmLayer {
         }
 
         let ok = BATCHED_OK.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        record_multi_rate(n, kk);
         if first_for_k(&ENGAGED_KMASK, kk) {
             tracing::info!(
                 "batched-verify GDN conv+WY ENGAGED (n={n}, k={kk}): per-layer {} launches \
@@ -328,6 +359,7 @@ impl Qwen3SsmLayer {
     /// `return Ok(self.gdn_multi_decline(n, kk))`.
     fn gdn_multi_decline(&self, n: usize, kk: usize) -> bool {
         let n_fb = FALLBACK.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        record_multi_rate(n, kk);
         if first_for_k(&DECLINED_KMASK, kk) {
             tracing::info!(
                 "batched-verify GDN conv+WY DECLINED (n={n}, k={kk}): batch is not on \

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -770,6 +770,9 @@ impl TransformerModel {
             verify4_graph: Mutex::new(std::collections::HashMap::new()),
             verify_batched_graphs: Mutex::new((std::collections::HashMap::new(), 0)),
             verify_wy_tables,
+            // Nothing staged yet: the buffer was memset to zero above, and no
+            // key describes zero, so the first verify step always uploads.
+            verify_wy_cache: Mutex::new(None),
             verify_kgamma_graph: Mutex::new(std::collections::HashMap::new()),
             fused_graph: Mutex::new(std::collections::HashMap::new()),
             prefix_cache,

--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -201,12 +201,18 @@ impl TransformerModel {
         // least-recently-replayed slot vector.
         let mut replay: Option<spark_runtime::gpu::GraphHandle> = None;
         let mut ghosts: Vec<(u32, u32)> = Vec::new();
+        // Graph outcome for the periodic ATLAS_MTP_ACCEPT_DEBUG summary
+        // (verify_e2). `Eager` until something claims otherwise — that is
+        // also the honest value when graphs are off or the batch is
+        // unkeyable.
+        let mut outcome = super::verify_e2::VerifyGraphOutcome::Eager;
         if let (Some(g), Some(key)) = (&mut graphs, &graph_key) {
             g.1 += 1;
             let tick = g.1;
             if let Some(e) = g.0.get_mut(key) {
                 e.1 = tick;
                 replay = Some(e.0);
+                outcome = super::verify_e2::VerifyGraphOutcome::Replay;
             } else if super::graph_borrow::graph_borrow_enabled() {
                 let wy_present = !wy_tables_base.is_null();
                 let borrowed =
@@ -230,6 +236,7 @@ impl TransformerModel {
                     e.1 = tick;
                     replay = Some(e.0);
                     ghosts = b.ghosts;
+                    outcome = super::verify_e2::VerifyGraphOutcome::Borrow;
                     // INFO once per transition (same cardinality as the
                     // captures this replaces); repeats of the same pair
                     // stay silent. Provable engagement: grep "graph borrow".
@@ -601,12 +608,18 @@ impl TransformerModel {
                         g.1 += 1;
                         let tick = g.1;
                         g.0.insert(key, (graph, tick));
+                        outcome = super::verify_e2::VerifyGraphOutcome::Capture;
                     }
                     self.gpu.launch_graph(graph, stream)?;
                 }
             }
         }
+        // Live key count read while the guard is still held — it is the
+        // other half of the capture-rate signal (churn against the 32-entry
+        // LRU is what turns a miss into a re-capture).
+        let live_keys = graphs.as_ref().map(|g| g.0.len()).unwrap_or(0);
         drop(graphs);
+        super::verify_e2::record_verify_graph_outcome(n, live_keys, outcome);
 
         // ── Phase 5: D2H + host bookkeeping ──
         // Argmax landed at scratch row 0 (graph replay and eager both write

--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -162,7 +162,7 @@ impl TransformerModel {
         // illegal access is attributed to the exact layer (same hatch as
         // verify_c2). Forces EAGER — per-layer syncs are illegal under
         // capture (verify_c2's gate pattern).
-        let k4_diag = std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1");
+        let k4_diag = super::verify_e2::k4_diag_enabled();
 
         // Pre-graph: stage the per-GDN-layer WY pointer tables into the
         // fixed staging buffer (contents refreshed BEFORE any replay, like
@@ -650,9 +650,9 @@ impl TransformerModel {
         // ATLAS_VERIFY_D2H_DEFAULT_STREAM=1 -> the original default-stream arm.
         if filled {
             // mapped path already read the results — no copy arm runs.
-        } else if std::env::var("ATLAS_VERIFY_D2H_DEFAULT_STREAM").as_deref() == Ok("1") {
+        } else if super::verify_e2::verify_d2h_default_stream() {
             self.gpu.copy_d2h(self.buffers.scratch(), &mut buf)?;
-        } else if std::env::var("ATLAS_NO_PINNED_VERIFY_D2H").as_deref() == Ok("1") {
+        } else if super::verify_e2::verify_d2h_no_pinned() {
             self.gpu
                 .copy_d2h_on_stream(self.buffers.scratch(), &mut buf, stream)?;
         } else {

--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -147,6 +147,72 @@ pub(super) fn verify_wy_cache_key(slots: &[u32], k: usize, ghosts: &[(u32, u32)]
     key
 }
 
+/// What the batched verify did with its CUDA graph on one step.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum VerifyGraphOutcome {
+    /// Exact slot-vector hit — the whole forward replayed.
+    Replay,
+    /// Drain-tail borrow: a WIDER captured key replayed with ghost rows.
+    Borrow,
+    /// Miss: the forward ran eagerly UNDER CAPTURE and a graph was
+    /// instantiated (the expensive outcome — `verify_key`'s module docs
+    /// price instantiate+destroy at 23.2 ms/step at an 89% recapture rate).
+    Capture,
+    /// No graph at all: `ATLAS_NO_MTP_VERIFY_GRAPHS`, `ATLAS_K4_DIAG`, or a
+    /// batch with a slotless sequence.
+    Eager,
+}
+
+/// Periodic INFO summary of the batched-verify graph outcomes, under the
+/// existing `ATLAS_MTP_ACCEPT_DEBUG` gate (checked FIRST, so a default serve
+/// pays one `OnceLock` load and no atomics).
+///
+/// ★ Why this exists. The n>=2 verify path carries a per-step FIXED cost the
+/// n==1 path does not, and the two candidates of the right magnitude — graph
+/// RE-capture, and the batched GDN conv+WY fast path declining into the
+/// per-sequence loop — were both unanswerable from a ladder log. Captures
+/// only logged one INFO line each (thousands of lines, no rate) and the GDN
+/// engage/decline counters only surfaced at `debug`. A rate, and the live key
+/// count next to it, is what distinguishes "the key space collapsed and the
+/// path replays" from "this rung re-captures every step".
+pub(super) fn record_verify_graph_outcome(n: usize, live_keys: usize, outcome: VerifyGraphOutcome) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    const PERIOD: u64 = 200;
+    static STEPS: AtomicU64 = AtomicU64::new(0);
+    static REPLAY: AtomicU64 = AtomicU64::new(0);
+    static BORROW: AtomicU64 = AtomicU64::new(0);
+    static CAPTURE: AtomicU64 = AtomicU64::new(0);
+    static EAGER: AtomicU64 = AtomicU64::new(0);
+    if !crate::speculative::mtp_accept_debug() {
+        return;
+    }
+    match outcome {
+        VerifyGraphOutcome::Replay => &REPLAY,
+        VerifyGraphOutcome::Borrow => &BORROW,
+        VerifyGraphOutcome::Capture => &CAPTURE,
+        VerifyGraphOutcome::Eager => &EAGER,
+    }
+    .fetch_add(1, Ordering::Relaxed);
+    if STEPS.fetch_add(1, Ordering::Relaxed) + 1 >= PERIOD {
+        let steps = STEPS.swap(0, Ordering::Relaxed).max(1);
+        let (replay, borrow) = (
+            REPLAY.swap(0, Ordering::Relaxed),
+            BORROW.swap(0, Ordering::Relaxed),
+        );
+        let (capture, eager) = (
+            CAPTURE.swap(0, Ordering::Relaxed),
+            EAGER.swap(0, Ordering::Relaxed),
+        );
+        tracing::info!(
+            "batched-verify graphs [{steps} steps, last n={n}]: replay={replay} \
+             borrow={borrow} CAPTURE={capture} eager={eager} capture_frac={:.3} \
+             live_keys={live_keys}/{}",
+            capture as f64 / steps as f64,
+            VERIFY_BATCHED_GRAPH_CAP,
+        );
+    }
+}
+
 impl TransformerModel {
     /// Batched-verify graph key: each sequence's ssm-pool slot in batch
     /// order — every SSM pointer the graph bakes (h/conv state, rollback

--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -90,6 +90,63 @@ pub(super) fn verify_d2h_no_pinned() -> bool {
     *ON.get_or_init(|| read_value_switch("ATLAS_NO_PINNED_VERIFY_D2H"))
 }
 
+/// WY-table staging cache: ON by default, disabled by PRESENCE of
+/// `ATLAS_NO_VERIFY_WY_CACHE` (house convention — `=0` is NOT off).
+/// Read once per process. OFF restores the unconditional per-step re-stage.
+pub(super) fn verify_wy_cache_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_VERIFY_WY_CACHE").is_none())
+}
+
+/// Encode the COMPLETE input set of `upload_verify_wy_tables`'s staged bytes.
+///
+/// ★ The proof obligation for the cache is that two calls with equal keys
+/// stage byte-identical tables. Every entry the fill loops write is
+/// `SsmLayerState::h_state` / `h_state_intermediates[t]` for a batch
+/// sequence, or `ssm_pool.h_state` / `h_intermediate` for a ghost — and
+/// those four are the SAME pool accessors:
+///
+/// * `h_state` is only ever assigned `ssm_pool.h_state(ssm_layer_idx, slot)`
+///   (`meta.rs` at alloc, `sequence.rs` at compaction) or `DevicePtr(0)` on
+///   free, and `ssm_pool.h_state` is `h_state_pools[layer].offset(slot *
+///   h_stored_bytes)` — pure address arithmetic over pool bases fixed at
+///   model construction.
+/// * `h_state_intermediates[t]` is only ever
+///   `ssm_pool.h_intermediate(ssm_layer_idx, slot, t)`, and its LENGTH is
+///   `ssm_pool.h_inter_count(slot)` — slot-keyed (tiered pools) and
+///   `has_mtp`-gated, where `has_mtp` is a MODEL property
+///   (`proposer.is_some() || self_speculative`), not a per-sequence one.
+///
+/// So a table entry is a pure function of `(layer, slot, t)`, the layer set
+/// is `config.num_ssm_layers()` (fixed), and the only step-varying inputs are
+/// the ones encoded here:
+///   1. `k` — how many of the four per-layer tables are filled.
+///   2. `slots.len()` — how many batch entries are filled, hence where the
+///      zero tail of each table starts.
+///   3. `slots` — the per-sequence ssm-pool slot, IN BATCH ORDER (entry `i`
+///      of every table is sequence `i`).
+///   4. `ghosts` — the drain-tail borrow's `(slot, depth)` pairs, in order,
+///      appended after the batch entries.
+///
+/// Everything else (pool base addresses, `h_stored_bytes`, the tiered
+/// `h_inter_offsets`, the GDN layer set) is fixed for the process at model
+/// construction.
+///
+/// The encoding is injective: `[k, n, slots[0..n], (slot, depth) * g]` — `n`
+/// disambiguates the slot run from the ghost tail, and the ghost count falls
+/// out of the remaining length.
+pub(super) fn verify_wy_cache_key(slots: &[u32], k: usize, ghosts: &[(u32, u32)]) -> Vec<u64> {
+    let mut key = Vec::with_capacity(2 + slots.len() + 2 * ghosts.len());
+    key.push(k as u64);
+    key.push(slots.len() as u64);
+    key.extend(slots.iter().map(|&s| s as u64));
+    for &(slot, depth) in ghosts {
+        key.push(slot as u64);
+        key.push(depth as u64);
+    }
+    key
+}
+
 impl TransformerModel {
     /// Batched-verify graph key: each sequence's ssm-pool slot in batch
     /// order — every SSM pointer the graph bakes (h/conv state, rollback
@@ -132,10 +189,29 @@ impl TransformerModel {
     /// Stage the per-GDN-layer WY pointer tables (`[h|Hi0|Hi1|Hi2]` ×
     /// `VERIFY_WY_TABLE_SEQS` u64 entries per layer, batch entries filled,
     /// tail zero) into the fixed `verify_wy_tables` device buffer. Runs
-    /// PRE-graph every batched verify step so a replayed graph reads tables
-    /// refreshed for the current batch (contents are constant per slot
-    /// vector; refreshing keeps replay correct by construction, not by
-    /// invariant).
+    /// PRE-graph on every batched verify step whose table content differs
+    /// from what is already staged, so a replayed graph reads tables valid
+    /// for the current batch.
+    ///
+    /// ★ CACHED since `perf/verify-fixed-cost`. This used to re-stage
+    /// unconditionally — a 48 KB zeroed host `Vec` + `num_ssm × n`
+    /// `Any` downcasts + a 48 KB pageable H2D on EVERY n>=2 verify step,
+    /// which the single-sequence path (n==1, `verify_c2`) never pays. The
+    /// staged bytes are a pure function of `(k, slot vector, ghosts)` —
+    /// `verify_wy_cache_key` carries the enumeration and the proof — so when
+    /// that key matches `verify_wy_cache` the device buffer already holds
+    /// exactly these bytes and both the build and the copy are skipped.
+    /// Nothing else writes `verify_wy_tables` (allocation memsets it to zero
+    /// once; this is its only writer), so "same key ⇒ same device content"
+    /// holds for the buffer, not merely for the host image.
+    ///
+    /// The trade is explicit: correctness moves from "by construction"
+    /// (re-upload every step) to "by invariant" (the enumeration above).
+    /// The invariant is backstopped twice — the per-layer batched arm
+    /// re-checks each state's intermediate capacity before reading a table
+    /// (`trait_decode_batched_conv_gdn_multi.rs`), and the wy-tables-present
+    /// sentinel is in the CUDA-graph key — and `ATLAS_NO_VERIFY_WY_CACHE`
+    /// restores the unconditional re-stage for A/B.
     ///
     /// `k` is this step's verify width (rows per sequence, 2..=4 from the
     /// ladder). Exactly `k` tables are filled — `[h | Hi_0 .. Hi_{k-2}]` —
@@ -171,6 +247,22 @@ impl TransformerModel {
         let num_ssm = self.config.num_ssm_layers();
         if num_ssm == 0 {
             return Ok(DevicePtr::NULL);
+        }
+        // Cache probe. A sequence without a pool slot is unkeyable (and would
+        // fail the `h_state` gate below anyway) — such a batch simply stages
+        // uncached, exactly as before.
+        let cache_key: Option<Vec<u64>> = if verify_wy_cache_enabled() {
+            seqs.iter()
+                .map(|s| s.ssm_slot_idx().map(|v| v as u32))
+                .collect::<Option<Vec<u32>>>()
+                .map(|slots| verify_wy_cache_key(&slots, k, ghosts))
+        } else {
+            None
+        };
+        if let Some(key) = cache_key.as_deref()
+            && self.verify_wy_cache.lock().as_deref() == Some(key)
+        {
+            return Ok(self.verify_wy_tables);
         }
         let entries_per_layer = VERIFY_WY_LAYER_STRIDE_BYTES / 8;
         let mut host = vec![0u64; num_ssm * entries_per_layer];
@@ -218,6 +310,13 @@ impl TransformerModel {
             unsafe { std::slice::from_raw_parts(host.as_ptr() as *const u8, host.len() * 8) };
         self.gpu
             .copy_h2d_async(bytes, self.verify_wy_tables, stream)?;
+        // Recorded only AFTER the copy is enqueued: every early return above
+        // (downcast miss / null h_state / short intermediates) leaves the
+        // device buffer — and therefore the cache — untouched and still
+        // describing the last successful stage.
+        if let Some(key) = cache_key {
+            *self.verify_wy_cache.lock() = Some(key);
+        }
         Ok(self.verify_wy_tables)
     }
 }

--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -46,6 +46,50 @@ pub(super) fn verify_graphs_enabled() -> bool {
     *ON.get_or_init(|| std::env::var_os("ATLAS_NO_MTP_VERIFY_GRAPHS").is_none())
 }
 
+/// House VALUE convention: a switch is armed by the literal `"1"` and by
+/// nothing else — `=0`, `=true`, `=` and mere presence all leave it OFF.
+/// SSOT for the three verify-path switches below, which the batched verify
+/// used to spell out inline as `std::env::var(..).ok().as_deref() ==
+/// Some("1")` / `== Ok("1")` at three separate sites. One expression, one
+/// test, no chance of a PRESENCE/VALUE mix-up when a site is edited.
+fn value_switch_armed(raw: Option<&str>) -> bool {
+    raw == Some("1")
+}
+
+/// Read a VALUE switch from the environment under [`value_switch_armed`].
+fn read_value_switch(name: &str) -> bool {
+    value_switch_armed(std::env::var(name).ok().as_deref())
+}
+
+/// Per-layer stream-sync diagnostic (`ATLAS_K4_DIAG=1`, VALUE check — this
+/// one predates the presence convention and `=1` is its documented form).
+///
+/// Read ONCE per process. The raw `std::env::var` sat in the batched verify
+/// hot path, so every n>=2 verify step paid a `getenv` + a `String`
+/// allocation for a switch that cannot change after launch — a cost the
+/// single-sequence path does not carry. Behaviourally identical for any
+/// process that does not mutate its own environment mid-run: nothing in the
+/// tree does, and `std::env::set_var` is `unsafe` since Rust 2024.
+pub(super) fn k4_diag_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| read_value_switch("ATLAS_K4_DIAG"))
+}
+
+/// Verify argmax D2H arm: `ATLAS_VERIFY_D2H_DEFAULT_STREAM=1` restores the
+/// original default-stream copy. Read once per process (was a per-step
+/// `std::env::var` in the D2H tail).
+pub(super) fn verify_d2h_default_stream() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| read_value_switch("ATLAS_VERIFY_D2H_DEFAULT_STREAM"))
+}
+
+/// Verify argmax D2H arm: `ATLAS_NO_PINNED_VERIFY_D2H=1` forces the pageable
+/// on-stream copy. Read once per process (was a per-step `std::env::var`).
+pub(super) fn verify_d2h_no_pinned() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| read_value_switch("ATLAS_NO_PINNED_VERIFY_D2H"))
+}
+
 impl TransformerModel {
     /// Batched-verify graph key: each sequence's ssm-pool slot in batch
     /// order — every SSM pointer the graph bakes (h/conv state, rollback
@@ -177,3 +221,7 @@ impl TransformerModel {
         Ok(self.verify_wy_tables)
     }
 }
+
+#[cfg(test)]
+#[path = "verify_e2_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/model/trait_impl/verify_e2_tests.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2_tests.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for the batched-verify staging helpers (`verify_e2.rs`).
+//!
+//! [`value_switch_armed`] must keep the house VALUE convention for the three
+//! verify switches hoisted out of the per-step hot path. An inverted or
+//! loosened predicate would arm `ATLAS_K4_DIAG` (which forces the verify path
+//! EAGER, destroying the graph replay) for anyone who exports it as `=0`.
+
+use super::value_switch_armed;
+
+/// The hoisted verify switches are VALUE switches: only the literal `"1"`
+/// arms them. Pins the exact predicate the three per-step `std::env::var`
+/// reads used to spell inline, so hoisting them behind a `OnceLock` cannot
+/// have widened (`presence`) or inverted the semantics.
+#[test]
+fn value_switch_is_armed_only_by_a_literal_one() {
+    assert!(value_switch_armed(Some("1")));
+    for raw in [
+        None,
+        Some(""),
+        Some("0"),
+        Some("2"),
+        Some("true"),
+        Some(" 1"),
+    ] {
+        assert!(
+            !value_switch_armed(raw),
+            "{raw:?} must not arm a VALUE switch"
+        );
+    }
+}

--- a/crates/spark-model/src/model/trait_impl/verify_e2_tests.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2_tests.rs
@@ -2,12 +2,189 @@
 
 //! Tests for the batched-verify staging helpers (`verify_e2.rs`).
 //!
-//! [`value_switch_armed`] must keep the house VALUE convention for the three
-//! verify switches hoisted out of the per-step hot path. An inverted or
-//! loosened predicate would arm `ATLAS_K4_DIAG` (which forces the verify path
-//! EAGER, destroying the graph replay) for anyone who exports it as `=0`.
+//! Two proof obligations live here, both load-bearing for correctness rather
+//! than for coverage:
+//!
+//! * [`verify_wy_cache_key`] must be INJECTIVE over everything the staged WY
+//!   pointer tables depend on. A collision means a verify step reuses device
+//!   tables staged for a DIFFERENT batch — every GDN layer would then read
+//!   another sequence's recurrent state, silently.
+//! * [`value_switch_armed`] must keep the house VALUE convention for the
+//!   three verify switches hoisted out of the per-step hot path. An inverted
+//!   or loosened predicate would arm `ATLAS_K4_DIAG` (which forces the verify
+//!   path EAGER, destroying the graph replay) for anyone who exports it as
+//!   `=0`.
 
-use super::value_switch_armed;
+use super::{value_switch_armed, verify_wy_cache_key};
+
+/// The full input set, so a test can vary exactly one axis at a time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Inputs {
+    slots: Vec<u32>,
+    k: usize,
+    ghosts: Vec<(u32, u32)>,
+}
+
+impl Inputs {
+    fn key(&self) -> Vec<u64> {
+        verify_wy_cache_key(&self.slots, self.k, &self.ghosts)
+    }
+}
+
+fn base() -> Inputs {
+    Inputs {
+        slots: vec![3, 7],
+        k: 4,
+        ghosts: vec![],
+    }
+}
+
+/// Nothing changed ⇒ the key is reused. Re-deriving the key from freshly
+/// built (not merely cloned) inputs must land on the same bytes, or the
+/// cache would miss on every step and the fast path would be dead code.
+#[test]
+fn key_is_reused_when_no_input_changes() {
+    let a = Inputs {
+        slots: vec![3, 7],
+        k: 4,
+        ghosts: vec![(11, 2)],
+    };
+    let b = Inputs {
+        slots: vec![3, 7],
+        k: 4,
+        ghosts: vec![(11, 2)],
+    };
+    assert_eq!(a.key(), b.key());
+}
+
+/// ENUMERATION of every input the staged tables depend on (see
+/// `verify_wy_cache_key`'s docs for why the list is complete): `k`, the
+/// sequence COUNT, each slot VALUE, the slot ORDER, ghost presence, each
+/// ghost slot, each ghost depth, and the ghost ORDER. Changing any one of
+/// them must change the key, i.e. must force a re-stage.
+#[test]
+fn key_changes_when_any_input_changes() {
+    let b = base();
+    let variants: Vec<(&str, Inputs)> = vec![
+        ("k", Inputs { k: 3, ..b.clone() }),
+        (
+            "sequence count (fewer)",
+            Inputs {
+                slots: vec![3],
+                ..b.clone()
+            },
+        ),
+        (
+            "sequence count (more)",
+            Inputs {
+                slots: vec![3, 7, 9],
+                ..b.clone()
+            },
+        ),
+        (
+            "a slot value",
+            Inputs {
+                slots: vec![3, 8],
+                ..b.clone()
+            },
+        ),
+        (
+            "slot order (batch order is table order)",
+            Inputs {
+                slots: vec![7, 3],
+                ..b.clone()
+            },
+        ),
+        (
+            "ghost presence",
+            Inputs {
+                ghosts: vec![(11, 2)],
+                ..b.clone()
+            },
+        ),
+    ];
+    for (what, v) in variants {
+        assert_ne!(b.key(), v.key(), "key must change when {what} changes");
+    }
+
+    // Ghost axes, against a ghost-bearing baseline.
+    let g = Inputs {
+        ghosts: vec![(11, 2), (13, 3)],
+        ..base()
+    };
+    let ghost_variants: Vec<(&str, Inputs)> = vec![
+        (
+            "a ghost slot",
+            Inputs {
+                ghosts: vec![(12, 2), (13, 3)],
+                ..base()
+            },
+        ),
+        (
+            "a ghost depth",
+            Inputs {
+                ghosts: vec![(11, 4), (13, 3)],
+                ..base()
+            },
+        ),
+        (
+            "ghost order",
+            Inputs {
+                ghosts: vec![(13, 3), (11, 2)],
+                ..base()
+            },
+        ),
+        (
+            "ghost count",
+            Inputs {
+                ghosts: vec![(11, 2)],
+                ..base()
+            },
+        ),
+    ];
+    for (what, v) in ghost_variants {
+        assert_ne!(g.key(), v.key(), "key must change when {what} changes");
+    }
+}
+
+/// INJECTIVITY over the whole reachable small domain: a slot run and a ghost
+/// tail are concatenated into one flat `Vec<u64>`, so the encoding has to
+/// keep them separable. `n` is written into the key for exactly this reason
+/// — without it `slots=[1,2], ghosts=[]` and `slots=[1], ghosts=[(2, ..)]`
+/// would collide, which is precisely the drain-tail-borrow shape.
+#[test]
+fn key_is_injective_over_the_reachable_domain() {
+    let mut seen: std::collections::HashMap<Vec<u64>, Inputs> = std::collections::HashMap::new();
+    let slot_sets: Vec<Vec<u32>> = vec![
+        vec![0],
+        vec![1],
+        vec![0, 1],
+        vec![1, 0],
+        vec![0, 2],
+        vec![0, 1, 2],
+    ];
+    let ghost_sets: Vec<Vec<(u32, u32)>> = vec![
+        vec![],
+        vec![(1, 2)],
+        vec![(2, 1)],
+        vec![(1, 2), (2, 3)],
+        vec![(2, 3), (1, 2)],
+    ];
+    for slots in &slot_sets {
+        for k in 2..=4usize {
+            for ghosts in &ghost_sets {
+                let inp = Inputs {
+                    slots: slots.clone(),
+                    k,
+                    ghosts: ghosts.clone(),
+                };
+                if let Some(prev) = seen.insert(inp.key(), inp.clone()) {
+                    panic!("WY cache key collision: {prev:?} and {inp:?} encode alike");
+                }
+            }
+        }
+    }
+}
 
 /// The hoisted verify switches are VALUE switches: only the literal `"1"`
 /// arms them. Pins the exact predicate the three per-step `std::env::var`

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -309,6 +309,18 @@ pub struct TransformerModel {
     /// single-launch table-form `gdn_decode_wy4` in the batched GDN arm.
     /// NULL without an MTP proposer (path self-gates).
     pub(super) verify_wy_tables: DevicePtr,
+    /// Encoded key of the bytes CURRENTLY staged in `verify_wy_tables`, or
+    /// `None` when nothing has been staged (the buffer is memset to zero at
+    /// allocation, which no key describes).
+    ///
+    /// `upload_verify_wy_tables` ran a 48 KB host build + a 48 KB H2D on
+    /// EVERY n>=2 verify step. The staged bytes are a pure function of
+    /// `(k, ssm-slot vector in batch order, ghost (slot, depth) pairs)` —
+    /// see `verify_wy_cache_key` for the enumeration and the proof — so a
+    /// step whose key matches what is already on the device may skip both.
+    /// Kill switch `ATLAS_NO_VERIFY_WY_CACHE` (PRESENCE) restores the
+    /// unconditional re-stage.
+    pub(super) verify_wy_cache: Mutex<Option<Vec<u64>>>,
     /// Cached CUDA graphs for DFlash K=γ verification, keyed by
     /// `(seq.slot_idx, K)`. K is `tokens.len()` (γ+1 typically). One graph
     /// per (slot, K) — different γ values coexist via the K dimension.

--- a/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
@@ -169,3 +169,31 @@ fn ratio_snaps_to_a_bucket() {
     assert_eq!(nearest(0.9), 1.0);
     assert_eq!(nearest(0.1), 0.25);
 }
+
+/// The C=2 rung PRUNES — so "skip the planner below a width threshold and
+/// keep the uniform shape" is NOT a hoist, it is a behaviour change.
+///
+/// At C=2 the ladder gives `ladder_nd = 3` (rows = 4), which puts the batch
+/// inside D-Cut's engagement envelope (`ladder_nd >= 2`, `n <= 8`). With the
+/// default ratio 0.75 the 2x2 = 4 prunable positions keep 3, so exactly one
+/// sequence loses its deepest draft and the plan is the RAGGED `{3, 2}`
+/// retained multiset — verify rows `{4, 3}`, R = 7 instead of the uniform 8.
+/// Anything that bypasses the planner at n = 2 therefore verifies one MORE
+/// row per step than the shipped path, and produces a different graph key.
+#[test]
+fn width_two_is_inside_the_pruning_envelope_and_is_not_uniform() {
+    // Both sequences confident, seq 1 slightly less so at its deepest draft.
+    let c = [vec![-0.01f32, -0.02, -0.03], vec![-0.01f32, -0.02, -0.40]];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    let retained = select(&refs, 3, VERIFY_ROW_BUDGET, 0.75);
+    assert_eq!(
+        retained,
+        vec![3, 2],
+        "ratio 0.75 drops exactly one position"
+    );
+    let rows: Vec<usize> = retained.iter().map(|r| r + 1).collect();
+    assert_ne!(rows, vec![4, 4], "the n=2 plan is NOT the uniform shape");
+    assert_eq!(rows.iter().sum::<usize>(), 7);
+    // ...and the row saving is real: one fewer verify row than uniform.
+    assert_eq!(chunk_ranges(&rows), vec![(0, 2)], "still a single chunk");
+}


### PR DESCRIPTION
## Target

The per-step **FIXED** cost of the `n>=2` batched verify path.

Tonight's ladder (apples-to-apples vs vLLM+MTP, fp8 KV, MTP K=4 both engines):

| C | Atlas | vLLM+MTP | ratio | note |
|---|---|---|---|---|
| 1 | 22.44 | 19.72 | 1.14x | WON — uses the SINGLE-SEQUENCE path |
| 2 | 31.00 | 38.79 | 0.80x | **worst rung** |
| 4 | 68.11 | 71.61 | 0.951x | within 5% |
| 8 | 106.48 | 124.48 | 0.86x | |
| 16 | 203.44 | 197.03 | 1.033x | WON |
| 32 | 291.52 | 283.48 | 1.028x | WON |
| 64 | 373.90 | 361.39 | 1.035x | WON |
| 128 | 442.83 | 358.57 | 1.235x | WON |

C=1 runs a different program (`decode_a2.rs` short-circuits `n==1`; batched verify requires `n>=2`).
A TPOT fit across n=2,4,8 is collinear at `58.9 + 4.28n` ms while n=1 sits ~30% **below** that line
— entering the batched path costs a large fixed amount that does not amortize at small n.

## Headline finding

**The five host-side items the prior audit named are all microseconds. They cannot be the fixed
cost, and this PR does not claim they move a rung.** I measured them rather than assumed them.
The fixed cost is not host bookkeeping; the two candidates of the right magnitude are CUDA-graph
re-capture and the batched-GDN fast path declining, and **neither was observable from a ladder log
until this PR**. The last commit fixes that.

## Per-item cost accounting

Microbenchmarked on the Grace CPU (`rustc -O`, 20k iterations), 48 GDN layers / 32-seq tables /
K=4 — i.e. the shipped `unsloth/Qwen3.8-27B-NVFP4` geometry.

| # | item | what runs per step | measured / estimated | verdict |
|---|---|---|---|---|
| 1 | `upload_verify_wy_tables` (`verify_e2.rs`) | 48 KB host alloc+zero, `48*n` `Any` downcasts + fill, 48 KB pageable H2D | build **0.90 µs @ n=2**, 1.4 @ n=4, 5.0 @ n=32; 48 KB memcpy 0.24 µs; + driver call ≈ 2-5 µs ⇒ **~3-6 µs/step** | **FIXED** (cached) |
| 2 | three `std::env::var` in the verify hot path (`verify_e.rs:165,653,655`) | 1 getenv + `String` alloc/step (3 on the non-UMA D2H arm) | **< 1 µs/step** | **FIXED** (OnceLock) |
| 3 | `stash_verify_hidden_rows` (`speculative.rs:305`) | `n` × `copy_d2d_async` of `hidden*2` B | ~2-3 µs/launch ⇒ **~5 µs @ n=2** | **not worth fixing** |
| 4 | D-Cut plan + chunk sort (`mtp_step.rs:378,395`) | rank 4 positions, sort, canonical permutation over 2 slots | **sub-µs @ n=2** | **must NOT be skipped** |
| 5 | host sampling pipeline (`verify_pipeline_helper.rs`) | per-seq pipeline; slow tail = `k*vocab*2` blocking D2H + dequant | **0 on this ladder** | **not reached** |

### 1. WY pointer tables — CACHED (commit 2)

Genuinely per-step, genuinely avoidable, and the only one of the five that is a *fixed* cost
(the 48 KB alloc+zero and the 48 KB H2D do not shrink with n). Staged bytes are a pure function of
`(k, ssm-slot vector in batch order, ghost (slot, depth) pairs)`:

* `SsmLayerState::h_state` is only ever assigned `ssm_pool.h_state(layer, slot)` (`meta.rs:276` at
  alloc, `sequence.rs:338` at compaction) or `DevicePtr(0)` on free — and `ssm_pool.h_state` is
  `h_state_pools[layer].offset(slot * h_stored_bytes)`, pure arithmetic over bases fixed at model
  construction (`ssm_pool.rs:464`).
* `h_state_intermediates[t]` is only ever `ssm_pool.h_intermediate(layer, slot, t)` and its LENGTH
  is `h_inter_count(slot)` — slot-keyed and `has_mtp`-gated, where `has_mtp` is a MODEL property
  (`proposer.is_some() || self_speculative`), not a per-sequence one. So a slot's intermediate
  capacity does not depend on its occupant.

Nothing else writes `verify_wy_tables` (allocation memsets it once; this is its only writer), so
"same key ⇒ same DEVICE content", not merely same host image. The ghost arm already relied on
exactly this invariant to synthesize a departed sequence's entries from the pool.

The trade is explicit: correctness moves from *by construction* (re-upload every step) to
*by invariant*. Backstopped twice — the per-layer batched GDN arm re-checks each state's
intermediate capacity before reading a table (`trait_decode_batched_conv_gdn_multi.rs:151`), and
the wy-tables-present sentinel is already in the CUDA-graph key. Kill switch
`ATLAS_NO_VERIFY_WY_CACHE` (PRESENCE).

### 2. Env lookups — HOISTED (commit 1)

`ATLAS_K4_DIAG` ran unconditionally every step; `ATLAS_VERIFY_D2H_DEFAULT_STREAM` /
`ATLAS_NO_PINNED_VERIFY_D2H` ran on the non-mapped-argmax D2H arm (so *not* on GB10, which takes
the UMA mapped-argmax path). The file already used `OnceLock` for `ATLAS_MTP_TIMING`,
`ATLAS_NO_MAPPED_ARGMAX` and `verify_graphs_enabled`.

The three sites spelled the same predicate two different ways (`.ok().as_deref() == Some("1")` and
`.as_deref() == Ok("1")`), so they now share one `value_switch_armed` helper — SSOT for the house
VALUE convention. Behaviour is identical for any process that does not mutate its own environment
mid-run: nothing in the tree does, and `std::env::set_var` has been `unsafe` since Rust 2024.

### 3. `stash_verify_hidden_rows` — NOT worth fixing

`n` `copy_d2d_async` of `hidden_size*2` B. It cannot fold into the verify graph: the stash row is
`off[i] + num_accepted`, and `num_accepted` is only known *after* the argmax D2H. Folding into one
launch needs a gather kernel plus an H2D of the row indices — 1 H2D + 1 launch against `n`
launches, i.e. a net loss at n=2 and n=4, **which are the rungs this PR targets**. ~5 µs at n=2.

### 4. D-Cut planner — must NOT be skipped (commit 4, test only)

The suggestion was to skip the planner below a width threshold "since at n=2 there is nothing to
prune". **That is false, and skipping it would change behaviour.** At C=2 the ladder gives
`ladder_nd=3`, which is inside D-Cut's envelope (`ladder_nd >= 2`, `n <= dcut_width_cap = 8`), so
`select` ranks `n*(k-1) = 4` prunable positions and keeps `round(4*0.75) = 3` — the plan is the
**ragged `{3,2}` retained multiset**, verify rows `{4,3}`, **R = 7, not the uniform 8**. Bypassing
it would verify one MORE row per step and mint a different graph key. Pinned by
`width_two_is_inside_the_pruning_envelope_and_is_not_uniform`. The planner itself is sub-µs at n=2.

### 5. Host sampling pipeline — NOT reached on this ladder

The ~1.34 ms/seq attribution is the SLOW tail (`k*vocab*2` blocking D2H + 248k BF16→F32 per row).
On this harness it never runs: temp 0.0, no grammar, `--disable-thinking`, so the grammarless
fast-greedy gate (`fast_greedy_chat`, on by default) returns the GPU argmax with **no D2H at all**.
`try_chat_fast_path` is hard-disabled for MTP by design, and the grammar arm needs
`grammar_state.is_some()` which batchable sequences never have (`mtp_step.rs`). It IS live for
thinking/tool traffic, where it is `n` separate blocking D2Hs that could be one contiguous copy
(rows are contiguous, `row_base = off[i]`) — logged as future work, not done here, because it is
worth ~one saved stream drain at n=2 and cannot move this rung.

## Graph-capture rate at n=2 / n=4 — asked, and answered as far as reading allows

`free_slots` is a LIFO `Vec` (`ssm_pool.rs:334,387,412`), so at steady concurrency C a completing
sequence's slot is immediately reused and the slot SET is stable — it does not churn the key.
D-Cut yields **one** depth multiset at n=2 (`ks = [4,3]`, always: `keep` is exactly 3 of 4 and the
retained set is prefix-closed) and **two** at n=4 (`{4,4,4,2}`, `{4,4,3,3}`) against a 32-entry
LRU. So the key space at these rungs should be 1-2 keys and captures should be rare after warmup —
consistent with the hypothesis in the brief. **But "should be" is not a measurement**, and the
alternative (every batch-composition change mints a key) is exactly the failure this cache has had
before. Commit 3 makes it a one-line read from the serve log instead of an argument.

## What commit 3 adds

Two periodic INFO lines under the **existing** `ATLAS_MTP_ACCEPT_DEBUG` gate (checked before any
atomic touches — a default serve pays one `OnceLock` load per step and nothing else; no production
decision reads either counter):

* `batched-verify graphs [N steps, last n=..]: replay=.. borrow=.. CAPTURE=.. eager=.. capture_frac=.. live_keys=../32`
* `batched-verify GDN conv+WY [last n=.. k=..]: engaged=.. declined=.. declined_frac=.. (a declined call is N launches/layer, not 2)`

Before this, captures logged one INFO line each (thousands of lines, no rate, no live-key count)
and the GDN engaged/declined counters only surfaced at `debug` — the per-`k` INFO lines fire once
each, proving *which* widths took each arm and never *how often*. A single decline is noise; a
decline rate is milliseconds (engaged = 2 launches/GDN layer, declined = `n*(2k-1)` — 768 vs 96 at
n=2, k=4 across 48 GDN layers).

## Expected per-rung effect

**Honestly: not measurable on any rung.** Removed per step: ~3-6 µs (WY stage) + <1 µs (env), against
a step of order 170 ms at C=2 — i.e. ~0.004%. C=2 and C=4 remain the targets and remain open.

The value of this PR is (a) two clean removals with proofs and kill switches, (b) a hard NO on the
three items that would have cost time or behaviour (one of which would have *regressed* the shape),
and (c) the instrumentation that makes the next attempt discriminating rather than another guess.

**Nothing here should move a rung, so any rung movement in validation is a signal to investigate,
not a win to bank.**

## Validation plan

1. **Full ladder** — `bench/ladder38/harness_w55_conc_ladder.py`, same box/checkpoint/client, 3
   reps + 1 warmup per rung, ISL 128 / OSL 1024 / temp 0.0 / seed 42. Floors that must not regress:

   | C | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 |
   |---|---|---|---|---|---|---|---|---|
   | floor | 22.44 | 31.00 | 68.11 | 106.48 | 203.44 | 291.52 | 373.90 | 442.83 |

2. **`ssm-state-poisoning-gate`** — the WY tables address every sequence's SSM state, so a stale
   stage is precisely cross-sequence state poisoning. This gate is the one that would catch a
   broken cache invariant. Must PASS.
3. **`decode-floor`** — `min_tok_s=20.5` on `unsloth/Qwen3.8-27B-NVFP4`; guards the C=1
   single-sequence path that this PR must leave untouched (it does — every change is on the `n>=2`
   program or is test/telemetry only).
4. **Cache A/B** — one leg with `ATLAS_NO_VERIFY_WY_CACHE=1` at C=2 and C=8. Expected: statistically
   identical. A visible delta means the cache is doing something other than skipping a redundant
   copy, and the kill switch is the revert.
5. **The measurement this PR exists to enable** — one C=2 and one C=4 leg with
   `ATLAS_MTP_ACCEPT_DEBUG=1`, reading `capture_frac` and `declined_frac`. If `capture_frac` is
   non-trivial, the fixed cost is the graph key space; if it is ~0 and `declined_frac` is not, it is
   the GDN arm. That result decides the next PR.

## Gates

```
$ export ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000
$ cargo fmt --all -- --check                      # clean
$ cargo clippy --workspace --tests                # clean, no new warnings
$ bash scripts/check-license-headers.sh
  INFO Totally checked 2251 files, valid: 2237, invalid: 0, ignored: 14, fixed: 0
$ cargo test -p spark-model --lib
  test result: ok. 615 passed; 0 failed; 0 ignored
$ cargo test -p spark-server --bins
  test result: ok. 2290 passed; 0 failed; 12 ignored
$ typos
  2 errors — both PRE-EXISTING on test/ladder-stack (preempt.rs:150 "requeueing",
  preempt_tests.rs:313 "preemptable"); neither is in a file this PR touches.
```

## Tests added

* `key_changes_when_any_input_changes` — enumerates every input the staged WY table depends on
  (`k`, sequence count, a slot value, slot ORDER, ghost presence, a ghost slot, a ghost depth,
  ghost order, ghost count) and asserts each one forces a re-stage.
* `key_is_reused_when_no_input_changes` — re-derived from freshly built inputs, so a cache that
  always missed would fail here rather than silently costing what it saves.
* `key_is_injective_over_the_reachable_domain` — the real proof obligation. A collision means a
  step replays tables staged for a different batch and every GDN layer reads another sequence's
  recurrent state, silently. `n` is in the key precisely so `slots=[1,2],ghosts=[]` cannot collide
  with `slots=[1],ghosts=[(2,..)]` — the drain-tail-borrow shape.
* `value_switch_is_armed_only_by_a_literal_one` — pins the VALUE convention the three hoisted reads
  must preserve. The failure being guarded is a site edited into the PRESENCE convention, which
  would force the verify path EAGER for anyone exporting `ATLAS_K4_DIAG=0`.
* `width_two_is_inside_the_pruning_envelope_and_is_not_uniform` — see item 4.

## Commits

| sha | commit |
|---|---|
| `f1161f661` | spark-server: pin that the n=2 D-Cut plan is not the uniform shape |
| `67cdf4d65` | spark-model: hoist the three per-step verify env lookups behind OnceLock |
| `1fc8ed49f` | spark-model: cache the batched-verify WY pointer-table stage |
| `f39ff866f` | spark-model: report batched-verify graph and GDN fast-path RATES |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
