### PR TITLE
test(atlas-core): cover Puzzle runtime dimension lookups

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -379,7 +379,10 @@ fn test_parse_nemotron_h_puzzle_config() {
     // Non-MoE layers fall back to scalar max
     assert_eq!(cfg.moe_intermediate_size, 2688);
     assert_eq!(cfg.num_experts_per_tok, 22);
+    assert_eq!(cfg.moe_intermediate_size_for(0), 2688);
+    assert_eq!(cfg.num_experts_per_tok_for(0), 22);
     assert_eq!(cfg.max_moe_intermediate_size(), 2688);
+    assert_eq!(cfg.moe_input_size(), 1024);
     assert_eq!(cfg.weight_prefix, "backbone");
 }
 


### PR DESCRIPTION
## Summary

The Nemotron-H Puzzle parser test stored per-layer MoE data but did not prove the runtime lookup behavior used by weight loading. This patch adds three assertions without changing production code.

## Broken proof

The test said non-MoE layers fall back to scalar maxima, but only asserted the scalar fields. It also asserted `moe_latent_size` without checking that `moe_input_size()` selects it.

## Mutation evidence

- Returning the zero schedule entry directly from `moe_intermediate_size_for(0)` left the old test green.
- Returning the zero schedule entry directly from `num_experts_per_tok_for(0)` left the old test green.
- Returning `hidden_size` from `moe_input_size()` left the old test green.

The new assertions fail those mutants at 0 versus 2688, 0 versus 22, and 4096 versus 1024.

## Runtime tie

The Nemotron weight loader and weight map use these helpers to size and load Puzzle expert matrices. Buffer sizing also uses the latent MoE input dimension.

NVIDIA's [BF16 config at revision `0102285a`](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-BF16/blob/0102285ae0e237124e228b67323c9ecbcb6970bc/config.json) confirms the 4096 hidden size, 1024 latent width, 88-entry schedules, and heterogeneous MoE dimensions. The local four-layer fixture remains a deliberate sample, not a full-checkpoint test.

## Test plan

- [x] `CUDARC_CUDA_VERSION=13010 cargo test -p atlas-core` (98 passed)
- [x] `CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-core/src/config/tests.rs`
- [x] `git diff --check`
- [x] Replayed all three production mutants against the repaired test

## Notes for reviewers

- The diff is three test assertions in an existing `#[cfg(test)]` module.
- #701 is merged. After updating this branch to include it, the PR benchmark gate passed at `bc7f966ebb`, confirming this exact test module preserves the standing records.
- This does not load checkpoint weights or execute a Nemotron kernel.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).

