### PR TITLE
test(atlas-core): cover NLLB config contracts

### DIFF
--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -730,6 +730,13 @@ fn test_parse_nllb_m2m100_config() {
     assert_eq!(cfg.head_dim, 128);
     assert_eq!(cfg.max_position_embeddings, 1024);
     assert_eq!(cfg.vocab_size, 256206);
+    assert_eq!(cfg.bos_token_id, 0);
+    assert_eq!(cfg.eos_token_id, 2);
+    assert!(cfg.tie_word_embeddings);
+    assert_eq!(cfg.num_experts, 0);
+    assert_eq!(cfg.mtp_num_hidden_layers, 0);
+    assert_eq!(cfg.num_attention_layers(), 24);
+    assert_eq!(cfg.num_ssm_layers(), 0);
     assert_eq!(cfg.weight_prefix, "model.decoder");
     assert!(!cfg.attn_gated);
 }

--- a/crates/atlas-core/src/config/tests.rs
+++ b/crates/atlas-core/src/config/tests.rs
@@ -742,10 +742,11 @@ fn test_parse_nllb_m2m100_config() {
 }
 
 #[test]
-fn test_parse_nllb_rejects_missing_required_dimension() {
+fn test_parse_nllb_rejects_missing_required_fields() {
     let json = r#"{
         "bos_token_id": 0,
         "d_model": 2048,
+        "decoder_attention_heads": 16,
         "decoder_ffn_dim": 8192,
         "decoder_layers": 24,
         "eos_token_id": 2,
@@ -754,11 +755,25 @@ fn test_parse_nllb_rejects_missing_required_dimension() {
         "vocab_size": 256206
     }"#;
 
-    let err = parse_config(json).unwrap_err().to_string();
-    assert!(
-        err.contains("nllb config missing required field `decoder_attention_heads`"),
-        "{err}"
-    );
+    let valid: serde_json::Value = serde_json::from_str(json).unwrap();
+    for field in [
+        "d_model",
+        "decoder_layers",
+        "decoder_ffn_dim",
+        "vocab_size",
+        "decoder_attention_heads",
+        "max_position_embeddings",
+        "bos_token_id",
+        "eos_token_id",
+    ] {
+        let mut missing = valid.clone();
+        missing.as_object_mut().unwrap().remove(field);
+        let err = parse_config(&missing.to_string()).unwrap_err().to_string();
+        assert!(
+            err.contains(&format!("nllb config missing required field `{field}`")),
+            "missing {field}: {err}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The NLLB parser tests checked core decoder dimensions but missed architecture resets inherited from the Qwen factory and covered only one missing required field. This patch strengthens both checks without changing production code.

## Broken proof

The happy-path test stayed green with swapped BOS/EOS, untied embeddings, 512 inherited routed experts, one inherited MTP layer, and a full-attention interval that reported only 12 of 24 decoder layers.

The missing-field test removed only `decoder_attention_heads`. Defaulting any other required field was invisible to it.

## Mutation evidence

The repaired happy path independently fails swapped-token, untied, inherited-expert, inherited-MTP, and wrong-attention-interval mutants.

The renamed required-fields test removes these inputs one at a time and checks the field-specific error:

- `d_model`;
- `decoder_layers`;
- `decoder_ffn_dim`;
- `vocab_size`;
- `decoder_attention_heads`;
- `max_position_embeddings`;
- `bos_token_id`;
- `eos_token_id`.

Defaulting missing decoder layers to 24 and missing BOS to 0 makes the old test green and the expanded test fail at `unwrap_err()`.

## Runtime tie

The dedicated NLLB runtime uses the token IDs, loads `model.shared.weight`, and sizes decoder KV state from attention geometry. MoE and MTP state inherited from the Qwen seed are false architecture claims.

Facebook's [NLLB-200 3.3B config at revision `1a07f7d1`](https://huggingface.co/facebook/nllb-200-3.3B/blob/1a07f7d195896b2114afcb79b7b57ab512e7b43e/config.json) confirms the external dimensions and token IDs.

## Test plan

- [x] `CUDARC_CUDA_VERSION=13010 cargo test -p atlas-core` (98 passed)
- [x] `CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-core/src/config/tests.rs`
- [x] `git diff --check`
- [x] Replayed each architecture-reset mutant and representative dimension/token defaults

## Notes for reviewers

- The diff changes only an existing `#[cfg(test)]` module.
- #701 is merged. After updating this branch to include it, the PR benchmark gate passed at `ecea405abf`, confirming this exact test module preserves the standing records.
- Removing `layer_types.clear()` already failed the old test through length validation, so this PR does not claim that as new coverage.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).

