### PR TITLE
perf(mtp): route the drafter's M=2..8 propose onto the batched BF16 GEMV

### DIFF
--- a/crates/spark-model/examples/bf16_batch_bitparity_microtest.rs
+++ b/crates/spark-model/examples/bf16_batch_bitparity_microtest.rs
@@ -1,27 +1,34 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! BYTE-parity gate for the native-BF16 batched projections.
 //!
-//! THIS GATE IS EXPECTED TO REPORT `FAIL` TODAY, AND THAT IS THE POINT. It is
-//! standing evidence of a KNOWN, deliberately-unfixed gap, checked in
-//! alongside the w4a16 twin so the BF16 arm's status is a measured number
-//! instead of an assumption. Do not "fix" it by loosening the comparison.
+//! Two legs against the same reference (`m x dense_gemv_bf16`, the kernel every
+//! SINGLE-sequence path runs), at production projection shapes, several seeds,
+//! and every M a batched arm can be handed at rungs 2..16:
 //!
-//! Batching the BF16 arm swaps `m x dense_gemv_bf16` (K split over 64 lanes,
-//! warp-shuffle reduction tree) for one `dense_gemm_bf16_pipelined` (m16n8k16
-//! tensor-core MMA, one FP32 accumulator marched sequentially over K in
-//! 32-wide steps). Unlike the w4a16 defect this test's twin found, that is a
-//! different ALGORITHM, not a reassociation that can be un-fused: there is no
-//! surgical reordering that recovers parity. The clean fix is a bit-exact
-//! batched BF16 GEMV, which is a kernel port, not an edit, and is not done
-//! here. Callers that require batch-invariant BF16 output must keep their
-//! batched-projection threshold above the rungs this arm serves.
+//! * **`dense_gemv_bf16_batchm`** — the batched-GEMV arm. ONE pass over the
+//!   weight matrix, M independent accumulators, same per-row K-iteration order
+//!   and reduction tree as the M=1 kernel (`--fmad=false` on the dir is what
+//!   makes that an identity and not an approximation). MUST be byte-identical
+//!   for M in 2..=8; **this leg alone decides the exit code**. Above M=8 the
+//!   kernel's compile-time `MAX_M` clamps silently, so it is not exercised
+//!   there — the Rust wrapper refuses those M.
+//! * **`dense_gemm_bf16_pipelined`** — the tile-GEMM arm. REPORTED, never
+//!   graded: it is a different ALGORITHM (m16n8k16 tensor-core MMA, one FP32
+//!   accumulator marched sequentially over K in 32-wide steps), so it is
+//!   expected to differ and no reassociation recovers parity. Its numbers are
+//!   kept as standing evidence of that known gap. Do not "fix" it by loosening
+//!   the comparison, and do not fold it into the verdict.
 //!
-//! Same standard as `w4a16_batch_bitparity_microtest.rs`: RAW BF16 BYTES at
-//! production projection shapes, several seeds, every M the batched arm can
-//! be handed at rungs 2..16.
+//! The `batchm` leg is why the drafter's M=2..8 propose
+//! (`layers::mtp_head::row_dispatch`) can move OFF the pipelined GEMM and be
+//! bit-exact to the per-sequence propose rather than merely close to it. It is
+//! also the "bit-exact batched BF16 GEMV" an earlier revision of this file
+//! called for as unbuilt — it was already in `kernels/gb10/common/`, just not
+//! wired into every caller.
 //!
-//! Exit: 0 all legs byte-identical, 1 any leg differs (the current, expected
-//! outcome), 2 kernels absent from this target's module set.
+//! Exit: 0 the batchm leg is byte-identical everywhere it is defined, 1 any
+//! batchm leg differs (or the negative control fails to fire), 2 kernels absent
+//! from this target's module set.
 //!
 //! Run:
 //!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=nemotron-3-nano-30b-a3b \
@@ -41,12 +48,27 @@ const MAX_M: usize = 16;
 /// rows cover the hidden-4096 Super/Puzzle backbone at the natural doubling
 /// (d_inner 8192); they are shape COVERAGE for a larger N and a deeper K, not
 /// a claim about that checkpoint's exact `in_proj_size`.
