### PR TITLE
fix(ci): stop the harvest from churning its own PR

### DIFF
--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -317,6 +317,19 @@ jobs:
             exit 0
           fi
 
+          # Nothing to do if the rolling branch already carries exactly this
+          # tree. The commit is rebuilt from scratch every run, so its sha
+          # differs even when the ledger does not; force-pushing that churn
+          # restarts the open PR's checks, and on a busy repo the restarts
+          # outrun the checks and the PR never converges.
+          if git fetch --quiet origin bot/governance-harvest 2>/dev/null; then
+            if [ "$(git rev-parse HEAD^{tree})" = "$(git rev-parse FETCH_HEAD^{tree})" ]; then
+              echo "rolling branch already carries this exact ledger — leaving it and its in-flight checks alone"
+              emit_landed unchanged
+              exit 0
+            fi
+          fi
+
           # One lane, two authors. The rolling branch is force-recreated as
           # main + this one harvest commit (stale never-merged content is
           # discarded; the cron sweep re-converges anything it carried).


### PR DESCRIPTION
**Observed on #568**: its head moved twice within two minutes, restarting every check.

The harvest runs on `workflow_run` (one per CI completion) and rebuilds its commit from scratch each time, so the sha differs even when the ledger content is byte-identical. Each run force-pushed the rolling branch, restarting the open PR's checks — and on a busy repo the restarts outrun the checks, so the PR can never converge and the loop never closes.

Fix: compare the new tree against the branch's current tree and skip the push entirely when nothing changed, leaving in-flight checks alone. The harvest stays prompt (still triggered per CI completion) but is now idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)