### PR TITLE
atlas-core: strengthen Qwen3-Next fixture contract

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -24,7 +24,7 @@ fn test_qwen3_default_config() {
 }
 
 #[test]
-fn test_parse_actual_config() {
+fn qwen3_next_fixture_parses_layout_routing_and_quantization() {
     let json = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../test_data/qwen3_config.json"
@@ -32,6 +32,7 @@ fn test_parse_actual_config() {
     let cfg = parse_config(json).unwrap();
     assert_eq!(cfg.hidden_size, 2048);
     assert_eq!(cfg.num_experts, 512);
+    assert_eq!(cfg.num_experts_per_tok, 10);
     assert_eq!(cfg.num_hidden_layers, 48);
     assert_eq!(cfg.layer_types.len(), 48);
     assert_eq!(cfg.layer_types[0], LayerType::LinearAttention);
@@ -44,6 +45,18 @@ fn test_parse_actual_config() {
     assert_eq!(cfg.partial_rotary_factor, 0.25);
     assert_eq!(cfg.model_type, "qwen3_next");
     assert!(cfg.weight_prefix.is_empty());
+
+    let quant = cfg
+        .quantization_config
+        .expect("NVIDIA NVFP4 fixture must retain quantization metadata");
+    assert_eq!(quant.quant_method, "modelopt");
+    assert_eq!(quant.quant_algo, "NVFP4");
+    assert!(
+        quant
+            .ignore_modules
+            .iter()
+            .any(|module| module == "lm_head")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`test_parse_actual_config` parsed NVIDIA's Qwen3-Next NVFP4 fixture but did not observe two runtime-facing results: the model's top-K routing fan-out or its quantization metadata. Forcing parsed `num_experts_per_tok` from 10 to 1 left the old test green; independently dropping `quantization_config` also left it green.

This renames the check to its actual layout/routing/quantization scope. It asserts top-K 10 and requires the published `modelopt`/`NVFP4` metadata plus the `lm_head` exclusion. The same mutants now fail at `1 != 10` and at the required-metadata expectation.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Two independent old-green/new-red mutation replays

## Notes for reviewers

Top-K feeds MoE kernel arguments and scratch sizing. Quantization metadata selects ModelOpt NVFP4 loading and its ignore list decides which modules remain BF16. This patch changes only the oracle because the valid publisher fixture already parses to the correct values.

It does not load weights, allocate GPU buffers, run inference, or validate every fixture field. Workspace Clippy is left for Linux CI because this macOS host reaches unrelated Linux-only paths. The ten-record benchmark gate is expected to request hardware evidence for this Rust test change.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
