### PR TITLE
feat(banner): Sparkrun is retired; atlasctl is the control plane now

### DIFF
--- a/site/src/app.css
+++ b/site/src/app.css
@@ -153,6 +153,22 @@ nav {
 .ann-line { font-size: 0.88rem; font-weight: 600; color: var(--t1); }
 .ann-sub { font-size: 0.82rem; color: var(--t2); }
 
+/* The second band row. Deliberately quieter and tighter than the first: it is
+   news, not a headline, and the band as a whole must not push the hero down the
+   page. Its own top border reads as two notices rather than one run-on. */
+.ann-note {
+  padding-top: 0.45rem; padding-bottom: 0.6rem;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  gap: 0.6rem;
+}
+.ann-note .ann-sub { font-size: 0.78rem; }
+.ann-tag {
+  flex-shrink: 0; padding: 0.08rem 0.42rem; border-radius: 4px;
+  background: color-mix(in srgb, var(--ch-cyan) 16%, transparent);
+  color: var(--ch-cyan); border: 1px solid color-mix(in srgb, var(--ch-cyan) 35%, transparent);
+  font-size: 0.64rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+}
+
 /* ---- hero ----------------------------------------------------------------- */
 .hero { padding: 4.5rem 2rem 4rem; }
 .hero-inner { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 3.5rem; align-items: center; }

--- a/site/src/lib/components/AnnouncementBanner.svelte
+++ b/site/src/lib/components/AnnouncementBanner.svelte
@@ -11,4 +11,14 @@
     <span class="ann-sub">{announcement.sub}</span>
     <a class="ann-cta" href={announcement.ctaUrl} target="_blank" rel="noopener">{announcement.ctaText} ↗</a>
   </div>
+  {#if announcement.note}
+    <!-- A second row rather than more words in the first: the partnership line
+         and the launcher change are unrelated pieces of news, and running them
+         together reads as one long sentence about neither. -->
+    <div class="ann-inner ann-note">
+      <span class="ann-tag">New</span>
+      <span class="ann-sub">{announcement.note}</span>
+      <a class="ann-cta" href="/control.html">Control plane →</a>
+    </div>
+  {/if}
 </div>

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -69,7 +69,13 @@ export const announcement = {
   line: 'Atlas is partnering with Avarok Cybersecurity.',
   sub: 'Post quantum security and high performance inference across edge, workstation, and datacenter deployments. The model and your data stay on hardware you own.',
   ctaText: 'avarok.net',
-  ctaUrl: 'https://avarok.net'
+  ctaUrl: 'https://avarok.net',
+  // A second line, kept to one sentence. The band sits above the hero on every
+  // page: it earns its height by saying what changed, not by explaining it.
+  // "In active development" is stated rather than implied — an operator who
+  // reads this and then finds an unfinished fleet manager was misled by us, not
+  // by their own optimism.
+  note: 'Sparkrun has been retired: Atlas now ships atlasctl, our own control plane for enterprise fleet management and telemetry. In active development.'
 };
 
 // --- nav (SSOT for both the desktop bar and the mobile drawer) ---------------


### PR DESCRIPTION
The announcement band carried one piece of news — the Avarok partnership. The
launcher change is a second, unrelated one.

Running them into a single sentence would read as one long claim about neither,
so this is a second row in the same band: quieter type, tighter padding, its own
top border, one sentence and one link.

> **New** — Sparkrun has been retired: Atlas now ships atlasctl, our own control
> plane for enterprise fleet management and telemetry. In active development.

**"In active development" is stated, not implied.** Someone who reads
"enterprise fleet management and telemetry" and then meets an unfinished control
plane was misled by us rather than by their own optimism.

Deliberately small: this band sits above the hero on every page, so every line
it gains pushes the actual product further down the screen. It is one row, one
sentence, and it does not touch the existing partnership line.

Site-only — nothing in `PERF_PATHS`, so no gate records are invalidated.