### PR TITLE
atlas-core: isolate unsupported GGUF architecture

### DIFF
--- a/crates/atlas-core/src/config/gguf/tests.rs
+++ b/crates/atlas-core/src/config/gguf/tests.rs
@@ -270,14 +270,23 @@ fn moe_without_used_count_errors() {
 }
 
 #[test]
-fn unmapped_arch_errors() {
+fn mamba_architecture_is_rejected_before_dimension_parsing() {
     let m = Meta::default()
         .s("general.architecture", "mamba")
-        .u("mamba.embedding_length", 4096);
+        .u("mamba.embedding_length", 4096)
+        .u("mamba.block_count", 32)
+        .u("mamba.feed_forward_length", 11008)
+        .u("mamba.attention.head_count", 32)
+        .u("mamba.context_length", 4096)
+        .u("mamba.vocab_size", 32000);
     let inp = GgufConfigInputs {
         meta: &m,
         token_embd_vocab: None,
         has_output_weight: true,
     };
-    assert!(config_from_gguf(&inp).is_err());
+    let err = config_from_gguf(&inp).unwrap_err().to_string();
+    assert!(
+        err.contains("GGUF general.architecture 'mamba' has no Atlas model_type mapping"),
+        "unexpected: {err}"
+    );
 }


### PR DESCRIPTION
## Summary

`unmapped_arch_errors` did not prove that the sampled Mamba architecture was rejected by `arch_to_model_type`. Its fixture supplied only `mamba.embedding_length` and accepted any error.

Adding an incorrect Mamba-to-Mistral mapping left the original test green because parsing continued and failed later on missing `mamba.block_count`.

This supplies every unconditional Mamba-namespaced dimension needed for parsing and requires the specific no-model-type-mapping error. The test is renamed to state the sampled architecture and parse-order contract.

## Production consequence

Architecture mapping happens before GGUF dimensions are read. The resulting Atlas model type later selects the weight loader. An accidental fallback can send incompatible Mamba metadata and checkpoint tensors into the Mistral path. A missing-dimension error does not prove that unsupported architecture values are rejected.

This check is not redundant with `missing_architecture_errors`. That test covers an absent key. This test covers a present but unsupported value.

## Failure proof

Before the repair:

1. Added `"mamba" => ("mistral", false)` to `arch_to_model_type`.
2. Ran the original `unmapped_arch_errors` test.
3. The test passed because the sparse fixture failed later on missing block count.

After the repair:

1. Reapplied the same Mamba-to-Mistral mutant.
2. The complete fixture produced a successful Mistral config.
3. `mamba_architecture_is_rejected_before_dimension_parsing` failed at `unwrap_err`.
4. Restored production and confirmed the repaired test passes.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (2,268 valid, 0 invalid)
- [x] `typos`
- [x] `git diff --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` (owned by Linux CI; the local Apple workspace reaches Linux-only paths outside this diff)
- [ ] Tested against a real model / hardware if the change affects runtime behavior (not applicable to this test-only change)

## Scope and remaining uncertainty

Production already rejects Mamba correctly, so this PR changes only the test oracle. It does not enumerate every unsupported architecture, validate tensor namespaces, load weights, or run inference. The remaining required CI checks still apply before review-ready status.

Fresh policy replay: after this branch was updated with merged #701, the PR benchmark gate passed at `38d8d0afcc`. The changed file is one of the exact modules proven absent from release builds.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).



