### PR TITLE
test(plugin): scope Linux process checks correctly

### DIFF
--- a/crates/atlas-plugin/src/benchmarks/agentic/agent_shell_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/agentic/agent_shell_tests.rs
@@ -97,7 +97,7 @@ async fn a_timed_out_command_takes_the_children_it_forked_with_it() {
     );
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn a_setsid_server_is_left_for_the_reaper() {
     // The counterpart: the prompt tells the model to detach its server, so the

--- a/crates/atlas-plugin/src/benchmarks/agentic/agent_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/agentic/agent_tests.rs
@@ -309,6 +309,7 @@ async fn shell_output_reaches_the_model_normalised() {
     assert!(out.contains("kill: (<pid>)"), "{out}");
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn a_detached_survivor_in_the_sandbox_is_reaped() {
     // The prompt tells the model to use `setsid`, so the server it leaves


### PR DESCRIPTION
## Summary

Two process-containment tests asserted Linux-only behavior while registering on macOS:

- `a_setsid_server_is_left_for_the_reaper` invoked the external `setsid` command under `cfg(unix)`, but macOS does not provide that command.
- `a_detached_survivor_in_the_sandbox_is_reaped` registered everywhere even though production `reap` explicitly returns without `/proc`.

The tests now register only on Linux, where both prerequisites and the production behavior exist.

## Broken proof

On macOS 27.0, `/proc` and `setsid` are both absent. At the unmodified base, both exact tests fail when run alone:

```text
a detached server must survive an unrelated command's timeout
pid 5689 survived the reap
```

The second failed test's owned sleep process was cleaned up explicitly.

This is not a containment bypass. The Linux tests retain their bodies and assertions unchanged and still register where `target_os = "linux"`.

## Runtime tie

The agentic benchmark runs model-authored shell commands on Linux. `run_shell` must leave an intentional `setsid` server alive across an unrelated timeout, then `reap` must find sandbox processes through `/proc` at the end of the run. Neither mechanism has a macOS implementation.

## Test plan

- [x] Reproduced both exact failures independently on the unmodified macOS base
- [x] Confirmed `/proc` and `setsid` are absent on the reproducing host
- [x] Confirmed both Linux-only names are absent from the repaired macOS test registry
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-plugin --lib` (816 passed, 0 failed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-plugin --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh`
- [x] `typos`
- [ ] Linux CI executes both unchanged test bodies

## Notes for reviewers

The timed-out process-group test remains `cfg(unix)` because it does not depend on `/proc` or the external `setsid` command and already passes on macOS.

Both changed files are dedicated test modules but are not in #701's current exact test-only registry. Their benchmark verdict is therefore also a policy-coverage data point.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
