### PR TITLE
atlas-core: preserve Gemma-4 config contracts

### DIFF
--- a/crates/atlas-core/src/config/parsers/gemma4.rs
+++ b/crates/atlas-core/src/config/parsers/gemma4.rs
@@ -107,7 +107,6 @@ pub(crate) fn parse_gemma4_params(raw: &serde_json::Value) -> Result<ModelConfig
         config.num_experts = num_experts;
         config.num_experts_per_tok = top_k_experts;
         config.moe_intermediate_size = moe_intermediate_size;
-        config.norm_topk_prob = true;
         config.shared_expert_intermediate_size = 0; // dense MLP is separate, not a shared expert
     } else {
         config.num_experts = 0;
@@ -155,7 +154,8 @@ pub(crate) fn parse_gemma4_params(raw: &serde_json::Value) -> Result<ModelConfig
     config.model_type = "gemma4".to_string();
     config.attn_gated = false;
     config.nested_config = true;
-    config.norm_topk_prob = false; // No MoE
+    // Gemma-4 MoE renormalizes the selected top-K router probabilities.
+    config.norm_topk_prob = num_experts > 0;
 
     // Embedding scale: embeddings *= sqrt(hidden_size) — Gemma family convention
     config.embed_scale = (hidden_size as f32).sqrt();

--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -435,7 +435,7 @@ fn test_tensor_parallelism_range() {
 }
 
 #[test]
-fn test_parse_gemma4_config() {
+fn gemma4_legacy_config_maps_attention_and_embedding_controls() {
     let json = r#"{
         "model_type": "gemma4",
         "tie_word_embeddings": true,
@@ -476,8 +476,10 @@ fn test_parse_gemma4_config() {
     assert_eq!(cfg.vocab_size, 262144);
     assert_eq!(cfg.rms_norm_eps, 1e-6);
     assert_eq!(cfg.max_position_embeddings, 262144);
+    assert_eq!(cfg.sliding_window, 1024);
     assert_eq!(cfg.rope_theta, 10000.0); // sliding theta
     assert_eq!(cfg.partial_rotary_factor, 0.25);
+    assert_eq!(cfg.embed_scale, 5376_f32.sqrt());
     assert!(cfg.tie_word_embeddings);
     assert!(!cfg.attn_gated);
     assert!(cfg.nested_config);

--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -500,6 +500,47 @@ fn gemma4_legacy_config_maps_attention_and_embedding_controls() {
 }
 
 #[test]
+fn gemma4_moe_config_preserves_routing_and_canonical_rope_controls() {
+    let json = r#"{
+        "model_type": "gemma4",
+        "tie_word_embeddings": true,
+        "text_config": {
+            "hidden_size": 2304,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "global_head_dim": 512,
+            "intermediate_size": 9216,
+            "vocab_size": 262144,
+            "sliding_window": 512,
+            "attention_pattern": ["full_attention"],
+            "rope_parameters": {
+                "full_attention": {
+                    "rope_theta": 1000000.0,
+                    "partial_rotary_factor": 0.25
+                },
+                "sliding_attention": {"rope_theta": 10000.0}
+            },
+            "num_experts": 128,
+            "top_k_experts": 8,
+            "moe_intermediate_size": 704,
+            "rms_norm_eps": 1e-6,
+            "max_position_embeddings": 131072
+        }
+    }"#;
+
+    let cfg = parse_config(json).unwrap();
+    assert_eq!(cfg.num_experts, 128);
+    assert_eq!(cfg.num_experts_per_tok, 8);
+    assert_eq!(cfg.moe_intermediate_size, 704);
+    assert!(cfg.norm_topk_prob);
+    assert_eq!(cfg.head_dim, 512);
+    assert_eq!(cfg.rope_theta, 10000.0);
+    assert_eq!(cfg.partial_rotary_factor, 0.25);
+}
+
+#[test]
 fn test_parse_deepseek_v4_config() {
     let json = r#"{
         "model_type": "deepseek_v4",


### PR DESCRIPTION
## Summary

The dense Gemma-4 parser check supplied a 1024-token sliding window and implied Gemma embedding scaling, but observed neither. Zeroing either parsed value left the old test green. While auditing that path, a separate functional defect surfaced: the MoE branch set `norm_topk_prob = true`, then common setup unconditionally overwrote it to `false`.

The first commit renames the dense check and observes the window mask plus `sqrt(hidden_size)` embedding scale; the exact zeroing mutants now fail. The second adds a canonical Gemma-4 MoE config regression and preserves normalization when `num_experts > 0`. The regression failed on the old production code, passes with the fix, and fails again when the unconditional `false` is restored.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Two old-green/new-red dense-control mutants
- [x] Old-red/new-green/old-mutant-red MoE normalization replay

## Notes for reviewers

Hugging Face's `Gemma4TextRouter` softmaxes all experts, selects top-K, then divides selected weights by their sum. Atlas passes `norm_topk_prob` into its MoE forward kernels, so the overwritten flag changed expert mixture weights rather than only config metadata.

The new fixture samples Google's published 128-expert/top-K-8/704-wide MoE values and canonical nested RoPE shape. It does not load the checkpoint, run a router kernel, or compare logits. Workspace Clippy is left for Linux CI; the Rust-crate benchmark gate will require external GPU records unavailable on this host.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
