### PR TITLE
atlas-core: strengthen quantization parser contract checks

### DIFF
--- a/crates/atlas-core/src/config/parsers/quantization.rs
+++ b/crates/atlas-core/src/config/parsers/quantization.rs
@@ -158,7 +158,7 @@ mod tests {
     /// `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4`, wrapped by
     /// `merge_sidecar_quant_config` into the `quantization_config` slot.
     #[test]
-    fn modelopt_sidecar_nested_schema_parses() {
+    fn modelopt_sidecar_nested_schema_preserves_exclusions() {
         let raw = serde_json::json!({
             "quantization_config": {
                 "producer": { "name": "modelopt", "version": "0.29.0" },
@@ -184,6 +184,11 @@ mod tests {
             qc.ignore_modules
                 .iter()
                 .any(|m| m == "backbone.layers.4.mixer.in_proj")
+        );
+        assert!(
+            qc.ignore_modules
+                .iter()
+                .any(|m| m == "backbone.layers.0.mixer.conv1d")
         );
     }
 

--- a/crates/atlas-core/src/config/parsers/quantization.rs
+++ b/crates/atlas-core/src/config/parsers/quantization.rs
@@ -210,7 +210,7 @@ mod tests {
     /// ModelOpt mixed-precision sidecar (Super-120B) — nested, no
     /// `exclude_modules`. Must still resolve `quant_method = modelopt`.
     #[test]
-    fn modelopt_mixed_precision_sidecar_parses() {
+    fn modelopt_mixed_precision_sidecar_parses_without_exclusions() {
         let raw = serde_json::json!({
             "quantization_config": {
                 "producer": { "name": "modelopt", "version": "0.43.0" },
@@ -224,5 +224,6 @@ mod tests {
             .expect("mixed-precision sidecar must yield a QuantizationConfig");
         assert_eq!(qc.quant_method, "modelopt");
         assert_eq!(qc.quant_algo, "MIXED_PRECISION");
+        assert!(qc.ignore_modules.is_empty());
     }
 }

--- a/crates/atlas-core/src/config/parsers/quantization.rs
+++ b/crates/atlas-core/src/config/parsers/quantization.rs
@@ -152,7 +152,7 @@ fn normalize_modelopt_sidecar(qc_raw: &serde_json::Value) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_quantization_config;
+    use super::{normalize_modelopt_sidecar, parse_quantization_config};
 
     /// The exact `hf_quant_config.json` schema shipped by
     /// `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4`, wrapped by
@@ -190,7 +190,7 @@ mod tests {
     /// An already-flat HF-standard block (compressed-tensors) must be
     /// unaffected by the ModelOpt normalization.
     #[test]
-    fn flat_compressed_tensors_block_unchanged() {
+    fn flat_compressed_tensors_block_is_not_normalized() {
         let raw = serde_json::json!({
             "quantization_config": {
                 "quant_method": "compressed-tensors",
@@ -198,6 +198,9 @@ mod tests {
                 "ignore": ["lm_head"]
             }
         });
+        let flat = &raw["quantization_config"];
+        assert_eq!(normalize_modelopt_sidecar(flat), flat.clone());
+
         let qc = parse_quantization_config(&raw).expect("flat block must still parse");
         assert_eq!(qc.quant_method, "compressed-tensors");
         assert_eq!(qc.format, "nvfp4-pack-quantized");


### PR DESCRIPTION
## Summary

Three quantization parser tests could pass while returning metadata different from their own fixtures. This patch adds the missing observations without changing production parsing.

## Why the old tests were broken

`flat_compressed_tensors_block_unchanged` said normalization left a flat block unchanged, but it only checked three fields after conversion to `QuantizationConfig`. A new field could be inserted into the normalized JSON and the test would never see it.

The Super-120B fixture represents a ModelOpt sidecar with no exclusions, but its test never checked `ignore_modules`. The Nano fixture contains three sampled exclusions, but its test checked the length and only two values. A same-length replacement of the third value stayed invisible.

## How we proved they were broken

- I injected `quant_algo = NVFP4` during flat-block normalization. The old test passed.
- I injected a default `lm_head` exclusion into the no-exclusions path. The old test passed.
- I replaced `backbone.layers.0.mixer.conv1d` with `corrupted.module`. The list still had three items, so the old Nano test passed.

The fixture shapes and sampled values were checked against NVIDIA's published Super-120B sidecar and a revision-pinned Nano sidecar.

## The fix

The flat-block test now compares the normalized JSON directly with its input before checking public parser output. The Super-120B test now requires an empty exclusion list. The Nano test now checks the third sampled exclusion.

The same three mutants fail after the change at the new observations. The tests stay separate because they cover different failures: normalization interference, an invented default when input is absent, and corruption when input is present.

## What this does not prove

This patch does not load a checkpoint, match exclusions against weight names, exercise duplicate exclusions, or preserve every entry from NVIDIA's full files. It proves only the fixture paths named above.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests`
- [x] `bash scripts/check-license-headers.sh` (2,268 valid, 0 invalid)
- [x] `typos crates/atlas-core/src/config/parsers/quantization.rs`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] PR CI: workspace tests, clippy, coverage, Metal tests, fmt, licenses, and typos passed
- [ ] PR benchmark gate: fresh CI after #701 still invalidates all ten records because `quantization.rs` mixes production parsing with inline tests
- [x] Added or updated tests where applicable

## Notes for reviewers

- Sources: [Super-120B sidecar](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/blob/main/hf_quant_config.json), [Nano sidecar at revision `a2deabac`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4/blob/a2deabacbbbb078caee549ca44f10dc114e7c961/hf_quant_config.json).
- The diff is entirely inside `#[cfg(test)]`.
- A whole-file exemption would be unsafe because `quantization.rs` contains the production parser beside these tests. The current options are real benchmark evidence or extracting the tests into a dedicated registered module.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
