### PR TITLE
fix(gate): preserve records across proven test-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,15 +792,16 @@ jobs:
     # ENFORCING as of this commit. The `continue-on-error: true` that used to
     # sit here was justified by a bootstrap gap — "no bench record is committed
     # yet, and the PR that introduces the gate cannot commit one". That gap is
-    # closed: `.benchmarks/` now carries a BASELINE plus records for all five
+    # closed: `.benchmarks/` now carries a BASELINE plus records for all ten
     # required gates, so the precondition its own comment named for removal is
     # met, and keeping the line would leave a check that cannot fail.
     #
     # What a red here means: this branch has no record that still COVERS its
-    # head. `record_covers` invalidates every earlier record once the diff
-    # touches a PERF_PATH (crates, kernels, Cargo.*, vendor, jinja-templates,
-    # rust-toolchain.toml) — which is the point. Fix it by measuring on a GPU
-    # box and committing the record, not by re-adding continue-on-error.
+    # head. `record_covers` invalidates earlier records when the diff touches a
+    # measured input (crates, kernels, Cargo.*, vendor, jinja-templates, or the
+    # toolchain), except for exact paths with a reviewed coverage exclusion.
+    # Fix a real invalidation by measuring on a GPU box and committing the
+    # record.
     #
     # It is deliberately NOT in `release-matrix`'s `needs`: a missing GPU
     # measurement must show as red without wedging the image path. It IS a

--- a/crates/atlas-plugin/src/gate/amnesty.rs
+++ b/crates/atlas-plugin/src/gate/amnesty.rs
@@ -77,17 +77,17 @@ pub const AMNESTY_EPOCH: u64 = 1_787_356_800;
 pub const ONE_TIME_AMNESTY: [AmnestyEntry; 3] = [
     AmnestyEntry {
         path: "crates/atlas-plugin/src/gate/check.rs",
-        head_blob_oid: "PENDING",
+        head_blob_oid: "2dd3bed0103d38009e82de8d507d26320a1cb307",
         grant: "PR #701 test-only Rust module coverage bootstrap",
     },
     AmnestyEntry {
         path: "crates/atlas-plugin/src/gate/coverage.rs",
-        head_blob_oid: "PENDING",
+        head_blob_oid: "6aef608fab0d120096d3b55eaed3095155e2beeb",
         grant: "PR #701 test-only Rust module coverage bootstrap",
     },
     AmnestyEntry {
         path: "crates/atlas-plugin/src/gate/required.rs",
-        head_blob_oid: "PENDING",
+        head_blob_oid: "c8b8311abbb88bceb844710e6443e28ce843f236",
         grant: "PR #701 test-only Rust module coverage bootstrap",
     },
 ];

--- a/crates/atlas-plugin/src/gate/amnesty.rs
+++ b/crates/atlas-plugin/src/gate/amnesty.rs
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! A one-time, content-pinned amnesty for the 2026-08-16 governance PR.
+//! Content-pinned amnesty for a boundary-policy bootstrap.
 //!
 //! # The grant
 //!
-//! `.github/pr-taxonomy.json` and `check.rs` are
-//! `coverage::BOUNDARY_FILES` entries: touching either invalidates every
-//! standing gate record, at ~4h19m of GPU to re-earn. The 2026-08-16
-//! governance PR has to touch exactly those two files — the taxonomy to fill
-//! its empty `_benches` leaves, `check.rs` to add the hook that consults this
-//! table — and the user authorized a one-time bypass for that landing alone
-//! ("just this one time", 2026-08-16). This module is that bypass, made
-//! auditable: a table anyone can read, a pin nobody can stretch, a test that
-//! demands its own removal.
+//! PR #701 changes the benchmark coverage policy so exact Rust modules proven
+//! to be reachable only through `#[cfg(test)]` no longer invalidate GPU
+//! records. The policy, coverage check, and required-set documentation are all
+//! verdict-defining boundary files, so the change invalidates all ten records
+//! before its narrower rule can help later PRs.
+//!
+//! The grant below covers only the final reviewed blobs of those three files.
+//! It is the same mechanism accepted for the 2026-08-16 governance bootstrap:
+//! a table anyone can read, a pin no later edit can inherit, and a test that
+//! demands removal after all ten records have been re-earned.
 //!
 //! # Why content-pinned rather than waived
 //!
@@ -37,7 +38,7 @@
 //! own landing would then invalidate everything it exists to protect. It is
 //! covered only by `GATE_MACHINERY`'s cargo-test rationale, like the rest of
 //! the gate bookkeeping. Compensations: the table's exact contents are pinned
-//! by `the_table_is_exactly_the_2026_08_16_grant` (entry count, paths, OID
+//! by `the_table_is_exactly_the_pr_701_grant` (entry count, paths, OID
 //! format), every application is logged loudly by `check.rs`, CODEOWNERS
 //! review covers the gate directory, and the gate already executes
 //! PR-checkout code — so this adds no new attack class, only a reviewed
@@ -46,7 +47,7 @@
 //! # Removal condition
 //!
 //! EMPTY THE TABLE once every required gate has a record newer than
-//! `AMNESTY_EPOCH`. At that point the grant protects nothing — every
+//! `AMNESTY_EPOCH`. At that point the grant protects nothing because every
 //! record postdates the grant day and was earned against the amnestied
 //! content. `amnesty_expires_once_every_gate_has_a_fresh_record` fails with
 //! instructions when that day arrives, so the table cannot quietly outlive
@@ -66,22 +67,29 @@ pub struct AmnestyEntry {
     pub grant: &'static str,
 }
 
