### PR TITLE
test(kernels): make shadow source scans nonvacuous

### DIFF
--- a/crates/atlas-kernels/tests/kernel_shadow_detector.rs
+++ b/crates/atlas-kernels/tests/kernel_shadow_detector.rs
@@ -153,12 +153,18 @@ fn every_common_source_declares_at_least_one_entry_point() {
     let mut checked = 0usize;
     let mut empty = Vec::new();
     for (hw, ext) in HW_SOURCE_EXT {
+        let mut hardware_checked = 0usize;
         for file in sources(&root.join(hw).join("common"), ext) {
             checked += 1;
+            hardware_checked += 1;
             if entry_points(&file).is_empty() {
                 empty.push(file.strip_prefix(&root).unwrap().display().to_string());
             }
         }
+        assert!(
+            hardware_checked > 0,
+            "no {ext} common sources found for {hw}: wrong extension or root?"
+        );
     }
     assert!(
         checked > 100,


### PR DESCRIPTION
## Summary

The shadow detector claimed to scan every configured hardware source tree, but its only reachability guard was one aggregate count. This adds a per-hardware non-vacuity assertion while retaining the existing repository-wide floor.

## Broken proof

Changing the Metal entry in `HW_SOURCE_EXT` from `("metal", "metal")` to `("metal", "cu")` removed all 43 Metal sources from the scan. The old test still passed because 181 GB10, Strix, and Strix-HIP sources remained, clearing `checked > 100` without checking one Metal entry point.

## Mutation evidence

With the per-hardware assertion, the same wrong-extension mutant fails with:

`no cu common sources found for metal: wrong extension or root?`

The restored mapping passes all four hardware partitions and the original aggregate floor. A separate real-tree probe added one temporary common `rms_norm` entry point; the sibling drift test rejected nine model shadows and named the effective `norm` module plus the missing symbol.

## Runtime tie

`build.rs` uses the same `build_shadow.rs` resolver to populate `TargetPtxSet::shadowed_dropped`. Startup kernel diagnostics use that list to distinguish a model shadow that dropped a common kernel from a kernel that never existed for the architecture. A hardware tree silently omitted from this scan recreates the empty-set blind spot the detector was introduced to prevent.

## Test plan

- [x] `cargo test -p atlas-kernels --test kernel_shadow_detector` (4 passed)
- [x] `cargo clippy -p atlas-kernels --test kernel_shadow_detector -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-kernels/tests/kernel_shadow_detector.rs`
- [x] `git diff --check`
- [x] Confirmed the wrong Metal extension passes the old aggregate oracle
- [x] Replayed the same mutant after the repair and observed the hardware-specific failure

## Notes for reviewers

- One dedicated Cargo integration-test file changes; production code and kernel sources do not.
- #701 is merged, but its exact registry currently covers cfg-test modules, not Cargo integration-test targets. The benchmark result on this PR is evidence for that remaining policy boundary.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).

