### PR TITLE
perf(verify): gate the canonical depth→slot assignment on batch width (n >= 8)

### DIFF
--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -228,14 +228,18 @@ impl TransformerModel {
     ///
     /// The scheduler dispatches each chunk in the ONE canonical order
     /// (`speculative::verify_key::verify_batch_order` — depths descending
-    /// paired with slots ascending), so the key is a pure function of
-    /// (slot set, depth multiset, sentinel): at n=8 the 266 D-Cut
+    /// paired with slots ascending) at batch widths >=
+    /// `verify_key::CANONICAL_KEY_MIN_WIDTH`, so the key is a pure function of
+    /// (slot set, depth multiset, sentinel) there: at n=8 the 266 D-Cut
     /// ARRANGEMENTS that thrashed this 32-entry cache collapse onto the 3
-    /// multisets behind them. Kill switch `ATLAS_NO_CANONICAL_VERIFY_KEY`
-    /// (scheduler side) restores the arrangement-keyed behaviour. Key BYTES
-    /// live in `verify_key` so the ordering rule and the key it produces
-    /// cannot drift apart. `None` → no graph (a sequence without a pool
-    /// slot).
+    /// multisets behind them. Below that width the key stays
+    /// arrangement-shaped ON PURPOSE — the space is 2 keys at n=2 and 10 at
+    /// n=4, so there is nothing to collapse and the assignment measured net
+    /// negative (`CANONICAL_KEY_MIN_WIDTH` carries the A/B table). Kill switch
+    /// `ATLAS_NO_CANONICAL_VERIFY_KEY` (scheduler side) restores the
+    /// arrangement-keyed behaviour at every width. Key BYTES live in
+    /// `verify_key` so the ordering rule and the key it produces cannot drift
+    /// apart. `None` → no graph (a sequence without a pool slot).
     pub(super) fn verify_batched_graph_key(
         &self,
         seqs: &[&mut SequenceState],

--- a/crates/spark-model/src/speculative/verify_key.rs
+++ b/crates/spark-model/src/speculative/verify_key.rs
@@ -63,12 +63,110 @@
 //! `=0` is NOT off) restores the pre-canonical behaviour: each sequence keeps
 //! its own confidence-chosen depth and the batch is sorted deepest-first,
 //! ssm-slot second.
+//!
+//! # The width gate: it only pays where the key space explodes
+//!
+//! Collapsing the key space is not free — forcing the assignment overrides
+//! D-Cut's confidence pairing and re-shapes the depth runs — and the key
+//! space only explodes at the TOP of D-Cut's width range. Measured key
+//! counts against `VERIFY_BATCHED_GRAPH_CAP` = 32: n=2 → 2, n=4 → 10,
+//! **n=8 → 160-253**, n=16 → 1. At n=2 and n=4 there is essentially nothing
+//! to collapse, and the A/B says so — see [`CANONICAL_KEY_MIN_WIDTH`], which
+//! is the ONE threshold and carries the table. Below it the pre-canonical
+//! assignment is restored BYTE-IDENTICALLY; at/above it the canonical
+//! assignment applies. [`canonical_assignment`] is the single gate; call
+//! sites never re-derive it.
 
 /// Canonical assignment ON unless `ATLAS_NO_CANONICAL_VERIFY_KEY` is present.
 /// Read once per process.
 pub fn canonical_verify_key_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var_os("ATLAS_NO_CANONICAL_VERIFY_KEY").is_none())
+}
+
+/// Batch WIDTH (sequences) at or above which the canonical depth→slot
+/// assignment is applied. Below it [`verify_batch_order`] /
+/// [`verify_batch_permutation`] take their `canonical = false` arm, which is
+/// the pre-canonical (pre-PR-#552) behaviour byte for byte: each sequence
+/// keeps its own confidence-chosen depth and the batch sorts deepest-first,
+/// ssm-slot second, ties on input index (a stable
+/// `sort_by_key(|(a, k)| (Reverse(k), slot))`, exactly what both call sites
+/// used before).
+///
+/// Default **8**, from a same-binary same-session A/B on dgx2 (ladder-38
+/// round 7, tip `e0b845f11`) with ONE variable — the kill switch
+/// `ATLAS_NO_CANONICAL_VERIFY_KEY=1`. tok/s, higher is better:
+///
+/// ```text
+///  C  | canonical ON            | canonical OFF          | verdict
+/// ----+-------------------------+------------------------+------------------
+///   2 | 30.09                   | 30.83                  | costs -2.4%
+///   4 | 64.00 (round 7: 65.56)  | 68.11 (round 6, no it) | costs ~-3.7%
+///   8 | 110.63                  | 106.48                 | GAINS +3.9%
+///  16 | 203.50                  | 203.44                 | no effect
+///  32 | 291.50                  | 291.52                 | no effect
+///  64 | 387.62                  | 386.99                 | no effect
+/// 128 | 477.55                  | 477.69                 | no effect
+/// ```
+///
+/// The shape of that table follows the key counts (module docs): the
+/// collapse pays exactly where the arrangement space is large. Above width 8
+/// the gate is inert in either direction — D-Cut is off there
+/// (`dcut_width_cap`), `ks` is uniform, and both arms reduce to "sort by
+/// slot" (pinned by `uniform_depths_are_identical_under_both_arms`), which
+/// is why the C>=16 rungs move by <= 0.2% either way.
+///
+/// Hypothesis for the cost below 8, recorded but NOT load-bearing for this
+/// threshold (the threshold is the measurement, not the mechanism): forcing
+/// the assignment makes the two-launch batched GDN conv+WY fast path decline
+/// more often, i.e. `n*(2k-1)` launches per layer instead of 2 — 768 vs 96
+/// per step at n=2, k=4 over 48 GDN layers. PR #553's rate telemetry under
+/// `ATLAS_MTP_ACCEPT_DEBUG` reports that decline rate directly.
+pub const CANONICAL_KEY_MIN_WIDTH: usize = 8;
+
+/// Sweep the threshold without a rebuild: `ATLAS_CANONICAL_KEY_MIN_WIDTH=<n>`
+/// (VALUE-parsed; 0 = canonical at every width, a value above the widest
+/// batch = never). Unset or unparseable ⇒ [`CANONICAL_KEY_MIN_WIDTH`].
+/// Parsed once per process, like `dcut_width_cap`.
+pub fn canonical_key_min_width() -> usize {
+    static N: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *N.get_or_init(|| min_width_from_env(std::env::var_os(ENV_MIN_WIDTH)))
+}
+
+/// The env var name, named once so the parser and its tests cannot drift.
+const ENV_MIN_WIDTH: &str = "ATLAS_CANONICAL_KEY_MIN_WIDTH";
+
+/// Pure parse of [`ENV_MIN_WIDTH`] — the I/O lives in
+/// [`canonical_key_min_width`] so the policy is testable without touching
+/// process env (which a `OnceLock` would latch anyway).
+fn min_width_from_env(raw: Option<std::ffi::OsString>) -> usize {
+    raw.and_then(|v| v.into_string().ok())
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(CANONICAL_KEY_MIN_WIDTH)
+}
+
+/// **THE GATE** — the one decision "does this batch get the canonical
+/// depth→slot assignment?". Both seams ask this and nothing else:
+/// `mtp_dcut::plan` (which decides order AND assignment) and `mtp_step`
+/// (permutation only), each passing the FULL batch width so the two can
+/// never disagree — `plan` gates on `batchable.len()`, and a chunked
+/// dispatch must use that same width, not the chunk's.
+///
+/// `n` is the batch width in SEQUENCES. All logic lives in
+/// [`canonical_assignment_at`]; this is only the env binding (SBIO).
+pub fn canonical_assignment(n: usize) -> bool {
+    canonical_assignment_at(n, canonical_key_min_width(), canonical_verify_key_enabled())
+}
+
+/// The gate policy, with its two environment inputs INJECTED (SBIO): the
+/// resolved threshold and whether the kill switch is CLEAR. The kill switch
+/// dominates — once `ATLAS_NO_CANONICAL_VERIFY_KEY` is set, no width and no
+/// `ATLAS_CANONICAL_KEY_MIN_WIDTH` value can turn the assignment back on.
+///
+/// Split out because `OnceLock`-latched env cannot be moved from a test, and
+/// a policy nobody can exercise is a policy nobody has checked.
+fn canonical_assignment_at(n: usize, min_width: usize, kill_switch_clear: bool) -> bool {
+    kill_switch_clear && n >= min_width
 }
 
 /// Dispatch ORDER for one verify batch — the permutation only.
