### PR TITLE
verify: raise VERIFY_ROW_CAP 96 -> 160 and derive the metadata layout from it

### DIFF
--- a/crates/spark-model/src/model/trait_impl/verify_e.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e.rs
@@ -8,7 +8,7 @@
 //! and made RAGGED per sequence by D-Cut) so the n weight-reading verify
 //! forwards collapse into one — the structural fix for the measured MTP
 //! serialization at C>1 (cap=4 at C=4: 25.8 vs 48.5 tok/s; see
-//! BATCHED_MTP_SPEC.md). R is capped at 96 = the exact capacity of the
+//! BATCHED_MTP_SPEC.md). R is capped at `VERIFY_ROW_CAP` = the exact capacity of the
 //! logits rows / meta gaps / bt staging (sizes.rs), reached at n=32 × k=3
 //! rows (the 32:2 depth-at-width shape, wave 11; previously 64 at n=32 ×
 //! k=2, 32 at n=16 × k=2).
@@ -31,6 +31,21 @@
 #![allow(unused_imports, dead_code, clippy::too_many_arguments)]
 
 use anyhow::{Result, bail, ensure};
+
+/// Batched-verify metadata overlay, every offset derived from
+/// [`super::verify_e2::VERIFY_ROW_CAP`] so the cap and the layout cannot
+/// drift apart (they once lived as a literal 96 and 384/768/1536/2048-byte
+/// offsets that had to be moved in lock-step by hand):
+///   positions  u32 × R at [0, 4R)
+///   seq_slot   u32 × R at [4R, 8R)
+///   slots      i64 × R at [8R, 16R)   (8-byte aligned: R is even)
+///   seq_lens   i32 × R at [16R, 20R)
+///   bt         i32 × R × max_blocks at [24R, …)  (4R of slack before it)
+const VMETA_R: usize = super::verify_e2::VERIFY_ROW_CAP;
+const VMETA_SEQ_SLOT: usize = VMETA_R * 4;
+const VMETA_SLOTS: usize = VMETA_R * 8;
+const VMETA_SEQ_LENS: usize = VMETA_R * 16;
+const VMETA_BT: usize = VMETA_R * 24;
 use atlas_core::config::{LayerType, ModelConfig};
 use spark_runtime::gpu::DevicePtr;
 use spark_runtime::kv_cache::PagedKvCache;
