### PR TITLE
atlas-core: validate GGUF Gemma softcaps

### DIFF
--- a/crates/atlas-core/src/config/gguf.rs
+++ b/crates/atlas-core/src/config/gguf.rs
@@ -215,10 +215,14 @@ pub fn config_from_gguf(inputs: &GgufConfigInputs) -> Result<ModelConfig> {
         config.embed_scale = (hidden_size as f32).sqrt();
         // Logit softcap: honor the GGUF key if present (gemma2), else 0.0
         // (disabled). gemma3+ dropped softcapping.
-        config.final_logit_softcapping = meta
-            .get_f64(&k("final_logit_softcapping"))
-            .map(|v| v as f32)
-            .unwrap_or(0.0);
+        config.final_logit_softcapping = match meta.get_f64(&k("final_logit_softcapping")) {
+            Some(v) if v >= 0.0 && v <= f32::MAX as f64 => v as f32,
+            Some(v) => bail!(
+                "GGUF metadata key '{}.final_logit_softcapping' must be non-negative and representable as a finite f32 (got {v})",
+                arch
+            ),
+            None => 0.0,
+        };
     }
 
     // Reuse the shared quantization-config + validation pass.

--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -54,6 +54,22 @@ fn llama_meta() -> Meta {
         .f("llama.rope.freq_base", 10000.0)
 }
 
+fn gemma2_meta() -> Meta {
+    Meta::default()
+        .s("general.architecture", "gemma2")
+        .u("gemma2.embedding_length", 2304)
+        .u("gemma2.block_count", 26)
+        .u("gemma2.feed_forward_length", 9216)
+        .u("gemma2.attention.head_count", 8)
+        .u("gemma2.attention.head_count_kv", 4)
+        .u("gemma2.attention.key_length", 256)
+        .u("gemma2.context_length", 8192)
+        .u("gemma2.vocab_size", 256000)
+        .u("gemma2.attention.sliding_window", 4096)
+        .f("gemma2.attention.layer_norm_rms_epsilon", 1e-6)
+        .f("gemma2.final_logit_softcapping", 30.0)
+}
+
 #[test]
 fn llama_dense_maps_to_mistral() {
     let m = llama_meta();
@@ -199,19 +215,7 @@ fn qwen3_moe_populates_expert_fields() {
 
 #[test]
 fn gemma_sets_embed_scale_and_softcap() {
-    let m = Meta::default()
-        .s("general.architecture", "gemma2")
-        .u("gemma2.embedding_length", 2304)
-        .u("gemma2.block_count", 26)
-        .u("gemma2.feed_forward_length", 9216)
-        .u("gemma2.attention.head_count", 8)
-        .u("gemma2.attention.head_count_kv", 4)
-        .u("gemma2.attention.key_length", 256)
-        .u("gemma2.context_length", 8192)
-        .u("gemma2.vocab_size", 256000)
-        .u("gemma2.attention.sliding_window", 4096)
-        .f("gemma2.attention.layer_norm_rms_epsilon", 1e-6)
-        .f("gemma2.final_logit_softcapping", 30.0);
+    let m = gemma2_meta();
     let inp = GgufConfigInputs {
         meta: &m,
         token_embd_vocab: None,
@@ -223,6 +227,39 @@ fn gemma_sets_embed_scale_and_softcap() {
     assert_eq!(c.sliding_window, 4096);
     assert!((c.embed_scale - (2304f32).sqrt()).abs() < 1e-3);
     assert!((c.final_logit_softcapping - 30.0).abs() < 1e-3);
+}
+
+#[test]
+fn gemma_validates_logit_softcap_domain() {
+    let mut accepted = Vec::new();
+    for value in [-30.0, f64::NAN, f64::INFINITY, f64::MAX] {
+        let mut m = gemma2_meta();
+        m.f.insert("gemma2.final_logit_softcapping".into(), value);
+        let inp = GgufConfigInputs {
+            meta: &m,
+            token_embd_vocab: None,
+            has_output_weight: false,
+        };
+        match config_from_gguf(&inp) {
+            Ok(_) => accepted.push(value),
+            Err(err) => assert!(err.to_string().contains("gemma2.final_logit_softcapping")),
+        }
+    }
+    assert!(
+        accepted.is_empty(),
+        "accepted invalid softcaps: {accepted:?}"
+    );
+
+    let mut disabled = gemma2_meta();
+    disabled
+        .f
+        .insert("gemma2.final_logit_softcapping".into(), 0.0);
+    let inp = GgufConfigInputs {
+        meta: &disabled,
+        token_embd_vocab: None,
+        has_output_weight: false,
+    };
+    assert_eq!(config_from_gguf(&inp).unwrap().final_logit_softcapping, 0.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The GGUF Gemma parser copied `final_logit_softcapping` from an `f64` metadata value into `f32` without validating its domain. Negative values, NaN, infinity, and finite values larger than `f32::MAX` all produced successful configs; the latter overflowed to positive infinity during the cast. At runtime, non-positive and NaN values silently skip the softcap kernel, while positive infinity is passed into the softcap formula.

This accepts the supported domain—zero to disable softcapping or a positive finite `f32`—and rejects values that cannot represent that contract. The regression reports all four previously accepted invalid partitions, verifies explicit zero remains valid, and names the namespaced GGUF key in every error.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Old-red/new-green invalid-domain regression plus validation-removal replay
- [x] Too-strict zero-rejection mutant replay

## Notes for reviewers

The existing `gemma_sets_embed_scale_and_softcap` check already rejects independently clearing the derived embedding scale and ignoring an explicit softcap of 30. It remains unchanged apart from reusing the extracted Gemma fixture.

For the new domain regression, previous production accepted `-30.0`, `NaN`, `+∞`, and `f64::MAX`; removing the validation after the fix restores that exact aggregate failure. Changing the lower bound from `>= 0` to `> 0` makes the explicit-disabled case fail, proving zero remains a supported boundary rather than being rejected accidentally.

This does not change missing-key behavior (still disabled at 0), positive finite values, embedding scaling, weight loading, or inference output. Workspace Clippy and the ten-record GPU benchmark requirement remain CI/external-hardware gates.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
