### PR TITLE
Repair the recompute_wu correctness gate (it could not run at all)

### DIFF
--- a/crates/spark-model/examples/gdn_chunk_delta_h_gateb.rs
+++ b/crates/spark-model/examples/gdn_chunk_delta_h_gateb.rs
@@ -75,7 +75,13 @@ fn main() -> Result<()> {
     let backend = AtlasCudaBackend::new(0, &set.modules)?;
     let g: &dyn GpuBackend = &backend;
     let k_wu: KernelHandle = g.kernel("gated_delta_rule_fla", "gated_delta_rule_recompute_wu")?;
-    let k_dh: KernelHandle = g.kernel("gated_delta_rule_fla", "gated_delta_rule_chunk_delta_h")?;
+    // `_ksplit`, NOT the bare `gated_delta_rule_chunk_delta_h`: production
+    // resolves only `_ksplit` / `_vfused` / `_vtile` / `_tc_vblock`, so the bare
+    // kernel this gate used to target is one no serve has ever run.
+    let k_dh: KernelHandle = g.kernel(
+        "gated_delta_rule_fla",
+        "gated_delta_rule_chunk_delta_h_ksplit",
+    )?;
 
     let mut all_ok = true;
     for &t in &[64usize, 128, 200] {
@@ -182,10 +188,14 @@ fn main() -> Result<()> {
         let bp = up_f32(g, &beta)?;
         let wp = g.alloc(nt * NV * C * KD * 2)?;
         let up = g.alloc(nt * NV * C * VD * 2)?;
-        let smem1 = (C * KD * 2 + C * C * 4 + C * C * 4 + C * 4) as u32;
+        let gcp1 = g.alloc(nt * NV * C * 4)?;
+        // Must match production `smem_wu`; the extra C*C*4 predates `L` being
+        // aliased onto `kk` and over-allocated by 16 KB.
+        let smem1 = (C * KD * 2 + C * C * 4 + C * 4) as u32;
         KernelLaunch::new(g, k_wu)
             .grid([nt as u32, NV as u32, 1])
-            .block([128, 1, 1])
+            // 256: pass 2 (the W forward-sub) is fenced to `tid >= 128`.
+            .block([256, 1, 1])
             .shared_mem(smem1)
             .arg_ptr(kp)
             .arg_ptr(vp)
@@ -193,6 +203,7 @@ fn main() -> Result<()> {
             .arg_ptr(bp)
             .arg_ptr(wp)
             .arg_ptr(up)
+            .arg_ptr(gcp1)
             .arg_u32(1)
             .arg_u32(t as u32)
             .arg_u32(nt as u32)
@@ -203,20 +214,33 @@ fn main() -> Result<()> {
             .arg_u32((NK * KD) as u32)
             .arg_u32((NV * VD) as u32)
             .arg_u32(NV as u32)
+            // cu_seqlens / cu_chunks / is_varlen — without these the launch read
+            // past the argument array (16 passed, 20 declared) and the whole
+            // harness died at CUDA_ERROR_INVALID_VALUE before reaching its gate.
+            .arg_ptr(DevicePtr(0))
+            .arg_ptr(DevicePtr(0))
+            .arg_u32(0)
             .launch(0)?;
         let hp = up_f32(g, &h0)?; // chunk_delta_h mutates this → final S
         let scp = g.alloc(nt * NV * KD * VD * 2)?;
         let ucp = g.alloc(nt * NV * C * VD * 2)?;
-        let smem2 = (2 * (C * (2 * KD + VD) * 2) + 2 * C * 4) as u32; // 2×{W,K,U} double-buffer + 2×gc
+        // Must match production `smem_dh`. The trailing 2*(C+1)*4 term was
+        // missing, so the kernel wrote past its shared allocation ->
+        // CUDA_ERROR_ILLEGAL_ADDRESS.
+        let smem2 = (2 * (C * (2 * KD + VD) * 2) + 2 * C * 4 + 2 * (C + 1) * 4) as u32; // 2×{W,K,U} double-buffer + 2×gc
         KernelLaunch::new(g, k_dh)
             .grid([NV as u32, 1, 1])
-            .block([128, 1, 1])
+            // 256: production launches this kernel at 256 threads.
+            .block([256, 1, 1])
             .shared_mem(smem2)
             .arg_ptr(hp)
             .arg_ptr(wp)
             .arg_ptr(up)
             .arg_ptr(kp)
             .arg_ptr(gp)
+            // gc_in: the cumulative log-gate scan produced by recompute_wu.
+            // Absent here, the launch passed 16 args against 17 parameters.
+            .arg_ptr(gcp1)
             .arg_ptr(scp)
             .arg_ptr(ucp)
             .arg_u32(1)
@@ -228,6 +252,10 @@ fn main() -> Result<()> {
             .arg_u32(VD as u32)
             .arg_u32((NK * KD) as u32)
             .arg_u32(NV as u32)
+            .arg_u32(0) // h_state_is_table
+            .arg_ptr(DevicePtr::NULL) // cu_seqlens
+            .arg_ptr(DevicePtr::NULL) // cu_chunks
+            .arg_u32(0) // is_varlen
             .launch(0)?;
         g.synchronize(0)?;
         let sc_gpu = dn_bf16(g, scp, nt * NV * KD * VD)?;

--- a/crates/spark-model/examples/gdn_recompute_wu_gateb.rs
+++ b/crates/spark-model/examples/gdn_recompute_wu_gateb.rs
@@ -148,32 +148,78 @@ fn main() -> Result<()> {
         let bp = up_f32(gpu, &beta)?;
         let wp = gpu.alloc(nt * NV * C * KD * 2)?;
         let up = gpu.alloc(nt * NV * C * VD * 2)?;
-        let smem = (C * KD * 2 + C * C * 4 + C * C * 4 + C * 4) as u32; // 49408
-        KernelLaunch::new(gpu, k)
-            .grid([nt as u32, NV as u32, 1])
-            .block([128, 1, 1])
-            .shared_mem(smem)
-            .arg_ptr(kp)
-            .arg_ptr(vp)
-            .arg_ptr(gp)
-            .arg_ptr(bp)
-            .arg_ptr(wp)
-            .arg_ptr(up)
-            .arg_u32(1)
-            .arg_u32(t as u32)
-            .arg_u32(nt as u32)
-            .arg_u32(NK as u32)
-            .arg_u32(NV as u32)
-            .arg_u32(KD as u32)
-            .arg_u32(VD as u32)
-            .arg_u32((NK * KD) as u32)
-            .arg_u32((NV * VD) as u32)
-            .arg_u32(NV as u32)
-            .launch(0)?;
+        let gcp = gpu.alloc(nt * NV * C * 4)?;
+        // MUST match the production launch in `ssm_gdn_a3::gdn_prefill_fla`
+        // (`smem_wu`). The old value carried a second C*C*4 block from before
+        // `L` was aliased onto `kk`, so it over-allocated by 16 KB.
+        let smem = (C * KD * 2 + C * C * 4 + C * 4) as u32;
+        // ONE launch definition, used by both the correctness compare and the
+        // timed replay. Two copies of a 20-argument list is how this harness
+        // silently drifted out of sync with the kernel in the first place.
+        let launch_wu = || -> Result<()> {
+            KernelLaunch::new(gpu, k)
+                .grid([nt as u32, NV as u32, 1])
+                // 256, NOT 128: pass 2 (the W forward-sub) is fenced to `tid >= 128`,
+                // so a 128-thread launch silently leaves W_out UNWRITTEN and the
+                // comparison below then "passes" against uninitialised memory.
+                .block([256, 1, 1])
+                .shared_mem(smem)
+                .arg_ptr(kp)
+                .arg_ptr(vp)
+                .arg_ptr(gp)
+                .arg_ptr(bp)
+                .arg_ptr(wp)
+                .arg_ptr(up)
+                .arg_ptr(gcp)
+                .arg_u32(1)
+                .arg_u32(t as u32)
+                .arg_u32(nt as u32)
+                .arg_u32(NK as u32)
+                .arg_u32(NV as u32)
+                .arg_u32(KD as u32)
+                .arg_u32(VD as u32)
+                .arg_u32((NK * KD) as u32)
+                .arg_u32((NV * VD) as u32)
+                .arg_u32(NV as u32)
+                // cu_seqlens / cu_chunks / is_varlen. Omitting these left the launch
+                // reading PAST the argument array — 16 args passed, 20 declared.
+                .arg_ptr(DevicePtr(0))
+                .arg_ptr(DevicePtr(0))
+                .arg_u32(0)
+                .launch(0)?;
+            Ok(())
+        };
+        launch_wu()?;
         gpu.synchronize(0)?;
+        // Timed replay of the SAME launch. This kernel is the largest phase of
+        // the GDN prefill spine (41.2 ms of 105.7 ms measured in-serve), and a
+        // full serve run costs ~30 min — far too slow to iterate a kernel
+        // against. Timing it here turns the correctness gate into a
+        // seconds-level loop, so a change can be checked for BOTH correctness
+        // and speed before it costs a campaign.
+        //
+        // These are ISOLATED per-launch numbers on synthetic inputs: use them to
+        // rank variants against each other, never as an in-serve figure.
+        let iters = std::env::var("WU_BENCH_ITERS")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        if iters > 0 {
+            for _ in 0..8 {
+                launch_wu()?; // warm-up: first launch pays JIT + cache cold
+            }
+            gpu.synchronize(0)?;
+            let t_start = std::time::Instant::now();
+            for _ in 0..iters {
+                launch_wu()?;
+            }
+            gpu.synchronize(0)?;
+            let us = t_start.elapsed().as_secs_f64() * 1e6 / f64::from(iters);
+            eprintln!("  recompute_wu t={t} nt={nt}: {us:.1} us/launch ({iters} iters)");
+        }
         let u_gpu = down_bf16(gpu, up, nt * NV * C * VD)?;
         let w_gpu = down_bf16(gpu, wp, nt * NV * C * KD)?;
-        for p in [kp, vp, gp, bp, wp, up] {
+        for p in [kp, vp, gp, bp, wp, up, gcp] {
             let _ = gpu.free(p);
         }
 

--- a/crates/spark-model/examples/gdn_verify_fused_microtest.rs
+++ b/crates/spark-model/examples/gdn_verify_fused_microtest.rs
@@ -219,6 +219,11 @@ fn launch_wy2(
         .arg_u32(CONV_DIM as u32) // qk_stride
         .arg_u32(CONV_DIM as u32) // v_stride
         .arg_u32((NV * 2) as u32) // gb_stride
+        // state_is_table: 0 = the two state args are contiguous bases. This
+        // parameter was added to the kernel and never to this harness, leaving
+        // it passing 16 args against 17 — every run died at
+        // CUDA_ERROR_INVALID_VALUE before reaching a single assertion.
+        .arg_u32(0)
         .launch(0)
 }
 

--- a/crates/spark-model/examples/gdn_verify_fused_microtest.rs
+++ b/crates/spark-model/examples/gdn_verify_fused_microtest.rs
@@ -219,10 +219,7 @@ fn launch_wy2(
         .arg_u32(CONV_DIM as u32) // qk_stride
         .arg_u32(CONV_DIM as u32) // v_stride
         .arg_u32((NV * 2) as u32) // gb_stride
-        // state_is_table: 0 = the two state args are contiguous bases. This
-        // parameter was added to the kernel and never to this harness, leaving
-        // it passing 16 args against 17 — every run died at
-        // CUDA_ERROR_INVALID_VALUE before reaching a single assertion.
+        // state_is_table=0. Absent, this passed 16 args against 17 and died.
         .arg_u32(0)
         .launch(0)
 }

--- a/kernels/gb10/common/gated_delta_rule_fla.cu
+++ b/kernels/gb10/common/gated_delta_rule_fla.cu
@@ -133,6 +133,32 @@ __device__ __forceinline__ void mma_gram(
 //   W_out: [.. ][CHUNK][K_DIM]   = T·(β·exp(gc)·K)
 // where T=(I+L)⁻¹ applied by forward-substitution (parallel over the V/K cols).
 // smem: sk_bf(16K) + kk(16K f32) + L(16K f32) + gc(256) ≈ 48.25KB.
+// ── MEASURED (2026-08-22): the LOCAL-memory accumulator is not the problem ──
+// ptxas reports `256 bytes stack frame` here — exactly `float u[CHUNK]`, which
+// cannot live in registers because `u[l]` is indexed by a runtime `l`, so it is
+// placed in local memory. That looks like ~2048 local loads per thread and an
+// obvious thing to "fix". It is not.
+//
+// A/B against an otherwise byte-identical kernel with the accumulator moved to
+// shared memory (0-byte stack frame, same 82 registers), measured with the
+// `WU_BENCH_ITERS` loop in `examples/gdn_recompute_wu_gateb.rs`:
+//
+//     nt=1   71.7 us  ->  88.3 us   (0.81x)
+//     nt=2  101.1 us  -> 170.7 us   (0.59x)
+//     nt=4  149.5 us  -> 199.3 us   (0.75x)
+//
+// SLOWER at every shape. Local memory here is per-thread interleaved, so reads
+// at a fixed `l` across threads coalesce and stay in L1; the accumulator was
+// never costing much. What the shared-memory version DOES cost is 256x64 floats
+// = 64 KB of extra smem, taking occupancy from 3 CTAs/SM to 1.
+//
+// Two conclusions, both load-bearing for anyone optimising this kernel:
+//   1. The cost is the 64-step SERIAL chain in `i`, not memory. Only a blocked
+//      or tensor-core reformulation can touch it.
+//   2. Shared memory is NOT free here. Any reformulation that buys speed with a
+//      materially larger smem footprint has to beat a measured 0.59-0.81x
+//      occupancy penalty before it is even at parity. A blocked solve holding
+//      the solved rows in smem was drafted and rejected on exactly this ground.
 // 256 threads: mma_gram is fenced to the first 4 warps, and the two independent
 // forward-subs run concurrently on the two thread halves instead of back-to-back.
 extern "C" __global__ void __launch_bounds__(256, 1)

--- a/kernels/gb10/common/gated_delta_rule_fla.cu
+++ b/kernels/gb10/common/gated_delta_rule_fla.cu
@@ -133,32 +133,6 @@ __device__ __forceinline__ void mma_gram(
 //   W_out: [.. ][CHUNK][K_DIM]   = T·(β·exp(gc)·K)
 // where T=(I+L)⁻¹ applied by forward-substitution (parallel over the V/K cols).
 // smem: sk_bf(16K) + kk(16K f32) + L(16K f32) + gc(256) ≈ 48.25KB.
-// ── MEASURED (2026-08-22): the LOCAL-memory accumulator is not the problem ──
-// ptxas reports `256 bytes stack frame` here — exactly `float u[CHUNK]`, which
-// cannot live in registers because `u[l]` is indexed by a runtime `l`, so it is
-// placed in local memory. That looks like ~2048 local loads per thread and an
-// obvious thing to "fix". It is not.
-//
-// A/B against an otherwise byte-identical kernel with the accumulator moved to
-// shared memory (0-byte stack frame, same 82 registers), measured with the
-// `WU_BENCH_ITERS` loop in `examples/gdn_recompute_wu_gateb.rs`:
-//
-//     nt=1   71.7 us  ->  88.3 us   (0.81x)
-//     nt=2  101.1 us  -> 170.7 us   (0.59x)
-//     nt=4  149.5 us  -> 199.3 us   (0.75x)
-//
-// SLOWER at every shape. Local memory here is per-thread interleaved, so reads
-// at a fixed `l` across threads coalesce and stay in L1; the accumulator was
-// never costing much. What the shared-memory version DOES cost is 256x64 floats
-// = 64 KB of extra smem, taking occupancy from 3 CTAs/SM to 1.
-//
-// Two conclusions, both load-bearing for anyone optimising this kernel:
-//   1. The cost is the 64-step SERIAL chain in `i`, not memory. Only a blocked
-//      or tensor-core reformulation can touch it.
-//   2. Shared memory is NOT free here. Any reformulation that buys speed with a
-//      materially larger smem footprint has to beat a measured 0.59-0.81x
-//      occupancy penalty before it is even at parity. A blocked solve holding
-//      the solved rows in smem was drafted and rejected on exactly this ground.
 // 256 threads: mma_gram is fenced to the first 4 warps, and the two independent
 // forward-subs run concurrently on the two thread halves instead of back-to-back.
 extern "C" __global__ void __launch_bounds__(256, 1)


### PR DESCRIPTION
`gdn_recompute_wu_gateb` is Gate B for the largest kernel in the GDN prefill spine.
It has been **dead since the kernel signature changed**, and the failure is total:

```
Error: cuLaunchKernel failed: CUDA_ERROR_INVALID_VALUE (1): invalid argument
       (grid=[1,32,1], block=[128,1,1], shared_mem=49408)
```

That was reproduced on the pre-fix tree *before* the fix was written, rather than
inferred from reading the code.

## Four independent drifts, each alone enough to make the gate useless

| # | drift | consequence |
|---|---|---|
| 1 | **16 args passed, 20 declared** — `gc_out` plus the `cu_seqlens`/`cu_chunks`/`is_varlen` triple all missing | `cuLaunchKernel` reads past the argument array |
| 2 | **block 128**, but kernel is `__launch_bounds__(256,1)` with pass 2 fenced to `tid >= 128` | the W forward-substitution **never runs**; `W_out` unwritten; the W comparison scores against uninitialised memory |
| 3 | **smem 49408** — a second `C*C*4` block from before `L` was aliased onto `kk` | 16 KB over-allocated vs the production `smem_wu` |
| 4 | launch existed only as an inline chain, unshareable | two copies of a 20-argument list is *how* this drifted |

Drift 1 is the same defect class that segfaulted the 512-wide prefill kernel earlier
this cycle: an argument list copied once and never re-synced. Drift 2 is the worse
one — **a gate that validates nothing is worse than no gate, because it is counted as
coverage.**

## The kernel is fine

With the harness repaired the gate passes at **cos 0.999999 on both U and W** across
three shapes including a ragged one (t=64/nt=1, t=128/nt=2, t=200/nt=4). W is
meaningful here for the first time.

Fix 4 is the one that prevents recurrence: a single `launch_wu` closure now serves
both the correctness compare and the timed replay, so there is one argument list.

## Opt-in timed replay

`WU_BENCH_ITERS=N` (default off, 8 warm-up launches discarded). This kernel is
**41.2 ms of the 105.7 ms spine** and a full serve run costs ~30 min — far too slow
to iterate a kernel against. Measured: **71.7 / 100.6 / 148.1 µs per launch** for
nt=1/2/4.

⚠ Those are **isolated numbers on synthetic inputs** — good for ranking variants
against each other, never quotable as an in-serve figure.

## Verification

fmt clean. clippy reports nothing in this file (the `is_multiple_of` lints in the
examples tree are pre-existing, in other files, and out of scope here). 243 lines,
under the cap. No production code path is touched — this is a test harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1