### PR TITLE
fix(server): honor min_tokens on legacy completions

### DIFF
--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -273,6 +273,71 @@ pub async fn completions(
     super::completions_exec::run_blocking(state, &req, prompts, params).await
 }
 
+/// Build the streaming `InferenceRequest` for the legacy completions path.
+///
+/// Extracted from `completions_stream` so the `min_tokens` passthrough is
+/// unit-testable; behavior identical to the original inline construction.
+fn build_streaming_request(
+    req: &CompletionRequest,
+    p: super::completions_exec::CompletionParams,
+    prompt_tokens: std::sync::Arc<Vec<u32>>,
+    session_hash: u64,
+    timeout_at: Option<std::time::Instant>,
+    token_tx: tokio::sync::mpsc::Sender<StreamEvent>,
+) -> InferenceRequest {
+    let echo = req.echo;
+    let logprobs_k = p.logprobs_k;
+    InferenceRequest::Streaming {
+        prompt_tokens,
+        session_hash,
+        adapter_slot: p.adapter_slot,
+        src_lang_id: p.src_lang_id,
+        tgt_lang_id: p.tgt_lang_id,
+        num_beams: p.num_beams,
+        length_penalty: p.length_penalty,
+        early_stopping: p.early_stopping,
+        image_pixels: Vec::new(),
+        max_tokens: req.max_tokens,
+        min_tokens: req.min_tokens,
+        temperature: p.temperature,
+        top_k: p.top_k,
+        top_p: p.top_p,
+        top_n_sigma: p.top_n_sigma,
+        min_p: p.min_p,
+        repetition_penalty: p.repetition_penalty,
+        presence_penalty: p.presence_penalty,
+        frequency_penalty: p.frequency_penalty,
+        // Legacy /v1/completions path doesn't have tool semantics.
+        dry_multiplier: 0.0,
+        dry_base: 1.75,
+        dry_allowed_length: 2,
+        lz_penalty: 0.0,
+        logit_bias: p.logit_bias,
+        stop_tokens: p.stop_tokens,
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: p.repetition_detection,
+        require_tool_call: false,
+        // Completions API defines no tools — multi-tool-call continuation off.
+        tools_present: false,
+        suppress_tool_call: false,
+        disable_mtp: false,
+        grammar_spec: None,
+        seed: req.seed,
+        top_logprobs: logprobs_k,
+        prompt_logprobs: if echo { logprobs_k } else { None },
+        echo,
+        // Was hard-coded `None`: streaming /v1/completions was the one
+        // surface with NO deadline while every other surface had 300 s.
+        timeout_at,
+        token_tx,
+        // /v1/completions has no guard pipeline yet — the flag is
+        // created so the scheduler's emit_step type-checks cleanly,
+        // but never flipped.
+        cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
 /// SSE streaming path for legacy completions (single prompt, n=1, handler-
 /// guarded). Echo: prompt text (+ logprobs when set) is the FIRST chunk; with
 /// `stream_options.include_usage` a `choices: []` usage chunk precedes `[DONE]`.
@@ -304,55 +369,14 @@ pub(super) async fn completions_stream(
     };
 
     let session_hash = crate::session_manager::compute_session_hash(&prompt_tokens);
-    let request = InferenceRequest::Streaming {
-        prompt_tokens: std::sync::Arc::new(prompt_tokens),
+    let request = build_streaming_request(
+        &req,
+        p,
+        std::sync::Arc::new(prompt_tokens),
         session_hash,
-        adapter_slot: p.adapter_slot,
-        src_lang_id: p.src_lang_id,
-        tgt_lang_id: p.tgt_lang_id,
-        num_beams: p.num_beams,
-        length_penalty: p.length_penalty,
-        early_stopping: p.early_stopping,
-        image_pixels: Vec::new(),
-        max_tokens: req.max_tokens,
-        min_tokens: 0,
-        temperature: p.temperature,
-        top_k: p.top_k,
-        top_p: p.top_p,
-        top_n_sigma: p.top_n_sigma,
-        min_p: p.min_p,
-        repetition_penalty: p.repetition_penalty,
-        presence_penalty: p.presence_penalty,
-        frequency_penalty: p.frequency_penalty,
-        // Legacy /v1/completions path doesn't have tool semantics.
-        dry_multiplier: 0.0,
-        dry_base: 1.75,
-        dry_allowed_length: 2,
-        lz_penalty: 0.0,
-        logit_bias: p.logit_bias,
-        stop_tokens: p.stop_tokens,
-        enable_thinking: false,
-        thinking_budget: None,
-        repetition_detection: p.repetition_detection,
-        require_tool_call: false,
-        // Completions API defines no tools — multi-tool-call continuation off.
-        tools_present: false,
-        suppress_tool_call: false,
-        disable_mtp: false,
-        grammar_spec: None,
-        seed: req.seed,
-        top_logprobs: logprobs_k,
-        prompt_logprobs: if echo { logprobs_k } else { None },
-        echo,
-        // Was hard-coded `None`: streaming /v1/completions was the one
-        // surface with NO deadline while every other surface had 300 s.
-        timeout_at: state.request_deadline(None),
+        state.request_deadline(None),
         token_tx,
-        // /v1/completions has no guard pipeline yet — the flag is
-        // created so the scheduler's emit_step type-checks cleanly,
-        // but never flipped.
-        cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-    };
+    );
 
     state.request_tx.send(request).await.map_err(|_| {
         (
@@ -500,4 +524,48 @@ pub(super) async fn completions_stream(
 /// as "wrong URL".
 pub(super) fn not_supported(message: &'static str) -> Response {
     openai_error_response(StatusCode::NOT_IMPLEMENTED, message.into())
+}
+
+#[cfg(test)]
+mod min_tokens_wiring_tests {
+    use super::*;
+
+    #[test]
+    fn streaming_path_wires_min_tokens() {
+        let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+            "min_tokens": 2048,
+        }))
+        .unwrap();
+        let (token_tx, _token_rx) = tokio::sync::mpsc::channel::<StreamEvent>(16);
+        let request = build_streaming_request(
+            &req,
+            crate::api::completions_exec::CompletionParams::test(),
+            std::sync::Arc::new(vec![1, 2, 3]),
+            42,
+            None,
+            token_tx,
+        );
+        assert_eq!(request.min_tokens(), 2048);
+    }
+
+    #[test]
+    fn streaming_path_defaults_min_tokens_to_zero() {
+        let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+        }))
+        .unwrap();
+        let (token_tx, _token_rx) = tokio::sync::mpsc::channel::<StreamEvent>(16);
+        let request = build_streaming_request(
+            &req,
+            crate::api::completions_exec::CompletionParams::test(),
+            std::sync::Arc::new(vec![1]),
+            42,
+            None,
+            token_tx,
+        );
+        assert_eq!(request.min_tokens(), 0);
+    }
 }

