### PR TITLE
dflash: drafter ctx capture shifted by cached-prefix length on every prefix-cache hit

### DIFF
--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -420,15 +420,15 @@ impl TransformerModel {
                 .map_err(|e| anyhow::anyhow!("Prefill layer {i} failed: {e}"))?;
             // DFlash prefill capture: writes layer i's hidden output for
             // all `proc_count` tokens into the seq's accumulator at slots
-            // [layer_kv_write_start .. layer_kv_write_start + proc_count].
-            // No-op when DFlash is disabled.
-            self.try_dflash_prefill_capture_layer(
-                seq,
-                i,
-                layer_kv_write_start,
-                proc_count,
-                stream,
-            )?;
+            // [seq_len_start .. seq_len_start + proc_count]. The base is the
+            // chunk's PROCESSING start (absolute position of buffer row 0),
+            // NOT `layer_kv_write_start` — on a prefix-cache hit the KV
+            // write floor sits at the matched boundary while the forward
+            // recomputes from 0, and using the floor here shifted every
+            // captured row by the cached-prefix length (see the twin call in
+            // `prefill_b::forward_layers` for the full failure). No-op when
+            // DFlash is disabled.
+            self.try_dflash_prefill_capture_layer(seq, i, seq_len_start, proc_count, stream)?;
 
             // MLA diagnostic: dump per-layer hidden state norm (once per model).
             // Per-model latch (see `ModelStats::dumped`) rather than a static: an
@@ -518,8 +518,11 @@ impl TransformerModel {
         self.prefill_save_snapshot_with_vision_gate(tokens, seq, &mut kv_cache, bs, stream);
 
         // DFlash: advance the seq's `ctx_len` to span all just-prefilled
-        // positions so the next propose() can read them.
-        self.update_dflash_ctx_len_after_prefill(seq, layer_kv_write_start, proc_count)?;
+        // positions so the next propose() can read them. Same base as the
+        // capture above: the PROCESSING start, not the KV write floor — the
+        // floor would claim `matched + proc_count` rows on a prefix-cache
+        // hit, past the prompt's end.
+        self.update_dflash_ctx_len_after_prefill(seq, seq_len_start, proc_count)?;
 
         Ok(self.decode_logits_ptr())
     }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/forward_layers.rs
@@ -208,11 +208,23 @@ impl TransformerModel {
                 t_in_prefill += t.elapsed();
             }
             let t_df = host_timing.then(std::time::Instant::now);
-            // DFlash chunked-prefill capture.
+            // DFlash chunked-prefill capture. The destination base is the
+            // chunk's PROCESSING start — the absolute position of buffer row
+            // 0 — NOT `layer_kv_write_start`. The two coincide on a cold
+            // prompt, which is how the KV write floor ended up here, but on a
+            // prefix-cache hit the forward recomputes from position 0 while
+            // KV writes start at the matched boundary: passing the floor
+            // shifted EVERY captured row up by the cached-prefix length, left
+            // ctx rows [0, matched) holding the pool slot's previous
+            // occupant, and advanced ctx_len past the prompt. At C=1 the
+            // stale rows were the identical previous request's (accidentally
+            // correct); under concurrency they were another sequence's, the
+            // drafts went to garbage, and acceptance pinned at ~0 — the
+            // cache-hit half of the 2026-08-21 derailment matrix.
             self.try_dflash_prefill_capture_layer(
                 seq,
                 i,
-                layer_kv_write_start,
+                effective_seq_len_start,
                 proc_count,
                 stream,
             )?;


### PR DESCRIPTION
Standalone against `main` — two files in `spark-model`, three call sites, no behaviour change on any cold prompt.

**The DFlash drafter's prompt-hidden capture is written at the wrong base on every prefix-cache hit: shifted up by the cached-prefix length.**

## The defect

`try_dflash_prefill_capture_layer` copies buffer row `t` (position `processing_start + t`) into the drafter's ctx accumulator at `chunk_start + t`. Both call sites pass `layer_kv_write_start` as `chunk_start`, and `prefill_a` passes the same value to `update_dflash_ctx_len_after_prefill`.

On a cold prompt the KV write floor and the processing start coincide — which is how the floor ended up there and why nothing ever caught it. On a **prefix-cache hit** they diverge: the forward recomputes from position 0 (no SSM snapshot → full recompute) while KV writes start at the matched boundary. Every captured row then lands `matched_tokens` slots high:

* ctx rows `[0, matched)` keep whatever the drafter pool slot's **previous occupant** left there,
* the copied rows sit at the wrong positions relative to the per-slot position seeding,
* `ctx_len` advances past the prompt's end (`matched + proc_count` on a 42-token prompt claims 74 rows).

## Why the obvious test can't see it

At C=1 on a repeat prompt, the stale rows are the identical previous request's — **accidentally correct content**. Measured live (qwen3.8-27B-NVFP4 + DFlash2 drafter, GB10, 2026-08-21): cold + two cache-hit repeats ran byte-identical completions at 88.7% acceptance *with the bug live*. It only degrades when the pool slot's previous occupant was a different sequence — i.e. under concurrency, which is exactly the agentic shared-system-prompt shape.

With the fix, the same C=1 cache-hit measured **88.7% → 90.9% acceptance**, same box, same binary otherwise.

## The change

Both capture calls now pass the chunk's processing start (`effective_seq_len_start` in `prefill_b::forward_layers`, `seq_len_start` in `prefill_a`), which is also correct under a Marconi skip, where buffer row 0 is position `snap_tok`. `prefill_b::finalize_last`'s ctx_len update already used chunk-positional coordinates and is untouched. Cold-prompt behaviour is byte-identical by construction — the two values are equal there.

Found while root-causing a prefix-cache + concurrency output derailment; this is one of that hunt's independently-verified defects (the radix partial-tail fix in #692 is another; the remaining scheduler-side commit desync is still open and tracked on our side). Verified building on `main`'s base; fmt clean.
