### PR TITLE
test(atlas-core): pin DeepSeek V4 runtime controls

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -556,6 +556,7 @@ fn test_parse_deepseek_v4_config() {
     assert_eq!(cfg.kv_lora_rank, 512); // fallback default
     assert_eq!(cfg.qk_nope_head_dim, 448); // head_dim - qk_rope_head_dim
     assert_eq!(cfg.v_head_dim, 512); // fallback to head_dim
+    assert_eq!(cfg.partial_rotary_factor, 0.125); // 64 / 512
     assert_eq!(cfg.num_experts, 256);
     assert_eq!(cfg.num_experts_per_tok, 6);
     assert_eq!(cfg.moe_intermediate_size, 2048);
@@ -563,6 +564,7 @@ fn test_parse_deepseek_v4_config() {
     assert!(cfg.norm_topk_prob);
     assert_eq!(cfg.scoring_func, "sqrtsoftplus"); // preserved, no fallback
     assert!(cfg.use_routing_bias);
+    assert_eq!(cfg.routed_scaling_factor, 1.5);
     assert_eq!(cfg.num_mtp_modules, 1);
     assert_eq!(cfg.mtp_transformer_layers, 1);
     assert_eq!(cfg.dspark_block_size, 5);
@@ -586,6 +588,9 @@ fn test_parse_deepseek_v4_config() {
     assert_eq!(cfg.index_head_dim, 128);
     assert_eq!(cfg.index_topk, 512);
     assert_eq!(cfg.num_hash_layers, 3);
+    assert_eq!(cfg.hc_mult, 4);
+    assert_eq!(cfg.hc_sinkhorn_iters, 20);
+    assert_eq!(cfg.hc_eps, 1e-6);
     // Fallback: all layers treated as FullAttention
     assert_eq!(cfg.num_attention_layers(), 43);
     assert_eq!(cfg.num_ssm_layers(), 0);


### PR DESCRIPTION
## Summary

The DeepSeek-V4 parser test omitted five runtime controls already produced by the parser. This patch pins their exact values without changing production code.

## Broken proof

The fixture contained the inputs for MLA rotary geometry, routed-expert scaling, and hyper-connections, but the test observed none of those outputs.

## Mutation evidence

The old test stayed green when production omitted the derived rotary fraction, reset routed scaling to 1.0, and left the three hyper-connection values at zero.

The repaired test independently fails at:

- rotary fraction: 1.0 versus 0.125;
- routed scale: 1.0 versus 1.5;
- residual streams: 0 versus 4;
- Sinkhorn iterations: 0 versus 20;
- HC epsilon: 0 versus 1e-6.

Removing only the explicit raw routed-scaling assignment is behaviorally equivalent because Serde already populated the field. The mutation proof resets the parsed value instead.

## Runtime tie

The rotary fraction selects the Q/K slice receiving position encoding. Routed scaling weights every selected expert contribution. HC stream count, iteration count, and epsilon control residual mixing.

DeepSeek's [published config](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/60d8d70770c6776ff598c94bb586a859a38244f1/config.json) records the corresponding 64/512 rotary geometry, 1.5 routed scale, four streams, 20 iterations, and 1e-6 epsilon.

## Test plan

- [x] `CUDARC_CUDA_VERSION=13010 cargo test -p atlas-core` (98 passed)
- [x] `CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-core/src/config/tests.rs`
- [x] `git diff --check`
- [x] Replayed each omitted/defaulted runtime control independently

## Notes for reviewers

- The diff is five assertions in an existing `#[cfg(test)]` module.
- #701 is merged. After updating this branch to include it, the PR benchmark gate passed at `15713912db`, confirming this exact test module preserves the standing records.
- Dedicated sibling tests already cover the YaRN factor, betas, original length, compressor theta, and amplitude terms; those assertions are not duplicated here.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).

