### PR TITLE
Name queue-composition failures; document the serialized-landing protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -838,3 +838,15 @@ jobs:
           # this gate through the flag within the PR's own run.
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: cargo run --locked -p spark-server --bin spark -- benchmark --pull-request-gate-check ${PR_NUMBER:+--pr "$PR_NUMBER"}
+      # ── Queue-composition diagnosis ──────────────────────────────────────
+      # A record-bearing perf PR can be GREEN at its head and still bounce
+      # here: the queue tests the MERGE tree, and records cannot compose
+      # across PRs — a campaign that covered this PR's tree does not cover a
+      # tree with another perf PR's kernels placed under it (observed
+      # 2026-08-23: #732 bounced behind #731, then behind post-#733 main; then
+      # #731 bounced behind post-#733 main — every head was green).
+      # When that is what happened, say so instead of ten bare NONEs.
+      - name: Name the failure if it is queue composition
+        if: failure() && github.event_name == 'merge_group'
+        run: |
+          echo "::error title=Queue-composition failure::This PR's benchmark records were valid at its head; the MERGE GROUP composed other performance changes underneath them, which invalidates records by design (unmeasured interaction). Retrying will not help. Apply the serialized-landing protocol (scripts/queue-perf-pr.sh): update the branch to current main, FREEZE that sha, run the ten gates against exactly that tree, commit the records, and queue with no other performance PR ahead. See docs/gate-queue-protocol.md."

