### PR TITLE
vision-fidelity: predict the serve's declared area bound instead of failing on it (9/14 -> 14/14)

### DIFF
--- a/crates/atlas-plugin/src/benchmarks/vision/driver.rs
+++ b/crates/atlas-plugin/src/benchmarks/vision/driver.rs
@@ -20,7 +20,7 @@ use crate::params::{ParamKind, ParamSpec, ParamValue, ParamValues};
 use crate::plugin::{Plugin, PluginHandle};
 use crate::result::{BenchmarkResult, LogLine, RunStatus, Stat, Verdict as RunVerdict};
 
-use super::geometry::expected_vision_tokens;
+use super::geometry::expected_vision_tokens_bounded;
 use super::probes::{CONTROL, PROBES, Probe};
 use super::provision::{FIXTURES, provision};
 use super::request;
@@ -44,8 +44,10 @@ pub const DESCRIPTOR: BenchmarkDescriptor = BenchmarkDescriptor {
              changes, and the one a capability check cannot see. CAPABILITY asks unambiguous \
              questions about those images. A no-image CONTROL runs last: if it answers as \
              though it saw a picture, the capability leg proved nothing and the run reports \
-             VACUOUS rather than PASS. Images above the server's encoder capacity report \
-             UNMEASURED, never FAIL — that is a deployment setting, not a defect.",
+             VACUOUS rather than PASS. Images the encoder REFUSES report UNMEASURED, never \
+             FAIL — that is a deployment setting, not a defect. A serve that caps vision \
+             area does not refuse, it downscales: declare its bound with vision_max_pixels \
+             and the ladder predicts the downscaled geometry and still asserts every rung.",
     duration_hint: "~1-2 min",
     updated: "2026-08-14",
     needs_confirmation: false,
@@ -92,6 +94,11 @@ pub struct VisionFidelity {
     integrity: Vec<crate::benchmarks::media_integrity::Cell>,
     max_tokens: usize,
     request_timeout_s: u64,
+    /// The area bound the TARGET serve was started with, as an area in pixels;
+    /// 0 means "not declared". Every geometry prediction is made under this
+    /// bound, because a serve that caps vision area answers normally with a
+    /// DOWNSCALED image rather than refusing it.
+    vision_max_pixels: u64,
 }
 
 impl VisionFidelity {
@@ -209,12 +216,38 @@ impl Benchmark for VisionFidelity {
                 ParamKind::Int { min: 30, max: 3600 },
                 ParamValue::Int(300),
             ),
+            ParamSpec::new(
+                "vision_max_pixels",
+                "Target serve's --vision-max-pixels (0 = not set)",
+                "Set this to the SAME area the target server was started with. It is an \
+                 area in pixels, not an edge length, exactly like the flag. Leave it 0 \
+                 when the serve does not pass the flag — the checkpoint's own bound is \
+                 far above every fixture, so nothing downscales and the ladder asserts \
+                 native geometry. \
+                 \n\nWhy this exists: a serve that caps vision area does NOT refuse an \
+                 oversized image, it silently downscales it and answers normally. The \
+                 reply then carries fewer vision tokens than a native-resolution \
+                 prediction expects, and the cell fails while the model is perfectly \
+                 healthy. A run against `--vision-max-pixels 262144` scored 9/14 for \
+                 exactly that reason (2026-08-21) — the five fixtures above the bound. \
+                 Declaring the bound here does not SKIP those rungs: the prediction is \
+                 recomputed for the downscaled geometry and the rung is still asserted, \
+                 so an engine that does not honour its own declared bound still fails.",
+                ParamKind::Int {
+                    min: 0,
+                    // 4096², the engine's own absolute long-side ceiling squared:
+                    // above this the area bound can never be the binding constraint.
+                    max: 16_777_216,
+                },
+                ParamValue::Int(0),
+            ),
         ]
     }
 
     fn configure(&mut self, values: &ParamValues) -> Result<()> {
         self.max_tokens = values.int("max_tokens")? as usize;
         self.request_timeout_s = values.int("request_timeout_s")? as u64;
+        self.vision_max_pixels = values.int("vision_max_pixels")? as u64;
         if self.max_tokens == 0 {
             bail!("max_tokens must be positive");
         }
@@ -240,7 +273,8 @@ impl Benchmark for VisionFidelity {
                 let out = http::chat_stream(handle.target(), &body, self.timeout())
                     .await
                     .context("calibration request failed — is this a vision-capable model?")?;
-                let want = expected_vision_tokens(w, h, 16, 2) as usize;
+                let want =
+                    expected_vision_tokens_bounded(w, h, 16, 2, self.vision_max_pixels) as usize;
                 let overhead = out.prompt_tokens.checked_sub(want).with_context(|| {
                     format!(
                         "calibration: {name} reported {} prompt tokens but its {want} vision \
@@ -264,7 +298,8 @@ impl Benchmark for VisionFidelity {
             Phase::Geometry => {
                 let (name, bytes, w, h) = FIXTURES[self.cursor];
                 let overhead = self.overhead.context("geometry ran before calibration")?;
-                let want = expected_vision_tokens(w, h, 16, 2) as usize;
+                let want =
+                    expected_vision_tokens_bounded(w, h, 16, 2, self.vision_max_pixels) as usize;
                 let body = request::body(&handle.target().model, &[bytes], "Colour?", 8);
                 let cell = match http::chat_stream(handle.target(), &body, self.timeout()).await {
                     Ok(o) => match request::vision_tokens(o.prompt_tokens, overhead) {
@@ -348,6 +383,12 @@ impl Benchmark for VisionFidelity {
                 let h = self.handle()?;
                 let model = h.target().model.clone();
                 let tmo = self.timeout();
+                // Same declared bound the geometry ladder predicts under. The two
+                // fixtures these probes diff are small enough that no realistic
+                // bound moves them, but the delta is an ASSERTED token count like
+                // any other and has no business being the one prediction in this
+                // file that ignores the serve's configuration.
+                let cap = self.vision_max_pixels;
                 // The flat red/blue split, used as the SECOND image of the cache
                 // probe: its dominant color cannot be confused with the gradient
                 // rungs. It lives in EXIF_PAIR, not the geometry ladder, so it is
@@ -560,8 +601,8 @@ impl Benchmark for VisionFidelity {
                     7 => {
                         let (_, small, sw, sh) = FIXTURES[0]; // 224 -> 49
                         let (_, large, lw, lh) = FIXTURES[1]; // 336 -> 121
-                        let delta = (expected_vision_tokens(lw, lh, 16, 2)
-                            - expected_vision_tokens(sw, sh, 16, 2))
+                        let delta = (expected_vision_tokens_bounded(lw, lh, 16, 2, cap)
+                            - expected_vision_tokens_bounded(sw, sh, 16, 2, cap))
                             as usize;
                         let q = "Reply with exactly one word: YES if this image contains a \
                                  white rectangle, NO otherwise.";
@@ -580,8 +621,8 @@ impl Benchmark for VisionFidelity {
                     8 => {
                         let (_, small, sw, sh) = FIXTURES[0]; // 224 -> 49
                         let (_, large, lw, lh) = FIXTURES[1]; // 336 -> 121
-                        let delta = (expected_vision_tokens(lw, lh, 16, 2)
-                            - expected_vision_tokens(sw, sh, 16, 2))
+                        let delta = (expected_vision_tokens_bounded(lw, lh, 16, 2, cap)
+                            - expected_vision_tokens_bounded(sw, sh, 16, 2, cap))
                             as usize;
                         let q = "Reply with exactly one word: YES if this image contains a \
                                  white rectangle, NO otherwise.";

--- a/crates/atlas-plugin/src/benchmarks/vision/driver.rs
+++ b/crates/atlas-plugin/src/benchmarks/vision/driver.rs
@@ -855,12 +855,54 @@ impl Benchmark for VisionFidelity {
                         "{asserted} geometry cells matched, {passed}/{} probes, control held",
                         self.probes.len()
                     )),
-                    VisionVerdict::Fail => RunVerdict::fail(format!(
-                        "{}/{} geometry cells asserted, {passed}/{} probes passed",
-                        asserted,
-                        self.geom.len(),
-                        self.probes.len()
-                    )),
+                    VisionVerdict::Fail => {
+                        // Name WHAT failed. The old reason recited two
+                        // green-looking counts ("14/14 asserted, 3/3 probes
+                        // passed") on a FAIL, and twice in one day a reader
+                        // took it for a pass while the real story — 5
+                        // geometry mismatches — lived only in the scrollback.
+                        let mism: Vec<String> = self
+                            .geom
+                            .iter()
+                            .filter_map(|c| match c {
+                                GeomCell::Mismatch { fixture, want, got } => {
+                                    Some(format!("{fixture} want {want} got {got}"))
+                                }
+                                GeomCell::Error { fixture, msg } => {
+                                    Some(format!("{fixture} ERROR {msg}"))
+                                }
+                                _ => None,
+                            })
+                            .collect();
+                        let mut reason = format!(
+                            "{matched}/{asserted} geometry matched, {passed}/{} probes",
+                            self.probes.len()
+                        );
+                        if !mism.is_empty() {
+                            reason.push_str(": ");
+                            reason.push_str(&mism[..mism.len().min(5)].join("; "));
+                            if mism.len() > 5 {
+                                reason.push_str(&format!(" (+{} more)", mism.len() - 5));
+                            }
+                        }
+                        // Every observed count LOWER than predicted with no
+                        // declared bound is the --vision-max-pixels shape:
+                        // the serve silently downscales, this benchmark
+                        // predicts native geometry, and the operator must
+                        // declare the bound (see the param's help).
+                        let all_low = self.geom.iter().all(|c| match c {
+                            GeomCell::Mismatch { want, got, .. } => got < want,
+                            _ => true,
+                        });
+                        if self.vision_max_pixels == 0 && !mism.is_empty() && all_low {
+                            reason.push_str(
+                                " — every mismatch reads LOW: if the target serve passes \
+                                 --vision-max-pixels, set the vision_max_pixels param to the \
+                                 same value",
+                            );
+                        }
+                        RunVerdict::fail(reason)
+                    }
                     VisionVerdict::Vacuous => RunVerdict::fail(
                         "VACUOUS: the no-image control answered as though it saw one, so the \
                          capability probes are not evidence"

--- a/crates/atlas-plugin/src/benchmarks/vision/geometry.rs
+++ b/crates/atlas-plugin/src/benchmarks/vision/geometry.rs
@@ -41,14 +41,83 @@ pub fn expected_vision_tokens(w: u32, h: u32, patch: u32, merge: u32) -> u32 {
 
 // A `within_bound(w, h, max_pixels)` helper used to live here, documented as
 // letting the geometry leg report UNMEASURED when the served bound could not
-// be determined. Nothing ever called it — the driver asserts every rung
-// unconditionally — so the doc described behaviour the benchmark did not have.
-// Removed rather than wired up: the ladder is deliberately built so that every
-// fixture is inside any plausible bound, which makes the prediction independent
-// of the bound and the unconditional assertion correct. The one rung that
-// straddles the retired 1280px clamp is the point of the exercise (see
-// `provision::FIXTURES`), and it must be ASSERTED rather than skipped, or the
-// regression it exists to catch would be reported as "unmeasured" and pass.
+// be determined. It was removed on the reasoning that "the ladder is
+// deliberately built so that every fixture is inside any plausible bound".
+//
+// ★ That premise turned out to be false, and this is what replaced it. A
+// serve started with `--vision-max-pixels 262144` — a perfectly ordinary
+// deployment setting — puts FIVE of the fourteen fixtures outside the bound,
+// and the run reported 9/14 geometry cells FAILING against a model whose
+// vision path was entirely healthy (2026-08-21). The engine does not REFUSE an
+// image above the bound; `preprocess_image_with_max_pixels` silently
+// downscales it and answers normally, so the reply is a success carrying fewer
+// vision tokens than a native-resolution prediction expects.
+//
+// The fix is NOT to skip those rungs. Skipping is what the removal comment
+// rightly warned against: the rung that straddles the retired 1280px clamp is
+// the entire point of the ladder (see `provision::FIXTURES`), and reporting it
+// "unmeasured" would let the regression it exists to catch pass silently.
+// Instead the bound became an INPUT to the prediction: tell the benchmark what
+// the serve declares, and it predicts the downscaled geometry and asserts THAT.
+// Every rung stays asserted at every bound, and an engine that downscales
+// differently from its own declared bound still fails — which is the property
+// the ladder was built for.
+
+/// The engine's historical long-side clamp, used only when NOTHING declares an
+/// area bound. Mirrors `FALLBACK_MAX_DIM` in `spark-model`'s
+/// `vision_preprocess`.
+pub const FALLBACK_MAX_DIM: u32 = 1280;
+
+/// The absolute long-side ceiling, applied bound or not. Mirrors `ABS_MAX_DIM`.
+/// This is what contains a strip like 64×2048, whose AREA is small but whose
+/// long side is not.
+pub const ABS_MAX_DIM: u32 = 4096;
+
+/// The `(w, h)` the server actually encodes for a `w × h` source under a
+/// declared area `max_pixels`.
+///
+/// Mirror of `spark_model::vision_preprocess::target_size_for`. It is a mirror
+/// rather than a call because `atlas-plugin` drives a server over HTTP and does
+/// not link the model crate; `the_mirror_matches_the_engines_anchors` pins it
+/// to the two figures the engine's own documentation records, so a drift in
+/// either direction fails a test rather than a benchmark run.
+///
+/// `max_pixels` is an AREA, matching the `--vision-max-pixels` flag.
+pub fn served_size(w: u32, h: u32, grid: u32, max_pixels: Option<u64>) -> (u32, u32) {
+    let long_side = w.max(h) as f32;
+    let area = (w as f32) * (h as f32);
+    let bound_scale = match max_pixels.filter(|&p| p > 0) {
+        // A declared AREA bound governs, and REPLACES the long-side clamp.
+        Some(p) => ((p as f32) / area).sqrt(),
+        None => (FALLBACK_MAX_DIM as f32) / long_side,
+    };
+    let abs_scale = (ABS_MAX_DIM as f32) / long_side;
+    let scale = bound_scale.min(abs_scale).min(1.0); // never upscale
+    let tw = ((w as f32 * scale / grid as f32).round() as u32).max(1) * grid;
+    let th = ((h as f32 * scale / grid as f32).round() as u32).max(1) * grid;
+    (tw, th)
+}
+
+/// Merged vision tokens for `w × h` when the serve declares an area bound.
+///
+/// `max_pixels == 0` means "nothing declared", and is NOT the same as passing
+/// `None` to [`served_size`]: an undeclared bound on a real checkpoint means
+/// the checkpoint's own (large) bound governs and nothing downscales, which is
+/// exactly [`expected_vision_tokens`]. The `None` arm of [`served_size`] models
+/// the historical 1280px fallback, which is a DEFECT mode here, not a default.
+pub fn expected_vision_tokens_bounded(
+    w: u32,
+    h: u32,
+    patch: u32,
+    merge: u32,
+    max_pixels: u64,
+) -> u32 {
+    if max_pixels == 0 {
+        return expected_vision_tokens(w, h, patch, merge);
+    }
+    let (tw, th) = served_size(w, h, patch * merge, Some(max_pixels));
+    (tw / patch) * (th / patch) / (merge * merge)
+}
 
 #[cfg(test)]
 #[path = "geometry_tests.rs"]

--- a/crates/atlas-plugin/src/benchmarks/vision/geometry_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/vision/geometry_tests.rs
@@ -144,3 +144,134 @@ fn the_rounding_mode_is_pinned() {
     assert_eq!(snap(720, 32), 736, "22.5 rounds away from zero");
     assert_eq!(snap(854, 32), 864, "26.69 rounds up");
 }
+
+// ── the declared area bound ──────────────────────────────────────────────
+//
+// These pin the mirror of the engine's `target_size_for`. A benchmark that
+// predicts geometry from a COPY of the engine's arithmetic is only as good as
+// the copy, so the copy is asserted against figures the engine's own source
+// documents rather than against itself.
+
+/// Every fixture in the committed ladder, as `(w, h)`.
+const LADDER: [(u32, u32); 14] = [
+    (224, 224),
+    (336, 336),
+    (512, 384),
+    (640, 360),
+    (768, 768),
+    (1024, 576),
+    (1280, 720),
+    (480, 854),
+    (1600, 900),
+    (8, 8),
+    (64, 2048),
+    (224, 224),
+    (224, 224),
+    (224, 224),
+];
+
+#[test]
+fn the_mirror_matches_the_engines_anchors() {
+    // Both figures are quoted in `provision::FIXTURES` for the 1600x900 rung,
+    // which exists precisely to tell these two apart:
+    //   * a correct engine honours the checkpoint's large declared bound and
+    //     leaves it alone                                   -> 1400 tokens
+    //   * the retired long-side clamp scales it to 1280x720 ->  920 tokens
+    assert_eq!(
+        expected_vision_tokens(1600, 900, 16, 2),
+        1400,
+        "unbounded: the checkpoint's own bound is far above 1.44M px"
+    );
+    let (tw, th) = served_size(1600, 900, 32, None);
+    assert_eq!((tw, th), (1280, 736), "the 1280px fallback clamp");
+    assert_eq!(
+        (tw / 16) * (th / 16) / 4,
+        920,
+        "the figure the fallback clamp produces, per provision::FIXTURES"
+    );
+}
+
+#[test]
+fn zero_means_nothing_was_declared() {
+    // The param default. It must be EXACTLY the historical behaviour, or
+    // adding the parameter would silently re-baseline every existing record.
+    for (w, h) in LADDER {
+        assert_eq!(
+            expected_vision_tokens_bounded(w, h, 16, 2, 0),
+            expected_vision_tokens(w, h, 16, 2),
+            "{w}x{h} moved when no bound was declared"
+        );
+    }
+}
+
+#[test]
+fn a_declared_bound_moves_exactly_the_fixtures_above_it() {
+    // The 2026-08-21 case: a serve started with `--vision-max-pixels 262144`
+    // scored 9/14 because five fixtures exceed that area and were silently
+    // downscaled. Predicting under the bound must move those five and ONLY
+    // those five — if it moved a sixth, the mirror would be manufacturing
+    // failures of its own.
+    const CAP: u64 = 262_144;
+    let moved: Vec<(u32, u32)> = LADDER
+        .iter()
+        .copied()
+        .filter(|&(w, h)| {
+            expected_vision_tokens_bounded(w, h, 16, 2, CAP) != expected_vision_tokens(w, h, 16, 2)
+        })
+        .collect();
+    assert_eq!(
+        moved,
+        vec![
+            (768, 768),
+            (1024, 576),
+            (1280, 720),
+            (480, 854),
+            (1600, 900)
+        ],
+        "exactly the five fixtures whose area exceeds {CAP}"
+    );
+    for &(w, h) in &moved {
+        assert!(
+            (w as u64) * (h as u64) > CAP,
+            "{w}x{h} moved but is inside the bound"
+        );
+    }
+}
+
+#[test]
+fn a_declared_bound_never_upscales() {
+    // A bound is a CEILING. The 8x8 and 64x2048 rungs are far inside 262144,
+    // and a `sqrt(bound/area)` scale factor is greater than 1 for both — so
+    // this is the arm where a missing `.min(1.0)` would inflate a fixture
+    // instead of leaving it alone.
+    assert_eq!(expected_vision_tokens_bounded(8, 8, 16, 2, 262_144), 1);
+    assert_eq!(
+        expected_vision_tokens_bounded(64, 2048, 16, 2, 262_144),
+        128
+    );
+}
+
+#[test]
+fn the_discriminating_rung_stays_discriminating_under_a_bound() {
+    // The reason the fix predicts rather than skips. Declaring a bound must
+    // not blunt the one rung the ladder exists for: under a 262144 bound the
+    // correct answer is 252, and an engine that ignored the declared bound and
+    // fell back to the 1280px clamp would still answer 920 and still FAIL.
+    let honoured = expected_vision_tokens_bounded(1600, 900, 16, 2, 262_144);
+    assert_eq!(honoured, 252);
+    let (tw, th) = served_size(1600, 900, 32, None);
+    assert_ne!(
+        honoured,
+        (tw / 16) * (th / 16) / 4,
+        "a declared bound must not make the fallback-clamp defect indistinguishable"
+    );
+}
+
+#[test]
+fn the_absolute_long_side_ceiling_still_applies_under_a_bound() {
+    // A generous AREA bound cannot license an unbounded long side: 64x8192 is
+    // only 512K px, but 8192 is past the 4096 ceiling, so the strip is scaled
+    // by the ceiling rather than by the area.
+    let (_, th) = served_size(64, 8192, 32, Some(16_777_216));
+    assert!(th <= ABS_MAX_DIM, "{th} exceeds the absolute ceiling");
+}


### PR DESCRIPTION
Standalone against `main` — no relation to the #649 train, and it touches no crate any of those PRs touch.

**`vision-fidelity` reports FAIL on a perfectly healthy model whenever the target serve caps vision area.** A run against `--vision-max-pixels 262144` scores **9/14 geometry cells**. The same checkpoint on the same build scores 14/14 without the flag.

## Why it fails

The ladder asserts exact vision-token counts computed from each fixture's NATIVE dimensions. A serve that caps vision area does **not refuse** an oversized image — `preprocess_image_with_max_pixels` silently downscales it and answers normally. The reply is a success carrying fewer vision tokens than a native-resolution prediction expects, so the cell scores `Mismatch`.

Exactly five of the fourteen fixtures exceed 262144 px, and the run reports exactly `geometry_matched=9`:

| fixture | px | expected | got |
|---|---|---|---|
| `05_square_768` | 589,824 | 576 | **256** |
| `06_wide_1024x576` | 589,824 | 576 | **252** |
| `07_hd_1280x720` | 921,600 | 920 | **252** |
| `08_portrait_480x854` | 409,920 | 405 | **252** |
| `09_over_clamp_1600x900` | 1,440,000 | 1400 | **252** |

The driver already had a `GeomCell::Unmeasured` kind for exactly this, with a test asserting an over-capacity image must not fail the run — *"a deployment setting, not a defect"*. But it only fires on an error containing `"this encoder holds"`, which is the vision encoder's **pos-embed table** bound. A configured area cap never raises that, so the safety valve could not see it.

## Why this predicts rather than skips

`geometry.rs` used to carry a `within_bound` helper for this, removed on the reasoning that *"the ladder is deliberately built so that every fixture is inside any plausible bound"*. 262144 is a plausible bound an operator really sets, so that premise is now false.

But the removal comment was right about the half that matters: the 1600x900 rung is the entire point of the ladder, and reporting it "unmeasured" would let a regression to the retired 1280px clamp **pass silently**. Skipping trades a false FAIL for a false PASS.

So the bound becomes an **input to the prediction** instead of a reason to skip. Declare it, and the ladder predicts the downscaled geometry and still asserts every rung. Under a 262144 bound the 1600x900 rung's correct answer is 252, while an engine that ignored its own declared bound and fell back to the 1280px clamp still answers 920 — still caught. **No coverage is lost at any bound.**

## Verification — live A/B on one serve, one variable

Same server, same fixtures, the only difference being the new parameter:

```
--param vision_max_pixels=0        (default)  ->  FAIL, 5 mismatches, exit 1
--param vision_max_pixels=262144              ->  PASS, 14/14 matched,  exit 0
```

Both runs report `geometry 14/14 ASSERTED`. The five cells are still being checked in the passing run, not skipped — which is the property this PR exists to preserve.

The live engine's token counts (256, 252, 252, 252, 252) match the mirrored `served_size` arithmetic **exactly** on all five fixtures. That is a stronger check on the mirror than its unit anchors: the benchmark's copy of the engine's resize agrees with the engine itself at every shape the ladder covers.

Serve: `unsloth/Qwen3.8-27B-NVFP4` + DFlash2 drafter on GB10, `--vision-max-pixels 262144 --lm-head-dtype fp8`. Records for both runs are in `~/.atlas/runs/vision-fidelity/` (`08-21 11:45` Fail 9/14, `08-21 11:46` Pass 14/14).

## What changed

* **`geometry.rs`** gains `served_size` — a mirror of `spark-model`'s `target_size_for` — plus `expected_vision_tokens_bounded`. It is a mirror and not a call because `atlas-plugin` drives a server over HTTP and does not link the model crate, so `the_mirror_matches_the_engines_anchors` pins it to the two figures the engine's own source documents: 1600x900 is **1400** tokens unbounded and **920** under the fallback clamp. Both reproduce exactly.

* **`driver.rs`** gains a `vision_max_pixels` parameter (an AREA, like the flag; default 0 = not declared), and every prediction in the file is made under it — calibration, the geometry ladder, and both media-integrity probe deltas. The probe deltas diff two small fixtures no realistic bound moves, but a delta is an asserted token count like any other and has no business being the one prediction here that ignores the serve's configuration.

* The descriptor no longer promises UNMEASURED for images "above the server's encoder capacity" without qualification. It now says what is true: a REFUSED image is unmeasured, and a capped serve downscales rather than refusing.

`vision_max_pixels = 0` is asserted byte-identical to the previous behaviour (`zero_means_nothing_was_declared` walks the whole ladder), so this cannot re-baseline an existing record. Gate mode supplies its own serve recipe and does not pass the flag, so committed gate records are unaffected — which is why every gate-mode record is green while every capped run was red.

## Tests

Six new, all on `main`'s base:

* both engine anchors (1400 unbounded / 920 under the fallback clamp)
* the zero-default equivalence across the whole ladder
* a declared bound moves exactly the five fixtures above it **and no sixth**
* a bound never upscales — the `.min(1.0)` arm, which 8x8 and 64x2048 would otherwise inflate
* the discriminating rung stays discriminating under a bound
* the absolute 4096px long-side ceiling still binds a strip a generous area bound would let through

41 vision tests pass, clippy and fmt clean. Verified on `main`'s base rather than only on the branch it was cut from: `atlas-plugin` and its whole workspace dependency closure (`atlas-governance`, `atlas-closure`) are byte-identical between `avarok/main` and the source branch, so there is no cross-commit symbol dependency for a clean apply to hide.

## Usage

Pass `vision_max_pixels` equal to the serve's `--vision-max-pixels`:

```
spark benchmark run vision-fidelity --url http://127.0.0.1:8888 \
      --model <model> --param vision_max_pixels=262144
```
