### PR TITLE
atlas-core: cover expert partition remainders

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -384,7 +384,7 @@ fn test_parse_nemotron_h_puzzle_config() {
 }
 
 #[test]
-fn test_expert_parallelism_range() {
+fn expert_parallelism_partitions_experts_without_dropping_remainder() {
     let mut cfg = ModelConfig::qwen3_next_80b_nvfp4();
     // Single GPU: all experts local
     assert_eq!(cfg.local_expert_range(), (0, 512));
@@ -407,6 +407,11 @@ fn test_expert_parallelism_range() {
     assert!(!cfg.is_local_expert(255));
     assert!(cfg.is_local_expert(256));
     assert!(cfg.is_local_expert(511));
+
+    // EP=2 with an uneven split: the final expert belongs to the last rank.
+    cfg.num_experts = 513;
+    assert_eq!(cfg.local_expert_range(), (256, 513));
+    assert!(cfg.is_local_expert(512));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`test_expert_parallelism_range` only split 512 experts across two ranks, so it exercised an exactly divisible case and could not verify its remainder rule. Removing the last-rank remainder branch (`end = start + per_rank`) left the old test green even though expert 512 would be dropped from a 513-expert model.

This renames the check to state the partition contract and adds the smallest non-divisible case: 513 experts across two ranks. Rank 1 must own `[256, 513)`, and expert 512 must map to its local index. Replaying the same production mutant now fails with `(256, 512)` instead of `(256, 513)`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Same remainder-dropping mutant: old test passed; strengthened test failed

## Notes for reviewers

This is test-only. It does not change expert partitioning and does not claim coverage of invalid ranks/world sizes, more ranks than experts, collectives, or end-to-end multi-GPU routing.

Fresh CI after #701 passed PR benchmark gate at the current head, confirming this exact test-only path preserves the existing benchmark records.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
