### PR TITLE
perf(gemma4): tensor-core 512-wide prefill attention — 4096-tok prefill 20.6 s → 3.8 s

### DIFF
--- a/crates/spark-model/src/layers/ops/prefill_attn_main_a.rs
+++ b/crates/spark-model/src/layers/ops/prefill_attn_main_a.rs
@@ -23,6 +23,23 @@ use super::*;
 ///         K/V [batch, seq_len, num_kv_heads, head_dim] BF16
 ///         O [batch, seq_len, num_q_heads, head_dim] BF16
 #[allow(clippy::too_many_arguments)]
+
+/// The HDIM>256 prefill kernel: its module/entry name and the BR its grid must
+/// be built for. ONE reader, because the name is chosen in `qwen3_attention::init`
+/// and the grid here, and a mismatch is silent.
+///
+/// Default is the tensor-core instantiation (`BR=32`). `ATLAS_ATTN_512_TC=0`
+/// selects the scalar reference (`BR=16`) — kept reachable because it is the
+/// oracle the TC path was validated against (cosine 0.999998, 64.7x faster on
+/// S=1024/4q/2kv/causal).
+pub fn wide_prefill_kernel() -> (&'static str, u32) {
+    if std::env::var("ATLAS_ATTN_512_TC").ok().as_deref() == Some("0") {
+        ("inferspark_prefill_512", 16)
+    } else {
+        ("inferspark_prefill_512tc", 32)
+    }
+}
+
 pub fn prefill_attention(
     gpu: &dyn GpuBackend,
     kernel: KernelHandle,
@@ -40,8 +57,15 @@ pub fn prefill_attention(
     sliding_window: u32, // 0 = no sliding limit; >0 = mask keys where q - k >= window
     stream: u64,
 ) -> Result<()> {
-    // BR=16 for HDIM=512 (Gemma-4 full attention), BR=32 otherwise
-    let br = if head_dim > 256 { 16u32 } else { 32u32 };
+    // ★ SSOT: the kernel NAME and its BR must agree, and they are chosen in two
+    // different files — `init.rs` resolves the handle, this launches it. A grid
+    // computed from the wrong BR does not fail, it silently computes the wrong
+    // q-tiles. `wide_prefill_kernel()` is the one reader of that decision.
+    let br = if head_dim > 256 {
+        wide_prefill_kernel().1
+    } else {
+        32u32
+    };
     KernelLaunch::new(gpu, kernel)
         .grid([num_q_heads, div_ceil(seq_len, br), batch])
         .block([128, 1, 1])

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -477,12 +477,13 @@ impl Qwen3AttentionLayer {
                 "dense_gemm_bf16_pipelined",
             ),
             prefill_attn_k: gpu.kernel("inferspark_prefill", "inferspark_prefill")?,
-            prefill_attn_512_k: gate(
-                probes.wide_head_dim,
-                gpu,
-                "inferspark_prefill_512",
-                "inferspark_prefill_512",
-            ),
+            // Name comes from the SSOT helper that also supplies the BR the
+            // launcher builds its grid from — see `ops::wide_prefill_kernel`.
+            // Module and entry share a name for both variants.
+            prefill_attn_512_k: {
+                let (name, _br) = crate::layers::ops::wide_prefill_kernel();
+                gate(probes.wide_head_dim, gpu, name, name)
+            },
             // DeepSeek-V4 sparse-attention compressor + compressed-KV prefill.
             csa_compress_k: gate(probes.compressed_attn, gpu, "csa_compress", "csa_compress"),
             prefill_attn_compressed_k: gate(

--- a/kernels/gb10/common/inferspark_prefill.cu
+++ b/kernels/gb10/common/inferspark_prefill.cu
@@ -31,9 +31,18 @@
 #include <cuda_bf16.h>
 
 #define BR 32
+// Overridable so a target can instantiate this kernel at another shape without
+// forking 500 lines. Gemma-4's global layers are HDIM=512, which at BC=32 needs
+// 132.8 KB of shared memory (cap is 101,376 B); BC=16 fits in 84,992 B. BR must
+// stay 32 — the warp mapping (`(warp_id & 1) * 16`, `warp_id < 2`) splits a
+// 32-row tile across two warp pairs.
+#ifndef BC
 #define BC 32
+#endif
+#ifndef HDIM
 #ifndef HDIM
 #define HDIM 256
+#endif
 #endif
 #define PAD_KV 8           // 16-byte row alignment: (256+8)*2 = 528 bytes
 #define HDIM_PAD (HDIM + PAD_KV)  // 264
@@ -61,7 +70,12 @@
 #define ATLAS_KB(x) (x)
 #endif
 
-extern "C" __global__ void inferspark_prefill(
+// Entry name is overridable alongside the shape, so the two instantiations do
+// not collide when both are compiled into one module.
+#ifndef ATLAS_PREFILL_ENTRY
+#define ATLAS_PREFILL_ENTRY inferspark_prefill
+#endif
+extern "C" __global__ void ATLAS_PREFILL_ENTRY(
     const __nv_bfloat16* __restrict__ Q,
     const __nv_bfloat16* __restrict__ K,
     const __nv_bfloat16* __restrict__ V,
@@ -542,6 +556,9 @@ extern "C" __global__ void inferspark_prefill(
 #define TILE_CHUNKS_Q64 (BR64 * (HDIM / 8))  // 2048
 #define TILE_CHUNKS_KV  (BC * (HDIM / 8))     // 1024
 
+// Skipped by the HDIM=512 instantiation: this variant needs 120,064 B of shared
+// memory at that shape, over the 101,376 B cap. The 512 path does not use it.
+#ifndef ATLAS_SKIP_PREFILL_64
 extern "C" __global__ void inferspark_prefill_64(
     const __nv_bfloat16* __restrict__ Q,
     const __nv_bfloat16* __restrict__ K,
@@ -970,3 +987,4 @@ extern "C" __global__ void inferspark_prefill_64(
         }
     }
 }
+#endif  // ATLAS_SKIP_PREFILL_64

--- a/kernels/gb10/gemma-4-26b-a4b/nvfp4/inferspark_prefill_512tc.cu
+++ b/kernels/gb10/gemma-4-26b-a4b/nvfp4/inferspark_prefill_512tc.cu
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Tensor-core prefill attention at HDIM=512, for Gemma-4's global layers.
+//
+// This is `kernels/gb10/common/inferspark_prefill.cu` instantiated at a second
+// shape — NOT a copy. The body is unchanged; only BC and HDIM differ, and the
+// four constants that made that possible were parameterised separately so the
+// change could be shown SASS-identical at the original shape.
+//
+// WHY IT EXISTS. Gemma-4-26B-A4B has 5 global (512-wide) and 25 sliding
+// (256-wide) attention layers. The sliding ones take the tensor-core kernel at
+// 2.0 ms/layer; the global ones fell through to `inferspark_prefill_512`, 114
+// lines of scalar code with no tensor cores, at 3296.9 ms/layer — 16,484 ms of
+// an 18,078 ms 4096-token prefill, 91% of the model's cold TTFT.
+//
+// SHAPE. BC=16, not 32: at HDIM=512 a 32-row K/V tile needs 132.8 KB of shared
+// memory against a 101,376 B cap. BC=16 fits in 84,992 B. BR stays 32 because
+// the warp mapping splits a 32-row Q tile across two warp pairs.
+//
+// MEASURED standalone against `inferspark_prefill_512` (S=1024, 4 q-heads,
+// 2 kv-heads, causal): cosine 0.999998, max abs 0.0039, 64.7x faster
+// (22.02 ms -> 0.34 ms). The residual is bf16 accumulation order, not error.
+#define HDIM 512
+#define BC 16
+#define ATLAS_PREFILL_ENTRY inferspark_prefill_512tc
+#define ATLAS_SKIP_PREFILL_64 1
+#include "../../common/inferspark_prefill.cu"


### PR DESCRIPTION
Gemma-4-26B-A4B has **5 global (512-wide)** and **25 sliding (256-wide)** attention
layers. The sliding ones take the tensor-core kernel; the global ones fell through
to `inferspark_prefill_512` — **114 lines of scalar code, no tensor cores, no
shared-memory tiling**:

| kernel | per layer | layers | total |
|---|---:|---:|---:|
| `flash_attn_512_scalar` | **3,296.9 ms** | 5 | **16,484 ms** |
| tensor-core path | 2.0 ms | 25 | 49.7 ms |

**Targets #698** (the parameterisation that makes a second shape possible). Rebase
to `main` once that lands.

## Measured end-to-end

`bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16`, 4096-token prefill, **one binary**,
both arms back-to-back, `ATLAS_ATTN_512_TC` the only variable:

| | scalar | **tensor-core** | Δ |
|---|---:|---:|---:|
| **wall (request → first token)** | 20,583 ms | **3,826 ms** | **−81.4%, 5.4×** |
| attention, all 30 layers | 16,884.4 ms | **123.5 ms** | **−99.3%, 137×** |
| serve errors | 0 | 0 | — |

Standalone against the kernel it replaces (S=1024, 4 q-heads, 2 kv-heads, causal):
**cosine 0.999998**, max abs 0.0039, **64.7×**.

## It is 26 lines, not a fork

```c
#define HDIM 512
#define BC 16
#define ATLAS_PREFILL_ENTRY inferspark_prefill_512tc
#define ATLAS_SKIP_PREFILL_64 1
#include "../../common/inferspark_prefill.cu"
```

## Correctness

**Gate C2 passes on both arms** — `tool_calls=3/3`, `coherent=3/3`, `degenerate=0`.
Output is not bit-identical and cannot be (tensor cores accumulate in a different
order), but every temp-0 prompt stayed coherent and correct on both arms, and the
standalone cosine bounds the difference.

## Shape

`BC=16`, not 32: at HDIM=512 a 32-row K/V tile needs **132.8 KB** of shared memory
against a **101,376 B** cap; BC=16 fits in **84,992 B**. `BR` stays 32 — the warp
mapping (`(warp_id & 1) * 16`, `warp_id < 2`) splits a 32-row Q tile across two warp
pairs. The `_64` variant is skipped here: it needs 120,064 B at this shape.

## ★ One reader for name and BR

The two 512 kernels want **different grids** (scalar BR=16, TC BR=32), and the name
is chosen in `qwen3_attention::init` while the grid is built in
`ops::prefill_attention`. A mismatch there **does not fail** — it silently computes
the wrong q-tiles. Both now read `ops::wide_prefill_kernel()`, which returns the pair
together. `ATLAS_ATTN_512_TC=0` selects the scalar reference, kept reachable because
it is the oracle this was validated against.

## Follow-up

`kernels/gb10/gemma-4-26b-a4b/BENCH.toml` commits a p90 ceiling of **24,490.81 ms**
and says in its own note that the number is a defect to ratchet down rather than
accept. That ratchet is now due.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1