### PR TITLE
test(plugin): place UTF-8 across the capture seam

### DIFF
--- a/crates/atlas-plugin/src/benchmarks/agentic/agent_shell_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/agentic/agent_shell_tests.rs
@@ -45,9 +45,13 @@ fn the_capture_keeps_both_ends_and_says_what_it_dropped() {
 fn a_character_split_across_the_seam_is_not_mangled() {
     // Head and tail decoded separately would each see half of the two-byte `é`
     // and emit a replacement character.
+    let text = format!("x{}y", "é".repeat(CAPTURE_END - 1));
+    assert_eq!(text.len(), 2 * CAPTURE_END);
+    assert!(!text.is_char_boundary(CAPTURE_END));
+
     let mut capture = Capture::default();
-    capture.push(&"é".repeat(CAPTURE_END).into_bytes());
-    assert!(!capture.text().contains('\u{fffd}'));
+    capture.push(text.as_bytes());
+    assert_eq!(capture.text(), text);
 }
 
 // ── truncation ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`a_character_split_across_the_seam_is_not_mangled` claimed to split a two-byte `é` between the capture head and tail. Its fixture repeated only `é`, while `CAPTURE_END` is even, so the seam always landed between complete characters.

The fixture now places one ASCII byte before the repeated characters and one after them. It proves the input is exactly the two-window size and that `CAPTURE_END` is not a UTF-8 boundary before exercising the capture.

## Broken proof

A production mutant decoded `head` and `tail` independently, then concatenated the two strings. That is the defect this test says it prevents.

- Old fixture: the mutant passed because both halves ended on valid UTF-8 boundaries.
- Repaired fixture: the same mutant fails with replacement characters at the split.
- Restored production: the repaired test reconstructs the exact original string.

## Runtime tie

The shell drain captures raw stdout and stderr chunks before returning text to the benchmark agent. A multi-byte compiler diagnostic or model-authored command output can cross the fixed head/tail boundary. Decoding each side separately would replace valid bytes and alter the evidence shown to the model.

## Test plan

- [x] Exact old-green replay with independent head/tail decoding
- [x] Exact repaired-test failure with the same mutant
- [x] Repaired fixture proves its own byte length and non-boundary seam
- [x] Five non-Linux-specific shell tests pass, including the real timeout child-containment test
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-plugin --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh`
- [x] `typos`

## Notes for reviewers

Production code is unchanged. The separate Linux-platform registration issue for the sixth shell test is isolated in #726.

This dedicated test module is not in #701's current exact test-only registry, so its benchmark verdict also supplies a policy-coverage data point.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
