### PR TITLE
Batched GEMV bit-parity: two arms that were not bit-identical to M=1 (w8a16 + FP8 vocab), gates + fixes

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -149,6 +149,10 @@ name = "w8a16_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]
+name = "dense_gemv_fp8w_bitparity_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "q2_0_gemv_microtest"
 required-features = ["cuda", "gpu-examples"]
 

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -145,6 +145,10 @@ name = "w8a16_gemv_batch4_microtest"
 required-features = ["cuda", "gpu-examples"]
 
 [[example]]
+name = "w8a16_batch_bitparity_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "q2_0_gemv_microtest"
 required-features = ["cuda", "gpu-examples"]
 

--- a/crates/spark-model/examples/batchm_bench.rs
+++ b/crates/spark-model/examples/batchm_bench.rs
@@ -149,8 +149,14 @@ fn launch_gemm(
     m: u32,
     n: u32,
     k: u32,
+    // `w4a16_gemm_t` grew a trailing `ldb` param (padded-B stride; the
+    // production caller passes the twin's padded row count). Contiguous
+    // bench pack ⇒ ldb = n. `None` for kernels without the param — an
+    // extra trailing arg is a CUDA_ERROR_INVALID_VALUE, which is exactly
+    // how the drift surfaced (grid=[40,1,1] crash at the gemm_t arm).
+    ldb: Option<u32>,
 ) -> Result<()> {
-    KernelLaunch::new(g, kh)
+    let mut l = KernelLaunch::new(g, kh)
         .grid([div_ceil(n, n_tile), div_ceil(m, 64), 1])
         .block([128, 1, 1])
         .arg_ptr(a)
@@ -160,8 +166,11 @@ fn launch_gemm(
         .arg_ptr(c)
         .arg_u32(m)
         .arg_u32(n)
-        .arg_u32(k)
-        .launch(0)
+        .arg_u32(k);
+    if let Some(v) = ldb {
+        l = l.arg_u32(v);
+    }
+    l.launch(0)
 }
 
 #[derive(Clone, Copy)]
@@ -387,8 +396,8 @@ fn main() -> Result<()> {
                     let (b, bs) = b_copies[i % copies];
                     match kind {
                         Kind::Batchm { .. } => launch_batchm(g, kh, a, b, bs, c, m, n, k),
-                        Kind::Gemm => launch_gemm(g, kh, 64, a, b, bs, c, m, n, k),
-                        Kind::GemmT => launch_gemm(g, kh, 128, a, b, bs, c, m, n, k),
+                        Kind::Gemm => launch_gemm(g, kh, 64, a, b, bs, c, m, n, k, None),
+                        Kind::GemmT => launch_gemm(g, kh, 128, a, b, bs, c, m, n, k, Some(n)),
                     }
                 };
                 for i in 0..WARMUP {

--- a/crates/spark-model/examples/dense_gemv_fp8w_bitparity_microtest.rs
+++ b/crates/spark-model/examples/dense_gemv_fp8w_bitparity_microtest.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Bit-parity gate for the FP8 row-scaled vocab GEMV: every batched arm must
+//! be byte-identical to M independent `dense_gemv_fp8w` calls.
+//!
+//! WHY THIS SHAPE MATTERS. This kernel family serves the TARGET's LM head.
+//! Under strict-argmax accept a drafter cannot change token identity, so a
+//! spec-on vs spec-off divergence at temp 0 is target-side arithmetic by
+//! construction — and the batched arm running at M>1 while serial decode runs
+//! M=1 is exactly such a difference, on the last projection before the argmax.
+//! A reduction-order discrepancy here is a different SAMPLED TOKEN, not a
+//! rounding curiosity. Same class as the w8a16 defect in #653.
+//!
+//! Two arms are checked:
+//!   * `dense_gemv_fp8w_batch2` — the pre-existing M=2 arm, whose `mac4`
+//!     contracts four products before accumulating rather than accumulating
+//!     one per statement as the M=1 kernel does. This gate exists to say
+//!     whether that is a real byte difference or only a reading of the source.
+//!   * `dense_gemv_fp8w_batchm` — the M<=8 arm, written to the M=1 chain
+//!     deliberately (same k order, per-row scale applied to each thread's
+//!     partial BEFORE the reduction, as the M=1 kernel does).
+//!
+//! Compares BF16 BYTES at the real LM-head shape plus two smaller ones.
+//! Exit: 0 all legs byte-identical, 1 any leg differs.
+//!
+//! Run:
+//!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.8-27b \
+//!   ATLAS_TARGET_QUANT=nvfp4 cargo run -p spark-model --release \
+//!     --features cuda,gpu-examples --example dense_gemv_fp8w_bitparity_microtest
+
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+const MAXM: usize = 8;
+
+/// (label, N, K). The qwen3.8-27b row is the real LM head: the checkpoint's
+/// native FP8 `lm_head.weight` is [248320 x 5120] (vocab 248077 padded).
+const SHAPES: [(&str, usize, usize); 3] = [
+    ("small       [  512 x 2048]", 512, 2048),
+    ("mid         [ 8192 x 5120]", 8192, 5120),
+    ("qwen3.8 lm_head [248320 x 5120]", 248320, 5120),
+];
+
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+    fn r(&mut self, lo: f32, hi: f32) -> f32 {
+        let x = ((self.next() >> 11) as f32) / ((1u64 << 53) as f32);
+        lo + x * (hi - lo)
+    }
+}
+
+fn up_u8(g: &dyn GpuBackend, d: &[u8]) -> Result<DevicePtr> {
+    let p = g.alloc(d.len())?;
+    g.copy_h2d(d, p)?;
+    Ok(p)
+}
+fn up_f32(g: &dyn GpuBackend, d: &[f32]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|v| v.to_ne_bytes()).collect();
+    let p = g.alloc(b.len())?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+fn up_bf16(g: &dyn GpuBackend, d: &[bf16]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|v| v.to_bits().to_ne_bytes()).collect();
+    let p = g.alloc(b.len())?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+fn down(g: &dyn GpuBackend, p: DevicePtr, elems: usize) -> Result<Vec<u16>> {
+    let mut b = vec![0u8; elems * 2];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b.chunks_exact(2)
+        .map(|c| u16::from_ne_bytes([c[0], c[1]]))
+        .collect())
+}
+
+fn main() -> Result<()> {
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &backend;
+
+    let m1_k = g.kernel("gemv_fp8w", "dense_gemv_fp8w")?;
+    let batch2_k = g.kernel("dense_gemv_fp8w_batch2", "dense_gemv_fp8w_batch2")?;
+    let batchm_k = g.kernel("dense_gemv_fp8w_batchm", "dense_gemv_fp8w_batchm")?;
+
+    let mut all_pass = true;
+    for (label, n, k) in SHAPES {
+        let mut rng = Lcg(0x4650_3857_0000_0001 ^ (n as u64) << 20 ^ k as u64);
+        let a: Vec<bf16> = (0..MAXM * k)
+            .map(|_| bf16::from_f32(rng.r(-1.0, 1.0)))
+            .collect();
+        // FP8 E4M3 bytes: avoid 0xFF/0x7F (NaN/Inf encodings) so the compare
+        // measures arithmetic order, not NaN propagation.
+        let weight: Vec<u8> = (0..n * k)
+            .map(|_| (rng.r(0.0, 240.0) as u8) & 0x7E)
+            .collect();
+        let row_scale: Vec<f32> = (0..n).map(|_| rng.r(0.01, 0.12)).collect();
+
+        let a_d = up_bf16(g, &a)?;
+        let w_d = up_u8(g, &weight)?;
+        let rs_d = up_f32(g, &row_scale)?;
+        let c_batch = g.alloc(MAXM * n * 2)?;
+        let c_ref = g.alloc(MAXM * n * 2)?;
+
+        // batch2 serves exactly M=2; batchm serves 2..=8.
+        let legs: [(&str, KernelHandle, &[usize]); 2] = [
+            ("batch2", batch2_k, &[2]),
+            ("batchm", batchm_k, &[2, 3, 4, 8]),
+        ];
+
+        for (name, kh, ms) in legs {
+            for &m in ms {
+                let mut launch = KernelLaunch::new(g, kh)
+                    .grid([div_ceil(n as u32, 4), 1, 1])
+                    .block([256, 1, 1])
+                    .arg_ptr(a_d)
+                    .arg_ptr(w_d)
+                    .arg_ptr(rs_d)
+                    .arg_ptr(c_batch);
+                // batch2's signature is fixed at M=2 and takes (N, K) only.
+                if name != "batch2" {
+                    launch = launch.arg_u32(m as u32);
+                }
+                launch.arg_u32(n as u32).arg_u32(k as u32).launch(0)?;
+
+                for t in 0..m {
+                    KernelLaunch::new(g, m1_k)
+                        .grid([div_ceil(n as u32, 4), 1, 1])
+                        .block([256, 1, 1])
+                        .arg_ptr(a_d.offset(t * k * 2))
+                        .arg_ptr(w_d)
+                        .arg_ptr(rs_d)
+                        .arg_ptr(c_ref.offset(t * n * 2))
+                        .arg_u32(n as u32)
+                        .arg_u32(k as u32)
+                        .launch(0)?;
+                }
+                g.synchronize(0)?;
+
+                let cb = down(g, c_batch, m * n)?;
+                let cr = down(g, c_ref, m * n)?;
+                let diff = cb.iter().zip(&cr).filter(|(x, y)| x != y).count();
+                let max_abs = cb
+                    .iter()
+                    .zip(&cr)
+                    .map(|(x, y)| {
+                        let fx = f32::from(bf16::from_bits(*x));
+                        let fy = f32::from(bf16::from_bits(*y));
+                        (fx - fy).abs()
+                    })
+                    .fold(0.0f32, f32::max);
+                let pass = diff == 0;
+                all_pass &= pass;
+                println!(
+                    "{label}  {name} M={m:2}  byte-identical={pass}  diff_elems={diff:<8} \
+                     max|delta|={max_abs:.6}"
+                );
+            }
+        }
+    }
+
+    if all_pass {
+        println!(
+            "PASS — every batched FP8 vocab GEMV arm is byte-identical to M x dense_gemv_fp8w."
+        );
+        Ok(())
+    } else {
+        println!(
+            "FAIL — a batched FP8 vocab arm is NOT byte-identical to sequential decode. \
+             At the LM head that is a different SAMPLED TOKEN, not a rounding curiosity."
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/examples/w4a16_batch_bitparity_microtest.rs
+++ b/crates/spark-model/examples/w4a16_batch_bitparity_microtest.rs
@@ -44,11 +44,23 @@ const SCALE2: f32 = 0.0123_f32;
 /// rows cover the hidden-4096 Super/Puzzle backbone at the natural doubling
 /// (d_inner 8192); they are shape COVERAGE for a larger N and a deeper K, not
 /// a claim about that checkpoint's exact `in_proj_size`.
-const SHAPES: [(&str, usize, usize); 4] = [
+const SHAPES: [(&str, usize, usize); 10] = [
     ("nano  in_proj  [10304 x 2688]", 10304, 2688),
     ("nano  out_proj [ 2688 x 4096]", 2688, 4096),
     ("super in_proj  [18560 x 4096]", 18560, 4096),
     ("super out_proj [ 4096 x 8192]", 4096, 8192),
+    // qwen3.8-27b dense (hidden 5120, 24q/4kv x head_dim 256, ffn 17408,
+    // vocab 248320): the EXACT projection + LM-head shapes the MTP verify
+    // forward dispatches at M=K. Added 2026-08-19 while hunting the temp-0
+    // spec-decode divergence — the nemotron rows above all PASS on the
+    // qwen3.8 target, but the prior defects in this family were
+    // SHAPE-specific, so parity must be proven at these dims too.
+    ("qwen3.8 q_proj  [ 6144 x  5120]", 6144, 5120),
+    ("qwen3.8 kv_proj [ 1024 x  5120]", 1024, 5120),
+    ("qwen3.8 o_proj  [ 5120 x  6144]", 5120, 6144),
+    ("qwen3.8 gate/up [17408 x  5120]", 17408, 5120),
+    ("qwen3.8 down    [ 5120 x 17408]", 5120, 17408),
+    ("qwen3.8 lm_head [248320 x 5120]", 248320, 5120),
 ];
 
 struct Lcg(u64);

--- a/crates/spark-model/examples/w8a16_batch_bitparity_microtest.rs
+++ b/crates/spark-model/examples/w8a16_batch_bitparity_microtest.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! BYTE-parity gate for the block-scaled W8A16 batched GEMVs.
+//!
+//! `w8a16_gemv_batch4` / `w8a16_gemv_batch16` are the arms the K<=8 MTP
+//! verify dispatch runs for the GDN QKVZ and out_proj projections on
+//! native-FP8 checkpoints (`trait_decode_batched.rs`), while sequential
+//! M=1 decode runs `w8a16_gemv` on the SAME weights (`ssm_forward.rs`).
+//! Speculative decode at temperature 0 is only output-invariant if the
+//! batched arm is byte-identical to M independent M=1 calls.
+//!
+//! The existing `w8a16_gemv_batch4_microtest` gates on COSINE > 0.99999 at
+//! one small shape (N=512, K=2048) — the gate style the w4a16 microtest's
+//! doc explicitly warns about ("a cosine gate is exactly what hid the
+//! `w8a16_gemv_batch4` fused-add defect"), and its own output shows
+//! max_abs=0.125 PASSing at M=16. This test is the strict version: RAW
+//! BF16 BYTES, at the EXACT qwen3.8-27b GDN projection shapes, at every M
+//! each arm serves in the verify dispatch.
+//!
+//! Exit: 0 all legs byte-identical, 1 any leg differs.
+//!
+//! Run:
+//!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=qwen3.8-27b \
+//!   ATLAS_TARGET_QUANT=nvfp4 cargo run -p spark-model --release \
+//!     --features cuda,gpu-examples --example w8a16_batch_bitparity_microtest
+
+use anyhow::Result;
+use half::bf16;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+const MAXM: usize = 16;
+const FP8_BLOCK: usize = 128;
+
+/// (label, N, K). The two qwen3.8-27b rows are the EXACT GDN projection
+/// shapes the K<=8 verify dispatch serves (QKVZ in_proj [16384 x 5120],
+/// out_proj [5120 x 6144] — see the M>8 arm's nsys note in
+/// `trait_decode_batched.rs`); the small row is the legacy microtest shape
+/// kept for continuity with its history.
+const SHAPES: [(&str, usize, usize); 3] = [
+    ("legacy   [  512 x 2048]", 512, 2048),
+    ("qwen3.8 qkvz    [16384 x 5120]", 16384, 5120),
+    ("qwen3.8 out_proj[ 5120 x 6144]", 5120, 6144),
+];
+
+struct Lcg(u64);
+impl Lcg {
+    fn f(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (((self.0 >> 11) as f64) / ((1u64 << 53) as f64)) as f32
+    }
+    fn r(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.f()
+    }
+}
+
+fn up_u8(g: &dyn GpuBackend, d: &[u8]) -> Result<DevicePtr> {
+    let p = g.alloc(d.len().max(1))?;
+    g.copy_h2d(d, p)?;
+    Ok(p)
+}
+fn up_f32(g: &dyn GpuBackend, d: &[f32]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|x| x.to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+fn up_bf16(g: &dyn GpuBackend, d: &[bf16]) -> Result<DevicePtr> {
+    let b: Vec<u8> = d.iter().flat_map(|x| x.to_bits().to_le_bytes()).collect();
+    let p = g.alloc(b.len().max(1))?;
+    g.copy_h2d(&b, p)?;
+    Ok(p)
+}
+fn dn_bytes(g: &dyn GpuBackend, p: DevicePtr, n_elems: usize) -> Result<Vec<u8>> {
+    let mut b = vec![0u8; n_elems * 2];
+    g.copy_d2h(p, &mut b)?;
+    Ok(b)
+}
+
+fn main() -> Result<()> {
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let g: &dyn GpuBackend = &backend;
+
+    let batch4_k = g.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch4")?;
+    let batch16_k = g.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch16")?;
+    let m1_k = g.kernel("w8a16_gemv", "w8a16_gemv")?;
+
+    let mut all_pass = true;
+    for (label, n, k) in SHAPES {
+        let mut rng = Lcg(0x5155_4d5f_b4b4_0001 ^ (n as u64) << 20 ^ k as u64);
+        let a: Vec<bf16> = (0..MAXM * k)
+            .map(|_| bf16::from_f32(rng.r(-1.0, 1.0)))
+            .collect();
+        let weight: Vec<u8> = (0..n * k).map(|_| rng.r(0.0, 256.0) as u8).collect();
+        let (nb, kb) = (n / FP8_BLOCK, k / FP8_BLOCK);
+        let block_scale: Vec<f32> = (0..nb * kb).map(|_| rng.r(0.01, 0.12)).collect();
+
+        let a_d = up_bf16(g, &a)?;
+        let w_d = up_u8(g, &weight)?;
+        let bs_d = up_f32(g, &block_scale)?;
+        let c_batch = g.alloc(MAXM * n * 2)?;
+        let c_ref = g.alloc(MAXM * n * 2)?;
+
+        // Every M each arm serves in the verify dispatch: batch4 at 2..4
+        // (K=4 MTP verify is M=4 — the production width), batch16 at 5..16.
+        let legs: [(&str, KernelHandle, &[usize]); 2] = [
+            ("batch4", batch4_k, &[2, 3, 4]),
+            ("batch16", batch16_k, &[5, 8, 16]),
+        ];
+        for (name, kh, ms) in legs {
+            for &m in ms {
+                KernelLaunch::new(g, kh)
+                    .grid([div_ceil(n as u32, 4), 1, 1])
+                    .block([256, 1, 1])
+                    .arg_ptr(a_d)
+                    .arg_ptr(w_d)
+                    .arg_ptr(bs_d)
+                    .arg_ptr(c_batch)
+                    .arg_u32(m as u32)
+                    .arg_u32(n as u32)
+                    .arg_u32(k as u32)
+                    .launch(0)?;
+                for t in 0..m {
+                    KernelLaunch::new(g, m1_k)
+                        .grid([div_ceil(n as u32, 4), 1, 1])
+                        .block([256, 1, 1])
+                        .arg_ptr(a_d.offset(t * k * 2))
+                        .arg_ptr(w_d)
+                        .arg_ptr(bs_d)
+                        .arg_ptr(c_ref.offset(t * n * 2))
+                        .arg_u32(n as u32)
+                        .arg_u32(k as u32)
+                        .launch(0)?;
+                }
+                g.synchronize(0)?;
+                let cb = dn_bytes(g, c_batch, m * n)?;
+                let cr = dn_bytes(g, c_ref, m * n)?;
+                let diff = cb
+                    .chunks_exact(2)
+                    .zip(cr.chunks_exact(2))
+                    .filter(|(x, y)| x != y)
+                    .count();
+                let max_abs = cb
+                    .chunks_exact(2)
+                    .zip(cr.chunks_exact(2))
+                    .map(|(x, y)| {
+                        (bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32()
+                            - bf16::from_bits(u16::from_le_bytes([y[0], y[1]])).to_f32())
+                        .abs()
+                    })
+                    .fold(0.0f32, f32::max);
+                let pass = diff == 0;
+                all_pass &= pass;
+                println!(
+                    "{label}  {name} M={m:2}  byte-identical={pass}  diff_elems={diff:<8} max|delta|={max_abs:.6}",
+                );
+            }
+        }
+    }
+    if all_pass {
+        println!(
+            "PASS — w8a16_gemv_batch4/batch16 byte-identical to M x w8a16_gemv at every shape and M."
+        );
+        Ok(())
+    } else {
+        println!("FAIL — batched W8A16 verify arm is NOT byte-identical to sequential decode.");
+        std::process::exit(1);
+    }
+}

--- a/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
+++ b/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
@@ -98,3 +98,47 @@ pub fn w8a16_gemv_batch2(
         .arg_u32(k)
         .launch(stream)
 }
+
+/// Batched row-scaled FP8 GEMV (M<=8), BIT-IDENTICAL to `m` separate
+/// `dense_gemv_fp8w` calls: same per-element accumulation chain, same k order,
+/// and the per-row scale applied to each thread's partial BEFORE the reduction
+/// exactly as the M=1 kernel does.
+///
+/// One pass over the weight serves every activation row. At a 248K vocab the
+/// FP8 LM head is ~1.27 GB, so the per-token loop this replaces re-read the
+/// whole head once per token.
+///
+/// `input` `[M, K]` BF16, `output` `[M, N]` BF16.
+/// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1). Requires K % 16 == 0.
+#[allow(clippy::too_many_arguments)]
+pub fn dense_gemv_fp8w_batchm(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &Fp8DenseWeight,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    ensure!(
+        (1..=8).contains(&m),
+        "dense_gemv_fp8w_batchm: m={m} outside 1..=8 (kernel BM_MAX_M)"
+    );
+    ensure!(
+        k.is_multiple_of(16),
+        "dense_gemv_fp8w_batchm: K={k} not a multiple of 16"
+    );
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(weight.row_scale)
+        .arg_ptr(output)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)
+}

--- a/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
+++ b/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
@@ -10,7 +10,7 @@
 //! weights but have distinct activations (lm_head, attention Q/K/V/O, SSM
 //! out_proj).
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
 

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -130,6 +130,13 @@ impl TransformerModel {
             "dense_gemv_fp8w_batch2",
             "dense_gemv_fp8w_batch2",
         );
+        // M<=8 batched FP8 vocab GEMV, bit-identical to the M=1 chain. Handle
+        // stays 0 on kernel sets that predate it and dispatch falls back.
+        let dense_gemv_fp8w_batchm_kernel = crate::layers::try_kernel(
+            gpu.as_ref(),
+            "dense_gemv_fp8w_batchm",
+            "dense_gemv_fp8w_batchm",
+        );
         let dense_gemm_kernel = gpu.kernel("gemm", "dense_gemm_bf16")?;
         let dense_gemv_batchm_kernel = gpu
             .kernel("dense_gemv_bf16_batchm", "dense_gemv_bf16_batchm")
@@ -712,6 +719,7 @@ impl TransformerModel {
             w4a16_gemv_batch16_kernel,
             dense_gemv_fp8w_kernel,
             dense_gemv_fp8w_batch2_kernel,
+            dense_gemv_fp8w_batchm_kernel,
             dense_gemm_kernel,
             dense_gemv_batchm_kernel,
             argmax_kernel,

--- a/crates/spark-model/src/model/impl_a3.rs
+++ b/crates/spark-model/src/model/impl_a3.rs
@@ -183,32 +183,7 @@ impl TransformerModel {
             // once for both K=2 verify tokens — bit-identical to two M=1 GEMVs
             // but halves the full-vocab weight bandwidth. Falls back to the
             // per-token loop for K!=2 or when the kernel is absent.
-            let bf16 = 2usize;
-            if num_tokens == 2 && self.dense_gemv_fp8w_batch2_kernel.0 != 0 {
-                ops::dense_gemv_fp8w_batch2(
-                    self.gpu.as_ref(),
-                    self.dense_gemv_fp8w_batch2_kernel,
-                    hidden,
-                    fp8,
-                    logits,
-                    v,
-                    h,
-                    stream,
-                )?;
-            } else {
-                for i in 0..num_tokens as usize {
-                    ops::dense_gemv_fp8w(
-                        self.gpu.as_ref(),
-                        self.dense_gemv_fp8w_kernel,
-                        hidden.offset(i * h as usize * bf16),
-                        fp8,
-                        logits.offset(i * v as usize * bf16),
-                        v,
-                        h,
-                        stream,
-                    )?;
-                }
-            }
+            self.fp8_vocab_project(fp8, hidden, logits, num_tokens, v, h, stream)?;
         } else if num_tokens == 2 {
             // Double-GEMV: reads weights once, computes 2 outputs.
             // GEMM M=2 with 64×64 tiles wastes 97% of M-dimension → ~3× slower.

--- a/crates/spark-model/src/model/impl_a3_vocab.rs
+++ b/crates/spark-model/src/model/impl_a3_vocab.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! FP8 vocab projection: which kernel serves `M` rows of the LM head.
+//!
+//! Split out of `impl_a3.rs` when the batched arm pushed that file past the
+//! 500-line cap. The decision is self-contained -- pick a kernel by row count
+//! -- so it moves whole rather than being shaved out of the file it grew.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use crate::layers::ops;
+use crate::weight_map::Fp8DenseWeight;
+
+impl super::TransformerModel {
+    /// Project `num_tokens` hidden rows through the FP8 LM head into `logits`.
+    ///
+    /// Every arm is bit-identical to the others: `dense_gemv_fp8w_batchm` uses
+    /// the same per-element chain and the same pre-reduction scale as the M=1
+    /// `dense_gemv_fp8w`, so the only thing that changes with M is how many
+    /// times the ~1.27 GB head is read.
+    pub(super) fn fp8_vocab_project(
+        &self,
+        fp8: &Fp8DenseWeight,
+        hidden: DevicePtr,
+        logits: DevicePtr,
+        num_tokens: u32,
+        v: u32,
+        h: u32,
+        stream: u64,
+    ) -> Result<()> {
+        let bf16 = 2usize;
+        // One pass over the head for up to 8 tokens. The loop below reads
+        // the ENTIRE ~1.27 GB FP8 head once PER TOKEN, which is why the
+        // FP8 head measured slower than BF16 at M>2 despite carrying half
+        // the bytes. `dense_gemv_fp8w_batchm` is bit-identical to that
+        // loop (same per-element chain, same k order, scale applied
+        // per-thread before the reduction), so this is bandwidth only.
+        //
+        // It also covers M=2, replacing `dense_gemv_fp8w_batch2`: that
+        // kernel's `mac4` contracts four products before accumulating,
+        // which is NOT the M=1 chain its header claims parity with.
+        if (2..=8).contains(&num_tokens) && self.dense_gemv_fp8w_batchm_kernel.0 != 0 {
+            ops::dense_gemv_fp8w_batchm(
+                self.gpu.as_ref(),
+                self.dense_gemv_fp8w_batchm_kernel,
+                hidden,
+                fp8,
+                logits,
+                num_tokens,
+                v,
+                h,
+                stream,
+            )?;
+        } else if num_tokens == 2 && self.dense_gemv_fp8w_batch2_kernel.0 != 0 {
+            ops::dense_gemv_fp8w_batch2(
+                self.gpu.as_ref(),
+                self.dense_gemv_fp8w_batch2_kernel,
+                hidden,
+                fp8,
+                logits,
+                v,
+                h,
+                stream,
+            )?;
+        } else if num_tokens > 8 && self.dense_gemv_fp8w_batchm_kernel.0 != 0 {
+            // Above the kernel's M bound, CHUNK rather than fall all the
+            // way back to one row at a time. A cross-sequence verify at
+            // C=8 presents 8*(gamma+1) = 64 rows; the per-token loop reads
+            // the whole 1.27 GB head 64 times, chunks of 8 read it 8.
+            // Each chunk is bit-identical to the rows it replaces, so the
+            // result is unchanged either way.
+            let mut done = 0u32;
+            while done < num_tokens {
+                let m = (num_tokens - done).min(8);
+                ops::dense_gemv_fp8w_batchm(
+                    self.gpu.as_ref(),
+                    self.dense_gemv_fp8w_batchm_kernel,
+                    hidden.offset(done as usize * h as usize * bf16),
+                    fp8,
+                    logits.offset(done as usize * v as usize * bf16),
+                    m,
+                    v,
+                    h,
+                    stream,
+                )?;
+                done += m;
+            }
+        } else {
+            for i in 0..num_tokens as usize {
+                ops::dense_gemv_fp8w(
+                    self.gpu.as_ref(),
+                    self.dense_gemv_fp8w_kernel,
+                    hidden.offset(i * h as usize * bf16),
+                    fp8,
+                    logits.offset(i * v as usize * bf16),
+                    v,
+                    h,
+                    stream,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod impl_a1;
 pub(crate) mod impl_a1_init;
 pub(crate) mod impl_a2;
 pub(crate) mod impl_a3;
+mod impl_a3_vocab;
 pub(crate) mod impl_b1;
 pub(crate) mod impl_b2;
 pub(crate) mod impl_b3;

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -137,6 +137,7 @@ pub struct TransformerModel {
     /// verify tokens. Bit-identical to two `dense_gemv_fp8w` calls; halves the
     /// FP8 weight bandwidth for the lm_head on the MTP verify path.
     pub(super) dense_gemv_fp8w_batch2_kernel: KernelHandle,
+    pub(super) dense_gemv_fp8w_batchm_kernel: KernelHandle,
     pub(super) dense_gemm_kernel: KernelHandle,
     /// Batched BF16 GEMV (M rows, one weight pass). Used for the BF16 lm_head
     /// at decode: reads the ~617 MB vocab weight once with coalesced uint4

--- a/kernels/gb10/common/dense_gemv_fp8w_batch2.cu
+++ b/kernels/gb10/common/dense_gemv_fp8w_batch2.cu
@@ -65,8 +65,17 @@ __device__ __forceinline__ void mac4(float& acc, unsigned int a32_lo, unsigned i
     *(unsigned short*)&a1 = (unsigned short)(a32_lo >> 16);
     *(unsigned short*)&a2 = (unsigned short)(a32_hi & 0xFFFF);
     *(unsigned short*)&a3 = (unsigned short)(a32_hi >> 16);
-    acc += __bfloat162float(a0) * wf0 + __bfloat162float(a1) * wf1
-         + __bfloat162float(a2) * wf2 + __bfloat162float(a3) * wf3;
+    // ONE product per statement, matching `dense_gemv_fp8w`'s chain. The
+    // previous 4-term form contracted each group before accumulating, which
+    // is a different rounding: measured 78 differing logits (max|delta| 2.0)
+    // against 2x M=1 at the [248320 x 5120] LM head. This kernel serves the
+    // K=2 verify while serial decode takes the M=1 path, so that difference
+    // is a spec-on vs spec-off divergence on the final projection before the
+    // argmax. See dense_gemv_fp8w_bitparity_microtest.
+    acc += __bfloat162float(a0) * wf0;
+    acc += __bfloat162float(a1) * wf1;
+    acc += __bfloat162float(a2) * wf2;
+    acc += __bfloat162float(a3) * wf3;
 }
 
 extern "C" __global__ void dense_gemv_fp8w_batch2(

--- a/kernels/gb10/common/dense_gemv_fp8w_batchm.cu
+++ b/kernels/gb10/common/dense_gemv_fp8w_batchm.cu
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// dense_gemv_fp8w_batchm.cu — batched row-scaled FP8 GEMV (M<=8) for the
+// full-vocab LM head, BIT-IDENTICAL to M separate `dense_gemv_fp8w` calls.
+//
+//   C[M,N] (bf16) = A[M,K] (bf16) @ dequant(B)^T * row_scale[N]
+//
+// Why it exists: the FP8 LM-head decode path had a batched arm only at M=2
+// and fell to a PER-TOKEN LOOP above it. At a 248K vocab the head is ~1.27 GB
+// of FP8, so an M=8 verify step re-read the entire head EIGHT times — which
+// is why the FP8 head measured slower than BF16 despite carrying half the
+// bytes. One pass over the weight now serves up to 8 activation rows.
+//
+// PARITY IS THE POINT, not a bonus. These logits are what the sampler
+// argmaxes, so a different rounding order is a different token. The
+// accumulation below is therefore the SAME per-element chain as the M=1
+// kernel — one product per `acc +=` statement, in the same k order:
+//
+//     acc += a_lo * w0;   acc += a_hi * w1;
+//     acc += a_lo * w2;   acc += a_hi * w3;
+//
+// NOT the 4-term `acc += a0*w0 + a1*w1 + a2*w2 + a3*w3` form used by
+// `dense_gemv_fp8w_batch2`'s `mac4`, which contracts each group of four
+// before accumulating and is therefore NOT bit-identical to the M=1 path its
+// header claims parity with. See dense_gemv_fp8w_bitparity_microtest.
+//
+// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1) — same geometry as the M=1 and
+// M=2 kernels, so launchers and any graph capture are unchanged.
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#define BM_BLOCK 256
+#define BM_N_PER_BLOCK 4
+#define BM_VEC 16
+#define BM_MAX_M 8
+
+__device__ __forceinline__ float bm_fp8_to_f32(unsigned char b) {
+    __nv_fp8_e4m3 v;
+    *(unsigned char*)&v = b;
+    return (float)v;
+}
+
+extern "C" __global__ void dense_gemv_fp8w_batchm(
+    const __nv_bfloat16* __restrict__ A,   // [M, K] bf16, row-major
+    const unsigned char* __restrict__ B,   // [N, K] fp8 e4m3
+    const float* __restrict__ row_scale,   // [N] f32
+    __nv_bfloat16* __restrict__ C,         // [M, N] bf16
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    const unsigned int threads_per_out = BM_BLOCK / BM_N_PER_BLOCK; // 64
+    const unsigned int local_out = threadIdx.x / threads_per_out;
+    const unsigned int lane = threadIdx.x % threads_per_out;
+    const unsigned int n = blockIdx.x * BM_N_PER_BLOCK + local_out;
+
+    // Tail blocks must not return early: the cross-warp reduction below has a
+    // __syncthreads() that every thread in the block has to reach (same class
+    // as the w4a16/w8a16 tail fixes).
+    const bool active = n < N;
+    const float scale = active ? row_scale[n] : 0.0f;
+
+    float acc[BM_MAX_M];
+    #pragma unroll
+    for (int t = 0; t < BM_MAX_M; t++) acc[t] = 0.0f;
+
+    const unsigned int K_VEC = K / BM_VEC;
+    for (unsigned int kv = lane; active && kv < K_VEC; kv += threads_per_out) {
+        // 16 FP8 weight bytes for this output row, read ONCE and reused by
+        // every activation row — this reuse is the whole point of the kernel.
+        const uint4 wb = *(const uint4*)(B + (unsigned long long)n * K
+                                           + (unsigned long long)kv * BM_VEC);
+        const unsigned int w_raw[4] = {wb.x, wb.y, wb.z, wb.w};
+
+        #pragma unroll
+        for (int t = 0; t < BM_MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            const __nv_bfloat16* At = A + (unsigned long long)t * K;
+            const uint4 a_d0 = ((const uint4*)At)[kv * 2];
+            const uint4 a_d1 = ((const uint4*)At)[kv * 2 + 1];
+            const unsigned int a_raw[8] = {a_d0.x, a_d0.y, a_d0.z, a_d0.w,
+                                           a_d1.x, a_d1.y, a_d1.z, a_d1.w};
+            #pragma unroll
+            for (int i = 0; i < 4; i++) {
+                const unsigned int w32 = w_raw[i];
+                const unsigned int a32_lo = a_raw[i * 2];
+                const unsigned int a32_hi = a_raw[i * 2 + 1];
+                __nv_bfloat16 a0, a1, a2, a3;
+                *(unsigned short*)&a0 = (unsigned short)(a32_lo & 0xFFFF);
+                *(unsigned short*)&a1 = (unsigned short)(a32_lo >> 16);
+                *(unsigned short*)&a2 = (unsigned short)(a32_hi & 0xFFFF);
+                *(unsigned short*)&a3 = (unsigned short)(a32_hi >> 16);
+                // One product per statement, k ascending — the M=1 chain.
+                acc[t] += __bfloat162float(a0) * bm_fp8_to_f32((unsigned char)(w32 & 0xFF));
+                acc[t] += __bfloat162float(a1) * bm_fp8_to_f32((unsigned char)((w32 >> 8) & 0xFF));
+                acc[t] += __bfloat162float(a2) * bm_fp8_to_f32((unsigned char)((w32 >> 16) & 0xFF));
+                acc[t] += __bfloat162float(a3) * bm_fp8_to_f32((unsigned char)((w32 >> 24) & 0xFF));
+            }
+        }
+    }
+
+    // Scale BEFORE the reduction, exactly like the M=1 kernel
+    // (`acc *= scale;` ahead of its shuffle). Scaling the summed result
+    // instead would be `(a+b)*s` against its `a*s + b*s` — a different
+    // rounding, and on a 248K-vocab argmax a different token.
+    #pragma unroll
+    for (int t = 0; t < BM_MAX_M; t++) {
+        if ((unsigned int)t >= M) continue;
+        acc[t] *= scale;
+    }
+
+    // 64-lane reduction: shuffle within each warp, cross-warp through smem.
+    __shared__ float s_red[BM_MAX_M][BM_N_PER_BLOCK * 2];
+    const unsigned int warp_in_out = lane / 32u;
+    #pragma unroll
+    for (int t = 0; t < BM_MAX_M; t++) {
+        if ((unsigned int)t >= M) continue;
+        float a = acc[t];
+        #pragma unroll
+        for (int off = 16; off > 0; off >>= 1) {
+            a += __shfl_down_sync(0xFFFFFFFF, a, off);
+        }
+        if ((lane & 31u) == 0u) {
+            s_red[t][local_out * 2 + warp_in_out] = a;
+        }
+    }
+    __syncthreads();
+
+    if (lane == 0 && active) {
+        #pragma unroll
+        for (int t = 0; t < BM_MAX_M; t++) {
+            if ((unsigned int)t >= M) continue;
+            // Same combine order as the M=1 kernel: smem[0] + smem[1],
+            // scale already applied per-thread above.
+            const float r = s_red[t][local_out * 2] + s_red[t][local_out * 2 + 1];
+            C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+        }
+    }
+}

--- a/kernels/gb10/common/w8a16_gemv_batch4.cu
+++ b/kernels/gb10/common/w8a16_gemv_batch4.cu
@@ -118,7 +118,11 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
     s_lut[threadIdx.x] = E4M3_LUT_B4[threadIdx.x];
     __syncthreads();
 
-    if (n >= N) return;
+    // Tail threads (n >= N) must NOT return here: the cross-warp reduction
+    // below has a second __syncthreads(), and exiting before a barrier that
+    // other threads still reach is UB (same class as the w4a16_gemv tail
+    // fix). Keep them alive and inert instead.
+    const bool active = n < N;
 
     const unsigned int K16 = K / 16;
     const unsigned int k_blocks = (K + FP8_BLOCK - 1) / FP8_BLOCK;
@@ -128,7 +132,7 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
     #pragma unroll
     for (int t = 0; t < MAX_M; t++) acc[t] = 0.0f;
 
-    for (unsigned int k16 = lane; k16 < K16; k16 += threads_per_out) {
+    for (unsigned int k16 = lane; active && k16 < K16; k16 += threads_per_out) {
         const unsigned int base_k = k16 * 16;
         const unsigned int k_block = base_k / FP8_BLOCK;
         const float scale = block_scale[n_block * k_blocks + k_block];
@@ -161,8 +165,19 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
                 __nv_bfloat16 lo, hi;
                 *(unsigned short*)&lo = (unsigned short)(ar[j] & 0xFFFF);
                 *(unsigned short*)&hi = (unsigned short)(ar[j] >> 16);
-                acc[t] += __bfloat162float(lo) * wf[j * 2]
-                        + __bfloat162float(hi) * wf[j * 2 + 1];
+                // ONE element per statement, exactly like w8a16_gemv's
+                // `acc += a*w` chain. The old paired form
+                // (`acc += lo*w0 + hi*w1`) contracts the pair before the
+                // accumulate — one fewer rounding step per pair — so the
+                // per-row reduction was NOT bit-identical to M=1 despite
+                // the header's claim: at qwen3.8's GDN shapes the final
+                // BF16 store flips by 1 ULP on scattered rows (measured
+                // max|delta|=2.0 at |C|~512 — see
+                // w8a16_batch_bitparity_microtest). Those flips are the
+                // verify-vs-decode logit divergence behind the qwen3.8
+                // temp-0 spec-decode wrong answers.
+                acc[t] += __bfloat162float(lo) * wf[j * 2];
+                acc[t] += __bfloat162float(hi) * wf[j * 2 + 1];
             }
         }
     }
@@ -182,7 +197,7 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
     }
     __syncthreads();
 
-    if (lane == 0) {
+    if (lane == 0 && active) {
         #pragma unroll
         for (int t = 0; t < MAX_M; t++) {
             if ((unsigned int)t >= M) continue;


### PR DESCRIPTION
Standalone against `main` — no relation to the #649 train.

**Two batched GEMV arms in this repo are not bit-identical to the M=1 kernel they claim parity with.** Both are fixed here, and both now have a gate that fails loudly rather than a header comment that asserts.

## Why this class of defect is worth its own PR

Under strict-argmax accept, a drafter cannot change token identity — so a spec-on vs spec-off divergence at temp 0 is **target-side arithmetic by construction**. A batched verify arm that isn't bit-identical to the M=1 decode arm is exactly that: speculation on runs the batched kernel, speculation off runs M=1, same weights, same activations, different reduction order, different logits. Neither kernel is wrong in isolation; the bug is that two arms of one op disagree, which is why it survives ordinary review and ordinary tolerance tests.

## Defect 1 — `w8a16_gemv_batch4/16`

Two independent bugs in `kernels/gb10/common/w8a16_gemv_batch4.cu`:

**Paired contraction.** `acc[t] += lo*w0 + hi*w1` sums two products before accumulating — one fewer rounding step per pair than `w8a16_gemv`'s `acc += a*w` chain. Now one element per statement.

**Tail threads returned before a barrier.** `if (n >= N) return;` sits above a cross-warp reduction with a second `__syncthreads()`. Threads exiting before a barrier others still reach is UB — the same class as the earlier `w4a16_gemv` tail fix. They're kept alive and inert.

Measured on `main` before the fix, and it is not exclusive to qwen3.8 — the legacy 512×2048 shapes diverge too:

```
legacy   [  512 x 2048]  batch16 M=16  diff_elems=3    max|delta|=0.125
qwen3.8 qkvz    [16384 x 5120]  batch16 M=16  diff_elems=56   max|delta|=2.000
qwen3.8 out_proj[ 5120 x 6144]  batch16 M= 8  diff_elems=18   max|delta|=4.000
FAIL — batched W8A16 verify arm is NOT byte-identical to sequential decode.
```

After: `byte-identical=true, diff_elems=0` at every shape and every M.

## Defect 2 — `dense_gemv_fp8w_batch2`, on the target's LM head

Found while chasing why the FP8 head ran *slower* than BF16. `mac4` sums four products before accumulating where `dense_gemv_fp8w` accumulates one per statement. Its header, and the dispatch comment above it, both claimed bit-parity with two M=1 GEMVs.

```
small       [   512 x 2048]  diff_elems=1    max|delta|=0.015625
mid         [  8192 x 5120]  diff_elems=1    max|delta|=1.000000
qwen3.8 lm_head [248320 x 5120]  diff_elems=78  max|delta|=2.000000
```

**78 differing logits on the last projection before the argmax**, and this arm fires at `num_tokens==2` — the K=2 verify — while serial decode takes M=1. That is a spec-on/spec-off divergence carrier on the most precision-sensitive tensor in the model. Zero at every shape after the fix.

## Also here: the FP8 vocab projection was never batched above M=2

The same investigation turned up a plain performance bug. The FP8 LM-head dispatch had a batched arm only at M=2 and fell to a **per-token loop** above it. At a 248K vocab the head is ~1.27 GB of FP8, so an M=8 verify read the whole head 8 times, and a cross-sequence verify at C=8 (8 × γ+1 = 64 rows) read it **64 times**. That — not bandwidth — is why the FP8 head lost to BF16 while carrying half the bytes.

`dense_gemv_fp8w_batchm` (M≤8) reads each weight chunk once for every row, and above M=8 the dispatch chunks in groups of 8 rather than dropping to single rows. Written to the M=1 chain deliberately: same k order, and the per-row scale applied to each thread's partial **before** the reduction, because `(a+b)*s` and `a*s + b*s` round differently.

| C | per-token loop | batched | |
|---|---|---|---|
| 1 | 41.7 | 54.6 | +31% |
| 2 | 47.5 | 65.5 | +38% |
| 4 | 68.8 | 105.3 | +53% |
| 8 | 77.5 | 130.5 | +68% |

Completion byte-identical (sha `a7862f7d91db007e`) to both the per-token-loop FP8 run and a BF16-head run. C=1 gains because DFlash verifies γ+1 = 8 rows in one step even at a single stream.

## Also: `batchm_bench`'s gemm_t arm was crashing

`w4a16_gemm_t` grew a trailing `ldb` parameter and the bench was never updated, so it launched one argument short — `CUDA_ERROR_INVALID_VALUE`, a `grid=[40,1,1]` crash. The bench packs B contiguously so `ldb = n`. This bench is the harness that measures the batched-GEMV tier, and a crashing arm is an arm nobody is measuring.

## The gates

Two `gpu-examples` binaries, both exiting non-zero on any byte difference so they can gate CI on a GPU box. They compare BF16 **bytes** — not tolerances — against M independent M=1 calls, at the real production shapes, at every M the dispatch serves:

```
cargo run --release -p spark-model --features "cuda gpu-examples" \
      --example w8a16_batch_bitparity_microtest
cargo run --release -p spark-model --features "cuda gpu-examples" \
      --example dense_gemv_fp8w_bitparity_microtest
```

Both PASS on this branch. The w4a16 gate is extended with qwen3.8 shapes as well; those already passed and are included because a parity gate covering only the shapes someone happened to look at is how this class survives.

## Verification

`ATLAS_TARGET_MODEL='*'` build clean · 639 spark-model tests · LoC cap clean · both gates run on GB10 and pass, with the pre-fix failures quoted above measured on the same box.
