### PR TITLE
atlas-core: partition kernel target equality

### DIFF
--- a/crates/atlas-core/src/target.rs
+++ b/crates/atlas-core/src/target.rs
@@ -65,14 +65,23 @@ mod tests {
     }
 
     #[test]
-    fn targets_are_comparable() {
+    fn target_equality_observes_each_dispatch_dimension() {
         let a = KernelTarget::GB10_QWEN3_NVFP4;
-        let b = KernelTarget {
-            arch: "sm_100a",
-            model: "llama-70b",
-            quant: "fp8",
-        };
-        assert_ne!(a, b);
         assert_eq!(a, KernelTarget::GB10_QWEN3_NVFP4);
+        assert_ne!(
+            a,
+            KernelTarget {
+                arch: "sm_100a",
+                ..a
+            }
+        );
+        assert_ne!(
+            a,
+            KernelTarget {
+                model: "llama-70b",
+                ..a
+            }
+        );
+        assert_ne!(a, KernelTarget { quant: "fp8", ..a });
     }
 }


### PR DESCRIPTION
## Summary

The kernel-target equality test compared the default target with one target that changed architecture, model, and quantization simultaneously. Equality implementations that ignored any one of those fields still left the old test green; comparing the default constant with itself added no field sensitivity.

This renames the check to its dispatch-key scope and changes one field at a time. Replaying equality implementations that independently ignore architecture, model, or quantization now fails at the corresponding assertion.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Three independent old-green/new-red equality mutation replays

## Notes for reviewers

`KernelTarget` is the structured key for architecture/model/quantization-specific PTX sets and dispatch metadata. Ignoring any one dimension aliases targets that can require different binaries or kernel implementations. The production implementation remains the derived field-wise `PartialEq`/`Eq`; this patch changes only the test oracle.

This does not verify hashing, target discovery, PTX availability, directory resolution, or kernel execution. Workspace Clippy and the ten-record GPU benchmark requirement remain CI/external-hardware gates.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
