### PR TITLE
atlas-core: validate GGUF vocab sources

### DIFF
--- a/crates/atlas-core/src/config/gguf.rs
+++ b/crates/atlas-core/src/config/gguf.rs
@@ -124,15 +124,25 @@ pub fn config_from_gguf(inputs: &GgufConfigInputs) -> Result<ModelConfig> {
     };
 
     // vocab_size: explicit key → token_embd rows → tokenizer token list length.
-    let vocab_size = meta
-        .get_u64(&k("vocab_size"))
-        .map(|v| v as usize)
+    let metadata_vocab = meta.get_u64(&k("vocab_size")).map(|v| v as usize);
+    if let (Some(metadata_vocab), Some(tensor_vocab)) = (metadata_vocab, inputs.token_embd_vocab)
+        && metadata_vocab != tensor_vocab
+    {
+        bail!(
+            "GGUF: '{arch}.vocab_size' ({metadata_vocab}) does not match token_embd.weight rows \
+             ({tensor_vocab})"
+        );
+    }
+    let vocab_size = metadata_vocab
         .or(inputs.token_embd_vocab)
         .or_else(|| meta.get_arr_len("tokenizer.ggml.tokens"))
         .context(
             "GGUF: could not determine vocab_size (no '{arch}.vocab_size', no token_embd rows, \
              no 'tokenizer.ggml.tokens')",
         )?;
+    if vocab_size == 0 {
+        bail!("GGUF: vocab_size must be non-zero");
+    }
 
     // ── Normalization / RoPE / context (documented explicit defaults) ──
     // rms_norm_eps: ggml default is 1e-5 when the key is absent (differs from

--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -130,6 +130,44 @@ fn vocab_from_token_embd_rows() {
 }
 
 #[test]
+fn vocab_sources_must_be_nonzero_and_consistent() {
+    let mut zero_tensor_rows = llama_meta();
+    zero_tensor_rows.u.remove("llama.vocab_size");
+
+    let mut zero_token_list = llama_meta();
+    zero_token_list.u.remove("llama.vocab_size");
+    zero_token_list
+        .arr
+        .insert("tokenizer.ggml.tokens".into(), 0);
+
+    let cases = [
+        (
+            "zero metadata vocab",
+            llama_meta().u("llama.vocab_size", 0),
+            None,
+        ),
+        ("zero token embedding rows", zero_tensor_rows, Some(0)),
+        ("zero tokenizer list", zero_token_list, None),
+        ("metadata/tensor mismatch", llama_meta(), Some(128256)),
+    ];
+    let mut accepted = Vec::new();
+    for (name, meta, token_embd_vocab) in cases {
+        let inputs = GgufConfigInputs {
+            meta: &meta,
+            token_embd_vocab,
+            has_output_weight: true,
+        };
+        if config_from_gguf(&inputs).is_ok() {
+            accepted.push(name);
+        }
+    }
+    assert!(
+        accepted.is_empty(),
+        "invalid vocab sources accepted: {accepted:?}"
+    );
+}
+
+#[test]
 fn tied_embeddings_when_no_output_tensor() {
     let m = llama_meta();
     let inp = GgufConfigInputs {


### PR DESCRIPTION
## Summary

The GGUF config path accepted a zero vocabulary from explicit metadata, zero `token_embd.weight` rows, or an empty tokenizer list. It also accepted metadata vocab size 32000 beside a physical embedding tensor with 128256 rows. All four cases produced successful configs before this change.

This rejects a selected zero vocabulary and rejects disagreement between explicit metadata and embedding rows. The four-partition regression fails on previous production, passes with both validations, admits the three zero cases if the nonzero guard is removed, and admits the mismatch if the consistency guard is removed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Replayed the nonzero and consistency guard removals independently

## Notes for reviewers

The existing `vocab_from_token_embd_rows` test is sound and unchanged. Removing the tensor-row fallback makes it fail because no later source exists in that fixture. This PR addresses the separate input-domain and cross-source risks found while auditing that test.

The GGUF reference maps the resolved vocabulary dimension directly into `token_embd.weight`: https://github.com/ggml-org/llama.cpp/blob/master/src/models/llama.cpp. Atlas likewise uses `vocab_size` for embedding, LM-head, logits, and token-mask shapes. Rejecting malformed metadata at config load gives a local error before those paths construct incompatible shapes.

Tokenizer token count remains a fallback only. This change does not require it to equal a potentially padded model vocabulary. It does not load weights, run a model, or validate inference output. Workspace Clippy and the ten-record GPU benchmark requirement remain CI and external-hardware gates.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).