### PR TITLE
feat(ci): move the PR telemetry view onto a Discussion

### DIFF
--- a/.github/actions/upsert-discussion-comment/action.yml
+++ b/.github/actions/upsert-discussion-comment/action.yml
@@ -1,0 +1,105 @@
+name: Upsert a Discussion comment
+description: >-
+  Keep exactly ONE bot-authored comment on a Discussion, rewriting it in place
+  instead of appending a new one on every run. The comment is found by a marker
+  embedded in the body itself, so there is no comment id to store anywhere and
+  a manually deleted comment simply results in a fresh one.
+
+# ── Why a Discussion and not an issue ───────────────────────────────────────
+#
+# These reports are standing documents, not work items. An issue that is never
+# closed reads as a task nobody finished; a Discussion reads as a page, which is
+# what a continuously-rewritten view actually is.
+#
+# ── Why this is an action and not copied into each workflow ─────────────────
+#
+# Discussion comments are GraphQL-ONLY. There is no REST `issues/comments`
+# equivalent, so the familiar `gh api -X PATCH .../issues/comments/$id` cannot
+# be reused and every caller would otherwise carry its own hand-written
+# mutation. Two callers already exist (pr-telemetry, intent-eigenvector), which
+# is one more than a copied implementation survives.
+
+inputs:
+  discussion-number:
+    description: >-
+      The Discussion to post into. MAY BE EMPTY: unset means "not configured
+      yet", and the action says so and succeeds rather than guessing a number
+      and commenting on something arbitrary. Callers render to the step summary
+      regardless, so an unconfigured repo still gets the report.
+    required: false
+    default: ""
+  marker:
+    description: >-
+      The sentinel that identifies OUR comment. Must appear verbatim in
+      `body-file` — the action does not insert it, because the renderer that
+      owns the body is also what should own the marker constant.
+    required: true
+  body-file:
+    description: Path to the rendered Markdown body.
+    required: true
+  token:
+    description: >-
+      A token with `discussions: write`. The caller's job should hold that scope
+      and nothing else.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Upsert
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        DISCUSSION: ${{ inputs.discussion-number }}
+        MARKER: ${{ inputs.marker }}
+        BODY_FILE: ${{ inputs.body-file }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${DISCUSSION:-}" ]; then
+          echo "no discussion configured — rendered the body but posted nothing."
+          echo "Set the repository variable to the Discussion number to enable it."
+          exit 0
+        fi
+        case "$DISCUSSION" in
+          ''|*[!0-9]*) echo "::error::discussion-number must be digits, got '$DISCUSSION'"; exit 1 ;;
+        esac
+        [ -s "$BODY_FILE" ] || { echo "::error::$BODY_FILE is missing or empty"; exit 1; }
+        grep -qF -- "$MARKER" "$BODY_FILE" \
+          || { echo "::error::$BODY_FILE does not contain the marker '$MARKER' — a comment posted without it could never be found again, so this is refused rather than posted"; exit 1; }
+
+        discussion_id=$(gh api graphql -F owner="$OWNER" -F name="$REPO" -F number="$DISCUSSION" -f query='
+          query($owner:String!,$name:String!,$number:Int!){
+            repository(owner:$owner,name:$name){ discussion(number:$number){ id } } }' \
+          --jq '.data.repository.discussion.id')
+        [ -n "$discussion_id" ] || { echo "::error::discussion #$DISCUSSION not found in $OWNER/$REPO"; exit 1; }
+
+        # ★ PAGINATED on purpose. Humans reply in these threads, and once the
+        # replies push our comment past the first page an unpaginated lookup
+        # stops finding it and starts posting a NEW one every run — the exact
+        # duplication the marker exists to prevent.
+        existing=$(gh api graphql --paginate \
+          -F owner="$OWNER" -F name="$REPO" -F number="$DISCUSSION" -f query='
+          query($owner:String!,$name:String!,$number:Int!,$endCursor:String){
+            repository(owner:$owner,name:$name){
+              discussion(number:$number){
+                comments(first:100, after:$endCursor){
+                  pageInfo{ hasNextPage endCursor }
+                  nodes{ id body }
+                } } } }' \
+          --jq ".data.repository.discussion.comments.nodes[] | select(.body | contains(\"$MARKER\")) | .id" \
+          | head -n 1)
+
+        if [ -n "$existing" ]; then
+          gh api graphql -F id="$existing" -F body=@"$BODY_FILE" -f query='
+            mutation($id:ID!,$body:String!){
+              updateDiscussionComment(input:{commentId:$id,body:$body}){ comment{ id } } }' > /dev/null
+          echo "updated comment $existing on discussion #$DISCUSSION"
+        else
+          gh api graphql -F id="$discussion_id" -F body=@"$BODY_FILE" -f query='
+            mutation($id:ID!,$body:String!){
+              addDiscussionComment(input:{discussionId:$id,body:$body}){ comment{ id } } }' > /dev/null
+          echo "created a new comment on discussion #$DISCUSSION"
+        fi

--- a/.github/workflows/pr-telemetry.yml
+++ b/.github/workflows/pr-telemetry.yml
@@ -114,7 +114,7 @@ jobs:
           set -euo pipefail
           cargo run --quiet -p atlas-plugin --bin pr_telemetry -- . < facts.json > body.md
           # The body is the artifact the next job posts. Also echoed into the
-          # run summary so the view is readable even when no tracking issue is
+          # run summary so the view is readable even when no Discussion is
           # configured and nothing gets posted anywhere.
           cat body.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -132,43 +132,31 @@ jobs:
     runs-on: ubuntu-latest
     # The ONLY job with a write scope, and it holds exactly one. Rendering runs
     # read-only, so a bug in the analysis has nowhere to write even in principle.
+    #
+    # `discussions`, not `issues`: this report is a standing document that
+    # rewrites itself every four hours, and an issue nobody ever closes reads as
+    # a task left unfinished. The thread it maintains is
+    # https://github.com/Avarok-Cybersecurity/atlas/discussions/619 — the old
+    # issue #434 carries a pointer to it.
     permissions:
-      issues: write
+      discussions: write
     steps:
+      # Only the composite action is needed, so only the composite action is
+      # fetched — the publish job never reads the tree it is reporting on.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          sparse-checkout: .github/actions/upsert-discussion-comment
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-telemetry-body
 
-      - name: Upsert the comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          # PCND: no default issue number. Unset means "not configured yet",
-          # and the step says so and exits 0 rather than guessing an issue and
-          # commenting on something arbitrary.
-          ISSUE: ${{ vars.PR_TELEMETRY_ISSUE }}
-          MARKER: "<!-- atlas-pr-telemetry:start -->"
-        run: |
-          set -euo pipefail
-          if [ -z "${ISSUE:-}" ]; then
-            echo "PR_TELEMETRY_ISSUE is not set — rendered the view but posted nothing."
-            echo "Set the repository variable to the tracking issue number to enable it."
-            echo "The body is attached to this run as the pr-telemetry-body artifact."
-            exit 0
-          fi
-
-          # Find OUR previous comment by its marker rather than by a stored id,
-          # so there is no state to keep in sync and a deleted comment simply
-          # results in a new one.
-          existing=$(gh api "repos/$REPO/issues/$ISSUE/comments" --paginate \
-            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | .[0].id // empty")
-
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
-              -F body=@body.md > /dev/null
-            echo "updated comment $existing"
-          else
-            gh api -X POST "repos/$REPO/issues/$ISSUE/comments" \
-              -F body=@body.md > /dev/null
-            echo "created a new comment"
-          fi
+      - uses: ./.github/actions/upsert-discussion-comment
+        with:
+          # PCND: no default number. Unset means "not configured yet", and the
+          # action says so and exits 0 rather than commenting somewhere arbitrary.
+          discussion-number: ${{ vars.PR_TELEMETRY_DISCUSSION }}
+          # Must match telemetry::MARKER_START, which is what the renderer emits.
+          marker: "<!-- atlas-pr-telemetry:start -->"
+          body-file: body.md
+          token: ${{ github.token }}


### PR DESCRIPTION
The telemetry view is a standing document — it rewrites itself every four hours and on every merge to `main`, and it is never "done". An issue that is never closed reads as a task nobody finished, which is not what this is.

It now upserts into **[[META] 📊 PR Telemetry](https://github.com/Avarok-Cybersecurity/atlas/discussions/619)**. Issue #434 keeps a pointer so existing links still lead somewhere.

### The one genuinely new mechanic

Discussion comments are **GraphQL-only** — there is no REST `issues/comments` equivalent, so `gh api -X PATCH .../issues/comments/$id` cannot be reused. Rather than hand-write that mutation in every caller, the upsert moves into `.github/actions/upsert-discussion-comment`. The intent-eigenvector report lands next and is the second caller, which is one more than a copied implementation survives.

The round-trip (create → find-by-marker → update → delete) was verified live against discussion #620 before this was written, including a body with backticks, `$dollars`, quotes and newlines.

### Stricter than the code it replaces

Two changes, both closing paths that end in silent duplicate comments:

- **The lookup paginates.** Humans reply in these threads. Once replies push our comment past the first page, an unpaginated lookup stops finding it and posts a new one *every run* — the exact duplication the marker exists to prevent.
- **A body without the marker is refused, not posted.** Such a comment could never be found again, so it would leak a new one on every subsequent run.

### Unchanged

The render/artifact/publish split, the renderer, and the `gate::telemetry` marker constants. Only the transport moved. The publish job still holds exactly one write scope — now `discussions: write` instead of `issues: write`.

### Verification

`vars.PR_TELEMETRY_DISCUSSION` is already set to `619`. After merge: dispatch the workflow twice and confirm the second run *updates in place* rather than adding a second comment.