### PR TITLE
atlas-core: strengthen Qwen3-VL config contract

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -109,7 +109,7 @@ fn test_parse_qwen35_nested_config() {
 }
 
 #[test]
-fn test_parse_qwen3_vl_config() {
+fn qwen3_vl_moe_config_maps_attention_and_routing_controls() {
     let json = r#"{
         "model_type": "qwen3_vl_moe",
         "text_config": {
@@ -137,7 +137,10 @@ fn test_parse_qwen3_vl_config() {
     assert_eq!(cfg.num_attention_heads, 32);
     assert_eq!(cfg.num_key_value_heads, 4);
     assert_eq!(cfg.num_experts, 128);
+    assert_eq!(cfg.num_experts_per_tok, 8);
+    assert_eq!(cfg.moe_intermediate_size, 768);
     assert_eq!(cfg.num_hidden_layers, 48);
+    assert!(!cfg.attn_gated);
     // Pure attention: all layers are FullAttention (full_attention_interval defaults to 1)
     assert_eq!(cfg.num_attention_layers(), 48);
     assert_eq!(cfg.num_ssm_layers(), 0);


### PR DESCRIPTION
## Summary

The reduced Qwen3-VL MoE config test checked broad model dimensions but could not detect three runtime-significant corruptions. Forcing gated attention on, reducing routed experts per token from 8 to 1, and clearing the MoE intermediate width from 768 to 0 each left the old test green.

This renames the test to state its attention-and-routing scope and directly observes all three controls. Replaying each exact production mutant now fails at the intended assertion, while the restored parser passes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Three independent old-green/new-red mutation replays

## Notes for reviewers

The fixture values match the text config published for [`Qwen/Qwen3-VL-30B-A3B-Instruct`](https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct/blob/main/config.json): 8 routed experts per token and a 768-wide expert MLP. These controls feed MoE kernel/scratch sizing and expert GEMMs; `attn_gated` changes attention projection and buffer sizing.

Production already returns the correct values for this reduced input, so the patch is test-only. The reduced fixture intentionally does not claim coverage of the publisher's vision tower or MRoPE fields, which have separate dispatch coverage. It does not load weights or run inference.

Fresh CI after #701 passed PR benchmark gate at the current head, confirming this exact test-only path preserves the existing benchmark records.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
