### PR TITLE
site(diligence): reproduce the chart — the walkthrough's serve command was serving a different engine

### DIFF
--- a/bench/ladder38/published.json
+++ b/bench/ladder38/published.json
@@ -55,7 +55,7 @@
         "64": "l38_r11_c64.json",
         "128": "l38_r11_c128.json"
       },
-      "source_note": "Round 11 throughout. C=2 is round 8 on the identical configuration -- round 11 re-measured that rung at 40.42, and we publish the lower, older number rather than the better one."
+      "source_note": "Round 11 throughout, except C=2. C=2 is the 2026-08-18 hardening run (c2_atlas_dgx2_20260818.json), not round 8: the certified table originally carried round 8's 38.95 there, which won by 1.004x -- a margin inside either engine's run-to-run spread. Both legs were re-measured back to back on dgx2 on 2026-08-18 (Atlas 15:05, vLLM+MTP 15:20) and that PAIR replaced the earlier pair, which is why the Atlas number rose to 41.02 while the paired vLLM number fell to 37.11 and the margin moved to 1.105x with non-overlapping distributions. A round-11 C=2 exists at 40.42 (l38_r11_c2.json) but has no same-day vLLM leg, so it is not publishable as a pair. See RESULTS.md, C=2 HARDENED."
     },
     {
       "id": "vllm-mtp",

--- a/site/scripts/gen-ladder.mjs
+++ b/site/scripts/gen-ladder.mjs
@@ -25,6 +25,7 @@
 // No third-party deps: Node builtins only.
 // =============================================================================
 
+import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -131,6 +132,17 @@ const rows = subject.rungs.map((row) => {
   };
 });
 
