### PR TITLE
atlas-core: observe GGUF Qwen3 attention controls

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -142,7 +142,7 @@ fn tied_embeddings_when_no_output_tensor() {
 }
 
 #[test]
-fn qwen3_dense_routes_to_qwen35_dense() {
+fn qwen3_dense_maps_attention_controls() {
     let m = Meta::default()
         .s("general.architecture", "qwen3")
         .u("qwen3.embedding_length", 2048)
@@ -164,7 +164,9 @@ fn qwen3_dense_routes_to_qwen35_dense() {
     assert_eq!(c.model_type, "qwen3_5");
     assert_eq!(c.num_experts, 0);
     assert!(c.is_qwen35_dense());
+    assert!(!c.attn_gated);
     assert_eq!(c.head_dim, 128);
+    assert!((c.rms_norm_eps - 1e-6).abs() < 1e-12);
     assert!((c.rope_theta - 1_000_000.0).abs() < 1e-3);
 }
 


### PR DESCRIPTION
## Summary

The Qwen3 dense GGUF test proved loader routing, head width, and RoPE theta, but it did not observe RMS epsilon or ungated attention. Ignoring the explicit RMS metadata and using `1e-5` passed. Marking Qwen3 attention as gated also passed.

This renames the test around its existing runtime-config scope and directly asserts both controls. The same RMS fallback mutant now fails at the RMS assertion, and the gated-attention mutant fails at the attention-mode assertion. Production code is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Replayed the RMS fallback and gated-attention mutants independently

## Notes for reviewers

RMS epsilon is passed into normalization kernels throughout Qwen3 attention. `attn_gated` changes the Q projection width in the Qwen3.5 dense loader and tensor-parallel sharder. These are active runtime controls, not parser-only fields.

The existing test already observed head width and RoPE, so adding the two missing observations there is smaller than adding another declaration. This does not load weights, launch a kernel, or compare model output.

Fresh CI after #701 passed PR benchmark gate at the current head, confirming this exact test-only path preserves the existing benchmark records.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).