### PR TITLE
ci(site): actually run the site's unit tests

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -30,6 +30,28 @@ permissions:
   contents: read
 
 jobs:
+  unit:
+    name: Site unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # `src/lib` only: the e2e specs under `e2e/` need a browser and a served
+      # build, and are a separate concern from these.
+      - name: Run unit tests
+        run: bun test src/lib
+
   build:
     name: Build SvelteKit site
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The site's tests have never run in CI

181 unit tests on main, and the only site check is **Build SvelteKit site** —
which builds and does not test. A pull request that broke every test in
`src/lib` would have merged green.

This came to light chasing a browser-contract bug in `ticker.js` that reached
main and broke every clock-driven badge on the control page (#767). The unit
suite could not have caught *that* one — Bun's timers are not `this`-sensitive,
so the runner physically cannot see it — but nothing was checking the suite
either way, and every test written against these modules was protecting nothing.

## What this adds

One job, `Site unit tests`, running `bun test src/lib`.

`src/lib` only: the specs under `e2e/` need a browser and a served build, and
are a larger change worth doing separately.

## Verified it is not a no-op

`bun test src/lib` exits **1** with a deliberately failing test and **0** when
green, so the job fails for the reason it exists rather than passing silently.

Workflow-only change. Nothing in `PERF_PATHS`.