### PR TITLE
test(governance): strengthen journey ledger contracts

### DIFF
--- a/crates/atlas-governance/src/ledger_tests.rs
+++ b/crates/atlas-governance/src/ledger_tests.rs
@@ -44,23 +44,19 @@ fn tmpdir() -> std::path::PathBuf {
 fn appending_then_reading_round_trips() {
     let dir = tmpdir();
     let path = path_for(&dir, 389);
-    append(&path, &ev("aaa", 0, gate("bfcl-subset", Verdict::Missing))).unwrap();
-    append(
-        &path,
-        &ev(
-            "bbb",
-            0,
-            EventKind::State {
-                to: "gates".to_string(),
-            },
-        ),
-    )
-    .unwrap();
+    let first = ev("aaa", 0, gate("bfcl-subset", Verdict::Missing));
+    let second = ev(
+        "bbb",
+        0,
+        EventKind::State {
+            to: "gates".to_string(),
+        },
+    );
+    append(&path, &first).unwrap();
+    append(&path, &second).unwrap();
 
     let journey = read_all(&path).unwrap();
-    assert_eq!(journey.events.len(), 2);
-    assert_eq!(journey.events[0].head_sha, "aaa");
-    assert_eq!(journey.events[1].pr, 389);
+    assert_eq!(journey.events, vec![first, second]);
 }
 
 #[test]
@@ -131,6 +127,36 @@ fn different_kinds_do_not_collide() {
     assert_ne!(a.identity(), c.identity());
 }
 
+#[test]
+fn gate_identity_includes_verdict_and_diagnostics() {
+    let pass = ev("aaa", 0, gate("bfcl-subset", Verdict::Pass));
+    let fail = ev("aaa", 0, gate("bfcl-subset", Verdict::Fail));
+    let invalidated = ev(
+        "aaa",
+        0,
+        EventKind::Gate {
+            id: "bfcl-subset".into(),
+            verdict: Verdict::Pass,
+            invalidated_by: vec!["kernels/common.cu".into()],
+            detail: None,
+        },
+    );
+    let detailed = ev(
+        "aaa",
+        0,
+        EventKind::Gate {
+            id: "bfcl-subset".into(),
+            verdict: Verdict::Pass,
+            invalidated_by: Vec::new(),
+            detail: Some("record expired".into()),
+        },
+    );
+
+    for other in [&fail, &invalidated, &detailed] {
+        assert_ne!(pass.identity(), other.identity());
+    }
+}
+
 /// ★ Dedup is order-independent — the property that makes concurrent appends
 /// safe. Two CI jobs writing in either order must yield the same set, which is
 /// what "grow-only set" buys and why `merge=union` is sound.
@@ -185,6 +211,7 @@ fn blank_lines_are_tolerated() {
             .open(&path)
             .unwrap();
         writeln!(f).unwrap();
+        writeln!(f, " \t ").unwrap();
     }
     assert_eq!(read_all(&path).unwrap().events.len(), 1);
 }


### PR DESCRIPTION
## Summary

The journey ledger's round-trip test observed only three fields, gate identity tests never varied facts within one gate, and blank-line coverage did not distinguish empty from whitespace-only lines. This patch makes those live JSONL and dedup contracts explicit without changing production code.

## Broken proof

Resetting every deserialized event timestamp to zero left the old “round trip” test green. It checked only event count, the first SHA, and the second PR number.

Reducing a gate event's identity to `gate:{id}` left all previous identity and dedup tests green. Pass, fail, invalidation cause, and detail for the same gate/run/attempt could then collapse into one event.

Replacing `line.trim().is_empty()` with `line.is_empty()` also stayed green because the fixture appended only a truly empty line.

## Mutation evidence

- Round-trip verification now compares both complete `Event` values in order. The timestamp-reset mutant fails with `at: 0` versus `at: 1786200000`.
- A new same-context identity test independently varies verdict, `invalidated_by`, and detail. All three collide under the gate-ID-only mutant and remain distinct under production.
- The blank-line fixture now includes spaces and a tab. The non-trimming mutant attempts JSON parsing on that line and fails at line 3.

## Runtime tie

The ledger append and harvest binaries write and read these JSONL events. Required-gate and taxonomy code consume category status and event history from the same per-PR files. Losing a field or collapsing two gate facts changes later CI diagnosis rather than only an internal test representation.

## Test plan

- [x] `cargo test -p atlas-governance --lib` (17 passed)
- [x] `cargo clippy -p atlas-governance --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-governance/src/ledger_tests.rs`
- [x] `git diff --check`
- [x] Replayed the timestamp-loss round-trip mutant
- [x] Replayed the gate-ID-only identity mutant and confirmed the other 16 tests stayed green
- [x] Replayed the non-trimming blank-line mutant

## Notes for reviewers

- This changes one existing test file. Ledger serialization, identity, and materialization code are unchanged.
- The graph materialization tests have separate unresolved gaps and are not claimed here. In particular, adding a lexicographically earlier commit moves current sorted commit IDs, so the existing stable-ID test does not prove its name.
- #701 does not register this governance test file as test-only, so the benchmark gate may request unrelated records until the narrow registry is extended.
- The container-based full license command could not run because Docker is unavailable locally. The repository's single-file SPDX checker passes, and the existing line-one header is unchanged.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
