### PR TITLE
verify: K4 verdict rewound by the draft list, erasing committed tokens — THE temp-0 spec degeneration carrier

### DIFF
--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -488,11 +488,21 @@ pub(crate) fn load_model(
         max_batch_tokens,
         spec_tokens: _spec_tokens,
     } = serve_phases::resolve_prefill_budget(&args, ssm_prefill_chunk);
-    if args.dflash && args.enable_prefix_caching {
-        tracing::warn!(
-            "dflash: --enable-prefix-caching has a community-reported correctness regression on SM12.x with DFlash; outputs may be wrong on multi-turn cache hits. Run a greedy diff-test against a non-DFlash baseline before relying on outputs."
-        );
-    }
+    // 2026-08-21: the community-reported "prefix caching × DFlash wrong
+    // outputs on multi-turn cache hits (SM12.x)" warning that used to print
+    // here is RESOLVED and was never a cache or hardware defect. The carrier
+    // was `k4_apply_verdict` rewinding by `drafts.len()` instead of the
+    // forward's row count (PR #699): a K=4 verify dispatched onto a γ-draft
+    // DFlash sequence emitted its accepted tokens and then erased them from
+    // the sequence's history. Cache hits merely shifted the mtp_gate's lane
+    // flips into that collision more often, which is why it presented as a
+    // cache regression. Verified on the fix: pre-fix failures were
+    // byte-identical cache on/off; post-fix, cache ON runs cold + two hits
+    // byte-identical at C=1, four concurrent shared-prefix requests complete
+    // coherently (accept 36% -> 79%), and video-fidelity passes 1/1, 2/2,
+    // 4/4. The warning is removed rather than kept: a standing accusation
+    // against a feature agentic serves depend on steers operators away from
+    // it for no remaining reason.
     // 2026-06-18: the previously-documented warm-Marconi-restore × MTP
     // corruption on hybrid SSM models is RESOLVED. Verified by a greedy
     // ground-truth A/B at batch=1 (the level MTP runs at — MTP is gated to

