### PR TITLE
perf(gemma4): build the MoE prefill copies — cold TTFT 5706 → 4975 ms (−12.8%)

### DIFF
--- a/crates/spark-model/src/weight_loader/gemma4/loader_a.rs
+++ b/crates/spark-model/src/weight_loader/gemma4/loader_a.rs
@@ -29,6 +29,9 @@ pub(super) fn load_layers_impl(
     let variant = detect_nvfp4_variant(store, config);
     tracing::info!("Gemma-4 NVFP4 variant: {:?}", variant);
 
+    // Decided once, before any layer allocates — see the doc on the parameter.
+    let moe_prefill_copies =
+        config.num_experts > 0 && crate::weight_loader::moe_prefill_copies_fit(config, gpu);
     let absmax_k = gpu.kernel("quantize_nvfp4", "nvfp4_global_absmax")?;
     let quantize_k = gpu.kernel("quantize_nvfp4", "quantize_bf16_to_nvfp4")?;
     let stream = gpu.default_stream();
@@ -371,7 +374,18 @@ pub(super) fn load_layers_impl(
 
         // ── MoE experts (Gemma-4 26B) — extracted to loader_b ──
         let moe_ffn = build_moe_ffn(
-            store, &lp, i, config, gpu, variant, qctx, h, absmax_k, quantize_k, stream,
+            store,
+            &lp,
+            i,
+            config,
+            gpu,
+            variant,
+            qctx,
+            h,
+            absmax_k,
+            quantize_k,
+            moe_prefill_copies,
+            stream,
         )?;
 
         tracing::info!("L{i}: building attention layer...");

--- a/crates/spark-model/src/weight_loader/gemma4/loader_b.rs
+++ b/crates/spark-model/src/weight_loader/gemma4/loader_b.rs
@@ -23,6 +23,11 @@ pub(super) fn build_moe_ffn(
     h: usize,
     absmax_k: spark_runtime::gpu::KernelHandle,
     quantize_k: spark_runtime::gpu::KernelHandle,
+    // Whether to build the transposed [K/2, N] prefill copies. Decided ONCE by
+    // the caller from `gpu.free_memory()`, not per layer: that probe shrinks as
+    // layers load, so a per-layer decision transposes the early layers and
+    // skips the late ones, leaving prefill straddling both paths.
+    moe_prefill_copies: bool,
     stream: u64,
 ) -> Result<Option<(FfnComponent, DenseWeight, DenseWeight, DenseWeight)>> {
     if config.num_experts == 0 {
@@ -53,6 +58,13 @@ pub(super) fn build_moe_ffn(
         config,
     )?;
     moe_layer.set_gelu_activation(gpu)?;
+    // MoE prefill copies. This loader built NONE, so every prefill took the
+    // fallback `moe_w4a16_grouped_gemm` over N-major weights. The same gap on
+    // the Qwen3-VL loader was 59% of that model's cold TTFT.
+    if moe_prefill_copies {
+        moe_layer.transpose_for_prefill(gpu, config)?;
+        moe_layer.predequant_for_prefill(gpu, config, stream)?;
+    }
     // Set pre-expert norm: router sees raw input, experts see normed input.
     let pre_expert_norm = dense(store, &format!("{lp}.pre_feedforward_layernorm_2.weight"))?;
     moe_layer.set_pre_expert_norm(pre_expert_norm);


### PR DESCRIPTION
Second loader with the gap #660 fixes for Qwen3-VL. `build_moe_ffn` constructed its
`MoeLayer` and called neither `transpose_for_prefill` nor `predequant_for_prefill`,
so every prefill took the fallback `moe_w4a16_grouped_gemm` over N-major weights.

**Targets #660** — it carries the shared helper. Rebase to `main` once that lands.

## Measured

`bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16`, dgx1, **one binary**, both arms
back-to-back, n=8, `ATLAS_MOE_PREFILL_COPIES` the only variable:

| | control (`=0`) | prefill copies | Δ |
|---|---:|---:|---:|
| **cold TTFT median** | 5705.61 ms | **4974.56 ms** | **−12.8% (−731 ms)** |
| spread | 0.77% | 1.97% | |
| `grouped_gate_up` | 543.2 ms | 115.3 ms | **−78.8%** |
| `grouped_silu_down` | 261.9 ms | 74.7 ms | **−71.5%** |
| `unpermute_blend` | 15.0 ms | 15.3 ms | control, flat |
| `pre_expert_norm` | 4.4 ms | 4.2 ms | control, flat |

−615 ms of MoE GEMM accounts for most of the −731 ms end-to-end. The two phases
reading the transposed tables fell ~75%; the two that don't are flat. At a ~5 s
baseline this is far outside the ~2% cross-restart variance seen on the 35B.

## Correctness

**Gate C2 (the NVFP4 tripwire) PASSES on both arms** — `tool_calls=3/3`,
`coherent=3/3`, `degenerate=0`.

Output is not bit-identical and **cannot** be: changing the weight layout changes
the GEMM reduction order, so low-margin argmax flips are expected. All 5 temp-0
prompts stayed coherent and correct on both arms — including the code prompt, where
both produce a valid two-pointer merge.

## SSOT

Uses `weight_loader::moe_prefill_copies_fit` from #660 — no second copy of the
budget arithmetic, and `ATLAS_MOE_PREFILL_COPIES=0` works here for free.

The probe is hoisted into `loader_a` and passed down, for the same reason as the VL
loader: `free_memory()` shrinks as layers load, so a per-layer probe would transpose
the early layers and skip the late ones, leaving prefill straddling both paths.

## Not touched

`loader_a.rs` carries a commented-out block disabling the **attention** prefill
weights:

```rust
// Skip prefill weight transpose for now — diagnose CUDA 700 first.
// TODO: re-enable once basic inference works
```

Different code path, different investigation. Re-enabling it inside a MoE change
would be silent scope creep — flagging it as worth its own look.

## Fan-out status

| Loader | Builds prefill copies? |
|---|---|
| qwen35, qwen3, minimax, laguna | yes (already) |
| qwen3_vl | **#660** |
| **gemma4** | **this PR** |
| nemotron, mistral, step3p7, deepseek_v4 | still not |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1