### PR TITLE
ci(site): do not delete the old bundle out from under a live session

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -172,6 +172,20 @@ jobs:
           DEPLOY_PATH:     ${{ secrets.DEPLOY_PATH }}
         run: |
           PORT="${DEPLOY_SSH_PORT:-22}"
-          rsync -az --delete --chmod=D755,F644 \
+          # `--delete-delay`, not a bare `--delete`: rsync's default removes files
+          # AS IT GOES, so an old content-hashed chunk can be deleted while a
+          # visitor is still loading the previous index.html that references it —
+          # a 404 on a lazily-imported chunk, mid-session, for the duration of a
+          # deploy. Deferring the deletions to the end means the old bundle stays
+          # whole until the new one is entirely in place.
+          #
+          # It does not make the deploy atomic, and the ordering does not help:
+          # `--itemize-changes` shows rsync sending `index.html` BEFORE the
+          # `_app/` chunks it references, so a visitor can still fetch a document
+          # naming a chunk that has not landed. What the service worker's
+          # network-first documents plus its previous cache cover, they cover;
+          # this flag closes the half that is ours to close — never deleting the
+          # old bundle out from under a session before the new one exists.
+          rsync -az --delete-delay --chmod=D755,F644 \
             -e "ssh -p ${PORT}" \
             site/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_PATH}/"


### PR DESCRIPTION
The deploy ran `rsync -az --delete`. rsync's default removes files **as it
goes**, demonstrated with `--itemize-changes` on a fixture:

```
--delete                --delete-delay
>f index.html           >f index.html
*deleting  old.js       >f _app/new.js
>f _app/new.js          *deleting  old.js
```

An old content-hashed chunk is deleted **before its replacement arrives**. A
visitor mid-session on the previous bundle, whose page then lazily imports a
chunk, gets a 404 — for the duration of the deploy, on every deploy.

`--delete-delay` finds the deletions during the transfer and applies them at the
end, so the old bundle stays whole until the new one is entirely in place.

## What it does not fix, stated in the comment

It does not make the deploy atomic. The same itemized output shows `index.html`
going out **before** the `_app/` chunks it names, so a document can still
reference something that has not landed yet. The service worker's network-first
documents and its previous cache cover part of that; this flag closes the half
that is ours to close.

## A correction worth recording

My first version of that comment claimed `_app/` sorts before `index.html` in
ASCII and that the ordering therefore already protected us. The itemized output
says otherwise — the document goes first. Checked rather than reasoned about,
because the reasoning was wrong.

Workflow-only change; nothing in `PERF_PATHS`.