### PR TITLE
ci(cla): allowlist the governance harvester App

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -53,7 +53,7 @@ jobs:
       # SSOT for the allowlist: both the pinned action's `allowlist` input
       # below and the merge-queue mirror step read this one value. Keep it
       # here, nowhere else.
-      CLA_ALLOWLIST: dependabot[bot],renovate[bot],google-labs-jules[bot],claude[bot],google-labs-jules,claude,AzeezIsh,tbraun96,cursoragent
+      CLA_ALLOWLIST: dependabot[bot],renovate[bot],google-labs-jules[bot],claude[bot],atlas-governance-harvester[bot],google-labs-jules,claude,AzeezIsh,tbraun96,cursoragent
     # Scoped to what contributor-assistant actually calls (verified against the
     # action source at the pinned sha):
     #   contents      — git refs/commits that persist signatures/version1/cla.json


### PR DESCRIPTION
#568 is the first PR the harvester App authored itself (which is the point of #567 — it makes the required checks report). CLA Assistant fails it because the bot identity is not on the allowlist.

A bot cannot sign a CLA, and the commits it pushes are authored by `tbraun96`, who has. This adds `atlas-governance-harvester[bot]` alongside the other bot identities already allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)