### PR TITLE
video-fidelity: measure the pad contract instead of accusing it (new mixed-media-pads cell)

### DIFF
--- a/crates/atlas-plugin/src/benchmarks/video/driver.rs
+++ b/crates/atlas-plugin/src/benchmarks/video/driver.rs
@@ -446,6 +446,46 @@ impl Benchmark for VideoFidelity {
             }
 
             // ── Mixed: an image and a video in one request ───────────────
+            //
+            // TWO cells, because one question could not tell two failures
+            // apart and for a while was read as accusing the wrong component.
+            //
+            //   * `mixed-media` asks for the clip's colors as a LIST. That is
+            //     a question about the ENGINE (are the clip's frames all
+            //     there?) only if the model cooperates, and qwen3.8-27B does
+            //     not: it treats the still as FRAME 1 OF THE VIDEO, so it
+            //     enumerates from the image and the clip's last color falls
+            //     off the end of a four-item list. What this cell really
+            //     measures is whether the CHECKPOINT keeps two media items
+            //     apart. qwen3.6 does; qwen3.8 does not. Kept strict, because
+            //     that difference is worth catching — but read as a model
+            //     property, not as an engine defect.
+            //
+            //   * `mixed-media-pads` MEASURES the contract instead of asking
+            //     about it: t(image+video) must equal t(image) + t(video) -
+            //     t(text), in the server's own `usage.prompt_tokens`. A pad
+            //     run of the wrong length cannot satisfy that, and no model
+            //     opinion enters. It is the cell whose failure should be
+            //     believed, and the only one entitled to accuse the contract.
+            //
+            // A content question was tried here first and does NOT work. On
+            // the failing pair every wording ("ends on", "final frame", "name
+            // the fourth", "the still is not part of the video") returned the
+            // same wrong color 5/5 — but swapping the grayscale still for a
+            // solid magenta one returned the RIGHT one, while the served rows
+            // were the identical 4 groups / 196 tokens in both cases. Whatever
+            // a still's colour can move is the model, not the splice.
+            //
+            // Measured on 2026-08-21 against a serve where `mixed-media` was
+            // red: the contract was INTACT. The clip's own allocation was
+            // identical in every ordering (4 temporal groups, 14x14 patches,
+            // 196 vision tokens), asked for the fourth frame the model said
+            // "Yellow", asked to describe the frames it called the still
+            // "Frame 1", and swapping the grayscale still for a solid magenta
+            // one returned all four clip colors from the plain list question.
+            // Beware when re-testing: this model's answers move across
+            // paraphrases (3, 4 and 6 colors for one clip), so a single
+            // wording is not evidence in either direction.
             Phase::Mixed => {
                 self.phase = Phase::Integrity;
                 let h = self.handle()?;
@@ -486,9 +526,10 @@ impl Benchmark for VideoFidelity {
                             CountCell::Mismatch {
                                 id: "mixed-media",
                                 detail: format!(
-                                    "image + video together: wanted [{}], got [{}] — the \
-                                     ordering contract between collection, markers and pad \
-                                     expansion is off",
+                                    "image + video together: wanted [{}], got [{}]. This cell \
+                                     does NOT localise the cause: see mixed-media-pads, which \
+                                     asks for the LAST frame directly and is the one that \
+                                     accuses the pad/marker contract",
                                     vid.colors.join(", "),
                                     super::score::colors_in_order(reply, PALETTE).join(", ")
                                 ),
@@ -510,20 +551,107 @@ impl Benchmark for VideoFidelity {
                         }
                     }
                 };
-                let line = match &cell {
-                    CountCell::Match { detail, .. } => {
-                        LogLine::info(format!("mixed-media: {detail}"))
+                // The contract cell: PAD ARITHMETIC, not a question about
+                // pixels. Four short requests, and the identity
+                //
+                //     t(image + video) == t(image) + t(video) - t(text)
+                //
+                // must hold exactly. Every term is a `usage.prompt_tokens`
+                // the server reports, so a pad run of the wrong length shows
+                // up as a non-zero delta and no model opinion is involved.
+                //
+                // It is a MEASUREMENT, not a probe, on purpose. A content
+                // question cannot do this job here: swapping the grayscale
+                // still for a solid magenta one changes whether the model
+                // reports the clip's last color, while the served rows are
+                // byte-for-byte the same 4 groups / 196 tokens either way. A
+                // desync is content-independent; anything a still's colour can
+                // move is the model, not the contract (measured 2026-08-21).
+                let model = h.target().model.clone();
+                let short = 16;
+                let b_text = request::text_array_body(&model, request::ORDER_PROMPT, short);
+                let b_img =
+                    request::image_body(&model, "image/png", png, request::ORDER_PROMPT, short);
+                let b_vid =
+                    request::video_body(&model, vid.mime, vid.bytes, request::ORDER_PROMPT, short);
+                let b_both = request::mixed_body(
+                    &model,
+                    png,
+                    vid.mime,
+                    vid.bytes,
+                    request::ORDER_PROMPT,
+                    short,
+                );
+                let t_text = http::chat_stream(h.target(), &b_text, self.timeout()).await;
+                let t_img = http::chat_stream(h.target(), &b_img, self.timeout()).await;
+                let t_vid = http::chat_stream(h.target(), &b_vid, self.timeout()).await;
+                let t_both = http::chat_stream(h.target(), &b_both, self.timeout()).await;
+                let tail_cell = match (t_text, t_img, t_vid, t_both) {
+                    (Ok(tx), Ok(ti), Ok(tv), Ok(tb)) => {
+                        let predicted =
+                            (ti.prompt_tokens + tv.prompt_tokens).saturating_sub(tx.prompt_tokens);
+                        if tb.prompt_tokens == predicted {
+                            CountCell::Match {
+                                id: "mixed-media-pads",
+                                detail: format!(
+                                    "pad arithmetic exact: image {} + video {} - text {} = {} \
+                                     served",
+                                    ti.prompt_tokens,
+                                    tv.prompt_tokens,
+                                    tx.prompt_tokens,
+                                    tb.prompt_tokens
+                                ),
+                            }
+                        } else {
+                            CountCell::Mismatch {
+                                id: "mixed-media-pads",
+                                detail: format!(
+                                    "pad run is the WRONG LENGTH in a mixed request: image {} + \
+                                     video {} - text {} predicts {predicted}, server charged {} \
+                                     (off by {}) — this IS the collection/marker/pad-expansion \
+                                     contract",
+                                    ti.prompt_tokens,
+                                    tv.prompt_tokens,
+                                    tx.prompt_tokens,
+                                    tb.prompt_tokens,
+                                    tb.prompt_tokens as i64 - predicted as i64
+                                ),
+                            }
+                        }
                     }
-                    CountCell::Mismatch { detail, .. } => {
-                        LogLine::warn(format!("mixed-media: {detail}"))
+                    (tx, ti, tv, tb) => {
+                        let msg = [tx.err(), ti.err(), tv.err(), tb.err()]
+                            .into_iter()
+                            .flatten()
+                            .map(|e| one_line(format!("{e:#}")))
+                            .next()
+                            .unwrap_or_else(|| "unknown".to_string());
+                        if request::is_decoder_unavailable(&msg) {
+                            CountCell::Skipped {
+                                id: "mixed-media-pads",
+                                why: msg,
+                            }
+                        } else {
+                            CountCell::Error {
+                                id: "mixed-media-pads",
+                                msg,
+                            }
+                        }
                     }
-                    CountCell::Skipped { why, .. } => {
-                        LogLine::info(format!("mixed-media: skipped — {why}"))
-                    }
-                    CountCell::Error { msg, .. } => LogLine::warn(format!("mixed-media: {msg}")),
                 };
+                let describe = |c: &CountCell, id: &str| match c {
+                    CountCell::Match { detail, .. } => LogLine::info(format!("{id}: {detail}")),
+                    CountCell::Mismatch { detail, .. } => LogLine::warn(format!("{id}: {detail}")),
+                    CountCell::Skipped { why, .. } => {
+                        LogLine::info(format!("{id}: skipped — {why}"))
+                    }
+                    CountCell::Error { msg, .. } => LogLine::warn(format!("{id}: {msg}")),
+                };
+                let line = describe(&cell, "mixed-media");
+                let tail_line = describe(&tail_cell, "mixed-media-pads");
                 self.counts.push(cell);
-                Ok(self.frame("mixed", vec![line]))
+                self.counts.push(tail_cell);
+                Ok(self.frame("mixed", vec![line, tail_line]))
             }
 
             // ── Integrity: the shapes that need MORE THAN ONE video item ─

--- a/crates/atlas-plugin/src/benchmarks/video/request.rs
+++ b/crates/atlas-plugin/src/benchmarks/video/request.rs
@@ -80,6 +80,43 @@ pub fn text_only_body(model: &str, prompt: &str, max_tokens: usize) -> Value {
     })
 }
 
+/// One request carrying a single IMAGE, and one carrying only text — the two
+/// baselines the pad-arithmetic cell subtracts.
+///
+/// Both send `content` as an ARRAY, matching [`video_body`] and [`mixed_body`].
+/// [`text_only_body`] sends a bare string instead, which renders through a
+/// different template branch and costs a different number of tokens: using it
+/// as the baseline makes the arithmetic disagree by a constant that has
+/// nothing to do with pad runs. That is why these exist rather than reusing it.
+pub fn image_body(model: &str, mime: &str, png: &[u8], prompt: &str, max_tokens: usize) -> Value {
+    json!({
+        "model": model,
+        "stream": true,
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "chat_template_kwargs": {"enable_thinking": false},
+        "messages": [{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": data_uri(mime, png)}},
+            {"type": "text", "text": prompt},
+        ]}],
+    })
+}
+
+/// Text only, as a content ARRAY. See [`image_body`] for why this is not
+/// [`text_only_body`].
+pub fn text_array_body(model: &str, prompt: &str, max_tokens: usize) -> Value {
+    json!({
+        "model": model,
+        "stream": true,
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "chat_template_kwargs": {"enable_thinking": false},
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": prompt},
+        ]}],
+    })
+}
+
 /// Does this error read as "the server cannot decode that container"?
 ///
 /// A server without ffmpeg is a DEPLOYMENT choice, not a defect, so those legs


