### PR TITLE
verify: sliding-window attention needs per-token metadata in every spec verify lane

### DIFF
--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn.rs
@@ -51,7 +51,16 @@ impl Qwen3AttentionLayer {
             static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
             *ON.get_or_init(|| std::env::var("ATLAS_NO_ROPE_STRIDED").ok().as_deref() != Some("1"))
         }
-        if n > 1 && self.rope_strided_k.0 != 0 && rope_strided_enabled() {
+        // YARN-scaled layers (yarn_inv_freq set -- Laguna full-attention) must
+        // take the per-seq loop below: rope_strided computes plain-theta rope
+        // and has no yarn table argument, so a K-row verify through it rotates
+        // Q/K differently than the serial decode path. Bit-parity for
+        // non-yarn layers is unchanged.
+        if n > 1
+            && self.rope_strided_k.0 != 0
+            && rope_strided_enabled()
+            && self.yarn_inv_freq.is_null()
+        {
             let stride_e = (per_seq_qkv / bf16) as u32;
             return ops::rope_strided(
                 fwd.gpu,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -758,6 +758,7 @@ impl TransformerModel {
             mtp_carry: parking_lot::Mutex::new(None),
             mtp_store_range: parking_lot::Mutex::new((0, 0)),
             dflash_hidden_save,
+            verify_ptok_meta: std::sync::OnceLock::new(),
             dflash_hidden_save_rows,
             dflash_capture_layers,
             verify2_graph: Mutex::new(std::collections::HashMap::new()),

--- a/crates/spark-model/src/model/trait_impl/verify_a.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_a.rs
@@ -67,7 +67,19 @@ impl TransformerModel {
         for (i, layer) in self.layers.iter().enumerate() {
             let layer_type = self.config.layer_type(i);
 
-            if layer_type == atlas_core::config::LayerType::FullAttention {
+            // BOTH attention flavors take the per-token path. SlidingAttention
+            // previously fell into the decode_batched fallback below, whose
+            // default per-token decode() loop reuses the caller's ONE
+            // attn_metadata upload -- every one of the K tokens then attends
+            // and writes KV at the SAME position, and the verify commits one
+            // token repeated (Laguna-XS DFlash 'ToToTo...' degeneration,
+            // 2026-08-25; Laguna is the first spec target with sliding
+            // layers, so no earlier model could hit this).
+            if matches!(
+                layer_type,
+                atlas_core::config::LayerType::FullAttention
+                    | atlas_core::config::LayerType::SlidingAttention
+            ) {
                 // Attention layers: sequential per-token (need per-token metadata)
                 for t in 0..k {
                     let pos = seq.seq_len + t;
@@ -486,5 +498,144 @@ impl TransformerModel {
             self.gpu.as_ref(),
             stream,
         )
+    }
+
+    /// Sequential per-token attention decode over K verify rows, uploading
+    /// CORRECT per-token metadata (position, KV slot, seq_len, block table)
+    /// before each `decode()` — the same pattern this file's eager verify
+    /// uses inline for its attention arm.
+    ///
+    /// Exists for SLIDING-WINDOW attention layers inside the K=2 / K=γ
+    /// verify bodies: those routes send non-FullAttention layers to
+    /// `decode_batched`, whose default per-token loop reuses the caller's
+    /// single multi-row metadata upload — every token then attends and
+    /// writes KV at the SAME position, and verify commits one token
+    /// repeated (Laguna-XS DFlash 'ToToTo…' degeneration, 2026-08-25;
+    /// `decode_multi_seq` is no alternative — it has no sliding-window
+    /// handling at all). Eager H2D uploads per token: callers must run
+    /// OUTSIDE CUDA-graph capture (the verify bodies drop graphs when the
+    /// model has sliding layers).
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn verify_attention_per_token(
+        &self,
+        layer: &dyn TransformerLayer,
+        layer_idx: usize,
+        hidden: DevicePtr,
+        residual: DevicePtr,
+        k: usize,
+        seq: &mut SequenceState,
+        kv_cache: &mut PagedKvCache,
+        stream: u64,
+    ) -> Result<()> {
+        let h = self.config.hidden_size;
+        let bf16 = 2usize;
+        // Dedicated staging — NOT `scratch + 32768`: the verify bodies'
+        // multi-seq metadata overlay lives there and can span the entire
+        // scratch buffer, and the interleaved FullAttention layers'
+        // decode_multi_seq still reads it between our per-token calls
+        // (clobbering it was a sticky CUDA-700 on Laguna-XS, 2026-08-25).
+        const PTOK_META_BYTES: usize = 16 * 1024;
+        let meta_base = match self.verify_ptok_meta.get() {
+            Some(&p) => p,
+            None => {
+                let p = self.gpu.alloc(PTOK_META_BYTES)?;
+                *self.verify_ptok_meta.get_or_init(|| p)
+            }
+        };
+        // +4 blocks of slack: ensure_blocks_through_decode below may grow the
+        // table by up to ceil(k/block_size)+1 entries before the upload.
+        anyhow::ensure!(
+            256 + (seq.block_table.len() + 4) * 4 <= PTOK_META_BYTES,
+            "verify_attention_per_token: block table ({} blocks) exceeds the \
+             16 KB per-token metadata staging",
+            seq.block_table.len(),
+        );
+        for t in 0..k {
+            let pos = seq.seq_len + t;
+            let bs = kv_cache.block_size();
+            let blocks_needed = (pos / bs) + 1;
+            ensure_blocks_through_decode(
+                seq,
+                blocks_needed - 1,
+                kv_cache,
+                self.prefix_cache.as_ref(),
+                self.gpu.as_ref(),
+                stream,
+                self.levers.kv_poison,
+            )?;
+
+            let max_blocks = seq.block_table.len() as u32;
+            let pos_val = pos as u32;
+            self.gpu
+                .copy_h2d_async(&pos_val.to_le_bytes(), meta_base, stream)?;
+            let block_idx = seq
+                .physical_block_for(pos / bs)
+                .unwrap_or(self.dummy_kv_block);
+            let global_slot = (block_idx as i64) * (bs as i64) + ((pos % bs) as i64);
+            self.gpu
+                .copy_h2d_async(&global_slot.to_le_bytes(), meta_base.offset(8), stream)?;
+            let actual_seq_len = (pos + 1) as i32;
+            self.gpu
+                .copy_h2d_async(&actual_seq_len.to_le_bytes(), meta_base.offset(16), stream)?;
+            let bt_i32: Vec<i32> = seq.block_table.iter().map(|&b| b as i32).collect();
+            // SAFETY: length derived from `bt_i32` itself (`len() * 4`), a
+            // fresh `collect()` above; i32 is POD; `bt_i32` outlives the
+            // H2D enqueue.
+            let bt_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(bt_i32.as_ptr() as *const u8, bt_i32.len() * 4) };
+            self.gpu
+                .copy_h2d_async(bt_bytes, meta_base.offset(256), stream)?;
+
+            let seq_slot =
+                self.upload_seq_slot_uniform(seq.adapter_slot, 1, meta_base.offset(128), stream)?;
+
+            let attn_metadata = AttnMetadataDev {
+                positions: meta_base,
+                positions_h: meta_base,
+                positions_w: meta_base,
+                slot: meta_base.offset(8),
+                seq_len: meta_base.offset(16),
+                block_table: meta_base.offset(256),
+                max_blocks_per_seq: max_blocks,
+                num_seqs: 1,
+                seq_slot,
+                moe_row_adapter: spark_runtime::gpu::DevicePtr::NULL,
+            };
+
+            let ctx = ForwardContext {
+                buffers: &self.buffers,
+                gpu: self.gpu.as_ref(),
+                config: &self.config,
+                dispatch: &self.dispatch,
+                derived: &self.derived,
+                levers: &self.levers,
+                stats: &self.stats,
+                attn_metadata: Some(attn_metadata),
+                profile: false,
+                comm: self.comm_ref(),
+                graph_capture: false,
+                gdn_exact_replay: false,
+                token_ids: None,
+                routed_lora_layers: None,
+                midchunk_capture: None,
+                moe_lora_route: self.decode_moe_route(),
+            };
+
+            let h_t = hidden.offset(t * h * bf16);
+            let r_t = residual.offset(t * h * bf16);
+            layer.decode(
+                h_t,
+                r_t,
+                seq.layer_states[layer_idx].as_mut(),
+                kv_cache,
+                pos,
+                &mut seq.block_table,
+                &mut seq.disk_block_ids,
+                &mut seq.disk_last_offloaded_per_layer,
+                &ctx,
+                stream,
+            )?;
+        }
+        Ok(())
     }
 }

--- a/crates/spark-model/src/model/trait_impl/verify_b.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_b.rs
@@ -229,7 +229,14 @@ impl TransformerModel {
             // illegal under CUDA graph capture.
             && !hss_engaged
             && !k2_diag_eager
-            && !lora_eager;
+            && !lora_eager
+            // Sliding-window layers verify via the eager per-token metadata
+            // loop (verify_attention_per_token) -- per-token H2D uploads are
+            // illegal under capture, and a captured verify would bake row-0's
+            // position into every token anyway (the Laguna-XS 'ToToTo...'
+            // failure this fix exists for).
+            && !(0..self.layers.len())
+                .any(|i| self.config.layer_type(i) == LayerType::SlidingAttention);
 
         // DeepSeek-V4 hash-MoE (first `num_hash_layers`) routes experts by token
         // id via the static tid2eid table, so the verify forward needs the 2
@@ -341,6 +348,21 @@ impl TransformerModel {
                             stream,
                         )?;
                     }
+                } else if layer_type == LayerType::SlidingAttention {
+                    // Sliding-window attention: per-token metadata loop --
+                    // the decode_batched default reuses ONE metadata upload
+                    // and decodes every token at the same position (Laguna
+                    // 'ToToTo...'). Graphs are off for sliding models above.
+                    self.verify_attention_per_token(
+                        layer.as_ref(),
+                        layer_idx,
+                        hidden,
+                        residual,
+                        k,
+                        seq,
+                        &mut kv_cache,
+                        stream,
+                    )?;
                 } else {
                     // SSM: process K=2 tokens for one sequence via decode_batched.
                     layer.decode_batched(

--- a/crates/spark-model/src/model/trait_impl/verify_c.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c.rs
@@ -184,7 +184,14 @@ impl TransformerModel {
         let hss_engaged = kv_cache.config().cache_blocks_per_seq.is_some();
         // ATLAS_LORA_EAGER: LoRA graph-vs-eager debugging hatch (see decode_a).
         let lora_eager = self.lora.is_some() && self.levers.lora_eager;
-        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager;
+        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager
+            // Sliding-window layers verify via the eager per-token metadata
+            // loop (verify_attention_per_token) -- per-token H2D uploads are
+            // illegal under capture, and a captured verify would bake row-0's
+            // position into every token anyway (the Laguna-XS 'ToToTo...'
+            // failure this fix exists for).
+            && !(0..self.layers.len())
+                .any(|i| self.config.layer_type(i) == LayerType::SlidingAttention);
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -272,6 +279,21 @@ impl TransformerModel {
                             stream,
                         )?;
                     }
+                } else if layer_type == LayerType::SlidingAttention {
+                    // Sliding-window attention: per-token metadata loop --
+                    // the decode_batched default reuses ONE metadata upload
+                    // and decodes every token at the same position (Laguna
+                    // 'ToToTo...'). Graphs are off for sliding models above.
+                    self.verify_attention_per_token(
+                        layer.as_ref(),
+                        layer_idx,
+                        hidden,
+                        residual,
+                        k,
+                        seq,
+                        &mut kv_cache,
+                        stream,
+                    )?;
                 } else {
                     layer.decode_batched(
                         hidden,

--- a/crates/spark-model/src/model/trait_impl/verify_c2.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_c2.rs
@@ -181,7 +181,14 @@ impl TransformerModel {
         // the K=2 path (verify_b.rs). Diagnostic only — default behavior is
         // byte-for-byte unchanged when the env is unset.
         let k4_diag = std::env::var("ATLAS_K4_DIAG").ok().as_deref() == Some("1");
-        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager && !k4_diag;
+        let use_graphs = self.comm.is_none() && !hss_engaged && !lora_eager && !k4_diag
+            // Sliding-window layers verify via the eager per-token metadata
+            // loop (verify_attention_per_token) -- per-token H2D uploads are
+            // illegal under capture, and a captured verify would bake row-0's
+            // position into every token anyway (the Laguna-XS 'ToToTo...'
+            // failure this fix exists for).
+            && !(0..self.layers.len())
+                .any(|i| self.config.layer_type(i) == LayerType::SlidingAttention);
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -269,6 +276,21 @@ impl TransformerModel {
                             stream,
                         )?;
                     }
+                } else if layer_type == LayerType::SlidingAttention {
+                    // Sliding-window attention: per-token metadata loop --
+                    // the decode_batched default reuses ONE metadata upload
+                    // and decodes every token at the same position (Laguna
+                    // 'ToToTo...'). Graphs are off for sliding models above.
+                    self.verify_attention_per_token(
+                        layer.as_ref(),
+                        layer_idx,
+                        hidden,
+                        residual,
+                        k,
+                        seq,
+                        &mut kv_cache,
+                        stream,
+                    )?;
                 } else {
                     layer.decode_batched(
                         hidden,

--- a/crates/spark-model/src/model/trait_impl/verify_d.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_d.rs
@@ -183,7 +183,14 @@ impl TransformerModel {
                 .load(std::sync::atomic::Ordering::Relaxed)
             && !hss_engaged
             && !force_eager
-            && !lora_eager;
+            && !lora_eager
+            // Sliding-window layers verify via the eager per-token metadata
+            // loop (verify_attention_per_token) -- per-token H2D uploads are
+            // illegal under capture, and a captured verify would bake row-0's
+            // position into every token anyway (the Laguna-XS 'ToToTo...'
+            // failure this fix exists for).
+            && !(0..self.layers.len())
+                .any(|i| self.config.layer_type(i) == LayerType::SlidingAttention);
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -271,6 +278,21 @@ impl TransformerModel {
                             stream,
                         )?;
                     }
+                } else if layer_type == LayerType::SlidingAttention {
+                    // Sliding-window attention: per-token metadata loop --
+                    // the decode_batched default reuses ONE metadata upload
+                    // and decodes every token at the same position (Laguna
+                    // 'ToToTo...'). Graphs are off for sliding models above.
+                    self.verify_attention_per_token(
+                        layer.as_ref(),
+                        layer_idx,
+                        hidden,
+                        residual,
+                        k,
+                        seq,
+                        &mut kv_cache,
+                        stream,
+                    )?;
                 } else {
                     layer.decode_batched(
                         hidden,

--- a/crates/spark-model/src/model/trait_impl/verify_fused.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_fused.rs
@@ -207,7 +207,14 @@ impl TransformerModel {
                 .suppress_graphs
                 .load(std::sync::atomic::Ordering::Relaxed)
             && !hss_engaged
-            && !lora_eager;
+            && !lora_eager
+            // Sliding-window layers verify via the eager per-token metadata
+            // loop (verify_attention_per_token) -- per-token H2D uploads are
+            // illegal under capture, and a captured verify would bake row-0's
+            // position into every token anyway (the Laguna-XS 'ToToTo...'
+            // failure this fix exists for).
+            && !(0..self.layers.len())
+                .any(|i| self.config.layer_type(i) == LayerType::SlidingAttention);
 
         let ctx = ForwardContext {
             buffers: &self.buffers,
@@ -294,6 +301,21 @@ impl TransformerModel {
                             stream,
                         )?;
                     }
+                } else if layer_type == LayerType::SlidingAttention {
+                    // Sliding-window attention: per-token metadata loop --
+                    // the decode_batched default reuses ONE metadata upload
+                    // and decodes every token at the same position (Laguna
+                    // 'ToToTo...'). Graphs are off for sliding models above.
+                    self.verify_attention_per_token(
+                        layer.as_ref(),
+                        layer_idx,
+                        hidden,
+                        residual,
+                        m,
+                        seq,
+                        &mut kv_cache,
+                        stream,
+                    )?;
                 } else {
                     // SSM: batch all M tokens together (M=2/3 fast paths exist).
                     layer.decode_batched(

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -266,6 +266,16 @@ pub struct TransformerModel {
     /// token's intermediate hiddens; the drafter consumes them via its `fc`
     /// projection on the next propose() call. None for non-DFlash runs.
     pub(super) dflash_hidden_save: Option<DevicePtr>,
+    /// Lazily-allocated 16 KB metadata staging for the sliding-attention
+    /// per-token verify loop (`verify_attention_per_token`). The verify
+    /// bodies' multi-seq metadata overlay at `scratch + 32768` can span the
+    /// ENTIRE scratch buffer (scratch is sized to exactly `bt_meta`), so the
+    /// per-token loop CANNOT stage there without clobbering the metadata the
+    /// interleaved FullAttention layers' `decode_multi_seq` still reads --
+    /// doing so was a sticky CUDA-700 on Laguna-XS (2026-08-25). Layout
+    /// mirrors the scratch meta block: pos@0, slot@8, seq_len@16,
+    /// seq_slot@128, block_table@256 (cap ~15.7 KB, about 4000 blocks).
+    pub(super) verify_ptok_meta: std::sync::OnceLock<DevicePtr>,
     /// Layer indices to capture for DFlash. Empty when DFlash is disabled.
     /// Sourced from drafter's `dflash_config.target_layer_ids` at model build.
     pub(super) dflash_capture_layers: Vec<usize>,


### PR DESCRIPTION
Every verify body (K=2/3/4/γ, fused, and the eager GEMM-batched lane) routed non-FullAttention layers to `decode_batched`, whose default loop calls single-token `decode()` K times under the caller's **one** metadata upload. Attention `decode()` reads position/KV-slot/seq_len from that metadata, so on a **SlidingAttention** layer all K verify rows attend and write KV at the *same position* — committed tokens collapse to one token repeated, and graph-capturing lanes can CUDA-700. No shipped speculative target had sliding layers until Laguna, which is how this survived.

**Measured** (Laguna-XS-2.1-NVFP4 + DFlash drafter, temp 0): before — 'ToToToTo…' from the first content-phase propose while plain serial is clean, fused M=4 lane CUDA-700; after — zero CUDA errors, coherent content, K=γ p1 0.929 (6.0 accepted/step), K=2 at 41.9 tok/s vs ~40 plain.

**Fix**: extracted `verify_attention_per_token` (the per-token-metadata loop verify_a already used inline for FullAttention) with its own lazily-allocated 16 KB staging (staging at `scratch+32768` clobbers the multi-seq overlay — that region can span the whole scratch allocation); SlidingAttention arms in all six lanes; `use_graphs` off when sliding layers exist (per-token H2D is illegal under capture). Plus a latent-bug gate: the strided multi-seq rope fast path must not fire on YARN-scaled layers (it computes plain-theta rope with no yarn table).

**Not covered**: `verify_e` (cross-sequence C≥2 batched verify) needs a per-band variant of the helper; sliding models should keep the batch-verify lever off until then.