### PR TITLE
stack: min_tokens on legacy completions + compact NVFP4 MoE prefill (#582 + #584)

### DIFF
--- a/crates/spark-model/src/layers/moe/dump.rs
+++ b/crates/spark-model/src/layers/moe/dump.rs
@@ -21,6 +21,36 @@
 use anyhow::Result;
 use spark_runtime::gpu::{DevicePtr, GpuBackend};
 
+/// Monotonic ordinal for raw per-layer prefill snapshots. A validation run
+/// starts one server process and executes a fixed prompt, so dense and compact
+/// runs receive identical names without changing the public forward API.
+static PREFILL_RAW_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Debug-only final BF16 output dump for the retained stage-1/3 comparator.
+/// Synchronization and D2H traffic are entirely absent unless
+/// `ATLAS_MOE_PREFILL_DUMP` is set.
+pub fn dump_prefill_bf16(
+    gpu: &dyn GpuBackend,
+    stream: u64,
+    ptr: DevicePtr,
+    elements: usize,
+    stage: &str,
+) -> Result<()> {
+    let dir = match std::env::var("ATLAS_MOE_PREFILL_DUMP") {
+        Ok(dir) if !dir.is_empty() => dir,
+        _ => return Ok(()),
+    };
+    gpu.synchronize(stream)?;
+    let mut bytes = vec![0u8; elements.saturating_mul(2)];
+    gpu.copy_d2h(ptr, &mut bytes)?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| anyhow::anyhow!("create dump directory {dir}: {e}"))?;
+    let layer = PREFILL_RAW_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = std::path::Path::new(&dir).join(format!("moe_final_L{layer:03}_{stage}.bin"));
+    std::fs::write(&path, &bytes).map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+    Ok(())
+}
+
 #[inline]
 pub fn enabled() -> bool {
     std::env::var("ATLAS_DUMP_EXPERT_IDS").ok().as_deref() == Some("1")

--- a/crates/spark-model/src/layers/moe/forward_prefill.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill.rs
@@ -354,6 +354,7 @@ impl MoeLayer {
             expert_input,
             expert_offsets,
             sorted_token_ids,
+            sorted_expert_ids,
             n,
             h,
             inter,
@@ -427,6 +428,9 @@ impl MoeLayer {
                 stream,
             )?;
         }
+        // Full retained-path bit-exact checkpoint. This is a no-op unless the
+        // explicit validation dump environment is enabled.
+        super::dump::dump_prefill_bf16(ctx.gpu, stream, output, num_tokens * h as usize, "output")?;
         super::dump::dump_moe_out(ctx.gpu, stream, output, n, h)?;
         prof_step!("unpermute_blend");
 

--- a/crates/spark-model/src/layers/moe/forward_prefill_routed.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_routed.rs
@@ -10,6 +10,62 @@
 
 use super::*;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static MOE_DUMP_LAYER_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// Debug-only raw BF16 snapshot used by the dense/compact numerical comparator.
+/// The environment gate keeps all synchronization and D2H traffic out of the
+/// normal prefill path.
+fn maybe_dump_moe_bf16(
+    gpu: &dyn GpuBackend,
+    ptr: DevicePtr,
+    elements: usize,
+    layer: usize,
+    stage: &str,
+    stream: u64,
+) -> Result<()> {
+    let dir = match std::env::var("ATLAS_MOE_PREFILL_DUMP") {
+        Ok(dir) if !dir.is_empty() => dir,
+        _ => return Ok(()),
+    };
+    gpu.synchronize(stream)?;
+    let mut bytes = vec![0u8; elements.saturating_mul(2)];
+    gpu.copy_d2h(ptr, &mut bytes)?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| anyhow::anyhow!("create dump directory {dir}: {e}"))?;
+    let path = std::path::Path::new(&dir).join(format!("moe_L{layer:03}_{stage}.bin"));
+    std::fs::write(&path, &bytes).map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+    tracing::info!(
+        "ATLAS_MOE_PREFILL_DUMP: wrote {} ({} BF16 elements)",
+        path.display(),
+        elements
+    );
+    Ok(())
+}
+
+fn maybe_dump_moe_i32(
+    gpu: &dyn GpuBackend,
+    ptr: DevicePtr,
+    elements: usize,
+    layer: usize,
+    stage: &str,
+    stream: u64,
+) -> Result<()> {
+    let dir = match std::env::var("ATLAS_MOE_PREFILL_DUMP") {
+        Ok(dir) if !dir.is_empty() => dir,
+        _ => return Ok(()),
+    };
+    gpu.synchronize(stream)?;
+    let mut bytes = vec![0u8; elements.saturating_mul(4)];
+    gpu.copy_d2h(ptr, &mut bytes)?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| anyhow::anyhow!("create dump directory {dir}: {e}"))?;
+    let path = std::path::Path::new(&dir).join(format!("moe_L{layer:03}_{stage}.bin"));
+    std::fs::write(&path, &bytes).map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+    Ok(())
+}
+
 /// Whether the single-launch CUTLASS grouped NVFP4 gate_up path is enabled
 /// (`ATLAS_HOLO_MOE_GROUPED_CUTLASS=1`). Off by default; falls back to the
 /// hand-rolled fused FP4/FP8 grouped kernels when unset.
@@ -36,6 +92,7 @@ impl MoeLayer {
         expert_input: DevicePtr,
         expert_offsets: DevicePtr,
         sorted_token_ids: DevicePtr,
+        sorted_expert_ids: DevicePtr,
         n: u32,
         h: u32,
         inter: u32,
@@ -104,6 +161,35 @@ impl MoeLayer {
         prof_step!("grid_setup");
 
         let total_expanded = n * top_k;
+        // A validation run uses one prefill request per process, so this
+        // ordinal is deterministic across dense and compact processes.
+        let dump_layer = if std::env::var_os("ATLAS_MOE_PREFILL_DUMP").is_some() {
+            MOE_DUMP_LAYER_COUNTER.fetch_add(1, Ordering::Relaxed)
+        } else {
+            usize::MAX
+        };
+        let prefill_max_exact =
+            std::env::var("ATLAS_PREFILL_MAX_EXACT").ok().as_deref() == Some("1");
+        // Stage 3 forward-selection result: K32 down is enabled by the total
+        // exact switch or the diagnostic knob.
+        let stage3_k32 = prefill_max_exact
+            || std::env::var("ATLAS_MOE_PREFILL_COMPACT_K32")
+                .ok()
+                .as_deref()
+                == Some("1");
+        // The compact row work-list is sized for the worst valid expert skew
+        // and is reused by gate/up and down; no per-layer allocation or host
+        // synchronization is needed.
+        let compact_nvfp4 = (self.compact_nvfp4 || prefill_max_exact)
+            && n > 64
+            && ctx.comm.is_none()
+            && ctx.config.ep_world_size <= 1
+            && self.experts_scale_kind == crate::weight_map::WeightQuantFormat::Nvfp4
+            && self.moe_fused_gate_up_t_k64.0 != 0
+            && self.moe_grouped_gemm_t_k64.0 != 0
+            && self.moe_build_row_worklist_k.0 != 0;
+        let compact_m_tiles = (total_expanded as usize).div_ceil(64) + ne.saturating_sub(1);
+        let compact_row_capacity = compact_m_tiles.max(1);
 
         // 5. Grouped gate+up GEMM — cp.async pipelined FP8-MMA K64 (transposed).
         let expert_gate_out = ctx.buffers.expert_gate_out();
@@ -217,6 +303,43 @@ impl MoeLayer {
                         max_m_tiles,
                         stream,
                     )?;
+                } else if compact_nvfp4 {
+                    ops::moe_build_row_worklist(
+                        ctx.gpu,
+                        self.moe_build_row_worklist_k,
+                        expert_offsets,
+                        gp.packed_ptrs,
+                        ctx.buffers.moe_worklist(),
+                        ctx.buffers.moe_worklist_total(),
+                        ctx.buffers.moe_worklist_overflow(),
+                        num_experts,
+                        64,
+                        compact_row_capacity as u32,
+                        stream,
+                    )?;
+                    prof_step!("worklist_build");
+                    ops::moe_w4a16_fused_gate_up_k64_n128_compact(
+                        ctx.gpu,
+                        self.moe_fused_gate_up_t_k64,
+                        expert_input,
+                        gp.packed_ptrs,
+                        gp.scale_ptrs,
+                        gp.scale2_vals,
+                        up.packed_ptrs,
+                        up.scale_ptrs,
+                        up.scale2_vals,
+                        expert_gate_out,
+                        expert_up_out,
+                        expert_offsets,
+                        sorted_token_ids,
+                        num_experts,
+                        inter,
+                        h,
+                        ctx.buffers.moe_worklist(),
+                        ctx.buffers.moe_worklist_total(),
+                        compact_row_capacity as u32,
+                        stream,
+                    )?;
                 } else {
                     // Block D #3 dispatch: M=128 path needs the env var on AND
                     // the kernel actually loaded (try_kernel returns 0 on
@@ -313,6 +436,40 @@ impl MoeLayer {
                 )?;
             }
         }
