### PR TITLE
atlas-core: make compute target checks deterministic

### DIFF
--- a/crates/atlas-core/src/compute.rs
+++ b/crates/atlas-core/src/compute.rs
@@ -255,24 +255,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vendor_from_str() {
+    fn vendor_parse_accepts_supported_names() {
         assert_eq!(Vendor::parse("nvidia"), Some(Vendor::Nvidia));
         assert_eq!(Vendor::parse("CUDA"), Some(Vendor::Nvidia));
         assert_eq!(Vendor::parse("amd"), Some(Vendor::Amd));
         assert_eq!(Vendor::parse("rocm"), Some(Vendor::Amd));
+        assert_eq!(Vendor::parse("hip"), Some(Vendor::Amd));
         assert_eq!(Vendor::parse("apple"), Some(Vendor::Apple));
         assert_eq!(Vendor::parse("metal"), Some(Vendor::Apple));
         assert_eq!(Vendor::parse("intel"), Some(Vendor::Intel));
+        assert_eq!(Vendor::parse("oneapi"), Some(Vendor::Intel));
+        assert_eq!(Vendor::parse("sycl"), Some(Vendor::Intel));
         assert_eq!(Vendor::parse("unknown"), None);
     }
 
     #[test]
-    fn nvidia_target_extensions() {
-        if let Some(target) = NvidiaTarget::new() {
-            assert_eq!(target.source_extension(), "cu");
-            assert_eq!(target.output_extension(), "ptx");
-            assert!(target.output_is_text());
-            assert_eq!(target.vendor(), Vendor::Nvidia);
-        }
+    fn nvidia_target_metadata() {
+        let target = NvidiaTarget::with_compiler(PathBuf::from("nvcc"));
+        assert_eq!(target.source_extension(), "cu");
+        assert_eq!(target.output_extension(), "ptx");
+        assert!(target.output_is_text());
+        assert_eq!(target.vendor(), Vendor::Nvidia);
     }
 }


### PR DESCRIPTION
## Summary

Two tests in `atlas-core` could miss real regressions. This patch makes the NVIDIA metadata test run on machines without `nvcc` and checks all vendor names already accepted by the parser.

## Why the old tests were broken

`nvidia_target_extensions` put every assertion inside `if let Some(NvidiaTarget::new())`. If compiler discovery returned `None`, the test passed without checking anything. Compiler discovery is setup noise for a test that only reads static metadata.

`vendor_from_str` skipped `hip`, `oneapi`, and `sycl`, even though production accepts them. If one of those match arms disappeared, the test stayed green. `target_for_vendor` then treats the missing parse result like an omitted vendor and falls back to NVIDIA.

## How we proved they were broken

- With CUDA variables unset and `PATH=/usr/bin:/bin`, I changed NVIDIA's source extension from `cu` to `metal`. The old test passed because `NvidiaTarget::new()` returned `None` and no assertion ran.
- I removed `hip` from the AMD parser arm. The old parser test passed because it never supplied `hip`.

These are executed mutants, not hypothetical gaps.

## The fix

The metadata test now uses the existing explicit compiler-path constructor. It always reaches the four metadata assertions and does not invoke compiler discovery. The parser test now supplies every accepted vendor spelling. Both tests were renamed to describe the functions and values they check.

The same mutants fail after the change: `cu` to `metal` fails the source-extension assertion, and deleting `hip` fails the new alias assertion. Production code is unchanged.

## What this does not prove

This patch does not test `find_nvcc`, invoke a compiler, compile a kernel, or exercise a real GPU. Those require different tests and different setup.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests`
- [x] `bash scripts/check-license-headers.sh` (2,268 valid, 0 invalid)
- [x] `typos crates/atlas-core/src/compute.rs`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] PR CI: workspace tests, clippy, coverage, Metal tests, fmt, licenses, typos, and all-target nvcc build passed
- [ ] PR benchmark gate: Atlas invalidates all ten hardware records for any change under this Rust path, including `#[cfg(test)]`; fresh GPU records are required
- [x] Added or updated tests where applicable

## Notes for reviewers

- The diff is entirely inside `#[cfg(test)]`.
- The benchmark-gate failure and its ten invalidated records are documented in the PR discussion. I did not add fake records or weaken the gate.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
