### PR TITLE
fix(scripts): read the command's exit status, and print the traps a campaign hits

### DIFF
--- a/scripts/bench_per_model.sh
+++ b/scripts/bench_per_model.sh
@@ -242,7 +242,10 @@ run_ep2_model() {
 
 log "Building ${IMAGE} (multi-target, all models)..."
 sudo docker build -f docker/gb10/Dockerfile -t "$IMAGE" "$REPO_ROOT" 2>&1 | tail -5
-if [ $? -ne 0 ]; then
+# PIPESTATUS[0], not $?: after a pipeline `$?` is `tail`'s status, and tail
+# succeeds on any input. A failed build passed this check and the script went
+# on to benchmark whatever stale image was still tagged.
+if [ "${PIPESTATUS[0]}" -ne 0 ]; then
   log "ERROR: Build failed for ${IMAGE}"
   exit 1
 fi

--- a/scripts/queue-perf-pr.sh
+++ b/scripts/queue-perf-pr.sh
@@ -21,6 +21,19 @@
 # This script performs step 1 and prints the step-2 campaign command; the
 # campaign itself needs a GPU box and is deliberately not run from here.
 #
+# THREE TRAPS the printed command now spells out, each of which cost hours on
+# 2026-08-28:
+#   * ATLAS_HOME must be writable. If it is not, every gate fails instantly
+#     with "recipe ... is not in the local index (0 cached)" and never says
+#     why.
+#   * The TTFT gates need TWO runs each on a box with no stored baseline. The
+#     first one only creates the baseline and records `info`, which the gate
+#     does not accept — so a ten-gate campaign silently comes back eight.
+#   * The exit code is not the evidence. A BFCL run generated all 995
+#     responses, died in scoring, and correctly wrote NO record; a driver that
+#     trusted `rc` called that a pass. Ask
+#     `--pull-request-gate-check` what was actually recorded.
+#
 # Usage: scripts/queue-perf-pr.sh <branch>
 set -euo pipefail
 BRANCH="${1:?usage: queue-perf-pr.sh <branch>}"
@@ -34,9 +47,28 @@ git push origin "HEAD:$BRANCH"
 echo
 echo "FROZEN: $BRANCH @ $SHA"
 echo "Now run, on a GPU box with the repo checked out at exactly $SHA:"
-echo '  for g in ttft-cold-gate ttft-warm-gate vision-fidelity ssm-state-poisoning-gate \'
-echo '           decode-floor concurrency-sweep video-fidelity bfcl-subset \'
-echo '           bfcl-subset-echolp agentic-webserver; do'
+echo
+echo '  # ATLAS_HOME must be WRITABLE. The gates read the recipe index and the'
+echo '  # same-box baselines from $ATLAS_HOME/.., default ~/.atlas. If that'
+echo '  # directory cannot be created, every gate dies instantly with'
+echo '  # "recipe ... is not in the local index (0 cached)" and the cause is'
+echo '  # nowhere in the message.'
+echo '  export ATLAS_HOME=${ATLAS_HOME:-$HOME/.atlas}'
+echo
+echo '  # The TTFT gates compare against a stored SAME-BOX baseline. On a box'
+echo '  # that has none, run 1 only CREATES it and records verdict `info`,'
+echo '  # which the gate does not accept. They need two runs each; listing'
+echo '  # them twice is the whole fix.'
+echo '  for g in decode-floor vision-fidelity video-fidelity \'
+echo '           ssm-state-poisoning-gate concurrency-sweep agentic-webserver \'
+echo '           ttft-cold-gate ttft-cold-gate ttft-warm-gate ttft-warm-gate \'
+echo '           bfcl-subset bfcl-subset-echolp; do'
 echo '    timeout 21600 ./target/release/spark benchmark run "$g" --pull-request-gate --yes'
+echo '    rc=$?   # capture IMMEDIATELY: a $(date) in the next line resets it'
+echo '    echo "$g rc=$rc"'
 echo '  done'
+echo
+echo '  # rc is a hint, not the evidence. Check what was actually recorded:'
+echo "  ./target/release/spark benchmark --pull-request-gate-check --pr <N>"
+echo
 echo "then commit .benchmarks/ and push, wait for green, and queue the PR alone."

--- a/scripts/test-minimax-ep2.sh
+++ b/scripts/test-minimax-ep2.sh
@@ -126,7 +126,10 @@ python3 "$ATLAS_ROOT/tests/single_gpu_suite.py" \
   --model "$MODEL" \
   --output "$OUT_JSON" \
   2>&1 | tee "$LOG"
-STATUS=$?
+# PIPESTATUS[0], not $?: `$?` after a pipeline is the LAST command's status,
+# which here is `tee` — and tee succeeds whenever it can write the log. A
+# failing suite therefore reported "exit: 0" and the run read as a pass.
+STATUS=${PIPESTATUS[0]}
 set -e
 
 echo ""


### PR DESCRIPTION
Split out of #777 so it can land now.

#777 also touches `crates/atlas-plugin/assets/bfcl/score.py` and `crates/atlas-plugin/src/benchmarks/bfcl/provision.rs`, and `crates` is a `PERF_PATH` — so that PR needs its own ten benchmark records before it can merge, and its one red check is exactly that. **Nothing here touches a perf path**, and holding process documentation hostage to an 8-hour GPU campaign helps nobody.

## `$?` after a pipeline is the wrong status

Two committed scripts read `$?` immediately after a pipeline, where it is the **last stage's** status:

| script | pipeline | why it lied |
|---|---|---|
| `bench_per_model.sh` | `docker build … \| tail -5` then `[ $? -ne 0 ]` | `tail` succeeds on any input, so a **failed build passed the check** and the script went on to benchmark whatever stale image was still tagged |
| `test-minimax-ep2.sh` | `single_gpu_suite.py … \| tee "$LOG"` then `STATUS=$?` | `tee` succeeds whenever it can write the log, so a **failing suite reported `exit: 0`** |

Both now read `${PIPESTATUS[0]}`.

## The three traps a ten-gate campaign actually hits

`queue-perf-pr.sh` prints the campaign command an operator pastes onto a GPU box. It now spells out the three that each cost hours on 2026-08-28:

1. **`ATLAS_HOME` must be writable.** If it is not, every gate dies instantly with `recipe … is not in the local index (0 cached)` and the cause appears nowhere in the message.
2. **The TTFT gates need two runs each** on a box with no stored baseline — run 1 only *creates* the baseline and records verdict `info`, which the gate does not accept. A ten-gate campaign silently comes back eight. They are now listed twice, which is the whole fix.
3. **The exit code is not the evidence.** A BFCL run generated all 995 responses, died in scoring, and correctly wrote *no* record; a driver that trusted `rc` called that a pass. The loop captures `rc` immediately — a `$(date)` on the same line resets it — and ends by asking `--pull-request-gate-check` what was actually recorded.

Cheap gates are ordered first, so a config mistake surfaces in minutes instead of after the 1.6-hour BFCL leg.

**Verification:** the emitted command text was extracted from the `echo` lines and run through `bash -n` — valid bash. All three scripts pass `bash -n`.