+        if dump_layer != usize::MAX {
+            maybe_dump_moe_i32(
+                ctx.gpu,
+                sorted_token_ids,
+                total_expanded as usize,
+                dump_layer,
+                "token_ids",
+                stream,
+            )?;
+            maybe_dump_moe_i32(
+                ctx.gpu,
+                sorted_expert_ids,
+                total_expanded as usize,
+                dump_layer,
+                "expert_ids",
+                stream,
+            )?;
+            maybe_dump_moe_bf16(
+                ctx.gpu,
+                expert_gate_out,
+                total_expanded as usize * inter as usize,
+                dump_layer,
+                "gate",
+                stream,
+            )?;
+            maybe_dump_moe_bf16(
+                ctx.gpu,
+                expert_up_out,
+                total_expanded as usize * inter as usize,
+                dump_layer,
+                "up",
+                stream,
+            )?;
+        }
         prof_step!("grouped_gate_up");
 
         // 6. Activation+mul for routed experts + grouped down GEMM (K64 pipelined).
@@ -342,6 +499,7 @@ impl MoeLayer {
                 total_expanded * inter,
                 stream,
             )?;
+            prof_step!("silu");
             // ── FP4 down (ATLAS_HOLO_MOE_DOWN_FP4) ── single block-scaled FP4
             // MMA per k64 tile (mxf4nvf4.scale_vec::4X.m16n8k64), reading the
             // post-SiLU intermediate (expert_gate_out) and the per-expert FP4
@@ -421,6 +579,45 @@ impl MoeLayer {
                         max_m_tiles,
                         stream,
                     )?;
+                } else if compact_nvfp4 {
+                    if stage3_k32 {
+                        ops::moe_w4a16_grouped_gemm_ptrtable_t_compact(
+                            ctx.gpu,
+                            self.moe_grouped_gemm_t,
+                            expert_gate_out,
+                            dp.packed_ptrs,
+                            dp.scale_ptrs,
+                            dp.scale2_vals,
+                            expert_down_out,
+                            expert_offsets,
+                            num_experts,
+                            h,
+                            inter,
+                            ctx.buffers.moe_worklist(),
+                            ctx.buffers.moe_worklist_total(),
+                            compact_row_capacity as u32,
+                            stream,
+                        )?;
+                    } else {
+                        ops::moe_w4a16_grouped_gemm_ptrtable_t_k64_compact(
+                            ctx.gpu,
+                            self.moe_grouped_gemm_t_k64,
+                            expert_gate_out,
+                            dp.packed_ptrs,
+                            dp.scale_ptrs,
+                            dp.scale2_vals,
+                            expert_down_out,
+                            expert_offsets,
+                            DevicePtr(0),
+                            num_experts,
+                            h,
+                            inter,
+                            ctx.buffers.moe_worklist(),
+                            ctx.buffers.moe_worklist_total(),
+                            compact_row_capacity as u32,
+                            stream,
+                        )?;
+                    }
                 } else {
                     let fp8_down = std::env::var("ATLAS_MOE_PREFILL_FP8_DOWN").ok().as_deref()
                         == Some("1")
@@ -452,7 +649,7 @@ impl MoeLayer {
                             stream,
                         )?;
                     } else {
-                        ops::moe_w4a16_grouped_gemm_ptrtable_n128(
+                        ops::moe_w4a16_grouped_gemm_ptrtable_k64_n128(
                             ctx.gpu,
                             self.moe_grouped_gemm_t_k64,
                             expert_gate_out,
@@ -494,7 +691,17 @@ impl MoeLayer {
                 )?;
             }
         }
-        prof_step!("grouped_silu_down");
+        if dump_layer != usize::MAX {
+            maybe_dump_moe_bf16(
+                ctx.gpu,
+                expert_down_out,
+                total_expanded as usize * h as usize,
+                dump_layer,
+                "down",
+                stream,
+            )?;
+        }
+        prof_step!("grouped_down");
 
         Ok(())
     }

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -196,6 +196,11 @@ impl MoeLayer {
                 "moe",
                 "moe_build_tile_worklist",
             ),
