### PR TITLE
feat(governance): bound the ledger to a FIFO window, indexed by archive.csv

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,10 @@ README.md merge=union
 # Union keeps both sides' lines, and `Journey::deduplicated` collapses any
 # duplicate on read — identity excludes `at`, so a replay converges.
 governance/*.jsonl merge=union
+
+# The bounded-FIFO archive index. Append-only for the same reason the ledgers
+# are, and gets the same conflict-free merge: two harvests evicting different
+# PRs concurrently produce two different tails of the same file, and union is
+# exactly the right resolution. The header row is written once and unions
+# idempotently with itself.
+governance/archive.csv merge=union

--- a/.github/scripts/governance-evict-test.sh
+++ b/.github/scripts/governance-evict-test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Table-driven test for governance-evict.sh. The ledger is a real record and
+# eviction is the only operation that removes anything from it, so every row
+# here is a case where getting it wrong deletes a file that was still needed.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+evict="$here/governance-evict.sh"
+fails=0
+
+check() {  # expected (space-separated, "" for none), cap, open, ledger, why
+  local expected="$1" cap="$2" open="$3" ledger="$4" why="$5" got
+  got="$(printf '%s\n' $ledger | "$evict" "$cap" "$open" 2>&1 | tr '\n' ' ')"
+  got="${got% }"
+  if [ "$got" != "$expected" ]; then
+    printf 'FAIL  cap=%-3s open=[%-9s] -> got [%s], wanted [%s]  (%s)\n' \
+      "$cap" "$open" "$got" "$expected" "$why"
+    fails=$((fails + 1))
+  else
+    printf 'ok    cap=%-3s open=[%-9s] -> [%-11s] %s\n' "$cap" "$open" "$got" "$why"
+  fi
+}
+
+# The common case: the window is not full, so nothing moves. This is what the
+# cap does for most of its life and it must be a true no-op.
+check ""            100 ""     "500 501 502 503 504 505" "under the cap evicts nothing"
+check ""            6   ""     "500 501 502 503 504 505" "exactly at the cap evicts nothing"
+
+# Over the cap: evict exactly what falls outside the newest-`cap` window, oldest
+# first. Never a round number, never "while we're here" — over-eviction is
+# unrecoverable once the source CI artifacts expire at 30 days.
+check "500"         5   ""     "500 501 502 503 504 505" "one over the cap evicts exactly one"
+check "500 501"     4   ""     "500 501 502 503 504 505" "two over evicts the two oldest"
+check "500 501 502 503 504 505" 0 "" "500 501 502 503 504 505" "cap 0 evicts every closed PR"
+
+# FIFO is by PR NUMBER, not by input order — the workflow's glob order is not
+# a contract and must not become one.
+check "500 501"     4   ""     "505 500 503 501 504 502" "unsorted input still evicts the oldest two"
+
+# ── The rule the whole script exists for ────────────────────────────────────
+# `gate::required::intent_source()` looks a ledger up by bare path with no
+# fallback. Evicting an OPEN PR's file does not raise — it silently reports
+# NotRecorded and that PR drops to path-only gating. A wrong answer with no
+# error, so the cap yields to this rule rather than the other way round.
+check "501"         4   "500"  "500 501 502 503 504 505" "an open PR outside the window is skipped, not substituted"
+check ""            4   "500 501" "500 501 502 503 504 505" "all outside candidates open: overshoots rather than break gating"
+
+# ★ The regression this table caught before it shipped. Walking from the oldest
+# and evicting until the count reaches `cap` also satisfies "bounded", but with
+# old PRs pinned open it gets there by evicting the NEWEST ledgers — the recent
+# intent data the trajectory view is built on. Only files outside the window are
+# ever candidates.
+check ""            2   "500 501" "500 501 502 503"       "never reaches into the window to make up the shortfall"
+
+# Degenerate input that occurs on the very first run.
+check ""            100 ""     ""                        "an empty ledger evicts nothing"
+
+# Malformed input is exit 2, never a guess. The candidate list comes from a
+# glob; if the glob changes shape, deleting files on a best-effort reading of
+# it is exactly the wrong response.
+bad() {  # why, cap, open, ledger
+  local why="$1" cap="$2" open="$3" ledger="$4" out rc
+  out="$(printf '%s\n' $ledger | "$evict" "$cap" "$open" 2>&1)"; rc=$?
+  if [ "$rc" -ne 2 ]; then
+    printf 'FAIL  expected exit 2 for %s, got %s (%s)\n' "$why" "$rc" "$out"
+    fails=$((fails + 1))
+  else
+    printf 'ok    exit 2  %s\n' "$why"
+  fi
+}
+bad "a non-numeric cap"          "abc" ""    "502"
+bad "a non-numeric open PR"      "1"   "x502" "502"
+bad "a non-numeric ledger entry" "1"   ""    "pr-502.jsonl"
+
+if [ "$fails" -gt 0 ]; then
+  echo "$fails eviction case(s) failed"
+  exit 1
+fi
+echo "all eviction cases pass"

--- a/.github/scripts/governance-evict.sh
+++ b/.github/scripts/governance-evict.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Decide which per-PR ledger files fall out of the bounded window.
+#
+# `governance/` holds one `pr-<n>.jsonl` per classified PR and has never had a
+# retention rule, so it grows one file per PR forever. This turns it into a
+# bounded FIFO queue: the newest `cap` PRs keep their own file, older ones are
+# evicted and recorded in `governance/archive.csv` as (pr, hash, merged_at) —
+# the hash being the commit that last carried the file, so
+# `git show <hash>:governance/pr-<n>.jsonl` recovers it verbatim. Nothing is
+# destroyed; the git tree is still the store, the CSV is the index into it.
+#
+# This lives outside the workflow for the same reason `harvest-triage.sh` does:
+# the decision is where the bugs are, and a decision in a YAML block is a
+# decision nobody can run.
+#
+# ── The rule that matters ───────────────────────────────────────────────────
+#
+# NEVER evict a PR that is still open. `gate::required::intent_source()` looks
+# its ledger up by bare path with no fallback, so an evicted file does not
+# raise — it silently reports `NotRecorded` and the PR quietly drops to
+# path-only gating. That is a wrong answer with no error, which is the worst
+# kind. The cap yields to this rule: if too few closed candidates exist, fewer
+# files are evicted and the window is allowed to run over.
+#
+# Usage: governance-evict.sh <cap> <open-prs>   [ledger PR numbers on stdin]
+#   <cap>       maximum per-PR files to keep as individual files
+#   <open-prs>  space-separated PR numbers that must not be evicted (may be "")
+#
+# Prints the PR numbers to evict, one per line, oldest first. Nothing else.
+# Exit 0 always on well-formed input (an empty result is a normal outcome);
+# exit 2 on malformed input.
+set -euo pipefail
+
+cap="${1?cap required}"
+open_prs="${2?open PR list required (may be empty)}"
+
+case "$cap" in
+  ''|*[!0-9]*) echo "cap must be a non-negative integer, got '$cap'" >&2; exit 2 ;;
+esac
+for pr in $open_prs; do
+  case "$pr" in
+    *[!0-9]*) echo "open PR list must be numbers, got '$pr'" >&2; exit 2 ;;
+  esac
+done
+
+# Read the candidate ledger PR numbers from stdin, rejecting anything that is
+# not a plain number rather than silently skipping it: a malformed line means
+# the caller's globbing changed, and guessing past that is how a file gets
+# deleted for the wrong reason.
+candidates=()
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  case "$line" in
+    *[!0-9]*) echo "ledger PR numbers must be digits, got '$line'" >&2; exit 2 ;;
+  esac
+  candidates+=("$line")
+done
+
+total=${#candidates[@]}
+outside=$(( total - cap ))
+[ "$outside" -gt 0 ] || exit 0
+
+# FIFO by PR number ascending. PR numbers are monotonic, so this is a stable
+# "oldest first" without consulting timestamps that a re-harvest could move.
+mapfile -t sorted < <(printf '%s\n' "${candidates[@]}" | sort -n)
+
+is_open() {
+  for o in $open_prs; do
+    [ "$o" = "$1" ] && return 0
+  done
+  return 1
+}
+
+# ★ Only the files OUTSIDE the newest-`cap` window are candidates, and an open
+# one among them is skipped rather than substituted for.
+#
+# The tempting alternative — walk from the oldest and keep evicting until the
+# count reaches `cap` — holds the bound exactly, and is wrong. With old PRs
+# still open it reaches the bound by evicting the NEWEST ledgers instead, which
+# is the recent intent data the trajectory view is built on. Better to overshoot
+# the window than to throw away the newest records to defend it.
+#
+# The overshoot is bounded by how many old PRs are open at once and disappears
+# on its own as they close, so it self-corrects without any extra machinery.
+for (( i = 0; i < outside; i++ )); do
+  pr="${sorted[$i]}"
+  is_open "$pr" && continue
+  echo "$pr"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,19 @@ jobs:
       # GPU, no network.
       - run: bash .github/scripts/harvest-triage-test.sh
 
+  governance-evict:
+    name: governance eviction decision table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Eviction is the ONLY operation that removes anything from the ledger,
+      # and the failure it guards against is silent: `intent_source()` looks a
+      # ledger up by bare path with no fallback, so evicting an open PR's file
+      # does not raise — that PR just quietly drops to path-only gating. A
+      # decision that can be wrong without saying so is a decision that gets a
+      # test table.
+      - run: bash .github/scripts/governance-evict-test.sh
+
   test:
     name: cargo test --workspace
     runs-on: ubuntu-latest

--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -299,6 +299,10 @@ jobs:
           APP_TOKEN: ${{ steps.apptoken.outputs.token }}
           # Boolean dispatch input; empty on schedule/workflow_run triggers.
           DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
+          # How many PRs keep their own ledger file. PCND: stated here, not
+          # defaulted inside the script, so changing the window is a reviewable
+          # diff in the workflow rather than a constant buried in bash.
+          LEDGER_CAP: "100"
         run: |
           set -euo pipefail
           d="__ATLAS_HARVEST_EOF_$RANDOM$RANDOM"
@@ -352,6 +356,47 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           git config user.name  "tbraun96"
           git config user.email "tbraun96@gmail.com"
+
+          # ── Bounded FIFO ────────────────────────────────────────────────
+          # `governance/` had no retention rule at all and grew one file per PR
+          # forever. The newest LEDGER_CAP PRs keep their own file; older ones
+          # are removed from the tree and indexed in `archive.csv`, which
+          # records the commit that last carried each file. Nothing is
+          # destroyed — `git show <hash>:governance/pr-<n>.jsonl` still returns
+          # it verbatim. The git tree stays the store; the CSV is the index.
+          #
+          # This rides along with a real harvest by construction: the "nothing
+          # new" guard above has already exited when there is nothing to land,
+          # so eviction never manufactures a commit purely to delete files.
+          open_prs=$(gh pr list --state open --limit 200 --json number --jq '[.[].number] | join(" ")')
+          evict=$(ls governance/pr-*.jsonl 2>/dev/null \
+            | sed 's#.*/pr-\(.*\)\.jsonl#\1#' \
+            | .github/scripts/governance-evict.sh "$LEDGER_CAP" "$open_prs")
+          if [ -n "$evict" ]; then
+            [ -f governance/archive.csv ] || echo "pr,hash,merged_at" > governance/archive.csv
+            for pr in $evict; do
+              # The commit that last carried this ledger. A file created in THIS
+              # run has no such commit yet — it is also, necessarily, among the
+              # newest and so never a candidate — but an unindexable file is
+              # skipped rather than deleted with an empty hash, because an
+              # archive row that cannot be resolved is worse than no row.
+              hash=$(git log -1 --format=%H -- "governance/pr-$pr.jsonl")
+              if [ -z "$hash" ]; then
+                echo "::warning::governance/pr-$pr.jsonl has no commit yet — not evicting it"
+                continue
+              fi
+              # The PR's OWN merge date, not the harvest commit's — the commit
+              # date is already recoverable from `hash` and would say nothing
+              # new. A PR closed without merging has no merge date and records
+              # an empty field, which is the honest answer rather than a
+              # substituted one.
+              merged_at=$(gh pr view "$pr" --json mergedAt --jq '.mergedAt // ""' 2>/dev/null || echo "")
+              printf '%s,%s,%s\n' "$pr" "$hash" "$merged_at" >> governance/archive.csv
+              git rm -q "governance/pr-$pr.jsonl"
+            done
+            echo "archived ledger(s): $evict"
+          fi
+
           git add governance/
           git commit -m "$subject" -m "$run_note"
           git show --stat HEAD

