### PR TITLE
atlas-core: reject zero GGUF key length

### DIFF
--- a/crates/atlas-core/src/config/gguf.rs
+++ b/crates/atlas-core/src/config/gguf.rs
@@ -111,6 +111,10 @@ pub fn config_from_gguf(inputs: &GgufConfigInputs) -> Result<ModelConfig> {
     // head_dim: explicit key_length if present, else hidden_size / head_count.
     // Erroring on a non-divisible fallback avoids a silently-wrong head_dim.
     let head_dim = match meta.get_u64(&k("attention.key_length")) {
+        Some(0) => bail!(
+            "GGUF metadata key '{}.attention.key_length' must be greater than zero",
+            arch
+        ),
         Some(v) => v as usize,
         None => {
             if num_attention_heads == 0 || !hidden_size.is_multiple_of(num_attention_heads) {

--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -104,6 +104,18 @@ fn explicit_key_length_wins() {
 }
 
 #[test]
+fn explicit_key_length_must_be_nonzero() {
+    let m = llama_meta().u("llama.attention.key_length", 0);
+    let inp = GgufConfigInputs {
+        meta: &m,
+        token_embd_vocab: None,
+        has_output_weight: true,
+    };
+    let err = config_from_gguf(&inp).unwrap_err();
+    assert!(err.to_string().contains("llama.attention.key_length"));
+}
+
+#[test]
 fn kv_heads_default_to_mha() {
     let mut m = llama_meta();
     m.u.remove("llama.attention.head_count_kv");


### PR DESCRIPTION
## Summary

The GGUF parser honors an explicit `{arch}.attention.key_length`, but it also accepted zero and returned a successful `ModelConfig` with `head_dim = 0`. That invalid dimension then reaches KV-cache sizing, attention projection shapes, rotary dimensions, scaling, and kernel arguments instead of failing at config load.

This rejects an explicit zero key length at the metadata boundary and names the offending namespaced key. The regression failed against the previous parser by receiving `Ok(ModelConfig { head_dim: 0, ... })`, passes with the validation, and fails again when the four-line guard is removed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Old-red/new-green regression plus validation-removal replay

## Notes for reviewers

The [GGUF metadata specification](https://github.com/ggml-org/ggml/blob/master/docs/gguf.md) defines `attention.key_length` as the size of a key head and says the parser should derive it from embedding width and head count only when the key is absent. This change preserves that precedence and rejects only the impossible explicit zero dimension.

The neighboring `explicit_key_length_wins` test already rejects replacing a valid explicit 96 with the derived 128, so it remains unchanged. This PR does not broaden validation to other zero-valued GGUF dimensions; those registered error paths are being audited separately. It does not load weights or run inference. Workspace Clippy and the ten-record GPU benchmark requirement remain CI/external-hardware gates.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
