### PR TITLE
bench: gate Gemma-4 cold TTFT — and record that its 4096-token prefill takes 23 s

### DIFF
--- a/.benchmarks/ttft-cold-gate/2026-08-21-27e9520c2e-bg-digitalservices-gemma-4-26b-a4b-it-nvfp4a16.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-21-27e9520c2e-bg-digitalservices-gemma-4-26b-a4b-it-nvfp4a16.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "27e9520c2e",
+  "dirty_paths": [
+    "kernels/gb10/gemma-4-26b-a4b/BENCH.toml"
+  ],
+  "recorded_at": 1787345144,
+  "target_model": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "gemma4/gemma-4-26b-a4b-nvfp4",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787344836,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 50.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.9
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 30535211237,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6579728,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1505836,
+      "gpu_compute_apps": [
+        {
+          "pid": 915673,
+          "name": "./target/release/spark",
+          "used_mib": 108351
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787345144,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.6
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 30535211237,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6596972,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1507552,
+      "gpu_compute_apps": [
+        {
+          "pid": 915673,
+          "name": "./target/release/spark",
+          "used_mib": 108385
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 308,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 25.0,
+      "hottest_chassis_delta_c": 26.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +27 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 1577.1111449999999,
+    "p90_ms": 23483.642246,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.2% (limit +3.0%) · p90 +0.7% (limit +5.0%)",
+  "summary": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16 · median_ms=1577.11, p90_ms=23483.64, samples=36.00 · Pass: median -0.2% (limit +3.0%) · p90 +0.7% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "2ae2e8bcf41716d3b53f913350adb737c0f7347cfee7111fd93de90581618660",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "b8eccc1dcdcef9bc9b2c0154016079fe1307aaae4b403885870a77147f3aef7c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "8d767cb1b60ed4024fdda72cc16de96e4fa79e06b83937758296c2b4e5081a17",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "3d853d690b7671d7f5d1006a5dbeae1b896c5303b96a48b15195a038ba786e3d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "3ef75bd78507af1baf025dca9eac7f23fe3554128b04350228f88dc5ea0ab7ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "45a9eedf0c61c362a0552c07ffeba2e4f576dff5638ac5c6c43e7659cf402204",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "372adff6c9ee94868e19178d8cf2128c900ad035864bb2ba1cd6185fae284faa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e0d7efe1a0afd04491078220cff612e95b2ea75bc023ed5f8bc064d2d4f3cacb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "3d2d8e9ffd1b31a8f24c1afcf0bde7937bb161bda03b278b0ab16ebcb8e6e1a0",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "926b9fc887de889c5eb758b0b983e5b8c0701c4d50305c74960bf419da7755aa",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "02dad9305712bdc6ab539debe39296c1b40d7a6a7626903272dd7e0c598344eb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "243073e34cfa15f1e41be725db0f5b5359dacd8ff7b974d0f631150ef52f0d5c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3cb96b3d20351c18007559cc9127351fca45e890534dedb068ee07af57e6e412",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "f0c131246529fb01c10df017227b5d74a4ff6ae66ebacf89aab3aca48b448385",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "2a4e7d6a00692e491a488f0ec721948112e5ff014bcb338ced69b6b93a9553a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "6b1237dcb001bf4566f739bc7f11fe1be30725c7f5e52fe1020c55cae2dc7563",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "c9b66899fb8f36ebf5405396d95f2be2a05450d11c9293df19d6bd109bf44443",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "cc5d9c11484d84036abc323c0349614fb6683a397e4002c33cdf183d3678ca19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "fa6668ac03a3a61846ee4099165e2e6c4359a79082f4bf60b2d7888085c122b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "424c124ccb004a59c53aaec84d5df11ce78e62316dce4b738ede4805d518dd53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "a80c984864947149c47958249aa72d103ecb5de41267c60c2f4b6c529654988b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8dc3dbc7893e23042e295f41a83b00965d46b54f4420a76f741c063319a99c7a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "f0cd7edfb2dd1992d5e872586dc13dcb5d160cc914e204cb572c14319b09e71b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/kernels/gb10/gemma-4-26b-a4b/BENCH.toml
+++ b/kernels/gb10/gemma-4-26b-a4b/BENCH.toml
@@ -1,0 +1,53 @@
+# Benchmarks for this model, and the thresholds its gate records must meet.
+#
+# Sibling of MODEL.toml so the numbers sit beside the thing they describe;
+# hardware and model are implied by the path. Read by `atlas_plugin::gate::bench`.
+#
+# Deliberately OUTSIDE the closure hash, so ratcheting a threshold does not
+# invalidate the record that justified the ratchet.
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16"
+gate = "ttft-cold-gate"
+recipe = "gemma4/gemma-4-26b-a4b-nvfp4"
+label = "Gemma-4-26B-A4B MoE (NVFP4A16)"
+status = "measured"
+note = """\
+FIRST gate for this target — it had no BENCH.toml, so building the MoE prefill \
+copies in the gemma4 loader (cold TTFT 5705.61 -> 4974.56 ms, -12.8%, \
+cold_ttft.py n=8) had nothing holding it.
+
+Ceilings = the GATE's own dgx1 baseline x the gate limits: median 1580.547 ms \
+x +3%, p90 23324.582 ms x +5%. `default` is UNSET — qwen3.6-35b-a3b claims the \
+default for this gate on gb10, and two defaults is a silent coin-flip over which \
+checkpoint a gate scores. The gate's numbers are NOT the cold_ttft.py numbers \
+(1580.5 vs 4974.6 ms); different harness, different prompt ladder, not \
+interchangeable.
+
+★ THE p90 IS PATHOLOGICAL AND THIS CEILING ENSHRINES IT DELIBERATELY. The three \
+legs measure 261.4 ms @256 tok, 1580.5 ms @1024, and 23324.6 ms @4096 — 4x the \
+tokens for 14.7x the time, sharply superlinear, and the 4096 leg alone sets the \
+aggregate p90. 23 SECONDS of cold TTFT at 4096 tokens is a defect, not a \
+baseline, and it should be investigated and RATCHETED DOWN rather than accepted. \
+It is committed at the measured value only so a regression from here is visible; \
+a gate that refuses to record a bad number protects nothing. The run was clean \
+(0 serve errors, all three legs produced samples), so this is real work, not a \
+harness artifact.
+
+★ NO ttft-warm-gate ENTRY, AND ONE CANNOT BE ADDED TODAY. This model cannot use \
+prefix caching at all: `enable_prefix_caching` makes partial hits take the \
+chunked-prefill path, which refuses on this architecture — "Gemma-4 HDIM=512 \
+chunked prefill only supports BF16 KV cache (kv_dtype=Fp8)" \
+(qwen3_attention/prefill/paged_attn.rs). Measured: 46 serve errors with the flag \
+and 0 without, with 2 of 3 warm legs returning NO samples while the surviving \
+1024-tok leg read 74.7 ms — i.e. it looks 20x FASTER precisely because it \
+mostly did not run. Fixing this needs bf16 KV (a memory cost) or fp8 support in \
+the HDIM=512 chunked path (kernel work); it is a PRODUCTION gap, not only a gate \
+gap, since Gemma-4 pays full cold prefill on every request."""
+
+[benchmarks.metrics.median_ms]
+max = 1627.96
+
+[benchmarks.metrics.p90_ms]
+max = 24490.81


### PR DESCRIPTION
`gemma-4-26b-a4b` had no `BENCH.toml`, so #668's −12.8% cold-TTFT win (5705.61 →
4974.56 ms) had nothing holding it. **Targets #668**; rebase to `main` once that
and #660 land.

Recorded **PASS** at this head: median 1577.1 ms (−0.2%), p90 23.5 s (+0.7%).

| | baseline (gate harness, dgx1) | ceiling |
|---|---:|---:|
| median | 1580.547 ms | 1627.96 (×1.03) |
| p90 | 23324.582 ms | 24490.81 (×1.05) |

`default` is unset — `qwen3.6-35b-a3b` claims it for this gate on gb10. The gate's
numbers are **not** the `cold_ttft.py` numbers (1580.5 vs 4974.6 ms): different
harness, different prompt ladder, not interchangeable.

## ★ The p90 is pathological, and enshrined deliberately

| prompt | median | scaling |
|---|---:|---|
| 256 tok | 261.4 ms | — |
| 1024 tok | 1580.5 ms | 6.0× for 4× the tokens |
| **4096 tok** | **23324.6 ms** | **14.7× for 4× the tokens** |

4096 tokens is 16× the 256-token prompt and costs **89×** the time. **23 seconds of
cold TTFT is a defect, not a baseline.**

It's committed at the measured value so a regression *from here* is visible — a gate
that refuses to record a bad number protects nothing — and it should be **ratcheted
down** once the cause is fixed. The run was clean: **0 serve errors**, all three legs
sampled. This is real work, not a harness artifact.

## ★ No warm gate, and none is possible today

This model **cannot use prefix caching at all**. With `enable_prefix_caching`,
partial hits take the chunked-prefill path, which refuses on this architecture:

```
Gemma-4 HDIM=512 chunked prefill only supports BF16 KV cache (layer 5, kv_dtype=Fp8)
```
(`qwen3_attention/prefill/paged_attn.rs`)

Measured: **46 serve errors** with the flag, **0** without — and **2 of 3 warm legs
returned no samples** while the surviving 1024-tok leg read 74.7 ms. It looks **20×
faster** precisely because it mostly did not run. `median — ms / cached 0 tok` was the
only visible tell, and it reads like a win at a glance.

## Both point at the same path

`HDIM=512` attention. And both are **production** gaps, not benchmark artifacts:
Gemma-4 pays full cold prefill on *every* request, and that prefill is superlinear.
Fixing needs bf16 KV (a memory cost) or fp8 support in the HDIM=512 chunked path
(kernel work) — neither attempted here.

469 `atlas-plugin` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1