### PR DESCRIPTION
Standalone against `main` — benchmark harness only, no engine code, unrelated to the #649 train.

`video-fidelity`'s `mixed-media` cell failed with a hardcoded verdict: *"the ordering contract between collection, markers and pad expansion is off"*. That verdict is wrong, and it cost a debugging session inside `msg_entry.rs` looking for a desync that was not there.

## The contract is intact — measured, not assumed

On the exact failing image+video pair:

* The clip's own allocation is **identical in every ordering** — 4 temporal groups, 14x14 patches, 196 vision tokens — and `image+video` is order-symmetric in `usage.prompt_tokens`. Nothing is truncated.
* Asked to *"describe each frame of the video in order"*, the model answers **"Frame 1: a white square with a black border..."** — that is the STILL IMAGE. It treats the still as frame 1 of the clip, so asked to list the clip's colours it enumerates from the image and the clip's last colour falls off the end of a four-item list.
* Swapping the grayscale still for a solid **magenta** one returns `magenta, red, green, blue, yellow` — all four clip colours — from the same plain list question. Video alone correctly answers "magenta? NO", so nothing bleeds.

A desync is content-independent. Anything a still's *colour* can move is the model, not the splice.

## What changed

**`mixed-media` keeps its strict assertion** — the qwen3.6-passes / qwen3.8-fails split is worth catching — but its failure text no longer names a cause it has not established, and a comment records what the cell actually measures: whether the CHECKPOINT keeps two media items apart.

