### PR TITLE
perf(graphs): retain DFlash verify graphs across sequences — adapter check moves to replay time

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
@@ -40,8 +40,16 @@ impl Qwen3AttentionLayer {
         // FP8 prefill perturbation on the attention projections.
         // Load-time weight prep runs before any `TransformerModel` exists to
         // carry the levers, so this resolves at the point of use. The
-        // interpretation stays SSOT in `ModelLevers`.
-        let bf16_proj = crate::layers::ops::ModelLevers::from_env().bf16_tc_proj;
+        // interpretation stays SSOT in `ModelLevers`. Resolved ONCE: this is
+        // called per attention layer per prefill chunk, and a full
+        // `from_env()` here re-read a dozen env vars (a process-global lock)
+        // and re-ran the drafter-context resolution — whose info line then
+        // spammed ~4 lines per prefill chunk × layer (193 on one warm turn).
+        // The env cannot change under a running process, so a OnceLock is
+        // exact, not a staleness risk.
+        static BF16_PROJ: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        let bf16_proj =
+            *BF16_PROJ.get_or_init(|| crate::layers::ops::ModelLevers::from_env().bf16_tc_proj);
         if bf16_proj && self.w4a16_gemm_t_m128_bf16_k.0 != 0 {
             return crate::layers::ops::w4a16_gemm_n128_m128_bf16(
                 gpu,

--- a/crates/spark-model/src/model/drafter_context.rs
+++ b/crates/spark-model/src/model/drafter_context.rs
@@ -162,17 +162,30 @@ pub fn resolve_from_env() -> DrafterContext {
                 );
             }
         }
-        tracing::info!(
-            "MTP drafter context: prefill={} carry={} ({}). Disable both with {}=1.",
-            on_off(cfg.prefill),
-            on_off(cfg.carry),
-            if cfg == DrafterContext::BOTH {
-                "default"
-            } else {
-                "overridden by environment"
-            },
-            DISABLE_ENV,
-        );
+        // Log on CHANGE, not on call: a second model resolving to a
+        // different policy still logs (the discrepancy this fn exists to
+        // surface — see the doc above on why the config itself is not
+        // OnceLock'd), but a hot caller re-resolving the same policy no
+        // longer spams (measured 193 identical lines on one warm prefill
+        // when a per-layer lever read went through `from_env()`).
+        static LAST_LOGGED: std::sync::Mutex<Option<DrafterContext>> = std::sync::Mutex::new(None);
+        if LAST_LOGGED.lock().map_or(true, |mut last| {
+            let changed = *last != Some(cfg);
+            *last = Some(cfg);
+            changed
+        }) {
+            tracing::info!(
+                "MTP drafter context: prefill={} carry={} ({}). Disable both with {}=1.",
+                on_off(cfg.prefill),
+                on_off(cfg.carry),
+                if cfg == DrafterContext::BOTH {
+                    "default"
+                } else {
+                    "overridden by environment"
+                },
+                DISABLE_ENV,
+            );
+        }
         if cfg.prefill && !cfg.carry {
             tracing::warn!(
                 "{PREFILL_ONLY_ENV}=1: drafter prefill is ON with cross-turn carry \

--- a/crates/spark-model/src/model/impl_lora.rs
+++ b/crates/spark-model/src/model/impl_lora.rs
@@ -407,12 +407,16 @@ impl TransformerModel {
             self.verify_kgamma_graph
                 .lock()
                 .drain()
-                .map(|(_, g)| g)
+                .map(|(_, (g, _))| g)
                 .collect(),
         );
         drain(
             "fused_graph",
-            self.fused_graph.lock().drain().map(|(_, g)| g).collect(),
+            self.fused_graph
+                .lock()
+                .drain()
+                .map(|(_, (g, _))| g)
+                .collect(),
         );
     }
 

--- a/crates/spark-model/src/model/trait_impl/decode_graph_key.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_graph_key.rs
@@ -87,8 +87,15 @@ pub(super) fn verify_k_graph_on_free() -> FreeSlotGraphPolicy {
     FreeSlotGraphPolicy::Retain
 }
 
+/// `verify_kgamma` / `fused` graphs bake the LoRA bgmv-vs-installed-pair
+/// branch of the capturing sequence, which used to force `DropThisSlot` — a
+/// ~0.3 s recapture on every request's first decode step, the largest fixed
+/// cost on a warm-turn TTFT. Retained since the replay-time occupant check:
+/// each cache entry carries the `adapter_slot` it baked, verify_d /
+/// verify_fused destroy + recapture on mismatch, and adapter (un)load still
+/// drains both maps wholesale (`impl_lora`).
 pub(super) fn lora_baked_graph_on_free() -> FreeSlotGraphPolicy {
-    FreeSlotGraphPolicy::DropThisSlot
+    FreeSlotGraphPolicy::Retain
 }
 
 /// Insert `graph` at `key`, evicting the LRU entry when at `cap` and the key
@@ -219,10 +226,11 @@ mod tests {
         assert_eq!(decode_graph_on_free(), FreeSlotGraphPolicy::Retain);
         assert_eq!(batch_decode_graphs_on_free(), FreeSlotGraphPolicy::Retain);
         assert_eq!(verify_k_graph_on_free(), FreeSlotGraphPolicy::Retain);
-        assert_eq!(
-            lora_baked_graph_on_free(),
-            FreeSlotGraphPolicy::DropThisSlot
-        );
+        // Retain since the replay-time adapter occupant check landed — the
+        // free-time drop was a ~0.3 s recapture tax on every request. The
+        // companion assertions in `free_sequence_does_not_destroy_slot_
+        // keyed_decode_graphs` pin the check that makes this sound.
+        assert_eq!(lora_baked_graph_on_free(), FreeSlotGraphPolicy::Retain);
     }
 
     #[test]
@@ -263,13 +271,18 @@ mod tests {
         assert_eq!(batch_decode_graph_cap(64), 80);
     }
 
-    /// NEGATIVE: `free_sequence_dispatch` must not drain slot-keyed decode
-    /// graphs. Recapturing on every completion was the cost this PR removes.
-    /// LoRA-baked `verify_kgamma` / `fused` still drop (adapter index baked).
+    /// NEGATIVE: `free_sequence_dispatch` must not drain ANY slot-keyed
+    /// graph cache. Recapturing on every completion was a ~0.3 s tax on
+    /// every request's first decode step (the largest fixed cost on a
+    /// warm-turn TTFT). The LoRA-branch correctness that used to justify
+    /// dropping `verify_kgamma` / `fused` lives at the replay site now: the
+    /// cached entry carries the `adapter_slot` it baked and the replay
+    /// destroys + recaptures on occupant mismatch.
     ///
-    /// PROVEN BY: restoring `self.decode_graph.lock()` or
-    /// `self.batch_decode_graphs.lock()` inside `free_sequence_dispatch`
-    /// turns this red.
+    /// PROVEN BY: restoring any `.lock()` of a graph map inside
+    /// `free_sequence_dispatch` turns this red; deleting the
+    /// adapter-mismatch check in verify_d/verify_fused turns the companion
+    /// assertion red.
     #[test]
     fn free_sequence_does_not_destroy_slot_keyed_decode_graphs() {
         let src = std::fs::read_to_string(
@@ -292,8 +305,24 @@ mod tests {
             "free_sequence must retain batch_decode_graphs"
         );
         assert!(
-            body.contains("verify_kgamma_graph") && body.contains("fused_graph"),
-            "LoRA-baked graphs still drop"
+            !body.contains("self.verify_kgamma_graph.lock()")
+                && !body.contains("self.fused_graph.lock()"),
+            "free_sequence must retain the DFlash verify graphs too — the \
+             adapter check moved to replay time"
         );
+        // Companion: the replay-time occupant check must exist in BOTH
+        // consumers, or a reused slot could replay a stale LoRA branch.
+        for f in ["verify_d.rs", "verify_fused.rs"] {
+            let consumer = std::fs::read_to_string(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("src/model/trait_impl")
+                    .join(f),
+            )
+            .unwrap();
+            assert!(
+                consumer.contains("baked_adapter != seq.adapter_slot"),
+                "{f} lost the replay-time adapter occupant check"
+            );
+        }
     }
 }

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -221,32 +221,18 @@ impl TransformerModel {
         // on every completion was an extra eager step per request. Policy is
         // pinned by `decode_graph_key` tests (`*_graph_on_free` → Retain).
         //
-        // verify_kgamma / fused still drop below: they bake a per-occupant
-        // LoRA adapter index (`lora_baked_graph_on_free` → DropThisSlot).
-        // verify_kgamma_graph + fused_graph are keyed by (slot, K). They now
-        // capture the LoRA bgmv-vs-installed-pair branch and read the per-seq
-        // seq_slot buffer, so a freed slot's entries MUST be destroyed — else a
-        // reused slot replays a stale adapter index (multi-adapter + DFlash
-        // spec-decode output corruption). Drop every K for this slot.
-        for graph_map in [&self.verify_kgamma_graph, &self.fused_graph] {
-            let mut cache = graph_map.lock();
-            let keys: Vec<(usize, usize)> = cache
-                .keys()
-                .filter(|k| k.0 == seq.slot_idx)
-                .copied()
-                .collect();
-            for k in keys {
-                if let Some(graph) = cache.remove(&k)
-                    && let Err(e) = self.gpu.destroy_graph(graph)
-                {
-                    tracing::error!(
-                        "free_sequence: destroy_graph(kgamma/fused[{},{}]): {e:#}",
-                        k.0,
-                        k.1
-                    );
-                }
-            }
-        }
+        // verify_kgamma / fused graphs are RETAINED here too
+        // (`lora_baked_graph_on_free` → Retain since the replay-time occupant
+        // check landed). They bake the LoRA bgmv-vs-installed-pair branch of
+        // the sequence that captured them, which is why this loop used to
+        // destroy every (slot, K) entry on free — costing a ~0.3 s recapture
+        // on EVERY request's first decode step, the single largest fixed
+        // cost on a warm-turn TTFT. The correctness the destroy provided now
+        // lives at the replay site: each cached entry carries the
+        // `adapter_slot` it baked, and verify_d / verify_fused destroy +
+        // recapture on occupant mismatch (adapter (un)load still drains both
+        // maps wholesale in `impl_lora`). On a non-LoRA serve every occupant
+        // bakes -1, so retained graphs replay across sequences unconditionally.
 
         // ATLAS_MTP_CARRY_DRAFTER: hand this turn's drafter KV to the model's
         // single carry slot BEFORE `free_state`, so the next turn of the same

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -213,10 +213,30 @@ impl TransformerModel {
         };
 
         let cache_key = (seq.slot_idx, k);
+        // Occupant check: the capture bakes the LoRA bgmv-vs-installed-pair
+        // branch of the sequence that captured it, so a retained graph is
+        // only replayable by an occupant with the SAME adapter_slot (-1 =
+        // base, the constant on every non-LoRA serve). A mismatch destroys
+        // the stale entry and recaptures below — this replay-time gate is
+        // what lets `free_sequence` retain these graphs across occupants.
         let cached_for_slot = graph_cache
             .as_ref()
             .and_then(|c| c.get(&cache_key).copied());
-        if let Some(graph) = cached_for_slot
+        let cached_for_slot = match cached_for_slot {
+            Some((graph, baked_adapter)) if baked_adapter != seq.adapter_slot => {
+                if let Some(cache) = graph_cache.as_mut()
+                    && let Some((old, _)) = cache.remove(&cache_key)
+                    && old.0 != 0
+                    && let Err(e) = self.gpu.destroy_graph(old)
+                {
+                    tracing::error!("kgamma graph adapter-mismatch destroy: {e:#}");
+                }
+                let _ = graph;
+                None
+            }
+            other => other,
+        };
+        if let Some((graph, _)) = cached_for_slot
             && graph.0 != 0
         {
             self.gpu.launch_graph(graph, stream)?;
@@ -353,7 +373,7 @@ impl TransformerModel {
                         k
                     );
                     if let Some(ref mut cache) = graph_cache {
-                        cache.insert(cache_key, graph);
+                        cache.insert(cache_key, (graph, seq.adapter_slot));
                     }
                     self.gpu.launch_graph(graph, stream)?;
                 }

--- a/crates/spark-model/src/model/trait_impl/verify_fused.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_fused.rs
@@ -237,10 +237,27 @@ impl TransformerModel {
             None
         };
 
+        // Same replay-time occupant check as verify_d: the capture bakes the
+        // LoRA branch, so a retained graph is only replayable by an occupant
+        // with the same adapter_slot; mismatch destroys and recaptures.
         let cached_for_slot = graph_cache
             .as_ref()
             .and_then(|c| c.get(&cache_key).copied());
-        if let Some(graph) = cached_for_slot
+        let cached_for_slot = match cached_for_slot {
+            Some((graph, baked_adapter)) if baked_adapter != seq.adapter_slot => {
+                if let Some(cache) = graph_cache.as_mut()
+                    && let Some((old, _)) = cache.remove(&cache_key)
+                    && old.0 != 0
+                    && let Err(e) = self.gpu.destroy_graph(old)
+                {
+                    tracing::error!("fused graph adapter-mismatch destroy: {e:#}");
+                }
+                let _ = graph;
+                None
+            }
+            other => other,
+        };
+        if let Some((graph, _)) = cached_for_slot
             && graph.0 != 0
         {
             self.gpu.launch_graph(graph, stream)?;
@@ -359,7 +376,7 @@ impl TransformerModel {
                         m
                     );
                     if let Some(ref mut cache) = graph_cache {
-                        cache.insert(cache_key, graph);
+                        cache.insert(cache_key, (graph, seq.adapter_slot));
                     }
                     self.gpu.launch_graph(graph, stream)?;
                 }

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -322,12 +322,20 @@ pub struct TransformerModel {
     /// Cached CUDA graphs for DFlash K=γ verification, keyed by
     /// `(seq.slot_idx, K)`. K is `tokens.len()` (γ+1 typically). One graph
     /// per (slot, K) — different γ values coexist via the K dimension.
-    pub(super) verify_kgamma_graph: Mutex<std::collections::HashMap<(usize, usize), GraphHandle>>,
+    /// Value carries the `adapter_slot` the capture baked (the LoRA
+    /// bgmv-vs-installed-pair branch is a capture-time decision): replay
+    /// checks it against the current occupant and recaptures on mismatch,
+    /// which is what lets `free_sequence` RETAIN these across occupants
+    /// instead of paying a ~0.3 s recapture on every request's first step.
+    pub(super) verify_kgamma_graph:
+        Mutex<std::collections::HashMap<(usize, usize), (GraphHandle, i32)>>,
     /// Cached CUDA graphs for the DFlash decode+verify fused pass, keyed by
     /// `(seq.slot_idx, M)` where M = tokens.len() = 1 + num_drafts.
     /// Replaces the separate `decode_graph` (M=1) + `verify{k}_graph` (M=k)
-    /// on the DFlash path with a single M-row weight sweep.
-    pub(super) fused_graph: Mutex<std::collections::HashMap<(usize, usize), GraphHandle>>,
+    /// on the DFlash path with a single M-row weight sweep. Value carries
+    /// the baked `adapter_slot` — same replay-time occupant check as
+    /// `verify_kgamma_graph`.
+    pub(super) fused_graph: Mutex<std::collections::HashMap<(usize, usize), (GraphHandle, i32)>>,
     /// Prefix cache for KV block reuse across requests.
     pub(super) prefix_cache: Box<dyn spark_runtime::prefix_cache::PrefixCache>,
     /// Secondary CUDA stream for pipelining checkpoint D2D with MTP propose.


### PR DESCRIPTION
## What this started as, and what it found

Chasing the "prefix cache gives no TTFT win" note on the qwen3.8-27B + DFlash2 serve. **The note is wrong for the case that matters**: on a realistic multi-turn conversation (2.2K-token system prompt), warm turns measure **2.80s cold → 1.00s / 0.89s warm (~3×)**, with `cached_tokens` correctly reported (2240/2400) and a Marconi checkpoint restore replaying only the ~190-token suffix. The old measurement was an *identical-repeat* full-prompt hit — a case whose exact-leaf snapshot shortcut is deliberately bypassed as unsound by construction (the recurrence isn't invertible; the shortcut poisons a shared KV block).

Decomposing the remaining warm-turn 1.0s exposed the changes here.

## Change 1: retain DFlash verify graphs across sequences

`free_sequence` destroyed every `(slot, K)` `verify_kgamma`/`fused` CUDA graph on completion, because a capture bakes the occupant's LoRA bgmv-vs-installed-pair branch — so **every request re-captured both graphs on its first decode step**. The cache entry now carries the `adapter_slot` it baked; `verify_d`/`verify_fused` destroy + recapture only on occupant mismatch, and `free_sequence` retains. On a non-LoRA serve every occupant bakes `-1`, so graphs persist for the process lifetime: **2 captures total across a 6-request session, versus 2 per request before**. Adapter (un)load still drains both maps wholesale, and the `decode_graph_key` pinning test now asserts both the retention and the presence of the replay-time check in both consumers.

**Honest measurement**: C=1 TTFT is *unchanged* (the captures were hidden under the ~0.41s DFlash drafter bootstrap window — see "next lever" below). What this removes is the per-request destroy+recapture GPU work itself. C=16 aggregate 114.2 tok/s, 16/16 coherent, temp-0 outputs byte-stable across builds.

## Change 2: hot-path lever read + log spam

A per-attention-layer lever read went through `ModelLevers::from_env()` — re-reading a dozen env vars (a process-global lock) per layer per prefill chunk and re-logging the drafter-context info line **193 times in one warm prefill**. The hot read is a `OnceLock`'d bool now (env is process-stable), and the drafter-context line logs on *change* — a second model resolving to a different policy still logs, per that module's own rationale for not caching the config.

## The next lever, scoped (not in this PR)

The warm turn's largest remaining cost is a ~0.41s DFlash drafter bootstrap: the DFlash proposer does not implement `take_drafter_kv`/`install_drafter_kv`, so every turn rebuilds drafter context from scratch — which is also why warm turns open with 0/7 accept steps before recovering. Implementing the cross-turn drafter carry for DFlash (prefix-validity by token equality, as the MTP carry does) would attack both the 0.4s and the warm-accept dip.

## Validation

644 spark-model tests + fmt clean + `cargo check --workspace` clean on this base · full serve boots ×3 with the changes, two-turn probe byte-stable (129/150/120 completion tokens identical across all three builds) · C=16 sweep coherent 16/16.
