### PR TITLE
prefix-cache: stop handing a partial tail block to a second writer (no COW exists)

### DIFF
--- a/crates/spark-runtime/src/radix_tree.rs
+++ b/crates/spark-runtime/src/radix_tree.rs
@@ -69,6 +69,17 @@ impl RadixTree {
             snapshot_index: Mutex::new(SsmSnapshotIndex::new()),
         }
     }
+
+    /// Explicit-arm constructor so BOTH sides of the partial-tail gate stay
+    /// deterministically testable (the default constructor reads the
+    /// `ATLAS_PREFIX_PARTIAL_TAIL` env, which is process-global and therefore
+    /// useless inside a test binary).
+    pub fn with_partial_tail_sharing(on: bool) -> Self {
+        Self {
+            inner: Mutex::new(RadixTreeInner::with_partial_tail_sharing(on)),
+            snapshot_index: Mutex::new(SsmSnapshotIndex::new()),
+        }
+    }
 }
 
 impl PrefixCache for RadixTree {

--- a/crates/spark-runtime/src/radix_tree/inner.rs
+++ b/crates/spark-runtime/src/radix_tree/inner.rs
@@ -68,10 +68,21 @@ pub(super) struct RadixTreeInner {
     /// the pre-LoRA single-root tree.
     roots: HashMap<u64, NodeId>,
     access_counter: u64,
+    /// Whether `walk` may match a PARTIAL tail block (the sub-block arm).
+    /// Default FALSE — that arm is unsound for a block the requester will
+    /// write into; see the comment at the match site. `ATLAS_PREFIX_PARTIAL_TAIL=1`
+    /// restores the old behaviour for A/B only.
+    allow_partial_tail: bool,
 }
 
 impl RadixTreeInner {
     pub(super) fn new() -> Self {
+        Self::with_partial_tail_sharing(
+            std::env::var("ATLAS_PREFIX_PARTIAL_TAIL").as_deref() == Ok("1"),
+        )
+    }
+
+    pub(super) fn with_partial_tail_sharing(allow_partial_tail: bool) -> Self {
         let root = RadixNode {
             children: HashMap::new(),
             block_idx: u32::MAX,     // sentinel — root has no block
@@ -90,6 +101,7 @@ impl RadixTreeInner {
             free_nodes: Vec::new(),
             roots,
             access_counter: 0,
+            allow_partial_tail,
         }
     }
 
@@ -185,8 +197,42 @@ impl RadixTreeInner {
         // 2. A partial suffix stored on the current node.
         // This enables warm-cache TTFT optimization by matching ALL prompt tokens
         // even when total % block_size != 0.
+        //
+        // ★ DEFAULT OFF (`allow_partial_tail`), because both arms hand the
+        // caller a block it will WRITE INTO while another owner still maps it.
+        // The matched partial block becomes the requester's TAIL: its very
+        // next KV rows (positions matched..block_end) are written into that
+        // shared physical block. Arm 2's donor is a LIVE sequence still
+        // decoding into the same rows; arm 1's donor block is full, but the
+        // requester's tail writes clobber committed rows other sequences map
+        // read-only. There is no copy-on-write anywhere in the paged KV
+        // manager, so this is two writers, one block.
+        //
+        // Measured consequence (2026-08-21, qwen3.8-27B + DFlash2, GB10):
+        // with identical prompts in flight the writers stay byte-identical in
+        // lockstep and the tear is BENIGN — which is why serial decode looked
+        // clean — but any desync (the batched verify's band-dependent
+        // rounding was the trigger) makes the writes differ, the block holds
+        // a mix of two streams, and every reader derails mid-token at the
+        // block boundary: C=4 went 0/4 with three sequences emitting
+        // IDENTICAL wrong text (all reading the same torn block).
+        //
+        // The same arm also has a refcount hole: `inc_refs` walks full-block
+        // NODES only, so a matched partial block is pushed into the
+        // requester's block_table WITHOUT a ref — the eventual free
+        // underflows the donor's count.
+        //
+        // Cost of OFF: up to block_size-1 tokens of prefill recompute per
+        // hit, and non-block-aligned exact-repeat prompts no longer reach the
+        // Marconi exact-leaf shortcut (matched < total). Correct first;
+        // a copy-on-write tail (fresh block + per-layer D2D of the matched
+        // rows, event-ordered against the donor's stream) is the way to win
+        // the tokens back if anyone wants them.
         let remainder = tokens.len() - matched_tokens;
-        if remainder > 0 && remainder < block_size && matched_tokens == num_full_blocks * block_size
+        if self.allow_partial_tail
+            && remainder > 0
+            && remainder < block_size
+            && matched_tokens == num_full_blocks * block_size
         {
             let suffix = &tokens[matched_tokens..];
             let mut found = false;

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -110,18 +110,48 @@ fn test_intermediate_snapshot_survives_tree_eviction() {
 }
 
 // ── Partial suffix tests ──
+//
+// The sub-block arm is DEFAULT OFF: a matched partial block becomes the
+// requester's writable TAIL while another owner still maps it, and there is
+// no copy-on-write in the paged KV manager. Measured 2026-08-21: two live
+// sequences sharing a partial tail derailed mid-token the moment their
+// streams desynced (batched DFlash verify at C=4 went 0/4, three sequences
+// emitting identical wrong text — all reading the same torn block). The
+// legacy arm stays testable through `with_partial_tail_sharing(true)`.
 
+/// ★ The regression test for the torn-tail bug: with the default tree, a
+/// prompt whose tail does not fill a block must match ONLY its full blocks —
+/// the partial block stays exclusively the donor's, because the requester
+/// would otherwise write into it.
 #[test]
-fn test_partial_suffix_insert_and_lookup() {
+fn a_partial_tail_block_is_never_handed_to_a_second_writer() {
     let tree = RadixTree::new();
     // 20 tokens = 1 full block (16) + 4 partial
     let tokens: Vec<u32> = (0..20).collect();
-    let block_table = vec![10, 20]; // block for full + block for partial
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
 
-    tree.insert(&tokens, &block_table, &[], 16, 0, 0);
     let m = tree.lookup(&tokens, 16, 0, 0);
+    assert_eq!(
+        m.matched_tokens, 16,
+        "the 4-token tail must NOT match: block 20 is the donor's live tail"
+    );
+    assert_eq!(
+        m.matched_blocks,
+        vec![10],
+        "block 20 handed out here becomes a second writer's tail — the torn-block bug"
+    );
+    tree.release(&tokens[..16], 16, 0);
+}
 
-    // Should match all 20 tokens (16 full + 4 partial)
+#[test]
+fn the_legacy_partial_arm_still_matches_when_opted_in() {
+    // The A/B arm (`ATLAS_PREFIX_PARTIAL_TAIL=1` in production): full match
+    // including the partial tail — the pre-fix behaviour, kept measurable.
+    let tree = RadixTree::with_partial_tail_sharing(true);
+    let tokens: Vec<u32> = (0..20).collect();
+    tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
+
+    let m = tree.lookup(&tokens, 16, 0, 0);
     assert_eq!(m.matched_tokens, 20);
     assert_eq!(m.matched_blocks, vec![10, 20]);
     tree.release(&tokens, 16, 0);
@@ -129,7 +159,9 @@ fn test_partial_suffix_insert_and_lookup() {
 
 #[test]
 fn test_partial_suffix_no_match_different_suffix() {
-    let tree = RadixTree::new();
+    // Opted IN, a different suffix must still refuse the partial block —
+    // this pins the content check inside the legacy arm itself.
+    let tree = RadixTree::with_partial_tail_sharing(true);
     // Insert 20 tokens
     let tokens_a: Vec<u32> = (0..20).collect();
     tree.insert(&tokens_a, &[10, 20], &[], 16, 0, 0);
@@ -207,7 +239,9 @@ fn test_partial_suffix_cleared_when_extended() {
 
 #[test]
 fn test_partial_suffix_multi_block_prefix() {
-    let tree = RadixTree::new();
+    // Legacy-arm pinning: the partial-tail match is default-OFF (torn-tail
+    // bug); these keep the opted-in arm's internals honest.
+    let tree = RadixTree::with_partial_tail_sharing(true);
     // 396 tokens = 24 full blocks + 12 partial
     let tokens: Vec<u32> = (0..396).collect();
     let block_table: Vec<u32> = (0..25).collect();
@@ -223,7 +257,9 @@ fn test_partial_suffix_multi_block_prefix() {
 
 #[test]
 fn test_partial_suffix_prefix_match_shorter_lookup() {
-    let tree = RadixTree::new();
+    // Legacy-arm pinning: the partial-tail match is default-OFF (torn-tail
+    // bug); these keep the opted-in arm's internals honest.
+    let tree = RadixTree::with_partial_tail_sharing(true);
     // Insert 31 tokens (1 full block + 15 partial) — simulates prompt+generation
     let tokens_31: Vec<u32> = (0..31).collect();
     tree.insert(&tokens_31, &[10, 20], &[], 16, 0, 0);
@@ -240,7 +276,9 @@ fn test_partial_suffix_prefix_match_shorter_lookup() {
 
 #[test]
 fn test_sub_block_match_via_child_key_prefix() {
-    let tree = RadixTree::new();
+    // Legacy-arm pinning: the partial-tail match is default-OFF (torn-tail
+    // bug); these keep the opted-in arm's internals honest.
+    let tree = RadixTree::with_partial_tail_sharing(true);
     // Insert 35 tokens (2 full blocks + 3 partial) — prompt + generation
     let tokens_35: Vec<u32> = (0..35).collect();
     tree.insert(&tokens_35, &[10, 20, 30], &[], 16, 0, 0);


### PR DESCRIPTION
Standalone against `main` — `spark-runtime` only, no engine or scheduler code.

**The radix walk's sub-block arm hands a shared physical block to a sequence that will write into it, and there is no copy-on-write anywhere in the paged KV manager.**

## The defect

When a lookup's tail doesn't fill a block, `walk()` matches a PARTIAL block from two sources: a child node whose full block starts with the remaining tokens, or the `partial_suffix` stashed on the current node. Either way the shared physical block is pushed into the requester's `block_table` — where it becomes the requester's **writable tail**: its very next KV rows (positions `matched..block_end`) are written into a block another owner still maps. The `partial_suffix` donor is a LIVE sequence still decoding into those very rows. Two writers, one block.

The same arm has a second, independent hole: `inc_refs` walks full-block NODES only, so the matched partial block enters the requester's block_table with **no ref taken** — the eventual `free_sequence` underflows the donor's count.

## Why it survived until now

Measured 2026-08-21 (qwen3.8-27B + DFlash2 on GB10, identical concurrent prompts at temperature 0): while two writers stay in byte-identical lockstep, the collisions write the same bytes and the tear is **benign** — which is exactly why serial decode always looked clean, and why every single-stream test passes. Any desync between the writers (in our case, batched speculative verify's band-dependent rounding) makes the writes differ, and every reader then attends over a torn block.

## The change

The sub-block arm is now **default OFF** (`allow_partial_tail`), with:

* `ATLAS_PREFIX_PARTIAL_TAIL=1` restoring the old behaviour for A/B only,
* an explicit `RadixTree::with_partial_tail_sharing(bool)` constructor so BOTH arms stay deterministically testable — the env read is process-global and useless inside a test binary.

Cost of OFF: up to `block_size - 1` tokens of prefill recompute per hit, and non-block-aligned exact-repeat prompts no longer reach the Marconi exact-leaf shortcut (`matched < total`). Correctness first; the win-back is a copy-on-write tail — fresh block + per-layer D2D of the matched rows, event-ordered against the donor's stream — documented at the match site for whoever wants those tokens back.

## Tests

New `a_partial_tail_block_is_never_handed_to_a_second_writer` pins the default contract by name. The five legacy partial-suffix tests now opt in explicitly via the constructor and keep the old arm's internals honest (different-suffix refusal, multi-block prefix, shorter-lookup prefix match, child-key sub-block match). 86 radix tests pass on this branch, fmt and clippy clean, built on `main`'s base rather than the branch the fix was found on.
