### PR TITLE
atlas-core: partition compressed prefix-cache safety

### DIFF
--- a/crates/atlas-core/src/config/methods.rs
+++ b/crates/atlas-core/src/config/methods.rs
@@ -382,12 +382,14 @@ mod tests {
     use super::ModelConfig;
 
     #[test]
-    fn compressed_deepseek_v4_requires_auxiliary_prefix_state() {
+    fn any_compressed_deepseek_v4_layer_is_not_kv_cache_complete() {
         let mut config = ModelConfig::qwen3_next_80b_nvfp4();
         config.model_type = "deepseek_v4".to_string();
-        config.compress_ratios = vec![0, 4, 128];
 
-        assert!(!config.kv_only_prefix_cache_is_safe());
+        for ratios in [vec![4, 0, 0], vec![0, 4, 0], vec![0, 0, 128]] {
+            config.compress_ratios = ratios;
+            assert!(!config.kv_only_prefix_cache_is_safe());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`compressed_deepseek_v4_requires_auxiliary_prefix_state` used one schedule, `[0, 4, 128]`. It proved that this aggregate schedule was unsafe, but not that compression in any layer position disables KV-only prefix reuse.

A wrong predicate that inspected only compression slot 1 left the original test green because slot 1 happened to contain 4.

This places the sole nonzero compression ratio at the first, middle, and last position in separate partitions. It also renames the test around the actual contract: a compressed DeepSeek V4 layer makes the current KV-only cache incomplete.

## Production consequence

The radix prefix cache stores KV blocks. DeepSeek V4 compressed attention also builds a compressor pool and ring that are not represented in those blocks. `spark-server::build_prefix_cache` consumes this helper and substitutes `NoPrefixCaching` when the state is incomplete. Missing a compressed layer can therefore allow an invalid warm-prefix reuse path.

The server-level `compressed_deepseek_v4_disables_incomplete_prefix_cache` check is complementary. It proves the helper is consumed during cache construction for one mixed schedule. This unit test proves the helper scans every layer position.

## Failure proof

Before the repair:

1. Replaced the all-ratio predicate with a check of `compress_ratios[1]` only.
2. Ran the original test with `[0, 4, 128]`.
3. The test passed.

After the repair:

1. Reapplied the same slot-1-only mutant.
2. The `[4, 0, 0]` partition incorrectly reported the config safe.
3. `any_compressed_deepseek_v4_layer_is_not_kv_cache_complete` failed.
4. Restored the all-layer scan and confirmed all partitions pass.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (98 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (2,268 valid, 0 invalid)
- [x] `typos`
- [x] `git diff --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` (owned by Linux CI; the local Apple workspace reaches Linux-only paths outside this diff)
- [ ] Tested against a real model / hardware if the change affects runtime behavior (not applicable to this test-only change)

## Scope and remaining uncertainty

Production already scans every compression ratio correctly, so this PR changes only the test oracle. It does not restore compressor state, execute a prefix-cache hit, or compare inference output. CI and any repository benchmark policy remain required before review-ready status.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