--- a/crates/spark-server/src/api/completions_exec.rs
+++ b/crates/spark-server/src/api/completions_exec.rs
@@ -86,7 +86,7 @@ pub(super) async fn run_blocking(
                 early_stopping: p.early_stopping,
                 image_pixels: Vec::new(),
                 max_tokens: req.max_tokens,
-                min_tokens: 0,
+                min_tokens: req.min_tokens,
                 temperature: p.temperature,
                 top_k: p.top_k,
                 top_p: p.top_p,
@@ -223,4 +223,30 @@ pub(super) async fn run_blocking(
         usage,
     ))
     .into_response()
+}
+
+#[cfg(test)]
+impl CompletionParams {
+    pub(super) fn test() -> Self {
+        Self {
+            temperature: 1.0,
+            top_k: 20,
+            top_p: 0.95,
+            top_n_sigma: 0.0,
+            min_p: 0.0,
+            repetition_penalty: 1.0,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
+            logit_bias: Vec::new(),
+            stop_tokens: Vec::new(),
+            repetition_detection: None,
+            logprobs_k: None,
+            adapter_slot: -1,
+            src_lang_id: 0,
+            tgt_lang_id: 0,
+            num_beams: 1,
+            length_penalty: 1.0,
+            early_stopping: false,
+        }
+    }
 }

--- a/crates/spark-server/src/openai/completions.rs
+++ b/crates/spark-server/src/openai/completions.rs
@@ -43,6 +43,12 @@ pub struct CompletionRequest {
     pub prompt: PromptInput,
     #[serde(default = "default_max_tokens")]
     pub max_tokens: usize,
+    /// Minimum number of tokens to generate before allowing EOS/stop.
+    /// 0 = no minimum (default). Mirrors the chat endpoint; without this,
+    /// a model-sampled EOS token ends the response early even when the
+    /// caller asked for a longer completion.
+    #[serde(default)]
+    pub min_tokens: usize,
     pub temperature: Option<f32>,
     /// Top-k: keep only the k highest-probability tokens before sampling.
     pub top_k: Option<u32>,
@@ -346,4 +352,40 @@ pub struct TokenizeRequest {
 pub struct TokenizeResponse {
     pub tokens: Vec<u32>,
     pub count: usize,
+}
+
+#[cfg(test)]
+mod min_tokens_tests {
+    use super::*;
+
+    fn req_with(json: serde_json::Value) -> CompletionRequest {
+        serde_json::from_value(json).expect("valid CompletionRequest JSON")
+    }
+
+    #[test]
+    fn min_tokens_defaults_to_zero() {
+        // Absent field → 0 (no minimum), preserving legacy behavior.
+        let req = req_with(serde_json::json!({ "model": "m", "prompt": "hi" }));
+        assert_eq!(req.min_tokens, 0);
+    }
+
+    #[test]
+    fn min_tokens_explicit_deserialization() {
+        let req = req_with(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+            "min_tokens": 2048
+        }));
+        assert_eq!(req.min_tokens, 2048);
+    }
+
+    #[test]
+    fn min_tokens_zero_is_valid_explicit_value() {
+        let req = req_with(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+            "min_tokens": 0
+        }));
+        assert_eq!(req.min_tokens, 0);
+    }
 }

