### PR TITLE
atlas-core: strengthen Qwen3-Next factory contract

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -7,10 +7,14 @@
 use super::*;
 
 #[test]
-fn test_qwen3_default_config() {
+fn qwen3_next_factory_preserves_attention_ssm_and_routing_shape() {
     let cfg = ModelConfig::qwen3_next_80b_nvfp4();
+    assert_eq!(cfg.hidden_size, 2048);
     assert_eq!(cfg.num_hidden_layers, 48);
+    assert_eq!(cfg.num_attention_heads, 16);
+    assert_eq!(cfg.num_key_value_heads, 2);
     assert_eq!(cfg.num_experts, 512);
+    assert_eq!(cfg.num_experts_per_tok, 10);
     assert_eq!(cfg.num_attention_layers(), 12);
     assert_eq!(cfg.num_ssm_layers(), 36);
     assert_eq!(cfg.gqa_ratio(), 8);
@@ -19,6 +23,9 @@ fn test_qwen3_default_config() {
     assert_eq!(cfg.layer_type(2), LayerType::LinearAttention);
     assert_eq!(cfg.layer_type(3), LayerType::FullAttention);
     assert_eq!(cfg.layer_type(47), LayerType::FullAttention);
+    assert_eq!(cfg.linear_num_key_heads, 16);
+    assert_eq!(cfg.linear_key_head_dim, 128);
+    assert_eq!(cfg.linear_conv_kernel_dim, 4);
     assert_eq!(cfg.ssm_qkvz_size(), 2048 + 2048 + 4096 + 4096);
     assert_eq!(cfg.ssm_ba_size(), 64);
 }


### PR DESCRIPTION
## Summary

The hard-coded Qwen3-Next factory test relied on derived ratios and aggregate SSM sizes, so it could not detect five shape corruptions. Doubling hidden width; doubling Q and KV heads together; changing linear key heads from 16×128 to 8×256; reducing routed experts per token from 10 to 1; and reducing convolution width from 4 to 1 each left the old test green.

This renames the check to its attention/SSM/routing scope and directly observes the factors and controls hidden by those aggregates. Replaying each exact factory mutant now fails at its intended assertion, while restored production passes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Five independent old-green/new-red mutation replays

## Notes for reviewers

The expected values match the checked-in Qwen3-Next publisher fixture and NVIDIA's [`Qwen3-Next-80B-A3B-Instruct-NVFP4` config](https://huggingface.co/nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4/blob/main/config.json). The individual factors control attention projection shape, SSM state/convolution layout, MoE kernel fan-out, scratch sizing, and expert execution; equal derived totals do not make different factorizations interchangeable.

Production already returns the correct values, so this patch is test-only. It does not prove real weight loading, allocation, kernel launch, or inference output. The hard-coded factory is also used as a construction baseline by other parsers and runtime tests; this PR does not claim every field in that broad struct is covered.

Fresh CI after #701 passed PR benchmark gate at the current head, confirming this exact test-only path preserves the existing benchmark records.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
