### PR TITLE
perf(gemma4): build the FFN transposed NVFP4 copies — dense FFN 23.7 s → 2.8 s

### DIFF
--- a/crates/spark-model/src/weight_loader/gemma4/loader_a.rs
+++ b/crates/spark-model/src/weight_loader/gemma4/loader_a.rs
@@ -18,6 +18,39 @@ use crate::weight_map::{
     quantize_to_nvfp4, quantized_any,
 };
 
+/// Can this box hold the transposed NVFP4 FFN copies for EVERY layer?
+///
+/// Same shape of question as `weight_loader::moe_prefill_copies_fit`, and the
+/// same reason for asking it once rather than per layer: `free_memory()` shrinks
+/// as layers load, so a per-layer probe transposes the early layers and skips the
+/// late ones, leaving prefill straddling two dispatch arms.
+///
+/// `ATLAS_GEMMA4_FFN_TRANSPOSE=0` forces the fallback — an A/B lever, and an
+/// escape hatch for a box under external memory pressure the probe cannot see.
+fn ffn_transpose_fits(config: &ModelConfig, gpu: &dyn GpuBackend) -> bool {
+    if std::env::var("ATLAS_GEMMA4_FFN_TRANSPOSE").ok().as_deref() == Some("0") {
+        tracing::info!("ATLAS_GEMMA4_FFN_TRANSPOSE=0: dense FFN prefill uses the w4a16 fallback");
+        return false;
+    }
+    let h = config.hidden_size;
+    let inter = config.intermediate_size;
+    // NVFP4: half a byte per weight plus one ue4m3 scale per 16 elements.
+    let per_weight = h * inter / 2 + h * inter / 16;
+    let total = 3 * per_weight * config.num_hidden_layers;
+    let available = gpu.free_memory().unwrap_or(0);
+    let headroom = 2 * 1024 * 1024 * 1024;
+    let fits = total <= available.saturating_sub(headroom);
+    if !fits {
+        tracing::warn!(
+            "Skipping Gemma-4 FFN transposition ({:.1} GB needed, {:.1} GB available). \
+             Prefill falls back to the untransposed w4a16 GEMM.",
+            total as f64 / (1024.0 * 1024.0 * 1024.0),
+            available as f64 / (1024.0 * 1024.0 * 1024.0),
+        );
+    }
+    fits
+}
+
 pub(super) fn load_layers_impl(
     store: &WeightStore,
     config: &ModelConfig,
@@ -345,14 +378,48 @@ pub(super) fn load_layers_impl(
             variant,
             qctx,
         )?;
+        // ★ Transposed NVFP4 copies for the prefill GEMMs.
+        //
+        // These used to be unconditionally `None`, justified by a comment reading
+        // "Gemma-4 uses the bf16_weights prefill path". That path is DISABLED —
+        // `bf16_mlp_default = false` a few hundred lines up, because it costs
+        // ~41 GB — so the justification went stale while the `None` stayed.
+        //
+        // Every fast arm of `DenseFfnLayer::forward_prefill`'s `w4_gemm!` is
+        // guarded on `Some(wt)`: the n128 family, the bf16-TC pair, and both
+        // `t_m128` variants. With all three `None`, all six are skipped and
+        // dispatch lands on the final `_ =>` fallback, plain `w4a16_gemm`.
+        //
+        // MEASURED on nvidia/Gemma-4-31B-IT-NVFP4, 4096-token prefill: the FFN
+        // took 23,714 ms of a 28,180 ms wall — 60 layers, ~395 ms each, split
+        // evenly across gate (7,929 ms), up (7,781 ms) and down (8,005 ms). For
+        // that shape (3 x 5376 x 21504 x 4012 tok x 60 layers = 167 TFLOP) that
+        // is ~7.0 TFLOP/s, against the ~51 TFLOP/s this file's own comments
+        // attribute to `t_m128`.
+        //
+        // COST is a quarter of what made the BF16 path unattractive: NVFP4 is
+        // half a byte per weight, so 3 x h x inter x 0.5 x layers = ~10.4 GB on
+        // the 31B, against ~41 GB for the bf16_mlp alternative. Gated on
+        // `moe_prefill_copies_fit`-style free-memory arithmetic rather than
+        // assumed to fit, and skipped entirely when `bf16_mlp` IS on, where the
+        // original comment's reasoning does hold.
+        let want_ffn_t = !bf16_mlp && ffn_transpose_fits(config, gpu);
+        let (gate_proj_t, up_proj_t, down_proj_t) = if want_ffn_t {
+            (
+                Some(gate_proj.transpose_for_gemm(gpu, config.intermediate_size, h)?),
+                Some(up_proj.transpose_for_gemm(gpu, config.intermediate_size, h)?),
+                Some(down_proj.transpose_for_gemm(gpu, h, config.intermediate_size)?),
+            )
+        } else {
+            (None, None, None)
+        };
         let ffn_weights = DenseFfnWeights {
             gate_proj,
             up_proj,
             down_proj,
-            // Gemma-4 uses the bf16_weights prefill path; no transposed NVFP4 copies.
-            gate_proj_t: None,
-            up_proj_t: None,
-            down_proj_t: None,
+            gate_proj_t,
+            up_proj_t,
+            down_proj_t,
         };
         let bf16_mlp_weights = build_bf16_mlp(store, &lp, bf16_mlp, config, gpu, h)?;
         gpu.synchronize(stream)?;


### PR DESCRIPTION
`gate_proj_t` / `up_proj_t` / `down_proj_t` were hardcoded `None`:

```rust
// Gemma-4 uses the bf16_weights prefill path; no transposed NVFP4 copies.
gate_proj_t: None,
```

**That path is disabled.** `bf16_mlp_default = false` a few hundred lines up, because
it costs ~41 GB — so the justification went stale while the `None` stayed.

Every fast arm of `DenseFfnLayer::forward_prefill`'s `w4_gemm!` is guarded on
`Some(wt)` — the n128 family, the bf16-TC pair, and both `t_m128` variants. With all
three `None`, **all six are skipped** and dispatch lands on the final `_ =>` fallback,
plain `w4a16_gemm`.

## Measured

dgx1, `nvidia/Gemma-4-31B-IT-NVFP4`, 4096-token prefill, **one binary**, both arms
back-to-back, `ATLAS_GEMMA4_FFN_TRANSPOSE` the only variable:

| | OFF | **ON** | Δ |
|---|---:|---:|---:|
| wall | 100,573 ms | **77,878 ms** | **−22.6%** |
| `FFN prefill [dense_total]` | 23,710.4 ms | **2,810.0 ms** | **−88.1%, 8.4×** |

The FFN saving accounts for **92%** of the wall saving. A cross-build observation
agreed to within 100 ms before this controlled run confirmed it.

**Why it was slow, in numbers:** 3 × 5376 × 21504 × 4012 tok × 60 layers = **167 TFLOP**.
23.7 s is **~7.0 TFLOP/s**, against the **~51 TFLOP/s** this file's own comments
attribute to `t_m128`.

## Scope — dense models only, and verified so

`bg-digitalservices/Gemma-4-26B-A4B` is **MoE**; its FFN never reaches
`DenseFfnLayer`, and it measures **19,682 → 19,081 ms** across the same A/B — inside
noise. A change that moved the 26B would have meant this touched something it
shouldn't.

## Cost

NVFP4 is half a byte per weight: 3 × h × inter × 0.5 × layers ≈ **10.4 GB** on the
31B, against ~41 GB for the `bf16_mlp` alternative that was rejected on memory
grounds. Gated on free-memory arithmetic rather than assumed to fit; decided **once**
before any layer allocates (a per-layer probe shrinks as layers load and would
transpose early layers while skipping late ones); skipped entirely when `bf16_mlp`
IS on, where the original comment's reasoning does hold.
`ATLAS_GEMMA4_FFN_TRANSPOSE=0` forces the fallback.

## Correctness

**Gate C2 passes on both arms** — `tool_calls=3/3`, `coherent=3/3`, `degenerate=0`.
Not bit-identical and cannot be (a different GEMM kernel accumulates in a different
order), but every temp-0 prompt stayed coherent and correct on both arms.

## Context

Fourth instance tonight of one pattern: **a fast path guarded on prepared weights
that a loader never prepares.** With #702's tensor-core 512 attention, Gemma-4-31B's
4096-token prefill goes **101.5 s → ~7.4 s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1