### PR TITLE
fix(control): tell an out-of-date operator which side is stale and what to run

### DIFF
--- a/site/src/lib/agent/client.svelte.js
+++ b/site/src/lib/agent/client.svelte.js
@@ -10,7 +10,8 @@ import {
   AGENT_URL,
   PROTOCOL_VERSION,
   describeError,
-  storedToken
+  storedToken,
+  versionAdvice
 } from './protocol.js';
 
 /** How long to wait for an agent before deciding there is not one. */
@@ -166,7 +167,11 @@ export class AgentClient {
       return this.#abandon(socket, 'unavailable');
     }
     if (PROTOCOL_VERSION < welcome.protocol_min || PROTOCOL_VERSION > welcome.protocol_max) {
-      this.message = `This page speaks protocol ${PROTOCOL_VERSION}; your agent speaks ${welcome.protocol_min}–${welcome.protocol_max}. Update whichever is older.`;
+      this.message = versionAdvice(
+        PROTOCOL_VERSION,
+        welcome.protocol_min,
+        welcome.protocol_max
+      ).message;
       return this.#abandon(socket, 'error');
     }
 

--- a/site/src/lib/agent/protocol.js
+++ b/site/src/lib/agent/protocol.js
@@ -101,3 +101,50 @@ export function describeError(error) {
       return error.code ?? 'The agent reported an unknown problem.';
   }
 }
+
+/**
+ * What to tell an operator whose agent and page disagree about the protocol.
+ *
+ * "Update whichever is older" was true and unhelpful: it named no command, and
+ * it made the operator work out which side was behind from two version numbers
+ * they have no reason to care about. Protocol 4 shipped to a fleet of agents
+ * that all speak something older, so this is now the first thing many people
+ * will see — it has to end with something they can run.
+ *
+ * The two directions have genuinely different remedies, which is why this does
+ * not just print both:
+ *
+ * - the AGENT is behind — reinstall it, which is one line;
+ * - the PAGE is behind — the browser is holding a cached bundle, and no amount
+ *   of updating the agent will fix it. That one is a hard reload.
+ *
+ * @param {number} page this bundle's `PROTOCOL_VERSION`
+ * @param {number} min the agent's lowest supported version
+ * @param {number} max the agent's highest
+ * @returns {{ok: true} | {ok: false, side: 'agent'|'page', message: string}}
+ */
+export function versionAdvice(page, min, max) {
+  if (!Number.isInteger(page) || !Number.isInteger(min) || !Number.isInteger(max)) {
+    // A malformed welcome is not a version mismatch, and guessing which side is
+    // behind from a non-number would name a remedy at random.
+    return {
+      ok: false,
+      side: 'agent',
+      message: 'The agent did not say which protocol it speaks, so this page cannot tell whether it is compatible. Reinstall the agent: curl -fsSL https://atlasinference.io/install.sh | sh'
+    };
+  }
+  if (page >= min && page <= max) return { ok: true };
+
+  if (page > max) {
+    return {
+      ok: false,
+      side: 'agent',
+      message: `Your agent is out of date — it speaks protocol ${min === max ? min : `${min}–${max}`}, this page speaks ${page}. Update it on that machine: curl -fsSL https://atlasinference.io/install.sh | sh`
+    };
+  }
+  return {
+    ok: false,
+    side: 'page',
+    message: `This page is out of date — it speaks protocol ${page}, your agent speaks ${min === max ? min : `${min}–${max}`}. Your browser is holding an old copy: reload with Ctrl-Shift-R (⌘-Shift-R on a Mac).`
+  };
+}

--- a/site/src/lib/agent/version.test.js
+++ b/site/src/lib/agent/version.test.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test, expect } from 'bun:test';
+import { versionAdvice } from './protocol.js';
+
+test('a version the agent supports is not a problem', () => {
+  expect(versionAdvice(4, 4, 4)).toEqual({ ok: true });
+  expect(versionAdvice(3, 1, 4)).toEqual({ ok: true });
+  expect(versionAdvice(1, 1, 4)).toEqual({ ok: true });
+});
+
+test('an out-of-date agent is named as the agent, with the line that fixes it', () => {
+  // The common case the day protocol 4 shipped: every existing agent speaks
+  // something older. "Update whichever is older" made the operator work out
+  // which side was behind from two numbers they have no reason to care about.
+  const a = versionAdvice(4, 1, 1);
+  expect(a.ok).toBe(false);
+  expect(a.side).toBe('agent');
+  expect(a.message).toContain('Your agent is out of date');
+  expect(a.message).toContain('install.sh');
+  // It has to say WHERE to run it — every hop of this product is a different
+  // machine, and the agent is not the one showing this page.
+  expect(a.message).toContain('on that machine');
+});
+
+test('a stale page is named as the page, because updating the agent cannot fix it', () => {
+  // A browser holding a cached bundle against a newer agent. Telling this
+  // operator to reinstall the agent sends them to the wrong machine to fix a
+  // problem that lives in their own tab.
+  const a = versionAdvice(3, 4, 4);
+  expect(a.ok).toBe(false);
+  expect(a.side).toBe('page');
+  expect(a.message).toContain('This page is out of date');
+  expect(a.message).toMatch(/reload/i);
+  expect(a.message).not.toContain('install.sh');
+});
+
+test('a single supported version reads as one number, not a range', () => {
+  expect(versionAdvice(4, 2, 2).message).toContain('protocol 2,');
+  expect(versionAdvice(4, 1, 3).message).toContain('1–3');
+});
+
+test('a welcome that carries no version is not guessed at', () => {
+  // Deciding which side is behind from a non-number would name a remedy at
+  // random, and half the time send the operator to the wrong machine.
+  for (const bad of [undefined, null, 'four', NaN, 1.5]) {
+    const a = versionAdvice(4, bad, bad);
+    expect(a.ok).toBe(false);
+    expect(a.message).toContain('did not say');
+  }
+});


### PR DESCRIPTION
The version-mismatch message read:

> This page speaks protocol 4; your agent speaks 1–1. Update whichever is older.

True, and it made the operator work out which side was behind from two numbers
they have no reason to care about, then guess at the remedy.

**Protocol 4 has just shipped** (#763 + atlas-recipes#63) to a fleet of agents
that all speak something older, so this is now the first thing many people will
see. It has to end with something they can run.

## Two directions, two different remedies

- **The agent is behind** → reinstall it, one line — and the message says to run
  it *on that machine*, because the agent is not the thing showing this page.
- **The page is behind** → the browser is holding a cached bundle, and no amount
  of updating the agent will fix it. That one is a hard reload.

Printing both would send half the readers to the wrong machine.

A welcome carrying no usable version is not guessed at either: deciding which
side is stale from a non-number would name a remedy at random.

## Verification

`versionAdvice` is pure and tested — 5 tests, including that the stale-page
branch never mentions the installer, and that a single supported version reads
as one number rather than a `2–2` range.

251 site tests pass, build clean. Site-only; nothing in `PERF_PATHS`.