### PR TITLE
fix(metrics): the SSM gauge read an orphaned counter — feed it the real Marconi pool

### DIFF
--- a/crates/spark-model/src/model/ssm_snapshot.rs
+++ b/crates/spark-model/src/model/ssm_snapshot.rs
@@ -107,6 +107,17 @@ pub(crate) struct SsmSnapshotPool {
 }
 
 impl SsmSnapshotPool {
+    /// Marconi occupancy: `(slots holding a live snapshot, total LRU
+    /// slots)`. The decode-rollback ring region is deliberately excluded —
+    /// it is deterministically addressed per sequence, not a cache whose
+    /// fullness means anything.
+    pub(super) fn occupancy(&self) -> (usize, usize) {
+        (
+            self.num_slots - self.free_slots.lock().len().min(self.num_slots),
+            self.num_slots,
+        )
+    }
+
     /// Build the snapshot pool.
     ///
     /// `num_slots` sizes the Marconi LRU region; `decode_ring_slots` ×

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -794,6 +794,10 @@ impl Model for TransformerModel {
     fn num_total_blocks(&self) -> usize {
         self.num_total_blocks_dispatch()
     }
+    fn ssm_snapshot_occupancy(&self) -> Option<(u32, u32)> {
+        let (used, total) = self.ssm_snapshots.occupancy();
+        (total > 0).then_some((used as u32, total as u32))
+    }
     fn reclaim_prefix_blocks(&self, num_blocks: usize) -> usize {
         self.reclaim_prefix_blocks_dispatch(num_blocks)
     }

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -1110,6 +1110,16 @@ pub trait Model: Send + Sync {
         0
     }
 
+    /// Marconi SSM snapshot-pool occupancy `(used, total)`. `None` for
+    /// models without a snapshot pool (non-SSM, CPU backends) — so metrics
+    /// consumers can fall back instead of rendering a fake 0/0. The TUI's
+    /// SSM gauge read the orphaned `SessionSsmManager` (whose
+    /// `save_snapshot` was never called anywhere) and showed 0/0 forever;
+    /// this accessor is the truth it now reads.
+    fn ssm_snapshot_occupancy(&self) -> Option<(u32, u32)> {
+        None
+    }
+
     /// Reclaim up to `num_blocks` blocks from the prefix cache, returning how
     /// many actually became free.
     ///

--- a/crates/spark-server/src/api/chat_stream/handle_token.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_token.rs
@@ -419,6 +419,13 @@ fn handle_token_inner(state: &mut StreamState, ctx: &StreamCtx, tok: u32) -> Del
     let stable_end = state.content_decoded.len();
     let _ = tok; // tok already in state.all_toks via line 86
     let mut delta = if stable_end > state.emitted {
+        // TTFT forensics: the moment the FIRST stable content bytes exist
+        // stream-side. Compare against the scheduler's "Prefill first
+        // token" and the client's first-delta wall time to attribute any
+        // emission-path latency (task: first-delta gap).
+        if state.emitted == 0 {
+            tracing::debug!("stream: first stable content delta ({stable_end} bytes)");
+        }
         let raw = state.content_decoded[state.emitted..stable_end].to_string();
         state.emitted = stable_end;
         raw

--- a/crates/spark-server/src/openai/encode_stream.rs
+++ b/crates/spark-server/src/openai/encode_stream.rs
@@ -160,7 +160,15 @@ pub(crate) fn encode_sse_response(
     let done_event = futures::stream::once(async {
         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
     });
+    // TTFT forensics twin of handle_token's first-delta line: the moment
+    // the first delta reaches the SSE encoder (i.e. hyper polled it off the
+    // channel). A gap between the two lines is channel/scheduling latency;
+    // a gap from here to the client is wire/client-side.
+    let first_event_logged = std::cell::Cell::new(false);
     let token_stream = deltas.flat_map(move |d| {
+        if !first_event_logged.replace(true) {
+            tracing::debug!("stream: first delta reaches the SSE encoder");
+        }
         let events: Vec<Result<Event, std::convert::Infallible>> =
             delta_to_chunk_events(&d, &model, &chunk_id, include_usage)
                 .into_iter()

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -456,8 +456,20 @@ pub fn run(
                 pending_len: new_reqs.len() as u32,
                 kv_blocks_free: model.num_free_blocks() as u32,
                 kv_blocks_total: model.num_total_blocks() as u32,
-                ssm_slots_used: session_manager.session_count() as u32,
-                ssm_slots_total: session_manager.total_slots() as u32,
+                // The REAL Marconi pool occupancy. This used to read
+                // `session_manager.{session_count,total_slots}` — but
+                // `SessionSsmManager::save_snapshot` has no callers, so both
+                // were 0 forever and the TUI's SSM gauge rendered 0/0 on
+                // every serve (user-reported 2026-08-22). Fall back to the
+                // orphaned counters only when the model has no pool.
+                ssm_slots_used: model
+                    .ssm_snapshot_occupancy()
+                    .map(|(u, _)| u)
+                    .unwrap_or(session_manager.session_count() as u32),
+                ssm_slots_total: model
+                    .ssm_snapshot_occupancy()
+                    .map(|(_, t)| t)
+                    .unwrap_or(session_manager.total_slots() as u32),
                 mtp_mode,
                 delivered_tps,
                 steps_total: snapshot_steps,


### PR DESCRIPTION
## The bug

The scheduler snapshot's `ssm_slots_used` / `ssm_slots_total` — the numbers behind the TUI's SSM gauge and any metrics consumer — were fed from `SessionSsmManager::{session_count, total_slots}`. But **`SessionSsmManager::save_snapshot` has no callers anywhere in the tree**, so both counters have been zero for the manager's entire life (its `evict_expired` loop is equally inert). The gauge rendered **0/0 on every serve, always** (user-reported), while the actual pool — `SsmSnapshotPool`, 16 Marconi slots on the DFlash recipe — saved and restored snapshots on every warm turn with nothing reporting it.

## The fix

- `SsmSnapshotPool` grows an `occupancy()` accessor: `(num_slots − free, num_slots)`, Marconi region only — the decode-rollback ring is deterministically addressed per sequence, so its fullness means nothing and is deliberately excluded.
- The `Model` trait exposes `ssm_snapshot_occupancy() -> Option<(u32, u32)>` — `None` for pool-less models (non-SSM, CPU backends), so consumers can fall back instead of faking a 0/0.
- The scheduler snapshot reads the model's occupancy, with the orphaned session-manager counters kept only as the pool-less fallback. The orphaned state of `SessionSsmManager` is documented at the site rather than removed — whether to retire the manager entirely is a separate decision.

## Also included

Two permanent one-line-per-stream `tracing::debug!` forensics for a TTFT investigation in flight (the client's first SSE delta lands ~0.5s after the scheduler emits the first token, with every hop statically immediate): `handle_token` logs the first stable content delta, `encode_stream` logs the first delta reaching the SSE encoder. Together with the existing scheduler line they triangulate channel-wait vs wire vs client. Debug level, silent at the production `RUST_LOG=info`.

## Validation

3,056 spark-server + spark-model tests pass on this base (the one failure is the known local-environment `closure_attestation` quirk that CI runs green) · fmt clean · verified live on the integration branch: the gauge reports real occupancy after a warm turn.
