### PR TITLE
test(atlas-core): cover safetensor span boundaries

### DIFF
--- a/crates/atlas-core/src/safetensors.rs
+++ b/crates/atlas-core/src/safetensors.rs
@@ -146,16 +146,40 @@ mod tests {
     #[test]
     fn rejects_offset_that_overflows_u64() {
         let err = tensor_span("w", &json!([u64::MAX, u64::MAX]), 72, 4096).unwrap_err();
-        assert!(err.to_string().contains("overflows"), "{err}");
+        assert!(
+            err.to_string().contains("data_offsets[0]") && err.to_string().contains("overflows"),
+            "{err}"
+        );
+    }
+
+    /// A valid absolute start can still overflow when its nonzero length is added.
+    #[test]
+    fn rejects_span_end_that_overflows_u64() {
+        let err = tensor_span("w", &json!([u64::MAX - 1, u64::MAX]), 1, u64::MAX).unwrap_err();
+        assert!(
+            err.to_string().contains("span") && err.to_string().contains("overflows"),
+            "{err}"
+        );
     }
 
     /// Malformed `data_offsets` shapes are named, not indexed into blindly.
     #[test]
     fn rejects_malformed_offsets() {
-        assert!(tensor_span("w", &json!("nope"), 8, 4096).is_err());
-        assert!(tensor_span("w", &json!([0]), 8, 4096).is_err());
-        assert!(tensor_span("w", &json!([0, 1, 2]), 8, 4096).is_err());
-        assert!(tensor_span("w", &json!([-1, 16]), 8, 4096).is_err());
-        assert!(tensor_span("w", &json!([0.5, 16]), 8, 4096).is_err());
+        let cases = [
+            (json!("nope"), "not an array"),
+            (json!([0]), "1 entries"),
+            (json!([0, 1, 2]), "3 entries"),
+            (json!([-1, 16]), "data_offsets[0]"),
+            (json!([0.5, 16]), "data_offsets[0]"),
+            (json!([0, -1]), "data_offsets[1]"),
+            (json!([0, 16.5]), "data_offsets[1]"),
+            (json!([0, "16"]), "data_offsets[1]"),
+        ];
+        for (offsets, cause) in cases {
+            let err = tensor_span("w", &offsets, 8, 4096).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("tensor w"), "{msg}");
+            assert!(msg.contains(cause), "expected {cause} in: {msg}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

The safetensor span tests covered overflow of the absolute start but never reached overflow of the span end. They also tested malformed numeric values only in the first offset. This patch adds the missing arithmetic and JSON partitions and makes overflow diagnostics identify which addition failed.

## Broken proof

Replacing `abs_offset.checked_add(len)` with wrapping addition left all seven old tests green. A maximal absolute start plus length one wrapped to zero, passed the file bound, and returned an impossible accepted span.

Parsing a malformed `data_offsets[1]` with `unwrap_or(rel_start)` also left every old test green. All malformed numeric fixtures placed the bad value at index 0, so a bad second value could become a legal empty tensor.

The first-overflow test required only the word `overflows`, so changing its diagnostic to generic `span overflows` stayed green even though it no longer identified `data_offsets[0]`.

## Mutation evidence

- The new end-overflow fixture uses `data_start=1`, offsets `[u64::MAX - 1, u64::MAX]`, and file length `u64::MAX`. The first addition is valid and maximal; the length-one second addition must fail. The wrapping mutant returns `Ok(TensorSpan { abs_offset: u64::MAX, len: 1 })` and fails at `unwrap_err()`.
- Malformed offsets now put negative, fractional, and string values independently in index 1. The defaulting mutant returns an empty span for `[0, -1]` and fails.
- Every malformed case now requires the tensor name plus its exact array-shape or field cause.
- The first-addition overflow now requires `data_offsets[0]`. The generic diagnostic mutant fails.

## Runtime tie

`spark-runtime` turns these spans into O_DIRECT read windows. `spark-storage` publishes the same offsets and lengths in RDMA manifests. A wrapped or defaulted span therefore leaves the parser and reaches disk or peer I/O metadata.

## Test plan

- [x] `CUDARC_CUDA_VERSION=13010 cargo test -p atlas-core --lib` (99 passed)
- [x] `CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-core --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-core/src/safetensors.rs`
- [x] `git diff --check`
- [x] Replayed the wrapping end-addition mutant after confirming all old tests survived
- [x] Replayed the malformed-second-offset default mutant after confirming all old tests survived
- [x] Replayed the generic first-overflow diagnostic mutant

## Notes for reviewers

- This changes only tests in an existing production module. Span validation code is unchanged.
- Shape, dtype, and span-length composition is a separate cross-crate gap. The direct header consumers do not yet reproduce the reference safetensors validator's complete metadata checks, but that should not be folded into this offset-only PR without consumer-level partitions.
- The tests are inline in the production `safetensors.rs` file. A path-only exclusion would be unsafe because it would also hide later span-validation changes. Making this class of PR benchmark-neutral requires moving the test module to a dedicated file or a fail-closed hunk-aware policy, not registering `safetensors.rs` as test-only.
- The container-based full license command could not run because Docker is unavailable locally. The repository's single-file SPDX checker passes, and the existing line-one header is unchanged.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
