### PR TITLE
atlas-core: distinguish GGUF Llama metadata from defaults

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -50,8 +50,8 @@ fn llama_meta() -> Meta {
         .u("llama.attention.head_count_kv", 8)
         .u("llama.context_length", 4096)
         .u("llama.vocab_size", 32000)
-        .f("llama.attention.layer_norm_rms_epsilon", 1e-5)
-        .f("llama.rope.freq_base", 10000.0)
+        .f("llama.attention.layer_norm_rms_epsilon", 1e-6)
+        .f("llama.rope.freq_base", 500_000.0)
 }
 
 #[test]
@@ -72,7 +72,8 @@ fn llama_dense_maps_to_mistral() {
     assert_eq!(c.head_dim, 128); // 4096/32
     assert_eq!(c.vocab_size, 32000);
     assert_eq!(c.max_position_embeddings, 4096);
-    assert!((c.rms_norm_eps - 1e-5).abs() < 1e-12);
+    assert!((c.rms_norm_eps - 1e-6).abs() < 1e-12);
+    assert!((c.rope_theta - 500_000.0).abs() < 1e-3);
     assert!(!c.attn_gated);
     assert!(!c.tie_word_embeddings); // has_output_weight = true
     assert_eq!(c.weight_prefix, "model"); // HF-name prefix the GGUF loader emits


### PR DESCRIPTION
## Summary

The Llama GGUF fixture supplied `1e-5` for RMS epsilon and `10000` for RoPE theta, exactly matching the parser fallbacks. Replacing either metadata lookup with its fallback left the original test green, and RoPE theta was not observed at all.

This uses non-default fixture values and asserts both parsed controls. Replacing the RMS lookup with `1e-5` now fails at the RMS assertion. Replacing the RoPE lookup with `10000` now fails at the RoPE assertion. Production parsing is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Replayed both metadata-to-fallback mutants and observed the strengthened test fail

## Notes for reviewers

RMS epsilon is consumed by normalization layers. RoPE theta controls rotary position frequencies used by attention. The prior values made the fixture unable to distinguish metadata parsing from fallback behavior, so a green test did not prove either lookup.

The broad Llama mapping test remains the right home because it already verifies the parsed runtime config. This PR adds no new test declaration and changes no production code. It does not prove the fallback path, weight loading, kernel numerics, or model output quality. Workspace Clippy remains required.

Fresh policy replay: after this branch was updated with merged #701, the PR benchmark gate passed at `d2caae1325`. The changed file is one of the exact modules proven absent from release builds.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

