### PR TITLE
test(ci): put the harvest triage decision behind a table

### DIFF
--- a/.github/scripts/harvest-triage-test.sh
+++ b/.github/scripts/harvest-triage-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Table-driven test for harvest-triage.sh. Every row is a state the harvest
+# has actually been in, or one it will be in eventually; the comment names the
+# incident where that row was learned the hard way.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+triage="$here/harvest-triage.sh"
+fails=0
+
+check() {  # expected, state, in_flight, broken, why
+  local expected="$1" state="$2" in_flight="$3" broken="$4" why="$5" got
+  got="$("$triage" "$state" "$in_flight" "$broken" 2>&1)" || got="EXIT$?:$got"
+  if [ "$got" != "$expected" ]; then
+    printf 'FAIL  %-7s %-9s in_flight=%s broken=%s -> got %-8s (%s)\n' \
+      "$expected" "$state" "$in_flight" "$broken" "$got" "$why"
+    fails=$((fails + 1))
+  else
+    printf 'ok    %-7s %-9s in_flight=%s broken=%s  %s\n' \
+      "$expected" "$state" "$in_flight" "$broken" "$why"
+  fi
+}
+
+# A healthy PR is never touched: pushing to it restarts its checks, and on a
+# busy repo the restarts outrun the checks. This is the #574 invariant.
+check leave  CLEAN     0 0 "healthy and idle stays untouched (#574)"
+check wait   CLEAN     3 0 "checks in flight are allowed to finish (#574)"
+check wait   BLOCKED   5 0 "blocked only because checks have not reported yet"
+
+# BEHIND must NOT repair while checks run, or every unrelated merge to main
+# restarts the PR and it never converges — the #571/#574 livelock.
+check wait   BEHIND    2 0 "BEHIND with checks running waits, no livelock (#571)"
+check repair BEHIND    0 0 "BEHIND and idle is terminal, rebuild it (#585)"
+
+# A hung or cancelled build never clears by waiting. #580 sat for six hours
+# after the linux CUDA job hit GitHub's job ceiling.
+check repair CLEAN     0 1 "a failed check with nothing running is terminal (#585)"
+check repair BLOCKED   0 2 "several broken checks, idle, rebuild (#585)"
+check wait   CLEAN     1 1 "one broken but another still running, let it finish"
+
+# DIRTY outranks in-flight checks: a conflict survives whatever they conclude.
+check repair DIRTY     0 0 "conflicting PR is not 'idle and healthy' (#595)"
+check repair DIRTY     4 0 "conflict beats in-flight checks, no wasted cycle"
+check repair DIRTY     0 3 "conflicting and broken still rebuilds"
+
+# Unknown states are left alone rather than churned: GitHub reports UNKNOWN
+# while it computes mergeability, and it resolves on its own.
+check leave  UNKNOWN   0 0 "transient UNKNOWN is not a reason to rebuild"
+
+# Bad input is refused rather than silently treated as zero.
+got="$("$triage" CLEAN x 0 2>&1)" && st=0 || st=$?
+if [ "$st" -ne 2 ]; then
+  echo "FAIL  non-numeric count should exit 2, got exit $st"
+  fails=$((fails + 1))
+else
+  echo "ok    exit 2  non-numeric count is refused, not read as zero"
+fi
+
+if [ "$fails" -ne 0 ]; then
+  echo "$fails triage case(s) failed"
+  exit 1
+fi
+echo "all triage cases pass"

--- a/.github/scripts/harvest-triage.sh
+++ b/.github/scripts/harvest-triage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# harvest-triage.sh — decide what governance-harvest.yml should do about an
+# already-open harvest PR. Prints exactly one word:
+#
+#   wait    — checks are running; leave it and let them finish
+#   leave   — healthy and idle; leave it, its successor carries anything new
+#   repair  — it cannot merge on its own; rebuild the branch on current main
+#
+# This lives outside the workflow because the decision is where every bug in
+# this subsystem has been. In one day it churned an open PR with identical
+# content (#571), churned it with legitimately new content (#574), abandoned
+# one whose build hung for six hours (#585), and called a conflicting PR
+# "idle and healthy" (#595). Each was found in production, on a stalled PR.
+# A table-driven test is cheaper than a fifth round of that.
+#
+# Usage: harvest-triage.sh <mergeStateStatus> <in_flight_count> <broken_count>
+set -euo pipefail
+
+state="${1:?mergeStateStatus required}"
+in_flight="${2:?in-flight check count required}"
+broken="${3:?failed-or-cancelled check count required}"
+
+case "$in_flight$broken" in
+  *[!0-9]*) echo "counts must be non-negative integers, got '$in_flight' and '$broken'" >&2; exit 2 ;;
+esac
+
+# DIRTY first, and deliberately ahead of the in-flight check. A conflicting
+# branch will still be conflicting when those checks finish, so waiting only
+# spends a full CI cycle to reach the same rebuild.
+if [ "$state" = DIRTY ]; then
+  echo repair
+  exit 0
+fi
+
+# BEHIND is NOT treated that way. main moves constantly here, so a PR can go
+# BEHIND minutes after opening; repairing on sight would restart its checks on
+# every unrelated merge, which is precisely the livelock #571 and #574 closed.
+# Waiting for the in-flight run first is what keeps it convergent.
+if [ "$in_flight" -gt 0 ]; then
+  echo wait
+  exit 0
+fi
+
+if [ "$broken" -gt 0 ] || [ "$state" = BEHIND ]; then
+  echo repair
+  exit 0
+fi
+
+echo leave

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,20 @@ jobs:
       # violation. Stdlib-only; the runner's system python3 suffices.
       - run: python3 scripts/check_kernel_shadows.py
 