-const SHAPES: [(&str, usize, usize); 4] = [
-    ("nano  in_proj  [10304 x 2688]", 10304, 2688),
-    ("nano  out_proj [ 2688 x 4096]", 2688, 4096),
-    ("super in_proj  [18560 x 4096]", 18560, 4096),
-    ("super out_proj [ 4096 x 8192]", 4096, 8192),
+const SHAPES: [(&str, usize, usize); 10] = [
+    ("nano  in_proj    [10304 x  2688]", 10304, 2688),
+    ("nano  out_proj   [ 2688 x  4096]", 2688, 4096),
+    ("super in_proj    [18560 x  4096]", 18560, 4096),
+    ("super out_proj   [ 4096 x  8192]", 4096, 8192),
+    // The six DISTINCT (N, K) pairs of one Qwen3.6-27B drafter draft position
+    // (h 5120, nq 24, nkv 4, head_dim 256, inter 17408). k_proj and v_proj
+    // share a shape, so eight projections are six rows. These are the shapes
+    // `mtp_head::row_dispatch` moves onto the batchm arm at M in 2..=8.
+    ("27B mtp fc       [ 5120 x 10240]", 5120, 10240),
+    ("27B mtp q_proj   [12288 x  5120]", 12288, 5120),
+    ("27B mtp k/v_proj [ 1024 x  5120]", 1024, 5120),
+    ("27B mtp o_proj   [ 5120 x  6144]", 5120, 6144),
+    ("27B mtp ffn_g/u  [17408 x  5120]", 17408, 5120),
+    ("27B mtp ffn_down [ 5120 x 17408]", 5120, 17408),
 ];
+
+/// Compile-time `MAX_M` of `dense_gemv_bf16_batchm`. The kernel CLAMPS above
+/// it rather than erroring, so the batchm leg must not be run past it — mirror
+/// of `ops::DENSE_GEMV_BATCHM_MAX_M`.
+const BATCHM_MAX_M: usize = 8;
 
 struct Lcg(u64);
 impl Lcg {
@@ -137,6 +159,33 @@ fn gemm(
         .launch(0)
 }
 
+/// `dense_gemv_bf16_batchm(A, B, C, M, N, K, out_stride)` — grid
+/// (ceil(N/4),1,1), block 256. Mirrors `ops::dense_gemv_batchm`; `out_stride`
+/// is N here, matching the contiguous `[m, n]` output the drafter uses.
+#[allow(clippy::too_many_arguments)]
+fn batchm(
+    g: &dyn GpuBackend,
+    kh: KernelHandle,
+    a: DevicePtr,
+    w: DevicePtr,
+    c: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+) -> Result<()> {
+    KernelLaunch::new(g, kh)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(w)
+        .arg_ptr(c)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .arg_u32(n)
+        .launch(0)
+}
+
 fn reference(
     g: &dyn GpuBackend,
     kh: KernelHandle,
@@ -165,18 +214,23 @@ fn main() -> Result<()> {
     let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
     let g: &dyn GpuBackend = &backend;
 
-    let (gemm_k, gemv_k) = match (
+    let (gemm_k, gemv_k, batchm_k) = match (
         g.kernel("gemm", "dense_gemm_bf16_pipelined"),
         g.kernel("gemv", "dense_gemv_bf16"),
+        g.kernel("dense_gemv_bf16_batchm", "dense_gemv_bf16_batchm"),
     ) {
-        (Ok(a), Ok(b)) => (a, b),
+        (Ok(a), Ok(b), Ok(c)) => (a, b, c),
         _ => {
-            println!("dense BF16 GEMM/GEMV kernels absent from this target set — SKIP");
+            println!("dense BF16 GEMM/GEMV/batchm kernels absent from this target set — SKIP");
             std::process::exit(2);
         }
     };
 
-    let mut clean = true;
+    // GRADED: the batchm arm, which is what the drafter's M=2..8 propose and
+    // the multi-seq decode projections dispatch.
+    let mut batchm_clean = true;
+    // REPORTED ONLY: the tile-GEMM arm's known non-parity.
+    let mut gemm_clean = true;
     let mut control_ok = true;
     for seed in [1u64, 99, 12345] {
         for (label, n, k) in SHAPES {
@@ -194,16 +248,40 @@ fn main() -> Result<()> {
             let c_ref = g.alloc(MAX_M * n * 2)?;
 
             for m in [2usize, 3, 4, 6, 8, 12, 16] {
-                g.memset(c_batch, 0, MAX_M * n * 2)?;
                 g.memset(c_ref, 0, MAX_M * n * 2)?;
-                gemm(g, gemm_k, a_d, w_d, c_batch, m as u32, n as u32, k as u32)?;
                 reference(g, gemv_k, a_d, w_d, c_ref, m, n, k)?;
                 g.synchronize(0)?;
-                let cb = down(g, c_batch, m * n * 2)?;
                 let cr = down(g, c_ref, m * n * 2)?;
+
+                // ── GRADED leg: batched GEMV, only where the kernel defines it.
+                if m <= BATCHM_MAX_M {
+                    g.memset(c_batch, 0, MAX_M * n * 2)?;
+                    batchm(g, batchm_k, a_d, w_d, c_batch, m as u32, n as u32, k as u32)?;
+                    g.synchronize(0)?;
+                    let cb = down(g, c_batch, m * n * 2)?;
+                    let identical = cb == cr;
+                    let (n_diff, worst, rel) = worst_delta(&cb, &cr);
+                    batchm_clean &= identical;
+                    let pct = 100.0 * n_diff as f32 / (m * n) as f32;
+                    println!(
+                        "seed {seed:>5}  {label}  batchm    M={m:<3} byte-identical={identical:<5} \
+                         diff_elems={n_diff:<7} ({pct:5.2}%) max|delta|={worst:.6} max_rel={rel:.6}"
+                    );
+                } else {
+                    println!(
+                        "seed {seed:>5}  {label}  batchm    M={m:<3} \
+                         n/a (kernel MAX_M={BATCHM_MAX_M}; the wrapper refuses this M)"
+                    );
+                }
+
+                // ── REPORTED leg: tile GEMM. Known non-parity; not graded.
+                g.memset(c_batch, 0, MAX_M * n * 2)?;
+                gemm(g, gemm_k, a_d, w_d, c_batch, m as u32, n as u32, k as u32)?;
+                g.synchronize(0)?;
+                let cb = down(g, c_batch, m * n * 2)?;
                 let identical = cb == cr;
                 let (n_diff, worst, rel) = worst_delta(&cb, &cr);
-                clean &= identical;
+                gemm_clean &= identical;
                 let pct = 100.0 * n_diff as f32 / (m * n) as f32;
                 println!(
                     "seed {seed:>5}  {label}  pipelined M={m:<3} byte-identical={identical:<5} \
@@ -214,13 +292,15 @@ fn main() -> Result<()> {
             // ── Negative control: the harness MUST see a 1-ULP activation
             // perturbation on row 1, so a "byte-identical" verdict is never
             // an artefact of comparing two blank buffers.
+            // Run against the GRADED (batchm) leg: a negative control that only
+            // exercises the ungraded arm proves nothing about the verdict.
             let m = 4usize;
             let mut pert = a_bytes.clone();
             pert[2 * (k + 7)] ^= 1;
             let a_pert = up(g, &pert)?;
             g.memset(c_batch, 0, MAX_M * n * 2)?;
             g.memset(c_ref, 0, MAX_M * n * 2)?;
-            gemm(g, gemm_k, a_d, w_d, c_batch, m as u32, n as u32, k as u32)?;
+            batchm(g, batchm_k, a_d, w_d, c_batch, m as u32, n as u32, k as u32)?;
             reference(g, gemv_k, a_pert, w_d, c_ref, m, n, k)?;
             g.synchronize(0)?;
             let differs = down(g, c_batch, m * n * 2)? != down(g, c_ref, m * n * 2)?;
@@ -234,23 +314,31 @@ fn main() -> Result<()> {
         }
     }
 
+    println!(
+        "\nREPORTED (ungraded) — dense_gemm_bf16_pipelined byte-identical to M x \
+         dense_gemv_bf16 across all legs: {gemm_clean}. `false` is the KNOWN BF16 gap \
+         documented at the top of this file, not a regression: the tile GEMM is a \
+         different algorithm. Callers needing batch-invariant BF16 output must take the \
+         batchm arm (M <= {BATCHM_MAX_M}) or keep their batched-projection threshold \
+         above the rungs the tile GEMM serves."
+    );
+
     if !control_ok {
         println!("FAIL — negative control did not mismatch; this harness is VACUOUS.");
         std::process::exit(1);
     }
-    if clean {
+    if batchm_clean {
         println!(
-            "PASS — dense_gemm_bf16_pipelined is byte-identical to M x dense_gemv_bf16 at \
-             every Nemotron projection shape and every M the batched arm serves."
+            "PASS — dense_gemv_bf16_batchm is byte-identical to M x dense_gemv_bf16 at \
+             every projection shape and every M in 2..={BATCHM_MAX_M}."
         );
         Ok(())
     } else {
         println!(
-            "FAIL (EXPECTED) — dense_gemm_bf16_pipelined is NOT byte-identical to the \
-             per-row GEMV. This is the known BF16 gap documented at the top of this \
-             file, not a regression: batching swaps in a tensor-core tile GEMM, a \
-             different algorithm. Callers needing batch-invariant BF16 output must keep \
-             their batched-projection threshold above the rungs this arm serves."
+            "FAIL — dense_gemv_bf16_batchm is NOT byte-identical to M x dense_gemv_bf16. \
+             Every caller of the batched arm (multi-seq decode projections, the MTP \
+             drafter's M=2..8 propose) claims that identity in its doc comment; one of \
+             them is now lying. Do NOT loosen this comparison."
         );
         std::process::exit(1);
     }

--- a/crates/spark-model/src/layers/mtp_head.rs
+++ b/crates/spark-model/src/layers/mtp_head.rs
@@ -234,6 +234,15 @@ pub struct MtpHead {
     /// drafter shapes: 2.7x the 4x-GEMV per-seq loop (5.1 vs 14.4 ms per
     /// draft position).
     dense_gemm_pipelined_k: KernelHandle,
+    /// `dense_gemv_bf16_batchm` — ONE pass over each BF16 drafter weight
+    /// producing all M rows — for the batched propose at M in 2..=8 (0 when
+    /// the target's kernel set lacks it, which falls back to the pipelined
+    /// GEMM). The pipelined GEMM above is the right tool at the C=16/32
+    /// propose widths but costs 5.43 ms/draft-position at M=2 against
+    /// 3.57 ms for the M=1 GEMV — 1.52x for two rows on a path that streams
+    /// the weights once. See [`row_dispatch`] for the measurements, the
+    /// 2..=8 band and the numerics statement.
+    dense_gemv_batchm_k: KernelHandle,
     /// `w4a16_gemv_batch{4..8}` (narrow family) and `_batch{16,32}` (wide) for
     /// the batched-propose LM head (0 when absent): reads the shared NVFP4 LM
     /// head once for up to MAX_M sequences. Selected per batch width by
@@ -381,6 +390,7 @@ mod forward_batch;
 mod moe_forward;
 mod new;
 mod prefill;
+pub(crate) mod row_dispatch;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spark-model/src/layers/mtp_head/forward_batch.rs
+++ b/crates/spark-model/src/layers/mtp_head/forward_batch.rs
@@ -12,10 +12,14 @@
 //!
 //! Microbenchmarked at M=4 on the real 27B drafter shapes (GB10):
 //! `dense_gemm_bf16_pipelined` 5.1 ms vs the 4x `dense_gemv_bf16` loop
-//! 14.4 ms per draft position (scalar `dense_gemm_bf16`: 8.1 ms). The small
-//! K/V projections (N = nkv*hd) stay on the per-row GEMV (44 us vs 194 us
-//! pipelined at N=1024 — the 128-wide tile under-fills the grid). The LM
-//! head batches through `w4a16_gemv_batch{4,8,16,32}`, selected per width.
+//! 14.4 ms per draft position (scalar `dense_gemm_bf16`: 8.1 ms). At the
+//! NARROW propose widths (M in 2..=8) both of those lose to
+//! `dense_gemv_bf16_batchm`, which streams each weight once for all M rows:
+//! the pipelined GEMM cost 5.43 ms/draft-position at M=2 against 3.57 ms for
+//! the M=1 GEMV — 1.52x for two rows. [`super::row_dispatch`] holds that
+//! measurement, the 2..=8 band, both kill switches and the numerics
+//! statement. The LM head batches through `w4a16_gemv_batch{4,8,16,32}`,
+//! selected per width.
 //!
 //! WIDTH: `n` is bounded by [`super::batch_caps::MtpHead::propose_batch_max`]
 //! (up to 32 since the 32:1 rung), NOT by a hardcoded 4 — see that module for
@@ -35,6 +39,7 @@
 use anyhow::{Result, ensure};
 use spark_runtime::gpu::DevicePtr;
 
+use super::row_dispatch;
 use super::{MtpHead, MtpProposerState, ProjectionWeight};
 use crate::layer::ForwardContext;
 use crate::layers::ops;
@@ -49,9 +54,18 @@ use crate::layers::mtp_meta::pack_mtp_attn_meta;
 const LP_SCRATCH_OFF: usize = 256;
 
 impl MtpHead {
-    /// M=n-row BF16 GEMM dispatch: pipelined tensor-core GEMM for the large
-    /// weight-bearing shapes (reads B once for all rows), per-row GEMV for
-    /// small N where the 128-wide tile under-fills the grid (measured).
+    /// M=n-row BF16 projection dispatch. Three tiers, selected by the pure
+    /// [`row_dispatch::drafter_row_kernel`] (which carries the measurements,
+    /// the 2..=8 band and the numerics statement):
+    ///
+    /// * **batched GEMV** at m in 2..=8 — one weight pass, m accumulators;
+    /// * **pipelined tensor-core GEMM** at the wider propose widths and for
+    ///   large N, where the batched-GEMV family measured negative;
+    /// * **per-row GEMV** for small N where the 128-wide tile under-fills the
+    ///   grid, and as the `ATLAS_MTP_KV_GEMV` arm.
+    ///
+    /// All three see the same `[m, k]` contiguous `input` and write m
+    /// contiguous `[n]` output rows, so `out_stride == n`.
     fn gemm_rows(
         &self,
         gpu: &dyn spark_runtime::gpu::GpuBackend,
@@ -63,19 +77,29 @@ impl MtpHead {
         k: u32,
         stream: u64,
     ) -> Result<()> {
-        // Small-N routing re-derived for the widened propose (2026-07-30):
-        // the "per-row GEMV wins at small N" measurement was taken at M=4
-        // (4 x 44 us ~= one 194 us under-filled tile — a tie). The propose has
-        // since widened to n=16 (a83627a2), where the loop is ~16 x 44 us
-        // ~= 700 us against the SAME ~200 us tile: the crossover flipped and
-        // the loop became the 5,200-launch `dense_gemv_bf16` line in the
-        // C=16 verify-tax profile (PROGRESS_LOG 6.11). Take the tile GEMM for
-        // small N once m >= 8; keep the GEMV loop below that (the measured
-        // small-m regime) and as the ATLAS_MTP_KV_GEMV=1 kill-switch arm.
-        let small_n_tile =
-            m >= 8 && (k & 7) == 0 && std::env::var_os("ATLAS_MTP_KV_GEMV").is_none();
-        if (n >= 4096 || small_n_tile) && (k & 7) == 0 {
-            ops::dense_gemm_bf16_pipelined(
+        match row_dispatch::drafter_row_kernel(
+            m,
+            n,
+            k,
+            self.dense_gemv_batchm_k.0 != 0,
+            row_dispatch::kv_gemv_pinned(),
+            row_dispatch::small_m_tier_off(),
+        ) {
+            row_dispatch::RowKernel::Batchm => ops::dense_gemv_batchm(
+                gpu,
+                self.dense_gemv_batchm_k,
+                input,
+                w,
+                output,
+                m as u32,
+                n,
+                k,
+                // Output rows are contiguous [n] blocks; the kernel wants the
+                // stride in BF16 ELEMENTS, which is exactly n.
+                n,
+                stream,
+            ),
+            row_dispatch::RowKernel::Pipelined => ops::dense_gemm_bf16_pipelined(
                 gpu,
                 self.dense_gemm_pipelined_k,
                 input,
@@ -85,22 +109,23 @@ impl MtpHead {
                 n,
                 k,
                 stream,
-            )
-        } else {
-            let gemv_k = self.dense_gemv_k.unwrap();
-            for r in 0..m {
-                ops::dense_gemv(
-                    gpu,
-                    gemv_k,
-                    input.offset(r * k as usize * 2),
-                    w,
-                    output.offset(r * n as usize * 2),
-                    n,
-                    k,
-                    stream,
-                )?;
+            ),
+            row_dispatch::RowKernel::GemvLoop => {
+                let gemv_k = self.dense_gemv_k.unwrap();
+                for r in 0..m {
+                    ops::dense_gemv(
+                        gpu,
+                        gemv_k,
+                        input.offset(r * k as usize * 2),
+                        w,
+                        output.offset(r * n as usize * 2),
+                        n,
+                        k,
+                        stream,
+                    )?;
+                }
+                Ok(())
             }
-            Ok(())
         }
     }
 
@@ -597,6 +622,30 @@ impl MtpHead {
         Ok(())
     }
 
+    /// The arm the large-N projections (fc/q/o/ffn) actually take at this
+    /// propose width — logged once per distinct `n` so a 0-handle or
+    /// kill-switch fallback cannot hide behind a green "propose_batch active"
+    /// line. The N=1024 K/V pair follows the same arm except under
+    /// `ATLAS_MTP_KV_GEMV`.
+    fn propose_proj_arm(&self, n: usize, h: usize) -> &'static str {
+        // Probed at the `fc` shape (N = h, K = 2h) — the first weight-bearing
+        // projection of every draft position. All the other large-N ones
+        // route identically; only the N < 4096 K/V pair can split off, and
+        // only under `ATLAS_MTP_KV_GEMV`.
+        match row_dispatch::drafter_row_kernel(
+            n,
+            h as u32,
+            (2 * h) as u32,
+            self.dense_gemv_batchm_k.0 != 0,
+            row_dispatch::kv_gemv_pinned(),
+            row_dispatch::small_m_tier_off(),
+        ) {
+            row_dispatch::RowKernel::Batchm => "GEMV-BATCHM",
+            row_dispatch::RowKernel::Pipelined => "PIPELINED-GEMM",
+            row_dispatch::RowKernel::GemvLoop => "GEMV-LOOP",
+        }
+    }
+
     /// Batched propose driver: `num_drafts` chained positions, each one
     /// M=n-row forward. Draft 0 consumes the caller's per-sequence target
     /// hiddens; draft j>0 consumes the drafter's own hidden row i (written
@@ -634,16 +683,21 @@ impl MtpHead {
                 && let Some((_, ldb)) = self.lm_head_nvfp4_t
             {
                 tracing::info!(
-                    "MTP propose_batch active: n={n} pipelined_gemm={:#x} \
-                     lm_head=TILE-TWIN (handle {:#x}, ldb={ldb}) — kill switch \
-                     ATLAS_NO_MTP_LMHEAD_TGEMM (presence)",
+                    "MTP propose_batch active: n={n} proj={} pipelined_gemm={:#x} \
+                     gemv_batchm={:#x} lm_head=TILE-TWIN (handle {:#x}, ldb={ldb}) \
+                     — kill switch ATLAS_NO_MTP_LMHEAD_TGEMM (presence)",
+                    self.propose_proj_arm(n, ctx.config.hidden_size),
                     self.dense_gemm_pipelined_k.0,
+                    self.dense_gemv_batchm_k.0,
                     self.w4a16_gemm_t_k.0,
                 );
             } else {
                 tracing::info!(
-                    "MTP propose_batch active: n={n} pipelined_gemm={:#x} lm_head_batchm={:#x}",
+                    "MTP propose_batch active: n={n} proj={} pipelined_gemm={:#x} \
+                     gemv_batchm={:#x} lm_head_batchm={:#x}",
+                    self.propose_proj_arm(n, ctx.config.hidden_size),
                     self.dense_gemm_pipelined_k.0,
+                    self.dense_gemv_batchm_k.0,
                     self.lm_head_batch_kernel(n).0
                 );
             }

--- a/crates/spark-model/src/layers/mtp_head/new.rs
+++ b/crates/spark-model/src/layers/mtp_head/new.rs
@@ -415,6 +415,14 @@ impl MtpHead {
                 "gemm",
                 "dense_gemm_bf16_pipelined",
             ),
+            // Batched BF16 GEMV for the M=2..8 propose widths; 0-handle on
+            // targets whose kernel set predates it (dispatch falls back to
+            // the pipelined GEMM — see `row_dispatch`).
+            dense_gemv_batchm_k: crate::layers::try_kernel(
+                gpu,
+                "dense_gemv_bf16_batchm",
+                "dense_gemv_bf16_batchm",
+            ),
             w4a16_batchm: crate::layers::w4a16_gemv_tiers::W4a16BatchmTiers::resolve(gpu),
             w4a16_gemv_batch16_k: crate::layers::try_kernel(
                 gpu,

--- a/crates/spark-model/src/layers/mtp_head/row_dispatch.rs
+++ b/crates/spark-model/src/layers/mtp_head/row_dispatch.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! M-row kernel selection for the batched cross-sequence drafter propose.
+//!
+//! Pure decision function + its two env levers, split out of
+//! [`super::forward_batch`] so the M→kernel table is testable without a GPU
+//! (and so the file stays under the 500-line cap).
+//!
+//! ## The defect this exists to fix
+//!
+//! nsys on dgx2 (C=1 vs C=2 decode, 27B, MTP K=4) attributed the drafter at
+//! **14.22 ms/step at C=1** and **21.46 ms/step at C=2** — +7.24 ms of the
+//! +51 ms/step cost of a second sequence, the second-largest term after the
+//! main projection GEMV. Per draft position:
+//!
+//! | M | dispatch today | cost |
+//! |---|---|---|
+//! | 1 | `dense_gemv_bf16` (per-seq [`super::forward`]) | 3.57 ms |
+//! | 2 | `dense_gemm_bf16_pipelined` ([`super::forward_batch`]) | 5.43 ms |
+//!
+//! One draft position reads ~849 MB of BF16 drafter weights (the eight
+//! projections below), so M=1 at 3.57 ms is **238 GB/s** — essentially the
+//! GB10 roofline (273 GB/s LPDDR5X). M=2 at 5.43 ms is 156 GB/s: **1.52x for
+//! two rows** on a path where the weights are streamed once and the second
+//! row should be nearly free.
+//!
+//! `dense_gemv_bf16_batchm` is exactly that "stream once, M accumulators"
+//! kernel and already exists — it is simply not wired into the drafter. Its
+//! gating microbench (commit 250931e97, `examples/dense_gemv_bf16_batchm_microtest`,
+//! real decode shapes, K=3072) measured one batchm launch against M separate
+//! M=1 launches:
+//!
+//! | shape | M | N | Mx M=1 | batchm | speedup |
+//! |---|---|---|---|---|---|
+//! | q_proj | 2 | 9216 | 0.4130 ms | 0.2059 ms | 2.01x |
+//! | q_proj | 4 | 9216 | 0.8398 ms | 0.2122 ms | 3.96x |
+//! | o_proj | 4 | 3072 | 0.0449 ms | 0.0199 ms | 2.26x |
+//! | k/v    | 4 | 1024 | 0.0208 ms | 0.0115 ms | 1.81x |
+//!
+//! The load-bearing number is `q_proj`: batchm at M=4 costs 0.2122 ms against
+//! 0.2100 ms for a single M=1 launch — **+1% for 4x the rows**. batchm's cost
+//! is flat in M, so on the drafter it should land at the M=1 3.57 ms rather
+//! than the pipelined GEMM's 5.1-5.4 ms, at every M it covers.
+//!
+//! ## Where the crossover comes from
+//!
+//! Not invented here. `dense_gemv_bf16_batchm` has a compile-time `MAX_M 8`
+//! ([`DENSE_GEMV_BATCHM_MAX_M`]) and **clamps silently** above it, so 8 is a
+//! hard ceiling, not a tuning choice. The floor is 2 because M=1 already has
+//! a dedicated kernel and never reaches this path. The main model runs the
+//! identical kernel over the identical `(2..=8)` band at three sites
+//! (`multi_seq/qkv.rs`, `multi_seq/attn/o_proj.rs` x2), measured +6% at C=2
+//! and +24% at C=4 (commit 84d5b763c). Above 8 the batched-GEMV family was
+//! measured NEGATIVE against the tile GEMM (-14.4% at C=16, -29.4% at C=32,
+//! commit 78d276832), which is why this tier stops at 8 instead of growing a
+//! wider kernel.
+//!
+//! No drafter-specific microbench exists for these shapes (`batchm_bench` is
+//! the w4a16 family, not the BF16 one), so the band is mirrored from the
+//! main-model tiering rather than re-measured — recorded here as the reason.
+//!
+//! ## Numerics
+//!
+//! `dense_gemv_bf16_batchm` is **bit-identical to M separate `dense_gemv_bf16`
+//! calls** (same per-row K-iteration order and reduction tree; the kernel dir
+//! builds with `--fmad=false`), verified across all 9 shape/M combinations of
+//! `examples/dense_gemv_bf16_batchm_microtest`. So:
+//!
+//! * vs the **per-row GEMV loop** it replaces (small N, m in 2..=7 today):
+//!   bit-exact.
+//! * vs the **pipelined tile GEMM** it replaces (N >= 4096, and small N at
+//!   m == 8): NOT bit-exact — a tensor-core tile GEMM has a different
+//!   accumulation order. The drafter output moves in the last bits.
+//! * vs the **single-sequence propose** ([`super::forward`], which runs
+//!   `ops::dense_gemv` for all eight projections): bit-exact, at every M this
+//!   tier covers. The batched propose becomes numerically identical to the
+//!   C=1 propose it is supposed to be a batched sibling of — today it is not.
+//!
+//! Drafts are proposals: every one is checked by the main model's verify, so
+//! accepted output is unaffected by construction. Only the ACCEPT RATE can
+//! move, and it moves toward the C=1 path.
+
+use crate::layers::ops::DENSE_GEMV_BATCHM_MAX_M;
+
+/// N at or above which the pipelined tile GEMM fills its 128-wide tile well
+/// enough to beat the per-row GEMV loop. Pre-existing threshold, unchanged —
+/// on the 27B drafter it separates {fc 5120, q 12288, o 5120, gate/up 17408,
+/// down 5120} from {k 1024, v 1024}.
+const TILE_N_MIN: u32 = 4096;
+
+/// Which kernel one `gemm_rows` projection dispatches to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RowKernel {
+    /// `dense_gemv_bf16_batchm`: ONE weight pass, M row accumulators.
+    Batchm,
+    /// `dense_gemm_bf16_pipelined`: tensor-core tile GEMM.
+    Pipelined,
+    /// `dense_gemv_bf16`, once per row.
+    GemvLoop,
+}
+
+/// Select the kernel for an `[m, k] x [n, k]^T` drafter projection.
+///
+/// Pure: every input is an explicit argument, including both env levers, so
+/// the whole table is a unit test.
+///
+/// * `batchm_ready` — the `dense_gemv_bf16_batchm` handle resolved
+///   (`try_kernel` misses are a silent 0; older kernel sets fall back).
+/// * `kv_gemv_pinned` — `ATLAS_MTP_KV_GEMV` present: the PRE-EXISTING lever
+///   that pins the small-N (K/V) projections to the per-row GEMV loop. It
+///   keeps that meaning here rather than going inert at m == 8, the one width
+///   where it used to bite and the new tier would otherwise swallow it.
+/// * `small_m_tier_off` — `ATLAS_NO_DRAFTER_SMALL_M_TIER=1`: restores the
+///   pre-tier dispatch exactly, for a same-session A/B control.
+pub(crate) fn drafter_row_kernel(
+    m: usize,
+    n: u32,
+    k: u32,
+    batchm_ready: bool,
+    kv_gemv_pinned: bool,
+    small_m_tier_off: bool,
+) -> RowKernel {
+    let small_n = n < TILE_N_MIN;
+    // `k & 7`: `dense_gemv_bf16_batchm` casts each `A + t*K` and `B + n*K` row
+    // base to `uint4*` (16-byte loads), so a K that is not a multiple of 8
+    // misaligns every row past the first. The whole BF16 GEMV family shares
+    // that assumption ("never hits for model dims"), but the tier must not be
+    // the one that newly reaches an unaligned shape — it stays on the arms
+    // that already served it. Every 27B drafter K (10240, 5120, 6144, 17408)
+    // is a multiple of 8.
+    let k_vec8 = (k & 7) == 0;
+    if batchm_ready
+        && !small_m_tier_off
+        && k_vec8
+        && (2..=DENSE_GEMV_BATCHM_MAX_M as usize).contains(&m)
+        && !(small_n && kv_gemv_pinned)
+    {
+        return RowKernel::Batchm;
+    }
+
+    // ── Pre-tier dispatch, verbatim. Reached at m == 1, at m > MAX_M (the
+    // C=16/32 propose widths, where the tile GEMM measured better anyway),
+    // when the kernel set lacks batchm, and under either kill switch.
+    let small_n_tile = m >= 8 && k_vec8 && !kv_gemv_pinned;
+    if (!small_n || small_n_tile) && k_vec8 {
+        RowKernel::Pipelined
+    } else {
+        RowKernel::GemvLoop
+    }
+}
+
+/// `ATLAS_NO_DRAFTER_SMALL_M_TIER=1` — restore the pre-tier dispatch.
+/// Read once (this is on the per-draft-position path: 8 projections x K
+/// draft positions x every step).
+pub(crate) fn small_m_tier_off() -> bool {
+    static OFF: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OFF.get_or_init(|| {
+        std::env::var("ATLAS_NO_DRAFTER_SMALL_M_TIER")
+            .ok()
+            .as_deref()
+            == Some("1")
+    })
+}
+
+/// `ATLAS_MTP_KV_GEMV` (presence) — pin the small-N K/V projections to the
+/// per-row GEMV loop. Pre-existing lever; hoisted out of the hot path into a
+/// `OnceLock` alongside the new one.
+pub(crate) fn kv_gemv_pinned() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_MTP_KV_GEMV").is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The eight weight-bearing projections of ONE drafter draft position on
+    /// Qwen3.6-27B (h 5120, nq 24, nkv 4, head_dim 256, inter 17408), in
+    /// forward order, as `(label, N, K)`. Their BF16 weight bytes sum to
+    /// 849.4 MB — the "~850 MB per forward" the module header divides by.
+    const DRAFTER_SHAPES: &[(&str, u32, u32)] = &[
+        ("fc", 5120, 10240),
+        ("q_proj", 12288, 5120),
+        ("k_proj", 1024, 5120),
+        ("v_proj", 1024, 5120),
+        ("o_proj", 5120, 6144),
+        ("ffn_gate", 17408, 5120),
+        ("ffn_up", 17408, 5120),
+        ("ffn_down", 5120, 17408),
+    ];
+
+    /// The dispatch as it stood before this tier, transcribed from
+    /// `forward_batch.rs::gemm_rows` at b08802cf1. Independent of the
+    /// production expression on purpose: the kill-switch test below is only
+    /// worth anything if it compares against a SEPARATE statement of the old
+    /// behaviour.
+    fn legacy(m: usize, n: u32, k: u32, kv_gemv_pinned: bool) -> RowKernel {
+        let small_n_tile = m >= 8 && (k & 7) == 0 && !kv_gemv_pinned;
+        if (n >= 4096 || small_n_tile) && (k & 7) == 0 {
+            RowKernel::Pipelined
+        } else {
+            RowKernel::GemvLoop
+        }
+    }
+
+    /// The whole point: at the widths the batched propose actually runs
+    /// (C=2 -> m=2, C=4 -> m=4, C=8 -> m=8), EVERY projection takes the
+    /// batched GEMV — including the two N=1024 K/V ones, which is the
+    /// `small_n_tile = m >= 8` sub-defect subsumed rather than re-tuned.
+    #[test]
+    fn every_projection_batches_across_the_covered_widths() {
+        for m in 2..=DENSE_GEMV_BATCHM_MAX_M as usize {
+            for &(label, n, k) in DRAFTER_SHAPES {
+                assert_eq!(
+                    drafter_row_kernel(m, n, k, true, false, false),
+                    RowKernel::Batchm,
+                    "{label} at m={m} must take the batched GEMV"
+                );
+            }
+        }
+    }
+
+    /// m=1 is unreachable in the batched propose (the scheduler only groups
+    /// `group.len() >= 2`), and m > MAX_M is where the batchm family measured
+    /// NEGATIVE. Both must be byte-for-byte the old dispatch, or the C=1 and
+    /// C=16/32/64/128 ladder rungs move under a change that claims not to
+    /// touch them.
+    #[test]
+    fn widths_outside_the_tier_are_untouched() {
+        let outside = [1usize, 9, 10, 12, 16, 17, 24, 32, 64];
+        for m in outside {
+            for &(label, n, k) in DRAFTER_SHAPES {
+                assert_eq!(
+                    drafter_row_kernel(m, n, k, true, false, false),
+                    legacy(m, n, k, false),
+                    "{label} at m={m} must keep the pre-tier dispatch"
+                );
+            }
+        }
+    }
+
+    /// `ATLAS_NO_DRAFTER_SMALL_M_TIER=1` must reproduce the pre-tier decision
+    /// for EVERY (m, shape, other-lever) combination — that is what makes it
+    /// a valid same-session A/B control for the ladder.
+    #[test]
+    fn kill_switch_restores_the_pre_tier_dispatch_exactly() {
+        for m in 1..=64usize {
+            for &(label, n, k) in DRAFTER_SHAPES {
+                for kv_pin in [false, true] {
+                    assert_eq!(
+                        drafter_row_kernel(m, n, k, true, kv_pin, true),
+                        legacy(m, n, k, kv_pin),
+                        "{label} m={m} kv_pin={kv_pin} under the kill switch"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A 0 handle (kernel absent from this target's set) must behave exactly
+    /// like the kill switch — `try_kernel` misses are silent, so the fallback
+    /// has to be total, not partial.
+    #[test]
+    fn missing_kernel_handle_falls_back_like_the_kill_switch() {
+        for m in 1..=16usize {
+            for &(_, n, k) in DRAFTER_SHAPES {
+                assert_eq!(
+                    drafter_row_kernel(m, n, k, false, false, false),
+                    legacy(m, n, k, false),
+                );
+            }
+        }
+    }
+
+    /// `ATLAS_MTP_KV_GEMV` keeps meaning "small-N K/V on the per-row loop" at
+    /// every width, including m=8 where the new tier would otherwise silently
+    /// swallow it. Large-N projections still batch.
+    #[test]
+    fn kv_gemv_lever_still_pins_small_n_at_every_width() {
+        for m in 2..=DENSE_GEMV_BATCHM_MAX_M as usize {
+            // N=1024 K/V.
+            assert_eq!(
+                drafter_row_kernel(m, 1024, 5120, true, true, false),
+                RowKernel::GemvLoop,
+                "K/V at m={m} under ATLAS_MTP_KV_GEMV"
+            );
+            // N=17408 FFN is not small-N; the lever does not reach it.
+            assert_eq!(
+                drafter_row_kernel(m, 17408, 5120, true, true, false),
+                RowKernel::Batchm,
+                "ffn_gate at m={m} is unaffected by ATLAS_MTP_KV_GEMV"
+            );
+        }
+    }
+
+    /// The tier must never hand `dense_gemv_batchm` an m the kernel clamps:
+    /// `MAX_M` is a compile-time cap that silently truncates, so rows
+    /// `MAX_M..m` would be left as stale bytes.
+    #[test]
+    fn never_selects_batchm_above_the_kernel_row_cap() {
+        for m in 1..=128usize {
+            for &(_, n, k) in DRAFTER_SHAPES {
+                for (batchm, kv_pin, off) in [
+                    (true, false, false),
+                    (true, true, false),
+                    (true, false, true),
+                    (false, false, false),
+                ] {
+                    if drafter_row_kernel(m, n, k, batchm, kv_pin, off) == RowKernel::Batchm {
+                        assert!(
+                            (2..=DENSE_GEMV_BATCHM_MAX_M as usize).contains(&m),
+                            "batchm selected at m={m}, outside 2..={DENSE_GEMV_BATCHM_MAX_M}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// A K that is not a multiple of 8 misaligns the 16-byte row loads of
+    /// BOTH batched kernels, so the tier must leave it exactly where it was —
+    /// on the per-row GEMV loop — rather than becoming the first arm to hand
+    /// an unaligned shape to a vectorized kernel.
+    #[test]
+    fn unaligned_k_stays_on_the_per_row_loop() {
+        for m in [1usize, 2, 4, 8, 16] {
+            for &(_, n, _) in DRAFTER_SHAPES {
+                assert_eq!(
+                    drafter_row_kernel(m, n, 5123, true, false, false),
+                    RowKernel::GemvLoop,
+                    "m={m} n={n} with an unaligned K"
+                );
+                assert_eq!(
+                    drafter_row_kernel(m, n, 5123, true, false, false),
+                    legacy(m, n, 5123, false),
+                    "m={m} n={n}: unaligned K must match the pre-tier dispatch"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The defect

nsys on dgx2 (C=1 vs C=2 decode profile, 27B, MTP K=4 both engines) attributes the drafter at **14.22 ms/step at C=1** and **21.46 ms/step at C=2** — **+7.24 ms of the +51 ms/step** cost of a second sequence, the second-largest term after the main projection GEMV (now fixed). Per draft position:

| M | dispatch today | cost |
|---|---|---|
| 1 | `dense_gemv_bf16` (per-seq propose, `forward.rs`) | **3.57 ms** |
| 2 | `dense_gemm_bf16_pipelined` (batched propose, `forward_batch.rs`) | **5.43 ms** |

One draft position streams **~849 MB** of BF16 drafter weights (fc 104.9 + q 125.8 + k/v 2×10.5 + o 62.9 + gate/up/down 3×178.3 MB), so M=1 at 3.57 ms is **238 GB/s** — essentially the GB10 roofline (273 GB/s LPDDR5X). M=2 at 5.43 ms is **156 GB/s**: **1.52x for two rows** on a path where the weights are read once and the second row should be nearly free.

The kernel that does exactly that already exists and was simply never wired into the drafter: **`dense_gemv_bf16_batchm`** (one weight pass, M row accumulators), dispatched at `impl_a1.rs:134` and used by the main model over `(2..=8)` at three sites since 84d5b763c. Same shape of fix as the main-model one — a batched-GEMV tier exists and the small-M path is not using it.

## What I found at each dispatch site

`crates/spark-model/src/layers/mtp_head/forward_batch.rs::gemm_rows` is the **single** M-dispatch for the batched propose; all eight weight-bearing projections of a draft position go through it. On Qwen3.6-27B (h 5120, nq 24, nkv 4, head_dim 256, inter 17408):

| projection | N | K | pre-tier arm at m=2..7 | at m=8 |
|---|---|---|---|---|
| fc | 5120 | 10240 | pipelined GEMM | pipelined GEMM |
| q_proj (gated `[Q\|gate]`) | 12288 | 5120 | pipelined GEMM | pipelined GEMM |
| **k_proj / v_proj** | **1024** | 5120 | **per-row GEMV loop** | pipelined GEMM |
| o_proj | 5120 | 6144 | pipelined GEMM | pipelined GEMM |
| ffn gate / up | 17408 | 5120 | pipelined GEMM | pipelined GEMM |
| ffn down | 5120 | 17408 | pipelined GEMM | pipelined GEMM |

M is the propose group width, from `verify_k4_batch_step.rs` (`pending.chunks(group_cap)`, `group.len() >= 2`), so **C=2 → m=2, C=4 → m=4, C=8 → m=8** — squarely the band this targets. `m == 1` is unreachable here (the scheduler never groups a single sequence); C=1 runs `forward_one`, whose eight projections all go through `ops::dense_gemv`.

Inputs at every call site are contiguous `[m, k]` and outputs contiguous `[m, n]`, so `out_stride == n` — the batchm wrapper's exact contract.

## What changed

- **New `layers::mtp_head::row_dispatch`**: the M→kernel decision as a **pure function** of `(m, n, k, handle_present, kv_gemv_pinned, small_m_tier_off)`, plus the two lever reads hoisted into `OnceLock`s (the old dispatch called `env::var_os` per projection per draft position — 32 reads/step at K=4). `gemm_rows` matches on it; the pipelined-GEMM and per-row-GEMV arms are unchanged.
- **`MtpHead` carries `dense_gemv_batchm_k`**, resolved with `try_kernel`. A 0-handle (target set predates the kernel) falls back to today's dispatch **in full**, and the propose's once-per-`n` "active" log now names the arm actually taken (`proj=GEMV-BATCHM|PIPELINED-GEMM|GEMV-LOOP`) so a fallback cannot hide behind a green line.

### Where the crossover comes from

Not invented here. `dense_gemv_bf16_batchm` has a compile-time `MAX_M 8` and **clamps silently** above it, so 8 is a hard ceiling, not a tuning choice; the floor is 2 because M=1 has its own kernel and is unreachable on this path. The repo has **no drafter-specific microbench for these BF16 shapes** (`batchm_bench` is the w4a16 family), so the band is **mirrored from the main-model tiering** and recorded as such. The evidence behind that tiering, from the kernel's own gating microbench (250931e97, real decode shapes, K=3072, one batchm launch vs M separate M=1 launches):

| shape | M | N | M× M=1 | batchm | speedup |
|---|---|---|---|---|---|
| q_proj | 2 | 9216 | 0.4130 ms | 0.2059 ms | **2.01x** |
| q_proj | 4 | 9216 | 0.8398 ms | 0.2122 ms | **3.96x** |
| o_proj | 4 | 3072 | 0.0449 ms | 0.0199 ms | 2.26x |
| k/v | 4 | 1024 | 0.0208 ms | 0.0115 ms | 1.81x |

The load-bearing number is `q_proj`: batchm at M=4 costs **0.2122 ms against 0.2100 ms for a single M=1 launch — +1% for 4x the rows**. batchm's cost is flat in M, so on the drafter it should land at the M=1 3.57 ms rather than the pipelined GEMM's 5.1–5.4 ms, at every M it covers. Wired into the main model it measured **+6% at C=2 and +24% at C=4** (84d5b763c). Above M=8 the batched-GEMV family measured **NEGATIVE** against the tile GEMM (−14.4% at C=16, −29.4% at C=32, 78d276832) — which is why this stops at 8 rather than growing a wider kernel, and why the C=16/32/64/128 rungs are untouched by construction.

### The `small_n_tile = m >= 8` threshold — checked, not assumed, and left alone

`m >= 8` picks **correctly between the two arms it chooses among**: at m=16 the per-row loop is ~16 × 44 µs against the same ~200 µs under-filled tile, which is exactly what put it there, and at m=4 the tile (~194 µs) is already only a tie against 4 × 44 µs. It was the wrong *answer* for m in 2..=8 only because a **third, strictly better arm existed and was not in the choice set** — batchm beats both (1.81x over the loop at N=1024 measured above; far under the tile). So this is the same class of *defect* as the main dispatch, but **not** a mis-tuned constant.

Therefore: the constant **stays at 8**, the new tier preempts it for m ≤ 8 (subsuming the ~+0.58 ms/step K/V term), and the kill switch restores today's behaviour byte for byte. `ATLAS_MTP_KV_GEMV` keeps its existing meaning at every width, including m == 8 where the new tier would otherwise have made it silently inert.

## Numerics — NOT bit-exact vs today; bit-exact vs the C=1 propose

`dense_gemv_bf16_batchm` is **bit-identical to M separate `dense_gemv_bf16` calls** (same per-row K-iteration order and reduction tree; the kernel dir builds with `--fmad=false`), verified across every shape/M combination of `examples/dense_gemv_bf16_batchm_microtest`. So:

- vs the **per-row GEMV loop** it replaces (small N, m in 2..=7): **bit-exact**.
- vs the **pipelined tile GEMM** it replaces (N ≥ 4096, and small N at m == 8): **NOT bit-exact** — a tensor-core tile GEMM accumulates in a different order. Drafter logits move in the last bits.
- vs the **single-sequence propose** (`forward_one`, which runs `ops::dense_gemv` for all eight projections): **bit-exact**, at every M this tier covers.

So the batched propose becomes numerically **identical to the C=1 propose it is a batched sibling of** — today it is not. Drafts are proposals: every one is checked by the main model's verify, so **accepted output is unaffected by construction**. Only the **accept rate** can move, and it moves toward the C=1 path. **BFCL, with its draw metadata, is the gate that must confirm it** (see the validation plan).

## Kill switch

`ATLAS_NO_DRAFTER_SMALL_M_TIER=1` restores the pre-tier dispatch exactly, at every `(m, shape, other-lever)` combination — pinned by a unit test that compares against a **separately written** transcription of the old logic, which is what makes it a valid same-session A/B control.

## Tests

- **7 unit tests** pin the decision table as a pure function: every projection batches across 2..=8; `m == 1` and `m > 8` are byte-for-byte the pre-tier dispatch; the kill switch reproduces the independently-transcribed old logic for every combination; a 0 handle behaves exactly like the kill switch; batchm is never selected outside the kernel's row cap (it clamps silently, which would leave rows as stale bytes); an unaligned K never reaches either vectorized kernel.
- **`examples/bf16_batch_bitparity_microtest` extended**: gains a `batchm` leg and the six distinct 27B drafter shapes. That harness previously graded only the pipelined GEMM and was *expected to FAIL*, with a header calling for "a bit-exact batched BF16 GEMV" as an unbuilt kernel port — it was already in `kernels/gb10/common/`, just not wired into every caller. The **batchm leg is now the graded one** (and what the negative control fires against); the pipelined leg's known non-parity is **reported, not graded**.
- Every existing drafter test stays green.

## Expected per-rung effect

Modelling the eight projections at the M=1 roofline (batchm ≈ M=1 cost + ~1%, per the q_proj measurement) against the measured pipelined per-draft-position cost:

| C | m | drafter now | drafter expected | Δ/step | rung | need | confidence |
|---|---|---|---|---|---|---|---|
| 1 | — | 14.22 ms | 14.22 ms (untouched) | 0 | 23.09 floor | — | high — path not entered |
| **2** | 2 | 21.46 ms | ~14.5 ms | **−7.0 ms** | 38.95 (won) | — | med-high |
| **4** | 4 | ~21 ms | ~14.6 ms | **−6.4 ms** | **69.73 vs 71.61, −2.6%** | **+1.88 tok/s** | **medium** |
| **8** | 8 | ~21 ms | ~15 ms | **−6 ms** | **123.26 vs 124.48, −1.0%** | **+1.22 tok/s** | **medium** |
| 16/32/64/128 | 16..32 | unchanged | unchanged | 0 | all won | — | high — `m > MAX_M`, no arm change |

Honest uncertainty: the per-draft-position saving is a **projection-level** number, and its translation into step tok/s depends on what fraction of the step the drafter is at C=4/C=8 — measured only at C=1/C=2. At C=2 the drafter was 21.46 of a step whose C=1 sibling was ~51 ms larger, so ~7 ms off a step is a **double-digit-percent** step cut; the two open rungs need 2.6% and 1.0%. That is why I rate C=4/C=8 medium rather than high: the direction and the mechanism are measured, the magnitude at those widths is extrapolated. **No rung is claimed won until the ladder legs below run.**

## Validation plan (CPU-only work; nothing measured here)

1. **Concurrency ladder C=2 / C=4 / C=8**, same box/harness/config as round 8 (matched fp8 KV, ctx 2048, MTP K=4 both engines), with a **same-session `ATLAS_NO_DRAFTER_SMALL_M_TIER=1` control leg** — A/B in one process, not against a remembered number. Floors that must not regress: C=1 23.09, C=2 38.95, C=4 69.73, C=8 123.26, C=16 203.14, C=32 291.42, C=64 387.14, C=128 477.79. Confirm the once-per-n log reads `proj=GEMV-BATCHM` at n=2/4/8 and `PIPELINED-GEMM` at n=16/32 — a 0-handle fallback would otherwise pass silently as "no change".
2. **ssm-state-poisoning-gate** — the propose writes drafter KV per row; the arm change must not perturb rollback.
3. **decode-floor**.
4. **BFCL, with its draw metadata** (`category_sample_pct` + N + the ordered-`sample_id` SHA256 recorded beside the score) — **required**, because this change is not bit-exact against today's dispatch and acceptance rate feeds directly into it. Compare like-for-like on a shared draw; a BFCL number without its draw is not comparable.
5. `examples/bf16_batch_bitparity_microtest` on the GPU box: the graded batchm leg must be byte-identical at every shape and every M in 2..=8, and the negative control must fire.

## Gates (verbatim)

```
ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000

cargo fmt --all -- --check                                   rc=0
cargo clippy --workspace --tests                              rc=0
cargo clippy -p spark-model --features cuda,gpu-examples \
  --example bf16_batch_bitparity_microtest                    rc=0
bash scripts/check-license-headers.sh
  INFO Totally checked 2255 files, valid: 2241, invalid: 0, ignored: 14, fixed: 0
typos crates/spark-model                                      rc=0
  (the 2 workspace hits are pre-existing in
   spark-server/src/scheduler/preempt.rs:150 and preempt_tests.rs:313 —
   files this PR does not touch)
cargo test --workspace                       5198 passed / 0 failed
cargo test -p spark-model --lib row_dispatch    7 passed / 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
