### PR TITLE
fix(site): move the concurrency ladder into the dashboard's Concurrency tab

### DIFF
--- a/site/src/lib/components/BenchmarkDashboard.svelte
+++ b/site/src/lib/components/BenchmarkDashboard.svelte
@@ -4,6 +4,7 @@
   // every chart point. Data: gates.generated.json — the union of gate records
   // across ALL branches at build time, so the newest run shows even before its
   // PR merges (provenance shown per point and in the footer).
+  import ConcurrencyLadder from './ConcurrencyLadder.svelte';
   import GateBenchSection from './GateBenchSection.svelte';
   import GatePointCard from './GatePointCard.svelte';
   import { gateData, tabs, unpublished, models, recordsFor, benchName, shortModel, colorFor } from '$lib/gates.js';
@@ -82,10 +83,13 @@
     </div>
 
     <div class="bd-body">
+      {#if activeTab === 'concurrency'}
+        <ConcurrencyLadder />
+      {/if}
       {#each sections as s (s.benchId)}
         <GateBenchSection {...s} onselect={(rec) => (selected = rec)} />
       {/each}
-      {#if sections.length === 0}
+      {#if sections.length === 0 && activeTab !== 'concurrency'}
         <p class="bd-empty">No records for this model in this benchmark family.</p>
       {/if}
       {#each hiddenByFilter as b}

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -67,7 +67,6 @@ export const nav = {
   links: [
     { text: 'News', href: '#news' },
     { text: 'Verified', href: '#verified' },
-    { text: 'Concurrency', href: '#concurrency' },
     { text: 'Hardware', href: '#hardware' },
     { text: 'Models', href: '#models' },
     { text: 'Get running', href: '#run' },

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -7,7 +7,6 @@
   import StarProof from '$lib/components/StarProof.svelte';
   import Community from '$lib/components/Community.svelte';
   import Verified from '$lib/components/Verified.svelte';
-  import ConcurrencyLadder from '$lib/components/ConcurrencyLadder.svelte';
   import Hardware from '$lib/components/Hardware.svelte';
   import ModelSlider from '$lib/components/ModelSlider.svelte';
   import GetRunning from '$lib/components/GetRunning.svelte';
@@ -26,7 +25,6 @@
 <StarProof />
 <Community />
 <Verified />
-<ConcurrencyLadder />
 <Hardware />
 <ModelSlider />
 <GetRunning />

--- a/site/src/styles/ladder.css
+++ b/site/src/styles/ladder.css
@@ -16,7 +16,10 @@
   border-radius: 12px;
   padding: 1rem 1.1rem 0.5rem;
 }
-.cl-panel svg { width: 100%; height: auto; display: block; }
+.cl-panel svg:not(.cl-swatch) { width: 100%; height: auto; display: block; }
+/* :not(.cl-swatch) matters — `.cl-panel svg` is specificity 0,1,1 and beats the
+   swatch's own 0,1,0 rule below, so the 22x8 legend swatches were rendering at
+   the chart's full width. */
 
 .cl-legend {
   display: flex;
@@ -149,3 +152,25 @@
 .cl-details > summary::-webkit-details-marker { display: none; }
 .cl-details > summary::before { content: '▸ '; color: var(--t3); }
 .cl-details[open] > summary::before { content: '▾ '; }
+
+/* ---- inside the benchmark dashboard ---------------------------------------
+   The ladder was written as a landing-page section and now lives in the modal's
+   Concurrency tab, beside the concurrency-sweep gate chart. Strip the
+   full-bleed section dressing so it reads as a panel rather than a page: the
+   modal supplies its own background, padding and heading scale. */
+.bd-body > .section-alt {
+  background: none;
+  padding: 0 0 1.5rem;
+}
+.bd-body > .section-alt > .container {
+  max-width: none;
+  padding: 0;
+}
+.bd-body > .section-alt .stitle {
+  font-size: 1.15rem;
+  line-height: 1.3;
+  margin-bottom: 0.35rem;
+}
+.bd-body > .section-alt .ssub {
+  font-size: 0.82rem;
+}


### PR DESCRIPTION
#587 published the C=1..128 ladder as a **landing-page section**. It was meant to live in the **benchmark dashboard modal**, under the **Concurrency** tab — which already exists for the `concurrency-sweep` gate, so the ladder now sits beside the record it explains: the sweep is the gated receipt, the ladder is the measured curve behind it.

The landing page and its nav entry drop the section. That also resolves the prerender error a dangling `#concurrency` link raises.

### Two fixes it needed to sit there honestly

**Modal dressing.** The section carried full-bleed background and page-scale heading, which read wrong inside a dialog. Toned down under `.bd-body` only, so nothing else changes.

**A real CSS bug, pre-existing.** `.cl-panel svg` is specificity 0,1,1 and beat `.cl-swatch` at 0,1,0, stretching the 22×8 legend swatches to the chart's full width. Measured on the **live site** at 340×123 before I touched anything, so this is not fallout from the move — it is visible in production right now. Scoped the chart rule with `:not(.cl-swatch)`.

### Verified

Headless: landing page has zero ladder markup; dashboard tabs read `AGENTIC BFCL TTFT DECODE CONCURRENCY` (no duplicate — my first attempt added a second Concurrency tab and I removed it); the ladder renders in that tab with C=1…128, the ratio table, and legend swatches measuring exactly 22×8. Full Playwright suite: **39 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)