### PR TITLE
bench: gate the NVFP4-MoE TTFT path — it had no gate at all

### DIFF
--- a/.benchmarks/ttft-cold-gate/2026-08-21-e341f2cd35-nvidia-qwen3.6-35b-a3b-nvfp4.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-21-e341f2cd35-nvidia-qwen3.6-35b-a3b-nvfp4.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "e341f2cd35",
+  "recorded_at": 1787285628,
+  "target_model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-nvfp4",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787285602,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 46.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 52.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 12436450703,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 2573004,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1876392,
+      "gpu_compute_apps": [
+        {
+          "pid": 414777,
+          "name": "./target/release/spark",
+          "used_mib": 112007
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787285627,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 12436450703,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 2494244,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1881556,
+      "gpu_compute_apps": [
+        {
+          "pid": 414777,
+          "name": "./target/release/spark",
+          "used_mib": 112044
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 25,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 22.0,
+      "hottest_chassis_delta_c": 24.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +24 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 435.828672,
+    "p90_ms": 1298.269309,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -1.5% (limit +3.0%) · p90 -1.2% (limit +5.0%)",
+  "summary": "nvidia/Qwen3.6-35B-A3B-NVFP4 · median_ms=435.83, p90_ms=1298.27, samples=36.00 · Pass: median -1.5% (limit +3.0%) · p90 -1.2% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "820241bf55480ef658abce284d6691c5696d80c1822d66eb412f2b1f1d05c028",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "c8c347e4a1730ed4663befbd939149089b5bc51c92165eb376e2b6fa8da4ea52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c4bb76e4e3d0bc2dd5534c9504c004cf456650975301ff09a7092f24e7290adf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "454b406c62b087b0750088eb29178d3a700feb252958670b17b8cb4cdaa929b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "66aac61e73286b92da992fab7710156de2e0d22c46509bfd30d9a83bb34cd739",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "c33b527db104e29bc1ccc51eabc8954c5d646b9b90e8ecfe200e9ab95d733b98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "bf2df708ecb03cccb722140063ac2587aa7a6e6966a55c2ea377360224e0ed8c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "d92b82d1e41bf54775d23ad4038810c59593a1b8419a8ab108d7c8fab7d77cb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "fa7ed3021d935ca9eb0413f92bcaa1f06ab34d70966e0122d7af556ddd4a8dbd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "674e0c0d06ea9769f5fdde8e6b24763544932b0a6427ea82d57dd58a3091d208",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "0d5ca0168ac27725b5db64bba0767da42deea005c106802c46a48f4fd3ab3977",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "1ae1724b6ee567465c539d7b907a0c536ec4e8d44bbd9940f0a6142e6e91de5d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "b33f7a1d04cacbab370114d7825a29c6c507a78aa610e9ed5ea88970ddf84239",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f42337600766abce3af6ddb3f9075af64649d0e6f321bef0695948d874667497",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4f430c0d9eb6101e729ad722300c6524131d73dcb5f452080542988d503cf27f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "5da1d402a85bb7d626ec621e4f80e3cf0c68244858ec58b814b50a77048b72ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6e8019fe719e56a976bb3f59987d6fc1380f02f8695877787c8224b1275f55ee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "1670b97c6f71f0cdb123b9a424b07f508a8eed73849f6d61487b03689eabcd99",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d12ee1156a92967000252c47a63df1318be0e04308fff9d4dac910075f294dda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "c7e0866e75e205ac3586a38f2113f7650497a928e1459f902bfa11eff8702db2",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "20730de727dd414b9855454cfbc638a108f7293a8909619a86d06d574f221600",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b7430a95e845f4993fb6751d254162edfe877eefa87f37c350f49bce29058aee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "20730de727dd414b9855454cfbc638a108f7293a8909619a86d06d574f221600",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ad853582c595dadc186e0a1d04fe431b9458b78bd71712b611f61e07f0129fb5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-21-e341f2cd35-nvidia-qwen3.6-35b-a3b-nvfp4.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-21-e341f2cd35-nvidia-qwen3.6-35b-a3b-nvfp4.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "e341f2cd35",
+  "recorded_at": 1787285753,
+  "target_model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-nvfp4",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2437.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787285705,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 50.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 12436450703,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 1995496,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1883144,
+      "gpu_compute_apps": [
+        {
+          "pid": 415305,
+          "name": "./target/release/spark",
+          "used_mib": 112037
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787285753,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        }
+      ],
+      "sm_clock_mhz": 2437.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 12436450703,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 1921472,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1883828,
+      "gpu_compute_apps": [
+        {
+          "pid": 415305,
+          "name": "./target/release/spark",
+          "used_mib": 112074
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 48,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 24.0,
+      "hottest_chassis_delta_c": 25.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +26 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 437.07314,
+    "p90_ms": 1288.0527769999999,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.6% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "summary": "nvidia/Qwen3.6-35B-A3B-NVFP4 · median_ms=437.07, p90_ms=1288.05, samples=36.00 · Pass: median -0.6% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "820241bf55480ef658abce284d6691c5696d80c1822d66eb412f2b1f1d05c028",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "c8c347e4a1730ed4663befbd939149089b5bc51c92165eb376e2b6fa8da4ea52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c4bb76e4e3d0bc2dd5534c9504c004cf456650975301ff09a7092f24e7290adf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "454b406c62b087b0750088eb29178d3a700feb252958670b17b8cb4cdaa929b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "66aac61e73286b92da992fab7710156de2e0d22c46509bfd30d9a83bb34cd739",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "c33b527db104e29bc1ccc51eabc8954c5d646b9b90e8ecfe200e9ab95d733b98",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "bf2df708ecb03cccb722140063ac2587aa7a6e6966a55c2ea377360224e0ed8c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "d92b82d1e41bf54775d23ad4038810c59593a1b8419a8ab108d7c8fab7d77cb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "fa7ed3021d935ca9eb0413f92bcaa1f06ab34d70966e0122d7af556ddd4a8dbd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "674e0c0d06ea9769f5fdde8e6b24763544932b0a6427ea82d57dd58a3091d208",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "0d5ca0168ac27725b5db64bba0767da42deea005c106802c46a48f4fd3ab3977",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "1ae1724b6ee567465c539d7b907a0c536ec4e8d44bbd9940f0a6142e6e91de5d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "b33f7a1d04cacbab370114d7825a29c6c507a78aa610e9ed5ea88970ddf84239",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f42337600766abce3af6ddb3f9075af64649d0e6f321bef0695948d874667497",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "4f430c0d9eb6101e729ad722300c6524131d73dcb5f452080542988d503cf27f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "5da1d402a85bb7d626ec621e4f80e3cf0c68244858ec58b814b50a77048b72ca",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6e8019fe719e56a976bb3f59987d6fc1380f02f8695877787c8224b1275f55ee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "1670b97c6f71f0cdb123b9a424b07f508a8eed73849f6d61487b03689eabcd99",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "d12ee1156a92967000252c47a63df1318be0e04308fff9d4dac910075f294dda",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "c7e0866e75e205ac3586a38f2113f7650497a928e1459f902bfa11eff8702db2",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "20730de727dd414b9855454cfbc638a108f7293a8909619a86d06d574f221600",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "b7430a95e845f4993fb6751d254162edfe877eefa87f37c350f49bce29058aee",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "20730de727dd414b9855454cfbc638a108f7293a8909619a86d06d574f221600",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "ad853582c595dadc186e0a1d04fe431b9458b78bd71712b611f61e07f0129fb5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
@@ -192,6 +192,46 @@ max = 1728.27
 [benchmarks.metrics.p90_ms]
 max = 4809.76
 
+# ── NVFP4-MoE VARIANT of the cold-TTFT guard ────────────────────────────────
+# The FP8 entry above is the DEFAULT subject, and until this entry existed it
+# was the ONLY one: no gate anywhere exercised an NVFP4 MoE checkpoint. That
+# mattered — the fast-MoE default-on work (#654) is gated on
+# `modelopt_mixed_precision || nvfp4_moe`, so it is INERT on FP8, and the whole
+# 10-gate suite passed it while never touching the path it changed.
+#
+# `default` is deliberately absent: this is a variant, so its records are named
+# `YYYY-MM-DD-<sha>-<slug>.json` and cannot collide with the FP8 record cut from
+# the same commit on the same day.
+#
+# CEILINGS = same-box baseline (dgx1, 2026-08-21, this recipe) x the gate limits,
+# derived exactly as the FP8 entries above are. Measured against a SELF-DRIVEN
+# server, because the machinery deliberately refuses to let an unmeasured entry
+# bootstrap itself: `status = "unmeasured"` entries are DROPPED rather than given
+# empty thresholds, so `resolve()` fails loudly instead of an unbounded entry
+# passing every check it is handed. A new variant is therefore always
+# measure-then-declare, never gate-then-fill-in.
+#   cold  median 442.3 ms  p90 1314.3 ms   (256/1024/4096 tok: 244.8 / 442.3 / 1310.7)
+#   warm  median 439.6 ms  p90 1291.1 ms   (256/1024/4096 tok: 230.7 / 439.6 / 1290.9)
+# TTFT is box-local — a different box must re-record these, not reuse them.
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/Qwen3.6-35B-A3B-NVFP4"
+gate = "ttft-cold-gate"
+recipe = "qwen3.6/qwen3.6-35b-a3b-nvfp4"
+status = "measured"
+note = """\
+Cold-TTFT guard for the NVFP4 MoE checkpoint — the path fast-MoE default-on \
+actually changes, and which no gate exercised before this entry. Ceilings = \
+dgx1 baseline 442.3 ms median x +3%, 1314.3 ms p90 x +5%."""
+
+[benchmarks.metrics.median_ms]
+max = 455.57
+
+[benchmarks.metrics.p90_ms]
+max = 1380.02
+
+
+
 [[benchmarks]]
 quant = "nvfp4"
 checkpoint = "Qwen/Qwen3.6-35B-A3B-FP8"
@@ -209,6 +249,25 @@ max = 1647.98
 
 [benchmarks.metrics.p90_ms]
 max = 4814.44
+
+# ── NVFP4-MoE VARIANT of the warm-TTFT guard (see the cold note above) ──────
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/Qwen3.6-35B-A3B-NVFP4"
+gate = "ttft-warm-gate"
+recipe = "qwen3.6/qwen3.6-35b-a3b-nvfp4"
+status = "measured"
+note = """\
+Warm-TTFT guard for the NVFP4 MoE checkpoint. Ceilings = dgx1 baseline \
+439.6 ms median x +3%, 1291.1 ms p90 x +5%."""
+
+[benchmarks.metrics.median_ms]
+max = 452.79
+
+[benchmarks.metrics.p90_ms]
+max = 1355.65
+
+
 
 [[benchmarks]]
 quant = "nvfp4"


### PR DESCRIPTION
No gate anywhere exercised an NVFP4 MoE checkpoint. Every entry in `kernels/gb10/qwen3.6-35b-a3b/BENCH.toml` serves `qwen3.6-35b-a3b-fp8-bf16head`, so #654's fast-MoE default-on — gated on `modelopt_mixed_precision || nvfp4_moe`, therefore **inert on FP8** — passed a full 10-gate campaign **without a single gate touching the code it changed**.

This adds `nvidia/Qwen3.6-35B-A3B-NVFP4` as a variant of `ttft-cold-gate` and `ttft-warm-gate`, and records its first baselines.

## Baselines (dgx1, 2026-08-21, recipe `qwen3.6/qwen3.6-35b-a3b-nvfp4`)

| gate | median | p90 | 256 / 1024 / 4096 tok |
|---|---|---|---|
| cold | **442.3 ms** | **1314.3 ms** | 244.8 / 442.3 / 1310.7 |
| warm | **439.6 ms** | **1291.1 ms** | 230.7 / 439.6 / 1290.9 |

Ceilings = baseline × the gates' own limits (+3% median, +5% p90), the same derivation the FP8 entries use:

| gate | subject | median max | p90 max |
|---|---|---|---|
| ttft-cold | Qwen3.6-35B-A3B-FP8 *(default)* | 1728.27 | 4809.76 |
| **ttft-cold** | **nvidia/Qwen3.6-35B-A3B-NVFP4** | **455.57** | **1380.02** |
| ttft-warm | Qwen3.6-35B-A3B-FP8 *(default)* | 1647.98 | 4814.44 |
| **ttft-warm** | **nvidia/Qwen3.6-35B-A3B-NVFP4** | **452.79** | **1355.65** |

The NVFP4 ceilings are **~3.8× tighter** than the FP8 ones. Not a stricter policy — this checkpoint is simply much faster, and a bound sitting 4× above the measured value cannot catch anything.

## Gate runs

| gate | result |
|---|---|
| ttft-cold (NVFP4) | **PASS** −1.5% median · −1.2% p90 |
| ttft-warm (NVFP4) | **PASS** −0.6% median · −0.2% p90 |

## No new benchmark id, no code change, no recipe change

Three things already existed and did the work:

- **Variant support** — `hw.models` is a map with one `default = true`, and `record_path_for` names non-default records `YYYY-MM-DD-<sha>-<slug>.json`. The NVFP4 records land as `…-nvidia-qwen3.6-35b-a3b-nvfp4.json` and cannot collide with the FP8 record from the same commit on the same day.
- **The recipe** — `qwen3.6/qwen3.6-35b-a3b-nvfp4` already exists and is described in-repo as "the DEFAULT 35B recipe". `atlas-recipes` is untouched.
- **The `bfcl-subset` / `-echolp` split was not needed** — that pattern is for genuinely different benchmarks, not for a second subject of the same one.

## A variant cannot bootstrap itself

`baseline_for` **drops** `status = "unmeasured"` entries rather than admitting them with empty thresholds, so `resolve()` fails loudly instead of an unbounded entry passing every check it is handed. A new variant is therefore always **measure-then-declare**: run it against a self-driven server, then commit the numbers. These baselines were produced that way.

That is also why a ceiling cannot be ratcheted in the same change that first records its baseline — the baseline has to exist first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1