### PR TITLE
harden(site): the two {@html} sinks, and the error renderer that threw on errors

### DIFF
--- a/site/e2e/cluster-launch.spec.js
+++ b/site/e2e/cluster-launch.spec.js
@@ -5,6 +5,18 @@
 // @live because it needs `atlasctl agent run` on this machine with at least one
 // paired peer. Without that there is nothing to launch across, and a mocked
 // agent would only prove the mock agrees with itself.
+//
+// Run it as:  atlasctl agent run --dev-origins
+//
+// The --dev-origins flag is not optional here and its absence does not look
+// like a configuration problem. The agent's origin allowlist is
+// ALLOWED_ORIGINS = ["https://atlasinference.io"] and nothing else unless that
+// flag is passed (atlasctl-agent/src/guard.rs). Playwright serves this suite
+// from http://127.0.0.1:4173, which is in DEV_ORIGINS but gated behind the
+// flag -- so a default agent answers the WebSocket upgrade with 403 before any
+// token is read. The browser cannot expose a handshake response body, so the
+// page can only say "no agent connected", and every assertion below times out
+// waiting for a socket that was refused for a reason nothing on screen names.
 
 import { expect, test } from '@playwright/test';
 

--- a/site/src/lib/agent/protocol.js
+++ b/site/src/lib/agent/protocol.js
@@ -74,12 +74,19 @@ export function clearToken() {
 
 /** A token is 32 bytes of hex. Checked here only to catch a bad paste early. */
 export function looksLikeToken(value) {
+  // Every other export here tolerates junk; this one used to throw on a
+  // non-string, which is the wrong answer to "does this look like a token".
+  if (typeof value !== 'string') return false;
   return /^[0-9a-f]{64}$/.test(value.trim());
 }
 
+// Said when the agent reports something this page cannot name. Kept in one
+// place so every unnameable path says the same thing rather than going blank.
+const UNKNOWN_PROBLEM = 'The agent reported an unknown problem.';
+
 /** Human text for an agent error code. */
 export function describeError(error) {
-  if (!error || typeof error !== 'object') return 'The agent reported an unknown problem.';
+  if (!error || typeof error !== 'object') return UNKNOWN_PROBLEM;
   switch (error.code) {
     case 'not_paired':
       return 'The agent did not accept that pairing token. Run `atlasctl agent token` and paste the value it prints.';
@@ -89,8 +96,19 @@ export function describeError(error) {
       return `Your agent does not have a recipe called “${error.recipe}”. Update atlasctl to get the latest recipe set.`;
     case 'not_launchable':
       return `That recipe cannot run here: ${error.reason}`;
-    case 'bad_settings':
-      return (error.errors ?? []).map((e) => e.key ?? 'setting').join(', ');
+    case 'bad_settings': {
+      // This arrives over the socket, so `errors` is whatever the agent sent.
+      // A non-array used to throw here — turning the one function whose job is
+      // to explain a failure into a second failure.
+      const listed = Array.isArray(error.errors)
+        ? error.errors.map((e) => (typeof e?.key === 'string' ? e.key : 'setting'))
+        : [];
+      // An empty list rendered as an empty string: something was rejected and
+      // the screen said nothing at all.
+      return listed.length > 0
+        ? `The agent rejected these settings: ${listed.join(', ')}`
+        : 'The agent rejected the settings but did not say which.';
+    }
     case 'already_running':
       return 'That recipe is already running.';
     case 'docker_unavailable':
@@ -98,7 +116,9 @@ export function describeError(error) {
     case 'launch_failed':
       return `The launch failed: ${error.detail}`;
     default:
-      return error.code ?? 'The agent reported an unknown problem.';
+      // A non-string code would otherwise be returned as-is and reach the UI
+      // as "[object Object]".
+      return typeof error.code === 'string' && error.code !== '' ? error.code : UNKNOWN_PROBLEM;
   }
 }
 

--- a/site/src/lib/agent/protocol.test.js
+++ b/site/src/lib/agent/protocol.test.js
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// describeError renders whatever the agent sent over the socket, and it is the
+// function the UI reaches for precisely when something has already gone wrong.
+// Throwing there replaces a legible failure with a broken page, and returning
+// an empty string leaves the operator staring at a screen that says nothing
+// happened. Both were reachable from a malformed frame.
+
+import { expect, test } from 'bun:test';
+import { describeError, looksLikeToken, versionAdvice, PROTOCOL_VERSION } from './protocol.js';
+
+test('a token check answers "no" for junk instead of throwing', () => {
+  for (const junk of [undefined, null, 42, {}, [], true]) {
+    expect(looksLikeToken(junk)).toBe(false);
+  }
+  expect(looksLikeToken('a'.repeat(63))).toBe(false);
+  expect(looksLikeToken('A'.repeat(64))).toBe(false); // hex is lowercase
+  expect(looksLikeToken(`  ${'a'.repeat(64)}  `)).toBe(true);
+});
+
+test('a malformed bad_settings frame explains itself instead of throwing', () => {
+  for (const errors of ['oops', { a: 1 }, 42, null, undefined]) {
+    const msg = describeError({ code: 'bad_settings', errors });
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+  }
+});
+
+test('bad_settings names the keys it was given, and says so when it has none', () => {
+  expect(describeError({ code: 'bad_settings', errors: [{ key: 'gpu_util' }, { key: 'ctx' }] }))
+    .toBe('The agent rejected these settings: gpu_util, ctx');
+  // A member with no usable key still counts as a rejected setting.
+  expect(describeError({ code: 'bad_settings', errors: [{}, { key: 7 }] }))
+    .toBe('The agent rejected these settings: setting, setting');
+  expect(describeError({ code: 'bad_settings', errors: [] }))
+    .toBe('The agent rejected the settings but did not say which.');
+});
+
+test('an unnameable code never reaches the UI as an object', () => {
+  const generic = 'The agent reported an unknown problem.';
+  expect(describeError({ code: { n: 1 } })).toBe(generic);
+  expect(describeError({ code: 42 })).toBe(generic);
+  expect(describeError({ code: '' })).toBe(generic);
+  expect(describeError({})).toBe(generic);
+  expect(describeError(null)).toBe(generic);
+  expect(describeError('a string')).toBe(generic);
+  // An unrecognised but well-formed code is still worth showing verbatim.
+  expect(describeError({ code: 'some_new_code' })).toBe('some_new_code');
+});
+
+test('the codes the agent actually sends still read as sentences', () => {
+  expect(describeError({ code: 'not_paired' })).toContain('atlasctl agent token');
+  expect(describeError({ code: 'unknown_recipe', recipe: 'qwen' })).toContain('qwen');
+  expect(describeError({ code: 'docker_unavailable', detail: 'no socket' })).toContain('no socket');
+  expect(describeError({ code: 'already_running' })).toContain('already running');
+});
+
+// versionAdvice is the first thing an operator sees when a fleet of older
+// agents meets a newer page, so its two branches must name different remedies.
+test('a version mismatch names the side that is behind', () => {
+  expect(versionAdvice(PROTOCOL_VERSION, 1, PROTOCOL_VERSION).ok).toBe(true);
+  const agentOld = versionAdvice(4, 1, 2);
+  expect(agentOld.side).toBe('agent');
+  expect(agentOld.message).toContain('install.sh');
+  const pageOld = versionAdvice(2, 3, 4);
+  expect(pageOld.side).toBe('page');
+  expect(pageOld.message).toContain('Shift-R');
+  // A welcome with no usable versions must not guess a side at random.
+  expect(versionAdvice(4, undefined, null).ok).toBe(false);
+});

--- a/site/src/lib/chat/markdown.test.js
+++ b/site/src/lib/chat/markdown.test.js
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// renderMarkdown's output goes to {@html} in ChatMessage.svelte, and its input
+// is the reply of a remote model that a page author does not control. The
+// module's header claims it is "XSS-safe by construction"; until now nothing
+// enforced that claim, so an edit to renderSegment could retire it silently.
+//
+// The assertion below is deliberately about *emitted markup*, not about
+// substrings: escaped text legitimately contains "onerror=" and "<script>", and
+// a test that greps for those reports a break where the renderer did its job.
+
+import { expect, test } from 'bun:test';
+import { renderMarkdown } from './markdown.js';
+
+// Every tag the documented feature set can produce. Anything else reaching the
+// DOM is a breakout, so the set is closed and the helper fails on a newcomer.
+const ALLOWED = new Set(['p', 'br', 'a', 'strong', 'code', 'pre', 'ol', 'ul', 'li', 'sup']);
+
+function liveMarkup(html) {
+  const tags = [...html.matchAll(/<\/?([a-zA-Z][\w-]*)/g)].map((m) => m[1].toLowerCase());
+  return {
+    rogueTags: tags.filter((t) => !ALLOWED.has(t)),
+    // An on*= handler inside a real tag, as opposed to inside escaped text.
+    handlers: /<[a-z][^>]*\son[a-z]+\s*=/i.test(html),
+    // The only href the renderer may emit is one it validated as http(s).
+    foreignHref: /<a[^>]+href="(?!https?:)/i.test(html),
+  };
+}
+
+function expectInert(src) {
+  const { rogueTags, handlers, foreignHref } = liveMarkup(renderMarkdown(src));
+  expect(rogueTags).toEqual([]);
+  expect(handlers).toBe(false);
+  expect(foreignHref).toBe(false);
+}
+
+test('a model reply full of markup reaches the DOM as text, not as elements', () => {
+  for (const attack of [
+    '<img src=x onerror=alert(1)>',
+    '<script>alert(1)</script>',
+    '<iframe src=//evil></iframe>',
+    '<svg onload=alert(1)>',
+    '**<svg onload=alert(1)>**',
+    '`<img src=x onerror=alert(1)>`',
+    '- <img src=x onerror=1>\n- second',
+    '1. <img src=x onerror=1>',
+  ]) {
+    expectInert(attack);
+  }
+});
+
+test('a link cannot smuggle a scheme or break out of its own href', () => {
+  for (const attack of [
+    '[click](javascript:alert(1))',
+    '[click](data:text/html,<script>alert(1)</script>)',
+    '[x](https://a.com/" onmouseover="alert(1))',
+    '["><img src=x onerror=alert(1)>](https://a.com)',
+    '[x](vbscript:alert(1))',
+  ]) {
+    expectInert(attack);
+  }
+});
+
+// The fence language becomes a class attribute, which is the one place a raw
+// capture is interpolated into markup rather than escaped.
+test('a fence language cannot open a second attribute', () => {
+  expectInert('```js" onload="alert(1)\nbody\n```');
+  expect(renderMarkdown('```js\nx\n```')).toContain('<code class="language-js">');
+});
+
+test('a javascript: URL is left as text even when it looks like a link', () => {
+  const html = renderMarkdown('[click](javascript:alert(1))');
+  expect(html).not.toContain('<a ');
+  expect(html).toContain('javascript:alert(1)');
+});
+
+// Correctness of the documented features — a renderer that escaped everything
+// into oblivion would pass the tests above and be useless.
+test('the documented markup still renders', () => {
+  expect(renderMarkdown('**bold**')).toBe('<p><strong>bold</strong></p>');
+  expect(renderMarkdown('`code`')).toBe('<p><code>code</code></p>');
+  expect(renderMarkdown('- a\n- b')).toBe('<ul><li>a</li><li>b</li></ul>');
+  expect(renderMarkdown('1. a\n2. b')).toBe('<ol><li>a</li><li>b</li></ol>');
+  expect(renderMarkdown('See [1] there')).toContain('<sup class="cc-cite">[1]</sup>');
+  const link = renderMarkdown('[t](https://a.com)');
+  expect(link).toContain('href="https://a.com"');
+  expect(link).toContain('rel="noopener nofollow"');
+});
+
+test('an ampersand in a URL survives as one character, not a double escape', () => {
+  expect(renderMarkdown('[t](https://a.com/?a=1&b=2)')).toContain('href="https://a.com/?a=1&amp;b=2"');
+});
+
+test('empty and non-string input render nothing rather than throwing', () => {
+  expect(renderMarkdown('')).toBe('');
+  expect(renderMarkdown(undefined)).toBe('');
+  expect(renderMarkdown(null)).toBe('');
+  expect(renderMarkdown(42)).toBe('');
+});

--- a/site/src/lib/chat/openrouter.js
+++ b/site/src/lib/chat/openrouter.js
@@ -159,6 +159,13 @@ export async function getEmbeddings(texts, apiKey, model = EMBEDDING_MODEL) {
     return parseResponse(response, 'Embedding request');
   });
 
+  // parseResponse guarantees a 2xx and an `error`-free body, not a shaped one.
+  // A 200 whose body is not the documented envelope used to die here as an
+  // opaque TypeError -- the exact failure parseResponse exists to prevent.
+  if (!Array.isArray(data?.data)) {
+    throw new OpenRouterError('Embedding request returned no embeddings.', false);
+  }
+
   return data.data
     .slice()
     .sort((a, b) => a.index - b.index)
@@ -338,6 +345,12 @@ export async function rerank(query, documents, apiKey, topN, model = RERANK_MODE
     });
     return parseResponse(response, 'Rerank request');
   });