+// The campaign driver stamps a sha256 of its own source into every record it
+// writes, and the published rungs carry the hash of the copy that produced
+// them. Hash the copy that ships in the tree so the deck can put the two side
+// by side: a reader who runs the repo's driver gets THIS hash in their output,
+// and a page that quoted only the recorded one would be inviting them to
+// compare against bytes they do not have. Computed, never typed — if the file
+// is ever edited this moves with it.
+const harnessRepoSha256 = createHash('sha256')
+  .update(readFileSync(resolve(REPO, manifest.workload.harness)))
+  .digest('hex');
+
 const out = {
   generated_utc: new Date().toISOString().replace(/\.\d+Z$/, 'Z'),
   title: manifest.title,
@@ -141,6 +153,7 @@ const out = {
   workload: manifest.workload,
   box: manifest.box,
   harness_shas: manifest.harness_shas,
+  harness_repo_sha256: harnessRepoSha256,
   concurrencies: subject.rungs.map((r) => r.c),
   series,
   rows,

--- a/site/src/lib/components/deck/acts/Ladder.svelte
+++ b/site/src/lib/components/deck/acts/Ladder.svelte
@@ -1,0 +1,365 @@
+<script>
+  // Act II, second half — measurement. Two instruments appear here and the
+  // distinction between them is the point of the act:
+  //
+  //   * `spark benchmark run concurrency-sweep` is what CI runs. It is the only
+  //     one that can mint a gate record, and it measures the GATE's workload.
+  //   * `bench/ladder38/harness_w55_conc_ladder.py` is what produced the chart
+  //     on this page. Nothing else reproduces the published ladder, so the deck
+  //     has to hand it over or the walkthrough stops short of its own headline.
+  //
+  // Setup (fingerprint, parity, Steps 1-4) is Reproduce.svelte, which precedes
+  // this act in the route.
+  import Slide from '../Slide.svelte';
+  import Cmd from '../Cmd.svelte';
+  import ConcurrencyLadder from '../../ConcurrencyLadder.svelte';
+  import { claim } from '$lib/deck/content.js';
+</script>
+
+<Slide
+  act="cyan"
+  eyebrow="Step 5"
+  title="The gate's instrument, pointed at both engines"
+  lede="The subcommand drives an endpoint that is already serving — it neither loads a model nor
+        touches the GPU. So the binary that gates our own pull requests is the binary that measures
+        vLLM. This measures the GATE's workload, not the chart's; Step 5b is the chart."
+  steps={2}
+>
+  <div class="wide2">
+    <div class="at" style="--n: 1">
+    <Cmd
+      label="the baseline leg, then the subject leg"
+      lines={[
+        `spark benchmark run concurrency-sweep \\`,
+        `  --url http://127.0.0.1:8000 --model ${claim.checkpoint} \\`,
+        `  --param concurrencies=1,4,8,16 --param isls=512 --param osl=320 \\`,
+        `  --skip-coherence-probe --format json > vllm.json`,
+        `spark benchmark run concurrency-sweep \\`,
+        `  --url http://127.0.0.1:8888 --model ${claim.checkpoint} \\`,
+        `  --param concurrencies=1,4,8,16 --param isls=512 --param osl=320 \\`,
+        `  --format json > atlas.json`
+      ]}
+      note="http:// only. stdout carries the record and stderr the progress, so the redirect gives a clean file. Those --param values are the ones the gate pins; an unknown key is an error, never a silent no-op."
+    />
+    </div>
+    <aside class="side at" style="--n: 2">
+      <p class="side-h mono">Two instruments, not interchangeable</p>
+      <p>
+        The published C=1…128 ladder came from <code class="mono">{claim.harnessFile}</code>, a
+        campaign driver with <code class="mono">--reps</code>; the gate's sweep runs one measured
+        batch per cell at pinned parameters.
+      </p>
+      <p>
+        Their prompt corpus is byte-identical, which makes a cell's throughput comparable across
+        the two. Their percentile rules are <em>not</em> — the driver interpolates, the gate takes a
+        nearest rank — so compare the aggregate tok/s the ladder publishes, never one instrument's
+        p50 TTFT against the other's. Only the gate's produces a record CI accepts.
+      </p>
+    </aside>
+  </div>
+</Slide>
+
+<Slide
+  act="cyan"
+  eyebrow="Step 5b"
+  title="The command that reproduces the chart"
+  lede="Step 5 measures what CI gates. This measures what this page publishes — the same driver, at
+        the same shape, that produced every number in the ladder overleaf."
+  steps={2}
+>
+  <div class="wide2">
+    <div class="at" style="--n: 1">
+      <Cmd
+        label="the published ladder, Atlas leg"
+        lines={[
+          `python3 -m venv .venv && .venv/bin/pip install aiohttp`,
+          ``,
+          `.venv/bin/python ${claim.harnessFile} \\`,
+          `  --url http://127.0.0.1:8888 --model ${claim.checkpoint} \\`,
+          `  --label atlas --out atlas_ladder.json \\`,
+          `  --concs ${claim.concsArg} \\`,
+          `  --reps ${claim.reps} --isl ${claim.isl} --osl ${claim.osl} --warmup ${claim.warmup}`
+        ]}
+        note={`Every knob is a required argument — the driver defaults nothing silently, so the command IS the methodology. Swap --url and --label for the vLLM leg and run them back to back. Budget about an hour per leg on a GB10: C=128 alone streams ${128 * claim.osl} tokens per rep, and there are ${claim.reps} timed reps plus ${claim.warmup} warmup at every rung.`}
+      />
+    </div>
+    <aside class="side at" style="--n: 2">
+      <p class="side-h mono">Check the driver hash first</p>
+      <p>
+        The driver prints its own <code class="mono">sha256</code> on the first line and writes it
+        into the output as <code class="mono">driver_sha256</code>. The published Atlas legs carry
+        <code class="mono">{claim.harnessShaAtlas}</code>; the copy in the repository today hashes
+        <code class="mono">{claim.harnessShaRepo}</code>.
+      </p>
+      <p>
+        Same sampling behaviour — both send <code class="mono">presence_penalty</code> and
+        <code class="mono">frequency_penalty</code> at 0.0, which is what the recorded pair differed
+        over — but they are not the same bytes, so record the hash you actually ran rather than
+        quoting ours.
+      </p>
+    </aside>
+  </div>
+</Slide>
+
+<Slide
+  act="cyan"
+  eyebrow="Step 6"
+  title="The command that gates every pull request"
+  lede="The same subcommand in its other mode. This one starts a server: it serves the benchmark's
+        own recipe on a free port, waits up to 900 s for a cold NVFP4 load, and tears it down."
+  steps={2}
+>
+  <div class="at" style="--n: 1">
+    <Cmd
+      label="scripts/queue-perf-pr.sh — the campaign it prints"
+      lines={[
+        `for g in ttft-cold-gate ttft-warm-gate vision-fidelity \\`,
+        `         ssm-state-poisoning-gate decode-floor concurrency-sweep \\`,
+        `         video-fidelity bfcl-subset bfcl-subset-echolp agentic-webserver; do`,
+        `  timeout 21600 ./target/release/spark benchmark run "$g" \\`,
+        `      --pull-request-gate --yes`,
+        `done`,
+        ``,
+        `spark benchmark --pull-request-gate-check    # what CI then runs`
+      ]}
+      note="One gate per process, which is why it is a loop. Each run writes .benchmarks/&lt;id&gt;/&lt;date&gt;-&lt;sha&gt;.json carrying the metrics, the verdict, the hardware fingerprint, the exact command and the commit sha."
+    />
+  </div>
+  <p class="after at" style="--n: 2">
+    <code class="mono">--url</code> and <code class="mono">--pull-request-gate</code> are mutually
+    exclusive by design: a run pointed at someone else's server can be measured and argued about,
+    but it can never become a record. The CLI draws the line between an experiment and evidence,
+    so a reviewer does not have to.
+  </p>
+</Slide>
+
+<Slide
+  act="cyan"
+  eyebrow="Result"
+  title="The ladder"
+  lede="{claim.won} of {claim.rungs} rungs, {claim.min} to {claim.max}. Log2 X, because the rungs double and linear spacing would crush the band where single-stream latency lives."
+  wide
+>
+  <div class="chart">
+    <ConcurrencyLadder embedded compact />
+  </div>
+</Slide>
+
+<Slide
+  act="cyan"
+  eyebrow="Batch sizing"
+  title="The batch cap is part of the comparison, not a free knob"
+  lede="The trap that caught the person who wrote the note warning about it — recorded as a
+        correction rather than quietly fixed."
+  steps={3}
+>
+  <div class="two">
+    <div class="at" style="--n: 1">
+      <table class="tb">
+        <thead>
+          <tr><th>C=32, same box, same day</th><th>cap 32</th><th>cap 128</th><th>effect</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Atlas</td><td class="mono">277.31</td><td class="mono">278.93</td><td>flat</td></tr>
+          <tr><td>vLLM + MTP</td><td class="mono">284.54</td><td class="mono">277.12</td><td class="up">+2.7% at cap 32</td></tr>
+        </tbody>
+      </table>
+      <p class="tb-note">
+        Lowering the cap to match the rung looks neutral. It is not: vLLM sizes its KV blocks and
+        scheduler budget from <code class="mono">max_num_seqs</code>, so a smaller cap changes
+        allocation, preemption and prefix reuse — and materially favours it.
+      </p>
+    </div>
+    <div class="at" style="--n: 2">
+      <p class="lead">
+        A matched cap-32 pair, adopted in good faith to dodge a hardware hazard, produced
+        <strong>0.975×</strong> and inverted the true ordering. Measured again at the certified
+        cap-128 configuration on the same box the same day: <strong>1.007×</strong>, with
+        non-overlapping distributions — Atlas's worst rep beat vLLM's best.
+      </p>
+      <p class="lead">
+        The certified table pins cap 128 on both engines at <em>every</em> rung, independently of
+        the concurrency being driven. That pin is load-bearing.
+      </p>
+    </div>
+  </div>
+  <p class="pull at" style="--n: 3">
+    If you re-cap to survive a hazard on your own box: say so beside the number, and re-pin both
+    engines to the same value. Do not fold it into the certified column.
+  </p>
+</Slide>
+
+<Slide
+  act="cyan"
+  eyebrow="Mechanism"
+  title="Where the margin actually comes from"
+  lede="Ask this before the numbers. A speedup with no stated mechanism and no known ceiling is a
+        configuration artefact waiting to be found."
+  steps={3}
+>
+  <div class="mech">
+    <article class="at" style="--n: 1">
+      <h3>MTP speculation, width-laddered</h3>
+      <p>
+        K is chosen per concurrency (<code class="mono">1:3,2:1,4:2,8:2,16:1</code>) rather than
+        fixed, and self-disables above 32 concurrent sequences where verify cost exceeds the win.
+      </p>
+    </article>
+    <article class="at" style="--n: 2">
+      <h3>Prefill co-dispatch + fp8 row-wise</h3>
+      <p>
+        Prefill overlaps decode rather than stalling it; row-wise fp8 moves fewer bytes on the
+        bandwidth-bound path. Decode at this scale is a memory-traffic problem, so this is where a
+        real win has to come from.
+      </p>
+    </article>
+    <article class="at" style="--n: 3">
+      <h3>Why C=128 is the widest rung</h3>
+      <p>
+        It is not that Atlas gets faster — it is that vLLM's C=128 falls <em>below</em> its own
+        C=64 when speculation stays on at high concurrency. Atlas's ladder has already switched it
+        off. The margin is a scheduling decision, and it is reproducible for that reason.
+      </p>
+    </article>
+  </div>
+</Slide>
+
+<style>
+  .wide2 {
+    display: grid;
+    grid-template-columns: 1.55fr 1fr;
+    gap: 2em;
+    align-items: start;
+  }
+  .side {
+    border: 1px solid var(--border-strong);
+    border-top: 2px solid var(--sx);
+    background: var(--card);
+    border-radius: 6px;
+    padding: 1em 1.1em;
+  }
+  .side-h {
+    font-size: 0.74em;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--sx);
+    margin-bottom: 0.6em;
+  }
+  .side p {
+    color: var(--t2);
+    line-height: 1.6;
+    font-size: 0.88em;
+    margin-bottom: 0.7em;
+  }
+  .side p:last-child {
+    margin-bottom: 0;
+  }
+  .two {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 2.4em;
+    align-items: start;
+  }
+  .lead {
+    color: var(--t2);
+    line-height: 1.65;
+    margin-bottom: 0.9em;
+    max-width: 60ch;
+  }
+  .lead strong {
+    color: var(--t1);
+  }
+  .after {
+    margin-top: 1em;
+    color: var(--t3);
+    font-size: 0.85em;
+    max-width: 74ch;
+  }
+
+  /* The ladder component stacks chart over table, which is a page layout. On a
+     slide they sit side by side and the table carries the exact figures the
+     chart only implies. */
+  .chart :global(.cl-embed-inner) {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    gap: 1.8em;
+    align-items: center;
+    max-width: none;
+  }
+  .chart :global(.cl-panel) {
+    margin: 0;
+  }
+  .chart :global(.cl-table),
+  .chart :global(.cl-caption) {
+    font-size: 0.62em;
+  }
+  .chart :global(.cl-tablewrap) {
+    margin: 0;
+  }
+
+  .tb {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.9em;
+  }
+  .tb th,
+  .tb td {
+    text-align: right;
+    padding: 0.45em 0.7em;
+    border-bottom: 1px solid var(--border);
+  }
+  .tb th:first-child,
+  .tb td:first-child {
+    text-align: left;
+  }
+  .tb th {
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--t3);
+    font-weight: 600;
+  }
+  .up {
+    color: var(--amber);
+  }
+  .tb-note {
+    margin-top: 0.9em;
+    color: var(--t3);
+    font-size: 0.85em;
+    line-height: 1.6;
+  }
+
+  .pull {
+    margin-top: 1em;
+    padding: 0.8em 1.1em;
+    border: 1px dashed var(--border-strong);
+    border-radius: 6px;
+    color: var(--t2);
+    font-size: 0.92em;
+    max-width: 90ch;
+  }
+
+  .mech {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.4em;
+  }
+  .mech article {
+    border-top: 2px solid var(--sx);
+    padding-top: 0.9em;
+  }
+  .mech h3 {
+    font-size: 1.02em;
+    font-weight: 700;
+    margin-bottom: 0.5em;
+  }
+  .mech p {
+    color: var(--t2);
+    line-height: 1.6;
+    font-size: 0.92em;
+  }
+  .mech code {
+    color: var(--accent-deep);
+    font-size: 0.88em;
+  }
+</style>

