### PR TITLE
feat(cli): spark sync-recipes — populate the recipe index without a terminal

### DIFF
--- a/.benchmarks/agentic-webserver/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/agentic-webserver/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787858444,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787857537,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 59.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.6
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8614756,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5533568,
+      "gpu_compute_apps": [
+        {
+          "pid": 2285121,
+          "name": "./target/release/spark",
+          "used_mib": 108998
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787858443,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 75.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8391716,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5989352,
+      "gpu_compute_apps": [
+        {
+          "pid": 2285121,
+          "name": "./target/release/spark",
+          "used_mib": 109024
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 906,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 9.0,
+      "hottest_chassis_delta_c": 7.199999999999989
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +7 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "decode_tps": 36.837495520069304,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 5.502362434582822,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 896.885076837,
+    "sum_completion_tokens": 33039.0,
+    "sum_tool_calls": 144.0,
+    "sum_turns": 163.0,
+    "sum_wall_s": 905.3856522919999,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 5.502s/turn ≤ 8.500 · Σwall 905s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=36.84, followed_directions=10.00, iterations=10.00, s_per_turn=5.50, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=896.89, sum_completion_tokens=33039.00, sum_tool_calls=144.00, sum_turns=163.00, sum_wall_s=905.39, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 5.502s/turn ≤ 8.500 · Σwall 905s ≤ 1800s",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,458 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787857505,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787848759,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 67.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.1
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8008376,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6259576,
+      "gpu_compute_apps": [
+        {
+          "pid": 1697030,
+          "name": "./target/release/spark",
+          "used_mib": 109007
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787857505,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 65.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 76.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.4
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6594920,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 5535680,
+      "gpu_compute_apps": [
+        {
+          "pid": 1697030,
+          "name": "./target/release/spark",
+          "used_mib": 109033
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 8746,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 5.0,
+      "hottest_chassis_delta_c": 8.599999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +9 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.61,
+    "overall_accuracy": 86.25,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.25 (baseline min 86.10) · normalized 86.61 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.61, overall_accuracy=86.25, samples=1004.00 · Pass: overall 86.25 (baseline min 86.10) · normalized 86.61 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/bfcl-subset/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,453 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787848728,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2405.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787842943,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 68.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.6
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 35113908,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6199308,
+      "gpu_compute_apps": [
+        {
+          "pid": 1306864,
+          "name": "./target/release/spark",
+          "used_mib": 83465
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787848728,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 74.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 35013220,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6259444,
+      "gpu_compute_apps": [
+        {
+          "pid": 1306864,
+          "name": "./target/release/spark",
+          "used_mib": 83601
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5785,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 8.0,
+      "hottest_chassis_delta_c": 6.299999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +6 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/concurrency-sweep/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787842893,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "16.2",
+    "min_c16": "72",
+    "min_c4": "33.5",
+    "min_c8": "50.5",
+    "min_peak": "72",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=16.2",
+    "--param",
+    "min_c16=72",
+    "--param",
+    "min_c4=33.5",
+    "--param",
+    "min_c8=50.5",
+    "--param",
+    "min_peak=72",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=32",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "32",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2502.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787842687,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14857324,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6189608,
+      "gpu_compute_apps": [
+        {
+          "pid": 1288207,
+          "name": "./target/release/spark",
+          "used_mib": 102149
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787842892,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 86.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 86.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.0
+        }
+      ],
+      "sm_clock_mhz": 2502.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14916000,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6190532,
+      "gpu_compute_apps": [
+        {
+          "pid": 1288207,
+          "name": "./target/release/spark",
+          "used_mib": 102359
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 205,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 17.0
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 88.19909778500003,
+    "c16_ttft_p50_ms": 8328.87491,
+    "c1_aggregate_tok_s": 19.02101037618353,
+    "c1_ttft_p50_ms": 905.782854,
+    "c4_aggregate_tok_s": 49.29196132754673,
+    "c4_ttft_p50_ms": 2996.4484150000003,
+    "c8_aggregate_tok_s": 58.44438961341473,
+    "c8_ttft_p50_ms": 4756.14583,
+    "min_completion_tokens": 320.0,
+    "peak_aggregate_tok_s": 88.19909778500003,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "4 cells, zero errors, zero vacuous — every populated floor met (C1 19.0/16.2 · C4 49.3/33.5 · C8 58.4/50.5 · C16 88.2/72.0 · peak 88.2/72.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=88.20, c16_ttft_p50_ms=8328.87, c1_aggregate_tok_s=19.02, c1_ttft_p50_ms=905.78, c4_aggregate_tok_s=49.29, c4_ttft_p50_ms=2996.45, c8_aggregate_tok_s=58.44, c8_ttft_p50_ms=4756.15, min_completion_tokens=320.00, peak_aggregate_tok_s=88.20, vacuous_cells=0.00 · Pass: 4 cells, zero errors, zero vacuous — every populated floor met (C1 19.0/16.2 · C4 49.3/33.5 · C8 58.4/50.5 · C16 88.2/72.0 · peak 88.2/72.0)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/decode-floor/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,433 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787859093,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "20.5",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=20.5",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787858975,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 46.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 51.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88981005969,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 17021708,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 950132,
+      "gpu_compute_apps": [
+        {
+          "pid": 2390947,
+          "name": "./target/release/spark",
+          "used_mib": 101466
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787859093,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 89.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 84.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 89.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.5
+        }
+      ],
+      "sm_clock_mhz": 2483.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88981005969,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 17241372,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 953916,
+      "gpu_compute_apps": [
+        {
+          "pid": 2390947,
+          "name": "./target/release/spark",
+          "used_mib": 101470
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 118,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 29.0,
+      "hottest_chassis_delta_c": 38.4
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +38 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "accept_len_mean": 2.682571857571858,
+    "output_tokens": 795.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 22.956784364790582
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 23.0 tok/s over 3 pinned runs (accept_len_mean 2.68) — clears the 20.5 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.68, output_tokens=795.00, runs=3.00, server_decode_tok_s=22.96 · Pass: median decode 23.0 tok/s over 3 pinned runs (accept_len_mean 2.68) — clears the 20.5 tok/s floor",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,447 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787842654,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787842570,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 58.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 65.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.9
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8035800,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6189396,
+      "gpu_compute_apps": [
+        {
+          "pid": 1279498,
+          "name": "./target/release/spark",
+          "used_mib": 108911
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787842654,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 74.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.9
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8204944,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6191824,
+      "gpu_compute_apps": [
+        {
+          "pid": 1279498,
+          "name": "./target/release/spark",
+          "used_mib": 108937
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 84,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 16.0,
+      "hottest_chassis_delta_c": 17.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +18 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 83.689860594,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=83.69, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/ttft-cold-gate/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787842329,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2502.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787842280,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 52.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 60.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.1
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7107456,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6189152,
+      "gpu_compute_apps": [
+        {
+          "pid": 1259900,
+          "name": "./target/release/spark",
+          "used_mib": 110006
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787842329,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 70.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.9
+        }
+      ],
+      "sm_clock_mhz": 2502.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7092044,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6191620,
+      "gpu_compute_apps": [
+        {
+          "pid": 1259900,
+          "name": "./target/release/spark",
+          "used_mib": 110030
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 49,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 18.0,
+      "hottest_chassis_delta_c": 22.1
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +22 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "median_ms": 920.9790350000001,
+    "p90_ms": 2073.874151,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +1.1% (limit +3.0%) · p90 +1.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=920.98, p90_ms=2073.87, samples=36.00 · Pass: median +1.1% (limit +3.0%) · p90 +1.1% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/ttft-warm-gate/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,444 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787842453,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2489.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1787842361,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 56.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.1
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8146536,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6189040,
+      "gpu_compute_apps": [
+        {
+          "pid": 1265247,
+          "name": "./target/release/spark",
+          "used_mib": 108928
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787842453,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 79.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 86.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 86.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 75.7
+        }
+      ],
+      "sm_clock_mhz": 2483.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8239624,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6191652,
+      "gpu_compute_apps": [
+        {
+          "pid": 1265247,
+          "name": "./target/release/spark",
+          "used_mib": 108952
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 92,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 23.0,
+      "hottest_chassis_delta_c": 23.799999999999997
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +24 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "median_ms": 842.2171655,
+    "p90_ms": 2059.110442,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 -0.0% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=842.22, p90_ms=2059.11, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 -0.0% (limit +5.0%)",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/video-fidelity/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,439 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787842926,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2509.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787842910,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 61.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.4
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 35166484,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6198800,
+      "gpu_compute_apps": [
+        {
+          "pid": 1303730,
+          "name": "./target/release/spark",
+          "used_mib": 82701
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787842926,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 73.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 79.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        }
+      ],
+      "sm_clock_mhz": 2509.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 35538464,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6199220,
+      "gpu_compute_apps": [
+        {
+          "pid": 1303730,
+          "name": "./target/release/spark",
+          "used_mib": 82711
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 16,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 12.0,
+      "hottest_chassis_delta_c": 9.599999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +10 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 727.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1449.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 2900.0,
+    "control_held": 1.0,
+    "legs_asserted": 13.0,
+    "legs_passed": 13.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "13/13 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=727.00, conc_2_correct=2.00, conc_2_wall_ms=1449.00, conc_4_correct=4.00, conc_4_wall_ms=2900.00, control_held=1.00, legs_asserted=13.00, legs_passed=13.00, legs_skipped=0.00 · Pass: 13/13 legs passed, control held, 0 skipped",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-08-27-d2ad2a13a9.json
+++ b/.benchmarks/vision-fidelity/2026-08-27-d2ad2a13a9.json
@@ -1,0 +1,441 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "d2ad2a13a9",
+  "recorded_at": 1787842539,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2502.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1787842485,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 58.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 67.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.3
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8032836,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6189276,
+      "gpu_compute_apps": [
+        {
+          "pid": 1273809,
+          "name": "./target/release/spark",
+          "used_mib": 108923
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1787842538,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 73.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 82.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 82.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.7
+        }
+      ],
+      "sm_clock_mhz": 2502.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 88801574322,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8108720,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6191680,
+      "gpu_compute_apps": [
+        {
+          "pid": 1273809,
+          "name": "./target/release/spark",
+          "used_mib": 108973
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 53,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 14.900000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +15 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 2017.0,
+    "conc_2_wall_ms": 3931.0,
+    "conc_4_wall_ms": 7549.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=2017.00, conc_2_wall_ms=3931.00, conc_4_wall_ms=7549.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "06230162dffb5a0a4e3d5a03809d661125966d254e2ad9e5bab024c00477502e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ca90eae33d06b930967e3ab6447cb3ab5bf66002c99ecada9dfc61728700019f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "eccad0343f9dd8f8a8f41292c6d049f1f4bf00cdada27fbbfdd9ea3df8580236",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "18f0e7fb6edc3403eb4f8a86b26676a8a779aeeaac8c8adbe5513ed42eaffc1b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "1a3661ba3340be9982726242892ef41a2144077f74d7bccf7a662e8c95ae467e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "72b23aa8f298795e08109b58358ef53cec9430442c4d1d364da031430948a713",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "cac67e218e44cb72f20f50f22532897544493188187e560422105ba9d2dcf819",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "85e1ef85282b4be2f055e3119cf72e7854ad4ae0a8e3c508c3fe94e691115b5a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "de30053d820d7e726e283f1efe1b2eee434f4bfeff046fa88656e1405445127f",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "a7e4abc9e1f214602d32c9ee9c41f7b0f3614c65e807d564a2965351b449d09b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "cb5d8d8955fe2a15bc37eb78db37eadb55c1c531af261dd7935b5be1438e13a9",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "da8beea4ce9dc2d798a84f9ae3f2dd9f5fadb61de77d33ad8bd2bdfa2a01b3e7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "2b55209fe211af59cb3f3e8dd61143f43fac3bfbb4b25991e73c262aee94d013",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "d0477703b836380657c5ec0ca6a132d4a318872c0ce0020e39c9fc894431a3bd",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "0cde4d16aad1f43baca8da17706439f3081d85cd537bb2621cd10a2ae9860374",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "8a81e944bb5fba6b44ffc5584a042d9767f18e77ba8cf26b736f0199d66f5de8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "6aa2f9c84a7faab093cf4c3d268b38ac62bef460ce2e3d150b4a499173bbcb19",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "4c4dbdda96565ff711778072f7a2c8092e81dde3f48f9354395957118df36e53",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "43be1913748c79e17006e35ae25b1f1c92beb0e084d06e2eb8ef6cbe1d1a7bdf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "b33e47e2da78de20d8d3426dfada8266cb7204466ba6164d99a98075b5937723",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "998dd7117fbc9b84fd473f5a5d519afb2b6f73d7c6922d04281fb40487e54da7",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "62499cc50d01eb8a09a7283d2eb0532d7a08bc6cd30eff70aeb5066991400e1c",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "38a463749c097697062fc9fda1d099adc15c876784c28291fbb233560286c52b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "dbe4fab2c92e8815ed80e9e68649956ca855856ed790b51dedfd7887f4fa19a1",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/crates/spark-server/src/cli.rs
+++ b/crates/spark-server/src/cli.rs
@@ -13,6 +13,7 @@ mod bench_selfstart;
 pub(crate) mod flag_values;
 pub(crate) mod manifest;
 mod serve_args;
+pub(crate) mod sync_recipes;
 mod validate;
 pub use bench_args::BenchmarkArgs;
 pub use serve_args::{DEFAULT_KV_CACHE_DTYPE, DEFAULT_NUM_DRAFTS, ServeArgs};
@@ -52,6 +53,18 @@ pub enum Command {
     /// as a diff in whatever consumes the output.
     #[command(hide = true)]
     DumpServeOptions,
+    /// Populate the local recipe index from the recipe repository.
+    ///
+    /// The index is what `benchmark run` resolves a recipe id against, and
+    /// until this existed the only thing that wrote it was the TUI Library —
+    /// so the error a headless box got was "open the TUI Library once to
+    /// populate it", which is advice a CI runner, a container, or a machine
+    /// reached over ssh cannot take. That is not a hint, it is a dead end.
+    ///
+    /// Deliberately explicit rather than an automatic fetch inside
+    /// `benchmark run`: a benchmark that silently reaches the network mid-run
+    /// is a benchmark whose result depends on something nobody declared.
+    SyncRecipes,
 }
 
 #[cfg(test)]

--- a/crates/spark-server/src/cli/bench_selfstart.rs
+++ b/crates/spark-server/src/cli/bench_selfstart.rs
@@ -176,7 +176,9 @@ pub async fn serve_for(
         .with_context(|| {
             format!(
                 "recipe {recipe_id:?} is not in the local index ({} cached). The index is read \
-                 from {}/atlas-recipes/index.json; open the TUI Library once to populate it.",
+                 from {}/atlas-recipes/index.json. Populate it with:\n    spark sync-recipes\n\
+                 (this used to say \"open the TUI Library once\", which a CI runner, a \
+                 container, or a machine reached over ssh cannot do.)",
                 index.recipes.len(),
                 store.root().display()
             )

--- a/crates/spark-server/src/cli/sync_recipes.rs
+++ b/crates/spark-server/src/cli/sync_recipes.rs
@@ -19,7 +19,12 @@ use std::sync::atomic::AtomicBool;
 /// # Errors
 /// When the refresh did not actually reach the repository, or reached it and
 /// found nothing.
-pub fn verdict(offline: Option<&str>, recipes: usize, before: usize) -> Result<(), String> {
+pub fn verdict(
+    offline: Option<&str>,
+    incomplete: Option<&str>,
+    recipes: usize,
+    before: usize,
+) -> Result<(), String> {
     // `refresh` serves the CACHE when the network fails, annotated with why.
     // Reporting that as a successful sync is how a CI job ends up believing it
     // has a fresh index and then failing to resolve a recipe added yesterday —
@@ -35,10 +40,25 @@ pub fn verdict(offline: Option<&str>, recipes: usize, before: usize) -> Result<(
     }
     if recipes == 0 {
         // A reachable repository that returned nothing is not a success either.
-        // Writing an empty index over a good one would be worse than failing.
         return Err(
             "the repository returned no recipes; refusing to call that a synced index".to_owned(),
         );
+    }
+    // Reached the repository, got something back, and still could not put it on
+    // disk — some files did not arrive, or the write failed. The fetch layer
+    // leaves the cache ALONE in both cases, so what is on disk is still the
+    // complete thing it was; it is simply not what was just asked for.
+    //
+    // This must be an error rather than a note. `sync-recipes` runs before the
+    // tracing subscriber exists, so anything reported at `warn!` on this path is
+    // discarded — the command would print "recipe index written to …" over a
+    // file it did not write, which is the success-with-stale-data this command
+    // exists to prevent.
+    if let Some(why) = incomplete {
+        return Err(format!(
+            "the recipe index was not written: {why}\n\
+             The cache is unchanged ({before} recipe(s)) — nothing was replaced."
+        ));
     }
     Ok(())
 }
@@ -61,7 +81,12 @@ pub fn run() -> Result<()> {
     // `refresh` serves the CACHE when the network fails, annotated with why.
     // Reporting that as a successful sync is how a CI job ends up believing it
     // has a fresh index and then failing to resolve a recipe added yesterday.
-    if let Err(why) = verdict(index.offline.as_deref(), index.recipes.len(), before) {
+    if let Err(why) = verdict(
+        index.offline.as_deref(),
+        index.incomplete.as_deref(),
+        index.recipes.len(),
+        before,
+    ) {
         bail!("{why}");
     }
 
@@ -83,7 +108,7 @@ mod tests {
 
     #[test]
     fn a_real_fetch_with_recipes_is_a_sync() {
-        assert!(verdict(None, 30, 0).is_ok());
+        assert!(verdict(None, None, 30, 0).is_ok());
     }
 
     /// The case this command exists to refuse.
@@ -92,7 +117,7 @@ mod tests {
         // `refresh` returns the cached index annotated with why the network
         // failed, so the recipe count looks healthy. A command that reported
         // success here would leave CI believing it had fresh data.
-        let e = verdict(Some("dns failure"), 30, 30).expect_err("must refuse");
+        let e = verdict(Some("dns failure"), None, 30, 30).expect_err("must refuse");
         assert!(e.contains("could not reach"), "{e}");
         assert!(
             e.contains("30 recipe(s)"),
@@ -106,14 +131,59 @@ mod tests {
 
     #[test]
     fn falling_back_with_no_cache_at_all_is_also_refused() {
-        assert!(verdict(Some("timed out"), 0, 0).is_err());
+        assert!(verdict(Some("timed out"), None, 0, 0).is_err());
     }
 
     /// A reachable repository that returns nothing is not success either:
     /// writing an empty index over a good one is worse than failing.
     #[test]
     fn an_empty_index_is_refused_even_when_the_network_worked() {
-        let e = verdict(None, 0, 30).expect_err("must refuse");
+        let e = verdict(None, None, 0, 30).expect_err("must refuse");
         assert!(e.contains("no recipes"), "{e}");
+    }
+
+    /// The failure an operator actually hits on a locked-down box: the fetch
+    /// worked, the write did not. It used to be a `warn!` that nothing was
+    /// listening for, so the command printed a success line naming a file it
+    /// had never written.
+    #[test]
+    fn a_fetch_that_could_not_be_cached_is_not_a_sync() {
+        let e = verdict(
+            None,
+            Some("the index could not be cached: permission denied"),
+            30,
+            12,
+        )
+        .expect_err("an uncached fetch is not a synced index");
+        assert!(e.contains("permission denied"), "{e}");
+        assert!(
+            e.contains("unchanged (12 recipe(s))"),
+            "the operator needs to know what is still on disk: {e}"
+        );
+    }
+
+    /// A partial fetch is the dangerous one: it looks like a success, and it is
+    /// the case where a complete cache would have been silently shrunk.
+    #[test]
+    fn a_partial_fetch_is_not_a_sync_even_though_recipes_arrived() {
+        let e = verdict(
+            None,
+            Some("27 of 30 recipe file(s) could not be fetched"),
+            3,
+            30,
+        )
+        .expect_err("3 of 30 recipes is not a synced index");
+        assert!(e.contains("27 of 30"), "{e}");
+    }
+
+    /// Offline is reported ahead of everything else: it is the more basic
+    /// failure, and naming a write problem for a fetch that never happened
+    /// would send the operator after the wrong thing.
+    #[test]
+    fn being_offline_is_reported_before_any_write_problem() {
+        let e = verdict(Some("dns failure"), Some("could not be cached"), 30, 30)
+            .expect_err("must refuse");
+        assert!(e.contains("dns failure"), "{e}");
+        assert!(!e.contains("could not be cached"), "{e}");
     }
 }

--- a/crates/spark-server/src/cli/sync_recipes.rs
+++ b/crates/spark-server/src/cli/sync_recipes.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `spark sync-recipes` — fill the local recipe index without a terminal.
+//!
+//! The index is what `benchmark run` resolves a recipe id against. Nothing but
+//! the TUI Library wrote it, so a headless box was told to "open the TUI
+//! Library once to populate it" — advice a CI runner, a container, or a machine
+//! reached over ssh cannot act on.
+
+use anyhow::{Context, Result, bail};
+use std::sync::atomic::AtomicBool;
+
+/// What a finished refresh means, as a decision separate from the I/O.
+///
+/// Pure so it can be tested: the interesting behaviour is which outcomes count
+/// as a successful sync, and the network call was the only thing standing
+/// between that judgement and a test.
+///
+/// # Errors
+/// When the refresh did not actually reach the repository, or reached it and
+/// found nothing.
+pub fn verdict(offline: Option<&str>, recipes: usize, before: usize) -> Result<(), String> {
+    // `refresh` serves the CACHE when the network fails, annotated with why.
+    // Reporting that as a successful sync is how a CI job ends up believing it
+    // has a fresh index and then failing to resolve a recipe added yesterday —
+    // far from here, with an error that names neither the network nor this
+    // command.
+    if let Some(why) = offline {
+        return Err(format!(
+            "could not reach the recipe repository: {why}\n\
+             The cache is unchanged ({before} recipe(s)). This command reports \
+             failure rather than success-with-stale-data, because a stale index \
+             fails later, somewhere less obvious."
+        ));
+    }
+    if recipes == 0 {
+        // A reachable repository that returned nothing is not a success either.
+        // Writing an empty index over a good one would be worse than failing.
+        return Err(
+            "the repository returned no recipes; refusing to call that a synced index".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+/// Fetch the recipe index and report what landed.
+///
+/// # Errors
+/// If the artifact store cannot be located, or the fetch did not reach the
+/// network.
+pub fn run() -> Result<()> {
+    let store = atlas_plugin::ArtifactStore::discover()
+        .context("locating the artifact store that holds the recipe cache")?;
+    let root = store.root();
+
+    let before = crate::recipe::fetch::cached(root).recipes.len();
+    // Not cancellable: there is no UI to cancel from, and the fetch has its own
+    // timeout.
+    let index = crate::recipe::fetch::refresh(root, &AtomicBool::new(false));
+
+    // `refresh` serves the CACHE when the network fails, annotated with why.
+    // Reporting that as a successful sync is how a CI job ends up believing it
+    // has a fresh index and then failing to resolve a recipe added yesterday.
+    if let Err(why) = verdict(index.offline.as_deref(), index.recipes.len(), before) {
+        bail!("{why}");
+    }
+
+    println!(
+        "recipe index written to {}/atlas-recipes/index.json",
+        root.display()
+    );
+    println!(
+        "  {} recipe(s), tree {}",
+        index.recipes.len(),
+        index.tree_sha
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verdict;
+
+    #[test]
+    fn a_real_fetch_with_recipes_is_a_sync() {
+        assert!(verdict(None, 30, 0).is_ok());
+    }
+
+    /// The case this command exists to refuse.
+    #[test]
+    fn falling_back_to_a_warm_cache_is_not_a_sync() {
+        // `refresh` returns the cached index annotated with why the network
+        // failed, so the recipe count looks healthy. A command that reported
+        // success here would leave CI believing it had fresh data.
+        let e = verdict(Some("dns failure"), 30, 30).expect_err("must refuse");
+        assert!(e.contains("could not reach"), "{e}");
+        assert!(
+            e.contains("30 recipe(s)"),
+            "must say what is actually there: {e}"
+        );
+        assert!(
+            e.contains("unchanged"),
+            "must not imply anything was written: {e}"
+        );
+    }
+
+    #[test]
+    fn falling_back_with_no_cache_at_all_is_also_refused() {
+        assert!(verdict(Some("timed out"), 0, 0).is_err());
+    }
+
+    /// A reachable repository that returns nothing is not success either:
+    /// writing an empty index over a good one is worse than failing.
+    #[test]
+    fn an_empty_index_is_refused_even_when_the_network_worked() {
+        let e = verdict(None, 0, 30).expect_err("must refuse");
+        assert!(e.contains("no recipes"), "{e}");
+    }
+}

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -13,7 +13,9 @@ fn parse(extra: &[&str]) -> ServeArgs {
     argv.extend_from_slice(extra);
     match super::super::Cli::parse_from(argv).command {
         super::super::Command::Serve(a) => a,
-        super::super::Command::Benchmark(_) | super::super::Command::DumpServeOptions => {
+        super::super::Command::Benchmark(_)
+        | super::super::Command::DumpServeOptions
+        | super::super::Command::SyncRecipes => {
             unreachable!("this test parses a serve command")
         }
     }

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -95,6 +95,13 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Same treatment as `DumpServeOptions`: it talks to the network and prints
+    // a line. No subscriber, no TUI, no GPU — and no reason to initialise a
+    // dashboard for a command whose whole output is two lines of text.
+    if matches!(cli.command, Command::SyncRecipes) {
+        return cli::sync_recipes::run();
+    }
+
     let no_tui = match &cli.command {
         // `--check-kernels` is a script's entry point too: it prints a report
         // and a JSON line on stdout and exits, so a dashboard would take the
@@ -104,7 +111,7 @@ async fn main() -> Result<()> {
         // nothing here reaches `tui::start` or takes the terminal.
         Command::Benchmark(_) => true,
         // Handled above; it never reaches here.
-        Command::DumpServeOptions => true,
+        Command::DumpServeOptions | Command::SyncRecipes => true,
     };
 
     let tui_channels = if tui::plain_mode(no_tui) {
@@ -134,7 +141,9 @@ async fn main() -> Result<()> {
         // Returned above, before anything initialised. Kept as an explicit arm
         // rather than a wildcard so a future subcommand cannot land here by
         // accident and silently do nothing.
-        Command::DumpServeOptions => unreachable!("handled before initialisation"),
+        Command::DumpServeOptions | Command::SyncRecipes => {
+            unreachable!("handled before initialisation")
+        }
         Command::Benchmark(args) => {
             // No model load, so none of the startup-escape plumbing below
             // applies — `dispatch` installs its own Ctrl-C handling. Drop the

--- a/crates/spark-server/src/main_modules/auto_swap_tests.rs
+++ b/crates/spark-server/src/main_modules/auto_swap_tests.rs
@@ -104,7 +104,9 @@ mod policy {
         argv.extend_from_slice(extra);
         match cli::Cli::parse_from(argv).command {
             cli::Command::Serve(a) => a,
-            cli::Command::Benchmark(_) | cli::Command::DumpServeOptions => unreachable!(),
+            cli::Command::Benchmark(_)
+            | cli::Command::DumpServeOptions
+            | cli::Command::SyncRecipes => unreachable!(),
         }
     }
 

--- a/crates/spark-server/src/main_modules/model_swap_tests.rs
+++ b/crates/spark-server/src/main_modules/model_swap_tests.rs
@@ -12,7 +12,7 @@ fn args(extra: &[&str]) -> cli::ServeArgs {
     argv.extend_from_slice(extra);
     match cli::Cli::parse_from(argv).command {
         cli::Command::Serve(a) => a,
-        cli::Command::Benchmark(_) | cli::Command::DumpServeOptions => {
+        cli::Command::Benchmark(_) | cli::Command::DumpServeOptions | cli::Command::SyncRecipes => {
             unreachable!("parsed a serve command")
         }
     }

--- a/crates/spark-server/src/main_modules/tests.rs
+++ b/crates/spark-server/src/main_modules/tests.rs
@@ -18,7 +18,7 @@ fn test_cli_parse_positional_model() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) | Command::DumpServeOptions => {
+        Command::Benchmark(_) | Command::DumpServeOptions | Command::SyncRecipes => {
             unreachable!("this test parses a serve command")
         }
         Command::Serve(args) => {
@@ -48,7 +48,7 @@ fn test_cli_parse_model_from_path() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) | Command::DumpServeOptions => {
+        Command::Benchmark(_) | Command::DumpServeOptions | Command::SyncRecipes => {
             unreachable!("this test parses a serve command")
         }
         Command::Serve(args) => {
@@ -74,7 +74,7 @@ fn test_cli_parse_slai_policy() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) | Command::DumpServeOptions => {
+        Command::Benchmark(_) | Command::DumpServeOptions | Command::SyncRecipes => {
             unreachable!("this test parses a serve command")
         }
         Command::Serve(args) => {
@@ -237,7 +237,7 @@ fn test_cli_parse_kv_high_precision_layers() {
     ]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) | Command::DumpServeOptions => {
+        Command::Benchmark(_) | Command::DumpServeOptions | Command::SyncRecipes => {
             unreachable!("this test parses a serve command")
         }
         Command::Serve(args) => {
@@ -251,7 +251,7 @@ fn test_cli_default_kv_high_precision_layers() {
     let cli = Cli::try_parse_from(["spark", "serve", "nvidia/model"]);
     assert!(cli.is_ok());
     match cli.unwrap().command {
-        Command::Benchmark(_) | Command::DumpServeOptions => {
+        Command::Benchmark(_) | Command::DumpServeOptions | Command::SyncRecipes => {
             unreachable!("this test parses a serve command")
         }
         Command::Serve(args) => {

--- a/crates/spark-server/src/recipe/fetch.rs
+++ b/crates/spark-server/src/recipe/fetch.rs
@@ -68,6 +68,17 @@ pub struct Index {
     pub fetched_at: u64,
     /// Set when the network failed and this came off disk instead.
     pub offline: Option<String>,
+    /// Set when the network was REACHED but the result was not good enough to
+    /// replace the cache with — some recipe files did not come back, or the
+    /// write itself failed.
+    ///
+    /// Distinct from [`Self::offline`], which means the repository was never
+    /// reached at all. Both mean "what is on disk is not what you just asked
+    /// for", but only this one can happen on a working network, and it used to
+    /// be reported as a clean success: the fetch loop logged unreachable files
+    /// at `warn!` and cached whatever did arrive, so a partial fetch silently
+    /// replaced a complete cache with a smaller one.
+    pub incomplete: Option<String>,
 }
 
 impl Index {
@@ -181,6 +192,7 @@ fn parse_cache(text: &str) -> Result<Index> {
             .to_string(),
         fetched_at: doc.get("fetched_at").and_then(|s| s.as_u64()).unwrap_or(0),
         offline: None,
+        incomplete: None,
     })
 }
 

--- a/crates/spark-server/src/recipe/fetch_github.rs
+++ b/crates/spark-server/src/recipe/fetch_github.rs
@@ -64,7 +64,10 @@ pub(super) fn try_refresh(root: &Path, cancel: &AtomicBool) -> Result<Index> {
         // sends this down the offline path, which serves the existing cache
         // untouched. Returning `Ok` with no recipes would have replaced a good
         // cache with an empty one BEFORE the caller could refuse it.
-        bail!("{REPO}@{tree_sha} listed {} recipe file(s) but none could be fetched", paths.len());
+        bail!(
+            "{REPO}@{tree_sha} listed {} recipe file(s) but none could be fetched",
+            paths.len()
+        );
     }
 
     let mut files: BTreeMap<String, String> = BTreeMap::new();

--- a/crates/spark-server/src/recipe/fetch_github.rs
+++ b/crates/spark-server/src/recipe/fetch_github.rs
@@ -59,6 +59,14 @@ pub(super) fn try_refresh(root: &Path, cancel: &AtomicBool) -> Result<Index> {
         bail!("refresh cancelled");
     }
 
+    if out.lock().is_empty() {
+        // Every file failed. Bailing (rather than returning an empty index)
+        // sends this down the offline path, which serves the existing cache
+        // untouched. Returning `Ok` with no recipes would have replaced a good
+        // cache with an empty one BEFORE the caller could refuse it.
+        bail!("{REPO}@{tree_sha} listed {} recipe file(s) but none could be fetched", paths.len());
+    }
+
     let mut files: BTreeMap<String, String> = BTreeMap::new();
     let mut recipes = Vec::new();
     for (id, body) in out.into_inner() {
@@ -74,13 +82,40 @@ pub(super) fn try_refresh(root: &Path, cancel: &AtomicBool) -> Result<Index> {
     recipes.sort_by(|a, b| a.id.cmp(&b.id));
 
     let fetched_at = unix_now();
-    write_cache(root, &tree_sha, fetched_at, &files)
-        .unwrap_or_else(|e| tracing::warn!("could not cache recipes: {e:#}"));
+
+    // The cache is replaced only by a COMPLETE fetch.
+    //
+    // Skipping an unreachable file is right for the index we return — one bad
+    // file must not cost the other 24 this session. It is wrong for the cache:
+    // writing the survivors DELETES the ones that did not come back, so a
+    // transient failure of `raw.githubusercontent.com` (a proxy that resolves
+    // the API host but not the raw host is a real topology) turns a complete
+    // 30-recipe cache into a 3-recipe one, permanently, while reporting
+    // success. Keeping the old cache is strictly better: it is complete, and it
+    // is what the caller already had.
+    let missing = paths.len().saturating_sub(files.len());
+    let incomplete = if missing > 0 {
+        Some(format!(
+            "{missing} of {} recipe file(s) could not be fetched, so the cache was left alone",
+            paths.len()
+        ))
+    } else {
+        // A write failure is NOT a warning here. `sync-recipes` dispatches
+        // before the tracing subscriber exists, so a `warn!` on this path goes
+        // nowhere at all and the command prints "recipe index written to …"
+        // over a file it never wrote — the exact success-with-stale-data this
+        // command exists to prevent.
+        write_cache(root, &tree_sha, fetched_at, &files)
+            .err()
+            .map(|e| format!("the index could not be cached: {e:#}"))
+    };
+
     Ok(Index {
         recipes,
         tree_sha,
         fetched_at,
         offline: None,
+        incomplete,
     })
 }
 

--- a/crates/spark-server/src/recipe/fetch_tests.rs
+++ b/crates/spark-server/src/recipe/fetch_tests.rs
@@ -138,6 +138,7 @@ fn a_successful_fetch_is_not_marked_offline() {
         tree_sha: "abc".into(),
         fetched_at: unix_now(),
         offline: None,
+        incomplete: None,
     };
     let index = refresh_with(&dir.0, || Ok(fresh));
     assert!(index.offline.is_none());


### PR DESCRIPTION
## The hole this closes

`spark bench --selfstart` on a fresh box fails with "no recipe matches", and the remedy it printed
was **"open the TUI Library once to populate it"**. That is not a remedy on a headless machine, in a
container, or in CI — the three places a self-starting benchmark is most likely to run. There was no
non-interactive way to fetch the recipe index at all.

## What this adds

`spark sync-recipes` — fetches the index and writes the cache. Dispatched **before** the tracing
subscriber, the TUI and any GPU probe, so it works on a box with no display and no accelerator.

The verdict logic is separated into a pure function precisely so the failure modes are testable:

- **Unreachable repository → exit 1**, and the message says the cache is *unchanged*, with the count
  it still holds. Reporting success after a failed fetch would leave a stale index looking fresh,
  and the next benchmark would silently run the wrong recipe.
- **Zero recipes returned → exit 1.** An empty index is not a synced index; calling it one caches
  the emptiness and turns one bad fetch into a persistent failure.

`bench --selfstart`'s error now names `spark sync-recipes` instead of the TUI.

## Verification

4 unit tests on the verdict function, plus the real paths exercised on a box:

| case | result |
|---|---|
| dead proxy, empty cache | exit 1, cache untouched |
| dead proxy, warm cache | exit 1, message reports the retained count |
| real fetch | exit 0, index populated |

## Gates

Touches `crates/`, which is in `PERF_PATHS`, so the ten gate records are invalidated and a fresh
campaign is required at this sha. Running now; this PR does not merge until it is green.