### PR TITLE
atlas-core: distinguish GGUF MoE widths

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -174,7 +174,7 @@ fn qwen3_moe_populates_expert_fields() {
         .s("general.architecture", "qwen3moe")
         .u("qwen3moe.embedding_length", 2048)
         .u("qwen3moe.block_count", 48)
-        .u("qwen3moe.feed_forward_length", 768)
+        .u("qwen3moe.feed_forward_length", 6144)
         .u("qwen3moe.attention.head_count", 32)
         .u("qwen3moe.attention.head_count_kv", 4)
         .u("qwen3moe.attention.key_length", 128)
@@ -192,6 +192,7 @@ fn qwen3_moe_populates_expert_fields() {
     };
     let c = config_from_gguf(&inp).unwrap();
     assert_eq!(c.model_type, "qwen3_5_moe");
+    assert_eq!(c.intermediate_size, 6144);
     assert_eq!(c.num_experts, 128);
     assert_eq!(c.num_experts_per_tok, 8);
     assert_eq!(c.moe_intermediate_size, 768);


### PR DESCRIPTION
## Summary

The Qwen3 MoE fixture assigned 768 to both ordinary `feed_forward_length` and per-expert `expert_feed_forward_length`. Replacing the expert-specific metadata lookup with the ordinary intermediate width therefore left the original expert-field test green.

This corrects the sampled Qwen3-30B-A3B Base ordinary width to 6144 and observes it beside the existing per-expert width 768. The exact wrong-source mutant now fails with observed MoE width 6144 instead of 768. Production code is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Replayed substitution of ordinary width for expert width

## Notes for reviewers

Qwen publishes ordinary intermediate width 6144 and per-expert width 768 for this sampled shape: https://huggingface.co/Qwen/Qwen3-30B-A3B-Base/blob/main/config.json. The GGUF reference also reads `expert_feed_forward_length` into its expert-specific dimension: https://github.com/ggml-org/llama.cpp/blob/master/src/models/qwen3moe.cpp.

Atlas uses `moe_intermediate_size` for expert weight shapes, tensor-parallel partitions, scratch sizing, and MoE kernels. Confusing it with the ordinary width would inflate the sampled expert dimension by eight times.

The neighboring missing-field test owns absence behavior. This PR only makes the positive source-selection oracle discriminating. It does not load weights, launch MoE kernels, or compare inference output. Workspace Clippy remains required.

Fresh policy replay: after this branch was updated with merged #701, the PR benchmark gate passed at `7e29e3a501`. The changed file is one of the exact modules proven absent from release builds.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

