### PR TITLE
test(plugin): reject impossible benchmark dates

### DIFF
--- a/crates/atlas-plugin/src/benchmark_desc_tests.rs
+++ b/crates/atlas-plugin/src/benchmark_desc_tests.rs
@@ -15,7 +15,7 @@ fn every_benchmark_declares_an_updated_date() {
         assert_eq!(d.updated.len(), 10, "{}: {:?}", d.id, d.updated);
         let parts: Vec<&str> = d.updated.split('-').collect();
         assert_eq!(parts.len(), 3, "{}: {:?}", d.id, d.updated);
-        for p in parts {
+        for p in &parts {
             assert!(
                 p.chars().all(|c| c.is_ascii_digit()),
                 "{}: {:?} is not a date",
@@ -23,5 +23,27 @@ fn every_benchmark_declares_an_updated_date() {
                 d.updated
             );
         }
+
+        let year: u32 = parts[0].parse().unwrap();
+        let month: u32 = parts[1].parse().unwrap();
+        let day: u32 = parts[2].parse().unwrap();
+        #[allow(
+            clippy::manual_is_multiple_of,
+            reason = "keep the workspace's Rust 1.85 MSRV"
+        )]
+        let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+        let days_in_month = match month {
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            4 | 6 | 9 | 11 => 30,
+            2 if leap => 29,
+            2 => 28,
+            _ => panic!("{}: {:?} has no such month", d.id, d.updated),
+        };
+        assert!(
+            (1..=days_in_month).contains(&day),
+            "{}: {:?} has no such day",
+            d.id,
+            d.updated
+        );
     }
 }


### PR DESCRIPTION
## Summary

`every_benchmark_declares_an_updated_date` required ten digits in three dash-separated fields, but it did not validate a calendar date. Values such as `2026-02-31`, `2026-13-01`, or `2026-00-00` satisfied the old oracle.

The test now validates month bounds, month-specific day bounds, and Gregorian leap years while retaining the existing fixed-width and digit checks.

## Broken proof

Changing the registered `cross-contamination` descriptor from `2026-08-09` to `2026-02-31` left the old test green.

With the repaired oracle, the same descriptor mutant fails with:

```text
cross-contamination: "2026-02-31" has no such day
```

The descriptor was restored after the replay. This PR changes only the test.

## Runtime tie

The benchmark list renders `descriptor.updated` directly in the TUI. The field tells operators when a measurement definition changed, so an impossible date defeats both display ordering and the comparability signal the test claims to enforce.

## Test plan

- [x] Exact old-green replay with `2026-02-31`
- [x] Exact repaired-test failure with the same mutant
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-plugin benchmark::desc_tests::every_benchmark_declares_an_updated_date -- --exact`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-plugin --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh`
- [x] `typos`

## Notes for reviewers

The divisibility expression retains the workspace's Rust 1.85 MSRV instead of using the newer integer convenience method.

This dedicated test module is not in #701's current exact test-only registry, so its benchmark verdict also supplies a policy-coverage data point.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