--- a/docs/gate-queue-protocol.md
+++ b/docs/gate-queue-protocol.md
@@ -1,0 +1,52 @@
+# Benchmark records and the merge queue: the serialized-landing protocol
+
+## The problem, precisely
+
+The PR benchmark gate requires committed records proving the ten mandatory
+benchmarks ran against the tree under test. Records are sha-anchored and are
+invalidated by any performance-path change they did not cover — including
+changes that arrive from *underneath*, when the merge queue composes the PR
+with other PRs or with a `main` that moved after the records were measured.
+
+This means a record-bearing performance PR can be **fully green at its head
+and still bounce in the queue, repeatedly, with zero code defects**. Observed
+2026-08-23: #732 bounced behind #731, then behind post-#733 `main`; #731 then
+bounced behind post-#733 `main`. Every head was green the whole time.
+
+This is not a gate bug. Two independently-measured campaigns do not compose:
+the combined tree's interactions are unmeasured, and "measure-then-declare"
+is the repo's core benchmark doctrine. The gate refusing to stitch records
+together is the doctrine working. What *was* missing is (a) a name for the
+failure — ten bare `NONE`s read as a broken PR, not a queue-composition
+condition — and (b) a documented landing protocol. CI now emits a
+`Queue-composition failure` annotation on `merge_group` gate failures, and the
+protocol is below.
+
+## The protocol: freeze → campaign → queue alone
+
+1. **Freeze**: update the branch to *current* `main` (merge, don't rebase —
+   rebasing orphans the record shas' ancestry) and push. Any later `main`
+   movement restarts the protocol.
+2. **Campaign**: run all ten gates against exactly the frozen sha, on a box
+   with an exclusive GPU. Commit the records, push, wait for green.
+3. **Queue alone**: enter the merge queue with **no other record-bearing PR
+   ahead of you**, and do not let one enter until you have landed.
+
+`scripts/queue-perf-pr.sh <branch>` performs the freeze and prints the
+campaign commands.
+
+## For queue administrators
+
+Two record-bearing performance PRs can never successfully share a merge-queue
+group; the second is guaranteed to bounce after burning a full CI run.
+Consider restricting the queue's max group size to 1, or socially serializing
+perf-PR landings. Non-perf PRs (docs, site, workflows, `scripts/`) compose
+freely — none of their paths invalidate records.
+
+## Known costs, accepted
+
+Serialization means N perf PRs cost N campaigns even when each is individually
+certified. The alternative — letting records compose — would declare unmeasured
+interactions measured, which is precisely the class of silent regression the
+gate exists to prevent (see the SPLIT=4, tree-scan, and P3 incidents: every
+one was invisible to isolated numeric checks and caught only by task gates).

--- a/scripts/queue-perf-pr.sh
+++ b/scripts/queue-perf-pr.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# queue-perf-pr.sh — the serialized-landing protocol for record-bearing
+# performance PRs.
+#
+# WHY THIS EXISTS. Benchmark records cannot compose across PRs: a campaign
+# that covered PR A's tree does not cover a tree with PR B's kernels placed
+# under it — the interaction is unmeasured, and the gate refuses by design.
+# The merge queue tests exactly such composed trees, so a perf PR can be
+# fully green at its head and bounce in the queue every time another perf PR
+# lands ahead of it. Observed 2026-08-23 (#731/#732/#733): three green PRs,
+# repeated bounces, zero code defects.
+#
+# THE PROTOCOL: freeze -> campaign -> queue alone.
+#   1. Update the branch to CURRENT main and push. This is the freeze; any
+#      later main movement restarts the protocol.
+#   2. Run all ten gates against exactly that sha (on a box with exclusive
+#      GPU), commit the records, push.
+#   3. Queue the PR with NO other performance PR ahead of it. Do not add a
+#      second record-bearing PR to the queue until this one has landed.
+#
+# This script performs step 1 and prints the step-2 campaign command; the
+# campaign itself needs a GPU box and is deliberately not run from here.
+#
+# Usage: scripts/queue-perf-pr.sh <branch>
+set -euo pipefail
+BRANCH="${1:?usage: queue-perf-pr.sh <branch>}"
+git fetch origin main "$BRANCH"
+WT="$(mktemp -d)/wt"
+git worktree add "$WT" "origin/$BRANCH"
+cd "$WT"
+git merge --no-edit origin/main -m "Merge main — freeze for the serialized queue protocol (see scripts/queue-perf-pr.sh)"
+SHA=$(git rev-parse --short=10 HEAD)
+git push origin "HEAD:$BRANCH"
+echo
+echo "FROZEN: $BRANCH @ $SHA"
+echo "Now run, on a GPU box with the repo checked out at exactly $SHA:"
+echo '  for g in ttft-cold-gate ttft-warm-gate vision-fidelity ssm-state-poisoning-gate \'
+echo '           decode-floor concurrency-sweep video-fidelity bfcl-subset \'
+echo '           bfcl-subset-echolp agentic-webserver; do'
+echo '    timeout 21600 ./target/release/spark benchmark run "$g" --pull-request-gate --yes'
+echo '  done'
+echo "then commit .benchmarks/ and push, wait for green, and queue the PR alone."


### PR DESCRIPTION
Response to @TheTom's analysis on #732 (and the #731/#733 queue bounces): the merge queue
composes trees that no single PR's benchmark records cover, so a record-bearing perf PR
can be green at its head and bounce repeatedly with zero code defects.

**This PR does not weaken the gate** — records refusing to compose across PRs is the
measure-then-declare doctrine working (the SPLIT=4, tree-scan, and P3 incidents were all
invisible to isolated checks and caught only by task gates). It fixes the two things that
*were* missing:

| change | file | effect |
|---|---|---|
| **Name the failure** | `ci.yml` | on `merge_group` gate failures, an error annotation says "queue-composition failure — retrying will not help" and points at the protocol, instead of ten bare `NONE`s |
| **Script the protocol** | `scripts/queue-perf-pr.sh` | freeze (merge current main + push) and print the exact ten-gate campaign commands for the frozen sha |
| **Document it** | `docs/gate-queue-protocol.md` | freeze → campaign → queue alone; admin note that two record-bearing PRs can never share a queue group (consider max group size 1); accepted costs |

Deliberately touches only `.github/`, `scripts/`, `docs/` — none are `PERF_PATHS` — so
the fix itself invalidates nobody's records and owes no campaign.

The deeper queue-aware coverage design (gate distinguishing "invalidated by my own diff"
from "invalidated by base drift" natively, in Rust) would touch `BOUNDARY_FILES` and cost
a campaign per iteration; left as follow-up with this PR as the operational stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1