### PR TITLE
Update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <a href="LICENSE"><img alt="License: AGPLv3" src="https://img.shields.io/badge/license-AGPLv3-yellow?style=flat-square"></a>
     <a href="#quick-start"><img alt="Pure Rust" src="https://img.shields.io/badge/runtime-pure%20Rust-orange?style=flat-square"></a>
     <a href="https://hub.docker.com/r/avarok/atlas-gb10"><img alt="Docker Hub" src="https://img.shields.io/badge/Docker%20Hub-avarok%2Fatlas--gb10-2496ED?style=flat-square&logo=docker&logoColor=white"></a>
-    <a href="https://discord.gg/6vDbKaKrKD"><img alt="Discord" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2F6vDbKaKrKD%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&label=discord&suffix=%20members&style=flat-square&logo=discord&logoColor=white&color=5865F2"></a>
+    <a href="https://discord.gg/RQcGakU2jW"><img alt="Discord" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FRQcGakU2jW%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&label=discord&suffix=%20members&style=flat-square&logo=discord&logoColor=white&color=5865F2"></a>
   </p>
 </p>
 

--- a/dez/src/lib/site.ts
+++ b/dez/src/lib/site.ts
@@ -28,7 +28,7 @@ export const LINKS = {
   atlasRepo: 'https://github.com/Avarok-Cybersecurity/atlas',
   atlasSite: 'https://atlasinference.io',
   atlasLicense: 'https://github.com/Avarok-Cybersecurity/atlas/blob/main/LICENSE',
-  discord: 'https://discord.gg/6vDbKaKrKD',
+  discord: 'https://discord.gg/RQcGakU2jW',
   webgpu: 'https://www.w3.org/TR/webgpu/'
 } as const;
 

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -13,7 +13,7 @@
 
 // --- canonical links ---------------------------------------------------------
 export const githubUrl = 'https://github.com/Avarok-Cybersecurity/atlas';
-export const discordUrl = 'https://discord.gg/6vDbKaKrKD';
+export const discordUrl = 'https://discord.gg/RQcGakU2jW';
 export const xUrl = 'https://x.com/atlasinference';
 export const xHandle = '@atlasinference';
 export const redditUrl = 'https://www.reddit.com/r/LocalLLaMA/comments/1rmvxo3/';

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -8,5 +8,5 @@ Pure Rust + CUDA LLM inference engine, hand-tuned for prosumer AI machines (NVID
 - MLPerf Edge Agentic benchmark (Atlas Inference named as a contributor): https://mlcommons.org/2026/07/mlperf-inference-v61-edge-agentic/
 - Deployment guide: https://github.com/Avarok-Cybersecurity/atlas/blob/main/docs/GB10_DEPLOYMENT_GUIDE.md
 - Recipes (model SSOT): https://github.com/Avarok-Cybersecurity/atlas-recipes
-- Discord: https://discord.gg/6vDbKaKrKD
+- Discord: https://discord.gg/RQcGakU2jW
 - Site: https://atlasinference.io


### PR DESCRIPTION
Updates the Discord invite link from `discord.gg/6vDbKaKrKD` to `https://discord.gg/RQcGakU2jW` everywhere it appears in the repo.

## Files changed
- `README.md` — badge link href, plus the invite code embedded in the shields.io dynamic member-count API query (`.../api/v10/invites/<code>`)
- `dez/src/lib/site.ts` — `LINKS.discord` (Dez IDE site)
- `site/src/lib/data.js` — `discordUrl` (main Atlas site canonical source)
- `site/static/llms.txt` — Discord line

## Notes
- Searched the whole repo (case-insensitive) for `discord.gg/` and `discord.com/invite/`. The only other hit was `vendor/cudarc/README.md`, which is a vendored third-party crate's own unrelated Discord server invite — left untouched.
- Checked `site/src/lib/*.generated.json` (gates/models/stars/ladder/benchmarks) — none contain a Discord link, so no generator source needed updating.
- No files outside `site/`, `dez/`, and top-level docs touched; `crates/` and `kernels/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1