### PR TITLE
docs(exact-verify): scope, cost, and what the flag does NOT fix (post-#699)

### DIFF
--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -60,14 +60,14 @@ pub struct GdnFlags {
     /// shape measured (#459). Closing that needs single-row routing for the
     /// whole verify forward, which is future work.
     ///
-    /// ★ Do not read "default off" as "default harmless". The divergence this
-    /// closes is not a cosmetic one-token difference at temperature 0: the
-    /// flipped token lands in a repetition attractor that the drafter then
-    /// AGREES with (7/7 accepted), so replies collapse into repetition or
-    /// unrelated text. Measured 2026-08-21 on qwen3.8-27B-NVFP4 + DFlash2,
-    /// `video-fidelity` went 0/2 and 0/4 correct at C=2/C=4 by default and
-    /// 2/2, 4/4 with this flag on. The operator-facing consequences and a
-    /// repro live on `ServeArgs::exact_verify`.
+    /// ★ Attribution warning, learned the hard way: a 2026-08-21 measurement
+    /// showed gross output degeneration (video-fidelity 0/2, 0/4 at C=2/C=4)
+    /// that this flag appeared to fix. The real cause was the K=4 verdict
+    /// rewind bug (#699); this flag only changed dispatch so the bug stopped
+    /// firing. The 1-ULP divergence this flag actually closes has never been
+    /// shown to cause more than an occasional flipped token at temperature 0.
+    /// If flipping this flag changes gross behavior, suspect a dispatch-
+    /// sensitive scheduler bug first. Details on `ServeArgs::exact_verify`.
     pub exact_verify: bool,
 }
 

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -59,6 +59,15 @@ pub struct GdnFlags {
     /// implementations round differently — ~5e-5 of lanes by 1 ULP, on every
     /// shape measured (#459). Closing that needs single-row routing for the
     /// whole verify forward, which is future work.
+    ///
+    /// ★ Do not read "default off" as "default harmless". The divergence this
+    /// closes is not a cosmetic one-token difference at temperature 0: the
+    /// flipped token lands in a repetition attractor that the drafter then
+    /// AGREES with (7/7 accepted), so replies collapse into repetition or
+    /// unrelated text. Measured 2026-08-21 on qwen3.8-27B-NVFP4 + DFlash2,
+    /// `video-fidelity` went 0/2 and 0/4 correct at C=2/C=4 by default and
+    /// 2/2, 4/4 with this flag on. The operator-facing consequences and a
+    /// repro live on `ServeArgs::exact_verify`.
     pub exact_verify: bool,
 }
 

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -318,6 +318,18 @@ pub struct ServeArgs {
     /// so a smoke test that only asks small questions will not see this.
     /// Fastest repro is a prompt whose correct answer is a short ordered list.
     ///
+    /// ★ AND THE COST CAN BE NEGATIVE. The ~+22-36% below is a per-decode-STEP
+    /// figure; end-to-end throughput also depends on how many drafts survive
+    /// verification, which is precisely what the divergence damages. Corrupted
+    /// verify logits REJECT CORRECT DRAFTS — the drafter proposes roughly what
+    /// the true model would say and a verifier reading wrong logits disagrees.
+    /// Measured at C=1 on the config above (one prompt, n=3 after a warm
+    /// request): 27.29 tok/s and 35.0% mean acceptance by default, versus
+    /// 32.45 tok/s and 45.5% acceptance with this flag on — +18.9% throughput
+    /// for turning exactness ON. Where the divergence actually bites, this is
+    /// not a tradeoff. The crossover against the concurrency rungs, where the
+    /// step costs below were measured, still needs its own sweep.
+    ///
     /// SCOPE, and it is narrower than this flag once claimed: it makes the
     /// GDN/SSM verify chain exact. It does NOT make speculative output
     /// bitwise-equal to non-speculative output end to end, and setting it

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -297,10 +297,35 @@ pub struct ServeArgs {
 
     /// Sequential-decode-exact GDN/SSM verify chain — OPT-IN (default: off).
     ///
+    /// ★ WHAT THE DEFAULT COSTS IN PRACTICE, because "a flipped argmax" reads
+    /// milder than it behaves (measured 2026-08-21, qwen3.8-27B-NVFP4 + DFlash2
+    /// on GB10, one binary, this flag the only variable):
+    ///
+    ///     prompt "count from 1 to 10"   default: `1, 2, 100, 100, 100, ...`
+    ///                                   exact:   `1, 2, 3, 4, 5, ..., 10`
+    ///     video-fidelity C=1/C=2/C=4    default: 1/1, 0/2, 0/4 correct
+    ///                                   exact:   1/1, 2/2, 4/4 correct
+    ///
+    /// A flipped token does not stay one wrong token. It lands the sequence in
+    /// a repetition attractor, and the DRAFTER THEN AGREES with it — verify
+    /// steps go 7/7 accepted — so the loop is locked in and the reply
+    /// degenerates into repetition or unrelated text until the token cap. This
+    /// is why the symptom looks like a broken drafter while acceptance
+    /// telemetry looks healthy: the accepts are honest, the logits they check
+    /// against are not the ones sequential decode would have produced.
+    ///
+    /// A short reply can hide it entirely — a 2-token "Paris" answer survives —
+    /// so a smoke test that only asks small questions will not see this.
+    /// Fastest repro is a prompt whose correct answer is a short ordered list.
+    ///
     /// SCOPE, and it is narrower than this flag once claimed: it makes the
     /// GDN/SSM verify chain exact. It does NOT make speculative output
     /// bitwise-equal to non-speculative output end to end, and setting it
-    /// will not give you a reproducible spec-on serve.
+    /// will not give you a reproducible spec-on serve. Measured with the flag
+    /// ON, the residual is still visible: an occasional single wrong token,
+    /// and the same request at temperature 0 answering with 45 tokens once and
+    /// 50 the next time — because the accepted-row COUNT varies with runtime
+    /// scheduling, so the row-count-selected projection kernel varies with it.
     ///
     /// Why not (measured on GB10, issue #459): every FFN and attention
     /// projection is computed by a kernel selected on ROW COUNT. A token

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -297,26 +297,24 @@ pub struct ServeArgs {
 
     /// Sequential-decode-exact GDN/SSM verify chain — OPT-IN (default: off).
     ///
-    /// ★ WHAT THE DEFAULT COSTS IN PRACTICE, because "a flipped argmax" reads
-    /// milder than it behaves (measured 2026-08-21, qwen3.8-27B-NVFP4 + DFlash2
-    /// on GB10, one binary, this flag the only variable):
+    /// ★ THIS FLAG IS NOT A CORRECTNESS SWITCH. A 2026-08-21 measurement on
+    /// this doc's earlier revision showed the default chain degenerating
+    /// ("count from 1 to 10" → `1, 2, 100, 100, ...`; video-fidelity 0/2 and
+    /// 0/4 at C=2/C=4) and this flag fixing all of it. That attribution was
+    /// WRONG. The degeneration was a scheduler bug — the K=4 verdict rewound
+    /// a sequence by its pending-draft count instead of the forward's row
+    /// count, erasing committed tokens (fixed in #699) — and this flag only
+    /// changed the gate's dispatch pattern so the bug stopped firing. With
+    /// #699 in place every one of those repros passes with the flag OFF.
     ///
-    ///     prompt "count from 1 to 10"   default: `1, 2, 100, 100, 100, ...`
-    ///                                   exact:   `1, 2, 3, 4, 5, ..., 10`
-    ///     video-fidelity C=1/C=2/C=4    default: 1/1, 0/2, 0/4 correct
-    ///                                   exact:   1/1, 2/2, 4/4 correct
-    ///
-    /// A flipped token does not stay one wrong token. It lands the sequence in
-    /// a repetition attractor, and the DRAFTER THEN AGREES with it — verify
-    /// steps go 7/7 accepted — so the loop is locked in and the reply
-    /// degenerates into repetition or unrelated text until the token cap. This
-    /// is why the symptom looks like a broken drafter while acceptance
-    /// telemetry looks healthy: the accepts are honest, the logits they check
-    /// against are not the ones sequential decode would have produced.
-    ///
-    /// A short reply can hide it entirely — a 2-token "Paris" answer survives —
-    /// so a smoke test that only asks small questions will not see this.
-    /// Fastest repro is a prompt whose correct answer is a short ordered list.
+    /// What the default chain actually does is what #435/#459 measured: ~5e-5
+    /// of lanes differ by 1 ULP against sequential decode, which can flip an
+    /// occasional argmax at temperature 0. No case of that flip causing gross
+    /// degeneration has survived root-causing; every "the default chain broke
+    /// my output" report so far has traced to a different bug that this flag
+    /// happened to perturb. If this flag ever appears to fix a correctness
+    /// problem, treat that as a dispatch-sensitivity SYMPTOM and go find the
+    /// real bug before pinning the flag.
     ///
     /// ★ THE COST IS REAL, and measuring it needs a validated serve profile.
     /// Measured on the LEAN profile (32K ctx, 8 seqs, NO prefix caching — the
@@ -328,9 +326,9 @@ pub struct ServeArgs {
     ///
     /// i.e. -7% to -31%. An earlier measurement of this same flag reported it
     /// as a THROUGHPUT WIN; that was taken on a serve with prefix caching on
-    /// at 128K, where the default arm was pathologically bad for an unrelated
-    /// reason, and it is withdrawn. Benchmark a correctness flag only on a
-    /// profile you have separately validated for throughput.
+    /// at 128K, where the default arm was degenerating under the #699 bug,
+    /// and it is withdrawn. Benchmark a numerics flag only on a profile you
+    /// have separately validated for throughput — and for correctness.
     ///
     /// It does not buy reproducibility either. On the pinned `decode-floor`
     /// benchmark this flag returned 943/553/943 tokens across three IDENTICAL

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -318,17 +318,23 @@ pub struct ServeArgs {
     /// so a smoke test that only asks small questions will not see this.
     /// Fastest repro is a prompt whose correct answer is a short ordered list.
     ///
-    /// ★ AND THE COST CAN BE NEGATIVE. The ~+22-36% below is a per-decode-STEP
-    /// figure; end-to-end throughput also depends on how many drafts survive
-    /// verification, which is precisely what the divergence damages. Corrupted
-    /// verify logits REJECT CORRECT DRAFTS — the drafter proposes roughly what
-    /// the true model would say and a verifier reading wrong logits disagrees.
-    /// Measured at C=1 on the config above (one prompt, n=3 after a warm
-    /// request): 27.29 tok/s and 35.0% mean acceptance by default, versus
-    /// 32.45 tok/s and 45.5% acceptance with this flag on — +18.9% throughput
-    /// for turning exactness ON. Where the divergence actually bites, this is
-    /// not a tradeoff. The crossover against the concurrency rungs, where the
-    /// step costs below were measured, still needs its own sweep.
+    /// ★ THE COST IS REAL, and measuring it needs a validated serve profile.
+    /// Measured on the LEAN profile (32K ctx, 8 seqs, NO prefix caching — the
+    /// profile this project's recorded baselines were taken on), code prompt,
+    /// aggregate tok/s at C=1/2/4/8:
+    ///
+    ///     default   56 /  88 / 113 / 123    accept 85 / 86 / 80 / 74 %
+    ///     exact     52 /  72 /  78 /  98    accept 81 / 76 / 58 / 64 %
+    ///
+    /// i.e. -7% to -31%. An earlier measurement of this same flag reported it
+    /// as a THROUGHPUT WIN; that was taken on a serve with prefix caching on
+    /// at 128K, where the default arm was pathologically bad for an unrelated
+    /// reason, and it is withdrawn. Benchmark a correctness flag only on a
+    /// profile you have separately validated for throughput.
+    ///
+    /// It does not buy reproducibility either. On the pinned `decode-floor`
+    /// benchmark this flag returned 943/553/943 tokens across three IDENTICAL
+    /// runs — the row-count residual below, showing up directly.
     ///
     /// SCOPE, and it is narrower than this flag once claimed: it makes the
     /// GDN/SSM verify chain exact. It does NOT make speculative output


### PR DESCRIPTION
Documentation only — no behaviour change, no default flipped.

`--exact-verify`'s doc already explains the **mechanism** well: every FFN and attention projection is selected by ROW COUNT, verify K=4 takes `w4a16_gemv_batch4` where decode takes `w4a16_gemv`, ~5e-5 of lanes differ by 1 ULP, enough to flip a thin top-2 argmax (#459). What it does not say is what that looks like from outside the engine, and the gap is wide enough to cost a debugging session — "an occasional flipped argmax" reads like an occasional different-but-fine token.

## What the default actually does

Measured 2026-08-21, `unsloth/Qwen3.8-27B-NVFP4` + `incoai/Qwen3.8-27B-DFlash2` on GB10, one binary, this flag the only variable:

| probe | default | `--exact-verify` |
|---|---|---|
| "count from 1 to 10" | `1, 2, 100, 100, 100, ...` | `1, 2, 3, 4, 5, 6, 7, 8, 9, 10` |
| "list four colors" | `Red, Blue, Green, 1999; Green, 2000; ...` | `Red, Blue, Green, Blue` |
| "two sentences about blue" | `...100% success rate.\n107 \| ### 3.3.2.2.1` | coherent |
| `video-fidelity` C=1 / C=2 / C=4 | 1/1, **0/2**, **0/4** | **1/1, 2/2, 4/4** |

A flipped token does not stay one wrong token. It lands the sequence in a repetition attractor, and **the drafter then agrees with it** — verify steps go 7/7 accepted — so the loop is locked in and the reply degenerates into repetition or unrelated prose until the token cap.

That coupling is the part worth writing down: the symptom presents as a broken drafter while acceptance telemetry looks perfectly healthy at 29-71%. The accepts are honest. The logits they are checking against are simply not the ones sequential decode would have produced.

## Two traps, both of which cost time here

**A short reply hides it entirely.** A 2-token "Paris" answer is correct on every arm. A smoke test that only asks small questions will not see this at all. The fastest repro is a prompt whose correct answer is a short ordered list.

**The residual with the flag ON is more than one token.** The same request at temperature 0 answered with 45 tokens once and 50 the next. The accepted-row COUNT varies with runtime scheduling, so the row-count-selected projection kernel varies with it, so the rounding does. Reproducibility needs the single-row routing the doc already describes as future work — this flag alone does not deliver it.

## Provenance of the numbers

Localized by first divergence rather than by inspection. On "count from 1 to 10" (31 prompt tokens) the first wrong token is completion index 6 (`'1'` id 16, where serial decode gives `'3'` id 18). The verify log maps it exactly, `seq_len` being the length after each step:

```
step 1  accepted=1/7  ends 33   -> completion idx 0-1
step 2  accepted=0/7  ends 34   -> idx 2
step 3  accepted=0/7  ends 35   -> idx 3
step 4  accepted=7/7  ends 43   -> idx 4-11
```

Index 6 falls inside step 4's accepted-draft run (4-10 are drafts, 11 is the bonus token), so the wrong token was **accepted** — which is only possible if the target's own verify logits chose it.

Excluded by one-variable measurement before landing on the GDN chain: batched propose (`ATLAS_DFLASH_BATCH_PROPOSE=1`), LM-head dtype (`fp8` and `default` alike), prefix caching (byte-identical on/off), multimodality (text-only degenerates on its own), `ATLAS_DFLASH_UNIFIED_CTX=0`, and the GEMV tier — `w4a16_batch_bitparity_microtest` PASSES on this box at every M=2..16 and every projection shape, with its 1-ULP control firing.

It is also not new and not specific to any branch in flight: it reproduces identically on `pull/648/head` (`acaf9533`), on `pull/649/head`, and on a local DFlash stack, each served under its own author's config, while spec-off is clean on all three.

## The cost is not what the doc implies — measured, it is a WIN here

The doc's ~+22-36% is a **per-decode-step** cost, measured at the n=8/K=4, n=16/K=2 and n=32/K=2 rungs. End-to-end throughput also depends on how many drafts get accepted per step, and that is exactly what the corruption damages. At C=1 on this config:

| | default | `--exact-verify` |
|---|---|---|
| decode | 27.29 tok/s | **32.45 tok/s** (+18.9%) |
| mean acceptance | 35.0% (103 steps) | **45.5%** (236 steps) |

Run-to-run spread was tight (27.27/28.29/27.29 vs 32.43/32.45/32.47, n=3 after a warm request).

The mechanism is the same defect seen from the other side: corrupted verify logits **reject correct drafts**. The drafter proposes roughly what the true model would say; a verifier working from wrong logits disagrees with it, so acceptance falls. Make the logits right and the drafts start matching again — the higher per-step cost is more than repaid.

Scope, so this is not over-read: one prompt, C=1, n=3, on this hardware and checkpoint. It does not contradict the per-step figures in the doc; it says the step cost is not the whole story, and that on a config where the divergence actually bites, exactness is not a tradeoff at all.

## What this PR deliberately does not do

It does not make exactness the default. That remains a policy call for the DFlash owners — the numbers above are C=1 and the documented step costs are measured at the concurrency rungs, so the crossover needs its own sweep, and the existing survey of vLLM / SGLang / TensorRT-LLM / TGI defaults in that same doc belongs in that decision rather than in a docs commit.

`ATLAS_TARGET_MODEL='*'` build clean, fmt clean, `--help` renders.


## Re-scope 2026-08-21 (d2f1b0d8): the correctness framing above is superseded by #699

Everything above that presents `--exact-verify` as fixing gross degeneration
(the count-to-10 collapse, video-fidelity 0/2 and 0/4 at C=2/C=4) turned out
to be a misattribution. #699 root-caused those repros to the K=4 verdict
rewinding sequences by their pending-draft count instead of the forward's row
count — erasing committed output. This flag never fixed that bug; it changed
the gate's dispatch so the bug stopped firing. With #699 applied, every one
of those repros passes with the flag OFF.

The final commit rewrites both doc blocks accordingly: the flag closes the
#435/#459 1-ULP / occasional-argmax divergence, it is not a correctness
switch, and an apparent correctness fix from flipping it should be treated as
a dispatch-sensitivity symptom pointing at a real scheduler bug. What stands
unchanged: the measured cost table (-7% to -31%), the withdrawal of the
earlier +18.9% throughput claim, and the reproducibility residual (row-count-
selected kernels vary with scheduling even with the flag on).

Suggested merge order: after #699, which this doc now references.
