### PR TITLE
fix(ci): repair a stuck harvest PR by replacing it, not pushing to it

### DIFF
--- a/.github/scripts/harvest-triage.sh
+++ b/.github/scripts/harvest-triage.sh
@@ -4,7 +4,8 @@
 #
 #   wait    — checks are running; leave it and let them finish
 #   leave   — healthy and idle; leave it, its successor carries anything new
-#   repair  — it cannot merge on its own; rebuild the branch on current main
+#   repair  — it cannot merge on its own; close it and open a fresh one
+#             (a pushed fix does not make an existing PR's checks report)
 #
 # This lives outside the workflow because the decision is where every bug in
 # this subsystem has been. In one day it churned an open PR with identical

--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -386,10 +386,21 @@ jobs:
                 exit 1
                 ;;
             esac
-            echo "::warning::harvest PR #$open_pr is stuck (mergeState=$pr_state, in-flight=${in_flight:-0}, failed/cancelled=${broken:-0}) — rebuilding it on current main to re-trigger CI"
+            echo "::warning::harvest PR #$open_pr is stuck (mergeState=$pr_state, in-flight=${in_flight:-0}, failed/cancelled=${broken:-0}) — closing it so a fresh one can be opened"
+            # CLOSE it rather than force-push a fix onto it. Pushing to an
+            # existing PR does not make its required checks report: #593 was
+            # rebuilt cleanly, the conflict went away, and the queue still
+            # answered "19 of 19 required status checks are expected" because
+            # zero workflow runs fired on the new head. Opening a PR as the App
+            # does trigger them (#575, #576, #579, #593 all ran on creation),
+            # so the reliable repair is close-then-recreate. Nothing is lost:
+            # every line is re-derived from the run artifacts below.
+            gh pr close "$open_pr" --comment "Superseded automatically: this PR could not merge (mergeState=$pr_state, failed or cancelled checks=${broken:-0}). A pushed fix would not make its required checks report, so the harvest opens a fresh PR with the same ledger instead." \
+              || echo "::warning::could not close #$open_pr; the next harvest will try again"
             repair=1
-            # fall through: the rebuild below force-updates the branch, which
-            # refreshes the PR against current main and restarts its checks.
+            # fall through: the branch is force-recreated below and, with no
+            # open PR left on it, the create path opens a new one whose checks
+            # actually run.
           fi
 
           # Nothing to do if the rolling branch already carries exactly this


### PR DESCRIPTION
**Found by watching #593 after #596 landed.**

#585 repaired a stuck PR by force-pushing a rebuilt branch onto it. That clears the conflict and nothing else. #593 was rebuilt cleanly — `DIRTY` → fresh head `731879395`, conflict gone — and the queue still answered:

```
Pull request 19 of 19 required status checks are expected
```

with **zero workflow runs on the new head**. Pushing to an existing PR does not make its required checks report, which is the same restriction that stranded #568 earlier.

Opening a PR *as the App* does trigger them — #575, #576, #579 and #593 itself all ran their full suite on creation. So the repair now **closes** the stuck PR and lets the create path open a fresh one. Nothing is lost: every ledger line is re-derived from the run artifacts on each harvest.

This is the fifth distinct failure mode in this subsystem and the second where the *decision* was right but the *remedy* could not work. The triage table still passes unchanged, since the decision (`repair`) has not changed — only what `repair` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)