### PR TITLE
atlas-core: validate GGUF MoE geometry

### DIFF
--- a/crates/atlas-core/src/config/gguf.rs
+++ b/crates/atlas-core/src/config/gguf.rs
@@ -153,10 +153,16 @@ pub fn config_from_gguf(inputs: &GgufConfigInputs) -> Result<ModelConfig> {
     let tie_word_embeddings = !inputs.has_output_weight;
 
     // ── MoE (only for MoE arches) ──
-    let num_experts = meta
-        .get_u64(&k("expert_count"))
-        .map(|v| v as usize)
-        .unwrap_or(0);
+    let num_experts = if arch == "qwen3moe" {
+        req_u64("expert_count")? as usize
+    } else {
+        meta.get_u64(&k("expert_count"))
+            .map(|v| v as usize)
+            .unwrap_or(0)
+    };
+    if arch == "qwen3moe" && num_experts == 0 {
+        bail!("GGUF metadata key '{arch}.expert_count' must be greater than zero");
+    }
 
     let mut body: Map<String, Value> = json!({
         "hidden_size": hidden_size,
@@ -185,6 +191,17 @@ pub fn config_from_gguf(inputs: &GgufConfigInputs) -> Result<ModelConfig> {
         let moe_ffn = req_u64("expert_feed_forward_length").with_context(|| {
             format!("GGUF: MoE arch '{arch}' missing '{arch}.expert_feed_forward_length'")
         })? as usize;
+        if experts_per_tok == 0 || experts_per_tok > num_experts {
+            bail!(
+                "GGUF metadata key '{arch}.expert_used_count' must be in 1..={num_experts}, \
+                 found {experts_per_tok}"
+            );
+        }
+        if moe_ffn == 0 {
+            bail!(
+                "GGUF metadata key '{arch}.expert_feed_forward_length' must be greater than zero"
+            );
+        }
         body.insert("num_experts".into(), json!(num_experts));
         body.insert("num_experts_per_tok".into(), json!(experts_per_tok));
         body.insert("moe_intermediate_size".into(), json!(moe_ffn));

--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -249,9 +249,8 @@ fn missing_required_dim_errors() {
     assert!(err.contains("embedding_length"), "unexpected: {err}");
 }
 
-#[test]
-fn moe_without_used_count_errors() {
-    let m = Meta::default()
+fn qwen3_moe_meta() -> Meta {
+    Meta::default()
         .s("general.architecture", "qwen3moe")
         .u("qwen3moe.embedding_length", 2048)
         .u("qwen3moe.block_count", 48)
@@ -259,14 +258,52 @@ fn moe_without_used_count_errors() {
         .u("qwen3moe.attention.head_count", 32)
         .u("qwen3moe.context_length", 32768)
         .u("qwen3moe.vocab_size", 151936)
-        .u("qwen3moe.expert_count", 128);
-    // expert_used_count / expert_feed_forward_length intentionally absent.
-    let inp = GgufConfigInputs {
-        meta: &m,
-        token_embd_vocab: None,
-        has_output_weight: true,
-    };
-    assert!(config_from_gguf(&inp).is_err());
+        .u("qwen3moe.expert_count", 128)
+        .u("qwen3moe.expert_used_count", 8)
+        .u("qwen3moe.expert_feed_forward_length", 768)
+}
+
+#[test]
+fn qwen3_moe_requires_each_expert_dimension() {
+    for suffix in [
+        "expert_count",
+        "expert_used_count",
+        "expert_feed_forward_length",
+    ] {
+        let mut m = qwen3_moe_meta();
+        let key = format!("qwen3moe.{suffix}");
+        m.u.remove(&key);
+        let inp = GgufConfigInputs {
+            meta: &m,
+            token_embd_vocab: None,
+            has_output_weight: true,
+        };
+        let err = config_from_gguf(&inp).unwrap_err().to_string();
+        assert!(err.contains(&key), "missing {key} failed for: {err}");
+    }
+}
+
+#[test]
+fn qwen3_moe_rejects_invalid_expert_geometry() {
+    for (suffix, value) in [
+        ("expert_count", 0),
+        ("expert_used_count", 0),
+        ("expert_used_count", 129),
+        ("expert_feed_forward_length", 0),
+    ] {
+        let key = format!("qwen3moe.{suffix}");
+        let m = qwen3_moe_meta().u(&key, value);
+        let inp = GgufConfigInputs {
+            meta: &m,
+            token_embd_vocab: None,
+            has_output_weight: true,
+        };
+        let err = config_from_gguf(&inp).unwrap_err().to_string();
+        assert!(
+            err.contains(&key),
+            "invalid {key}={value} failed for: {err}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`moe_without_used_count_errors` did not prove that `expert_used_count` was required. Its fixture also omitted `expert_feed_forward_length`, and it accepted any error. Defaulting the missing used count to one left the test green because parsing failed later on the missing expert width.

The audit also found a production boundary gap. A `qwen3moe` GGUF with missing or zero `expert_count` returned a successful `qwen3_5_moe` config with zero experts. Routed top-K zero, routed top-K greater than the expert count, and per-expert width zero also survived GGUF parsing.

This change starts from complete valid MoE metadata and removes each required expert dimension one at a time, with a key-specific error oracle. It also rejects invalid expert geometry at the GGUF boundary before loader allocation or kernel setup.

## Production consequence

These fields are not inert parser metadata. `num_experts` selects expert loops and weight loading, `num_experts_per_tok` sizes routing scratch and drives top-K kernels, and `moe_intermediate_size` controls expert weight and activation shapes. Allowing malformed geometry pushes a configuration error into later model construction, or permits a zero routed top-K that the later `MoeLayer::new` condition does not reject.

## Failure proof

Before the fix:

- Replacing the required `expert_used_count` lookup with a default of one left the original test passing.
- Missing or zero `expert_count` parsed successfully.
- `expert_used_count` values 0 and 129 parsed successfully with 128 experts.
- `expert_feed_forward_length = 0` parsed successfully.

After the fix:

- The exact default-to-one mutant fails `qwen3_moe_requires_each_expert_dimension` because the isolated used-count partition returns success and reaches `unwrap_err`.
- Removing the expert-count guard fails the zero-count partition.
- Removing the routed top-K guard fails the zero-top-K partition.
- Removing the expert-width guard fails the zero-width partition.

Each mutant was applied and run independently, then restored.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (99 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (2,268 valid, 0 invalid)
- [x] `typos`
- [x] `git diff --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` (owned by Linux CI; the local Apple workspace reaches Linux-only paths outside this diff)
- [ ] Tested against a real model / hardware if the change affects valid inference behavior (not required for this malformed-metadata rejection path)

## Scope and remaining uncertainty

The production change is limited to GGUF MoE metadata validation. Valid Qwen3 MoE metadata maps identically, and the existing positive expert-field test still passes. This does not load a real GGUF, allocate expert weights, launch MoE kernels, or compare generated output. CI and any repository benchmark policy remain required before review-ready status.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

