### PR TITLE
feat(cli): emit the serve flag surface as a machine-readable snapshot

### DIFF
--- a/crates/spark-server/src/cli.rs
+++ b/crates/spark-server/src/cli.rs
@@ -11,6 +11,7 @@ mod bench_resolve;
 pub mod bench_run;
 mod bench_selfstart;
 pub(crate) mod flag_values;
+pub(crate) mod manifest;
 mod serve_args;
 mod validate;
 pub use bench_args::BenchmarkArgs;
@@ -42,6 +43,15 @@ pub enum Command {
     Serve(ServeArgs),
     /// Run and inspect the benchmark suite, without the dashboard.
     Benchmark(BenchmarkArgs),
+    /// Print the serve flag surface as JSON.
+    ///
+    /// Hidden because it is a build tool, not part of the supported CLI: it
+    /// exists so downstream tooling can be GENERATED from clap rather than
+    /// transcribed from it. `ServeArgs` still has no `Serialize` derive and
+    /// this does not promise that any flag keeps its name — a rename shows up
+    /// as a diff in whatever consumes the output.
+    #[command(hide = true)]
+    DumpServeOptions,
 }
 
 #[cfg(test)]

--- a/crates/spark-server/src/cli/manifest.rs
+++ b/crates/spark-server/src/cli/manifest.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Emitting the serve flag surface as a machine-readable snapshot.
+//!
+//! **This is a build artifact, not a public interface.** `ServeArgs` still has
+//! no `Serialize` derive and this does not give it one: nothing here promises
+//! that a flag will keep its name, and a rename shows up as a diff in whatever
+//! consumes the snapshot rather than as a silent break. That is the point —
+//! `atlas-recipes` currently hand-transcribes this surface from a *Python*
+//! launcher that predates the Rust one, and the drift is invisible until a
+//! launch dies inside a container.
+//!
+//! The reflection is the same one [`crate::tui::lib_fields`] already does, for
+//! the same reason: clap is the single source of truth for the flag surface,
+//! so reading it beats writing it down twice. What this adds over the TUI's
+//! view is the **action** — whether a flag is presence-only — which is what a
+//! downstream renderer cannot guess and gets wrong in a way that only fails on
+//! the machine, at launch.
+
+use clap::{ArgAction, CommandFactory};
+use serde::Serialize;
+
+/// Schema version of the emitted document.
+///
+/// Bumped when the *shape* changes, never when a flag does. A consumer pins
+/// this and refuses a document it cannot read, rather than half-reading one.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The whole snapshot.
+#[derive(Debug, Serialize)]
+pub struct Manifest {
+    /// Shape of this document.
+    pub schema_version: u32,
+    /// Version of the engine that produced it.
+    pub spark_version: String,
+    /// Every serve flag, in clap's declaration order.
+    pub flags: Vec<Flag>,
+}
+
+/// One flag, as clap describes it.
+#[derive(Debug, Serialize)]
+pub struct Flag {
+    /// Recipe `defaults:` spelling — the long name with underscores.
+    pub key: String,
+    /// The long flag itself, hyphenated, without the leading dashes.
+    pub flag: String,
+    /// Whether the flag takes no value at all.
+    ///
+    /// The field a transcription gets wrong. `--gdn-fused-norm` is
+    /// presence-only and `--ssm-h-dtype` is not; rendering either as the other
+    /// produces a command clap refuses, on the serving machine, after the
+    /// operator has already reviewed it.
+    pub presence_only: bool,
+    /// Whether clap parses the value as a bool.
+    pub is_bool: bool,
+    /// The closed set of accepted values, when there is one.
+    ///
+    /// Empty means free-form. Taken from `cli::flag_values`, the same module
+    /// `validate_serve_args` enforces against, so a picker built from this
+    /// cannot offer a value the launch would refuse.
+    pub options: Vec<String>,
+    /// clap's default, when it declares one.
+    pub default: Option<String>,
+    /// First line of help, for a label.
+    pub help: Option<String>,
+    /// Recipe spellings that mean this flag but do not match its name.
+    ///
+    /// A consumer cannot derive these: `max_model_len` is vLLM's spelling kept
+    /// in the recipes for cross-runtime familiarity, and the flag is
+    /// `--max-seq-len`. Omitting them would make a generated table silently
+    /// stop claiming keys that shipping recipes actually set — which is the
+    /// class of bug this whole document exists to end.
+    pub recipe_aliases: Vec<String>,
+}
+
+/// Build the snapshot by asking clap.
+#[must_use]
+pub fn build() -> Manifest {
+    let bool_parser = clap::builder::ValueParser::bool().type_id();
+    let command = super::ServeArgs::command();
+
+    let flags = command
+        .get_arguments()
+        .filter_map(|arg| {
+            // No long name is the positional MODEL. Help and version are
+            // clap's own and describe nothing a recipe can set.
+            let long = arg.get_long()?;
+            match arg.get_action() {
+                ArgAction::Help
+                | ArgAction::HelpShort
+                | ArgAction::HelpLong
+                | ArgAction::Version => return None,
+                _ => {}
+            }
+            let presence_only = matches!(arg.get_action(), ArgAction::SetTrue);
+            let is_bool = arg.get_value_parser().type_id() == bool_parser;
+            let options = if is_bool && presence_only {
+                Vec::new()
+            } else if is_bool {
+                vec!["true".to_owned(), "false".to_owned()]
+            } else {
+                super::flag_values::options_for_flag(long).unwrap_or_default()
+            };
+            Some(Flag {
+                key: long.replace('-', "_"),
+                flag: long.to_owned(),
+                presence_only,
+                is_bool,
+                options,
+                default: arg
+                    .get_default_values()
+                    .first()
+                    .map(|v| v.to_string_lossy().into_owned()),
+                help: arg
+                    .get_help()
+                    .map(|h| h.to_string().lines().next().unwrap_or_default().to_owned()),
+                recipe_aliases: crate::recipe::schema::RENAMES
+                    .iter()
+                    .filter(|(_, flag)| *flag == long)
+                    .map(|(key, _)| (*key).to_owned())
+                    .collect(),
+            })
+        })
+        .collect();
+
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        spark_version: super::ATLAS_VERSION.to_owned(),
+        flags,
+    }
+}
+
+#[cfg(test)]
+#[path = "manifest_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/cli/manifest.rs
+++ b/crates/spark-server/src/cli/manifest.rs
@@ -63,6 +63,14 @@ pub struct Flag {
     pub default: Option<String>,
     /// First line of help, for a label.
     pub help: Option<String>,
+    /// Other long names clap accepts for this same flag.
+    ///
+    /// `--bind` carries `alias = "host"`, and `get_long()` returns only the
+    /// primary name — so a snapshot built from it alone says `--host` does not
+    /// exist, when shipping recipes set `host:` and the engine accepts it. A
+    /// consumer that rewrote or rejected it would be breaking a working recipe
+    /// on the strength of an incomplete document.
+    pub cli_aliases: Vec<String>,
     /// Recipe spellings that mean this flag but do not match its name.
     ///
     /// A consumer cannot derive these: `max_model_len` is vLLM's spelling kept
@@ -114,6 +122,10 @@ pub fn build() -> Manifest {
                 help: arg
                     .get_help()
                     .map(|h| h.to_string().lines().next().unwrap_or_default().to_owned()),
+                cli_aliases: arg
+                    .get_all_aliases()
+                    .map(|a| a.iter().map(|s| (*s).to_owned()).collect())
+                    .unwrap_or_default(),
                 recipe_aliases: crate::recipe::schema::RENAMES
                     .iter()
                     .filter(|(_, flag)| *flag == long)

--- a/crates/spark-server/src/cli/manifest_tests.rs
+++ b/crates/spark-server/src/cli/manifest_tests.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The snapshot has one job: let a downstream renderer build a command clap
+//! will accept. Each test below is a way it could fail to do that while still
+//! looking like a valid document.
+
+use super::*;
+
+fn flag<'a>(m: &'a Manifest, key: &str) -> &'a Flag {
+    m.flags
+        .iter()
+        .find(|f| f.key == key)
+        .unwrap_or_else(|| panic!("{key} is not in the manifest"))
+}
+
+/// The whole reason this exists. `--gdn-fused-norm` takes no value and
+/// `--ssm-h-dtype` does; a renderer that guesses produces a command clap
+/// refuses, on the serving machine, after the operator has reviewed it.
+#[test]
+fn presence_only_is_reported_per_flag_not_guessed() {
+    let m = build();
+    // A bare toggle: clap parses it as SetTrue.
+    assert!(
+        flag(&m, "video_allow_ffmpeg").presence_only,
+        "video_allow_ffmpeg is a bare flag"
+    );
+    // A value flag that happens to be a bool: `--flag true` is required.
+    assert!(
+        !flag(&m, "gdn_fused_norm").presence_only,
+        "gdn_fused_norm takes an explicit value"
+    );
+    // A value flag that is not a bool at all.
+    assert!(!flag(&m, "ssm_h_dtype").presence_only);
+    assert!(!flag(&m, "ssm_h_dtype").is_bool);
+}
+
+/// A closed value set must come from the module the validator enforces, or a
+/// picker will offer something the launch refuses. This is the `fcfs` bug in
+/// test form: atlas-recipes offered a policy the engine never accepted.
+#[test]
+fn enumerated_values_come_from_the_validator_not_from_prose() {
+    let m = build();
+    assert_eq!(
+        flag(&m, "scheduling_policy").options,
+        vec!["fifo".to_owned(), "slai".to_owned()]
+    );
+    assert!(
+        flag(&m, "kv_cache_dtype").options.len() >= 16,
+        "the KV catalog has 16 variants, the manifest offered {}",
+        flag(&m, "kv_cache_dtype").options.len()
+    );
+    assert!(
+        flag(&m, "lm_head_dtype")
+            .options
+            .contains(&"nvfp4".to_owned()),
+        "lm_head_dtype must carry its closed set"
+    );
+}
+
+/// The key is the recipe `defaults:` spelling, because that is what a
+/// downstream table is indexed by.
+/// The key is derived from the flag, so a recipe that uses a different
+/// spelling needs the alias carried explicitly. `max_model_len` is vLLM's
+/// spelling kept in shipping recipes; the flag is `--max-seq-len`. A consumer
+/// cannot work that out, and dropping it means a generated table silently
+/// stops claiming a key recipes actually set.
+#[test]
+fn recipe_aliases_travel_with_the_flag_that_owns_them() {
+    let m = build();
+    let seq = flag(&m, "max_seq_len");
+    assert_eq!(seq.flag, "max-seq-len");
+    assert!(
+        seq.recipe_aliases.contains(&"max_model_len".to_owned()),
+        "max_model_len must map to --max-seq-len, got {:?}",
+        seq.recipe_aliases
+    );
+
+    let tp = flag(&m, "tp_size");
+    assert!(tp.recipe_aliases.contains(&"tensor_parallel".to_owned()));
+
+    // And a flag with no alias carries none, rather than an empty guess.
+    assert!(flag(&m, "port").recipe_aliases.is_empty());
+}
+
+#[test]
+fn flags_are_the_cli_spelling_and_keys_the_underscored_one() {
+    let m = build();
+    for f in &m.flags {
+        assert!(!f.flag.contains('_'), "the flag is hyphenated: {}", f.flag);
+        assert!(!f.flag.starts_with('-'), "no leading dashes: {}", f.flag);
+        assert_eq!(f.key, f.flag.replace('-', "_"));
+    }
+}
+
+/// clap's own `--help`/`--version` describe nothing a recipe can set, and a
+/// positional has no long name to key on.
+#[test]
+fn clap_own_arguments_are_not_flags_a_recipe_can_set() {
+    let m = build();
+    for k in ["help", "version"] {
+        assert!(
+            !m.flags.iter().any(|f| f.key == k),
+            "{k} must not appear as a settable flag"
+        );
+    }
+}
+
+/// A consumer pins the shape and refuses a document it cannot read. If this
+/// number moves, every downstream generator has to be looked at.
+#[test]
+fn the_document_declares_its_shape_and_its_engine() {
+    let m = build();
+    assert_eq!(m.schema_version, SCHEMA_VERSION);
+    assert!(!m.spark_version.is_empty());
+    assert!(
+        m.flags.len() > 90,
+        "ServeArgs has ~100 settable flags; the manifest found {}",
+        m.flags.len()
+    );
+}
+
+/// Two flags sharing a key would make a downstream map silently lose one.
+#[test]
+fn every_key_is_unique() {
+    let m = build();
+    let mut keys: Vec<&str> = m.flags.iter().map(|f| f.key.as_str()).collect();
+    keys.sort_unstable();
+    let before = keys.len();
+    keys.dedup();
+    assert_eq!(before, keys.len(), "duplicate keys in the manifest");
+}

