### PR TITLE
bench: tighten the TTFT ceilings (they had drifted 3x loose) + key the rolling baseline per model

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/agentic-webserver/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787321563,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787320898,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 49.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 53.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 16267661034,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8945096,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5134084,
+      "gpu_compute_apps": [
+        {
+          "pid": 117601,
+          "name": "./target/release/spark",
+          "used_mib": 109190
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787321563,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 62.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.9
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 16267661034,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8726524,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5271088,
+      "gpu_compute_apps": [
+        {
+          "pid": 117601,
+          "name": "./target/release/spark",
+          "used_mib": 109216
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 665,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 7.0,
+      "hottest_chassis_delta_c": 8.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +8 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "decode_tps": 34.66355440211359,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 5.899043583636363,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 648.8947942,
+    "sum_completion_tokens": 22493.0,
+    "sum_tool_calls": 106.0,
+    "sum_turns": 110.0,
+    "sum_wall_s": 663.231574599,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 5.899s/turn ≤ 8.500 · Σwall 663s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=34.66, followed_directions=10.00, iterations=10.00, s_per_turn=5.90, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=648.89, sum_completion_tokens=22493.00, sum_tool_calls=106.00, sum_turns=110.00, sum_wall_s=663.23, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 5.899s/turn ≤ 8.500 · Σwall 663s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787320865,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787311542,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 42.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 49.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 42.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 43.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 43.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 44.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 44.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 16267661034,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7625308,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5127636,
+      "gpu_compute_apps": [
+        {
+          "pid": 101259,
+          "name": "./target/release/spark",
+          "used_mib": 109972
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787320865,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 64.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.4
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 16267661034,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6168544,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5133956,
+      "gpu_compute_apps": [
+        {
+          "pid": 101259,
+          "name": "./target/release/spark",
+          "used_mib": 109998
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 9323,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 15.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +15 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.77,
+    "overall_accuracy": 86.35,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.35 (baseline min 86.10) · normalized 86.77 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.77, overall_accuracy=86.35, samples=1004.00 · Pass: overall 86.35 (baseline min 86.10) · normalized 86.77 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/bfcl-subset/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,454 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787317257,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787311527,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 47.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 53.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.5
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 19102070353,
+        "sw_thermal_us": 19190,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34709708,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4475232,
+      "gpu_compute_apps": [
+        {
+          "pid": 87985,
+          "name": "./target/release/spark",
+          "used_mib": 84423
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787317257,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 19102070353,
+        "sw_thermal_us": 57194,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34849316,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4490220,
+      "gpu_compute_apps": [
+        {
+          "pid": 87985,
+          "name": "./target/release/spark",
+          "used_mib": 84559
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5730,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 38004,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 23.0,
+      "hottest_chassis_delta_c": 29.499999999999993
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "thermally throttled for 0.00% of the run",
+        "hottest chassis zone moved +29 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/concurrency-sweep/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787317633,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2502.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787317418,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 19102070353,
+        "sw_thermal_us": 57194,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 16624380,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4490392,
+      "gpu_compute_apps": [
+        {
+          "pid": 94905,
+          "name": "./target/release/spark",
+          "used_mib": 102137
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787317633,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 85.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.5
+        }
+      ],
+      "sm_clock_mhz": 2502.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 19102070353,
+        "sw_thermal_us": 57194,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15832968,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4490924,
+      "gpu_compute_apps": [
+        {
+          "pid": 94905,
+          "name": "./target/release/spark",
+          "used_mib": 102365
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 215,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 17.299999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 87.91855328006419,
+    "c16_ttft_p50_ms": 15935.894681,
+    "c1_aggregate_tok_s": 19.18547365569324,
+    "c1_ttft_p50_ms": 1361.45915,
+    "c4_aggregate_tok_s": 45.056099553362344,
+    "c4_ttft_p50_ms": 3536.9935219999998,
+    "c8_aggregate_tok_s": 59.887724709093334,
+    "c8_ttft_p50_ms": 8626.592383000001,
+    "min_completion_tokens": 320.0,
+    "peak_aggregate_tok_s": 87.91855328006419,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 19.2/16.2 · C4 45.1/33.5 · C8 59.9/50.5 · C16 87.9/72.0 · peak 87.9/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=87.92, c16_ttft_p50_ms=15935.89, c1_aggregate_tok_s=19.19, c1_ttft_p50_ms=1361.46, c4_aggregate_tok_s=45.06, c4_ttft_p50_ms=3536.99, c8_aggregate_tok_s=59.89, c8_ttft_p50_ms=8626.59, min_completion_tokens=320.00, peak_aggregate_tok_s=87.92, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 19.2/16.2 · C4 45.1/33.5 · C8 59.9/50.5 · C16 87.9/72.0 · peak 87.9/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/decode-floor/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787317400,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787317275,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 63.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 72.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 19102070353,
+        "sw_thermal_us": 57194,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 16709616,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4490308,
+      "gpu_compute_apps": [
+        {
+          "pid": 94524,
+          "name": "./target/release/spark",
+          "used_mib": 102074
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787317400,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 79.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 91.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 91.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.7
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 19102070353,
+        "sw_thermal_us": 57194,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 16797160,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4490316,
+      "gpu_compute_apps": [
+        {
+          "pid": 94524,
+          "name": "./target/release/spark",
+          "used_mib": 102078
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 125,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 16.0,
+      "hottest_chassis_delta_c": 18.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +18 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.988231075447512
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 23.0 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=22.99 · Pass: median decode 23.0 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787312160,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787312047,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 53.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5274432,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4689552,
+      "gpu_compute_apps": [
+        {
+          "pid": 649586,
+          "name": "./target/release/spark",
+          "used_mib": 109360
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787312159,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 72.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 78.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5540816,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4767580,
+      "gpu_compute_apps": [
+        {
+          "pid": 649586,
+          "name": "./target/release/spark",
+          "used_mib": 109386
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 112,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 16.9
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 112.020826999,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=112.02, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787311740,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787311656,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 47.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5076552,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4715556,
+      "gpu_compute_apps": [
+        {
+          "pid": 647619,
+          "name": "./target/release/spark",
+          "used_mib": 109332
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787311739,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.4
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5008080,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4753748,
+      "gpu_compute_apps": [
+        {
+          "pid": 647619,
+          "name": "./target/release/spark",
+          "used_mib": 109356
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 83,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 21.0,
+      "hottest_chassis_delta_c": 21.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +21 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1573.242005,
+    "p90_ms": 4259.864130999999,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.2% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1573.24, p90_ms=4259.86, samples=36.00 · Pass: median -0.2% (limit +3.0%) · p90 -0.2% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787311974,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787311813,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 50.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 55.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.3
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5383752,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4313840,
+      "gpu_compute_apps": [
+        {
+          "pid": 648412,
+          "name": "./target/release/spark",
+          "used_mib": 109290
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787311973,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 71.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 81.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5214568,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4374080,
+      "gpu_compute_apps": [
+        {
+          "pid": 648412,
+          "name": "./target/release/spark",
+          "used_mib": 109314
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 160,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 21.0,
+      "hottest_chassis_delta_c": 25.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +26 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1510.6203950000001,
+    "p90_ms": 4279.2204759999995,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.2% (limit +3.0%) · p90 -0.3% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=1510.62, p90_ms=4279.22, samples=36.00 · Pass: median -0.2% (limit +3.0%) · p90 -0.3% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/video-fidelity/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787311584,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787311568,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 48.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 56.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 31154908,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 8493536,
+      "gpu_compute_apps": [
+        {
+          "pid": 646579,
+          "name": "./target/release/spark",
+          "used_mib": 83618
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787311584,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 70.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.4
+        }
+      ],
+      "sm_clock_mhz": 2483.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 21174451605,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 31160708,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 8495112,
+      "gpu_compute_apps": [
+        {
+          "pid": 646579,
+          "name": "./target/release/spark",
+          "used_mib": 83628
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 16,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 14.100000000000009
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +14 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 731.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1459.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 2916.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=731.00, conc_2_correct=2.00, conc_2_wall_ms=1459.00, conc_4_correct=4.00, conc_4_wall_ms=2916.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-21-3f04d9a8cc.json
+++ b/.benchmarks/vision-fidelity/2026-08-21-3f04d9a8cc.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "3f04d9a8cc",
+  "recorded_at": 1787321652,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787321598,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 50.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 56.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 16267661034,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8817092,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5271228,
+      "gpu_compute_apps": [
+        {
+          "pid": 128150,
+          "name": "./target/release/spark",
+          "used_mib": 109300
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787321652,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.5
+        }
+      ],
+      "sm_clock_mhz": 2509.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 16267661034,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8906476,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5271328,
+      "gpu_compute_apps": [
+        {
+          "pid": 128150,
+          "name": "./target/release/spark",
+          "used_mib": 109337
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 54,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 11.0,
+      "hottest_chassis_delta_c": 10.299999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +10 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 474.0,
+    "conc_2_wall_ms": 945.0,
+    "conc_4_wall_ms": 1794.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=474.00, conc_2_wall_ms=945.00, conc_4_wall_ms=1794.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/crates/atlas-plugin/src/benchmarks/baseline.rs
+++ b/crates/atlas-plugin/src/benchmarks/baseline.rs
@@ -55,17 +55,84 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
-fn path(store: &ArtifactStore, benchmark_id: &str) -> Result<std::path::PathBuf> {
-    Ok(store.runs_dir(benchmark_id)?.join("baseline.json"))
+/// Where ONE MODEL's baseline for `benchmark_id` lives.
+///
+/// Keyed by model, mirroring `gate::record::record_path_for`. A gate can carry
+/// several checkpoints (BENCH.toml `hw.models`), and one shared `baseline.json`
+/// per gate means the variants overwrite each other: run the NVFP4 variant with
+/// `update_baseline = true` and the next default-FP8 run finds a baseline from
+/// another target, correctly declines to compare, and emits `info` instead of a
+/// verdict — so the gate cannot pass. Observed on ttft-cold/warm within hours of
+/// the first variant being added.
+///
+/// The detection was already right (`Baseline::target`/`model` are recorded and
+/// a mismatch is reported, never silently compared); only the storage was not
+/// keyed to match. `None` keeps the historical name for single-model gates.
+fn path(
+    store: &ArtifactStore,
+    benchmark_id: &str,
+    model: Option<&str>,
+) -> Result<std::path::PathBuf> {
+    let name = match model {
+        Some(m) => format!("baseline-{}.json", crate::gate::record::variant_slug(m)),
+        None => "baseline.json".to_string(),
+    };
+    Ok(store.runs_dir(benchmark_id)?.join(name))
 }
 
 /// Read the stored baseline, if any. A corrupt file is treated as absent —
 /// running without a baseline is a degraded but correct mode, while refusing to
 /// start because of an unreadable cache file is not.
 pub fn load(store: &ArtifactStore, benchmark_id: &str) -> Option<Baseline> {
-    let p = path(store, benchmark_id).ok()?;
+    // No model named: legacy `baseline.json` first, else the sole model-keyed
+    // file if exactly one exists. With two or more we refuse to guess — picking
+    // one would be the silent cross-target comparison this keying prevents.
+    if let Ok(p) = path(store, benchmark_id, None)
+        && let Ok(text) = std::fs::read_to_string(p)
+        && let Ok(b) = serde_json::from_str::<Baseline>(&text)
+    {
+        return Some(b);
+    }
+    let dir = store.runs_dir(benchmark_id).ok()?;
+    let mut found: Option<Baseline> = None;
+    for e in std::fs::read_dir(dir).ok()? {
+        let path = e.ok()?.path();
+        let name = path.file_name()?.to_string_lossy().to_string();
+        if !(name.starts_with("baseline-") && name.ends_with(".json")) {
+            continue;
+        }
+        if found.is_some() {
+            return None; // ambiguous
+        }
+        found = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|t| serde_json::from_str::<Baseline>(&t).ok());
+    }
+    found
+}
+
+/// Load the baseline for one model. Falls back to the legacy unkeyed file only
+/// when it belongs to the SAME model, so upgrading keeps history without ever
+/// inheriting another checkpoint's numbers.
+pub fn load_for(
+    store: &ArtifactStore,
+    benchmark_id: &str,
+    model: Option<&str>,
+) -> Option<Baseline> {
+    if let Some(m) = model
+        && let Ok(p) = path(store, benchmark_id, Some(m))
+        && let Ok(text) = std::fs::read_to_string(p)
+        && let Ok(b) = serde_json::from_str::<Baseline>(&text)
+    {
+        return Some(b);
+    }
+    let p = path(store, benchmark_id, None).ok()?;
     let text = std::fs::read_to_string(p).ok()?;
-    serde_json::from_str(&text).ok()
+    let b: Baseline = serde_json::from_str(&text).ok()?;
+    match model {
+        Some(m) if b.model != m => None,
+        _ => Some(b),
+    }
 }
 
 /// Record a new baseline. Call only after a run that is trustworthy — a gate
@@ -83,7 +150,7 @@ pub fn save(
         model: model.to_string(),
         metrics,
     };
-    let p = path(store, benchmark_id)?;
+    let p = path(store, benchmark_id, Some(model))?;
     std::fs::write(&p, serde_json::to_string_pretty(&baseline)?)
         .with_context(|| format!("writing {}", p.display()))
 }
@@ -96,6 +163,51 @@ mod tests {
         let d = std::env::temp_dir().join(format!("atlas-baseline-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&d);
         ArtifactStore::with_root(d)
+    }
+
+    /// Two checkpoints of ONE gate must not clobber each other's baseline.
+    ///
+    /// Regression pin: ttft-cold-gate gained an NVFP4 variant, the variant ran
+    /// with `update_baseline = true`, and the next default-FP8 run found NVFP4
+    /// numbers under a shared `baseline.json`. It correctly refused to compare —
+    /// and therefore produced `info`, not a verdict, so the gate could not pass.
+    #[test]
+    fn two_models_of_one_gate_keep_separate_baselines() {
+        let s = store("variants");
+        let mut a = BTreeMap::new();
+        a.insert("median_ms".into(), 1677.9);
+        save(&s, "ttft-cold", "http://h:1", "Qwen/Qwen3.6-35B-A3B-FP8", a).unwrap();
+        let mut b = BTreeMap::new();
+        b.insert("median_ms".into(), 442.3);
+        save(
+            &s,
+            "ttft-cold",
+            "http://h:1",
+            "nvidia/Qwen3.6-35B-A3B-NVFP4",
+            b,
+        )
+        .unwrap();
+        let fp8 = load_for(&s, "ttft-cold", Some("Qwen/Qwen3.6-35B-A3B-FP8")).unwrap();
+        assert_eq!(fp8.get("median_ms"), Some(1677.9));
+        let nv = load_for(&s, "ttft-cold", Some("nvidia/Qwen3.6-35B-A3B-NVFP4")).unwrap();
+        assert_eq!(nv.get("median_ms"), Some(442.3));
+    }
+
+    /// A model with no baseline of its own reads as ABSENT rather than
+    /// inheriting the legacy shared file from a different checkpoint.
+    #[test]
+    fn legacy_shared_baseline_is_not_inherited_by_another_model() {
+        let s = store("legacy");
+        let p = s.runs_dir("ttft-warm").unwrap().join("baseline.json");
+        let legacy = Baseline {
+            recorded_at: now_secs(),
+            target: "http://h:1".into(),
+            model: "Qwen/Qwen3.6-35B-A3B-FP8".into(),
+            metrics: BTreeMap::from([("median_ms".to_string(), 1600.0)]),
+        };
+        std::fs::write(&p, serde_json::to_string(&legacy).unwrap()).unwrap();
+        assert!(load_for(&s, "ttft-warm", Some("Qwen/Qwen3.6-35B-A3B-FP8")).is_some());
+        assert!(load_for(&s, "ttft-warm", Some("nvidia/Qwen3.6-35B-A3B-NVFP4")).is_none());
     }
 
     #[test]

--- a/crates/atlas-plugin/src/benchmarks/ttft_verdict.rs
+++ b/crates/atlas-plugin/src/benchmarks/ttft_verdict.rs
@@ -33,7 +33,12 @@ impl TtftGate {
             Err(_) => return (Verdict::info("no handle"), Vec::new()),
         };
         let id = self.mode.descriptor().id;
-        let stored = baseline::load(&store, id);
+        // Model-keyed: a gate with several checkpoints (BENCH.toml `hw.models`)
+        // otherwise has its variants overwrite one shared baseline.json, and the
+        // run after every variant switch finds another target's numbers,
+        // declines to compare, and reports `info` instead of a verdict.
+        let model_now = self.handle().ok().map(|h| h.target().model.clone());
+        let stored = baseline::load_for(&store, id, model_now.as_deref());
         let mut summary = vec![
             Stat::new("Median TTFT", stats::fmt_ms(median), "ms").with_style(CellStyle::Accent),
             Stat::new("p90 TTFT", stats::fmt_ms(p90), "ms"),

--- a/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
@@ -182,15 +182,23 @@ recipe = "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head"
 default = true
 status = "measured"
 note = """\
-Gate C cold-TTFT guard. Ceilings = same-box baseline (dgx1, 2026-08-04, canonical serve \
-recipe) × the gate limits: median 1677.93 ms × +3% and p90 4580.73 ms × +5%. TTFT is \
-box-local by nature — a different box must re-record this baseline, not reuse it."""
+Gate C cold-TTFT guard. Ceilings = same-box baseline (dgx1, 2026-08-21, canonical serve \
+recipe) × the gate limits: median 1576.3 ms × +3% and p90 4268.6 ms × +5%. TTFT is \
+box-local by nature — a different box must re-record this baseline, not reuse it.
+
+RE-CUT 2026-08-21. The prior ceilings came from a 2026-08-04 baseline and were never \
+re-derived, so they had drifted to 9.6% (median) and 12.7% (p90) of slack against a \
+gate designed for 3%/5% — a backstop 3x looser than intended cannot catch the \
+regression it exists for. Note `update_baseline = true` means the gate compares each \
+run to the PREVIOUS run, so it tracks drift while these committed values are the only \
+ABSOLUTE bound; they therefore have to be re-cut whenever the path gets materially \
+faster, which it did (shared-kernel wins: fused GDN spine + token-parallel conv1d)."""
 
 [benchmarks.metrics.median_ms]
-max = 1728.27
+max = 1623.59
 
 [benchmarks.metrics.p90_ms]
-max = 4809.76
+max = 4482.03
 
 # ── NVFP4-MoE VARIANT of the cold-TTFT guard ────────────────────────────────
 # The FP8 entry above is the DEFAULT subject, and until this entry existed it
@@ -240,15 +248,18 @@ recipe = "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head"
 default = true
 status = "measured"
 note = """\
-Gate C warm-TTFT guard. Ceilings = same-box baseline (dgx1, 2026-08-04, canonical serve \
-recipe) × the gate limits: median 1599.98 ms × +3% and p90 4585.18 ms × +5%. TTFT is \
-box-local by nature — a different box must re-record this baseline, not reuse it."""
+Gate C warm-TTFT guard. Ceilings = same-box baseline (dgx1, 2026-08-21, canonical serve \
+recipe) × the gate limits: median 1513.9 ms × +3% and p90 4292.8 ms × +5%. TTFT is \
+box-local by nature — a different box must re-record this baseline, not reuse it.
+
+RE-CUT 2026-08-21, same reasoning as the cold entry above: the 2026-08-04 ceilings had \
+drifted to 8.9%/12.2% of slack on a 3%/5% gate."""
 
 [benchmarks.metrics.median_ms]
-max = 1647.98
+max = 1559.32
 
 [benchmarks.metrics.p90_ms]
-max = 4814.44
+max = 4507.44
 
 # ── NVFP4-MoE VARIANT of the warm-TTFT guard (see the cold note above) ──────
 [[benchmarks]]


### PR DESCRIPTION
Two gate-integrity fixes, batched into one campaign.

## 1. The TTFT ceilings had drifted 3× looser than designed

Measured on dgx1 today, canonical recipe, after the shared-kernel wins (#647 fused GDN spine, #657 token-parallel conv1d — both live in `kernels/gb10/common/` and reach **dense and MoE** via `Qwen3SsmLayer`):

| | measured | old ceiling | slack | designed for |
|---|---|---|---|---|
| cold median | 1576.3 ms | 1728.27 | **9.6%** | 3% |
| cold p90 | 4268.6 ms | 4809.76 | **12.7%** | 5% |
| warm median | 1513.9 ms | 1647.98 | **8.9%** | 3% |
| warm p90 | 4292.8 ms | 4814.44 | **12.2%** | 5% |

A backstop sitting 3× looser than its own limit cannot catch the regression it exists for. Re-derived at the gates' own +3% / +5%:

| gate | median max | p90 max |
|---|---|---|
| ttft-cold | 1728.27 → **1623.59** | 4809.76 → **4482.03** |
| ttft-warm | 1647.98 → **1559.32** | 4814.44 → **4507.44** |

Cold-median backstop tightens by **105 ms**, cold-p90 by **328 ms**.

**Why this drifts silently:** `update_baseline = true` means the gate compares each run to the *previous* run, so it tracks drift continuously while these committed values are the only **absolute** bound. Improvements ratchet the rolling baseline down without touching the ceiling, and the gap widens unnoticed until someone measures. These need re-cutting whenever the path gets materially faster.

**Both TTFT gates pass at −0.2% against the new ceilings** — tight enough to bind, not so tight they're brittle.

## 2. The rolling baseline was keyed per gate, not per model

`BENCH.toml` is variant-aware and record filenames are namespaced by variant — but the rolling baseline was a single `baseline.json` per gate, so variants overwrote each other.

Observed within hours of adding the first variant gate (#656): the NVFP4 arm ran with `update_baseline = true`, and the next default-FP8 run found NVFP4 numbers and emitted

```
Info: baseline was recorded against ... nvidia/Qwen3.6-35B-A3B-NVFP4
      — not comparable, reporting only
```

That's `info`, **not a verdict** — so the gate cannot pass. **A gate silently becomes unverdictable for one run after every variant switch.**

The detection was already right (`Baseline` records `target`/`model`, and a mismatch is reported rather than silently compared); only the storage wasn't keyed to match. Now `baseline-<slug>.json` via the existing `gate::record::variant_slug`, mirroring `record_path_for`:

- `load_for(store, id, Some(model))` is the real API; `ttft_verdict` passes `handle().target().model`
- the legacy unkeyed file is inherited **only** by the model that wrote it, so upgrading keeps history without ever lending one checkpoint's numbers to another
- `load()` with no model reads legacy first, then the sole keyed file if exactly one exists; with two or more it **refuses to guess**

Two regression tests pin both halves.

## Gates — 10/10

| gate | result |
|---|---|
| **ttft-cold** | **−0.2% / −0.2%** vs the NEW ceilings |
| **ttft-warm** | **−0.2% / −0.3%** vs the NEW ceilings |
| bfcl-subset | 84.22 / 84.12 — historical value exactly |
| bfcl-subset-echolp | 86.35 / 86.77 — historical value exactly |
| agentic-webserver | 10/10 · 10/10 · 5.899 s/turn |
| ssm-state-poisoning | 12/12 byte-identical |
| decode-floor | 23.0 tok/s |
| concurrency-sweep | 4 cells, zero vacuous |
| vision / video | 14 cells · 13/13 legs, 0 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1