### PR TITLE
fix(a11y): the collapsed "soon" popover was never announced

### DIFF
--- a/site/src/lib/components/control/ActionsBar.svelte
+++ b/site/src/lib/components/control/ActionsBar.svelte
@@ -16,7 +16,7 @@
 
   import { VERBS, availability, onTarget, route, travelWarning } from '$lib/agent/verbs.js';
   import { refusal } from '$lib/agent/refusal.js';
-  import { placeholder, placeholdersFor } from '$lib/agent/placeholders.js';
+  import { placeholdersFor } from '$lib/agent/placeholders.js';
   import ComingSoon from './ComingSoon.svelte';
 
   let { fleet, node, nodes = [], solo = false, onverb, onlog, onstats } = $props();
@@ -28,7 +28,6 @@
 
   let confirmingStop = $state(false);
   let stopping = $state(false);
-  let soonOpen = $state(false);
 
   // The id, not the object: `node` is a new object on every 1Hz vitals event,
   // and an effect keyed on it would disarm the Stop confirm once a second —
@@ -138,27 +137,13 @@
     {#if chip.id === 'soon-menu'}
       <!-- Solo mode: the chips collapse into one, so a single-machine console
            never reads as a roadmap. The popover still names every missing
-           capability, one sentence each. -->
-      <span class="cs-wrap">
-        <button
-          type="button"
-          class="cs-btn cs-chip"
-          aria-haspopup="dialog"
-          aria-expanded={soonOpen}
-          onclick={() => (soonOpen = !soonOpen)}
-          onkeydown={(e) => e.key === 'Escape' && (soonOpen = false)}
-        >
-          <span class="cs-label">soon ▾</span>
-        </button>
-        {#if soonOpen}
-          <div class="cs-pop" role="dialog" aria-label="Coming soon" tabindex="-1">
-            {#each chip.collapsed as e (e.id)}
-              <p class="cs-text"><strong>{placeholder(e.id).label}</strong> — {placeholder(e.id).soon}</p>
-            {/each}
-            <button type="button" class="cs-close" onclick={() => (soonOpen = false)}>Close</button>
-          </div>
-        {/if}
-      </span>
+           capability, one sentence each.
+
+           `ComingSoon` rather than a second popover written here: this one was
+           hand-rolled and skipped the whole ceremony — the dialog never took
+           focus, so it was never announced; Tab left it; Escape only worked
+           while the BUTTON still had focus; and nothing closed it on click-out. -->
+      <ComingSoon ids={chip.collapsed.map((e) => e.id)} label={chip.label} kind="chip" />
     {:else}
       <ComingSoon id={chip.id} kind="chip" />
     {/if}

--- a/site/src/lib/components/control/ComingSoon.svelte
+++ b/site/src/lib/components/control/ComingSoon.svelte
@@ -19,12 +19,25 @@
 
   let {
     /** A registered placeholder id — unknown ids throw in `placeholder()`. */
-    id,
+    id = null,
+    /**
+     * Several ids, for the solo-mode chip that collapses the whole set into
+     * one. The alternative was a second popover hand-rolled in `ActionsBar`,
+     * and it was: a `role="dialog"` that never took focus, trapped no Tab and
+     * closed on no click-out. A dialog a screen reader is never moved into is
+     * not announced at all, so the "honest about what is missing" chip was the
+     * one placeholder nobody could read.
+     */
+    ids = null,
+    /** Button text, when the collapsed chip names the group rather than an entry. */
+    label = null,
     /** 'chip' (actions bar, command strip, alert lane) or 'tile' (I/O strip). */
     kind = 'chip'
   } = $props();
 
-  const entry = $derived(placeholder(id));
+  const entries = $derived((ids ?? [id]).map(placeholder));
+  const entry = $derived(entries[0]);
+  const collapsed = $derived(Array.isArray(ids));
 
   let open = $state(false);
   let btn = $state(null);
@@ -81,20 +94,28 @@
     onclick={() => (open ? close(true) : (open = true))}
     onkeydown={onBtnKey}
   >
-    <span class="cs-label">{entry.label}</span>
-    <span class="cs-chip">soon</span>
+    <span class="cs-label">{label ?? entry.label}</span>
+    {#if !collapsed}<span class="cs-chip">soon</span>{/if}
   </button>
 
   {#if open}
     <div
       class="cs-pop"
       role="dialog"
-      aria-label="{entry.label} — coming soon"
+      aria-label={collapsed ? 'Coming soon' : `${entry.label} — coming soon`}
       tabindex="-1"
       bind:this={pop}
       onkeydown={onPopKey}
     >
-      <p class="cs-text">{entry.soon}</p>
+      {#if collapsed}
+        <!-- Each one named, because collapsing them is a layout decision and
+             must not cost the operator the list. -->
+        {#each entries as e (e.id)}
+          <p class="cs-text"><strong>{e.label}</strong> — {e.soon}</p>
+        {/each}
+      {:else}
+        <p class="cs-text">{entry.soon}</p>
+      {/if}
       <button type="button" class="cs-close" bind:this={closeBtn} onclick={() => close(true)}>
         Close
       </button>


### PR DESCRIPTION
Deferred from the control-plane review; unblocked now #772 has landed.

`ActionsBar` hand-rolled a second popover for solo mode instead of using `ComingSoon`, and skipped the entire ceremony that component exists to perform:

- the `role="dialog"` **never received focus**, so a screen reader was never moved into it and never announced it — the chip whose whole job is being honest about what is missing was the one placeholder nobody could read;
- **Tab left** the dialog instead of cycling inside it;
- **Escape was bound to the button**, so it stopped working the moment the operator reached the dialog;
- nothing closed it on **click-out**.

`ComingSoon` now accepts `ids` + `label`, so the collapsed chip runs the same ceremony as every other placeholder. Removing the duplicate rather than teaching it the ceremony twice — duplication is why it drifted. The label comes from `chip.label` in the registry, which already owns it.

411 tests, build clean.