### PR TITLE
fix(bfcl): prove the scorer imports before generating 995 responses

### DIFF
--- a/crates/atlas-plugin/assets/bfcl/score.py
+++ b/crates/atlas-plugin/assets/bfcl/score.py
@@ -111,7 +111,31 @@ def _read_jsonl(path):
                 yield json.loads(line)
 
 
+def _selftest() -> int:
+    """Import what scoring imports, and nothing else.
+
+    The AST checker is imported INSIDE `_score_ast`, so nothing at module
+    scope touches `bfcl_eval` — `score.py --help` succeeds against a venv that
+    cannot score at all. That is how a missing transitive dependency
+    (`qwen_agent` -> `soundfile`) stayed invisible until after 995 responses
+    had been generated: an hour and a half of inference, then an import error,
+    and no gate record because the run ended Failed.
+
+    Kept here rather than as a list of module names in the provisioner, so it
+    cannot drift from what the scorer actually needs.
+    """
+    from bfcl_eval.constants.enums import Language  # noqa: F401
+    from bfcl_eval.eval_checker.ast_eval.ast_checker import ast_checker  # noqa: F401
+
+    return 0
+
+
 def main() -> int:
+    # Handled before the parser is built, so `--dataset`/`--responses` keep
+    # argparse's own `required=True` contract: a scoring invocation that omits
+    # them must still fail exactly as it always has.
+    if "--selftest" in sys.argv[1:]:
+        return _selftest()
     ap = argparse.ArgumentParser()
     ap.add_argument("--dataset", required=True)
     ap.add_argument("--responses", required=True)

--- a/crates/atlas-plugin/src/benchmarks/bfcl/provision.rs
+++ b/crates/atlas-plugin/src/benchmarks/bfcl/provision.rs
@@ -113,6 +113,34 @@ pub async fn ensure(store: &ArtifactStore, handle: &PluginHandle) -> Result<Arti
     handle.status("BFCL: downloading bfcl-eval (needs network)");
     python::pip_install(&interpreter, &dir.join("requirements.txt")).await?;
 