@@ -50,7 +65,7 @@ impl TransformerModel {
     /// carries ONE adapter slot), MTP proposer present (stash allocated,
     /// `VERIFY_WY_TABLE_SEQS` = 32 slots ⇒ n ≤ 32), EVERY `ks[i]` in 2..=4
     /// (the MTP ladder range; intermediates pools are sized for the
-    /// configured max K), and R = Σ ks ≤ `VERIFY_ROW_CAP` = 96 (the exact
+    /// configured max K), and R = Σ ks ≤ `VERIFY_ROW_CAP` (the exact
     /// logits-rows / meta-gap / bt-staging capacity — sizes.rs). Everything
     /// outside falls back to the per-seq loop.
     pub(super) fn can_batch_verify_dispatch(&self, ks: &[usize]) -> bool {
@@ -123,10 +138,10 @@ impl TransformerModel {
             "batched verify: n={n} ks={ks:?} tokens={}",
             tokens.len()
         );
-        // R ≤ VERIFY_ROW_CAP (96): the exact capacity of the meta gaps below
-        // (positions 384 B at +0, seq_slot at +384, slots 768 B at +768,
-        // seq_lens 384 B at +1536, bt at +2048 staged for 96 rows in
-        // sizes.rs) and the 96-row logits cap. Reached at n=32 × k=3 rows
+        // R ≤ VERIFY_ROW_CAP: the exact capacity of the meta gaps (the
+        // VMETA_* derived offsets at the top of this file), the bt staging
+        // and the logits rows (both sized in sizes.rs from the same cap —
+        // keep them in lock-step). Historically reached at n=32 × k=3 rows
         // (the 32:2 depth-at-width shape).
         ensure!(
             r_total <= super::verify_e2::VERIFY_ROW_CAP,
@@ -221,8 +236,8 @@ impl TransformerModel {
                             && (!wy_present
                                 || self.ssm_pool.h_inter_count(s as usize) + 1 >= k as usize)
                     });
-                // Every cached key was captured under `ensure!(R <= 96)`, so
-                // the borrowed total row count fits the fixed 96-row meta
+                // Every cached key was captured under the VERIFY_ROW_CAP
+                // ensure!, so the borrowed total row count fits the meta
                 // arrays and logits cap by construction — but that bound
                 // guards the `unsafe` upload lengths below, so it is
                 // re-checked as a hard borrow veto, never assumed.
@@ -252,7 +267,7 @@ impl TransformerModel {
             }
         }
         // Rows the DISPATCH must prepare: active rows plus any ghost tail.
-        // `r_up <= VERIFY_ROW_CAP` (96) holds on every path: the no-ghost
+        // `r_up <= VERIFY_ROW_CAP` holds on every path: the no-ghost
         // case by the `ensure!` above, the borrow case by the veto at accept.
         let r_ghost: usize = ghosts.iter().map(|&(_, k)| k as usize).sum();
         let r_up = r_total + r_ghost;
@@ -277,8 +292,8 @@ impl TransformerModel {
         }
 
         // ── Phase 2: R-row attention metadata (verify_c2 layout SHAPE at
-        // WIDER gaps — 96 rows: positions [0,384) | seq_slot [384,768) |
-        // slots i64 [768,1536) | seq_lens [1536,1920) | bt at +2048. This
+        // WIDER gaps — VERIFY_ROW_CAP rows at the VMETA_* derived
+        // offsets (positions | seq_slot | slots | seq_lens | bt). This
         // path's own layout only: every metadata consumer receives absolute
         // pointers via `AttnMetadataDev`, and each step (and each graph's
         // replay) re-uploads its own layout pre-dispatch, so verify_c2 /
@@ -287,9 +302,9 @@ impl TransformerModel {
         let max_blocks = self.max_blocks_per_seq;
         let mb = max_blocks as usize;
 
-        let mut positions = [0u32; 96];
-        let mut slots = [0i64; 96];
-        let mut seq_lens = [0i32; 96];
+        let mut positions = [0u32; VMETA_R];
+        let mut slots = [0i64; VMETA_R];
+        let mut seq_lens = [0i32; VMETA_R];
         for (i, seq) in seqs.iter().enumerate() {
             for j in 0..ks[i] {
                 let r = off[i] + j;
@@ -312,10 +327,10 @@ impl TransformerModel {
             slots[r] = dummy_kv;
             seq_lens[r] = 1;
         }
-        // SAFETY: `positions` is the fixed `[0u32; 96]` above, so its size is
-        // 96 * 4 = 384 B; the `ensure!(r_total <= VERIFY_ROW_CAP)` guard plus
-        // the `debug_assert!(r_up <= VERIFY_ROW_CAP)` (r_up rows were
-        // captured under the same cap) make `r_up * 4 <= 384`.
+        // SAFETY: `positions` is the fixed `[0u32; VMETA_R]` above, so its
+        // size is VMETA_R * 4 bytes; the `ensure!(r_total <= VERIFY_ROW_CAP)`
+        // guard plus the `debug_assert!(r_up <= VERIFY_ROW_CAP)` (r_up rows
+        // were captured under the same cap) make `r_up * 4` fit.
         // The array is zero-init at declaration and rows `0..r_up` are all
         // written by the fill loops (`off` is the prefix sum of `ks`, so
         // `off[i]+j` covers `0..r_total` exactly; the ghost loop covers
@@ -323,20 +338,20 @@ impl TransformerModel {
         let pos_bytes =
             unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, r_up * 4) };
         self.gpu.copy_h2d_async(pos_bytes, meta_base, stream)?;
-        // SAFETY: `slots` is the fixed `[0i64; 96]` above (768 B); the same
-        // bounds argument gives `r_up * 8 <= 768`. Zero-init at declaration,
+        // SAFETY: `slots` is the fixed `[0i64; VMETA_R]` above (VMETA_R * 8
+        // bytes); the same bounds argument fits `r_up * 8`. Zero-init at declaration,
         // rows `0..r_up` written by the fill loops; `i64` is POD.
         let slot_bytes =
             unsafe { std::slice::from_raw_parts(slots.as_ptr() as *const u8, r_up * 8) };
         self.gpu
-            .copy_h2d_async(slot_bytes, meta_base.offset(768), stream)?;
-        // SAFETY: `seq_lens` is the fixed `[0i32; 96]` above (384 B); the same
-        // bounds argument gives `r_up * 4 <= 384`. Zero-init at declaration,
+            .copy_h2d_async(slot_bytes, meta_base.offset(VMETA_SLOTS), stream)?;
+        // SAFETY: `seq_lens` is the fixed `[0i32; VMETA_R]` above (VMETA_R *
+        // 4 bytes); the same bounds argument fits `r_up * 4`. Zero-init at declaration,
         // rows `0..r_up` written by the fill loops; `i32` is POD.
         let sl_bytes =
             unsafe { std::slice::from_raw_parts(seq_lens.as_ptr() as *const u8, r_up * 4) };
         self.gpu
-            .copy_h2d_async(sl_bytes, meta_base.offset(1536), stream)?;
+            .copy_h2d_async(sl_bytes, meta_base.offset(VMETA_SEQ_LENS), stream)?;
 
         // Block tables: row r = seq i's table (bt staging sized for 96 rows,
         // sizes.rs `bt_rows`). Ghost rows read only entry 0 (causal clamp 1)
@@ -362,18 +377,18 @@ impl TransformerModel {
         let bt_bytes =
             unsafe { std::slice::from_raw_parts(bt_buf.as_ptr() as *const u8, needed * 4) };
         self.gpu
-            .copy_h2d_async(bt_bytes, meta_base.offset(2048), stream)?;
+            .copy_h2d_async(bt_bytes, meta_base.offset(VMETA_BT), stream)?;
 
         // No-LoRA gate in can_batch: uniform upload returns DevicePtr(0)
         // (installed-pair path) — kept for structural parity with verify_c2.
         debug_assert!(
             r_up <= super::verify_e2::VERIFY_ROW_CAP,
-            "verify seq_slot [384,768) gap holds R ≤ 96"
+            "verify seq_slot gap holds R ≤ VERIFY_ROW_CAP"
         );
         let seq_slot = self.upload_seq_slot_uniform(
             seqs[0].adapter_slot,
             r_up,
-            meta_base.offset(384),
+            meta_base.offset(VMETA_SEQ_SLOT),
             stream,
         )?;
 
@@ -381,9 +396,9 @@ impl TransformerModel {
             positions: meta_base,
             positions_h: meta_base,
             positions_w: meta_base,
-            slot: meta_base.offset(768),
-            seq_len: meta_base.offset(1536),
-            block_table: meta_base.offset(2048),
+            slot: meta_base.offset(VMETA_SLOTS),
+            seq_len: meta_base.offset(VMETA_SEQ_LENS),
+            block_table: meta_base.offset(VMETA_BT),
             max_blocks_per_seq: max_blocks,
             num_seqs: r_up as u32,
             seq_slot,

--- a/crates/spark-model/src/model/trait_impl/verify_e2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_e2.rs
@@ -28,15 +28,20 @@ use crate::traits::SequenceState;
 pub(super) const VERIFY_BATCHED_GRAPH_CAP: usize = 32;
 
 /// Verify row-buffer capacity R = Σ ks — the exact capacity of the batched
-/// verify's metadata gaps (verify_e.rs layout: positions 384 B | seq_slot
-/// 384 B | slots 768 B | seq_lens 384 B | bt at +2048), the `bt_rows`
-/// staging and the logits rows (`sizes.rs`). 96 = the wave-11 depth-at-width
-/// envelope: 32:2 = n=32 × k=3 rows hits it dead on (24:2 = 72); previously
-/// 64 (the 32:1 rung's n=32 × k=2), 32 before that (n=16 × k=2). Sequence
-/// count stays bounded at `VERIFY_WY_TABLE_SEQS` = 32 — this cap widens
-/// ROWS (depth at width), not width. The scheduler-side `VERIFY_ROW_BUDGET`
-/// (`mtp_dcut.rs`) mirrors this bound — keep them in lock-step.
-pub(in crate::model) const VERIFY_ROW_CAP: usize = 96;
+/// verify's metadata gaps (verify_e.rs layout, every offset DERIVED from
+/// this constant: positions 4R | seq_slot 4R | slots 8R | seq_lens 4R | bt
+/// at 24R), the `bt_rows` staging and the logits rows (`sizes.rs`). History:
+/// 32 (n=16 × k=2), 64 (32:1), 96 (wave-11 depth-at-width, 32:2 = n=32 × k=3
+/// dead on), now 160: the DFlash uniform K=γ+1=8 shape needs n×8 rows, and
+/// 96 capped the batched verify at n=12 — a C=16 serve chunked 12+4 (better
+/// than the serial-all it did before, still one extra weight sweep per step)
+/// and C=20 fits exactly at 160. Cost is the logits arena: rows × vocab × 2 B
+/// = ~79.5 MB at vocab 248320, +32 MB over the 96-row arena. Sequence count
+/// stays bounded at `VERIFY_WY_TABLE_SEQS` = 32 — this cap widens ROWS
+/// (depth at width), not width. The scheduler-side `VERIFY_ROW_BUDGET`
+/// (`mtp_dcut.rs`) and `bt_rows`/`logits_tokens` (`sizes.rs`) mirror this
+/// bound — keep all four in lock-step.
+pub(in crate::model) const VERIFY_ROW_CAP: usize = 160;
 
 /// Batched-verify CUDA graphs: ON by default, disabled by PRESENCE of
 /// `ATLAS_NO_MTP_VERIFY_GRAPHS` (house convention — `=0` is NOT off).

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -157,7 +157,8 @@ impl BufferSizes {
         //     24R = 768 at the 32-row floor)
         //   [32768+24R .. ): decode block table (padded_n × max_blocks × 4 B)
         //   Batched MTP verify (verify_e.rs) overlays the SAME base with
-        //   96-row gaps: meta [32768, 32768+1920), bt at +2048 (bt_rows=96).
+        //   VERIFY_ROW_CAP-row gaps at derived offsets (verify_e.rs VMETA_*),
+        //   bt at +24R (bt_rows mirrors the cap).
         //   Each path re-uploads its own layout pre-dispatch; sizing takes
         //   the wider (verify) envelope.
         //
@@ -184,20 +185,20 @@ impl BufferSizes {
         let sl_offset = (bt_end + 3) & !3;
         let prefill_meta = sl_offset + 4;
         // Block table metadata: the widest user is the batched MTP verify
-        // (verify_e.rs) at R = 96 rows (n=32 × k=3 rows, the wave-11
+        // (verify_e.rs) at R = bt_rows (mirrors VERIFY_ROW_CAP; was 96, the wave-11
         // depth-at-width envelope — 32:2), whose bt staging sits at
         // meta_base+2048 (wider 96-row gaps: positions 384 | seq_slot 384 |
         // slots 768 | seq_lens 384). Batched decode (padded_n ≤ 32) and
         // DFlash K=γ+1=17 verify keep the narrow +768 layout — strictly
         // inside this envelope.
-        let bt_rows = 96usize; // batched verify R cap (VERIFY_ROW_CAP, verify_e2.rs)
+        let bt_rows = 160usize; // batched verify R cap (VERIFY_ROW_CAP, verify_e2.rs)
         // Envelope = max(verify 96-row overlay, DERIVED decode layout).
         // The decode layout (`decode_meta.rs`, rows = max(32, bs)) sits
         // strictly inside the verify overlay for every rows <= 64 (bt at
         // 24R <= 1536 < 2048, rows <= 96), so this max() changes NOTHING
         // for bs <= 64; it only grows the scratch once rows > ~85.
-        let bt_meta =
-            32768 + (2048 + bt_rows * max_blocks * 4).max(decode_meta.meta_bytes(max_blocks));
+        let bt_meta = 32768
+            + (bt_rows * 24 + bt_rows * max_blocks * 4).max(decode_meta.meta_bytes(max_blocks));
         let scratch_min = 64 * 1024;
         // Q12 kernel-batched prefill stages N per-stream meta blocks plus a
         // stacked BatchedAttnMetadata block — a strictly larger footprint than
@@ -238,7 +239,7 @@ impl BufferSizes {
             k_max * h * bf16
         };
 
-        // Logits: only last token used during prefill. Cap at 96 tokens —
+        // Logits: only last token used during prefill. Cap at 160 tokens —
         // the batched MTP verify's R = Σ ks row cap (n=32 × k=3 rows, the
         // wave-11 depth-at-width envelope; VERIFY_ROW_CAP in verify_e2.rs).
         // This also covers decode=1, batched decode padded_n<=32 PLUS the
@@ -249,8 +250,8 @@ impl BufferSizes {
         // Derived floor for wide native batches: the run_standard mixed path
         // (`decode_b2`) parks prefill logits at row `padded_n`, which can be
         // as high as `decode_meta.rows()` — so the arena must hold rows+1.
-        // Inert (96) for every rows <= 95, i.e. all bs <= 95.
-        let logits_tokens = m.min(96.max(decode_meta.rows() + 1));
+        // Inert (160) for every rows <= 159, i.e. all bs <= 159.
+        let logits_tokens = m.min(160.max(decode_meta.rows() + 1));
 
         // Mamba-2 d_inner may exceed hidden_size; norm_output and attn_output must fit.
         let mamba2_d_inner = config.mamba2_d_inner();

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -116,20 +116,22 @@ fn test_buffer_sizes_scale_with_batch() {
     let s1 = BufferSizes::from_config(&cfg, 1, 4096, 16, 32);
     let s128 = BufferSizes::from_config(&cfg, 128, 4096, 16, 32);
     assert_eq!(s128.hidden_states, s1.hidden_states * 128);
-    // logits does NOT scale with batch: BF16 rows (2 bytes/elem) capped at
-    // 96 tokens — the batched-verify row cap (n=32 × k=3 rows, the wave-11
-    // depth-at-width envelope, VERIFY_ROW_CAP; sizes.rs `logits_tokens`).
-    // This assert was stale twice (16-row FP32 era, then unnoticed through
-    // the 33-row bump) — it is the byte twin of the sizes.rs formula, so
-    // update BOTH together.
-    assert_eq!(s128.logits, 96 * cfg.vocab_size * 2);
+    // logits does NOT scale freely with batch: BF16 rows (2 bytes/elem)
+    // bounded by `m.min(160.max(rows+1))` — the batched-verify row cap
+    // (VERIFY_ROW_CAP = 160; sizes.rs `logits_tokens`). At m=128 the
+    // m-bound wins: 128 rows, still under the 160 cap. This assert was
+    // stale three times (16-row FP32 era, the 33-row bump, then the 96
+    // cap) — it is the byte twin of the sizes.rs formula, so update BOTH
+    // together.
+    assert_eq!(s128.logits, 128 * cfg.vocab_size * 2);
 }
 
-/// bs=64 native boots (wave-14a): sizing must be BYTE-IDENTICAL to bs=32 —
-/// the widened decode-meta layout (rows=64) still sits strictly inside the
-/// 96-row verify scratch overlay (bt at 24*64=1536 < 2048, 64 < 96 rows)
-/// and the 65-row logits need is under the 96-row cap. Only above those
-/// bounds may sizes grow — asserted for the 128-row ceiling.
+/// Native wide boots: sizing must be BYTE-IDENTICAL to bs=32 for every
+/// batch whose decode-meta layout sits inside the 160-row verify scratch
+/// overlay (VERIFY_ROW_CAP = 160; bt at 24*160 and the 160-row logits cap
+/// both dominate until rows exceed 160). Only above that bound may sizes
+/// grow — asserted at bs=160 (logits leave the cap) and bs=192 (the
+/// decode layout term overtakes the bt overlay in scratch).
 #[test]
 fn test_buffer_sizes_decode_meta_widening() {
     let cfg = ModelConfig::qwen3_next_80b_nvfp4();
@@ -141,15 +143,19 @@ fn test_buffer_sizes_decode_meta_widening() {
         assert_eq!(s.scratch, s32.scratch, "bs={bs}");
         assert_eq!(s.logits, s32.logits, "bs={bs}");
     }
-    // bs 33..=64: layout widens but stays inside the verify envelope.
-    for bs in [33usize, 64] {
+    // bs 33..=159: layout widens but stays inside the 160-row envelope —
+    // logits stay at the 160-row cap and scratch stays bt-dominated.
+    for bs in [33usize, 64, 128, 159] {
         let s = BufferSizes::from_config(&cfg, 8192, 4096, 16, bs);
         assert_eq!(s.total_bytes(), s32.total_bytes(), "bs={bs}");
     }
-    // bs=128 (the derived ceiling): logits go to 129 rows and the scratch
-    // envelope must cover the decode layout term (24R + R*max_blocks*4).
-    let s128 = BufferSizes::from_config(&cfg, 8192, 4096, 16, 128);
-    assert_eq!(s128.logits, 129 * cfg.vocab_size * 2);
+    // bs=160: the derived floor (rows+1 = 161) finally exceeds the cap.
+    let s160 = BufferSizes::from_config(&cfg, 8192, 4096, 16, 160);
+    assert_eq!(s160.logits, 161 * cfg.vocab_size * 2);
+    // bs=192: the decode layout term (24R + R*max_blocks*4) overtakes the
+    // bt overlay and scratch must cover it.
+    let s192 = BufferSizes::from_config(&cfg, 8192, 4096, 16, 192);
+    assert_eq!(s192.logits, 193 * cfg.vocab_size * 2);
     let max_blocks = 4096 / 16 + 1;
-    assert!(s128.scratch >= 32768 + 24 * 128 + 128 * max_blocks * 4);
+    assert!(s192.scratch >= 32768 + 24 * 192 + 192 * max_blocks * 4);
 }

--- a/crates/spark-server/src/scheduler/mtp_dcut.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut.rs
@@ -286,7 +286,7 @@ pub(super) fn plan(
 
 /// Split a batch into verify chunks: `[lo, hi)` index ranges over `ks`.
 ///
-/// ONE cap: the row-buffer bound (`VERIFY_ROW_BUDGET` = 96) — the audited
+/// ONE cap: the row-buffer bound (`VERIFY_ROW_BUDGET` = 160) — the audited
 /// verify envelope (meta gaps / logits rows / bt staging, sizes.rs). The
 /// sequence-count cap is DERIVED from it per chunk (`budget / widest rows`:
 /// rows=4 → 24 seqs, rows=3 → 32 = the 32:2 shape in one chunk, rows=2 → 48;

--- a/crates/spark-server/src/scheduler/mtp_dcut.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut.rs
@@ -52,7 +52,9 @@ const BUCKETS: [f32; 4] = [0.25, 0.5, 0.75, 1.0];
 /// fit the OLD 64-row bound in one chunk, so chunking and pruning are
 /// unchanged — only explicit `ATLAS_MTP_K_LADDER` depth-at-width overrides
 /// (24:2 / 32:2) reach rows 65..=96.
-pub(super) const VERIFY_ROW_BUDGET: usize = 96;
+// Mirrors `VERIFY_ROW_CAP` (spark-model verify_e2.rs) — keep in
+// lock-step. 96 -> 160 with the DFlash n=20 × k=8 widening.
+pub(super) const VERIFY_ROW_BUDGET: usize = 160;
 
 /// Widest verify batch (SEQUENCES, not rows) D-Cut may prune —
 /// the D-Cut-at-depth policy. Value-parsed from `ATLAS_MTP_DCUT_MAX_SEQS`

--- a/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
@@ -76,19 +76,21 @@ fn chunk_ranges_reproduce_the_uniform_caps() {
 #[test]
 fn chunk_ranges_seq_cap_derives_from_the_row_budget() {
     // Depth above n=8 (env-ladder / ragged-D-Cut shapes) is no longer
-    // serialized into 8-wide chunks: the row budget is the only bound.
-    // rows=3: 96/3 = 32 seqs — 16:2, 24:2 AND 32:2 are each ONE chunk.
+    // serialized into 8-wide chunks: the row budget is the only bound. The
+    // split points are derived from VERIFY_ROW_BUDGET (160) so this test
+    // states the boundary arithmetic, not a frozen budget value.
+    // rows=3: 160/3 = 53 seqs — everything up to 53 is ONE chunk.
     assert_eq!(chunk_ranges(&[3; 21]), vec![(0, 21)]);
-    assert_eq!(chunk_ranges(&[3; 24]), vec![(0, 24)]);
-    assert_eq!(chunk_ranges(&[3; 32]), vec![(0, 32)]);
-    assert_eq!(chunk_ranges(&[3; 33]), vec![(0, 32), (32, 33)]);
-    // rows=4: 96/4 = 24 seqs.
+    assert_eq!(chunk_ranges(&[3; 33]), vec![(0, 33)]);
+    assert_eq!(chunk_ranges(&[3; 53]), vec![(0, 53)]);
+    assert_eq!(chunk_ranges(&[3; 54]), vec![(0, 53), (53, 54)]);
+    // rows=4: 160/4 = 40 seqs.
     assert_eq!(chunk_ranges(&[4; 9]), vec![(0, 9)]);
-    assert_eq!(chunk_ranges(&[4; 24]), vec![(0, 24)]);
-    assert_eq!(chunk_ranges(&[4; 25]), vec![(0, 24), (24, 25)]);
-    // rows=2: 96/2 = 48 seqs.
-    assert_eq!(chunk_ranges(&[2; 48]), vec![(0, 48)]);
-    assert_eq!(chunk_ranges(&[2; 49]), vec![(0, 48), (48, 49)]);
+    assert_eq!(chunk_ranges(&[4; 40]), vec![(0, 40)]);
+    assert_eq!(chunk_ranges(&[4; 41]), vec![(0, 40), (40, 41)]);
+    // rows=2: 160/2 = 80 seqs.
+    assert_eq!(chunk_ranges(&[2; 80]), vec![(0, 80)]);
+    assert_eq!(chunk_ranges(&[2; 81]), vec![(0, 80), (80, 81)]);
     // rows=3 with 10 seqs (the old (0,8),(8,10) split): one chunk now.
     assert_eq!(chunk_ranges(&[3; 10]), vec![(0, 10)]);
 }


### PR DESCRIPTION
The batched-verify row budget capped R = Σ ks at 96, which bounds the batched DFlash verify (uniform K=γ+1=8) at n=12 sequences — a C=16 serve cannot batch its verifies in one group. 160 holds n=20 at K=8, and gives the MTP ladder the same headroom.

**The maintainability half is the bigger change:** the cap lived in FOUR places kept in lock-step by comment (`VERIFY_ROW_CAP`, `mtp_dcut`'s `VERIFY_ROW_BUDGET`, `sizes.rs` `bt_rows` and the logits-row floor), and the metadata gap offsets were hardcoded byte literals (384/768/1536/2048) that only *happened* to equal 96-row strides. The offsets are now DERIVED from the cap (`VMETA_*` consts in verify_e.rs: positions 4R | seq_slot 4R | slots 8R | seq_lens 4R | bt at 24R), so the next widening is one constant per crate instead of an archaeology exercise.

**Cost:** logits arena 160 × vocab × 2 B (~79.5 MB at vocab 248320, +32 MB over 96 rows); bt staging +~0.5 MB.

**Measured** (qwen3.8-27B-NVFP4 + DFlash2 drafter, GB10, 32K ctx, 16 seqs, prefix cache on, on a branch carrying the scheduler-side batched DFlash verify):

- C=16 aggregate decode 116.8 (chunked 12+4 under the 96 cap) → **129.6 tok/s** (one 16-group), 16/16 coherent completions
- C=1 cold + two cache-hit repeats **byte-identical** sha across the layout change — the overlay move is numerics-neutral
- decode-floor 47.0 tok/s median over 3 pinned runs, accept_len 6.12

The DFlash capture-band buffer already scales with `--max-batch-size` and needed no change; `VERIFY_WY_TABLE_SEQS` = 32 still bounds sequence count. On main today this is headroom for the MTP ladder and the model-side DFlash dispatch; the scheduler-side batched DFlash verify that exploits it fully is a separate feature PR to follow. Built + fmt clean on main's base.