--- a/crates/atlas-governance/src/lib.rs
+++ b/crates/atlas-governance/src/lib.rs
@@ -31,6 +31,14 @@
 //! concurrently cannot conflict semantically, and `.gitattributes` can declare
 //! `merge=union` so they do not conflict textually either.
 //!
+//! The directory holding those files is separately bounded to the newest 100
+//! PRs, with older ones removed from the tree and indexed by commit hash in
+//! `governance/archive.csv` (see that directory's README). That bounds the
+//! DIRECTORY, not the ledgers: eviction removes a whole file, never a line
+//! from one, so the G-Set property described here is unaffected — and the
+//! evicted content is still in git history, byte-identical, at the recorded
+//! hash.
+//!
 //! It is the same order-theoretic shape as the gate's required set in
 //! `atlas-plugin`'s `gate::coverage` (not linked: this crate deliberately does
 //! not depend on it, since the ledger must never be able to reach the gate):

--- a/governance/README.md
+++ b/governance/README.md
@@ -37,6 +37,50 @@ Consequence: never edit or delete lines. A wrong opinion is still a true
 record of what the classifier said; correcting history is exactly what a
 ledger must not do.
 
+## The bounded window, and `archive.csv`
+
+One file per PR, forever, is not a plan — it was 75 files before anything
+capped it. The directory is now a bounded FIFO queue: the newest **100** PRs
+keep their own `pr-<n>.jsonl`, and older ones are removed from the tree and
+recorded in `archive.csv`:
+
+```csv
+pr,hash,merged_at
+519,d3b8ec461c3d5257cb99479a95695ec8f512073b,2026-08-15T20:41:16Z
+```
+
+`hash` is the commit that last carried that file, so the record is not gone —
+it is one command away, byte-identical:
+
+```bash
+git show d3b8ec461c3d5257cb99479a95695ec8f512073b:governance/pr-519.jsonl
+```
+
+That is the whole design: **the git tree is still the store, and the CSV is
+the index into it.** Nothing is copied, so nothing can drift from the original.
+`merged_at` is the PR's own merge date (empty for a PR closed without merging),
+because the commit date is already recoverable from `hash` and would say
+nothing new.
+
+This does not weaken the grow-only property above. Eviction removes a whole
+FILE from the working tree; it never removes a LINE from a file, so the G-Set
+semantics within each ledger are untouched. `archive.csv` is itself append-only
+and carries `merge=union` for the same reason the ledgers do.
+
+**An open PR is never evicted.** `gate::required::intent_source()` resolves a
+ledger by bare path with no fallback, so an evicted file does not raise — the
+PR silently reports `NotRecorded` and drops to path-only gating, which is a
+wrong answer with no error attached. The window yields to this rule: when too
+many old PRs are open, the directory is allowed to run slightly over 100 rather
+than break gating, and it self-corrects as they close.
+
+The decision lives in `.github/scripts/governance-evict.sh` with a test table
+in `governance-evict-test.sh`, for the same reason the harvest triage does —
+a decision expressed in a YAML block is a decision nobody can run.
+
+⚠️ Archive rows point into git history. A history rewrite (the repo had one in
+August 2026, to purge `.buncache`) invalidates every `hash` recorded before it.
+
 ## The `intent:<path>` override label
 
 A maintainer can preempt the model entirely by applying a label of the form