--- a/crates/spark-server/src/scheduler/decode_logits_step.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_step.rs
@@ -39,6 +39,7 @@ fn logits_ctx<'a>(
         think_start_token,
         tool_call_start_token,
         tool_call_end_token,
+        verify_pos: 0,
         watchdog: sched.watchdog,
         scratch,
         dumps: &sched.dumps,
@@ -165,7 +166,10 @@ pub fn process_decode_logits(
         let excused = admit_think_ended && think_ended_gpu_ok(a);
         (a.inside_thinking || a.think_ended || a.grammar_state.is_some()) && !excused
     }) || any_logprobs
-        || model_logits_fp32;
+        || model_logits_fp32
+        // GPU argmax bypasses the pre-sampling EOS mask. Keep requests with
+        // an active minimum-token floor on the host pipeline.
+        || active.iter().any(|a| a.min_tokens > a.output_tokens.len());
 
     // Try the GPU argmax first. `None` here means "not eligible, or the result
     // needs the host pipeline after all" and falls through to the host branch —
@@ -276,6 +280,7 @@ pub fn process_decode_logits(
                             think_start_token,
                             tool_call_start_token,
                             tool_call_end_token,
+                            verify_pos: 0,
                             watchdog,
                             scratch,
                             dumps,

--- a/crates/spark-server/src/scheduler/logit_processors/forced_token.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/forced_token.rs
@@ -37,7 +37,17 @@ impl LogitsProcessor for ForcedTokenFastPath {
             && let Some(ref mut gs) = a.grammar_state
             && let Some(forced) = gs.forced_token()
         {
-            return ProcessorOutcome::EmitToken(forced as u32);
+            let forced = forced as u32;
+            // `min_tokens` guard: the fast path bypasses sampling, so a
+            // grammar-forced EOS would otherwise surface before the request
+            // reached its minimum token count even though the normal path
+            // masks EOS logits. Fall through to the standard pipeline (where
+            // the mask applies) instead of emitting the EOS early.
+            let effective_len = a.output_tokens.len().saturating_add(ctx.verify_pos);
+            if effective_len < a.min_tokens && a.eos_tokens.contains(&forced) {
+                return ProcessorOutcome::Continue;
+            }
+            return ProcessorOutcome::EmitToken(forced);
         }
         ProcessorOutcome::Continue
     }

--- a/crates/spark-server/src/scheduler/logit_processors/min_tokens_eos.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/min_tokens_eos.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pre-sampling EOS mask for the request `min_tokens` floor.
+
+use super::{LogitsContext, LogitsProcessor, ProcessorOutcome};
+use crate::scheduler::ActiveSeq;
+
+/// Mask EOS ids while the effective output length is below `min_tokens`.
+pub fn mask_eos_before_min(
+    logits: &mut [f32],
+    eos_tokens: &[u32],
+    effective_len: usize,
+    min_tokens: usize,
+) {
+    if min_tokens > 0 && effective_len < min_tokens {
+        for &eos in eos_tokens {
+            if let Some(slot) = logits.get_mut(eos as usize) {
+                *slot = f32::NEG_INFINITY;
+            }
+        }
+    }
+}
+
+/// Pipeline stage applying the mask to final decode and MTP verify positions.
+pub struct MinTokensEosMask;
+
+impl LogitsProcessor for MinTokensEosMask {
+    fn apply(
+        &self,
+        logits: &mut [f32],
+        seq: &mut ActiveSeq,
+        ctx: &LogitsContext,
+    ) -> ProcessorOutcome {
+        let effective_len = seq.output_tokens.len().saturating_add(ctx.verify_pos);
+        mask_eos_before_min(logits, &seq.eos_tokens, effective_len, seq.min_tokens);
+        ProcessorOutcome::Continue
+    }
+
+    fn name(&self) -> &'static str {
+        "min_tokens_eos_mask"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mask_eos_before_min;
+
+    #[test]
+    fn masks_only_before_boundary() {
+        let mut logits = [0.5, 1.0, 2.0];
+        mask_eos_before_min(&mut logits, &[1], 0, 5);
+        assert_eq!(logits[1], f32::NEG_INFINITY);
+        let mut at_boundary = [0.5, 1.0, 2.0];
+        mask_eos_before_min(&mut at_boundary, &[1], 5, 5);
+        assert_eq!(at_boundary[1], 1.0);
+    }
+
+    #[test]
+    fn zero_min_is_noop_and_oov_is_safe() {
+        let mut logits = [0.5, 1.0];
+        mask_eos_before_min(&mut logits, &[99_999], 0, 0);
+        assert_eq!(logits, [0.5, 1.0]);
+    }
+}

--- a/crates/spark-server/src/scheduler/logit_processors/mod.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/mod.rs
@@ -48,6 +48,7 @@ pub mod forced_think_end;
 pub mod forced_token;
 pub mod grammar_bitmask;
 pub mod mid_word;
+pub mod min_tokens_eos;
 pub mod pin_tool_call;
 pub mod post_close;
 pub mod tool_during_think;
@@ -71,6 +72,8 @@ pub struct LogitsContext<'a> {
     pub think_start_token: Option<u32>,
     pub tool_call_start_token: Option<u32>,
     pub tool_call_end_token: Option<u32>,
+    /// Verify-position offset used by position-aware request masks.
+    pub verify_pos: usize,
     /// `mask[id]` iff token `id` decodes to text ending in a generation
     /// boundary. Vocab-sized and INDEXED BY TOKEN ID, so it is meaningless
     /// against a different tokenizer — carried beside the token ids it belongs
@@ -188,7 +191,8 @@ pub fn run_pipeline_with_path(
     ctx: &LogitsContext,
     path: &'static str,
 ) -> Option<u32> {
-    let stages: [&dyn LogitsProcessor; 8] = [
+    let stages: [&dyn LogitsProcessor; 9] = [
+        &min_tokens_eos::MinTokensEosMask,
         &f2_confidence::F2ConfidenceEarlyStop,
         &mid_word::MidWordThinkEndMask,
         &post_close::PostCloseThinkMask,

--- a/crates/spark-server/src/scheduler/logit_processors/pipeline_tests.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/pipeline_tests.rs
@@ -159,6 +159,7 @@ fn logits_context_field_set_is_stable() {
         think_start_token: Some(2),
         tool_call_start_token: Some(3),
         tool_call_end_token: Some(4),
+        verify_pos: 0,
     };
     // Clone semantics — the context now carries the vocab-indexed sched, which
     // are `Arc`s, so it is Clone rather than Copy. Pipeline stages still take

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -685,6 +685,7 @@ pub fn run(
                 think_start_token,
                 tool_call_start_token,
                 tool_call_end_token,
+                verify_pos: 0,
                 boundary_mask: sched.masks.boundary.clone(),
                 mid_word_mask: sched.masks.mid_word.clone(),
                 sampling: sched.levers.sampling(),

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
@@ -151,10 +151,17 @@ pub fn verify_pick_with_pipeline(
     //    advance the grammar matcher; the K-loop in
     //    `verify_pick_all_with_pipeline` owns `accept_token` / `rollback`.
     let t_proc = std::time::Instant::now();
+    // Per-position context: carry the verify index so the min-tokens EOS
+    // mask counts this position's tokens (`output_tokens.len() + verify_pos`)
+    // toward the `min_tokens` floor before it commits.
+    let pos_ctx = LogitsContext {
+        verify_pos,
+        ..ctx.clone()
+    };
     if let Some(tok) = crate::scheduler::logit_processors::process_position_logits(
         &mut f32_logits,
         a,
-        ctx,
+        &pos_ctx,
         &penalties,
         crate::scheduler::sample_step::PositionKind::Verify,
     ) {


### PR DESCRIPTION
## Summary

Adds `min_tokens` support to the legacy completions endpoint and carries it through blocking, streaming, decode, and speculative verification paths. EOS is masked until the requested floor, forced-token handling cannot emit EOS early, and GPU argmax falls back to the host logits pipeline when the floor requires masking.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p spark-server --tests -- -D warnings`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo check -p spark-server --tests`
- [x] `cargo test -p spark-server --bin spark min_tokens` — 8 passed
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo build --release -p spark-server`
- [x] `python3 scripts/check_spdx.py`

## Notes for reviewers

The public change is limited to the existing legacy completions request schema. Existing requests that omit `min_tokens` retain current behavior.

## CLA

- [ ] I have read and agree to the Contributor License Agreement.