**New `mixed-media-pads` measures the contract instead of asking about it:**

```
t(image + video) == t(image) + t(video) - t(text)
```

in the server's own `usage.prompt_tokens`. A pad run of the wrong length cannot satisfy it, and no model opinion enters. Verified exact on a live serve — `image 93 + video 240 - text 42 = 291 served`, delta 0 — and delta 0 again at a second image size (336x336) and in both media orders.

A **content** probe was tried here first and is recorded in the comment as a dead end, because it looks like the obvious design and does not work: on the failing pair every wording — "ends on", "final frame", "name the fourth", even "the still is not part of the video" — returned the same wrong colour 5/5, while the magenta swap returned the right one against byte-identical served rows.

**`request::image_body` and `request::text_array_body`** are the two baselines the arithmetic subtracts. They send `content` as an ARRAY to match `video_body`/`mixed_body`; `text_only_body` sends a bare string, which renders through a different template branch and costs a different number of tokens, so reusing it would make the identity disagree by a constant that has nothing to do with pad runs.

## Result

Legs go 13 -> 14. On the serve above: **13/14, with `mixed-media-pads` GREEN and `mixed-media` the only red** — which is now a legible statement (the engine is fine; this checkpoint merges two media items) rather than a false accusation pointing at the wrong file.

42 video tests pass, clippy and fmt clean, verified on `main`'s base rather than only on the branch it was cut from.
