### PR TITLE
DFlash C>=2 correctness: ctx rows on the batched decode path, gate pin, pool uniformity (merge after #651)

### DIFF
--- a/crates/spark-model/examples/batchm_bench.rs
+++ b/crates/spark-model/examples/batchm_bench.rs
@@ -46,7 +46,8 @@ const ITERS: usize = 50;
 /// Weight bytes to cycle through so back-to-back launches miss L2/SLC.
 const COLD_CYCLE_BYTES: usize = 256 << 20;
 const M_SWEEP: &[u32] = &[1, 3, 4, 5, 6, 8];
-const M_MAX: usize = 8;
+const M_WIDE: &[u32] = &[1, 8, 9, 12, 18, 24, 36]; // GEMM-only: batched verify = n seqs × 9 rows
+const M_MAX: usize = 36;
 /// N rows checked against the CPU reference (full N for GPU-GPU bit checks).
 const CPU_CHECK_ROWS: usize = 256;
 
@@ -416,7 +417,7 @@ fn main() -> Result<()> {
         correctness_gate(g, &kernels, a, b0, bs0, c, n, k, &a_host, &b_host, &bs_host)?;
 
         for &(kname, kh, kind) in &kernels {
-            for &m in M_SWEEP {
+            for &m in [M_SWEEP, M_WIDE][matches!(kind, Kind::Gemm | Kind::GemmT) as usize] {
                 if let Kind::Batchm { max_m } = kind
                     && m > max_m
                 {

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -678,6 +678,7 @@ pub fn build_model(
                 args.window_size,
                 model.gpu_backend(),
                 max_seq_len,
+                max_batch_size,
             )?;
             model.set_dflash_proposer(std::sync::Arc::new(head));
             tracing::info!("DFlash drafter installed as the active proposer");

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -385,6 +385,8 @@ pub struct BlockDiffusionDraftHead {
     pub vocab_size: usize,
     pub draft_vocab_size: usize,
     pub gamma: usize,
+    /// Widest cross-sequence batch the scratch bands can hold.
+    pub(super) max_batch: usize,
     pub mask_token_id: u32,
     pub window_size: Option<usize>,
     /// `target_layer_ids`. Same data as `TransformerModel::dflash_capture_layers`,
@@ -613,7 +615,155 @@ impl DraftProposer for BlockDiffusionDraftHead {
             draft_embed_target,
             grammar_bitmask,
             target_hidden_stack,
+            None,
         )
+    }
+
+    /// Widest batch one drafter forward can carry. Bounded by the scratch
+    /// bands (`max_batch`); `1` means the batched path cannot run and the
+    /// caller stays on `propose`.
+    fn propose_batch_max(
+        &self,
+        _buffers: &spark_runtime::buffers::BufferArena,
+        _config: &atlas_core::config::ModelConfig,
+    ) -> usize {
+        if !self.dflash2_active() {
+            return 1;
+        }
+        // OPT-IN (ATLAS_DFLASH_BATCH_PROPOSE=1) and OFF by default: the
+        // batched forward is wired end to end and produces the correct
+        // ANSWER — output is byte-identical, because a bad draft is rejected
+        // and the target's own token is emitted — but the drafts themselves
+        // are wrong at n > 1 and acceptance collapses (84/78/72% per-sequence
+        // vs 77/63/24% batched at C=2/4/8), which makes it a net LOSS: 54
+        // tok/s against 127 at C=8. Shipping it default-on would trade a
+        // measured win for a measured loss.
+        //
+        // Ruled out so far: the conv/selector band width (both now take the
+        // real n_seq), CUDA-graph replay of an n=1 capture (gated to
+        // n_seq == 1), and the shared slot-0 hidden staging (moved back to
+        // the per-sequence arm). The remaining suspect list is in the commit
+        // message; the per-sequence path is untouched and stays the default.
+        if std::env::var("ATLAS_DFLASH_BATCH_PROPOSE").ok().as_deref() != Some("1") {
+            return 1;
+        }
+        self.max_batch.max(1)
+    }
+
+    /// Cross-sequence batched propose: ONE drafter forward over `n * gamma`
+    /// rows instead of `n` forwards.
+    ///
+    /// Per-sequence preparation (ctx append, Option-B block growth, the
+    /// incremental ctx precompute) still runs per sequence — it is cheap,
+    /// touching only the uncommitted ctx tail — and it reuses
+    /// `propose_drafts`' own prep through the `collect_prep` sink so the two
+    /// paths cannot drift. The expensive part, the drafter layers plus an
+    /// lm_head against a 248k vocab, runs ONCE for the whole batch. That is
+    /// the entire win.
+    ///
+    /// Returns `Ok(None)` to decline, and the caller falls back to the
+    /// per-sequence loop — never a wrong answer.
+    fn propose_batch(
+        &self,
+        last_tokens: &[u32],
+        _target_hiddens: &[spark_runtime::gpu::DevicePtr],
+        positions: &[usize],
+        num_drafts: usize,
+        states: &mut [&mut dyn ProposerState],
+        ctx: &crate::layer::ForwardContext,
+        stream: u64,
+        _out_conf: Option<&mut Vec<Vec<f32>>>,
+    ) -> Result<Option<Vec<Vec<u32>>>> {
+        let n = last_tokens.len();
+        if n < 2
+            || n > self.max_batch
+            || positions.len() != n
+            || states.len() != n
+            || !self.dflash2_active()
+        {
+            return Ok(None);
+        }
+
+        // Phase 1 — per-sequence prep, collecting each sequence's paged
+        // descriptor. A sequence that cannot run Option B (drafter block pool
+        // exhausted, say) aborts the WHOLE batch to the per-sequence path
+        // rather than letting the rest draft against a missing band.
+        let mut prep: Vec<(spark_runtime::gpu::DevicePtr, u32)> = Vec::with_capacity(n);
+        for (i, st) in states.iter_mut().enumerate() {
+            let before = prep.len();
+            match self.propose_drafts(
+                last_tokens[i],
+                spark_runtime::gpu::DevicePtr::NULL,
+                positions[i],
+                num_drafts,
+                *st,
+                ctx,
+                stream,
+                None,
+                None,
+                None,
+                Some(&mut prep),
+            ) {
+                Ok(_) if prep.len() == before + 1 => {}
+                Ok(_) => return Ok(None),
+                Err(e) => {
+                    tracing::warn!("DFlash batched propose prep (seq {i}): {e:#} — per-seq path");
+                    return Ok(None);
+                }
+            }
+        }
+
+        // Phase 2 — ONE forward over every band.
+        let batch = DflashBatch {
+            last_tokens,
+            positions,
+            block_tables: prep.iter().map(|p| p.0).collect(),
+            ctx_counts: prep.iter().map(|p| p.1).collect(),
+        };
+        let all = match self.forward_block(
+            last_tokens[0],
+            positions[0],
+            ctx,
+            stream,
+            None,
+            Some(prep[0]),
+            Some(&batch),
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("DFlash batched forward_block: {e:#} — falling back to per-seq");
+                return Ok(None);
+            }
+        };
+        if all.len() < n * self.gamma {
+            tracing::warn!(
+                "DFlash batched forward returned {} rows, expected {} — per-seq path",
+                all.len(),
+                n * self.gamma
+            );
+            return Ok(None);
+        }
+
+        // Phase 3 — split bands. Row 0 of each band is the anchor echo the
+        // single-sequence path drops too; the rest are that sequence's drafts.
+        let cap = std::env::var("ATLAS_DFLASH_DRAFT_CAP")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(self.gamma);
+        let mut out: Vec<Vec<u32>> = Vec::with_capacity(n);
+        for (i, st) in states.iter_mut().enumerate() {
+            let band = &all[i * self.gamma..(i + 1) * self.gamma];
+            let drafts: Vec<u32> = if self.mask_token_id != 0 {
+                band.iter().skip(1).copied().take(cap).collect()
+            } else {
+                band.iter().copied().take(cap).collect()
+            };
+            if let Some(d) = st.as_any_mut().downcast_mut::<DflashProposerState>() {
+                d.last_num_drafted = drafts.len();
+            }
+            out.push(drafts);
+        }
+        Ok(Some(out))
     }
 
     fn after_verify(

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -110,6 +110,22 @@ pub struct DflashKernels {
     pub dflash2_selector_walk: KernelHandle,
 }
 
+/// Cross-sequence batch descriptor for one drafter forward.
+///
+/// Rows are seq-major: sequence `i` owns `[i*gamma, (i+1)*gamma)` in every
+/// scratch buffer, and its drafts land in band `i`. Only attention, the KV
+/// slot writes and the selector's chain seed are per-sequence; every
+/// weight-bearing op runs once over all `n * gamma` rows, which is the whole
+/// point of batching.
+pub(super) struct DflashBatch<'a> {
+    pub last_tokens: &'a [u32],
+    pub positions: &'a [usize],
+    /// Per-sequence drafter block table device pointers.
+    pub block_tables: Vec<DevicePtr>,
+    /// Per-sequence populated ctx slot counts (drives kv_len / q_offset).
+    pub ctx_counts: Vec<u32>,
+}
+
 /// Per-step scratch buffers for the γ-block forward.
 ///
 /// Sized for `n_attn_slots = ctx_window + γ` rows, where ctx_window is the

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -630,24 +630,20 @@ impl DraftProposer for BlockDiffusionDraftHead {
         if !self.dflash2_active() {
             return 1;
         }
-        // OPT-IN (ATLAS_DFLASH_BATCH_PROPOSE=1) and OFF by default: the
-        // batched forward is wired end to end and produces the correct
-        // ANSWER — output is byte-identical, because a bad draft is rejected
-        // and the target's own token is emitted — but the drafts themselves
-        // are wrong at n > 1 and acceptance collapses (84/78/72% per-sequence
-        // vs 77/63/24% batched at C=2/4/8), which makes it a net LOSS: 54
-        // tok/s against 127 at C=8. Shipping it default-on would trade a
-        // measured win for a measured loss.
-        //
-        // Ruled out so far: the conv/selector band width (both now take the
-        // real n_seq), CUDA-graph replay of an n=1 capture (gated to
-        // n_seq == 1), and the shared slot-0 hidden staging (moved back to
-        // the per-sequence arm). The remaining suspect list is in the commit
-        // message; the per-sequence path is untouched and stays the default.
-        if std::env::var("ATLAS_DFLASH_BATCH_PROPOSE").ok().as_deref() != Some("1") {
+        // DEFAULT-ON. `ATLAS_DFLASH_BATCH_PROPOSE=<width>` overrides: `1`
+        // (or `0`) disables and restores the per-sequence loop, `N` caps the
+        // batch at N sequences. Numeric rather than boolean because
+        // bisecting the WIDTH against acceptance is what localises a banding
+        // bug — "correct at 2 bands, wrong at 4" is the observation that
+        // found the lm_head tile bound, and an on/off flag cannot ask it.
+        let want: usize = std::env::var("ATLAS_DFLASH_BATCH_PROPOSE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(usize::MAX);
+        if want < 2 {
             return 1;
         }
-        self.max_batch.max(1)
+        want.min(self.max_batch.max(1))
     }
 
     /// Cross-sequence batched propose: ONE drafter forward over `n * gamma`

--- a/crates/spark-model/src/layers/dflash_head/dflash2.rs
+++ b/crates/spark-model/src/layers/dflash_head/dflash2.rs
@@ -144,7 +144,15 @@ impl BlockDiffusionDraftHead {
             h,
             stream,
         )?;
-        self.conv_apply(ctx, hidden_in, base, self.scratch.conv_tmp, 0, n_seq, stream)?;
+        self.conv_apply(
+            ctx,
+            hidden_in,
+            base,
+            self.scratch.conv_tmp,
+            0,
+            n_seq,
+            stream,
+        )?;
         Ok(self.scratch.conv_tmp)
     }
 
@@ -166,7 +174,15 @@ impl BlockDiffusionDraftHead {
         let Some((base, _proj)) = self.conv_weights(layer, site) else {
             return Ok(sublayer_out);
         };
-        self.conv_apply(ctx, sublayer_out, base, self.scratch.conv_tmp, 1, n_seq, stream)?;
+        self.conv_apply(
+            ctx,
+            sublayer_out,
+            base,
+            self.scratch.conv_tmp,
+            1,
+            n_seq,
+            stream,
+        )?;
         Ok(self.scratch.conv_tmp)
     }
 

--- a/crates/spark-model/src/layers/dflash_head/dflash2.rs
+++ b/crates/spark-model/src/layers/dflash_head/dflash2.rs
@@ -79,9 +79,11 @@ impl BlockDiffusionDraftHead {
         base: DevicePtr,
         out: DevicePtr,
         application: u32, // 0 = prepare, 1 = finish
+        n_seq: u32,       // sequences packed seq-major; 1 = the single-seq path
         stream: u64,
     ) -> Result<()> {
-        let g = self.gamma as u32;
+        let block_g = self.gamma as u32;
+        let g = block_g * n_seq.max(1);
         let h = self.hidden_size as u32;
         let groups = h / self.conv_group_size as u32;
         let k = self.conv_kernel_size as u32;
@@ -101,6 +103,8 @@ impl BlockDiffusionDraftHead {
             .arg_u32(self.conv_group_size as u32)
             .arg_u32(dyn_stride)
             .arg_u32(app_off)
+            // Rows per band, so row 0 of each sequence has no predecessor.
+            .arg_u32(block_g)
             .launch(stream)
     }
 
@@ -115,6 +119,7 @@ impl BlockDiffusionDraftHead {
         site: ConvSite,
         hidden_in: DevicePtr,
         ctx: &ForwardContext,
+        n_seq: u32,
         stream: u64,
     ) -> Result<DevicePtr> {
         if !self.dflash2_active() {
@@ -123,7 +128,7 @@ impl BlockDiffusionDraftHead {
         let Some((base, proj)) = self.conv_weights(layer, site) else {
             return Ok(hidden_in);
         };
-        let g = self.gamma as u32;
+        let g = self.gamma as u32 * n_seq.max(1);
         let h = self.hidden_size as u32;
         let groups = h / self.conv_group_size as u32;
         let dyn_cols = 2 * self.conv_kernel_size as u32 * groups;
@@ -139,7 +144,7 @@ impl BlockDiffusionDraftHead {
             h,
             stream,
         )?;
-        self.conv_apply(ctx, hidden_in, base, self.scratch.conv_tmp, 0, stream)?;
+        self.conv_apply(ctx, hidden_in, base, self.scratch.conv_tmp, 0, n_seq, stream)?;
         Ok(self.scratch.conv_tmp)
     }
 
@@ -152,6 +157,7 @@ impl BlockDiffusionDraftHead {
         site: ConvSite,
         sublayer_out: DevicePtr,
         ctx: &ForwardContext,
+        n_seq: u32,
         stream: u64,
     ) -> Result<DevicePtr> {
         if !self.dflash2_active() {
@@ -160,7 +166,7 @@ impl BlockDiffusionDraftHead {
         let Some((base, _proj)) = self.conv_weights(layer, site) else {
             return Ok(sublayer_out);
         };
-        self.conv_apply(ctx, sublayer_out, base, self.scratch.conv_tmp, 1, stream)?;
+        self.conv_apply(ctx, sublayer_out, base, self.scratch.conv_tmp, 1, n_seq, stream)?;
         Ok(self.scratch.conv_tmp)
     }
 
@@ -172,10 +178,13 @@ impl BlockDiffusionDraftHead {
         &self,
         ctx: &ForwardContext,
         norm_noise: DevicePtr,
+        n_seq: u32,
         stream: u64,
     ) -> Result<()> {
         let gpu = ctx.gpu;
+        let n = n_seq.max(1);
         let g = self.gamma as u32;
+        let rows = g * n;
         let vocab = self.vocab_size as u32;
         let rank = self.selector_rank as u32;
         let hproj = self
@@ -198,7 +207,7 @@ impl BlockDiffusionDraftHead {
         // topk (non-destructive to tokens) → hproj → WALK (reads tokens[0] =
         // last_token) → row-0 argmax LAST.
         KernelLaunch::new(gpu, self.kernels.dflash2_topk16)
-            .grid([g, 1, 1])
+            .grid([rows, 1, 1])
             .block([1024, 1, 1])
             .arg_ptr(self.scratch.logits)
             .arg_ptr(self.scratch.sel_vals)
@@ -213,7 +222,7 @@ impl BlockDiffusionDraftHead {
             norm_noise,
             hproj,
             self.scratch.sel_hproj,
-            g,
+            rows,
             rank,
             self.hidden_size as u32,
             stream,
@@ -221,7 +230,8 @@ impl BlockDiffusionDraftHead {
 
         // Chain walk: rows 1..γ, prev_1 = tokens[0] (= last_token).
         KernelLaunch::new(gpu, self.kernels.dflash2_selector_walk)
-            .grid([1, 1, 1])
+            // One block per sequence; each chains from its own anchor row.
+            .grid([n, 1, 1])
             .block([512, 1, 1])
             .arg_ptr(self.scratch.sel_vals)
             .arg_ptr(self.scratch.sel_idx)

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -640,7 +640,7 @@ impl BlockDiffusionDraftHead {
             // subgraph. Row 0 keeps holding last_token (the walk's anchor
             // predecessor), which the propose echo-drop discards anyway.
             if self.dflash2_active() {
-                self.dflash2_select_block(ctx, norm_noise_local, stream)?;
+                self.dflash2_select_block(ctx, norm_noise_local, 1, stream)?;
             } else
             // DSpark: when the drafter ships a Markov head, sample the block
             // left-to-right with the low-rank bigram bias (markov.rs). The

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -27,10 +27,20 @@ impl BlockDiffusionDraftHead {
         stream: u64,
         ctx_buffer: Option<(DevicePtr, usize)>,
         option_b: Option<(DevicePtr, u32)>,
+        // `Some` => cross-sequence batch. `last_token` / `position` /
+        // `option_b` then describe sequence 0 only and the batch supplies the
+        // rest; `None` is the single-sequence path, unchanged.
+        batch: Option<&super::DflashBatch<'_>>,
     ) -> Result<Vec<u32>> {
         use crate::layers::ops;
 
-        let g = self.gamma as u32;
+        let n_seq = batch.map_or(1usize, |b| b.last_tokens.len().max(1));
+        // Rows per SEQUENCE vs TOTAL rows in this forward. Weight-bearing ops
+        // take the total; per-sequence things (attention, KV slot writes, the
+        // selector's chain seed) index by band.
+        let block_g = self.gamma as u32;
+        let g = block_g * n_seq as u32;
+        let rows_total = self.gamma * n_seq;
         let h = self.hidden_size as u32;
         let q_dim = (self.num_q_heads * self.head_dim) as u32;
         let kv_dim = (self.num_kv_heads * self.head_dim) as u32;
@@ -286,7 +296,11 @@ impl BlockDiffusionDraftHead {
         let ctx_start = position.saturating_sub(eff_ctx);
         let pos_host: Vec<i32> = (0..eff_ctx)
             .map(|i| (ctx_start + i) as i32)
-            .chain((0..self.gamma).map(|i| (position + i) as i32))
+            .chain((0..n_seq).flat_map(|b| {
+                // Each sequence ropes from ITS OWN absolute position.
+                let base = batch.map_or(position, |x| x.positions[b]);
+                (0..self.gamma).map(move |i| (base + i) as i32)
+            }))
             .collect();
         let pos_bytes: Vec<u8> = pos_host.iter().flat_map(|p| p.to_le_bytes()).collect();
         gpu.copy_h2d(&pos_bytes, self.scratch.position_ids)?;
@@ -317,11 +331,14 @@ impl BlockDiffusionDraftHead {
             )?;
         }
         let token_ids_host: Vec<i32> = std::iter::repeat_n(0i32, eff_ctx)
-            .chain(std::iter::once(last_token as i32))
-            .chain(std::iter::repeat_n(
-                self.mask_token_id as i32,
-                self.gamma - 1,
-            ))
+            .chain((0..n_seq).flat_map(|b| {
+                // Band b: that sequence's own anchor, then gamma-1 masks.
+                let anchor = batch.map_or(last_token, |x| x.last_tokens[b]);
+                std::iter::once(anchor as i32).chain(std::iter::repeat_n(
+                    self.mask_token_id as i32,
+                    self.gamma - 1,
+                ))
+            }))
             .collect();
         if debug_dump {
             tracing::info!(
@@ -395,33 +412,45 @@ impl BlockDiffusionDraftHead {
         // once and reused across all drafter layers.
         let slot_mapping_gamma_opt = if option_b_on {
             let bt = option_b_block_table.unwrap();
-            // Build γ slot indices starting at logical position ctx_count.
-            ops::fill_slots_from_block_table(
-                gpu,
-                self.kernels.fill_slots,
-                self.scratch.slot_mapping_dev,
-                bt,
-                option_b_ctx_count,
-                self.gamma as u32,
-                16,
-                stream,
-            )?;
+            // Build γ slot indices per sequence, each starting at ITS OWN
+            // ctx_count and addressed through ITS OWN block table, packed
+            // seq-major so the layer body's single reshape_and_cache over
+            // `n*γ` rows writes every sequence's K/V to the right pages.
+            for b in 0..n_seq {
+                let (bt_b, cc_b) = match batch {
+                    Some(x) => (x.block_tables[b], x.ctx_counts[b]),
+                    None => (bt, option_b_ctx_count),
+                };
+                ops::fill_slots_from_block_table(
+                    gpu,
+                    self.kernels.fill_slots,
+                    self.scratch.slot_mapping_dev.offset(b * self.gamma * 8),
+                    bt_b,
+                    cc_b,
+                    self.gamma as u32,
+                    16,
+                    stream,
+                )?;
+            }
             // Phase 5 (CUDA graph) pre-graph write: stash the per-propose
             // dynamic `[kv_len, q_offset, q_rope_pos]` triple into the
             // indirect-args buffer (12 bytes). The graph-captured paged-
             // attention launch reads from this pointer at kernel entry.
             // q_offset = ctx_count (cache-block addressing).
             // q_rope_pos = position (true decode position for query RoPE).
-            let kv_len = option_b_ctx_count + self.gamma as u32;
-            let q_offset = option_b_ctx_count;
-            let q_rope_pos = position as u32;
-            let indirect_bytes: [u8; 12] = {
-                let mut b = [0u8; 12];
-                b[0..4].copy_from_slice(&kv_len.to_ne_bytes());
-                b[4..8].copy_from_slice(&q_offset.to_ne_bytes());
-                b[8..12].copy_from_slice(&q_rope_pos.to_ne_bytes());
-                b
-            };
+            // One triple per sequence — attention launches per band and reads
+            // the triple at its own slot (`+ b*12`).
+            let mut indirect_bytes: Vec<u8> = Vec::with_capacity(n_seq * 12);
+            for b in 0..n_seq {
+                let cc_b = match batch {
+                    Some(x) => x.ctx_counts[b],
+                    None => option_b_ctx_count,
+                };
+                let pos_b = batch.map_or(position, |x| x.positions[b]) as u32;
+                indirect_bytes.extend_from_slice(&(cc_b + block_g).to_ne_bytes());
+                indirect_bytes.extend_from_slice(&cc_b.to_ne_bytes());
+                indirect_bytes.extend_from_slice(&pos_b.to_ne_bytes());
+            }
             gpu.copy_h2d(&indirect_bytes, self.scratch.option_b_indirect_args_dev)?;
             Some(self.scratch.slot_mapping_dev)
         } else {
@@ -523,8 +552,8 @@ impl BlockDiffusionDraftHead {
                     block_dump: block_dump_armed,
                     // Single-sequence propose. The batched entry builds its
                     // own args with n_seq > 1 and per-sequence tables.
-                    n_seq: 1,
-                    seq_block_tables: Vec::new(),
+                    n_seq: n_seq as u32,
+                    seq_block_tables: batch.map(|x| x.block_tables.clone()).unwrap_or_default(),
                 })
             };
 
@@ -558,7 +587,7 @@ impl BlockDiffusionDraftHead {
                 stream_noise_local,
                 &self.norm,
                 norm_noise_local,
-                self.gamma as u32,
+                g,
                 h_local,
                 self.rms_norm_eps,
                 stream,
@@ -581,7 +610,7 @@ impl BlockDiffusionDraftHead {
                     // numerics are correctness-free under strict-argmax
                     // accept. ATLAS_NO_DFLASH_FP8_RT=1 restores the tile.
                     if self.kernels.fp8_gemv_rt2.0 != 0
-                        && self.gamma as u32 <= 8
+                        && g <= 8
                         && h_local.is_multiple_of(16)
                         && super::fp8_rt_enabled()
                     {
@@ -591,7 +620,7 @@ impl BlockDiffusionDraftHead {
                             norm_noise_local,
                             fp8,
                             self.scratch.logits,
-                            self.gamma as u32,
+                            g,
                             self.vocab_size as u32,
                             h_local,
                             stream,
@@ -603,7 +632,7 @@ impl BlockDiffusionDraftHead {
                             norm_noise_local,
                             fp8,
                             self.scratch.logits,
-                            self.gamma as u32,
+                            g,
                             self.vocab_size as u32,
                             h_local,
                             stream,
@@ -618,7 +647,7 @@ impl BlockDiffusionDraftHead {
                             weight: self.lm_head_shared,
                         },
                         self.scratch.logits,
-                        self.gamma as u32,
+                        g,
                         self.vocab_size as u32,
                         h_local,
                         stream,
@@ -633,7 +662,7 @@ impl BlockDiffusionDraftHead {
                         weight: self.lm_head_shared,
                     },
                     self.scratch.logits,
-                    self.gamma as u32,
+                    g,
                     self.vocab_size as u32,
                     h_local,
                     stream,
@@ -1012,7 +1041,7 @@ impl BlockDiffusionDraftHead {
         // would mean the field was never initialised.
         anyhow::ensure!(
             !pinned_ptr.is_null(),
-            "DFlash draft-token pinned staging buffer is null (γ={})",
+            "DFlash draft-token pinned staging buffer is null (γ={}, rows={rows_total})",
             self.gamma
         );
         // SAFETY: `pinned_ptr` is the page-locked allocation made by
@@ -1032,8 +1061,12 @@ impl BlockDiffusionDraftHead {
         // code path, and `host_buf` is the sole live reference to it (dropped
         // before the next propose). `copy_d2h_on_stream` drains `stream` before
         // returning, so no DMA is in flight against it when we read below.
+        // `rows_total * 4` bytes: one u32 per drafted row across every band.
+        // The allocation is `nb * gamma * 4` (from_weights) and n_seq <= nb,
+        // so this span is within it; at n_seq == 1 it is exactly `gamma * 4`
+        // as before.
         let host_buf: &mut [u8] =
-            unsafe { std::slice::from_raw_parts_mut(pinned_ptr, self.gamma * 4) };
+            unsafe { std::slice::from_raw_parts_mut(pinned_ptr, rows_total * 4) };
         gpu.copy_d2h_on_stream(self.scratch.draft_tokens_dev, host_buf, stream)?;
         gpu.record_event(self.scratch.draft_tokens_event, stream)?;
         gpu.event_synchronize(self.scratch.draft_tokens_event)?;

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -472,6 +472,12 @@ impl BlockDiffusionDraftHead {
         // ramp, and L2 warming all happen eagerly before capture freezes
         // a steady-state SASS pick.
         let graph_eligible = option_b_on
+            // A captured graph bakes in the row count, the per-band pointers
+            // and the attention launch count. Replaying an n=1 capture for a
+            // batch runs one sequence's shapes over n sequences' rows, which
+            // shows up as a silent accept collapse rather than an error. The
+            // batched path is a different shape per width, so it stays eager.
+            && n_seq == 1
             && !self
                 .suppress_graphs
                 .load(std::sync::atomic::Ordering::Relaxed)
@@ -673,7 +679,7 @@ impl BlockDiffusionDraftHead {
             // subgraph. Row 0 keeps holding last_token (the walk's anchor
             // predecessor), which the propose echo-drop discards anyway.
             if self.dflash2_active() {
-                self.dflash2_select_block(ctx, norm_noise_local, 1, stream)?;
+                self.dflash2_select_block(ctx, norm_noise_local, n_seq as u32, stream)?;
             } else
             // DSpark: when the drafter ships a Markov head, sample the block
             // left-to-right with the low-rank bigram bias (markov.rs). The

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -84,7 +84,12 @@ impl BlockDiffusionDraftHead {
         let option_b_on = option_b_block_table.is_some();
         let eff_ctx = if option_b_on { 0 } else { eff_ctx };
         let _ = ctx_base_ptr; // Option B doesn't read ctx from this path
-        let n_attn = (eff_ctx + self.gamma) as u32;
+        // Rows this forward actually touches: the ctx window (legacy path)
+        // plus gamma rows PER SEQUENCE. This is the row count the embed and
+        // every row-bounded op take, so leaving it at one band's worth means
+        // only band 0 gets embedded and every other sequence drafts from
+        // whatever the previous propose left in stream_buf.
+        let n_attn = (eff_ctx + self.gamma * n_seq) as u32;
         let target_hidden_dim = self.target_layer_ids.len() * self.target_hidden_size;
         let ctx_slot_bytes = target_hidden_dim * bf16;
 
@@ -632,9 +637,33 @@ impl BlockDiffusionDraftHead {
                             stream,
                         )?;
                     } else {
-                        ops::fp8_gemm_n128_row_scaled_m16(
+                        // `fp8_gemm_t_row_scaled_m16` is a single-warp
+                        // M_TILE=16 kernel: valid only to M=16. One sequence
+                        // (gamma rows) always fits, which is why the
+                        // single-sequence path can call it unconditionally —
+                        // but a cross-sequence batch does NOT: at n=4 this is
+                        // 32 rows and at n=8 it is 64, and past the tile the
+                        // kernel silently returns garbage for the rows it
+                        // never covered. That reads as a drafter that has
+                        // stopped guessing well (accept 73% -> 24% at C=8),
+                        // not as a kernel used out of contract. Above the
+                        // tile, take the general row-scaled GEMM.
+                        let (k_lm, h_lm) = if g <= 16 {
+                            (
+                                self.kernels.fp8_gemm_n128_row_scaled_m16,
+                                ops::fp8_gemm_n128_row_scaled_m16
+                                    as fn(_, _, _, _, _, _, _, _, _) -> Result<()>,
+                            )
+                        } else {
+                            (
+                                self.kernels.fp8_gemm_n128_row_scaled,
+                                ops::fp8_gemm_n128_row_scaled
+                                    as fn(_, _, _, _, _, _, _, _, _) -> Result<()>,
+                            )
+                        };
+                        h_lm(
                             gpu,
-                            self.kernels.fp8_gemm_n128_row_scaled_m16,
+                            k_lm,
                             norm_noise_local,
                             fp8,
                             self.scratch.logits,

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -521,6 +521,10 @@ impl BlockDiffusionDraftHead {
                     block_table_dev: bt,
                     stream,
                     block_dump: block_dump_armed,
+                    // Single-sequence propose. The batched entry builds its
+                    // own args with n_seq > 1 and per-sequence tables.
+                    n_seq: 1,
+                    seq_block_tables: Vec::new(),
                 })
             };
 

--- a/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
@@ -217,9 +217,7 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Attention,
             self.scratch.norm_buf,
-            ctx,
-            stream,
-        )?;
+            ctx, 1, stream)?;
 
         // Phase G: when self.quant == Fp8Weights, swap each dense_gemm
         // for fp8_gemm_n128_row_scaled against the FP8 mirror weight.
@@ -954,9 +952,7 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Attention,
             self.scratch.stream_acc,
-            ctx,
-            stream,
-        )?;
+            ctx, 1, stream)?;
 
         // 3h. First residual add: hidden = residual + attn_output.
         // dflash.py:138  hidden_states = residual + hidden_states
@@ -996,9 +992,7 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Mlp,
             self.scratch.norm_buf,
-            ctx,
-            stream,
-        )?;
+            ctx, 1, stream)?;
 
         // 3j. MLP: gate_proj + up_proj + silu_mul + down_proj — γ rows.
         // dflash.py:141  hidden_states = self.mlp(hidden_states)
@@ -1045,9 +1039,7 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Mlp,
             self.scratch.stream_acc,
-            ctx,
-            stream,
-        )?;
+            ctx, 1, stream)?;
 
         // 3k. Second residual add: hidden = (residual + attn) + mlp_output.
         // dflash.py:142  hidden_states = residual + hidden_states

--- a/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
@@ -234,7 +234,10 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Attention,
             self.scratch.norm_buf,
-            ctx, 1, stream)?;
+            ctx,
+            args.n_seq.max(1),
+            stream,
+        )?;
 
         // Phase G: when self.quant == Fp8Weights, swap each dense_gemm
         // for fp8_gemm_n128_row_scaled against the FP8 mirror weight.
@@ -1004,7 +1007,10 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Attention,
             self.scratch.stream_acc,
-            ctx, 1, stream)?;
+            ctx,
+            args.n_seq.max(1),
+            stream,
+        )?;
 
         // 3h. First residual add: hidden = residual + attn_output.
         // dflash.py:138  hidden_states = residual + hidden_states
@@ -1044,7 +1050,10 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Mlp,
             self.scratch.norm_buf,
-            ctx, 1, stream)?;
+            ctx,
+            args.n_seq.max(1),
+            stream,
+        )?;
 
         // 3j. MLP: gate_proj + up_proj + silu_mul + down_proj — γ rows.
         // dflash.py:141  hidden_states = self.mlp(hidden_states)
@@ -1091,7 +1100,10 @@ impl BlockDiffusionDraftHead {
             layer,
             super::dflash2::ConvSite::Mlp,
             self.scratch.stream_acc,
-            ctx, 1, stream)?;
+            ctx,
+            args.n_seq.max(1),
+            stream,
+        )?;
 
         // 3k. Second residual add: hidden = (residual + attn) + mlp_output.
         // dflash.py:142  hidden_states = residual + hidden_states

--- a/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
@@ -73,6 +73,19 @@ pub(super) struct PagedLayerArgs {
     /// ATLAS_DFLASH_BLOCK_DUMP=1 upstream; forces the eager path (graph
     /// capture cannot contain the D2H/sync this dump injects).
     pub block_dump: bool,
+    /// Sequences packed into this forward. Rows are seq-major: sequence i owns
+    /// `[i*gamma, (i+1)*gamma)`. Every weight-bearing op below runs over all
+    /// `n_seq * gamma` rows at once, which is the entire point — the drafter
+    /// weights are read once instead of n times. `1` is the single-sequence
+    /// path and behaves exactly as before.
+    pub n_seq: u32,
+    /// Per-sequence drafter block tables, `n_seq` long. Attention is the ONLY
+    /// op that needs them: it reads each sequence's own KV pages, so it runs
+    /// as `n_seq` launches over row bands rather than one batched launch.
+    /// That costs launch overhead only — attention reads no WEIGHTS, so there
+    /// is nothing to amortise. Empty on the single-sequence path, which uses
+    /// `block_table_dev`.
+    pub seq_block_tables: Vec<DevicePtr>,
 }
 
 impl BlockDiffusionDraftHead {
@@ -175,8 +188,12 @@ impl BlockDiffusionDraftHead {
             ..
         } = *args;
         let gpu = ctx.gpu;
-        let g = self.gamma as u32;
-        let kv_len = ctx_count + g;
+        // `block_g` = rows per SEQUENCE, `g` = TOTAL rows in this forward.
+        // Weight-bearing ops below want the total; anything describing one
+        // sequence's attention window wants the per-sequence length.
+        let block_g = self.gamma as u32;
+        let g = block_g * args.n_seq.max(1);
+        let kv_len = ctx_count + block_g;
 
         // 3a. input_layernorm — γ rows.
         // dflash.py:125  hidden_states = self.input_layernorm(hidden_states)
@@ -604,24 +621,46 @@ impl BlockDiffusionDraftHead {
         // as scalar args, so the captured launch survives per-call value
         // changes. Host writes the 8-byte pair in forward_block.rs
         // pre-graph; replays pick up whatever's there.
-        ops::prefill_attention_paged_dflash_bf16_indirect(
-            gpu,
-            self.kernels.prefill_attn_dflash_bf16_indirect,
-            self.scratch.q_buf,
-            k_pool,
-            v_pool,
-            self.scratch.attn_out,
-            block_table_dev,
-            g,
-            self.scratch.option_b_indirect_args_dev,
-            self.num_q_heads as u32,
-            self.num_kv_heads as u32,
-            self.head_dim as u32,
-            16, // cache_block_size
-            0,  // sliding_window — drafter not windowed for now
-            inv_sqrt_d,
-            stream,
-        )?;
+        // One launch per sequence over its own row band. `g` here is the
+        // PER-SEQUENCE block length (q_len), never the batch total: each
+        // sequence's gamma queries attend over its own ctx+gamma KV pages.
+        // Attention reads no weights, so looping costs launch overhead and
+        // nothing else — there is no weight traffic to amortise here.
+        let n_seq = args.n_seq.max(1) as usize;
+        let q_dim_bytes = (self.num_q_heads * self.head_dim) * 2;
+        for i in 0..n_seq {
+            let (bt_i, args_i) = if n_seq == 1 {
+                (block_table_dev, self.scratch.option_b_indirect_args_dev)
+            } else {
+                (
+                    // Sequence i's own drafter block table, and its own
+                    // [kv_len, q_offset, q_rope_pos] triple written by the
+                    // caller at slot i (3 x u32 = 12 bytes).
+                    *args.seq_block_tables.get(i).ok_or_else(|| {
+                        anyhow::anyhow!("dflash attn: no block table for seq {i}")
+                    })?,
+                    self.scratch.option_b_indirect_args_dev.offset(i * 12),
+                )
+            };
+            ops::prefill_attention_paged_dflash_bf16_indirect(
+                gpu,
+                self.kernels.prefill_attn_dflash_bf16_indirect,
+                self.scratch.q_buf.offset(i * g as usize * q_dim_bytes),
+                k_pool,
+                v_pool,
+                self.scratch.attn_out.offset(i * g as usize * q_dim_bytes),
+                bt_i,
+                g,
+                args_i,
+                self.num_q_heads as u32,
+                self.num_kv_heads as u32,
+                self.head_dim as u32,
+                16, // cache_block_size
+                0,  // sliding_window — drafter not windowed for now
+                inv_sqrt_d,
+                stream,
+            )?;
+        }
 
         // id259 per-layer dump: post-attention output (pre o_proj), γ × q_dim.
         if args.block_dump {
@@ -671,6 +710,17 @@ impl BlockDiffusionDraftHead {
             ..
         } = *args;
         let gpu = ctx.gpu;
+        // CONTIG_ATTN is the non-indirect fallback and is single-sequence
+        // only: it addresses one contiguous ctx+gamma window, which is not
+        // what a seq-major batch looks like. Refuse rather than silently
+        // reading another sequence's rows — the caller drops to per-sequence
+        // propose when this returns an error.
+        anyhow::ensure!(
+            args.n_seq.max(1) == 1,
+            "CONTIG_ATTN: batched propose (n_seq={}) needs the indirect paged \
+             attention path; set ATLAS_DFLASH_CONTIG_ATTN=0",
+            args.n_seq
+        );
         let g = self.gamma as u32;
         let ctx_us = ctx_count as usize;
         let g_us = g as usize;
@@ -869,7 +919,9 @@ impl BlockDiffusionDraftHead {
             ..
         } = *args;
         let gpu = ctx.gpu;
-        let g = self.gamma as u32;
+        // Total rows: o_proj and the FFN are weight-bearing, so they span
+        // every sequence in the batch.
+        let g = self.gamma as u32 * args.n_seq.max(1);
 
         // Phase G — same swap helper as pre_attn (q/k/v). Single call
         // site per logical GEMM; the row-scaled FP8 GEMM kernel applies

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -28,7 +28,13 @@ impl BlockDiffusionDraftHead {
         window_size: Option<usize>,
         gpu: &dyn GpuBackend,
         max_seq_len: usize,
+        // Widest cross-sequence batch the drafter must serve in ONE forward.
+        // The gamma-sized scratch below is allocated in per-sequence BANDS of
+        // gamma rows so a batched propose can stack n sequences; nb == 1 keeps
+        // the original single-band sizes byte for byte.
+        max_batch: usize,
     ) -> Result<Self> {
+        let nb = max_batch.max(1);
         // Drafter's `fc` is `[draft_hidden, len(target_layer_ids) * target_hidden]`.
         // We rely on the drafter config's `hidden_size` and the parsed
         // `target_layer_ids` to derive the expected target_hidden, then
@@ -259,18 +265,21 @@ impl BlockDiffusionDraftHead {
             ctx_window
         );
         let n_attn = g + ctx_window; // total attention slots
+        // Rows the scratch must hold: the legacy ctx+gamma window, or nb
+        // bands of gamma for a batched propose, whichever is larger.
+        let rows_max = n_attn.max(nb * gamma_val);
         let q_dim = num_q_heads * head_dim;
         let kv_dim = num_kv_heads * head_dim;
         let scratch = DflashScratch {
-            stream_buf: gpu.alloc(n_attn * hidden_size * bf16)?,
-            norm_buf: gpu.alloc(n_attn * hidden_size * bf16)?,
-            q_buf: gpu.alloc(n_attn * q_dim * bf16)?,
-            k_buf: gpu.alloc(n_attn * kv_dim * bf16)?,
-            v_buf: gpu.alloc(n_attn * kv_dim * bf16)?,
-            attn_out: gpu.alloc(n_attn * q_dim * bf16)?,
-            mlp_intermediate: gpu.alloc(n_attn * intermediate_size * bf16)?,
-            mlp_up: gpu.alloc(n_attn * intermediate_size * bf16)?,
-            stream_acc: gpu.alloc(n_attn * hidden_size * bf16)?,
+            stream_buf: gpu.alloc(rows_max * hidden_size * bf16)?,
+            norm_buf: gpu.alloc(rows_max * hidden_size * bf16)?,
+            q_buf: gpu.alloc(rows_max * q_dim * bf16)?,
+            k_buf: gpu.alloc(rows_max * kv_dim * bf16)?,
+            v_buf: gpu.alloc(rows_max * kv_dim * bf16)?,
+            attn_out: gpu.alloc(rows_max * q_dim * bf16)?,
+            mlp_intermediate: gpu.alloc(rows_max * intermediate_size * bf16)?,
+            mlp_up: gpu.alloc(rows_max * intermediate_size * bf16)?,
+            stream_acc: gpu.alloc(rows_max * hidden_size * bf16)?,
             fc_proj: gpu.alloc(ctx_window * hidden_size * bf16)?,
             // Phase 2 (Option B) precompute scratch. Worst-case the
             // first propose runs precompute over the whole captured
@@ -286,7 +295,7 @@ impl BlockDiffusionDraftHead {
             // `[u32 kv_len, u32 q_offset, u32 q_rope_pos]` that the indirect
             // paged-attention kernel reads at entry. Host writes via H2D
             // BEFORE entering the captured region.
-            option_b_indirect_args_dev: gpu.alloc(12)?,
+            option_b_indirect_args_dev: gpu.alloc(nb * 12)?,
             // Phase E.2: pinned host buffer + event for the per-propose
             // drafter D2H. Pinned memory lets cuMemcpyDtoHAsync issue a
             // true async DMA on the caller's stream (vs. the synchronous
@@ -295,16 +304,16 @@ impl BlockDiffusionDraftHead {
             // so target-model verify work issued on the same stream can
             // proceed in parallel.
             draft_tokens_host_pinned: std::sync::atomic::AtomicPtr::new(
-                gpu.alloc_host_pinned(gamma_val * 4)?,
+                gpu.alloc_host_pinned(nb * gamma_val * 4)?,
             ),
             draft_tokens_event: gpu.create_event()?,
             // γ rows only — NOT n_attn. The lm_head GEMM writes M=γ rows,
             // argmax + BLOCK_DUMP read rows 0..γ, and no path indexes logits
             // by ctx offset. Sizing at n_attn×vocab would cost 2.04 GB at
             // cw=4096 for rows nothing ever touches (γ rows ≈ 8.4 MB).
-            logits: gpu.alloc(g * vocab_size * bf16)?,
-            draft_tokens_dev: gpu.alloc(n_attn * 4)?,
-            position_ids: gpu.alloc(n_attn * 4)?,
+            logits: gpu.alloc(nb * g * vocab_size * bf16)?,
+            draft_tokens_dev: gpu.alloc(rows_max * 4)?,
+            position_ids: gpu.alloc(rows_max * 4)?,
             // DSpark Markov scratch. Only allocated when the drafter config
             // declares a Markov head; `DevicePtr(0)` otherwise so the plain
             // DFlash path costs nothing.
@@ -329,22 +338,22 @@ impl BlockDiffusionDraftHead {
                 let cfg = weights.config.dflash_config.as_ref();
                 let ksz = cfg.map(|c| c.conv_kernel_size).unwrap_or(0).max(1);
                 let gsz = cfg.map(|c| c.conv_group_size).unwrap_or(0).max(1);
-                gpu.alloc(g * 2 * ksz * (hidden_size / gsz) * bf16)?
+                gpu.alloc(nb * g * 2 * ksz * (hidden_size / gsz) * bf16)?
             } else {
                 DevicePtr(0)
             },
             conv_tmp: if weights.selector_pred.is_some() {
-                gpu.alloc(g * hidden_size * bf16)?
+                gpu.alloc(nb * g * hidden_size * bf16)?
             } else {
                 DevicePtr(0)
             },
             sel_vals: if weights.selector_pred.is_some() {
-                gpu.alloc(g * 16 * 4)?
+                gpu.alloc(nb * g * 16 * 4)?
             } else {
                 DevicePtr(0)
             },
             sel_idx: if weights.selector_pred.is_some() {
-                gpu.alloc(g * 16 * 4)?
+                gpu.alloc(nb * g * 16 * 4)?
             } else {
                 DevicePtr(0)
             },
@@ -356,7 +365,7 @@ impl BlockDiffusionDraftHead {
                     .map(|c| c.selector_rank)
                     .unwrap_or(256)
                     .max(1);
-                gpu.alloc(g * rank * bf16)?
+                gpu.alloc(nb * g * rank * bf16)?
             } else {
                 DevicePtr(0)
             },

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -515,6 +515,7 @@ impl BlockDiffusionDraftHead {
             vocab_size,
             draft_vocab_size: weights.config.draft_vocab_size.unwrap_or(vocab_size),
             gamma: gamma_val,
+            max_batch: nb,
             mask_token_id,
             window_size,
             target_layer_ids,

--- a/crates/spark-model/src/layers/dflash_head/propose.rs
+++ b/crates/spark-model/src/layers/dflash_head/propose.rs
@@ -274,50 +274,89 @@ impl BlockDiffusionDraftHead {
         }
 
         // ── Phase 2 Option B: lazy block_table allocation ─────────────
-        // When ATLAS_DFLASH_OPTION_B=1 and the proposer hasn't yet
-        // allocated paged blocks, do it now. We allocate enough blocks
-        // to cover the full ctx_hidden_acc plus a safety margin for γ.
-        // Block_size matches from_weights.rs:68 (=16).
-        // Default ON since the 54.5 record config (2026-08-19): the paged
-        // drafter cache is the proven path. `=0` is the kill switch.
+        // DEFAULT-ON (ATLAS_DFLASH_OPTION_B=0 opts out to the legacy
+        // full-rebuild path): every working DFlash recipe sets it, the
+        // KV budget reserves for its drafter blocks (factory/build.rs
+        // dflash_reserve), and the O(ctx²) rebuild it replaces is the
+        // slow path. When enabled and the proposer hasn't yet allocated
+        // paged blocks, do it now — enough to cover the full
+        // ctx_hidden_acc plus a safety margin for γ. Block_size matches
+        // from_weights.rs:68 (=16).
         let option_b_enabled = std::env::var("ATLAS_DFLASH_OPTION_B").ok().as_deref() != Some("0");
         let option_b_arg: Option<(DevicePtr, u32)> = if option_b_enabled {
-            // Lazy block table init. ctx slots come from precompute over the
-            // accumulated target hiddens; γ slots come from the layer body.
-            // We need ceil((max_ctx_len + γ) / block_size) blocks.
+            // Incremental block allocation. ctx slots come from precompute
+            // over the accumulated target hiddens; γ slots come from the
+            // layer body. The pool holds ONE max-seq-len sequence's worth of
+            // blocks, so the old up-front `max_ctx_len + γ` grab was a
+            // winner-takes-the-pool bug at C>=2: the first sequence took all
+            // ~2049 blocks and every other stream's propose failed at block
+            // 0/2049 — drafting blind for its whole overlap (measured 59% vs
+            // 4-7% accept across C=4 streams). Allocate only what the CURRENT
+            // ctx needs, growing in `GROW_BLOCKS` chunks as ctx accumulates;
+            // the device table is sized for the max up front (u32 per block,
+            // ~8 KB) so growth only appends entries at a fixed address.
             const BLOCK_SIZE: usize = 16;
-            let blocks_needed = (dstate.max_ctx_len + self.gamma + 1).div_ceil(BLOCK_SIZE);
+            const GROW_BLOCKS: usize = 64; // 1024 slots per growth step
+            let max_blocks = (dstate.max_ctx_len + self.gamma + 1).div_ceil(BLOCK_SIZE);
+            let need_blocks = (dstate.ctx_len + self.gamma + 1)
+                .div_ceil(BLOCK_SIZE)
+                .next_multiple_of(GROW_BLOCKS)
+                .min(max_blocks);
             if dstate.block_table_dev.is_none() {
-                let mut cache = self.kv_cache.lock();
+                // First propose: full-size device table, empty host vec.
+                let bt_dev = ctx.gpu.alloc(max_blocks * std::mem::size_of::<u32>())?;
                 dstate.block_table.clear();
-                for _ in 0..blocks_needed {
-                    match cache.try_alloc_block() {
-                        Some(b) => dstate.block_table.push(b),
-                        None => {
-                            anyhow::bail!(
-                                "DFlash Option B: paged KV cache exhausted at block {}/{}",
-                                dstate.block_table.len(),
-                                blocks_needed
-                            );
+                dstate.block_table_dev = Some(bt_dev);
+                dstate.max_ctx_count_drafter = 0;
+            }
+            if need_blocks > dstate.block_table.len() {
+                let have = dstate.block_table.len();
+                let mut fresh: Vec<u32> = Vec::with_capacity(need_blocks - have);
+                {
+                    let mut cache = self.kv_cache.lock();
+                    for _ in have..need_blocks {
+                        match cache.try_alloc_block() {
+                            Some(b) => fresh.push(b),
+                            None => break,
                         }
                     }
                 }
-                drop(cache);
-                // Copy block_table to device.
-                let bt_bytes: Vec<u8> = dstate
-                    .block_table
-                    .iter()
-                    .flat_map(|b| b.to_le_bytes())
-                    .collect();
-                let bt_dev = ctx.gpu.alloc(bt_bytes.len())?;
-                ctx.gpu.copy_h2d(&bt_bytes, bt_dev)?;
-                dstate.block_table_dev = Some(bt_dev);
-                dstate.max_ctx_count_drafter = blocks_needed * BLOCK_SIZE;
-                tracing::info!(
-                    "DFlash Option B: allocated {} blocks ({} slots) for drafter paged cache",
-                    blocks_needed,
-                    dstate.max_ctx_count_drafter
-                );
+                // Shortfall that leaves even the CURRENT ctx uncovered: put
+                // the partial grab back (the old code leaked it via a later
+                // `clear()`), skip drafting this step, and retry next propose
+                // — blocks free up when a concurrent stream completes.
+                let covered = (have + fresh.len()) * BLOCK_SIZE;
+                if covered < dstate.ctx_len + self.gamma + 1 {
+                    if !fresh.is_empty() {
+                        self.kv_cache.lock().free_blocks(&fresh);
+                    }
+                    tracing::warn!(
+                        "DFlash Option B: drafter block pool exhausted \
+                         (have {} blocks, need {} for ctx_len={}); drafting \
+                         blind this step, will retry",
+                        have,
+                        need_blocks,
+                        dstate.ctx_len
+                    );
+                    return Ok(Vec::new());
+                }
+                if !fresh.is_empty() {
+                    let bt_bytes: Vec<u8> = fresh.iter().flat_map(|b| b.to_le_bytes()).collect();
+                    let bt_dev = dstate.block_table_dev.expect("initialized above");
+                    ctx.gpu
+                        .copy_h2d(&bt_bytes, bt_dev.offset(have * std::mem::size_of::<u32>()))?;
+                    dstate.block_table.extend_from_slice(&fresh);
+                    dstate.max_ctx_count_drafter = dstate.block_table.len() * BLOCK_SIZE;
+                    if have == 0 {
+                        tracing::info!(
+                            "DFlash Option B: allocated {} blocks ({} slots) for drafter \
+                             paged cache (incremental, max {})",
+                            dstate.block_table.len(),
+                            dstate.max_ctx_count_drafter,
+                            max_blocks
+                        );
+                    }
+                }
             }
             // Phase I (v2) — incremental ctx precompute (design doc §18).
             // Only the new tail [ctx_committed..ctx_len) needs its K/V

--- a/crates/spark-model/src/layers/dflash_head/propose.rs
+++ b/crates/spark-model/src/layers/dflash_head/propose.rs
@@ -507,6 +507,9 @@ impl BlockDiffusionDraftHead {
                     None
                 },
                 option_b_arg,
+                // Single-sequence propose. `propose_drafts_batched` is the
+                // cross-sequence entry.
+                None,
             )
             .map_err(|e| {
                 tracing::warn!("DFlash forward_block failed, falling back to no-spec: {e:#}");

--- a/crates/spark-model/src/layers/dflash_head/propose.rs
+++ b/crates/spark-model/src/layers/dflash_head/propose.rs
@@ -25,6 +25,13 @@ impl BlockDiffusionDraftHead {
         _draft_embed_target: Option<DevicePtr>,
         _grammar_bitmask: Option<&[i32]>,
         target_hidden_stack: Option<DevicePtr>,
+        // `Some` => run only the per-sequence PREP (ctx append, Option-B block
+        // growth, the incremental ctx precompute), push this sequence's
+        // `(block_table, ctx_count)` and return without a forward. The batched
+        // entry collects n of these and runs ONE forward over all the bands.
+        // Sharing the prep this way is deliberate: the batched and
+        // single-sequence paths cannot drift apart if only one of them exists.
+        collect_prep: Option<&mut Vec<(DevicePtr, u32)>>,
     ) -> Result<Vec<u32>> {
         let dstate = state
             .as_any_mut()
@@ -492,6 +499,17 @@ impl BlockDiffusionDraftHead {
         } else {
             None
         };
+
+        if let Some(sink) = collect_prep {
+            let arg = option_b_arg.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "batched DFlash propose requires Option B (paged drafter KV); \
+                     set ATLAS_DFLASH_OPTION_B=1 or let the batched path decline"
+                )
+            })?;
+            sink.push(arg);
+            return Ok(Vec::new());
+        }
 
         let drafts = self
             .forward_block(

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -502,10 +502,17 @@ impl TransformerModel {
         // max verify K = gamma) so the K=gamma EAGLE path can capture every verify row;
         // pre-fix paths use only rows 0-1. Stored on the model as the single
         // source of truth so `try_dflash_capture_all` can bound its writes.
+        //
+        // Widened to `max_batch_size` K-row BANDS: a cross-sequence batched
+        // K=gamma verify (and batched decode) captures every (sequence, row)
+        // pair, sequence i writing band i at row `i * dflash_kgamma`. The
+        // scheduler reads a band back through `commit_ctx`'s `scratch_row`.
+        // Cost is trivial (8 seqs x 9 rows x 5 layers x 5120 x 2 B ~ 3.7 MB)
+        // and the single-sequence paths keep using band 0 unchanged.
         let dflash_hidden_save_rows = if dflash_capture_layers.is_empty() {
             0
         } else {
-            dflash_kgamma.max(2)
+            dflash_kgamma.max(2) * max_batch_size.max(1)
         };
         let dflash_hidden_save = if dflash_capture_layers.is_empty() {
             None
@@ -804,6 +811,7 @@ impl TransformerModel {
             mtp_store_range: parking_lot::Mutex::new((0, 0)),
             dflash_hidden_save,
             dflash_hidden_save_rows,
+            dflash_kgamma,
             dflash_capture_layers,
             verify2_graph: Mutex::new(std::collections::HashMap::new()),
             verify3_graph: Mutex::new(std::collections::HashMap::new()),

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -437,6 +437,25 @@ impl TransformerModel {
         k: usize,
         stream: u64,
     ) -> Result<()> {
+        self.try_dflash_capture_all_at(layer_idx, 0, k, 0, stream)
+    }
+
+    /// [`Self::try_dflash_capture_all`] with explicit SOURCE and DESTINATION
+    /// row bases — the cross-sequence form.
+    ///
+    /// A batched K=γ verify packs `n` sequences seq-major into
+    /// `hidden_states`, so sequence `i`'s rows start at `src_row0 = off[i]`,
+    /// and its capture band starts at `dst_row0 = i * dflash_kgamma`. The
+    /// scheduler then hands that same `dst_row0` to `commit_ctx` as
+    /// `scratch_row`. Single-sequence callers pass 0/0 and are unchanged.
+    pub(super) fn try_dflash_capture_all_at(
+        &self,
+        layer_idx: usize,
+        src_row0: usize,
+        k: usize,
+        dst_row0: usize,
+        stream: u64,
+    ) -> Result<()> {
         let dst = match self.dflash_hidden_save {
             Some(p) => p,
             None => return Ok(()),
@@ -459,13 +478,17 @@ impl TransformerModel {
         let ctx_slot_bytes = self.dflash_capture_layers.len() * h * bf16;
         let kmax = self.dflash_hidden_save_rows;
         debug_assert!(
-            k <= kmax,
-            "try_dflash_capture_all: k={k} exceeds dflash_hidden_save_rows={kmax}"
+            dst_row0 + k <= kmax,
+            "try_dflash_capture_all: rows {dst_row0}..{} exceed capacity {kmax}",
+            dst_row0 + k
         );
-        let k_capped = k.min(kmax);
+        let k_capped = k.min(kmax.saturating_sub(dst_row0));
         for t in 0..k_capped {
-            let src = self.buffers.hidden_states().offset(t * h * bf16);
-            let dst_slot = dst.offset(t * ctx_slot_bytes + slot * h * bf16);
+            let src = self
+                .buffers
+                .hidden_states()
+                .offset((src_row0 + t) * h * bf16);
+            let dst_slot = dst.offset((dst_row0 + t) * ctx_slot_bytes + slot * h * bf16);
             self.gpu.copy_d2d_async(src, dst_slot, h * bf16, stream)?;
         }
         Ok(())

--- a/crates/spark-model/src/model/ssm_pool.rs
+++ b/crates/spark-model/src/model/ssm_pool.rs
@@ -252,7 +252,17 @@ impl SsmStatePool {
         // dead K-1 snapshot on-device. `num_intermediates` remains the K
         // ceiling (conv count); the uniform H count is `num_intermediates-1`.
         let replay = rollback_mode == crate::ssm_reserve::SsmRollbackMode::Replay;
-        let uniform_h = num_intermediates != num_drafts + 1;
+        // DFlash's K=γ verify hits EVERY slot at the full width, so its
+        // pools must be uniform — and that must be stated, not inferred.
+        // The old inference (`num_intermediates != num_drafts + 1`) only
+        // held by accident while the DFlash ceiling was a hardcoded 17:
+        // once the pools sized from the real γ (config.dflash_gamma), a
+        // γ+1 at or below num_drafts+1 made the widths EQUAL, the inference
+        // flipped to the MTP ladder tiers, and slots with 3-6 h
+        // intermediates 500'd the first K=8 verify ("SSM MTP intermediate
+        // buffers not allocated", 2026-08-19 C=1/2/4 report run).
+        let uniform_h =
+            !config.dflash_capture_layers.is_empty() || num_intermediates != num_drafts + 1;
         let h_inter_counts: Vec<usize> = if has_mtp && replay {
             // Replay: no per-token snapshots exist — every slot's count is 0
             // (the vec stays populated so accessors keep their shape).

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -481,6 +481,16 @@ impl TransformerModel {
                         attn_us += dt;
                     }
                 }
+                // DFlash multi-row hidden capture: batched decode advances
+                // EVERY sequence one position per step, so every batch row's
+                // per-layer hidden must reach the capture scratch (row i =
+                // seq i) for the scheduler's per-seq `commit_ctx(.., i)`.
+                // Captured inside the graph region — src (shared hidden
+                // buffer) and dst (scratch) are fixed addresses, so replays
+                // stay correct; a borrowed wider graph writes garbage into
+                // rows n..padded_n, which the scheduler never commits.
+                // No-op unless DFlash is on and this is a capture layer.
+                self.try_dflash_capture_all(layer_idx, padded_n, stream)?;
                 if conc_hsd {
                     let _ = dump_hidden(&format!("after_L{:02}", layer_idx), stream);
                 }

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -579,6 +579,7 @@ impl Model for TransformerModel {
         seq: &mut SequenceState,
         num_committed: usize,
         base_pos: usize,
+        scratch_row: usize,
     ) -> Result<()> {
         if num_committed == 0 {
             return Ok(());
@@ -605,6 +606,21 @@ impl Model for TransformerModel {
         }
         let ctx_slot_bytes = n_layers * self.config.hidden_size * 2;
         let stream = self.gpu.default_stream();
+
+        // Scratch-capacity guard: `try_dflash_capture_all` caps its writes at
+        // `dflash_hidden_save_rows` (γ+1), so a batch row beyond that was
+        // never captured — committing it would append a STALE row (poisoned
+        // ctx is worse than a hole). Skip with a warning; only reachable if
+        // --max-num-seqs exceeds γ+1 on a DFlash serve.
+        if scratch_row + num_committed > self.dflash_hidden_save_rows {
+            tracing::warn!(
+                "commit_ctx: scratch rows {}..{} exceed capture capacity {} — skipping (ctx hole)",
+                scratch_row,
+                scratch_row + num_committed,
+                self.dflash_hidden_save_rows,
+            );
+            return Ok(());
+        }
 
         // Watermark slide FIRST, on the ctx_len (row-index) axis. If the
         // incoming rows would exceed capacity, keep the NEWEST rows and drop
@@ -638,7 +654,7 @@ impl Model for TransformerModel {
         // only until the first slide — and the sliding prompts ARE the reds.
         debug_assert_eq!(d.ctx_positions.len(), d.ctx_len);
         for t in 0..num_committed {
-            let row = base.offset(t * ctx_slot_bytes);
+            let row = base.offset((scratch_row + t) * ctx_slot_bytes);
             let dst = d.ctx_hidden_acc.offset(d.ctx_len * ctx_slot_bytes);
             self.gpu.copy_d2d_async(row, dst, ctx_slot_bytes, stream)?;
             d.ctx_positions.push((base_pos + t) as i32);
@@ -649,6 +665,15 @@ impl Model for TransformerModel {
         // internal decode-append so this capture is never double-appended.
         d.skip_next_decode_append = true;
 
+        // Per-commit ledger (debug): the C>=2 GAP diagnosis reads this to
+        // find steps whose commits under-append vs the positions committed.
+        tracing::debug!(
+            "CTX_COMMIT slot={} rows={} base_pos={} ctx_len_after={}",
+            seq.slot_idx,
+            num_committed,
+            base_pos,
+            d.ctx_len,
+        );
         // One-shot activation log so A/B runs can confirm the path is live.
         if self.stats.once("log:dflash_unified_ctx") {
             tracing::info!(

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -574,6 +574,10 @@ impl Model for TransformerModel {
         Ok(())
     }
 
+    fn dflash_capture_band(&self) -> usize {
+        self.dflash_kgamma
+    }
+
     fn commit_ctx(
         &self,
         seq: &mut SequenceState,

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -301,11 +301,22 @@ impl TransformerModel {
                 // the WRONG token's hidden and rows 1.. are stale garbage
                 // (2026-07-09 accept-collapse root cause: EAGLE_FIX=0 under
                 // UNIFIED=1 starved this capture and poisoned drafter ctx).
-                // EAGLE_FIX default ON since the 54.5 record config
-                // (2026-08-19); `=0` is the kill switch.
-                let capture_all = std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref()
-                    != Some("0")
-                    || std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() == Some("1");
+                // Capture-all is DEFAULT-ON. Two names reached this same
+                // behaviour from different directions -- the base layer's
+                // ATLAS_DFLASH_EAGLE_FIX and this lane's
+                // ATLAS_DFLASH_UNIFIED_CTX -- so EITHER set to "0" turns it
+                // off and neither name silently loses its kill switch.
+                // Mirrors the scheduler lever (levers.rs
+                // `dflash_unified_ctx: on_unless_zero`): commit_ctx copies
+                // scratch rows 0..=num_accepted and only capture_all fills
+                // them. Read ONCE -- this site runs under CUDA-graph capture,
+                // where a per-call env read is both a cost and a way to bake
+                // a stale value into a captured graph.
+                static CAPTURE_ALL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+                let capture_all = *CAPTURE_ALL.get_or_init(|| {
+                    std::env::var("ATLAS_DFLASH_EAGLE_FIX").ok().as_deref() != Some("0")
+                        && std::env::var("ATLAS_DFLASH_UNIFIED_CTX").ok().as_deref() != Some("0")
+                });
                 if capture_all {
                     self.try_dflash_capture_all(layer_idx, k, stream)?;
                 } else {

--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -55,8 +55,30 @@ impl TransformerModel {
     /// outside falls back to the per-seq loop.
     pub(super) fn can_batch_verify_dispatch(&self, ks: &[usize]) -> bool {
         let n = ks.len();
+        // Two admissible shapes:
+        //  * MTP ladder — every k in 2..=4, no DFlash capture buffer.
+        //  * DFlash — every k EXACTLY γ+1 (uniform; the block drafter has no
+        //    ragged ladder), and the per-sequence capture bands must fit.
+        //    K=γ+1 has no fused WY kernel, so the GDN body takes the
+        //    per-sequence fallback inside `decode_verify_multi` — byte-
+        //    identical to the single-sequence K=γ path it replaces, while
+        //    every weight-bearing op (QKVZ / o_proj / FFN / lm_head) batches
+        //    across all R rows. That is where the win is: measured gemm_t
+        //    M=9 3679us vs M=36 3837us, i.e. 4x the rows for +4%.
+        let shape_ok = if self.dflash_hidden_save.is_some() {
+            // UNIFORM k, any width the capture band holds. k is
+            // `drafts + 1` and the block drafter returns γ-1 drafts on a
+            // first propose and γ later, so k ranges over 2..=γ+1 — pinning
+            // it to exactly γ+1 silently refused every real batch.
+            self.dflash_kgamma >= 2
+                && ks.iter().all(|&k| (2..=self.dflash_kgamma).contains(&k))
+                && ks.iter().all(|&k| k == ks[0])
+                && n * self.dflash_kgamma <= self.dflash_hidden_save_rows
+        } else {
+            ks.iter().all(|k| (2..=4).contains(k))
+        };
         (2..=crate::layer::VERIFY_WY_TABLE_SEQS).contains(&n)
-            && ks.iter().all(|k| (2..=4).contains(k))
+            && shape_ok
             && ks.iter().sum::<usize>() <= super::verify_e2::VERIFY_ROW_CAP
             && self.comm.is_none()
             // LoRA is NOT a barrier here. Every weight-bearing op this path
@@ -129,12 +151,20 @@ impl TransformerModel {
         off.push(acc);
         let r_total = acc;
         let k_max = ks.iter().copied().max().unwrap_or(0);
+        // Width contract mirrors `can_batch_verify_dispatch`: the MTP ladder
+        // range, or DFlash's uniform K=γ+1.
+        let dflash_k = self
+            .dflash_hidden_save
+            .is_some()
+            .then_some(self.dflash_kgamma);
         ensure!(
             n >= 2
                 && ks.len() == n
-                && ks.iter().all(|k| (2..=4).contains(k))
+                && ks
+                    .iter()
+                    .all(|&k| dflash_k.map_or((2..=4).contains(&k), |g| (2..=g).contains(&k)))
                 && tokens.len() == r_total,
-            "batched verify: n={n} ks={ks:?} tokens={}",
+            "batched verify: n={n} ks={ks:?} tokens={} dflash_k={dflash_k:?}",
             tokens.len()
         );
         // R ≤ VERIFY_ROW_CAP (96): the exact capacity of the meta gaps below
@@ -518,6 +548,26 @@ impl TransformerModel {
                         &ctx,
                         stream,
                     )?;
+                }
+
+                // DFlash per-sequence hidden capture. The rows of this
+                // batched forward are seq-major, so sequence i's k rows start
+                // at `off[i]` and land in ITS OWN capture band at
+                // `i * dflash_kgamma` — the `scratch_row` the scheduler then
+                // passes to `commit_ctx`. Without the band offset every
+                // sequence would overwrite band 0 (the single-sequence
+                // assumption that made batched decode drop ctx rows).
+                // No-op unless DFlash is on and this is a capture layer.
+                if self.dflash_hidden_save.is_some() {
+                    for i in 0..n {
+                        self.try_dflash_capture_all_at(
+                            layer_idx,
+                            off[i],
+                            ks[i],
+                            i * self.dflash_kgamma,
+                            stream,
+                        )?;
+                    }
                 }
 
                 if k4_diag && let Err(e) = self.gpu.synchronize(stream) {

--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -96,7 +96,15 @@ impl TransformerModel {
             // because every sequence fell back to the per-sequence verify
             // loop. `ATLAS_LORA_NO_BATCH_VERIFY=1` restores the refusal.
             && !(self.lora.is_some() && crate::lora::no_batch_verify())
-            && self.dflash_hidden_save.is_none()
+            // NOT `dflash_hidden_save.is_none()`. That guard predates the
+            // DFlash gamma-block path and meant "batched verify is for plain
+            // MTP only". `shape_ok` above now branches on exactly that field:
+            // Some => the DFlash branch (uniform k, rows within
+            // dflash_hidden_save_rows), None => the K=2..4 ladder. Re-testing
+            // it here contradicts the Some arm and makes the DFlash batched
+            // verify unreachable — the whole path silently falls back to the
+            // per-sequence loop, which reads as "concurrency does not
+            // amortise" rather than as a disabled feature.
             && !self.verify_hidden_stash.is_null()
             // HSS: the paged-decode kernel reads HBM only, missing on-disk
             // history (see verify_c2's HSS fallback) — batched path unsupported.

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -273,6 +273,12 @@ pub struct TransformerModel {
     /// `try_dflash_capture_all` must never write past this many rows. Single
     /// source of truth for the buffer's KMAX; 0 when DFlash is disabled.
     pub(super) dflash_hidden_save_rows: usize,
+    /// Rows per per-sequence capture BAND in `dflash_hidden_save` (= γ+1).
+    /// Sequence `i` of a batched K=γ verify owns rows
+    /// `[i * dflash_kgamma, i * dflash_kgamma + k)`; single-sequence paths
+    /// use band 0. This is the stride the scheduler passes to `commit_ctx`
+    /// as `scratch_row`.
+    pub(super) dflash_kgamma: usize,
     /// Cached CUDA graphs for K=2 verification, **keyed by `seq.slot_idx`**.
     /// Same rationale as `decode_graph`: the captured graph has SSM
     /// h_state/conv_state pointers baked in as kernel arguments, so replay for

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -864,6 +864,15 @@ pub trait Model: Send + Sync {
         Ok(())
     }
 
+    /// Rows per per-sequence capture BAND in the DFlash hidden scratch (γ+1).
+    /// Sequence `i` of a batched K=γ verify captures into band `i`, so its
+    /// `commit_ctx` `scratch_row` is `i * dflash_capture_band()`. Returning
+    /// the model's own stride keeps the capture and the commit from ever
+    /// disagreeing. `0` when there is no DFlash drafter.
+    fn dflash_capture_band(&self) -> usize {
+        0
+    }
+
     /// Run the MTP proposer for one draft token off the saved hidden state.
     /// `None` when no proposer is wired.
     fn run_mtp_propose(

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -845,17 +845,21 @@ pub trait Model: Send + Sync {
 
     /// Unified DFlash ctx commit (ATLAS_DFLASH_UNIFIED_CTX=1). Copies
     /// `num_committed` scratch rows (`dflash_hidden_save` rows
-    /// `0..num_committed`) into `ctx_hidden_acc` at the CURRENT TAIL
-    /// (`ctx_len`), stamping RoPE positions `base_pos..base_pos+num_committed`,
-    /// folding the watermark slide in first. `base_pos` is the RoPE position,
-    /// NOT the acc row index (they diverge after a watermark slide — DDD §4.1
-    /// landmine). The single structural replacement for the ~5 fragmented
-    /// appends. Default no-op for models without a DFlash drafter.
+    /// `scratch_row..scratch_row+num_committed`) into `ctx_hidden_acc` at the
+    /// CURRENT TAIL (`ctx_len`), stamping RoPE positions
+    /// `base_pos..base_pos+num_committed`, folding the watermark slide in
+    /// first. `base_pos` is the RoPE position, NOT the acc row index (they
+    /// diverge after a watermark slide — DDD §4.1 landmine). `scratch_row` is
+    /// 0 on every single-sequence path; batched decode (n>1) captures ALL
+    /// batch rows, so seq i commits from scratch row i. The single structural
+    /// replacement for the ~5 fragmented appends. Default no-op for models
+    /// without a DFlash drafter.
     fn commit_ctx(
         &self,
         _seq: &mut SequenceState,
         _num_committed: usize,
         _base_pos: usize,
+        _scratch_row: usize,
     ) -> Result<()> {
         Ok(())
     }

--- a/crates/spark-server/src/scheduler/decode_step.rs
+++ b/crates/spark-server/src/scheduler/decode_step.rs
@@ -94,23 +94,29 @@ pub fn step_decode_only(
     // never the mtp bootstrap), so their captured target hiddens were
     // overwritten and permanently lost — the dominant ctx hole: a 270-token
     // think stretch leaves the drafter conditioned on the prompt alone
-    // (observed GAP≈290 at first propose, accept ≤6%). Append each decoded
-    // token's capture. n==1 only: `try_dflash_capture` stores row 0, which
-    // is ambiguous in a multi-seq batch (fine here — DFlash runs
-    // --max-batch-size 1).
-    if n == 1 {
-        if sched.levers.dflash_unified_ctx {
+    // (observed GAP≈290 at first propose, accept ≤6%).
+    //
+    // Batched decode (n>1) captures ALL batch rows (`decode_multi_seq` layer
+    // loop → `try_dflash_capture_all`), so seq i's per-layer hidden lives in
+    // scratch row i — commit each seq from its own row. The old `n == 1`
+    // gate silently dropped every batched-decode token's ctx row: the C>=2
+    // accept-collapse root cause (84%→31%/22%; CTXLEN_PROBE GAP grew while
+    // position advanced, and adaptive-spec suspension routed the starved seq
+    // right back here — a self-reinforcing spiral).
+    if sched.levers.dflash_unified_ctx {
+        for (i, a) in active.iter_mut().enumerate() {
             // Unified ctx commit: serial token at RoPE position seq_len-1
-            // (decode() advanced seq_len past the token just processed).
-            let base_pos = active[0].seq.seq_len.saturating_sub(1);
-            if let Err(e) = model.commit_ctx(&mut active[0].seq, 1, base_pos) {
-                tracing::error!("commit_ctx (decode_only serial): {e:#}");
+            // (decode advanced seq_len past the token just processed).
+            let base_pos = a.seq.seq_len.saturating_sub(1);
+            if let Err(e) = model.commit_ctx(&mut a.seq, 1, base_pos, i) {
+                tracing::error!("commit_ctx (decode_only, row {i}): {e:#}");
             }
-        } else if sched.levers.dflash_serial_append
-            && let Err(e) = model.dflash_serial_ctx_append(&mut active[0].seq)
-        {
-            tracing::error!("dflash_serial_ctx_append (decode_only): {e:#}");
         }
+    } else if n == 1
+        && sched.levers.dflash_serial_append
+        && let Err(e) = model.dflash_serial_ctx_append(&mut active[0].seq)
+    {
+        tracing::error!("dflash_serial_ctx_append (decode_only): {e:#}");
     }
 
     process_decode_logits(

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -18,6 +18,17 @@ pub fn emit_token(
     logprobs: Option<crate::api::TokenLogprobs>,
     sched: &crate::scheduler::sched_ctx::SchedCtx,
 ) {
+    // Per-token ledger (debug): every emission path funnels through here,
+    // so `slot + out_idx + tok` gives a diffable per-stream token stream.
+    // The C>=2 temp-0 fork forensics reads this to find the first token
+    // where a concurrent run diverges from the C=1 run of the same prompt
+    // (step type comes from adjacent CTX_VERIFY / CTX_COMMIT debug lines).
+    tracing::debug!(
+        "TOK slot={} out_idx={} tok={}",
+        a.seq.slot_idx,
+        a.output_tokens.len(),
+        tok,
+    );
     // Cooperative cancellation from the streaming pipeline. The
     // stream-side guards (Bug-2 name-run cap, F11 within-dedup, F44
     // perm-fail, loop-watchdog, client stop-sequence match) flip this

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -54,6 +54,11 @@ pub struct SchedLevers {
     /// and completions EOS normally. C>=3 keeps arbitration — per-seq serial
     /// verify genuinely loses there (22.0 vs 28.1 tok/s at C=4).
     pub dflash_gate_pin_c2: bool,
+    /// Cross-sequence batched DFlash K=γ verify (`ATLAS_DFLASH_BATCH_VERIFY=0`
+    /// forces the per-sequence loop). One R=n*(γ+1)-row forward replaces n
+    /// full weight sweeps; the GDN body still runs per sequence, so accepts
+    /// are unchanged and only the wall moves.
+    pub dflash_batch_verify: bool,
     /// Mean accepted drafts below which adaptive speculation suspends.
     pub dflash_adaptive_min: f32,
     /// Serially-decoded tokens between adaptive re-probes.
@@ -177,6 +182,7 @@ impl SchedLevers {
             dflash_unified_ctx: on_unless_zero("ATLAS_DFLASH_UNIFIED_CTX"),
             dflash_spec_think: opt_in("ATLAS_DFLASH_SPEC_THINK"),
             dflash_gate_pin_c2: on_unless_zero("ATLAS_DFLASH_GATE_PIN_C2"),
+            dflash_batch_verify: on_unless_zero("ATLAS_DFLASH_BATCH_VERIFY"),
             dflash_adaptive_min: num("ATLAS_DFLASH_ADAPTIVE_MIN", 2.0),
             dflash_adaptive_reprobe: num("ATLAS_DFLASH_ADAPTIVE_REPROBE", 256),
             dflash_resume_guard: num("ATLAS_DFLASH_RESUME_GUARD", 0),
@@ -222,6 +228,7 @@ impl SchedLevers {
             dflash_unified_ctx: true,
             dflash_spec_think: false,
             dflash_gate_pin_c2: true,
+            dflash_batch_verify: true,
             dflash_adaptive_min: 2.0,
             dflash_adaptive_reprobe: 256,
             dflash_resume_guard: 0,

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -44,6 +44,16 @@ pub struct SchedLevers {
     pub dflash_serial_append: bool,
     pub dflash_unified_ctx: bool,
     pub dflash_spec_think: bool,
+    /// Pin the MTP throughput gate to the VERIFY arm for DFlash at
+    /// `active.len() <= 2` (`ATLAS_DFLASH_GATE_PIN_C2=0` restores
+    /// arbitration). Measured 2026-08-19 (qwen3.8-27B+DFlash2, C=2):
+    /// arbitration was par on tok/s (25.4 vs 24.4) but its serial↔batch-K
+    /// forward flips FORK the temp-0 token stream mid-answer and the bad
+    /// attractor degenerates into repetition (content-loop watchdog kills,
+    /// 300-cap rambles); pinned verify holds C1-parity accept (75% vs 38%)
+    /// and completions EOS normally. C>=3 keeps arbitration — per-seq serial
+    /// verify genuinely loses there (22.0 vs 28.1 tok/s at C=4).
+    pub dflash_gate_pin_c2: bool,
     /// Mean accepted drafts below which adaptive speculation suspends.
     pub dflash_adaptive_min: f32,
     /// Serially-decoded tokens between adaptive re-probes.
@@ -146,6 +156,7 @@ impl SchedLevers {
             dflash_serial_append: opt_in("ATLAS_DFLASH_SERIAL_APPEND"),
             dflash_unified_ctx: opt_in("ATLAS_DFLASH_UNIFIED_CTX"),
             dflash_spec_think: opt_in("ATLAS_DFLASH_SPEC_THINK"),
+            dflash_gate_pin_c2: on_unless_zero("ATLAS_DFLASH_GATE_PIN_C2"),
             dflash_adaptive_min: num("ATLAS_DFLASH_ADAPTIVE_MIN", 2.0),
             dflash_adaptive_reprobe: num("ATLAS_DFLASH_ADAPTIVE_REPROBE", 256),
             dflash_resume_guard: num("ATLAS_DFLASH_RESUME_GUARD", 0),
@@ -190,6 +201,7 @@ impl SchedLevers {
             dflash_serial_append: false,
             dflash_unified_ctx: false,
             dflash_spec_think: false,
+            dflash_gate_pin_c2: true,
             dflash_adaptive_min: 2.0,
             dflash_adaptive_reprobe: 256,
             dflash_resume_guard: 0,

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -89,6 +89,14 @@ fn opt_in(var: &str) -> bool {
     std::env::var(var).ok().as_deref() == Some("1")
 }
 
+/// `ATLAS_FOO=0` DISABLES — a default-ON lever whose kill-switch is an
+/// explicit zero. NOT interchangeable with [`on_unless`]: swapping them
+/// inverts the switch, so `=0` would leave the lever on and `=1` would turn
+/// it off.
+fn on_unless_zero(var: &str) -> bool {
+    std::env::var(var).ok().as_deref() != Some("0")
+}
+
 /// `ATLAS_FOO=1` DISABLES — the flag names a negative, the field stores the
 /// positive, so the inversion happens here instead of at every read site.
 fn on_unless(var: &str) -> bool {

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -93,6 +93,10 @@ fn opt_in(var: &str) -> bool {
 /// explicit zero. NOT interchangeable with [`on_unless`]: swapping them
 /// inverts the switch, so `=0` would leave the lever on and `=1` would turn
 /// it off.
+///
+/// Ships ON; `=0` opts out. For levers that graduated from opt-in after
+/// validation — the variable keeps its historical name and `=1` stays a
+/// harmless no-op, so every recipe that set it remains correct.
 fn on_unless_zero(var: &str) -> bool {
     std::env::var(var).ok().as_deref() != Some("0")
 }
@@ -162,7 +166,15 @@ impl SchedLevers {
             dflash_seam_serial: opt_in("ATLAS_DFLASH_SEAM_SERIAL"),
             dflash_adaptive: opt_in("ATLAS_DFLASH_ADAPTIVE"),
             dflash_serial_append: opt_in("ATLAS_DFLASH_SERIAL_APPEND"),
-            dflash_unified_ctx: opt_in("ATLAS_DFLASH_UNIFIED_CTX"),
+            // DEFAULT-ON since 2026-08-19: without the unified ctx commit the
+            // drafter conditions on a starved/poisoned hidden accumulator
+            // (only row k-1 — an almost-always-rejected draft — captured, one
+            // slot per step regardless of num_accepted, serial stretches
+            // dropped entirely). Validated on qwen3.8-27B+DFlash2: code-leg
+            // 10.5 -> 36.8 tok/s (+250%, accept 41% -> 84%), prose +130%,
+            // count +31% (PR #604). `ATLAS_DFLASH_UNIFIED_CTX=0` restores the
+            // legacy append for A/B.
+            dflash_unified_ctx: on_unless_zero("ATLAS_DFLASH_UNIFIED_CTX"),
             dflash_spec_think: opt_in("ATLAS_DFLASH_SPEC_THINK"),
             dflash_gate_pin_c2: on_unless_zero("ATLAS_DFLASH_GATE_PIN_C2"),
             dflash_adaptive_min: num("ATLAS_DFLASH_ADAPTIVE_MIN", 2.0),
@@ -207,7 +219,7 @@ impl SchedLevers {
             dflash_seam_serial: false,
             dflash_adaptive: false,
             dflash_serial_append: false,
-            dflash_unified_ctx: false,
+            dflash_unified_ctx: true,
             dflash_spec_think: false,
             dflash_gate_pin_c2: true,
             dflash_adaptive_min: 2.0,

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -67,6 +67,7 @@ mod test_support;
 #[cfg(test)]
 mod think_skip_tests;
 mod types;
+mod verify_dflash_batch_step;
 mod verify_dflash_step;
 mod verify_k2_step;
 mod verify_k3_step;
@@ -103,6 +104,7 @@ use sample_step::*;
 use spec_step::*;
 use ssm_decode_ring::SsmDecodeRing;
 use types::*;
+use verify_dflash_batch_step::*;
 use verify_dflash_step::*;
 use verify_k2_step::*;
 use verify_k3_step::*;

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -804,7 +804,20 @@ pub fn run(
                         .map(|a| a.post_think_emitted)
                         .min()
                         .unwrap_or(u32::MAX);
-                    if mtp_gate::entry_pin_forces_verify(min_post_think_emitted)
+                    // DFlash C<=2 pin: hold the verify arm whenever <=2
+                    // sequences are active. Arbitration is par on tok/s
+                    // there, but its serial<->batch-K forward flips fork
+                    // the temp-0 token stream mid-answer and the bad
+                    // attractor degenerates into repetition loops (see
+                    // `dflash_gate_pin_c2` lever doc for the measurements).
+                    // Pinned steps skip recording exactly like the
+                    // entry pin: charging verify walls to a Serial-mode
+                    // accumulator would corrupt the arbitration baselines
+                    // it resumes with at C>=3.
+                    let dflash_pin = dflash_verify_raw_argmax
+                        && active.len() <= 2
+                        && sched.levers.dflash_gate_pin_c2;
+                    if (dflash_pin || mtp_gate::entry_pin_forces_verify(min_post_think_emitted))
                         && gate.next_step() == mtp_gate::GateStep::MeasureDecode
                     {
                         let lens_before: Vec<usize> =

--- a/crates/spark-server/src/scheduler/mtp_bootstrap_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_bootstrap_step.rs
@@ -301,6 +301,21 @@ pub(super) fn step_mtp_bootstrap_batched(
     // per-position and the batched path is grammarless by contract). ──
     if stash_ok {
         let group_cap = model.mtp_propose_batch_max().max(1);
+        // One-shot attribution for "why is propose not batching": each of
+        // these can individually keep every sequence on the per-sequence
+        // propose, which looks like missing amortisation rather than a
+        // declined feature.
+        {
+            static WHY: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+            WHY.get_or_init(|| {
+                tracing::debug!(
+                    group_cap,
+                    proposing = proposing.len(),
+                    ladder_nd,
+                    "DFlash batched propose gate (first tick)"
+                );
+            });
+        }
         let batchable: Vec<usize> = (0..proposing.len())
             .filter(|&s| {
                 let a = &refs[proposing[s]];

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -349,6 +349,22 @@ pub fn step_mtp(
     // to the per-sequence step. One R=n*(γ+1)-row forward replaces n full
     // weight sweeps (the per-step verify wall was flat ~115ms per SEQUENCE
     // from C=1..4 before this). Kill switch: ATLAS_DFLASH_BATCH_VERIFY=0.
+    // One-shot attribution for "why is the batched path not running": each
+    // of these four is individually capable of silently keeping every
+    // sequence on the per-sequence verify, which reads as "no concurrency
+    // amortisation" rather than as a disabled feature.
+    {
+        static WHY: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        WHY.get_or_init(|| {
+            tracing::debug!(
+                raw_argmax = dflash_verify_raw_argmax,
+                n_verify = verify_idxs.len(),
+                lever = sched.levers.dflash_batch_verify,
+                killed = batch_verify_disabled(),
+                "DFlash batched verify gate (first tick with drafts)"
+            );
+        });
+    }
     if dflash_verify_raw_argmax
         && verify_idxs.len() >= 2
         && sched.levers.dflash_batch_verify

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -267,7 +267,7 @@ pub fn step_mtp(
             // so commit and propose decode-append never both cover a token.
             if !will_propose || reprobe_resume {
                 let base_pos = a.seq.seq_len.saturating_sub(1);
-                if let Err(e) = model.commit_ctx(&mut a.seq, 1, base_pos) {
+                if let Err(e) = model.commit_ctx(&mut a.seq, 1, base_pos, 0) {
                     tracing::error!("commit_ctx (mtp serial): {e:#}");
                 }
             }

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -383,20 +383,43 @@ pub fn step_mtp(
                 serial_idxs.push(idx);
             }
         }
-        if batchable_idxs.len() >= 2
-            && model.can_batch_verify(&vec![gamma + 1; batchable_idxs.len()])
-        {
+        // Widest group the model accepts. `can_batch_verify` bounds R = n*k
+        // by the verify row budget (96 rows), so at γ=7 the cap is 12
+        // sequences — and this gate used to be ALL-OR-NOTHING: a C=16 tick
+        // asked for 16×8 = 128 rows, was refused, and every sequence fell to
+        // the per-sequence serial loop, which is exactly the flat
+        // no-amortization wall the batched path exists to remove (measured
+        // 2026-08-21: the C=16 sweep cell ROLLED OVER below C=8, 63.5 vs
+        // 65.9 aggregate). Chunking to the widest accepted group batches
+        // 12 + 4 instead of serializing 16 — the same shape the batched
+        // PROPOSE already uses (`pending.chunks(group_cap)`).
+        let k_rows = gamma + 1;
+        let mut m_max = batchable_idxs.len();
+        while m_max >= 2 && !model.can_batch_verify(&vec![k_rows; m_max]) {
+            m_max -= 1;
+        }
+        if batchable_idxs.len() >= 2 && m_max >= 2 {
             let mut asc = batchable_idxs.clone();
             asc.sort_unstable();
-            let mut refs: Vec<&mut ActiveSeq> = Vec::with_capacity(asc.len());
-            let mut it = active.iter_mut();
-            let mut consumed = 0usize;
-            for &i in &asc {
-                let a = it.nth(i - consumed).expect("verify index within active");
-                consumed = i + 1;
-                refs.push(a);
+            for chunk in asc.chunks(m_max) {
+                if chunk.len() >= 2 {
+                    let mut refs: Vec<&mut ActiveSeq> = Vec::with_capacity(chunk.len());
+                    let mut it = active.iter_mut();
+                    let mut consumed = 0usize;
+                    for &i in chunk {
+                        let a = it.nth(i - consumed).expect("verify index within active");
+                        consumed = i + 1;
+                        refs.push(a);
+                    }
+                    step_verify_dflash_batched(
+                        model, &mut refs, sched, gamma, num_drafts, verify_ctx,
+                    );
+                } else {
+                    // A trailing single cannot batch — it takes the serial
+                    // loop below, same as before this gate existed.
+                    serial_idxs.extend_from_slice(chunk);
+                }
             }
-            step_verify_dflash_batched(model, &mut refs, sched, gamma, num_drafts, verify_ctx);
         } else {
             // Loud on the FIRST decline only: a silently-refused gate looks
             // exactly like "the batched path is off", which cost a whole

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -343,6 +343,91 @@ pub fn step_mtp(
     // (PRESENCE check) forces the serialized loop for A/B.
     let mut serial_idxs: Vec<usize> = Vec::new();
     let mut batchable_idxs: Vec<usize> = Vec::new();
+    // ── DFlash: cross-sequence batched K=γ verify ──
+    // The block drafter has no ragged ladder, so the batch is the set of
+    // grammarless sequences carrying the SAME γ drafts; anything else falls
+    // to the per-sequence step. One R=n*(γ+1)-row forward replaces n full
+    // weight sweeps (the per-step verify wall was flat ~115ms per SEQUENCE
+    // from C=1..4 before this). Kill switch: ATLAS_DFLASH_BATCH_VERIFY=0.
+    if dflash_verify_raw_argmax
+        && verify_idxs.len() >= 2
+        && sched.levers.dflash_batch_verify
+        && !batch_verify_disabled()
+    {
+        let mut gamma = 0usize;
+        for &idx in &verify_idxs {
+            let a = &active[idx];
+            let g = a.pending_drafts.len();
+            if a.grammar_state.is_some() || g < 1 {
+                serial_idxs.push(idx);
+            } else if gamma == 0 || g == gamma {
+                gamma = g;
+                batchable_idxs.push(idx);
+            } else {
+                serial_idxs.push(idx);
+            }
+        }
+        if batchable_idxs.len() >= 2
+            && model.can_batch_verify(&vec![gamma + 1; batchable_idxs.len()])
+        {
+            let mut asc = batchable_idxs.clone();
+            asc.sort_unstable();
+            let mut refs: Vec<&mut ActiveSeq> = Vec::with_capacity(asc.len());
+            let mut it = active.iter_mut();
+            let mut consumed = 0usize;
+            for &i in &asc {
+                let a = it.nth(i - consumed).expect("verify index within active");
+                consumed = i + 1;
+                refs.push(a);
+            }
+            step_verify_dflash_batched(model, &mut refs, sched, gamma, num_drafts, verify_ctx);
+        } else {
+            // Loud on the FIRST decline only: a silently-refused gate looks
+            // exactly like "the batched path is off", which cost a whole
+            // validation cycle when k=γ-1+1 failed an over-strict width check.
+            if !batchable_idxs.is_empty() && sched.stats.once("log:dflash_batch_decline") {
+                tracing::info!(
+                    "DFlash batched verify DECLINED: n={} k={} (model.can_batch_verify said no) \
+                     — running the per-sequence loop",
+                    batchable_idxs.len(),
+                    gamma + 1,
+                );
+            }
+            serial_idxs.extend_from_slice(&batchable_idxs);
+        }
+        batchable_idxs.clear();
+        for &idx in &serial_idxs {
+            let a = &mut active[idx];
+            let mut drafts: Vec<u32> = std::mem::take(&mut a.pending_drafts);
+            a.pending_draft_conf.clear();
+            if drafts.is_empty() {
+                continue;
+            }
+            if let Some(ref mut gs) = a.grammar_state {
+                let kept = truncate_drafts_at_grammar_boundary(gs, &drafts);
+                drafts.truncate(kept);
+                if drafts.is_empty() {
+                    continue;
+                }
+            }
+            step_verify_dflash(
+                model,
+                a,
+                sched,
+                &drafts,
+                num_drafts,
+                verify_ctx,
+                dflash_verify_raw_argmax,
+            );
+        }
+        // Same StepOuter record the shared tail makes — this arm returns
+        // early, and dropping it would blind the phase telemetry exactly
+        // where the batched path is meant to show its win.
+        sched
+            .timing
+            .record(crate::scheduler::mtp_timing::Phase::StepOuter, t_step_outer);
+        return;
+    }
     if verify_idxs.len() >= 2
         && spark_model::speculative::mtp_multi_seq_mode()
         && !dflash_verify_raw_argmax

--- a/crates/spark-server/src/scheduler/verify_dflash_batch_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_batch_step.rs
@@ -228,8 +228,16 @@ pub fn step_verify_dflash_batched(
     // applied to a shared forward).
     let prop_idx: Vec<usize> = (0..batch.len()).filter(|&i| eligible[i]).collect();
     let group_cap = model.mtp_propose_batch_max().max(1);
-    let mut batched_done = false;
-    if group_cap >= 2 && prop_idx.len() >= 2 {
+    // Chunk by the width the proposer DECLARED, not by however many
+    // sequences happen to be eligible: handing it more than it said it can
+    // carry is how a declared cap becomes a silent lie.
+    let mut batched_done = !prop_idx.is_empty();
+    for group in prop_idx.chunks(group_cap.max(1)) {
+        if group_cap < 2 || group.len() < 2 {
+            batched_done = false;
+            break;
+        }
+        let prop_idx: Vec<usize> = group.to_vec();
         let tokens: Vec<u32> = prop_idx.iter().map(|&i| batch[i].last_token).collect();
         let positions: Vec<usize> = prop_idx.iter().map(|&i| batch[i].seq.seq_len).collect();
         let stash_idx: Vec<usize> = prop_idx.clone();
@@ -257,11 +265,15 @@ pub fn step_verify_dflash_batched(
                         batch[row].pending_drafts = all[g].clone();
                     }
                 }
-                batched_done = true;
             }
-            Ok(_) => {}
+            Ok(_) => {
+                batched_done = false;
+                break;
+            }
             Err(e) => {
                 tracing::warn!("DFlash batched propose: {e:#} — per-sequence path");
+                batched_done = false;
+                break;
             }
         }
     }

--- a/crates/spark-server/src/scheduler/verify_dflash_batch_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_batch_step.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Cross-sequence batched DFlash K=γ verify.
+//!
+//! The single-sequence [`super::verify_dflash_step::step_verify_dflash`] runs
+//! ONE target forward per sequence, so a C=4 round pays four full weight
+//! sweeps. Measured 2026-08-19 on qwen3.8-27B+DFlash2: the per-step verify
+//! wall is FLAT at ~115 ms from C=1 to C=4 (propose ~40 ms likewise) — i.e.
+//! DFlash had zero concurrency amortisation, which is exactly why the
+//! throughput gate arbitrates verify away at C>=3 despite it holding ~72%
+//! acceptance there.
+//!
+//! This step packs `n` sequences' `[last_token, d0..d_{γ-1}]` rows into ONE
+//! `R = n*(γ+1)`-row forward. Every weight-bearing op (QKVZ / o_proj / FFN /
+//! lm_head) reads the weights ONCE for the whole batch; only the GDN
+//! recurrent body stays per-sequence (K=γ+1 has no fused WY kernel, so
+//! `decode_verify_multi` takes its byte-identical per-sequence fallback —
+//! the same arm the single-sequence K=γ path already used). Kernel evidence
+//! for the win: `gemm_t` costs 3679 us at M=9 and 3837 us at M=36 — 4x the
+//! rows for +4%.
+//!
+//! PHASE ORDER IS LOAD-BEARING (same hazard as `verify_k4_batch_step`): the
+//! forward leaves per-row logits and per-sequence capture bands live in
+//! SHARED buffers. Every read of them (accept walk, `commit_ctx`, hidden
+//! stash) must complete for ALL sequences before the first `propose`, which
+//! overwrites `hidden_states`.
+
+use super::*;
+
+/// Batched DFlash verify for `batch.len()` sequences at uniform K = γ+1.
+///
+/// `drafts_per_seq` is γ — every sequence must carry exactly that many
+/// pending drafts (the caller gates on it; the block drafter has no ragged
+/// ladder, unlike the MTP D-Cut path).
+pub fn step_verify_dflash_batched(
+    model: &dyn Model,
+    batch: &mut [&mut ActiveSeq],
+    sched: &crate::scheduler::sched_ctx::SchedCtx,
+    drafts_per_seq: usize,
+    num_drafts: usize,
+    _verify_ctx: &crate::scheduler::logit_processors::LogitsContext,
+) {
+    let n = batch.len();
+    let k = drafts_per_seq + 1;
+    debug_assert!(n >= 2 && drafts_per_seq >= 1);
+
+    // ONE secondary-stream sync for the whole batch: the previous step's
+    // commit/restore must land before this forward reads SSM state.
+    if let Err(e) = model.sync_secondary() {
+        tracing::error!("sync_secondary (dflash batched): {e:#}");
+        for a in batch.iter_mut() {
+            a.finished = true;
+        }
+        return;
+    }
+
+    // Flat seq-major token rows + the per-sequence drafts they encode.
+    let mut tokens: Vec<u32> = Vec::with_capacity(n * k);
+    let mut drafts_all: Vec<Vec<u32>> = Vec::with_capacity(n);
+    for a in batch.iter_mut() {
+        let drafts: Vec<u32> = std::mem::take(&mut a.pending_drafts);
+        a.pending_draft_conf.clear();
+        debug_assert_eq!(drafts.len(), drafts_per_seq);
+        tokens.push(a.last_token);
+        tokens.extend_from_slice(&drafts);
+        drafts_all.push(drafts);
+    }
+    let ks = vec![k; n];
+
+    let t_verify = std::time::Instant::now();
+    let results = {
+        let mut seq_refs: Vec<&mut SequenceState> = batch.iter_mut().map(|a| &mut a.seq).collect();
+        match model.decode_verify_batched(&tokens, &ks, &mut seq_refs, 0) {
+            Ok(v) => v,
+            Err(e) => {
+                // No sequence state was advanced on Err — restore the drafts
+                // so the caller's next tick re-verifies them serially rather
+                // than losing a step's work.
+                tracing::error!("decode_verify_batched (dflash): {e:#}");
+                for (a, d) in batch.iter_mut().zip(drafts_all.into_iter()) {
+                    a.pending_drafts = d;
+                }
+                return;
+            }
+        }
+    };
+    let verify_ms = t_verify.elapsed().as_secs_f64() * 1000.0;
+    if results.len() < n * k {
+        tracing::error!(
+            "decode_verify_batched (dflash): short result {} < {}",
+            results.len(),
+            n * k
+        );
+        for a in batch.iter_mut() {
+            a.finished = true;
+        }
+        return;
+    }
+
+    // ── Phase A: per-sequence verdict, ctx commit, emit, SSM commit ──
+    // All shared-buffer reads live here, before ANY propose.
+    let mut accepted_per_seq: Vec<usize> = Vec::with_capacity(n);
+    let mut stash_rows: Vec<usize> = Vec::with_capacity(n);
+    let now = Instant::now();
+    for (i, a) in batch.iter_mut().enumerate() {
+        let off = i * k;
+        let verified = &results[off..off + k];
+        let drafts = &drafts_all[i];
+        a.last_token_time = now;
+
+        // DFlash judges on RAW argmax so the verifier and the drafter share
+        // one basis (mirrors the single-sequence path's default arm).
+        let mut num_accepted = 0usize;
+        for j in 0..drafts.len() {
+            if j + 1 >= verified.len() || drafts[j] != verified[j] {
+                break;
+            }
+            num_accepted += 1;
+        }
+        accepted_per_seq.push(num_accepted);
+        crate::scheduler::adaptive_spec::record_verify(a, num_accepted, sched);
+
+        // Rewind the forward's unconditional +k to the accepted prefix plus
+        // the bonus slot (identical arithmetic to the single-seq path).
+        let pre_verify_len = a.seq.seq_len.saturating_sub(k);
+        let target_seq_len = pre_verify_len + num_accepted + 1;
+        let to_drop = a.seq.seq_len.saturating_sub(target_seq_len);
+        if to_drop > 0 {
+            a.seq.seq_len = target_seq_len;
+            let pop_n = to_drop.min(a.seq.tokens.len());
+            for _ in 0..pop_n {
+                a.seq.tokens.pop();
+            }
+        }
+
+        // Commit this sequence's ctx rows from ITS OWN capture band. The
+        // band base is the same `i * kgamma` the model captured into; the
+        // model exposes it so the two can never disagree.
+        tracing::debug!(
+            "CTX_VERIFY slot={} pre_verify_len={} na={} k={} band={}",
+            a.seq.slot_idx,
+            pre_verify_len,
+            num_accepted,
+            k,
+            i * model.dflash_capture_band(),
+        );
+        if sched.levers.dflash_unified_ctx
+            && let Err(e) = model.commit_ctx(
+                &mut a.seq,
+                num_accepted + 1,
+                pre_verify_len,
+                i * model.dflash_capture_band(),
+            )
+        {
+            tracing::error!("commit_ctx (dflash batched): {e:#}");
+        }
+
+        for j in 0..num_accepted {
+            emit_token(a, drafts[j], None, sched);
+            if a.finished {
+                break;
+            }
+        }
+        if !a.finished && num_accepted < verified.len() {
+            let bonus = verified[num_accepted];
+            emit_token(a, bonus, None, sched);
+            a.last_token = bonus;
+        }
+
+        crate::metrics::SPEC_DECODE_VERIFY
+            .with_label_values(&[
+                "dflash",
+                if num_accepted == drafts.len() {
+                    "accept_all"
+                } else {
+                    "accept_partial"
+                },
+            ])
+            .inc();
+
+        // STree-style in-place SSM commit: h_state is canonical, a partial
+        // accept restores intermediate[total_accepted-1].
+        if let Err(e) = model.commit_accepted_prefix(&mut a.seq, num_accepted + 1, k) {
+            tracing::error!("commit_accepted_prefix (dflash batched): {e:#}");
+            a.finished = true;
+        }
+        // Row of THIS sequence's bonus generator in the shared hidden buffer.
+        stash_rows.push(off + num_accepted);
+    }
+
+    // Park every sequence's bonus hidden in the 32-slot stash while the rows
+    // are still live — a single `save_hidden_for_mtp` would keep only the
+    // last sequence's row once proposes start overwriting the buffer.
+    if let Err(e) = model.stash_verify_hidden_rows(&stash_rows, 0) {
+        tracing::warn!("stash_verify_hidden_rows (dflash batched): {e:#}");
+    }
+
+    // ── Phase B: per-sequence trim + re-propose ──
+    // Safe to clobber the shared buffers from here on.
+    let t_propose = std::time::Instant::now();
+    for (i, a) in batch.iter_mut().enumerate() {
+        if a.finished {
+            continue;
+        }
+        let num_accepted = accepted_per_seq[i];
+        if let Err(e) = model.save_hidden_for_mtp_from_stash(i, 0) {
+            tracing::warn!("save_hidden_for_mtp_from_stash (dflash batched): {e:#}");
+        }
+        if let Err(e) = model.trim_proposer_state(&mut a.seq, num_accepted, 0) {
+            tracing::error!("trim_proposer_state (dflash batched): {e:#}");
+        }
+        if !crate::scheduler::adaptive_spec::spec_allowed(a, sched) {
+            continue;
+        }
+        let gmask = mtp_grammar_mask_for(a);
+        match model.run_mtp_propose_multi(
+            a.last_token,
+            a.seq.seq_len,
+            num_drafts,
+            &mut a.seq,
+            0,
+            gmask.as_deref(),
+        ) {
+            Ok(d) if !d.is_empty() => a.pending_drafts = d,
+            Ok(_) => {}
+            Err(e) => tracing::error!("run_mtp_propose_multi (dflash batched): {e:#}"),
+        }
+    }
+
+    let total_accepted: usize = accepted_per_seq.iter().sum();
+    tracing::info!(
+        "DFLASH BATCHED verify: n={n} γ={drafts_per_seq} accepted={total_accepted}/{} ({:.0}%) \
+         verify={verify_ms:.1}ms propose={:.1}ms",
+        n * drafts_per_seq,
+        100.0 * (total_accepted as f64) / ((n * drafts_per_seq) as f64),
+        t_propose.elapsed().as_secs_f64() * 1000.0,
+    );
+}

--- a/crates/spark-server/src/scheduler/verify_dflash_batch_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_batch_step.rs
@@ -195,35 +195,99 @@ pub fn step_verify_dflash_batched(
         tracing::warn!("stash_verify_hidden_rows (dflash batched): {e:#}");
     }
 
-    // ── Phase B: per-sequence trim + re-propose ──
+    // ── Phase B: per-sequence trim, then ONE batched re-propose ──
     // Safe to clobber the shared buffers from here on.
     let t_propose = std::time::Instant::now();
+    // Trim first for everyone: the batched propose reads each sequence's
+    // proposer state, so every state must already reflect what its verify
+    // accepted.
+    // `spec_allowed` takes &mut, so eligibility is decided in this pass while
+    // the mutable borrow is already held.
+    let mut eligible = vec![false; batch.len()];
     for (i, a) in batch.iter_mut().enumerate() {
         if a.finished {
             continue;
         }
         let num_accepted = accepted_per_seq[i];
-        if let Err(e) = model.save_hidden_for_mtp_from_stash(i, 0) {
-            tracing::warn!("save_hidden_for_mtp_from_stash (dflash batched): {e:#}");
-        }
+        // NO save_hidden_for_mtp_from_stash here. It stages into a SHARED
+        // destination slot, so calling it for every sequence before any
+        // propose leaves only the LAST sequence's hidden staged and every
+        // other sequence appends the wrong row to its drafter context. The
+        // batched arm gets each sequence's hidden from its own stash row
+        // (`verify_hidden_stash.offset(i * h * 2)`, built in the dispatch);
+        // the per-sequence arm below stages per sequence, immediately before
+        // that sequence's own propose, which is the only ordering that works.
         if let Err(e) = model.trim_proposer_state(&mut a.seq, num_accepted, 0) {
             tracing::error!("trim_proposer_state (dflash batched): {e:#}");
         }
-        if !crate::scheduler::adaptive_spec::spec_allowed(a, sched) {
-            continue;
-        }
-        let gmask = mtp_grammar_mask_for(a);
-        match model.run_mtp_propose_multi(
-            a.last_token,
-            a.seq.seq_len,
-            num_drafts,
-            &mut a.seq,
-            0,
-            gmask.as_deref(),
-        ) {
-            Ok(d) if !d.is_empty() => a.pending_drafts = d,
+        eligible[i] =
+            crate::scheduler::adaptive_spec::spec_allowed(a, sched) && a.grammar_state.is_none();
+    }
+    // Eligible = not finished, speculation allowed, no grammar (the batched
+    // propose is grammarless by contract — a per-position mask cannot be
+    // applied to a shared forward).
+    let prop_idx: Vec<usize> = (0..batch.len()).filter(|&i| eligible[i]).collect();
+    let group_cap = model.mtp_propose_batch_max().max(1);
+    let mut batched_done = false;
+    if group_cap >= 2 && prop_idx.len() >= 2 {
+        let tokens: Vec<u32> = prop_idx.iter().map(|&i| batch[i].last_token).collect();
+        let positions: Vec<usize> = prop_idx.iter().map(|&i| batch[i].seq.seq_len).collect();
+        let stash_idx: Vec<usize> = prop_idx.clone();
+        let result = {
+            let mut seq_refs: Vec<&mut SequenceState> = Vec::with_capacity(prop_idx.len());
+            for (i, a) in batch.iter_mut().enumerate() {
+                if prop_idx.contains(&i) {
+                    seq_refs.push(&mut a.seq);
+                }
+            }
+            model.run_mtp_propose_batched(
+                &tokens,
+                &positions,
+                &stash_idx,
+                num_drafts,
+                &mut seq_refs,
+                0,
+                None,
+            )
+        };
+        match result {
+            Ok(Some(all)) if all.len() == prop_idx.len() => {
+                for (g, &row) in prop_idx.iter().enumerate() {
+                    if !all[g].is_empty() {
+                        batch[row].pending_drafts = all[g].clone();
+                    }
+                }
+                batched_done = true;
+            }
             Ok(_) => {}
-            Err(e) => tracing::error!("run_mtp_propose_multi (dflash batched): {e:#}"),
+            Err(e) => {
+                tracing::warn!("DFlash batched propose: {e:#} — per-sequence path");
+            }
+        }
+    }
+    if batched_done {
+        // Batched path covered every eligible sequence; nothing left to do.
+    } else {
+        for (i, a) in batch.iter_mut().enumerate() {
+            if a.finished || !crate::scheduler::adaptive_spec::spec_allowed(a, sched) {
+                continue;
+            }
+            if let Err(e) = model.save_hidden_for_mtp_from_stash(i, 0) {
+                tracing::warn!("save_hidden_for_mtp_from_stash (dflash batched): {e:#}");
+            }
+            let gmask = mtp_grammar_mask_for(a);
+            match model.run_mtp_propose_multi(
+                a.last_token,
+                a.seq.seq_len,
+                num_drafts,
+                &mut a.seq,
+                0,
+                gmask.as_deref(),
+            ) {
+                Ok(d) if !d.is_empty() => a.pending_drafts = d,
+                Ok(_) => {}
+                Err(e) => tracing::error!("run_mtp_propose_multi (dflash batched): {e:#}"),
+            }
         }
     }
 

--- a/crates/spark-server/src/scheduler/verify_dflash_step.rs
+++ b/crates/spark-server/src/scheduler/verify_dflash_step.rs
@@ -137,8 +137,15 @@ pub fn step_verify_dflash(
     // Unified ctx commit (ATLAS_DFLASH_UNIFIED_CTX=1): ONE unconditional
     // commit at the K=gamma point — rows 0..=num_accepted at RoPE base
     // pre_verify_len. Structural replacement for dflash_eagle_kgamma_append.
+    tracing::debug!(
+        "CTX_VERIFY slot={} pre_verify_len={} na={} k={}",
+        a.seq.slot_idx,
+        pre_verify_len,
+        num_accepted,
+        drafts.len() + 1,
+    );
     if sched.levers.dflash_unified_ctx {
-        if let Err(e) = model.commit_ctx(&mut a.seq, num_accepted + 1, pre_verify_len) {
+        if let Err(e) = model.commit_ctx(&mut a.seq, num_accepted + 1, pre_verify_len, 0) {
             tracing::error!("commit_ctx (kgamma): {e:#}");
         }
     } else {

--- a/kernels/gb10/common/dflash2.cu
+++ b/kernels/gb10/common/dflash2.cu
@@ -36,12 +36,19 @@ extern "C" __global__ void dflash2_conv2(
     unsigned int h,
     unsigned int group_size,
     unsigned int dyn_stride,   // elements per dyn row (both applications)
-    unsigned int app_off       // 0 (prepare) or kernel_size*groups (finish)
+    unsigned int app_off,      // 0 (prepare) or kernel_size*groups (finish)
+    unsigned int gamma         // rows per SEQUENCE band; 0 == one band (legacy)
 ) {
     const unsigned int t = blockIdx.x;
     const unsigned int groups = h / group_size;
     const __nv_bfloat16* xr = x + (size_t)t * h;
-    const __nv_bfloat16* xp = (t > 0) ? x + (size_t)(t - 1) * h : nullptr;
+    // Row t-1 is this row's convolution predecessor ONLY within its own
+    // sequence. With n sequences packed seq-major as [n*gamma, h], row 0 of
+    // band b must not convolve against row gamma-1 of band b-1 — that is a
+    // different conversation. gamma == 0 keeps the single-band behaviour, and
+    // at n == 1 the test reduces to (t == 0) exactly as before.
+    const bool first_in_band = (gamma == 0u) ? (t == 0u) : (t % gamma == 0u);
+    const __nv_bfloat16* xp = first_in_band ? nullptr : x + (size_t)(t - 1) * h;
     const __nv_bfloat16* dr = dyn + (size_t)t * dyn_stride + app_off;
     __nv_bfloat16* orow = out + (size_t)t * h;
 
@@ -127,10 +134,14 @@ extern "C" __global__ void dflash2_selector_walk(
     const __nv_bfloat16* __restrict__ pred,    // [vocab, rank] A codebook
     const __nv_bfloat16* __restrict__ succ,    // [vocab, rank] B codebook
     unsigned int* __restrict__ tokens,         // [rows] draft token slots
-    unsigned int rows,
+    unsigned int rows,       // rows per BAND (gamma), not the grand total
     unsigned int rank,       // 256
     unsigned int first_row   // 1 (row 0 = anchor, not selected)
 ) {
+    // One block per sequence: block b owns rows [b*rows, (b+1)*rows) and
+    // chains from its OWN anchor. Launched with grid=1 this is byte-identical
+    // to the single-sequence walk it replaces.
+    const size_t base_row = (size_t)blockIdx.x * rows;
     __shared__ float s_gate[256];
     __shared__ float s_score[16];
     __shared__ unsigned int s_prev;
@@ -140,14 +151,15 @@ extern "C" __global__ void dflash2_selector_walk(
     const unsigned int lane = tid & 31;
 
     if (tid == 0) {
-        s_prev = tokens[0];  // last_token — slot 0 pre-argmax state
+        s_prev = tokens[base_row];  // this band's last_token
     }
     __syncthreads();
 
     for (unsigned int t = first_row; t < rows; ++t) {
+        const size_t row = base_row + t;
         // gate[r] = pred[prev][r] * hproj[t][r]
         const __nv_bfloat16* pr = pred + (size_t)s_prev * rank;
-        const __nv_bfloat16* hr = hproj + (size_t)t * rank;
+        const __nv_bfloat16* hr = hproj + row * rank;
         for (unsigned int r = tid; r < rank; r += blockDim.x) {
             s_gate[r] = __bfloat162float(pr[r]) * __bfloat162float(hr[r]);
         }
@@ -155,7 +167,7 @@ extern "C" __global__ void dflash2_selector_walk(
 
         // warp k: score_k = unary_k + Σ_r gate[r] * succ[cand_k][r]
         if (warp < 16) {
-            const unsigned int cand = top_idx[(size_t)t * 16 + warp];
+            const unsigned int cand = top_idx[row * 16 + warp];
             const __nv_bfloat16* sr = succ + (size_t)cand * rank;
             float acc = 0.0f;
             for (unsigned int r = lane; r < rank; r += 32) {
@@ -166,7 +178,7 @@ extern "C" __global__ void dflash2_selector_walk(
                 acc += __shfl_down_sync(0xffffffff, acc, off);
             }
             if (lane == 0) {
-                s_score[warp] = top_vals[(size_t)t * 16 + warp] + acc;
+                s_score[warp] = top_vals[row * 16 + warp] + acc;
             }
         }
         __syncthreads();
@@ -181,8 +193,8 @@ extern "C" __global__ void dflash2_selector_walk(
                     best_k = k;
                 }
             }
-            const unsigned int chosen = top_idx[(size_t)t * 16 + best_k];
-            tokens[t] = chosen;
+            const unsigned int chosen = top_idx[row * 16 + best_k];
+            tokens[row] = chosen;
             s_prev = chosen;
         }
         __syncthreads();


### PR DESCRIPTION
**MERGE AFTER #651**, which merges after #650, which merges after #649. Top of the train; base is `stack/lora-hybrid` so the diff here is only these four commits.

## What this fixes

Three C≥2 correctness fixes from the WIP branch, plus the lever helper they need. Measured on this stack, MinHeap prompt, temp 0, 32K/8-seq profile:

| C | accept before | accept after |
|---|---|---|
| 2 | 59% | **84%** |
| 4 | 68% | **77%** |
| 8 | 63% | **62%** |

- **batched decode dropped every ctx row** — the drafter's context accumulator was not being fed on the batched decode path, so at C≥2 every sequence proposed from an empty context. This is the big one.
- **mtp_gate pinned to verify at C≤2** — the throughput arbiter flips between serial and batch-K mid-stream, and at temp 0 that forks two streams that should be identical.
- **SSM pools state uniformity stated explicitly** — inference over pool widths broke when γ-sized widths were in play.

`on_unless_zero` is a small but load-bearing addition: this branch only had `on_unless`, whose contract is the opposite (`=1` disables). The gate-pin lever documents `ATLAS_DFLASH_GATE_PIN_C2=0` as its opt-out, so reusing the existing helper would have inverted the switch silently — `=0` leaving the pin on, `=1` turning it off. That is worse than a compile error, because it looks like it works.

## Cross-sequence batched verify — ported, and it works

The batched K=γ verify from the WIP branch DOES port onto this base. My first
read of it as "a re-implementation against a different head" was wrong, and
worth correcting explicitly: of the conflicts, one was two doc comments for
the same function, one was two names for the same default-ON behaviour
(`ATLAS_DFLASH_EAGLE_FIX` and `ATLAS_DFLASH_UNIFIED_CTX` — now EITHER `=0`
disables, so neither name loses its kill switch), and one was HEAD's
LoRA-aware guard correctly superseding the older blanket refusal.

Then it landed and still did not run, because of a contradiction I introduced
resolving that third conflict. `can_batch_verify` picks `shape_ok` by
branching on `dflash_hidden_save`: `Some` selects the DFlash γ-block arm,
`None` the K=2..4 ladder. The eligibility list also carried
`&& dflash_hidden_save.is_none()`, which predates the DFlash arm and meant
"batched verify is for plain MTP only". Both present = the Some arm computes
a shape it can never use. Unreachable by construction, and from the outside
it looks like "concurrency does not amortise" rather than a disabled feature
— which is why a one-shot gate diagnostic is now permanent at debug level.

| C | before | after | |
|---|---|---|---|
| 1 | 54.7 | 54.6 | unchanged, as expected — n=1 never batches |
| 2 | 54.4 | **84.7** | **+56%** |
| 4 | 51.7 | **98.7** | **+91%** |
| 8 | 55.5 | **124.1** | **+124%** |

Accept unchanged at 84 / 78 / 74%, completion byte-identical (sha
`62ff5ed75f0cc2fd`). This changes how many forwards an answer costs, not the
answer.

## Batched propose — ported, correct, DEFAULT-ON

One drafter forward over `n·γ` rows instead of n forwards. Kernels banded per
sequence, paged layer batch-capable, scratch banded, `forward_block` takes an
optional `DflashBatch`, and the scheduler drives it from the batched verify's
Phase B where the n sequences are already in hand.

| C | per-sequence | batched | |
|---|---|---|---|
| 1 | 54.7 | 54.6 | n=1 never batches |
| 2 | 85.0 | 84.2 | |
| 4 | 99.4 | **114.4** | **+15%** |
| 8 | 124.1 | **149.9** | **+21%** |

Acceptance at parity (84/77/74% vs 84/78/73%), completion byte-identical
(sha `62ff5ed75f0cc2fd`). `ATLAS_DFLASH_BATCH_PROPOSE=<width>`: `1`/`0`
restores the per-sequence loop, `N` caps the batch at N.

### Two bugs worth naming

Both were mine from the port, and both were found by bisecting the batch
WIDTH against acceptance rather than by reading code.

**`n_attn` never learned about the batch.** It stayed `eff_ctx + gamma` while
being the row count `batched_embed` takes, so only band 0 was embedded and
every other sequence drafted from stale `stream_buf`. The arithmetic matched
the measurement exactly: one sequence of eight drafting correctly is 24%
acceptance against a 73% baseline.

**The lm_head was called past its tile bound.** `fp8_gemm_t_row_scaled_m16`
is a single-warp `M_TILE=16` kernel. The single-sequence path calls it
unconditionally because γ=8 always fits — but switching those sites to the
batch total made it 32 rows at n=4 and 64 at n=8, past the tile, where it
silently leaves rows it never covered. Row-count selection is restored.

The second one is the instructive one: it does not look like a kernel fault
from outside. The ANSWER stays correct throughout — a bad draft is rejected
and the target's own token is emitted — so nothing errors, output stays
byte-identical, and only the accept rate moves. It reads as "the drafter got
worse", not "a kernel was used out of contract". Correct at 2 bands (16 rows,
inside the tile) and wrong at 4 (32 rows, outside it) is what separated them,
which is why the lever is a numeric width rather than a boolean.

Also fixed: the scheduler passed every eligible sequence to `propose_batch`
regardless of the width the proposer declared via `propose_batch_max`. It now
chunks by that width, which is what makes a declared cap mean anything.

## Verification
`ATLAS_TARGET_MODEL='*'` build clean · 641 spark-model + 104 spark-server tests · LoC cap clean · output byte-identical to #649's own branch under its own config (sha `62ff5ed75f0cc2fd`), which is the cross-check that these fixes change acceptance and not answers.


## Update 2026-08-21: chunk the batched verify to the widest accepted group (44a0ce15)

The batched-verify gate was all-or-nothing: `can_batch_verify` was asked once
with every eligible sequence, so the moment n×(γ+1) rows crossed
`VERIFY_ROW_CAP` (C=16 at γ=8 → 144 rows > 96) the ENTIRE step fell back to
serial per-sequence verifies — the feature turned itself off exactly at the
concurrency it exists for. The gate now walks the group width down until the
cap accepts it and dispatches the batch in chunks of that width; the rest of
the arithmetic (per-sequence verdicts, drafter trims) is untouched.

Measured on GB10 (Qwen3.8-27B-NVFP4 + DFlash2, small profile, 16 slots,
C=16 aggregate streaming decode): 63.5 → 116.8 tok/s with this commit alone;
129.6 with #704's cap raise on top. C=1 output byte-identical. Accepts
unchanged (76–86%).

Note the correctness baseline for all these numbers is #699 — before it,
C≥2 accept/throughput figures were contaminated by the verdict-rewind
degeneration. The merge result of this branch with today's `main` compiles
clean across the workspace and passes all 104 spark-server tests.
