### PR TITLE
bench: gate Qwen3-VL cold TTFT — the −45.3% had nothing holding it

### DIFF
--- a/.benchmarks/ttft-cold-gate/2026-08-21-27e9520c2e-ig1-qwen3-vl-30b-a3b-instruct-nvfp4.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-21-27e9520c2e-ig1-qwen3-vl-30b-a3b-instruct-nvfp4.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "27e9520c2e",
+  "dirty_paths": [
+    "kernels/gb10/qwen3-vl-30b-a3b/BENCH.toml"
+  ],
+  "recorded_at": 1787341891,
+  "target_model": "ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3-vl/qwen3-vl-30b-a3b-nvfp4",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2450.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787341850,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 49.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 55.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.7
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 29950097131,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7004496,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2049620,
+      "gpu_compute_apps": [
+        {
+          "pid": 898999,
+          "name": "./target/release/spark",
+          "used_mib": 108074
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787341891,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 82.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.8
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 29950097131,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6961512,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2050256,
+      "gpu_compute_apps": [
+        {
+          "pid": 898999,
+          "name": "./target/release/spark",
+          "used_mib": 108098
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 41,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 25.0,
+      "hottest_chassis_delta_c": 27.1
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +27 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 549.138798,
+    "p90_ms": 2206.8030830000002,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.5% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "summary": "ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4 · median_ms=549.14, p90_ms=2206.80, samples=36.00 · Pass: median -0.5% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/kernels/gb10/qwen3-vl-30b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3-vl-30b-a3b/BENCH.toml
@@ -1,0 +1,53 @@
+# Benchmarks for this model, and the thresholds its gate records must meet.
+#
+# Sibling of MODEL.toml so the numbers sit beside the thing they describe;
+# hardware and model are implied by the path and cannot disagree with the
+# contents. Read by `atlas_plugin::gate::bench`.
+#
+# This file is deliberately OUTSIDE the closure hash (`taxon::configs` does not
+# list it), so ratcheting a threshold does not invalidate the record that
+# justified the ratchet.
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4"
+gate = "ttft-cold-gate"
+recipe = "qwen3-vl/qwen3-vl-30b-a3b-nvfp4"
+label = "Qwen3-VL-30B-A3B vision MoE (NVFP4)"
+status = "measured"
+note = """\
+FIRST gate for this target — it had no BENCH.toml at all, so nothing held its \
+cold TTFT in place. That mattered: building the MoE prefill copies in \
+Qwen3VLWeightLoader took this model's cold TTFT from 1797.20 ms to 982.95 ms \
+(-45.3%, cold_ttft.py n=8), and an unguarded win is one silent loader change \
+away from being given back.
+
+Ceilings = the GATE's own dgx1 baseline x the gate limits: median 552.2 ms x \
++3% and p90 2203.7 ms x +5%. Measured through `--url` against a hand-served \
+endpoint, which is the only way to bootstrap a target with no entry yet: \
+`baseline_for` DROPS status="unmeasured" rows, so an unmeasured row cannot be \
+written first and then filled in — the gate simply refuses to resolve. NOTE the \
+gate's numbers are NOT the cold_ttft.py numbers (552.2 vs 982.95); different \
+harness, different prompt ladder, not interchangeable. Only the gate's own \
+figures may be cut into ceilings.
+
+TTFT is box-local by nature — a different box must re-record this baseline \
+rather than reuse it."""
+
+[benchmarks.metrics.median_ms]
+max = 568.77
+
+[benchmarks.metrics.p90_ms]
+max = 2313.89
+
+
+# ── ttft-warm-gate: DELIBERATELY ABSENT until atlas-recipes#24 lands ──────────
+# This recipe does not set `enable_prefix_caching`, so the gate serves it, every
+# warm leg returns `cached 0 tok`, and it re-measures COLD prefill under a warm
+# label. Measured on dgx1: warm 1024 tok 546.1 ms vs cold 1024 tok 549.1 ms —
+# 0.5% apart because they are the same work. With the flag the same box measures
+# warm at 21.8 ms with 1136 tokens cached, 25x apart.
+#
+# An entry here would therefore either fail every run, or be cut from the
+# cold-prefill numbers and gate nothing. Absence is the honest state; the entry
+# lands with the recipe fix.


### PR DESCRIPTION
`qwen3-vl-30b-a3b` had **no `BENCH.toml` at all**, so #660's −45.3% cold-TTFT win
(1797.20 → 982.95 ms) was one silent loader change away from being given back.

**Targets #660.** Rebase to `main` once that lands.

## The gate

| | baseline (gate harness, dgx1) | ceiling | recorded at this head |
|---|---:|---:|---:|
| median | 552.2 ms | 568.77 (×1.03) | **549.1 ms, −0.5% PASS** |
| p90 | 2203.7 ms | 2313.89 (×1.05) | **2206.8 ms, +0.1% PASS** |

## Bootstrap: why this is one PR, not two

A target with no entry cannot be gated in two steps — `baseline_for` **drops**
`status = "unmeasured"` rows, so writing one first and filling it in later just
makes the gate refuse to resolve. `--url` against a hand-served endpoint doesn't
consult `BENCH.toml` ceilings at all, so it yields the gate's own numbers to cut
from. Measure, then declare, in one change.

> ★ The gate's numbers are **not** the `cold_ttft.py` numbers — **552.2 vs 982.95 ms**
> for the same model on the same box. Different harness, different prompt ladder,
> not interchangeable. Only the gate's own figures may become ceilings.

`default` is deliberately **unset**: `qwen3.6-35b-a3b` already claims the default
for these gates on gb10, and two defaults is a silent coin-flip over which
checkpoint a gate scores. `bench.rs` refuses to assemble — which is how I caught it.

## ttft-warm-gate is deliberately absent

This recipe doesn't set `enable_prefix_caching`, so the gate serves it, every warm
leg returns `cached 0 tok`, and it re-measures cold prefill under a warm label:

| leg | median | cached |
|---|---:|---:|
| warm 1024 tok | 546.1 ms | **0 tok** |
| *cold* 1024 tok | 549.1 ms | 0 tok |

0.5% apart because they're the same work. With the flag the same box measures warm
at **21.8 ms** with **1136 tokens cached** — 25× apart.

An entry now would either fail every run, or be cut from the cold numbers and gate
nothing. The reason is written into the file where the entry would go. Fix is
**atlas-recipes#24**; the warm entry lands with it.

469 `atlas-plugin` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1