### PR TITLE
bench(ladder38): decode_tps is NOT a tighter gate than s_per_turn — negative result

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-19-d3b8ec461c.json
+++ b/.benchmarks/agentic-webserver/2026-08-19-d3b8ec461c.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "d3b8ec461c",
+  "recorded_at": 1787103150,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787102353,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 58.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 32659853421,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6099644,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4646900,
+      "gpu_compute_apps": [
+        {
+          "pid": 1006987,
+          "name": "./target/release/spark",
+          "used_mib": 109282
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787103150,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 62.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        }
+      ],
+      "sm_clock_mhz": 2398.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 32659853421,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5848608,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4743496,
+      "gpu_compute_apps": [
+        {
+          "pid": 1006987,
+          "name": "./target/release/spark",
+          "used_mib": 109308
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 797,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 4.0,
+      "hottest_chassis_delta_c": 2.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +2 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "decode_tps": 30.965584739932755,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 7.099133785945946,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 788.00385024,
+    "sum_completion_tokens": 24401.0,
+    "sum_tool_calls": 107.0,
+    "sum_turns": 111.0,
+    "sum_wall_s": 795.7694212479998,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 7.099s/turn ≤ 8.500 · Σwall 796s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=30.97, followed_directions=10.00, iterations=10.00, s_per_turn=7.10, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=788.00, sum_completion_tokens=24401.00, sum_tool_calls=107.00, sum_turns=111.00, sum_wall_s=795.77, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 7.099s/turn ≤ 8.500 · Σwall 796s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "f5baad3883ae860862c2ba901f4e3c4414d40fefdcfbe9c14076573d5214c874",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "6056b0ef750608f321364f4a67b9c3f0864d88cdec1fc1dccdbe952292142e40",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "593c1bb4038724ae7f9739ab82abd4bf343350f1e504539603d27206d72e03d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "708886c3a943d4526f651d8d54ccc1de08209dd59feadd25f5cd4367870ed3c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "ac22a181f3efc5380b21b76dde595d6544c4c908f696c9b1dc9c9915d2eee228",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "067c0989a6a20fd7a8ead6459a6f1db52224ae5694f3e1d0b372290c871b9328",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "63f2dcf2842e1efaff07d0c4a013aa10d33c14088413b9f64372a4af9897dcda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "8b87d7c7a59fe021fec563e37ac4910f7b1e6c7d19365b4935903bc067848119",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "b3f22c73710c60679ef410aed7d8630b1f90cc2f04c308608dc182281a7f4c77",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc9a13c5e19fb2e912d0db04ffee31df79aa5efdffb330512c7e261ef2a7198b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "3b6907b4ed6f2ea107c79451651342e3b9c95bc4d3d7f0ed3dfeaa75a7c69a90",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f3a70c5e9915edfe639a8581cc1c0d4a79a17391bdd4a428e4729d8b853aa248",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "5d79e039af9db4f547c74a5a5c0f017f6e640e3d5fec200a47a9cff5e20234bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "bb8059ebb18c4eac87791d82ea264825c92219549ba8370fe743602684cde7df",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4fa63efcbdf653889c5d8f9d89eff2414633c90ed1b75c6bedf298a45336f15d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "55ff56614462d7bb0c4116ca6ed9564e140b9e005156cb48d3f05a62ca76db3f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c4cdc8bcf8c2ec8bf8cd30102ced8155448a9d9c5e53b8fa389cd1e0867cc06b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "96475f7b1d900481c458e4050efcbbaf7f910a09d197cdfd5680cf6054bbb51b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d4a1b3f6c27db77e667a3e3a3397d0e9d7c69c41f8da9bc4f4f556eec680bb15",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "8080afa25ff18e27f77b50cf62b117601b6e57ca0ca11a5e34e4df548439c7c0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "c3ba893552a7ed561f3fbae6b8babeb8d886524192dbd1062ecc20b15275a2d4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "3ba3252a020846a8186185e3f449603c018a28531e49cd95225a0cc6eb87573e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "4bcb65e31eaafa9da31191faa21a37a1fb36a0c6b6cd12ffe08a38794bb9e57b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/bench/ladder38/RESULTS.md
+++ b/bench/ladder38/RESULTS.md
@@ -932,6 +932,44 @@ like-for-like. Do not fold such a number into the certified column.
 the right mitigation, but it must be applied to BOTH engines or reported as a separate
 configuration.)
 
+### NEGATIVE RESULT (2026-08-19) — `decode_tps` is NOT a tighter gate than `s_per_turn`
+
+atlas#581 made `s_per_turn` the agentic speed bound and recorded `decode_tps`
+(tokens / agent-wall) unbounded, with a note that tokens are "the honest denominator" and
+that a future change should ratchet onto it. Six measured tiers say **do not**.
+
+| tier | `sum_turns` | `s_per_turn` | `decode_tps` |
+|---:|---:|---:|---:|
+| 1 | 115 | 7.000 | 34.384 |
+| 2 | 127 | 7.118 | 34.229 |
+| 3 | 117 | 6.928 | 34.218 |
+| 4 | 133 | 7.018 | 33.876 |
+| 5 | 114 | 6.452 | 33.747 |
+| 6 | 111 | 7.099 | **30.966** |
+
+| metric | min | max | spread |
+|---|---:|---:|---:|
+| `sum_turns` | 111 | 133 | 19.8% |
+| `s_per_turn` | 6.452 | 7.118 | **10.3%** |
+| `decode_tps` | 30.966 | 34.384 | **11.0%** |
+
+**The two bounds are equally noisy, and `decode_tps` is marginally worse.**
+
+★ This conclusion REVERSES at five tiers, which is the trap. Through tier 5 `decode_tps`
+spanned only 1.9% against `s_per_turn`'s 10.3% — a five-times-tighter result that looked
+like a clear mandate to ratchet. Tier 6 came in at 30.966 (8% below the previous minimum)
+while its `s_per_turn` of 7.099 sat mid-range, and the advantage vanished. Anyone who stops
+at five tiers will conclude the opposite of the truth.
+
+Tier 5 is the other warning: it is the FASTEST tier per turn (6.452) and the SLOWEST per
+token of the first five (33.747). The two metrics do not even rank runs the same way, so
+"tokens are more physical" is not by itself a reason to prefer one.
+
+**Action: none.** `s_per_turn` stays the bound; `decode_tps`, `sum_turns`,
+`sum_agent_wall_s` and `sum_tool_calls` stay recorded and unbounded — they are worth having
+for diagnosis, which is what tier 6 just demonstrated. Do not re-derive this from a short
+run.
+
 ### Round 11 complete — the full ladder, independently reproduced
 
 | C | round 11 | round 10 | vLLM+MTP | ratio |


### PR DESCRIPTION
#581 made `s_per_turn` the agentic speed bound, recorded `decode_tps` unbounded, and noted that tokens are "the honest denominator" with a future change to ratchet onto it.

**Six tiers say don't.**

| tier | `sum_turns` | `s_per_turn` | `decode_tps` |
|---:|---:|---:|---:|
| 1 | 115 | 7.000 | 34.384 |
| 2 | 127 | 7.118 | 34.229 |
| 3 | 117 | 6.928 | 34.218 |
| 4 | 133 | 7.018 | 33.876 |
| 5 | 114 | 6.452 | 33.747 |
| 6 | 111 | 7.099 | **30.966** |

| metric | min | max | spread |
|---|---:|---:|---:|
| `sum_turns` | 111 | 133 | 19.8% |
| `s_per_turn` | 6.452 | 7.118 | **10.3%** |
| `decode_tps` | 30.966 | 34.384 | **11.0%** |

Equally noisy, and `decode_tps` marginally worse. **`s_per_turn` stays the bound.**

## Why this is worth a PR rather than a shrug

**The conclusion reverses at five tiers.** Through tier 5, `decode_tps` spanned just **1.9%** against `s_per_turn`'s 10.3% — five times tighter, and it read as a clear mandate to ratchet. I said so out loud before tier 6 landed at 30.966, 8% below the previous minimum, with its `s_per_turn` of 7.099 sitting mid-range. The advantage vanished on a single sample.

Anyone who stops at five tiers concludes the *opposite* of the truth — which is exactly the failure mode the repo's own "ratchet only after repeated back-to-back tiers, never to the best tier" rule exists to prevent.

**Tier 5 is the second warning.** It is the fastest tier per turn (6.452) and the slowest per token of the first five (33.747). The two metrics don't even rank runs the same way, so "tokens are more physical" is not on its own a reason to switch bounds.

## Action

None to the gate. `decode_tps`, `sum_turns`, `sum_agent_wall_s` and `sum_tool_calls` stay recorded and unbounded — they earn their keep for diagnosis, which is precisely what tier 6 just did.

## Scope

`bench/ladder38/RESULTS.md` only — outside the benchmark closure, so main's records stay valid.