+  harvest-triage:
+    name: harvest triage decision table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # governance-harvest.yml decides whether to leave an open harvest PR
+      # alone or rebuild it. Four separate bugs have lived in that decision and
+      # every one was found on a stalled PR, never in CI: churn on identical
+      # content, churn on new content, abandoning a PR whose build hung for six
+      # hours, and calling a conflicting PR "idle and healthy". The decision is
+      # now a script with a table of those exact cases behind it. Seconds, no
+      # GPU, no network.
+      - run: bash .github/scripts/harvest-triage-test.sh
+
   test:
     name: cargo test --workspace
     runs-on: ubuntu-latest

--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -364,17 +364,29 @@ jobs:
             in_flight=$(printf '%s' "$buckets" | jq '[.[]|select(.=="pending")]|length')
             broken=$(printf '%s' "$buckets" | jq '[.[]|select(.=="fail" or .=="cancel")]|length')
 
-            if [ "${in_flight:-0}" -gt 0 ]; then
-              echo "harvest PR #$open_pr has ${in_flight} check(s) in flight — leaving it to converge"
-              emit_landed "waiting on #$open_pr"
-              exit 0
-            fi
-            if [ "${broken:-0}" -eq 0 ] && [ "$pr_state" != "BEHIND" ]; then
-              echo "harvest PR #$open_pr is idle and healthy — leaving it alone"
-              emit_landed "waiting on #$open_pr"
-              exit 0
-            fi
-            echo "::warning::harvest PR #$open_pr is stuck (mergeState=$pr_state, failed/cancelled checks=${broken:-0}) — rebuilding it on current main to re-trigger CI"
+            # The decision itself lives in .github/scripts/harvest-triage.sh so
+            # it can be unit-tested. Every bug in this subsystem has been in
+            # this decision, and each one was found on a stalled PR rather than
+            # in CI.
+            decision=$(.github/scripts/harvest-triage.sh "$pr_state" "${in_flight:-0}" "${broken:-0}")
+            case "$decision" in
+              wait)
+                echo "harvest PR #$open_pr has ${in_flight} check(s) in flight — leaving it to converge"
+                emit_landed "waiting on #$open_pr"
+                exit 0
+                ;;
+              leave)
+                echo "harvest PR #$open_pr is idle and healthy — leaving it alone"
+                emit_landed "waiting on #$open_pr"
+                exit 0
+                ;;
+              repair) ;;
+              *)
+                echo "::error::harvest-triage.sh returned '$decision', which is not a decision"
+                exit 1
+                ;;
+            esac
+            echo "::warning::harvest PR #$open_pr is stuck (mergeState=$pr_state, in-flight=${in_flight:-0}, failed/cancelled=${broken:-0}) — rebuilding it on current main to re-trigger CI"
             repair=1
             # fall through: the rebuild below force-updates the branch, which
             # refreshes the PR against current main and restarts its checks.


### PR DESCRIPTION
Four bugs have lived in a single decision — leave an open harvest PR alone, or rebuild it — and **every one was found on a stalled PR, never in CI**:

| incident | bug |
|---|---|
| #571 | churned the PR on identical content |
| #574 | churned it on legitimately new content |
| #585 | abandoned a PR whose build hung for six hours |
| #595 | called a *conflicting* PR "idle and healthy" |

So the decision moves into `.github/scripts/harvest-triage.sh` and gets a table whose rows are those exact incidents, plus a new `harvest triage decision table` job (seconds, no GPU, no network).

**The test is effective, not decorative** — I checked by deleting the DIRTY branch from the script, and precisely the two #595 rows fail:
```
FAIL  repair  DIRTY  in_flight=0 broken=0 -> got leave
FAIL  repair  DIRTY  in_flight=4 broken=0 -> got wait
```

### One deliberate behaviour change
`DIRTY` now outranks in-flight checks: a conflict survives whatever those checks conclude, so waiting only burns a full CI cycle to reach the same rebuild.

`BEHIND` deliberately keeps waiting. main moves constantly here, so a PR can go BEHIND minutes after opening — repairing on sight would restart its checks on every unrelated merge, which is exactly the livelock #571 and #574 closed. That asymmetry is now pinned by two rows rather than living in my head.

Supersedes the inline logic in #595 (same fix, now testable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)