### PR TITLE
fix(ci): keep the harvest commit subject to one line

### DIFF
--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -326,12 +326,17 @@ jobs:
           # API caps it at 256 characters, and a full sweep of 47 runs blew past
           # that and failed PR creation outright. Title states the count, body
           # carries the ids.
-          msg="chore(governance): harvest PR intent ledgers (runs ${run_ids:-unknown})"
+          # A git SUBJECT is a one-line summary and tooling treats it that way.
+          # Interpolating every harvested run id put 110+ ids on that line and
+          # made `git log --oneline` unreadable. The ids are provenance worth
+          # keeping, so they move to the body, where length costs nothing.
           title="chore(governance): harvest PR intent ledgers (${run_count:-0} run(s))"
+          msg="$title"
+          msg_body="Harvested runs: ${run_ids:-unknown}"
           git config user.name  "tbraun96"
           git config user.email "tbraun96@gmail.com"
           git add governance/
-          git commit -m "$msg"
+          git commit -m "$msg" -m "$msg_body"
           git show --stat HEAD
 
           if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
Look at `git log --oneline` on main right now:

```
24b08f26 chore(governance): harvest PR intent ledgers (runs 31917879724 31918802406 31924904384 … 110 more …)
```

The harvest interpolates every run id it swept into the **commit subject**. That is the line `git log --oneline`, `git shortlog`, and every PR list renders, so main's history is now unreadable at a glance.

#578 fixed exactly this for the PR *title* — a 47-run sweep blew the 256-character API limit — and stopped there. The commit subject kept growing because git imposes no limit.

Subject now states the run count; the ids move to the commit body, where length costs nothing and the provenance is still fully recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)