### PR TITLE
stream: give the SimHash semantic-loop guard the standard kill switch

### DIFF
--- a/crates/spark-server/src/api/chat_stream/handle_token.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_token.rs
@@ -15,6 +15,15 @@ use super::super::sanitizer::sanitize_content_chunk;
 use super::super::stream_guards::{bump_f12_tool_call_count, check_loop_watchdog};
 use super::ctx::StreamCtx;
 use super::state::StreamState;
+
+/// `ATLAS_SIMHASH_LOOP=0` disables the F4 SimHash semantic-loop guard.
+/// Default ON — see the comment at the check site for why an operator would
+/// turn it off (one-strike near-duplicate detection kills streams over
+/// legitimately repetitive structured output).
+fn simhash_loop_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_SIMHASH_LOOP").as_deref() != Ok("0"))
+}
 use super::strip::{
     maybe_log_decode_trace, strip_all_preserving_boundary, strip_preserving_boundary,
 };
@@ -620,8 +629,16 @@ fn process_detector_content(
     // post-sanitizer text in both call sites.
     let sanitized = sanitized_or_raw;
 
-    // F4 SimHash guard.
-    let semantic_trip = if !state.loop_watchdog_triggered {
+    // F4 SimHash guard. `ATLAS_SIMHASH_LOOP=0` disables it (house watchdog
+    // convention, same shape as ATLAS_TOOL_ENVELOPE_WATCHDOG): the guard is
+    // ONE-STRIKE at Jaccard 0.55 over a 16-sentence ring, which legitimate
+    // structured output crosses easily — per-method docstrings, enumerations,
+    // boilerplate-heavy code all produce >=0.55 bigram overlap between
+    // honest sentences, and a fire KILLS the stream mid-reply. Before the
+    // #699 verdict fix most of its fires were masking genuinely degenerate
+    // output; with generation clean, the remaining fires skew
+    // false-positive (observed 2026-08-21: fired on a healthy TUI session).
+    let semantic_trip = if simhash_loop_enabled() && !state.loop_watchdog_triggered {
         state.simhash_pending.push_str(sanitized);
         let mut dup = false;
         if crate::loop_simhash::ends_at_sentence_boundary(&state.simhash_pending).is_some()


### PR DESCRIPTION
The F4 SimHash guard was the only watchdog with no operator control: hardcoded one-strike at Jaccard 0.55 over a 16-sentence ring, and a fire **kills the stream mid-reply** (`guard_stop=simhash_semantic_loop`). Legitimate structured output crosses that bar easily — per-method docstrings, enumerations, boilerplate-heavy code all produce ≥0.55 bigram overlap between honest sentences.

Post-#699 (with genuinely degenerate output gone) its remaining fires skew false-positive: observed 2026-08-21 killing a healthy interactive session mid-answer. Before #699 most of its fires were masking the real defect.

`ATLAS_SIMHASH_LOOP=0` disables it — house convention, same shape as `ATLAS_TOOL_ENVELOPE_WATCHDOG`. **Default stays ON**; this adds the lever, not a policy change. The token-level loop watchdog is untouched and still guards true verbatim loops.

Verified with the switch off: a prompt mandating identical-form docstrings ran to a full 512-token coherent completion (that exact shape previously died at the guard), an identical-sentence litany streamed unimpeded, zero SimHash warnings in the serve log. Built + fmt clean on main's base.