### PR TITLE
fix(dez): clear the open npm advisories

### DIFF
--- a/dez/package-lock.json
+++ b/dez/package-lock.json
@@ -20,6 +20,10 @@
       },
       "engines": {
         "node": ">=20.19"
+      },
+      "overrides": {
+        "cookie": "^0.7.0",
+        "nanoid": "^3.3.18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1118,9 +1122,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1543,9 +1547,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/dez/package.json
+++ b/dez/package.json
@@ -24,5 +24,9 @@
     "svelte-check": "^4.4.3",
     "typescript": "^5.9.3",
     "vite": "^8.2.1"
+  },
+  "overrides": {
+    "cookie": "^0.7.0",
+    "nanoid": "^3.3.18"
   }
 }


### PR DESCRIPTION
Two advisories in `dez/`:

- **cookie 0.6.0** — accepts out-of-bounds characters in name, path and domain (the open Dependabot alert)
- **nanoid 3.3.17** — custom generators loop indefinitely at size zero. **This one never reached the Security tab**; it only surfaced once cookie was fixed and `npm audit` could see past it.

Both need overrides rather than a plain update: SvelteKit 2.70.2, the current release, still requires `cookie ^0.6.0` and the fix landed in 0.7.0. `npm audit` now reports **zero vulnerabilities** for dez.

The lockfile is edited in place rather than regenerated — the local npm writes a different dialect, and a full rewrite stripped `"libc": ["glibc"]` platform metadata that has nothing to do with either advisory.

**h2 needs nothing**: main already carries 0.4.16, so RUSTSEC-2026-0258 is resolved upstream and `cargo deny` is no longer blocking the repo. **lru** is left to Dependabot #557, which resolves it to 0.18.2 via the ratatui bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)