### PR TITLE
perf(registry): load each kernel module once — derive the raw handle from the cudarc load

### DIFF
--- a/crates/atlas-core/src/registry.rs
+++ b/crates/atlas-core/src/registry.rs
@@ -24,10 +24,10 @@ use cudarc::nvrtc::Ptx;
 pub use crate::cuda_host::{CudaHost, host, release};
 use crate::error::{AtlasError, Result};
 
-// Raw CUDA driver API
+// Raw CUDA driver API. (`cuModuleLoadData`/`cuModuleUnload` left this list
+// when the raw handles became views into the cudarc-loaded modules — the
+// registry no longer loads or unloads anything through the raw API.)
 unsafe extern "C" {
-    fn cuModuleLoadData(module: *mut *mut c_void, image: *const c_void) -> i32;
-    fn cuModuleUnload(hmod: *mut c_void) -> i32;
     fn cuModuleGetFunction(hfunc: *mut *mut c_void, hmod: *mut c_void, name: *const i8) -> i32;
     fn cuLaunchKernel(
         f: *mut c_void,
@@ -223,25 +223,18 @@ impl AtlasRegistry {
             let module = ctx
                 .load_module(ptx)
                 .map_err(|e| AtlasError::ModuleLoad(format!("{name}: {e}")))?;
-            modules.insert(name, module);
 
-            // Load via raw CUDA API (for launch_on_stream — avoids cudarc layout issues)
-            let mut raw_mod: *mut c_void = std::ptr::null_mut();
-            let status = if is_binary {
-                // Self-describing binary object: pass the bytes directly.
-                unsafe { cuModuleLoadData(&mut raw_mod, blob.as_ptr() as *const c_void) }
-            } else {
-                let src_nul = CString::new(blob)
-                    .map_err(|e| AtlasError::ModuleLoad(format!("{name}: CString: {e}")))?;
-                unsafe { cuModuleLoadData(&mut raw_mod, src_nul.as_ptr() as *const c_void) }
-            };
-            if status != 0 {
-                return Err(AtlasError::ModuleLoad(format!(
-                    "{name}: cuModuleLoadData failed: {}",
-                    cuda_error_text(status)
-                )));
-            }
-            raw_modules.insert(name, raw_mod);
+            // The raw handle for launch_on_stream (which avoids cudarc's
+            // struct layouts) is the SAME module: derive it instead of
+            // JIT-compiling the blob a second time through
+            // `cuModuleLoadData`. The double load kept a second copy of
+            // every module's SASS resident and doubled driver-JIT time at
+            // boot for the entire kernel set. Lifetime: the handle is owned
+            // by the `Arc<CudaModule>` stored right beside it — `modules`
+            // and `raw_modules` live and die together in this struct, and
+            // `unload_raw` no longer unloads (cudarc's `Drop` does).
+            raw_modules.insert(name, module.cu_module_raw() as *mut c_void);
+            modules.insert(name, module);
         }
 
         Ok(AtlasRegistry {
@@ -314,23 +307,18 @@ impl AtlasRegistry {
         Ok(raw)
     }
 
-    /// Unload every raw module. Idempotent; `Drop` calls it.
+    /// Retire the raw handles. Idempotent; `Drop` calls it.
     ///
-    /// The cudarc-owned `modules` map unloads itself when its `Arc<CudaModule>`s
-    /// drop; only the handles obtained through the raw driver API need this.
+    /// Since the raw map stopped being a second `cuModuleLoadData` of every
+    /// blob and became views into the cudarc-owned `modules`, there is
+    /// nothing to `cuModuleUnload` here — the `Arc<CudaModule>`s unload the
+    /// one real copy when they drop. Draining first keeps the invariant
+    /// that no raw handle survives its module: the maps are torn down
+    /// together, raw side first.
     pub(crate) fn unload_raw(&mut self) -> Vec<String> {
-        let mut failures = Vec::new();
-        for (name, raw) in self.raw_modules.drain() {
-            // SAFETY: `raw` came from `cuModuleLoadData` in `init` on this
-            // process's context, has not been unloaded (the map is drained), and
-            // no launch can be in flight — the caller guarantees quiescence.
-            let status = unsafe { cuModuleUnload(raw) };
-            // A context that is already gone took its modules with it.
-            if status != 0 && !is_teardown_noop(status) {
-                failures.push(format!("{name}: {}", cuda_error_text(status)));
-            }
-        }
-        failures
+        self.raw_modules.drain().for_each(drop);
+        self.modules.drain().for_each(drop);
+        Vec::new()
     }
 
     /// Get the raw CUstream handle for Atlas's own stream.

--- a/vendor/cudarc/src/driver/safe/core.rs
+++ b/vendor/cudarc/src/driver/safe/core.rs
@@ -1895,6 +1895,16 @@ unsafe impl Send for CudaFunction {}
 unsafe impl Sync for CudaFunction {}
 
 impl CudaModule {
+    /// The raw driver handle for this loaded module. (Atlas vendor addition:
+    /// lets `AtlasRegistry` derive `cuModuleGetFunction` handles from the ONE
+    /// module this struct loaded instead of JIT-compiling every PTX blob a
+    /// second time through the raw driver API.) The handle stays owned by
+    /// this `CudaModule`: callers must not `cuModuleUnload` it and must not
+    /// use it after the module drops.
+    pub fn cu_module_raw(&self) -> sys::CUmodule {
+        self.cu_module
+    }
+
     /// Loads a function from the loaded module with the given name.
     pub fn load_function(self: &Arc<Self>, fn_name: &str) -> Result<CudaFunction, DriverError> {
         let fn_name_c = CString::new(fn_name).unwrap();


### PR DESCRIPTION
## What

`AtlasRegistry::init` loaded every kernel blob **twice**: once through cudarc's `ctx.load_module` (driver JIT #1 — backs `function()` lookups) and again through raw `cuModuleLoadData` (driver JIT #2 — backs `launch_on_stream`). Two JIT compilations of the same PTX and two resident SASS copies per module, for the entire embedded kernel set, on every model load.

This PR loads each module once: the vendored cudarc grows a `cu_module_raw()` accessor on `CudaModule`, and the registry's `raw_modules` map becomes views into the one cudarc-loaded module. `cuModuleGetFunction` / `cuLaunchKernel` against the derived handle are unchanged.

## Lifetime

The raw handles are owned by the `Arc<CudaModule>`s stored beside them — the two maps live and die together inside `AtlasRegistry`. `unload_raw` therefore stops calling `cuModuleUnload` (that would now double-free the single copy); it drains both maps, raw side first, and cudarc's `Drop` performs the one real unload. The now-unused raw `cuModuleLoadData`/`cuModuleUnload` extern declarations are removed.

## Measured (GB10, 27B + DFlash2 serve, warm JIT cache)

- Boot to ready: **40.1 s → 34.3 s (−14%)**. Cold-JIT boots save proportionally more (the JIT ran twice per module).
- ~0.3 GB less resident at serve-ready (the duplicate SASS copies).
- Correctness: temp-0 outputs unchanged (count smoke byte-stable across the change, MinHeap correct), C=16 aggregate decode 113.7 tok/s with 16/16 coherent streams — within noise of the double-load build. The kernel load audit resolves identically.

## Validation

`cargo test -p atlas-core` (98 passed) · `cargo check --workspace` clean on this base · fmt clean · full serve boot + smoke + C=16 sweep on the branch content (as part of the integration branch).
