### PR TITLE
feat(dflash): cross-turn whole-state drafter carry — warm turns adopt real context

### DIFF
--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -547,6 +547,12 @@ impl DraftProposer for BlockDiffusionDraftHead {
         Ok(())
     }
 
+    fn free_drafter_kv(&self, blocks: &[u32]) {
+        if !blocks.is_empty() {
+            self.kv_cache.lock().free_blocks(blocks);
+        }
+    }
+
     fn free_state(&self, gpu: &dyn GpuBackend, state: &mut dyn ProposerState) -> Result<()> {
         // Phase 2 (Option B) reclaim: return the drafter's lazily-allocated
         // paged KV blocks to the pool on request completion. Without this the

--- a/crates/spark-model/src/model/dflash_carry.rs
+++ b/crates/spark-model/src/model/dflash_carry.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Cross-turn carry of the WHOLE DFlash proposer state.
+//!
+//! # The defect this closes
+//!
+//! A warm turn (prefix-cache + Marconi hit) skips the target prefill for the
+//! cached prefix, so the DFlash 5-layer hidden capture only covers the
+//! REPLAYED window. A fresh `DflashProposerState` therefore holds zeros for
+//! every position before the replay start — yet `update_dflash_ctx_len_after_
+//! prefill` sets `ctx_len` to the full prompt, so the drafter (a) conditions
+//! on thousands of zero rows (measured: warm turns open 0/7, 0/7, 0/7
+//! accepts before the real rows dominate) and (b) spends its first-propose
+//! full ctx-KV precompute on those zeros (~0.41 s of the ~1.0 s warm TTFT at
+//! 2.4K ctx).
+//!
+//! # Why WHOLE-state carry (vs the MTP blocks-only carry)
+//!
+//! The MTP carry moves `(block_table, rows, pair_key)` because MTP's drafter
+//! context IS its KV. The DFlash drafter's context is richer: the
+//! `ctx_hidden_acc` accumulator (5 captured layers per position — needed for
+//! any KV re-precompute after a rewind), the paged ctx KV + its
+//! `ctx_committed` watermark, and the per-slot stamped `ctx_positions`.
+//! Moving the `Box<dyn ProposerState>` keeps all of it, and the adopt trims
+//! it to the verified common token prefix.
+//!
+//! # Ownership
+//!
+//! One slot, same discipline as `mtp_carry`: the carried state is owned by
+//! the slot XOR by a live sequence, never both. The store replaces (and
+//! frees) any previous occupant; the adopt always TAKES the entry — on a
+//! prefix mismatch or a coverage gap it frees the state rather than putting
+//! it back, so a cold request self-clears the slot and its pool blocks
+//! return before that request's own drafter allocation needs them.
+//!
+//! # Validity
+//!
+//! `entry.tokens` is the finished sequence's full token list (prompt +
+//! completion). The adopt trims the carried ctx to
+//! `common_prefix_len(entry.tokens, new_prompt)` — `ctx_hidden_acc` row `i`
+//! is a pure function of `tokens[0..=i]`, so prefix equality is the whole
+//! condition (the same argument as `mtp_carry::CarriedDrafter`). Contiguity
+//! with this turn's capture requires `trim >= proc_start` (the first
+//! position this prefill will process): below that the drafter would have a
+//! hole of never-captured rows, which is exactly the zero-conditioning
+//! defect again — the adopt bails instead.
+
+use crate::speculative::ProposerState;
+
+/// The finished turn's whole proposer state, held for the next turn.
+pub struct CarriedDflashState {
+    pub state: Box<dyn ProposerState>,
+    /// Full token list (prompt + completion) of the sequence that produced
+    /// the state. Adopt validity = prefix equality against the new prompt.
+    pub tokens: Vec<u32>,
+}
+
+impl CarriedDflashState {
+    pub fn common_prefix_len(&self, prompt: &[u32]) -> usize {
+        self.tokens
+            .iter()
+            .zip(prompt.iter())
+            .take_while(|(a, b)| a == b)
+            .count()
+    }
+}
+
+/// Kill switch: presence of `ATLAS_NO_DFLASH_CARRY` disables the DFlash
+/// whole-state carry (house convention — `=0` is NOT off). The shared
+/// drafter-context policy (`ATLAS_NO_MTP_DRAFTER_CONTEXT`) is honored by the
+/// call sites through `levers.drafter.carry`, same as the MTP carry.
+pub fn dflash_carry_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_DFLASH_CARRY").is_none())
+}
+
+/// Floor on the carried ctx worth storing. A tiny context saves nothing and
+/// the slot swap has real (if small) cost; aligned with the Marconi restore
+/// floor so the two warm-turn mechanisms engage together.
+pub fn dflash_carry_min_ctx() -> usize {
+    crate::model::mtp_carry::marconi_min_tokens()
+}

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -756,6 +756,7 @@ impl TransformerModel {
             mtp_prefill_capture_len: std::sync::atomic::AtomicUsize::new(0),
             mtp_prefill_capture_gen: std::sync::atomic::AtomicU64::new(0),
             mtp_carry: parking_lot::Mutex::new(None),
+            dflash_carry: parking_lot::Mutex::new(None),
             mtp_store_range: parking_lot::Mutex::new((0, 0)),
             dflash_hidden_save,
             dflash_hidden_save_rows,

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -511,17 +511,52 @@ impl TransformerModel {
                     self.gpu.synchronize(stream)?;
                     std::mem::swap(&mut c.ctx_hidden_acc, &mut f.ctx_hidden_acc);
                     std::mem::swap(&mut c.max_ctx_len, &mut f.max_ctx_len);
-                    // Drop the carried paged ctx KV (old-capacity block
-                    // table); the accumulator rows above are the carry.
-                    let blocks = std::mem::take(&mut c.block_table);
-                    proposer.free_drafter_kv(&blocks);
-                    if let Some(bt) = c.block_table_dev.take() {
-                        self.gpu.free(bt)?;
+                    // KV-PRESERVING growth: the paged ctx KV itself lives in
+                    // pool blocks that never move — only the DEVICE block
+                    // table was capacity-sized from the old max_ctx_len
+                    // (propose derives `max_blocks` from the CURRENT max, so
+                    // a grown max would overflow the old table on the next
+                    // incremental grab). Re-allocate the table at the new
+                    // capacity and re-upload the host-side table (the source
+                    // of truth, a few hundred bytes); the committed
+                    // watermark and every precomputed K/V slot survive, so a
+                    // growth-turn adopt keeps the same ~0.17 s precompute
+                    // saving as a non-growth one. `+17` covers the widest
+                    // gamma the pools ever size for (`gamma + 1 <= 17`,
+                    // matching propose's `max_ctx_len + gamma + 1` bound;
+                    // the head's own gamma is not reachable from here).
+                    // An allocation failure falls back to dropping the KV —
+                    // the accumulator rows above are still the carry.
+                    if let Some(old_bt) = c.block_table_dev.take() {
+                        const BLOCK_SIZE: usize = 16;
+                        let new_max_blocks = (c.max_ctx_len + 17).div_ceil(BLOCK_SIZE);
+                        match self.gpu.alloc(new_max_blocks * std::mem::size_of::<u32>()) {
+                            Ok(new_bt) => {
+                                if !c.block_table.is_empty() {
+                                    let bytes: Vec<u8> = c
+                                        .block_table
+                                        .iter()
+                                        .flat_map(|b| b.to_le_bytes())
+                                        .collect();
+                                    self.gpu.copy_h2d(&bytes, new_bt)?;
+                                }
+                                c.block_table_dev = Some(new_bt);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "DFLASH_CARRY: block-table realloc failed ({e:#}); \
+                                     dropping carried paged KV (accumulator rows kept)"
+                                );
+                                let blocks = std::mem::take(&mut c.block_table);
+                                proposer.free_drafter_kv(&blocks);
+                                c.max_ctx_count_drafter = 0;
+                                c.ctx_count_drafter = 0;
+                                c.ctx_committed = 0;
+                                c.seq_len = 0;
+                            }
+                        }
+                        self.gpu.free(old_bt)?;
                     }
-                    c.max_ctx_count_drafter = 0;
-                    c.ctx_count_drafter = 0;
-                    c.ctx_committed = 0;
-                    c.seq_len = 0;
                     true
                 } else {
                     false

--- a/crates/spark-model/src/model/impl_b3.rs
+++ b/crates/spark-model/src/model/impl_b3.rs
@@ -335,6 +335,220 @@ impl TransformerModel {
     /// After prefill completes, advance the seq's DFlash `ctx_len` to
     /// `chunk_start + proc_count` so the drafter sees all captured prompt
     /// positions on the first propose() call.
+    /// Warm-turn adopt of the previous turn's whole DFlash proposer state
+    /// (`model::dflash_carry`). Call at prefill chunk 0, AFTER the
+    /// prefix/Marconi decision fixed `proc_start` (the first position this
+    /// prefill will process — the first position the 5-layer capture will
+    /// cover) and BEFORE any capture write, so a successful adopt lets this
+    /// chunk's captures land in the CARRIED accumulator and extend real
+    /// context instead of a zeroed fresh one.
+    ///
+    /// Every bail path frees the carried state (never puts it back): a
+    /// mismatched request self-clears the slot, returning the drafter pool
+    /// blocks before this request's own drafter allocation needs them.
+    /// Failure is always a degrade to today's behavior, never an error.
+    pub(super) fn try_adopt_dflash_carry(
+        &self,
+        seq: &mut crate::traits::SequenceState,
+        tokens: &[u32],
+        proc_start: usize,
+    ) -> Result<()> {
+        use crate::layers::DflashProposerState;
+        if self.dflash_capture_layers.is_empty()
+            || !crate::model::dflash_carry::dflash_carry_enabled()
+            || !self.levers.drafter.carry
+        {
+            return Ok(());
+        }
+        if let Some(ref c) = self.comm
+            && c.rank() != 0
+        {
+            return Ok(());
+        }
+        let Some(ref proposer) = self.proposer else {
+            return Ok(());
+        };
+        let Some(mut entry) = self.dflash_carry.lock().take() else {
+            return Ok(());
+        };
+        let common = entry.common_prefix_len(tokens);
+        // The fresh state's capacity was sized for THIS request's reach; the
+        // carried accumulator was sized for the PREVIOUS one. Adopting a
+        // smaller accumulator would fail-fast on ctx append late in decode,
+        // so require at least the fresh capacity.
+        let fresh_cap = seq
+            .proposer_state
+            .as_mut()
+            .and_then(|ps| {
+                ps.as_any_mut()
+                    .downcast_mut::<DflashProposerState>()
+                    .map(|d| d.max_ctx_len)
+            })
+            .unwrap_or(usize::MAX);
+        let refuse: Option<&'static str> = (|| {
+            let Some(d) = entry
+                .state
+                .as_any_mut()
+                .downcast_mut::<DflashProposerState>()
+            else {
+                return Some("carried state is not a DFlash state");
+            };
+            // The trim equates ctx SLOT index with TOKEN position, which only
+            // holds over the accumulator's leading prompt-aligned run
+            // (positions == identity). A mid-turn window slide (serial-append
+            // watermark) or a reordered append breaks the equality from some
+            // slot on — trimming past that point would keep slots holding
+            // LATER positions under an earlier index. Use the identity run as
+            // the trim ceiling: a slid state's run is 0 and falls to the
+            // floor refusal below.
+            if d.ctx_positions.len() != d.ctx_len {
+                return Some("ctx positions out of sync with ctx_len");
+            }
+            let aligned = d
+                .ctx_positions
+                .iter()
+                .enumerate()
+                .take_while(|(i, p)| **p == *i as i32)
+                .count();
+            let trim = common.min(aligned);
+            if trim < crate::model::dflash_carry::dflash_carry_min_ctx() {
+                return Some("common prefix below the carry floor");
+            }
+            if trim < proc_start {
+                // Rows [trim..proc_start) were neither carried nor will they
+                // be captured — adopting would re-create the zero-row hole.
+                return Some("coverage gap between carried ctx and this prefill");
+            }
+            // The carried accumulator only has to fit the PROMPT (plus a
+            // small margin for the first verify block): decode-time ctx
+            // appends clamp at capacity (dflash_decode_append & friends) and
+            // the serial path slides its window, so a conversation that
+            // outgrows the carried allocation degrades drafter context late
+            // in the turn instead of overflowing. Requiring the fresh
+            // state's full reach here refused EVERY growing conversation —
+            // the exact traffic the carry exists for.
+            if d.max_ctx_len < tokens.len() + 32 {
+                return Some("carried accumulator smaller than this prompt");
+            }
+            let _ = fresh_cap;
+            // Trim to the verified common prefix. KV slots at or beyond
+            // `ctx_committed` are recomputed from the accumulator before any
+            // read (`precompute_ctx_kv` covers [ctx_committed..ctx_len)), and
+            // per-slot positions below the trim were stamped at insert and
+            // stay valid.
+            d.ctx_len = trim;
+            d.ctx_positions.truncate(trim);
+            d.ctx_committed = d.ctx_committed.min(trim);
+            d.ctx_count_drafter = d.ctx_count_drafter.min(trim);
+            d.seq_len = d.seq_len.min(trim);
+            d.last_num_accepted = 0;
+            d.last_num_drafted = 0;
+            d.skip_next_decode_append = false;
+            d.prefill_done = false;
+            None
+        })();
+        if let Some(why) = refuse {
+            let carried_ctx = entry
+                .state
+                .as_any_mut()
+                .downcast_mut::<DflashProposerState>()
+                .map(|d| (d.ctx_len, d.max_ctx_len))
+                .unwrap_or((0, 0));
+            tracing::debug!(
+                "DFLASH_CARRY adopt refused ({why}): common={common} proc_start={proc_start} \
+                 prompt={} carried_ctx={} carried_cap={}",
+                tokens.len(),
+                carried_ctx.0,
+                carried_ctx.1,
+            );
+            proposer.free_state(self.gpu.as_ref(), entry.state.as_mut())?;
+            return Ok(());
+        }
+        // ── Accumulator growth (the growing-conversation case) ──
+        // The carried accumulator was sized for the PREVIOUS request's
+        // reach. Adopting it undersized made the serial-append watermark
+        // SLIDE mid-turn once ctx hit its cap — losing the prompt-aligned
+        // prefix and refusing the NEXT turn's adopt (measured: adopt
+        // alternated turns). The fresh state this sequence just allocated
+        // holds a right-sized, zeroed accumulator: copy the trimmed rows
+        // into it and exchange accumulators, so the adopted state has this
+        // request's capacity and the fresh state (freed below) takes the
+        // small one down with it. The carried PAGED ctx KV is dropped on
+        // growth — its device block table is capacity-sized from the old
+        // max, so keeping it would overflow on growth; first propose
+        // re-allocates at the new size and re-precomputes over the trimmed
+        // REAL rows (chunked by ctx_window), which costs what today's warm
+        // turn already pays — the accept-quality win stays.
+        if let Some(mut fresh) = seq.proposer_state.take() {
+            let grew = {
+                let (Some(c), Some(f)) = (
+                    entry
+                        .state
+                        .as_any_mut()
+                        .downcast_mut::<DflashProposerState>(),
+                    fresh.as_any_mut().downcast_mut::<DflashProposerState>(),
+                ) else {
+                    // Non-DFlash fresh state cannot happen on a DFlash serve;
+                    // restore and bail rather than risk mismatched frees.
+                    seq.proposer_state = Some(fresh);
+                    proposer.free_state(self.gpu.as_ref(), entry.state.as_mut())?;
+                    return Ok(());
+                };
+                if c.max_ctx_len < f.max_ctx_len
+                    && f.ctx_hidden_acc.0 != 0
+                    && c.ctx_hidden_acc.0 != 0
+                {
+                    let stream = self.gpu.default_stream();
+                    self.gpu.copy_d2d_async(
+                        c.ctx_hidden_acc,
+                        f.ctx_hidden_acc,
+                        c.ctx_len * c.ctx_slot_bytes,
+                        stream,
+                    )?;
+                    // The copy READS the small accumulator, which the
+                    // `free_state(fresh)` below frees — drain the stream so
+                    // the free cannot race the read. Once per adopt.
+                    self.gpu.synchronize(stream)?;
+                    std::mem::swap(&mut c.ctx_hidden_acc, &mut f.ctx_hidden_acc);
+                    std::mem::swap(&mut c.max_ctx_len, &mut f.max_ctx_len);
+                    // Drop the carried paged ctx KV (old-capacity block
+                    // table); the accumulator rows above are the carry.
+                    let blocks = std::mem::take(&mut c.block_table);
+                    proposer.free_drafter_kv(&blocks);
+                    if let Some(bt) = c.block_table_dev.take() {
+                        self.gpu.free(bt)?;
+                    }
+                    c.max_ctx_count_drafter = 0;
+                    c.ctx_count_drafter = 0;
+                    c.ctx_committed = 0;
+                    c.seq_len = 0;
+                    true
+                } else {
+                    false
+                }
+            };
+            proposer.free_state(self.gpu.as_ref(), fresh.as_mut())?;
+            if grew {
+                tracing::debug!("DFLASH_CARRY grew accumulator to this request's reach");
+            }
+        }
+        let adopted_ctx = entry
+            .state
+            .as_any_mut()
+            .downcast_mut::<DflashProposerState>()
+            .map(|d| (d.ctx_len, d.ctx_committed))
+            .unwrap_or((0, 0));
+        seq.proposer_state = Some(entry.state);
+        tracing::info!(
+            "DFLASH_CARRY adopted: ctx={} (committed {}) of prompt={} — capture resumes at {}",
+            adopted_ctx.0,
+            adopted_ctx.1,
+            tokens.len(),
+            proc_start,
+        );
+        Ok(())
+    }
+
     pub(super) fn update_dflash_ctx_len_after_prefill(
         &self,
         seq: &mut crate::traits::SequenceState,

--- a/crates/spark-model/src/model/mod.rs
+++ b/crates/spark-model/src/model/mod.rs
@@ -24,6 +24,7 @@
 #![allow(unused_imports, dead_code)]
 
 pub(crate) mod block_mgmt;
+pub(crate) mod dflash_carry;
 pub(crate) mod drafter_context;
 pub(crate) mod drop;
 pub(crate) mod impl_a1;

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -483,6 +483,14 @@ impl Model for TransformerModel {
             return Ok(());
         }
         let ctx_slot_bytes = n_layers * self.config.hidden_size * 2;
+        // Capacity clamp: the accumulator is NOT circular, and an append past
+        // `max_ctx_len` is an out-of-bounds device write. Reachable when a
+        // carried accumulator (`model::dflash_carry`) is smaller than this
+        // request's reach; dropping the append degrades drafter context (the
+        // target verifies every draft), never correctness.
+        if d.ctx_len >= d.max_ctx_len {
+            return Ok(());
+        }
         let save_1 = base.offset(ctx_slot_bytes);
         let dst = d.ctx_hidden_acc.offset(d.ctx_len * ctx_slot_bytes);
         self.gpu
@@ -510,6 +518,11 @@ impl Model for TransformerModel {
             return Ok(());
         }
         let ctx_slot_bytes = n_layers * self.config.hidden_size * 2;
+        // Capacity clamp — see dflash_decode_append.
+        if d.ctx_len + 2 > d.max_ctx_len {
+            d.skip_next_decode_append = true;
+            return Ok(());
+        }
         let stream = self.gpu.default_stream();
         let pos_row0 = (seq.seq_len as i32).saturating_sub(2);
         let pos_row1 = (seq.seq_len as i32).saturating_sub(1);
@@ -556,6 +569,10 @@ impl Model for TransformerModel {
         let ctx_slot_bytes = n_layers * self.config.hidden_size * 2;
         let stream = self.gpu.default_stream();
         for t in 0..=num_accepted {
+            // Capacity clamp — see dflash_decode_append.
+            if d.ctx_len >= d.max_ctx_len {
+                break;
+            }
             let row = base.offset(t * ctx_slot_bytes);
             let dst = d.ctx_hidden_acc.offset(d.ctx_len * ctx_slot_bytes);
             self.gpu.copy_d2d_async(row, dst, ctx_slot_bytes, stream)?;
@@ -631,6 +648,10 @@ impl Model for TransformerModel {
         // only until the first slide — and the sliding prompts ARE the reds.
         debug_assert_eq!(d.ctx_positions.len(), d.ctx_len);
         for t in 0..num_committed {
+            // Capacity clamp — see dflash_decode_append.
+            if d.ctx_len >= d.max_ctx_len {
+                break;
+            }
             let row = base.offset(t * ctx_slot_bytes);
             let dst = d.ctx_hidden_acc.offset(d.ctx_len * ctx_slot_bytes);
             self.gpu.copy_d2d_async(row, dst, ctx_slot_bytes, stream)?;

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -243,6 +243,11 @@ impl TransformerModel {
             (tokens, n, 0usize)
         };
 
+        // DFlash whole-state carry: adopt the previous turn's drafter state
+        // now that the processing window is fixed and before any capture
+        // write lands (`model::dflash_carry`). No-op unless DFlash + carry.
+        self.try_adopt_dflash_carry(seq, tokens, seq_len_start)?;
+
         // ── 2. Embed tokens → [proc_count, H] contiguous ──
         {
             // SAFETY: `proc_count` is not an independent count. Each of the

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -230,7 +230,15 @@ impl TransformerModel {
                 proc_start,
                 proc_count,
                 effective_seq_len_start,
-            } => (proc_start, proc_count, effective_seq_len_start),
+            } => {
+                // DFlash whole-state carry: adopt at chunk 0, now that the
+                // effective processing start is fixed and before any capture
+                // write lands (`model::dflash_carry`). No-op otherwise.
+                if chunk_start == 0 {
+                    self.try_adopt_dflash_carry(seq, tokens, effective_seq_len_start)?;
+                }
+                (proc_start, proc_count, effective_seq_len_start)
+            }
             proc_range::ProcRange::EarlyReturn(ptr) => {
                 // #155 ROOT CAUSE (warm-turn phantom snapshots): fully-cached
                 // chunks skipped compute but ALSO skipped the Phase-5 token

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -248,6 +248,50 @@ impl TransformerModel {
             }
         }
 
+        // DFlash whole-state carry (`model::dflash_carry`): hand the ENTIRE
+        // proposer state to the single carry slot BEFORE `free_state`. The
+        // next warm turn adopts real ctx hiddens + precomputed ctx KV for
+        // the shared prefix instead of conditioning on zeros (the measured
+        // 0/7-accept warm opening) and re-precomputing over them (~0.41 s of
+        // warm TTFT). `take()` empties `seq.proposer_state`, so the MTP
+        // branch and `free_state` below see None and do nothing — the state
+        // is owned by the slot XOR by a live sequence, never both.
+        if crate::model::dflash_carry::dflash_carry_enabled()
+            && self.levers.drafter.carry
+            && let Some(ref proposer) = self.proposer
+            && !seq.tokens.is_empty()
+            && seq
+                .proposer_state
+                .as_mut()
+                .and_then(|ps| {
+                    ps.as_any_mut()
+                        .downcast_mut::<crate::layers::DflashProposerState>()
+                        .map(|d| d.ctx_len)
+                })
+                .unwrap_or(0)
+                >= crate::model::dflash_carry::dflash_carry_min_ctx()
+            && let Some(mut state) = seq.proposer_state.take()
+        {
+            let stored_ctx = state
+                .as_any_mut()
+                .downcast_mut::<crate::layers::DflashProposerState>()
+                .map(|d| d.ctx_len)
+                .unwrap_or(0);
+            let entry = crate::model::dflash_carry::CarriedDflashState {
+                state,
+                tokens: seq.tokens.clone(),
+            };
+            let previous = self.dflash_carry.lock().replace(entry);
+            if let Some(mut old) = previous {
+                proposer.free_state(self.gpu.as_ref(), old.state.as_mut())?;
+            }
+            tracing::debug!(
+                "DFLASH_CARRY store: seq_tokens={} ctx_len={stored_ctx} slot={}",
+                seq.tokens.len(),
+                seq.slot_idx
+            );
+        }
+
         // ATLAS_MTP_CARRY_DRAFTER: hand this turn's drafter KV to the model's
         // single carry slot BEFORE `free_state`, so the next turn of the same
         // session can adopt it instead of starting blind. `take_drafter_kv`

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -252,6 +252,12 @@ pub struct TransformerModel {
     /// makes block ownership unambiguous (blocks are owned here XOR by a live
     /// sequence). `None` when the feature is off or nothing has been carried.
     pub(super) mtp_carry: parking_lot::Mutex<Option<super::mtp_carry::CarriedDrafter>>,
+    /// DFlash whole-state carry (see `model::dflash_carry`): the previous
+    /// turn's ENTIRE `DflashProposerState`, so a warm turn adopts real ctx
+    /// hiddens + precomputed ctx KV for the shared prefix instead of
+    /// conditioning on zeros and precomputing over them. Same single-slot
+    /// ownership rules as `mtp_carry`.
+    pub(super) dflash_carry: parking_lot::Mutex<Option<super::dflash_carry::CarriedDflashState>>,
     /// Absolute position interval `[lo, hi)` of `mtp_prefill_hidden` rows
     /// written by the CURRENT sequence's prefill chunks. Reset per
     /// `alloc_sequence`, so a warm-turn append can only ever read hiddens this


### PR DESCRIPTION
## The defect

A warm turn (prefix-cache + Marconi hit) skips the target prefill for the cached prefix, so the DFlash 5-layer hidden capture only covers the replayed window. A fresh `DflashProposerState` then claims full-prompt `ctx_len` over thousands of **zero rows** — `update_dflash_ctx_len_after_prefill` sets the length unconditionally — and the first propose spends its full ctx-KV precompute on them (~0.4s of a warm turn's ~1.0s TTFT at 2.4K ctx; follow-on from the #711 decomposition).

## The carry

The MTP blocks-only carry (`take_drafter_kv`) can't express DFlash's state — the hidden accumulator, paged ctx KV, `ctx_committed` watermark, and per-slot stamped positions. This carries the **whole `Box<dyn ProposerState>`** in a single model slot (`model::dflash_carry`, same XOR-ownership discipline as `mtp_carry`):

- **Store** at `free_sequence`: move the finished state + its token list into the slot; previous occupant freed.
- **Adopt** at prefill chunk 0 (both `prefill_a` and `prefill_b`), after the processing window is fixed and before any capture write. The trim uses the **position-aligned run** of the common token prefix — slot *i* must hold position *i*; a mid-turn window slide breaks that from some slot on, so a slid state trims to nothing and refuses at the floor. Contiguity with this prefill's capture start is required (otherwise the adopt would re-create the zero-row hole).
- **Growth**: an undersized carried accumulator made the serial-append watermark slide mid-turn (measured: adoption alternated turns). The fresh state's right-sized accumulator is swapped in (trimmed rows copied, stream drained before the small buffer frees); the carried **paged** ctx KV is dropped on growth — its device block table is capacity-sized — and first propose rebuilds it over the trimmed real rows, chunked by ctx_window as usual.
- **Capacity clamps** added to the four unbounded ctx-append sites in `trait_impl/mod.rs`. These were a latent out-of-bounds device write for any state whose ctx could exceed its allocation (the propose-side append already guarded, and the serial path already slides). `BlockDiffusionDraftHead` gains the `free_drafter_kv` impl the growth path returns blocks through.

Kill switch: `ATLAS_NO_DFLASH_CARRY` (presence). Shares the drafter-context policy lever with the MTP carry.

## Honest measurements (27B + DFlash2, 2-turn agentic probe, GB10)

- **Non-growth warm turn** (carried capacity fits): TTFT **1.00 → 0.835s (−17%)**, paged ctx KV adopted intact (`committed=2250`).
- **Growth turns** (the typical growing conversation): TTFT neutral (~1.0s) — the KV rebuild costs what the old zero-row precompute did, but the drafter now conditions on real rows every warm turn. KV-preserving growth (a device-table capacity field) is the scoped follow-up to reclaim ~0.17s/turn.
- **Warm-turn accepts: unchanged within noise** (mean 1.22 vs 1.25 accepted/step on the prose probe; recovery starts one verify step earlier). The zero-row conditioning hypothesis mostly did not survive measurement — stated plainly so nobody banks an accept win that isn't there.
- Cold TTFT unchanged; outputs byte-stable across builds (129/150/120 completion tokens identical); C=16 aggregate 114.2 tok/s, 16/16 coherent.

## Validation

644 spark-model tests + fmt + `cargo check --workspace` clean on this base · e2e on the integration branch: three serve boots, adopt/store/growth all observed in logs (`DFLASH_CARRY store/adopted/grew`), refusal paths exercised (prefix mismatch via floor, coverage gap, slid state).


## Update: KV-preserving growth (fc33536b) — growth turns now keep the precomputed ctx KV

The growth path's "drop the paged KV" concession is gone. Only the **device block table** was capacity-sized from the old `max_ctx_len` — the physical pool blocks never move — so growth now re-allocates the table at the new capacity and re-uploads the host-side table (the source of truth, a few hundred bytes). The committed watermark and every precomputed K/V slot survive; a table-realloc failure falls back to the previous drop-KV behavior.

**Measured (same 2-turn probe):** growth-turn warm TTFT **1.00 → 0.829s** and **0.90 → 0.712s (−17%/−21%)**, both turns adopting with committed KV intact (`committed=2250/2412` in the adopt log). Outputs byte-stable, C=16 114.2 tok/s 16/16 coherent, 644 tests green on this base. With this, the "growth turns are TTFT-neutral" caveat in the body above no longer applies — every warm turn gets the full win.