+    // Prove the SCORER can import before spending an hour and a half
+    // generating responses for it. `pip install` succeeding is not the same
+    // claim: bfcl-eval pulls `qwen_agent`, which imports `soundfile`, which
+    // the pinned requirements did not carry — and because the AST checker is
+    // imported inside a function, nothing at module scope touched it. A run
+    // on 2026-08-28 generated all 995 responses, failed here, and wrote no
+    // gate record, because a record is evidence a benchmark RAN.
+    //
+    // `--selftest` lives in `score.py` so the list of what scoring needs
+    // cannot drift from what scoring does.
+    handle.status("BFCL: checking the scorer can import");
+    python::run(
+        &interpreter,
+        &[
+            dir.join("score.py")
+                .to_str()
+                .context("artifact path is not valid UTF-8")?,
+            "--selftest",
+        ],
+        Some(&dir),
+    )
+    .await
+    .context(
+        "the BFCL scorer cannot import its dependencies. Delete \
+         ~/.atlas/artifacts/bfcl to re-provision; if it recurs, a transitive \
+         dependency is missing from requirements.txt",
+    )?;
+
     handle.status("BFCL: materializing the single-turn dataset");
     let out = python::run(
         &interpreter,
@@ -220,6 +248,23 @@ mod tests {
             .output()
             .unwrap();
         assert_eq!(out.status.code(), Some(2), "provision.py accepted no --out");
+
+        // `--selftest` must exist and must be the thing provisioning calls.
+        // Against a bare system python it will FAIL (no bfcl-eval), which is
+        // the point: the exit code has to distinguish "cannot import" from
+        // "argument not recognised". Argparse answers an unknown flag with 2.
+        let selftest = std::process::Command::new(python())
+            .arg(&scorer)
+            .arg("--selftest")
+            .output()
+            .unwrap();
+        assert_ne!(
+            selftest.status.code(),
+            Some(2),
+            "score.py does not recognise --selftest, so provisioning's check \
+             would pass for the wrong reason: {}",
+            String::from_utf8_lossy(&selftest.stderr)
+        );
         let stderr = String::from_utf8(out.stderr).unwrap();
         assert!(
             stderr.contains("the following arguments are required: --out"),

--- a/scripts/bench_per_model.sh
+++ b/scripts/bench_per_model.sh
@@ -242,7 +242,10 @@ run_ep2_model() {
 
 log "Building ${IMAGE} (multi-target, all models)..."
 sudo docker build -f docker/gb10/Dockerfile -t "$IMAGE" "$REPO_ROOT" 2>&1 | tail -5
-if [ $? -ne 0 ]; then
+# PIPESTATUS[0], not $?: after a pipeline `$?` is `tail`'s status, and tail
+# succeeds on any input. A failed build passed this check and the script went
+# on to benchmark whatever stale image was still tagged.
+if [ "${PIPESTATUS[0]}" -ne 0 ]; then
   log "ERROR: Build failed for ${IMAGE}"
   exit 1
 fi

--- a/scripts/queue-perf-pr.sh
+++ b/scripts/queue-perf-pr.sh
@@ -21,6 +21,19 @@
 # This script performs step 1 and prints the step-2 campaign command; the
 # campaign itself needs a GPU box and is deliberately not run from here.
 #
+# THREE TRAPS the printed command now spells out, each of which cost hours on
+# 2026-08-28:
+#   * ATLAS_HOME must be writable. If it is not, every gate fails instantly
+#     with "recipe ... is not in the local index (0 cached)" and never says
+#     why.
+#   * The TTFT gates need TWO runs each on a box with no stored baseline. The
+#     first one only creates the baseline and records `info`, which the gate
+#     does not accept — so a ten-gate campaign silently comes back eight.
+#   * The exit code is not the evidence. A BFCL run generated all 995
+#     responses, died in scoring, and correctly wrote NO record; a driver that
+#     trusted `rc` called that a pass. Ask
+#     `--pull-request-gate-check` what was actually recorded.
+#
 # Usage: scripts/queue-perf-pr.sh <branch>
 set -euo pipefail
 BRANCH="${1:?usage: queue-perf-pr.sh <branch>}"
@@ -34,9 +47,28 @@ git push origin "HEAD:$BRANCH"
 echo
 echo "FROZEN: $BRANCH @ $SHA"
 echo "Now run, on a GPU box with the repo checked out at exactly $SHA:"
-echo '  for g in ttft-cold-gate ttft-warm-gate vision-fidelity ssm-state-poisoning-gate \'
-echo '           decode-floor concurrency-sweep video-fidelity bfcl-subset \'
-echo '           bfcl-subset-echolp agentic-webserver; do'
+echo
+echo '  # ATLAS_HOME must be WRITABLE. The gates read the recipe index and the'
+echo '  # same-box baselines from $ATLAS_HOME/.., default ~/.atlas. If that'
+echo '  # directory cannot be created, every gate dies instantly with'
+echo '  # "recipe ... is not in the local index (0 cached)" and the cause is'
+echo '  # nowhere in the message.'
+echo '  export ATLAS_HOME=${ATLAS_HOME:-$HOME/.atlas}'
+echo
+echo '  # The TTFT gates compare against a stored SAME-BOX baseline. On a box'
+echo '  # that has none, run 1 only CREATES it and records verdict `info`,'
+echo '  # which the gate does not accept. They need two runs each; listing'
+echo '  # them twice is the whole fix.'
+echo '  for g in decode-floor vision-fidelity video-fidelity \'
+echo '           ssm-state-poisoning-gate concurrency-sweep agentic-webserver \'
+echo '           ttft-cold-gate ttft-cold-gate ttft-warm-gate ttft-warm-gate \'
+echo '           bfcl-subset bfcl-subset-echolp; do'
 echo '    timeout 21600 ./target/release/spark benchmark run "$g" --pull-request-gate --yes'
+echo '    rc=$?   # capture IMMEDIATELY: a $(date) in the next line resets it'
+echo '    echo "$g rc=$rc"'
 echo '  done'
+echo
+echo '  # rc is a hint, not the evidence. Check what was actually recorded:'
+echo "  ./target/release/spark benchmark --pull-request-gate-check --pr <N>"
+echo
 echo "then commit .benchmarks/ and push, wait for green, and queue the PR alone."

--- a/scripts/test-minimax-ep2.sh
+++ b/scripts/test-minimax-ep2.sh
@@ -126,7 +126,10 @@ python3 "$ATLAS_ROOT/tests/single_gpu_suite.py" \
   --model "$MODEL" \
   --output "$OUT_JSON" \
   2>&1 | tee "$LOG"
-STATUS=$?
+# PIPESTATUS[0], not $?: `$?` after a pipeline is the LAST command's status,
+# which here is `tee` — and tee succeeds whenever it can write the log. A
+# failing suite therefore reported "exit: 0" and the run read as a pass.
+STATUS=${PIPESTATUS[0]}
 set -e
 
 echo ""


### PR DESCRIPTION
A gate run tonight generated **all 995 responses**, then died in scoring:

```
ModuleNotFoundError: No module named 'soundfile'
```

`soundfile` is a transitive import of `qwen_agent`, which bfcl-eval pulls, and the pinned requirements never carried it. The gate then did the right thing and wrote **no record** — *"a record is evidence that a benchmark RAN"* — so 1.6 h of inference produced nothing.

Provisioning already checks python, the venv, and that `pip install` succeeds. **None of those is the claim that matters.** The AST checker is imported *inside* `_score_ast`, so nothing at module scope touches bfcl-eval and `score.py --help` exits 0 against a venv that cannot score at all. Measured on the broken venv: `--help` → exit 0, `--selftest` → exit 1.

`score.py --selftest` performs exactly the imports scoring performs, and provisioning runs it as a step. The list lives in `score.py` so it cannot drift from what the scorer does — a list of module names in the provisioner would be a second copy nobody updates.

`--selftest` is handled *before* the parser is built, so `--dataset`/`--responses` keep argparse's `required=True` contract: an existing test asserts a scoring invocation omitting them fails exactly as it always has, and it still does. That test now also asserts `--selftest` is **recognised** — argparse answers an unknown flag with 2, so without it the new provisioning step would pass for the wrong reason.