@@ -165,256 +263,5 @@ pub fn verify_graph_key(pairs: &[(u32, u32)], wy_tables_null: bool) -> Vec<u32> 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Build the key the dispatch would produce for a batch given as
-    /// `(slot, k)` pairs in the scheduler's arbitrary pre-sort order.
-    fn key_for(batch: &[(usize, usize)], canonical: bool) -> Vec<u32> {
-        let slots: Vec<usize> = batch.iter().map(|&(s, _)| s).collect();
-        let ks: Vec<usize> = batch.iter().map(|&(_, k)| k).collect();
-        let (order, depths) = verify_batch_order(&slots, &ks, canonical);
-        let pairs: Vec<(u32, u32)> = order
-            .iter()
-            .zip(&depths)
-            .map(|(&i, &k)| (slots[i] as u32, k as u32))
-            .collect();
-        verify_graph_key(&pairs, false)
-    }
-
-    /// THE DEFECT, pinned. The same depth multiset spread over the same slots
-    /// in different arrangements — exactly what D-Cut re-ranking produces
-    /// step to step — must collapse onto ONE key.
-    #[test]
-    fn same_multiset_different_arrangement_is_one_key() {
-        // Multiset {4,4,3,3} over slots {0,1,2,3}: 4!/(2!·2!) = 6 arrangements.
-        let arrangements: [[(usize, usize); 4]; 6] = [
-            [(0, 4), (1, 4), (2, 3), (3, 3)],
-            [(0, 4), (1, 3), (2, 4), (3, 3)],
-            [(0, 4), (1, 3), (2, 3), (3, 4)],
-            [(0, 3), (1, 4), (2, 4), (3, 3)],
-            [(0, 3), (1, 4), (2, 3), (3, 4)],
-            [(0, 3), (1, 3), (2, 4), (3, 4)],
-        ];
-        let keys: std::collections::HashSet<Vec<u32>> =
-            arrangements.iter().map(|a| key_for(a, true)).collect();
-        assert_eq!(keys.len(), 1, "6 arrangements must collapse to 1 key");
-        // And the ONE key is the canonical pairing: slots ascending, depths
-        // descending.
-        assert_eq!(
-            keys.into_iter().next().unwrap(),
-            vec![0, 4, 1, 4, 2, 3, 3, 3, u32::MAX]
-        );
-    }
-
-    /// The n=8 arithmetic from the module docs, executed: the three depth
-    /// multisets the profile observed produce 266 keys pre-canonicalization
-    /// and 3 after. Generated exhaustively so the count is computed, not
-    /// asserted from a comment.
-    #[test]
-    fn n8_key_space_collapses_266_to_3() {
-        // (count of depth 4, count of 3, count of 2) for each observed shape.
-        let multisets = [(5usize, 2usize, 1usize), (4, 4, 0), (6, 0, 2)];
-        let mut legacy: std::collections::HashSet<Vec<u32>> = Default::default();
-        let mut canon: std::collections::HashSet<Vec<u32>> = Default::default();
-        for &(c4, c3, c2) in &multisets {
-            let mut depths: Vec<usize> = Vec::new();
-            depths.extend(std::iter::repeat_n(4usize, c4));
-            depths.extend(std::iter::repeat_n(3usize, c3));
-            depths.extend(std::iter::repeat_n(2usize, c2));
-            assert_eq!(depths.len(), 8);
-            // Every distinct arrangement of this multiset over slots 0..8.
-            let mut perm: Vec<usize> = (0..8).collect();
-            permute(&mut perm, 0, &mut |p| {
-                let batch: Vec<(usize, usize)> = (0..8).map(|s| (s, depths[p[s]])).collect();
-                legacy.insert(key_for(&batch, false));
-                canon.insert(key_for(&batch, true));
-            });
-        }
-        assert_eq!(legacy.len(), 266, "pre-canonical arrangement count");
-        assert_eq!(canon.len(), 3, "one key per depth multiset");
-    }
-
-    /// Every permutation of `v`, in place.
-    fn permute(v: &mut Vec<usize>, i: usize, f: &mut impl FnMut(&[usize])) {
-        if i == v.len() {
-            f(v);
-            return;
-        }
-        for j in i..v.len() {
-            v.swap(i, j);
-            permute(v, i + 1, f);
-            v.swap(i, j);
-        }
-    }
-
-    /// Different multisets must NOT collide — a graph baked for one depth
-    /// shape replaying against another is the state-poisoning failure mode.
-    #[test]
-    fn different_multisets_have_different_keys() {
-        let a = key_for(&[(0, 4), (1, 4), (2, 3), (3, 3)], true);
-        let b = key_for(&[(0, 4), (1, 3), (2, 3), (3, 3)], true);
-        let c = key_for(&[(0, 4), (1, 4), (2, 4), (3, 3)], true);
-        assert_ne!(a, b);
-        assert_ne!(a, c);
-        assert_ne!(b, c);
-    }
-
-    /// A different SLOT SET at the same depth multiset must also differ: the
-    /// graph bakes those pool addresses.
-    #[test]
-    fn different_slot_sets_have_different_keys() {
-        let a = key_for(&[(0, 4), (1, 3)], true);
-        let b = key_for(&[(0, 4), (2, 3)], true);
-        assert_ne!(a, b);
-    }
-
-    /// The sentinel keeps a table-less capture from replaying a table-full
-    /// step.
-    #[test]
-    fn wy_table_presence_splits_the_key() {
-        let pairs = [(0u32, 4u32), (1, 3)];
-        assert_ne!(
-            verify_graph_key(&pairs, true),
-            verify_graph_key(&pairs, false)
-        );
-    }
-
-    /// The invariants the SSM batched arms depend on, asserted explicitly on
-    /// the canonical order: slots ASCENDING in batch order (the
-    /// consecutive-slot precondition of `ssm_batched_recurrent.rs` and
-    /// `trait_decode_batched_conv_gdn_multi.rs`) and depths NON-INCREASING
-    /// (equal depths form contiguous runs — `decode_batched_inner`'s run
-    /// loop).
-    #[test]
-    fn canonical_order_holds_both_dispatch_invariants() {
-        // Deliberately hostile input: slot order and depth order disagree.
-        let slots = [7usize, 2, 5, 0, 3];
-        let ks = [2usize, 4, 2, 3, 4];
-        let (order, depths) = verify_batch_order(&slots, &ks, true);
-        let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
-        assert!(
-            placed.windows(2).all(|w| w[0] < w[1]),
-            "slots must be ascending in batch order, got {placed:?}"
-        );
-        assert!(
-            depths.windows(2).all(|w| w[0] >= w[1]),
-            "depths must be non-increasing, got {depths:?}"
-        );
-        // The multiset — and therefore Σ rows, the row budget and chunking —
-        // is preserved exactly.
-        let mut before = ks.to_vec();
-        before.sort_unstable();
-        let mut after = depths.clone();
-        after.sort_unstable();
-        assert_eq!(before, after);
-        assert_eq!(placed, vec![0, 2, 3, 5, 7]);
-        assert_eq!(depths, vec![4, 4, 3, 2, 2]);
-    }
-
-    /// Contiguous slots stay contiguous per depth RUN — the precondition the
-    /// two-launch conv+WY fast path actually checks.
-    #[test]
-    fn each_depth_run_owns_a_consecutive_slot_block() {
-        let slots = [0usize, 1, 2, 3, 4, 5, 6, 7];
-        let ks = [2usize, 4, 3, 4, 2, 3, 4, 3];
-        let (order, depths) = verify_batch_order(&slots, &ks, true);
-        let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
-        let mut g0 = 0usize;
-        while g0 < depths.len() {
-            let mut g1 = g0 + 1;
-            while g1 < depths.len() && depths[g1] == depths[g0] {
-                g1 += 1;
-            }
-            assert!(
-                placed[g0..g1].windows(2).all(|w| w[1] == w[0] + 1),
-                "run {g0}..{g1} (k={}) must be consecutive slots, got {:?}",
-                depths[g0],
-                &placed[g0..g1]
-            );
-            g0 = g1;
-        }
-    }
-
-    /// The permutation-only entry point must NEVER re-pair depths — a
-    /// downstream stage re-assigning them could hand a sequence a depth
-    /// deeper than the drafts the planner truncated it to.
-    #[test]
-    fn permutation_leaves_depths_attached_to_their_member() {
-        // An arrangement the canonical planner would never emit (depths
-        // ascending along the slots), to prove the permutation does not
-        // "repair" it.
-        let slots = [7usize, 2, 5, 0];
-        let ks = [4usize, 2, 3, 2];
-        for canonical in [true, false] {
-            let order = verify_batch_permutation(&slots, &ks, canonical);
-            let (_, assigned) = verify_batch_order(&slots, &ks, canonical);
-            let carried: Vec<usize> = order.iter().map(|&i| ks[i]).collect();
-            if canonical {
-                // The planner's entry point DOES re-pair; the permutation
-                // does not. That difference is the point of the split.
-                assert_eq!(carried, vec![2, 2, 3, 4]);
-                assert_eq!(assigned, vec![4, 3, 2, 2]);
-            } else {
-                assert_eq!(carried, assigned);
-            }
-        }
-    }
-
-    /// Idempotence: a chunked caller re-applies the ordering per chunk.
-    #[test]
-    fn canonical_order_is_idempotent() {
-        let slots = [7usize, 2, 5, 0, 3];
-        let ks = [2usize, 4, 2, 3, 4];
-        let (o1, d1) = verify_batch_order(&slots, &ks, true);
-        let s1: Vec<usize> = o1.iter().map(|&i| slots[i]).collect();
-        let (o2, d2) = verify_batch_order(&s1, &d1, true);
-        assert_eq!(o2, (0..s1.len()).collect::<Vec<_>>());
-        assert_eq!(d2, d1);
-    }
-
-    /// Kill switch: the legacy ordering keeps each sequence's own depth, so
-    /// the same multiset in different arrangements yields DIFFERENT keys —
-    /// today's behaviour, restored exactly.
-    #[test]
-    fn kill_switch_restores_the_arrangement_keyed_behaviour() {
-        let a = key_for(&[(0, 4), (1, 4), (2, 3), (3, 3)], false);
-        let b = key_for(&[(0, 3), (1, 3), (2, 4), (3, 4)], false);
-        assert_ne!(a, b, "legacy keys must still separate arrangements");
-        // Legacy order is deepest-first, slot second — each member keeps its
-        // OWN depth.
-        assert_eq!(b, vec![2, 4, 3, 4, 0, 3, 1, 3, u32::MAX]);
-    }
-
-    /// Uniform depths (D-Cut off, above `dcut_width_cap`, or ratio 1.0):
-    /// both arms reduce to "sort by slot", so the whole D-Cut-off regime is
-    /// byte-identical under either setting.
-    #[test]
-    fn uniform_depths_are_identical_under_both_arms() {
-        let slots = [3usize, 1, 2, 0];
-        let ks = [3usize; 4];
-        let canon = verify_batch_order(&slots, &ks, true);
-        let legacy = verify_batch_order(&slots, &ks, false);
-        assert_eq!(canon, legacy);
-        assert_eq!(
-            canon.0.iter().map(|&i| slots[i]).collect::<Vec<_>>(),
-            vec![0, 1, 2, 3]
-        );
-    }
-
-    /// Env-independent as long as the test process does not set the kill
-    /// switch (CI does not) — same pattern as `dcut_width_cap`'s default pin.
-    #[test]
-    fn canonical_is_on_by_default() {
-        assert!(canonical_verify_key_enabled());
-    }
-
-    /// Degenerate widths must not panic: the key path runs for every batch
-    /// the scheduler forms.
-    #[test]
-    fn empty_and_single_batches_are_well_formed() {
-        assert_eq!(verify_batch_order(&[], &[], true), (vec![], vec![]));
-        assert_eq!(verify_batch_order(&[5], &[3], true), (vec![0], vec![3]));
-        assert_eq!(verify_graph_key(&[], false), vec![u32::MAX]);
-    }
-}
+#[path = "verify_key_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/speculative/verify_key_tests.rs
+++ b/crates/spark-model/src/speculative/verify_key_tests.rs
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (`verify_key`). A sibling file via `#[path]` — the
+//! `ssm_reserve.rs`/`ssm_reserve_tests.rs` idiom — so `verify_key.rs` stays
+//! under the 500-line cap; module position (child of `verify_key`) is
+//! unchanged, so `super::*` paths are untouched.
+use super::*;
+
+/// Build the key the dispatch would produce for a batch given as
+/// `(slot, k)` pairs in the scheduler's arbitrary pre-sort order.
+fn key_for(batch: &[(usize, usize)], canonical: bool) -> Vec<u32> {
+    let slots: Vec<usize> = batch.iter().map(|&(s, _)| s).collect();
+    let ks: Vec<usize> = batch.iter().map(|&(_, k)| k).collect();
+    let (order, depths) = verify_batch_order(&slots, &ks, canonical);
+    let pairs: Vec<(u32, u32)> = order
+        .iter()
+        .zip(&depths)
+        .map(|(&i, &k)| (slots[i] as u32, k as u32))
+        .collect();
+    verify_graph_key(&pairs, false)
+}
+
+/// THE DEFECT, pinned. The same depth multiset spread over the same slots
+/// in different arrangements — exactly what D-Cut re-ranking produces
+/// step to step — must collapse onto ONE key.
+#[test]
+fn same_multiset_different_arrangement_is_one_key() {
+    // Multiset {4,4,3,3} over slots {0,1,2,3}: 4!/(2!·2!) = 6 arrangements.
+    let arrangements: [[(usize, usize); 4]; 6] = [
+        [(0, 4), (1, 4), (2, 3), (3, 3)],
+        [(0, 4), (1, 3), (2, 4), (3, 3)],
+        [(0, 4), (1, 3), (2, 3), (3, 4)],
+        [(0, 3), (1, 4), (2, 4), (3, 3)],
+        [(0, 3), (1, 4), (2, 3), (3, 4)],
+        [(0, 3), (1, 3), (2, 4), (3, 4)],
+    ];
+    let keys: std::collections::HashSet<Vec<u32>> =
+        arrangements.iter().map(|a| key_for(a, true)).collect();
+    assert_eq!(keys.len(), 1, "6 arrangements must collapse to 1 key");
+    // And the ONE key is the canonical pairing: slots ascending, depths
+    // descending.
+    assert_eq!(
+        keys.into_iter().next().unwrap(),
+        vec![0, 4, 1, 4, 2, 3, 3, 3, u32::MAX]
+    );
+}
+
+/// The n=8 arithmetic from the module docs, executed: the three depth
+/// multisets the profile observed produce 266 keys pre-canonicalization
+/// and 3 after. Generated exhaustively so the count is computed, not
+/// asserted from a comment.
+#[test]
+fn n8_key_space_collapses_266_to_3() {
+    // (count of depth 4, count of 3, count of 2) for each observed shape.
+    let multisets = [(5usize, 2usize, 1usize), (4, 4, 0), (6, 0, 2)];
+    let mut legacy: std::collections::HashSet<Vec<u32>> = Default::default();
+    let mut canon: std::collections::HashSet<Vec<u32>> = Default::default();
+    for &(c4, c3, c2) in &multisets {
+        let mut depths: Vec<usize> = Vec::new();
+        depths.extend(std::iter::repeat_n(4usize, c4));
+        depths.extend(std::iter::repeat_n(3usize, c3));
+        depths.extend(std::iter::repeat_n(2usize, c2));
+        assert_eq!(depths.len(), 8);
+        // Every distinct arrangement of this multiset over slots 0..8.
+        let mut perm: Vec<usize> = (0..8).collect();
+        permute(&mut perm, 0, &mut |p| {
+            let batch: Vec<(usize, usize)> = (0..8).map(|s| (s, depths[p[s]])).collect();
+            legacy.insert(key_for(&batch, false));
+            canon.insert(key_for(&batch, true));
+        });
+    }
+    assert_eq!(legacy.len(), 266, "pre-canonical arrangement count");
+    assert_eq!(canon.len(), 3, "one key per depth multiset");
+}
+
+/// Every permutation of `v`, in place.
+fn permute(v: &mut Vec<usize>, i: usize, f: &mut impl FnMut(&[usize])) {
+    if i == v.len() {
+        f(v);
+        return;
+    }
+    for j in i..v.len() {
+        v.swap(i, j);
+        permute(v, i + 1, f);
+        v.swap(i, j);
+    }
+}
+
+/// Different multisets must NOT collide — a graph baked for one depth
+/// shape replaying against another is the state-poisoning failure mode.
+#[test]
+fn different_multisets_have_different_keys() {
+    let a = key_for(&[(0, 4), (1, 4), (2, 3), (3, 3)], true);
+    let b = key_for(&[(0, 4), (1, 3), (2, 3), (3, 3)], true);
+    let c = key_for(&[(0, 4), (1, 4), (2, 4), (3, 3)], true);
+    assert_ne!(a, b);
+    assert_ne!(a, c);
+    assert_ne!(b, c);
+}
+
+/// A different SLOT SET at the same depth multiset must also differ: the
+/// graph bakes those pool addresses.
+#[test]
+fn different_slot_sets_have_different_keys() {
+    let a = key_for(&[(0, 4), (1, 3)], true);
+    let b = key_for(&[(0, 4), (2, 3)], true);
+    assert_ne!(a, b);
+}
+
+/// The sentinel keeps a table-less capture from replaying a table-full
+/// step.
+#[test]
+fn wy_table_presence_splits_the_key() {
+    let pairs = [(0u32, 4u32), (1, 3)];
+    assert_ne!(
+        verify_graph_key(&pairs, true),
+        verify_graph_key(&pairs, false)
+    );
+}
+
+/// The invariants the SSM batched arms depend on, asserted explicitly on
+/// the canonical order: slots ASCENDING in batch order (the
+/// consecutive-slot precondition of `ssm_batched_recurrent.rs` and
+/// `trait_decode_batched_conv_gdn_multi.rs`) and depths NON-INCREASING
+/// (equal depths form contiguous runs — `decode_batched_inner`'s run
+/// loop).
+#[test]
+fn canonical_order_holds_both_dispatch_invariants() {
+    // Deliberately hostile input: slot order and depth order disagree.
+    let slots = [7usize, 2, 5, 0, 3];
+    let ks = [2usize, 4, 2, 3, 4];
+    let (order, depths) = verify_batch_order(&slots, &ks, true);
+    let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
+    assert!(
+        placed.windows(2).all(|w| w[0] < w[1]),
+        "slots must be ascending in batch order, got {placed:?}"
+    );
+    assert!(
+        depths.windows(2).all(|w| w[0] >= w[1]),
+        "depths must be non-increasing, got {depths:?}"
+    );
+    // The multiset — and therefore Σ rows, the row budget and chunking —
+    // is preserved exactly.
+    let mut before = ks.to_vec();
+    before.sort_unstable();
+    let mut after = depths.clone();
+    after.sort_unstable();
+    assert_eq!(before, after);
+    assert_eq!(placed, vec![0, 2, 3, 5, 7]);
+    assert_eq!(depths, vec![4, 4, 3, 2, 2]);
+}
+
+/// Contiguous slots stay contiguous per depth RUN — the precondition the
+/// two-launch conv+WY fast path actually checks.
+#[test]
+fn each_depth_run_owns_a_consecutive_slot_block() {
+    let slots = [0usize, 1, 2, 3, 4, 5, 6, 7];
+    let ks = [2usize, 4, 3, 4, 2, 3, 4, 3];
+    let (order, depths) = verify_batch_order(&slots, &ks, true);
+    let placed: Vec<usize> = order.iter().map(|&i| slots[i]).collect();
+    let mut g0 = 0usize;
+    while g0 < depths.len() {
+        let mut g1 = g0 + 1;
+        while g1 < depths.len() && depths[g1] == depths[g0] {
+            g1 += 1;
+        }
+        assert!(
+            placed[g0..g1].windows(2).all(|w| w[1] == w[0] + 1),
+            "run {g0}..{g1} (k={}) must be consecutive slots, got {:?}",
+            depths[g0],
+            &placed[g0..g1]
+        );
+        g0 = g1;
+    }
+}
+
+/// The permutation-only entry point must NEVER re-pair depths — a
+/// downstream stage re-assigning them could hand a sequence a depth
+/// deeper than the drafts the planner truncated it to.
+#[test]
+fn permutation_leaves_depths_attached_to_their_member() {
+    // An arrangement the canonical planner would never emit (depths
+    // ascending along the slots), to prove the permutation does not
+    // "repair" it.
+    let slots = [7usize, 2, 5, 0];
+    let ks = [4usize, 2, 3, 2];
+    for canonical in [true, false] {
+        let order = verify_batch_permutation(&slots, &ks, canonical);
+        let (_, assigned) = verify_batch_order(&slots, &ks, canonical);
+        let carried: Vec<usize> = order.iter().map(|&i| ks[i]).collect();
+        if canonical {
+            // The planner's entry point DOES re-pair; the permutation
+            // does not. That difference is the point of the split.
+            assert_eq!(carried, vec![2, 2, 3, 4]);
+            assert_eq!(assigned, vec![4, 3, 2, 2]);
+        } else {
+            assert_eq!(carried, assigned);
+        }
+    }
+}
+
+/// Idempotence: a chunked caller re-applies the ordering per chunk.
+#[test]
+fn canonical_order_is_idempotent() {
+    let slots = [7usize, 2, 5, 0, 3];
+    let ks = [2usize, 4, 2, 3, 4];
+    let (o1, d1) = verify_batch_order(&slots, &ks, true);
+    let s1: Vec<usize> = o1.iter().map(|&i| slots[i]).collect();
+    let (o2, d2) = verify_batch_order(&s1, &d1, true);
+    assert_eq!(o2, (0..s1.len()).collect::<Vec<_>>());
+    assert_eq!(d2, d1);
+}
+
+/// Kill switch: the legacy ordering keeps each sequence's own depth, so
+/// the same multiset in different arrangements yields DIFFERENT keys —
+/// today's behaviour, restored exactly.
+#[test]
+fn kill_switch_restores_the_arrangement_keyed_behaviour() {
+    let a = key_for(&[(0, 4), (1, 4), (2, 3), (3, 3)], false);
+    let b = key_for(&[(0, 3), (1, 3), (2, 4), (3, 4)], false);
+    assert_ne!(a, b, "legacy keys must still separate arrangements");
+    // Legacy order is deepest-first, slot second — each member keeps its
+    // OWN depth.
+    assert_eq!(b, vec![2, 4, 3, 4, 0, 3, 1, 3, u32::MAX]);
+}
+
+/// Uniform depths (D-Cut off, above `dcut_width_cap`, or ratio 1.0):
+/// both arms reduce to "sort by slot", so the whole D-Cut-off regime is
+/// byte-identical under either setting.
+#[test]
+fn uniform_depths_are_identical_under_both_arms() {
+    let slots = [3usize, 1, 2, 0];
+    let ks = [3usize; 4];
+    let canon = verify_batch_order(&slots, &ks, true);
+    let legacy = verify_batch_order(&slots, &ks, false);
+    assert_eq!(canon, legacy);
+    assert_eq!(
+        canon.0.iter().map(|&i| slots[i]).collect::<Vec<_>>(),
+        vec![0, 1, 2, 3]
+    );
+}
+
+/// Env-independent as long as the test process does not set the kill
+/// switch (CI does not) — same pattern as `dcut_width_cap`'s default pin.
+#[test]
+fn canonical_is_on_by_default() {
+    assert!(canonical_verify_key_enabled());
+}
+
+/// Degenerate widths must not panic: the key path runs for every batch
+/// the scheduler forms.
+#[test]
+fn empty_and_single_batches_are_well_formed() {
+    assert_eq!(verify_batch_order(&[], &[], true), (vec![], vec![]));
+    assert_eq!(verify_batch_order(&[5], &[3], true), (vec![0], vec![3]));
+    assert_eq!(verify_graph_key(&[], false), vec![u32::MAX]);
+}
+
+// ───────────────────────── the width gate ─────────────────────────
+
+/// Build the key through THE GATE with the threshold and kill switch
+/// injected — the same composition production uses
+/// ([`canonical_assignment`] → [`canonical_assignment_at`]), so these tests
+/// exercise the shipped policy rather than a re-derivation of it.
+fn key_through_gate(batch: &[(usize, usize)], min_width: usize, kill_clear: bool) -> Vec<u32> {
+    key_for(
+        batch,
+        canonical_assignment_at(batch.len(), min_width, kill_clear),
+    )
+}
+
+/// The threshold is the documented constant, and CI does not move it.
+#[test]
+fn min_width_is_the_documented_default() {
+    assert_eq!(CANONICAL_KEY_MIN_WIDTH, 8);
+    assert_eq!(canonical_key_min_width(), CANONICAL_KEY_MIN_WIDTH);
+}
+
+/// The boundary sits exactly at the constant: n=7 legacy, n=8 canonical.
+/// n=8 is the rung the A/B measured the +3.9% at, and n<8 the rungs it
+/// measured -2.4% / -3.7% at.
+#[test]
+fn the_gate_boundary_is_the_constant() {
+    for n in 0..CANONICAL_KEY_MIN_WIDTH {
+        assert!(!canonical_assignment(n), "n={n} must take the legacy arm");
+    }
+    for n in CANONICAL_KEY_MIN_WIDTH..=64 {
+        assert!(canonical_assignment(n), "n={n} must take the canonical arm");
+    }
+}
+
+/// ★ THE POINT OF THE GATE. Below the threshold the ASSIGNMENT and the KEY
+/// BYTES are byte-identical to the pre-canonical (pre-#552) behaviour, for
+/// every batch shape reachable at those widths.
+///
+/// "Pre-canonical" is reproduced here from first principles rather than from
+/// the `canonical = false` arm: a STABLE sort by `(Reverse(k), slot)` with
+/// each member keeping its own depth — literally the
+/// `refs.sort_by_key(|(a, k)| (Reverse(*k), slot))` both call sites ran
+/// before #552.
+#[test]
+fn below_the_threshold_is_byte_identical_to_pre_canonical() {
+    // Every ragged shape D-Cut can emit at n in 1..8: rows per sequence are
+    // in 2..=4 (`mtp_dcut` v1 keeps >= 1 draft, ladder_nd <= 3), over slot
+    // sets that are neither sorted nor contiguous.
+    let slot_sets: [&[usize]; 4] = [&[0], &[3, 1], &[5, 0, 2, 9], &[7, 2, 5, 0, 3, 11, 4]];
+    for slots in slot_sets {
+        let n = slots.len();
+        assert!(n < CANONICAL_KEY_MIN_WIDTH);
+        for shape in 0..4usize.pow(n as u32) {
+            let ks: Vec<usize> = (0..n).map(|i| 2 + (shape >> (2 * i)) % 3).collect();
+            // Pre-#552: stable sort, deepest first then slot, depth stays
+            // with its member.
+            let mut pre: Vec<(usize, usize)> = slots.iter().copied().zip(ks.clone()).collect();
+            pre.sort_by_key(|&(slot, k)| (std::cmp::Reverse(k), slot));
+            let pre_key: Vec<u32> = pre
+                .iter()
+                .flat_map(|&(s, k)| [s as u32, k as u32])
+                .chain(std::iter::once(u32::MAX))
+                .collect();
+
+            let (order, depths) = verify_batch_order(slots, &ks, canonical_assignment(n));
+            let got: Vec<(usize, usize)> = order
+                .iter()
+                .zip(&depths)
+                .map(|(&i, &k)| (slots[i], k))
+                .collect();
+            assert_eq!(got, pre, "assignment drifted at n={n} shape={shape}");
+
+            let batch: Vec<(usize, usize)> = slots.iter().copied().zip(ks).collect();
+            assert_eq!(
+                key_for(&batch, canonical_assignment(n)),
+                pre_key,
+                "key bytes drifted at n={n} shape={shape}"
+            );
+        }
+    }
+}
+
+/// A hard byte pin at n=4 so the two arms cannot silently converge: the
+/// gated key is the ARRANGEMENT-keyed one and is NOT the canonical one.
+#[test]
+fn n4_gated_key_is_the_legacy_bytes_not_the_canonical_ones() {
+    let batch = [(0usize, 4usize), (1, 3), (2, 4), (3, 2)];
+    let gated = key_for(&batch, canonical_assignment(batch.len()));
+    assert_eq!(gated, vec![0, 4, 2, 4, 1, 3, 3, 2, u32::MAX]);
+    assert_ne!(gated, key_for(&batch, true));
+    assert_eq!(
+        key_for(&batch, true),
+        vec![0, 4, 1, 4, 2, 3, 3, 2, u32::MAX]
+    );
+}
+
+/// At the threshold the gate selects the canonical arm, so #552's collapse
+/// still happens where it was measured to pay: the same multiset in any
+/// arrangement is ONE key at n=8.
+#[test]
+fn at_the_threshold_the_gate_selects_the_canonical_arm() {
+    let a: Vec<(usize, usize)> = (0..8).map(|s| (s, if s < 5 { 4 } else { 3 })).collect();
+    let b: Vec<(usize, usize)> = (0..8).map(|s| (s, if s < 3 { 3 } else { 4 })).collect();
+    assert_eq!(a.len(), CANONICAL_KEY_MIN_WIDTH);
+    let ka = key_for(&a, canonical_assignment(a.len()));
+    assert_eq!(ka, key_for(&b, canonical_assignment(b.len())));
+    assert_eq!(ka, key_for(&a, true));
+    // The same two arrangements are TWO keys below the gate.
+    assert_ne!(key_for(&a, false), key_for(&b, false));
+}
+
+/// `ATLAS_CANONICAL_KEY_MIN_WIDTH` parsing, as a pure function of the raw
+/// value — the sweep knob must not silently ignore what it is handed.
+#[test]
+fn min_width_override_parses() {
+    let os = |v: &str| Some(std::ffi::OsString::from(v));
+    assert_eq!(min_width_from_env(None), CANONICAL_KEY_MIN_WIDTH);
+    assert_eq!(min_width_from_env(os("4")), 4);
+    assert_eq!(min_width_from_env(os("0")), 0);
+    assert_eq!(min_width_from_env(os(" 16 ")), 16);
+    // Unparseable is NOT silently "off" — it falls back to the measured
+    // default, the same contract `dcut_width_cap` has.
+    assert_eq!(min_width_from_env(os("")), CANONICAL_KEY_MIN_WIDTH);
+    assert_eq!(min_width_from_env(os("-1")), CANONICAL_KEY_MIN_WIDTH);
+    assert_eq!(min_width_from_env(os("eight")), CANONICAL_KEY_MIN_WIDTH);
+}
+
+/// The override MOVES the boundary, end to end in key bytes: at
+/// `ATLAS_CANONICAL_KEY_MIN_WIDTH=4` the n=4 batch that is legacy-keyed by
+/// default becomes canonical, and at `=16` the n=8 batch that is canonical
+/// by default falls back to legacy.
+#[test]
+fn min_width_override_moves_the_boundary() {
+    let n4 = [(0usize, 4usize), (1, 3), (2, 4), (3, 2)];
+    let n8: Vec<(usize, usize)> = (0..8).map(|s| (s, if s < 5 { 4 } else { 3 })).collect();
+    let lowered = min_width_from_env(Some(std::ffi::OsString::from("4")));
+    let raised = min_width_from_env(Some(std::ffi::OsString::from("16")));
+
+    assert_eq!(key_through_gate(&n4, lowered, true), key_for(&n4, true));
+    assert_eq!(
+        key_through_gate(&n4, CANONICAL_KEY_MIN_WIDTH, true),
+        key_for(&n4, false)
+    );
+    assert_eq!(key_through_gate(&n8, raised, true), key_for(&n8, false));
+    assert_eq!(
+        key_through_gate(&n8, CANONICAL_KEY_MIN_WIDTH, true),
+        key_for(&n8, true)
+    );
+    // `=0` is the "canonical everywhere" sweep point, i.e. plain #552.
+    let all = min_width_from_env(Some(std::ffi::OsString::from("0")));
+    assert_eq!(key_through_gate(&n4, all, true), key_for(&n4, true));
+}
+
+/// The kill switch disables the assignment ENTIRELY — it dominates both the
+/// width and the override, so no sweep value can resurrect it.
+#[test]
+fn kill_switch_dominates_width_and_override() {
+    let n8: Vec<(usize, usize)> = (0..8).map(|s| (s, if s < 5 { 4 } else { 3 })).collect();
+    for min_width in [0usize, 1, 4, CANONICAL_KEY_MIN_WIDTH, 64] {
+        for n in [0usize, 1, 2, 4, 8, 16, 128] {
+            assert!(
+                !canonical_assignment_at(n, min_width, false),
+                "kill switch must dominate at n={n} min_width={min_width}"
+            );
+        }
+        assert_eq!(key_through_gate(&n8, min_width, false), key_for(&n8, false));
+    }
+}

