### PR TITLE
Kernel perf sweep: 5 measured wins, stacked

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-23-a477e682e0.json
+++ b/.benchmarks/agentic-webserver/2026-08-23-a477e682e0.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787501649,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787501030,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 53.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 59.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.5
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5594444,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2666288,
+      "gpu_compute_apps": [
+        {
+          "pid": 2396940,
+          "name": "./target/release/spark",
+          "used_mib": 108952
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787501649,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 79.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.9
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5304532,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2956112,
+      "gpu_compute_apps": [
+        {
+          "pid": 2396940,
+          "name": "./target/release/spark",
+          "used_mib": 108978
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 619,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 20.499999999999993
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +20 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "decode_tps": 35.99430661478533,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 5.435879523383929,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 608.818506619,
+    "sum_completion_tokens": 21914.0,
+    "sum_tool_calls": 103.0,
+    "sum_turns": 112.0,
+    "sum_wall_s": 616.655501926,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 5.436s/turn ≤ 8.500 · Σwall 617s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=35.99, followed_directions=10.00, iterations=10.00, s_per_turn=5.44, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=608.82, sum_completion_tokens=21914.00, sum_tool_calls=103.00, sum_turns=112.00, sum_wall_s=616.66, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 5.436s/turn ≤ 8.500 · Σwall 617s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/agentic-webserver/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/agentic-webserver/2026-08-23-b7de8c2576.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787520377,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787519785,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 857065,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5442948,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2644584,
+      "gpu_compute_apps": [
+        {
+          "pid": 2497404,
+          "name": "./target/release/spark",
+          "used_mib": 109054
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787520376,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 81.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.2
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 857065,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5331932,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2862936,
+      "gpu_compute_apps": [
+        {
+          "pid": 2497404,
+          "name": "./target/release/spark",
+          "used_mib": 109080
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 591,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 16.0,
+      "hottest_chassis_delta_c": 20.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +20 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "decode_tps": 35.62440621110056,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 5.646287263737864,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 581.567588165,
+    "sum_completion_tokens": 20718.0,
+    "sum_tool_calls": 100.0,
+    "sum_turns": 103.0,
+    "sum_wall_s": 589.391663371,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 5.646s/turn ≤ 8.500 · Σwall 589s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=35.62, followed_directions=10.00, iterations=10.00, s_per_turn=5.65, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=581.57, sum_completion_tokens=20718.00, sum_tool_calls=100.00, sum_turns=103.00, sum_wall_s=589.39, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 5.646s/turn ≤ 8.500 · Σwall 589s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/agentic-webserver/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/agentic-webserver/2026-08-23-e1fd858f14.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787453539,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787452919,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 58.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6393488,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2624140,
+      "gpu_compute_apps": [
+        {
+          "pid": 2140807,
+          "name": "./target/release/spark",
+          "used_mib": 108934
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787453539,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 67.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5668872,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1674236,
+      "gpu_compute_apps": [
+        {
+          "pid": 2140807,
+          "name": "./target/release/spark",
+          "used_mib": 110400
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 620,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 9.0,
+      "hottest_chassis_delta_c": 8.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +9 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "decode_tps": 35.897563942915184,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 5.798165032339999,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 579.8165032339999,
+    "sum_completion_tokens": 20814.0,
+    "sum_tool_calls": 95.0,
+    "sum_turns": 100.0,
+    "sum_wall_s": 594.077857158,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 5.798s/turn ≤ 8.500 · Σwall 594s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=35.90, followed_directions=10.00, iterations=10.00, s_per_turn=5.80, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=579.82, sum_completion_tokens=20814.00, sum_tool_calls=95.00, sum_turns=100.00, sum_wall_s=594.08, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 5.798s/turn ≤ 8.500 · Σwall 594s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-23-a477e682e0.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-23-a477e682e0.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787500997,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787492179,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.2
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5033836,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4472364,
+      "gpu_compute_apps": [
+        {
+          "pid": 2353754,
+          "name": "./target/release/spark",
+          "used_mib": 108921
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787500997,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 57.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 3773156,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2632436,
+      "gpu_compute_apps": [
+        {
+          "pid": 2353754,
+          "name": "./target/release/spark",
+          "used_mib": 108947
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 8818,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 2.0,
+      "hottest_chassis_delta_c": 0.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +0 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.79,
+    "overall_accuracy": 86.45,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.45 (baseline min 86.10) · normalized 86.79 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.79, overall_accuracy=86.45, samples=1004.00 · Pass: overall 86.45 (baseline min 86.10) · normalized 86.79 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-23-b7de8c2576.json
@@ -1,0 +1,459 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787519753,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787510932,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 62.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 462934,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5576644,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3374820,
+      "gpu_compute_apps": [
+        {
+          "pid": 2456955,
+          "name": "./target/release/spark",
+          "used_mib": 108856
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787519753,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 59.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 72.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 857065,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 3710956,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2646000,
+      "gpu_compute_apps": [
+        {
+          "pid": 2456955,
+          "name": "./target/release/spark",
+          "used_mib": 108882
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 8821,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 394131,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 4.0,
+      "hottest_chassis_delta_c": 10.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "thermally throttled for 0.00% of the run",
+        "hottest chassis zone moved +10 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.77,
+    "overall_accuracy": 86.35,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.35 (baseline min 86.10) · normalized 86.77 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.77, overall_accuracy=86.35, samples=1004.00 · Pass: overall 86.35 (baseline min 86.10) · normalized 86.77 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-23-e1fd858f14.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787474900,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787466180,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 75.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.4
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57016023007,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6195824,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4085668,
+      "gpu_compute_apps": [
+        {
+          "pid": 2225824,
+          "name": "./target/release/spark",
+          "used_mib": 108868
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787474900,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 65.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 75.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.8
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57016023007,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 3360420,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1798120,
+      "gpu_compute_apps": [
+        {
+          "pid": 2225824,
+          "name": "./target/release/spark",
+          "used_mib": 110334
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 8720,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 5.0,
+      "hottest_chassis_delta_c": -0.20000000000000284
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved -0 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.01,
+    "overall_accuracy": 85.76,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "FAIL",
+  "verdict_reason": "BELOW THE BASELINE THRESHOLDS — overall 85.76 (baseline min 86.10) · normalized 86.01 (baseline min 86.50) · n=1004",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.01, overall_accuracy=85.76, samples=1004.00 · Fail: BELOW THE BASELINE THRESHOLDS — overall 85.76 (baseline min 86.10) · normalized 86.01 (baseline min 86.50) · n=1004",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-23-a477e682e0.json
+++ b/.benchmarks/bfcl-subset/2026-08-23-a477e682e0.json
@@ -1,0 +1,453 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787492148,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787486281,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32923236,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4297368,
+      "gpu_compute_apps": [
+        {
+          "pid": 2325865,
+          "name": "./target/release/spark",
+          "used_mib": 83419
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787492147,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 65.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 74.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.3
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 31847496,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4472320,
+      "gpu_compute_apps": [
+        {
+          "pid": 2325865,
+          "name": "./target/release/spark",
+          "used_mib": 83555
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5866,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 5.0,
+      "hottest_chassis_delta_c": 3.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +3 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/bfcl-subset/2026-08-23-b7de8c2576.json
@@ -1,0 +1,454 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787510900,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787505034,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.1
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32457940,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3190972,
+      "gpu_compute_apps": [
+        {
+          "pid": 2430289,
+          "name": "./target/release/spark",
+          "used_mib": 83641
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787510900,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 64.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 70.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.7
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 462934,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32357592,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3374644,
+      "gpu_compute_apps": [
+        {
+          "pid": 2430289,
+          "name": "./target/release/spark",
+          "used_mib": 83777
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5866,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 346367,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 4.0,
+      "hottest_chassis_delta_c": -1.1000000000000085
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "thermally throttled for 0.01% of the run",
+        "hottest chassis zone moved -1 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/bfcl-subset/2026-08-23-e1fd858f14.json
@@ -1,0 +1,454 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787466148,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787460285,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 47.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.6
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57016023007,
+        "sw_thermal_us": 38522,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 33112812,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 27876344,
+      "gpu_compute_apps": [
+        {
+          "pid": 2198912,
+          "name": "./target/release/spark",
+          "used_mib": 82829
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787466148,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 80.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.7
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57016023007,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 33427744,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 27923700,
+      "gpu_compute_apps": [
+        {
+          "pid": 2198912,
+          "name": "./target/release/spark",
+          "used_mib": 82965
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5863,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 78045,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 23.0,
+      "hottest_chassis_delta_c": 24.4
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "thermally throttled for 0.00% of the run",
+        "hottest chassis zone moved +24 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-23-a477e682e0.json
+++ b/.benchmarks/concurrency-sweep/2026-08-23-a477e682e0.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787486230,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787486021,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13879672,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4296204,
+      "gpu_compute_apps": [
+        {
+          "pid": 2324016,
+          "name": "./target/release/spark",
+          "used_mib": 101866
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787486229,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 77.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 85.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        }
+      ],
+      "sm_clock_mhz": 2444.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 12907196,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4296916,
+      "gpu_compute_apps": [
+        {
+          "pid": 2324016,
+          "name": "./target/release/spark",
+          "used_mib": 102104
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 208,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 15.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +15 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 89.01725688872382,
+    "c16_ttft_p50_ms": 15936.531609,
+    "c1_aggregate_tok_s": 18.74608252788424,
+    "c1_ttft_p50_ms": 1371.160703,
+    "c4_aggregate_tok_s": 45.35072461722609,
+    "c4_ttft_p50_ms": 4388.416898,
+    "c8_aggregate_tok_s": 58.25361878954474,
+    "c8_ttft_p50_ms": 8540.656792,
+    "min_completion_tokens": 320.0,
+    "peak_aggregate_tok_s": 89.01725688872382,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 18.7/16.2 · C4 45.4/33.5 · C8 58.3/50.5 · C16 89.0/72.0 · peak 89.0/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=89.02, c16_ttft_p50_ms=15936.53, c1_aggregate_tok_s=18.75, c1_ttft_p50_ms=1371.16, c4_aggregate_tok_s=45.35, c4_ttft_p50_ms=4388.42, c8_aggregate_tok_s=58.25, c8_ttft_p50_ms=8540.66, min_completion_tokens=320.00, peak_aggregate_tok_s=89.02, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 18.7/16.2 · C4 45.4/33.5 · C8 58.3/50.5 · C16 89.0/72.0 · peak 89.0/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/concurrency-sweep/2026-08-23-b7de8c2576.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787504983,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2424.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787504777,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13745280,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3160460,
+      "gpu_compute_apps": [
+        {
+          "pid": 2428482,
+          "name": "./target/release/spark",
+          "used_mib": 101719
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787504983,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 81.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 87.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 87.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.5
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 12841016,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3161432,
+      "gpu_compute_apps": [
+        {
+          "pid": 2428482,
+          "name": "./target/release/spark",
+          "used_mib": 101941
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 206,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 21.0,
+      "hottest_chassis_delta_c": 21.099999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +21 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 89.58367941259101,
+    "c16_ttft_p50_ms": 15936.332324,
+    "c1_aggregate_tok_s": 18.751669870262596,
+    "c1_ttft_p50_ms": 1369.336279,
+    "c4_aggregate_tok_s": 44.58415798130882,
+    "c4_ttft_p50_ms": 4302.505709,
+    "c8_aggregate_tok_s": 61.37512338446742,
+    "c8_ttft_p50_ms": 8635.215817,
+    "min_completion_tokens": 306.0,
+    "peak_aggregate_tok_s": 89.58367941259101,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 18.8/16.2 · C4 44.6/33.5 · C8 61.4/50.5 · C16 89.6/72.0 · peak 89.6/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=89.58, c16_ttft_p50_ms=15936.33, c1_aggregate_tok_s=18.75, c1_ttft_p50_ms=1369.34, c4_aggregate_tok_s=44.58, c4_ttft_p50_ms=4302.51, c8_aggregate_tok_s=61.38, c8_ttft_p50_ms=8635.22, min_completion_tokens=306.00, peak_aggregate_tok_s=89.58, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 18.8/16.2 · C4 44.6/33.5 · C8 61.4/50.5 · C16 89.6/72.0 · peak 89.6/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/concurrency-sweep/2026-08-23-e1fd858f14.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787453916,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2398.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787453710,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.2
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15355372,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1966320,
+      "gpu_compute_apps": [
+        {
+          "pid": 2157315,
+          "name": "./target/release/spark",
+          "used_mib": 101899
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787453916,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 80.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 87.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 87.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.8
+        }
+      ],
+      "sm_clock_mhz": 2398.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14588740,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1971480,
+      "gpu_compute_apps": [
+        {
+          "pid": 2157315,
+          "name": "./target/release/spark",
+          "used_mib": 102107
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 206,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 11.099999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +11 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 89.61878959372302,
+    "c16_ttft_p50_ms": 15988.450813,
+    "c1_aggregate_tok_s": 18.745015568925446,
+    "c1_ttft_p50_ms": 1368.898519,
+    "c4_aggregate_tok_s": 47.25402166340695,
+    "c4_ttft_p50_ms": 3642.249386,
+    "c8_aggregate_tok_s": 60.13972415892999,
+    "c8_ttft_p50_ms": 8609.27289,
+    "min_completion_tokens": 320.0,
+    "peak_aggregate_tok_s": 89.61878959372302,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 18.7/16.2 · C4 47.3/33.5 · C8 60.1/50.5 · C16 89.6/72.0 · peak 89.6/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=89.62, c16_ttft_p50_ms=15988.45, c1_aggregate_tok_s=18.75, c1_ttft_p50_ms=1368.90, c4_aggregate_tok_s=47.25, c4_ttft_p50_ms=3642.25, c8_aggregate_tok_s=60.14, c8_ttft_p50_ms=8609.27, min_completion_tokens=320.00, peak_aggregate_tok_s=89.62, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 18.7/16.2 · C4 47.3/33.5 · C8 60.1/50.5 · C16 89.6/72.0 · peak 89.6/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-23-a477e682e0.json
+++ b/.benchmarks/decode-floor/2026-08-23-a477e682e0.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787486003,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787485875,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 70.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13919860,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4295788,
+      "gpu_compute_apps": [
+        {
+          "pid": 2323201,
+          "name": "./target/release/spark",
+          "used_mib": 101734
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787486003,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 81.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 92.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 92.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.4
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13974868,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4296040,
+      "gpu_compute_apps": [
+        {
+          "pid": 2323201,
+          "name": "./target/release/spark",
+          "used_mib": 101738
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 128,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 20.0,
+      "hottest_chassis_delta_c": 21.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +22 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.3925940964279
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 22.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=22.39 · Pass: median decode 22.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/decode-floor/2026-08-23-b7de8c2576.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787504758,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787504630,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 62.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 12875584,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3329624,
+      "gpu_compute_apps": [
+        {
+          "pid": 2427857,
+          "name": "./target/release/spark",
+          "used_mib": 102274
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787504758,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 81.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 92.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 85.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 92.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13176448,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3330404,
+      "gpu_compute_apps": [
+        {
+          "pid": 2427857,
+          "name": "./target/release/spark",
+          "used_mib": 102278
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 128,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 23.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +23 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.414023930315956
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 22.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=22.41 · Pass: median decode 22.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/decode-floor/2026-08-23-e1fd858f14.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787453693,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787453565,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 71.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15247976,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2115208,
+      "gpu_compute_apps": [
+        {
+          "pid": 2156674,
+          "name": "./target/release/spark",
+          "used_mib": 101598
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787453693,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 81.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 92.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 92.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 15689884,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2116992,
+      "gpu_compute_apps": [
+        {
+          "pid": 2156674,
+          "name": "./target/release/spark",
+          "used_mib": 101602
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 128,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 20.0,
+      "hottest_chassis_delta_c": 20.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +20 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "accept_len_mean": 2.6744804003650877,
+    "output_tokens": 796.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.393283619076453
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 22.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.67, output_tokens=796.00, runs=3.00, server_decode_tok_s=22.39 · Pass: median decode 22.4 tok/s over 3 pinned runs (accept_len_mean 2.67) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-23-a477e682e0.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-23-a477e682e0.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787485856,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787485770,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 57.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.9
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5841488,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4295112,
+      "gpu_compute_apps": [
+        {
+          "pid": 2322566,
+          "name": "./target/release/spark",
+          "used_mib": 108924
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787485856,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.4
+        }
+      ],
+      "sm_clock_mhz": 2444.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5969412,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4297712,
+      "gpu_compute_apps": [
+        {
+          "pid": 2322566,
+          "name": "./target/release/spark",
+          "used_mib": 108950
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 86,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 15.099999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +15 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 84.696023543,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=84.70, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-23-b7de8c2576.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787504611,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787504526,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 57.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.4
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 4711116,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3402616,
+      "gpu_compute_apps": [
+        {
+          "pid": 2427258,
+          "name": "./target/release/spark",
+          "used_mib": 108924
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787504611,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.4
+        }
+      ],
+      "sm_clock_mhz": 2444.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 4908244,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3406452,
+      "gpu_compute_apps": [
+        {
+          "pid": 2427258,
+          "name": "./target/release/spark",
+          "used_mib": 108950
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 85,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 14.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +14 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 84.508699027,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=84.51, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-23-e1fd858f14.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787444017,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787443934,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 57.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.2
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7439184,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1437756,
+      "gpu_compute_apps": [
+        {
+          "pid": 2087606,
+          "name": "./target/release/spark",
+          "used_mib": 108862
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787444017,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.4
+        }
+      ],
+      "sm_clock_mhz": 2444.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6057960,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1452452,
+      "gpu_compute_apps": [
+        {
+          "pid": 2087606,
+          "name": "./target/release/spark",
+          "used_mib": 110328
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 83,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 17.099999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 0.0,
+    "jittered": 12.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 82.627037449,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "0 of 12 replays byte-identical, 12 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=0.00, jittered=12.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=82.63, unmeasured=0.00 · Pass: 0 of 12 replays byte-identical, 12 jittered within bounds (restore anchor selection varies between rounds on a healthy engine), 0 collapsed",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-23-a477e682e0.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-23-a477e682e0.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787485535,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787485486,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 46.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 50.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.7
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5044196,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4288572,
+      "gpu_compute_apps": [
+        {
+          "pid": 2320977,
+          "name": "./target/release/spark",
+          "used_mib": 109848
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787485535,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 82.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.1
+        }
+      ],
+      "sm_clock_mhz": 2437.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5088012,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4293888,
+      "gpu_compute_apps": [
+        {
+          "pid": 2320977,
+          "name": "./target/release/spark",
+          "used_mib": 109872
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 49,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 28.0,
+      "hottest_chassis_delta_c": 31.699999999999996
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +32 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 998.918105,
+    "p90_ms": 2162.9576930000003,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +2.4% (limit +3.0%) · p90 +3.5% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=998.92, p90_ms=2162.96, samples=36.00 · Pass: median +2.4% (limit +3.0%) · p90 +3.5% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-23-b7de8c2576.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787504291,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2470.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787504242,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 47.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 53.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 49.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 3944204,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3393804,
+      "gpu_compute_apps": [
+        {
+          "pid": 2425857,
+          "name": "./target/release/spark",
+          "used_mib": 109959
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787504291,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.1
+        }
+      ],
+      "sm_clock_mhz": 2470.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 3904144,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3397860,
+      "gpu_compute_apps": [
+        {
+          "pid": 2425857,
+          "name": "./target/release/spark",
+          "used_mib": 109983
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 49,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 23.0,
+      "hottest_chassis_delta_c": 27.800000000000004
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +28 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 997.230181,
+    "p90_ms": 2152.950068,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.2% (limit +3.0%) · p90 -0.5% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=997.23, p90_ms=2152.95, samples=36.00 · Pass: median -0.2% (limit +3.0%) · p90 -0.5% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-23-e1fd858f14.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787443699,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2437.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787443648,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 50.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 58.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.9
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6395304,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4451488,
+      "gpu_compute_apps": [
+        {
+          "pid": 2085844,
+          "name": "./target/release/spark",
+          "used_mib": 109837
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787443699,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 72.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        }
+      ],
+      "sm_clock_mhz": 2431.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5924800,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 959528,
+      "gpu_compute_apps": [
+        {
+          "pid": 2085844,
+          "name": "./target/release/spark",
+          "used_mib": 111301
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 51,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 22.0,
+      "hottest_chassis_delta_c": 24.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +25 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 975.864809,
+    "p90_ms": 2089.057664,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "info",
+  "verdict_reason": "no baseline on this box yet — this run is recorded as the baseline",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=975.86, p90_ms=2089.06, samples=36.00 · Info: no baseline on this box yet — this run is recorded as the baseline",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-23-a477e682e0.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-23-a477e682e0.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787503106,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2450.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787503013,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 57.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.3
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57664751238,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5562424,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3182312,
+      "gpu_compute_apps": [
+        {
+          "pid": 2411963,
+          "name": "./target/release/spark",
+          "used_mib": 108929
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787503106,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 76.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 89.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 89.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57664751238,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5687784,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3184808,
+      "gpu_compute_apps": [
+        {
+          "pid": 2411963,
+          "name": "./target/release/spark",
+          "used_mib": 108953
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 93,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 19.0,
+      "hottest_chassis_delta_c": 24.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +25 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 926.73524,
+    "p90_ms": 2165.272828,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -38.6% (limit +3.0%) · p90 -49.4% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=926.74, p90_ms=2165.27, samples=36.00 · Pass: median -38.6% (limit +3.0%) · p90 -49.4% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-23-b7de8c2576.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787504418,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2437.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787504325,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 52.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.7
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 4844364,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3398712,
+      "gpu_compute_apps": [
+        {
+          "pid": 2426296,
+          "name": "./target/release/spark",
+          "used_mib": 108937
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787504418,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 87.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 87.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5019980,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3402168,
+      "gpu_compute_apps": [
+        {
+          "pid": 2426296,
+          "name": "./target/release/spark",
+          "used_mib": 108961
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 93,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 23.0,
+      "hottest_chassis_delta_c": 29.500000000000007
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +30 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 922.984062,
+    "p90_ms": 2157.122776,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median -0.4% (limit +3.0%) · p90 -0.4% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=922.98, p90_ms=2157.12, samples=36.00 · Pass: median -0.4% (limit +3.0%) · p90 -0.4% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-23-e1fd858f14.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787443825,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2424.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787443735,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 63.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.0
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7777764,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1389884,
+      "gpu_compute_apps": [
+        {
+          "pid": 2086498,
+          "name": "./target/release/spark",
+          "used_mib": 108716
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787443825,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 87.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 87.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.3
+        }
+      ],
+      "sm_clock_mhz": 2424.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6471840,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1410776,
+      "gpu_compute_apps": [
+        {
+          "pid": 2086498,
+          "name": "./target/release/spark",
+          "used_mib": 110180
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 90,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 21.0,
+      "hottest_chassis_delta_c": 24.39999999999999
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +24 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "median_ms": 889.1637999999999,
+    "p90_ms": 2043.080409,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "info",
+  "verdict_reason": "no baseline on this box yet — this run is recorded as the baseline",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=889.16, p90_ms=2043.08, samples=36.00 · Info: no baseline on this box yet — this run is recorded as the baseline",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-23-a477e682e0.json
+++ b/.benchmarks/video-fidelity/2026-08-23-a477e682e0.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787486263,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787486247,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.3
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32942308,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4297192,
+      "gpu_compute_apps": [
+        {
+          "pid": 2325141,
+          "name": "./target/release/spark",
+          "used_mib": 83393
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787486263,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32807768,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4297332,
+      "gpu_compute_apps": [
+        {
+          "pid": 2325141,
+          "name": "./target/release/spark",
+          "used_mib": 83403
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 16,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 9.0,
+      "hottest_chassis_delta_c": 11.900000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +12 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 738.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1471.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 2933.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=738.00, conc_2_correct=2.00, conc_2_wall_ms=1471.00, conc_4_correct=4.00, conc_4_wall_ms=2933.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/video-fidelity/2026-08-23-b7de8c2576.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787505016,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2398.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787505000,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 62.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 73.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32699268,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3181292,
+      "gpu_compute_apps": [
+        {
+          "pid": 2429553,
+          "name": "./target/release/spark",
+          "used_mib": 83261
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787505016,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        }
+      ],
+      "sm_clock_mhz": 2470.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32576140,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3190796,
+      "gpu_compute_apps": [
+        {
+          "pid": 2429553,
+          "name": "./target/release/spark",
+          "used_mib": 83271
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 16,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 8.0,
+      "hottest_chassis_delta_c": 7.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +8 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 735.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1476.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 2937.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=735.00, conc_2_correct=2.00, conc_2_wall_ms=1476.00, conc_4_correct=4.00, conc_4_wall_ms=2937.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/video-fidelity/2026-08-23-e1fd858f14.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787474936,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787474919,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 67.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57016023007,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 33611940,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2042856,
+      "gpu_compute_apps": [
+        {
+          "pid": 2266146,
+          "name": "./target/release/spark",
+          "used_mib": 83449
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787474935,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.0
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57016023007,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 33462604,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2052732,
+      "gpu_compute_apps": [
+        {
+          "pid": 2266146,
+          "name": "./target/release/spark",
+          "used_mib": 83459
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 16,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 15.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +16 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 738.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1475.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 2942.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=738.00, conc_2_correct=2.00, conc_2_wall_ms=1475.00, conc_4_correct=4.00, conc_4_wall_ms=2942.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-23-a477e682e0.json
+++ b/.benchmarks/vision-fidelity/2026-08-23-a477e682e0.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "a477e682e0",
+  "recorded_at": 1787485739,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787485695,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.7
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5863656,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4293488,
+      "gpu_compute_apps": [
+        {
+          "pid": 2322118,
+          "name": "./target/release/spark",
+          "used_mib": 108908
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787485739,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 82.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.6
+        }
+      ],
+      "sm_clock_mhz": 2457.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 57363209425,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 5981208,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 4297376,
+      "gpu_compute_apps": [
+        {
+          "pid": 2322118,
+          "name": "./target/release/spark",
+          "used_mib": 108945
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 44,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 17.299999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 359.0,
+    "conc_2_wall_ms": 720.0,
+    "conc_4_wall_ms": 1329.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=359.00, conc_2_wall_ms=720.00, conc_4_wall_ms=1329.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-23-b7de8c2576.json
+++ b/.benchmarks/vision-fidelity/2026-08-23-b7de8c2576.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "b7de8c2576",
+  "recorded_at": 1787504493,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2450.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787504450,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 65.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 4890204,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3400312,
+      "gpu_compute_apps": [
+        {
+          "pid": 2426872,
+          "name": "./target/release/spark",
+          "used_mib": 108808
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787504493,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 71.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 81.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 78.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        }
+      ],
+      "sm_clock_mhz": 2450.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 58067021533,
+        "sw_thermal_us": 116567,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 4983664,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 3403296,
+      "gpu_compute_apps": [
+        {
+          "pid": 2426872,
+          "name": "./target/release/spark",
+          "used_mib": 108843
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 43,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 15.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +16 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 360.0,
+    "conc_2_wall_ms": 719.0,
+    "conc_4_wall_ms": 1328.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=360.00, conc_2_wall_ms=719.00, conc_4_wall_ms=1328.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a1744b17e3950f68d79dddc07c4a11f36cb757f64fdc926dbfa48d02074dc696",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ede8dd3cc348653ed2b34323291b23c3305e211a963a03b5774a4633eb471b6c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "2c32dcdc22c36991e2f1ea39d7b34da76dd16d943ae99c07e40bbce094d84e2c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "2b4b913e0e99e397c9a01def8390259f1ea4b7265ede3893ded00d81b63a266e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "62faf42199a60aeefe76bd6fd9a6616ee8b724952135915f0de0692ac7045488",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "fff2198dfee6094efe2d0fc190fe585666049524ae2c27da26a31c0fefcb65cf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "7e4ebced31b3edd41f1e140605231ca95f40f571cb9f6a209025b3bed18a6bb9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "c6803cb01292adc949f2c7d9dca869f572d552302bf349e223d68ae641d6f793",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "e1960fee156dc3eee9c147d096ff18df3257b90f09200e994f4cf079b13724a6",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "4eef1bb2fa09dcb24c9a39adf1655630773403dd3da3f38968fbfd5c65658706",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "bd626f8f4b768e22485b5568c88ccca62a0c84140c38be7f240bf053955c886d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "24b43c627892dfec8198258bb972b7660a2f78b6b804ad7a116d5d565f5d4a80",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "577ed7b90f6076f5551836c140efa92d62bec5b991023be74e54216a01e0f1dd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "01764ab7b7273cbeb5a4b2d28f9b97a3c78fb56233e5ac1a15e1f02531132731",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c6dfb5507d76fd35810cb05750552f5538badcbbe8812fc3475cbaef913a23ad",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "56a709347ad83b95c123b1328131d1d777bbf153b61d59928c7feaf2d9b5c82b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "5ecc90615eb1faa5447771ca9b44efe4953de40540bcf51c07f8fa4f904436a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "502db3cff8aef194e0c1de4432ac281bc5122b1d43c85c876655236aacde0020",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "67b1471423d47793f8d9bf55bd6e77000d2e7ef62990b715b633d7617742b8fd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "2e6f38245173496fc3ecbeda9ecfe4bdf18a40ecbffe38ee6512e61469729353",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "da47d11d6700509841af078d665f7feaa28e6c401c790b186271798e209014bf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "8fb653c85613f859d5a5b99b30fca9072bf0259371a83a44c83760268ed79804",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "7920e1922c2803090b168d3e29afe851e1ab771cddf5d53e95027ac992d69cf4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-23-e1fd858f14.json
+++ b/.benchmarks/vision-fidelity/2026-08-23-e1fd858f14.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "e1fd858f14",
+  "recorded_at": 1787443902,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787443857,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 65.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.4
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7637596,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1412256,
+      "gpu_compute_apps": [
+        {
+          "pid": 2087141,
+          "name": "./target/release/spark",
+          "used_mib": 108968
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787443902,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 73.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 82.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.3
+        }
+      ],
+      "sm_clock_mhz": 2437.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 56841491878,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6015828,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 1430228,
+      "gpu_compute_apps": [
+        {
+          "pid": 2087141,
+          "name": "./target/release/spark",
+          "used_mib": 110443
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 45,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 16.69999999999999
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 357.0,
+    "conc_2_wall_ms": 715.0,
+    "conc_4_wall_ms": 1397.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=357.00, conc_2_wall_ms=715.00, conc_4_wall_ms=1397.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "a47002bc7d7aacb2bb46e6d6ba02125ccec95a1493d35b16f8c081aa7161a133",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ac2d38e94b4975ad98551fd705d095325eac2b929db9082f0c93bf45264aa279",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "c776083991f9a2dc5bafc72bc76df8ea10e3e4c762413e7a630da862f4c75d4f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "00991b90487a50655b8d4ba343fc7616d9b614e26e561ce7f9e2e42cfdbe9c9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "c93f5352a3a2242aa4164ca27798c9df9861284105dde949a2da9ac590a47f5f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "988db029d82c36863067a250c097df414a0e900eeb58a8f42ddb02ea74944ffb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "e93d7f4a79eddf65bd6184f491dcea2d8571e531ddf4640660174c2a1ed3472d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "e7bdc229bd9dca80b9b3059b19d557fa99e8e4c8f931ae604d4a0658b3a5417b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "d182268e01fdadcafb365085adcfd7fa55a60a5c43f6a5656224a58b7dbc393a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "bc2564520b1121a03f4b903baf969b9d04fe742be7ceb031383be6ab1c64e624",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "7d7f86c17fa783fbfb00e4d0cbc2baefa45534d7f6dc56dacd650d46eb16323c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "a51d32e2c8141771bf3be35fca0ac9f3da02e9111d9250bcb23f2ed47a7566a5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "9d3d7c9556e9e3ce36019b8e528c21fb4671f259f0684e335076d96f90b277cb",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "02fb9d5c6f30cb32f0a2125d943e273e0aec218944fc7b67e27d5d352a6378da",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "1bd5407c618e6b44162d7e2621599e3f5f3e2368b0b001e4024bcb3445665df7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "82208bcb709a04d32f7efdf678bd4e7f15e66cf587058243d9fb1f200e646c53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "7837216113289292481dbcb146ba08f9b81e9cbfc3879ad40063e1f047e1dc37",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "16c256402aa88ae03f049a941f3c7495c339c024b02038c5a05d990b6bce1738",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "63d15c85b323390b6794df0a1b0a4e456fdd2e81a388fe6322e4cef49d2e4b4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "ea82456209de330563432508fa4c48e6a4be034d425255f642d1d277e243cff8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "ff14b127aae8d30483d4b69efb0c861d8f55f9a318078281ea98b44b5bc1ca52",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "958754040036d410bce7127de89a6d24fb8ac4862fd2be0a126843de5739f0ba",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "c82354daab16d93b4900f4981bd3aaa1c5c069ac3e336e3c2f05b1efe19e086c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/crates/spark-model/examples/kernel_probe.rs
+++ b/crates/spark-model/examples/kernel_probe.rs
@@ -40,8 +40,8 @@ fn main() -> anyhow::Result<()> {
         ("gemm", "dense_gemm_bf16_pipelined"),
         ("w8a16_gemm_t", "w8a16_gemm_t_pipelined"),
         ("gemm", "dense_gemm_bf16_router"), // order-preserving router GEMM
-        ("gemm", "dense_gemm_bf16"),      // known-good control
-        ("w8a16_gemm_t", "w8a16_gemm_t"), // known-good control (non-pipelined)
+        ("gemm", "dense_gemm_bf16"),        // known-good control
+        ("w8a16_gemm_t", "w8a16_gemm_t"),   // known-good control (non-pipelined)
     ];
     for (m, f) in probes {
         match gpu.kernel(m, f) {

--- a/crates/spark-model/examples/kernel_probe.rs
+++ b/crates/spark-model/examples/kernel_probe.rs
@@ -39,6 +39,7 @@ fn main() -> anyhow::Result<()> {
         ("w8a16_gemm_pipelined", "w8a16_gemm_pipelined"),
         ("gemm", "dense_gemm_bf16_pipelined"),
         ("w8a16_gemm_t", "w8a16_gemm_t_pipelined"),
+        ("gemm", "dense_gemm_bf16_router"), // order-preserving router GEMM
         ("gemm", "dense_gemm_bf16"),      // known-good control
         ("w8a16_gemm_t", "w8a16_gemm_t"), // known-good control (non-pipelined)
     ];

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -428,41 +428,109 @@ impl MoeLayer {
                 h,
                 stream,
             )?;
-            ops::moe_w8a8_grouped_gemm(
-                ctx.gpu,
-                self.moe_w8a8_grouped_gemm_k,
-                input_fp8,
-                input_a_scale,
-                gp.weight_ptrs,
-                gp.scale_ptrs,
-                expert_gate_out,
-                expert_offsets,
-                sorted_token_ids,
-                num_experts,
-                inter,
-                h,
-                max_m_tiles,
-                stream,
-            )?;
-            mprof!("grouped_gemm_w8a8");
-            ops::moe_w8a8_grouped_gemm(
-                ctx.gpu,
-                self.moe_w8a8_grouped_gemm_k,
-                input_fp8,
-                input_a_scale,
-                up.weight_ptrs,
-                up.scale_ptrs,
-                expert_up_out,
-                expert_offsets,
-                sorted_token_ids,
-                num_experts,
-                inter,
-                h,
-                max_m_tiles,
-                stream,
-            )?;
-            mprof!("grouped_gemm_w8a8");
-            ctx.gpu.synchronize(stream)?;
+            if self.moe_w8a8_grouped_gemm_pm4_k.0 != 0 && self.moe_build_tile_worklist_k.0 != 0 {
+                // PM4-geometry W8A8 over the compacted work-list (bit-identical
+                // numerics to the dense kernel, ~4.8× at the 36080-row prod
+                // shape). Build the work-list ONCE (gate and up share
+                // expert_offsets / NULL-ness / N=inter tiling), reuse for both.
+                // Builder + GEMMs on the SAME stream (read-after-write of
+                // total_tiles/worklist).
+                let n_tiles_gu = inter.div_ceil(PM4_N_TILE);
+                let wl_cap_items =
+                    (te.div_ceil(PM4_M_TILE as usize) + ne + 1) * n_tiles_gu as usize;
+                let wl_gu = ctx.gpu.alloc(wl_cap_items * 2 * 4)?;
+                let tt_gu = ctx.gpu.alloc(4)?;
+                ops::moe_build_tile_worklist(
+                    ctx.gpu,
+                    self.moe_build_tile_worklist_k,
+                    expert_offsets,
+                    gp.weight_ptrs,
+                    wl_gu,
+                    tt_gu,
+                    num_experts,
+                    n_tiles_gu,
+                    PM4_M_TILE,
+                    stream,
+                )?;
+                mprof!("tile_worklist");
+                ops::moe_w8a8_grouped_gemm_pm4(
+                    ctx.gpu,
+                    self.moe_w8a8_grouped_gemm_pm4_k,
+                    input_fp8,
+                    input_a_scale,
+                    gp.weight_ptrs,
+                    gp.scale_ptrs,
+                    expert_gate_out,
+                    expert_offsets,
+                    sorted_token_ids,
+                    num_experts,
+                    inter,
+                    h,
+                    wl_gu,
+                    tt_gu,
+                    wl_cap_items as u32,
+                    stream,
+                )?;
+                mprof!("grouped_gemm_w8a8");
+                ops::moe_w8a8_grouped_gemm_pm4(
+                    ctx.gpu,
+                    self.moe_w8a8_grouped_gemm_pm4_k,
+                    input_fp8,
+                    input_a_scale,
+                    up.weight_ptrs,
+                    up.scale_ptrs,
+                    expert_up_out,
+                    expert_offsets,
+                    sorted_token_ids,
+                    num_experts,
+                    inter,
+                    h,
+                    wl_gu,
+                    tt_gu,
+                    wl_cap_items as u32,
+                    stream,
+                )?;
+                mprof!("grouped_gemm_w8a8");
+                ctx.gpu.synchronize(stream)?;
+                ctx.gpu.free(wl_gu)?;
+                ctx.gpu.free(tt_gu)?;
+            } else {
+                ops::moe_w8a8_grouped_gemm(
+                    ctx.gpu,
+                    self.moe_w8a8_grouped_gemm_k,
+                    input_fp8,
+                    input_a_scale,
+                    gp.weight_ptrs,
+                    gp.scale_ptrs,
+                    expert_gate_out,
+                    expert_offsets,
+                    sorted_token_ids,
+                    num_experts,
+                    inter,
+                    h,
+                    max_m_tiles,
+                    stream,
+                )?;
+                mprof!("grouped_gemm_w8a8");
+                ops::moe_w8a8_grouped_gemm(
+                    ctx.gpu,
+                    self.moe_w8a8_grouped_gemm_k,
+                    input_fp8,
+                    input_a_scale,
+                    up.weight_ptrs,
+                    up.scale_ptrs,
+                    expert_up_out,
+                    expert_offsets,
+                    sorted_token_ids,
+                    num_experts,
+                    inter,
+                    h,
+                    max_m_tiles,
+                    stream,
+                )?;
+                mprof!("grouped_gemm_w8a8");
+                ctx.gpu.synchronize(stream)?;
+            }
             ctx.gpu.free(input_fp8)?;
             ctx.gpu.free(input_a_scale)?;
         } else if max_m_tiles > 0 {
@@ -582,24 +650,71 @@ impl MoeLayer {
                 inter,
                 stream,
             )?;
-            ops::moe_w8a8_grouped_gemm(
-                ctx.gpu,
-                self.moe_w8a8_grouped_gemm_k,
-                down_in_fp8,
-                down_in_scale,
-                dp.weight_ptrs,
-                dp.scale_ptrs,
-                expert_down_out,
-                expert_offsets,
-                spark_runtime::gpu::DevicePtr(0),
-                num_experts,
-                h,
-                inter,
-                max_m_tiles,
-                stream,
-            )?;
-            mprof!("grouped_gemm_w8a8");
-            ctx.gpu.synchronize(stream)?;
+            if self.moe_w8a8_grouped_gemm_pm4_k.0 != 0 && self.moe_build_tile_worklist_k.0 != 0 {
+                // PM4-geometry W8A8 down-proj: separate work-list (N=h, K=inter
+                // → different n_tiles than gate/up). sorted_token_ids=NULL keeps
+                // the direct-index A-prefetch branch. Builder + GEMM on the SAME
+                // stream (read-after-write of total_tiles/worklist).
+                let n_tiles_dn = h.div_ceil(PM4_N_TILE);
+                let wl_cap_items =
+                    (te.div_ceil(PM4_M_TILE as usize) + ne + 1) * n_tiles_dn as usize;
+                let wl_dn = ctx.gpu.alloc(wl_cap_items * 2 * 4)?;
+                let tt_dn = ctx.gpu.alloc(4)?;
+                ops::moe_build_tile_worklist(
+                    ctx.gpu,
+                    self.moe_build_tile_worklist_k,
+                    expert_offsets,
+                    dp.weight_ptrs,
+                    wl_dn,
+                    tt_dn,
+                    num_experts,
+                    n_tiles_dn,
+                    PM4_M_TILE,
+                    stream,
+                )?;
+                mprof!("tile_worklist");
+                ops::moe_w8a8_grouped_gemm_pm4(
+                    ctx.gpu,
+                    self.moe_w8a8_grouped_gemm_pm4_k,
+                    down_in_fp8,
+                    down_in_scale,
+                    dp.weight_ptrs,
+                    dp.scale_ptrs,
+                    expert_down_out,
+                    expert_offsets,
+                    spark_runtime::gpu::DevicePtr(0),
+                    num_experts,
+                    h,
+                    inter,
+                    wl_dn,
+                    tt_dn,
+                    wl_cap_items as u32,
+                    stream,
+                )?;
+                mprof!("grouped_gemm_w8a8");
+                ctx.gpu.synchronize(stream)?;
+                ctx.gpu.free(wl_dn)?;
+                ctx.gpu.free(tt_dn)?;
+            } else {
+                ops::moe_w8a8_grouped_gemm(
+                    ctx.gpu,
+                    self.moe_w8a8_grouped_gemm_k,
+                    down_in_fp8,
+                    down_in_scale,
+                    dp.weight_ptrs,
+                    dp.scale_ptrs,
+                    expert_down_out,
+                    expert_offsets,
+                    spark_runtime::gpu::DevicePtr(0),
+                    num_experts,
+                    h,
+                    inter,
+                    max_m_tiles,
+                    stream,
+                )?;
+                mprof!("grouped_gemm_w8a8");
+                ctx.gpu.synchronize(stream)?;
+            }
             ctx.gpu.free(down_in_fp8)?;
             ctx.gpu.free(down_in_scale)?;
         } else if max_m_tiles > 0 {
@@ -633,6 +748,7 @@ impl MoeLayer {
                 PM4_M_TILE,
                 stream,
             )?;
+            mprof!("tile_worklist");
             ops::moe_fp8_grouped_gemm(
                 ctx.gpu,
                 self.moe_fp8_grouped_gemm_k,

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -5,6 +5,20 @@
 use super::*;
 
 impl MoeLayer {
+    /// Whether the fused `silu_mul_quant_fp8` kernel may replace the
+    /// `silu_mul` → `per_token_group_quant_fp8` pair for a K-dim of `k`
+    /// (bit-identical when it does). Requires: the kernel handle (a model
+    /// shadowing `moe_silu_mul.cu` without the entry point gets handle 0),
+    /// the SiLU activation (the fused kernel bakes SiLU — GeGLU models keep
+    /// the pair), and `k` within the kernel's per-thread register cap
+    /// (`K % 128 == 0`, `K/128 <= SILU_QUANT_MAX_GROUPS = 16`).
+    fn fused_silu_quant_ok(&self, k: u32) -> bool {
+        self.silu_mul_quant_fp8_k.0 != 0
+            && !self.gelu_activation
+            && k.is_multiple_of(128)
+            && k / 128 <= 16
+    }
+
     /// EP token dispatch/combine forward pass (Workstream 3A scaffold).
     ///
     /// Instead of dense all-reduce, this:
@@ -140,32 +154,50 @@ impl MoeLayer {
             ctx.gpu.synchronize(stream)?;
             ctx.gpu.free(input_fp8)?;
             ctx.gpu.free(input_scale)?;
-            ops::silu_mul(
-                ctx.gpu,
-                self.moe_act_mul,
-                shared_gate_out,
-                shared_up_out,
-                shared_gate_out,
-                n * shared_inter,
-                stream,
-            )?;
-            mprof!("silu_mul");
             let shared_down_out = ctx.buffers.attn_output();
             // Quant the post-silu intermediate (K=shared_inter)
             let a2_bytes: usize = m_us * shared_inter as usize;
             let a2_scale_bytes: usize = m_us * (shared_inter as usize / 128) * 4;
             let down_in_fp8 = ctx.gpu.alloc(a2_bytes)?;
             let down_in_scale = ctx.gpu.alloc(a2_scale_bytes)?;
-            ops::per_token_group_quant_fp8(
-                ctx.gpu,
-                self.per_token_group_quant_fp8_k,
-                shared_gate_out,
-                down_in_fp8,
-                down_in_scale,
-                n,
-                shared_inter,
-                stream,
-            )?;
+            if self.fused_silu_quant_ok(shared_inter) {
+                // Nothing downstream reads the post-SiLU BF16 shared
+                // intermediate (no shared-expert LoRA fold), so skip the
+                // BF16 write entirely.
+                ops::silu_mul_quant_fp8(
+                    ctx.gpu,
+                    self.silu_mul_quant_fp8_k,
+                    shared_gate_out,
+                    shared_up_out,
+                    down_in_fp8,
+                    down_in_scale,
+                    spark_runtime::gpu::DevicePtr::NULL,
+                    n,
+                    shared_inter,
+                    stream,
+                )?;
+            } else {
+                ops::silu_mul(
+                    ctx.gpu,
+                    self.moe_act_mul,
+                    shared_gate_out,
+                    shared_up_out,
+                    shared_gate_out,
+                    n * shared_inter,
+                    stream,
+                )?;
+                ops::per_token_group_quant_fp8(
+                    ctx.gpu,
+                    self.per_token_group_quant_fp8_k,
+                    shared_gate_out,
+                    down_in_fp8,
+                    down_in_scale,
+                    n,
+                    shared_inter,
+                    stream,
+                )?;
+            }
+            mprof!("silu_mul_quant");
             ops::fp8_gemm_t_blockscaled(
                 ctx.gpu,
                 self.fp8_gemm_t_blockscaled_k,
@@ -623,16 +655,6 @@ impl MoeLayer {
         // 6. Activation+mul + down GEMM
         let expert_down_out = ctx.buffers.expert_down_out();
         if force_w8a8 && max_m_tiles > 0 {
-            ops::silu_mul(
-                ctx.gpu,
-                self.moe_act_mul,
-                expert_gate_out,
-                expert_up_out,
-                expert_gate_out,
-                total_expanded * inter,
-                stream,
-            )?;
-            mprof!("silu_mul");
             // Quant the permuted post-silu intermediate. Length is
             // total_expanded, K is `inter` (down_proj input dim).
             let m: usize = total_expanded as usize;
@@ -640,16 +662,53 @@ impl MoeLayer {
             let a_scale_bytes: usize = m * (inter as usize / 128) * 4;
             let down_in_fp8 = ctx.gpu.alloc(a_fp8_bytes)?;
             let down_in_scale = ctx.gpu.alloc(a_scale_bytes)?;
-            ops::per_token_group_quant_fp8(
-                ctx.gpu,
-                self.per_token_group_quant_fp8_k,
-                expert_gate_out,
-                down_in_fp8,
-                down_in_scale,
-                m as u32,
-                inter,
-                stream,
-            )?;
+            if self.fused_silu_quant_ok(inter) {
+                // `apply_expert_lora_prefill_down` below consumes the
+                // post-SiLU BF16 `expert_gate_out`. When ANY MoE LoRA is
+                // installed, also write the BF16 rows (exact `moe_silu_mul`
+                // output, in place — group g's slice is fully written before
+                // group g+1's is read, so aliasing gate is safe) rather than
+                // silently dropping the fold's input. Base runs skip the
+                // extra write entirely.
+                let lora_bf16_out = if self.lora.is_some() {
+                    expert_gate_out
+                } else {
+                    spark_runtime::gpu::DevicePtr::NULL
+                };
+                ops::silu_mul_quant_fp8(
+                    ctx.gpu,
+                    self.silu_mul_quant_fp8_k,
+                    expert_gate_out,
+                    expert_up_out,
+                    down_in_fp8,
+                    down_in_scale,
+                    lora_bf16_out,
+                    m as u32,
+                    inter,
+                    stream,
+                )?;
+            } else {
+                ops::silu_mul(
+                    ctx.gpu,
+                    self.moe_act_mul,
+                    expert_gate_out,
+                    expert_up_out,
+                    expert_gate_out,
+                    total_expanded * inter,
+                    stream,
+                )?;
+                ops::per_token_group_quant_fp8(
+                    ctx.gpu,
+                    self.per_token_group_quant_fp8_k,
+                    expert_gate_out,
+                    down_in_fp8,
+                    down_in_scale,
+                    m as u32,
+                    inter,
+                    stream,
+                )?;
+            }
+            mprof!("silu_mul_quant");
             if self.moe_w8a8_grouped_gemm_pm4_k.0 != 0 && self.moe_build_tile_worklist_k.0 != 0 {
                 // PM4-geometry W8A8 down-proj: separate work-list (N=h, K=inter
                 // → different n_tiles than gate/up). sorted_token_ids=NULL keeps

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -385,7 +385,7 @@ impl MoeLayer {
             top_k,
             stream,
         )?;
-            mprof!("sort_by_expert");
+        mprof!("sort_by_expert");
 
         // 4. Max M tiles — sized for worst-case expert skew, not 2× avg.
         // The `(avg * 2)` heuristic silently truncated heavy experts:
@@ -859,7 +859,7 @@ impl MoeLayer {
             top_k,
             stream,
         )?;
-            mprof!("unpermute_reduce");
+        mprof!("unpermute_reduce");
 
         // EP all-reduce of routed-expert output FIRST.
         // Shared experts are NOT EP-sharded (every rank loads the full

--- a/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
+++ b/crates/spark-model/src/layers/moe/forward_prefill_fp8.rs
@@ -16,6 +16,9 @@ impl MoeLayer {
     ///
     /// Same pipeline as NVFP4 forward_prefill but uses moe_fp8_grouped_gemm
     /// with FP8 pointer tables instead of NVFP4 pointer tables.
+    // `mt` is re-armed by the last mprof! and not read again; that is the
+    // macro working as intended, not a bug.
+    #[allow(unused_assignments)]
     pub(super) fn forward_prefill_fp8(
         &self,
         input: DevicePtr,
@@ -31,6 +34,33 @@ impl MoeLayer {
         let n = num_tokens as u32;
         let total_expanded = n * top_k;
         let ne = num_experts as usize;
+
+        // ── Profiling (PCND: inert unless `--profile`) ─────────────────────
+        // This path had NO instrumentation, and it is 71.6% of cold prefill
+        // (2204 ms of 3078 ms measured on the 35B at 4k tokens) while the GDN
+        // spine beside it — 6.8% — carries thirteen timers. Every large win
+        // this session came from somewhere the instruments were missing.
+        let profile = ctx.profile;
+        let mut mt = if profile {
+            ctx.gpu.synchronize(stream)?;
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+        macro_rules! mprof {
+            ($label:expr) => {
+                if let Some(t) = mt.take() {
+                    ctx.gpu.synchronize(stream)?;
+                    tracing::info!(
+                        "  MOE prefill [{}] N={}: {}\u{b5}s",
+                        $label,
+                        n,
+                        t.elapsed().as_micros()
+                    );
+                    mt = Some(std::time::Instant::now());
+                }
+            };
+        }
 
         let (gp, up, dp, sh) = match (
             &self.fp8_gate_weight_ptrs,
@@ -119,6 +149,7 @@ impl MoeLayer {
                 n * shared_inter,
                 stream,
             )?;
+            mprof!("silu_mul");
             let shared_down_out = ctx.buffers.attn_output();
             // Quant the post-silu intermediate (K=shared_inter)
             let a2_bytes: usize = m_us * shared_inter as usize;
@@ -220,6 +251,7 @@ impl MoeLayer {
                 n * shared_inter,
                 stream,
             )?;
+            mprof!("silu_mul");
             let shared_down_out = ctx.buffers.attn_output();
             sh_gemm(
                 shared_gate_out,
@@ -284,6 +316,7 @@ impl MoeLayer {
                 n,
                 stream,
             )?;
+            mprof!("routing_topk");
         } else {
             ops::moe_topk_softmax_batched(
                 ctx.gpu,
@@ -320,6 +353,7 @@ impl MoeLayer {
             top_k,
             stream,
         )?;
+            mprof!("sort_by_expert");
 
         // 4. Max M tiles — sized for worst-case expert skew, not 2× avg.
         // The `(avg * 2)` heuristic silently truncated heavy experts:
@@ -410,6 +444,7 @@ impl MoeLayer {
                 max_m_tiles,
                 stream,
             )?;
+            mprof!("grouped_gemm_w8a8");
             ops::moe_w8a8_grouped_gemm(
                 ctx.gpu,
                 self.moe_w8a8_grouped_gemm_k,
@@ -426,6 +461,7 @@ impl MoeLayer {
                 max_m_tiles,
                 stream,
             )?;
+            mprof!("grouped_gemm_w8a8");
             ctx.gpu.synchronize(stream)?;
             ctx.gpu.free(input_fp8)?;
             ctx.gpu.free(input_a_scale)?;
@@ -456,6 +492,7 @@ impl MoeLayer {
                 PM4_M_TILE,
                 stream,
             )?;
+            mprof!("tile_worklist");
             ops::moe_fp8_grouped_gemm(
                 ctx.gpu,
                 self.moe_fp8_grouped_gemm_k,
@@ -473,6 +510,7 @@ impl MoeLayer {
                 wl_cap_items as u32,
                 stream,
             )?;
+            mprof!("grouped_gemm_fp8");
             ops::moe_fp8_grouped_gemm(
                 ctx.gpu,
                 self.moe_fp8_grouped_gemm_k,
@@ -490,6 +528,7 @@ impl MoeLayer {
                 wl_cap_items as u32,
                 stream,
             )?;
+            mprof!("grouped_gemm_fp8");
             ctx.gpu.synchronize(stream)?;
             ctx.gpu.free(wl_gu)?;
             ctx.gpu.free(tt_gu)?;
@@ -525,6 +564,7 @@ impl MoeLayer {
                 total_expanded * inter,
                 stream,
             )?;
+            mprof!("silu_mul");
             // Quant the permuted post-silu intermediate. Length is
             // total_expanded, K is `inter` (down_proj input dim).
             let m: usize = total_expanded as usize;
@@ -558,6 +598,7 @@ impl MoeLayer {
                 max_m_tiles,
                 stream,
             )?;
+            mprof!("grouped_gemm_w8a8");
             ctx.gpu.synchronize(stream)?;
             ctx.gpu.free(down_in_fp8)?;
             ctx.gpu.free(down_in_scale)?;
@@ -571,6 +612,7 @@ impl MoeLayer {
                 total_expanded * inter,
                 stream,
             )?;
+            mprof!("silu_mul");
             // ── down-proj: separate work-list (N=h, K=inter → different
             // n_tiles than gate/up). sorted_token_ids=NULL keeps the
             // direct-index A-prefetch branch (R6). Builder + grouped GEMM on the
@@ -608,6 +650,7 @@ impl MoeLayer {
                 wl_cap_items as u32,
                 stream,
             )?;
+            mprof!("grouped_gemm_fp8");
             ctx.gpu.synchronize(stream)?;
             ctx.gpu.free(wl_dn)?;
             ctx.gpu.free(tt_dn)?;
@@ -641,6 +684,7 @@ impl MoeLayer {
             top_k,
             stream,
         )?;
+            mprof!("unpermute_reduce");
 
         // EP all-reduce of routed-expert output FIRST.
         // Shared experts are NOT EP-sharded (every rank loads the full
@@ -681,6 +725,7 @@ impl MoeLayer {
                 n,
                 stream,
             )?;
+            mprof!("blend");
         }
 
         super::dump::dump_moe_out(ctx.gpu, stream, output, n, h)?;

--- a/crates/spark-model/src/layers/moe/helpers_c.rs
+++ b/crates/spark-model/src/layers/moe/helpers_c.rs
@@ -240,7 +240,7 @@ impl MoeLayer {
     /// Router gate GEMM for a BF16 (dense) gate weight at prefill:
     /// `gate_logits[n, num_experts] = router_in @ gate^T`.
     ///
-    /// PINNED to the scalar `dense_gemm` kernel, never a rerouted fast GEMM.
+    /// PINNED to scalar-ORDER numerics, never a reassociating fast GEMM.
     /// Router logits are selection inputs, not data: top-k reads them after a
     /// BF16 store, where near-tied experts sit 1 ulp apart, so ANY change in
     /// accumulation order flips selections on borderline tokens and the flip
@@ -250,8 +250,18 @@ impl MoeLayer {
     /// 84.76 overall — deterministic, reproduced to the hundredth on two
     /// trees (2026-08-12, 03a74eac19 / cb9f8ecab4) — while every dense-model
     /// gate stayed inside noise. The routed-expert GEMMs tolerate order
-    /// changes; the router does not. Perf is a non-argument at this shape:
-    /// N = num_experts is tiny next to the expert GEMMs this feeds.
+    /// changes; the router does not.
+    ///
+    /// `dense_gemm_bf16_router` satisfies the pin: it keeps the scalar
+    /// kernel's exact per-output FP32 fma chain in strict k = 0..K-1 order
+    /// (only blocking/vectorization differ) and is verified BIT-IDENTICAL to
+    /// `dense_gemm_bf16` under the production `--fmad=false` build (0
+    /// differing elements over [4510,2048]x[2048,256] and
+    /// [2255,2048]x[2048,256]) at ~2x the speed — the router GEMM is 40
+    /// layers x ~3.2 ms of cold prefill (the real payload of the mprof
+    /// "sort_by_expert" bucket), so the 2x is ~65 ms per 4.5k-token prefill.
+    /// Falls back to the scalar kernel when the variant is absent from a
+    /// model's gemm module.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn router_gate_gemm_dense(
         &self,
@@ -263,6 +273,19 @@ impl MoeLayer {
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
+        if self.dense_gemm_router.0 != 0 {
+            return ops::dense_gemm_router(
+                ctx.gpu,
+                self.dense_gemm_router,
+                router_in,
+                &self.weights.gate,
+                gate_logits,
+                num_tokens,
+                num_experts,
+                hidden_size,
+                stream,
+            );
+        }
         ops::dense_gemm(
             ctx.gpu,
             self.dense_gemm,

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -201,6 +201,13 @@ impl MoeLayer {
                 "moe_w8a8_grouped_gemm",
                 "moe_w8a8_grouped_gemm",
             ),
+            // PM4-geometry W8A8 grouped GEMM (same module). Handle may be 0 on
+            // targets/images without it; dispatch falls back to the dense grid.
+            moe_w8a8_grouped_gemm_pm4_k: super::super::try_kernel(
+                gpu,
+                "moe_w8a8_grouped_gemm",
+                "moe_w8a8_grouped_gemm_pm4",
+            ),
             per_token_group_quant_fp8_k: super::super::try_kernel(
                 gpu,
                 "per_token_group_quant_fp8",

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -214,6 +214,14 @@ impl MoeLayer {
                 "per_token_group_quant_fp8",
                 "per_token_group_quant_fp8",
             ),
+            // Fused silu_mul + per-token-group quant. Same module as
+            // moe_silu_mul, so a model that shadows moe_silu_mul.cu without
+            // this entry point gets handle 0 → unfused fallback.
+            silu_mul_quant_fp8_k: super::super::try_kernel(
+                gpu,
+                "moe_silu_mul",
+                "silu_mul_quant_fp8",
+            ),
             fp8_gemm_t_blockscaled_k: super::super::try_kernel(
                 gpu,
                 "fp8_gemm_t_blockscaled",

--- a/crates/spark-model/src/layers/moe/init.rs
+++ b/crates/spark-model/src/layers/moe/init.rs
@@ -80,6 +80,7 @@ impl MoeLayer {
             w4a16_gemv_sw: super::super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w4a16_gemm: gpu.kernel("w4a16", "w4a16_gemm")?,
             dense_gemm: gpu.kernel("gemm", "dense_gemm_bf16")?,
+            dense_gemm_router: super::super::try_kernel(gpu, "gemm", "dense_gemm_bf16_router"),
             dense_gemm_pipelined: super::super::try_kernel(
                 gpu,
                 "gemm",

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -122,6 +122,11 @@ pub struct MoeLayer {
     w4a16_gemv_sw: KernelHandle,
     w4a16_gemm: KernelHandle,
     dense_gemm: KernelHandle,
+    /// Order-preserving register-blocked router GEMM (`dense_gemm_bf16_router`):
+    /// bit-identical to the scalar `dense_gemm` (same per-output FP32 k-order,
+    /// `--fmad=false` build) at ~2x speed. `KernelHandle(0)` on miss → the
+    /// pinned scalar kernel. Used ONLY by `router_gate_gemm_dense`.
+    dense_gemm_router: KernelHandle,
     dense_gemm_pipelined: KernelHandle,
     /// FP32-output router GEMM + FP32-input top-K for the ATLAS_FP32_GATE path.
     /// Zero (unresolved) when the kernels are absent; dispatch falls back to BF16.

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -353,6 +353,11 @@ pub struct MoeLayer {
     // 3D-grid `moe_w8a8_grouped_gemm_k`.
     moe_w8a8_grouped_gemm_pm4_k: KernelHandle,
     per_token_group_quant_fp8_k: KernelHandle,
+    /// Fused SiLU·mul + per-token-group FP8 quant (bit-identical replacement
+    /// for the `silu_mul` → `per_token_group_quant_fp8` pair on the W8A8
+    /// prefill down-path). Optional: handle 0 (e.g. a model shadowing
+    /// moe_silu_mul.cu without this entry point) falls back to the pair.
+    silu_mul_quant_fp8_k: KernelHandle,
     // Dense W8A8 (same kernel used by attention QKV/O proj) for shared-expert path.
     fp8_gemm_t_blockscaled_k: KernelHandle,
     // BF16 grouped GEMM — for FP8-source models dequanted to BF16 at load.

--- a/crates/spark-model/src/layers/moe/mod.rs
+++ b/crates/spark-model/src/layers/moe/mod.rs
@@ -341,6 +341,12 @@ pub struct MoeLayer {
     // W8A8 + FP32 epilogue MoE GEMM (vLLM-equivalent). Opt-in via
     // ATLAS_FP8_W8A8=1. Requires per-token-quanted A_fp8 + a_scale.
     moe_w8a8_grouped_gemm_k: KernelHandle,
+    // PM4-geometry W8A8 grouped GEMM over the compacted work-list (kernel
+    // `moe_w8a8_grouped_gemm_pm4`, same module). Bit-identical numerics to
+    // the dense kernel; preferred when present (gb10). Handle may be 0 on
+    // targets/images that don't ship it — dispatch falls back to the dense
+    // 3D-grid `moe_w8a8_grouped_gemm_k`.
+    moe_w8a8_grouped_gemm_pm4_k: KernelHandle,
     per_token_group_quant_fp8_k: KernelHandle,
     // Dense W8A8 (same kernel used by attention QKV/O proj) for shared-expert path.
     fp8_gemm_t_blockscaled_k: KernelHandle,

--- a/crates/spark-model/src/layers/ops/activations.rs
+++ b/crates/spark-model/src/layers/ops/activations.rs
@@ -36,6 +36,45 @@ pub fn silu_mul(
         .launch(stream)
 }
 
+/// Fused SiLU·mul + per-token-group(128) FP8-E4M3 quantization — replaces the
+/// `silu_mul` → `per_token_group_quant_fp8` pair on the W8A8 prefill down-path
+/// without materializing the BF16 intermediate. Bit-identical to the pair
+/// (product rounds through BF16 before the group max; same reduction order,
+/// scale floor, and SATFINITE encode).
+///
+/// `out_bf16` is nullable (`DevicePtr::NULL`): pass the post-SiLU BF16 buffer
+/// only when a downstream consumer needs it (expert down_proj LoRA fold).
+///
+/// Kernel: `silu_mul_quant_fp8(gate, up, out_fp8, a_scale, out_bf16, M, K)`
+/// Grid: (M, 1, 1)  Block: (128, 1, 1). Caller must ensure `k % 128 == 0`
+/// and `k / 128 <= 16` (SILU_QUANT_MAX_GROUPS) — fall back to the unfused
+/// pair otherwise.
+#[allow(clippy::too_many_arguments)]
+pub fn silu_mul_quant_fp8(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    gate: DevicePtr,
+    up: DevicePtr,
+    out_fp8: DevicePtr,
+    a_scale: DevicePtr,
+    out_bf16: DevicePtr,
+    m: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([m, 1, 1])
+        .block([128, 1, 1])
+        .arg_ptr(gate)
+        .arg_ptr(up)
+        .arg_ptr(out_fp8)
+        .arg_ptr(a_scale)
+        .arg_ptr(out_bf16)
+        .arg_u32(m)
+        .arg_u32(k)
+        .launch(stream)
+}
+
 /// L2 normalization (in-place): `data[i] = data[i] / sqrt(sum(data^2) + eps)`.
 ///
 /// Applied per head: data is [num_heads, head_dim], each head normalized independently.

--- a/crates/spark-model/src/layers/ops/dispatch_config.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_config.rs
@@ -33,16 +33,6 @@ pub struct GemmDispatch {
     /// gauge ~1400 → ~100 once block-scaled prefill is on).
     /// Opt out with `ATLAS_FP8_SINGLE_SCALE=1` — diagnostic/fallback only.
     pub fp8_blockscaled_prefill: bool,
-    /// SSM QKVZ prefill through the dequant-once-cached cuBLASLt BF16 GEMM
-    /// (W16A16) instead of the block-scaled W8A8 path. Default ON since
-    /// 2026-08-22 (candidate P3_ssm_cublas_route): 2.8× at the production
-    /// shape [4510×2048]×[2048×12288] AND ~7× lower max-abs error vs the f64
-    /// reference (0.019 vs 0.135 — W8A8 quantises the activations, W16A16
-    /// does not). Costs +50 MB BF16 weight cache per GDN layer, allocated
-    /// fail-fast on first prefill. NOTE: deliberately departs from
-    /// "vLLM-equivalent W8A8" parity on this projection; opt out with
-    /// `ATLAS_SSM_QKVZ_W8A8=1` to restore the previous route for A/B.
-    pub ssm_qkvz_cublas_bf16: bool,
     /// cuBLASLt BF16 GEMM. The hand-written mma.sync projection GEMMs reach
     /// only ~30% of the cuBLAS bf16 ceiling on GB10.
     pub cublas_gemm: bool,
@@ -86,8 +76,6 @@ impl GemmDispatch {
             },
             // Note the inverted sense: this one is on unless opted out.
             fp8_blockscaled_prefill: !on("ATLAS_FP8_SINGLE_SCALE"),
-            // Also inverted: on unless opted out (see the field doc).
-            ssm_qkvz_cublas_bf16: !on("ATLAS_SSM_QKVZ_W8A8"),
             cublas_gemm: on("ATLAS_CUBLAS_GEMM"),
             cublas_fp8: on("ATLAS_CUBLAS_FP8"),
             cutlass_gemm: on("ATLAS_CUTLASS_GEMM"),
@@ -109,7 +97,6 @@ impl GemmDispatch {
         Self {
             w4a16_variant: 0,
             fp8_blockscaled_prefill: true,
-            ssm_qkvz_cublas_bf16: true,
             cublas_gemm: false,
             cublas_fp8: false,
             cutlass_gemm: false,
@@ -146,7 +133,6 @@ mod tests {
     fn defaults_have_only_blockscaled_prefill_on() {
         let d = GemmDispatch::defaults();
         assert!(d.fp8_blockscaled_prefill, "on unless opted out");
-        assert!(d.ssm_qkvz_cublas_bf16, "on unless opted out");
         assert!(!d.cublas_gemm && !d.cutlass_gemm && !d.cutlass_nvfp4_gemm);
     }
 

--- a/crates/spark-model/src/layers/ops/dispatch_config.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_config.rs
@@ -33,6 +33,16 @@ pub struct GemmDispatch {
     /// gauge ~1400 → ~100 once block-scaled prefill is on).
     /// Opt out with `ATLAS_FP8_SINGLE_SCALE=1` — diagnostic/fallback only.
     pub fp8_blockscaled_prefill: bool,
+    /// SSM QKVZ prefill through the dequant-once-cached cuBLASLt BF16 GEMM
+    /// (W16A16) instead of the block-scaled W8A8 path. Default ON since
+    /// 2026-08-22 (candidate P3_ssm_cublas_route): 2.8× at the production
+    /// shape [4510×2048]×[2048×12288] AND ~7× lower max-abs error vs the f64
+    /// reference (0.019 vs 0.135 — W8A8 quantises the activations, W16A16
+    /// does not). Costs +50 MB BF16 weight cache per GDN layer, allocated
+    /// fail-fast on first prefill. NOTE: deliberately departs from
+    /// "vLLM-equivalent W8A8" parity on this projection; opt out with
+    /// `ATLAS_SSM_QKVZ_W8A8=1` to restore the previous route for A/B.
+    pub ssm_qkvz_cublas_bf16: bool,
     /// cuBLASLt BF16 GEMM. The hand-written mma.sync projection GEMMs reach
     /// only ~30% of the cuBLAS bf16 ceiling on GB10.
     pub cublas_gemm: bool,
@@ -76,6 +86,8 @@ impl GemmDispatch {
             },
             // Note the inverted sense: this one is on unless opted out.
             fp8_blockscaled_prefill: !on("ATLAS_FP8_SINGLE_SCALE"),
+            // Also inverted: on unless opted out (see the field doc).
+            ssm_qkvz_cublas_bf16: !on("ATLAS_SSM_QKVZ_W8A8"),
             cublas_gemm: on("ATLAS_CUBLAS_GEMM"),
             cublas_fp8: on("ATLAS_CUBLAS_FP8"),
             cutlass_gemm: on("ATLAS_CUTLASS_GEMM"),
@@ -97,6 +109,7 @@ impl GemmDispatch {
         Self {
             w4a16_variant: 0,
             fp8_blockscaled_prefill: true,
+            ssm_qkvz_cublas_bf16: true,
             cublas_gemm: false,
             cublas_fp8: false,
             cutlass_gemm: false,
@@ -133,6 +146,7 @@ mod tests {
     fn defaults_have_only_blockscaled_prefill_on() {
         let d = GemmDispatch::defaults();
         assert!(d.fp8_blockscaled_prefill, "on unless opted out");
+        assert!(d.ssm_qkvz_cublas_bf16, "on unless opted out");
         assert!(!d.cublas_gemm && !d.cutlass_gemm && !d.cutlass_nvfp4_gemm);
     }
 

--- a/crates/spark-model/src/layers/ops/gemm_dense.rs
+++ b/crates/spark-model/src/layers/ops/gemm_dense.rs
@@ -115,7 +115,7 @@ pub fn dense_gemm(
 /// Same math AND the same per-output FP32 accumulation order (strict
 /// k = 0..K-1) as the scalar `dense_gemm` — bit-identical output under the
 /// kernel dir's `--fmad=false` build (verified 0 differing elements at the
-/// router shapes M=4510/M=2255, [M,2048]x[2048,256]) — at ~2x the speed via
+/// router shapes M=4510/M=2255, `[M,2048]x[2048,256]`) — at ~2x the speed via
 /// register blocking + vectorized smem staging. This is the ONLY fast GEMM
 /// that satisfies the 2026-08-12 router-numerics pin (see
 /// `router_gate_gemm_dense`); tensor-core kernels reassociate and stay

--- a/crates/spark-model/src/layers/ops/gemm_dense.rs
+++ b/crates/spark-model/src/layers/ops/gemm_dense.rs
@@ -110,6 +110,41 @@ pub fn dense_gemm(
         .launch(stream)
 }
 
+/// Order-preserving register-blocked BF16 GEMM (kernel `dense_gemm_bf16_router`).
+///
+/// Same math AND the same per-output FP32 accumulation order (strict
+/// k = 0..K-1) as the scalar `dense_gemm` — bit-identical output under the
+/// kernel dir's `--fmad=false` build (verified 0 differing elements at the
+/// router shapes M=4510/M=2255, [M,2048]x[2048,256]) — at ~2x the speed via
+/// register blocking + vectorized smem staging. This is the ONLY fast GEMM
+/// that satisfies the 2026-08-12 router-numerics pin (see
+/// `router_gate_gemm_dense`); tensor-core kernels reassociate and stay
+/// forbidden there.
+///
+/// Grid: (ceil(N/64), ceil(M/16), 1)  Block: (16, 16, 1)
+pub fn dense_gemm_router(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &DenseWeight,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 64), div_ceil(m, 16), 1])
+        .block([16, 16, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(output)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)
+}
+
 /// Pipelined tensor-core BF16 GEMM — drop-in faster `dense_gemm` (kernel
 /// `dense_gemm_bf16_pipelined`): mma.sync.m16n8k16 + cp.async 2-stage, 128x128
 /// tile. ~40x the scalar `dense_gemm` on large-M shapes (cosine=1.0, same math).

--- a/crates/spark-model/src/layers/ops/gemm_quant.rs
+++ b/crates/spark-model/src/layers/ops/gemm_quant.rs
@@ -617,6 +617,62 @@ pub fn moe_w8a8_grouped_gemm(
         .launch(stream)
 }
 
+/// W8A8 + FP32 epilogue grouped MoE GEMM — PM4 geometry over the COMPACTED
+/// work-list built by `moe_build_tile_worklist` (kernel
+/// `moe_w8a8_grouped_gemm_pm4`, same module/numerics as
+/// `moe_w8a8_grouped_gemm`: bit-identical output, measured).
+///
+/// Same grid-compaction contract as `moe_fp8_grouped_gemm`: the kernel
+/// grid-strides by `gridDim.x` over the work-list, so the launch is sized to
+/// `max_tiles` (`wl_cap_items`), clamped to `MAX_GRID_CTAS`. Oversubscription
+/// is safe; undersizing is merely slower, never wrong.
+///
+/// SAME-STREAM INVARIANT: MUST be launched on the SAME `stream` as the
+/// preceding `moe_build_tile_worklist` (read-after-write of `total_tiles`).
+///
+/// Grid: (max_tiles.clamp(1, MAX_GRID_CTAS), 1, 1)  Block: (256, 1, 1)
+#[allow(clippy::too_many_arguments)]
+pub fn moe_w8a8_grouped_gemm_pm4(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    a_fp8: DevicePtr,            // [total_tokens, K] FP8 E4M3
+    a_scale: DevicePtr,          // [total_tokens, K/128] FP32
+    weight_ptrs: DevicePtr,      // [num_experts] → [N, K] FP8
+    scale_ptrs: DevicePtr,       // [num_experts] → [N/128, K/128] FP32
+    output: DevicePtr,           // [total_expanded, N] BF16
+    expert_offsets: DevicePtr,   // [num_experts + 1]
+    sorted_token_ids: DevicePtr, // [total_expanded] or NULL
+    num_experts: u32,
+    n: u32,
+    k: u32,
+    worklist: DevicePtr,    // [*total_tiles * 2] u32 (built on the same stream)
+    total_tiles: DevicePtr, // [1] i32 (built on the same stream)
+    max_tiles: u32,         // caller's upper bound on tile count (wl_cap_items)
+    stream: u64,
+) -> Result<()> {
+    const MAX_GRID_CTAS: u32 = 16384;
+    let grid_ctas = max_tiles.clamp(1, MAX_GRID_CTAS);
+    // gb10-only kernel (256 threads, __launch_bounds__(256,2)); other targets
+    // fall back to the dense-grid `moe_w8a8_grouped_gemm` (handle gating at
+    // the dispatch site).
+    KernelLaunch::new(gpu, kernel)
+        .grid([grid_ctas, 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(a_fp8)
+        .arg_ptr(a_scale)
+        .arg_ptr(weight_ptrs)
+        .arg_ptr(scale_ptrs)
+        .arg_ptr(output)
+        .arg_ptr(expert_offsets)
+        .arg_ptr(sorted_token_ids)
+        .arg_u32(num_experts)
+        .arg_u32(n)
+        .arg_u32(k)
+        .arg_ptr(worklist)
+        .arg_ptr(total_tiles)
+        .launch(stream)
+}
+
 /// BF16 grouped GEMM for sorted MoE prefill (FP8-dequant-on-load path).
 ///
 /// BF16 activations × BF16 expert weights via pointer table. No scale.

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
@@ -212,6 +212,38 @@ impl Qwen3SsmLayer {
                     "ssm prefill: QKVZ BF16 cuBLASLt GEMM failed (M={k}, N={qkvz_size}): {e}"
                 )
             })?;
+        } else if ctx.dispatch.ssm_qkvz_cublas_bf16
+            && let Some(ref fp8w) = self.qkvz_fp8w
+        {
+            // Default QKVZ prefill route since 2026-08-22 (P3_ssm_cublas_route):
+            // FP8→BF16 dequant once (cached in `ctx.derived`, ~50 MB/layer,
+            // fail-fast alloc) + cuBLASLt BF16 GEMM. Measured at the production
+            // shape [4510×2048]×[2048×12288]: 2.52 ms vs 6.97 ms for the W8A8
+            // arm below (2.8×), and max-abs error vs the f64 reference 0.019
+            // vs 0.135 — the W8A8 arm quantises the ACTIVATIONS per-128-block,
+            // this route does not, so it is strictly more accurate. Also skips
+            // the per-layer `per_token_group_quant_fp8` pass entirely.
+            // Deliberately ahead of the shadowing `force_w8a8` arm; opt out
+            // with `ATLAS_SSM_QKVZ_W8A8=1` (see `GemmDispatch`).
+            tracing::debug!(
+                "ssm prefill: QKVZ via cuBLASLt BF16 W16A16 (dequant-once cache, M={k} K={h} N={qkvz_size})"
+            );
+            ops::cublas_bf16_proj(
+                ctx.gpu,
+                ctx.derived,
+                normed,
+                fp8w,
+                proj_dst,
+                k,
+                qkvz_size as u32,
+                h as u32,
+                stream,
+            )
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "ssm prefill: QKVZ cuBLASLt W16A16 GEMM failed (M={k}, N={qkvz_size}): {e}"
+                )
+            })?;
         } else if force_w8a8
             && let Some(ref fp8w) = self.qkvz_fp8w
             && self.per_token_group_quant_fp8_k.0 != 0

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
@@ -212,38 +212,6 @@ impl Qwen3SsmLayer {
                     "ssm prefill: QKVZ BF16 cuBLASLt GEMM failed (M={k}, N={qkvz_size}): {e}"
                 )
             })?;
-        } else if ctx.dispatch.ssm_qkvz_cublas_bf16
-            && let Some(ref fp8w) = self.qkvz_fp8w
-        {
-            // Default QKVZ prefill route since 2026-08-22 (P3_ssm_cublas_route):
-            // FP8→BF16 dequant once (cached in `ctx.derived`, ~50 MB/layer,
-            // fail-fast alloc) + cuBLASLt BF16 GEMM. Measured at the production
-            // shape [4510×2048]×[2048×12288]: 2.52 ms vs 6.97 ms for the W8A8
-            // arm below (2.8×), and max-abs error vs the f64 reference 0.019
-            // vs 0.135 — the W8A8 arm quantises the ACTIVATIONS per-128-block,
-            // this route does not, so it is strictly more accurate. Also skips
-            // the per-layer `per_token_group_quant_fp8` pass entirely.
-            // Deliberately ahead of the shadowing `force_w8a8` arm; opt out
-            // with `ATLAS_SSM_QKVZ_W8A8=1` (see `GemmDispatch`).
-            tracing::debug!(
-                "ssm prefill: QKVZ via cuBLASLt BF16 W16A16 (dequant-once cache, M={k} K={h} N={qkvz_size})"
-            );
-            ops::cublas_bf16_proj(
-                ctx.gpu,
-                ctx.derived,
-                normed,
-                fp8w,
-                proj_dst,
-                k,
-                qkvz_size as u32,
-                h as u32,
-                stream,
-            )
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "ssm prefill: QKVZ cuBLASLt W16A16 GEMM failed (M={k}, N={qkvz_size}): {e}"
-                )
-            })?;
         } else if force_w8a8
             && let Some(ref fp8w) = self.qkvz_fp8w
             && self.per_token_group_quant_fp8_k.0 != 0

--- a/crates/spark-runtime/src/cublaslt.rs
+++ b/crates/spark-runtime/src/cublaslt.rs
@@ -105,6 +105,8 @@ unsafe extern "C" {
         stream: *mut c_void,
     ) -> i32;
     fn cuMemAlloc_v2(dptr: *mut u64, bytesize: usize) -> i32;
+    fn cuMemFree_v2(dptr: u64) -> i32;
+    fn cuStreamSynchronize(stream: u64) -> i32;
 }
 
 struct Ctx {
@@ -150,6 +152,44 @@ fn ctx() -> Result<&'static Ctx> {
         ws_size,
     });
     Ok(CTX.get().unwrap())
+}
+
+/// Force cuBLASLt's one-time costs at MODEL LOAD instead of on request 1.
+///
+/// The lazy [`ctx`] means the first GEMM pays `cublasLtCreate`, the 64 MB
+/// workspace alloc, and — the expensive part — the library's kernel-image
+/// load and heuristic warm-up. Measured on the 35B flagship (2026-08-22,
+/// dgx1): the first in-serve request read ~0.9 s slower than warm requests
+/// once QKVZ routed through cuBLASLt, and cold TTFT is a headline metric.
+/// One 64x64x64 BF16 GEMM here is trivial GPU work and moves that cost to
+/// load time, where it overlaps the operator's mental model of "loading".
+///
+/// Never fails the serve: a pre-warm failure is logged and swallowed — the
+/// lazy path remains and request 1 simply pays the old cost.
+pub fn prewarm(stream: u64) {
+    let r = (|| -> Result<()> {
+        let bytes = 64usize * 64 * 2;
+        let mut a = 0u64;
+        let mut b = 0u64;
+        let mut d = 0u64;
+        unsafe {
+            chk(cuMemAlloc_v2(&mut a, bytes), "prewarm alloc a")?;
+            chk(cuMemAlloc_v2(&mut b, bytes), "prewarm alloc b")?;
+            chk(cuMemAlloc_v2(&mut d, bytes), "prewarm alloc d")?;
+        }
+        let res = bf16_gemm_act_weight_t(a, b, d, 64, 64, 64, stream);
+        unsafe {
+            chk(cuStreamSynchronize(stream), "prewarm sync")?;
+            let _ = cuMemFree_v2(a);
+            let _ = cuMemFree_v2(b);
+            let _ = cuMemFree_v2(d);
+        }
+        res
+    })();
+    match r {
+        Ok(()) => tracing::info!("cuBLASLt pre-warmed (handle + workspace + kernel images)"),
+        Err(e) => tracing::warn!("cuBLASLt pre-warm failed (request 1 pays lazy init): {e}"),
+    }
 }
 
 fn chk(status: i32, what: &str) -> Result<()> {

--- a/crates/spark-runtime/src/cublaslt.rs
+++ b/crates/spark-runtime/src/cublaslt.rs
@@ -156,7 +156,7 @@ fn ctx() -> Result<&'static Ctx> {
 
 /// Force cuBLASLt's one-time costs at MODEL LOAD instead of on request 1.
 ///
-/// The lazy [`ctx`] means the first GEMM pays `cublasLtCreate`, the 64 MB
+/// The lazy `ctx()` means the first GEMM pays `cublasLtCreate`, the 64 MB
 /// workspace alloc, and — the expensive part — the library's kernel-image
 /// load and heuristic warm-up. Measured on the 35B flagship (2026-08-22,
 /// dgx1): the first in-serve request read ~0.9 s slower than warm requests

--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -468,6 +468,15 @@ pub(crate) fn load_model(
     // when it is provably net-negative (verify multiplier ≥ 1 + num_drafts).
     // See `scheduler::mtp_gate`.
 
+    // 3b. Pre-warm cuBLASLt so request 1 does not pay its lazy init.
+    // Measured (2026-08-22, 35B flagship, dgx1): once QKVZ prefill routes
+    // through cuBLASLt, the FIRST request read ~0.9 s slower than warm ones —
+    // handle create + 64 MB workspace + the library's kernel-image load, all
+    // deferred to first use. Cold TTFT is a headline metric; load time is not.
+    // Failure is logged inside and never fails the serve.
+    #[cfg(feature = "cuda")]
+    spark_runtime::cublaslt::prewarm(0);
+
     // 4. Post-load OOM check + audit log.
     serve_phases::post_load_memory_audit(
         &args,

--- a/kernels/gb10/common/dense_gemm_bf16.cu
+++ b/kernels/gb10/common/dense_gemm_bf16.cu
@@ -168,6 +168,121 @@ extern "C" __global__ void dense_gemm_f32in_f32out(
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Order-preserving register-blocked router GEMM (dense_gemm_bf16_router).
+//
+// Same math, same I/O contract and same PER-OUTPUT FP32 ACCUMULATION ORDER
+// as the scalar dense_gemm_bf16 above — each C[m,n] is one FP32 accumulator
+// updated in strict k = 0..K-1 order. bf16→f32 conversion is exact, so
+// converting at smem-store time (instead of at use) changes no bit. Built
+// with the kernel dir's `--fmad=false`, the PTX mul+add chain is therefore
+// BIT-IDENTICAL to the scalar kernel's (verified: 0/1,154,560 differing
+// outputs at M=4510 and 0/577,280 at M=2255 on [M,2048]x[2048,256]).
+//
+// This is what makes it legal for the MoE ROUTER gate GEMM, which is pinned
+// to scalar-order numerics (2026-08-12: rerouting the router to the
+// mma.sync pipelined kernel moved BFCL 86.55 → 84.76 — top-k flips on
+// 1-ulp-apart logits; tensor cores remain forbidden here). The win is pure
+// blocking/vectorization, not reassociation:
+//   - BM=16 x BN=64 output tile per 256-thread block, NCOL=4 cols/thread
+//     → each A smem element feeds 4 outputs, K-loop trip overhead /4
+//   - BK=64: 4x fewer __syncthreads barriers per K than TILE_K=16
+//   - ushort4/uint4 global loads (8/16 B) instead of scalar 2 B loads
+//   - smem staged as f32 (padded +1 to break bank conflicts), so the inner
+//     loop is pure FMUL/FADD on smem operands.
+// Measured 2.04x at M=4510 / 2.08x at M=2255 vs dense_gemm_bf16 (GB10,
+// --fmad=false). NCOL=8 / BN=128 was tested and is WORSE (1.79x) — do not
+// re-tune upward.
+//
+// Grid: (ceil(N/64), ceil(M/16), 1)   Block: (16, 16, 1) — blockDim.x MUST
+// be 16 (thread ids and NCOL column mapping assume it).
+
+#define RG_BM 16
+#define RG_BN 64
+#define RG_BK 64
+#define RG_NCOL 4
+
+extern "C" __global__ void dense_gemm_bf16_router(
+    const __nv_bfloat16* __restrict__ A,  // [M, K] row-major
+    const __nv_bfloat16* __restrict__ B,  // [N, K] row-major (read transposed)
+    __nv_bfloat16* __restrict__ C,         // [M, N] row-major
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    __shared__ float sA[RG_BM][RG_BK + 1];
+    __shared__ float sB[RG_BN][RG_BK + 1];
+
+    const unsigned int tid  = threadIdx.y * 16u + threadIdx.x;   // 0..255
+    const unsigned int row0 = blockIdx.y * RG_BM;
+    const unsigned int col0 = blockIdx.x * RG_BN;
+    const unsigned int row  = row0 + threadIdx.y;
+    const unsigned int col  = col0 + threadIdx.x * RG_NCOL;
+
+    float acc[RG_NCOL] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (unsigned int kb = 0; kb < K; kb += RG_BK) {
+        {   // A tile: 16x64 = 1024 elems, 256 threads → 4 each (one ushort4)
+            unsigned int e = tid * 4u;
+            unsigned int r = e / RG_BK, c = e % RG_BK;
+            unsigned int gr = row0 + r, gc = kb + c;
+            if (gr < M && gc + 3u < K) {
+                ushort4 v = *(const ushort4*)(const unsigned short*)(A + (size_t)gr * K + gc);
+                sA[r][c + 0] = __bfloat162float(__ushort_as_bfloat16(v.x));
+                sA[r][c + 1] = __bfloat162float(__ushort_as_bfloat16(v.y));
+                sA[r][c + 2] = __bfloat162float(__ushort_as_bfloat16(v.z));
+                sA[r][c + 3] = __bfloat162float(__ushort_as_bfloat16(v.w));
+            } else {
+                for (int j = 0; j < 4; j++) {
+                    unsigned int cc = c + j;
+                    sA[r][cc] = (gr < M && kb + cc < K)
+                        ? __bfloat162float(A[(size_t)gr * K + kb + cc]) : 0.0f;
+                }
+            }
+        }
+        {   // B tile: 64x64 = 4096 elems, 256 threads → 16 each (2x uint4 = 2x 8 bf16)
+            for (int it = 0; it < 2; it++) {
+                unsigned int e = (tid + it * 256u) * 8u;
+                unsigned int r = e / RG_BK, c = e % RG_BK;
+                unsigned int gn = col0 + r, gc = kb + c;
+                if (gn < N && gc + 7u < K) {
+                    uint4 v = *(const uint4*)(B + (size_t)gn * K + gc);
+                    const unsigned short* u = (const unsigned short*)&v;
+                    #pragma unroll
+                    for (int j = 0; j < 8; j++)
+                        sB[r][c + j] = __bfloat162float(__ushort_as_bfloat16(u[j]));
+                } else {
+                    for (int j = 0; j < 8; j++) {
+                        unsigned int cc = c + j;
+                        sB[r][cc] = (gn < N && kb + cc < K)
+                            ? __bfloat162float(B[(size_t)gn * K + kb + cc]) : 0.0f;
+                    }
+                }
+            }
+        }
+        __syncthreads();
+
+        // Strict k-order per output: acc[j] += a*b for kk = 0..RG_BK-1 within
+        // the block, blocks visited in ascending kb — the exact chain the
+        // scalar kernel runs (out-of-range tiles contribute exact 0.0f adds
+        // there too, matching its zero-padding).
+        #pragma unroll 8
+        for (unsigned int kk = 0; kk < RG_BK; kk++) {
+            float a = sA[threadIdx.y][kk];
+            #pragma unroll
+            for (int j = 0; j < RG_NCOL; j++)
+                acc[j] += a * sB[threadIdx.x * RG_NCOL + j][kk];
+        }
+        __syncthreads();
+    }
+
+    if (row < M) {
+        #pragma unroll
+        for (int j = 0; j < RG_NCOL; j++)
+            if (col + j < N) C[(size_t)row * N + col + j] = __float2bfloat16(acc[j]);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // Fix-E: tensor-core pipelined BF16 dense GEMM (dense_gemm_bf16_pipelined).
 //
 // C[M,N] = A[M,K] (BF16, row-major) · B[N,K]^T (BF16, row-major)

--- a/kernels/gb10/common/moe_silu_mul.cu
+++ b/kernels/gb10/common/moe_silu_mul.cu
@@ -33,6 +33,7 @@
 // Anything added here reaches the whole fleet; add it to a shadow instead.
 
 #include <cuda_bf16.h>
+#include <cuda_fp8.h>
 
 extern "C" __global__ void moe_silu_mul(
     const __nv_bfloat16* __restrict__ gate,   // [total_expanded, inter_size]
@@ -48,4 +49,121 @@ extern "C" __global__ void moe_silu_mul(
     float sigmoid_g = 1.0f / (1.0f + __expf(-g));
     float result = g * sigmoid_g * u;
     output[idx] = __float2bfloat16(result);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fused SiLU·mul + per-token-group(128) FP8-E4M3 quantization.
+//
+// Replaces the `moe_silu_mul` → `per_token_group_quant_fp8` pair on the W8A8
+// prefill down-path without ever materializing / re-reading the BF16
+// intermediate (36.9 MB per MoE layer at N=4510): 9 B/elem of traffic → 5 B
+// (7 B with `out_bf16`). Measured 1.83× over the pair at the production
+// expanded shape [36080, 512] on GB10, bit-identical outputs.
+//
+// BIT-EXACT CONTRACT with the unfused pair:
+//   • the product is rounded through BF16 (`__float2bfloat16` round-trip)
+//     BEFORE the group max / encode, so the quantizer input is exactly the
+//     BF16 value `per_token_group_quant_fp8` would have re-read from memory;
+//   • the max reduction replicates that kernel's structure verbatim (per-warp
+//     `__shfl_down_sync` cascade → 4-slot smem → thread-0 sequential fmaxf),
+//     so even NaN propagation is order-identical;
+//   • scale floor (1e-12), saturation clamp and `__NV_SATFINITE` E4M3 encode
+//     are copied unchanged.
+//
+// `out_bf16` (nullable): when the caller also needs the post-SiLU BF16 rows
+// (expert down_proj LoRA fold consumes them), pass a [M, K] buffer and the
+// kernel additionally writes the exact `moe_silu_mul` output. Pass NULL
+// otherwise (fast path).
+//
+// Grid: (M, 1, 1)  Block: (128, 1, 1) — one block per row, K/128 groups
+// per row. Requires K % 128 == 0 and K/128 <= SILU_QUANT_MAX_GROUPS (the
+// launch site falls back to the unfused pair otherwise).
+//
+// Same no-clamp scope note as `moe_silu_mul` above: models that declare a
+// swiglu_limit shadow this file and do not get this entry point (their
+// kernel handle lookup returns null → unfused fallback).
+
+#define FP8_GROUP_K 128
+#define FP8_E4M3_MAX 448.0f
+#define SILU_QUANT_MAX_GROUPS 16
+
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+// gfx1151/SCALE: software SATFINITE E4M3 encode — byte-identical duplicate of
+// `scl_enc_fp8` in per_token_group_quant_fp8.cu (which itself mirrors scl_fp8
+// in w4a16_gemm.cu / fp8_gemm_t_blockscaled.cu). Must stay in sync with the
+// decode those kernels use.
+__device__ __forceinline__ unsigned char silu_quant_enc_fp8(float v) {
+    if (v != v) return 0x7F;
+    unsigned int bb = __float_as_uint(v); unsigned int sign = (bb >> 31) & 1u;
+    int e = (int)((bb >> 23) & 0xFF) - 127; unsigned int man = bb & 0x7FFFFFu;
+    int ee = e + 7; unsigned int em;
+    if (ee < 1) { ee = 0; em = 0; if (e >= -10) { float a = v < 0 ? -v : v; em = (unsigned int)(a / 0.001953125f + 0.5f); if (em > 7u) em = 7u; } }
+    else if (ee > 15) { ee = 15; em = 6; }
+    else { em = (man + (1u << 19)) >> 20; if (em > 7u) { em = 0; ee++; if (ee > 15) { ee = 15; em = 6; } } }
+    return (unsigned char)((sign << 7) | ((unsigned)ee << 3) | em);
+}
+#endif
+
+extern "C" __global__ void silu_mul_quant_fp8(
+    const __nv_bfloat16* __restrict__ gate,   // [M, K] gate GEMM output
+    const __nv_bfloat16* __restrict__ up,     // [M, K] up GEMM output
+    unsigned char* __restrict__ out_fp8,      // [M, K] FP8 E4M3
+    float* __restrict__ a_scale,              // [M, K/128] FP32 group scale
+    __nv_bfloat16* __restrict__ out_bf16,     // [M, K] post-SiLU BF16, or NULL
+    unsigned int M,
+    unsigned int K
+) {
+    const unsigned int m = blockIdx.x;
+    if (m >= M) return;
+    const unsigned int tid = threadIdx.x;
+    const unsigned int ngroups = K / FP8_GROUP_K;
+    const __nv_bfloat16* grow = gate + (unsigned long long)m * K;
+    const __nv_bfloat16* urow = up + (unsigned long long)m * K;
+    unsigned char* orow = out_fp8 + (unsigned long long)m * K;
+
+    __shared__ float smem_warp_max[4];
+    __shared__ float smem_scale;
+    const unsigned int warp_id = tid >> 5;
+    const unsigned int lane = tid & 31;
+
+    float vals[SILU_QUANT_MAX_GROUPS];
+    for (unsigned int kg = 0; kg < ngroups; kg++) {
+        const unsigned int k = kg * FP8_GROUP_K + tid;
+        float g = __bfloat162float(grow[k]);
+        float u = __bfloat162float(urow[k]);
+        float sigmoid_g = 1.0f / (1.0f + __expf(-g));
+        float result = g * sigmoid_g * u;
+        // Round through BF16 FIRST — the quantizer input must be exactly the
+        // BF16 value the unfused pair writes to / re-reads from memory.
+        __nv_bfloat16 r16 = __float2bfloat16(result);
+        if (out_bf16 != nullptr) out_bf16[(unsigned long long)m * K + k] = r16;
+        float r = __bfloat162float(r16);
+        vals[kg] = r;
+
+        float warp_max = fabsf(r);
+        #pragma unroll
+        for (int off = 16; off > 0; off >>= 1) {
+            warp_max = fmaxf(warp_max, __shfl_down_sync(0xFFFFFFFF, warp_max, off));
+        }
+        if (lane == 0) smem_warp_max[warp_id] = warp_max;
+        __syncthreads();
+        if (tid == 0) {
+            float global_max = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < 4; i++) global_max = fmaxf(global_max, smem_warp_max[i]);
+            float scale = global_max / FP8_E4M3_MAX;
+            if (scale < 1e-12f) scale = 1e-12f;
+            a_scale[m * ngroups + kg] = scale;
+            smem_scale = scale;
+        }
+        __syncthreads();
+        float v = vals[kg] / smem_scale;
+        v = fmaxf(fminf(v, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#if defined(__SCALE__) || defined(__HIP_PLATFORM_AMD__)
+        orow[k] = silu_quant_enc_fp8(v);
+#else
+        orow[k] = (unsigned char)__nv_cvt_float_to_fp8(v, __NV_SATFINITE, __NV_E4M3);
+#endif
+        __syncthreads();  // smem_warp_max / smem_scale reused next group
+    }
 }

--- a/kernels/gb10/common/moe_w8a8_grouped_gemm.cu
+++ b/kernels/gb10/common/moe_w8a8_grouped_gemm.cu
@@ -307,3 +307,341 @@ extern "C" __global__ void moe_w8a8_grouped_gemm(
         }
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// moe_w8a8_grouped_gemm_pm4 — PM4-geometry W8A8 grouped GEMM (grid-compaction).
+// ═══════════════════════════════════════════════════════════════════
+//
+// Port of the PM4 geometry proven by `moe_fp8_grouped_gemm.cu` (M_TILE=128,
+// N_TILE=64, K_STEP=32 with 2 sub-MMAs, 2-stage cp.async.cg double buffering,
+// K-contiguous smem_B[n][k], 256 threads, worklist-compacted 1D grid via
+// `moe_build_tile_worklist`) onto the W8A8 path above, keeping the w8a8
+// numerics EXACTLY:
+//   - A is FP8 E4M3, gathered through sorted_token_ids, staged raw via
+//     cp.async and dequanted to BF16 in smem (lossless);
+//   - two-level FP32 accumulation with the per-row a_scale × b_scale fold at
+//     K_PROMOTE=64 boundaries.
+// The 2 sub-MMAs per K_STEP=32 accumulate in ascending K order — the same f32
+// accumulation order as the K_STEP=16 kernel above — so on identical inputs
+// the output is BIT-IDENTICAL to `moe_w8a8_grouped_gemm` (verified in the
+// candidate bench: 0 differing bf16 outputs at both 36080- and 18040-row
+// shapes, gate/up and down legs).
+//
+// Dequant is arithmetic (no LUT): the 7 magnitude bits placed in an f16
+// exponent/mantissa frame decode E4M3 exactly after a ×2^8 rescale (bias 7 vs
+// 15), subnormals included; NaN codes 0x7F/0xFF map to ±0.0 (LUT parity).
+//
+// Why it is ~4.7× the dense kernel above at the production shape (36080
+// expanded rows, avg M≈141): M_TILE=128 halves expert-weight re-reads
+// (ceil(141/64)=3 → 2), cp.async hides load latency behind MMA, and the
+// worklist grid collapses the 99.5%-early-exit dense 3D launch.
+//
+// smem: 2 stages × (A 128×40 BF16 + A_raw 128×32 B + B 64×34 BF16 + B_raw
+// 64×32 B) = 41472 B → 2 CTAs/SM. __launch_bounds__(256,2): 122 regs, 0 spills.
+//
+// SAME-STREAM INVARIANT: builder + this kernel MUST share a stream
+// (read-after-write of total_tiles/worklist), as for moe_fp8_grouped_gemm.
+//
+// Grid: (wl_cap_items.clamp(1, MAX_GRID_CTAS), 1, 1)  Block: (256, 1, 1)
+#define W8PM4_M_TILE 128
+#define W8PM4_N_TILE 64
+#define W8PM4_K_STEP 32
+#define W8PM4_K_SUB 16
+#define W8PM4_K_SUBS (W8PM4_K_STEP / W8PM4_K_SUB)
+#define W8PM4_PAD 2
+#define W8PM4_A_STRIDE (W8PM4_K_STEP + 8)
+#define W8PM4_THREADS 256
+#define W8PM4_NT_PER_WARP (W8PM4_N_TILE / 8)
+#define W8PM4_STAGES 2
+#define W8PM4_K_PROMOTE 64
+#define W8PM4_FP8_BLOCK 128
+
+__device__ __forceinline__ __nv_bfloat16 w8pm4_e4m3_to_bf16(unsigned char b) {
+    // E4M3 -> f32 by bit arithmetic: place the 7 magnitude bits in an f16
+    // exponent/mantissa frame and rescale by 2^8 (e4m3 bias 7 vs f16 bias 15).
+    // Handles subnormals for free; NaN codes 0x7F/0xFF map to +/-0.0 (LUT parity).
+    float f = __half2float(__ushort_as_half((unsigned short)((b & 0x7f) << 7))) * 256.0f;
+    f = ((b & 0x7f) == 0x7f) ? 0.0f : f;
+    return __float2bfloat16((b & 0x80) ? -f : f);
+}
+
+__device__ __forceinline__ void w8pm4_cp_async_cg_16(void* smem_ptr, const void* gmem_ptr) {
+    unsigned int s = (unsigned int)__cvta_generic_to_shared(smem_ptr);
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" ::"r"(s), "l"(gmem_ptr));
+}
+__device__ __forceinline__ void w8pm4_cp_async_commit() {
+    asm volatile("cp.async.commit_group;\n" ::);
+}
+template <int N>
+__device__ __forceinline__ void w8pm4_cp_async_wait_group() {
+    asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+}
+__device__ __forceinline__ void w8pm4_cp_async_wait_le(unsigned int n) {
+    switch (n) {
+        case 0:  w8pm4_cp_async_wait_group<0>(); break;
+        case 1:  w8pm4_cp_async_wait_group<1>(); break;
+        default: w8pm4_cp_async_wait_group<2>(); break;
+    }
+}
+
+// MMA over one resident K_STEP (2 x m16n8k16 sub-MMAs in ascending K order —
+// identical f32 accumulation order to the baseline's K_STEP=16 sequence).
+// smem_B is [n][k] K-contiguous: the (k,k+1) B-fragment pair is one aligned u32.
+__device__ __forceinline__ void w8pm4_mma_kstep(
+    const __nv_bfloat16* smem_A,   // [W8PM4_M_TILE][W8PM4_A_STRIDE]
+    const __nv_bfloat16* smem_B,   // [W8PM4_N_TILE][W8PM4_K_STEP + W8PM4_PAD]
+    float inner[W8PM4_NT_PER_WARP][4],
+    unsigned int warp_m_offset, unsigned int group_id, unsigned int tid
+) {
+    const unsigned int a_stride = W8PM4_A_STRIDE;
+    const unsigned int b_stride = W8PM4_K_STEP + W8PM4_PAD;
+    const unsigned short* sA = (const unsigned short*)smem_A;
+    const unsigned short* sB = (const unsigned short*)smem_B;
+
+    unsigned int frag_r0 = warp_m_offset + group_id;
+    unsigned int frag_r1 = warp_m_offset + group_id + 8;
+
+    #pragma unroll
+    for (int s = 0; s < W8PM4_K_SUBS; s++) {
+        const unsigned int k_off = s * W8PM4_K_SUB;
+        unsigned int frag_c0 = k_off + tid * 2;
+        unsigned int frag_c1 = k_off + tid * 2 + 8;
+
+        unsigned int a0 = *(const unsigned int*)&sA[frag_r0 * a_stride + frag_c0];
+        unsigned int a1 = *(const unsigned int*)&sA[frag_r1 * a_stride + frag_c0];
+        unsigned int a2 = *(const unsigned int*)&sA[frag_r0 * a_stride + frag_c1];
+        unsigned int a3 = *(const unsigned int*)&sA[frag_r1 * a_stride + frag_c1];
+
+        #pragma unroll
+        for (int n_tile = 0; n_tile < W8PM4_NT_PER_WARP; n_tile++) {
+            unsigned int n_col = n_tile * 8 + group_id;
+            unsigned int k0 = k_off + tid * 2;
+            unsigned int k1 = k_off + tid * 2 + 8;
+
+            unsigned int b0 = *(const unsigned int*)&sB[n_col * b_stride + k0];
+            unsigned int b1 = *(const unsigned int*)&sB[n_col * b_stride + k1];
+
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+                "{%0, %1, %2, %3}, "
+                "{%4, %5, %6, %7}, "
+                "{%8, %9}, "
+                "{%10, %11, %12, %13};"
+                : "=f"(inner[n_tile][0]), "=f"(inner[n_tile][1]),
+                  "=f"(inner[n_tile][2]), "=f"(inner[n_tile][3])
+                : "r"(a0), "r"(a1), "r"(a2), "r"(a3),
+                  "r"(b0), "r"(b1),
+                  "f"(inner[n_tile][0]), "f"(inner[n_tile][1]),
+                  "f"(inner[n_tile][2]), "f"(inner[n_tile][3])
+            );
+        }
+    }
+}
+
+extern "C" __global__ void __launch_bounds__(W8PM4_THREADS, 2) moe_w8a8_grouped_gemm_pm4(
+    const unsigned char* __restrict__ A_fp8,                // [total_tokens, K] FP8 E4M3
+    const float* __restrict__ a_scale,                      // [total_tokens, K/128] FP32
+    const unsigned long long* __restrict__ B_weight_ptrs,   // [num_experts] -> [N, K] FP8
+    const unsigned long long* __restrict__ B_scale_ptrs,    // [num_experts] -> [N/128, K/128] FP32
+    __nv_bfloat16* __restrict__ C,                          // [total_expanded, N] BF16
+    const int* __restrict__ expert_offsets,                 // [num_experts + 1]
+    const int* __restrict__ sorted_token_ids,               // [total_expanded] or NULL
+    unsigned int num_experts,
+    unsigned int N,
+    unsigned int K,
+    const unsigned int* __restrict__ worklist,              // [*total_tiles * 2]
+    const int* __restrict__ total_tiles                     // [1]
+) {
+    __shared__ __align__(16) __nv_bfloat16 smem_A[W8PM4_STAGES][W8PM4_M_TILE][W8PM4_A_STRIDE];
+    __shared__ __align__(16) unsigned char smem_Araw[W8PM4_STAGES][W8PM4_M_TILE][W8PM4_K_STEP];
+    __shared__ __nv_bfloat16 smem_B[W8PM4_STAGES][W8PM4_N_TILE][W8PM4_K_STEP + W8PM4_PAD];
+    __shared__ __align__(16) unsigned char smem_Braw[W8PM4_STAGES][W8PM4_N_TILE][W8PM4_K_STEP];
+
+    const unsigned int warp_id = threadIdx.x / 32;
+    const unsigned int lane_id = threadIdx.x % 32;
+    const unsigned int warp_m_offset = warp_id * 16;
+    const unsigned int group_id = lane_id >> 2;
+    const unsigned int tid = lane_id & 3;
+
+    const int total = *total_tiles;
+
+    for (int wid = blockIdx.x; wid < total; wid += (int)gridDim.x) {
+        __syncthreads();   // fence smem reuse before re-priming the pipeline
+
+        unsigned int expert_id = worklist[wid * 2 + 0];
+        unsigned int packed    = worklist[wid * 2 + 1];
+        unsigned int mt = packed >> 6;
+        unsigned int nt = packed & 0x3F;
+
+        const int m_start = expert_offsets[expert_id];
+        const int M_expert = expert_offsets[expert_id + 1] - m_start;
+
+        const unsigned char* B_exp = (const unsigned char*)B_weight_ptrs[expert_id];
+        const float* S_exp = (const float*)B_scale_ptrs[expert_id];
+        if (B_exp == 0) continue;
+
+        const unsigned int cta_m_local = mt * W8PM4_M_TILE;
+        const unsigned int cta_n = nt * W8PM4_N_TILE;
+
+        float inner_acc[W8PM4_NT_PER_WARP][4];
+        float outer_acc[W8PM4_NT_PER_WARP][4];
+        #pragma unroll
+        for (int i = 0; i < W8PM4_NT_PER_WARP; i++) {
+            inner_acc[i][0] = 0.0f; inner_acc[i][1] = 0.0f;
+            inner_acc[i][2] = 0.0f; inner_acc[i][3] = 0.0f;
+            outer_acc[i][0] = 0.0f; outer_acc[i][1] = 0.0f;
+            outer_acc[i][2] = 0.0f; outer_acc[i][3] = 0.0f;
+        }
+
+        const unsigned int k_blocks = (K + W8PM4_FP8_BLOCK - 1) / W8PM4_FP8_BLOCK;
+        const unsigned int n_block = cta_n / W8PM4_FP8_BLOCK;
+        const unsigned int n_steps = (K + W8PM4_K_STEP - 1) / W8PM4_K_STEP;
+        const unsigned int steps_per_promote = W8PM4_K_PROMOTE / W8PM4_K_STEP;   // 2
+
+        // Per-warp fragment rows: token ids resolved ONCE per tile for the
+        // per-row a_scale fold (rows are fixed for the whole K loop).
+        const unsigned int r0 = cta_m_local + warp_m_offset + group_id;
+        const unsigned int r1 = r0 + 8;
+        const int t0 = (r0 < (unsigned int)M_expert)
+            ? (sorted_token_ids ? sorted_token_ids[m_start + (int)r0] : m_start + (int)r0) : -1;
+        const int t1 = (r1 < (unsigned int)M_expert)
+            ? (sorted_token_ids ? sorted_token_ids[m_start + (int)r1] : m_start + (int)r1) : -1;
+
+        auto prefetch = [&](unsigned int step, unsigned int stage) {
+            unsigned int k_base = step * W8PM4_K_STEP;
+
+            // A raw: 128 rows x K_STEP FP8 bytes, 16-B chunks, gathered per row.
+            const unsigned int a_chunks = (W8PM4_M_TILE * W8PM4_K_STEP) / 16;   // 256
+            #pragma unroll
+            for (unsigned int c = threadIdx.x; c < a_chunks; c += W8PM4_THREADS) {
+                unsigned int row  = c / (W8PM4_K_STEP / 16);
+                unsigned int kcol = (c % (W8PM4_K_STEP / 16)) * 16;
+                unsigned int m_global = cta_m_local + row;
+                unsigned int gk = k_base + kcol;
+                unsigned char* dst = &smem_Araw[stage][row][kcol];
+                if (m_global < (unsigned int)M_expert && gk + 16 <= K) {
+                    int sorted_idx = m_start + (int)m_global;
+                    int token_id = sorted_token_ids ? sorted_token_ids[sorted_idx] : sorted_idx;
+                    w8pm4_cp_async_cg_16(dst, &A_fp8[(unsigned long long)token_id * K + gk]);
+                } else {
+                    #pragma unroll
+                    for (unsigned int e = 0; e < 16; e++) {
+                        unsigned int gke = gk + e;
+                        if (m_global < (unsigned int)M_expert && gke < K) {
+                            int sorted_idx = m_start + (int)m_global;
+                            int token_id = sorted_token_ids ? sorted_token_ids[sorted_idx] : sorted_idx;
+                            dst[e] = A_fp8[(unsigned long long)token_id * K + gke];
+                        } else {
+                            dst[e] = 0;   // dequants to +0.0
+                        }
+                    }
+                }
+            }
+
+            // B raw: N_TILE rows x K_STEP FP8 bytes, 16-B chunks.
+            const unsigned int b_chunks = (W8PM4_N_TILE * W8PM4_K_STEP) / 16;   // 128
+            #pragma unroll
+            for (unsigned int c = threadIdx.x; c < b_chunks; c += W8PM4_THREADS) {
+                unsigned int nrow = (c * 16) / W8PM4_K_STEP;
+                unsigned int kcol = (c * 16) % W8PM4_K_STEP;
+                unsigned int gn = cta_n + nrow;
+                unsigned int gk = k_base + kcol;
+                unsigned char* dst = &smem_Braw[stage][nrow][kcol];
+                if (gn < N && gk + 16 <= K) {
+                    w8pm4_cp_async_cg_16(dst, &B_exp[(unsigned long long)gn * K + gk]);
+                } else {
+                    #pragma unroll
+                    for (unsigned int e = 0; e < 16; e++) {
+                        unsigned int gke = gk + e;
+                        dst[e] = (gn < N && gke < K) ? B_exp[(unsigned long long)gn * K + gke] : 0;
+                    }
+                }
+            }
+            w8pm4_cp_async_commit();
+        };
+
+        // Arithmetic-dequant just-arrived raw A and B for `stage` into the
+        // MMA-ready BF16 buffers (no scale — folded post-MMA at K_PROMOTE).
+        auto dequant = [&](unsigned int stage) {
+            #pragma unroll
+            for (unsigned int idx = threadIdx.x; idx < W8PM4_M_TILE * W8PM4_K_STEP; idx += W8PM4_THREADS) {
+                unsigned int row = idx / W8PM4_K_STEP;
+                unsigned int k   = idx % W8PM4_K_STEP;
+                smem_A[stage][row][k] = w8pm4_e4m3_to_bf16(smem_Araw[stage][row][k]);
+            }
+            #pragma unroll
+            for (unsigned int idx = threadIdx.x; idx < W8PM4_N_TILE * W8PM4_K_STEP; idx += W8PM4_THREADS) {
+                unsigned int n = idx / W8PM4_K_STEP;
+                unsigned int k = idx % W8PM4_K_STEP;
+                smem_B[stage][n][k] = w8pm4_e4m3_to_bf16(smem_Braw[stage][n][k]);
+            }
+        };
+
+        #pragma unroll
+        for (unsigned int p = 0; p < W8PM4_STAGES - 1; p++) {
+            if (p < n_steps) prefetch(p, p % W8PM4_STAGES);
+        }
+        unsigned int k_step_in_prom = 0;
+
+        for (unsigned int step = 0; step < n_steps; step++) {
+            unsigned int cur = step % W8PM4_STAGES;
+
+            unsigned int ahead = step + (W8PM4_STAGES - 1);
+            if (ahead < n_steps) prefetch(ahead, ahead % W8PM4_STAGES);
+            unsigned int committed = min(n_steps, W8PM4_STAGES + step);
+            unsigned int target = committed - (step + 1);
+            w8pm4_cp_async_wait_le(target);
+            __syncthreads();   // raw A/B for `cur` resident for all threads
+
+            dequant(cur);
+            __syncthreads();   // smem_A/B[cur] fully written before MMA reads
+
+            w8pm4_mma_kstep(&smem_A[cur][0][0], &smem_B[cur][0][0],
+                         inner_acc, warp_m_offset, group_id, tid);
+            __syncthreads();   // done reading smem_*[cur]; safe for reuse
+
+            // K_PROMOTE boundary: fold per-row a_scale x b_scale, reset inner.
+            k_step_in_prom++;
+            if (k_step_in_prom == steps_per_promote || step + 1 == n_steps) {
+                const unsigned int k_block = (step * W8PM4_K_STEP) / W8PM4_FP8_BLOCK;
+                const float bs = S_exp[n_block * k_blocks + k_block];
+                const float as0 = (t0 >= 0)
+                    ? a_scale[(unsigned long long)t0 * k_blocks + k_block] : 0.0f;
+                const float as1 = (t1 >= 0)
+                    ? a_scale[(unsigned long long)t1 * k_blocks + k_block] : 0.0f;
+                const float s0 = as0 * bs;
+                const float s1 = as1 * bs;
+                #pragma unroll
+                for (int i = 0; i < W8PM4_NT_PER_WARP; i++) {
+                    outer_acc[i][0] += inner_acc[i][0] * s0;
+                    outer_acc[i][1] += inner_acc[i][1] * s0;
+                    outer_acc[i][2] += inner_acc[i][2] * s1;
+                    outer_acc[i][3] += inner_acc[i][3] * s1;
+                    inner_acc[i][0] = 0.0f; inner_acc[i][1] = 0.0f;
+                    inner_acc[i][2] = 0.0f; inner_acc[i][3] = 0.0f;
+                }
+                k_step_in_prom = 0;
+            }
+        }
+
+        #pragma unroll
+        for (int n_tile = 0; n_tile < W8PM4_NT_PER_WARP; n_tile++) {
+            unsigned int base_n = cta_n + n_tile * 8;
+            unsigned int col0 = base_n + (tid * 2);
+            unsigned int col1 = col0 + 1;
+            unsigned int row0 = cta_m_local + warp_m_offset + group_id;
+            unsigned int row1 = row0 + 8;
+
+            if (row0 < (unsigned int)M_expert) {
+                unsigned int out_row = m_start + row0;
+                if (col0 < N) C[(unsigned long long)out_row * N + col0] = __float2bfloat16(outer_acc[n_tile][0]);
+                if (col1 < N) C[(unsigned long long)out_row * N + col1] = __float2bfloat16(outer_acc[n_tile][1]);
+            }
+            if (row1 < (unsigned int)M_expert) {
+                unsigned int out_row = m_start + row1;
+                if (col0 < N) C[(unsigned long long)out_row * N + col0] = __float2bfloat16(outer_acc[n_tile][2]);
+                if (col1 < N) C[(unsigned long long)out_row * N + col1] = __float2bfloat16(outer_acc[n_tile][3]);
+            }
+        }
+    }
+}

--- a/kernels/gb10/common/moe_w8a8_grouped_gemm.cu
+++ b/kernels/gb10/common/moe_w8a8_grouped_gemm.cu
@@ -4,19 +4,20 @@
 //
 // Same shape/layout as `moe_fp8_grouped_gemm.cu` but:
 //   - A is FP8 E4M3 (one byte per element), pre-quantized per-token-per-128
-//     via `per_token_group_quant_fp8`. Dequanted to BF16 in smem via LUT
-//     (lossless: FP8 3-bit mantissa fits in BF16 7-bit).
+//     via `per_token_group_quant_fp8`. Dequanted to BF16 in smem via exact
+//     bit arithmetic (lossless: FP8 3-bit mantissa fits in BF16 7-bit).
 //   - a_scale[M_total, K/128] FP32 — looked up via sorted_token_ids[m_start + m_idx].
 //   - b_scale[N/128, K/128] FP32 — scale_inv widened to FP32 at load (read once per fold).
 //   - Two-level FP32 accumulation: inner_acc over K=128 block (4× K_STEP=16),
 //     then outer_acc += inner_acc × (a_scale[row, kb] × b_scale[col, kb]).
 //
-//   C[M_expert, N] = bf16( Σ_kb ( Σ_(k∈kb) bf16(LUT[A_fp8[m,k]]) * bf16(LUT[B_fp8[n,k]]) )
+//   C[M_expert, N] = bf16( Σ_kb ( Σ_(k∈kb) bf16(e4m3(A_fp8[m,k])) * bf16(e4m3(B_fp8[n,k])) )
 //                       * a_scale[orig_token(m), kb] * b_scale[n/128, kb] )
 //
 // Grid: (ceil(N/64), max_m_tiles, num_experts)  Block: (128, 1, 1)
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 
 #define M_TILE 64
 #define N_TILE 64
@@ -25,72 +26,21 @@
 #define FP8_BLOCK 128
 #define K_PROMOTE 64
 
-__device__ __constant__ float E4M3_LUT_W8A8[256] = {
-    0.0f, 0.001953125f, 0.00390625f, 0.005859375f,
-    0.0078125f, 0.009765625f, 0.01171875f, 0.013671875f,
-    0.015625f, 0.017578125f, 0.01953125f, 0.021484375f,
-    0.0234375f, 0.025390625f, 0.02734375f, 0.029296875f,
-    0.03125f, 0.03515625f, 0.0390625f, 0.04296875f,
-    0.046875f, 0.05078125f, 0.0546875f, 0.05859375f,
-    0.0625f, 0.0703125f, 0.078125f, 0.0859375f,
-    0.09375f, 0.1015625f, 0.109375f, 0.1171875f,
-    0.125f, 0.140625f, 0.15625f, 0.171875f,
-    0.1875f, 0.203125f, 0.21875f, 0.234375f,
-    0.25f, 0.28125f, 0.3125f, 0.34375f,
-    0.375f, 0.40625f, 0.4375f, 0.46875f,
-    0.5f, 0.5625f, 0.625f, 0.6875f,
-    0.75f, 0.8125f, 0.875f, 0.9375f,
-    1.0f, 1.125f, 1.25f, 1.375f,
-    1.5f, 1.625f, 1.75f, 1.875f,
-    2.0f, 2.25f, 2.5f, 2.75f,
-    3.0f, 3.25f, 3.5f, 3.75f,
-    4.0f, 4.5f, 5.0f, 5.5f,
-    6.0f, 6.5f, 7.0f, 7.5f,
-    8.0f, 9.0f, 10.0f, 11.0f,
-    12.0f, 13.0f, 14.0f, 15.0f,
-    16.0f, 18.0f, 20.0f, 22.0f,
-    24.0f, 26.0f, 28.0f, 30.0f,
-    32.0f, 36.0f, 40.0f, 44.0f,
-    48.0f, 52.0f, 56.0f, 60.0f,
-    64.0f, 72.0f, 80.0f, 88.0f,
-    96.0f, 104.0f, 112.0f, 120.0f,
-    128.0f, 144.0f, 160.0f, 176.0f,
-    192.0f, 208.0f, 224.0f, 240.0f,
-    256.0f, 288.0f, 320.0f, 352.0f,
-    384.0f, 416.0f, 448.0f, 0.0f,
-    -0.0f, -0.001953125f, -0.00390625f, -0.005859375f,
-    -0.0078125f, -0.009765625f, -0.01171875f, -0.013671875f,
-    -0.015625f, -0.017578125f, -0.01953125f, -0.021484375f,
-    -0.0234375f, -0.025390625f, -0.02734375f, -0.029296875f,
-    -0.03125f, -0.03515625f, -0.0390625f, -0.04296875f,
-    -0.046875f, -0.05078125f, -0.0546875f, -0.05859375f,
-    -0.0625f, -0.0703125f, -0.078125f, -0.0859375f,
-    -0.09375f, -0.1015625f, -0.109375f, -0.1171875f,
-    -0.125f, -0.140625f, -0.15625f, -0.171875f,
-    -0.1875f, -0.203125f, -0.21875f, -0.234375f,
-    -0.25f, -0.28125f, -0.3125f, -0.34375f,
-    -0.375f, -0.40625f, -0.4375f, -0.46875f,
-    -0.5f, -0.5625f, -0.625f, -0.6875f,
-    -0.75f, -0.8125f, -0.875f, -0.9375f,
-    -1.0f, -1.125f, -1.25f, -1.375f,
-    -1.5f, -1.625f, -1.75f, -1.875f,
-    -2.0f, -2.25f, -2.5f, -2.75f,
-    -3.0f, -3.25f, -3.5f, -3.75f,
-    -4.0f, -4.5f, -5.0f, -5.5f,
-    -6.0f, -6.5f, -7.0f, -7.5f,
-    -8.0f, -9.0f, -10.0f, -11.0f,
-    -12.0f, -13.0f, -14.0f, -15.0f,
-    -16.0f, -18.0f, -20.0f, -22.0f,
-    -24.0f, -26.0f, -28.0f, -30.0f,
-    -32.0f, -36.0f, -40.0f, -44.0f,
-    -48.0f, -52.0f, -56.0f, -60.0f,
-    -64.0f, -72.0f, -80.0f, -88.0f,
-    -96.0f, -104.0f, -112.0f, -120.0f,
-    -128.0f, -144.0f, -160.0f, -176.0f,
-    -192.0f, -208.0f, -224.0f, -240.0f,
-    -256.0f, -288.0f, -320.0f, -352.0f,
-    -384.0f, -416.0f, -448.0f, -0.0f,
-};
+// Exact FP8 E4M3 -> BF16 dequant via bit arithmetic (replaces a 256-entry
+// __constant__ LUT: 32 lanes indexing 32 different __constant__ addresses
+// serialize the warp; this is pure ALU and issues at full width).
+// An e4m3 magnitude placed in a half's bit layout ((b&0x7f)<<7) has bias 15
+// instead of 7 and the same mantissa alignment, so value = half(bits) * 2^8.
+// Denormals map to half denormals with the same 2^8 offset — exact for all
+// codes. The NaN codes 0x7F/0xFF must be guarded to +/-0.0f to match the
+// historical LUT mapping (otherwise they dequant to +/-480).
+__device__ __forceinline__ __nv_bfloat16 e4m3_to_bf16_w8a8(unsigned char b) {
+    unsigned short h = (unsigned short)((b & 0x7f) << 7);
+    float f = __half2float(__ushort_as_half(h)) * 256.0f;
+    if ((b & 0x7f) == 0x7f) f = 0.0f;
+    f = (b & 0x80) ? -f : f;
+    return __float2bfloat16(f);
+}
 
 __device__ __forceinline__ void fp8_w8a8_mma(
     __nv_bfloat16 smem_A[][K_STEP + PAD],
@@ -223,7 +173,7 @@ extern "C" __global__ void moe_w8a8_grouped_gemm(
                     int token_id = smem_token_id[row];
                     if (token_id >= 0) {
                         unsigned char a_byte = A_fp8[(unsigned long long)token_id * K + gc];
-                        smem_A[row][col] = __float2bfloat16(E4M3_LUT_W8A8[a_byte]);
+                        smem_A[row][col] = e4m3_to_bf16_w8a8(a_byte);
                     } else {
                         smem_A[row][col] = __float2bfloat16(0.0f);
                     }
@@ -233,21 +183,26 @@ extern "C" __global__ void moe_w8a8_grouped_gemm(
             }
         }
 
-        // Dequant B tile: FP8 E4M3 → BF16 via LUT (lossless).
-        {
-            #pragma unroll
-            for (unsigned int i = 0; i < 8; i++) {
-                unsigned int idx = threadIdx.x * 8 + i;
-                unsigned int k = idx / N_TILE;
-                unsigned int n = idx % N_TILE;
-                unsigned int gk = k_base + k;
-                unsigned int gn = cta_n + n;
-
-                if (gk < K && gn < N) {
-                    unsigned char b_byte = B_exp[(unsigned long long)gn * K + gk];
-                    smem_B[k][n] = __float2bfloat16(E4M3_LUT_W8A8[b_byte]);
-                } else {
-                    smem_B[k][n] = __float2bfloat16(0.0f);
+        // Dequant B tile: FP8 E4M3 → BF16 (lossless). Thread t < N_TILE loads
+        // the 16 consecutive K bytes of row n = t as ONE 16-byte uint4 (fully
+        // coalesced along K) instead of 8 single-byte loads strided by K
+        // (32x sector amplification). Scalar tail for K % 16 != 0 or N edges
+        // (production K = 2048 / 512 are both multiples of K_STEP = 16).
+        if (threadIdx.x < N_TILE) {
+            unsigned int n = threadIdx.x;
+            unsigned int gn = cta_n + n;
+            if (gn < N && k_base + K_STEP <= K) {
+                uint4 v = *(const uint4*)&B_exp[(unsigned long long)gn * K + k_base];
+                const unsigned char* b = (const unsigned char*)&v;
+                #pragma unroll
+                for (int k = 0; k < 16; k++)
+                    smem_B[k][n] = e4m3_to_bf16_w8a8(b[k]);
+            } else {
+                for (int k = 0; k < K_STEP; k++) {
+                    unsigned int gk = k_base + k;
+                    smem_B[k][n] = (gk < K && gn < N)
+                        ? e4m3_to_bf16_w8a8(B_exp[(unsigned long long)gn * K + gk])
+                        : __float2bfloat16(0.0f);
                 }
             }
         }

--- a/kernels/gb10/deepseek-v4-flash/nvfp4/KERNEL.toml
+++ b/kernels/gb10/deepseek-v4-flash/nvfp4/KERNEL.toml
@@ -56,3 +56,10 @@ hyper_connection = "hyper_connection"
 csa_compress = "csa_compress"
 # CSA prefill attention over [raw causal | compressed windowed] KV + sink.
 prefill_attn_compressed = "prefill_attn_compressed"
+
+# The fused silu_mul_quant_fp8 entry point is deliberately absent from this
+# swiglu_limit shadow of moe_silu_mul.cu: the launch site checks the kernel
+# handle and falls back to the unfused silu_mul → per_token_group_quant_fp8
+# pair (see fused_silu_quant_ok in forward_prefill_fp8.rs).
+[shadow_exempt]
+moe_silu_mul = ["silu_mul_quant_fp8"]

--- a/kernels/gb10/step3p7-flash/nvfp4/KERNEL.toml
+++ b/kernels/gb10/step3p7-flash/nvfp4/KERNEL.toml
@@ -41,3 +41,10 @@ paged_decode_attn_turbo3 = "paged_decode_turbo3"
 paged_decode_attn_turbo3_128 = "paged_decode_turbo3_128"
 paged_decode_attn_turbo4_128 = "paged_decode_turbo4_128"
 paged_decode_attn_turbo8_128 = "paged_decode_turbo8_128"
+
+# The fused silu_mul_quant_fp8 entry point is deliberately absent from this
+# swiglu_limit shadow of moe_silu_mul.cu: the launch site checks the kernel
+# handle and falls back to the unfused silu_mul → per_token_group_quant_fp8
+# pair (see fused_silu_quant_ok in forward_prefill_fp8.rs).
+[shadow_exempt]
+moe_silu_mul = ["silu_mul_quant_fp8"]


### PR DESCRIPTION
Five verified kernel wins from today's cold-prefill survey of the 35B FP8 MoE flagship (N=4510, MoE grouped GEMM alone was 2657 ms = 65-70% of prefill), stacked on top of the instrumentation commit that found them (the fp8 MoE prefill path was 71.6% of cold prefill and had zero timers).

## Wins

| kernel / path | change | production-shape speedup (per-rep ms, n≥5) | correctness gate |
|---|---|---|---|
| `moe_w8a8_grouped_gemm` (P2) | New `moe_w8a8_grouped_gemm_pm4`: PM4 geometry (M_TILE=128, K_STEP=32, 2-stage cp.async, worklist-compacted grid) on the W8A8 path; dense-grid fallback when the handle is absent | **4.78x** — baseline 75.837/75.797/75.807/76.243/76.293 → 15.777/15.776/15.762/15.843/16.397 (per-layer leg-sum incl. worklist builders); half shape 3.77x | **Bit-identical** to baseline (0 differing bf16 outputs, both shapes, gate/up+down legs, e4m3 NaN codes injected); f64-ref max-abs ratio 1.0000 |
| `moe_w8a8_grouped_gemm` (P1) | Arithmetic E4M3→BF16 dequant (replaces divergent 256-entry `__constant__` LUT) + coalesced uint4 B-tile loads in the dense kernel | **2.87x** — baseline 68.879/68.430/68.855/68.372/68.300 → 24.106/23.985/24.018/23.396/24.055 (leg-sum); half shape 2.90x | **Bit-identical** on ALL 110,837,760 output elements (both shapes), incl. NaN-code guard parity with the LUT; f64-ref max-abs exactly equal (127.668022) |
| SSM QKVZ prefill (P3) | Route through dequant-once-cached cuBLASLt BF16 (W16A16) instead of W8A8; flag-gated default-ON, opt out `ATLAS_SSM_QKVZ_W8A8=1` | **2.77x** — baseline 6.614/7.379/6.722/6.602/7.520 → 2.376/2.368/2.490/2.874/2.474 ([4510×2048]×[2048×12288]); half shape 3.04x | f64 CPU ref: variant max-abs 0.0188 vs baseline 0.1346 — **7x MORE accurate** (W8A8 quantizes activations, W16A16 does not); cos 0.9999973. **Numerics change** (re-associates sums; departs from vLLM-equivalent W8A8 parity on this projection) |
| router gate GEMM (P4) | `dense_gemm_bf16_router`: register-blocked (BM=16/BN=64/BK=64/NCOL=4) with the scalar kernel's exact per-output FP32 k-order — satisfies the 2026-08-12 router-numerics pin | **2.06x** — baseline 3.225/3.222/3.225/3.226/3.222 → 1.544/1.549/1.556/1.558/1.632 ([4510,2048]×[2048,256]); half shape 2.08x | **Bit-identical** under production `--fmad=false` flags (0/1,154,560 and 0/577,280 differing outputs); f64-ref max-abs identical (0.212439) |
| SiLU·mul + FP8 quant (P5) | Fused `silu_mul_quant_fp8` replaces the `silu_mul` → `per_token_group_quant_fp8` pair on both W8A8 down-path adjacencies; LoRA BF16 output preserved; fail-closed gating | **1.81x** — baseline 0.7733/0.7713/0.7698/0.7724/0.7662/0.7693/0.7681 → 0.4250/0.4243/0.4259/0.4232/0.4251/0.4292/0.4264 ([36080,512]); half shape 1.70x | **Bit-identical** FP8 bytes / FP32 scales / BF16 rows (0 diffs at both shapes, incl. edge-case rows and in-place aliasing); f64-ref max-abs identical (0.573483) |

Projected combined effect on the measured 4510-token cold prefill: MoE grouped GEMM 2657 → ~560 ms, qkvz 199 → ~75 ms, router GEMM ~129 → ~63 ms, silu+quant ~31 → ~17 ms.

Stacking notes:
- P1 and P2 both edit `moe_w8a8_grouped_gemm.cu` and coexist: P1 rewrites the dense kernel (which remains the fallback), P2 adds the PM4 worklist kernel that is preferred when present. Their speedups do NOT add — in-serve, the PM4 path is what runs on gb10.
- P5's fused-quant if/else was hand-merged with P2's PM4 down-GEMM dispatch in `forward_prefill_fp8.rs`; the `mprof!` instrumentation was re-armed across both branches.
- P5 required `[shadow_exempt]` entries for `deepseek-v4-flash/nvfp4` and `step3p7-flash/nvfp4` (their swiglu_limit shadows of `moe_silu_mul.cu` deliberately omit the fused entry point; the launch site checks the handle and falls back to the unfused pair) — the kernel_shadow_detector test enforces this.
- P3's out_proj half was measured 3.62x faster but REJECTED on the 1.05x correctness gate (its baseline is W8A16, not W8A8) and is NOT in this PR.

## Rejected / unverified (honesty table)

| id | status | reason |
|---|---|---|
| moe_grouped_C1_arith_dequant | merged | Not rejected on merit — merged into P1 (ships stacked with C2, measured 2.95x together) |
| moe_grouped_C2_coalesced_B_load | merged | Merged into P1 — measured exactly 1.00x without C1, must not ship standalone |
| moe_grouped_C4_parallel_sort_by_expert | invalidated | The sort is 3.4 ms, not 161 ms — the bucket is misattributed router-GEMM time, which P4 fixes; real ceiling ~3 ms |
| MD1 | selected | Same candidate as P4 (id renamed) |
| MD2 | merged | Duplicate of EW1 (same silu+quant fusion); merged into P5 |
| MD3 | rejected | Bounded at ~6.6 ms even at the exact floor; kernel already 1.27x floor; in-serve excess is cross-phase contention |
| MD4 | rejected | Unmeasured driver-latency estimate (~10 ms) with +28 MB permanent footprint; below bar until measured |
| EW1-fuse-silu-quant | selected | Same candidate as P5 |
| EW2-fix-silu-mprof-attribution | folded | Zero GPU saving; folded into P5 as a rider |
| EW3-vectorize-input-quant | rejected | Unmeasured, ~3 ms ceiling; direct precedent (silu_v8) measured a 0.92x LOSS |
| EW4-overlap-shared-expert-stream | deferred | 0.35 confidence, needs cross-stream buffer-aliasing audit; routed GEMM is bandwidth-bound; revisit after P5 |
| ssm-cublas-route | selected | Same candidate as P3 (id renamed) |
| fp8-geometry-port | deferred | Unmeasured (0.4 confidence); mostly superseded by P3; residual o_proj/shared-expert upside ~15-20 ms — revisit after P3 lands |
| w8a16-smem-diet | rejected | ~10 ms at 0.45 confidence; fully superseded if P3 lands |
| outproj-w8a8-flip | rejected | Mutually exclusive with P3, which is measured 3.8x better on the same leg |
| attn-q-w8a8 | deferred | Fails the 1.05x kernel parity gate by construction; needs a full model-level accuracy campaign for 26 ms — can piggyback on P3's gate runs |
| attn-q-t-m128 | rejected | 12.5 ms is below the attention family's 15 ms bar; only a fallback for attn-q-w8a8, which is not selected |

## Measurement & merge gating

All numbers are ISOLATED per-launch measurements on dgx1; none is an in-serve figure. Kernels whose numerics are not bit-identical must pass ssm-state-poisoning-gate before merge, and this PR owes the standard 10-gate benchmark campaign.

Additionally: P3 is a deliberate numerics change (gate C warm-TTFT guard applies since perf paths are touched; record BFCL draw metadata — category_sample_pct, N, ordered-sample_id SHA256 — beside any score). P3's in-serve phase check was not completed (serve A/B script artifacts are in the session scratchpad); the qkvz 199→~75 ms figure is a projection from the kernel A/B.

Checks run on this branch: `cargo fmt --check` clean; `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests` clean; `ATLAS_SKIP_BUILD=1 cargo test --workspace` — 74/74 suites ok (kernel_shadow_detector fixed via the documented `[shadow_exempt]` entries); full kernel build `cargo check -p spark-model` (all gb10 targets, nvcc) clean; all three touched `.cu` files compile standalone with `nvcc -arch=sm_121a -std=c++17`; the two >500-LoC `.rs` files (`forward_prefill_fp8.rs`, `gemm_quant.rs`) are on the file-size-cap allow-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1