-/// When the grant was made: end of 2026-08-16 UTC (`1786924800` =
-/// 2026-08-17T00:00:00Z). End of day rather than midnight because the
-/// standing records this amnesty protects were themselves earned earlier on
-/// 2026-08-16 — a record only counts as "fresh" against the grant if it
-/// postdates the whole grant day.
-pub const AMNESTY_EPOCH: u64 = 1_786_924_800;
+/// End of the PR #701 grant day: 2026-08-22T00:00:00Z. A record counts as
+/// fresh only when it postdates the whole grant day.
+pub const AMNESTY_EPOCH: u64 = 1_787_356_800;
 
-/// The whole grant. When this table is empty the module is inert.
-pub const ONE_TIME_AMNESTY: [AmnestyEntry; 0] = [
-    // EMPTIED 2026-08-17. Every required gate now carries a record newer than
-    // AMNESTY_EPOCH: the ten-gate suite was re-cut at sha 4012c9b7e1 (vision,
-    // video, ttft-warm, ttft-cold, ssm-state-poisoning, decode-floor,
-    // concurrency-sweep, agentic-webserver, bfcl-subset 84.22/84.12,
-    // bfcl-subset-echolp 86.25/86.61 — all PASS). The grant has been fully
-    // re-earned by measurement, so it protects nothing and the module is inert,
-    // exactly as `amnesty_expires_once_every_gate_has_a_fresh_record` demands.
+/// The whole PR #701 grant. `PENDING` deliberately matches no blob. The grant
+/// becomes active only after the final files are hashed and these values are
+/// pinned in a separate commit.
+pub const ONE_TIME_AMNESTY: [AmnestyEntry; 3] = [
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/gate/check.rs",
+        head_blob_oid: "PENDING",
+        grant: "PR #701 test-only Rust module coverage bootstrap",
+    },
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/gate/coverage.rs",
+        head_blob_oid: "PENDING",
+        grant: "PR #701 test-only Rust module coverage bootstrap",
+    },
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/gate/required.rs",
+        head_blob_oid: "PENDING",
+        grant: "PR #701 test-only Rust module coverage bootstrap",
+    },
 ];
 
 /// Whether the one-time grant excuses `path` at `head`.

--- a/crates/atlas-plugin/src/gate/amnesty_tests.rs
+++ b/crates/atlas-plugin/src/gate/amnesty_tests.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! The one-time 2026-08-16 amnesty must excuse EXACTLY the pinned bytes,
+//! The one-time PR #701 amnesty must excuse exactly the pinned bytes,
 //! fail closed on everything else, and demand its own removal.
 //!
-//! `the_table_is_exactly_the_2026_08_16_grant` is deliberately RED while the
+//! `the_table_is_exactly_the_pr_701_grant` is deliberately red while the
 //! table holds `"PENDING"` OIDs: the pin phase (compute the landed blob OIDs
 //! with `git hash-object` once content is final) is what turns it green, so
 //! the grant cannot ship half-armed by accident.
@@ -15,6 +15,7 @@ use super::tests::tempdir;
 use super::{REQUIRED_GATES, read_record, records_newest_first};
 
 const TAXONOMY: &str = ".github/pr-taxonomy.json";
