### PR TITLE
test(kernels): make target tree scans nonvacuous

### DIFF
--- a/crates/atlas-kernels/tests/target_resolution.rs
+++ b/crates/atlas-kernels/tests/target_resolution.rs
@@ -254,10 +254,12 @@ fn every_colliding_target_declares_match_names() {
                 .push(t);
         }
     }
+    let mut colliding_groups = 0usize;
     for ((model_type, hidden), group) in by_pair {
         if group.len() < 2 {
             continue;
         }
+        colliding_groups += 1;
         for t in group {
             assert!(
                 !t.match_names.is_empty(),
@@ -267,6 +269,10 @@ fn every_colliding_target_declares_match_names() {
             );
         }
     }
+    assert!(
+        colliding_groups >= 2,
+        "expected the Nemotron and dense-27B collision groups, saw {colliding_groups}"
+    );
 }
 
 /// Mirror of build.rs's dominated-needle check: within a colliding
@@ -291,7 +297,11 @@ fn no_colliding_target_is_needle_dominated() {
                 .push(t);
         }
     }
+    let mut colliding_groups = 0usize;
     for ((model_type, hidden), group) in by_pair {
+        if group.len() >= 2 {
+            colliding_groups += 1;
+        }
         for a in &group {
             for b in &group {
                 if a.name == b.name {
@@ -312,6 +322,10 @@ fn no_colliding_target_is_needle_dominated() {
             }
         }
     }
+    assert!(
+        colliding_groups >= 2,
+        "expected the Nemotron and dense-27B collision groups, saw {colliding_groups}"
+    );
 }
 
 /// The (qwen3_6_moe, 5120) belt-and-braces tier — the hypothetical MoE
@@ -339,10 +353,12 @@ fn qwen36_moe_beltandbraces_tier_resolves_uncontested() {
 fn kernel_source_redirects_are_wellformed() {
     let parsed = parse_targets();
     let names: Vec<&str> = parsed.iter().map(|t| t.name).collect();
+    let mut redirects = 0usize;
     for t in &parsed {
         let Some(src) = &t.kernel_source else {
             continue;
         };
+        redirects += 1;
         assert!(
             names.contains(&src.as_str()),
             "{}: kernel_source '{src}' names no gb10 target",
@@ -360,6 +376,7 @@ fn kernel_source_redirects_are_wellformed() {
             t.name
         );
     }
+    assert!(redirects > 0, "no kernel_source redirects were checked");
 }
 
 /// qwen3.8-27b exists, reuses qwen3.6-27b's kernels, and keeps the


### PR DESCRIPTION
## Summary

Three tree-wide target-declaration tests could pass after checking no collision groups or no source redirects. This adds explicit non-vacuity to each owning loop.

## Broken proof

Clearing the map immediately before either collision loop left its old test green. Defaulting every parsed `kernel_source` to `None` also left the redirect test green. In all three cases, the assertion body was sound but unreachable.

The checked-in tree currently contains two intentional collision groups:

- `(nemotron_h_puzzle, 4096)` for Puzzle and Super
- `(qwen3_5, 5120)` for Qwen3.6 and Qwen3.8

It also contains one source redirect, Qwen3.8 to Qwen3.6.

## Mutation evidence

- Clearing `by_pair` now makes `every_colliding_target_declares_match_names` fail with zero groups.
- Clearing its independent map now makes `no_colliding_target_is_needle_dominated` fail with zero groups.
- Defaulting parsed redirects to `None` now fails with `no kernel_source redirects were checked`.

Restoring the parser yields ten passing target-resolution integration tests. The two collision assertions remain separate because they own different claims: nonempty identity needles and absence of dominated needles.

## Runtime tie

These tests parse the MODEL.toml declarations used by `build.rs`. The declarations decide compiled target routing, source-tree reuse, sampling presets, and behavior selection. A vacuous tree scan can report the routing registry healthy after the parser stops exposing the data it was meant to validate.

## Test plan

- [x] `cargo test -p atlas-kernels --test target_resolution` (10 passed)
- [x] `cargo clippy -p atlas-kernels --test target_resolution -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_spdx.py crates/atlas-kernels/tests/target_resolution.rs`
- [x] `git diff --check`
- [x] Confirmed all three zero-work mutants pass their old tests
- [x] Replayed the same mutants after repair and observed exact non-vacuity failures

## Notes for reviewers

- One dedicated Cargo integration-test file changes; production code and MODEL.toml data do not.
- The lower bound names the two collision groups that the integration suite already treats as fleet contracts. Additional valid collision groups still pass.
- #701 is merged, but its exact registry currently covers cfg-test modules, not Cargo integration-test targets. The benchmark result on this PR is evidence for that remaining policy boundary.
- Authorship: AI-generated under an RST-guided mutation audit; human review requested.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/Avarok-Cybersecurity/atlas/blob/main/CLA.md).
