### PR TITLE
profile: name the attention kernel that actually ran

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip.rs
@@ -625,7 +625,8 @@ impl Qwen3AttentionLayer {
                 .arg_u32(hd)
                 .launch(stream)?;
         }
-        if hd > 256 && self.prefill_attn_512_k.0 != 0 {
+        let wide_head_path = hd > 256 && self.prefill_attn_512_k.0 != 0;
+        if wide_head_path {
             // HDIM=512: use scalar reference kernel (BR=16, correct for any head_dim)
             // Full-attention layers (this path) always pass sliding_window=0.
             ops::prefill_attention(
@@ -690,7 +691,21 @@ impl Qwen3AttentionLayer {
                 .arg_u32(hd)
                 .launch(stream)?;
         }
-        aprof!("flash_attn_64", t0);
+        // ★ The two branches above run DIFFERENT kernels — `inferspark_prefill_512`
+        // for wide heads, `prefill_attention_64` otherwise — and this label named
+        // the second for BOTH. Profiling Gemma-4, whose 5 global layers are
+        // 512-wide, therefore attributed 16,484 ms of an 18,078 ms prefill to
+        // "flash_attn_64" — a kernel that accounts for 49.7 ms across its 25
+        // sliding layers. Two successive root-cause hypotheses were built on that
+        // label and both were wrong. Name the kernel that actually ran.
+        aprof!(
+            if wide_head_path {
+                "flash_attn_512_scalar"
+            } else {
+                "flash_attn_64"
+            },
+            t0
+        );
         t0 = if ctx.profile {
             ctx.gpu.synchronize(stream)?;
             Some(std::time::Instant::now())


### PR DESCRIPTION
`aprof!("flash_attn_64", t0)` sat **after** an if/else that dispatches two different
kernels — `inferspark_prefill_512` when `hd > 256` and the handle resolves,
`prefill_attention_64` otherwise — and labelled both with the second one's name.

## What that hid

Measured on `bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16`, 4096-token prefill.
This model has **5 global (512-wide)** and **25 sliding (256-wide)** attention layers:

| kernel | total | layers | per layer |
|---|---:|---:|---:|
| **`flash_attn_512_scalar`** | **16,484.4 ms** | 5 | **3,296.9 ms** |
| `flash_attn_64` | 49.7 ms | 25 | 2.0 ms |

The old label attributed all **16,484 ms** to `flash_attn_64` — a kernel that in
truth accounts for **49.7 ms**. Off by 330×, and pointing at the wrong kernel
entirely.

I built two root-cause hypotheses on that reading and **both were wrong**:

- *"the 512 kernel isn't shipped for this target"* — it is, for three targets
  (`deepseek-v4-flash`, `gemma-4-26b-a4b`, `gemma-4-31b`);
- *"the `wide_head_dim` probe gates it off"* — `config/parsers/gemma4.rs:138` sets
  `config.head_dim = global_head_dim` (512), so the probe is true.

Only after fixing the label did the real picture appear: **3,297 ms per layer on the
scalar 512-wide path vs 2.0 ms on the tiled 64 path — a 1,650× per-layer gap**, and
91% of this model's prefill.

## The change

One bool hoisted out of the condition; the label reads from it. **No behaviour
change** — profiling-only path, gated on `ctx.profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1