### PR TITLE
cutlass: skip null-weight expert groups — unblocks grouped MoE under EP

### DIFF
--- a/crates/spark-runtime/cuda/cutlass_nvfp4_grouped_gemm.cu
+++ b/crates/spark-runtime/cuda/cutlass_nvfp4_grouped_gemm.cu
@@ -13,6 +13,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime_api.h>
+#include <cstdlib>
 #include <vector>
 
 #include "cute/tensor.hpp"
@@ -353,15 +354,48 @@ struct GroupedAPrep {
 };
 
 // Gather+pack A once (per active group), upload the A-side argument arrays.
+//
+// `b_valid_ptrs` (nullable) is the per-expert B weight-pointer table. Under
+// EXPERT PARALLELISM the router and the sort stay GLOBAL-width, so a rank
+// receives routed rows (m_e > 0) for experts it does not own — and those
+// experts' weights are null placeholders (`ExpertWeight::null()`). Grouping
+// them would bind a null B and fault the grouped GEMM with an illegal address,
+// which is exactly what made the CUTLASS MoE path unusable under EP while the
+// hand-written ptrtable kernels survived (they open with `if (B_expert == 0)
+// return;`). Skipping the group here reproduces that semantic: the rank
+// contributes nothing for a remote expert, its C rows stay as pre-zeroed by
+// the EP memset in forward_prefill_routed, and the owning rank's contribution
+// arrives via the all-reduce.
+//
+// Pass nullptr to disable filtering. Single-GPU tables are never null, so this
+// is a strict no-op off EP.
 static GroupedAPrep prep_grouped_a(
     const __nv_bfloat16* A_global,
     const int* sorted_token_ids,
     const int* expert_offsets_host,
+    const unsigned long long* b_valid_ptrs,
     int num_experts,
     int n,
     int k,
     unsigned char* ws,
     cudaStream_t stream) {
+  // A/B arm: ATLAS_CUTLASS_EP_NULL_GUARD=0 restores the pre-fix behaviour
+  // (group every expert with rows, null B included). Off EP the two arms are
+  // identical; under EP the disabled arm faults, which is what makes this a
+  // usable experiment rather than just a switch.
+  static const bool null_guard = [] {
+    const char* v = getenv("ATLAS_CUTLASS_EP_NULL_GUARD");
+    return !(v != nullptr && v[0] == '0');
+  }();
+  // Both passes below must apply the SAME predicate or the per-group staging
+  // offsets (a_grp_off/sfa_grp_off, indexed by `gi`) desynchronize from the
+  // groups actually built.
+  auto group_active = [&](int e) -> bool {
+    if (expert_offsets_host[e + 1] - expert_offsets_host[e] <= 0) {
+      return false;
+    }
+    return !null_guard || b_valid_ptrs == nullptr || b_valid_ptrs[e] != 0;
+  };
   GroupedAPrep p;
   std::vector<const ElementA::DataType*> hA;
   std::vector<const ElementSF*> hSFA;
@@ -374,7 +408,7 @@ static GroupedAPrep prep_grouped_a(
   size_t sfa_acc = 0;
   for (int e = 0; e < num_experts; ++e) {
     int m_e = expert_offsets_host[e + 1] - expert_offsets_host[e];
-    if (m_e <= 0) {
+    if (!group_active(e)) {
       continue;
     }
     auto lsa =
@@ -397,7 +431,7 @@ static GroupedAPrep prep_grouped_a(
   for (int e = 0; e < num_experts; ++e) {
     int ms = expert_offsets_host[e];
     int m_e = expert_offsets_host[e + 1] - ms;
-    if (m_e <= 0) {
+    if (!group_active(e)) {
       continue;
     }
     auto lsa =
@@ -511,6 +545,13 @@ static int launch_projection(
     int e = a.eidx[g];
     int m_e = a.me[g];
     size_t ms = (size_t)a.ms[g];
+    // A null B/SFB here means a group survived the prep filter that should not
+    // have (see `b_valid_ptrs` on prep_grouped_a — EP remote experts). Report it
+    // as a status instead of letting the grouped GEMM fault on a null
+    // dereference, which surfaces as an opaque CUDA 700 far from the cause.
+    if (packed_ptrs[e] == 0 || sfb_ptrs[e] == 0) {
+      return -140;
+    }
     hB[g] = reinterpret_cast<const ElementB::DataType*>(packed_ptrs[e]);
     hSFB[g] = reinterpret_cast<const ElementSF*>(sfb_ptrs[e]);
     hC[g] = reinterpret_cast<const ElementC*>(C_bf16 + ms * n);
@@ -617,8 +658,11 @@ extern "C" int atlas_cutlass_nvfp4_grouped_gate_up_fused(
   }
   unsigned char* ws = static_cast<unsigned char*>(workspace);
   // Pack A ONCE (gate + up share the same activation).
+  // gate/up/down are null for the SAME (remote) experts, so gate's table is a
+  // sufficient validity mask for the shared A-prep.
   GroupedAPrep a = prep_grouped_a(static_cast<const __nv_bfloat16*>(A_bf16),
-                                  sorted_token_ids, expert_offsets_host, num_experts,
+                                  sorted_token_ids, expert_offsets_host,
+                                  gate_packed_ptrs, num_experts,
                                   n, k, ws, stream);
   if (a.G == 0) {
     return 0;
@@ -680,7 +724,8 @@ extern "C" int atlas_cutlass_nvfp4_grouped_down(
   }
   unsigned char* ws = static_cast<unsigned char*>(workspace);
   GroupedAPrep a = prep_grouped_a(static_cast<const __nv_bfloat16*>(A_bf16), nullptr,
-                                  expert_offsets_host, num_experts, n, k, ws, stream);
+                                  expert_offsets_host, packed_ptrs, num_experts, n, k,
+                                  ws, stream);
   if (a.G == 0) {
     return 0;
   }


### PR DESCRIPTION
## Problem

Under expert parallelism the CUTLASS grouped-MoE path faults with `CUDA_ERROR_ILLEGAL_ADDRESS (700)` in `ffn.forward_prefill`. The hand-written ptrtable kernels are unaffected, so EP has been usable only by **turning the fast MoE path off** — which is where the ~3.6x prefill gap between EP and single-node recorded on Laguna comes from.

## Root cause

The router and `moe_sort_by_expert` stay **global-width** under EP: every rank receives routed rows for experts it does not own, and those experts' weights are `ExpertWeight::null()` placeholders (`weight_map/loaders_moe.rs:62-65` allocates the expert vector at full width and nulls the remote ones).

`prep_grouped_a` filtered groups on rows alone:

```c
if (m_e <= 0) { continue; }
```

so a remote expert with routed rows became a CUTLASS group, and `launch_projection` then bound `hB[g] = packed_ptrs[e]` — a null pointer — with no check.

The ptrtable kernels never hit this because **all ten variants** open with `if (B_expert == 0) return;`. The CUTLASS path simply never learned the same lesson, even though the SFB builder already skips remote experts (`if sptr == 0 { continue; } // remote/placeholder expert`) and therefore deliberately hands nulls forward.

## Fix

Pass the B pointer table into `prep_grouped_a` and apply the same predicate. It is applied in **both passes** — they must agree, or the per-group staging offsets (`a_grp_off`/`sfa_grp_off`, indexed by `gi`) desynchronize from the groups actually built.

The correctness precondition already holds: `forward_prefill_routed` memsets the gate/up/down outputs whenever `ctx.comm.is_some()`, precisely so a remote expert can contribute zeros while the owning rank's result arrives via the all-reduce. That is exactly the ptrtable semantics.

Also converts a null bind in `launch_projection` into `status -140` rather than letting the GEMM fault — an opaque CUDA 700 surfaces far from its cause.

**Strict no-op off EP:** single-GPU tables contain no nulls, so no group can be skipped. This matters because the file is reached by every NVFP4 grouped-MoE model, not just the one tested here.

## Evidence

Holo-3.1-35B-A3B-NVFP4, EP=2 across two GB10 nodes, one variable (`ATLAS_CUTLASS_EP_NULL_GUARD`):

| arm | result |
|---|---|
| guard **off** (pre-fix) | `CUTLASS nvfp4 grouped(fused) gate_up failed: status -140` at layer 0, **both ranks** |
| guard **on** | serves, coherent output, zero errors on either rank |

The `-140` is the new check firing, which proves a null-B group was actually constructed — a stronger signal than the fault it replaces.

Single-node with the full CUTLASS flag set: SFB built on all 40 layers, coherent output, behaviour unchanged.

EP=2 prefill @6K, CUTLASS on vs off: **4019 vs 3804 tok/s (+5.7%)**, 2 reps.

⚠️ That is far short of the 3.6x implied by the older Laguna note, because the off-arm here retains `LOW_MEMORY_MOE` + `FAST_MOE_MODE=full` and so falls back to the transposed grouped path, not to slow w4a16. The headline of this PR is **correctness** — the fast path becomes *available* under EP; how much it is worth depends on what the fallback would have been.

## Scope of validation

- **Confirmed on Holo-35B.** **Inferred, not retested, for Laguna-S-2.1**, where the original crash was recorded. Same defect, same shared code path.
- The flag the old note blamed, `ATLAS_MOE_CUTLASS_DEVICE_OFFSETS`, no longer exists in the tree — that hypothesis (offsets computed over a full table while EP holds half) is wrong: the expert vector is always global-width, so offsets and pointer tables do agree.
- `ATLAS_CUTLASS_EP_NULL_GUARD=0` restores the old behaviour for A/B.

## Gates

`cargo fmt` clean. Release build with `ATLAS_TARGET_MODEL='*'` clean. `spark-model` 639 passed, `spark-runtime` 274 passed, 0 failed.

⚠️ `cargo clippy --all-targets` fails on **`crates/spark-model/examples/dense_gemv_bf16_batchm_microtest.rs:124`** (`print_literal`). That file is untouched by this PR (`git diff main..HEAD` = one `.cu` file) — the failure is **pre-existing on main**, not introduced here.
