### PR TITLE
test(plugin): prove unchanged assets are not rewritten

### DIFF
--- a/crates/atlas-plugin/src/artifacts.rs
+++ b/crates/atlas-plugin/src/artifacts.rs
@@ -156,13 +156,37 @@ mod tests {
     #[test]
     fn write_asset_rewrites_only_on_change() {
         let dir = tmp("asset");
+        let path = dir.join("s.py");
         assert!(write_asset(&dir, "s.py", "print(1)").unwrap());
+
+        let old = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(old))
+            .unwrap();
+        let pinned_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+
         assert!(!write_asset(&dir, "s.py", "print(1)").unwrap());
-        assert!(write_asset(&dir, "s.py", "print(2)").unwrap());
         assert_eq!(
-            std::fs::read_to_string(dir.join("s.py")).unwrap(),
-            "print(2)"
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            pinned_mtime,
+            "unchanged contents must not rewrite the asset"
         );
+        assert!(write_asset(&dir, "s.py", "print(2)").unwrap());
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "print(2)");
+    }
+
+    #[test]
+    fn binary_assets_are_compared_as_bytes() {
+        let dir = tmp("binary-asset");
+        let path = dir.join("image.bin");
+        let bytes = [0xff, 0x00, 0xfe];
+
+        assert!(write_asset_bytes(&dir, "image.bin", &bytes).unwrap());
+        assert!(!write_asset_bytes(&dir, "image.bin", &bytes).unwrap());
+        assert_eq!(std::fs::read(path).unwrap(), bytes);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`write_asset_rewrites_only_on_change` accepted the helper's `false` return value as proof that no write occurred. The test now pins the existing file's modification time and verifies that an identical write leaves it unchanged.

The byte helper also had no invalid UTF-8 fixture even though vision and video provisioning use it for binary assets. A focused test now writes invalid UTF-8 bytes twice and requires the second comparison to be unchanged.

## Broken proof

- Adding a real `std::fs::write` immediately before the existing `Ok(false)` return left the old test green. The repaired test fails because the pinned modification time changes.
- Replacing `std::fs::read` with `read_to_string` left all three old artifact tests green. The new binary test fails because invalid UTF-8 can no longer be compared and is reported as rewritten.

Both mutants were replayed independently. Restoring production makes all four artifact tests pass.

## Runtime tie

BFCL and MLPerf provisioning use the text helper for shipped scripts and requirements. Vision and video provisioning use the byte helper for media assets. Unnecessary rewrites churn mtimes used by downstream provisioning stamps; treating binary files as text causes every load to rewrite them.

This PR changes only test observations. It does not change artifact paths, write behavior, or stamp semantics.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-plugin artifacts::tests --lib` (4 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-plugin --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh`
- [x] `typos`
- [x] Full `atlas-plugin` library run reached 817 passes

## Notes for reviewers

The full library run also hit two process-reaping failures on this macOS host: `a_setsid_server_is_left_for_the_reaper` and `a_detached_survivor_in_the_sandbox_is_reaped`. Both fail again when run alone, and this branch has no diff under `benchmarks/agentic`. They are not counted as passing validation for this PR and will be audited in their declaration-order turn.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
