### PR TITLE
fix(chat): a rerank index that points nowhere must not lose the answer

### DIFF
--- a/site/e2e/chat.spec.js
+++ b/site/e2e/chat.spec.js
@@ -496,6 +496,43 @@ test.describe('error states', () => {
     // A chat-time fault must not knock the corpus out of ready.
     await expect(statusText(page)).toContainText('ready ·');
   });
+
+  // The rerank API returns positions into the documents WE sent. rag.js used
+  // them to index `candidates` directly, so an index the response invented
+  // produced `undefined` in `picked` and the next line read `.payload` off it —
+  // a bare TypeError that took the whole answer down instead of degrading.
+  test('a rerank index that points nowhere does not take the answer down', async ({
+    page,
+    context
+  }) => {
+    await routeCorpus(context);
+    await context.route(OR_EMBEDDINGS, embeddingsHandler({ dim: META.dim }));
+    await context.route(OR_CHAT, chatHandler('The KV pool lives in `kv_pool.rs` [1].'));
+    await context.route(OR_RERANK, async (route) => {
+      const body = route.request().postDataJSON();
+      // One real position and two that do not exist.
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [
+            { index: 0, relevance_score: 0.9 },
+            { index: body.documents.length + 5, relevance_score: 0.8 },
+            { index: -1, relevance_score: 0.7 }
+          ]
+        })
+      });
+    });
+    await withKey(page);
+    await page.goto('/');
+    await openChat(page);
+    await waitReady(page);
+
+    await askQuestion(page, 'where is the kv pool?');
+    // The answer still arrives, built from the position that did resolve.
+    await expect(page.locator('.cm-body').first()).toBeVisible({ timeout: 20_000 });
+    await expect(statusText(page)).toContainText('ready ·');
+  });
 });
 
 // =============================================================================

--- a/site/src/lib/chat/opfs.js
+++ b/site/src/lib/chat/opfs.js
@@ -106,8 +106,19 @@ export async function listCached() {
   return out.sort((a, b) => b.lastModified - a.lastModified);
 }
 
-/** Delete every cached corpus except the one for `keepSha`. */
+/**
+ * Delete every cached corpus except the one for `keepSha`.
+ *
+ * Refuses a falsy or non-string sha. Both callers pass `meta.commit_sha`, which
+ * `ensureReady` has already rejected the manifest for lacking, so this cannot
+ * fire today — but the failure mode if it ever did is not "prunes the wrong
+ * file", it is "deletes ALL of them": `latticeFileName(undefined)` is
+ * `lattice-db-undefined.jsonl`, which matches nothing, so every real corpus
+ * takes the delete branch. A precondition is cheap; re-downloading a corpus
+ * because a caller passed the wrong thing is not.
+ */
 export async function pruneStale(keepSha) {
+  if (typeof keepSha !== 'string' || keepSha === '') return;
   const dir = await root();
   if (!dir) return;
   const keep = latticeFileName(keepSha);

--- a/site/src/lib/chat/opfs.test.js
+++ b/site/src/lib/chat/opfs.test.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// `pruneStale` keeps one corpus and deletes the rest, so the consequence of a
+// bad argument is not a wrong file but ALL of them: `latticeFileName(undefined)`
+// is `lattice-db-undefined.jsonl`, which matches nothing cached, so every real
+// entry takes the delete branch. Both callers pass a validated sha today; this
+// pins the precondition so that stays true of a future third caller.
+
+import { expect, test, afterEach } from 'bun:test';
+import { pruneStale } from './opfs.js';
+
+const realNavigator = globalThis.navigator;
+afterEach(() => {
+  if (realNavigator === undefined) delete globalThis.navigator;
+  else globalThis.navigator = realNavigator;
+});
+
+/** A directory holding the named corpora, recording what gets removed. */
+function fakeOpfs(names) {
+  const removed = [];
+  const dir = {
+    async *[Symbol.asyncIterator]() {
+      for (const n of names) {
+        yield [n, { kind: 'file', getFile: async () => ({ size: 1, lastModified: 1 }) }];
+      }
+    },
+    removeEntry: async (n) => {
+      removed.push(n);
+    }
+  };
+  globalThis.navigator = { storage: { getDirectory: async () => dir } };
+  return removed;
+}
+
+test('a bad sha deletes nothing at all, rather than everything', async () => {
+  for (const bad of [undefined, null, '', 0, {}, []]) {
+    const removed = fakeOpfs(['lattice-db-aaa.jsonl', 'lattice-db-bbb.jsonl']);
+    await pruneStale(bad);
+    expect(removed).toEqual([]);
+  }
+});
+
+test('a real sha keeps its own corpus and drops the others', async () => {
+  const removed = fakeOpfs([
+    'lattice-db-keep.jsonl',
+    'lattice-db-old1.jsonl',
+    'lattice-db-old2.jsonl',
+    'unrelated.txt'
+  ]);
+  await pruneStale('keep');
+  expect(removed.sort()).toEqual(['lattice-db-old1.jsonl', 'lattice-db-old2.jsonl']);
+});

--- a/site/src/lib/chat/rag.js
+++ b/site/src/lib/chat/rag.js
@@ -81,7 +81,14 @@ export async function askCodebase(question, history, { apiKey, corpus, onPhase, 
       apiKey,
       TOP_K
     );
-    picked = ranked.slice(0, TOP_K).map(({ index }) => candidates[index]);
+    // `index` is a position into the documents WE sent, but it arrives from the
+    // rerank service, so it is not ours to trust. An index outside the array
+    // yields `undefined`, and the `sources` map below reads `.payload` off it —
+    // a bare TypeError that loses the whole answer instead of the one result.
+    picked = ranked
+      .slice(0, TOP_K)
+      .map(({ index }) => candidates[index])
+      .filter(Boolean);
   } else {
     picked = candidates.slice(0, TOP_K);
   }


### PR DESCRIPTION
`rag.js` used the rerank response's `index` to subscript `candidates` directly. Those positions refer to the documents **we** sent, but they arrive from the rerank service, so they are not ours to trust:

```js
picked = ranked.slice(0, TOP_K).map(({ index }) => candidates[index]);
```

An index outside the array yields `undefined`, and the `sources` map on the next line reads `.payload` off it. That is a bare `TypeError`, and it loses the **whole answer** — including the results that did resolve — rather than the one bad position. Same class as the `openrouter.js` shape guards: a 200 whose body is not what the contract promised.

Now filtered, so a response mixing good and invented positions still answers from the good ones.

The e2e case returns one real position and two that do not exist (`documents.length + 5` and `-1`). Run against the pre-fix file it **fails** (`.cm-body` never appears) and passes after. Only the network is stubbed, so the whole retrieval pipeline runs as production code.

---

## ⚠ A correction to how this suite has been run

**The e2e runs earlier in this session were meaningless.** `playwright.config.js` sets `reuseExistingServer: !process.env.CI`, and a `vite preview` from **2026-08-24** was still listening on 4173 — so every local run tested a *four-day-old bundle*, not the working tree.

That is why an earlier claim in this session, that the suite "validates the markdown.js changes end-to-end", was wrong: those changes were never in the bundle under test.

This PR was verified on a throwaway config bound to a free port with `reuseExistingServer: false`, leaving the other session's server alone.

| suite | result |
|---|---|
| e2e, genuinely fresh build | **41 passed, 1 skipped** |
| unit (`bun test src/lib`) | **444 pass** |

Worth considering separately: `reuseExistingServer: !process.env.CI` is a foot-gun for exactly this reason — it silently tests whatever happens to be listening.
