### PR TITLE
test(atlas-core): bound Holo model detection

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -677,6 +677,35 @@ fn test_parse_holo31_vlm_config() {
     assert_eq!(vision.image_pad_token_id, 248056);
 }
 
+#[test]
+fn test_holo31_discriminator_requires_all_signals() {
+    let mut wrong_image_token: serde_json::Value = serde_json::from_str(HOLO31_VLM_CONFIG).unwrap();
+    wrong_image_token["image_token_id"] = serde_json::json!(248_055);
+    assert_eq!(
+        parse_config(&wrong_image_token.to_string())
+            .unwrap()
+            .model_type,
+        "qwen3_6_moe",
+        "the Holo rewrite requires its checkpoint image token"
+    );
+
+    let mut no_vision: serde_json::Value = serde_json::from_str(HOLO31_VLM_CONFIG).unwrap();
+    no_vision.as_object_mut().unwrap().remove("vision_config");
+    assert_eq!(
+        parse_config(&no_vision.to_string()).unwrap().model_type,
+        "qwen3_6_moe",
+        "a text-only config is not Holo-3.1 VLM"
+    );
+
+    let mut other_family: serde_json::Value = serde_json::from_str(HOLO31_VLM_CONFIG).unwrap();
+    other_family["model_type"] = serde_json::json!("qwen3_vl_moe");
+    assert_eq!(
+        parse_config(&other_family.to_string()).unwrap().model_type,
+        "qwen3_6_moe",
+        "the Holo rewrite is limited to its qwen3_5_moe source family"
+    );
+}
+
 // Regression: the FLAGSHIP Qwen/Qwen3.6-35B-A3B-FP8 checkpoint carries the
 // SAME vision tower + image_token_id 248056 as Holo-3.1 but ships an MTP
 // head (mtp_num_hidden_layers=1). It must stay qwen3_6_moe — the Holo


### PR DESCRIPTION
## Summary

Holo-3.1 detection uses four signals, but existing tests protected only the positive Holo case and the MTP-present Qwen3.6 case. This patch adds negative controls for the remaining three predicates.

## Missing boundary coverage

The new test varies one signal at a time while retaining the Holo-shaped MRoPE schedule:

- image token 248055 instead of 248056;
- no `vision_config`;
- top-level family `qwen3_vl_moe` instead of `qwen3_5_moe`.

Each variant must remain `qwen3_6_moe` rather than being rewritten to `holo3_1_moe`.

## Mutation evidence

Removing the image-token, vision-presence, and source-family predicates independently misclassifies the matching variant and fails its named assertion. The existing `test_qwen36_35b_with_mtp_is_not_holo` continues to own the fourth predicate, MTP absence.

## Runtime tie

The rewritten model type participates in kernel-target selection. Over-broad Holo detection can route another Qwen-family VLM to the wrong target.

Qwen's [initial Qwen3.6-35B-A3B-FP8 config](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8/blob/61a5771f218894aaacf97551e24a25b866750fc2/config.json) confirms the shared family, image token, MRoPE schedule, vision tower, and one MTP layer used by the neighboring negative control.

## Test plan

- [x] `CUDARC_CUDA_VERSION=13010 cargo test -p atlas-core` (99 passed)
- [x] `CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-core/src/config/tests.rs`
- [x] `git diff --check`
- [x] Replayed each removed discriminator predicate independently

## Notes for reviewers

- The diff adds one table-shaped boundary test. Production detection is unchanged.
- #701 is merged. After updating this branch to include it, the PR benchmark gate passed at `dffc74c560`, confirming this exact test module preserves the standing records.
- This proves model classification only. It does not resolve a kernel target or load weights.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).

