### PR TITLE
atlas-core: validate Nemotron-H config geometry

### DIFF
--- a/crates/atlas-core/src/config.rs
+++ b/crates/atlas-core/src/config.rs
@@ -629,5 +629,20 @@ pub(crate) fn validate_config(config: &ModelConfig) -> Result<()> {
         );
     }
 
+    if config.mamba_num_heads > 0 {
+        if config.mamba_head_dim == 0 {
+            anyhow::bail!("mamba_head_dim must be greater than zero");
+        }
+        if config.ssm_state_size == 0 {
+            anyhow::bail!("ssm_state_size must be greater than zero");
+        }
+        if config.n_groups == 0 {
+            anyhow::bail!("n_groups must be greater than zero");
+        }
+        if !config.mamba2_d_inner().is_multiple_of(config.n_groups) {
+            anyhow::bail!("mamba_num_heads * mamba_head_dim must be divisible by n_groups");
+        }
+    }
+
     Ok(())
 }

--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -275,7 +275,7 @@ fn test_layer_prefix() {
 }
 
 #[test]
-fn test_parse_nemotron_h_config() {
+fn nemotron_h_fixture_maps_mamba_moe_and_weight_layout() {
     let json = r#"{
         "model_type": "nemotron_h",
         "hidden_size": 2688,
@@ -310,6 +310,10 @@ fn test_parse_nemotron_h_config() {
     assert_eq!(cfg.shared_expert_intermediate_size, 3712);
     assert_eq!(cfg.rms_norm_eps, 1e-5);
     assert_eq!(cfg.linear_conv_kernel_dim, 4);
+    assert_eq!(cfg.mamba_num_heads, 64);
+    assert_eq!(cfg.mamba_head_dim, 64);
+    assert_eq!(cfg.ssm_state_size, 128);
+    assert_eq!(cfg.n_groups, 8);
     assert_eq!(cfg.mamba2_d_inner(), 4096); // 64*64, NOT expand*hidden
     // Pattern: 23 M + 23 E + 6 * = 52
     assert_eq!(cfg.layer_types.len(), 52);
@@ -322,6 +326,8 @@ fn test_parse_nemotron_h_config() {
     assert_eq!(cfg.gqa_ratio(), 16); // 32/2
     assert_eq!(cfg.rotary_dim(), 128); // partial_rotary_factor=1.0
     assert_eq!(cfg.routed_scaling_factor, 2.5);
+    assert!(cfg.norm_topk_prob);
+    assert_eq!(cfg.weight_prefix, "backbone");
 }
 
 #[test]

--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -331,6 +331,41 @@ fn nemotron_h_fixture_maps_mamba_moe_and_weight_layout() {
 }
 
 #[test]
+fn nemotron_h_rejects_invalid_mamba_geometry() {
+    let base = serde_json::json!({
+        "model_type": "nemotron_h",
+        "hidden_size": 2688,
+        "num_hidden_layers": 1,
+        "hybrid_override_pattern": "M",
+        "mamba_num_heads": 64,
+        "mamba_head_dim": 64,
+        "ssm_state_size": 128,
+        "n_groups": 8,
+        "conv_kernel": 4
+    });
+    let mut accepted = Vec::new();
+
+    for (field, value) in [
+        ("mamba_head_dim", 0),
+        ("ssm_state_size", 0),
+        ("n_groups", 0),
+        ("n_groups", 7),
+    ] {
+        let mut raw = base.clone();
+        raw[field] = serde_json::json!(value);
+        match parse_config(&raw.to_string()) {
+            Ok(_) => accepted.push(field),
+            Err(error) => assert!(
+                error.to_string().contains(field),
+                "error for {field} did not name the invalid field: {error}"
+            ),
+        }
+    }
+
+    assert!(accepted.is_empty(), "parser accepted invalid {accepted:?}");
+}
+
+#[test]
 fn test_parse_nemotron_h_puzzle_config() {
     // Minimal Puzzle-shaped schedule: 4 layers with heterogeneous MoE dims.
     // Full checkpoint has 88 layers; this covers dispatch + per-layer lookup.


### PR DESCRIPTION
## Summary

The Nemotron-H test claimed 64×64 Mamba geometry but observed only the product 4096. A same-product 32×128 corruption stayed green, as did zero state size, zero group count, an erased `backbone` prefix, and disabled routing normalization. The parser also accepted zero/non-divisible Mamba geometry that later becomes allocation, kernel geometry, and `d_inner / n_groups` input.

The first commit directly observes NVIDIA's published Mamba factors, state, groups, routing normalization, and Atlas weight prefix; every exact mutant now fails. The second validates Mamba head dimension, state size, nonzero groups, and group divisibility. Its table-driven regression originally reported every invalid case accepted, passes with validation, and fails again if validation is removed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Five independent old-green/new-red parser mutants
- [x] Aggregate old-red/new-green/validation-removed-red replay

## Notes for reviewers

The positive fixture values come from NVIDIA's `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` config. The new validation is shared so every Mamba-backed config fails before allocation or kernel launch with a field-naming error.

This does not bound maximum dimensions, prove multiplication cannot overflow, validate checkpoint tensor shapes, or run a Mamba/MoE kernel. Workspace Clippy is left to Linux CI, and the benchmark gate requires hardware records unavailable on this host.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
