### PR TITLE
test(kernels): cover case-insensitive target pins

### DIFF
--- a/crates/atlas-kernels/src/resolve_tests.rs
+++ b/crates/atlas-kernels/src/resolve_tests.rs
@@ -277,6 +277,7 @@ fn empty_match_names_never_matches() {
 fn pin_overrides_the_tie_break() {
     let c = dense_27b_fixture();
     assert_eq!(resolve_pinned(&c, "qwen3.8-27b", "qwen3_5", 5120), Ok(2));
+    assert_eq!(resolve_pinned(&c, "QWEN3.8-27B", "qwen3_5", 5120), Ok(2));
     // Pin selects even a target whose needles would NOT have matched.
     assert_eq!(resolve_pinned(&c, "qwen3.6-27b", "qwen3_5", 5120), Ok(1));
     // Wildcard declarations satisfy a pin.


### PR DESCRIPTION
## Summary

Kernel-target pin matching is implemented case-insensitively, but every existing pin fixture used exact lowercase spelling. This adds the missing case partition to the existing pin-override test.

## Broken proof

Replacing `eq_ignore_ascii_case(pin)` with exact string equality left all 15 resolver tests green. A user-provided `--kernel-target QWEN3.8-27B` would then report `PinNotFound` even though the target is compiled.

## Mutation evidence

The repaired test resolves both `qwen3.8-27b` and `QWEN3.8-27B` to candidate index 2. Replaying exact comparison makes only the uppercase assertion fail, returning the complete available-target list instead of `Ok(2)`.

## Runtime tie

`ptx_for_config` sends the CLI `--kernel-target` value through `resolve_pinned`. This pin is the explicit escape hatch for checkpoints whose path carries no identity, so spelling case must not change whether the compiled target can be selected.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13010 cargo test -p atlas-kernels 'resolve::tests::' --lib` (15 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13010 cargo clippy -p atlas-kernels --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-kernels/src/resolve_tests.rs`
- [x] `git diff --check`
- [x] Confirmed the exact-comparison mutant leaves all old resolver tests green
- [x] Replayed the same mutant after the new partition and observed `PinNotFound`

## Notes for reviewers

- One assertion is added to an existing pure, GPU-free resolver test.
- Production resolution code is unchanged.
- This dedicated test file is not currently registered by #701's test-only benchmark policy.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
