### PR TITLE
atlas-core: cover required GGUF dimensions

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -237,16 +237,24 @@ fn missing_architecture_errors() {
 }
 
 #[test]
-fn missing_required_dim_errors() {
-    let mut m = llama_meta();
-    m.u.remove("llama.embedding_length");
-    let inp = GgufConfigInputs {
-        meta: &m,
-        token_embd_vocab: None,
-        has_output_weight: true,
-    };
-    let err = config_from_gguf(&inp).unwrap_err().to_string();
-    assert!(err.contains("embedding_length"), "unexpected: {err}");
+fn missing_required_dimensions_name_each_key() {
+    for key in [
+        "embedding_length",
+        "block_count",
+        "feed_forward_length",
+        "attention.head_count",
+        "context_length",
+    ] {
+        let mut m = llama_meta();
+        m.u.remove(&format!("llama.{key}"));
+        let inp = GgufConfigInputs {
+            meta: &m,
+            token_embd_vocab: None,
+            has_output_weight: true,
+        };
+        let err = config_from_gguf(&inp).unwrap_err().to_string();
+        assert!(err.contains(key), "missing {key}, unexpected: {err}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The required-dimension test removed only `embedding_length`. Defaulting a different required field, `block_count`, to 32 left the original test green, so its generic name overstated the sampled requirement.

This removes each of the five unconditional GGUF dimensions from an otherwise valid fixture and requires the error to name that key. The exact defaulted-block-count mutant now returns success for that partition and fails the strengthened test. Production code is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings`
- [x] `bash scripts/check-license-headers.sh`
- [ ] Tested against a real model / hardware if the change affects runtime behaviour
- [x] Added or updated tests where applicable
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `typos`
- [x] Replayed defaulting missing `block_count` to 32

## Notes for reviewers

The sampled keys are `embedding_length`, `block_count`, `feed_forward_length`, `attention.head_count`, and `context_length`. Each is read unconditionally before model construction. Vocabulary and head width have documented fallback paths and are intentionally not included.

One loop keeps the identical setup and oracle visible while reporting the exact missing key on failure. This does not test zero-valued dimensions, optional metadata, or MoE-only requirements. Those are separate input partitions.

No runtime or hardware behavior changes. Workspace Clippy remains required.

Fresh policy replay: after this branch was updated with merged #701, the PR benchmark gate passed at `310958492f`. The changed file is one of the exact modules proven absent from release builds.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

