### PR TITLE
fix(spec): in-think EOS suppression on the verify emit path

### DIFF
--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -417,7 +417,27 @@ pub fn emit_token(
             || crate::grammar::grammar_blocks_stop(a.grammar_state.as_mut(), &a.eos_tokens));
     let legacy_suppresses_eos = a.require_tool_call;
     let min_tokens_suppresses = a.output_tokens.len() < a.min_tokens;
-    let suppress_eos = grammar_suppresses_eos || legacy_suppresses_eos || min_tokens_suppresses;
+    // Thinking EOS suppression — the twin of decode_logits_step's explicit
+    // `thinking_suppresses_eos` term, which this emit path NEVER HAD (the
+    // grammar term above only covers grammar-armed turns). Invisible on the
+    // Qwen family, whose temp-0 argmax never lands on EOS inside <think>;
+    // Nemotron-3.5-Lightning DOES — its greedy reasoning opens by restating
+    // the prompt and then argmaxes <|im_end|>, which the serial lane
+    // discards (reasoning continues, 2k+ tokens) and this lane previously
+    // honored, ending every speculative thinking turn at ~30 tokens
+    // (found on Lightning + DFlash, 2026-08-25). Same hard-ceiling escape
+    // as the serial twin so generation cannot overrun at the budget edge.
+    let hard_ceiling = crate::scheduler::helpers::hard_ceiling_hit(
+        a.remaining,
+        a.seq.seq_len,
+        sched.limits.max_seq_len,
+    );
+    let thinking_suppresses_eos =
+        crate::scheduler::helpers::eos_suppressed_by_thinking(a.inside_thinking, hard_ceiling);
+    let suppress_eos = grammar_suppresses_eos
+        || legacy_suppresses_eos
+        || min_tokens_suppresses
+        || thinking_suppresses_eos;
 
     if a.eos_tokens.contains(&tok) && !suppress_eos {
         a.finished = true;


### PR DESCRIPTION
The serial decode path (`decode_logits_step`) discards a greedy EOS that lands inside `<think>` (`thinking_suppresses_eos`); the speculative emit path (`emit_step`) never had that term — its own comment said so — so its in-think EOS discard only covered grammar-armed turns.

Invisible on Qwen (temp-0 argmax never lands on EOS inside think). Nemotron-3.5-Lightning's greedy reasoning opens by restating the prompt and then argmaxes `<|im_end|>`: serial discards it and reasons on for 2k+ tokens; spec emitted it and the response died ~30 tokens in — making speculation look like a verify divergence when both lanes' logits were identical.

Fix mirrors the serial path exactly (same `helpers::eos_suppressed_by_thinking` + hard-ceiling escape hatch).

**Validation**: Lightning + DFlash spec-think output is now byte-exact vs the serial serve on the standard MinHeap probe (content 6259 B / reasoning 2165 B, finish stop, identical bytes). Applies to every thinking model under speculation.

Standalone against main — no dependency on the Nemotron stack (#544/#545/#566), though it was found there.