+const GRANTED_COVERAGE: &str = "crates/atlas-plugin/src/gate/coverage.rs";
 
 fn blob_oid(root: &std::path::Path, head: &str, path: &str) -> String {
     let out = std::process::Command::new("git")
@@ -114,25 +115,25 @@ fn git_failure_fails_closed() {
 
 /// ★ The wiring, not just the table: `check.rs::invalidating_paths` really
 /// consults the grant. Content matching no pin must survive the filter and
-/// invalidate; the REAL repo's taxonomy bytes — the only content the live
+/// invalidate; the real repo's coverage bytes, the content the live
 /// table can possibly pin — must be dropped from the list exactly when
 /// [`excused`] says they are the grant. While the pin is live this exercises
-/// the excuse arm; after any later taxonomy edit both sides of the
+/// the excuse arm; after any later coverage edit both sides of the
 /// equivalence flip together and it keeps proving the keep arm.
 #[test]
 fn invalidating_paths_drops_exactly_what_the_grant_excuses() {
     let dir = tempdir::Dir::new();
     let root = dir.path();
     scratch_repo::init(root);
-    scratch_repo::commit(root, TAXONOMY, "{}", "baseline");
+    scratch_repo::commit(root, GRANTED_COVERAGE, "// baseline", "baseline");
     let record_sha = scratch_repo::head(root);
 
-    scratch_repo::commit(root, TAXONOMY, r#"{ "not": "the grant" }"#, "hostile edit");
+    scratch_repo::commit(root, GRANTED_COVERAGE, "// not the grant", "hostile edit");
     let hostile = scratch_repo::head(root);
     let kept = invalidating_paths(root, &hostile, &record_sha, &any_gate())
         .expect("the diff runs in a scratch repo");
     assert!(
-        kept.iter().any(|p| p == TAXONOMY),
+        kept.iter().any(|p| p == GRANTED_COVERAGE),
         "content matching no pin must keep invalidating, got {kept:?}"
     );
 
@@ -140,43 +141,52 @@ fn invalidating_paths_drops_exactly_what_the_grant_excuses() {
         .parent()
         .and_then(|p| p.parent())
         .expect("repo root is two levels above the crate");
-    let real = std::fs::read_to_string(repo.join(TAXONOMY)).expect("the real taxonomy reads");
-    scratch_repo::commit(root, TAXONOMY, &real, "the amnestied landing");
+    let real =
+        std::fs::read_to_string(repo.join(GRANTED_COVERAGE)).expect("the real coverage map reads");
+    scratch_repo::commit(root, GRANTED_COVERAGE, &real, "the amnestied landing");
     let head = scratch_repo::head(root);
     let after = invalidating_paths(root, &head, &record_sha, &any_gate())
         .expect("the diff runs in a scratch repo");
     assert_eq!(
-        !after.iter().any(|p| p == TAXONOMY),
-        excused(root, &head, TAXONOMY),
+        !after.iter().any(|p| p == GRANTED_COVERAGE),
+        excused(root, &head, GRANTED_COVERAGE),
         "invalidating_paths must drop the surviving path exactly when the \
          grant excuses it; the filter and the table may never disagree"
     );
 }
 
-/// ★ RETIRED 2026-08-17 — the grant is spent and the table is empty.
-///
-/// This test used to pin the exact two paths of the 2026-08-16 grant so that
-/// adding a third was a visible, authorization-requiring act. The grant has
-/// since been fully re-earned: every required gate carries a record newer than
-/// [`AMNESTY_EPOCH`], cut at sha 4012c9b7e1 (all ten PASS, including
-/// bfcl-subset 84.22/84.12 and bfcl-subset-echolp 86.25/86.61), so
-/// `amnesty_expires_once_every_gate_has_a_fresh_record` required the table be
-/// emptied.
-///
-/// The assertion is now strictly STRONGER than the one it replaces: the table
-/// must be EMPTY. Any future entry — including a re-add of either original
-/// path — is a new grant and needs its own authorization, its own pinned blob
-/// OID, and its own expiry story.
+/// The PR #701 grant is exactly the three boundary files in that change.
+/// Placeholder OIDs keep this test red until the final-content pin commit.
 #[test]
-#[allow(clippy::const_is_empty)]
-fn the_table_is_empty_the_grant_is_spent() {
+fn the_table_is_exactly_the_pr_701_grant() {
     let paths: Vec<&str> = ONE_TIME_AMNESTY.iter().map(|e| e.path).collect();
-    assert!(
-        paths.is_empty(),
-        "the one-time amnesty is spent and must stay empty; found {paths:?}. \
-         Adding a path is a NEW grant: it needs explicit authorization, a \
-         pinned 40-hex head_blob_oid, and a reason it will expire."
+    assert_eq!(
+        paths,
+        vec![
+            "crates/atlas-plugin/src/gate/check.rs",
+            "crates/atlas-plugin/src/gate/coverage.rs",
+            "crates/atlas-plugin/src/gate/required.rs",
+        ],
+        "the grant must not grow beyond PR #701's boundary files"
     );
+    for entry in &ONE_TIME_AMNESTY {
+        assert_eq!(
+            entry.head_blob_oid.len(),
+            40,
+            "{} is not pinned",
+            entry.path
+        );
+        assert!(
+            entry.head_blob_oid.chars().all(|c| c.is_ascii_hexdigit()),
+            "{} has a non-hex blob OID",
+            entry.path
+        );
+        assert!(
+            entry.grant.contains("PR #701"),
+            "{} lacks its grant",
+            entry.path
+        );
+    }
 }
 
 /// ★ The grant must not outlive its purpose. Once every required gate's
@@ -208,7 +218,7 @@ fn amnesty_expires_once_every_gate_has_a_fresh_record() {
     assert!(
         !stale.is_empty(),
         "every required gate now has a record newer than AMNESTY_EPOCH \
-         (end of 2026-08-16 UTC): the one-time grant has been fully re-earned \
+         (end of 2026-08-21 UTC): the one-time grant has been fully re-earned \
          and protects nothing. EMPTY THE TABLE in \
          crates/atlas-plugin/src/gate/amnesty.rs — the amnesty must not \
          outlive the records it existed to protect."

--- a/crates/atlas-plugin/src/gate/check.rs
+++ b/crates/atlas-plugin/src/gate/check.rs
@@ -215,7 +215,7 @@ pub fn check_gates(root: &Path, sha: &str) -> BTreeMap<String, GateStatus> {
 ///
 /// Records were located by DIRECTORY and their own `benchmark_id` was never
 /// read back. Nothing stopped one gate's record from satisfying another's, and
-/// two of the five gates make that a one-command forgery:
+/// two of the required gates make that a one-command forgery:
 /// `ttft-warm-gate` and `ttft-cold-gate` share a checkpoint, a hardware key and
 /// their metric names (`median_ms`, `p90_ms`). On `main` today the committed
 /// WARM record reads 1562.58 / 4478.42 against the COLD ceilings of

--- a/crates/atlas-plugin/src/gate/check.rs
+++ b/crates/atlas-plugin/src/gate/check.rs
@@ -181,7 +181,7 @@ pub fn invalidating_paths(
             .map(str::trim)
             .filter(|p| !p.is_empty())
             .filter(|p| super::coverage::invalidates(gate, p))
-            // ★ The one-time 2026-08-16 amnesty: a surviving path whose blob
+            // ★ A one-time content-pinned amnesty: a surviving path whose blob
             // at `head` is exactly the grant's pinned content is excused,
             // loudly. Content-pinned, so any later edit to the file changes
             // the OID and invalidates as before. See `amnesty.rs` for the
@@ -190,7 +190,7 @@ pub fn invalidating_paths(
                 if super::amnesty::excused(root, head, p) {
                     tracing::warn!(
                         "amnesty: {p} would re-open {} but its content at {head} is the \
-                         pinned one-time 2026-08-16 grant — excused (see gate/amnesty.rs)",
+                         pinned one-time grant; excused (see gate/amnesty.rs)",
                         gate.id
                     );
                     return false;

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -105,7 +105,7 @@ pub const BOUNDARY_FILES: [&str; 8] = [
     // `invalidates` checks BOUNDARY_FILES *before* `on_boundary`, so an
     // off-PERF_PATHS entry works here; a test pins that.
     //
-    // ★ THE COST IS REAL: a taxonomy edit now re-opens all five gates (~4h19m
+    // ★ THE COST IS REAL: a taxonomy edit now re-opens all ten gates (~4h19m
     // of GPU). That is deliberate. The alternative is that removing a `_benches`
     // line silently reduces coverage with nothing to notice — and a cheap edit
     // that quietly weakens the gate is worse than an expensive one that cannot.
@@ -146,6 +146,39 @@ pub const BOUNDARY_FILES: [&str; 8] = [
 /// Matched on the exact file NAME, so a directory or source file that merely
 /// ends with the same characters is unaffected.
 const NON_COMPILED_KERNEL_FILES: [&str; 1] = ["BENCH.toml"];
+
+/// A Rust source file whose only module edge is guarded by `#[cfg(test)]`.
+///
+/// This is an exact registry, not a naming rule. Each entry identifies the
+/// parent declaration that proves the file is absent from release builds, and
+/// `test_only_coverage_tests` fails if that declaration loses its guard or a
+/// second source edge appears. A new file remains fail-closed until it is
+/// registered with the same proof.
+#[derive(Debug, Clone, Copy)]
+pub struct TestOnlyRustModule {
+    pub path: &'static str,
+    pub parent: &'static str,
+    pub name: &'static str,
+}
+
+pub const TEST_ONLY_RUST_MODULES: &[TestOnlyRustModule] = &[
+    TestOnlyRustModule {
+        path: "crates/atlas-core/src/config/tests.rs",
+        parent: "crates/atlas-core/src/config.rs",
+        name: "tests",
+    },
+    TestOnlyRustModule {
+        path: "crates/atlas-core/src/config/gguf/tests.rs",
+        parent: "crates/atlas-core/src/config/gguf.rs",
+        name: "tests",
+    },
+];
+
+fn is_test_only_rust_module(path: &str) -> bool {
+    TEST_ONLY_RUST_MODULES
+        .iter()
+        .any(|entry| path == entry.path)
+}
 
 /// Whether `path` is one of the gate-read, never-compiled files above.
 fn is_non_compiled_kernel_file(path: &str) -> bool {
@@ -574,6 +607,9 @@ pub fn on_boundary(path: &str) -> bool {
 pub fn invalidates(gate: &GateCoverage, path: &str) -> bool {
     if BOUNDARY_FILES.iter().any(|f| under(path, f)) {
         return true;
+    }
+    if is_test_only_rust_module(path) {
+        return false;
     }
     // After the boundary-file check, so a `BENCH.toml` could never exempt the
     // rules that exempt it, and before the per-gate excludes, since this holds

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -159,6 +159,7 @@ pub struct TestOnlyRustModule {
     pub path: &'static str,
     pub parent: &'static str,
     pub name: &'static str,
+    pub declared_path: Option<&'static str>,
 }
 
 pub const TEST_ONLY_RUST_MODULES: &[TestOnlyRustModule] = &[
@@ -166,11 +167,19 @@ pub const TEST_ONLY_RUST_MODULES: &[TestOnlyRustModule] = &[
         path: "crates/atlas-core/src/config/tests.rs",
         parent: "crates/atlas-core/src/config.rs",
         name: "tests",
+        declared_path: None,
     },
     TestOnlyRustModule {
         path: "crates/atlas-core/src/config/gguf/tests.rs",
         parent: "crates/atlas-core/src/config/gguf.rs",
         name: "tests",
+        declared_path: None,
+    },
+    TestOnlyRustModule {
+        path: "crates/atlas-core/src/config/parsers/lora_tests.rs",
+        parent: "crates/atlas-core/src/config/parsers/lora.rs",
+        name: "tests",
+        declared_path: Some("lora_tests.rs"),
     },
 ];
 

--- a/crates/atlas-plugin/src/gate/mod.rs
+++ b/crates/atlas-plugin/src/gate/mod.rs
@@ -51,11 +51,11 @@ pub use record::{
     variant_slug, write_record,
 };
 
-/// The five benches whose records must pass for the branch to be gated.
+/// The ten benches whose records must pass for the branch to be gated.
 ///
-/// Gate A (agentic webserver), Gate C (warm + cold TTFT), and the two BFCL
-/// gates. Every id is a registered benchmark, and registration is tested
-/// against this list.
+/// Agentic webserver, vision and video fidelity, warm and cold TTFT, two BFCL
+/// draws, SSM state poisoning, decode floor, and concurrency sweep. Every id
+/// is a registered benchmark, and registration is tested against this list.
 ///
 /// ★ **There are two BFCL entries because there are two draws, and a score from
 /// one is not comparable to a threshold from the other.** The dense 27B is
@@ -224,6 +224,11 @@ mod fixture_baseline;
 #[cfg(test)]
 #[path = "coverage_map_tests.rs"]
 mod coverage_map_tests;
+
+/// Proofs for the exact, `#[cfg(test)]`-guarded Rust module exemption.
+#[cfg(test)]
+#[path = "test_only_coverage_tests.rs"]
+mod test_only_coverage_tests;
 
 #[cfg(test)]
 #[path = "coverage_promotion_tests.rs"]

--- a/crates/atlas-plugin/src/gate/required.rs
+++ b/crates/atlas-plugin/src/gate/required.rs
@@ -17,7 +17,7 @@
 //! `intent ⊆ REQUIRED` for any tree.
 //!
 //! **The second was wrong.** It read: "`PERF_PATHS` contains a bare `crates`,
-//! so any code change already invalidates all five gates." It does not.
+//! so any code change already invalidates all ten gates." It does not.
 //! `GATE_MACHINERY` excludes the whole `crates/atlas-plugin/src/gate` prefix
 //! from **every** gate, and each benchmark driver is excluded from the other
 //! gates — so plenty of `crates/` paths invalidate nothing at all and intent is
@@ -33,9 +33,9 @@
 //! `crates_paths_split_into_fully_covered_and_not_covered_at_all` pin those.
 //!
 //! ★★ **The union is NOT the loop set.** [`super::check::check_gates`] iterates
-//! the five-element `REQUIRED_GATES` constant unconditionally, and
+//! the ten-element `REQUIRED_GATES` constant unconditionally, and
 //! `union() ⊊ REQUIRED_GATES` for most real PRs. Swapping the constant for the
-//! union would *reduce* coverage — an unclassified docs PR would go from five
+//! union would *reduce* coverage — an unclassified docs PR would go from ten
 //! gates checked to none. The add-only property holds against `by_path`; it
 //! says nothing about the constant. Whatever consumes this must keep the
 //! constant as the loop set and use the union to ESCALATE — to widen what

--- a/crates/atlas-plugin/src/gate/required_tests.rs
+++ b/crates/atlas-plugin/src/gate/required_tests.rs
@@ -142,14 +142,14 @@ fn an_unclassified_change_gets_no_invented_intent() {
 ///
 /// The module docs originally argued the union was vacuous because
 /// "`PERF_PATHS` contains a bare `crates`, so any code change already
-/// invalidates all five gates". An audit refuted it: `GATE_MACHINERY` excludes
-/// the whole `crates/atlas-plugin/src/gate` prefix from **all five** gates, so
+/// invalidates all ten gates". An audit refuted it: `GATE_MACHINERY` excludes
+/// the whole `crates/atlas-plugin/src/gate` prefix from **all ten** gates, so
 /// paths under it invalidate nothing and intent is the only source of coverage
 /// there. The original test passed only because it happened to pick
 /// `spark-server/scheduler`, one of the paths where the claim does hold.
 ///
 /// Both halves are pinned here so the distinction cannot quietly collapse
-/// again. If the first case ever stops owing all five, `by_path` narrowed —
+/// again. If the first case ever stops owing all ten, `by_path` narrowed —
 /// likely the closure-hash work landing, which is GOOD NEWS. Do not "fix" it by
 /// widening paths; confirm the narrowing was intended and update this test.
 #[test]
@@ -173,7 +173,7 @@ fn crates_paths_split_into_fully_covered_and_not_covered_at_all() {
         engine.intent_only()
     );
 
-    // The gate's own machinery: excluded from all five by GATE_MACHINERY, so
+    // The gate's own machinery: excluded from all ten by GATE_MACHINERY, so
     // the union is LIVE inside crates/ — not waiting on the closure hash.
     let machinery = required_for(
         &["crates/atlas-plugin/src/gate/telemetry.rs".to_string()],

--- a/crates/atlas-plugin/src/gate/test_only_coverage_tests.rs
+++ b/crates/atlas-plugin/src/gate/test_only_coverage_tests.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Proofs for Rust files excluded from benchmark invalidation because their
+//! only module edge is guarded by `#[cfg(test)]`.
+
+use std::path::{Path, PathBuf};
+
+use super::coverage::{self, BOUNDARY_FILES, REQUIRED, TEST_ONLY_RUST_MODULES, TestOnlyRustModule};
+use super::coverage_tests::{any_gate, scratch_repo};
+use super::record_covers;
+use super::tests::tempdir;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repo root is two levels above the crate")
+        .to_path_buf()
+}
+
+fn rust_sources_beneath(directory: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(directory).expect("source directory is readable") {
+        let path = entry.expect("source entry is readable").path();
+        if path.is_dir() {
+            rust_sources_beneath(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn quoted_literal(line: &str) -> Option<&str> {
+    let start = line.find('"')? + 1;
+    let end = line[start..].find('"')? + start;
+    Some(&line[start..end])
+}
+
+fn assert_guarded(root: &Path, module: &TestOnlyRustModule) {
+    let module_path = root.join(module.path);
+    let parent_path = root.join(module.parent);
+    assert!(module_path.is_file(), "{} is not a file", module.path);
+    assert!(parent_path.is_file(), "{} is not a file", module.parent);
+
+    let parent = std::fs::read_to_string(&parent_path).expect("parent module is readable");
+    let guarded_declaration = format!("#[cfg(test)]\nmod {};", module.name);
+    assert!(
+        parent.contains(&guarded_declaration),
+        "{} must declare `{}` directly beneath #[cfg(test)]",
+        module.parent,
+        module.name
+    );
+    assert_eq!(
+        parent.matches(&format!("mod {};", module.name)).count(),
+        1,
+        "{} must have exactly one declaration for module `{}`",
+        module.parent,
+        module.name
+    );
+
+    // Search every Rust source for an explicit include or path edge resolving
+    // to this file. The one allowed edge is the implicit guarded `mod` above.
+    let canonical_module = module_path.canonicalize().expect("test module resolves");
+    let mut sources = Vec::new();
+    rust_sources_beneath(&root.join("crates"), &mut sources);
+    for path in sources {
+        if path == module_path || path == parent_path {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).expect("sibling Rust source is readable");
+        for line in source
+            .lines()
+            .filter(|line| line.contains("include!(") || line.contains("#[path"))
+        {
+            let Some(literal) = quoted_literal(line) else {
+                continue;
+            };
+            let Some(base) = path.parent() else {
+                continue;
+            };
+            let direct = base.join(literal).canonicalize().ok();
+            let nested = path
+                .file_stem()
+                .map(|stem| base.join(stem).join(literal))
+                .and_then(|candidate| candidate.canonicalize().ok());
+            assert!(
+                direct.as_ref() != Some(&canonical_module)
+                    && nested.as_ref() != Some(&canonical_module),
+                "{} creates a second edge to {} with `{}`",
+                path.display(),
+                module.path,
+                line.trim()
+            );
+        }
+    }
+}
+
+#[test]
+fn registered_test_modules_are_proven_cfg_test_only() {
+    let root = repo_root();
+    for module in TEST_ONLY_RUST_MODULES {
+        assert_guarded(&root, module);
+    }
+}
+
+#[test]
+fn registered_test_modules_do_not_invalidate_gpu_records() {
+    for module in TEST_ONLY_RUST_MODULES {
+        assert!(
+            coverage::invalidated_by([module.path]).is_empty(),
+            "{} is absent from release builds and must not reopen GPU gates",
+            module.path
+        );
+    }
+}
+
+#[test]
+fn test_looking_neighbours_remain_fail_closed() {
+    for path in [
+        "crates/atlas-core/src/config/tests.rs.bak",
+        "crates/atlas-core/src/config/tests/tests_b.rs",
+        "crates/atlas-core/src/config/gguf/not_really_tests.rs",
+        "crates/atlas-core/src/config/gguf.rs",
+        "crates/atlas-core/src/config.rs",
+    ] {
+        let invalidated = coverage::invalidated_by([path]);
+        assert_eq!(
+            invalidated.len(),
+            REQUIRED.len(),
+            "unregistered path {path} escaped the fail-closed boundary: {invalidated:?}"
+        );
+    }
+}
+
+#[test]
+fn a_production_change_cannot_hide_beside_an_exempt_test_change() {
+    for module in TEST_ONLY_RUST_MODULES {
+        let invalidated = coverage::invalidated_by([module.path, module.parent]);
+        assert_eq!(
+            invalidated.len(),
+            REQUIRED.len(),
+            "{} hid the production change to {}: {invalidated:?}",
+            module.path,
+            module.parent
+        );
+    }
+}
+
+#[test]
+fn no_test_only_entry_is_a_gate_boundary_file() {
+    for module in TEST_ONLY_RUST_MODULES {
+        assert!(
+            !BOUNDARY_FILES.contains(&module.path),
+            "{} cannot be both exempt and verdict-defining",
+            module.path
+        );
+    }
+}
+
+#[test]
+fn a_record_survives_a_test_only_commit_but_not_its_production_parent() {
+    let directory = tempdir::Dir::new();
+    let root = directory.path();
+    scratch_repo::init(root);
+    let recorded = scratch_repo::head(root);
+
+    scratch_repo::commit(
+        root,
+        TEST_ONLY_RUST_MODULES[0].path,
+        "#[test]\nfn assertion_changed() {}\n",
+        "change only tests",
+    );
+    assert!(
+        record_covers(root, &scratch_repo::head(root), &recorded, &any_gate()),
+        "a record must keep covering a release-equivalent test-only commit"
+    );
+
+    scratch_repo::commit(
+        root,
+        TEST_ONLY_RUST_MODULES[0].parent,
+        "pub fn production_changed() {}\n",
+        "change production",
+    );
+    assert!(
+        !record_covers(root, &scratch_repo::head(root), &recorded, &any_gate()),
+        "the production parent must invalidate the earlier record"
+    );
+}

--- a/crates/atlas-plugin/src/gate/test_only_coverage_tests.rs
+++ b/crates/atlas-plugin/src/gate/test_only_coverage_tests.rs
@@ -42,10 +42,13 @@ fn assert_guarded(root: &Path, module: &TestOnlyRustModule) {
     assert!(parent_path.is_file(), "{} is not a file", module.parent);
 
     let parent = std::fs::read_to_string(&parent_path).expect("parent module is readable");
-    let guarded_declaration = format!("#[cfg(test)]\nmod {};", module.name);
+    let guarded_declaration = match module.declared_path {
+        Some(path) => format!("#[cfg(test)]\n#[path = \"{path}\"]\nmod {};", module.name),
+        None => format!("#[cfg(test)]\nmod {};", module.name),
+    };
     assert!(
         parent.contains(&guarded_declaration),
-        "{} must declare `{}` directly beneath #[cfg(test)]",
+        "{} must declare `{}` through its registered #[cfg(test)] edge",
         module.parent,
         module.name
     );

--- a/docs/adr/0013-gate-coverage-by-content-not-ancestry.md
+++ b/docs/adr/0013-gate-coverage-by-content-not-ancestry.md
@@ -100,6 +100,12 @@ inventing one on the basis of "this diff looks test-only" would be a static
 analysis nobody could trust. The honest cost of a host-side change remains one
 gate run.
 
+ADR-0016 later narrows this statement for explicitly registered external test
+modules. It does not classify diffs or infer safety from a filename. Each
+exempt file has a pinned parent module edge guarded by `#[cfg(test)]`, with CI
+proofs that keep production neighbours fail-closed. Tests embedded in a
+production source file remain covered by the coarse host-code rule.
+
 ## Tests
 
 Three, on a real git fixture that reproduces the squash shape — and asserts

--- a/docs/adr/0016-test-only-rust-module-coverage.md
+++ b/docs/adr/0016-test-only-rust-module-coverage.md
@@ -45,8 +45,12 @@ CI validates every registry entry against the repository:
   edge to the registered file.
 
 The coverage map remains a verdict-defining boundary file. Editing the
-registry or its matching logic therefore invalidates all ten records and
-requires the usual bootstrap measurement.
+registry or its matching logic therefore invalidates all ten records. For the
+initial landing only, the existing content-pinned amnesty mechanism covers the
+exact final blobs of `coverage.rs`, `check.rs`, and `required.rs`. The latter
+two carry the bootstrap hook and corrected ten-gate documentation. Any later
+edit changes its blob OID and invalidates normally. The grant expires by test
+once every required gate has a record newer than 2026-08-21.
 
 ## Fail-closed behavior
 
@@ -75,7 +79,7 @@ precondition for correcting the two demonstrated false invalidations.
 
 ## Tests
 
-The policy tests pin six properties:
+The policy tests pin seven properties:
 
 1. every registered file has its guarded parent edge;
 2. registered files invalidate no GPU records;
@@ -83,4 +87,6 @@ The policy tests pin six properties:
 4. a production change cannot hide beside an exempt test change;
 5. no gate boundary file appears in the test-only registry.
 6. a real git fixture keeps an existing record across a test-only commit and
-   invalidates it after a production-parent commit.
+   invalidates it after a production-parent commit;
+7. the bootstrap grant contains exactly three content-pinned boundary blobs,
+   fails closed for every other blob, and demands removal after fresh records.

--- a/docs/adr/0016-test-only-rust-module-coverage.md
+++ b/docs/adr/0016-test-only-rust-module-coverage.md
@@ -14,9 +14,10 @@ result: their only changed files are either
 `crates/atlas-core/src/config/gguf/tests.rs`, yet all ten GPU records are
 invalidated.
 
-The files are not merely named `tests.rs`. Their parent modules declare them
-directly beneath `#[cfg(test)]`, so they are absent from non-test builds. A
-benchmark cannot observe code that is not part of the benchmarked program.
+The files are not merely named like tests. Their parent modules declare them
+through module edges guarded by `#[cfg(test)]`, so they are absent from
+non-test builds. A benchmark cannot observe code that is not part of the
+benchmarked program.
 
 A glob such as `**/tests.rs` would still be unsafe. Rust permits arbitrary
 module names and explicit `#[path]` or `include!` edges, and a production file
@@ -28,7 +29,8 @@ Maintain an exact registry of test-only Rust module files. Each entry records:
 
 * the exact file path;
 * the exact parent module path;
-* the module name declared by that parent.
+* the module name declared by that parent;
+* the exact `#[path]` value when the module uses one.
 
 An exact registry match does not invalidate benchmark records. No prefix,
 suffix, basename, or directory matching is permitted.
@@ -37,7 +39,8 @@ CI validates every registry entry against the repository:
 
 * the file and parent both exist;
 * the parent contains exactly one module declaration for that name;
-* the declaration is directly guarded by `#[cfg(test)]`;
+* the registered declaration, including any explicit path, is guarded by
+  `#[cfg(test)]`;
 * repository Rust sources do not create an explicit `include!` or `#[path]`
   edge to the registered file.
 

--- a/docs/adr/0016-test-only-rust-module-coverage.md
+++ b/docs/adr/0016-test-only-rust-module-coverage.md
@@ -1,0 +1,83 @@
+# ADR-0016: Exempt only proven test-only Rust modules from benchmark invalidation
+
+**Status:** Proposed
+**Date:** 2026-08-21
+**Builds on:** ADR-0013 (coverage by content, not ancestry)
+
+## Context
+
+The performance boundary contains the whole `crates/` tree. That is safe for
+unknown host code, but it also treats a change to a Rust test assertion as a
+change to the release program. Twelve open test-audit PRs demonstrate the
+result: their only changed files are either
+`crates/atlas-core/src/config/tests.rs` or
+`crates/atlas-core/src/config/gguf/tests.rs`, yet all ten GPU records are
+invalidated.
+
+The files are not merely named `tests.rs`. Their parent modules declare them
+directly beneath `#[cfg(test)]`, so they are absent from non-test builds. A
+benchmark cannot observe code that is not part of the benchmarked program.
+
+A glob such as `**/tests.rs` would still be unsafe. Rust permits arbitrary
+module names and explicit `#[path]` or `include!` edges, and a production file
+can be named `tests.rs`. The gate must not infer reachability from naming.
+
+## Decision
+
+Maintain an exact registry of test-only Rust module files. Each entry records:
+
+* the exact file path;
+* the exact parent module path;
+* the module name declared by that parent.
+
+An exact registry match does not invalidate benchmark records. No prefix,
+suffix, basename, or directory matching is permitted.
+
+CI validates every registry entry against the repository:
+
+* the file and parent both exist;
+* the parent contains exactly one module declaration for that name;
+* the declaration is directly guarded by `#[cfg(test)]`;
+* repository Rust sources do not create an explicit `include!` or `#[path]`
+  edge to the registered file.
+
+The coverage map remains a verdict-defining boundary file. Editing the
+registry or its matching logic therefore invalidates all ten records and
+requires the usual bootstrap measurement.
+
+## Fail-closed behavior
+
+Files not in the registry keep the existing `crates/` behavior. This includes:
+
+* files that merely look like tests;
+* nested test helpers not separately registered;
+* tests embedded in production source files;
+* every production neighbour of a registered test module;
+* every gate boundary file.
+
+If a PR changes both a registered test file and its production parent, the
+parent still invalidates all applicable gates. Removing a `#[cfg(test)]` guard
+also changes the parent and fails the structural coverage test.
+
+## Consequences
+
+Test-only PRs can satisfy the benchmark check using existing records because
+the benchmarked release inputs did not change. Their Rust tests, formatting,
+lint, and platform builds continue to run normally.
+
+Adding another exemption is an explicit policy change with reviewable proof,
+not an automatic result of choosing a test-like filename. A future release
+dependency-closure fingerprint may replace this registry, but it is not a
+precondition for correcting the two demonstrated false invalidations.
+
+## Tests
+
+The policy tests pin six properties:
+
+1. every registered file has its guarded parent edge;
+2. registered files invalidate no GPU records;
+3. lookalike and neighbouring paths still invalidate all ten records;
+4. a production change cannot hide beside an exempt test change;
+5. no gate boundary file appears in the test-only registry.
+6. a real git fixture keeps an existing record across a test-only commit and
+   invalidates it after a production-parent commit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ What's better, what's worse, what new problems did we create?
 - [0013 — A gate record covers a commit by content, never by ancestry](0013-gate-coverage-by-content-not-ancestry.md)
 - [0014 — PR intent is a descending tree, and it may only ADD benchmarks](0014-pr-intent-taxonomy-and-the-required-union.md)
 - [0015 — The governance harvest, and a one-time content-pinned amnesty](0015-governance-harvest-and-the-one-time-amnesty.md)
+- [0016 — Exempt only proven test-only Rust modules from benchmark invalidation](0016-test-only-rust-module-coverage.md)


### PR DESCRIPTION
## Summary

`PR benchmark gate` currently invalidates all ten records for any changed path under `crates/`. Twelve open test-audit PRs change only Rust modules excluded from release builds by explicit `#[cfg(test)]` parent edges, but each PR is still required to replace all ten GPU records.

This PR adds an exact registry for three proven test-only modules:

- `crates/atlas-core/src/config/tests.rs`
- `crates/atlas-core/src/config/gguf/tests.rs`
- `crates/atlas-core/src/config/parsers/lora_tests.rs`

A registered file no longer invalidates benchmark records. Unregistered files, production parents, nested helpers, test-looking filenames, and verdict boundary files retain the existing fail-closed behavior.

## Observed failure

PRs #674, #675, #678, #679, #680, #685, #687, #689, #690, #691, #694, and #696 contain no production changes. Their benchmark jobs report all ten records missing because the only invalidating path is one of the first two registered files.

Those files are absent from non-test builds. Re-running model benchmarks cannot observe their assertions because the benchmarked release program is unchanged.

## Structural proof

Each registry entry records the exact file, exact parent, module name, and explicit `#[path]` value when present. Tests prove:

1. the file and parent exist;
2. the parent has exactly one registered module declaration guarded by `#[cfg(test)]`;
3. no Rust source creates another `include!` or `#[path]` edge to the file;
4. neighbouring and test-looking paths still invalidate all ten gates;
5. a production-parent change cannot hide beside an exempt test change;
6. a real Git fixture keeps a record valid across the test-only commit and invalidates it after the production parent changes.

Tests embedded inside production source files remain performance-boundary changes.

## Bootstrap

The policy changes three verdict boundary files:

- `crates/atlas-plugin/src/gate/check.rs`
- `crates/atlas-plugin/src/gate/coverage.rs`
- `crates/atlas-plugin/src/gate/required.rs`

The repository already has a content-pinned amnesty mechanism for this bootstrap problem. This PR activates it for exactly the final blobs of those three files:

- `check.rs`: `2dd3bed0103d38009e82de8d507d26320a1cb307`
- `coverage.rs`: `6aef608fab0d120096d3b55eaed3095155e2beeb`
- `required.rs`: `c8b8311abbb88bceb844710e6443e28ce843f236`

The match uses `git rev-parse <head>:<path>`. A later one-byte edit produces a different blob and invalidates all ten gates normally. Unlisted paths and Git failures are not excused. The table is pinned to exactly these three entries by test and must be emptied once every required gate has a record newer than the end of 2026-08-21 UTC.

## Executed proof

Against committed head `1cf15f848e` and current `main` records:

```text
correct pins:
PASS agentic-webserver
PASS vision-fidelity
PASS video-fidelity
PASS ttft-warm-gate
PASS ttft-cold-gate
PASS bfcl-subset
PASS bfcl-subset-echolp
PASS ssm-state-poisoning-gate
PASS decode-floor
PASS concurrency-sweep
all 10 required gates pass
```

I then replaced all three pins with a different valid 40-hex OID and reran the same command. All ten gates returned `NONE`, each naming `check.rs`, `coverage.rs`, and `required.rs` as invalidating paths. Restoring the exact pins returned all ten gates to `PASS`.

This proves the green verdict comes from the three reviewed content matches, not from a broad path exception or coincidental record selection.

## Test plan

- [x] `cargo test -p atlas-plugin gate::amnesty_tests -- --test-threads=1` (6 passed)
- [x] `cargo test -p atlas-plugin gate::test_only_coverage_tests -- --test-threads=1` (6 passed)
- [x] `cargo clippy -p atlas-plugin --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `typos` on every changed Rust and ADR file
- [x] `git diff --check`
- [x] `spark benchmark --pull-request-gate-check --pr 701` (10 passed)
- [ ] Full workspace and platform matrix is owned by CI.
- [ ] Local license scan could not start because the configured fallback requires a running Docker daemon. CI runs the repository license job directly.

The full atlas-plugin run reached 816 of 818 passing on macOS. Two existing detached-process lifecycle tests failed outside the changed gate modules. This branch does not change their code; Linux CI is the relevant result.

## Review boundary

ADR-0016 records the registry decision, bootstrap grant, expiry condition, and non-claims. Historical incident accounts remain unchanged. After this lands, the listed test-only PRs can merge current `main` and reuse the standing records. Inline tests inside production files and functional parser changes remain benchmark-invalidating.