--- a/site/src/lib/components/deck/acts/Reproduce.svelte
+++ b/site/src/lib/components/deck/acts/Reproduce.svelte
@@ -7,7 +7,7 @@
   import Slide from '../Slide.svelte';
   import Cmd from '../Cmd.svelte';
   import Kv from '../Kv.svelte';
-  import { claim, fingerprint, parity } from '$lib/deck/content.js';
+  import { claim, fingerprint, parity, serve } from '$lib/deck/content.js';
 
   const VLLM_DIGEST = 'sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967';
 </script>
@@ -161,19 +161,17 @@
   />
 </Slide>
 
-<Slide act="cyan" eyebrow="Step 4" title="Bring up the subject leg" lede="Same box, same checkpoint, same client. Back to back, not from memory.">
+<Slide
+  act="cyan"
+  eyebrow="Step 4"
+  title="Bring up the subject leg"
+  lede="Same box, same checkpoint, same client. Every flag, not the interesting ones — this is the
+        whole certified configuration, rendered from the record the harness wrote."
+>
   <Cmd
-    label="Atlas — round-11 flags"
-    lines={[
-      `ATLAS_PREFILL_CODISPATCH=1 ATLAS_FP8_ROWWISE=1 \\`,
-      `ATLAS_MTP_DCUT_RATIO=1.0 ATLAS_MTP_K_LADDER=1:3,2:1,4:2,8:2,16:1 \\`,
-      `spark serve ${claim.checkpoint} \\`,
-      `  --host 0.0.0.0 --port 8888 --max-seq-len 2048 --max-batch-size 128 \\`,
-      `  --gpu-memory-utilization 0.85 --kv-cache-dtype fp8 \\`,
-      `  --enable-prefix-caching true --speculative --num-drafts 3 \\`,
-      `  --mtp-quantization bf16 --disable-thinking --no-tui`
-    ]}
-    note="The full flag list, including the SSM cache and scheduling knobs, is in ladder.generated.json under series[atlas].cli — the site renders it from the same record the harness wrote."
+    label="Atlas — round-11 flags, complete"
+    lines={[...serve.env.map((l) => `${l} \\`), ...serve.cli.map((l, i, a) => (i < a.length - 1 ? `${l} \\` : l))]}
+    note="Do not trim this. Six of these are kernel and scheduling knobs whose defaults are the OPPOSITE of the certified values — ssm-h-dtype, gdn-fused-norm, ssm-batched-recurrent, ssm-tail-midchunk, mtp-gate and prefill-varlen-batch — and serving without them measures a different engine. An abridged version of this command, run on 2026-08-26, landed 4.7% under the published ladder at C=1 and 14% under at C=4, the gap widening with concurrency exactly as those knobs predict. With the full command the same box reproduced every rung to within 2.2%."
   />
 </Slide>
 

