### PR TITLE
dflash: support NVFP4-packed drafter checkpoints + packed shared lm_head

### DIFF
--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -567,7 +567,28 @@ impl BlockDiffusionDraftHead {
             // kernel (fixed: 2-round A-load covers all 32 K-cols).
             // BF16 path (default, or Fp8 mirror missing) unchanged.
             let lm_head_fp8 = matches!(self.quant, super::DflashQuantization::Fp8Weights);
-            if lm_head_fp8 {
+            // Target ships an NVFP4-PACKED lm_head (Lightning: U8 [vocab,
+            // h/2] + F8 scales): `lm_head_shared` then points at PACKED
+            // bytes and a BF16 GEMM on it reads 4x past the allocation —
+            // exactly the OOB this field's declaration warns about (it was
+            // stored but never consumed until the Lightning DFlash port,
+            // 2026-08-24; the fault fingerprint was grid=[vocab/128,1,1]).
+            // The w4a16 tile GEMM consumes the packed form directly, and a
+            // numpy-from-safetensors reference matched its logits to
+            // argmax-parity (cos 1.0000) during the Lightning parity audit.
+            if let Some(q) = self.lm_head_nvfp4.as_ref() {
+                ops::w4a16_gemm(
+                    gpu,
+                    self.kernels.w4a16_gemm,
+                    norm_noise_local,
+                    q,
+                    self.scratch.logits,
+                    self.gamma as u32,
+                    self.vocab_size as u32,
+                    h_local,
+                    stream,
+                )?;
+            } else if lm_head_fp8 {
                 if let Some(fp8) = self.lm_head_shared_fp8.as_ref() {
                     ops::fp8_gemm_n128_row_scaled_m16(
                         gpu,

--- a/crates/spark-model/src/weight_loader/dflash_loader.rs
+++ b/crates/spark-model/src/weight_loader/dflash_loader.rs
@@ -32,6 +32,39 @@ use spark_runtime::weights::WeightStore;
 
 use crate::weight_map::{DenseWeight, dense};
 
+/// Load a drafter GEMM weight that may be NVFP4-packed.
+///
+/// ModelOpt NVFP4 drafter exports (NVIDIA-Nemotron-3.5-Lightning DFlash:
+/// `fc` + every attention/MLP projection) ship U8 `[n, k/2]` packed nibbles
+/// with F8_E4M3 `[n, k/16]` per-block scales and an F32 `weight_scale_2` —
+/// under the SAME tensor names a BF16 checkpoint uses. Loading them as BF16
+/// made every GEMM read 4x past the allocation (the Lightning bring-up's
+/// CUDA 700, fault grid [21,12,1] = the fc [2688, 16128] GEMM). Detect the
+/// packed form by dtype and GPU-dequantize to BF16; BF16 tensors pass
+/// through untouched, so existing drafters are byte-identical.
+fn dense_bf16_or_nvfp4(
+    store: &WeightStore,
+    name: &str,
+    gpu: &dyn GpuBackend,
+) -> Result<DenseWeight> {
+    let t = store.get(name)?;
+    if t.dtype == spark_runtime::weights::WeightDtype::UInt8 {
+        let prefix = name.strip_suffix(".weight").unwrap_or(name);
+        anyhow::ensure!(
+            t.shape.len() == 2,
+            "NVFP4-packed drafter tensor {name} has shape {:?} (want 2-D)",
+            t.shape
+        );
+        let (n, half_k) = (t.shape[0], t.shape[1]);
+        tracing::info!(
+            "DFlash drafter: dequantizing NVFP4 {name} [{n}, {}] -> BF16",
+            half_k * 2
+        );
+        return crate::weight_map::dequant_nvfp4_to_bf16(store, prefix, n, half_k * 2, gpu);
+    }
+    Ok(DenseWeight { weight: t.ptr })
+}
+
 /// Drafter HF `config.json` (subset Atlas consumes). Mirrors
 /// `z-lab/Qwen3.6-35B-A3B-DFlash/config.json` field names verbatim so
 /// `serde_json::from_str` works directly on the raw file.
@@ -224,7 +257,7 @@ pub fn load_dflash_weights(
         ""
     };
 
-    let fc = dense(drafter_store, &format!("{prefix}fc.weight"))
+    let fc = dense_bf16_or_nvfp4(drafter_store, &format!("{prefix}fc.weight"), _gpu)
         .context("DFlash drafter: load fc.weight")?;
     let hidden_norm = dense(drafter_store, &format!("{prefix}hidden_norm.weight"))
         .context("DFlash drafter: load hidden_norm.weight")?;
@@ -241,15 +274,15 @@ pub fn load_dflash_weights(
                 drafter_store,
                 &format!("{lp}.post_attention_layernorm.weight"),
             )?,
-            q_proj: dense(drafter_store, &format!("{lp}.self_attn.q_proj.weight"))?,
-            k_proj: dense(drafter_store, &format!("{lp}.self_attn.k_proj.weight"))?,
-            v_proj: dense(drafter_store, &format!("{lp}.self_attn.v_proj.weight"))?,
-            o_proj: dense(drafter_store, &format!("{lp}.self_attn.o_proj.weight"))?,
+            q_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.self_attn.q_proj.weight"), _gpu)?,
+            k_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.self_attn.k_proj.weight"), _gpu)?,
+            v_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.self_attn.v_proj.weight"), _gpu)?,
+            o_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.self_attn.o_proj.weight"), _gpu)?,
             q_norm: dense(drafter_store, &format!("{lp}.self_attn.q_norm.weight"))?,
             k_norm: dense(drafter_store, &format!("{lp}.self_attn.k_norm.weight"))?,
-            gate_proj: dense(drafter_store, &format!("{lp}.mlp.gate_proj.weight"))?,
-            up_proj: dense(drafter_store, &format!("{lp}.mlp.up_proj.weight"))?,
-            down_proj: dense(drafter_store, &format!("{lp}.mlp.down_proj.weight"))?,
+            gate_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.mlp.gate_proj.weight"), _gpu)?,
+            up_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.mlp.up_proj.weight"), _gpu)?,
+            down_proj: dense_bf16_or_nvfp4(drafter_store, &format!("{lp}.mlp.down_proj.weight"), _gpu)?,
         };
         layers.push(layer);
     }

--- a/crates/spark-model/src/weight_map.rs
+++ b/crates/spark-model/src/weight_map.rs
@@ -13,6 +13,7 @@ mod expert;
 mod fp8_dequant;
 #[path = "weight_map/fp8_lut.rs"]
 mod fp8_lut;
+pub(crate) use fp8_lut::dequant_nvfp4_to_bf16;
 #[path = "weight_map/loaders_fp8.rs"]
 mod loaders_fp8;
 #[path = "weight_map/loaders_moe.rs"]


### PR DESCRIPTION
Two OOB classes found bringing up NVIDIA-Nemotron-3.5-Lightning DFlash (the first ModelOpt NVFP4 drafter export Atlas has loaded) — both generic to any NVFP4-packed checkpoint, no Nemotron dependency:

**1. Drafter weights.** ModelOpt exports ship `fc` + every attention/MLP projection as U8 `[n, k/2]` packed nibbles + F8_E4M3 `[n, k/16]` block scales + F32 `weight_scale_2` — under the **same tensor names** a BF16 checkpoint uses. The loader read them as BF16 → every GEMM read 4x past the allocation (CUDA 700, fault grid `[21,12,1]` = the fc GEMM). New `dense_bf16_or_nvfp4()` detects the packed form by dtype and GPU-dequantizes via the existing `dequant_nvfp4_to_bf16` kernel. BF16 tensors pass through untouched — existing drafters are byte-identical.

**2. Shared lm_head.** When the *target* ships an NVFP4-packed lm_head, `lm_head_shared` points at packed bytes and the drafter's Phase-G BF16 GEMM is the same 4x OOB (fault grid `[vocab/128,1,1]`). `lm_head_nvfp4` was stored but never consumed on this path — the tail now consumes it first via the w4a16 tile GEMM.

**Validation**: full numpy-from-safetensors parity audit on Lightning — dequantized fc GEMM cos 1.0000 (low-nibble-first E2M1 + E4M3 block scales × weight_scale_2) and w4a16 head logits cos 1.0000 with identical argmax vs the engine.