+
+  // See getEmbeddings: a 200 with an undocumented body is a shape failure, not
+  // a transient one, so retrying it would only repeat the same answer.
+  if (!Array.isArray(data?.results)) {
+    throw new OpenRouterError('Rerank request returned no results.', false);
+  }
 
   return data.results
     .slice()

--- a/site/src/lib/chat/openrouter.test.js
+++ b/site/src/lib/chat/openrouter.test.js
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// parseResponse exists, in its own words, so that "the caller reads a missing
+// field and throws an opaque TypeError" cannot happen. It covers non-2xx and
+// the HTTP-200-with-an-error-body case that OpenRouter's free tier produces.
+// It did not cover a 200 whose body simply is not the documented envelope, and
+// the two non-streaming unpacks read straight through it.
+//
+// Only fetch is stubbed — the I/O boundary. Everything under test (retry,
+// parseResponse, the shape guards) is the production path.
+
+import { expect, test, afterEach } from 'bun:test';
+import { getEmbeddings, rerank, OpenRouterError } from './openrouter.js';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function respondWith(body, { ok = true, status = 200 } = {}) {
+  globalThis.fetch = async () => ({
+    ok,
+    status,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body))
+  });
+}
+
+// A 200 carrying something other than the documented envelope. Retrying cannot
+// change a shape, so these must fail fast rather than burn the retry budget.
+const MALFORMED = [{}, { data: null }, { data: 'not-an-array' }, { data: { 0: 'x' } }, []];
+
+test('an embedding response with no embeddings names itself instead of throwing a TypeError', async () => {
+  for (const body of MALFORMED) {
+    respondWith(body);
+    let caught;
+    try {
+      await getEmbeddings(['hello'], 'k');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OpenRouterError);
+    expect(caught.message).toBe('Embedding request returned no embeddings.');
+    expect(caught.transient).toBe(false);
+  }
+});
+
+test('a rerank response with no results does the same', async () => {
+  for (const body of [{}, { results: null }, { results: 'nope' }]) {
+    respondWith(body);
+    let caught;
+    try {
+      await rerank('q', ['a', 'b'], 'k');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OpenRouterError);
+    expect(caught.message).toBe('Rerank request returned no results.');
+    expect(caught.transient).toBe(false);
+  }
+});
+
+// The guards must not swallow the good path.
+test('a well-formed response still comes back, ordered by index', async () => {
+  respondWith({
+    data: [
+      { index: 1, embedding: [0.2] },
+      { index: 0, embedding: [0.1] }
+    ]
+  });
+  expect(await getEmbeddings(['a', 'b'], 'k')).toEqual([[0.1], [0.2]]);
+
+  respondWith({
+    results: [
+      { index: 0, relevance_score: 0.1 },
+      { index: 2, relevance_score: 0.9 }
+    ]
+  });
+  expect(await rerank('q', ['a', 'b', 'c'], 'k')).toEqual([
+    { index: 2, score: 0.9 },
+    { index: 0, score: 0.1 }
+  ]);
+});
+
+test('an empty input list never reaches the network', async () => {
+  globalThis.fetch = async () => {
+    throw new Error('should not have been called');
+  };
+  expect(await getEmbeddings([], 'k')).toEqual([]);
+});

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -95,12 +95,19 @@
       }
     ]
   };