--- a/site/src/lib/components/deck/acts/Reproduce.svelte
+++ b/site/src/lib/components/deck/acts/Reproduce.svelte
@@ -1,11 +1,12 @@
 <script>
-  // Act II — the walkthrough. Four commands and a chart. The commands are the
-  // ones in bench/ladder38/RESULTS.md, not a simplified retelling of them:
-  // a reproduction that needs a translation step is not a reproduction.
+  // Act II, first half — the reference frame and the setup: fingerprint,
+  // parity, and the four steps that get an outsider to two serving engines.
+  // Measuring them is Ladder.svelte, which follows this act in the route.
+  // The commands are the ones in bench/ladder38/RESULTS.md, not a simplified
+  // retelling: a reproduction that needs a translation step is not one.
   import Slide from '../Slide.svelte';
   import Cmd from '../Cmd.svelte';
   import Kv from '../Kv.svelte';
-  import ConcurrencyLadder from '../../ConcurrencyLadder.svelte';
   import { claim, fingerprint, parity } from '$lib/deck/content.js';
 
   const VLLM_DIGEST = 'sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967';
@@ -176,172 +177,6 @@
   />
 </Slide>
 
-<Slide
-  act="cyan"
-  eyebrow="Step 5"
-  title="One instrument, pointed at both engines"
-  lede="The subcommand drives an endpoint that is already serving — it neither loads a model nor
-        touches the GPU. So the binary that gates our own pull requests is the binary that measures
-        vLLM, on the same parameters and the same prompt fixture."
-  steps={2}
->
-  <div class="wide2">
-    <div class="at" style="--n: 1">
-    <Cmd
-      label="the baseline leg, then the subject leg"
-      lines={[
-        `spark benchmark run concurrency-sweep \\`,
-        `  --url http://127.0.0.1:8000 --model ${claim.checkpoint} \\`,
-        `  --param concurrencies=1,4,8,16 --param isls=512 --param osl=320 \\`,
-        `  --skip-coherence-probe --format json > vllm.json`,
-        `spark benchmark run concurrency-sweep \\`,
-        `  --url http://127.0.0.1:8888 --model ${claim.checkpoint} \\`,
-        `  --param concurrencies=1,4,8,16 --param isls=512 --param osl=320 \\`,
-        `  --format json > atlas.json`
-      ]}
-      note="http:// only. stdout carries the record and stderr the progress, so the redirect gives a clean file. Those --param values are the ones the gate pins; an unknown key is an error, never a silent no-op."
-    />
-    </div>
-    <aside class="side at" style="--n: 2">
-      <p class="side-h mono">Two instruments, not interchangeable</p>
-      <p>
-        The published C=1…128 ladder came from <code class="mono">{claim.harnessFile}</code>, a
-        campaign driver with <code class="mono">--reps</code>; the gate's sweep runs one measured
-        batch per cell at pinned parameters.
-      </p>
-      <p>
-        Their prompt corpus is byte-identical, which makes a cell's throughput comparable across
-        the two. Their percentile rules are <em>not</em> — the driver interpolates, the gate takes a
-        nearest rank — so compare the aggregate tok/s the ladder publishes, never one instrument's
-        p50 TTFT against the other's. Only the gate's produces a record CI accepts.
-      </p>
-    </aside>
-  </div>
-</Slide>
-
-<Slide
-  act="cyan"
-  eyebrow="Step 6"
-  title="The command that gates every pull request"
-  lede="The same subcommand in its other mode. This one starts a server: it serves the benchmark's
-        own recipe on a free port, waits up to 900 s for a cold NVFP4 load, and tears it down."
-  steps={2}
->
-  <div class="at" style="--n: 1">
-    <Cmd
-      label="scripts/queue-perf-pr.sh — the campaign it prints"
-      lines={[
-        `for g in ttft-cold-gate ttft-warm-gate vision-fidelity \\`,
-        `         ssm-state-poisoning-gate decode-floor concurrency-sweep \\`,
-        `         video-fidelity bfcl-subset bfcl-subset-echolp agentic-webserver; do`,
-        `  timeout 21600 ./target/release/spark benchmark run "$g" \\`,
-        `      --pull-request-gate --yes`,
-        `done`,
-        ``,
-        `spark benchmark --pull-request-gate-check    # what CI then runs`
-      ]}
-      note="One gate per process, which is why it is a loop. Each run writes .benchmarks/&lt;id&gt;/&lt;date&gt;-&lt;sha&gt;.json carrying the metrics, the verdict, the hardware fingerprint, the exact command and the commit sha."
-    />
-  </div>
-  <p class="after at" style="--n: 2">
-    <code class="mono">--url</code> and <code class="mono">--pull-request-gate</code> are mutually
-    exclusive by design: a run pointed at someone else's server can be measured and argued about,
-    but it can never become a record. The CLI draws the line between an experiment and evidence,
-    so a reviewer does not have to.
-  </p>
-</Slide>
-
-<Slide
-  act="cyan"
-  eyebrow="Result"
-  title="The ladder"
-  lede="{claim.won} of {claim.rungs} rungs, {claim.min} to {claim.max}. Log2 X, because the rungs double and linear spacing would crush the band where single-stream latency lives."
-  wide
->
-  <div class="chart">
-    <ConcurrencyLadder embedded compact />
-  </div>
-</Slide>
-
-<Slide
-  act="cyan"
-  eyebrow="Batch sizing"
-  title="The batch cap is part of the comparison, not a free knob"
-  lede="The trap that caught the person who wrote the note warning about it — recorded as a
-        correction rather than quietly fixed."
-  steps={3}
->
-  <div class="two">
-    <div class="at" style="--n: 1">
-      <table class="tb">
-        <thead>
-          <tr><th>C=32, same box, same day</th><th>cap 32</th><th>cap 128</th><th>effect</th></tr>
-        </thead>
-        <tbody>
-          <tr><td>Atlas</td><td class="mono">277.31</td><td class="mono">278.93</td><td>flat</td></tr>
-          <tr><td>vLLM + MTP</td><td class="mono">284.54</td><td class="mono">277.12</td><td class="up">+2.7% at cap 32</td></tr>
-        </tbody>
-      </table>
-      <p class="tb-note">
-        Lowering the cap to match the rung looks neutral. It is not: vLLM sizes its KV blocks and
-        scheduler budget from <code class="mono">max_num_seqs</code>, so a smaller cap changes
-        allocation, preemption and prefix reuse — and materially favours it.
-      </p>
-    </div>
-    <div class="at" style="--n: 2">
-      <p class="lead">
-        A matched cap-32 pair, adopted in good faith to dodge a hardware hazard, produced
-        <strong>0.975×</strong> and inverted the true ordering. Measured again at the certified
-        cap-128 configuration on the same box the same day: <strong>1.007×</strong>, with
-        non-overlapping distributions — Atlas's worst rep beat vLLM's best.
-      </p>
-      <p class="lead">
-        The certified table pins cap 128 on both engines at <em>every</em> rung, independently of
-        the concurrency being driven. That pin is load-bearing.
-      </p>
-    </div>
-  </div>
-  <p class="pull at" style="--n: 3">
-    If you re-cap to survive a hazard on your own box: say so beside the number, and re-pin both
-    engines to the same value. Do not fold it into the certified column.
-  </p>
-</Slide>
-
-<Slide
-  act="cyan"
-  eyebrow="Mechanism"
-  title="Where the margin actually comes from"
-  lede="Ask this before the numbers. A speedup with no stated mechanism and no known ceiling is a
-        configuration artefact waiting to be found."
-  steps={3}
->
-  <div class="mech">
-    <article class="at" style="--n: 1">
-      <h3>MTP speculation, width-laddered</h3>
-      <p>
-        K is chosen per concurrency (<code class="mono">1:3,2:1,4:2,8:2,16:1</code>) rather than
-        fixed, and self-disables above 32 concurrent sequences where verify cost exceeds the win.
-      </p>
-    </article>
-    <article class="at" style="--n: 2">
-      <h3>Prefill co-dispatch + fp8 row-wise</h3>
-      <p>
-        Prefill overlaps decode rather than stalling it; row-wise fp8 moves fewer bytes on the
-        bandwidth-bound path. Decode at this scale is a memory-traffic problem, so this is where a
-        real win has to come from.
-      </p>
-    </article>
-    <article class="at" style="--n: 3">
-      <h3>Why C=128 is the widest rung</h3>
-      <p>
-        It is not that Atlas gets faster — it is that vLLM's C=128 falls <em>below</em> its own
-        C=64 when speculation stays on at high concurrency. Atlas's ladder has already switched it
-        off. The margin is a scheduling decision, and it is reproducible for that reason.
-      </p>
-    </article>
-  </div>
-</Slide>
-
 <style>
   .parity {
     max-width: 92%;
@@ -387,9 +222,6 @@
     margin-bottom: 0.9em;
     max-width: 60ch;
   }
