### PR TITLE
test(atlas-core): strengthen GPU fault contracts

### DIFF
--- a/crates/atlas-core/src/fault_tests.rs
+++ b/crates/atlas-core/src/fault_tests.rs
@@ -33,10 +33,15 @@ fn failed_probe_means_context_lost() {
     );
     match v {
         Fatality::ContextLost(reason) => {
-            // The message must name BOTH the originating op and the probe, or
-            // an operator reading only the log cannot tell which call died.
+            // The message must preserve the originating operation and error,
+            // plus the probe failure. An operator reading only the log needs
+            // all three to distinguish the first failure from its sticky echo.
             assert!(reason.contains("w4a16_gemm_t launch"), "reason: {reason}");
-            assert!(reason.contains("cuStreamSynchronize"), "reason: {reason}");
+            assert!(reason.contains(STICKY_716), "reason: {reason}");
+            assert!(
+                reason.contains("cuStreamSynchronize returned 716"),
+                "reason: {reason}"
+            );
         }
         Fatality::Isolated => panic!("a failed probe must be fatal"),
     }
@@ -48,10 +53,9 @@ fn failed_probe_means_context_lost() {
 /// This is the test that forbids re-implementing classification as a
 /// string/code match. Any such implementation returns ContextLost here.
 ///
-/// PROVEN BY: replacing the body of `classify` with
-/// `if err.contains("716") { ContextLost } else { Isolated }` — the
-/// error-code allowlist an author would naturally reach for — turns this red
-/// while leaving every other test in this file green.
+/// PROVEN BY: adding a pre-match guard that returns `ContextLost` when a
+/// healthy probe accompanies error text containing `716` turns only this
+/// partition red. The failed-probe and ordinary-OOM partitions stay green.
 #[test]
 fn scary_error_text_with_a_healthy_probe_is_not_fatal() {
     assert_eq!(
@@ -62,7 +66,8 @@ fn scary_error_text_with_a_healthy_probe_is_not_fatal() {
 
 /// NEGATIVE: an ordinary recoverable failure is never fatal.
 ///
-/// PROVEN BY: the same match-arm swap as the positive case.
+/// PROVEN BY: treating `OUT_OF_MEMORY` as fatal even when the probe is healthy
+/// turns this red while the sticky-716 and failed-probe partitions stay green.
 #[test]
 fn isolated_failure_with_healthy_probe_is_not_fatal() {
     assert_eq!(
@@ -123,20 +128,26 @@ fn latch_is_first_writer_wins() {
 /// once when a context dies. Exactly one caller may be told it was first —
 /// that is what gates "log once, shut down once".
 ///
-/// PROVEN BY: replacing `self.reason.set(..).is_ok()` with a
-/// get-then-set-then-`true` sequence (i.e. every caller returns `true`) turns
-/// this red with `winners = 8`.
+/// PROVEN BY: replacing the atomic set result with `get().is_none()`, then a
+/// yield, set, and unconditional `true` lets multiple callers report first.
+/// The sequential first-writer test stays green while this test turns red.
 #[test]
 fn exactly_one_caller_wins_the_race() {
-    use std::sync::Arc;
+    use std::sync::{Arc, Barrier};
     let l = Arc::new(FaultLatch::new());
+    let start = Arc::new(Barrier::new(9));
     let winners: usize = std::thread::scope(|s| {
         let handles: Vec<_> = (0..8)
             .map(|i| {
                 let l = Arc::clone(&l);
-                s.spawn(move || usize::from(l.latch(format!("thread {i}"))))
+                let start = Arc::clone(&start);
+                s.spawn(move || {
+                    start.wait();
+                    usize::from(l.latch(format!("thread {i}")))
+                })
             })
             .collect();
+        start.wait();
         handles.into_iter().map(|h| h.join().unwrap()).sum()
     });
     assert_eq!(winners, 1, "exactly one latch call may report first");


### PR DESCRIPTION
## Summary

The GPU fault tests proved the fatality decision but allowed the originating CUDA error to disappear from the terminal diagnosis. The concurrency test also started callers opportunistically, weakening its stated race setup. This patch repairs both test oracles and makes two mutation notes match the defects actually executed.

## Broken proof

Removing the original `{err}` from `Fatality::ContextLost` left `failed_probe_means_context_lost` green. It still found the operation and probe text, even though the log had lost the status from the operation that initiated diagnosis.

Replacing atomic `OnceLock::set(...).is_ok()` ownership with check, yield, set, and unconditional success passes the sequential first-writer test. Without a coordinated release, the race fixture depended on thread startup timing rather than explicitly creating contention.

## Mutation evidence

The repaired classification test independently requires:

- `w4a16_gemm_t launch`;
- the exact original `CUDA_ERROR_MISALIGNED_ADDRESS (716)` text;
- the exact `cuStreamSynchronize returned 716` probe failure.

Replaying the original-error deletion now fails at the second observation.

The race test now blocks eight caller threads on one barrier. Restored production reports one winner. The check-then-set mutant still passes the sequential test but reports eight winners in the coordinated replay.

The healthy-probe mutation notes were also made executable and partition-specific. A 716-text fatality guard fails only the sticky-looking case; an OOM-specific guard fails only the ordinary recoverable case.

## Runtime tie

`spark-runtime/src/cuda_backend/fault_probe.rs::note_failure` passes CUDA failures through this classifier, stores the first terminal reason in the process-global latch, and uses the winning latch result to emit the terminal log once. API health, middleware, scheduler shutdown, and both process exit paths consume that state.

## Test plan

- [x] `CUDARC_CUDA_VERSION=13010 cargo test -p atlas-core --lib` (98 passed)
- [x] `CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-core/src/fault_tests.rs`
- [x] `git diff --check`
- [x] Replayed the missing-original-error mutant
- [x] Replayed the non-atomic ownership mutant and confirmed the sequential test remains green

## Notes for reviewers

- This changes only an existing `#[cfg(test)]` module.
- The direct `note_failure` FFI composition and real GPU probe timing are not claimed by these unit tests. They need a separate injected seam and hardware experiment.
- #701 currently registers three config test modules only. It does not cover `fault_tests.rs`, so the benchmark gate may continue requesting unrelated records for this PR until the narrow test-only registry is extended.
- The container-based full license command could not run because Docker is unavailable locally. The repository's single-file SPDX checker passes, and this patch does not alter the existing line-one header.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
