### PR TITLE
atlas-core: remove redundant GGUF head dimension check

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -80,18 +80,6 @@ fn llama_dense_maps_to_mistral() {
 }
 
 #[test]
-fn head_dim_derived_when_key_absent() {
-    let m = llama_meta();
-    let inp = GgufConfigInputs {
-        meta: &m,
-        token_embd_vocab: None,
-        has_output_weight: true,
-    };
-    let c = config_from_gguf(&inp).unwrap();
-    assert_eq!(c.head_dim, 128);
-}
-
-#[test]
 fn explicit_key_length_wins() {
     let m = llama_meta().u("llama.attention.key_length", 96);
     let inp = GgufConfigInputs {


### PR DESCRIPTION
## Summary

`head_dim_derived_when_key_absent` duplicated an observation already present in `llama_dense_maps_to_mistral`. Both construct the same `llama_meta`, pass identical `GgufConfigInputs`, call `config_from_gguf`, and assert the resulting head dimension is 128.

This removes only the narrower duplicate. Replacing fallback derivation with `hidden_size / num_key_value_heads` makes both tests fail with 512 versus 128, proving the broader retained test rejects the same production defect.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (97 passed after removing one declaration)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Same fallback mutant replayed independently against removed and retained checks

## Notes for reviewers

This is demonstrated redundancy across setup, stimulus, observation, and mutant sensitivity—not merely similar test code. The neighboring `explicit_key_length_wins` check is retained because it exercises the opposite partition: a present explicit value must override derivation.

No production code or coverage boundary changes. The retained Llama mapping test still observes fallback head dimension alongside the dimensions that feed it.

Fresh CI after #701 passed PR benchmark gate at the current head, confirming this exact test-only path preserves the existing benchmark records.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