-  .lead strong {
-    color: var(--t1);
-  }
   .quote {
     border-left: 3px solid var(--sx);
     padding: 0.4em 0 0.4em 1.1em;
@@ -409,92 +241,5 @@
     color: var(--t3);
     font-size: 0.85em;
     max-width: 74ch;
-  }
-
-  /* The ladder component stacks chart over table, which is a page layout. On a
-     slide they sit side by side and the table carries the exact figures the
-     chart only implies. */
-  .chart :global(.cl-embed-inner) {
-    display: grid;
-    grid-template-columns: 1.5fr 1fr;
-    gap: 1.8em;
-    align-items: center;
-    max-width: none;
-  }
-  .chart :global(.cl-panel) {
-    margin: 0;
-  }
-  .chart :global(.cl-table),
-  .chart :global(.cl-caption) {
-    font-size: 0.62em;
-  }
-  .chart :global(.cl-tablewrap) {
-    margin: 0;
-  }
-
-  .tb {
-    border-collapse: collapse;
-    width: 100%;
-    font-size: 0.9em;
-  }
-  .tb th,
-  .tb td {
-    text-align: right;
-    padding: 0.45em 0.7em;
-    border-bottom: 1px solid var(--border);
-  }
-  .tb th:first-child,
-  .tb td:first-child {
-    text-align: left;
-  }
-  .tb th {
-    font-size: 0.8em;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--t3);
-    font-weight: 600;
-  }
-  .up {
-    color: var(--amber);
-  }
-  .tb-note {
-    margin-top: 0.9em;
-    color: var(--t3);
-    font-size: 0.85em;
-    line-height: 1.6;
-  }
-
-  .pull {
-    margin-top: 1em;
-    padding: 0.8em 1.1em;
-    border: 1px dashed var(--border-strong);
-    border-radius: 6px;
-    color: var(--t2);
-    font-size: 0.92em;
-    max-width: 90ch;
-  }
-
-  .mech {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1.4em;
-  }
-  .mech article {
-    border-top: 2px solid var(--sx);
-    padding-top: 0.9em;
-  }
-  .mech h3 {
-    font-size: 1.02em;
-    font-weight: 700;
-    margin-bottom: 0.5em;
-  }
-  .mech p {
-    color: var(--t2);
-    line-height: 1.6;
-    font-size: 0.92em;
-  }
-  .mech code {
-    color: var(--accent-deep);
-    font-size: 0.88em;
   }
 </style>

