### PR TITLE
atlas-core: strengthen Qwen3.5 nested config contract

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -47,7 +47,7 @@ fn test_parse_actual_config() {
 }
 
 #[test]
-fn test_parse_qwen35_nested_config() {
+fn qwen35_moe_nested_config_maps_attention_ssm_and_layout_controls() {
     let json = r#"{
         "model_type": "qwen3_5_moe",
         "text_config": {
@@ -102,7 +102,13 @@ fn test_parse_qwen35_nested_config() {
     assert_eq!(cfg.eos_token_id, 248044);
     assert_eq!(cfg.rope_theta, 10_000_000.0);
     assert!(cfg.is_qwen35());
+    assert!(cfg.nested_config);
+    assert!(cfg.attn_gated);
+    assert!(cfg.weight_prefix.is_empty());
     assert!(cfg.norm_topk_prob); // Qwen3.5 unconditionally normalizes
+    assert_eq!(cfg.partial_rotary_factor, 0.25);
+    assert_eq!(cfg.rotary_dim(), 64);
+    assert_eq!(cfg.linear_conv_kernel_dim, 4);
     assert_eq!(cfg.ssm_qkv_size(), 2048 + 2048 + 4096); // 8192
     assert_eq!(cfg.ssm_z_size(), 4096);
     assert_eq!(cfg.mtp_num_hidden_layers, 1);


### PR DESCRIPTION
## Summary

The reduced Qwen3.5 MoE nested-config test observed dimensions and aggregate SSM sizes but could not detect four runtime-control corruptions. Disabling gated attention, clearing nested-layout detection, expanding rotary coverage from 0.25 to 1.0, and reducing the convolution kernel width from 4 to 1 each left the old test green.

This renames the check to its attention/SSM/layout scope and directly observes those four controls plus the initial empty prefix used by nested weight-prefix detection. Replaying each exact mutant now fails at the intended assertion.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Four independent old-green/new-red mutation replays

## Notes for reviewers

These fields feed attention projection sizing, buffer sizing, prefix auto-detection, rotary dimensions, convolution state, and SSM kernels. Production already returns the correct values for this reduced input, so the patch is test-only.

This is not an exact copy of current `Qwen/Qwen3.5-35B-A3B`: current publisher configs also carry MRoPE and vision fields handled by separate dispatch tests. It does not load weights or run inference.

Fresh CI after #701 passed PR benchmark gate at the current head, confirming this exact test-only path preserves the existing benchmark records.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
