### PR TITLE
[DO NOT MERGE] W4A4 native FP4 GEMM — parked at 1.77x with a multi-day continuation plan

### DIFF
--- a/crates/spark-model/examples/w4a4_bench.rs
+++ b/crates/spark-model/examples/w4a4_bench.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! PHASE-1 MMA PROOF: hand-rolled Sm120 block-scaled FP4 MMA vs the CUTLASS
+//! collective.
+//!
+//! The simplest possible single-tile-looped [M,N,K] GEMM built on a hand-written
+//!   mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3
+//! (kernel module `fp4_mma_microtest`, kernels `fp4_microtest_pack` +
+//! `fp4_microtest_mma`). NO cp.async, NO grouping, NO gate+up fusion.
+//!
+//! Oracle: spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t — the SAME Sm120
+//! block-scaled FP4 math. MUST agree cos >= 0.999 at M=64, N=1024, K=2048.
+//!
+//! Build (remote GB10):
+//!   cargo build --release -p spark-model --example fp4_mma_microproof \
+//!     --no-default-features --features "cuda gpu-examples"
+//! Run: target/release/examples/fp4_mma_microproof
+
+use anyhow::{Result, bail};
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
+
+// ───────────────────────── deterministic PRNG ─────────────────────────
+struct Rng(u64);
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn unit(&mut self) -> f32 {
+        ((self.next_u64() >> 40) as f32) / ((1u64 << 24) as f32)
+    }
+    fn uniform(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + (hi - lo) * self.unit()
+    }
+}
+
+fn f32_to_bf16_bits(f: f32) -> u16 {
+    let bits = f.to_bits();
+    if (bits & 0x7FFF_FFFF) > 0x7F80_0000 {
+        return ((bits >> 16) | 0x0040) as u16;
+    }
+    let rounding_bias = 0x7FFF + ((bits >> 16) & 1);
+    (bits.wrapping_add(rounding_bias) >> 16) as u16
+}
+fn bf16_bits_to_f32(b: u16) -> f32 {
+    f32::from_bits((b as u32) << 16)
+}
+
+fn u16s_to_le(v: &[u16]) -> Vec<u8> {
+    v.iter().flat_map(|x| x.to_le_bytes()).collect()
+}
+fn upload_bytes(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len())?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+fn read_bf16(gpu: &dyn GpuBackend, ptr: DevicePtr, m: usize, n: usize) -> Result<Vec<u16>> {
+    let mut raw = vec![0u8; m * n * 2];
+    gpu.copy_d2h(ptr, &mut raw)?;
+    Ok(raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect())
+}
+
+fn cosine_u16(a: &[u16], b: &[u16]) -> f64 {
+    let (mut dot, mut na, mut nb) = (0f64, 0f64, 0f64);
+    for i in 0..a.len() {
+        let x = bf16_bits_to_f32(a[i]) as f64;
+        let y = bf16_bits_to_f32(b[i]) as f64;
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na > 0.0 && nb > 0.0 {
+        dot / (na.sqrt() * nb.sqrt())
+    } else {
+        0.0
+    }
+}
+
+fn main() -> Result<()> {
+    // Real qkvz shape on the 35B NVFP4: hidden 2048 -> q2048+k2048+v4096+z4096.
+    let m: usize = std::env::var("W4A4_M").ok().and_then(|v| v.parse().ok()).unwrap_or(2048);
+    let n: usize = std::env::var("W4A4_N").ok().and_then(|v| v.parse().ok()).unwrap_or(12288);
+    let k: usize = std::env::var("W4A4_K").ok().and_then(|v| v.parse().ok()).unwrap_or(2048);
+    let seed = 0x_5151_A7A7u64;
+    println!("=== W4A4 native GEMM: correctness + speed vs CUTLASS ===");
+    println!("M={m} N={n} K={k}; oracle = nvfp4_gemm_bf16_act_weight_t (same Sm120 FP4 math)");
+
+    let backend = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let gpu: &dyn GpuBackend = &backend;
+    let stream = gpu.create_stream()?;
+
+    let mut rng = Rng(seed);
+    let a_bf16: Vec<u16> = (0..m * k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-1.0, 1.0)))
+        .collect();
+    let b_bf16: Vec<u16> = (0..n * k)
+        .map(|_| f32_to_bf16_bits(rng.uniform(-0.5, 0.5)))
+        .collect();
+
+    let a_ptr = upload_bytes(gpu, &u16s_to_le(&a_bf16))?;
+    let b_ptr = upload_bytes(gpu, &u16s_to_le(&b_bf16))?;
+
+    // ── Oracle: CUTLASS collective. Pack B once into [K/2,N]/[K/16,N]. ──
+    let packed_len = (k / 2) * n;
+    let scale_len = (k / 16) * n;
+    let packed_ptr = gpu.alloc(packed_len)?;
+    let scale_ptr = gpu.alloc(scale_len)?;
+    spark_runtime::cutlass::pack_bf16_weight_to_nvfp4_t(
+        b_ptr.0,
+        packed_ptr.0,
+        scale_ptr.0,
+        n as u32,
+        k as u32,
+        stream,
+    )?;
+    gpu.synchronize(stream)?;
+
+    let out_oracle = gpu.alloc(m * n * 2)?;
+    spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t(
+        a_ptr.0,
+        packed_ptr.0,
+        scale_ptr.0,
+        1.0,
+        out_oracle.0,
+        m as u32,
+        n as u32,
+        k as u32,
+        stream,
+    )?;
+    gpu.synchronize(stream)?;
+    let c_oracle = read_bf16(gpu, out_oracle, m, n)?;
+
+    // ── Hand-rolled MMA path ──
+    // Pre-pass pack A[M][K] and B[N][K] into natural-layout packed+scales.
+    let pack_handle = gpu.kernel("w4a4_gemm", "w4a4_pack_act")?;
+    let mma_handle = gpu.kernel("w4a4_gemm", std::env::var("W4A4_KERNEL").as_deref().unwrap_or("w4a4_gemm_t_tiled"))?;
+
+    let a_packed = gpu.alloc((k / 2) * m)?;
+    let a_scales = gpu.alloc((k / 16) * m)?;
+    let b_packed = gpu.alloc((k / 2) * n)?;
+    let b_scales = gpu.alloc((k / 16) * n)?;
+
+    // pack A: grid (rows, groups/threads), block 128 over groups
+    let groups = (k / 16) as u32;
+    let pack_a = || -> Result<()> {
+        KernelLaunch::new(gpu, pack_handle)
+            .grid([div_ceil((m as u32) * groups, 256), 1, 1])
+            .block([256, 1, 1])
+            .arg_ptr(a_ptr)
+            .arg_ptr(a_packed)
+            .arg_ptr(a_scales)
+            .arg_u32(m as u32)
+            .arg_u32(k as u32)
+            .launch(stream)?;
+        Ok(())
+    };
+    let pack_b = || -> Result<()> {
+        KernelLaunch::new(gpu, pack_handle)
+            .grid([div_ceil((n as u32) * groups, 256), 1, 1])
+            .block([256, 1, 1])
+            .arg_ptr(b_ptr)
+            .arg_ptr(b_packed)
+            .arg_ptr(b_scales)
+            .arg_u32(n as u32)
+            .arg_u32(k as u32)
+            .launch(stream)?;
+        Ok(())
+    };
+    pack_a()?;
+    pack_b()?;
+    gpu.synchronize(stream)?;
+
+    let out_mma = gpu.alloc(m * n * 2)?;
+    let mma_launch = || -> Result<()> {
+        KernelLaunch::new(gpu, mma_handle)
+            .grid([
+                div_ceil(n as u32, if std::env::var("W4A4_KERNEL").as_deref()==Ok("w4a4_gemm_t") {32} else {128}),
+                div_ceil(m as u32, match std::env::var("W4A4_KERNEL").as_deref() {
+                    Ok("w4a4_gemm_t") => 32,
+                    Ok("w4a4_gemm_t_big") => 128,
+                    Ok("w4a4_gemm_t_huge") => 256,
+                    _ => 64,
+                }), 1])
+            .block([256, 1, 1])
+            .arg_ptr(a_packed)
+            .arg_ptr(a_scales)
+            .arg_ptr(b_packed)
+            .arg_ptr(b_scales)
+            .arg_ptr(out_mma)
+            .arg_u32(m as u32)
+            .arg_u32(n as u32)
+            .arg_u32(k as u32)
+            .launch(stream)?;
+        Ok(())
+    };
+    mma_launch()?;
+    gpu.synchronize(stream)?;
+    let c_mma = read_bf16(gpu, out_mma, m, n)?;
+
+    // ── timing: 3 warmup + 20 timed, CUDA-stream synchronised ──
+    let time_it = |f: &dyn Fn() -> Result<()>| -> Result<f64> {
+        for _ in 0..3 { f()?; }
+        gpu.synchronize(stream)?;
+        let t0 = std::time::Instant::now();
+        for _ in 0..20 { f()?; }
+        gpu.synchronize(stream)?;
+        Ok(t0.elapsed().as_secs_f64() * 1000.0 / 20.0)
+    };
+    let t_w4a4 = time_it(&mma_launch)?;
+    // CUTLASS oracle at the SAME shape. NOTE: this call includes CUTLASS's own
+    // in-kernel activation pack (atlas_cutlass_pack_bf16_act_nvfp4), so for a
+    // like-for-like number our pack is timed with us below.
+    let oracle_launch = || -> Result<()> {
+        spark_runtime::cutlass::nvfp4_gemm_bf16_act_weight_t(
+            a_ptr.0, packed_ptr.0, scale_ptr.0, 1.0, out_oracle.0,
+            m as u32, n as u32, k as u32, stream,
+        )?;
+        Ok(())
+    };
+    let t_cut = time_it(&oracle_launch)?;
+    let t_ours_full = time_it(&(|| -> Result<()> { pack_a()?; mma_launch() }))?;
+    println!();
+    println!("  w4a4 GEMM only        {t_w4a4:8.3} ms/iter");
+    println!("  w4a4 pack+GEMM        {t_ours_full:8.3} ms/iter   <- like-for-like");
+    println!("  CUTLASS (pack+GEMM)   {t_cut:8.3} ms/iter");
+    println!("  ratio (ours/CUTLASS)  {:8.3}x", t_ours_full / t_cut);
+
+    let cos = cosine_u16(&c_mma, &c_oracle);
+    println!();
+    println!("hand-rolled MMA  vs  CUTLASS collective  cosine = {cos:.6}");
+    // sample a few values
+    println!(
+        "sample [0][0..4]: mma={:?} oracle={:?}",
+        &c_mma[0..4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>(),
+        &c_oracle[0..4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>()
+    );
+    println!(
+        "sample [1][0..4]: mma={:?} oracle={:?}",
+        &c_mma[n..n + 4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>(),
+        &c_oracle[n..n + 4]
+            .iter()
+            .map(|&b| bf16_bits_to_f32(b))
+            .collect::<Vec<_>>()
+    );
+
+    for p in [
+        a_ptr, b_ptr, packed_ptr, scale_ptr, out_oracle, a_packed, a_scales, b_packed, b_scales,
+        out_mma,
+    ] {
+        gpu.free(p).ok();
+    }
+
+    if cos >= 0.999 {
+        println!("\nPASS: cos {cos:.6} >= 0.999");
+        Ok(())
+    } else {
+        bail!("FAIL: cos {cos:.6} < 0.999");
+    }
+}

--- a/kernels/gb10/qwen3.6-35b-a3b/nvfp4/w4a4_gemm.cu
+++ b/kernels/gb10/qwen3.6-35b-a3b/nvfp4/w4a4_gemm.cu
@@ -21,6 +21,91 @@
 // proves this exact instruction and operand mapping against the CUTLASS Sm120
 // collective at cos = 1.000000 (see examples/fp4_mma_microproof.rs).
 
+// ═══════════════════════════════════════════════════════════════════════════
+// ⛔ PARKED — DO NOT WIRE INTO ANY DISPATCH PATH WITHOUT AN EXPLICIT DECISION.
+//
+// This file is CORRECT and UNUSED. It is kept as a proven building block plus a
+// continuation plan, so whoever resumes starts at 1.77x rather than at zero.
+//
+// ── WHY IT IS PARKED ──────────────────────────────────────────────────────
+// Enabling it moves the flagship NVFP4 path from W4A16 to W4A4: activations go
+// bf16 -> e2m1. That is a NUMERICS change on a shipping model, and at the
+// current 1.77x it would buy only ~15 ms of cold TTFT (574 -> ~559, -2.6%).
+// A precision change is not worth 2.6%. It becomes worth discussing at ~1.1x or
+// better, where the prize is the full ~71 ms.
+//
+// ── WHAT IS ALREADY ESTABLISHED (do not re-derive) ────────────────────────
+// 1. The gap to CUTLASS is PRECISION, not engineering. An add-one-in survey of
+//    all 8 CUTLASS-selectable paths (35B NVFP4, cold TTFT, n=8/arm, one binary):
+//        nvfp4-qkvz   -35.5 ms     moe-grouped  -38.7 ms
+//        dense-gemm     0.0 ms     attn-kv/-o   +1.3/+1.4 ms (WE are faster)
+//        ssm-out/attn-q -5.0/-4.4 ms (marginal)
+//    Only qkvz and grouped-MoE carry a gap, and both route through the
+//    `w4a16_gemm*` family.
+// 2. IT IS NOT MISSING PIPELINING. `moe_w4a16_grouped_gemm_ptrtable_t_k64` — the
+//    kernel `grouped_silu_down` actually runs — ALREADY has K_STEP_T64=64,
+//    double buffering, 45 cp.async uses, PAD_T64/BP_PAD bank padding and
+//    N_TILE_LG=128. Checked, not assumed. There is no structural work left at
+//    W4A16, which is why W4A4 is the only route.
+// 3. The MMA and its operand/scale layout are PROVEN: cos = 1.000000 against the
+//    CUTLASS Sm120 collective at every shape tried. See
+//    `examples/fp4_mma_microproof.rs` and `fp4_mma_microtest.cu`.
+//
+// ── MEASURED LADDER (M=2048 N=12288 K=2048, the real qkvz shape; like-for-like
+//    including the activation pack) ──────────────────────────────────────────
+//        naive (no reuse)          15.254 ms   24.8x    ~4.7 GB redundant reads
+//        tiled 64x128               1.353 ms    2.24x
+//        pipelined 64x128           1.437 ms    2.40x   NO HELP at large M
+//        128x128                    1.117 ms    1.87x
+//        256x128                    1.173 ms    1.83x   REGRESSED: 209 regs -> 1 CTA/SM
+//        128x128 + bank padding     1.115 ms    1.77x   <- best, this file
+//        CUTLASS                    ~0.63  ms   1.00x   <- target
+//        w4a16 (derived)            ~1.5   ms   2.4x    <- the bar to beat
+//
+// ── THE MULTI-DAY PLAN, IN ORDER ──────────────────────────────────────────
+// Three consecutive structural fixes each delivered far LESS than their model
+// predicted (pipelining, bigger tile, bank padding). That pattern says the
+// remaining 1.77x is not reachable by more of the same. DO NOT START WITH TILE
+// SIZE SWEEPS — that ground is covered above.
+//
+// Day 1 — measure where the 1.77x actually goes.
+//   ncu the 128x128 kernel and CUTLASS's collective on the SAME shape and diff
+//   them: sm__throughput, dram__throughput, warp stall reasons, achieved
+//   occupancy, smem bank conflicts. Every optimisation above was chosen from a
+//   traffic model; none was chosen from a stall profile, and the models kept
+//   over-predicting. ★ Do NOT ncu a live serve on GB10: kernel replay snapshots
+//   the working set and unified memory has no headroom — it hard-froze this box
+//   twice. Profile `examples/w4a4_bench.rs` instead (~6 GB).
+//
+// Day 2 — multi-stage async pipeline (3-4 deep), not 2.
+//   The 2-stage attempt here hurt at large M because 3072 CTAs already hide the
+//   load latency between CTAs. A deeper pipeline only pays alongside a LARGER
+//   tile, where CTA count drops and intra-CTA overlap starts to matter. These
+//   two must be tried TOGETHER; separately they cancel (that is exactly what the
+//   256x128 row above shows).
+//
+// Day 3 — warp specialisation.
+//   Split producer (cp.async staging) from consumer (MMA) warps, as the CUTLASS
+//   collective does. This is the single biggest structural difference remaining
+//   and the reason its 128x128x128 tile sustains what ours cannot.
+//
+// Day 4 — swizzled smem layout.
+//   The `W4A4_KBP 48` padding here is a crude stand-in for a real XOR swizzle.
+//   Padding cost smem and bought ~0 absolute time, so a swizzle is worth doing
+//   properly rather than widening the pad further.
+//
+// Day 5 — grouped variant for the MoE path.
+//   qkvz is a dense GEMM; `grouped_silu_down`/`grouped_gate_up` need per-expert
+//   pointer tables. Do this only AFTER the dense kernel is within ~1.1x, or the
+//   grouped version inherits the same deficit with more moving parts.
+//
+// ── GATE BEFORE ANY CLAIM ─────────────────────────────────────────────────
+// cos >= 0.999 vs the CUTLASS oracle is NECESSARY BUT NOT SUFFICIENT. The
+// shelved SPLIT=4 GDN spine read cos 1.0000 and still failed two accuracy gates.
+// Run the 4-minute ssm-poisoning tripwire (12/12 byte-identical) and then the
+// FULL accuracy suite before treating any speed number as shippable.
+// ═══════════════════════════════════════════════════════════════════════════
+
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>

--- a/kernels/gb10/qwen3.6-35b-a3b/nvfp4/w4a4_gemm.cu
+++ b/kernels/gb10/qwen3.6-35b-a3b/nvfp4/w4a4_gemm.cu
@@ -1,0 +1,762 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// W4A4 NVFP4 GEMM for SM120 — the native answer to the CUTLASS grouped/dense
+// NVFP4 path, with NO CUTLASS dependency.
+//
+// WHY THIS EXISTS. An add-one-in survey of all 8 CUTLASS-selectable paths found
+// exactly two carrying a real gap on the 35B NVFP4 (cold TTFT, n=8/arm):
+//     nvfp4-qkvz    -35.5 ms      moe-grouped   -38.7 ms
+//     dense-gemm      0.0 ms      attn-kv/o     +1.3/+1.4 ms (we are FASTER)
+// Both gaps route through the `w4a16_gemm*` family, and both have one cause:
+// CUTLASS quantizes ACTIVATIONS to NVFP4 and feeds block-scaled FP4 tensor
+// cores (`m16n8k64.e2m1.e2m1`), while w4a16 dequantizes weights to bf16 and
+// runs `m16n8k16.bf16.bf16`. That is 4x the K-depth per instruction and 4x less
+// smem traffic for B.
+//
+// ★ THIS CHANGES NUMERICS: activations go bf16 -> e2m1 (per-16-element ue4m3
+// scale). It is NOT a drop-in for w4a16 and must clear the full accuracy gate
+// suite before it can be a default. Gated behind ATLAS_W4A4_QKVZ.
+//
+// The MMA fragment/scale layout below is not guesswork: `fp4_mma_microtest.cu`
+// proves this exact instruction and operand mapping against the CUTLASS Sm120
+// collective at cos = 1.000000 (see examples/fp4_mma_microproof.rs).
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+// 8 warps per CTA, each owning one 16x8 MMA tile: 2 along M (2*16=32) x 4 along
+// N (4*8=32). The CTA tile MUST equal that coverage — declaring 64x64 here while
+// the warps only reach 32x32 leaves 3/4 of the output unwritten (cos 0.4955).
+#define W4A4_M_TILE   32
+#define W4A4_N_TILE   32
+#define W4A4_K_STEP   64
+#define W4A4_GROUP    16     // elements per ue4m3 scale
+
+// ── ue4m3 encode/decode (mirrors the cutlass pack; see microtest) ────────────
+// ue4m3 is the CUTLASS float_ue4m3_t byte: e4m3 magnitude with the sign bit
+// clear (scales are non-negative). Use the HARDWARE conversion rather than
+// hand-rolled exponent/mantissa bit work — a hand-rolled version of this
+// scored cos 0.9909 against the CUTLASS oracle where this one scores 1.000000.
+__device__ __forceinline__ unsigned char w4a4_f2ue4m3(float scale) {
+    __nv_fp8_e4m3 v = __nv_fp8_e4m3(scale);
+    return *reinterpret_cast<unsigned char*>(&v);
+}
+
+// Decode a ue4m3 byte back to float. REQUIRED, not cosmetic: elements must be
+// quantized against the scale the MMA will actually multiply by (the ROUNDED
+// ue4m3), not the raw float it was derived from. Dividing by the unrounded
+// scale leaves a systematic residual on every element — measured cos 0.9909
+// against the CUTLASS oracle at every shape tried, versus 1.000000 with this.
+__device__ __forceinline__ float w4a4_ue4m3_to_f(unsigned char byte) {
+    __nv_fp8_e4m3 v = *reinterpret_cast<__nv_fp8_e4m3*>(&byte);
+    return (float)v;
+}
+
+// e2m1 round-to-nearest of v/scale, returned as a 4-bit code.
+__device__ __forceinline__ unsigned char w4a4_f2e2m1(float x) {
+    unsigned char sign = x < 0.0f ? 8 : 0;
+    float a = fabsf(x);
+    unsigned char mag;
+    if      (a <= 0.25f) mag = 0;
+    else if (a <= 0.75f) mag = 1;
+    else if (a <= 1.25f) mag = 2;
+    else if (a <= 1.75f) mag = 3;
+    else if (a <= 2.5f)  mag = 4;
+    else if (a <= 3.5f)  mag = 5;
+    else if (a <= 5.0f)  mag = 6;
+    else                mag = 7;
+    return (unsigned char)(sign | mag);
+}
+
+// ── Pack bf16 activations [M,K] -> packed e2m1 [M,K/2] + ue4m3 [M,K/16] ──────
+// One thread per 16-element group. Mirrors fp4_microtest_pack, which is the
+// kernel validated against the CUTLASS activation pack.
+extern "C" __global__ void w4a4_pack_act(
+    const __nv_bfloat16* __restrict__ src,
+    unsigned char* __restrict__ packed,
+    unsigned char* __restrict__ scales,
+    int m, int k) {
+    const unsigned long long gid =
+        (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    const int groups = k / W4A4_GROUP;
+    const unsigned long long total = (unsigned long long)m * groups;
+    if (gid >= total) return;
+    const int row = (int)(gid / groups);
+    const int group = (int)(gid % groups);
+    const int base = group * W4A4_GROUP;
+
+    float v[W4A4_GROUP];
+    float max_abs = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < W4A4_GROUP; ++i) {
+        v[i] = __bfloat162float(src[(unsigned long long)row * k + base + i]);
+        max_abs = fmaxf(max_abs, fabsf(v[i]));
+    }
+    const float scale = max_abs > 0.0f ? max_abs / 6.0f : 1.0f;
+    const unsigned char sf = w4a4_f2ue4m3(scale);
+    scales[(unsigned long long)row * groups + group] = sf;
+    const float decoded = w4a4_ue4m3_to_f(sf);
+    const float inv = decoded > 0.0f ? 1.0f / decoded : 0.0f;
+    #pragma unroll
+    for (int i = 0; i < W4A4_GROUP; i += 2) {
+        const unsigned char lo = w4a4_f2e2m1(v[i] * inv);
+        const unsigned char hi = w4a4_f2e2m1(v[i + 1] * inv);
+        packed[(unsigned long long)row * (k / 2) + (base + i) / 2] =
+            (unsigned char)(lo | (hi << 4));
+    }
+}
+
+// ── fragment gather helpers (layout proven by fp4_mma_microtest) ─────────────
+// 8 consecutive e2m1 from packed[row][kk..kk+7] (kk even) into one u32:
+// nibble j is element kk+j; byte (kk+j)/2 low/high.
+__device__ __forceinline__ unsigned int w4a4_gather_a8(
+    const unsigned char* __restrict__ packed, int row, int kk, int k) {
+    const unsigned char* p = packed + (unsigned long long)row * (k / 2) + kk / 2;
+    unsigned int out = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j += 2) {
+        const unsigned char b = p[j / 2];
+        out |= (unsigned int)(b & 0x0F) << (4 * j);
+        out |= (unsigned int)(b >> 4) << (4 * (j + 1));
+    }
+    return out;
+}
+
+// 4 ue4m3 scale bytes for k-groups [g0, g0+4) of `row`.
+__device__ __forceinline__ unsigned int w4a4_gather_sf4(
+    const unsigned char* __restrict__ scales, int row, int g0, int k) {
+    const int groups = k / W4A4_GROUP;
+    const unsigned char* s = scales + (unsigned long long)row * groups + g0;
+    unsigned int out = 0;
+    #pragma unroll
+    for (int j = 0; j < 4; ++j) out |= (unsigned int)s[j] << (8 * j);
+    return out;
+}
+
+// ── W4A4 GEMM: C[M,N] = A[M,K] * B[N,K]^T, all NVFP4 block-scaled ───────────
+// Warp-per-(16m x 8n) output tile, K walked in 64-element steps — one
+// m16n8k64 MMA per step, versus four m16n8k16 bf16 MMAs in w4a16.
+//
+// B is the WEIGHT in [N,K] packed layout (already NVFP4 on disk — no dequant,
+// which is the whole point: w4a16 spends a smem buffer and a LUT pass turning
+// these nibbles into bf16 before every MMA).
+extern "C" __global__ void __launch_bounds__(256, 1)
+w4a4_gemm_t(
+    const unsigned char* __restrict__ packed_a,
+    const unsigned char* __restrict__ scales_a,
+    const unsigned char* __restrict__ packed_b,
+    const unsigned char* __restrict__ scales_b,
+    __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    // 8 warps per CTA: 2 along M (16 rows each) x 4 along N (8 cols each)
+    const int tile_m = blockIdx.y * W4A4_M_TILE + (warp >> 2) * 16;
+    const int tile_n = blockIdx.x * W4A4_N_TILE + (warp & 3) * 8;
+    if (tile_m >= m || tile_n >= n) return;
+
+    const int q = lane & 3;
+    const int r = lane >> 2;
+    const int sfa_m = (lane & 1) * 8 + (lane >> 2);
+    const int sfb_n = lane >> 2;
+
+    float acc[4] = {0.f, 0.f, 0.f, 0.f};
+
+    for (int k0 = 0; k0 < k; k0 += W4A4_K_STEP) {
+        const unsigned int a0 = w4a4_gather_a8(packed_a, tile_m + r,     k0 +      q * 8, k);
+        const unsigned int a1 = w4a4_gather_a8(packed_a, tile_m + r + 8, k0 +      q * 8, k);
+        const unsigned int a2 = w4a4_gather_a8(packed_a, tile_m + r,     k0 + 32 + q * 8, k);
+        const unsigned int a3 = w4a4_gather_a8(packed_a, tile_m + r + 8, k0 + 32 + q * 8, k);
+        const unsigned int b0 = w4a4_gather_a8(packed_b, tile_n + r,     k0 +      q * 8, k);
+        const unsigned int b1 = w4a4_gather_a8(packed_b, tile_n + r,     k0 + 32 + q * 8, k);
+        const unsigned int sfa = w4a4_gather_sf4(scales_a, tile_m + sfa_m, k0 / 16, k);
+        const unsigned int sfb = w4a4_gather_sf4(scales_b, tile_n + sfb_n, k0 / 16, k);
+#if (__CUDA_ARCH__ >= 1200)
+        unsigned short bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+        asm volatile(
+            "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+            "{%0,  %1,  %2,  %3},"
+            "{%4,  %5,  %6,  %7},"
+            "{%8,  %9},"
+            "{%10, %11, %12, %13},"
+            "{%14},"
+            "{%15, %16},"
+            "{%17},"
+            "{%18, %19};\n"
+            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+            : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+              "r"(b0), "r"(b1),
+              "f"(acc[0]), "f"(acc[1]), "f"(acc[2]), "f"(acc[3]),
+              "r"(sfa), "h"(bidA), "h"(tidA),
+              "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+    }
+
+    // Epilogue: acc[0..3] -> rows (r, r+8) x cols (2q, 2q+1) of the 16x8 tile.
+    const int om0 = tile_m + r;
+    const int om1 = tile_m + r + 8;
+    const int on0 = tile_n + q * 2;
+    if (om0 < m && on0     < n) out[(unsigned long long)om0 * n + on0]     = __float2bfloat16(acc[0]);
+    if (om0 < m && on0 + 1 < n) out[(unsigned long long)om0 * n + on0 + 1] = __float2bfloat16(acc[1]);
+    if (om1 < m && on0     < n) out[(unsigned long long)om1 * n + on0]     = __float2bfloat16(acc[2]);
+    if (om1 < m && on0 + 1 < n) out[(unsigned long long)om1 * n + on0 + 1] = __float2bfloat16(acc[3]);
+}
+
+
+// ── TILED W4A4 GEMM ─────────────────────────────────────────────────────────
+// The kernel above is correct (cos 1.000000 vs CUTLASS) but has NO reuse: each
+// 16x8 warp tile re-reads its own A and B slices from global, which at
+// M=2048,N=12288,K=2048 is ~4.7 GB of traffic and measured 15.2 ms/iter --
+// almost exactly 4.7GB / 273 GB/s, i.e. purely redundant-read bound.
+//
+// This version stages a 64(M) x 128(N) CTA tile through shared memory, one
+// K_STEP=64 slice at a time. Same MMA, same fragment layout, same epilogue --
+// only the operand source changes (smem instead of global), so correctness is
+// inherited. Traffic drops to ~590 MB for the same GEMM.
+//
+// 8 warps, each owning 2 M-positions x 4 N-positions = 8 output tiles, so the
+// staged slice is reused 8x per warp before the next K step.
+#define W4A4_M_CTA 64
+#define W4A4_N_CTA 128
+#define W4A4_KB    (W4A4_K_STEP / 2)        // 32 packed bytes per row per step
+#define W4A4_KG    (W4A4_K_STEP / W4A4_GROUP) // 4 scale bytes per row per step
+
+// Padded smem row stride. A warp reads bank (row*stride/4 + q) % 32 with
+// row = lane>>2 (0..7) and q = lane&3. At the natural 32 B stride that is
+// (row*8+q)%32 -> only 16 distinct banks, a 2-way conflict on EVERY smem read.
+// 48 B gives (row*12+q)%32 -> all 32 banks, conflict-free.
+#define W4A4_KBP 48
+
+__device__ __forceinline__ unsigned int w4a4_smem_a8(
+    const unsigned char* __restrict__ sm, int row, int kloc) {
+    // 8 e2m1 = 4 bytes at [row][kloc/2]; kloc is a multiple of 8 so 4-byte aligned.
+    return *reinterpret_cast<const unsigned int*>(sm + row * W4A4_KB + (kloc >> 1));
+}
+__device__ __forceinline__ unsigned int w4a4_smem_a8p(
+    const unsigned char* __restrict__ sm, int row, int kloc) {
+    return *reinterpret_cast<const unsigned int*>(sm + row * W4A4_KBP + (kloc >> 1));
+}
+__device__ __forceinline__ unsigned int w4a4_smem_sf4(
+    const unsigned char* __restrict__ sm, int row) {
+    return *reinterpret_cast<const unsigned int*>(sm + row * W4A4_KG);
+}
+
+extern "C" __global__ void __launch_bounds__(256, 1)
+w4a4_gemm_t_tiled(
+    const unsigned char* __restrict__ packed_a,
+    const unsigned char* __restrict__ scales_a,
+    const unsigned char* __restrict__ packed_b,
+    const unsigned char* __restrict__ scales_b,
+    __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ unsigned char sA[W4A4_M_CTA * W4A4_KB];
+    __shared__ unsigned char sAs[W4A4_M_CTA * W4A4_KG];
+    __shared__ unsigned char sB[W4A4_N_CTA * W4A4_KB];
+    __shared__ unsigned char sBs[W4A4_N_CTA * W4A4_KG];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int cta_m = blockIdx.y * W4A4_M_CTA;
+    const int cta_n = blockIdx.x * W4A4_N_CTA;
+
+    const int q = lane & 3;
+    const int r = lane >> 2;
+    const int sfa_m = (lane & 1) * 8 + (lane >> 2);
+    const int sfb_n = lane >> 2;
+    const int wm = warp >> 2;    // 0..1
+    const int wn = warp & 3;     // 0..3
+
+    float acc[2][4][4];
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int j = 0; j < 4; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0.0f;
+
+    const int groups = k / W4A4_GROUP;
+
+    for (int k0 = 0; k0 < k; k0 += W4A4_K_STEP) {
+        __syncthreads();
+        // Stage A: 64 rows x 32 bytes = 2048 B -> 8 B per thread.
+        {
+            const int row = tid >> 2, col4 = (tid & 3) << 3;   // 8 bytes each
+            const int gm = cta_m + row;
+            unsigned long long src = (unsigned long long)gm * (k / 2) + (k0 >> 1) + col4;
+            unsigned char* dst = sA + row * W4A4_KB + col4;
+            if (gm < m) *reinterpret_cast<ulonglong1*>(dst) = *reinterpret_cast<const ulonglong1*>(packed_a + src);
+            else *reinterpret_cast<ulonglong1*>(dst) = make_ulonglong1(0);
+        }
+        // Stage B: 128 rows x 32 bytes = 4096 B -> 16 B per thread.
+        {
+            const int row = tid >> 1, col8 = (tid & 1) << 4;
+            const int gn = cta_n + row;
+            unsigned long long src = (unsigned long long)gn * (k / 2) + (k0 >> 1) + col8;
+            unsigned char* dst = sB + row * W4A4_KB + col8;
+            if (gn < n) *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(packed_b + src);
+            else *reinterpret_cast<uint4*>(dst) = make_uint4(0, 0, 0, 0);
+        }
+        // Scales: A 64x4 = 256 B, B 128x4 = 512 B -> one u32 per row.
+        if (tid < W4A4_M_CTA) {
+            const int gm = cta_m + tid;
+            *reinterpret_cast<unsigned int*>(sAs + tid * W4A4_KG) =
+                (gm < m) ? *reinterpret_cast<const unsigned int*>(
+                    scales_a + (unsigned long long)gm * groups + (k0 / W4A4_GROUP)) : 0u;
+        }
+        if (tid < W4A4_N_CTA) {
+            const int gn = cta_n + tid;
+            *reinterpret_cast<unsigned int*>(sBs + tid * W4A4_KG) =
+                (gn < n) ? *reinterpret_cast<const unsigned int*>(
+                    scales_b + (unsigned long long)gn * groups + (k0 / W4A4_GROUP)) : 0u;
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const int lm = wm * 16 + i * 32;          // 0,32 / 16,48
+            const unsigned int a0 = w4a4_smem_a8(sA, lm + r,     q * 8);
+            const unsigned int a1 = w4a4_smem_a8(sA, lm + r + 8, q * 8);
+            const unsigned int a2 = w4a4_smem_a8(sA, lm + r,     32 + q * 8);
+            const unsigned int a3 = w4a4_smem_a8(sA, lm + r + 8, 32 + q * 8);
+            const unsigned int sfa = w4a4_smem_sf4(sAs, lm + sfa_m);
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const int ln = wn * 8 + j * 32;       // 0..31 + {0,32,64,96}
+                const unsigned int b0 = w4a4_smem_a8(sB, ln + r,     q * 8);
+                const unsigned int b1 = w4a4_smem_a8(sB, ln + r, 32 + q * 8);
+                const unsigned int sfb = w4a4_smem_sf4(sBs, ln + sfb_n);
+#if (__CUDA_ARCH__ >= 1200)
+                unsigned short bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+                asm volatile(
+                    "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                    "{%0,  %1,  %2,  %3},"
+                    "{%4,  %5,  %6,  %7},"
+                    "{%8,  %9},"
+                    "{%10, %11, %12, %13},"
+                    "{%14},"
+                    "{%15, %16},"
+                    "{%17},"
+                    "{%18, %19};\n"
+                    : "=f"(acc[i][j][0]), "=f"(acc[i][j][1]), "=f"(acc[i][j][2]), "=f"(acc[i][j][3])
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+                      "r"(b0), "r"(b1),
+                      "f"(acc[i][j][0]), "f"(acc[i][j][1]), "f"(acc[i][j][2]), "f"(acc[i][j][3]),
+                      "r"(sfa), "h"(bidA), "h"(tidA),
+                      "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+            }
+        }
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int crow0 = cta_m + wm * 16 + i * 32 + r;
+        const int crow1 = crow0 + 8;
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const int ccol0 = cta_n + wn * 8 + j * 32 + 2 * q;
+            if (crow0 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow0 * n + ccol0]     = __float2bfloat16(acc[i][j][0]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow0 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][1]);
+            }
+            if (crow1 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow1 * n + ccol0]     = __float2bfloat16(acc[i][j][2]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow1 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][3]);
+            }
+        }
+    }
+}
+
+
+// ── PIPELINED W4A4 GEMM (2-stage cp.async double buffer) ────────────────────
+// The tiled kernel above is 11.5x the naive one but still 2.27x off CUTLASS
+// (1.392 vs 0.614 ms/iter at M=2048,N=12288,K=2048, like-for-like incl. pack).
+// Its remaining stall is structural: one __syncthreads-bounded global load per
+// K-step with nothing overlapping it. This version prefetches step i+1 into the
+// alternate smem buffer with cp.async while the MMAs for step i run, which is
+// the same 2-stage structure w4a16_gemm_t already uses.
+//
+// Same MMA, same fragment layout, same epilogue as the tiled kernel, so the
+// cos=1.000000 correctness carries over unchanged.
+__device__ __forceinline__ void w4a4_cp16(void* dst_smem, const void* src, bool pred) {
+    unsigned int d = __cvta_generic_to_shared(dst_smem);
+    unsigned int nbytes = pred ? 16u : 0u;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;" :: "r"(d), "l"(src), "r"(nbytes));
+}
+__device__ __forceinline__ void w4a4_cp_commit() { asm volatile("cp.async.commit_group;"); }
+__device__ __forceinline__ void w4a4_cp_wait0() { asm volatile("cp.async.wait_group 0;"); }
+
+extern "C" __global__ void __launch_bounds__(256, 1)
+w4a4_gemm_t_pipe(
+    const unsigned char* __restrict__ packed_a,
+    const unsigned char* __restrict__ scales_a,
+    const unsigned char* __restrict__ packed_b,
+    const unsigned char* __restrict__ scales_b,
+    __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ unsigned char sA[2][W4A4_M_CTA * W4A4_KB];
+    __shared__ unsigned char sAs[2][W4A4_M_CTA * W4A4_KG];
+    __shared__ unsigned char sB[2][W4A4_N_CTA * W4A4_KB];
+    __shared__ unsigned char sBs[2][W4A4_N_CTA * W4A4_KG];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int cta_m = blockIdx.y * W4A4_M_CTA;
+    const int cta_n = blockIdx.x * W4A4_N_CTA;
+    const int q = lane & 3, r = lane >> 2;
+    const int sfa_m = (lane & 1) * 8 + (lane >> 2);
+    const int sfb_n = lane >> 2;
+    const int wm = warp >> 2, wn = warp & 3;
+    const int groups = k / W4A4_GROUP;
+
+    // Staging coordinates, fixed across steps.
+    // cp.async.16 requires BOTH operands 16-byte aligned, so every thread must
+    // own a 16-byte-aligned 16-byte span. A row is W4A4_KB=32 B => 2 threads per
+    // row. An earlier revision used 4 threads/row (8 B each, offsets {0,8,16,24})
+    // with a 16-byte copy: misaligned AND overlapping, which faults the whole
+    // context with CUDA_ERROR_MISALIGNED_ADDRESS.
+    const int arow = tid >> 1, acol = (tid & 1) << 4;      // threads 0..127 -> A
+    const int brow = tid >> 1, bcol = (tid & 1) << 4;      // threads 0..255 -> B
+    const int agm = cta_m + arow, bgn = cta_n + brow;
+
+    #define W4A4_STAGE(buf, kk)                                                              \
+        do {                                                                                 \
+            const int _k = (kk);                                                             \
+            if (tid < W4A4_M_CTA * 2)                                                        \
+                w4a4_cp16(sA[buf] + arow * W4A4_KB + acol,                                    \
+                          packed_a + (unsigned long long)agm * (k / 2) + (_k >> 1) + acol,    \
+                          agm < m);                                                          \
+            w4a4_cp16(sB[buf] + brow * W4A4_KB + bcol,                                        \
+                      packed_b + (unsigned long long)bgn * (k / 2) + (_k >> 1) + bcol,        \
+                      bgn < n);                                                               \
+            if (tid < W4A4_M_CTA)                                                             \
+                *reinterpret_cast<unsigned int*>(sAs[buf] + tid * W4A4_KG) =                  \
+                    (cta_m + tid < m) ? *reinterpret_cast<const unsigned int*>(               \
+                        scales_a + (unsigned long long)(cta_m + tid) * groups                 \
+                        + (_k / W4A4_GROUP)) : 0u;                                            \
+            if (tid < W4A4_N_CTA)                                                             \
+                *reinterpret_cast<unsigned int*>(sBs[buf] + tid * W4A4_KG) =                  \
+                    (cta_n + tid < n) ? *reinterpret_cast<const unsigned int*>(               \
+                        scales_b + (unsigned long long)(cta_n + tid) * groups                 \
+                        + (_k / W4A4_GROUP)) : 0u;                                            \
+            w4a4_cp_commit();                                                                 \
+        } while (0)
+
+    float acc[2][4][4];
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int j = 0; j < 4; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0.0f;
+
+    W4A4_STAGE(0, 0);
+    int buf = 0;
+    for (int k0 = 0; k0 < k; k0 += W4A4_K_STEP) {
+        w4a4_cp_wait0();
+        __syncthreads();
+        const int nxt = k0 + W4A4_K_STEP;
+        if (nxt < k) W4A4_STAGE(buf ^ 1, nxt);
+
+        const unsigned char* pA  = sA[buf];
+        const unsigned char* pAs = sAs[buf];
+        const unsigned char* pB  = sB[buf];
+        const unsigned char* pBs = sBs[buf];
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const int lm = wm * 16 + i * 32;
+            const unsigned int a0 = w4a4_smem_a8(pA, lm + r,     q * 8);
+            const unsigned int a1 = w4a4_smem_a8(pA, lm + r + 8, q * 8);
+            const unsigned int a2 = w4a4_smem_a8(pA, lm + r,     32 + q * 8);
+            const unsigned int a3 = w4a4_smem_a8(pA, lm + r + 8, 32 + q * 8);
+            const unsigned int sfa = w4a4_smem_sf4(pAs, lm + sfa_m);
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const int ln = wn * 8 + j * 32;
+                const unsigned int b0 = w4a4_smem_a8(pB, ln + r,     q * 8);
+                const unsigned int b1 = w4a4_smem_a8(pB, ln + r, 32 + q * 8);
+                const unsigned int sfb = w4a4_smem_sf4(pBs, ln + sfb_n);
+#if (__CUDA_ARCH__ >= 1200)
+                unsigned short bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+                asm volatile(
+                    "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                    "{%0,  %1,  %2,  %3},{%4,  %5,  %6,  %7},{%8,  %9},"
+                    "{%10, %11, %12, %13},{%14},{%15, %16},{%17},{%18, %19};\n"
+                    : "=f"(acc[i][j][0]), "=f"(acc[i][j][1]), "=f"(acc[i][j][2]), "=f"(acc[i][j][3])
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+                      "f"(acc[i][j][0]), "f"(acc[i][j][1]), "f"(acc[i][j][2]), "f"(acc[i][j][3]),
+                      "r"(sfa), "h"(bidA), "h"(tidA), "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+            }
+        }
+        buf ^= 1;
+    }
+    #undef W4A4_STAGE
+
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int crow0 = cta_m + wm * 16 + i * 32 + r, crow1 = crow0 + 8;
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const int ccol0 = cta_n + wn * 8 + j * 32 + 2 * q;
+            if (crow0 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow0 * n + ccol0]     = __float2bfloat16(acc[i][j][0]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow0 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][1]);
+            }
+            if (crow1 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow1 * n + ccol0]     = __float2bfloat16(acc[i][j][2]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow1 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][3]);
+            }
+        }
+    }
+}
+
+
+// ── W4A4 GEMM, 128x128 CTA tile ────────────────────────────────────────────
+// The 64x128 tiled kernel measured 1.389 ms/iter at M=2048,N=12288,K=2048 vs
+// CUTLASS 0.643. Its traffic is 3072 CTAs x (64 KB A + 128 KB B) = 590 MB;
+// doubling the M extent halves the CTA count and the A re-reads:
+//   1536 CTAs x (128 KB A + 128 KB B) = 393 MB.
+// Each warp now owns 4 M-positions x 4 N-positions = 16 output tiles (64 acc
+// registers). Same MMA, same fragment layout, same epilogue.
+#define W4A4_M_CTA2 128
+
+extern "C" __global__ void __launch_bounds__(256, 1)
+w4a4_gemm_t_big(
+    const unsigned char* __restrict__ packed_a,
+    const unsigned char* __restrict__ scales_a,
+    const unsigned char* __restrict__ packed_b,
+    const unsigned char* __restrict__ scales_b,
+    __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ unsigned char sA[W4A4_M_CTA2 * W4A4_KBP];
+    __shared__ unsigned char sAs[W4A4_M_CTA2 * W4A4_KG];
+    __shared__ unsigned char sB[W4A4_N_CTA * W4A4_KBP];
+    __shared__ unsigned char sBs[W4A4_N_CTA * W4A4_KG];
+
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int cta_m = blockIdx.y * W4A4_M_CTA2;
+    const int cta_n = blockIdx.x * W4A4_N_CTA;
+    const int q = lane & 3, r = lane >> 2;
+    const int sfa_m = (lane & 1) * 8 + (lane >> 2);
+    const int sfb_n = lane >> 2;
+    const int wm = warp >> 2, wn = warp & 3;
+    const int groups = k / W4A4_GROUP;
+    const int row2 = tid >> 1, col2 = (tid & 1) << 4;   // 16 B/thread, 16 B aligned
+
+    float acc[4][4][4];
+    #pragma unroll
+    for (int i = 0; i < 4; i++)
+        #pragma unroll
+        for (int j = 0; j < 4; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0.0f;
+
+    for (int k0 = 0; k0 < k; k0 += W4A4_K_STEP) {
+        __syncthreads();
+        // A: 128 rows x 32 B = 4096 B -> 16 B per thread across 256 threads.
+        {
+            const int gm = cta_m + row2;
+            unsigned char* dst = sA + row2 * W4A4_KBP + col2;
+            if (gm < m)
+                *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(
+                    packed_a + (unsigned long long)gm * (k / 2) + (k0 >> 1) + col2);
+            else *reinterpret_cast<uint4*>(dst) = make_uint4(0, 0, 0, 0);
+        }
+        // B: 128 rows x 32 B = 4096 B -> same shape.
+        {
+            const int gn = cta_n + row2;
+            unsigned char* dst = sB + row2 * W4A4_KBP + col2;
+            if (gn < n)
+                *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(
+                    packed_b + (unsigned long long)gn * (k / 2) + (k0 >> 1) + col2);
+            else *reinterpret_cast<uint4*>(dst) = make_uint4(0, 0, 0, 0);
+        }
+        if (tid < W4A4_M_CTA2) {
+            const int gm = cta_m + tid;
+            *reinterpret_cast<unsigned int*>(sAs + tid * W4A4_KG) =
+                (gm < m) ? *reinterpret_cast<const unsigned int*>(
+                    scales_a + (unsigned long long)gm * groups + (k0 / W4A4_GROUP)) : 0u;
+        }
+        if (tid < W4A4_N_CTA) {
+            const int gn = cta_n + tid;
+            *reinterpret_cast<unsigned int*>(sBs + tid * W4A4_KG) =
+                (gn < n) ? *reinterpret_cast<const unsigned int*>(
+                    scales_b + (unsigned long long)gn * groups + (k0 / W4A4_GROUP)) : 0u;
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            const int lm = wm * 16 + i * 32;      // 0,32,64,96 / 16,48,80,112
+            const unsigned int a0 = w4a4_smem_a8p(sA, lm + r,     q * 8);
+            const unsigned int a1 = w4a4_smem_a8p(sA, lm + r + 8, q * 8);
+            const unsigned int a2 = w4a4_smem_a8p(sA, lm + r,     32 + q * 8);
+            const unsigned int a3 = w4a4_smem_a8p(sA, lm + r + 8, 32 + q * 8);
+            const unsigned int sfa = w4a4_smem_sf4(sAs, lm + sfa_m);
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const int ln = wn * 8 + j * 32;
+                const unsigned int b0 = w4a4_smem_a8p(sB, ln + r,     q * 8);
+                const unsigned int b1 = w4a4_smem_a8p(sB, ln + r, 32 + q * 8);
+                const unsigned int sfb = w4a4_smem_sf4(sBs, ln + sfb_n);
+#if (__CUDA_ARCH__ >= 1200)
+                unsigned short bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+                asm volatile(
+                    "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                    "{%0,  %1,  %2,  %3},{%4,  %5,  %6,  %7},{%8,  %9},"
+                    "{%10, %11, %12, %13},{%14},{%15, %16},{%17},{%18, %19};\n"
+                    : "=f"(acc[i][j][0]), "=f"(acc[i][j][1]), "=f"(acc[i][j][2]), "=f"(acc[i][j][3])
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+                      "f"(acc[i][j][0]), "f"(acc[i][j][1]), "f"(acc[i][j][2]), "f"(acc[i][j][3]),
+                      "r"(sfa), "h"(bidA), "h"(tidA), "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+            }
+        }
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const int crow0 = cta_m + wm * 16 + i * 32 + r, crow1 = crow0 + 8;
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const int ccol0 = cta_n + wn * 8 + j * 32 + 2 * q;
+            if (crow0 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow0 * n + ccol0]     = __float2bfloat16(acc[i][j][0]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow0 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][1]);
+            }
+            if (crow1 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow1 * n + ccol0]     = __float2bfloat16(acc[i][j][2]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow1 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][3]);
+            }
+        }
+    }
+}
+
+
+// ── W4A4 GEMM, 256x128 CTA tile ────────────────────────────────────────────
+// Traffic accounting at M=2048,N=12288,K=2048 (A=2 MB, B=12 MB packed):
+//   traffic = (N/N_CTA)*A + (M/M_CTA)*B
+//   64x128 -> 96*2 + 32*12 = 576 MB   measured 1.353 ms
+//  128x128 -> 96*2 + 16*12 = 384 MB   measured 1.143 ms
+//  256x128 -> 96*2 +  8*12 = 288 MB   <- this kernel
+// Extending M (not N) is what cuts the expensive term, because B is 6x larger
+// than A here. Each warp owns 8 M-positions x 4 N-positions = 32 tiles.
+#define W4A4_M_CTA3 256
+
+extern "C" __global__ void __launch_bounds__(256, 1)
+w4a4_gemm_t_huge(
+    const unsigned char* __restrict__ packed_a,
+    const unsigned char* __restrict__ scales_a,
+    const unsigned char* __restrict__ packed_b,
+    const unsigned char* __restrict__ scales_b,
+    __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ unsigned char sA[W4A4_M_CTA3 * W4A4_KB];
+    __shared__ unsigned char sAs[W4A4_M_CTA3 * W4A4_KG];
+    __shared__ unsigned char sB[W4A4_N_CTA * W4A4_KB];
+    __shared__ unsigned char sBs[W4A4_N_CTA * W4A4_KG];
+
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int cta_m = blockIdx.y * W4A4_M_CTA3;
+    const int cta_n = blockIdx.x * W4A4_N_CTA;
+    const int q = lane & 3, r = lane >> 2;
+    const int sfa_m = (lane & 1) * 8 + (lane >> 2);
+    const int sfb_n = lane >> 2;
+    const int wm = warp >> 2, wn = warp & 3;
+    const int groups = k / W4A4_GROUP;
+    const int row2 = tid >> 1, col2 = (tid & 1) << 4;
+
+    float acc[8][4][4];
+    #pragma unroll
+    for (int i = 0; i < 8; i++)
+        #pragma unroll
+        for (int j = 0; j < 4; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0.0f;
+
+    for (int k0 = 0; k0 < k; k0 += W4A4_K_STEP) {
+        __syncthreads();
+        // A: 256 rows x 32 B = 8192 B -> two 16 B stores per thread.
+        #pragma unroll
+        for (int h = 0; h < 2; h++) {
+            const int lr = row2 + h * 128;
+            const int gm = cta_m + lr;
+            unsigned char* dst = sA + lr * W4A4_KB + col2;
+            if (gm < m)
+                *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(
+                    packed_a + (unsigned long long)gm * (k / 2) + (k0 >> 1) + col2);
+            else *reinterpret_cast<uint4*>(dst) = make_uint4(0, 0, 0, 0);
+        }
+        {
+            const int gn = cta_n + row2;
+            unsigned char* dst = sB + row2 * W4A4_KB + col2;
+            if (gn < n)
+                *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(
+                    packed_b + (unsigned long long)gn * (k / 2) + (k0 >> 1) + col2);
+            else *reinterpret_cast<uint4*>(dst) = make_uint4(0, 0, 0, 0);
+        }
+        #pragma unroll
+        for (int h = 0; h < 1; h++) {
+            const int gm = cta_m + tid;
+            *reinterpret_cast<unsigned int*>(sAs + tid * W4A4_KG) =
+                (gm < m) ? *reinterpret_cast<const unsigned int*>(
+                    scales_a + (unsigned long long)gm * groups + (k0 / W4A4_GROUP)) : 0u;
+        }
+        if (tid < W4A4_N_CTA) {
+            const int gn = cta_n + tid;
+            *reinterpret_cast<unsigned int*>(sBs + tid * W4A4_KG) =
+                (gn < n) ? *reinterpret_cast<const unsigned int*>(
+                    scales_b + (unsigned long long)gn * groups + (k0 / W4A4_GROUP)) : 0u;
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            const int lm = wm * 16 + i * 32;
+            const unsigned int a0 = w4a4_smem_a8(sA, lm + r,     q * 8);
+            const unsigned int a1 = w4a4_smem_a8(sA, lm + r + 8, q * 8);
+            const unsigned int a2 = w4a4_smem_a8(sA, lm + r,     32 + q * 8);
+            const unsigned int a3 = w4a4_smem_a8(sA, lm + r + 8, 32 + q * 8);
+            const unsigned int sfa = w4a4_smem_sf4(sAs, lm + sfa_m);
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const int ln = wn * 8 + j * 32;
+                const unsigned int b0 = w4a4_smem_a8(sB, ln + r,     q * 8);
+                const unsigned int b1 = w4a4_smem_a8(sB, ln + r, 32 + q * 8);
+                const unsigned int sfb = w4a4_smem_sf4(sBs, ln + sfb_n);
+#if (__CUDA_ARCH__ >= 1200)
+                unsigned short bidA = 0, tidA = 0, bidB = 0, tidB = 0;
+                asm volatile(
+                    "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+                    "{%0,  %1,  %2,  %3},{%4,  %5,  %6,  %7},{%8,  %9},"
+                    "{%10, %11, %12, %13},{%14},{%15, %16},{%17},{%18, %19};\n"
+                    : "=f"(acc[i][j][0]), "=f"(acc[i][j][1]), "=f"(acc[i][j][2]), "=f"(acc[i][j][3])
+                    : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+                      "f"(acc[i][j][0]), "f"(acc[i][j][1]), "f"(acc[i][j][2]), "f"(acc[i][j][3]),
+                      "r"(sfa), "h"(bidA), "h"(tidA), "r"(sfb), "h"(bidB), "h"(tidB));
+#endif
+            }
+        }
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        const int crow0 = cta_m + wm * 16 + i * 32 + r, crow1 = crow0 + 8;
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const int ccol0 = cta_n + wn * 8 + j * 32 + 2 * q;
+            if (crow0 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow0 * n + ccol0]     = __float2bfloat16(acc[i][j][0]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow0 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][1]);
+            }
+            if (crow1 < m) {
+                if (ccol0     < n) out[(unsigned long long)crow1 * n + ccol0]     = __float2bfloat16(acc[i][j][2]);
+                if (ccol0 + 1 < n) out[(unsigned long long)crow1 * n + ccol0 + 1] = __float2bfloat16(acc[i][j][3]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ⛔ DO NOT MERGE

Parked deliberately. The kernel is **correct and unused** — it is not wired into any dispatch path and changes no default. This PR exists so the work is resumable rather than archaeology.

## Why parked

Enabling it moves the flagship NVFP4 path from **W4A16 → W4A4** (activations bf16 → e2m1). At the current **1.77×** off CUTLASS that buys ~15 ms of cold TTFT (574 → ~559, **−2.6%**) in exchange for a numerics change on a shipping model. That is a poor trade. It becomes worth discussing at **~1.1×**, where the prize is the full **~71 ms**.

## What is already established — do not re-derive

| finding | evidence |
|---|---|
| The gap is **precision, not engineering** | Add-one-in survey of all 8 CUTLASS-selectable paths (35B NVFP4, cold TTFT, n=8/arm, one binary): only `nvfp4-qkvz` (−35.5 ms) and `moe-grouped` (−38.7 ms) carry a gap. `dense-gemm` is a dead heat; **`attn-kv`/`attn-o` we already beat** (+1.3/+1.4 ms); `ssm-out`/`attn-q` are marginal |
| It is **not** missing pipelining | `moe_w4a16_grouped_gemm_ptrtable_t_k64` — the kernel `grouped_silu_down` actually runs — already has `K_STEP_T64=64`, double buffering, 45 `cp.async` uses, `PAD_T64`/`BP_PAD` bank padding, `N_TILE_LG=128`. Checked, not assumed |
| The MMA and its operand/scale layout are proven | **cos = 1.000000** vs the CUTLASS Sm120 collective at every shape, zero CUTLASS dependency at runtime |

## Measured ladder (M=2048 N=12288 K=2048, real qkvz shape, like-for-like incl. activation pack)

| variant | ms/iter | vs CUTLASS | note |
|---|---|---|---|
| naive | 15.254 | 24.8× | ~4.7 GB redundant reads |
| tiled 64×128 | 1.353 | 2.24× | |
| pipelined 64×128 | 1.437 | 2.40× | **no help at large M** |
| 128×128 | 1.117 | 1.87× | |
| 256×128 | 1.173 | 1.83× | **regressed** — 209 regs ⇒ 1 CTA/SM |
| **128×128 + bank padding** | **1.115** | **1.77×** | best |
| CUTLASS | ~0.63 | 1.00× | target |
| *w4a16 (derived)* | *~1.5* | *2.4×* | the bar |

## The plan, in order

**Anti-pattern first:** three consecutive structural fixes each delivered far less than their model predicted. **Do not start with tile-size sweeps** — that ground is covered above.

| day | work |
|---|---|
| **1** | **ncu-diff** ours vs CUTLASS on one shape (stall reasons, occupancy, bank conflicts). Every choice so far came from a *traffic model*, none from a *stall profile*, and the models over-predicted. ⚠️ Profile `examples/w4a4_bench.rs`, **never a live serve** — kernel replay on GB10 unified memory hard-froze the box twice |
| **2** | 3–4 stage async pipeline **together with** a larger tile. Separately they cancel — that is exactly what the 256×128 row shows |
| **3** | **Warp specialisation** (producer/consumer split), the biggest remaining structural difference from the CUTLASS collective |
| **4** | Real XOR swizzle instead of the crude `W4A4_KBP=48` pad |
| **5** | Grouped variant for the MoE path — only **after** dense is within ~1.1×, or it inherits the deficit with more moving parts |

## Gate before any claim

`cos >= 0.999` is **necessary but not sufficient**. The shelved SPLIT=4 GDN spine read **cos 1.0000** and still failed two accuracy gates. Run the 4-minute `ssm-poisoning` tripwire (expect 12/12 byte-identical), then the **full** accuracy suite, before treating any speed number as shippable.

The same plan is written into the header of `kernels/gb10/qwen3.6-35b-a3b/nvfp4/w4a4_gemm.cu`, so it cannot drift from the code if this PR is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1