### PR TITLE
fix(ticker): bind the default timers, which throw in every real browser

### DIFF
--- a/site/src/lib/agent/ticker.js
+++ b/site/src/lib/agent/ticker.js
@@ -10,6 +10,27 @@
 // is all expressible without a single rune.
 
 /**
+ * The real timers, wrapped so they are called on the global object.
+ *
+ * NOT `{ setInterval, clearInterval }`. That object's properties hold the
+ * global functions, but calling `timers.setInterval(...)` invokes them with
+ * `this === timers` — and a browser's `setInterval` is a method of `Window`
+ * that WebIDL requires to be called on one. Chromium throws
+ * `TypeError: Illegal invocation` on the first acquire, which took out every
+ * clock-driven badge on the control page.
+ *
+ * Node and Bun's timers are plain functions and are not `this`-sensitive, so
+ * the unit tests passed against a default that could never work in the browser
+ * the code exists to run in. The arrow wrappers below call them on the global.
+ */
+function browserTimers() {
+  return {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (h) => clearInterval(h)
+  };
+}
+
+/**
  * Make a ticker that runs `onTick` every `ms` while at least one consumer holds
  * it.
  *
@@ -18,7 +39,7 @@
  * @param {{setInterval: Function, clearInterval: Function}} [timers] injected
  *   for tests, which must not wait a real second to observe a tick
  */
-export function makeTicker(onTick, ms, timers = { setInterval, clearInterval }) {
+export function makeTicker(onTick, ms, timers = browserTimers()) {
   let handle = null;
   let users = 0;
 

--- a/site/src/lib/agent/ticker.test.js
+++ b/site/src/lib/agent/ticker.test.js
@@ -86,3 +86,45 @@ test('it actually ticks while held', () => {
   f.fire();
   expect(n).toBe(2);
 });
+
+test('the default timers survive a this-sensitive global, as in every browser', () => {
+  // The bug this pins: `timers = { setInterval, clearInterval }` puts the
+  // globals on an object and then calls them as ITS methods. A browser's
+  // setInterval is a Window method that WebIDL requires to be called on a
+  // Window, so Chromium throws "Illegal invocation" on the first acquire and
+  // every clock-driven badge on the page stops.
+  //
+  // Node and Bun's timers are plain functions, so the default was untestable
+  // by accident — the runner could not see the failure the browser has. This
+  // replaces the globals with this-sensitive stand-ins, which is the contract
+  // the browser actually implements.
+  const realSet = globalThis.setInterval;
+  const realClear = globalThis.clearInterval;
+  let started = 0;
+  try {
+    // The real contract: WebIDL rejects a call whose `this` is some OTHER
+    // object. A bare call from an ES module passes `this === undefined`, which
+    // browsers accept — so modelling it as "must be globalThis" would fail a
+    // correct implementation.
+    const illegal = (t) => t !== undefined && t !== globalThis;
+    globalThis.setInterval = function (fn, ms) {
+      if (illegal(this)) throw new TypeError('Illegal invocation');
+      started += 1;
+      return 42;
+    };
+    globalThis.clearInterval = function (h) {
+      if (illegal(this)) throw new TypeError('Illegal invocation');
+    };
+
+    // No `timers` argument: the default is what is under test.
+    const t = makeTicker(() => {}, 1000);
+    const release = t.acquire();
+    expect(started).toBe(1);
+    expect(t.running()).toBe(true);
+    release();
+    expect(t.running()).toBe(false);
+  } finally {
+    globalThis.setInterval = realSet;
+    globalThis.clearInterval = realClear;
+  }
+});


### PR DESCRIPTION
## This is live on main

`makeTicker(onTick, ms, timers = { setInterval, clearInterval })` puts the global
functions on an object and then calls them as **that object's** methods. A
browser's `setInterval` is a `Window` method and WebIDL requires it to be called
on a Window — Chromium throws `TypeError: Illegal invocation` on the first
`acquire()`.

`useClock()` is held by every `NodeCard`, so on the deployed control page **the
first node card to mount throws**, and every clock-driven badge stops: "last seen
Ns ago" freezes, the stale marker never appears.

## Why the tests did not catch it

Node's and Bun's timers are plain functions and are not `this`-sensitive. The
suite passed against a default that could never work in the browser the code
exists to run in — the runner physically could not see the failure.

Found by a real-Chromium smoke run of the control page while building something
else, not by the suite.

## The regression test

Replaces the globals with stand-ins enforcing the real contract: reject a call
whose `this` is some **other object**, accept `undefined`, which is what a bare
call from an ES module passes and what browsers allow.

It fails against the old default and passes against the wrapped one. Worth
noting that my first version of the stand-in was too strict — it demanded
`this === globalThis` and so failed the *correct* implementation. A test that
models the contract wrongly is how the next person "fixes" working code, so the
comment in the test states what the contract actually is.

## Scope

Two files, no behaviour change beyond the fix. 182 site tests pass, build clean.
Site-only: nothing in `PERF_PATHS`, so no gate records are invalidated.