### PR DESCRIPTION
> **Stacked on #622.** Base is `fix/harvest-title-hygiene`; it retargets to `main` automatically when that merges. Both touch the same step of the harvester, so stacking avoids a guaranteed conflict and a second gate run.

`governance/` has held one `pr-<n>.jsonl` per classified PR since it was created, with **no retention rule of any kind** — 75 files today, one more on every PR, forever.

### The design: the tree is the store, the CSV is the index

The newest **100** PRs keep their own file. Older ones leave the tree and are recorded in `archive.csv`:

```csv
pr,hash,merged_at
519,d3b8ec461c3d5257cb99479a95695ec8f512073b,2026-08-15T20:41:16Z
```

`hash` is the commit that last carried the file, so nothing is destroyed:

```bash
git show d3b8ec461c3d5257cb99479a95695ec8f512073b:governance/pr-519.jsonl
```

returns it byte-identically. **No ledger content is copied anywhere**, so the archive cannot drift from the original — it only points at it.

`merged_at` is the PR's own merge date (empty for a PR closed unmerged). The *commit* date is already recoverable from `hash` and would have said nothing new.

### It does not weaken the grow-only property

Eviction removes a whole **file**; it never removes a **line** from a file. The CRDT G-Set semantics inside each ledger are untouched, and `archive.csv` is itself append-only with `merge=union` for the same reason the ledgers have it.

### An open PR is never evicted

`gate::required::intent_source()` resolves a ledger by bare path with **no fallback**. An evicted file therefore does not raise — the PR silently reports `NotRecorded` and drops to path-only gating. A wrong answer with no error attached is the worst failure available here, so the window yields to the rule: with too many old PRs open the directory runs slightly over 100 rather than break gating, and self-corrects as they close.

### The test table earned itself immediately

13 cases in `governance-evict-test.sh`, wired into CI as its own cheap job. The first implementation walked from the oldest and evicted until the count reached the cap — bounded, and **wrong**: with old PRs pinned open it reaches the bound by evicting the *newest* ledgers, which is the recent intent data. The table caught it before it shipped; only files outside the window are candidates now, and that case is row 9.

### Verification

Rehearsed against the **live** 76-file ledger at `cap=70`:

- 4 evictions selected (519, 520, 525, 526)
- the two open PRs in range (502, 521) correctly skipped
- all four recovered from their recorded hash with **matching SHA-256**

Plus: 13/13 table cases pass, YAML parses, and every `run:` block in the harvester passes `bash -n`.