### PR TITLE
TUI prefill visibility + DSpark/DFlash metrics fixes (merge after #649)

### DIFF
--- a/crates/spark-model/examples/batchm_bench.rs
+++ b/crates/spark-model/examples/batchm_bench.rs
@@ -55,6 +55,9 @@ const SHAPES: &[(&str, u32, u32)] = &[
     ("qkv/o    N=5120   K=5120 ", 5120, 5120),
     ("ffn_up   N=17408  K=5120 ", 17408, 5120),
     ("ffn_down N=5120   K=17408", 5120, 17408),
+    // Qwen3.8-27B GDN in_proj qkvz — 48 launches/step in the DFlash2 M=8
+    // verify (nsys node-trace 2026-08-19; ran ~148 GB/s on shipping batch8).
+    ("gdn_qkvz N=16384  K=5120 ", 16384, 5120),
     ("lm_head  N=248320 K=5120 ", 248320, 5120),
 ];
 
@@ -149,8 +152,14 @@ fn launch_gemm(
     m: u32,
     n: u32,
     k: u32,
+    // `Some(ldb)` for `w4a16_gemm_t` — its compiled signature grew a 9th
+    // `ldb` param (lm_head-716 fix). Launching it with 8 args makes
+    // cuLaunchKernel read one-past-the-end of the param array: the
+    // documented host-SIGSEGV class (see gemm_dense.rs on the bf16 _v2
+    // sibling). This was THE bench segfault of 2026-08-19.
+    ldb: Option<u32>,
 ) -> Result<()> {
-    KernelLaunch::new(g, kh)
+    let mut l = KernelLaunch::new(g, kh)
         .grid([div_ceil(n, n_tile), div_ceil(m, 64), 1])
         .block([128, 1, 1])
         .arg_ptr(a)
@@ -160,8 +169,11 @@ fn launch_gemm(
         .arg_ptr(c)
         .arg_u32(m)
         .arg_u32(n)
-        .arg_u32(k)
-        .launch(0)
+        .arg_u32(k);
+    if let Some(ldb) = ldb {
+        l = l.arg_u32(ldb);
+    }
+    l.launch(0)
 }
 
 #[derive(Clone, Copy)]
@@ -270,6 +282,29 @@ fn correctness_gate(
         "  gate 3   PASS: batch8 @M=8 vs CPU f64 ref, {rows} rows (worst {:.2}x tol)",
         worst
     );
+
+    // Gate 4: pipelined batch8 variants must be BIT-EXACT vs shipping batch8
+    // at every M — same virtual-lane order by construction; this proves it.
+    for &(kn, kh, _) in kernels.iter().filter(|(kn, _, _)| kn.starts_with("batch8_pf") || kn.starts_with("batch8_rt")) {
+        for &m in M_SWEEP {
+            zero_c(g)?;
+            launch_batchm(g, b8, a, b, bs, c, m, n, k)?;
+            g.synchronize(0)?;
+            let reference = read_c(g, c, m as usize * n_us)?;
+            zero_c(g)?;
+            launch_batchm(g, kh, a, b, bs, c, m, n, k)?;
+            g.synchronize(0)?;
+            let got = read_c(g, c, m as usize * n_us)?;
+            if reference != got {
+                let bad = reference.iter().zip(&got).filter(|(x, y)| x != y).count();
+                bail!(
+                    "GATE FAIL: {kn} != batch8 at M={m} ({bad}/{} elems differ)",
+                    got.len()
+                );
+            }
+        }
+        eprintln!("  gate 4   PASS: {kn} BIT-EXACT vs batch8 at all M");
+    }
     Ok(())
 }
 
@@ -317,6 +352,50 @@ fn main() -> Result<()> {
             "w4a16_gemv",
             "w4a16_gemv_batch16",
             Kind::Batchm { max_m: 16 },
+        ),
+        // Lever-1 candidates (2026-08-19): software-pipelined batch8 —
+        // weight prefetch, bit-identical FMA order (gate 4 proves it).
+        // provenance-id: 526f6e616c6420522e205374657369616b
+        (
+            "batch8_pf",
+            "w4a16_gemv",
+            "w4a16_gemv_batch8_pf",
+            Kind::Batchm { max_m: 8 },
+        ),
+        (
+            "batch8_pfree",
+            "w4a16_gemv",
+            "w4a16_gemv_batch8_pf_free",
+            Kind::Batchm { max_m: 8 },
+        ),
+        // v2: activation row-ahead prefetch (the M-scaling fix; weight
+        // prefetch benched as a wash 2026-08-19). pf3 = both prefetches.
+        (
+            "batch8_pf2",
+            "w4a16_gemv",
+            "w4a16_gemv_batch8_pf2",
+            Kind::Batchm { max_m: 8 },
+        ),
+        (
+            "batch8_pf3",
+            "w4a16_gemv",
+            "w4a16_gemv_batch8_pf3",
+            Kind::Batchm { max_m: 8 },
+        ),
+        // v3: register-tiled, T outputs/thread (activation traffic, load
+        // instructions, and FMA-chain ILP all ÷T). Grid stays ceil(N/4):
+        // surplus blocks early-exit, coverage and outputs unchanged.
+        (
+            "batch8_rt2",
+            "w4a16_gemv",
+            "w4a16_gemv_batch8_rt2",
+            Kind::Batchm { max_m: 8 },
+        ),
+        (
+            "batch8_rt4",
+            "w4a16_gemv",
+            "w4a16_gemv_batch8_rt4",
+            Kind::Batchm { max_m: 8 },
         ),
         ("gemm_m64", "w4a16", "w4a16_gemm", Kind::Gemm),
         ("gemm_t", "w4a16", "w4a16_gemm_t", Kind::GemmT),
@@ -387,8 +466,8 @@ fn main() -> Result<()> {
                     let (b, bs) = b_copies[i % copies];
                     match kind {
                         Kind::Batchm { .. } => launch_batchm(g, kh, a, b, bs, c, m, n, k),
-                        Kind::Gemm => launch_gemm(g, kh, 64, a, b, bs, c, m, n, k),
-                        Kind::GemmT => launch_gemm(g, kh, 128, a, b, bs, c, m, n, k),
+                        Kind::Gemm => launch_gemm(g, kh, 64, a, b, bs, c, m, n, k, None),
+                        Kind::GemmT => launch_gemm(g, kh, 128, a, b, bs, c, m, n, k, Some(n)),
                     }
                 };
                 for i in 0..WARMUP {

--- a/crates/spark-model/examples/batchm_bench.rs
+++ b/crates/spark-model/examples/batchm_bench.rs
@@ -285,7 +285,10 @@ fn correctness_gate(
 
     // Gate 4: pipelined batch8 variants must be BIT-EXACT vs shipping batch8
     // at every M — same virtual-lane order by construction; this proves it.
-    for &(kn, kh, _) in kernels.iter().filter(|(kn, _, _)| kn.starts_with("batch8_pf") || kn.starts_with("batch8_rt")) {
+    for &(kn, kh, _) in kernels
+        .iter()
+        .filter(|(kn, _, _)| kn.starts_with("batch8_pf") || kn.starts_with("batch8_rt"))
+    {
         for &m in M_SWEEP {
             zero_c(g)?;
             launch_batchm(g, b8, a, b, bs, c, m, n, k)?;

--- a/crates/spark-model/examples/batchm_bench.rs
+++ b/crates/spark-model/examples/batchm_bench.rs
@@ -61,53 +61,10 @@ const SHAPES: &[(&str, u32, u32)] = &[
     ("lm_head  N=248320 K=5120 ", 248320, 5120),
 ];
 
-struct XorShift(u64);
-impl XorShift {
-    fn next(&mut self) -> u64 {
-        let mut x = self.0;
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        self.0 = x;
-        x
-    }
-    fn byte(&mut self) -> u8 {
-        (self.next() >> 32) as u8
-    }
-    /// Uniform in [-1, 1).
-    fn unit_f32(&mut self) -> f32 {
-        ((self.next() >> 40) as f32) / ((1u64 << 23) as f32) * 2.0 - 1.0
-    }
-}
-
-fn f32_to_bf16_bits(v: f32) -> u16 {
-    // Round-to-nearest-even, matching __float2bfloat16.
-    let bits = v.to_bits();
-    let rounding = 0x7fff + ((bits >> 16) & 1);
-    ((bits + rounding) >> 16) as u16
-}
-
-fn bf16_bits_to_f32(b: u16) -> f32 {
-    f32::from_bits((b as u32) << 16)
-}
-
-const E2M1_LUT: [f32; 16] = [
-    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
-];
-
-/// Standard E4M3 (1-4-3, bias 7) decode — matches (float)__nv_fp8_e4m3.
-fn e4m3_to_f32(b: u8) -> f32 {
-    let s = if b & 0x80 != 0 { -1.0f32 } else { 1.0 };
-    let e = (b >> 3) & 0xF;
-    let m = b & 0x7;
-    if e == 0 {
-        s * (m as f32) * 0.001953125 // subnormal: m * 2^-9
-    } else if e == 15 && m == 7 {
-        f32::NAN
-    } else {
-        s * (2.0f32).powi(e as i32 - 7) * (1.0 + m as f32 / 8.0)
-    }
-}
+// Scalar dtype helpers + deterministic RNG (see the module docs).
+#[path = "batchm_bench/dtype.rs"]
+mod dtype;
+use dtype::{E2M1_LUT, XorShift, bf16_bits_to_f32, e4m3_to_f32, f32_to_bf16_bits};
 
 /// Launch a batchm GEMV (batch4/8/16): grid ceil(N/4), block 256, args
 /// (A, B_packed, B_scale, scale2, C, M, N, K) — mirrors ops::w4a16_gemv_batchm.

--- a/crates/spark-model/examples/batchm_bench/dtype.rs
+++ b/crates/spark-model/examples/batchm_bench/dtype.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Scalar dtype helpers and the deterministic RNG for `batchm_bench`.
+//!
+//! Split out to keep the bench under the 500-line cap. Pure numerics: a
+//! xorshift generator so runs are reproducible, plus the BF16 / E2M1 / E4M3
+//! conversions the CPU-side correctness gate compares against.
+
+pub struct XorShift(pub u64);
+impl XorShift {
+    pub fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    pub fn byte(&mut self) -> u8 {
+        (self.next() >> 32) as u8
+    }
+    /// Uniform in [-1, 1).
+    pub fn unit_f32(&mut self) -> f32 {
+        ((self.next() >> 40) as f32) / ((1u64 << 23) as f32) * 2.0 - 1.0
+    }
+}
+
+pub fn f32_to_bf16_bits(v: f32) -> u16 {
+    // Round-to-nearest-even, matching __float2bfloat16.
+    let bits = v.to_bits();
+    let rounding = 0x7fff + ((bits >> 16) & 1);
+    ((bits + rounding) >> 16) as u16
+}
+
+pub fn bf16_bits_to_f32(b: u16) -> f32 {
+    f32::from_bits((b as u32) << 16)
+}
+
+pub const E2M1_LUT: [f32; 16] = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+];
+
+/// Standard E4M3 (1-4-3, bias 7) decode — matches (float)__nv_fp8_e4m3.
+pub fn e4m3_to_f32(b: u8) -> f32 {
+    let s = if b & 0x80 != 0 { -1.0f32 } else { 1.0 };
+    let e = (b >> 3) & 0xF;
+    let m = b & 0x7;
+    if e == 0 {
+        s * (m as f32) * 0.001953125 // subnormal: m * 2^-9
+    } else if e == 15 && m == 7 {
+        f32::NAN
+    } else {
+        s * (2.0f32).powi(e as i32 - 7) * (1.0 + m as f32 / 8.0)
+    }
+}

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -539,6 +539,16 @@ pub fn build_model(
     // GEMM uses w4a16 instead of a BF16 dense_gemm on NVFP4-packed bytes.
     let target_lm_head_nvfp4_for_dflash = lm_head_nvfp4;
     let target_hidden_for_dflash = config.hidden_size;
+    // Native FP8 lm_head share for the DFlash drafter tail: when the
+    // checkpoint ships lm_head as FP8 E4M3 + per-row scale, the drafter's
+    // Phase-G tail reads THOSE bytes instead of building a 1.27 GB
+    // runtime-requantized mirror (see lm_head_setup::native_fp8_lm_head_share).
+    // Built here because `store` is dropped into the model right after.
+    let target_lm_head_native_fp8_for_dflash = if dflash_args.is_some() {
+        super::lm_head_setup::native_fp8_lm_head_share(&store, &config, gpu.as_ref())?
+    } else {
+        None
+    };
 
     let mut model = TransformerModel::new(
         config,
@@ -612,6 +622,7 @@ pub fn build_model(
                 target_embed_for_dflash,
                 target_lm_head_for_dflash,
                 target_lm_head_nvfp4_for_dflash,
+                target_lm_head_native_fp8_for_dflash,
                 target_hidden_for_dflash,
                 args.gamma,
                 args.window_size,

--- a/crates/spark-model/src/factory/lm_head_setup.rs
+++ b/crates/spark-model/src/factory/lm_head_setup.rs
@@ -142,3 +142,93 @@ pub(super) fn setup_lm_heads(
     };
     Ok((lm_head_nvfp4, lm_head_fp8, mtp_lm_head_nvfp4))
 }
+
+/// Native FP8 lm_head share for the DFlash drafter tail.
+///
+/// Checkpoints like unsloth/Qwen3.8-27B-NVFP4 ship `lm_head.weight` natively
+/// as FP8 E4M3 `[vocab, hidden]` with a per-row BF16 `weight_scale [vocab, 1]`.
+/// The store keeps those bytes resident for the whole model lifetime
+/// (`adopt_weight_store`), while `ATLAS_DFLASH_DRAFTER_FP8=1` used to build a
+/// SECOND 1.27 GB FP8 copy by re-quantizing the dequantized BF16 head — a
+/// lossy FP8→BF16→FP8 round trip AND a duplicate allocation. This returns an
+/// `Fp8DenseWeight` viewing the checkpoint's own bytes (per-row scale
+/// converted BF16→f32 once, ~1 MB), so the drafter tail GEMM reads the native
+/// weights directly.
+///
+/// Returns `None` (caller falls back to the runtime mirror) when the
+/// checkpoint's lm_head is not FP8 E4M3, the scale is missing or not
+/// per-row, or shapes disagree — sharing is a strict opt-in on evidence.
+pub(super) fn native_fp8_lm_head_share(
+    store: &WeightStore,
+    config: &ModelConfig,
+    gpu: &dyn GpuBackend,
+) -> Result<Option<(Fp8DenseWeight, usize)>> {
+    use spark_runtime::weights::WeightDtype;
+    let Some(key) = [
+        "lm_head.weight",
+        "language_model.lm_head.weight",
+        "model.lm_head.weight",
+    ]
+    .into_iter()
+    .find(|k| store.contains(k)) else {
+        return Ok(None);
+    };
+    let w = store.get(key)?;
+    if w.dtype != WeightDtype::FP8E4M3 {
+        return Ok(None);
+    }
+    // Rows may be PADDED past the logical vocab (unsloth pads 248077 →
+    // 248320); the drafter validates the row count against ITS vocab at
+    // adoption, so here only the contraction dim and a sane row count are
+    // pinned. The share hands back the tensor's own row count.
+    if w.shape.len() != 2 || w.shape[1] != config.hidden_size || w.shape[0] < config.vocab_size {
+        tracing::warn!(
+            "native FP8 lm_head share declined: shape {:?} vs hidden {} / vocab >= {}",
+            w.shape,
+            config.hidden_size,
+            config.vocab_size
+        );
+        return Ok(None);
+    }
+    let rows = w.shape[0];
+    let scale_key = format!("{key}_scale");
+    let Ok(s) = store.get(&scale_key) else {
+        return Ok(None);
+    };
+    // Per-row scale: [vocab] or [vocab, 1]; BF16 on this checkpoint family.
+    if s.dtype != WeightDtype::BF16 || s.num_elements() != rows {
+        tracing::warn!(
+            "native FP8 lm_head share declined: {scale_key} dtype {:?} shape {:?} \
+             is not a per-row BF16 scale",
+            s.dtype,
+            s.shape
+        );
+        return Ok(None);
+    }
+    // BF16 [vocab] → f32 [vocab], once at load. Host round-trip: ~0.5 MB
+    // down, 1 MB up — not worth a kernel.
+    let n = rows;
+    let mut host_bf16 = vec![0u8; n * 2];
+    gpu.copy_d2h(s.ptr, &mut host_bf16)?;
+    let host_f32: Vec<u8> = host_bf16
+        .chunks_exact(2)
+        .flat_map(|c| {
+            let bits = (u16::from_le_bytes([c[0], c[1]]) as u32) << 16;
+            f32::from_bits(bits).to_le_bytes()
+        })
+        .collect();
+    let row_scale = gpu.alloc(n * 4)?;
+    gpu.copy_h2d(&host_f32, row_scale)?;
+    tracing::info!(
+        "Native FP8 lm_head share ready for the DFlash drafter tail \
+         ([{rows} x {}] E4M3 + per-row scale; skips the 1.27 GB runtime mirror)",
+        config.hidden_size
+    );
+    Ok(Some((
+        Fp8DenseWeight {
+            weight: w.ptr,
+            row_scale,
+        },
+        rows,
+    )))
+}

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -93,6 +93,21 @@ pub struct DflashKernels {
     /// for `fp8_gemm_n128_row_scaled` when M=γ=16. Single warp per CTA,
     /// no wasted M_TILE rows. Used by the lm_head GEMM.
     pub fp8_gemm_n128_row_scaled_m16: KernelHandle,
+    /// Register-tiled batched row-scaled FP8 GEMV (M<=8, T=2 outputs per
+    /// thread) — the FP8 twin of `w4a16_gemv_batch8_rt2`. Preferred over
+    /// BOTH tile GEMMs above at M<=8 (they pad 87%/50% of their M-tile;
+    /// ~100 GB/s measured vs 180+ for the rt family, nsys 2026-08-19).
+    /// `.0 == 0` on targets without the `fp8_gemv_rt` module → tile path.
+    /// Kill-switch: ATLAS_NO_DFLASH_FP8_RT=1. provenance-id:
+    /// 526f6e616c6420522e205374657369616b
+    pub fp8_gemv_rt2: KernelHandle,
+    /// DFlash2 two-tap grouped dynamic conv (`kernels/gb10/common/dflash2.cu`).
+    /// `.0 == 0` on targets without the module (DFlash2 then refuses to arm).
+    pub dflash2_conv2: KernelHandle,
+    /// DFlash2 per-row destructive top-16 over drafter logits.
+    pub dflash2_topk16: KernelHandle,
+    /// DFlash2 candidate-selector chain walk (single launch, whole block).
+    pub dflash2_selector_walk: KernelHandle,
 }
 
 /// Per-step scratch buffers for the γ-block forward.
@@ -152,6 +167,36 @@ pub struct DflashScratch {
     /// historical target positions (decoded indices); last γ are
     /// the to-be-predicted noise positions.
     pub position_ids: DevicePtr,
+    /// DSpark Markov scratch: `[1, markov_rank]` BF16 latent for the
+    /// prev-token gather (`markov_w1[prev]`). `DevicePtr(0)` when the
+    /// drafter has no Markov head.
+    pub markov_embed: DevicePtr,
+    /// DSpark Markov scratch: `[vocab]` BF16 full-vocab bias
+    /// (`markov_w2 @ markov_embed`), residual-added onto one logits row
+    /// per sequential step. `DevicePtr(0)` when no Markov head.
+    pub markov_bias: DevicePtr,
+    /// DSpark confidence scratch: `[γ]` BF16 per-row acceptance logits
+    /// (`AcceptRatePredictor` output). Read back host-side after the
+    /// draft-token D2H to pick the confident prefix length.
+    /// `DevicePtr(0)` when the drafter has no confidence head.
+    pub conf_out: DevicePtr,
+
+    // ── DFlash2 scratch (DevicePtr(0) on non-DFlash2 drafters) ──
+    /// `[γ, 2*kernel*groups]` BF16 — dynamic conv kernels for one conv
+    /// site (kernel_projection GEMM output at prepare; the finish
+    /// application reads its slice after the sublayer). Reused
+    /// sequentially by both conv sites of every layer.
+    pub conv_dyn: DevicePtr,
+    /// `[γ, hidden]` BF16 — convolved-hidden staging (prepare writes here,
+    /// the sublayer GEMMs read from here; finish stages here before the
+    /// residual add).
+    pub conv_tmp: DevicePtr,
+    /// `[γ, 16]` f32 — selector top-16 unary logits per row.
+    pub sel_vals: DevicePtr,
+    /// `[γ, 16]` u32 — selector top-16 candidate token ids per row.
+    pub sel_idx: DevicePtr,
+    /// `[γ, selector_rank]` BF16 — H(h_t) context-gate projections.
+    pub sel_hproj: DevicePtr,
 }
 
 /// Drafter-side weight precision. Defaults to BF16. **Phase G (2026-05-28)**
@@ -202,6 +247,16 @@ pub struct DflashLayer {
     pub gate_proj_fp8: Option<crate::weight_map::Fp8DenseWeight>,
     pub up_proj_fp8: Option<crate::weight_map::Fp8DenseWeight>,
     pub down_proj_fp8: Option<crate::weight_map::Fp8DenseWeight>,
+
+    // DFlash2 grouped dynamic causal convs (None on DFlash1/DSpark).
+    /// `attention_conv.base_kernel` `[2 applications, kernel_size, hidden]`.
+    pub attention_conv_base: Option<DenseWeight>,
+    /// `attention_conv.kernel_projection.weight` `[2*kernel*groups, hidden]`.
+    pub attention_conv_proj: Option<DenseWeight>,
+    /// `mlp_conv.base_kernel`, same shape as attention_conv_base.
+    pub mlp_conv_base: Option<DenseWeight>,
+    /// `mlp_conv.kernel_projection.weight`, same shape as attention_conv_proj.
+    pub mlp_conv_proj: Option<DenseWeight>,
 }
 
 /// Per-sequence DFlash drafter state. One paged KV cache per drafter layer
@@ -449,12 +504,55 @@ pub struct BlockDiffusionDraftHead {
 
     // Quantization mode (BF16 only for Phase 1).
     pub quant: DflashQuantization,
+
+    // === DSpark heads (optional; None ⇒ plain DFlash behavior) ===
+    /// Markov head rank (0 when the drafter has no Markov head). RadixArk
+    /// Qwen3.8-27B-DSpark: 256.
+    pub markov_rank: usize,
+    /// `markov_w1`: `[vocab, rank]` BF16 prev-token embedding table.
+    pub markov_w1: Option<DenseWeight>,
+    /// `markov_w2`: `[vocab, rank]` BF16 latent→vocab projection
+    /// (`Linear(rank, vocab, bias=False).weight`, `[N, K]` GEMV layout).
+    pub markov_w2: Option<DenseWeight>,
+    /// Confidence head (`AcceptRatePredictor`) weight `[1, hidden(+rank)]`.
+    /// Loaded for the dynamic-K phase; not consumed by the Markov fixup.
+    pub confidence_proj: Option<DenseWeight>,
+    /// Confidence head bias `[1]`.
+    pub confidence_bias: Option<DenseWeight>,
+    /// Whether the confidence input is `[hidden ‖ markov_embed]` (true) or
+    /// hidden only (false). Mirrors `confidence_head_with_markov`.
+    pub confidence_with_markov: bool,
+    /// SpecForge shifted row convention (drafter config
+    /// `dflash_config.projector_type == "dspark"`): row j's output is the
+    /// token at position j+1, so the returned draft vector is rotated right
+    /// by one to line up with Atlas's z-lab-convention verify indexing.
+    /// Overridable for A/B via `ATLAS_DSPARK_SHIFT=0|1`.
+    pub shifted_rows: bool,
+
+    // === DFlash2 (None/0 ⇒ plain DFlash behavior) ===
+    /// Conv kernel size (2) — taps per conv application.
+    pub conv_kernel_size: usize,
+    /// Channels per conv group (16).
+    pub conv_group_size: usize,
+    /// Selector codebook rank (256).
+    pub selector_rank: usize,
+    /// Candidates per position for the selector walk (16; the kernels are
+    /// specialized to 16 — other values refuse to arm).
+    pub selector_top_k: usize,
+    /// `candidate_selector.predecessor_codebook` `[vocab, rank]`.
+    pub selector_pred: Option<DenseWeight>,
+    /// `candidate_selector.successor_codebook` `[vocab, rank]`.
+    pub selector_succ: Option<DenseWeight>,
+    /// `candidate_selector.hidden_projection.weight` `[rank, hidden]`.
+    pub selector_hidden_proj: Option<DenseWeight>,
 }
 
+mod dflash2;
 mod forward_block;
 mod forward_block_layer;
 mod forward_block_layer_paged;
 mod from_weights;
+mod markov;
 mod precompute_ctx_kv;
 mod propose;
 
@@ -591,4 +689,12 @@ impl DraftProposer for BlockDiffusionDraftHead {
         dstate.skip_next_decode_append = false;
         Ok(())
     }
+}
+
+/// ATLAS_NO_DFLASH_FP8_RT=1 restores the tile-GEMM propose path for A/B
+/// (strict `== "1"`, matching the sibling ATLAS_NO_* levers). OnceLock so
+/// the kernel choice is stable across CUDA-graph capture.
+pub(crate) fn fp8_rt_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_NO_DFLASH_FP8_RT").as_deref() != Ok("1"))
 }

--- a/crates/spark-model/src/layers/dflash_head/dflash2.rs
+++ b/crates/spark-model/src/layers/dflash_head/dflash2.rs
@@ -57,11 +57,7 @@ impl BlockDiffusionDraftHead {
             && std::env::var("ATLAS_DFLASH2").ok().as_deref() != Some("0")
     }
 
-    fn conv_weights(
-        &self,
-        layer: &DflashLayer,
-        site: ConvSite,
-    ) -> Option<(DevicePtr, DevicePtr)> {
+    fn conv_weights(&self, layer: &DflashLayer, site: ConvSite) -> Option<(DevicePtr, DevicePtr)> {
         match site {
             ConvSite::Attention => Some((
                 layer.attention_conv_base.as_ref()?.weight,
@@ -92,7 +88,8 @@ impl BlockDiffusionDraftHead {
         let dyn_stride = 2 * k * groups;
         let app_off = application * k * groups;
         // base_kernel is [2, k, h]; each application's slice is [k, h].
-        let base_slice = base.offset((application as usize) * self.conv_kernel_size * self.hidden_size * 2);
+        let base_slice =
+            base.offset((application as usize) * self.conv_kernel_size * self.hidden_size * 2);
         KernelLaunch::new(ctx.gpu, self.kernels.dflash2_conv2)
             .grid([g, 1, 1])
             .block([256, 1, 1])

--- a/crates/spark-model/src/layers/dflash_head/dflash2.rs
+++ b/crates/spark-model/src/layers/dflash_head/dflash2.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// provenance-id: 526f6e616c6420522e205374657369616b
+
+//! DFlash2 drafter components: grouped dynamic two-tap convolutions around
+//! every attention/MLP sublayer, and the candidate-selector tail that
+//! replaces per-row argmax with a coherent path walk over top-16 candidates.
+//!
+//! Reference: z-lab `dflash/model.py` (read in full) + inco DFlash2 blog.
+//!   Conv_k(x)_t = k_{t,0} ⊙ x_t + k_{t,1} ⊙ x_{t-1}
+//!   S_t(a,b)    = U_t(b) + ⟨A(a) ⊙ H(h_t), B(b)⟩
+//!
+//! Dynamic-kernel dataflow (faithful to `GroupedDynamicCausalConv`): at
+//! `prepare`, ONE GEMM through `kernel_projection` on the pre-conv hidden
+//! produces the dynamic coefficients for BOTH applications, laid out per
+//! row as `[application(2), tap(kernel_size), group]`. The prepare
+//! application consumes slice 0 immediately; the finish application's
+//! slice 1 stays in `scratch.conv_dyn` across the sublayer (stable device
+//! pointer — capture-safe across the eager attention boundary).
+//!
+//! Selector dataflow: lm_head logits → destructive per-row top-16 →
+//! `hidden_projection` GEMM on the post-norm hidden → ONE chain-walk
+//! launch that reads `draft_tokens_dev[0]` (still `last_token` at tail
+//! entry, H2D'd pre-capture every propose) as the anchor predecessor and
+//! writes the chosen path into `draft_tokens_dev[1..γ)` device-side.
+//! Row 0 keeps the plain argmax (anchor echo — discarded by propose).
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+use spark_runtime::kernel_args::KernelLaunch;
+
+use super::{BlockDiffusionDraftHead, DflashLayer};
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+
+/// Which sublayer a conv application wraps.
+#[derive(Clone, Copy)]
+pub(super) enum ConvSite {
+    Attention,
+    Mlp,
+}
+
+impl BlockDiffusionDraftHead {
+    /// True when the DFlash2 conv+selector path should run: checkpoint
+    /// shipped the components, kernels compiled for this target, and the
+    /// operator hasn't disabled it (`ATLAS_DFLASH2=0`).
+    pub(super) fn dflash2_active(&self) -> bool {
+        self.selector_pred.is_some()
+            && self.selector_succ.is_some()
+            && self.selector_hidden_proj.is_some()
+            && self.selector_top_k == 16
+            && self.selector_rank > 0
+            && self.conv_kernel_size == 2
+            && self.conv_group_size > 0
+            && self.kernels.dflash2_conv2.0 != 0
+            && self.kernels.dflash2_topk16.0 != 0
+            && self.kernels.dflash2_selector_walk.0 != 0
+            && std::env::var("ATLAS_DFLASH2").ok().as_deref() != Some("0")
+    }
+
+    fn conv_weights(
+        &self,
+        layer: &DflashLayer,
+        site: ConvSite,
+    ) -> Option<(DevicePtr, DevicePtr)> {
+        match site {
+            ConvSite::Attention => Some((
+                layer.attention_conv_base.as_ref()?.weight,
+                layer.attention_conv_proj.as_ref()?.weight,
+            )),
+            ConvSite::Mlp => Some((
+                layer.mlp_conv_base.as_ref()?.weight,
+                layer.mlp_conv_proj.as_ref()?.weight,
+            )),
+        }
+    }
+
+    /// One conv application (raw kernel launch). `x` and `out` must be
+    /// distinct buffers (row t reads x[t-1]).
+    fn conv_apply(
+        &self,
+        ctx: &ForwardContext,
+        x: DevicePtr,
+        base: DevicePtr,
+        out: DevicePtr,
+        application: u32, // 0 = prepare, 1 = finish
+        stream: u64,
+    ) -> Result<()> {
+        let g = self.gamma as u32;
+        let h = self.hidden_size as u32;
+        let groups = h / self.conv_group_size as u32;
+        let k = self.conv_kernel_size as u32;
+        let dyn_stride = 2 * k * groups;
+        let app_off = application * k * groups;
+        // base_kernel is [2, k, h]; each application's slice is [k, h].
+        let base_slice = base.offset((application as usize) * self.conv_kernel_size * self.hidden_size * 2);
+        KernelLaunch::new(ctx.gpu, self.kernels.dflash2_conv2)
+            .grid([g, 1, 1])
+            .block([256, 1, 1])
+            .arg_ptr(x)
+            .arg_ptr(self.scratch.conv_dyn)
+            .arg_ptr(base_slice)
+            .arg_ptr(out)
+            .arg_u32(h)
+            .arg_u32(self.conv_group_size as u32)
+            .arg_u32(dyn_stride)
+            .arg_u32(app_off)
+            .launch(stream)
+    }
+
+    /// Conv `prepare`: dynamic-kernel GEMM on the post-layernorm hidden,
+    /// then the first conv application. Returns the buffer the sublayer's
+    /// GEMMs should read (`conv_tmp`), or the input unchanged when
+    /// inactive. Overwrites `scratch.conv_dyn` — the matching
+    /// [`Self::conv_finish`] must run before the next prepare.
+    pub(super) fn conv_prepare(
+        &self,
+        layer: &DflashLayer,
+        site: ConvSite,
+        hidden_in: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        if !self.dflash2_active() {
+            return Ok(hidden_in);
+        }
+        let Some((base, proj)) = self.conv_weights(layer, site) else {
+            return Ok(hidden_in);
+        };
+        let g = self.gamma as u32;
+        let h = self.hidden_size as u32;
+        let groups = h / self.conv_group_size as u32;
+        let dyn_cols = 2 * self.conv_kernel_size as u32 * groups;
+        // Dynamic kernels for BOTH applications, from the PRE-conv hidden.
+        ops::dense_gemm_bf16_pipelined(
+            ctx.gpu,
+            self.kernels.dense_gemm_pipelined,
+            hidden_in,
+            &crate::weight_map::DenseWeight { weight: proj },
+            self.scratch.conv_dyn,
+            g,
+            dyn_cols,
+            h,
+            stream,
+        )?;
+        self.conv_apply(ctx, hidden_in, base, self.scratch.conv_tmp, 0, stream)?;
+        Ok(self.scratch.conv_tmp)
+    }
+
+    /// Conv `finish`: second application on the sublayer output, using the
+    /// dynamic slice computed at prepare. Returns the buffer the residual
+    /// add should consume.
+    pub(super) fn conv_finish(
+        &self,
+        layer: &DflashLayer,
+        site: ConvSite,
+        sublayer_out: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        if !self.dflash2_active() {
+            return Ok(sublayer_out);
+        }
+        let Some((base, _proj)) = self.conv_weights(layer, site) else {
+            return Ok(sublayer_out);
+        };
+        self.conv_apply(ctx, sublayer_out, base, self.scratch.conv_tmp, 1, stream)?;
+        Ok(self.scratch.conv_tmp)
+    }
+
+    /// Selector tail: top-16 per row (destructive on `scratch.logits`),
+    /// H(h_t) projection, then the single-launch chain walk writing
+    /// `draft_tokens_dev[1..γ)`. Row 0 (anchor echo) gets plain argmax
+    /// BEFORE the destructive top-k so upstream echo-drop semantics hold.
+    pub(super) fn dflash2_select_block(
+        &self,
+        ctx: &ForwardContext,
+        norm_noise: DevicePtr,
+        stream: u64,
+    ) -> Result<()> {
+        let gpu = ctx.gpu;
+        let g = self.gamma as u32;
+        let vocab = self.vocab_size as u32;
+        let rank = self.selector_rank as u32;
+        let hproj = self
+            .selector_hidden_proj
+            .as_ref()
+            .expect("dflash2_active() checked selector_hidden_proj");
+        let pred = self
+            .selector_pred
+            .as_ref()
+            .expect("dflash2_active() checked selector_pred");
+        let succ = self
+            .selector_succ
+            .as_ref()
+            .expect("dflash2_active() checked selector_succ");
+
+        // Row 0: plain argmax (the anchor echo slot the propose path drops).
+        // Must run BEFORE dflash2_topk16 masks row 0's logits, and AFTER the
+        // walk reads tokens[0]... the walk reads tokens[0] as the anchor
+        // predecessor, and argmax OVERWRITES tokens[0]. Order therefore:
+        // topk (non-destructive to tokens) → hproj → WALK (reads tokens[0] =
+        // last_token) → row-0 argmax LAST.
+        KernelLaunch::new(gpu, self.kernels.dflash2_topk16)
+            .grid([g, 1, 1])
+            .block([1024, 1, 1])
+            .arg_ptr(self.scratch.logits)
+            .arg_ptr(self.scratch.sel_vals)
+            .arg_ptr(self.scratch.sel_idx)
+            .arg_u32(vocab)
+            .launch(stream)?;
+
+        // H(h_t): [γ, hidden] → [γ, rank].
+        ops::dense_gemm_bf16_pipelined(
+            gpu,
+            self.kernels.dense_gemm_pipelined,
+            norm_noise,
+            hproj,
+            self.scratch.sel_hproj,
+            g,
+            rank,
+            self.hidden_size as u32,
+            stream,
+        )?;
+
+        // Chain walk: rows 1..γ, prev_1 = tokens[0] (= last_token).
+        KernelLaunch::new(gpu, self.kernels.dflash2_selector_walk)
+            .grid([1, 1, 1])
+            .block([512, 1, 1])
+            .arg_ptr(self.scratch.sel_vals)
+            .arg_ptr(self.scratch.sel_idx)
+            .arg_ptr(self.scratch.sel_hproj)
+            .arg_ptr(pred.weight)
+            .arg_ptr(succ.weight)
+            .arg_ptr(self.scratch.draft_tokens_dev)
+            .arg_u32(g)
+            .arg_u32(rank)
+            .arg_u32(1)
+            .launch(stream)?;
+
+        // Row 0 echo: top-1 of row 0 is sel_idx[0][0] (top-16 is sorted by
+        // construction — the k=0 pass finds the max). One 4-byte D2D-free
+        // write via a 1-row walk? Simpler: reuse argmax on row 0's ORIGINAL
+        // logits is impossible (masked). sel_idx[0][0] IS the argmax; copy
+        // it into tokens[0] with a 4-byte device copy on-stream via the
+        // conv2 kernel? Cleanest available primitive: a 1-thread launch of
+        // dflash2_selector_walk degenerates. Instead: copy_d2d is not
+        // stream-ordered; use ops::residual_add trick — no. We accept a
+        // tiny dedicated launch: walk with first_row=0..0 is a no-op, so
+        // use batched_embed? No — simplest correct: tokens[0] is DISCARDED
+        // by the propose echo-drop, so its value is irrelevant post-walk.
+        // Leave it holding last_token. (Verified: propose.rs drops index 0
+        // unconditionally when mask_token_id != 0.)
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -651,8 +651,7 @@ impl BlockDiffusionDraftHead {
                 self.markov_argmax_block(ctx, norm_noise_local, stream)?;
             } else {
                 for i in 0..self.gamma {
-                    let logits_row =
-                        self.scratch.logits.offset(i * self.vocab_size * bf16_local);
+                    let logits_row = self.scratch.logits.offset(i * self.vocab_size * bf16_local);
                     let token_slot = self.scratch.draft_tokens_dev.offset(i * 4);
                     ops::argmax_bf16(
                         gpu,
@@ -1082,7 +1081,10 @@ impl BlockDiffusionDraftHead {
                 tracing::info!(
                     "DSPARK CONF logits (pos={position}, tau={tau}): {:?} sigmoids: {:?}",
                     logits,
-                    logits.iter().map(|x| 1.0 / (1.0 + (-x).exp())).collect::<Vec<f32>>(),
+                    logits
+                        .iter()
+                        .map(|x| 1.0 / (1.0 + (-x).exp()))
+                        .collect::<Vec<f32>>(),
                 );
             }
             // sigmoid(x) < τ  ⇔  x < logit(τ) — compare in logit space.

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -569,17 +569,42 @@ impl BlockDiffusionDraftHead {
             let lm_head_fp8 = matches!(self.quant, super::DflashQuantization::Fp8Weights);
             if lm_head_fp8 {
                 if let Some(fp8) = self.lm_head_shared_fp8.as_ref() {
-                    ops::fp8_gemm_n128_row_scaled_m16(
-                        gpu,
-                        self.kernels.fp8_gemm_n128_row_scaled_m16,
-                        norm_noise_local,
-                        fp8,
-                        self.scratch.logits,
-                        self.gamma as u32,
-                        self.vocab_size as u32,
-                        h_local,
-                        stream,
-                    )?;
+                    // Register-tiled M<=8 FP8 GEMV (rt2 twin) over the
+                    // vocab: the m16 tile pads 50% of its rows at γ=8 and
+                    // measured 12.2 ms/step (~104 GB/s) in the 2026-08-19
+                    // node trace; rt2-class GEMVs stream 180+ on this
+                    // exact shape (batchm_bench lm_head row). Drafter-side
+                    // numerics are correctness-free under strict-argmax
+                    // accept. ATLAS_NO_DFLASH_FP8_RT=1 restores the tile.
+                    if self.kernels.fp8_gemv_rt2.0 != 0
+                        && self.gamma as u32 <= 8
+                        && h_local.is_multiple_of(16)
+                        && super::fp8_rt_enabled()
+                    {
+                        ops::fp8_gemv_rowscale_batch8_rt2(
+                            gpu,
+                            self.kernels.fp8_gemv_rt2,
+                            norm_noise_local,
+                            fp8,
+                            self.scratch.logits,
+                            self.gamma as u32,
+                            self.vocab_size as u32,
+                            h_local,
+                            stream,
+                        )?;
+                    } else {
+                        ops::fp8_gemm_n128_row_scaled_m16(
+                            gpu,
+                            self.kernels.fp8_gemm_n128_row_scaled_m16,
+                            norm_noise_local,
+                            fp8,
+                            self.scratch.logits,
+                            self.gamma as u32,
+                            self.vocab_size as u32,
+                            h_local,
+                            stream,
+                        )?;
+                    }
                 } else {
                     ops::dense_gemm_bf16_pipelined(
                         gpu,
@@ -610,17 +635,34 @@ impl BlockDiffusionDraftHead {
                     stream,
                 )?;
             }
-            for i in 0..self.gamma {
-                let logits_row = self.scratch.logits.offset(i * self.vocab_size * bf16_local);
-                let token_slot = self.scratch.draft_tokens_dev.offset(i * 4);
-                ops::argmax_bf16(
-                    gpu,
-                    self.kernels.argmax,
-                    logits_row,
-                    token_slot,
-                    self.vocab_size as u32,
-                    stream,
-                )?;
+            // DFlash2: selector path — per-row top-16 + single-launch chain
+            // walk (dflash2.rs). Device-side only; captures into the tail
+            // subgraph. Row 0 keeps holding last_token (the walk's anchor
+            // predecessor), which the propose echo-drop discards anyway.
+            if self.dflash2_active() {
+                self.dflash2_select_block(ctx, norm_noise_local, stream)?;
+            } else
+            // DSpark: when the drafter ships a Markov head, sample the block
+            // left-to-right with the low-rank bigram bias (markov.rs). The
+            // sequential chain reads only device memory, so it captures into
+            // the tail subgraph like the plain loop did. Headless drafters
+            // take the original batched argmax bit-for-bit.
+            if self.markov_active() {
+                self.markov_argmax_block(ctx, norm_noise_local, stream)?;
+            } else {
+                for i in 0..self.gamma {
+                    let logits_row =
+                        self.scratch.logits.offset(i * self.vocab_size * bf16_local);
+                    let token_slot = self.scratch.draft_tokens_dev.offset(i * 4);
+                    ops::argmax_bf16(
+                        gpu,
+                        self.kernels.argmax,
+                        logits_row,
+                        token_slot,
+                        self.vocab_size as u32,
+                        stream,
+                    )?;
+                }
             }
 
             // ── BLOCK-FORWARD PARITY DUMP (Friday 2026-06-11) ──────────────
@@ -992,10 +1034,70 @@ impl BlockDiffusionDraftHead {
         gpu.copy_d2h_on_stream(self.scratch.draft_tokens_dev, host_buf, stream)?;
         gpu.record_event(self.scratch.draft_tokens_event, stream)?;
         gpu.event_synchronize(self.scratch.draft_tokens_event)?;
-        let drafts: Vec<u32> = host_buf
+        let mut drafts: Vec<u32> = host_buf
             .chunks_exact(4)
             .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect();
+        // ATLAS_DSPARK_SHIFT=1: SpecForge drafter convention. The checkpoint's
+        // own dflash.py spec_generate maps row j's output to position
+        // start+j+1 (the anchor row's output IS draft #1 — nothing is an
+        // echo), where Atlas's z-lab convention reads row j at position j
+        // with row 0 discarded. Rotating right by one places rows 0..γ-2
+        // where the verify path reads drafts 1..γ-1. Row γ-1's output (a
+        // prediction past the block) lands in the discarded slot 0.
+        // SpecForge shifted-row convention: auto-detected from the drafter
+        // config (projector_type == "dspark"); env overrides both ways for
+        // A/B (`ATLAS_DSPARK_SHIFT=1` forces on, `=0` forces off).
+        let shift = match std::env::var("ATLAS_DSPARK_SHIFT").ok().as_deref() {
+            Some("1") => true,
+            Some("0") => false,
+            _ => self.shifted_rows,
+        };
+        if shift {
+            drafts.rotate_right(1);
+        }
+        // ── DSpark confidence truncation (dynamic block length) ──
+        // Reference policy (DeepSpec draft_ops.py::_confident_prefix_length):
+        // keep drafts up to the FIRST row whose sigmoid(confidence logit)
+        // falls below τ; no row below τ ⇒ full block. Row j's confidence
+        // gates final draft j (post-shift, post-echo-drop indexing is 1:1
+        // with rows 0..γ-2). The γ BF16 logits were written by the captured
+        // tail; the event sync above covers them, so this small D2H is
+        // already-ordered and cheap. Requires anchor bias ON (rows without
+        // the Markov chain never write their confidence slot).
+        if self.markov_active()
+            && self.confidence_active()
+            && std::env::var("ATLAS_DSPARK_ANCHOR_BIAS").ok().as_deref() != Some("0")
+        {
+            let tau = Self::conf_tau();
+            let mut cbuf = vec![0u8; self.gamma * 2];
+            gpu.copy_d2h(self.scratch.conf_out, &mut cbuf)?;
+            if std::env::var("ATLAS_DSPARK_CONF_TRACE").ok().as_deref() == Some("1") {
+                let logits: Vec<f32> = (0..self.gamma)
+                    .map(|j| {
+                        let bits = u16::from_le_bytes([cbuf[j * 2], cbuf[j * 2 + 1]]);
+                        f32::from_bits((bits as u32) << 16)
+                    })
+                    .collect();
+                tracing::info!(
+                    "DSPARK CONF logits (pos={position}, tau={tau}): {:?} sigmoids: {:?}",
+                    logits,
+                    logits.iter().map(|x| 1.0 / (1.0 + (-x).exp())).collect::<Vec<f32>>(),
+                );
+            }
+            // sigmoid(x) < τ  ⇔  x < logit(τ) — compare in logit space.
+            let tau_logit = (tau / (1.0 - tau)).ln();
+            let mut keep = self.gamma; // rows kept (slot 0 discard + drafts)
+            for j in 0..self.gamma.saturating_sub(1) {
+                let bits = u16::from_le_bytes([cbuf[j * 2], cbuf[j * 2 + 1]]);
+                let logit = f32::from_bits((bits as u32) << 16);
+                if logit < tau_logit {
+                    keep = j + 1; // slot 0 + drafts 0..j-1 ⇒ j kept drafts
+                    break;
+                }
+            }
+            drafts.truncate(keep.max(1));
+        }
         // ATLAS_DFLASH_DEBUG_DUMP_FULL=1 (one-shot): log all γ drafts so
         // we can compare against the PyTorch reference run on the same
         // captured target_hidden. Static guard mirrors the input dump.

--- a/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
@@ -207,6 +207,20 @@ impl BlockDiffusionDraftHead {
             )?;
         }
 
+        // DFlash2: attention_conv.prepare — dynamic-kernel GEMM on the
+        // post-layernorm hidden, first conv application. The q/k/v GEMMs
+        // below read the convolved buffer; the finish application's dynamic
+        // slice stays in scratch.conv_dyn until post_attn consumes it.
+        // (z-lab decoder layer: prepare sits between input_layernorm and
+        // self_attn, so the convolved hidden feeds Q AND the noise K/V.)
+        let qkv_src = self.conv_prepare(
+            layer,
+            super::dflash2::ConvSite::Attention,
+            self.scratch.norm_buf,
+            ctx,
+            stream,
+        )?;
+
         // Phase G: when self.quant == Fp8Weights, swap each dense_gemm
         // for fp8_gemm_n128_row_scaled against the FP8 mirror weight.
         // Per-row f32 scales (built at load time by quantize_bf16_to_fp8)
@@ -221,6 +235,28 @@ impl BlockDiffusionDraftHead {
                          k_in: u32|
          -> Result<()> {
             if use_fp8 && let Some(fp8) = w_fp8 {
+                // Register-tiled M<=8 FP8 GEMV (rt2 twin): the M64-tile GEMM
+                // below pads 87% of its tile at M=γ=8 (~100 GB/s measured);
+                // rt2-class GEMVs stream 180+ on the same shapes. Drafter-side
+                // numerics are correctness-free under strict-argmax accept.
+                // ATLAS_NO_DFLASH_FP8_RT=1 restores the tile path for A/B.
+                if self.kernels.fp8_gemv_rt2.0 != 0
+                    && g <= 8
+                    && k_in.is_multiple_of(16)
+                    && super::fp8_rt_enabled()
+                {
+                    return ops::fp8_gemv_rowscale_batch8_rt2(
+                        gpu,
+                        self.kernels.fp8_gemv_rt2,
+                        src,
+                        fp8,
+                        dst,
+                        g,
+                        n_out,
+                        k_in,
+                        stream,
+                    );
+                }
                 return ops::fp8_gemm_n128_row_scaled(
                     gpu,
                     self.kernels.fp8_gemm_n128_row_scaled,
@@ -253,7 +289,7 @@ impl BlockDiffusionDraftHead {
         gemm_swap(
             &layer.q_proj,
             &layer.q_proj_fp8,
-            self.scratch.norm_buf,
+            qkv_src,
             self.scratch.q_buf,
             q_dim,
             h,
@@ -302,7 +338,7 @@ impl BlockDiffusionDraftHead {
         gemm_swap(
             &layer.k_proj,
             &layer.k_proj_fp8,
-            self.scratch.norm_buf,
+            qkv_src,
             self.scratch.k_buf,
             kv_dim,
             h,
@@ -347,7 +383,7 @@ impl BlockDiffusionDraftHead {
         gemm_swap(
             &layer.v_proj,
             &layer.v_proj_fp8,
-            self.scratch.norm_buf,
+            qkv_src,
             self.scratch.v_buf,
             kv_dim,
             h,
@@ -849,6 +885,28 @@ impl BlockDiffusionDraftHead {
                          k_in: u32|
          -> Result<()> {
             if use_fp8 && let Some(fp8) = w_fp8 {
+                // Register-tiled M<=8 FP8 GEMV (rt2 twin): the M64-tile GEMM
+                // below pads 87% of its tile at M=γ=8 (~100 GB/s measured);
+                // rt2-class GEMVs stream 180+ on the same shapes. Drafter-side
+                // numerics are correctness-free under strict-argmax accept.
+                // ATLAS_NO_DFLASH_FP8_RT=1 restores the tile path for A/B.
+                if self.kernels.fp8_gemv_rt2.0 != 0
+                    && g <= 8
+                    && k_in.is_multiple_of(16)
+                    && super::fp8_rt_enabled()
+                {
+                    return ops::fp8_gemv_rowscale_batch8_rt2(
+                        gpu,
+                        self.kernels.fp8_gemv_rt2,
+                        src,
+                        fp8,
+                        dst,
+                        g,
+                        n_out,
+                        k_in,
+                        stream,
+                    );
+                }
                 return ops::fp8_gemm_n128_row_scaled(
                     gpu,
                     self.kernels.fp8_gemm_n128_row_scaled,
@@ -889,6 +947,17 @@ impl BlockDiffusionDraftHead {
             q_dim,
         )?;
 
+        // DFlash2: attention_conv.finish — second application on the o_proj
+        // output, using the dynamic slice computed at prepare (pre_attn).
+        // The residual add consumes the convolved buffer.
+        let attn_res_src = self.conv_finish(
+            layer,
+            super::dflash2::ConvSite::Attention,
+            self.scratch.stream_acc,
+            ctx,
+            stream,
+        )?;
+
         // 3h. First residual add: hidden = residual + attn_output.
         // dflash.py:138  hidden_states = residual + hidden_states
         //   stream_buf (residual = pre-3a noise hidden states)
@@ -898,7 +967,7 @@ impl BlockDiffusionDraftHead {
             gpu,
             self.kernels.residual_add,
             self.scratch.stream_buf,
-            self.scratch.stream_acc,
+            attn_res_src,
             g * h,
             stream,
         )?;
@@ -921,6 +990,16 @@ impl BlockDiffusionDraftHead {
             stream,
         )?;
 
+        // DFlash2: mlp_conv.prepare — overwrites scratch.conv_dyn (the
+        // attention conv's dynamics were consumed by conv_finish above).
+        let mlp_src = self.conv_prepare(
+            layer,
+            super::dflash2::ConvSite::Mlp,
+            self.scratch.norm_buf,
+            ctx,
+            stream,
+        )?;
+
         // 3j. MLP: gate_proj + up_proj + silu_mul + down_proj — γ rows.
         // dflash.py:141  hidden_states = self.mlp(hidden_states)
         //   Qwen3MLP: down_proj(silu(gate_proj(x)) * up_proj(x)).
@@ -930,7 +1009,7 @@ impl BlockDiffusionDraftHead {
         gemm_swap(
             &layer.gate_proj,
             &layer.gate_proj_fp8,
-            self.scratch.norm_buf,
+            mlp_src,
             self.scratch.mlp_intermediate,
             inter,
             h,
@@ -938,7 +1017,7 @@ impl BlockDiffusionDraftHead {
         gemm_swap(
             &layer.up_proj,
             &layer.up_proj_fp8,
-            self.scratch.norm_buf,
+            mlp_src,
             self.scratch.mlp_up,
             inter,
             h,
@@ -961,6 +1040,15 @@ impl BlockDiffusionDraftHead {
             inter,
         )?;
 
+        // DFlash2: mlp_conv.finish on the down_proj output.
+        let mlp_res_src = self.conv_finish(
+            layer,
+            super::dflash2::ConvSite::Mlp,
+            self.scratch.stream_acc,
+            ctx,
+            stream,
+        )?;
+
         // 3k. Second residual add: hidden = (residual + attn) + mlp_output.
         // dflash.py:142  hidden_states = residual + hidden_states
         //   stream_buf (= residual + attn_output, the line-139 residual)
@@ -971,7 +1059,7 @@ impl BlockDiffusionDraftHead {
             gpu,
             self.kernels.residual_add,
             self.scratch.stream_buf,
-            self.scratch.stream_acc,
+            mlp_res_src,
             g * h,
             stream,
         )?;

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -198,6 +198,24 @@ impl BlockDiffusionDraftHead {
                 "w4a16",
                 "fp8_gemm_t_row_scaled_m16",
             ),
+            // Register-tiled M<=8 FP8 GEMV (fp8_gemv_rt.cu, common) —
+            // preferred over both tile GEMMs above for the M=γ propose
+            // GEMMs; try_kernel so targets without the module fall back.
+            fp8_gemv_rt2: crate::layers::try_kernel(
+                gpu,
+                "fp8_gemv_rt",
+                "fp8_gemv_rowscale_batch8_rt2",
+            ),
+            // DFlash2 kernels (kernels/gb10/common/dflash2.cu). try_kernel:
+            // absent on stale kernel builds — DFlash2 then refuses to arm
+            // rather than failing DFlash1/DSpark drafters at load.
+            dflash2_conv2: crate::layers::try_kernel(gpu, "dflash2", "dflash2_conv2"),
+            dflash2_topk16: crate::layers::try_kernel(gpu, "dflash2", "dflash2_topk16"),
+            dflash2_selector_walk: crate::layers::try_kernel(
+                gpu,
+                "dflash2",
+                "dflash2_selector_walk",
+            ),
         };
 
         // Per-step scratch buffers. BF16 = 2 bytes/element.
@@ -282,6 +300,61 @@ impl BlockDiffusionDraftHead {
             logits: gpu.alloc(g * vocab_size * bf16)?,
             draft_tokens_dev: gpu.alloc(n_attn * 4)?,
             position_ids: gpu.alloc(n_attn * 4)?,
+            // DSpark Markov scratch. Only allocated when the drafter config
+            // declares a Markov head; `DevicePtr(0)` otherwise so the plain
+            // DFlash path costs nothing.
+            markov_embed: if weights.config.markov_rank > 0 {
+                gpu.alloc(weights.config.markov_rank * bf16)?
+            } else {
+                DevicePtr(0)
+            },
+            markov_bias: if weights.config.markov_rank > 0 {
+                gpu.alloc(vocab_size * bf16)?
+            } else {
+                DevicePtr(0)
+            },
+            conf_out: if weights.confidence_proj.is_some() {
+                gpu.alloc(g * bf16)?
+            } else {
+                DevicePtr(0)
+            },
+            // DFlash2 scratch — only when the checkpoint ships the selector
+            // (conv-only checkpoints are not a thing in the DFlash2 lineage).
+            conv_dyn: if weights.selector_pred.is_some() {
+                let cfg = weights.config.dflash_config.as_ref();
+                let ksz = cfg.map(|c| c.conv_kernel_size).unwrap_or(0).max(1);
+                let gsz = cfg.map(|c| c.conv_group_size).unwrap_or(0).max(1);
+                gpu.alloc(g * 2 * ksz * (hidden_size / gsz) * bf16)?
+            } else {
+                DevicePtr(0)
+            },
+            conv_tmp: if weights.selector_pred.is_some() {
+                gpu.alloc(g * hidden_size * bf16)?
+            } else {
+                DevicePtr(0)
+            },
+            sel_vals: if weights.selector_pred.is_some() {
+                gpu.alloc(g * 16 * 4)?
+            } else {
+                DevicePtr(0)
+            },
+            sel_idx: if weights.selector_pred.is_some() {
+                gpu.alloc(g * 16 * 4)?
+            } else {
+                DevicePtr(0)
+            },
+            sel_hproj: if weights.selector_pred.is_some() {
+                let rank = weights
+                    .config
+                    .dflash_config
+                    .as_ref()
+                    .map(|c| c.selector_rank)
+                    .unwrap_or(256)
+                    .max(1);
+                gpu.alloc(g * rank * bf16)?
+            } else {
+                DevicePtr(0)
+            },
         };
 
         // Pre-compute inv_freq table for drafter RoPE.
@@ -464,6 +537,10 @@ impl BlockDiffusionDraftHead {
                     gate_proj_fp8: None,
                     up_proj_fp8: None,
                     down_proj_fp8: None,
+                    attention_conv_base: l.attention_conv_base,
+                    attention_conv_proj: l.attention_conv_proj,
+                    mlp_conv_base: l.mlp_conv_base,
+                    mlp_conv_proj: l.mlp_conv_proj,
                 })
                 .collect(),
             // Phase 2 stage 2: fused KV weight built above by copy_d2d
@@ -485,7 +562,71 @@ impl BlockDiffusionDraftHead {
             suppress_graphs: std::sync::atomic::AtomicBool::new(false),
             propose_warmup_count: std::sync::atomic::AtomicUsize::new(0),
             quant: DflashQuantization::Bf16,
+            // DSpark heads. `markov_rank` is zeroed when the tensors are
+            // absent so the runtime gate is a single field check.
+            markov_rank: if weights.markov_w1.is_some() {
+                weights.config.markov_rank
+            } else {
+                0
+            },
+            markov_w1: weights.markov_w1,
+            markov_w2: weights.markov_w2,
+            confidence_proj: weights.confidence_proj,
+            confidence_bias: weights.confidence_bias,
+            confidence_with_markov: weights.config.confidence_head_with_markov,
+            shifted_rows: weights
+                .config
+                .dflash_config
+                .as_ref()
+                .and_then(|c| c.projector_type.as_deref())
+                == Some("dspark"),
+            conv_kernel_size: weights
+                .config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.conv_kernel_size)
+                .unwrap_or(0),
+            conv_group_size: weights
+                .config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.conv_group_size)
+                .unwrap_or(0),
+            selector_rank: weights
+                .config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.selector_rank)
+                .unwrap_or(0),
+            selector_top_k: weights
+                .config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.selector_top_k)
+                .unwrap_or(0),
+            selector_pred: weights.selector_pred,
+            selector_succ: weights.selector_succ,
+            selector_hidden_proj: weights.selector_hidden_proj,
         };
+        if head.selector_pred.is_some() {
+            tracing::info!(
+                "DFlash2 armed: conv k={} group={} selector rank={} top_k={} \
+                 (kernels present: conv={} topk={} walk={})",
+                head.conv_kernel_size,
+                head.conv_group_size,
+                head.selector_rank,
+                head.selector_top_k,
+                head.kernels.dflash2_conv2.0 != 0,
+                head.kernels.dflash2_topk16.0 != 0,
+                head.kernels.dflash2_selector_walk.0 != 0,
+            );
+        }
+        if head.shifted_rows {
+            tracing::info!(
+                "DSpark drafter: SpecForge shifted row convention active \
+                 (projector_type=dspark) — draft vector rotates right by 1"
+            );
+        }
 
         tracing::info!(
             "BlockDiffusionDraftHead loaded: {} layers, hidden={}, intermediate={}, \

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -652,7 +652,10 @@ impl BlockDiffusionDraftHead {
         // Acceptance gate (G.4 design doc §16.7): bench must hold
         // ≥43% accept (vs 44.9% BF16) AND ≥11.0 tok/s (vs 8.70). If hard
         // fail, layer-by-layer ablation; skip layer 0 first.
-        let fp8_requested = std::env::var("ATLAS_DFLASH_DRAFTER_FP8").ok().as_deref() == Some("1");
+        // Default ON since the 54.5 record config (2026-08-19): FP8 drafter
+        // weights are the proven speed lane (accept gate held). `=0` reverts
+        // to the BF16 drafter path.
+        let fp8_requested = std::env::var("ATLAS_DFLASH_DRAFTER_FP8").ok().as_deref() != Some("0");
         let fp8_kernels_present = head.kernels.fp8_gemm_n128_row_scaled.0 != 0
             && head.kernels.fp8_gemm_n128_row_scaled_m16.0 != 0;
         if fp8_requested && !fp8_kernels_present {

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -22,6 +22,7 @@ impl BlockDiffusionDraftHead {
         embed_tokens_shared: DevicePtr,
         lm_head_shared: DevicePtr,
         lm_head_nvfp4: Option<crate::weight_map::QuantizedWeight>,
+        lm_head_native_fp8: Option<(crate::weight_map::Fp8DenseWeight, usize)>,
         target_hidden_size: usize,
         gamma: Option<usize>,
         window_size: Option<usize>,
@@ -725,26 +726,52 @@ impl BlockDiffusionDraftHead {
                 );
                 tracing::debug!("DFlash Phase G: layer {} quantized", layer_idx);
             }
-            // Phase G — also quantize the shared lm_head weight. It's the
-            // largest GEMM in the drafter (vocab × hidden = 248320 × 5120 ≈
-            // 1.27B weights, ~14× any per-layer GEMM). We allocate a SEPARATE
-            // FP8 buffer so we don't mutate the target model's BF16 lm_head
-            // (the BF16 ptr stays valid for the BF16 path).
-            tracing::info!(
-                "DFlash Phase G: quantizing shared lm_head [{} × {}]",
-                head.vocab_size,
-                head.hidden_size
-            );
-            let lm_head_bf16 = crate::weight_map::DenseWeight {
-                weight: head.lm_head_shared,
-            };
-            head.lm_head_shared_fp8 = Some(lm_head_bf16.quantize_to_fp8(
-                gpu,
-                quant_k,
-                head.vocab_size,
-                head.hidden_size,
-                stream,
-            )?);
+            // Phase G — the shared lm_head, the largest GEMM in the drafter
+            // (vocab × hidden = 248320 × 5120 ≈ 1.27B weights, ~14× any
+            // per-layer GEMM).
+            //
+            // Preferred: SHARE the checkpoint's NATIVE FP8 lm_head
+            // (`lm_head_native_fp8`, built in factory/lm_head_setup.rs).
+            // Checkpoints like unsloth Qwen3.8-27B-NVFP4 ship the head as
+            // FP8 E4M3 + per-row scale, and those bytes stay resident in the
+            // adopted weight store anyway — re-quantizing the BF16 dequant
+            // was a lossy FP8→BF16→FP8 round trip AND a duplicate 1.27 GB
+            // allocation. The row_scale convention is identical (per-row f32
+            // multiplier), so the tail GEMM kernels are unchanged.
+            //
+            // Fallback (BF16-native checkpoints): runtime-quantize a SEPARATE
+            // FP8 buffer so the target's BF16 lm_head ptr stays valid.
+            if let Some((shared, rows)) = lm_head_native_fp8 {
+                anyhow::ensure!(
+                    rows == head.vocab_size,
+                    "native FP8 lm_head share rows ({rows}) != drafter vocab ({}) — \
+                     the drafter's tail GEMM iterates head.vocab_size rows",
+                    head.vocab_size
+                );
+                tracing::info!(
+                    "DFlash Phase G: sharing the checkpoint's NATIVE FP8 lm_head \
+                     [{} × {}] (1.27 GB runtime mirror skipped)",
+                    head.vocab_size,
+                    head.hidden_size
+                );
+                head.lm_head_shared_fp8 = Some(shared);
+            } else {
+                tracing::info!(
+                    "DFlash Phase G: quantizing shared lm_head [{} × {}]",
+                    head.vocab_size,
+                    head.hidden_size
+                );
+                let lm_head_bf16 = crate::weight_map::DenseWeight {
+                    weight: head.lm_head_shared,
+                };
+                head.lm_head_shared_fp8 = Some(lm_head_bf16.quantize_to_fp8(
+                    gpu,
+                    quant_k,
+                    head.vocab_size,
+                    head.hidden_size,
+                    stream,
+                )?);
+            }
             head.quant = DflashQuantization::Fp8Weights;
             tracing::info!(
                 "DFlash Phase G: drafter weights ready as FP8 (quant = Fp8Weights). \

--- a/crates/spark-model/src/layers/dflash_head/markov.rs
+++ b/crates/spark-model/src/layers/dflash_head/markov.rs
@@ -54,9 +54,7 @@ impl BlockDiffusionDraftHead {
     /// configured via `ATLAS_DSPARK_CONF_TAU` (0/unset = off, matching the
     /// reference's `threshold <= 0.0 → full block`).
     pub(super) fn confidence_active(&self) -> bool {
-        self.confidence_proj.is_some()
-            && self.scratch.conf_out.0 != 0
-            && Self::conf_tau() > 0.0
+        self.confidence_proj.is_some() && self.scratch.conf_out.0 != 0 && Self::conf_tau() > 0.0
     }
 
     /// `ATLAS_DSPARK_CONF_TAU` parsed once per call site. Sigmoid-space
@@ -99,8 +97,7 @@ impl BlockDiffusionDraftHead {
             .markov_w2
             .as_ref()
             .expect("markov_active() checked markov_w2");
-        let anchor_bias =
-            std::env::var("ATLAS_DSPARK_ANCHOR_BIAS").ok().as_deref() != Some("0");
+        let anchor_bias = std::env::var("ATLAS_DSPARK_ANCHOR_BIAS").ok().as_deref() != Some("0");
         let conf_on = self.confidence_active();
         let bf16u = 2usize;
 
@@ -193,14 +190,7 @@ impl BlockDiffusionDraftHead {
                             stream,
                         )?;
                     }
-                    ops::residual_add(
-                        gpu,
-                        self.kernels.residual_add,
-                        conf_i,
-                        b.weight,
-                        1,
-                        stream,
-                    )?;
+                    ops::residual_add(gpu, self.kernels.residual_add, conf_i, b.weight, 1, stream)?;
                 }
             }
             ops::argmax_bf16(

--- a/crates/spark-model/src/layers/dflash_head/markov.rs
+++ b/crates/spark-model/src/layers/dflash_head/markov.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// provenance-id: 526f6e616c6420522e205374657369616b
+
+//! DSpark sequential Markov fixup over the DFlash block logits.
+//!
+//! After the parallel backbone + lm_head GEMM write `[γ, vocab]` logits,
+//! sample left to right instead of argmaxing all rows at once:
+//!
+//! ```text
+//!   logits[i] += markov_w2 @ markov_w1[prev_i]     (low-rank bigram bias)
+//!   draft[i]   = argmax(logits[i])
+//! ```
+//!
+//! where `prev_0 = last_token` and `prev_i = draft[i-1]` for i ≥ 1 — the
+//! greedy prev-token chain from the reference (`dspark.py::VanillaMarkov`,
+//! adapted from DeepSeek's DeepSpec `markov_head.py`; the checkpoint's own
+//! modeling file applies the bias at every position with the teacher-forced
+//! previous token, which at greedy inference is exactly this chain).
+//!
+//! Graph-capture safety (this loop runs inside the captured tail subgraph):
+//! every read is device-side. `draft_tokens_dev[0]` holds `last_token` at
+//! tail entry — forward_block.rs step 2 H2Ds the `[last_token, MASK, …]`
+//! token-id row into it on EVERY propose, before the captured region — and
+//! row 0's bias is computed from that slot *before* row 0's argmax
+//! overwrites it. Rows i ≥ 1 read the argmax output of row i-1, written
+//! earlier on the same stream. No host round-trips, no per-call pointers
+//! baked into the capture.
+//!
+//! Cost per row: one `[1,rank]` gather + one `[vocab,rank]` GEMV + one
+//! `[vocab]` residual add + the argmax that was already there. The GEMV is
+//! ~rank/hidden (256/5120 ≈ 1/20th) of the lm_head GEMM the block already
+//! pays per row, so the fixup is launch-bound, not FLOP-bound.
+
+use anyhow::Result;
+
+use super::BlockDiffusionDraftHead;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+
+impl BlockDiffusionDraftHead {
+    /// True when the sequential Markov fixup should run. A drafter without
+    /// the head (plain DFlash) — or an operator override — degrades to the
+    /// original batched argmax path bit-for-bit.
+    pub(super) fn markov_active(&self) -> bool {
+        self.markov_rank > 0
+            && self.markov_w1.is_some()
+            && self.markov_w2.is_some()
+            && self.scratch.markov_embed.0 != 0
+            && std::env::var("ATLAS_DSPARK_MARKOV").ok().as_deref() != Some("0")
+    }
+
+    /// True when the confidence head should also run inside the sequential
+    /// chain: weights present, scratch allocated, and a positive threshold
+    /// configured via `ATLAS_DSPARK_CONF_TAU` (0/unset = off, matching the
+    /// reference's `threshold <= 0.0 → full block`).
+    pub(super) fn confidence_active(&self) -> bool {
+        self.confidence_proj.is_some()
+            && self.scratch.conf_out.0 != 0
+            && Self::conf_tau() > 0.0
+    }
+
+    /// `ATLAS_DSPARK_CONF_TAU` parsed once per call site. Sigmoid-space
+    /// threshold; the confident prefix ends at the first row whose predicted
+    /// acceptance probability falls below it.
+    pub(super) fn conf_tau() -> f32 {
+        std::env::var("ATLAS_DSPARK_CONF_TAU")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(0.0)
+    }
+
+    /// Sequential Markov-biased argmax over the γ block logits. Replaces the
+    /// tail's per-row argmax loop when [`Self::markov_active`] is true.
+    ///
+    /// `norm_noise`: base pointer of the γ post-final-norm hidden rows (the
+    /// same buffer the lm_head GEMM consumed) — the confidence head's hidden
+    /// feature per the reference (`proposal_hidden_states` = backbone output
+    /// after `norm`).
+    ///
+    /// Bias-vs-anchor convention: the reference applies the bigram bias at
+    /// every position, so row 0 (the anchor row, prev = `last_token`) is
+    /// biased by default. `ATLAS_DSPARK_ANCHOR_BIAS=0` exempts row 0
+    /// (Lightning's official DSpark convention) for A/B measurement.
+    pub(super) fn markov_argmax_block(
+        &self,
+        ctx: &ForwardContext,
+        norm_noise: spark_runtime::gpu::DevicePtr,
+        stream: u64,
+    ) -> Result<()> {
+        let gpu = ctx.gpu;
+        let bf16 = 2usize;
+        let vocab = self.vocab_size as u32;
+        let rank = self.markov_rank as u32;
+        let w1 = self
+            .markov_w1
+            .as_ref()
+            .expect("markov_active() checked markov_w1");
+        let w2 = self
+            .markov_w2
+            .as_ref()
+            .expect("markov_active() checked markov_w2");
+        let anchor_bias =
+            std::env::var("ATLAS_DSPARK_ANCHOR_BIAS").ok().as_deref() != Some("0");
+        let conf_on = self.confidence_active();
+        let bf16u = 2usize;
+
+        for i in 0..self.gamma {
+            let logits_row = self.scratch.logits.offset(i * self.vocab_size * bf16);
+            let token_slot = self.scratch.draft_tokens_dev.offset(i * 4);
+            let biased = i > 0 || anchor_bias;
+            if biased {
+                // prev_0 lives in slot 0 itself (still `last_token` — this
+                // read happens before row 0's argmax overwrites the slot);
+                // prev_i for i ≥ 1 is row i-1's argmax output.
+                let prev_slot = self
+                    .scratch
+                    .draft_tokens_dev
+                    .offset(i.saturating_sub(1) * 4);
+                ops::batched_embed(
+                    gpu,
+                    self.kernels.batched_embed,
+                    prev_slot,
+                    w1.weight,
+                    self.scratch.markov_embed,
+                    1,
+                    rank,
+                    stream,
+                )?;
+                ops::dense_gemv(
+                    gpu,
+                    self.kernels.dense_gemv,
+                    self.scratch.markov_embed,
+                    w2,
+                    self.scratch.markov_bias,
+                    vocab,
+                    rank,
+                    stream,
+                )?;
+                ops::residual_add(
+                    gpu,
+                    self.kernels.residual_add,
+                    logits_row,
+                    self.scratch.markov_bias,
+                    vocab,
+                    stream,
+                )?;
+                // ── Confidence head (AcceptRatePredictor) for this row ──
+                // conf[i] = W · [hidden_i ‖ markov_embed_i] + b, computed as
+                // two GEMV slices over the contiguous [1, hidden+rank] weight
+                // (hidden cols first — dspark.py builds conf_input_dim as
+                // hidden_size then += markov_rank). The prev-token embed is
+                // the one just gathered for the Markov bias (the reference
+                // uses the same prev chain for both heads). markov_bias[0]
+                // is free as a 1-element staging slot here — its vocab-wide
+                // content was consumed by the residual_add above.
+                if conf_on {
+                    let (w, b) = (
+                        self.confidence_proj.as_ref().expect("confidence_active"),
+                        self.confidence_bias.as_ref().expect("confidence_active"),
+                    );
+                    let conf_i = self.scratch.conf_out.offset(i * bf16u);
+                    let hidden_row = norm_noise.offset(i * self.hidden_size * bf16u);
+                    ops::dense_gemv(
+                        gpu,
+                        self.kernels.dense_gemv,
+                        hidden_row,
+                        w,
+                        conf_i,
+                        1,
+                        self.hidden_size as u32,
+                        stream,
+                    )?;
+                    if self.confidence_with_markov {
+                        let w_embed = crate::weight_map::DenseWeight {
+                            weight: w.weight.offset(self.hidden_size * bf16u),
+                        };
+                        ops::dense_gemv(
+                            gpu,
+                            self.kernels.dense_gemv,
+                            self.scratch.markov_embed,
+                            &w_embed,
+                            self.scratch.markov_bias,
+                            1,
+                            rank,
+                            stream,
+                        )?;
+                        ops::residual_add(
+                            gpu,
+                            self.kernels.residual_add,
+                            conf_i,
+                            self.scratch.markov_bias,
+                            1,
+                            stream,
+                        )?;
+                    }
+                    ops::residual_add(
+                        gpu,
+                        self.kernels.residual_add,
+                        conf_i,
+                        b.weight,
+                        1,
+                        stream,
+                    )?;
+                }
+            }
+            ops::argmax_bf16(
+                gpu,
+                self.kernels.argmax,
+                logits_row,
+                token_slot,
+                vocab,
+                stream,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/layers/dflash_head/propose.rs
+++ b/crates/spark-model/src/layers/dflash_head/propose.rs
@@ -278,7 +278,9 @@ impl BlockDiffusionDraftHead {
         // allocated paged blocks, do it now. We allocate enough blocks
         // to cover the full ctx_hidden_acc plus a safety margin for γ.
         // Block_size matches from_weights.rs:68 (=16).
-        let option_b_enabled = std::env::var("ATLAS_DFLASH_OPTION_B").ok().as_deref() == Some("1");
+        // Default ON since the 54.5 record config (2026-08-19): the paged
+        // drafter cache is the proven path. `=0` is the kill switch.
+        let option_b_enabled = std::env::var("ATLAS_DFLASH_OPTION_B").ok().as_deref() != Some("0");
         let option_b_arg: Option<(DevicePtr, u32)> = if option_b_enabled {
             // Lazy block table init. ctx slots come from precompute over the
             // accumulated target hiddens; γ slots come from the layer body.

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -302,6 +302,31 @@ pub fn try_kernel(gpu: &dyn GpuBackend, module: &str, func: &str) -> KernelHandl
     }
 }
 
+/// Resolve the M<=8 batched-GEMV kernel for the chain-verify tier.
+/// provenance-id: 526f6e616c6420522e205374657369616b
+///
+/// Prefers the register-tiled `w4a16_gemv_batch8_rt2` (T=2 output rows per
+/// thread: one activation load feeds two FMA chains, halving activation
+/// traffic, load-instruction count, and exposing 2x FMA-chain ILP).
+/// batchm_bench 2026-08-19 @M=8: +17-26% GB/s on every verify shape
+/// (qkv/o 143->168, ffn_up 149->182, ffn_down 150->186, gdn_qkvz 149->181,
+/// lm_head 143->181), BIT-EXACT vs batch8 at all M (gate 4) — per-output
+/// FMA order is identical, only the thread<->output mapping changed.
+///
+/// Launch geometry is IDENTICAL to batch8 (grid ceil(N/4), block 256; rt2's
+/// surplus blocks early-exit on `n0 >= N`), so every call site, launcher,
+/// and CUDA-graph capture is unchanged. `ATLAS_NO_BATCH8_RT=1` restores the
+/// classic batch8 for A/B (strict `== "1"`, matching the sibling levers).
+pub(crate) fn batch8_kernel(gpu: &dyn GpuBackend) -> KernelHandle {
+    if std::env::var("ATLAS_NO_BATCH8_RT").as_deref() != Ok("1") {
+        let h = try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch8_rt2");
+        if h.0 != 0 {
+            return h;
+        }
+    }
+    try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_batch8")
+}
+
 /// FFN component: MoE (expert routing), dense SwiGLU, or None (standalone attention).
 #[allow(clippy::large_enum_variant)]
 pub enum FfnComponent {

--- a/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
+++ b/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
@@ -10,11 +10,53 @@
 //! weights but have distinct activations (lm_head, attention Q/K/V/O, SSM
 //! out_proj).
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
 
 use crate::weight_map::Fp8DenseWeight;
+
+/// Register-tiled batched row-scaled FP8 GEMV (M<=8, T=2 outputs/thread) —
+/// the FP8 twin of `w4a16_gemv_batch8_rt2`, for the DFlash drafter PROPOSE
+/// path. `input` `[M, K]` BF16, `output` `[M, N]` BF16; per-row f32 scale
+/// applied at write-out inside the kernel. Replaces the prefill-class tile
+/// GEMMs (`fp8_gemm_t_row_scaled` M64-tile / `_m16`) that pad 87%/50% of
+/// their M-tile at M=8 (~100 GB/s measured vs 180+ for the rt family).
+/// Drafter-side numerics: correctness-free under strict-argmax accept.
+/// Kernel: `fp8_gemv_rowscale_batch8_rt2` (module `fp8_gemv_rt`).
+/// Grid: (ceil(N/8), 1, 1)  Block: (256, 1, 1). Requires K % 16 == 0.
+#[allow(clippy::too_many_arguments)]
+pub fn fp8_gemv_rowscale_batch8_rt2(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &Fp8DenseWeight,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    ensure!(
+        (1..=8).contains(&m),
+        "fp8_gemv_rowscale_batch8_rt2: m={m} outside 1..=8 (kernel MAX_M)"
+    );
+    ensure!(
+        k.is_multiple_of(16),
+        "fp8_gemv_rowscale_batch8_rt2: K={k} not a multiple of 16"
+    );
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 8), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(weight.row_scale)
+        .arg_ptr(output)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)
+}
 
 /// FP8-weight dual-GEMV. `input` is `[2, K]` BF16, `output` is `[2, N]` BF16.
 /// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)

--- a/crates/spark-model/src/layers/w4a16_gemv_tiers.rs
+++ b/crates/spark-model/src/layers/w4a16_gemv_tiers.rs
@@ -133,7 +133,16 @@ impl W4a16BatchmTiers {
     pub fn resolve(gpu: &dyn GpuBackend) -> Self {
         let mut handles = [KernelHandle(0); W4A16_BATCHM_WIDTHS.len()];
         for (h, w) in handles.iter_mut().zip(W4A16_BATCHM_WIDTHS) {
-            *h = super::try_kernel(gpu, "w4a16_gemv", &format!("w4a16_gemv_batch{w}"));
+            // Width 8 resolves through the rt2-preferring helper: the
+            // register-tiled T=2 variant is bit-exact vs classic batch8
+            // (same per-row FMA chain; batchm_bench gate 4) and carries its
+            // own kill switch (`ATLAS_NO_BATCH8_RT=1`). All five tier
+            // consumers inherit the preference from this one site.
+            *h = if w == 8 {
+                super::batch8_kernel(gpu)
+            } else {
+                super::try_kernel(gpu, "w4a16_gemv", &format!("w4a16_gemv_batch{w}"))
+            };
         }
         Self { handles }
     }

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -301,8 +301,10 @@ impl TransformerModel {
                 // the WRONG token's hidden and rows 1.. are stale garbage
                 // (2026-07-09 accept-collapse root cause: EAGLE_FIX=0 under
                 // UNIFIED=1 starved this capture and poisoned drafter ctx).
+                // EAGLE_FIX default ON since the 54.5 record config
+                // (2026-08-19); `=0` is the kill switch.
                 let capture_all = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref()
-                    == Some("1")
+                    != Some("0")
                     || std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() == Some("1");
                 if capture_all {
                     self.try_dflash_capture_all(layer_idx, k, stream)?;

--- a/crates/spark-model/src/weight_loader/dflash_loader.rs
+++ b/crates/spark-model/src/weight_loader/dflash_loader.rs
@@ -61,8 +61,36 @@ pub struct DflashConfig {
     /// Qwen3.6-DFlash drafter ships `rope_scaling: null`). When present and
     /// `rope_type == "yarn"`, the drafter's YaRN parameters are used to
     /// build the inv_freq table at construction time.
-    #[serde(default)]
+    /// `alias = "rope_parameters"`: newer transformers releases (RadixArk
+    /// DSpark, incoai DFlash2) ship the block under that key — without the
+    /// alias Atlas silently drops the scaling (the RadixArk config.json had
+    /// to be hand-patched before this).
+    #[serde(default, alias = "rope_parameters")]
     pub rope_scaling: Option<DflashRopeScaling>,
+    /// DSpark Markov head rank. `0` (default) ⇒ plain DFlash drafter with no
+    /// Markov head. RadixArk `Qwen3.8-27B-DSpark` ships `markov_rank: 256`
+    /// top-level (SpecForge `DSparkConfig` convention — see the checkpoint's
+    /// `dspark.py`: DSpark fields are declared as top-level config attrs).
+    #[serde(default)]
+    pub markov_rank: usize,
+    /// DSpark Markov head flavor. Only `"vanilla"` (low-rank learned bigram
+    /// bias) is defined by the reference; anything else is rejected at load.
+    #[serde(default)]
+    pub markov_head_type: Option<String>,
+    /// DSpark confidence head (`AcceptRatePredictor`): a `Linear(input, 1)`
+    /// predicting per-draft-position acceptance probability, used for
+    /// adaptive block length. Loaded when present; consumed by the dynamic-K
+    /// scheduling phase (the Markov fixup works without it).
+    #[serde(default)]
+    pub enable_confidence_head: bool,
+    /// When true the confidence head's input is `[hidden ‖ markov_embed]`
+    /// (input_dim = hidden_size + markov_rank); when false, hidden only.
+    #[serde(default = "default_true")]
+    pub confidence_head_with_markov: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_rope_theta() -> f32 {
@@ -102,6 +130,30 @@ pub struct DflashSubConfig {
     /// `[1, 10, 19, 28, 37]` for Qwen3.6-35B-A3B-DFlash. Order matters:
     /// shallow-to-deep concatenation is what `fc` expects.
     pub target_layer_ids: Vec<usize>,
+    /// Draft flavor tag. `"dspark"` marks a SpecForge-lineage drafter, whose
+    /// row convention is SHIFTED (row j's output = token at position j+1; the
+    /// anchor row's output is draft #1) versus the z-lab convention Atlas's
+    /// forward was built for (row j predicts at j, row 0 = echo). The runtime
+    /// keys the draft-vector rotation off this tag. DFlash2 checkpoints have
+    /// no tag and keep the z-lab convention (verified against z-lab
+    /// `dflash/model.py::dflash_generate` — anchor-row output discarded,
+    /// mask rows fill in place).
+    #[serde(default)]
+    pub projector_type: Option<String>,
+
+    // ── DFlash2 fields (incoai/z-lab `DFlash2DraftModel`); absent = DFlash1 ──
+    /// Two-tap dynamic conv kernel size (2 for DFlash2).
+    #[serde(default)]
+    pub conv_kernel_size: usize,
+    /// Channels per conv group (16 for DFlash2 → hidden/16 groups).
+    #[serde(default)]
+    pub conv_group_size: usize,
+    /// Selector codebook rank (256 for DFlash2).
+    #[serde(default)]
+    pub selector_rank: usize,
+    /// Candidates kept per position for the selector walk (16 for DFlash2).
+    #[serde(default)]
+    pub selector_top_k: usize,
 }
 
 /// Raw weight bundle for the DFlash drafter, post-load.
@@ -133,6 +185,28 @@ pub struct DflashWeights {
     /// `draft_vocab_size != target_vocab_size`). Absent for
     /// Qwen3.6-35B-A3B-DFlash (both vocabs = 248320).
     pub draft_id_to_target_id: Option<Vec<i64>>,
+
+    // ── DSpark heads (optional; RadixArk Qwen3.8-27B-DSpark ships all 4) ──
+    /// Markov head `markov_w1`: `[vocab, markov_rank]` BF16 embedding table
+    /// (prev-token → latent). Present iff `config.markov_rank > 0` and the
+    /// checkpoint carries the tensor.
+    pub markov_w1: Option<DenseWeight>,
+    /// Markov head `markov_w2`: `[vocab, markov_rank]` BF16
+    /// (`nn.Linear(rank, vocab, bias=False).weight`, i.e. `[N, K]` for the
+    /// GEMV convention). Projects the latent back to a full-vocab bias.
+    pub markov_w2: Option<DenseWeight>,
+    /// Confidence head weight: `[1, hidden(+rank)]` BF16.
+    pub confidence_proj: Option<DenseWeight>,
+    /// Confidence head bias: `[1]` BF16.
+    pub confidence_bias: Option<DenseWeight>,
+
+    // ── DFlash2 candidate selector (None on DFlash1/DSpark drafters) ──
+    /// `candidate_selector.predecessor_codebook` `[vocab, selector_rank]` BF16.
+    pub selector_pred: Option<DenseWeight>,
+    /// `candidate_selector.successor_codebook` `[vocab, selector_rank]` BF16.
+    pub selector_succ: Option<DenseWeight>,
+    /// `candidate_selector.hidden_projection.weight` `[selector_rank, hidden]`.
+    pub selector_hidden_proj: Option<DenseWeight>,
 }
 
 /// Per-drafter-layer raw weights (BF16). Same shape across all 8 layers.
@@ -149,6 +223,18 @@ pub struct DflashLayerWeights {
     pub gate_proj: DenseWeight,
     pub up_proj: DenseWeight,
     pub down_proj: DenseWeight,
+
+    // ── DFlash2 grouped dynamic causal convs (None on DFlash1 drafters) ──
+    /// `attention_conv.base_kernel` `[2, kernel_size, hidden]` BF16 —
+    /// static tap weights (index 0 = prepare/pre-sublayer, 1 = finish/post).
+    pub attention_conv_base: Option<DenseWeight>,
+    /// `attention_conv.kernel_projection.weight`
+    /// `[2 * kernel_size * groups, hidden]` BF16 — dynamic tap generator.
+    pub attention_conv_proj: Option<DenseWeight>,
+    /// `mlp_conv.base_kernel`, same shape as attention_conv_base.
+    pub mlp_conv_base: Option<DenseWeight>,
+    /// `mlp_conv.kernel_projection.weight`, same shape as attention_conv_proj.
+    pub mlp_conv_proj: Option<DenseWeight>,
 }
 
 /// Probe a [`WeightStore`] for the presence of DFlash drafter weights.
@@ -231,10 +317,39 @@ pub fn load_dflash_weights(
     let norm = dense(drafter_store, &format!("{prefix}norm.weight"))
         .context("DFlash drafter: load norm.weight")?;
 
+    // DFlash2 detection: conv/selector dims declared in dflash_config AND the
+    // layer-0 conv tensor present. All four families load per layer or none.
+    let dflash2_conv = drafter_config
+        .dflash_config
+        .as_ref()
+        .map(|c| c.conv_kernel_size > 0 && c.conv_group_size > 0)
+        .unwrap_or(false)
+        && drafter_store.contains(&format!("{prefix}layers.0.attention_conv.base_kernel"));
+
     let layer_count = drafter_config.num_hidden_layers;
     let mut layers = Vec::with_capacity(layer_count);
     for i in 0..layer_count {
         let lp = format!("{prefix}layers.{i}");
+        let (attention_conv_base, attention_conv_proj, mlp_conv_base, mlp_conv_proj) =
+            if dflash2_conv {
+                (
+                    Some(dense(
+                        drafter_store,
+                        &format!("{lp}.attention_conv.base_kernel"),
+                    )?),
+                    Some(dense(
+                        drafter_store,
+                        &format!("{lp}.attention_conv.kernel_projection.weight"),
+                    )?),
+                    Some(dense(drafter_store, &format!("{lp}.mlp_conv.base_kernel"))?),
+                    Some(dense(
+                        drafter_store,
+                        &format!("{lp}.mlp_conv.kernel_projection.weight"),
+                    )?),
+                )
+            } else {
+                (None, None, None, None)
+            };
         let layer = DflashLayerWeights {
             input_layernorm: dense(drafter_store, &format!("{lp}.input_layernorm.weight"))?,
             post_attention_layernorm: dense(
@@ -250,8 +365,52 @@ pub fn load_dflash_weights(
             gate_proj: dense(drafter_store, &format!("{lp}.mlp.gate_proj.weight"))?,
             up_proj: dense(drafter_store, &format!("{lp}.mlp.up_proj.weight"))?,
             down_proj: dense(drafter_store, &format!("{lp}.mlp.down_proj.weight"))?,
+            attention_conv_base,
+            attention_conv_proj,
+            mlp_conv_base,
+            mlp_conv_proj,
         };
         layers.push(layer);
+    }
+
+    // DFlash2 candidate selector. NOTE: the two codebooks ship with NO
+    // `.weight` suffix (raw nn.Parameter-style keys — the z-lab loader
+    // key-maps them; verified against the incoai safetensors header).
+    let selector_key = format!("{prefix}candidate_selector.predecessor_codebook");
+    let (selector_pred, selector_succ, selector_hidden_proj) = if drafter_config
+        .dflash_config
+        .as_ref()
+        .map(|c| c.selector_rank > 0 && c.selector_top_k > 0)
+        .unwrap_or(false)
+        && drafter_store.contains(&selector_key)
+    {
+        (
+            Some(dense(drafter_store, &selector_key)
+                .context("DFlash2: load candidate_selector.predecessor_codebook")?),
+            Some(dense(
+                drafter_store,
+                &format!("{prefix}candidate_selector.successor_codebook"),
+            )
+            .context("DFlash2: load candidate_selector.successor_codebook")?),
+            Some(dense(
+                drafter_store,
+                &format!("{prefix}candidate_selector.hidden_projection.weight"),
+            )
+            .context("DFlash2: load candidate_selector.hidden_projection.weight")?),
+        )
+    } else {
+        (None, None, None)
+    };
+    if dflash2_conv || selector_pred.is_some() {
+        tracing::info!(
+            "DFlash2 heads loaded: convs={} (k={}, group={}), selector={} (rank={}, top_k={})",
+            dflash2_conv,
+            drafter_config.dflash_config.as_ref().map(|c| c.conv_kernel_size).unwrap_or(0),
+            drafter_config.dflash_config.as_ref().map(|c| c.conv_group_size).unwrap_or(0),
+            selector_pred.is_some(),
+            drafter_config.dflash_config.as_ref().map(|c| c.selector_rank).unwrap_or(0),
+            drafter_config.dflash_config.as_ref().map(|c| c.selector_top_k).unwrap_or(0),
+        );
     }
 
     // `d2t` (draft-id → target-id) is absent from Qwen3.6-DFlash because
@@ -271,6 +430,67 @@ pub fn load_dflash_weights(
     } else {
         None
     };
+
+    // ── DSpark heads (optional) ──────────────────────────────────────
+    // Tensor names verified against RadixArk/Qwen3.8-27B-DSpark
+    // (model.safetensors, 62 tensors): `markov_head.markov_w1.weight`
+    // [248320, 256], `markov_head.markov_w2.weight` [248320, 256],
+    // `confidence_head.proj.weight` [1, 5376], `confidence_head.proj.bias`
+    // [1] — all BF16, bare layout (same prefix convention as fc.weight).
+    let markov_key = format!("{prefix}markov_head.markov_w1.weight");
+    let (markov_w1, markov_w2) = if drafter_config.markov_rank > 0
+        && drafter_store.contains(&markov_key)
+    {
+        if let Some(kind) = drafter_config.markov_head_type.as_deref()
+            && kind != "vanilla"
+        {
+            anyhow::bail!(
+                "DSpark drafter declares markov_head_type={kind:?}; only \"vanilla\" \
+                 (low-rank bigram bias) is defined by the reference implementation"
+            );
+        }
+        let w1 = dense(drafter_store, &markov_key)
+            .context("DSpark drafter: load markov_head.markov_w1.weight")?;
+        let w2 = dense(
+            drafter_store,
+            &format!("{prefix}markov_head.markov_w2.weight"),
+        )
+        .context("DSpark drafter: load markov_head.markov_w2.weight")?;
+        (Some(w1), Some(w2))
+    } else {
+        if drafter_config.markov_rank > 0 {
+            tracing::warn!(
+                "DSpark drafter config declares markov_rank={} but the checkpoint has \
+                 no {markov_key} — running as plain DFlash (Markov bias disabled)",
+                drafter_config.markov_rank,
+            );
+        }
+        (None, None)
+    };
+    let conf_key = format!("{prefix}confidence_head.proj.weight");
+    let (confidence_proj, confidence_bias) = if drafter_config.enable_confidence_head
+        && drafter_store.contains(&conf_key)
+    {
+        let w = dense(drafter_store, &conf_key)
+            .context("DSpark drafter: load confidence_head.proj.weight")?;
+        let b = dense(
+            drafter_store,
+            &format!("{prefix}confidence_head.proj.bias"),
+        )
+        .context("DSpark drafter: load confidence_head.proj.bias")?;
+        (Some(w), Some(b))
+    } else {
+        (None, None)
+    };
+    if markov_w1.is_some() || confidence_proj.is_some() {
+        tracing::info!(
+            "DSpark heads loaded: markov={} (rank={}), confidence={} (with_markov={})",
+            markov_w1.is_some(),
+            drafter_config.markov_rank,
+            confidence_proj.is_some(),
+            drafter_config.confidence_head_with_markov,
+        );
+    }
 
     tracing::info!(
         "DFlash drafter loaded: {} layers, hidden={}, vocab={}, γ={}, target_layers={:?}",
@@ -292,6 +512,13 @@ pub fn load_dflash_weights(
         norm,
         layers,
         draft_id_to_target_id,
+        markov_w1,
+        markov_w2,
+        confidence_proj,
+        confidence_bias,
+        selector_pred,
+        selector_succ,
+        selector_hidden_proj,
     }))
 }
 

--- a/crates/spark-model/src/weight_loader/dflash_loader.rs
+++ b/crates/spark-model/src/weight_loader/dflash_loader.rs
@@ -385,18 +385,24 @@ pub fn load_dflash_weights(
         && drafter_store.contains(&selector_key)
     {
         (
-            Some(dense(drafter_store, &selector_key)
-                .context("DFlash2: load candidate_selector.predecessor_codebook")?),
-            Some(dense(
-                drafter_store,
-                &format!("{prefix}candidate_selector.successor_codebook"),
-            )
-            .context("DFlash2: load candidate_selector.successor_codebook")?),
-            Some(dense(
-                drafter_store,
-                &format!("{prefix}candidate_selector.hidden_projection.weight"),
-            )
-            .context("DFlash2: load candidate_selector.hidden_projection.weight")?),
+            Some(
+                dense(drafter_store, &selector_key)
+                    .context("DFlash2: load candidate_selector.predecessor_codebook")?,
+            ),
+            Some(
+                dense(
+                    drafter_store,
+                    &format!("{prefix}candidate_selector.successor_codebook"),
+                )
+                .context("DFlash2: load candidate_selector.successor_codebook")?,
+            ),
+            Some(
+                dense(
+                    drafter_store,
+                    &format!("{prefix}candidate_selector.hidden_projection.weight"),
+                )
+                .context("DFlash2: load candidate_selector.hidden_projection.weight")?,
+            ),
         )
     } else {
         (None, None, None)
@@ -405,11 +411,27 @@ pub fn load_dflash_weights(
         tracing::info!(
             "DFlash2 heads loaded: convs={} (k={}, group={}), selector={} (rank={}, top_k={})",
             dflash2_conv,
-            drafter_config.dflash_config.as_ref().map(|c| c.conv_kernel_size).unwrap_or(0),
-            drafter_config.dflash_config.as_ref().map(|c| c.conv_group_size).unwrap_or(0),
+            drafter_config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.conv_kernel_size)
+                .unwrap_or(0),
+            drafter_config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.conv_group_size)
+                .unwrap_or(0),
             selector_pred.is_some(),
-            drafter_config.dflash_config.as_ref().map(|c| c.selector_rank).unwrap_or(0),
-            drafter_config.dflash_config.as_ref().map(|c| c.selector_top_k).unwrap_or(0),
+            drafter_config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.selector_rank)
+                .unwrap_or(0),
+            drafter_config
+                .dflash_config
+                .as_ref()
+                .map(|c| c.selector_top_k)
+                .unwrap_or(0),
         );
     }
 
@@ -438,50 +460,45 @@ pub fn load_dflash_weights(
     // `confidence_head.proj.weight` [1, 5376], `confidence_head.proj.bias`
     // [1] — all BF16, bare layout (same prefix convention as fc.weight).
     let markov_key = format!("{prefix}markov_head.markov_w1.weight");
-    let (markov_w1, markov_w2) = if drafter_config.markov_rank > 0
-        && drafter_store.contains(&markov_key)
-    {
-        if let Some(kind) = drafter_config.markov_head_type.as_deref()
-            && kind != "vanilla"
-        {
-            anyhow::bail!(
-                "DSpark drafter declares markov_head_type={kind:?}; only \"vanilla\" \
+    let (markov_w1, markov_w2) =
+        if drafter_config.markov_rank > 0 && drafter_store.contains(&markov_key) {
+            if let Some(kind) = drafter_config.markov_head_type.as_deref()
+                && kind != "vanilla"
+            {
+                anyhow::bail!(
+                    "DSpark drafter declares markov_head_type={kind:?}; only \"vanilla\" \
                  (low-rank bigram bias) is defined by the reference implementation"
-            );
-        }
-        let w1 = dense(drafter_store, &markov_key)
-            .context("DSpark drafter: load markov_head.markov_w1.weight")?;
-        let w2 = dense(
-            drafter_store,
-            &format!("{prefix}markov_head.markov_w2.weight"),
-        )
-        .context("DSpark drafter: load markov_head.markov_w2.weight")?;
-        (Some(w1), Some(w2))
-    } else {
-        if drafter_config.markov_rank > 0 {
-            tracing::warn!(
-                "DSpark drafter config declares markov_rank={} but the checkpoint has \
+                );
+            }
+            let w1 = dense(drafter_store, &markov_key)
+                .context("DSpark drafter: load markov_head.markov_w1.weight")?;
+            let w2 = dense(
+                drafter_store,
+                &format!("{prefix}markov_head.markov_w2.weight"),
+            )
+            .context("DSpark drafter: load markov_head.markov_w2.weight")?;
+            (Some(w1), Some(w2))
+        } else {
+            if drafter_config.markov_rank > 0 {
+                tracing::warn!(
+                    "DSpark drafter config declares markov_rank={} but the checkpoint has \
                  no {markov_key} — running as plain DFlash (Markov bias disabled)",
-                drafter_config.markov_rank,
-            );
-        }
-        (None, None)
-    };
+                    drafter_config.markov_rank,
+                );
+            }
+            (None, None)
+        };
     let conf_key = format!("{prefix}confidence_head.proj.weight");
-    let (confidence_proj, confidence_bias) = if drafter_config.enable_confidence_head
-        && drafter_store.contains(&conf_key)
-    {
-        let w = dense(drafter_store, &conf_key)
-            .context("DSpark drafter: load confidence_head.proj.weight")?;
-        let b = dense(
-            drafter_store,
-            &format!("{prefix}confidence_head.proj.bias"),
-        )
-        .context("DSpark drafter: load confidence_head.proj.bias")?;
-        (Some(w), Some(b))
-    } else {
-        (None, None)
-    };
+    let (confidence_proj, confidence_bias) =
+        if drafter_config.enable_confidence_head && drafter_store.contains(&conf_key) {
+            let w = dense(drafter_store, &conf_key)
+                .context("DSpark drafter: load confidence_head.proj.weight")?;
+            let b = dense(drafter_store, &format!("{prefix}confidence_head.proj.bias"))
+                .context("DSpark drafter: load confidence_head.proj.bias")?;
+            (Some(w), Some(b))
+        } else {
+            (None, None)
+        };
     if markov_w1.is_some() || confidence_proj.is_some() {
         tracing::info!(
             "DSpark heads loaded: markov={} (rank={}), confidence={} (with_markov={})",

--- a/crates/spark-model/src/weight_loader/dflash_loader.rs
+++ b/crates/spark-model/src/weight_loader/dflash_loader.rs
@@ -26,135 +26,14 @@
 //! (`MTP loads ALL experts on every rank — no EP all_reduce needed`).
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
 use spark_runtime::gpu::GpuBackend;
 use spark_runtime::weights::WeightStore;
 
 use crate::weight_map::{DenseWeight, dense};
 
-/// Drafter HF `config.json` (subset Atlas consumes). Mirrors
-/// `z-lab/Qwen3.6-35B-A3B-DFlash/config.json` field names verbatim so
-/// `serde_json::from_str` works directly on the raw file.
-#[derive(Debug, Clone, Deserialize)]
-pub struct DflashConfig {
-    pub hidden_size: usize,
-    pub num_hidden_layers: usize,
-    pub intermediate_size: usize,
-    pub num_attention_heads: usize,
-    pub num_key_value_heads: usize,
-    pub head_dim: usize,
-    pub vocab_size: usize,
-    #[serde(default)]
-    pub draft_vocab_size: Option<usize>,
-    #[serde(default)]
-    pub tie_word_embeddings: bool,
-    /// Block size γ. Qwen3.6-DFlash ships `block_size: 16`.
-    #[serde(default = "default_block_size")]
-    pub block_size: usize,
-    /// DFlash-specific nested config object.
-    #[serde(default)]
-    pub dflash_config: Option<DflashSubConfig>,
-    /// Drafter base RoPE θ. Defaults to 10M (matches Qwen3.6-DFlash).
-    #[serde(default = "default_rope_theta")]
-    pub rope_theta: f32,
-    /// HF-style `rope_scaling` block. `None` ⇒ plain RoPE (the v2 2026-04-27
-    /// Qwen3.6-DFlash drafter ships `rope_scaling: null`). When present and
-    /// `rope_type == "yarn"`, the drafter's YaRN parameters are used to
-    /// build the inv_freq table at construction time.
-    /// `alias = "rope_parameters"`: newer transformers releases (RadixArk
-    /// DSpark, incoai DFlash2) ship the block under that key — without the
-    /// alias Atlas silently drops the scaling (the RadixArk config.json had
-    /// to be hand-patched before this).
-    #[serde(default, alias = "rope_parameters")]
-    pub rope_scaling: Option<DflashRopeScaling>,
-    /// DSpark Markov head rank. `0` (default) ⇒ plain DFlash drafter with no
-    /// Markov head. RadixArk `Qwen3.8-27B-DSpark` ships `markov_rank: 256`
-    /// top-level (SpecForge `DSparkConfig` convention — see the checkpoint's
-    /// `dspark.py`: DSpark fields are declared as top-level config attrs).
-    #[serde(default)]
-    pub markov_rank: usize,
-    /// DSpark Markov head flavor. Only `"vanilla"` (low-rank learned bigram
-    /// bias) is defined by the reference; anything else is rejected at load.
-    #[serde(default)]
-    pub markov_head_type: Option<String>,
-    /// DSpark confidence head (`AcceptRatePredictor`): a `Linear(input, 1)`
-    /// predicting per-draft-position acceptance probability, used for
-    /// adaptive block length. Loaded when present; consumed by the dynamic-K
-    /// scheduling phase (the Markov fixup works without it).
-    #[serde(default)]
-    pub enable_confidence_head: bool,
-    /// When true the confidence head's input is `[hidden ‖ markov_embed]`
-    /// (input_dim = hidden_size + markov_rank); when false, hidden only.
-    #[serde(default = "default_true")]
-    pub confidence_head_with_markov: bool,
-}
+mod config;
 
-fn default_true() -> bool {
-    true
-}
-
-fn default_rope_theta() -> f32 {
-    10_000_000.0
-}
-
-/// Subset of HF `rope_scaling` block consumed by Atlas. Mirrors the field
-/// names in `transformers`' Qwen3 config so `serde_json::from_str` works
-/// directly on the drafter's `config.json`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct DflashRopeScaling {
-    /// Currently only `"yarn"` is recognised; anything else falls back to
-    /// plain RoPE with a warning logged at construction time.
-    #[serde(default)]
-    pub rope_type: Option<String>,
-    #[serde(default)]
-    pub factor: Option<f32>,
-    #[serde(default)]
-    pub beta_fast: Option<f32>,
-    #[serde(default)]
-    pub beta_slow: Option<f32>,
-    #[serde(default)]
-    pub original_max_position_embeddings: Option<f32>,
-}
-
-fn default_block_size() -> usize {
-    16
-}
-
-/// Nested `dflash_config` block in the drafter's `config.json`.
-#[derive(Debug, Clone, Deserialize)]
-pub struct DflashSubConfig {
-    /// Token id used to fill the γ "to-be-predicted" positions during draft
-    /// inference. `248070` for Qwen3.6-DFlash.
-    pub mask_token_id: u32,
-    /// Target-model layer indices to capture intermediate hidden states from.
-    /// `[1, 10, 19, 28, 37]` for Qwen3.6-35B-A3B-DFlash. Order matters:
-    /// shallow-to-deep concatenation is what `fc` expects.
-    pub target_layer_ids: Vec<usize>,
-    /// Draft flavor tag. `"dspark"` marks a SpecForge-lineage drafter, whose
-    /// row convention is SHIFTED (row j's output = token at position j+1; the
-    /// anchor row's output is draft #1) versus the z-lab convention Atlas's
-    /// forward was built for (row j predicts at j, row 0 = echo). The runtime
-    /// keys the draft-vector rotation off this tag. DFlash2 checkpoints have
-    /// no tag and keep the z-lab convention (verified against z-lab
-    /// `dflash/model.py::dflash_generate` — anchor-row output discarded,
-    /// mask rows fill in place).
-    #[serde(default)]
-    pub projector_type: Option<String>,
-
-    // ── DFlash2 fields (incoai/z-lab `DFlash2DraftModel`); absent = DFlash1 ──
-    /// Two-tap dynamic conv kernel size (2 for DFlash2).
-    #[serde(default)]
-    pub conv_kernel_size: usize,
-    /// Channels per conv group (16 for DFlash2 → hidden/16 groups).
-    #[serde(default)]
-    pub conv_group_size: usize,
-    /// Selector codebook rank (256 for DFlash2).
-    #[serde(default)]
-    pub selector_rank: usize,
-    /// Candidates kept per position for the selector walk (16 for DFlash2).
-    #[serde(default)]
-    pub selector_top_k: usize,
-}
+pub use config::{DflashConfig, DflashRopeScaling, DflashSubConfig};
 
 /// Raw weight bundle for the DFlash drafter, post-load.
 ///

--- a/crates/spark-model/src/weight_loader/dflash_loader/config.rs
+++ b/crates/spark-model/src/weight_loader/dflash_loader/config.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Drafter `config.json` types.
+//!
+//! Split out of `dflash_loader.rs` to keep that file under the 500-line cap:
+//! these are the pure `serde` shapes for the checkpoint's config, with no
+//! loading logic. The weight structures and the loader itself stay in the
+//! parent module.
+
+use serde::Deserialize;
+
+/// Drafter HF `config.json` (subset Atlas consumes). Mirrors
+/// `z-lab/Qwen3.6-35B-A3B-DFlash/config.json` field names verbatim so
+/// `serde_json::from_str` works directly on the raw file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DflashConfig {
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub intermediate_size: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    #[serde(default)]
+    pub draft_vocab_size: Option<usize>,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    /// Block size γ. Qwen3.6-DFlash ships `block_size: 16`.
+    #[serde(default = "default_block_size")]
+    pub block_size: usize,
+    /// DFlash-specific nested config object.
+    #[serde(default)]
+    pub dflash_config: Option<DflashSubConfig>,
+    /// Drafter base RoPE θ. Defaults to 10M (matches Qwen3.6-DFlash).
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+    /// HF-style `rope_scaling` block. `None` ⇒ plain RoPE (the v2 2026-04-27
+    /// Qwen3.6-DFlash drafter ships `rope_scaling: null`). When present and
+    /// `rope_type == "yarn"`, the drafter's YaRN parameters are used to
+    /// build the inv_freq table at construction time.
+    /// `alias = "rope_parameters"`: newer transformers releases (RadixArk
+    /// DSpark, incoai DFlash2) ship the block under that key — without the
+    /// alias Atlas silently drops the scaling (the RadixArk config.json had
+    /// to be hand-patched before this).
+    #[serde(default, alias = "rope_parameters")]
+    pub rope_scaling: Option<DflashRopeScaling>,
+    /// DSpark Markov head rank. `0` (default) ⇒ plain DFlash drafter with no
+    /// Markov head. RadixArk `Qwen3.8-27B-DSpark` ships `markov_rank: 256`
+    /// top-level (SpecForge `DSparkConfig` convention — see the checkpoint's
+    /// `dspark.py`: DSpark fields are declared as top-level config attrs).
+    #[serde(default)]
+    pub markov_rank: usize,
+    /// DSpark Markov head flavor. Only `"vanilla"` (low-rank learned bigram
+    /// bias) is defined by the reference; anything else is rejected at load.
+    #[serde(default)]
+    pub markov_head_type: Option<String>,
+    /// DSpark confidence head (`AcceptRatePredictor`): a `Linear(input, 1)`
+    /// predicting per-draft-position acceptance probability, used for
+    /// adaptive block length. Loaded when present; consumed by the dynamic-K
+    /// scheduling phase (the Markov fixup works without it).
+    #[serde(default)]
+    pub enable_confidence_head: bool,
+    /// When true the confidence head's input is `[hidden ‖ markov_embed]`
+    /// (input_dim = hidden_size + markov_rank); when false, hidden only.
+    #[serde(default = "default_true")]
+    pub confidence_head_with_markov: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_rope_theta() -> f32 {
+    10_000_000.0
+}
+
+/// Subset of HF `rope_scaling` block consumed by Atlas. Mirrors the field
+/// names in `transformers`' Qwen3 config so `serde_json::from_str` works
+/// directly on the drafter's `config.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DflashRopeScaling {
+    /// Currently only `"yarn"` is recognised; anything else falls back to
+    /// plain RoPE with a warning logged at construction time.
+    #[serde(default)]
+    pub rope_type: Option<String>,
+    #[serde(default)]
+    pub factor: Option<f32>,
+    #[serde(default)]
+    pub beta_fast: Option<f32>,
+    #[serde(default)]
+    pub beta_slow: Option<f32>,
+    #[serde(default)]
+    pub original_max_position_embeddings: Option<f32>,
+}
+
+fn default_block_size() -> usize {
+    16
+}
+
+/// Nested `dflash_config` block in the drafter's `config.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DflashSubConfig {
+    /// Token id used to fill the γ "to-be-predicted" positions during draft
+    /// inference. `248070` for Qwen3.6-DFlash.
+    pub mask_token_id: u32,
+    /// Target-model layer indices to capture intermediate hidden states from.
+    /// `[1, 10, 19, 28, 37]` for Qwen3.6-35B-A3B-DFlash. Order matters:
+    /// shallow-to-deep concatenation is what `fc` expects.
+    pub target_layer_ids: Vec<usize>,
+    /// Draft flavor tag. `"dspark"` marks a SpecForge-lineage drafter, whose
+    /// row convention is SHIFTED (row j's output = token at position j+1; the
+    /// anchor row's output is draft #1) versus the z-lab convention Atlas's
+    /// forward was built for (row j predicts at j, row 0 = echo). The runtime
+    /// keys the draft-vector rotation off this tag. DFlash2 checkpoints have
+    /// no tag and keep the z-lab convention (verified against z-lab
+    /// `dflash/model.py::dflash_generate` — anchor-row output discarded,
+    /// mask rows fill in place).
+    #[serde(default)]
+    pub projector_type: Option<String>,
+
+    // ── DFlash2 fields (incoai/z-lab `DFlash2DraftModel`); absent = DFlash1 ──
+    /// Two-tap dynamic conv kernel size (2 for DFlash2).
+    #[serde(default)]
+    pub conv_kernel_size: usize,
+    /// Channels per conv group (16 for DFlash2 → hidden/16 groups).
+    #[serde(default)]
+    pub conv_group_size: usize,
+    /// Selector codebook rank (256 for DFlash2).
+    #[serde(default)]
+    pub selector_rank: usize,
+    /// Candidates kept per position for the selector walk (16 for DFlash2).
+    #[serde(default)]
+    pub selector_top_k: usize,
+}

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -405,7 +405,9 @@ fn finalize_response(
     };
 
     // REQUESTS_ACTIVE released by the caller's ActiveRequestGuard on return.
-    crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(prompt_len as u64);
+    // PROMPT_TOKENS_TOTAL is incremented per chunk at ingest
+    // (scheduler/phase_continue_prefills/*). Counting it here too
+    // would double-count.
     // GENERATION_TOKENS_TOTAL is incremented PER TOKEN as the scheduler
     // emits it (scheduler/emit_step.rs, decode_logits_step.rs). Adding the
     // completion total here too would double-count — and counting only

--- a/crates/spark-server/src/api/chat_blocking.rs
+++ b/crates/spark-server/src/api/chat_blocking.rs
@@ -406,7 +406,11 @@ fn finalize_response(
 
     // REQUESTS_ACTIVE released by the caller's ActiveRequestGuard on return.
     crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(prompt_len as u64);
-    crate::metrics::GENERATION_TOKENS_TOTAL.inc_by(total_completion_tokens as u64);
+    // GENERATION_TOKENS_TOTAL is incremented PER TOKEN as the scheduler
+    // emits it (scheduler/emit_step.rs, decode_logits_step.rs). Adding the
+    // completion total here too would double-count — and counting only
+    // here is what made the TUI throughput graph flat-then-spiky: the
+    // counter did not move until a request finished.
     crate::metrics::TTFT_SECONDS
         .with_label_values(&[state.model_name.as_str()])
         .observe(first_ttft / 1000.0);

--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -223,7 +223,11 @@ pub(super) fn handle_done(
     // StreamCtx when the stream is dropped — not here, so a stream that ends
     // without a terminal event still decrements.)
     crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(ctx.prompt_len as u64);
-    crate::metrics::GENERATION_TOKENS_TOTAL.inc_by(completion_tokens as u64);
+    // GENERATION_TOKENS_TOTAL is incremented PER TOKEN as the scheduler
+    // emits it (scheduler/emit_step.rs, decode_logits_step.rs). Adding the
+    // completion total here too would double-count — and counting only
+    // here is what made the TUI throughput graph flat-then-spiky: the
+    // counter did not move until a request finished.
     crate::metrics::TTFT_SECONDS
         .with_label_values(&[ctx.model.as_str()])
         .observe(time_to_first_token_ms / 1000.0);

--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -222,7 +222,9 @@ pub(super) fn handle_done(
     // Metrics. (REQUESTS_ACTIVE is released by the ActiveRequestGuard in
     // StreamCtx when the stream is dropped — not here, so a stream that ends
     // without a terminal event still decrements.)
-    crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(ctx.prompt_len as u64);
+    // PROMPT_TOKENS_TOTAL is incremented per chunk at ingest
+    // (scheduler/phase_continue_prefills/*). Counting it here too
+    // would double-count.
     // GENERATION_TOKENS_TOTAL is incremented PER TOKEN as the scheduler
     // emits it (scheduler/emit_step.rs, decode_logits_step.rs). Adding the
     // completion total here too would double-count — and counting only

--- a/crates/spark-server/src/main_modules/serve_phases/weights.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/weights.rs
@@ -147,6 +147,57 @@ pub(crate) fn load_dflash_drafter(
     Ok(Some((drafter_store, drafter_config)))
 }
 
+/// Best-effort: does the TARGET checkpoint ship `lm_head.weight` natively as
+/// FP8 E4M3? Reads only the safetensors JSON header of the shard that holds
+/// the tensor (8-byte length prefix + header), never the weights. Any failure
+/// returns `false`, which keeps the pre-flight estimate conservative.
+fn target_ships_native_fp8_lm_head(args: &cli::ServeArgs) -> bool {
+    fn inner(args: &cli::ServeArgs) -> Option<bool> {
+        let dir = if let Some(p) = &args.model_from_path {
+            p.clone()
+        } else {
+            crate::model_resolver::resolve_model_dir(
+                args.model.as_deref()?,
+                args.cache_dir.as_deref(),
+            )
+            .ok()?
+        };
+        const KEYS: [&str; 3] = [
+            "lm_head.weight",
+            "language_model.lm_head.weight",
+            "model.lm_head.weight",
+        ];
+        // Multi-shard: index.json names the shard; single-file fallback.
+        let shard = if let Ok(idx) = std::fs::read(dir.join("model.safetensors.index.json")) {
+            let idx: serde_json::Value = serde_json::from_slice(&idx).ok()?;
+            let map = idx.get("weight_map")?;
+            KEYS.iter()
+                .find_map(|k| map.get(*k).and_then(|v| v.as_str()))
+                .map(|s| dir.join(s))?
+        } else {
+            dir.join("model.safetensors")
+        };
+        use std::io::Read as _;
+        let mut f = std::fs::File::open(shard).ok()?;
+        let mut len8 = [0u8; 8];
+        f.read_exact(&mut len8).ok()?;
+        let hlen = u64::from_le_bytes(len8);
+        if hlen > 64 << 20 {
+            return None; // implausible header — refuse to slurp
+        }
+        let mut hdr = vec![0u8; hlen as usize];
+        f.read_exact(&mut hdr).ok()?;
+        let hdr: serde_json::Value = serde_json::from_slice(&hdr).ok()?;
+        let dtype = KEYS
+            .iter()
+            .find_map(|k| hdr.get(*k))
+            .and_then(|t| t.get("dtype"))
+            .and_then(|d| d.as_str())?;
+        Some(dtype == "F8_E4M3")
+    }
+    inner(args).unwrap_or(false)
+}
+
 /// Startup-loaded LoRA adapter: its own WeightStore + parsed PEFT config.
 /// One `LoraAdapterState` per repeated `--lora-adapter NAME=PATH`; each becomes
 /// one resident pool slot. A single adapter is byte-identical to the v0 path.

--- a/crates/spark-server/src/scheduler/decode_logits_step.rs
+++ b/crates/spark-server/src/scheduler/decode_logits_step.rs
@@ -360,6 +360,9 @@ pub fn process_decode_logits(
             && tok == trs
         {
             a.output_tokens.push(tok);
+            crate::metrics::GENERATION_TOKENS_TOTAL.inc();
+            // Permanent diagnostic — see emit_step::emit_token's twin log.
+            tracing::debug!("emit tok={tok} n={}", a.output_tokens.len());
             a.finished = true;
             // Name the cut. Without this the ladder skips its guard rung,
             // budget is untouched, and the turn wires as "stop" -- telling
@@ -586,6 +589,9 @@ pub fn process_decode_logits(
                         "tool-call repetition runaway: model re-opened {MAX_POST_COMPLETION_TOOL_OPENS}+ tool-call blocks after a completed call on a tool_choice=auto turn; ending response (was burning to max_tokens). Sanitizer keeps the first valid call(s)."
                     );
                     a.output_tokens.push(tok);
+                    crate::metrics::GENERATION_TOKENS_TOTAL.inc();
+                    // Permanent diagnostic — see emit_step::emit_token's twin log.
+                    tracing::debug!("emit tok={tok} n={}", a.output_tokens.len());
                     a.tool_call_opened = true;
                     if let Some(ref mut gs) = a.grammar_state {
                         gs.accept_token(tok);
@@ -616,6 +622,9 @@ pub fn process_decode_logits(
         // that spuriously emits `</tool_call>` hard-stops here.
         if tool_call_end_token == Some(tok) && !a.inside_thinking {
             a.output_tokens.push(tok);
+            crate::metrics::GENERATION_TOKENS_TOTAL.inc();
+            // Permanent diagnostic — see emit_step::emit_token's twin log.
+            tracing::debug!("emit tok={tok} n={}", a.output_tokens.len());
             // Fix A (2026-06-05): mark the tool call complete so the EOS-escape
             // gate (below) can lift suppression. Inert unless
             // `tool_eos_escape_enabled()` (default OFF).
@@ -767,6 +776,9 @@ pub fn process_decode_logits(
             // output_tokens for correct token count; the API layer strips the
             // decoded text for blocking responses.
             a.output_tokens.push(tok);
+            crate::metrics::GENERATION_TOKENS_TOTAL.inc();
+            // Permanent diagnostic — see emit_step::emit_token's twin log.
+            tracing::debug!("emit tok={tok} n={}", a.output_tokens.len());
             crate::scheduler::emit_step::update_tool_param_state(a, tok);
             a.finished = true;
         } else if a.eos_tokens.contains(&tok) && suppress_eos {
@@ -842,6 +854,9 @@ pub fn process_decode_logits(
             );
         } else {
             a.output_tokens.push(tok);
+            crate::metrics::GENERATION_TOKENS_TOTAL.inc();
+            // Permanent diagnostic — see emit_step::emit_token's twin log.
+            tracing::debug!("emit tok={tok} n={}", a.output_tokens.len());
             // SM1 (2026-05-26): drive the tool-body / parameter-body
             // state machine from the non-spec decode path. Previously
             // only spec/verify paths called this (via emit_token),

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -58,6 +58,7 @@ pub fn emit_token(
         // The streamed-text path strips stop tokens server-side, so the
         // client never sees the literal `<|im_start|>` bytes.
         a.output_tokens.push(tok);
+        crate::metrics::GENERATION_TOKENS_TOTAL.inc();
         a.finished = true;
         tracing::debug!(
             "<|im_start|> hard-stop fired (id={ims}); ending turn before grammar/suppress_eos"
@@ -73,6 +74,7 @@ pub fn emit_token(
         && tok == trs
     {
         a.output_tokens.push(tok);
+        crate::metrics::GENERATION_TOKENS_TOTAL.inc();
         a.finished = true;
         // Name the cut -- MTP twin of the decode_logits_step site.
         a.guard_stop = Some(GUARD_STOP_TOOL_RESPONSE);
@@ -202,6 +204,12 @@ pub fn emit_token(
     }
 
     a.output_tokens.push(tok);
+    crate::metrics::GENERATION_TOKENS_TOTAL.inc();
+    // Permanent diagnostic (RUST_LOG=...,spark::scheduler::emit_step=debug):
+    // the emitted token id at the single choke point every path funnels
+    // through — the token-exact stream needed for byte-level A/B of two
+    // serve configs (e.g. the qwen3.8 spec-decode divergence hunt).
+    tracing::debug!("emit tok={tok} n={}", a.output_tokens.len());
 
     // Spec-resume guard bookkeeping: count tokens emitted after `</think>`.
     // The `</think>` token itself is not counted (think_ended is still false
@@ -519,6 +527,7 @@ pub(crate) fn emit_grammar_close(a: &mut ActiveSeq) {
     for tok in close {
         let tok = tok as u32;
         a.output_tokens.push(tok);
+        crate::metrics::GENERATION_TOKENS_TOTAL.inc();
         if !send_stream_event(a, StreamEvent::Token(tok)) {
             break;
         }

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -445,6 +445,7 @@ pub fn run(
         snapshot_steps += 1;
         let t_loop = std::time::Instant::now();
         {
+            let last_chunk = sched.snapshot.last_prefill_chunk();
             let (mtp_mode, delivered_tps) = match mtp_gate.as_ref() {
                 Some(g) => g.observe(),
                 None => (snapshot::MtpModeSnap::Off, 0.0),
@@ -461,6 +462,15 @@ pub fn run(
                 mtp_mode,
                 delivered_tps,
                 steps_total: snapshot_steps,
+                // O(prefilling) over a list bounded by --max-num-seqs, of two
+                // field reads each, once per tick.
+                prefill_tokens_done: prefilling.iter().map(|p| p.chunk_offset as u32).sum(),
+                prefill_tokens_total: prefilling
+                    .iter()
+                    .map(|p| p.prompt_tokens.len() as u32)
+                    .sum(),
+                prefill_chunk_width: last_chunk.0,
+                prefill_fused: last_chunk.1,
                 published_at: std::time::Instant::now(),
             });
         }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
@@ -140,6 +140,14 @@ pub(super) fn run_batched_mixed_step(
     debug_assert_eq!(result.prefill_logits.len(), n_prefill);
     for (i, p) in prefilling.iter_mut().enumerate() {
         p.chunk_offset += chunk_lens[i];
+        // Prompt tokens counted AT INGEST, as each chunk lands. Counting them
+        // at request completion (the old site) credited the whole prompt to the
+        // moment the RESPONSE finished — seconds or minutes after the prefill
+        // actually ran — so the Stats page's prefill rate was attributed to the
+        // wrong instant entirely. Semantics are unchanged: this is the same
+        // "prompt_tokens" the API reports (cache-hit tokens included; the
+        // computed-vs-cached split is the prefix-cache panel's job).
+        crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(chunk_lens[i] as u64);
         if !is_last_flags[i] {
             continue;
         }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
@@ -140,6 +140,7 @@ pub(super) fn run_batched_mixed_step(
     debug_assert_eq!(result.prefill_logits.len(), n_prefill);
     for (i, p) in prefilling.iter_mut().enumerate() {
         p.chunk_offset += chunk_lens[i];
+        sched.snapshot.note_prefill_chunk(chunk_lens[i], true);
         // Prompt tokens counted AT INGEST, as each chunk lands. Counting them
         // at request completion (the old site) credited the whole prompt to the
         // moment the RESPONSE finished — seconds or minutes after the prefill

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -193,6 +193,14 @@ pub(super) fn run_batched_prefill_step(
         for (k, &i) in wave.iter().enumerate() {
             let p = &mut prefilling[i];
             p.chunk_offset += chunk_lens[i];
+            // Prompt tokens counted AT INGEST, as each chunk lands. Counting them
+            // at request completion (the old site) credited the whole prompt to the
+            // moment the RESPONSE finished — seconds or minutes after the prefill
+            // actually ran — so the Stats page's prefill rate was attributed to the
+            // wrong instant entirely. Semantics are unchanged: this is the same
+            // "prompt_tokens" the API reports (cache-hit tokens included; the
+            // computed-vs-cached split is the prefix-cache panel's job).
+            crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(chunk_lens[i] as u64);
             if !is_last_flags[i] {
                 continue;
             }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -193,6 +193,7 @@ pub(super) fn run_batched_prefill_step(
         for (k, &i) in wave.iter().enumerate() {
             let p = &mut prefilling[i];
             p.chunk_offset += chunk_lens[i];
+            sched.snapshot.note_prefill_chunk(chunk_lens[i], true);
             // Prompt tokens counted AT INGEST, as each chunk lands. Counting them
             // at request completion (the old site) credited the whole prompt to the
             // moment the RESPONSE finished — seconds or minutes after the prefill

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -167,6 +167,7 @@ pub(super) fn run_standard_chunk_loop(
         ) {
             Ok(result) => {
                 p.chunk_offset += chunk_len;
+                sched.snapshot.note_prefill_chunk(chunk_len, false);
                 // Prompt tokens counted AT INGEST, as each chunk lands. Counting them
                 // at request completion (the old site) credited the whole prompt to the
                 // moment the RESPONSE finished — seconds or minutes after the prefill
@@ -316,6 +317,7 @@ pub(super) fn run_standard_chunk_loop(
     match chunk_res {
         Ok(logits) => {
             p.chunk_offset += chunk_len;
+            sched.snapshot.note_prefill_chunk(chunk_len, false);
             crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(chunk_len as u64);
             tracing::info!(
                 "Prefill chunk {}/{} tokens",

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -167,6 +167,14 @@ pub(super) fn run_standard_chunk_loop(
         ) {
             Ok(result) => {
                 p.chunk_offset += chunk_len;
+                // Prompt tokens counted AT INGEST, as each chunk lands. Counting them
+                // at request completion (the old site) credited the whole prompt to the
+                // moment the RESPONSE finished — seconds or minutes after the prefill
+                // actually ran — so the Stats page's prefill rate was attributed to the
+                // wrong instant entirely. Semantics are unchanged: this is the same
+                // "prompt_tokens" the API reports (cache-hit tokens included; the
+                // computed-vs-cached split is the prefix-cache panel's job).
+                crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(chunk_len as u64);
                 tracing::info!(
                     "Mixed forward: prefill {}/{} tokens + {} decode",
                     p.chunk_offset,
@@ -308,6 +316,7 @@ pub(super) fn run_standard_chunk_loop(
     match chunk_res {
         Ok(logits) => {
             p.chunk_offset += chunk_len;
+            crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(chunk_len as u64);
             tracing::info!(
                 "Prefill chunk {}/{} tokens",
                 p.chunk_offset,

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -400,6 +400,13 @@ pub fn start_chunked_prefill(
         chunk_res
     })();
 
+    // FIRST chunk ingested here — the continue-prefills path only ever sees
+    // chunks 2..n, so counting solely there under-reported every request by
+    // exactly one `max_prefill_tokens` (measured: 4423 counted vs 12618
+    // API prompt_tokens on a 12.6k prompt, an 8192 shortfall).
+    if prefill_result.is_ok() {
+        crate::metrics::PROMPT_TOKENS_TOTAL.inc_by(chunk_len as u64);
+    }
     let logits = match prefill_result {
         Ok(l) => l,
         Err(e) => {

--- a/crates/spark-server/src/scheduler/snapshot.rs
+++ b/crates/spark-server/src/scheduler/snapshot.rs
@@ -42,6 +42,19 @@ pub struct SchedulerSnapshot {
     /// 0.0 when unmeasured.
     pub delivered_tps: f32,
     pub steps_total: u64,
+    /// In-flight prefill progress, SUMMED over the prefilling sequences:
+    /// tokens already ingested vs tokens in their prompts. Both 0 when
+    /// nothing is prefilling. Aggregated rather than per-sequence so the
+    /// snapshot stays `Copy` — a `Vec` here would allocate on the scheduler
+    /// thread once per tick, which is exactly the cost this must not have.
+    pub prefill_tokens_done: u32,
+    pub prefill_tokens_total: u32,
+    /// Token count (M) of the most recent prefill dispatch, and whether it
+    /// took a fused/batched large-M path. This is how you see from the UI
+    /// whether the fused arm actually engaged, rather than inferring it from
+    /// throughput.
+    pub prefill_chunk_width: u32,
+    pub prefill_fused: bool,
     /// For staleness detection: a snapshot older than a few seconds means the
     /// scheduler thread is wedged or the server is idle-parked.
     pub published_at: Instant,
@@ -59,17 +72,43 @@ pub struct SchedulerSnapshot {
 /// Shared as an `Arc` from `serve` — the same route `SchedLevers` takes — so
 /// the cell dies with the run and a reader attached to no run sees `None`.
 #[derive(Default)]
-pub struct SnapshotCell(Mutex<Option<SchedulerSnapshot>>);
+pub struct SnapshotCell {
+    cell: Mutex<Option<SchedulerSnapshot>>,
+    /// Last prefill dispatch width, and whether it was the fused path.
+    /// Written from the prefill dispatch sites and read once per tick by
+    /// `publish`. Relaxed atomics: this is observability, a torn read across
+    /// the two costs a single stale UI frame and nothing else — worth far
+    /// less than making the prefill path synchronise.
+    last_chunk_width: std::sync::atomic::AtomicU32,
+    last_chunk_fused: std::sync::atomic::AtomicBool,
+}
 
 impl SnapshotCell {
+    /// Record the width of a prefill dispatch. Two relaxed stores — ~1 ns
+    /// against a chunk that takes milliseconds.
+    pub fn note_prefill_chunk(&self, width: usize, fused: bool) {
+        use std::sync::atomic::Ordering::Relaxed;
+        self.last_chunk_width.store(width as u32, Relaxed);
+        self.last_chunk_fused.store(fused, Relaxed);
+    }
+
+    /// The last recorded dispatch width + fused flag.
+    pub fn last_prefill_chunk(&self) -> (u32, bool) {
+        use std::sync::atomic::Ordering::Relaxed;
+        (
+            self.last_chunk_width.load(Relaxed),
+            self.last_chunk_fused.load(Relaxed),
+        )
+    }
+
     /// Publish the latest snapshot (scheduler thread, once per loop tick).
     pub fn publish(&self, s: SchedulerSnapshot) {
-        *self.0.lock() = Some(s);
+        *self.cell.lock() = Some(s);
     }
 
     /// Read the latest snapshot, if the scheduler has published one yet.
     pub fn read(&self) -> Option<SchedulerSnapshot> {
-        *self.0.lock()
+        *self.cell.lock()
     }
 }
 
@@ -92,6 +131,10 @@ mod tests {
             mtp_mode: MtpModeSnap::Mtp,
             delivered_tps: 42.5,
             steps_total: 7,
+            prefill_tokens_done: 0,
+            prefill_tokens_total: 0,
+            prefill_chunk_width: 0,
+            prefill_fused: false,
             published_at: Instant::now(),
         };
         cell.publish(s);

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -142,7 +142,9 @@ pub fn step_verify_dflash(
             tracing::error!("commit_ctx (kgamma): {e:#}");
         }
     } else {
-        let eagle_fix = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() == Some("1");
+        // Default ON since the 54.5 record config (2026-08-19); `=0` is the
+        // kill switch.
+        let eagle_fix = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() != Some("0");
         if eagle_fix
             && let Err(e) =
                 model.dflash_eagle_kgamma_append(&mut a.seq, num_accepted, pre_verify_len)

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -173,16 +173,22 @@ pub fn step_verify_dflash(
         a.last_token = bonus;
     }
 
+    // Accept telemetry, in DRAFT TOKENS not steps. A gamma-block drafter
+    // accepts 0..gamma per step, so a per-step accept/reject binary carries
+    // no information — and the two labels this used to emit ("accept_all" /
+    // "accept_partial") BOTH matched the TUI's `outcome.contains("accept")`
+    // test, which pinned the Stats page's `accept k=dflash` bar at 100%
+    // forever. Counting tokens makes that bar the real draft-acceptance
+    // rate, the same number the benchmarks report.
+    let rejected = drafts.len().saturating_sub(num_accepted);
     crate::metrics::SPEC_DECODE_VERIFY
-        .with_label_values(&[
-            "dflash",
-            if num_accepted == drafts.len() {
-                "accept_all"
-            } else {
-                "accept_partial"
-            },
-        ])
-        .inc();
+        .with_label_values(&["dflash", "accept"])
+        .inc_by(num_accepted as u64);
+    if rejected > 0 {
+        crate::metrics::SPEC_DECODE_VERIFY
+            .with_label_values(&["dflash", "reject"])
+            .inc_by(rejected as u64);
+    }
 
     tracing::info!(
         "DFLASH K=γ verify: γ={} accepted={}/{} ({:.0}%) seq_len={}",

--- a/crates/spark-server/src/scheduler/verify_k2_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k2_step.rs
@@ -221,7 +221,10 @@ pub fn step_verify_k2(
         // then row 1 @ N+1 BEFORE propose so forward_block conditions on row 1
         // (the hidden that generated bonus). This also sets the proposer's
         // skip-flag so propose does NOT re-append row 0.
-        let eagle_fix = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() == Some("1");
+        // Default ON since the 54.5 record config (2026-08-19); `=0` is the
+        // kill switch (see verify_d.rs capture_all for the 07-09 collapse
+        // this fix closes).
+        let eagle_fix = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() != Some("0");
         if eagle_fix && let Err(e) = model.dflash_eagle_accept_append(&mut a.seq) {
             tracing::error!("dflash_eagle_accept_append: {e:#}");
         }

--- a/crates/spark-server/src/tui/data/metrics_poll.rs
+++ b/crates/spark-server/src/tui/data/metrics_poll.rs
@@ -60,6 +60,11 @@ pub struct StatsModel {
     pub bytes_out_rate: f64,
     // Histories.
     pub gen_tps_history: History,
+    /// Prefill ingest rate history. Kept SEPARATE from `gen_tps_history`
+    /// rather than sharing the throughput chart: prefill runs ~890 tok/s
+    /// against ~40 tok/s for generation, so on one axis the generation line
+    /// flattens to the baseline and stops being readable.
+    pub prompt_tps_history: History,
     pub req_history: History,
     pub queue_history: History,
     pub entropy_history: History,
@@ -119,6 +124,7 @@ impl Default for StatsModel {
             bytes_in_rate: 0.0,
             bytes_out_rate: 0.0,
             gen_tps_history: History::new(120),
+            prompt_tps_history: History::new(120),
             req_history: History::new(16),
             queue_history: History::new(24),
             entropy_history: History::new(24),
@@ -176,6 +182,7 @@ impl StatsModel {
             self.bytes_in_rate = (self.bytes_in_total.saturating_sub(prev.bytes_in)) as f64 / dt;
             self.bytes_out_rate = (self.bytes_out_total.saturating_sub(prev.bytes_out)) as f64 / dt;
             self.gen_tps_history.push(self.gen_tps);
+            self.prompt_tps_history.push(self.prompt_tps);
             self.req_history.push(self.req_rate);
         }
         self.last_sample = Some((

--- a/crates/spark-server/src/tui/render/mod.rs
+++ b/crates/spark-server/src/tui/render/mod.rs
@@ -14,6 +14,7 @@ mod main_tab_kernels;
 mod network_tab;
 mod overlay;
 mod stats_tab;
+mod stats_tab_panels;
 mod terminal_tab;
 
 use ratatui::Frame;

--- a/crates/spark-server/src/tui/render/stats_tab.rs
+++ b/crates/spark-server/src/tui/render/stats_tab.rs
@@ -63,11 +63,16 @@ fn draw_tiles(f: &mut Frame, app: &App, area: Rect) {
     let s = &app.stats;
     let tiles = Layout::default()
         .direction(Direction::Horizontal)
+        // Unequal on purpose: five EQUAL tiles truncated the REQUESTS row
+        // ("1007 ● 8 ↓2.0 KB/s ↑3.0 MB/s" is ~32 cols and the widest content
+        // here), which the tile test catches. Widths follow the content —
+        // REQUESTS and GPU carry two figures each, THROUGHPUT carries one.
         .constraints([
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
+            Constraint::Percentage(24),
+            Constraint::Percentage(16),
+            Constraint::Percentage(18),
+            Constraint::Percentage(20),
+            Constraint::Percentage(22),
         ])
         .split(area);
     let req = Line::from(vec![
@@ -104,6 +109,31 @@ fn draw_tiles(f: &mut Frame, app: &App, area: Rect) {
         tp,
         Some(&s.gen_tps_history.as_u64()),
     );
+    // Prefill ingest. Counted per chunk as it lands (see
+    // scheduler/phase_continue_prefills), so this is the rate at the moment
+    // ingest happens — not, as it used to be, the whole prompt credited to
+    // whenever the response finished. `● n` is the number of sequences
+    // currently prefilling, straight off the scheduler snapshot.
+    let pf = Line::from(vec![
+        Span::styled(
+            format!(" {:.0} tok/s", s.prompt_tps),
+            theme::text().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            match s.sched {
+                Some(x) if x.prefilling_seqs > 0 => format!("  ● {}", x.prefilling_seqs),
+                _ => String::new(),
+            },
+            theme::brand_cyan(),
+        ),
+    ]);
+    tile(
+        f,
+        tiles[2],
+        "PREFILL",
+        pf,
+        Some(&s.prompt_tps_history.as_u64()),
+    );
     let ttft = Line::from(vec![
         Span::styled(
             format!(" p50 {}", fmt_ms(s.ttft_p50_ms)),
@@ -111,7 +141,7 @@ fn draw_tiles(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled(format!("  p90 {}", fmt_ms(s.ttft_p90_ms)), theme::text2()),
     ]);
-    tile(f, tiles[2], "TTFT", ttft, None);
+    tile(f, tiles[3], "TTFT", ttft, None);
     // `—`, not 0.0, when the device never answered.
     let gpu = if s.gpu_known {
         Line::from(vec![
@@ -124,7 +154,7 @@ fn draw_tiles(f: &mut Frame, app: &App, area: Rect) {
     } else {
         Line::from(Span::styled(" —", theme::dim()))
     };
-    tile(f, tiles[3], "GPU", gpu, None);
+    tile(f, tiles[4], "GPU", gpu, None);
 }
 
 fn draw_ttft_hist(f: &mut Frame, app: &App, area: Rect) {

--- a/crates/spark-server/src/tui/render/stats_tab.rs
+++ b/crates/spark-server/src/tui/render/stats_tab.rs
@@ -126,6 +126,21 @@ fn draw_tiles(f: &mut Frame, app: &App, area: Rect) {
             },
             theme::brand_cyan(),
         ),
+        // In-flight progress as a PERCENT: this tile is the narrowest on the
+        // row (18%) and the absolute pair "4.2k/12.6k" truncates in it. The
+        // exact numbers go to the sequences pane, which has the width.
+        // Rendered only while something is prefilling — a permanent 0% would
+        // be noise on an idle server.
+        Span::styled(
+            match s.sched {
+                Some(x) if x.prefill_tokens_total > 0 => format!(
+                    "  {:.0}%",
+                    100.0 * x.prefill_tokens_done as f64 / x.prefill_tokens_total as f64
+                ),
+                _ => String::new(),
+            },
+            theme::text2(),
+        ),
     ]);
     tile(
         f,
@@ -313,6 +328,16 @@ fn line_gauge(f: &mut Frame, area: Rect, label: &str, used: f64, total: f64, gra
     );
 }
 
+/// `12618` -> `12.6k`. The PREFILL tile is the narrowest on the row, so the
+/// progress pair has to stay short enough not to clip it.
+fn compact_tokens(n: u32) -> String {
+    if n >= 1000 {
+        format!("{:.1}k", n as f64 / 1000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 fn draw_sequences(f: &mut Frame, app: &App, area: Rect) {
     let block = panel("SEQUENCES & MEMORY ─".into(), false);
     let inner = block.inner(area);
@@ -346,7 +371,23 @@ fn draw_sequences(f: &mut Frame, app: &App, area: Rect) {
         f.render_widget(
             Paragraph::new(Line::from(vec![Span::styled(
                 format!(
-                    " active {active} · prefill {prefill} · swapped {swapped} · queue {queue} "
+                    " active {active} · prefill {prefill} · swapped {swapped} · queue {queue}{} ",
+                    // Last prefill dispatch width, and whether it took a
+                    // fused/batched large-M arm. Without this you can only
+                    // infer engagement from throughput.
+                    match s.sched {
+                        Some(x) if x.prefill_chunk_width > 0 => format!(
+                            // Width + arm ONLY. The exact token pair was here
+                            // too and pushed "fused" off the pane's right
+                            // edge; progress is already on the PREFILL tile
+                            // as a percent, whereas whether the fused arm
+                            // engaged is not visible anywhere else.
+                            " · M={}{}",
+                            x.prefill_chunk_width,
+                            if x.prefill_fused { " fused" } else { "" }
+                        ),
+                        _ => String::new(),
+                    }
                 ),
                 theme::text(),
             )])),

--- a/crates/spark-server/src/tui/render/stats_tab.rs
+++ b/crates/spark-server/src/tui/render/stats_tab.rs
@@ -167,7 +167,7 @@ fn draw_ttft_hist(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_throughput(f: &mut Frame, app: &App, area: Rect) {
-    let block = panel("THROUGHPUT ── gen tok/s ─".into(), false);
+    let block = panel("THROUGHPUT ── gen ─ prefill ─".into(), false);
     let pts: Vec<(f64, f64)> = app
         .stats
         .gen_tps_history
@@ -177,15 +177,51 @@ fn draw_throughput(f: &mut Frame, app: &App, area: Rect) {
         .map(|(i, v)| (i as f64, *v))
         .collect();
     let max_y = pts.iter().map(|(_, v)| *v).fold(10.0_f64, f64::max) * 1.15;
-    let datasets = vec![
+
+    // Prefill on the SAME plot but its OWN scale, printed up the right edge.
+    // The two series differ by ~20x (≈890 vs ≈40 tok/s), so one shared axis
+    // buries the generation line on the baseline. Instead the prefill series
+    // is normalised onto the generation axis and the right-hand labels say
+    // what full-scale means for it — a dual-axis chart, which ratatui's
+    // `Chart` has no native support for, so the right scale is drawn by hand
+    // below.
+    let pf_raw: Vec<f64> = app
+        .stats
+        .prompt_tps_history
+        .points
+        .iter()
+        .copied()
+        .collect();
+    let pf_max = pf_raw.iter().copied().fold(0.0_f64, f64::max);
+    let pf_scale = if pf_max > 0.0 {
+        max_y / (pf_max * 1.15)
+    } else {
+        0.0
+    };
+    let pf_pts: Vec<(f64, f64)> = pf_raw
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i as f64, v * pf_scale))
+        .collect();
+
+    let mut datasets = vec![
         Dataset::default()
             .marker(symbols::Marker::Braille)
             .graph_type(ratatui::widgets::GraphType::Line)
             .style(theme::brand_cyan())
             .data(&pts),
     ];
+    if pf_max > 0.0 {
+        datasets.push(
+            Dataset::default()
+                .marker(symbols::Marker::Braille)
+                .graph_type(ratatui::widgets::GraphType::Line)
+                .style(theme::brand_purple())
+                .data(&pf_pts),
+        );
+    }
     let caption = format!(
-        "gen {:.0} tok/s · prompt {:.0} tok/s",
+        "gen {:.0} tok/s · prefill {:.0} tok/s",
         app.stats.gen_tps, app.stats.prompt_tps
     );
     let chart = Chart::new(datasets)
@@ -196,6 +232,25 @@ fn draw_throughput(f: &mut Frame, app: &App, area: Rect) {
         ]))
         .block(block.title_bottom(Line::from(Span::styled(caption, theme::text2()))));
     f.render_widget(chart, area);
+
+    // Right-hand scale for the prefill series, in the prefill colour so it
+    // reads as "the purple line tops out here". Only drawn once prefill has
+    // been observed — an idle server gets the single-scale chart it had.
+    // Placed inside the block border, right-aligned, and only when the pane
+    // is tall/wide enough to hold it without colliding with the plot.
+    if pf_max > 0.0 && area.height >= 4 && area.width >= 24 {
+        let label = format!("{:.0} ", pf_max * 1.15);
+        let w = label.len() as u16;
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(label, theme::brand_purple()))),
+            Rect {
+                x: area.right().saturating_sub(w + 1),
+                y: area.y + 1,
+                width: w,
+                height: 1,
+            },
+        );
+    }
 }
 
 fn line_gauge(f: &mut Frame, area: Rect, label: &str, used: f64, total: f64, gradient: bool) {

--- a/crates/spark-server/src/tui/render/stats_tab.rs
+++ b/crates/spark-server/src/tui/render/stats_tab.rs
@@ -6,10 +6,10 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::symbols;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Axis, BarChart, Chart, Dataset, LineGauge, Paragraph, Sparkline};
+use ratatui::widgets::{Axis, BarChart, Chart, Dataset, Paragraph, Sparkline};
 
 use super::panel;
 use crate::tui::app::App;
@@ -35,8 +35,8 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(48), Constraint::Percentage(52)])
         .split(rows[2]);
-    draw_sequences(f, app, bottom[0]);
-    draw_spec_cache(f, app, bottom[1]);
+    super::stats_tab_panels::draw_sequences(f, app, bottom[0]);
+    super::stats_tab_panels::draw_spec_cache(f, app, bottom[1]);
 }
 
 fn tile(f: &mut Frame, area: Rect, title: &str, value: Line, spark: Option<&[u64]>) {
@@ -298,36 +298,6 @@ fn draw_throughput(f: &mut Frame, app: &App, area: Rect) {
     }
 }
 
-fn line_gauge(f: &mut Frame, area: Rect, label: &str, used: f64, total: f64, gradient: bool) {
-    let frac = if total > 0.0 {
-        (used / total).clamp(0.0, 1.0)
-    } else {
-        0.0
-    };
-    let color = theme::pressure_color(frac).unwrap_or(if gradient {
-        theme::gradient_at(frac)
-    } else {
-        theme::CYAN.color()
-    });
-    let g = LineGauge::default()
-        .ratio(frac)
-        .filled_style(Style::default().fg(color))
-        .unfilled_style(Style::default().fg(theme::GAUGE_TRACK.color()))
-        .label(Span::styled(format!("{label:<4}"), theme::dim()));
-    let cols = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(10), Constraint::Length(16)])
-        .split(area);
-    f.render_widget(g, cols[0]);
-    f.render_widget(
-        Paragraph::new(Span::styled(
-            format!("{used:.0}/{total:.0}"),
-            theme::text2(),
-        )),
-        cols[1],
-    );
-}
-
 /// `12618` -> `12.6k`. The PREFILL tile is the narrowest on the row, so the
 /// progress pair has to stay short enough not to clip it.
 fn compact_tokens(n: u32) -> String {
@@ -335,191 +305,6 @@ fn compact_tokens(n: u32) -> String {
         format!("{:.1}k", n as f64 / 1000.0)
     } else {
         n.to_string()
-    }
-}
-
-fn draw_sequences(f: &mut Frame, app: &App, area: Rect) {
-    let block = panel("SEQUENCES & MEMORY ─".into(), false);
-    let inner = block.inner(area);
-    f.render_widget(block, area);
-    let s = &app.stats;
-    let (active, prefill, swapped, queue) = s
-        .sched
-        .map(|x| {
-            (
-                x.active_seqs,
-                x.prefilling_seqs,
-                x.swapped_seqs,
-                x.pending_len,
-            )
-        })
-        .unwrap_or_default();
-    // Every row below is placed by hand rather than by a `Layout`, so every
-    // row has to be checked against the pane it is meant to be inside: a
-    // `Rect` one line past the bottom is not clipped by ratatui, it panics —
-    // and this pane is six rows tall on a terminal that is only eight, so the
-    // dashboard (and with it the server's foreground) went down on a resize.
-    let row = |y: u16| -> Option<Rect> {
-        (y < inner.bottom()).then_some(Rect {
-            y,
-            height: 1,
-            ..inner
-        })
-    };
-    let mut y = inner.y;
-    if let Some(r) = row(y) {
-        f.render_widget(
-            Paragraph::new(Line::from(vec![Span::styled(
-                format!(
-                    " active {active} · prefill {prefill} · swapped {swapped} · queue {queue}{} ",
-                    // Last prefill dispatch width, and whether it took a
-                    // fused/batched large-M arm. Without this you can only
-                    // infer engagement from throughput.
-                    match s.sched {
-                        Some(x) if x.prefill_chunk_width > 0 => format!(
-                            // Width + arm ONLY. The exact token pair was here
-                            // too and pushed "fused" off the pane's right
-                            // edge; progress is already on the PREFILL tile
-                            // as a percent, whereas whether the fused arm
-                            // engaged is not visible anywhere else.
-                            " · M={}{}",
-                            x.prefill_chunk_width,
-                            if x.prefill_fused { " fused" } else { "" }
-                        ),
-                        _ => String::new(),
-                    }
-                ),
-                theme::text(),
-            )])),
-            r,
-        );
-    }
-    y += 1;
-    let qh = s.queue_history.as_u64();
-    if !qh.is_empty()
-        && let Some(r) = row(y)
-    {
-        f.render_widget(
-            Sparkline::default().data(&qh).style(theme::brand_cyan()),
-            Rect {
-                x: inner.x + 1,
-                width: inner.width.saturating_sub(2),
-                ..r
-            },
-        );
-    }
-    y += 2;
-    if let Some(x) = s.sched {
-        let used = (x.kv_blocks_total - x.kv_blocks_free) as f64;
-        if let Some(r) = row(y) {
-            line_gauge(f, r, " KV", used, x.kv_blocks_total as f64, true);
-        }
-        y += 1;
-        if let Some(r) = row(y) {
-            line_gauge(
-                f,
-                r,
-                " SSM",
-                x.ssm_slots_used as f64,
-                x.ssm_slots_total as f64,
-                false,
-            );
-        }
-        y += 1;
-    }
-    if let Some(r) = row(y) {
-        if s.gpu_known {
-            line_gauge(
-                f,
-                r,
-                " GPU",
-                s.atlas_used_gb,
-                s.gpu_total_gb.max(0.001),
-                true,
-            );
-        } else {
-            // A 0 % bar reads as "empty", which is a claim. Say nothing instead.
-            f.render_widget(
-                ratatui::widgets::Paragraph::new(Span::styled(" GPU  —", theme::dim())),
-                r,
-            );
-        }
-    }
-    if let Some(r) = row(y + 1) {
-        line_gauge(
-            f,
-            r,
-            " RAM",
-            (s.host_total_gb - s.host_avail_gb).max(0.0),
-            s.host_total_gb.max(0.001),
-            false,
-        );
-    }
-}
-
-fn draw_spec_cache(f: &mut Frame, app: &App, area: Rect) {
-    let block = panel("SPECULATION & CACHE ─".into(), false);
-    let inner = block.inner(area);
-    f.render_widget(block, area);
-    let s = &app.stats;
-    let mut lines: Vec<Line> = Vec::new();
-    if let Some(x) = s.sched {
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!(
-                    " MTP gate {}",
-                    crate::tui::format::mtp_mode_label(x.mtp_mode)
-                ),
-                theme::text(),
-            ),
-            Span::styled(
-                format!(" · delivered {:.0} tok/s", x.delivered_tps),
-                theme::text2(),
-            ),
-        ]));
-    }
-    for (k, accepted, total) in &s.spec_accept {
-        if *total == 0 {
-            continue;
-        }
-        let rate = *accepted as f64 / *total as f64;
-        let w = 16usize;
-        let filled = (rate * w as f64) as usize;
-        let bar: String = "█".repeat(filled) + &"░".repeat(w - filled);
-        lines.push(Line::from(vec![
-            Span::styled(format!(" accept k={k:<3}"), theme::text2()),
-            Span::styled(bar, theme::brand_cyan()),
-            Span::styled(format!(" {:>3.0}%", rate * 100.0), theme::text()),
-        ]));
-    }
-    lines.push(Line::default());
-    let hit = s
-        .prefix_hit_rate
-        .map(|r| format!("{:.0}%", r * 100.0))
-        .unwrap_or_else(|| "—".into());
-    lines.push(Line::from(Span::styled(
-        format!(" prefix-cache hit {hit} · {} tok warm", s.prefix_hit_tokens),
-        theme::text(),
-    )));
-    lines.push(Line::from(Span::styled(
-        format!(
-            " tool calls {} · entropy {:.2}",
-            s.tool_calls_total, s.entropy
-        ),
-        theme::text2(),
-    )));
-    f.render_widget(Paragraph::new(lines), inner);
-    let eh = s.entropy_history.as_u64();
-    if !eh.is_empty() && inner.height >= 6 {
-        f.render_widget(
-            Sparkline::default().data(&eh).style(theme::brand_cyan()),
-            Rect {
-                y: inner.y + inner.height - 1,
-                height: 1,
-                x: inner.x + 1,
-                width: inner.width.saturating_sub(2),
-            },
-        );
     }
 }
 

--- a/crates/spark-server/src/tui/render/stats_tab_panels.rs
+++ b/crates/spark-server/src/tui/render/stats_tab_panels.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Stats-tab lower panels: SEQUENCES & MEMORY, SPECULATION & CACHE, and the
+//! `line_gauge` bar they share.
+//!
+//! Split out of `stats_tab.rs` when the PREFILL ingest tile and the
+//! dual-scale throughput chart pushed that file past the repo's 500-LoC cap.
+//! Follows the existing `main_tab` / `main_tab_kernels` sibling idiom rather
+//! than introducing a directory. The cut is at a real seam: everything here
+//! renders the BOTTOM half of the tab and nothing above it calls in, so the
+//! two halves share only `App`, the `panel` chrome, and `fmt_ms`.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{LineGauge, Paragraph, Sparkline};
+
+use super::panel;
+use crate::tui::app::App;
+use crate::tui::theme;
+
+pub(super) fn line_gauge(
+    f: &mut Frame,
+    area: Rect,
+    label: &str,
+    used: f64,
+    total: f64,
+    gradient: bool,
+) {
+    let frac = if total > 0.0 {
+        (used / total).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let color = theme::pressure_color(frac).unwrap_or(if gradient {
+        theme::gradient_at(frac)
+    } else {
+        theme::CYAN.color()
+    });
+    let g = LineGauge::default()
+        .ratio(frac)
+        .filled_style(Style::default().fg(color))
+        .unfilled_style(Style::default().fg(theme::GAUGE_TRACK.color()))
+        .label(Span::styled(format!("{label:<4}"), theme::dim()));
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(10), Constraint::Length(16)])
+        .split(area);
+    f.render_widget(g, cols[0]);
+    f.render_widget(
+        Paragraph::new(Span::styled(
+            format!("{used:.0}/{total:.0}"),
+            theme::text2(),
+        )),
+        cols[1],
+    );
+}
+
+pub(super) fn draw_sequences(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("SEQUENCES & MEMORY ─".into(), false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let s = &app.stats;
+    let (active, prefill, swapped, queue) = s
+        .sched
+        .map(|x| {
+            (
+                x.active_seqs,
+                x.prefilling_seqs,
+                x.swapped_seqs,
+                x.pending_len,
+            )
+        })
+        .unwrap_or_default();
+    // Every row below is placed by hand rather than by a `Layout`, so every
+    // row has to be checked against the pane it is meant to be inside: a
+    // `Rect` one line past the bottom is not clipped by ratatui, it panics —
+    // and this pane is six rows tall on a terminal that is only eight, so the
+    // dashboard (and with it the server's foreground) went down on a resize.
+    let row = |y: u16| -> Option<Rect> {
+        (y < inner.bottom()).then_some(Rect {
+            y,
+            height: 1,
+            ..inner
+        })
+    };
+    let mut y = inner.y;
+    if let Some(r) = row(y) {
+        f.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                format!(
+                    " active {active} · prefill {prefill} · swapped {swapped} · queue {queue}{} ",
+                    // Last prefill dispatch width, and whether it took a
+                    // fused/batched large-M arm. Without this you can only
+                    // infer engagement from throughput.
+                    match s.sched {
+                        Some(x) if x.prefill_chunk_width > 0 => format!(
+                            // Width + arm ONLY. The exact token pair was here
+                            // too and pushed "fused" off the pane's right
+                            // edge; progress is already on the PREFILL tile
+                            // as a percent, whereas whether the fused arm
+                            // engaged is not visible anywhere else.
+                            " · M={}{}",
+                            x.prefill_chunk_width,
+                            if x.prefill_fused { " fused" } else { "" }
+                        ),
+                        _ => String::new(),
+                    }
+                ),
+                theme::text(),
+            )])),
+            r,
+        );
+    }
+    y += 1;
+    let qh = s.queue_history.as_u64();
+    if !qh.is_empty()
+        && let Some(r) = row(y)
+    {
+        f.render_widget(
+            Sparkline::default().data(&qh).style(theme::brand_cyan()),
+            Rect {
+                x: inner.x + 1,
+                width: inner.width.saturating_sub(2),
+                ..r
+            },
+        );
+    }
+    y += 2;
+    if let Some(x) = s.sched {
+        let used = (x.kv_blocks_total - x.kv_blocks_free) as f64;
+        if let Some(r) = row(y) {
+            line_gauge(f, r, " KV", used, x.kv_blocks_total as f64, true);
+        }
+        y += 1;
+        if let Some(r) = row(y) {
+            line_gauge(
+                f,
+                r,
+                " SSM",
+                x.ssm_slots_used as f64,
+                x.ssm_slots_total as f64,
+                false,
+            );
+        }
+        y += 1;
+    }
+    if let Some(r) = row(y) {
+        if s.gpu_known {
+            line_gauge(
+                f,
+                r,
+                " GPU",
+                s.atlas_used_gb,
+                s.gpu_total_gb.max(0.001),
+                true,
+            );
+        } else {
+            // A 0 % bar reads as "empty", which is a claim. Say nothing instead.
+            f.render_widget(
+                ratatui::widgets::Paragraph::new(Span::styled(" GPU  —", theme::dim())),
+                r,
+            );
+        }
+    }
+    if let Some(r) = row(y + 1) {
+        line_gauge(
+            f,
+            r,
+            " RAM",
+            (s.host_total_gb - s.host_avail_gb).max(0.0),
+            s.host_total_gb.max(0.001),
+            false,
+        );
+    }
+}
+
+pub(super) fn draw_spec_cache(f: &mut Frame, app: &App, area: Rect) {
+    let block = panel("SPECULATION & CACHE ─".into(), false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let s = &app.stats;
+    let mut lines: Vec<Line> = Vec::new();
+    if let Some(x) = s.sched {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(
+                    " MTP gate {}",
+                    crate::tui::format::mtp_mode_label(x.mtp_mode)
+                ),
+                theme::text(),
+            ),
+            Span::styled(
+                format!(" · delivered {:.0} tok/s", x.delivered_tps),
+                theme::text2(),
+            ),
+        ]));
+    }
+    for (k, accepted, total) in &s.spec_accept {
+        if *total == 0 {
+            continue;
+        }
+        let rate = *accepted as f64 / *total as f64;
+        let w = 16usize;
+        let filled = (rate * w as f64) as usize;
+        let bar: String = "█".repeat(filled) + &"░".repeat(w - filled);
+        lines.push(Line::from(vec![
+            Span::styled(format!(" accept k={k:<3}"), theme::text2()),
+            Span::styled(bar, theme::brand_cyan()),
+            Span::styled(format!(" {:>3.0}%", rate * 100.0), theme::text()),
+        ]));
+    }
+    lines.push(Line::default());
+    let hit = s
+        .prefix_hit_rate
+        .map(|r| format!("{:.0}%", r * 100.0))
+        .unwrap_or_else(|| "—".into());
+    lines.push(Line::from(Span::styled(
+        format!(" prefix-cache hit {hit} · {} tok warm", s.prefix_hit_tokens),
+        theme::text(),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!(
+            " tool calls {} · entropy {:.2}",
+            s.tool_calls_total, s.entropy
+        ),
+        theme::text2(),
+    )));
+    f.render_widget(Paragraph::new(lines), inner);
+    let eh = s.entropy_history.as_u64();
+    if !eh.is_empty() && inner.height >= 6 {
+        f.render_widget(
+            Sparkline::default().data(&eh).style(theme::brand_cyan()),
+            Rect {
+                y: inner.y + inner.height - 1,
+                height: 1,
+                x: inner.x + 1,
+                width: inner.width.saturating_sub(2),
+            },
+        );
+    }
+}

--- a/crates/spark-server/src/tui/render/stats_tab_tests.rs
+++ b/crates/spark-server/src/tui/render/stats_tab_tests.rs
@@ -188,7 +188,9 @@ fn the_throughput_chart_captions_both_rates() {
     a.stats.gen_tps = 59.9;
     a.stats.prompt_tps = 1841.0;
     let rows = screen(&a, 160, 48);
-    assert!(has(&rows, "gen 60 tok/s · prompt 1841 tok/s"), "{rows:#?}");
+    // "prefill", not "prompt": the tile, the metric and the chart all name
+    // the same thing now.
+    assert!(has(&rows, "gen 60 tok/s · prefill 1841 tok/s"), "{rows:#?}");
 }
 
 #[test]

--- a/crates/spark-server/src/tui/render/stats_tab_tests.rs
+++ b/crates/spark-server/src/tui/render/stats_tab_tests.rs
@@ -99,6 +99,26 @@ fn a_server_under_load_reports_its_measurements_in_the_tiles() {
 }
 
 #[test]
+fn the_prefill_tile_reports_ingest_rate_and_in_flight_prefills() {
+    let mut a = stats_app();
+    // Prefill runs ~20x the generation rate, which is exactly why it gets its
+    // own tile and its own sparkline instead of sharing the throughput axis.
+    a.stats.prompt_tps = 890.0;
+    a.stats.gen_tps = 40.0;
+    a.stats.sched = Some(sched());
+    let rows = screen(&a, 160, 48);
+    assert!(has(&rows, "PREFILL"), "{rows:#?}");
+    assert!(has(&rows, "890 tok/s"), "ingest rate:\n{rows:#?}");
+    // `sched()` publishes prefilling_seqs = 1.
+    assert!(has(&rows, "● 1"), "in-flight prefills:\n{rows:#?}");
+    // The other tiles must survive the narrower split.
+    assert!(
+        has(&rows, "40.0 tok/s"),
+        "throughput still there:\n{rows:#?}"
+    );
+}
+
+#[test]
 fn the_sequences_pane_shows_the_scheduler_only_once_one_has_published() {
     let mut a = stats_app();
     let bare = screen(&a, 160, 48);

--- a/crates/spark-server/src/tui/render/stats_tab_tests.rs
+++ b/crates/spark-server/src/tui/render/stats_tab_tests.rs
@@ -31,6 +31,13 @@ fn sched() -> SchedulerSnapshot {
         mtp_mode: MtpModeSnap::Mtp,
         delivered_tps: 42.0,
         steps_total: 900,
+        // A 12.6k-token prompt a third of the way through,
+        // dispatched on the fused arm — the shape the tile and the
+        // sequences line render.
+        prefill_tokens_done: 4200,
+        prefill_tokens_total: 12618,
+        prefill_chunk_width: 8192,
+        prefill_fused: true,
         published_at: std::time::Instant::now(),
     }
 }
@@ -111,6 +118,13 @@ fn the_prefill_tile_reports_ingest_rate_and_in_flight_prefills() {
     assert!(has(&rows, "890 tok/s"), "ingest rate:\n{rows:#?}");
     // `sched()` publishes prefilling_seqs = 1.
     assert!(has(&rows, "● 1"), "in-flight prefills:\n{rows:#?}");
+    // In-flight progress, compacted so it fits the narrowest tile.
+    assert!(has(&rows, "33%"), "in-flight progress percent:\n{rows:#?}");
+    // Dispatch width + fused arm, in the pane with room for it.
+    assert!(
+        has(&rows, "M=8192 fused"),
+        "dispatch width + fused arm:\n{rows:#?}"
+    );
     // The other tiles must survive the narrower split.
     assert!(
         has(&rows, "40.0 tok/s"),
@@ -281,4 +295,14 @@ fn a_box_with_no_gpu_reading_shows_a_dash_not_zero() {
         has(&rows, "atlas 12.5 GB"),
         "a real reading must still be shown:\n{rows:#?}"
     );
+}
+
+#[test]
+fn an_idle_server_shows_no_prefill_progress_or_chunk_width() {
+    // "0/0" and "M=0" on an idle box would be noise dressed as data.
+    let a = stats_app();
+    let rows = screen(&a, 160, 48);
+    assert!(has(&rows, "PREFILL"), "tile is always present:\n{rows:#?}");
+    assert!(!has(&rows, "0/0 M="), "{rows:#?}");
+    assert!(!has(&rows, "M=0"), "{rows:#?}");
 }

--- a/kernels/gb10/common/dflash2.cu
+++ b/kernels/gb10/common/dflash2.cu
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// provenance-id: 526f6e616c6420522e205374657369616b
+
+// DFlash2 drafter kernels: grouped dynamic two-tap conv, per-row top-16,
+// and the candidate-selector chain walk.
+//
+// Reference semantics: z-lab dflash/model.py (GroupedDynamicCausalConv,
+// CandidateSelector) + inco.ai/blog/dflash2 formulas:
+//   Conv_k(x)_t = k_{t,0} ⊙ x_t + k_{t,1} ⊙ x_{t-1}
+//   S_t(a,b)    = U_t(b) + ⟨A(a) ⊙ H(h_t), B(b)⟩
+// All math in f32, storage BF16 (matching the drafter's training dtype).
+
+#include <cuda_bf16.h>
+
+// ─────────────────────────────────────────────────────────────────────────
+// Two-tap grouped dynamic causal convolution — ONE application (prepare OR
+// finish). Per row t, channel c, with group g = c / group_size:
+//   coef_k(t,c) = base[k*h + c] + dyn[t*dyn_stride + app_off + k*groups + g]
+//   out[t][c]   = coef_0 * x[t][c] + (t > 0 ? coef_1 * x[t-1][c] : 0)
+// Row 0's second tap reads nothing (zero pad) — in DFlash blocks row 0 IS
+// the anchor (last verified token's embedding), so "the first draft
+// position reads the last verified token" holds by construction.
+//
+// dyn layout per row (from kernel_projection GEMM, row-major view
+// [2 applications, kernel_size, groups]): app_off selects the application
+// (0 = prepare, kernel_size*groups = finish).
+//
+// NOT in-place safe: out must not alias x (row t reads x[t-1] after row
+// t-1 was consumed elsewhere only if distinct buffers). Grid: (rows,1,1),
+// Block: (256,1,1).
+extern "C" __global__ void dflash2_conv2(
+    const __nv_bfloat16* __restrict__ x,     // [rows, h]
+    const __nv_bfloat16* __restrict__ dyn,   // [rows, dyn_stride]
+    const __nv_bfloat16* __restrict__ base,  // [kernel_size, h] (app slice)
+    __nv_bfloat16* __restrict__ out,         // [rows, h]
+    unsigned int h,
+    unsigned int group_size,
+    unsigned int dyn_stride,   // elements per dyn row (both applications)
+    unsigned int app_off       // 0 (prepare) or kernel_size*groups (finish)
+) {
+    const unsigned int t = blockIdx.x;
+    const unsigned int groups = h / group_size;
+    const __nv_bfloat16* xr = x + (size_t)t * h;
+    const __nv_bfloat16* xp = (t > 0) ? x + (size_t)(t - 1) * h : nullptr;
+    const __nv_bfloat16* dr = dyn + (size_t)t * dyn_stride + app_off;
+    __nv_bfloat16* orow = out + (size_t)t * h;
+
+    for (unsigned int c = threadIdx.x; c < h; c += blockDim.x) {
+        const unsigned int g = c / group_size;
+        const float c0 = __bfloat162float(base[c]) + __bfloat162float(dr[g]);
+        float acc = c0 * __bfloat162float(xr[c]);
+        if (xp != nullptr) {
+            const float c1 =
+                __bfloat162float(base[h + c]) + __bfloat162float(dr[groups + g]);
+            acc += c1 * __bfloat162float(xp[c]);
+        }
+        orow[c] = __float2bfloat16(acc);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Per-row top-16 over BF16 logits. DESTRUCTIVE: masks selected entries in
+// `logits` to -inf (drafter logits are not consumed after selection).
+// 16 sequential tree-argmax passes per row — simple, proven reduction
+// pattern, one launch for all rows. Grid: (rows,1,1), Block: (1024,1,1).
+extern "C" __global__ void dflash2_topk16(
+    __nv_bfloat16* __restrict__ logits,  // [rows, n] — masked in place
+    float* __restrict__ top_vals,        // [rows, 16]
+    unsigned int* __restrict__ top_idx,  // [rows, 16]
+    unsigned int n
+) {
+    __shared__ float s_val[1024];
+    __shared__ unsigned int s_idx[1024];
+
+    const unsigned int row = blockIdx.x;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int stride = blockDim.x;
+    __nv_bfloat16* lrow = logits + (size_t)row * n;
+
+    for (unsigned int k = 0; k < 16; ++k) {
+        float local_max = -1e30f;
+        unsigned int local_idx = 0;
+        for (unsigned int i = tid; i < n; i += stride) {
+            const float v = __bfloat162float(lrow[i]);
+            if (v > local_max) {
+                local_max = v;
+                local_idx = i;
+            }
+        }
+        s_val[tid] = local_max;
+        s_idx[tid] = local_idx;
+        __syncthreads();
+        for (unsigned int off = stride >> 1; off > 0; off >>= 1) {
+            if (tid < off && s_val[tid + off] > s_val[tid]) {
+                s_val[tid] = s_val[tid + off];
+                s_idx[tid] = s_idx[tid + off];
+            }
+            __syncthreads();
+        }
+        if (tid == 0) {
+            top_vals[(size_t)row * 16 + k] = s_val[0];
+            top_idx[(size_t)row * 16 + k] = s_idx[0];
+            lrow[s_idx[0]] = __float2bfloat16(-1e30f);
+        }
+        __syncthreads();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Candidate-selector chain walk — the ONLY sequential piece, fused into a
+// single launch for the whole block (vs one launch per position).
+//
+//   S_t(a,b) = U_t(b) + Σ_r pred[a][r] * hproj[t][r] * succ[b][r]
+//
+// Walks rows first_row..rows-1. prev for the first walked row is read from
+// `tokens[0]`, which at tail entry still holds last_token (H2D'd fresh
+// every propose BEFORE graph capture — same capture-safe device-side chain
+// as the DSpark Markov path). Each chosen token is written to `tokens[t]`
+// and becomes the next row's predecessor.
+//
+// Grid: (1,1,1), Block: (512,1,1) = 16 warps; warp k owns candidate k's
+// rank-256 dot (8 lanes-elements each, shuffle-reduced).
+extern "C" __global__ void dflash2_selector_walk(
+    const float* __restrict__ top_vals,        // [rows, 16] unary logits
+    const unsigned int* __restrict__ top_idx,  // [rows, 16] candidate ids
+    const __nv_bfloat16* __restrict__ hproj,   // [rows, rank] context gate H(h_t)
+    const __nv_bfloat16* __restrict__ pred,    // [vocab, rank] A codebook
+    const __nv_bfloat16* __restrict__ succ,    // [vocab, rank] B codebook
+    unsigned int* __restrict__ tokens,         // [rows] draft token slots
+    unsigned int rows,
+    unsigned int rank,       // 256
+    unsigned int first_row   // 1 (row 0 = anchor, not selected)
+) {
+    __shared__ float s_gate[256];
+    __shared__ float s_score[16];
+    __shared__ unsigned int s_prev;
+
+    const unsigned int tid = threadIdx.x;
+    const unsigned int warp = tid >> 5;
+    const unsigned int lane = tid & 31;
+
+    if (tid == 0) {
+        s_prev = tokens[0];  // last_token — slot 0 pre-argmax state
+    }
+    __syncthreads();
+
+    for (unsigned int t = first_row; t < rows; ++t) {
+        // gate[r] = pred[prev][r] * hproj[t][r]
+        const __nv_bfloat16* pr = pred + (size_t)s_prev * rank;
+        const __nv_bfloat16* hr = hproj + (size_t)t * rank;
+        for (unsigned int r = tid; r < rank; r += blockDim.x) {
+            s_gate[r] = __bfloat162float(pr[r]) * __bfloat162float(hr[r]);
+        }
+        __syncthreads();
+
+        // warp k: score_k = unary_k + Σ_r gate[r] * succ[cand_k][r]
+        if (warp < 16) {
+            const unsigned int cand = top_idx[(size_t)t * 16 + warp];
+            const __nv_bfloat16* sr = succ + (size_t)cand * rank;
+            float acc = 0.0f;
+            for (unsigned int r = lane; r < rank; r += 32) {
+                acc += s_gate[r] * __bfloat162float(sr[r]);
+            }
+            #pragma unroll
+            for (unsigned int off = 16; off > 0; off >>= 1) {
+                acc += __shfl_down_sync(0xffffffff, acc, off);
+            }
+            if (lane == 0) {
+                s_score[warp] = top_vals[(size_t)t * 16 + warp] + acc;
+            }
+        }
+        __syncthreads();
+
+        if (tid == 0) {
+            float best = s_score[0];
+            unsigned int best_k = 0;
+            #pragma unroll
+            for (unsigned int k = 1; k < 16; ++k) {
+                if (s_score[k] > best) {
+                    best = s_score[k];
+                    best_k = k;
+                }
+            }
+            const unsigned int chosen = top_idx[(size_t)t * 16 + best_k];
+            tokens[t] = chosen;
+            s_prev = chosen;
+        }
+        __syncthreads();
+    }
+}

--- a/kernels/gb10/common/fp8_gemv_rt.cu
+++ b/kernels/gb10/common/fp8_gemv_rt.cu
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// provenance-id: 526f6e616c6420522e205374657369616b
+//
+// fp8_gemv_rt.cu — register-tiled batched FP8 GEMV for the DFlash drafter
+// PROPOSE path (Phase G weights: B[N,K] FP8 E4M3 + per-row f32 scale).
+//
+//   C[M,N] (bf16) = A[M,K] (bf16) @ dequant(B)^T * row_scale[N]
+//
+// Why it exists (nsys node-trace + batchm_bench, 2026-08-19): the propose
+// pipeline ran its M=8 GEMMs on prefill-class tile kernels
+// (fp8_gemm_t_row_scaled M64-tile = 87% padding, _m16 = 50%), measuring
+// ~100 GB/s while the register-tiled GEMV family proves 180+ GB/s at M=8
+// on this memory system. This kernel is the FP8 twin of
+// `w4a16_gemv_batch8_rt2`: T=2 adjacent output rows per 64-lane group, one
+// activation load feeds both FMA chains (activation traffic, load
+// instructions, and chain ILP all improved 2x vs one-output-per-group).
+//
+// DRAFTER-SIDE NUMERICS ARE CORRECTNESS-FREE: under strict-argmax accept,
+// draft quality only moves the accept RATE, never the output tokens. So
+// unlike the w4a16 verify family there is NO bit-order contract here; this
+// kernel uses a plain single-phase accumulation and applies row_scale once
+// at write-out. Accuracy is gated by accept-rate A/B on the live server
+// (kill-switch: ATLAS_NO_DFLASH_FP8_RT=1 restores the tile kernels).
+//
+// Dequant uses the proven 256-entry E4M3 smem LUT (branchless, no
+// cvt.rn.satfinite dependency on SM121 — same rationale as w8a16_gemv).
+//
+// Grid: (ceil(N/8), 1, 1)  Block: (256, 1, 1). Requires K % 16 == 0
+// (holds for h=5120 and inter=17408). M clamped to 8 by the Rust launcher.
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#define RT_BLOCK 256
+#define RT_GROUPS 4
+#define RT_T 2
+#define RT_MAXM 8
+
+extern "C" __global__ void fp8_gemv_rowscale_batch8_rt2(
+    const __nv_bfloat16* __restrict__ A,   // [M, K] bf16
+    const unsigned char* __restrict__ B,   // [N, K] fp8 e4m3
+    const float* __restrict__ row_scale,   // [N] f32
+    __nv_bfloat16* __restrict__ C,         // [M, N] bf16
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int tpo = RT_BLOCK / RT_GROUPS;     // 64 lanes per group
+    const unsigned int local_out = threadIdx.x / tpo;  // 0..3
+    const unsigned int lane = threadIdx.x % tpo;       // 0..63
+    const unsigned int n0 = (blockIdx.x * RT_GROUPS + local_out) * RT_T;
+
+    __shared__ float s_lut[256];
+    {
+        __nv_fp8_e4m3 f;
+        *(unsigned char*)&f = (unsigned char)threadIdx.x;
+        s_lut[threadIdx.x] = (float)f;
+    }
+    __syncthreads();
+    if (n0 >= N) return;
+
+    const unsigned int K16 = K / 16;
+
+    float acc[RT_T][RT_MAXM];
+    #pragma unroll
+    for (int o = 0; o < RT_T; o++)
+        #pragma unroll
+        for (int t = 0; t < RT_MAXM; t++) acc[o][t] = 0.0f;
+
+    for (unsigned int kk = lane; kk < K16; kk += tpo) {
+        // T weight chunks: 16 FP8 bytes each, one uint4 load per output.
+        float wl[RT_T][16];
+        #pragma unroll
+        for (int o = 0; o < RT_T; o++) {
+            const unsigned long long n = n0 + o;
+            if (n < N) {
+                uint4 wb = *(const uint4*)(B + n * K + (unsigned long long)kk * 16u);
+                const unsigned int wr[4] = {wb.x, wb.y, wb.z, wb.w};
+                #pragma unroll
+                for (int w = 0; w < 4; w++)
+                    #pragma unroll
+                    for (int b = 0; b < 4; b++)
+                        wl[o][w * 4 + b] = s_lut[(wr[w] >> (b * 8)) & 0xFF];
+            } else {
+                #pragma unroll
+                for (int i = 0; i < 16; i++) wl[o][i] = 0.0f;
+            }
+        }
+
+        #pragma unroll
+        for (int t = 0; t < RT_MAXM; t++) {
+            if ((unsigned int)t >= M) continue;
+            const __nv_bfloat16* At = A + (unsigned long long)t * K;
+            // ONE activation load per (chunk, row) feeding both chains.
+            uint4 a_lo = ((const uint4*)At)[kk * 2];
+            uint4 a_hi = ((const uint4*)At)[kk * 2 + 1];
+            const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                        a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+            #pragma unroll
+            for (int o = 0; o < RT_T; o++) {
+                float part = 0.0f;
+                #pragma unroll
+                for (int b = 0; b < 8; b++) {
+                    float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
+                    part = fmaf(af.x, wl[o][b * 2], part);
+                    part = fmaf(af.y, wl[o][b * 2 + 1], part);
+                }
+                acc[o][t] += part;
+            }
+        }
+    }
+
+    // 64-lane reduce: 32-lane shuffle tree per warp, cross-warp via smem.
+    __shared__ float s_red[RT_MAXM][RT_GROUPS * RT_T * 2];
+    const unsigned int warp_in_out = lane / 32u;
+    #pragma unroll
+    for (int o = 0; o < RT_T; o++) {
+        #pragma unroll
+        for (int t = 0; t < RT_MAXM; t++) {
+            if ((unsigned int)t >= M) continue;
+            float a = acc[o][t];
+            #pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                a += __shfl_down_sync(0xFFFFFFFF, a, off);
+            if ((lane & 31u) == 0u)
+                s_red[t][(local_out * RT_T + o) * 2 + warp_in_out] = a;
+        }
+    }
+    __syncthreads();
+
+    if (lane == 0) {
+        #pragma unroll
+        for (int o = 0; o < RT_T; o++) {
+            const unsigned int n = n0 + o;
+            if (n >= N) continue;
+            const float rs = row_scale[n];
+            #pragma unroll
+            for (int t = 0; t < RT_MAXM; t++) {
+                if ((unsigned int)t >= M) continue;
+                float r = s_red[t][(local_out * RT_T + o) * 2]
+                        + s_red[t][(local_out * RT_T + o) * 2 + 1];
+                C[(unsigned long long)t * N + n] = __float2bfloat16(r * rs);
+            }
+        }
+    }
+}

--- a/kernels/gb10/common/w4a16_gemv.cu
+++ b/kernels/gb10/common/w4a16_gemv.cu
@@ -767,6 +767,572 @@ extern "C" __global__ __launch_bounds__(BLOCK_SIZE, 5) void w4a16_gemv_batch8(
     w4a16_gemv_batchm_impl<8>(A, B_packed, B_scale, scale2, C, M, N, K);
 }
 
+// ── Software-pipelined batchm (weight prefetch) ─────────────────────────
+// provenance-id: 526f6e616c6420522e205374657369616b
+//
+// Identical math to `w4a16_gemv_batchm_impl`: same virtual-lane chunk
+// order, same per-chunk FMA sequence, same pair-fold + reduction tree, so
+// outputs are BIT-IDENTICAL by construction (proven by batchm_bench gate 4,
+// never assumed). The only change is scheduling: the NEXT chunk's 8-byte
+// packed weight + scale byte are loaded BEFORE the current chunk's FMA
+// work, overlapping the weight stream's DRAM latency with compute.
+//
+// Motivation (nsys node-trace 2026-08-19, DFlash2 M=8 verify): the
+// shallow-K legs (K=5120 — gate/up, GDN qkvz, lm_head) run at ~147 GB/s
+// while the deep-K down_proj leg runs 204 GB/s in the SAME kernel. At
+// K=5120 each thread walks only ~2-3 chunks per phase, so the unpipelined
+// loop exposes nearly a full DRAM latency per chunk; deep K amortizes it.
+template <int MAX_M>
+__device__ __forceinline__ void w4a16_gemv_batchm_impl_pf(
+    const __nv_bfloat16* __restrict__ A,         // [M, K]
+    const unsigned char* __restrict__ B_packed,   // [N, K/2] uint8
+    const unsigned char* __restrict__ B_scale,    // [N, K/GROUP_SIZE] FP8-E4M3
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,                // [M, N]
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;  // 64
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
+
+    __shared__ float s_lut[16];
+    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
+    __syncthreads();
+
+    if (n >= N) return;
+
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int K16 = K / 16;
+
+    float acc[MAX_M];
+    __shared__ float s_vl[MAX_M][N_PER_BLOCK][2 * WARP_SIZE];
+
+    #pragma unroll 1
+    for (unsigned int phase = 0; phase < 2u; phase++) {
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) acc[t] = 0.0f;
+
+        // Prime the pipeline: first chunk's weight bytes in flight before
+        // the loop body. Same kk sequence as the unpipelined body.
+        unsigned int kk = lane + phase * threads_per_out;
+        unsigned long long packed8 = 0;
+        unsigned char scale_byte = 0;
+        if (kk < K16) {
+            packed8 =
+                *(const unsigned long long*)(B_packed + (unsigned long long)n * half_K + kk * 8);
+            scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
+        }
+
+        while (kk < K16) {
+            // Issue the NEXT chunk's loads before touching this chunk's
+            // bytes — this is the entire diff vs the unpipelined body.
+            const unsigned int kn = kk + threads_per_out * 2u;
+            unsigned long long packed8_n = 0;
+            unsigned char scale_byte_n = 0;
+            if (kn < K16) {
+                packed8_n = *(const unsigned long long*)(B_packed +
+                                                         (unsigned long long)n * half_K + kn * 8);
+                scale_byte_n = B_scale[(unsigned long long)n * num_groups + kn];
+            }
+
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+            float scale = scl_fp8(scale_byte) * scale2;
+#else
+            float scale = (float)fp8 * scale2;
+#endif
+            float wl[16];
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                wl[b * 2]     = s_lut[byte_val & 0xF];   // W[2j]   <-> act 2j
+                wl[b * 2 + 1] = s_lut[byte_val >> 4];    // W[2j+1] <-> act 2j+1
+            }
+
+            #pragma unroll
+            for (int t = 0; t < MAX_M; t++) {
+                if ((unsigned int)t >= M) continue;
+                const __nv_bfloat16* At = A + (unsigned long long)t * K;
+                uint4 a_lo = ((const uint4*)At)[kk * 2];
+                uint4 a_hi = ((const uint4*)At)[kk * 2 + 1];
+                const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+                // TWO separate fmaf per byte — the M=1 kernel's exact order.
+                float part = 0.0f;
+                #pragma unroll
+                for (int b = 0; b < 8; b++) {
+                    float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
+                    part = fmaf(af.x, wl[b * 2], part);
+                    part = fmaf(af.y, wl[b * 2 + 1], part);
+                }
+                acc[t] = fmaf(scale, part, acc[t]);
+            }
+
+            kk = kn;
+            packed8 = packed8_n;
+            scale_byte = scale_byte_n;
+        }
+
+        // Pair-fold + virtual-lane landing: verbatim from the base impl.
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            const float v = acc[t] + __shfl_xor_sync(0xFFFFFFFF, acc[t], 1);
+            if ((lane & 1u) == 0u) {
+                s_vl[t][local_out][phase * WARP_SIZE + (lane >> 1)] = v;
+            }
+        }
+    }
+    __syncthreads();
+
+    __shared__ float smem[MAX_M][N_PER_BLOCK * 2];  // 2 warps/output, per row
+    const unsigned int warp_in_out = lane / WARP_SIZE;
+    #pragma unroll
+    for (int t = 0; t < MAX_M; t++) {
+        if ((unsigned int)t >= M) continue;
+        float a = s_vl[t][local_out][lane];
+        #pragma unroll
+        for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+            a += __shfl_down_sync(0xFFFFFFFF, a, offset);
+        }
+        if (lane % WARP_SIZE == 0) smem[t][local_out * 2 + warp_in_out] = a;
+    }
+    __syncthreads();
+
+    if (lane == 0) {
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            float r = smem[t][local_out * 2] + smem[t][local_out * 2 + 1];
+            C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+        }
+    }
+}
+
+// Pipelined batch8, pinned like the shipping batch8 (48 regs / 5 CTA per
+// SM). The prefetch registers may interact with the pin — the _free twin
+// below lets batchm_bench price that interaction instead of guessing.
+extern "C" __global__ __launch_bounds__(BLOCK_SIZE, 5) void w4a16_gemv_batch8_pf(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    w4a16_gemv_batchm_impl_pf<8>(A, B_packed, B_scale, scale2, C, M, N, K);
+}
+
+// Pipelined batch8 with free register allocation (no __launch_bounds__).
+extern "C" __global__ void w4a16_gemv_batch8_pf_free(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    w4a16_gemv_batchm_impl_pf<8>(A, B_packed, B_scale, scale2, C, M, N, K);
+}
+
+// ── Activation row-ahead prefetch (lever-1 v2) ──────────────────────────
+// provenance-id: 526f6e616c6420522e205374657369616b
+//
+// batchm_bench 2026-08-19 killed the weight-prefetch hypothesis (wash at
+// M=8) and exposed the real scaling law: efficiency degrades with M, not
+// K — 241 GB/s at M=1 down to 142 at M=8 on the same shape. Each row adds
+// two DEPENDENT activation loads per chunk (a_lo/a_hi -> immediate FMAs);
+// at K=5120 a thread walks only ~2-3 chunks per phase, so that L2 latency
+// never gets hidden. Deep-K legs (down_proj, 8.5 chunks/thread) hide it,
+// which is why they measured 204 GB/s live.
+//
+// Fix: while row t's FMA chain runs, issue row t+1's a_lo/a_hi loads
+// (+2 uint4 registers); row 0's loads are issued BEFORE the 16-lookup LUT
+// expansion so they overlap it. Math order is UNTOUCHED — same chunk walk,
+// same per-row FMA chain, same reductions — so bit-identity vs batch8 is
+// by construction, and batchm_bench gate 4 still proves it, never assumes.
+// `WPF` folds the weight-prefetch pipeline from impl_pf on top (pf3 arm).
+template <int MAX_M, bool WPF>
+__device__ __forceinline__ void w4a16_gemv_batchm_impl_apf(
+    const __nv_bfloat16* __restrict__ A,         // [M, K]
+    const unsigned char* __restrict__ B_packed,   // [N, K/2] uint8
+    const unsigned char* __restrict__ B_scale,    // [N, K/GROUP_SIZE] FP8-E4M3
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,                // [M, N]
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;  // 64
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
+
+    __shared__ float s_lut[16];
+    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
+    __syncthreads();
+
+    if (n >= N) return;
+
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int K16 = K / 16;
+
+    float acc[MAX_M];
+    __shared__ float s_vl[MAX_M][N_PER_BLOCK][2 * WARP_SIZE];
+
+    #pragma unroll 1
+    for (unsigned int phase = 0; phase < 2u; phase++) {
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) acc[t] = 0.0f;
+
+        unsigned long long packed8 = 0;
+        unsigned char scale_byte = 0;
+        if (WPF) {
+            const unsigned int kk0 = lane + phase * threads_per_out;
+            if (kk0 < K16) {
+                packed8 = *(const unsigned long long*)(B_packed +
+                                                       (unsigned long long)n * half_K + kk0 * 8);
+                scale_byte = B_scale[(unsigned long long)n * num_groups + kk0];
+            }
+        }
+
+        for (unsigned int kk = lane + phase * threads_per_out; kk < K16;
+             kk += threads_per_out * 2u) {
+            if (WPF) {
+                // rotate happens at loop tail; nothing to do at head
+            } else {
+                packed8 = *(const unsigned long long*)(B_packed +
+                                                       (unsigned long long)n * half_K + kk * 8);
+                scale_byte = B_scale[(unsigned long long)n * num_groups + kk];
+            }
+            // Row 0's activation loads in flight BEFORE the LUT expansion
+            // (M >= 1 always, so row 0 is always live).
+            uint4 a_lo_c = ((const uint4*)A)[kk * 2];
+            uint4 a_hi_c = ((const uint4*)A)[kk * 2 + 1];
+
+            unsigned long long packed8_n = 0;
+            unsigned char scale_byte_n = 0;
+            if (WPF) {
+                const unsigned int kn = kk + threads_per_out * 2u;
+                if (kn < K16) {
+                    packed8_n = *(const unsigned long long*)(B_packed +
+                                                             (unsigned long long)n * half_K +
+                                                             kn * 8);
+                    scale_byte_n = B_scale[(unsigned long long)n * num_groups + kn];
+                }
+            }
+
+            __nv_fp8_e4m3 fp8;
+            *(unsigned char*)&fp8 = scale_byte;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+            float scale = scl_fp8(scale_byte) * scale2;
+#else
+            float scale = (float)fp8 * scale2;
+#endif
+            float wl[16];
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                unsigned char byte_val = (unsigned char)(packed8 >> (b * 8));
+                wl[b * 2]     = s_lut[byte_val & 0xF];   // W[2j]   <-> act 2j
+                wl[b * 2 + 1] = s_lut[byte_val >> 4];    // W[2j+1] <-> act 2j+1
+            }
+
+            #pragma unroll
+            for (int t = 0; t < MAX_M; t++) {
+                if ((unsigned int)t >= M) continue;
+                // Issue row t+1's loads before row t's FMA chain consumes
+                // the current registers — the entire point of this variant.
+                uint4 a_lo_n = a_lo_c;
+                uint4 a_hi_n = a_hi_c;
+                if (t + 1 < MAX_M && (unsigned int)(t + 1) < M) {
+                    const __nv_bfloat16* At_n = A + (unsigned long long)(t + 1) * K;
+                    a_lo_n = ((const uint4*)At_n)[kk * 2];
+                    a_hi_n = ((const uint4*)At_n)[kk * 2 + 1];
+                }
+                const unsigned int ar[8] = {a_lo_c.x, a_lo_c.y, a_lo_c.z, a_lo_c.w,
+                                            a_hi_c.x, a_hi_c.y, a_hi_c.z, a_hi_c.w};
+                // TWO separate fmaf per byte — the M=1 kernel's exact order.
+                float part = 0.0f;
+                #pragma unroll
+                for (int b = 0; b < 8; b++) {
+                    float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
+                    part = fmaf(af.x, wl[b * 2], part);
+                    part = fmaf(af.y, wl[b * 2 + 1], part);
+                }
+                acc[t] = fmaf(scale, part, acc[t]);
+                a_lo_c = a_lo_n;
+                a_hi_c = a_hi_n;
+            }
+
+            if (WPF) {
+                packed8 = packed8_n;
+                scale_byte = scale_byte_n;
+            }
+        }
+
+        // Pair-fold + virtual-lane landing: verbatim from the base impl.
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            const float v = acc[t] + __shfl_xor_sync(0xFFFFFFFF, acc[t], 1);
+            if ((lane & 1u) == 0u) {
+                s_vl[t][local_out][phase * WARP_SIZE + (lane >> 1)] = v;
+            }
+        }
+    }
+    __syncthreads();
+
+    __shared__ float smem[MAX_M][N_PER_BLOCK * 2];  // 2 warps/output, per row
+    const unsigned int warp_in_out = lane / WARP_SIZE;
+    #pragma unroll
+    for (int t = 0; t < MAX_M; t++) {
+        if ((unsigned int)t >= M) continue;
+        float a = s_vl[t][local_out][lane];
+        #pragma unroll
+        for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+            a += __shfl_down_sync(0xFFFFFFFF, a, offset);
+        }
+        if (lane % WARP_SIZE == 0) smem[t][local_out * 2 + warp_in_out] = a;
+    }
+    __syncthreads();
+
+    if (lane == 0) {
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            float r = smem[t][local_out * 2] + smem[t][local_out * 2 + 1];
+            C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+        }
+    }
+}
+
+// ── Register-tiled batchm (lever-1 v3: T outputs per thread) ────────────
+// provenance-id: 526f6e616c6420522e205374657369616b
+//
+// The M-sweep verdict (batchm_bench 2026-08-19, clean runs): near-peak at
+// M=1 (250 GB/s), monotonic decay to ~143 at M=8; batch16-vs-batch8 at
+// equal M shows template footprint alone costs bandwidth; both prefetch
+// families were washes. The remaining suspects — L2 activation traffic
+// (256 B per (chunk,row) re-read per output), activation load-instruction
+// count, and single-dependent-FMA-chain ILP — are ALL divided by T when
+// each thread computes T adjacent output rows from ONE set of activation
+// registers. Layout: N_PER_BLOCK lane-groups of 64 as before, each group
+// covering T ADJACENT n rows; grid shrinks to ceil(N / (N_PER_BLOCK*T)).
+// Each output row\'s chunk walk, per-chunk FMA sequence, pair-fold and
+// reduction tree are IDENTICAL to `w4a16_gemv_batchm_impl` — bit-exact by
+// construction, and batchm_bench gate 4 proves it, never assumes it.
+template <int MAX_M, int T>
+__device__ __forceinline__ void w4a16_gemv_batchm_impl_rt(
+    const __nv_bfloat16* __restrict__ A,         // [M, K]
+    const unsigned char* __restrict__ B_packed,   // [N, K/2] uint8
+    const unsigned char* __restrict__ B_scale,    // [N, K/GROUP_SIZE] FP8-E4M3
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,                // [M, N]
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;  // 64
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    // This lane group covers T ADJACENT output rows n0 .. n0+T-1.
+    const unsigned int n0 = (blockIdx.x * N_PER_BLOCK + local_out) * T;
+
+    __shared__ float s_lut[16];
+    if (threadIdx.x < 16) s_lut[threadIdx.x] = E2M1_LUT[threadIdx.x];
+    __syncthreads();
+
+    if (n0 >= N) return;
+
+    const unsigned int half_K = K / 2;
+    const unsigned int num_groups = K / GROUP_SIZE;
+    const unsigned int K16 = K / 16;
+
+    float acc[T][MAX_M];
+    // Virtual-lane slab per (row, group, OUTPUT) — the T dimension is what
+    // the first draft of this kernel missed.
+    __shared__ float s_vl[MAX_M][N_PER_BLOCK][T][2 * WARP_SIZE];
+
+    #pragma unroll 1
+    for (unsigned int phase = 0; phase < 2u; phase++) {
+        #pragma unroll
+        for (int o = 0; o < T; o++)
+            #pragma unroll
+            for (int t = 0; t < MAX_M; t++) acc[o][t] = 0.0f;
+
+        for (unsigned int kk = lane + phase * threads_per_out; kk < K16;
+             kk += threads_per_out * 2u) {
+            // T weight chunks (one per adjacent output row) + T scales.
+            unsigned long long packed8[T];
+            float scale[T];
+            #pragma unroll
+            for (int o = 0; o < T; o++) {
+                const unsigned long long n = n0 + o;
+                if (n < N) {
+                    packed8[o] = *(const unsigned long long*)(B_packed + n * half_K + kk * 8);
+                    const unsigned char sb = B_scale[n * num_groups + kk];
+                    __nv_fp8_e4m3 fp8;
+                    *(unsigned char*)&fp8 = sb;
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+                    scale[o] = scl_fp8(sb) * scale2;
+#else
+                    scale[o] = (float)fp8 * scale2;
+#endif
+                } else {
+                    packed8[o] = 0ull;
+                    scale[o] = 0.0f;
+                }
+            }
+            float wl[T][16];
+            #pragma unroll
+            for (int o = 0; o < T; o++) {
+                #pragma unroll
+                for (int b = 0; b < 8; b++) {
+                    unsigned char byte_val = (unsigned char)(packed8[o] >> (b * 8));
+                    wl[o][b * 2]     = s_lut[byte_val & 0xF];
+                    wl[o][b * 2 + 1] = s_lut[byte_val >> 4];
+                }
+            }
+
+            #pragma unroll
+            for (int t = 0; t < MAX_M; t++) {
+                if ((unsigned int)t >= M) continue;
+                const __nv_bfloat16* At = A + (unsigned long long)t * K;
+                // ONE activation load per (chunk, row) feeding T chains.
+                uint4 a_lo = ((const uint4*)At)[kk * 2];
+                uint4 a_hi = ((const uint4*)At)[kk * 2 + 1];
+                const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
+                                            a_hi.x, a_hi.y, a_hi.z, a_hi.w};
+                #pragma unroll
+                for (int o = 0; o < T; o++) {
+                    // Per-output chain: the M=1 kernel\'s exact FMA order.
+                    float part = 0.0f;
+                    #pragma unroll
+                    for (int b = 0; b < 8; b++) {
+                        float2 af = __bfloat1622float2(*(const __nv_bfloat162*)&ar[b]);
+                        part = fmaf(af.x, wl[o][b * 2], part);
+                        part = fmaf(af.y, wl[o][b * 2 + 1], part);
+                    }
+                    acc[o][t] = fmaf(scale[o], part, acc[o][t]);
+                }
+            }
+        }
+
+        // Pair-fold + virtual-lane landing, per output row — same tree.
+        #pragma unroll
+        for (int o = 0; o < T; o++) {
+            #pragma unroll
+            for (int t = 0; t < MAX_M; t++) {
+                if ((unsigned int)t >= M) continue;
+                const float v = acc[o][t] + __shfl_xor_sync(0xFFFFFFFF, acc[o][t], 1);
+                if ((lane & 1u) == 0u) {
+                    s_vl[t][local_out][o][phase * WARP_SIZE + (lane >> 1)] = v;
+                }
+            }
+        }
+    }
+    __syncthreads();
+
+    __shared__ float smem[MAX_M][N_PER_BLOCK * T * 2];  // 2 warps per (out,o)
+    const unsigned int warp_in_out = lane / WARP_SIZE;
+    #pragma unroll
+    for (int o = 0; o < T; o++) {
+        #pragma unroll
+        for (int t = 0; t < MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            float a = s_vl[t][local_out][o][lane];
+            #pragma unroll
+            for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+                a += __shfl_down_sync(0xFFFFFFFF, a, offset);
+            }
+            if (lane % WARP_SIZE == 0)
+                smem[t][(local_out * T + o) * 2 + warp_in_out] = a;
+        }
+    }
+    __syncthreads();
+
+    if (lane == 0) {
+        #pragma unroll
+        for (int o = 0; o < T; o++) {
+            const unsigned int n = n0 + o;
+            if (n >= N) continue;
+            #pragma unroll
+            for (int t = 0; t < MAX_M; t++) {
+                if ((unsigned int)t >= M) continue;
+                float r = smem[t][(local_out * T + o) * 2]
+                        + smem[t][(local_out * T + o) * 2 + 1];
+                C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+            }
+        }
+    }
+}
+
+// Register-tiled batch8, T=2 outputs/thread. Grid: ceil(N/8).
+extern "C" __global__ void w4a16_gemv_batch8_rt2(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    w4a16_gemv_batchm_impl_rt<8, 2>(A, B_packed, B_scale, scale2, C, M, N, K);
+}
+
+// Register-tiled batch8, T=4 outputs/thread. Grid: ceil(N/16).
+extern "C" __global__ void w4a16_gemv_batch8_rt4(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    w4a16_gemv_batchm_impl_rt<8, 4>(A, B_packed, B_scale, scale2, C, M, N, K);
+}
+
+// Activation row-ahead prefetch only (free register allocation).
+extern "C" __global__ void w4a16_gemv_batch8_pf2(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    w4a16_gemv_batchm_impl_apf<8, false>(A, B_packed, B_scale, scale2, C, M, N, K);
+}
+
+// Activation row-ahead prefetch + weight prefetch pipeline.
+extern "C" __global__ void w4a16_gemv_batch8_pf3(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const unsigned char* __restrict__ B_scale,
+    const float scale2,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    w4a16_gemv_batchm_impl_apf<8, true>(A, B_packed, B_scale, scale2, C, M, N, K);
+}
+
 // M<=16 (high-concurrency decode, n=5..16) — sibling of w8a16_gemv_batch16.
 extern "C" __global__ void w4a16_gemv_batch16(
     const __nv_bfloat16* __restrict__ A,


### PR DESCRIPTION
**MERGE AFTER #649.** Sibling of #650 — independent of the memory and LoRA PRs, so it can go in any order relative to them, but it sits on #649's base.

Because #649's branch lives on a fork, GitHub cannot take it as a base here, so this targets `main` and its first two commits are #649's; they leave the diff when #649 lands. **The six commits to review are mine.**

## What this is

The TUI prefill work and the DSpark/DFlash metrics fixes, cut from #604.

### Prefill was invisible

The TUI could show decode throughput while a long prefill was in flight and look idle, because prompt tokens were counted nowhere until the request finished.

- **PREFILL ingest tile** — prompt tokens counted at ingest, with its own sparkline. The tile's total is exact against the API's `prompt_tokens`.
- **In-flight prefill progress**, plus the dispatch width and which fused arm the step took — so a stall is attributable while it is happening rather than afterwards.
- **Prefill on the throughput chart** with its own right-hand scale, since prefill and decode differ by an order of magnitude and sharing one axis flattens decode into the floor.

### Metrics that were wrong

- **Generation tokens counted as emitted, not at request completion.** Counting at completion means a long stream contributes nothing until it ends, so the rate line reads zero through exactly the period it is meant to describe. The counter now increments at the single choke point every emit path funnels through, which also gets a permanent `tracing::debug!` of the emitted token id — that is the token-exact stream a byte-level A/B of two serve configs needs (it is what the qwen3.8 spec-decode divergence hunt ran on).
- **The Stats accept bar was pinned at 100%.** Accept telemetry was per-step, but a γ-block drafter accepts 0..γ per step, so a per-step accept/reject binary carries no information — and both labels it emitted (`accept_all`, `accept_partial`) matched the TUI's `outcome.contains("accept")` test. Counting draft TOKENS makes the bar the real acceptance rate: the same number the benchmarks report, so the TUI and a bench run can finally be compared without translation. Reported from the Stats page.

### Housekeeping

The tile and the progress row pushed `stats_tab.rs` to 540 lines, past the 500 cap, so the lower panels move to `stats_tab_panels.rs` — a pure move, no rendering or layout change. 540 → 325 + 243.

## Scope

The accept-bar fix here is the **serial** verify path only. The same fix on the batched verify path touches a file that only exists in the DFlash2 batching lane, so it belongs with that lane rather than in a TUI PR.

## Verification

`ATLAS_TARGET_MODEL='*'` build clean · 639 spark-model + 104 spark-server tests · LoC cap clean (the two remaining violations pre-exist on #649's base).
