### PR TITLE
fix(ci): treat a conflicting harvest PR as stuck, not healthy

### DIFF
--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -369,7 +369,16 @@ jobs:
               emit_landed "waiting on #$open_pr"
               exit 0
             fi
-            if [ "${broken:-0}" -eq 0 ] && [ "$pr_state" != "BEHIND" ]; then
+            # BEHIND means main moved; DIRTY means the branch now conflicts
+            # with it. Both are terminal for the PR — no amount of waiting
+            # clears either, and a rebuild resolves both by construction, since
+            # the branch is recreated as main plus a fresh ledger. #593 sat
+            # DIRTY while this said "idle and healthy" and walked away.
+            case "$pr_state" in
+              BEHIND | DIRTY) stuck=1 ;;
+              *) stuck="" ;;
+            esac
+            if [ "${broken:-0}" -eq 0 ] && [ -z "$stuck" ]; then
               echo "harvest PR #$open_pr is idle and healthy — leaving it alone"
               emit_landed "waiting on #$open_pr"
               exit 0


### PR DESCRIPTION
Caught in production. #585 taught the harvest to repair a stuck PR, but it only recognised `BEHIND`. After the five merges today, **#593 went `DIRTY`** — conflicting with main — and the triage logged:

```
harvest PR #593 is idle and healthy — leaving it alone
```

It is neither. `BEHIND` means main moved; `DIRTY` means the branch now conflicts with it. Neither clears by waiting, and a rebuild resolves both by construction, since the branch is recreated as main plus a freshly derived ledger.

**#593 is deliberately left open as the test case**: once this merges, the next harvest should rebuild it automatically instead of walking away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)