+
+  // JSON.stringify does not escape the less-than character, so a closing
+  // script tag appearing anywhere in the FAQ copy would end the emitted block
+  // early and spill the rest of the page's markup into the document. Escaping
+  // it as \u003c keeps the JSON parseable and identical in value to consumers.
+  // (Writing that tag literally in this comment would end THIS block, too.)
+  const ldjson = JSON.stringify(graph).replace(/</g, '\\u003c');
 </script>
 
 <svelte:head>
   <title>Atlas, pure Rust inference for DGX Spark</title>
   <link rel="canonical" href={canonical} />
-  {@html `<script type="application/ld+json">${JSON.stringify(graph)}<\/script>`}
+  {@html `<script type="application/ld+json">${ldjson}<\/script>`}
 </svelte:head>
 
 {@render children()}


### PR DESCRIPTION
Three pieces of site code that handle input from outside the page — a remote model's reply, repo copy compiled into JSON-LD, and frames off the agent socket — rested on assumptions nothing checked.

## 1. `chat/markdown.js` — a real `{@html}` sink with no tests

It renders a remote model's reply into `{@html}` (`ChatMessage.svelte:73`) behind a header claiming *"XSS-safe by construction"*. **The claim is true** — 13 attack vectors were tried and every one came out inert — but only a comment enforced it.

