### PR TITLE
Tidy up website

### DIFF
--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -30,7 +30,7 @@ export const discussionsUrl = 'https://github.com/Avarok-Cybersecurity/atlas/dis
 export const goodFirstIssuesUrl =
   'https://github.com/Avarok-Cybersecurity/atlas/labels/good%20first%20issue';
 // Single source of truth for contact addresses (footer + reach-out section).
-export const contactEmails = ['thomas@atlasinference.io', 'azeez@atlasinference.io'];
+export const contactEmails = ['thomas@atlasinference.io'];
 
 // third-party artifacts (link-or-cut, each verified live July 2026)
 export const transformersPrUrl = 'https://github.com/huggingface/transformers/pull/46423';


### PR DESCRIPTION
Reduce the site contact list to a single address.

`contactEmails` in `site/src/lib/data.js` is the single source of truth for both
the footer (`Footer.svelte`) and the reach-out section (`ReachOut.svelte`). Both
render it with a plain `{#each}`, so a one-element list needs no other change —
no separator or "and" logic to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1