--- a/site/src/lib/deck/content.js
+++ b/site/src/lib/deck/content.js
@@ -44,6 +44,16 @@ export const claim = {
   reps: ladder.workload.reps,
   warmup: ladder.workload.warmup,
   harnessFile: ladder.workload.harness,
+  // The --concs argument, from the same rung list the chart is drawn from, so a
+  // lost rung shortens the command as well as the ladder.
+  concsArg: ladder.concurrencies.join(','),
+  // The driver hash the published Atlas legs carry, beside the one a reader will
+  // actually get from the tree. Both derived: the first is the manifest key whose
+  // note names the Atlas legs, the second is hashed from the file at build time.
+  harnessShaAtlas: Object.keys(ladder.harness_shas).find((k) =>
+    /Atlas legs/i.test(ladder.harness_shas[k])
+  ),
+  harnessShaRepo: ladder.harness_repo_sha256.slice(0, 10),
   resultsUrl: ladder.results_doc_url,
   resultsDoc: ladder.results_doc
 };

--- a/site/src/lib/deck/content.js
+++ b/site/src/lib/deck/content.js
@@ -135,7 +135,13 @@ export const audit = [
   {
     state: 'clear',
     risk: 'Best-of instead of representative',
-    answer: 'Where a rung was re-measured higher, the older, lower number is published. C=2 is the documented case.'
+    // C=8 is the case that actually answers this, and C=2 is not: C=2's
+    // published pair IS the better Atlas number (41.02, over round 11's 40.42)
+    // — defensible because both legs were re-measured back to back that day and
+    // the pair replaced the pair, but it is not an example of declining a
+    // better number. C=8 is: re-measured at a HIGHER ratio and the lower one
+    // still stands.
+    answer: `Re-measuring C=8 on a later build gave 1.013×; the certified 1.012× is what is published. Both engines came out ~2.2% below their certified absolutes in that run while the ratio held, which is why every rung is quoted as a same-day A/B rather than against a stored number.`
   },
   {
     state: 'open',

--- a/site/src/lib/deck/content.js
+++ b/site/src/lib/deck/content.js
@@ -58,6 +58,48 @@ export const claim = {
   resultsDoc: ladder.results_doc
 };
 
+// Step 4's serve command, rendered FROM THE RECORD rather than hand-abridged.
+//
+// It used to be a shortened list with a note pointing at series[atlas].cli for
+// "the full flag list, including the SSM cache and scheduling knobs". That
+// pointer was not enough: the abridged command omits thirteen flags, six of
+// which are kernel and scheduling knobs whose defaults are the OPPOSITE of the
+// certified values (ssm_h_dtype f32 not f16-pool, gdn_fused_norm off,
+// ssm_batched_recurrent off, ssm_tail_midchunk on, mtp_gate auto not force,
+// prefill_varlen_batch off). Serving that way and then running the ladder in
+// Step 5b measures a differently-configured engine and lands well under the
+// chart — the walkthrough manufacturing evidence against its own claim, which
+// is the worst failure available to a page like this. Measured on 2026-08-26:
+// the abridged config ran 4.7% under at C=1 and 14% under at C=4, the gap
+// widening with concurrency exactly as those knobs predict.
+//
+// Wrapped here rather than in the component so the command cannot drift from
+// the record: change the serve config and this moves with it.
+const argvLines = (argv, { width = 66, indent = '  ', breakAnywhere = false } = {}) => {
+  const out = [];
+  let line = '';
+  for (const tok of argv) {
+    // In a CLI a value belongs to the flag before it, so only a `--` token may
+    // start a new line. An env prefix is all standalone assignments, so any
+    // token may.
+    const canBreak = breakAnywhere || tok.startsWith('--');
+    const joined = line ? `${line} ${tok}` : tok;
+    if (line && joined.length > width && canBreak) {
+      out.push(line);
+      line = indent + tok;
+    } else {
+      line = joined;
+    }
+  }
+  if (line) out.push(line);
+  return out;
+};
+
+export const serve = {
+  env: argvLines(subject.env.split(/\s+/), { breakAnywhere: true, indent: '' }),
+  cli: argvLines(subject.cli.split(/\s+/))
+};
+
 // The rungs won by a margin small enough that ordinary run-to-run drift could
 // swallow them. Derived, not typed: the earlier hand-written sentence said
 // "1.007x to 1.03x" while the record said 1.012x to 1.032x -- the exact staleness

--- a/site/src/lib/ladder.generated.json
+++ b/site/src/lib/ladder.generated.json
@@ -1,5 +1,5 @@
 {
-  "generated_utc": "2026-08-26T21:28:56Z",
+  "generated_utc": "2026-08-26T23:01:23Z",
   "title": "Qwen3.8-27B NVFP4 concurrency ladder",
   "subtitle": "Atlas vs vLLM 0.27.1, C=1..128, every workload axis matched",
   "aggregate": "mean tok/s over 3 timed reps (1 warmup discarded)",
@@ -29,6 +29,7 @@
     "1c77e1d8e9": "Atlas legs (rounds 7-11). Adds explicit presence_penalty/frequency_penalty = 0.0.",
     "equivalence": "The only difference is those two keys. vLLM already defaults both to 0.0, so its sampling is byte-identical either way; the keys exist to stop Atlas's non_thinking preset injecting presence_penalty=1.5. Both engines therefore ran identical sampling."
   },
+  "harness_repo_sha256": "1f10d4887b39a86ee946bc2aa0395e31c43ce1b3dfac778f51abbad11832d880",
   "concurrencies": [
     1,
     2,

--- a/site/src/lib/ladder.generated.json
+++ b/site/src/lib/ladder.generated.json
@@ -1,5 +1,5 @@
 {
-  "generated_utc": "2026-08-26T23:01:23Z",
+  "generated_utc": "2026-08-26T23:01:27Z",
   "title": "Qwen3.8-27B NVFP4 concurrency ladder",
   "subtitle": "Atlas vs vLLM 0.27.1, C=1..128, every workload axis matched",
   "aggregate": "mean tok/s over 3 timed reps (1 warmup discarded)",
@@ -53,7 +53,7 @@
       "env": "ATLAS_PREFILL_CODISPATCH=1 ATLAS_FP8_ROWWISE=1 ATLAS_MTP_DCUT_RATIO=1.0 ATLAS_MTP_K_LADDER=1:3,2:1,4:2,8:2,16:1",
       "cli": "spark serve unsloth/Qwen3.8-27B-NVFP4 --host 0.0.0.0 --port 8888 --model-name unsloth/Qwen3.8-27B-NVFP4 --max-seq-len 2048 --max-batch-size 128 --gpu-memory-utilization 0.85 --kv-cache-dtype fp8 --enable-prefix-caching true --ssm-cache-slots 8 --ssm-checkpoint-interval 32 --speculative --num-drafts 3 --mtp-quantization bf16 --scheduling-policy fifo --tool-call-parser qwen3_coder --disable-tool-grammar true --disable-thinking --request-timeout 0 --ssm-h-dtype f16-pool --gdn-fused-norm --ssm-batched-recurrent --ssm-tail-midchunk false --mtp-gate force --prefill-varlen-batch --no-tui",
       "speculation": "MTP, K=4 (--num-drafts 3); self-disables above 32 concurrent sequences",
-      "source_note": "Round 11 throughout. C=2 is round 8 on the identical configuration -- round 11 re-measured that rung at 40.42, and we publish the lower, older number rather than the better one.",
+      "source_note": "Round 11 throughout, except C=2. C=2 is the 2026-08-18 hardening run (c2_atlas_dgx2_20260818.json), not round 8: the certified table originally carried round 8's 38.95 there, which won by 1.004x -- a margin inside either engine's run-to-run spread. Both legs were re-measured back to back on dgx2 on 2026-08-18 (Atlas 15:05, vLLM+MTP 15:20) and that PAIR replaced the earlier pair, which is why the Atlas number rose to 41.02 while the paired vLLM number fell to 37.11 and the margin moved to 1.105x with non-overlapping distributions. A round-11 C=2 exists at 40.42 (l38_r11_c2.json) but has no same-day vLLM leg, so it is not publishable as a pair. See RESULTS.md, C=2 HARDENED.",
       "rungs": [
         {
           "c": 1,

--- a/site/src/routes/diligence/+page.svelte
+++ b/site/src/routes/diligence/+page.svelte
@@ -5,6 +5,7 @@
   import Deck from '$lib/components/deck/Deck.svelte';
   import Frame from '$lib/components/deck/acts/Frame.svelte';
   import Reproduce from '$lib/components/deck/acts/Reproduce.svelte';
+  import Ladder from '$lib/components/deck/acts/Ladder.svelte';
   import Evidence from '$lib/components/deck/acts/Evidence.svelte';
   import { stamp } from '$lib/deck/content.js';
 </script>
@@ -20,5 +21,6 @@
 <Deck title="Verification steps" {stamp}>
   <Frame />
   <Reproduce />
+  <Ladder />
   <Evidence />
 </Deck>


### PR DESCRIPTION
Follow-up to #756. That PR made the deck's commands *valid*; this one makes the walkthrough
actually reach its own headline.

## The gap

#756 verified every command it printed, and they all ran — but none of them reproduces the chart.
Step 5 runs the gate's instrument at the gate's workload; the slide immediately after it shows the
published ladder, measured by a different driver at a different shape:

| | published ladder (the chart) | Step 5 (the gate) |
|---|---|---|
| instrument | `bench/ladder38/harness_w55_conc_ladder.py` | `spark benchmark run concurrency-sweep` |
| ISL / OSL | 128 / 1024 | 512 / 320 |
| concurrencies | 1,2,4,8,16,32,64,128 | 1,4,8,16 |
| reps | 3 timed + 1 warmup | one measured batch per cell |

A reader who ran every command in order got numbers that cannot be compared to the figure in front
of them. The deck named that driver in the fingerprint and never handed over a command to run it.

## What this adds

**Step 5b — the command that reproduces the chart**, at the exact shape `published.json` records,
all eight rungs. Every argument is derived (`--concs` from the rung list the chart is drawn from;
`--reps`/`--isl`/`--osl`/`--warmup` from the workload block), so the command cannot drift from the
figures beside it. The driver itself defaults nothing — every argument is `required=True` — which is
what lets the command stand as the methodology. Step 5 is retitled to say it measures the gate's
workload, not the chart's.

**The two driver hashes, side by side.** The driver sha256s its own source into every record. The
published Atlas legs carry `1c77e1d8e9`; the copy in the tree hashes `1f10d4887b` — neither of the
two `harness_shas` names. Behaviour matches (both send `presence_penalty`/`frequency_penalty` at
0.0, the difference the recorded pair was distinguished by) but the bytes do not, so the slide tells
a reader to record the hash they ran. `gen-ladder` computes the tree's hash at build time.

**C=2 is described correctly, and the best-of row cites C=8.** `published.json` said C=2 was "round
8" and that "we publish the lower, older number rather than the better one". The manifest points at
`c2_atlas_dgx2_20260818.json`, and the three Atlas C=2 means are 41.02 / 40.42 / 38.95 — the
published figure is the *highest*. The practice is sound and the note simply misstated it: both legs
were re-measured back to back on dgx2 that day (Atlas 15:05, vLLM+MTP 15:20) and the pair replaced
the pair, moving a 1.004x margin — thinner than either engine's spread — to 1.105x with
non-overlapping distributions. The deck's "Best-of instead of representative" row had inherited the
wrong version and cited C=2 as an example of declining a better number, which inverts it. C=8 is the
case that actually answers the crime: re-measured at 1.013x, and the certified 1.012x still stands.

Act II is split at the measurement boundary to make room — `Reproduce.svelte` keeps the reference
frame and Steps 1-4, `Ladder.svelte` takes Step 5 onward. Both drop well under the 500-line rule the
single file was sitting exactly on.

## Measured: the new command reproduces the chart

Run on `spark-256a` — which the gate records show is machine id `7af66f30`, the same physical box as
`spark-43fa` where the ladder was certified, renamed since. Atlas built from this branch, served with
the Step 4 command below, measured with the Step 5b command, nine days after the certified run.

| rung | this run | published | delta | spread |
|---|---|---|---|---|
| C = 1 | 23.46 | 23.59 | -0.55% | 2.85% |
| C = 2 | 40.30 | 41.02 | -1.76% | 1.67% |
| C = 4 | 72.58 | 74.21 | -2.20% | 1.89% |
| C = 8 | 125.38 | 125.95 | -0.45% | 1.36% |
| C = 16 | 201.47 | 203.36 | -0.93% | 0.57% |
| C = 32 | 292.52 | 291.01 | +0.52% | 0.61% |
| C = 64 | 386.75 | 386.63 | +0.03% | 0.04% |
| C = 128 | 473.70 | 478.11 | -0.92% | 0.98% |

Worst deviation **2.2%**; four of eight rungs inside 1%; spreads 0.04–2.85%. Every rung, C=1 to
C=128, at ISL 128 / OSL 1024, 3 timed reps and a warmup.

### What it took to get there, which is why Step 4 changed

The first three attempts did **not** reproduce, and the reason is the defect this PR fixes. Serving
with the deck's previously-abridged Step 4 command:

| rung | abridged Step 4 | full certified config | published |
|---|---|---|---|
| C = 1 | 22.47 (−4.7%) | 23.46 (−0.55%) | 23.59 |
| C = 2 | 38.27 (−6.7%) | 40.30 (−1.76%) | 41.02 |
| C = 4 | 63.76 (−14.1%) | 72.58 (−2.20%) | 74.21 |

The gap widened with concurrency exactly as the six omitted kernel and scheduling knobs predict.
Anyone following the deck as merged would have measured this, compared it to the chart on the next
slide, and concluded the published claim was inflated.

A separate run on a box with a 4.8-core CPU competitor is also recorded: it moved SM clocks 100–150
MHz and cost 0.9% at C=1 but 4.6% at C=2, so the contention penalty grows with concurrency too. The
gate's hardware precheck counts foreign **GPU** processes and free host memory; a CPU-only competitor
passes both clean. Not addressed in this PR, but worth knowing before trusting a rung.

## Correcting the record on #756

#756's title was edited before merge to drop an overclaim, but the merge queue had already
snapshotted the old one, so the squash commit on main reads "with every command actually run". That
was not true: `docker build -f docker/gb10/Dockerfile` and the `apt-get install` line were never run,
Step 6's loop was exercised for 1 of 10 gates, the recipe index was copied rather than populated via
the TUI, and the vLLM leg was skipped throughout. #756's body was corrected before merge; its commit
subject on main was not.

## Checks

- `bun --bun run build` — clean, `/diligence` prerenders
- `bun test src/lib` — 96 pass, 0 fail
- No file over 500 lines; `bench/` and `site/` are not `PERF_PATHS`, so no gate record is invalidated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
