### PR TITLE
fix(ci): let an open harvest PR converge

### DIFF
--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -317,6 +317,19 @@ jobs:
             exit 0
           fi
 
+          # Leave an open harvest PR alone. New ledger lines arrive whenever
+          # any PR is categorised, which on a busy day is faster than CI can
+          # finish; pushing each one restarts the open PR's checks and it never
+          # converges. Lines are never lost — the artifacts stay downloadable
+          # and the next harvest, after this PR merges, sweeps them all up.
+          open_pr=$(gh pr list --head bot/governance-harvest --base main --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$open_pr" ]; then
+            echo "harvest PR #$open_pr is still open — leaving it to converge; its successor will carry anything new"
+            emit_landed "waiting on #$open_pr"
+            exit 0
+          fi
+
           # Nothing to do if the rolling branch already carries exactly this
           # tree. The commit is rebuilt from scratch every run, so its sha
           # differs even when the ledger does not; force-pushing that churn


### PR DESCRIPTION
**Observed on #573**: its head was reset twice inside an hour, each time by *legitimately* new content (`pr-572.jsonl` arriving from another PR's categorisation). #571 stopped identical-tree churn, but this is the other half of the problem — real new lines arrive faster than CI finishes (~30 min), so the PR restarts its checks forever and can never merge.

Fix: while a harvest PR is open, leave it alone. Nothing is lost — the run artifacts stay downloadable and the next harvest, after that PR merges, sweeps up everything that arrived meanwhile. The daily cron is the backstop if a PR ever stalls.

With #571 this makes the loop provably convergent: one PR at a time, no self-inflicted restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)