### PR TITLE
atlas-core: validate GGUF KV head geometry

### DIFF
--- a/crates/atlas-core/src/config/gguf.rs
+++ b/crates/atlas-core/src/config/gguf.rs
@@ -107,6 +107,14 @@ pub fn config_from_gguf(inputs: &GgufConfigInputs) -> Result<ModelConfig> {
         .get_u64(&k("attention.head_count_kv"))
         .map(|v| v as usize)
         .unwrap_or(num_attention_heads);
+    if num_attention_heads > 0
+        && (num_key_value_heads == 0 || !num_attention_heads.is_multiple_of(num_key_value_heads))
+    {
+        bail!(
+            "GGUF metadata key '{}.attention.head_count_kv' ({num_key_value_heads}) must be a non-zero divisor of attention.head_count ({num_attention_heads})",
+            arch
+        );
+    }
 
     // head_dim: explicit key_length if present, else hidden_size / head_count.
     // Erroring on a non-divisible fallback avoids a silently-wrong head_dim.

--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -117,6 +117,28 @@ fn kv_heads_default_to_mha() {
 }
 
 #[test]
+fn explicit_kv_heads_must_form_valid_gqa_groups() {
+    let mut accepted = Vec::new();
+    for kv_heads in [0, 7, 64] {
+        let mut m = llama_meta();
+        m.u.insert("llama.attention.head_count_kv".into(), kv_heads);
+        let inp = GgufConfigInputs {
+            meta: &m,
+            token_embd_vocab: None,
+            has_output_weight: true,
+        };
+        match config_from_gguf(&inp) {
+            Ok(_) => accepted.push(kv_heads),
+            Err(err) => assert!(err.to_string().contains("llama.attention.head_count_kv")),
+        }
+    }
+    assert!(
+        accepted.is_empty(),
+        "accepted invalid KV head counts: {accepted:?}"
+    );
+}
+
+#[test]
 fn vocab_from_token_embd_rows() {
     let mut m = llama_meta();
     m.u.remove("llama.vocab_size");


### PR DESCRIPTION
## Summary

The GGUF parser accepted explicit KV head counts that cannot form valid grouped-query attention: zero, a count that does not divide the Q-head count, and a count larger than the Q-head count. For a 32-head fixture, values 0, 7, and 64 all produced successful configs and reached cache and attention shape construction.

This requires an explicit KV head count to be a non-zero divisor of the Q-head count. The regression reported all three values accepted on previous production, passes with validation, and reports all three again when that exact guard is removed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Old-red/new-green three-partition regression plus validation-removal replay

## Notes for reviewers

The existing `kv_heads_default_to_mha` test is sound and unchanged. Replacing its absent-key default with 1 makes it fail with 1 versus 32. This PR addresses the separate explicit-value domain.

The guard is scoped to nonzero Q-head counts so `attention.head_count = 0` remains owned by the required-dimension audit and can produce a field-specific error. Valid MHA and GQA partitions, including 32 KV heads and the fixture's explicit 8 KV heads, continue to pass.

KV head count controls KV-cache dimensions, projection shapes, GQA grouping, and attention kernels. This change does not load weights or run inference. Workspace Clippy and the ten-record GPU benchmark requirement remain CI and external-hardware gates.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
