### PR TITLE
atlas-core: isolate missing GGUF architecture

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -227,13 +227,15 @@ fn gemma_sets_embed_scale_and_softcap() {
 
 #[test]
 fn missing_architecture_errors() {
-    let m = Meta::default().u("llama.embedding_length", 4096);
+    let mut m = llama_meta();
+    m.s.remove("general.architecture");
     let inp = GgufConfigInputs {
         meta: &m,
         token_embd_vocab: None,
         has_output_weight: true,
     };
-    assert!(config_from_gguf(&inp).is_err());
+    let err = config_from_gguf(&inp).unwrap_err().to_string();
+    assert!(err.contains("general.architecture"), "unexpected: {err}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The missing-architecture test used a fixture that also omitted nearly every required Llama dimension and asserted only that some error occurred. Defaulting absent architecture to `llama` left the original test green because parsing failed later on missing `block_count`.

This starts from an otherwise valid Llama fixture, removes only `general.architecture`, and requires the error to name that key. The exact default-architecture mutant now returns a successful config, so the strengthened test fails instead of passing for the wrong reason. Production code is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Replayed defaulting missing architecture to `llama`

## Notes for reviewers

Architecture selects the metadata namespace and Atlas model loader before any dimensions are read. A later missing-dimension error does not prove that architecture is required.

Using the shared complete fixture isolates one changed condition. Checking the key in the error isolates the intended oracle. This does not test unsupported architecture values, which remain owned by `unmapped_arch_errors`, or other missing required dimensions, which remain owned by `missing_required_dim_errors`.

No runtime or hardware behavior changes. Workspace Clippy remains required.

Fresh policy replay: after this branch was updated with merged #701, the PR benchmark gate passed at `8c40399c10`. The changed file is one of the exact modules proven absent from release builds.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