--- a/crates/spark-server/src/scheduler/verify_k4_verdict.rs
+++ b/crates/spark-server/src/scheduler/verify_k4_verdict.rs
@@ -70,9 +70,38 @@ pub(super) fn k4_apply_verdict(
     verify_us: u128,
 ) {
     let defer = matches!(hidden, K4Hidden::DeferPropose);
-    let nd = drafts.len();
-    let k_rows = nd + 1;
-    debug_assert_eq!(v.len(), k_rows, "verdict picks must cover every row");
+    // ★ The rewind arithmetic below is sized by the FORWARD, not the draft
+    // list. `v` has one pick per verified row, so `v.len()` is ground truth
+    // for how many rows the forward committed (`seq_len += k_rows` happened
+    // in the model call); `drafts` is whatever the caller carried and CAN be
+    // longer. The single-seq K=4 step verifies only `drafts[0..3]` of a
+    // sequence that may hold DFlash γ=7 pending drafts — passing the full
+    // slice here made `nd = 7`, and `seq_len -= nd - na` rewound 4 rows the
+    // 4-row forward never added: the verdict EMITTED its accepted tokens and
+    // then erased them from the sequence (seq 46 -> 42, tokens popped back to
+    // the prompt, last_token left dangling on the emitted bonus). The model
+    // then continued from a history missing its own output — measured
+    // 2026-08-21 as the prefix-cache/concurrency "class Minimizing"
+    // derailment, though the trigger is any surplus-draft dispatch, cache or
+    // not. The old `debug_assert_eq!(v.len(), k_rows)` knew the contract and
+    // compiled out in release; the clamp below enforces it.
+    let k_rows = v.len();
+    debug_assert!(k_rows >= 1, "verdict needs at least the bonus row");
+    let nd = drafts.len().min(k_rows.saturating_sub(1));
+    if drafts.len() > nd {
+        // Surplus drafts were never verified: they are dropped here (the
+        // caller already took them out of `pending_drafts`), and the
+        // drafter's own row accounting is handled by `trim_proposer_state`,
+        // which trims from the drafter's internal `last_num_drafted` — not
+        // from this slice's length.
+        tracing::debug!(
+            "k4 verdict: {} drafts carried into a {}-row verify — verifying the \
+             first {nd}, dropping the surplus",
+            drafts.len(),
+            k_rows,
+        );
+    }
+    let drafts = &drafts[..nd];
     let na = num_accepted.min(nd);
 
     if na == nd {


### PR DESCRIPTION
Standalone against `main` — one file, ~30 lines, and it is the root cause of the qwen3.8 temp-0 spec-decode degeneration family (#604's subject).

**`k4_apply_verdict` sizes its rewind by the DRAFT LIST instead of by the forward, and erases committed tokens whenever the two disagree.**

## The defect

The verdict takes `nd = drafts.len()` and rewinds the rejected tail with `seq_len -= nd - na`. That arithmetic is only correct when the verify forward ran `nd + 1` rows. The single-sequence K=4 step verifies `drafts[0..3]` of a sequence that can carry **DFlash γ=7 pending drafts** — and passes the FULL slice into the verdict.

With `nd = 7` against a 4-row forward: the verdict **emits** its accepted tokens (they are correct — the model's own output), then rewinds `7 − 3 = 4` rows the forward never added. `seq_len` 46 → 42, `seq.tokens` popped back to the prompt, `last_token` left dangling on the emitted bonus. The stream keeps the four tokens; the model's own history loses them. Every subsequent step continues from a context missing the model's own output — which at temperature 0 lands in repetition attractors and confabulation.

The contract was known and asserted: `debug_assert_eq!(v.len(), k_rows)` — **compiled out in release**. The trigger is any dispatch of a K=4 verify onto a sequence holding more than 3 pending drafts, which the mtp_gate's lane arbitration does routinely on a DFlash (γ=8) serve. The batched multi-seq path enforces draft-count equality at intake and is unaffected.

## The fix

`v` has one pick per verified row, so `v.len()` is ground truth for what the forward committed. The verdict now derives `k_rows` from it and clamps `nd`, dropping surplus drafts (they were never verified; the drafter's own row accounting is internal to `trim_proposer_state`, which trims from `last_num_drafted`, not from this slice's length). A debug line reports the clamp so the dispatch mismatch is visible instead of silent.

## Measured, one binary, before → after

`unsloth/Qwen3.8-27B-NVFP4` + `incoai/Qwen3.8-27B-DFlash2`, GB10, DEFAULT verify chain, temperature 0:

| probe | before | after |
|---|---|---|
| "count from 1 to 10" (C=1, cache off) | `1, 2, 100, 100, 100, ...` | `1, 2, 3, 4, 5, 6, 7, 8, 9, 10` |
| "list four colors" | `Red, Blue, Green, 1999; Green, 2000; ...` | `Red, Blue, Green, Yellow` |
| "two sentences" ×2 identical runs | NONDETERMINISTIC garbage | deterministic, coherent |
| `video-fidelity` C=1/2/4 (prefix cache ON) | 1/1, **0/2**, **0/4** | **1/1, 2/2, 4/4** |
| MinHeap ×4 concurrent, shared prefix | **0/4** — three streams identical derailed text ("class Minimizing the number of edges…"), accept 36% | **4/4 coherent**, accept 79% |

## Attribution corrections this forces

* The C=1 degeneration was previously localized to the inexact GDN verify chain (the #435 divergence), because `--exact-verify` made it disappear. That flag helped by **changing the gate's dispatch** so the K4-with-γ-drafts collision stopped firing — not by its numerics. The ~1-ULP #459 row-count class is real but was never the gross-degeneration carrier.
* A "prefix-cache aliasing" theory also dissolves: the cache changes prefill timing, the gate flips lanes more often, and each collision drops four tokens of history. The cache was a trigger distribution, not a mechanism.
* This reproduces on `pull/648/head` and `pull/649/head` under their authors' own configs — it dates from the first day the γ=8 drafter met the K=4 ladder, and likely underlies the reported temp-0 completion-length regressions (dropped history ⇒ byte-different, shorter completions) attributed to a `main` window.

Localized by first-divergence token forensics: a caller-tagged emit ledger showed a sequence emitting four correct tokens from `verify_k4_verdict` and then entering its next verify with `seq_len` back at the prompt and `last_token` still holding the emitted bonus. The step's own closing line (`K8 ACCEPT-3 … seq_len=42`) names the mismatch: an 8-row verdict applied to a 4-row forward.

Built and fmt-clean on `main`'s base.