--- a/crates/spark-server/src/cli/manifest_tests.rs
+++ b/crates/spark-server/src/cli/manifest_tests.rs
@@ -82,6 +82,22 @@ fn recipe_aliases_travel_with_the_flag_that_owns_them() {
     assert!(flag(&m, "port").recipe_aliases.is_empty());
 }
 
+/// clap accepts more names than `get_long()` reports. `--bind` carries
+/// `alias = "host"`, and shipping recipes set `host:` — a document that omits
+/// it says a working recipe uses a flag that does not exist.
+#[test]
+fn clap_aliases_are_captured_not_just_the_primary_name() {
+    let m = build();
+    let bind = flag(&m, "bind");
+    assert!(
+        bind.cli_aliases.contains(&"host".to_owned()),
+        "--bind accepts --host; the manifest reported {:?}",
+        bind.cli_aliases
+    );
+    // And a flag without aliases reports none rather than a guess.
+    assert!(flag(&m, "port").cli_aliases.is_empty());
+}
+
 #[test]
 fn flags_are_the_cli_spelling_and_keys_the_underscored_one() {
     let m = build();

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -13,7 +13,9 @@ fn parse(extra: &[&str]) -> ServeArgs {
     argv.extend_from_slice(extra);
     match super::super::Cli::parse_from(argv).command {
         super::super::Command::Serve(a) => a,
-        super::super::Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+        super::super::Command::Benchmark(_) | super::super::Command::DumpServeOptions => {
+            unreachable!("this test parses a serve command")
+        }
     }
 }
 

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -82,6 +82,19 @@ async fn main() -> Result<()> {
     // Parse BEFORE subscriber install so the TUI gate can see `--no-tui`.
     // clap emits no tracing events, so plain-mode output is unchanged.
     let cli = Cli::parse();
+
+    // Answered before anything else initialises. This prints a document and
+    // exits: no subscriber, no TUI, no GPU. A dashboard would take the
+    // terminal and garble the only output the caller wants.
+    if matches!(cli.command, Command::DumpServeOptions) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&cli::manifest::build())
+                .expect("the manifest is plain data and always serialises")
+        );
+        return Ok(());
+    }
+
     let no_tui = match &cli.command {
         // `--check-kernels` is a script's entry point too: it prints a report
         // and a JSON line on stdout and exits, so a dashboard would take the
@@ -90,6 +103,8 @@ async fn main() -> Result<()> {
         // The benchmark subcommand is a script's entry point: always plain, so
         // nothing here reaches `tui::start` or takes the terminal.
         Command::Benchmark(_) => true,
+        // Handled above; it never reaches here.
+        Command::DumpServeOptions => true,
     };
 
     let tui_channels = if tui::plain_mode(no_tui) {
@@ -116,6 +131,10 @@ async fn main() -> Result<()> {
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<&'static str>();
     tui::shutdown::arm_startup_escape(shutdown_tx);
     let result = match cli.command {
+        // Returned above, before anything initialised. Kept as an explicit arm
+        // rather than a wildcard so a future subcommand cannot land here by
+        // accident and silently do nothing.
+        Command::DumpServeOptions => unreachable!("handled before initialisation"),
         Command::Benchmark(args) => {
             // No model load, so none of the startup-escape plumbing below
             // applies — `dispatch` installs its own Ctrl-C handling. Drop the

--- a/crates/spark-server/src/main_modules/auto_swap_tests.rs
+++ b/crates/spark-server/src/main_modules/auto_swap_tests.rs
@@ -104,7 +104,7 @@ mod policy {
         argv.extend_from_slice(extra);
         match cli::Cli::parse_from(argv).command {
             cli::Command::Serve(a) => a,
-            cli::Command::Benchmark(_) => unreachable!(),
+            cli::Command::Benchmark(_) | cli::Command::DumpServeOptions => unreachable!(),
         }
     }
 

--- a/crates/spark-server/src/main_modules/model_swap_tests.rs
+++ b/crates/spark-server/src/main_modules/model_swap_tests.rs
@@ -12,7 +12,9 @@ fn args(extra: &[&str]) -> cli::ServeArgs {
     argv.extend_from_slice(extra);
     match cli::Cli::parse_from(argv).command {
         cli::Command::Serve(a) => a,
-        cli::Command::Benchmark(_) => unreachable!("parsed a serve command"),
+        cli::Command::Benchmark(_) | cli::Command::DumpServeOptions => {
+            unreachable!("parsed a serve command")
+        }
     }
 }
 

--- a/crates/spark-server/src/main_modules/tests.rs
+++ b/crates/spark-server/src/main_modules/tests.rs
@@ -18,7 +18,9 @@ fn test_cli_parse_positional_model() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+        Command::Benchmark(_) | Command::DumpServeOptions => {
+            unreachable!("this test parses a serve command")
+        }
         Command::Serve(args) => {
             assert_eq!(
                 args.model.as_deref(),
@@ -46,7 +48,9 @@ fn test_cli_parse_model_from_path() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+        Command::Benchmark(_) | Command::DumpServeOptions => {
+            unreachable!("this test parses a serve command")
+        }
         Command::Serve(args) => {
             assert!(args.model.is_none());
             assert_eq!(
@@ -70,7 +74,9 @@ fn test_cli_parse_slai_policy() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+        Command::Benchmark(_) | Command::DumpServeOptions => {
+            unreachable!("this test parses a serve command")
+        }
         Command::Serve(args) => {
             assert_eq!(args.scheduling_policy, "slai");
             assert_eq!(args.tbt_deadline_ms, 50);
@@ -231,7 +237,9 @@ fn test_cli_parse_kv_high_precision_layers() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+        Command::Benchmark(_) | Command::DumpServeOptions => {
+            unreachable!("this test parses a serve command")
+        }
         Command::Serve(args) => {
             assert_eq!(args.kv_high_precision_layers, "3");
         }
@@ -243,7 +251,9 @@ fn test_cli_default_kv_high_precision_layers() {
     let cli = Cli::try_parse_from(["spark", "serve", "nvidia/model"]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) => unreachable!("this test parses a serve command"),
+        Command::Benchmark(_) | Command::DumpServeOptions => {
+            unreachable!("this test parses a serve command")
+        }
         Command::Serve(args) => {
             assert_eq!(args.kv_high_precision_layers, "0");
         }

--- a/crates/spark-server/src/recipe/schema.rs
+++ b/crates/spark-server/src/recipe/schema.rs
@@ -18,7 +18,7 @@
 ///
 /// Verified 2026-07-31 against `cli/serve_args.rs`: neither `max_model_len`
 /// nor `tensor_parallel` exists as a field, and the listen address is `--bind`.
-const RENAMES: &[(&str, &str)] = &[
+pub(crate) const RENAMES: &[(&str, &str)] = &[
     // vLLM's spelling, kept in the recipes for cross-runtime familiarity.
     ("max_model_len", "max-seq-len"),
     ("tensor_parallel", "tp-size"),


### PR DESCRIPTION
`atlas-recipes` hand-transcribes this repo's flag surface — and not from here. Its 48-entry table came from the **Python** launcher that predates the Rust one, and the drift is invisible until a launch dies inside a container:

- the website has offered `scheduling_policy: "fcfs"` for four releases; `validate_serve_args` has never accepted it *(fixed downstream in atlas-recipes#60)*
- `kv_cache_dtype` offered 3 of the 16 in `KvCacheDtype::ALL`
- nine keys shipping recipes set — including `lm_head_dtype`, described in-recipe as a correctness pin — are silently dropped

`spark dump-serve-options` prints what clap actually knows: **102 flags**.

## This is a build artifact, not a public interface

`ServeArgs` still has no `Serialize` derive, and this does not give it one. `recipe/schema.rs:5-11` refuses to make the CLI a public serialization format because a cross-repo rename would become a compat break — that reasoning is intact. Nothing here promises a flag keeps its name; a rename shows up as a **diff in whatever consumes the snapshot**, which is exactly the drift detection missing today.

The subcommand is `hide = true` and answers before any subscriber, TUI, or GPU init — it prints a document and exits. The reflection is the same one `tui/lib_fields.rs` already does.

## Two fields a consumer cannot derive

**`presence_only`** — `--video-allow-ffmpeg` takes no value; `--gdn-fused-norm` requires one:

```
video_allow_ffmpeg    presence_only=true    is_bool=true   opts=[]
gdn_fused_norm        presence_only=false   is_bool=true   opts=["true","false"]
```

Both are written `: true` in a recipe and look identical there. Rendering either as the other produces a command clap refuses — on the serving machine, after the operator has reviewed it.

**`recipe_aliases`** — `max_model_len` is vLLM's spelling kept in the recipes; the flag is `--max-seq-len`. Nothing about the flag reveals that, and omitting it makes a generated table silently stop claiming keys recipes set. `RENAMES` is now `pub(crate)` so there is one list rather than a copy:

```
--max-seq-len  ← ["max_model_len"]
--tp-size      ← ["tensor_parallel"]
--bind         ← ["host"]
```

I only found this because a test failed — my first version derived the key from the flag and lost all three.

## Compile-time guard did its job

Adding the subcommand **failed to compile** until eight existing matches on `Command` were extended. A new subcommand cannot exist without every site deciding what it means.

## Verified against the real binary

```
$ spark dump-serve-options | …
flags              : 102
scheduling_policy  : ["fifo", "slai"]
kv_cache_dtype     : 16 variants
9 dropped keys     : all present
```

7 tests, `cargo fmt`/`clippy` clean under `--no-default-features --features cuda`.

## Next

`atlas-recipes` vendors this snapshot and generates its flag + settings tables from it, with CI regenerating and diffing. The deny-list and the numeric bounds stay hand-written — those are judgement, not data, and the engine carries no ranges at all.