+            moe_build_row_worklist_k: super::super::try_kernel(
+                gpu,
+                "moe",
+                "moe_build_row_worklist",
+            ),
             moe_w8a8_grouped_gemm_k: super::super::try_kernel(
                 gpu,
                 "moe_w8a8_grouped_gemm",
@@ -362,6 +367,9 @@ impl MoeLayer {
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),
             down_fp4: std::env::var("ATLAS_HOLO_MOE_DOWN_FP4")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
+            compact_nvfp4: std::env::var("ATLAS_MOE_PREFILL_COMPACT_NVFP4")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),
             shared_gate_t: None,

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -252,6 +252,10 @@ pub struct MoeLayer {
     /// `ATLAS_HOLO_MOE_DOWN_FP4=1` — same, for the prefill down projection over
     /// the shared `down_ptrs_t` table.
     down_fp4: bool,
+    /// `ATLAS_MOE_PREFILL_COMPACT_NVFP4=1` enables the exact GPU-built
+    /// work-list launch for the Standard-NVFP4 K64 routed prefill path.
+    /// Default off until the GB10 A/B gate is recorded.
+    compact_nvfp4: bool,
     /// `ATLAS_HYBRID_MOE_LAYOUT=1` opts in to the hybrid-layout path:
     /// keep BOTH original `[N, K/2]` weights (for decode + MTP verify) AND
     /// transposed `[K/2, N]` weights (for prefill). Doubles MoE-weight
@@ -338,6 +342,8 @@ pub struct MoeLayer {
     // Launched on the SAME stream as the grouped GEMM (read-after-write of
     // total_tiles). Handle may be 0 on older images.
     moe_build_tile_worklist_k: KernelHandle,
+    // NVFP4 row work-list builder (one (expert,m_tile) item; module "moe").
+    moe_build_row_worklist_k: KernelHandle,
     // W8A8 + FP32 epilogue MoE GEMM (vLLM-equivalent). Opt-in via
     // ATLAS_FP8_W8A8=1. Requires per-token-quanted A_fp8 + a_scale.
     moe_w8a8_grouped_gemm_k: KernelHandle,

--- a/crates/spark-model/src/layers/ops/gemm_quant.rs
+++ b/crates/spark-model/src/layers/ops/gemm_quant.rs
@@ -508,6 +508,37 @@ pub fn moe_build_tile_worklist(
         .launch(stream)
 }
 
+/// Build the NVFP4 row work-list: one `(expert, m_tile)` pair per non-empty
+/// expert row tile.  The capacity is a proven upper bound supplied by the
+/// caller; overflow is reported on device for diagnostics.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_build_row_worklist(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    expert_offsets: DevicePtr,
+    weight_ptrs: DevicePtr,
+    worklist: DevicePtr,
+    total_rows: DevicePtr,
+    overflow: DevicePtr,
+    num_experts: u32,
+    m_tile: u32,
+    capacity: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([1, 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(expert_offsets)
+        .arg_ptr(weight_ptrs)
+        .arg_ptr(worklist)
+        .arg_ptr(total_rows)
+        .arg_ptr(overflow)
+        .arg_u32(num_experts)
+        .arg_u32(m_tile)
+        .arg_u32(capacity)
+        .launch(stream)
+}
+
 /// FP8 grouped GEMM for sorted MoE prefill — grid-compaction over the COMPACTED
 /// work-list built by `moe_build_tile_worklist`. THE routed-expert FP8 prefill
 /// kernel.

--- a/crates/spark-model/src/layers/ops/moe_grouped_a.rs
+++ b/crates/spark-model/src/layers/ops/moe_grouped_a.rs
@@ -289,6 +289,98 @@ pub fn moe_w4a16_grouped_gemm_ptrtable_k64_n128(
         .arg_u32(num_experts)
         .arg_u32(n_out)
         .arg_u32(k)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_u32(0)
+        .arg_u32(0)
+        .launch(stream)
+}
+
+/// Compact K64 down GEMM. `worklist` contains `(expert, m_tile)` row pairs;
+/// the kernel expands the N tiles from each row on its 1-D grid.
+/// to `moe_w4a16_grouped_gemm_ptrtable_t_k64`.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_w4a16_grouped_gemm_ptrtable_t_k64_compact(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    a: DevicePtr,
+    b_packed_ptrs: DevicePtr,
+    b_scale_ptrs: DevicePtr,
+    scale2_vals: DevicePtr,
+    c: DevicePtr,
+    expert_offsets: DevicePtr,
+    sorted_token_ids: DevicePtr,
+    num_experts: u32,
+    n_out: u32,
+    k: u32,
+    worklist: DevicePtr,
+    total_tiles: DevicePtr,
+    row_capacity: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([
+            row_capacity.saturating_mul(div_ceil(n_out, 128)).max(1),
+            1,
+            1,
+        ])
+        .block([128, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(b_packed_ptrs)
+        .arg_ptr(b_scale_ptrs)
+        .arg_ptr(scale2_vals)
+        .arg_ptr(c)
+        .arg_ptr(expert_offsets)
+        .arg_ptr(sorted_token_ids)
+        .arg_u32(num_experts)
+        .arg_u32(n_out)
+        .arg_u32(k)
+        .arg_ptr(worklist)
+        .arg_ptr(total_tiles)
+        .arg_u32(row_capacity)
+        .arg_u32(div_ceil(n_out, 128))
+        .launch(stream)
+}
+
+/// Diagnostic compact K32 down GEMM candidate.  It uses the legacy
+/// transposed K32 kernel with the same row-list ABI; disabled unless the
+/// stage-3 environment switch is set.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_w4a16_grouped_gemm_ptrtable_t_compact(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    a: DevicePtr,
+    b_packed_ptrs: DevicePtr,
+    b_scale_ptrs: DevicePtr,
+    scale2_vals: DevicePtr,
+    c: DevicePtr,
+    expert_offsets: DevicePtr,
+    num_experts: u32,
+    n_out: u32,
+    k: u32,
+    worklist: DevicePtr,
+    total_rows: DevicePtr,
+    row_capacity: u32,
+    stream: u64,
+) -> Result<()> {
+    let n_tiles = div_ceil(n_out, 128);
+    KernelLaunch::new(gpu, kernel)
+        .grid([row_capacity.saturating_mul(n_tiles).max(1), 1, 1])
+        .block([128, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(b_packed_ptrs)
+        .arg_ptr(b_scale_ptrs)
+        .arg_ptr(scale2_vals)
+        .arg_ptr(c)
+        .arg_ptr(expert_offsets)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_u32(num_experts)
+        .arg_u32(n_out)
+        .arg_u32(k)
+        .arg_ptr(worklist)
+        .arg_ptr(total_rows)
+        .arg_u32(row_capacity)
+        .arg_u32(n_tiles)
         .launch(stream)
 }
 
@@ -333,6 +425,63 @@ pub fn moe_w4a16_fused_gate_up_k64_n128(
         .arg_u32(num_experts)
         .arg_u32(n_out)
         .arg_u32(k)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_ptr(DevicePtr::NULL)
+        .arg_u32(0)
+        .arg_u32(0)
+        .launch(stream)
+}
+
+/// Compact K64 fused gate/up GEMM. The work-list N dimension spans the
+/// concatenated `[gate | up]` output, so `n_tiles = ceil(2*n_out/128)`.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_w4a16_fused_gate_up_k64_n128_compact(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    a: DevicePtr,
+    gate_packed_ptrs: DevicePtr,
+    gate_scale_ptrs: DevicePtr,
+    gate_scale2_vals: DevicePtr,
+    up_packed_ptrs: DevicePtr,
+    up_scale_ptrs: DevicePtr,
+    up_scale2_vals: DevicePtr,
+    c_gate: DevicePtr,
+    c_up: DevicePtr,
+    expert_offsets: DevicePtr,
+    sorted_token_ids: DevicePtr,
+    num_experts: u32,
+    n_out: u32,
+    k: u32,
+    worklist: DevicePtr,
+    total_tiles: DevicePtr,
+    row_capacity: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([
+            row_capacity.saturating_mul(div_ceil(2 * n_out, 128)).max(1),
+            1,
+            1,
+        ])
+        .block([128, 1, 1])
+        .arg_ptr(a)
+        .arg_ptr(gate_packed_ptrs)
+        .arg_ptr(gate_scale_ptrs)
+        .arg_ptr(gate_scale2_vals)
+        .arg_ptr(up_packed_ptrs)
+        .arg_ptr(up_scale_ptrs)
+        .arg_ptr(up_scale2_vals)
+        .arg_ptr(c_gate)
+        .arg_ptr(c_up)
+        .arg_ptr(expert_offsets)
+        .arg_ptr(sorted_token_ids)
+        .arg_u32(num_experts)
+        .arg_u32(n_out)
+        .arg_u32(k)
+        .arg_ptr(worklist)
+        .arg_ptr(total_tiles)
+        .arg_u32(row_capacity)
+        .arg_u32(div_ceil(2 * n_out, 128))
         .launch(stream)
 }
 

--- a/crates/spark-runtime/src/buffers.rs
+++ b/crates/spark-runtime/src/buffers.rs
@@ -74,6 +74,12 @@ pub struct BufferArena {
     expert_up_out: DevicePtr,
     /// Expert down projection output: [k2 * top_k, hidden_size] BF16.
     expert_down_out: DevicePtr,
+    /// Persistent compact NVFP4 MoE work-list (two u32 words per tile).
+    moe_worklist: DevicePtr,
+    /// Persistent compact NVFP4 MoE work-list tile count (one i32).
+    moe_worklist_total: DevicePtr,
+    /// Device-side compact work-list overflow diagnostic flag.
+    moe_worklist_overflow: DevicePtr,
     /// Split-K decode attention workspace: partials from split CTAs (F32).
     splitk_workspace: DevicePtr,
     /// Grouped O-projection latent: [M, o_groups*o_lora_rank] BF16 (V4-Flash).
@@ -175,6 +181,10 @@ impl BufferArena {
         let expert_gate_out = gpu.alloc(sizes.expert_gate_out)?;
         let expert_up_out = gpu.alloc(sizes.expert_up_out)?;
         let expert_down_out = gpu.alloc(sizes.expert_down_out)?;
+        let moe_worklist = gpu.alloc(sizes.moe_worklist)?;
+        let moe_worklist_total = gpu.alloc(sizes.moe_worklist_total)?;
+        let moe_worklist_overflow = gpu.alloc(sizes.moe_worklist_overflow)?;
+        gpu.memset(moe_worklist_overflow, 0, sizes.moe_worklist_overflow)?;
         let splitk_workspace = gpu.alloc(sizes.splitk_workspace)?;
         let o_latent = gpu.alloc(sizes.o_latent)?;
         // Zero-filled "weight" for unweighted RMSNorm under the offset-from-1
@@ -281,6 +291,9 @@ impl BufferArena {
             expert_gate_out,
             expert_up_out,
             expert_down_out,
+            moe_worklist,
+            moe_worklist_total,
+            moe_worklist_overflow,
             splitk_workspace,
             o_latent,
             norm_unit_w,
@@ -347,6 +360,9 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for BufferArena {
             expert_gate_out,
             expert_up_out,
             expert_down_out,
+            moe_worklist,
+            moe_worklist_total,
+            moe_worklist_overflow,
             splitk_workspace,
             o_latent,
             norm_unit_w,
@@ -390,6 +406,9 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for BufferArena {
             *expert_gate_out,
             *expert_up_out,
             *expert_down_out,
+            *moe_worklist,
+            *moe_worklist_total,
+            *moe_worklist_overflow,
             *splitk_workspace,
             *o_latent,
             *norm_unit_w,
@@ -438,6 +457,9 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for BufferArena {
         *expert_gate_out = DevicePtr::NULL;
         *expert_up_out = DevicePtr::NULL;
         *expert_down_out = DevicePtr::NULL;
+        *moe_worklist = DevicePtr::NULL;
+        *moe_worklist_total = DevicePtr::NULL;
+        *moe_worklist_overflow = DevicePtr::NULL;
         *splitk_workspace = DevicePtr::NULL;
         *o_latent = DevicePtr::NULL;
         *norm_unit_w = DevicePtr::NULL;

--- a/crates/spark-runtime/src/buffers/accessors.rs
+++ b/crates/spark-runtime/src/buffers/accessors.rs
@@ -85,6 +85,18 @@ impl BufferArena {
     pub fn expert_down_out(&self) -> DevicePtr {
         self.expert_down_out
     }
+    /// Persistent compact NVFP4 MoE work-list storage.
+    pub fn moe_worklist(&self) -> DevicePtr {
+        self.moe_worklist
+    }
+    /// Device counter for the compact NVFP4 MoE work-list.
+    pub fn moe_worklist_total(&self) -> DevicePtr {
+        self.moe_worklist_total
+    }
+    /// Persistent compact NVFP4 work-list overflow diagnostic flag.
+    pub fn moe_worklist_overflow(&self) -> DevicePtr {
+        self.moe_worklist_overflow
+    }
     /// Split-K decode attention workspace (F32 partials).
     /// GDN FLA chunked-prefill scratch base (W|U|S|uc sub-divided by the caller).
     /// `DevicePtr::NULL` unless this is a 128-dim-linear-head GDN model.
@@ -270,6 +282,17 @@ impl BufferArena {
             "expert_down_out",
             self.expert_down_out,
             self.sizes.expert_down_out,
+        );
+        probe("moe_worklist", self.moe_worklist, self.sizes.moe_worklist);
+        probe(
+            "moe_worklist_total",
+            self.moe_worklist_total,
+            self.sizes.moe_worklist_total,
+        );
+        probe(
+            "moe_worklist_overflow",
+            self.moe_worklist_overflow,
+            self.sizes.moe_worklist_overflow,
         );
         probe(
             "splitk_workspace",

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -34,6 +34,14 @@ pub struct BufferSizes {
     pub expert_gate_out: usize,
     pub expert_up_out: usize,
     pub expert_down_out: usize,
+    /// Persistent NVFP4 MoE prefill work-list: two u32 words per tile.
+    /// Sized for the worst valid expert skew and reused by gate/up and down.
+    pub moe_worklist: usize,
+    /// Device counter paired with `moe_worklist`.
+    pub moe_worklist_total: usize,
+    /// Device-side diagnostic flag reserved for work-list capacity overflow.
+    /// The proven capacity bound keeps this at zero on valid launches.
+    pub moe_worklist_overflow: usize,
     pub splitk_workspace: usize,
     /// GDN FLA chunked-prefill scratch (single buffer, sub-divided W|U|S|uc).
     /// 0 unless the model is a 128-dim-linear-head GDN model (ATLAS_GDN_FLA path).
@@ -238,6 +246,16 @@ impl BufferSizes {
             k_max * h * bf16
         };
 
+        // Compact NVFP4 grouped GEMM row-list.  K64 kernels use M_TILE=64;
+        // the sum of ceil(M_e/64) over all experts is bounded by
+        // ceil(total_expanded/64) + num_experts - 1.  Each entry is only the
+        // expert id and local M tile; gate/up and down reuse the same list.
+        let total_expanded = m.saturating_mul(top_k);
+        let m_tiles_bound = total_expanded.div_ceil(64) + config.num_experts.saturating_sub(1);
+        let moe_worklist = (m_tiles_bound.max(1) * 2 * std::mem::size_of::<u32>()).max(256);
+        let moe_worklist_total = std::mem::size_of::<i32>();
+        let moe_worklist_overflow = std::mem::size_of::<i32>();
+
         // Logits: only last token used during prefill. Cap at 96 tokens —
         // the batched MTP verify's R = Σ ks row cap (n=32 × k=3 rows, the
         // wave-11 depth-at-width envelope; VERIFY_ROW_CAP in verify_e2.rs).
@@ -439,6 +457,9 @@ impl BufferSizes {
             expert_gate_out,
             expert_up_out,
             expert_down_out,
+            moe_worklist,
+            moe_worklist_total,
+            moe_worklist_overflow,
             splitk_workspace,
             gdn_fla_scratch,
             ssd_scratch,
@@ -503,6 +524,9 @@ impl BufferSizes {
             + self.expert_gate_out
             + self.expert_up_out
             + self.expert_down_out
+            + self.moe_worklist
+            + self.moe_worklist_total
+            + self.moe_worklist_overflow
             + self.splitk_workspace
             + self.gdn_fla_scratch
             + self.ssd_scratch

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -69,11 +69,9 @@ fn test_buffer_arena_alloc() {
     //     allocated unconditionally even for models without hash routing).
     // plus 2 added by the Holo-3.1/Ornith GB10 enablement (buffers.rs):
     //   - fp8_act + fp8_act_scale (persistent FP8 prefill-projection scratch,
-    //     allocated unconditionally). 27 + 2 = 29.
-    // (wip-laguna-lora counts 30 here: its keep-packed GGUF grouped MoE adds
-    // a moe_grouped_q8 arena buffer (06c89a33) that this branch does not
-    // carry. Re-sync this count if that work is ever picked.)
-    assert_eq!(gpu.alloc_count(), 29);
+    //     allocated unconditionally), plus the compact MoE work-list, counter,
+    //     and overflow flag. 27 + 2 + 3 = 32.
+    assert_eq!(gpu.alloc_count(), 32);
 }
 
 #[test]

--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -273,6 +273,71 @@ pub async fn completions(
     super::completions_exec::run_blocking(state, &req, prompts, params).await
 }
 
+/// Build the streaming `InferenceRequest` for the legacy completions path.
+///
+/// Extracted from `completions_stream` so the `min_tokens` passthrough is
+/// unit-testable; behavior identical to the original inline construction.
+fn build_streaming_request(
+    req: &CompletionRequest,
+    p: super::completions_exec::CompletionParams,
+    prompt_tokens: std::sync::Arc<Vec<u32>>,
+    session_hash: u64,
+    timeout_at: Option<std::time::Instant>,
+    token_tx: tokio::sync::mpsc::Sender<StreamEvent>,
+) -> InferenceRequest {
+    let echo = req.echo;
+    let logprobs_k = p.logprobs_k;
+    InferenceRequest::Streaming {
+        prompt_tokens,
+        session_hash,
+        adapter_slot: p.adapter_slot,
+        src_lang_id: p.src_lang_id,
+        tgt_lang_id: p.tgt_lang_id,
+        num_beams: p.num_beams,
+        length_penalty: p.length_penalty,
+        early_stopping: p.early_stopping,
+        image_pixels: Vec::new(),
+        max_tokens: req.max_tokens,
+        min_tokens: req.min_tokens,
+        temperature: p.temperature,
+        top_k: p.top_k,
+        top_p: p.top_p,
+        top_n_sigma: p.top_n_sigma,
+        min_p: p.min_p,
+        repetition_penalty: p.repetition_penalty,
+        presence_penalty: p.presence_penalty,
+        frequency_penalty: p.frequency_penalty,
+        // Legacy /v1/completions path doesn't have tool semantics.
+        dry_multiplier: 0.0,
+        dry_base: 1.75,
+        dry_allowed_length: 2,
+        lz_penalty: 0.0,
+        logit_bias: p.logit_bias,
+        stop_tokens: p.stop_tokens,
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: p.repetition_detection,
+        require_tool_call: false,
+        // Completions API defines no tools — multi-tool-call continuation off.
+        tools_present: false,
+        suppress_tool_call: false,
+        disable_mtp: false,
+        grammar_spec: None,
+        seed: req.seed,
+        top_logprobs: logprobs_k,
+        prompt_logprobs: if echo { logprobs_k } else { None },
+        echo,
+        // Was hard-coded `None`: streaming /v1/completions was the one
+        // surface with NO deadline while every other surface had 300 s.
+        timeout_at,
+        token_tx,
+        // /v1/completions has no guard pipeline yet — the flag is
+        // created so the scheduler's emit_step type-checks cleanly,
+        // but never flipped.
+        cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
 /// SSE streaming path for legacy completions (single prompt, n=1, handler-
 /// guarded). Echo: prompt text (+ logprobs when set) is the FIRST chunk; with
 /// `stream_options.include_usage` a `choices: []` usage chunk precedes `[DONE]`.
@@ -304,55 +369,14 @@ pub(super) async fn completions_stream(
     };
 
     let session_hash = crate::session_manager::compute_session_hash(&prompt_tokens);
-    let request = InferenceRequest::Streaming {
-        prompt_tokens: std::sync::Arc::new(prompt_tokens),
+    let request = build_streaming_request(
+        &req,
+        p,
+        std::sync::Arc::new(prompt_tokens),
         session_hash,
-        adapter_slot: p.adapter_slot,
-        src_lang_id: p.src_lang_id,
-        tgt_lang_id: p.tgt_lang_id,
-        num_beams: p.num_beams,
-        length_penalty: p.length_penalty,
-        early_stopping: p.early_stopping,
-        image_pixels: Vec::new(),
-        max_tokens: req.max_tokens,
-        min_tokens: 0,
-        temperature: p.temperature,
-        top_k: p.top_k,
-        top_p: p.top_p,
-        top_n_sigma: p.top_n_sigma,
-        min_p: p.min_p,
-        repetition_penalty: p.repetition_penalty,
-        presence_penalty: p.presence_penalty,
-        frequency_penalty: p.frequency_penalty,
-        // Legacy /v1/completions path doesn't have tool semantics.
-        dry_multiplier: 0.0,
-        dry_base: 1.75,
-        dry_allowed_length: 2,
-        lz_penalty: 0.0,
-        logit_bias: p.logit_bias,
-        stop_tokens: p.stop_tokens,
-        enable_thinking: false,
-        thinking_budget: None,
-        repetition_detection: p.repetition_detection,
-        require_tool_call: false,
-        // Completions API defines no tools — multi-tool-call continuation off.
-        tools_present: false,
-        suppress_tool_call: false,
-        disable_mtp: false,
-        grammar_spec: None,
-        seed: req.seed,
-        top_logprobs: logprobs_k,
-        prompt_logprobs: if echo { logprobs_k } else { None },
-        echo,
-        // Was hard-coded `None`: streaming /v1/completions was the one
-        // surface with NO deadline while every other surface had 300 s.
-        timeout_at: state.request_deadline(None),
+        state.request_deadline(None),
         token_tx,
-        // /v1/completions has no guard pipeline yet — the flag is
-        // created so the scheduler's emit_step type-checks cleanly,
-        // but never flipped.
-        cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-    };
+    );
 
     state.request_tx.send(request).await.map_err(|_| {
         (
@@ -500,4 +524,48 @@ pub(super) async fn completions_stream(
 /// as "wrong URL".
 pub(super) fn not_supported(message: &'static str) -> Response {
     openai_error_response(StatusCode::NOT_IMPLEMENTED, message.into())
+}
+
+#[cfg(test)]
+mod min_tokens_wiring_tests {
+    use super::*;
+
+    #[test]
+    fn streaming_path_wires_min_tokens() {
+        let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+            "min_tokens": 2048,
+        }))
+        .unwrap();
+        let (token_tx, _token_rx) = tokio::sync::mpsc::channel::<StreamEvent>(16);
+        let request = build_streaming_request(
+            &req,
+            crate::api::completions_exec::CompletionParams::test(),
+            std::sync::Arc::new(vec![1, 2, 3]),
+            42,
+            None,
+            token_tx,
+        );
+        assert_eq!(request.min_tokens(), 2048);
+    }
+
+    #[test]
+    fn streaming_path_defaults_min_tokens_to_zero() {
+        let req: CompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+        }))
+        .unwrap();
+        let (token_tx, _token_rx) = tokio::sync::mpsc::channel::<StreamEvent>(16);
+        let request = build_streaming_request(
+            &req,
+            crate::api::completions_exec::CompletionParams::test(),
+            std::sync::Arc::new(vec![1]),
+            42,
+            None,
+            token_tx,
+        );
+        assert_eq!(request.min_tokens(), 0);
+    }
 }

--- a/crates/spark-server/src/api/completions_exec.rs
+++ b/crates/spark-server/src/api/completions_exec.rs
@@ -86,7 +86,7 @@ pub(super) async fn run_blocking(
                 early_stopping: p.early_stopping,
                 image_pixels: Vec::new(),
                 max_tokens: req.max_tokens,
-                min_tokens: 0,
+                min_tokens: req.min_tokens,
                 temperature: p.temperature,
                 top_k: p.top_k,
                 top_p: p.top_p,
@@ -223,4 +223,30 @@ pub(super) async fn run_blocking(
         usage,
     ))
     .into_response()
+}
+
+#[cfg(test)]
+impl CompletionParams {
+    pub(super) fn test() -> Self {
+        Self {
+            temperature: 1.0,
+            top_k: 20,
+            top_p: 0.95,
+            top_n_sigma: 0.0,
+            min_p: 0.0,
+            repetition_penalty: 1.0,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
+            logit_bias: Vec::new(),
+            stop_tokens: Vec::new(),
+            repetition_detection: None,
+            logprobs_k: None,
+            adapter_slot: -1,
+            src_lang_id: 0,
+            tgt_lang_id: 0,
+            num_beams: 1,
+            length_penalty: 1.0,
+            early_stopping: false,
+        }
+    }
 }

--- a/crates/spark-server/src/openai/completions.rs
+++ b/crates/spark-server/src/openai/completions.rs
@@ -43,6 +43,12 @@ pub struct CompletionRequest {
     pub prompt: PromptInput,
     #[serde(default = "default_max_tokens")]
     pub max_tokens: usize,
+    /// Minimum number of tokens to generate before allowing EOS/stop.
+    /// 0 = no minimum (default). Mirrors the chat endpoint; without this,
+    /// a model-sampled EOS token ends the response early even when the
+    /// caller asked for a longer completion.
+    #[serde(default)]
+    pub min_tokens: usize,
     pub temperature: Option<f32>,
     /// Top-k: keep only the k highest-probability tokens before sampling.
     pub top_k: Option<u32>,
@@ -346,4 +352,40 @@ pub struct TokenizeRequest {
 pub struct TokenizeResponse {
     pub tokens: Vec<u32>,
     pub count: usize,
+}
+
+#[cfg(test)]
+mod min_tokens_tests {
+    use super::*;
+
+    fn req_with(json: serde_json::Value) -> CompletionRequest {
+        serde_json::from_value(json).expect("valid CompletionRequest JSON")
+    }
+
+    #[test]
+    fn min_tokens_defaults_to_zero() {
+        // Absent field → 0 (no minimum), preserving legacy behavior.
+        let req = req_with(serde_json::json!({ "model": "m", "prompt": "hi" }));
+        assert_eq!(req.min_tokens, 0);
+    }
+
+    #[test]
+    fn min_tokens_explicit_deserialization() {
+        let req = req_with(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+            "min_tokens": 2048
+        }));
+        assert_eq!(req.min_tokens, 2048);
+    }
+
+    #[test]
+    fn min_tokens_zero_is_valid_explicit_value() {
+        let req = req_with(serde_json::json!({
+            "model": "m",
+            "prompt": "hi",
+            "min_tokens": 0
+        }));
+        assert_eq!(req.min_tokens, 0);
+    }
 }

--- a/crates/spark-server/src/scheduler/decode_logits_step.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_step.rs
@@ -39,6 +39,7 @@ fn logits_ctx<'a>(
         think_start_token,
         tool_call_start_token,
         tool_call_end_token,
+        verify_pos: 0,
         watchdog: sched.watchdog,
         scratch,
         dumps: &sched.dumps,
@@ -165,7 +166,10 @@ pub fn process_decode_logits(
         let excused = admit_think_ended && think_ended_gpu_ok(a);
         (a.inside_thinking || a.think_ended || a.grammar_state.is_some()) && !excused
     }) || any_logprobs
-        || model_logits_fp32;
+        || model_logits_fp32
+        // GPU argmax bypasses the pre-sampling EOS mask. Keep requests with
+        // an active minimum-token floor on the host pipeline.
+        || active.iter().any(|a| a.min_tokens > a.output_tokens.len());
 
     // Try the GPU argmax first. `None` here means "not eligible, or the result
     // needs the host pipeline after all" and falls through to the host branch —
@@ -276,6 +280,7 @@ pub fn process_decode_logits(
                             think_start_token,
                             tool_call_start_token,
                             tool_call_end_token,
+                            verify_pos: 0,
                             watchdog,
                             scratch,
                             dumps,

--- a/crates/spark-server/src/scheduler/logit_processors/forced_token.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/forced_token.rs
@@ -37,7 +37,17 @@ impl LogitsProcessor for ForcedTokenFastPath {
             && let Some(ref mut gs) = a.grammar_state
             && let Some(forced) = gs.forced_token()
         {
-            return ProcessorOutcome::EmitToken(forced as u32);
+            let forced = forced as u32;
+            // `min_tokens` guard: the fast path bypasses sampling, so a
+            // grammar-forced EOS would otherwise surface before the request
+            // reached its minimum token count even though the normal path
+            // masks EOS logits. Fall through to the standard pipeline (where
+            // the mask applies) instead of emitting the EOS early.
+            let effective_len = a.output_tokens.len().saturating_add(ctx.verify_pos);
+            if effective_len < a.min_tokens && a.eos_tokens.contains(&forced) {
+                return ProcessorOutcome::Continue;
+            }
+            return ProcessorOutcome::EmitToken(forced);
         }
         ProcessorOutcome::Continue
     }

--- a/crates/spark-server/src/scheduler/logit_processors/min_tokens_eos.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/min_tokens_eos.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pre-sampling EOS mask for the request `min_tokens` floor.
+
+use super::{LogitsContext, LogitsProcessor, ProcessorOutcome};
+use crate::scheduler::ActiveSeq;
+
+/// Mask EOS ids while the effective output length is below `min_tokens`.
+pub fn mask_eos_before_min(
+    logits: &mut [f32],
+    eos_tokens: &[u32],
+    effective_len: usize,
+    min_tokens: usize,
+) {
+    if min_tokens > 0 && effective_len < min_tokens {
+        for &eos in eos_tokens {
+            if let Some(slot) = logits.get_mut(eos as usize) {
+                *slot = f32::NEG_INFINITY;
+            }
+        }
+    }
+}
+
+/// Pipeline stage applying the mask to final decode and MTP verify positions.
+pub struct MinTokensEosMask;
+
+impl LogitsProcessor for MinTokensEosMask {
+    fn apply(
+        &self,
+        logits: &mut [f32],
+        seq: &mut ActiveSeq,
+        ctx: &LogitsContext,
+    ) -> ProcessorOutcome {
+        let effective_len = seq.output_tokens.len().saturating_add(ctx.verify_pos);
+        mask_eos_before_min(logits, &seq.eos_tokens, effective_len, seq.min_tokens);
+        ProcessorOutcome::Continue
+    }
+
+    fn name(&self) -> &'static str {
+        "min_tokens_eos_mask"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mask_eos_before_min;
+
+    #[test]
+    fn masks_only_before_boundary() {
+        let mut logits = [0.5, 1.0, 2.0];
+        mask_eos_before_min(&mut logits, &[1], 0, 5);
+        assert_eq!(logits[1], f32::NEG_INFINITY);
+        let mut at_boundary = [0.5, 1.0, 2.0];
+        mask_eos_before_min(&mut at_boundary, &[1], 5, 5);
+        assert_eq!(at_boundary[1], 1.0);
+    }
+
+    #[test]
+    fn zero_min_is_noop_and_oov_is_safe() {
+        let mut logits = [0.5, 1.0];
+        mask_eos_before_min(&mut logits, &[99_999], 0, 0);
+        assert_eq!(logits, [0.5, 1.0]);
+    }
+}

--- a/crates/spark-server/src/scheduler/logit_processors/mod.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/mod.rs
@@ -48,6 +48,7 @@ pub mod forced_think_end;
 pub mod forced_token;
 pub mod grammar_bitmask;
 pub mod mid_word;
+pub mod min_tokens_eos;
 pub mod pin_tool_call;
 pub mod post_close;
 pub mod tool_during_think;
@@ -71,6 +72,8 @@ pub struct LogitsContext<'a> {
     pub think_start_token: Option<u32>,
     pub tool_call_start_token: Option<u32>,
     pub tool_call_end_token: Option<u32>,
+    /// Verify-position offset used by position-aware request masks.
+    pub verify_pos: usize,
     /// `mask[id]` iff token `id` decodes to text ending in a generation
     /// boundary. Vocab-sized and INDEXED BY TOKEN ID, so it is meaningless
     /// against a different tokenizer — carried beside the token ids it belongs
@@ -188,7 +191,8 @@ pub fn run_pipeline_with_path(
     ctx: &LogitsContext,
     path: &'static str,
 ) -> Option<u32> {
-    let stages: [&dyn LogitsProcessor; 8] = [
+    let stages: [&dyn LogitsProcessor; 9] = [
+        &min_tokens_eos::MinTokensEosMask,
         &f2_confidence::F2ConfidenceEarlyStop,
         &mid_word::MidWordThinkEndMask,
         &post_close::PostCloseThinkMask,

--- a/crates/spark-server/src/scheduler/logit_processors/pipeline_tests.rs
+++ b/crates/spark-server/src/scheduler/logit_processors/pipeline_tests.rs
@@ -159,6 +159,7 @@ fn logits_context_field_set_is_stable() {
         think_start_token: Some(2),
         tool_call_start_token: Some(3),
         tool_call_end_token: Some(4),
+        verify_pos: 0,
     };
     // Clone semantics — the context now carries the vocab-indexed sched, which
     // are `Arc`s, so it is Clone rather than Copy. Pipeline stages still take

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -685,6 +685,7 @@ pub fn run(
                 think_start_token,
                 tool_call_start_token,
                 tool_call_end_token,
+                verify_pos: 0,
                 boundary_mask: sched.masks.boundary.clone(),
                 mid_word_mask: sched.masks.mid_word.clone(),
                 sampling: sched.levers.sampling(),

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
@@ -151,10 +151,17 @@ pub fn verify_pick_with_pipeline(
     //    advance the grammar matcher; the K-loop in
     //    `verify_pick_all_with_pipeline` owns `accept_token` / `rollback`.
     let t_proc = std::time::Instant::now();
+    // Per-position context: carry the verify index so the min-tokens EOS
+    // mask counts this position's tokens (`output_tokens.len() + verify_pos`)
+    // toward the `min_tokens` floor before it commits.
+    let pos_ctx = LogitsContext {
+        verify_pos,
+        ..ctx.clone()
+    };
     if let Some(tok) = crate::scheduler::logit_processors::process_position_logits(
         &mut f32_logits,
         a,
-        ctx,
+        &pos_ctx,
         &penalties,
         crate::scheduler::sample_step::PositionKind::Verify,
     ) {

--- a/kernels/gb10/common/moe_permute.cu
+++ b/kernels/gb10/common/moe_permute.cu
@@ -301,3 +301,40 @@ extern "C" __global__ void moe_build_tile_worklist(
     }
     total_tiles[0] = (int)w;
 }
+
+// NVFP4 routed-prefill row work-list.  Unlike the legacy FP8 list above this
+// emits one item per non-empty (expert, m_tile) row group; the grouped GEMM
+// expands the N dimension in its 1-D launch.  The bound
+// ceil(total_expanded/64) + num_experts - 1 is supplied by the host and is
+// sufficient for every valid non-negative expert histogram.
+extern "C" __global__ void moe_build_row_worklist(
+    const int* __restrict__ expert_offsets,
+    const unsigned long long* __restrict__ B_weight_ptrs,
+    unsigned int* __restrict__ worklist,       // [capacity * 2]
+    int* __restrict__ total_rows,              // [1]
+    unsigned int* __restrict__ overflow,       // [1]
+    unsigned int num_experts,
+    unsigned int m_tile,
+    unsigned int capacity
+) {
+    if (threadIdx.x != 0) return;
+    unsigned int w = 0;
+    unsigned int ov = 0;
+    for (unsigned int e = 0; e < num_experts; ++e) {
+        const int begin = expert_offsets[e];
+        const int rows = expert_offsets[e + 1] - begin;
+        if (rows <= 0 || B_weight_ptrs[e] == 0) continue;
+        const unsigned int tiles = ((unsigned int)rows + m_tile - 1) / m_tile;
+        for (unsigned int mt = 0; mt < tiles; ++mt) {
+            if (w < capacity) {
+                worklist[w * 2 + 0] = e;
+                worklist[w * 2 + 1] = mt;
+            } else {
+                ov = 1;
+            }
+            ++w;
+        }
+    }
+    total_rows[0] = (int)(w < capacity ? w : capacity);
+    overflow[0] = ov;
+}

--- a/kernels/gb10/qwen3.6-35b-a3b/nvfp4/moe_w4a16_grouped_gemm.cu
+++ b/kernels/gb10/qwen3.6-35b-a3b/nvfp4/moe_w4a16_grouped_gemm.cu
@@ -229,9 +229,21 @@ extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t(
     const int* __restrict__ sorted_token_ids,
     unsigned int num_experts,
     unsigned int N,
-    unsigned int K
+    unsigned int K,
+    const unsigned int* __restrict__ worklist,
+    const int* __restrict__ total_rows,
+    unsigned int row_capacity,
+    unsigned int n_tiles
 ) {
-    const unsigned int expert_id = blockIdx.z;
+    const bool compact = worklist != nullptr && total_rows != nullptr;
+    const unsigned int work_id = blockIdx.x;
+    if (compact && work_id >= row_capacity * n_tiles) return;
+    const unsigned int row_id = compact ? work_id / n_tiles : 0;
+    const unsigned int n_id = compact ? work_id % n_tiles : blockIdx.x;
+    if (compact && (int)row_id >= *total_rows) return;
+    const unsigned int packed = compact ? worklist[row_id * 2] : 0;
+    const unsigned int coords = compact ? worklist[row_id * 2 + 1] : 0;
+    const unsigned int expert_id = compact ? packed : blockIdx.z;
     if (expert_id >= num_experts) return;
 
     const int m_start = expert_offsets[expert_id];
@@ -239,11 +251,12 @@ extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t(
     const int M_expert = m_end - m_start;
     if (M_expert <= 0) return;
 
-    const int cta_m_local = blockIdx.y * M_TILE;
+    const int cta_m_local = compact ? (int)coords * M_TILE
+                                    : (int)blockIdx.y * M_TILE;
     if (cta_m_local >= M_expert) return;
 
     const unsigned int cta_m = m_start + cta_m_local;
-    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_n = (compact ? n_id : blockIdx.x) * N_TILE_LG;
 
     const unsigned char* B_expert = (const unsigned char*)B_packed_ptrs[expert_id];
     const unsigned char* S_expert = (const unsigned char*)B_scale_ptrs[expert_id];
@@ -456,9 +469,21 @@ extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t_k64(
     const int* __restrict__ sorted_token_ids,
     unsigned int num_experts,
     unsigned int N,
-    unsigned int K
+    unsigned int K,
+    const unsigned int* __restrict__ worklist,
+    const int* __restrict__ total_rows,
+    unsigned int row_capacity,
+    unsigned int n_tiles
 ) {
-    const unsigned int expert_id = blockIdx.z;
+    const bool compact = worklist != nullptr && total_rows != nullptr;
+    const unsigned int work_id = blockIdx.x;
+    if (compact && work_id >= row_capacity * n_tiles) return;
+    const unsigned int row_id = compact ? work_id / n_tiles : 0;
+    const unsigned int n_id = compact ? work_id % n_tiles : blockIdx.x;
+    if (compact && (int)row_id >= *total_rows) return;
+    const unsigned int compact_packed = compact ? worklist[row_id * 2] : 0;
+    const unsigned int compact_coords = compact ? worklist[row_id * 2 + 1] : 0;
+    const unsigned int expert_id = compact ? compact_packed : blockIdx.z;
     if (expert_id >= num_experts) return;
 
     const int m_start = expert_offsets[expert_id];
@@ -466,11 +491,12 @@ extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t_k64(
     const int M_expert = m_end - m_start;
     if (M_expert <= 0) return;
 
-    const int cta_m_local = blockIdx.y * M_TILE;
+    const int cta_m_local = compact ? (int)compact_coords * M_TILE
+                                    : (int)blockIdx.y * M_TILE;
     if (cta_m_local >= M_expert) return;
 
     const unsigned int cta_m = m_start + cta_m_local;
-    const unsigned int cta_n = blockIdx.x * N_TILE_LG;
+    const unsigned int cta_n = (compact ? n_id : blockIdx.x) * N_TILE_LG;
 
     const unsigned char* B_expert = (const unsigned char*)B_packed_ptrs[expert_id];
     const unsigned char* S_expert = (const unsigned char*)B_scale_ptrs[expert_id];
@@ -483,7 +509,6 @@ extern "C" __global__ void moe_w4a16_grouped_gemm_ptrtable_t_k64(
     const unsigned int warp_m_offset = warp_id * 16;
     const unsigned int group_id = lane_id >> 2;
     const unsigned int tid = lane_id & 3;
-
     // B_fp8 padding: row stride 80 bytes (K64+16) gives zero bank conflicts.
     // Without pad: 64-byte rows (16 banks/row) → 4-way conflicts for nc spaced 2 apart.
     // With pad: 80-byte rows (20 banks/row) → nc*20 % 32 hits all distinct banks for nc=0..7.
@@ -706,9 +731,21 @@ extern "C" __global__ void moe_w4a16_fused_gate_up_t_k64(
     const int* __restrict__ sorted_token_ids,
     unsigned int num_experts,
     unsigned int N,
-    unsigned int K
+    unsigned int K,
+    const unsigned int* __restrict__ worklist,
+    const int* __restrict__ total_rows,
+    unsigned int row_capacity,
+    unsigned int n_tiles
 ) {
-    const unsigned int expert_id = blockIdx.z;
+    const bool compact = worklist != nullptr && total_rows != nullptr;
+    const unsigned int work_id = blockIdx.x;
+    if (compact && work_id >= row_capacity * n_tiles) return;
+    const unsigned int row_id = compact ? work_id / n_tiles : 0;
+    const unsigned int n_id = compact ? work_id % n_tiles : blockIdx.x;
+    if (compact && (int)row_id >= *total_rows) return;
+    const unsigned int compact_packed = compact ? worklist[row_id * 2] : 0;
+    const unsigned int compact_coords = compact ? worklist[row_id * 2 + 1] : 0;
+    const unsigned int expert_id = compact ? compact_packed : blockIdx.z;
     if (expert_id >= num_experts) return;
 
     const int m_start = expert_offsets[expert_id];
@@ -716,10 +753,11 @@ extern "C" __global__ void moe_w4a16_fused_gate_up_t_k64(
     const int M_expert = m_end - m_start;
     if (M_expert <= 0) return;
 
-    const int cta_m_local = blockIdx.y * M_TILE;
+    const int cta_m_local = compact ? (int)compact_coords * M_TILE
+                                    : (int)blockIdx.y * M_TILE;
     if (cta_m_local >= M_expert) return;
 
-    const unsigned int global_n = blockIdx.x * N_TILE_LG;
+    const unsigned int global_n = (compact ? n_id : blockIdx.x) * N_TILE_LG;
     const bool is_up = (global_n >= N);
     const unsigned int cta_n = is_up ? (global_n - N) : global_n;
 


### PR DESCRIPTION
Stacks **#582** and **#584** by @zhachar14h-cell (cherry-picked, authorship preserved) so they share **one** gate certification.

## Why stack them

Any change under `crates/` invalidates all ten benchmark records. #582 and #584 each do, so merging them separately costs **two full re-cuts (~8 h of GPU)**; certified together it is **one (~4 h)**. #584's kernel changes are the numerically risky half, and the BFCL/agentic evidence that clears them is exactly the evidence #582 needs too.

## #582 — `min_tokens` on legacy completions (correctness)

Carries `min_tokens` through blocking, streaming, decode and speculative verification: EOS masked until the floor, forced-token handling cannot emit EOS early, GPU argmax falls back to the host logits pipeline when masking is required. Requests omitting `min_tokens` are unaffected.

Note this is **not** a prefill change despite riding with one — it touches decode-side logit processing (`min_tokens_eos.rs`, `forced_token.rs`, `decode_logits_step.rs`).

## #584 — compact NVFP4 MoE prefill (performance)

| Stage | Dense | Compact | Δ |
|---|---:|---:|---:|
| stage-1 TTFT | 601.62 ms | **467.73 ms** | −22% |
| gate/up | 155.85 ms | 107.92 ms | −31% |
| down | 167.34 ms | **59.50 ms** | −64% |
| + K32 down | 467.51 ms | 456.40 ms | −2.4% |

Bit-exact against the dense path across 40 layers / 240 routing+GEMM+final snapshots. Builds a GPU `(expert, m_tile)` row-list once per layer and reuses it for gate/up and down, avoiding the dense worst-case expert grid.

**Both paths are off by default** — `ATLAS_MOE_PREFILL_COMPACT_NVFP4=1`, `ATLAS_MOE_PREFILL_COMPACT_K32=1`.

## Verification so far

- `cargo test --workspace` — **5280 passed, 0 failed**
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --tests` — clean
- Real kernel build (`cargo build --release -p spark-server`, no `ATLAS_SKIP_BUILD`) — succeeds

## Gate records: deliberately not cut yet

#588 is CLEAN and about to land, and it touches `Cargo.lock` + `crates/`. Cutting records now would guarantee a second re-cut the moment it merges — which is what happened to #588 itself earlier today when main moved mid-certification. So this branch will take main, then be certified **once** against a settled main.

## Follow-up this PR does not do

#584's win is **off by default**, so merging it changes nothing measurable until enabled. An off-by-default optimization that no gate exercises is the PR #296 failure mode — a silently-disabled win that passes every gate. A follow-up should enable it in the recipes and add a TTFT leg with it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)