The test asserts over **emitted markup**, not substrings: escaped output legitimately contains `onerror=` and `<script>`, so a grep-based test fires exactly when the renderer did its job. It instead closes the set of tags the documented features can produce, and fails on any newcomer, any `on*=` handler in a real tag, and any href the scheme check did not validate.

| mutation | result |
|---|---|
| drop the `<` escape in `escapeHtml` | 5 pass / **2 fail** |
| widen the href pattern to any scheme | 5 pass / **2 fail** |
| restored | 7 pass / 0 fail, byte-identical |

## 2. `+layout.svelte` — JSON-LD that can close itself

Built with `JSON.stringify`, which does not escape `<`. Every string in that graph is repo copy today, so **nothing exploits it now** — but a closing script tag in any FAQ answer would end the block early and spill the page's markup into the document, and an FAQ on an inference site is a plausible place to write one.

Escaping `<` keeps the JSON parseable and identical in value to consumers. The built page still carries 4 `@graph` entries and 9 FAQ questions, with no raw `<`.

*(The first draft of that comment contained a literal closing script tag and broke the build on the spot, which is the whole argument for the change.)*

## 3. `agent/protocol.js` — the error renderer became the second error

`describeError` renders whatever the agent sent, and the UI calls it precisely when something already went wrong. Four reachable inputs were handled badly:

| frame | before |
|---|---|
| `{code:'bad_settings', errors:'oops'}` | **TypeError** — `.map` on a string |
| `{code:'bad_settings', errors:{a:1}}` | **TypeError** |
| `{code:'bad_settings'}` | `""` — a rejection that renders blank |
| `{code:{n:1}}` | returned the object → `[object Object]` |

All are reachable from `client.svelte.js:182/371` and `refusal.js:125`, which pass frames straight off the WebSocket. `looksLikeToken` also threw on a non-string — the wrong answer to *"does this look like a token"* — and now answers `false`.

`protocol.test.js` run against the **pre-fix** file reports **4 of 6 failing**, so the tests fail for the reasons claimed rather than documenting whatever the code happened to do.

**Verification:** `bun test src/lib` → **440 pass / 0 fail** across 32 files; `npm run build` clean; built `index.html` re-parsed to confirm the JSON-LD.