--- a/crates/spark-server/src/scheduler/mtp_dcut.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut.rs
@@ -191,15 +191,22 @@ pub(super) fn select(
 /// the resulting per-sequence ROW count (`retained + 1`) in dispatch order.
 ///
 /// ★ The depth→slot ASSIGNMENT is canonical (`verify_key::verify_batch_order`
-/// — depths descending paired with slots ascending), not confidence-ordered.
-/// D-Cut's row saving comes from the multiset, which stays confidence-chosen;
-/// WHO gets which depth was the half that multiplied the batched-verify
-/// CUDA-graph key space (266 arrangements at n=8 against a 32-entry cache →
-/// 89% of steps re-capturing, 23.2 ms/step). It also RECONCILES the batch's
-/// two ordering demands — contiguous equal-depth runs and ascending
-/// consecutive ssm slots — which the confidence-ordered arrangement put in
-/// direct conflict. See `verify_key`'s module docs for the full argument and
-/// the kill switch `ATLAS_NO_CANONICAL_VERIFY_KEY`.
+/// — depths descending paired with slots ascending), not confidence-ordered,
+/// AT BATCH WIDTHS >= `verify_key::CANONICAL_KEY_MIN_WIDTH` (8). D-Cut's row
+/// saving comes from the multiset, which stays confidence-chosen; WHO gets
+/// which depth was the half that multiplied the batched-verify CUDA-graph key
+/// space (266 arrangements at n=8 against a 32-entry cache → 89% of steps
+/// re-capturing, 23.2 ms/step). It also RECONCILES the batch's two ordering
+/// demands — contiguous equal-depth runs and ascending consecutive ssm slots
+/// — which the confidence-ordered arrangement put in direct conflict.
+///
+/// Below that width the key space is 2 (n=2) or 10 (n=4) keys against a
+/// 32-entry cache — nothing to collapse — and the forced assignment measured
+/// NET NEGATIVE there (-2.4% at C=2, -3.7% at C=4), so this falls back to the
+/// pre-canonical assignment byte for byte. `verify_key::canonical_assignment`
+/// is the single gate (threshold + `ATLAS_CANONICAL_KEY_MIN_WIDTH` override +
+/// the `ATLAS_NO_CANONICAL_VERIFY_KEY` kill switch); see `verify_key`'s module
+/// docs and `CANONICAL_KEY_MIN_WIDTH` for the A/B table.
 ///
 /// With `ATLAS_NO_MTP_DCUT` set — or the batch wider than [`dcut_width_cap`]
 /// sequences (the D-Cut-at-depth policy: pruning at the 16:2 rung's n=16
@@ -241,7 +248,10 @@ pub(super) fn plan(
     // with the graph key. Canonical: depths descending onto slots ascending,
     // so `ks_out[p]` is the multiset's p-th deepest row count, NOT
     // necessarily the confidence-chosen depth of the sequence placed there.
-    // Kill switch: each sequence keeps its own depth, deepest-first.
+    // Below `CANONICAL_KEY_MIN_WIDTH` (or with the kill switch set): each
+    // sequence keeps its own depth, deepest-first. This is the ONE place the
+    // assignment is decided, so it is the ONE place the width gate is asked —
+    // `mtp_step` re-applies the ORDER for the same `batchable.len()`.
     let slots: Vec<usize> = batchable
         .iter()
         .map(|&idx| active[idx].seq.ssm_slot_idx().unwrap_or(usize::MAX))
@@ -249,7 +259,7 @@ pub(super) fn plan(
     let (order, ks_out) = spark_model::speculative::verify_key::verify_batch_order(
         &slots,
         &ks,
-        spark_model::speculative::verify_key::canonical_verify_key_enabled(),
+        spark_model::speculative::verify_key::canonical_assignment(batchable.len()),
     );
     // Truncate to the ASSIGNED depth. Every batchable sequence entered the
     // step with exactly `ladder_nd` drafts (`mtp_step` truncates the surplus)

--- a/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
@@ -197,3 +197,55 @@ fn width_two_is_inside_the_pruning_envelope_and_is_not_uniform() {
     // ...and the row saving is real: one fewer verify row than uniform.
     assert_eq!(chunk_ranges(&rows), vec![(0, 2)], "still a single chunk");
 }
+
+/// The width gate reverts the ASSIGNMENT below
+/// `verify_key::CANONICAL_KEY_MIN_WIDTH`, NOT the pruning. Composed exactly
+/// as `plan` composes it (`select` → gate → `verify_batch_order`), because
+/// `plan` itself needs GPU-backed `ActiveSeq`s.
+///
+/// At n=2 the ragged `{4, 3}` row multiset — D-Cut's whole row saving, R=7
+/// against the uniform 8 — survives untouched, and each sequence keeps the
+/// depth its own confidence earned. Under the canonical arm the deepest row
+/// count would move to the LOWEST slot instead, which at this width buys a
+/// key-space collapse from 2 keys to 1 and measured -2.4% at C=2.
+#[test]
+fn below_the_gate_the_pairing_is_legacy_but_the_pruning_is_kept() {
+    use spark_model::speculative::verify_key::{canonical_assignment, verify_batch_order};
+    let c = [vec![-0.01f32, -0.02, -0.03], vec![-0.01f32, -0.02, -0.40]];
+    let refs: Vec<&[f32]> = c.iter().map(|v| v.as_slice()).collect();
+    let ks: Vec<usize> = select(&refs, 3, VERIFY_ROW_BUDGET, 0.75)
+        .iter()
+        .map(|r| r + 1)
+        .collect();
+    assert_eq!(ks, vec![4, 3]);
+    // Seq 0 (the deeper one) sits on the HIGHER pool slot, so the two arms
+    // disagree — the case the gate is actually deciding.
+    let slots = [5usize, 0];
+    assert!(!canonical_assignment(slots.len()));
+
+    let (order, depths) = verify_batch_order(&slots, &ks, canonical_assignment(slots.len()));
+    let paired: Vec<(usize, usize)> = order.iter().map(|&i| (slots[i], ks[i])).collect();
+    assert_eq!(
+        depths.iter().sum::<usize>(),
+        7,
+        "the row saving must survive the gate — this is not a D-Cut kill switch"
+    );
+    assert_eq!(
+        paired,
+        vec![(5, 4), (0, 3)],
+        "each sequence keeps the depth its confidence earned"
+    );
+    assert_eq!(depths, vec![4, 3]);
+    assert_eq!(chunk_ranges(&depths), vec![(0, 2)]);
+
+    // The canonical arm re-pairs: deepest onto the lowest slot.
+    let (c_order, c_depths) = verify_batch_order(&slots, &ks, true);
+    let c_paired: Vec<(usize, usize)> = c_order
+        .iter()
+        .zip(&c_depths)
+        .map(|(&i, &k)| (slots[i], k))
+        .collect();
+    assert_eq!(c_paired, vec![(0, 4), (5, 3)]);
+    assert_ne!(c_paired, paired);
+    assert_eq!(c_depths.iter().sum::<usize>(), 7);
+}

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -376,6 +376,11 @@ pub fn step_mtp(
     // ⇒ `ks` is the uniform ladder shape and everything below reduces to the
     // pre-D-Cut path exactly.
     let ks = mtp_dcut::plan(active, &mut batchable_idxs, ladder_nd, rows);
+    // The width the ASSIGNMENT was gated on (`plan` reorders `batchable_idxs`,
+    // never resizes it): the per-chunk re-ordering below must ask the gate with
+    // THIS width, never the chunk's, or a chunked batch could take the opposite
+    // arm from the one its depths were assigned under.
+    let batch_n = batchable_idxs.len();
 
     // Chunking: the 96-row buffer bound `can_batch_verify` enforces, with the
     // per-chunk sequence cap DERIVED from it (`VERIFY_ROW_BUDGET / widest
@@ -414,16 +419,19 @@ pub fn step_mtp(
                 consumed = i + 1;
                 refs.push((a, k));
             }
-            // Canonical batch order, from the ONE ordering rule shared with
-            // the graph key (`verify_key`): ssm slots ascending, which under
-            // the canonical depth assignment is ALSO deepest-first, so the
-            // key is a function of the depth MULTISET rather than its
-            // arrangement (266 keys → 3 at n=8) and each depth run owns a
-            // consecutive slot block for the batched-GDN precondition.
-            // Idempotent on `plan`'s already-canonical order; it still runs
-            // because `plan` returns the batch UNORDERED whenever D-Cut
-            // declines, and that uniform-`k` case is the pre-D-Cut sort by
-            // slot. PERMUTATION ONLY — depths stay attached to the sequence
+            // Batch order, from the ONE ordering rule shared with the graph
+            // key (`verify_key`), asked with the SAME width gate `plan` used so
+            // order and assignment can never disagree. Canonical (n >=
+            // `CANONICAL_KEY_MIN_WIDTH` = 8): ssm slots ascending = also
+            // deepest-first under the canonical assignment, so the key is a
+            // function of the depth MULTISET not its arrangement (266 keys → 3
+            // at n=8) and each depth run owns a consecutive slot block for the
+            // batched-GDN precondition; below it, deepest-first then slot — the
+            // pre-canonical order byte for byte. Idempotent on `plan`'s ordered
+            // batch under both arms; it still runs because `plan` returns the
+            // batch UNORDERED whenever D-Cut declines, and that uniform-`k`
+            // case is the pre-D-Cut sort by slot. PERMUTATION ONLY — depths
+            // stay attached to the sequence
             // `plan` truncated for (`verify_k4_batch_step` pins
             // `drafts + 1 == ks[i]`). Verdicts are index-mapped inside the
             // step, so batch order is free to the caller.
@@ -435,7 +443,7 @@ pub fn step_mtp(
             let order = spark_model::speculative::verify_key::verify_batch_permutation(
                 &chunk_slots,
                 &chunk_depths,
-                spark_model::speculative::verify_key::canonical_verify_key_enabled(),
+                spark_model::speculative::verify_key::canonical_assignment(batch_n),
             );
             let sorted_ks: Vec<usize> = order.iter().map(|&p| chunk_depths[p]).collect();
             let mut slotted: Vec<Option<&mut ActiveSeq>> =


### PR DESCRIPTION
## The measurement

PR #552 made the batched-verify graph key canonical (depths descending paired with slots ascending), collapsing the n=8 key space from 266 to 3. A/B on dgx2, **same binary, same session, one variable** — the kill switch `ATLAS_NO_CANONICAL_VERIFY_KEY=1`. tok/s, higher is better:

| C | canonical ON | canonical OFF | verdict |
|---|---|---|---|
| 2 | 30.09 | **30.83** | canonical costs **-2.4%** |
| 4 | 64.00 (round 7: 65.56) | 68.11 (round 6, without it) | canonical costs ~**-3.7%** |
| 8 | **110.63** | 106.48 | canonical **gains +3.9%** |
| 16 | 203.50 | 203.44 | no effect |
| 32 | 291.50 | 291.52 | no effect |
| 64 | 387.62 | 386.99 | no effect |
| 128 | 477.55 | 477.69 | no effect |

The canonical assignment pays for itself only where the key space actually explodes. Measured key counts against `VERIFY_BATCHED_GRAPH_CAP` = 32: **n=2 → 2, n=4 → 10, n=8 → 160-253, n=16 → 1**. At n=2 the key space was 2 and at n=4 it was 10 — there is almost nothing to collapse, and forcing the assignment costs more than it saves.

Above width 8 the question is moot: D-Cut is off there (`dcut_width_cap` = 8), `ks` is uniform, and both arms reduce to "sort by slot" — which is exactly why those four rungs move by ≤ 0.2% in either direction.

*Hypothesis for the cost below 8, recorded but **not** load-bearing (the threshold is the measurement, not the mechanism): the forced assignment makes the two-launch batched GDN conv+WY fast path decline, i.e. `n*(2k-1)` launches per layer instead of 2 — 768 vs 96 per step at n=2, k=4 over 48 GDN layers. PR #553's rate telemetry under `ATLAS_MTP_ACCEPT_DEBUG` reports that rate directly, so the next ladder run can confirm or drop it.*

## The threshold

`verify_key::CANONICAL_KEY_MIN_WIDTH = 8` — **one** named threshold, documented in place with the table above (the `ssm_reserve.rs` / `adaptive_rung.rs` house style of recording the numbers that justify a constant). At batch widths ≥ it the canonical assignment applies; below it `verify_batch_order` / `verify_batch_permutation` take their `canonical = false` arm.

* `ATLAS_CANONICAL_KEY_MIN_WIDTH=<n>` sweeps the threshold without a rebuild — VALUE-parsed once per process behind a `OnceLock`, like `dcut_width_cap`. `0` = canonical everywhere (plain #552), a value above the widest batch = never, unset/unparseable = the constant.
* `ATLAS_NO_CANONICAL_VERIFY_KEY` (PRESENCE) still disables it **entirely** and **dominates** both the width and the override.

## Why the gate belongs at the assignment seam

#552's structure is why this is a small change: `plan` decides order **and** assignment, `mtp_step` takes order only, `verify_e2` builds the key from whatever order it is handed. So there is exactly **one** decision to gate, and the gate is one function — `verify_key::canonical_assignment(n)` — which both seams ask and neither re-derives.

Sprinkling a width test at each call site would let the order and the assignment disagree, which is precisely the failure the seam split was built to make unrepresentable (`verify_k4_batch_step` pins `drafts + 1 == ks[i]`).

The one subtlety the gate introduces is **chunking**: `mtp_step` re-applies the ORDER per verify chunk, so it must ask the gate with the width `plan` gated on (`batchable_idxs.len()`, captured as `batch_n`), never the chunk's. Today those coincide in every ragged case — D-Cut only prunes at n ≤ 8, and an n ≤ 8 batch of rows ≤ 4 is a single chunk under the 96-row budget — but relying on that coincidence is the kind of thing that rots, so the width is passed explicitly.

## Byte-identity below the threshold

The whole point of the gate, so it is pinned rather than argued.

`below_the_threshold_is_byte_identical_to_pre_canonical` enumerates every ragged shape D-Cut can emit at n = 1, 2, 4, 7 (rows 2..=4 per sequence, over slot sets that are neither sorted nor contiguous — 16,660 cases) and asserts both the **assignment** and the **key bytes** equal a pre-#552 reproduction built from first principles: a stable `sort_by_key(|(a, k)| (Reverse(k), slot))` with each member keeping its own depth — literally what both call sites ran before #552, not a re-read of the `canonical = false` arm.

D-Cut itself is **untouched** below the threshold: this reverts the ASSIGNMENT, not the pruning. `below_the_gate_the_pairing_is_legacy_but_the_pruning_is_kept` composes `select` → gate → `verify_batch_order` the way `plan` does and pins that the n=2 ragged `{4,3}` multiset (R=7 against the uniform 8) survives while each sequence keeps the depth its own confidence earned.

The D-Cut planner and the SSM row-order invariants are otherwise unchanged — `canonical_order_holds_both_dispatch_invariants`, `each_depth_run_owns_a_consecutive_slot_block`, `canonical_assignment_preserves_the_selected_row_total` and the `chunk_ranges_*` tests all still pass unmodified, and #552's `n8_key_space_collapses_266_to_3` (all 8! placements, key space 266 → 3) is untouched and green.

## Tests

+9, 35 total across the two seams, all pure/CPU:

* `below_the_threshold_is_byte_identical_to_pre_canonical` — the guarantee.
* `n4_gated_key_is_the_legacy_bytes_not_the_canonical_ones` — a hard byte pin so the two arms cannot silently converge.
* `at_the_threshold_the_gate_selects_the_canonical_arm` — #552's collapse still happens at n=8, where it was measured to pay.
* `the_gate_boundary_is_the_constant`, `min_width_is_the_documented_default`.
* `min_width_override_parses` + `min_width_override_moves_the_boundary` — the override moves the boundary end-to-end **in key bytes** (`=4` makes n=4 canonical, `=16` makes n=8 legacy, `=0` is plain #552).
* `kill_switch_dominates_width_and_override`.
* `below_the_gate_the_pairing_is_legacy_but_the_pruning_is_kept` (D-Cut seam).

`verify_key.rs`'s tests move to a sibling `verify_key_tests.rs` via `#[path]` (the `ssm_reserve.rs` idiom) so the file stays under the 500-line cap: 420 → 267.

## Validation plan

1. **Ladder rungs C=1, 2, 4, 8** on dgx2, with a **same-session kill-switch control leg** (`ATLAS_NO_CANONICAL_VERIFY_KEY=1`) so the comparison stays one-variable, plus optionally an `ATLAS_CANONICAL_KEY_MIN_WIDTH=0` leg to reproduce plain #552 from the same binary.
2. **ssm-state-poisoning-gate** — the assignment touches which slot gets which depth, so the graph-replay-against-the-wrong-shape failure mode must stay clean.
3. **decode-floor**.

### Expected effect (to be measured — not claimed here)

C=2 30.09 → ~30.8 · C=4 64.00 → ~68 · C=8 keeps 110.63 · C ≥ 16 unchanged.

Floors that must not regress: **C=1 23.66, C=2 31.00, C=4 68.11, C=8 110.63, C=16 203.50, C=32 291.52, C=64 387.62, C=128 477.69.**

## Gates

```
cargo fmt --all -- --check                                             OK
ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy --workspace --tests   OK (rc=0)
scripts/check-license-headers.sh                       2238 valid, 0 invalid
cargo test -p spark-model  --lib     623 passed; 0 failed
cargo test -p spark-server --bins   2291 passed; 0 failed; 12 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
