### PR TITLE
test(kernels): run PTX content checks on real builds

### DIFF
--- a/.github/workflows/kernel-compile.yml
+++ b/.github/workflows/kernel-compile.yml
@@ -153,11 +153,9 @@ jobs:
         run: |
           set -euo pipefail
           export PATH="$PATH_CUDA:$PATH"
-          # `atlas-kernels`'s four `#[ignore]`d tests are marked
-          # "requires nvcc and ATLAS_SKIP_BUILD unset" — which, until this
-          # workflow, described no machine in CI. They have therefore never
-          # run anywhere but a developer's box. They assert more than the
-          # file count above: every module non-empty, every module carrying a
-          # `.version` directive, >= 31 modules per resolved target, and the
-          # default-model lookup resolving.
+          # Run every registry test marked "requires nvcc and ATLAS_SKIP_BUILD
+          # unset". They assert more than the file count above: every module
+          # is non-empty, every module carries a `.version` directive, each
+          # resolved target has at least 31 modules, and default-model lookup
+          # resolves.
           cargo test -p atlas-kernels -- --ignored

--- a/crates/atlas-kernels/src/lib_tests.rs
+++ b/crates/atlas-kernels/src/lib_tests.rs
@@ -7,6 +7,7 @@
 use super::*;
 
 #[test]
+#[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
 fn all_ptx_modules_non_empty() {
     for (name, blob) in ptx_modules() {
         assert!(
@@ -33,13 +34,6 @@ fn all_ptx_modules_non_empty() {
 // `cargo test` is green; they're still exercised on a developer
 // machine via `cargo test -p atlas-kernels -- --ignored` after a
 // real PTX build.
-
-#[test]
-#[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
-fn module_count_matches_cu_files() {
-    let count = ptx_modules().len();
-    assert!(count >= 31, "Expected at least 31 PTX modules, got {count}");
-}
 
 #[test]
 #[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
@@ -150,10 +144,10 @@ fn exact_verify_snap_lookups_resolve_or_are_declared_on_every_gdn_target() {
 #[test]
 #[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
 fn ptx_for_model_lookup() {
-    let found = ptx_for_model("qwen3-next-80b");
-    assert!(
-        found.is_some(),
-        "ptx_for_model('qwen3-next-80b') should find the default target"
+    let found = ptx_for_model("qwen3-next-80b").expect("compiled qwen3-next target");
+    assert_eq!(
+        found.target.model, "qwen3-next-80b",
+        "lookup returned a different compiled target"
     );
 }
 

--- a/crates/atlas-kernels/src/lib_tests.rs
+++ b/crates/atlas-kernels/src/lib_tests.rs
@@ -146,7 +146,7 @@ fn exact_verify_snap_lookups_resolve_or_are_declared_on_every_gdn_target() {
 fn ptx_for_model_lookup() {
     let found = ptx_for_model("qwen3-next-80b").expect("compiled qwen3-next target");
     assert_eq!(
-        found.target.model, "qwen3-next-80b",
+        found.target.model, "qwen3-next-80b-a3b",
         "lookup returned a different compiled target"
     );
 }

--- a/crates/atlas-kernels/tests/kernel_arity.rs
+++ b/crates/atlas-kernels/tests/kernel_arity.rs
@@ -78,6 +78,7 @@ fn ptx_param_count(ptx: &str, kernel: &str) -> Option<usize> {
 }
 
 #[test]
+#[ignore = "requires nvcc and ATLAS_SKIP_BUILD unset"]
 fn w4a16_launch_family_arity_pins() {
     // `ATLAS_SKIP_BUILD=1` (the CI environment, and any host without nvcc)
     // makes build.rs emit a STUB `target_ptx.rs` with no compiled kernels.


### PR DESCRIPTION
## Summary

The PTX content test ran in stub CI over an empty registry and was skipped by the real nvcc workflow because that job runs only ignored tests. This patch routes the content check to the real-build runner, removes a redundant target-0 count test, and makes model lookup verify which target was returned.

## Broken proof

With `ATLAS_SKIP_BUILD=1`, `all_ptx_modules_non_empty` iterated zero modules and passed. The dedicated wildcard nvcc job invokes `cargo test -p atlas-kernels -- --ignored`, so the unignored test did not run there either. The workflow comment nevertheless claimed it checked every blob and `.version` directive.

`module_count_matches_cu_files` did not count CU files or require equality. It checked only that `ptx_modules()`, the wildcard target-0 alias, had at least 31 entries. `all_targets_have_modules` already applies that floor to every target, including target 0.

`ptx_for_model_lookup` asserted only `Some`, so a wrong compiled target could satisfy the qwen3-next lookup.

## Evidence

- After marking the content and arity tests real-build-only, stub-mode execution reports them honestly ignored instead of passing over empty registries.
- `cargo test -p atlas-kernels -- --ignored --list` now includes `all_ptx_modules_non_empty` and `w4a16_launch_family_arity_pins` with the other five compiled-registry tests.
- The redundant target-0 floor is removed; the every-target floor and workflow aggregate PTX count remain.
- The model lookup now requires the exact declared target, `found.target.model == "qwen3-next-80b-a3b"`.
- The workflow's stale fixed test count and historical claim were replaced with the actual invariants it runs.

## Runtime tie

`atlas-kernels` embeds these generated module sets into serving binaries. An empty, malformed, or incorrectly selected PTX registry changes kernel availability and model dispatch. The dedicated `nvcc -> PTX (all gb10 targets)` job is the only CI environment that can execute these checks against real generated blobs.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13010 cargo test -p atlas-kernels` (stub-dependent content and arity tests honestly ignored)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13010 cargo test -p atlas-kernels -- --ignored --list` (all 7 real-build tests registered)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-kernels --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-kernels/src/lib_tests.rs`
- [x] Parsed `.github/workflows/kernel-compile.yml` as YAML
- [x] `git diff --check`
- [x] Dedicated wildcard nvcc CI executed all six registered ignored unit tests against real PTX; five passed and the first strengthened lookup oracle exposed its wrong expected declaration
- [x] Dedicated wildcard nvcc CI passed the corrected declaration and ignored `kernel_arity` integration target against real PTX

## Notes for reviewers

- The first real nvcc run returned the correct compiled target `qwen3-next-80b-a3b`; the test had incorrectly expected `qwen3-next-80b`. Commit `da1a8149` corrects that oracle. The fresh wildcard nvcc job passed against the generated PTX registry.
- Local nvcc is a Docker-backed shim and Docker is unavailable. The dedicated CI job supplied the real PTX execution and passed at `da1a8149`.
- The removed test was subsumed only in wildcard builds, which is exactly how the dedicated job sets `ATLAS_TARGET_MODEL=*`.
- The test file is dedicated, but it is not currently registered by #701's test-only benchmark policy.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).

