### PR TITLE
qwen4_exp: load + audit the MTP draft module (NO speculation yet)

### DIFF
--- a/crates/atlas-core/src/config/parsers/qwen4_exp.rs
+++ b/crates/atlas-core/src/config/parsers/qwen4_exp.rs
@@ -67,6 +67,8 @@ pub(crate) fn parse_qwen4_exp(raw: &Value) -> Result<ModelConfig> {
     // shared loader helpers need no qwen4_exp-specific naming.
     config.weight_prefix = "model.language_model".to_string();
 
+    parse_mtp(text, &mut config)?;
+
     ensure!(
         config.hidden_size > 0,
         "qwen4_exp hidden_size must be non-zero"
@@ -132,6 +134,72 @@ pub(crate) fn parse_qwen4_exp(raw: &Value) -> Result<ModelConfig> {
     );
 
     Ok(config)
+}
+
+/// The MTP (multi-token-prediction) draft block, declared as a NESTED
+/// `text_config.mtp` object rather than the flat `mtp_num_hidden_layers` the
+/// qwen3_5/3_6 family uses.
+///
+/// Sets `num_mtp_modules`, which is the field every MTP module loader
+/// short-circuits on (`deepseek_v4/mtp.rs`: `if config.num_mtp_modules == 0 {
+/// return Ok(None) }`). Without it the block is declared in the checkpoint and
+/// invisible to the engine.
+///
+/// The shape is REFUSED rather than adapted when it is not the single
+/// full-attention layer this checkpoint ships: a `layer_types` naming
+/// `linear_attention` would have the module loader build a GDN body off keys
+/// that do not exist, and >1 layer would have it build one layer and silently
+/// drop the rest. Neither failure looks wrong at load.
+///
+/// An ABSENT `mtp` key leaves `num_mtp_modules` at 0 — speculation stays off,
+/// which is the pre-existing behaviour for every qwen4_exp checkpoint.
+fn parse_mtp(text: &Value, config: &mut ModelConfig) -> Result<()> {
+    let Some(mtp) = text.get("mtp") else {
+        return Ok(());
+    };
+
+    // ⚠ THESE CHECKS MUST NOT FAIL THE PARSE. parse_mtp runs on EVERY
+    // qwen4_exp launch, long before anything knows whether MTP was asked for,
+    // so an `ensure!` here refuses to boot a checkpoint that serves perfectly
+    // well today with its MTP block simply ignored — turning an unsupported
+    // OPTIONAL feature into a hard startup failure. The refusal belongs at
+    // MTP-load time (probe_mtp::ensure_loadable), which only runs when the
+    // module is actually requested. Here we decline to ADVERTISE the module:
+    // leaving num_mtp_modules at 0 is exactly the absent-key path, so
+    // speculation stays off and the main model is untouched.
+    let layers = mtp
+        .get("num_hidden_layers")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let types: Vec<&str> = mtp
+        .get("layer_types")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    // Declining is SILENT here: atlas-core carries no `tracing` dependency,
+    // and adding one to a core crate to narrate an optional-feature opt-out is
+    // the wrong trade. Nothing is lost — the operator only cares when they
+    // actually ask for MTP, and then `probe_mtp::ensure_loadable` refuses by
+    // name with the full reason.
+    //
+    // `layers != 1`: >1 would have the module loader build one layer and
+    // silently drop the rest; 0/missing means the block describes no body.
+    // `types != ["full_attention"]`: a GDN body would be assembled from
+    // `linear_attn.*` keys the `mtp.*` namespace does not carry.
+    if layers != 1 || types != ["full_attention"] {
+        return Ok(());
+    }
+
+    config.num_mtp_modules = 1;
+    // Mirror the nested count onto the flat field. serde already parsed
+    // `text_config.mtp_num_hidden_layers` (=1 in the shipped config), so this
+    // normally re-states it; the nested value wins when the two disagree
+    // because it is the one that describes the block that actually ships.
+    if layers > 0 {
+        config.mtp_num_hidden_layers = layers;
+    }
+    Ok(())
 }
 
 /// mRoPE + partial rotary live under `rope_parameters`, not at text_config

--- a/crates/atlas-core/src/config/parsers/qwen4_exp_tests.rs
+++ b/crates/atlas-core/src/config/parsers/qwen4_exp_tests.rs
@@ -59,6 +59,15 @@ const RAW: &str = r#"{
     "ple_embed_dim": 2560,
     "ple_conv_kernel_size": 4,
     "output_gate_type": "sigmoid",
+    "mtp_num_hidden_layers": 1,
+    "mtp_use_dedicated_embeddings": false,
+    "mtp": {
+      "hybrid": true,
+      "layer_types": ["full_attention"],
+      "mtp_use_hidden_state_from_layer": null,
+      "num_hidden_layers": 1,
+      "rope_theta": 10000000
+    },
     "partial_rotary_factor": 0.25,
     "rope_parameters": {
       "mrope_interleaved": true,
@@ -200,6 +209,61 @@ fn layer_types_length_must_match_num_hidden_layers() {
     assert!(err.contains("layer_types has 4 entries"), "{err}");
 }
 
+/// `num_mtp_modules` is the field every MTP module loader short-circuits on.
+/// Left at the factory default 0 it does not matter what the checkpoint
+/// ships — the block is never built.
+#[test]
+fn mtp_module_count_is_parsed() {
+    let c = parse_qwen4_exp(&raw_config()).expect("parse");
+    assert_eq!(c.num_mtp_modules, 1, "text_config.mtp declares one module");
+    assert_eq!(c.mtp_num_hidden_layers, 1, "one layer inside that module");
+}
+
+/// A checkpoint with no `mtp` key must leave speculation OFF, exactly as
+/// before this parser learned the field.
+#[test]
+fn mtp_absent_leaves_speculation_off() {
+    let mut raw = raw_config();
+    raw["text_config"]
+        .as_object_mut()
+        .expect("text_config object")
+        .remove("mtp");
+    let c = parse_qwen4_exp(&raw).expect("parse");
+    assert_eq!(c.num_mtp_modules, 0);
+}
+
+/// The loader builds exactly one MTP body; a two-layer module would have it
+/// build the first and silently drop the second — so it must not be
+/// ADVERTISED. It must also not fail the parse: this runs on every launch,
+/// and refusing here would stop a checkpoint booting AT ALL over an optional
+/// feature nobody asked for. num_mtp_modules == 0 is the absent-key path.
+#[test]
+fn mtp_multi_layer_is_not_advertised_but_still_boots() {
+    let mut raw = raw_config();
+    raw["text_config"]["mtp"]["num_hidden_layers"] = Value::from(2);
+    let c = parse_qwen4_exp(&raw).expect("an unsupported MTP block must not fail the parse");
+    assert_eq!(c.num_mtp_modules, 0);
+}
+
+/// A `linear_attention` MTP body would be assembled from `linear_attn.*` keys
+/// the `mtp.*` namespace does not carry. Same contract as above: decline the
+/// module, boot the model.
+#[test]
+fn mtp_non_full_attention_is_not_advertised_but_still_boots() {
+    let mut raw = raw_config();
+    raw["text_config"]["mtp"]["layer_types"] = Value::from(vec!["linear_attention"]);
+    let c = parse_qwen4_exp(&raw).expect("an unsupported MTP block must not fail the parse");
+    assert_eq!(c.num_mtp_modules, 0);
+}
+
+/// The shipped checkpoint's block IS supported, so it must be advertised —
+/// otherwise the two tests above would pass vacuously.
+#[test]
+fn mtp_supported_block_is_advertised() {
+    let c = parse_qwen4_exp(&raw_config()).expect("parse");
+    assert_eq!(c.num_mtp_modules, 1);
+}
+
 #[test]
 fn missing_text_config_is_refused() {
     let err = parse_qwen4_exp(&serde_json::json!({"model_type": "qwen4_exp"}))
@@ -253,6 +317,10 @@ fn parses_the_real_config_json_when_present() {
     );
     assert_eq!(c.ple_layer_ids, vec![2]);
     assert!(c.vision.is_some());
+    assert_eq!(
+        c.num_mtp_modules, 1,
+        "the shipped config declares one single-layer full-attention MTP block"
+    );
 }
 
 /// Qwen3.8-Flash-Next shipped under `qwen3_8_flash_next` and was later

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -668,6 +668,10 @@ pub fn build_model(
         vision_encoder,
         ssm_cache_slots,
         ssm_checkpoint_interval,
+        // A bespoke MTP module is present, so the SSM verify pools must exist
+        // even though `mtp_weights` is empty. Known here: the module is loaded
+        // in Step 5 above, before construction.
+        qwen4_exp_mtp_module.is_some(),
     )?;
 
     // ── Step 6b: DeepSeek-V4 MTP proposer (optional, post-construction) ──

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -289,14 +289,17 @@ pub fn build_model(
     if use_speculative && mtp_weights.is_empty() {
         if qwen4_exp_mtp_module.is_some() {
             // Saying "no MTP weights were loaded" here would be a lie: the
-            // block IS loaded and audited. What is missing is the proposer.
+            // block IS loaded and audited. Whether a proposer gets wired
+            // depends on ATLAS_QWEN4EXP_MTP_VERIFY — this arm only fires when
+            // it is OFF, since the proposer install path logs its own line.
             tracing::warn!(
-                "qwen4_exp: the MTP module is loaded and audited, but no \
-                 proposer is wired yet — speculative decoding stays OFF. This \
-                 is deliberate: a proposer installed today would route the \
-                 draft into `refuse_batched_under_hc` mid-verify, which the \
-                 scheduler turns into a truncated response rather than a \
-                 fallback."
+                "qwen4_exp: the MTP module is loaded and audited, but the \
+                 proposer is NOT armed — speculative decoding stays OFF. Set \
+                 ATLAS_QWEN4EXP_MTP_VERIFY=1 to arm the draft head together \
+                 with the mHC K-row verify path it needs; the two arm together \
+                 because a proposer without that verify path routes the draft \
+                 into `refuse_batched_under_hc` mid-step, which the scheduler \
+                 turns into a truncated response rather than a fallback."
             );
         } else {
             tracing::warn!(
@@ -713,11 +716,19 @@ pub fn build_model(
         // ATLAS_QWEN4EXP_MTP_SHADOW the module is just held (unchanged
         // behaviour), because the head's pool is real memory outside the util
         // pledge and nothing should pay for it unless it is being measured.
-        if crate::layers::qwen4_exp_mtp::shadow_enabled() {
-            if let Err(e) = model.set_qwen4_exp_mtp_head(*module, target_embed_for_mtp, max_seq_len)
+        // Speculation needs the head installed as the ACTIVE proposer; shadow
+        // needs it held but inert. `ATLAS_QWEN4EXP_MTP_VERIFY=1` is the same
+        // flag the mHC K-row verify path is gated on, so the two arm together
+        // or not at all — a proposer without that verify path would produce
+        // drafts the verify step then refuses on, mid-request.
+        let arm_spec =
+            use_speculative && std::env::var("ATLAS_QWEN4EXP_MTP_VERIFY").as_deref() == Ok("1");
+        if crate::layers::qwen4_exp_mtp::shadow_enabled() || arm_spec {
+            if let Err(e) =
+                model.set_qwen4_exp_mtp_head(*module, target_embed_for_mtp, max_seq_len, arm_spec)
             {
                 tracing::error!(
-                    "qwen4_exp MTP shadow head FAILED to build: {e:#}. \
+                    "qwen4_exp MTP head FAILED to build: {e:#}. \
                      Serving continues with no MTP."
                 );
             }

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -223,15 +223,88 @@ pub fn build_model(
             None
         };
 
+    // qwen4_exp ships a Track-B MTP block too (mHC + QSA + its own 512-expert
+    // MoE), so `load_mtp_weights` returns None and the real loader is
+    // `qwen4_exp::load_qwen4_exp_mtp_module`. Loaded under `--speculative` OR
+    // ATLAS_QWEN4EXP_MTP=1 — the latter loads and audits the block without
+    // arming anything, which is the only way to measure its cost today.
+    // Rank 0 only: the MTP MoE has no `force_all_experts` path and the upload
+    // never shards `mtp.*`.
+    // ⚠ The UPLOAD gate (`want_mtp` in spark-server: --speculative or the env
+    // flag) and this LOAD gate are DIFFERENT predicates — `use_speculative`
+    // also covers --dflash. When they disagree the `mtp.*` tensors were
+    // filtered at upload and every key is absent, which used to fall through
+    // to the Err arm and log "MTP module load FAILED" on every boot with a
+    // message that blamed the wrong thing. Rather than couple the two
+    // predicates across crates, require the tensors to actually BE here: that
+    // is the real precondition, and it stays correct however the flags drift.
+    let mtp_tensors_present = store.contains("mtp.fc_embedding.weight");
+    let qwen4_exp_mtp_module = if config.model_type == "qwen4_exp"
+        && (use_speculative || std::env::var("ATLAS_QWEN4EXP_MTP").as_deref() == Ok("1"))
+        && config.ep_rank == 0
+        && mtp_tensors_present
+    {
+        match crate::weight_loader::qwen4_exp::load_qwen4_exp_mtp_module(
+            &store,
+            &config,
+            gpu.as_ref(),
+        ) {
+            Ok(Some(m)) => {
+                tracing::info!(
+                    "qwen4_exp MTP draft module loaded and audited (num_mtp_modules={})",
+                    config.num_mtp_modules
+                );
+                Some(Box::new(m))
+            }
+            Ok(None) => {
+                tracing::info!("qwen4_exp: config declares no MTP module (num_mtp_modules=0)");
+                None
+            }
+            Err(e) => {
+                tracing::error!("qwen4_exp MTP module load FAILED: {e:#}");
+                None
+            }
+        }
+    } else {
+        if config.model_type == "qwen4_exp"
+            && (use_speculative || std::env::var("ATLAS_QWEN4EXP_MTP").as_deref() == Ok("1"))
+            && config.ep_rank == 0
+            && !mtp_tensors_present
+        {
+            // Requested, but the weight store has no `mtp.*` — the upload gate
+            // filtered them (e.g. --dflash without --speculative). Name the
+            // real cause and the fix instead of failing.
+            tracing::info!(
+                "qwen4_exp: MTP module requested but no `mtp.*` tensors are \
+                 resident — they were filtered at upload. Pass --speculative \
+                 or ATLAS_QWEN4EXP_MTP=1 so the upload keeps them."
+            );
+        }
+        None
+    };
+
     // Capability warning: user asked for `--speculative` but the model has no
     // MTP head bundled, so speculative decoding will silently no-op. Surface
     // this loudly so the user knows the flag was inert.
     if use_speculative && mtp_weights.is_empty() {
-        tracing::warn!(
-            "`--speculative` was requested but no MTP weights were loaded for this \
-             model — speculative decoding will be disabled. Either drop `--speculative` \
-             or use a checkpoint that ships an MTP head (e.g. `mtp.safetensors`)."
-        );
+        if qwen4_exp_mtp_module.is_some() {
+            // Saying "no MTP weights were loaded" here would be a lie: the
+            // block IS loaded and audited. What is missing is the proposer.
+            tracing::warn!(
+                "qwen4_exp: the MTP module is loaded and audited, but no \
+                 proposer is wired yet — speculative decoding stays OFF. This \
+                 is deliberate: a proposer installed today would route the \
+                 draft into `refuse_batched_under_hc` mid-verify, which the \
+                 scheduler turns into a truncated response rather than a \
+                 fallback."
+            );
+        } else {
+            tracing::warn!(
+                "`--speculative` was requested but no MTP weights were loaded for this \
+                 model — speculative decoding will be disabled. Either drop `--speculative` \
+                 or use a checkpoint that ships an MTP head (e.g. `mtp.safetensors`)."
+            );
+        }
     }
     let vision_encoder = loader.load_vision_encoder(&store, &config, gpu.as_ref())?;
 
@@ -619,6 +692,16 @@ pub fn build_model(
                 "Failed to build DeepSeek-V4 MTP proposer: {e:#}. Speculative decoding disabled."
             ),
         }
+    }
+
+    // ── Step 6c: qwen4_exp MTP module (optional, post-construction) ──
+    //
+    // Handed to the model so it is not dropped. `DevicePtr` has no `Drop`, so
+    // dropping the module here would leak its quantized MoE and attention
+    // buffers for the process lifetime. No proposer is built from it yet, so
+    // `has_proposer()` stays false and speculation stays off.
+    if let Some(module) = qwen4_exp_mtp_module {
+        model.set_qwen4_exp_mtp(module);
     }
 
     // ── Step 7: DFlash drafter (optional, post-construction) ──

--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -634,6 +634,9 @@ pub fn build_model(
     // shares embed_tokens + lm_head with the target). DenseWeight is Copy
     // so this clones the device pointer cheaply.
     let target_embed_for_dflash = embed.weight;
+    // Same trick for the MTP draft head: it gathers the next-token embedding
+    // from the shared table. `DenseWeight` is Copy, so this is a pointer.
+    let target_embed_for_mtp = embed;
     let target_lm_head_for_dflash = lm_head.weight;
     // NVFP4 lm_head (Copy) shared with the DFlash drafter so its final logits
     // GEMM uses w4a16 instead of a BF16 dense_gemm on NVFP4-packed bytes.
@@ -701,7 +704,22 @@ pub fn build_model(
     // buffers for the process lifetime. No proposer is built from it yet, so
     // `has_proposer()` stays false and speculation stays off.
     if let Some(module) = qwen4_exp_mtp_module {
-        model.set_qwen4_exp_mtp(module);
+        // SHADOW MODE builds the draft head, which consumes the module and
+        // allocates its own single-layer KV pool. Off by default: without
+        // ATLAS_QWEN4EXP_MTP_SHADOW the module is just held (unchanged
+        // behaviour), because the head's pool is real memory outside the util
+        // pledge and nothing should pay for it unless it is being measured.
+        if crate::layers::qwen4_exp_mtp::shadow_enabled() {
+            if let Err(e) = model.set_qwen4_exp_mtp_head(*module, target_embed_for_mtp, max_seq_len)
+            {
+                tracing::error!(
+                    "qwen4_exp MTP shadow head FAILED to build: {e:#}. \
+                     Serving continues with no MTP."
+                );
+            }
+        } else {
+            model.set_qwen4_exp_mtp(module);
+        }
     }
 
     // ── Step 7: DFlash drafter (optional, post-construction) ──

--- a/crates/spark-model/src/layer/transformer_layer.rs
+++ b/crates/spark-model/src/layer/transformer_layer.rs
@@ -119,6 +119,40 @@ pub trait TransformerLayer: Send + Sync {
         false
     }
 
+    /// Align this layer's aux carry to an ABSOLUTE sequence position.
+    ///
+    /// Used before a verify replays rows the carry may already have ingested.
+    /// Absolute, because the overlap is not a constant — see
+    /// `QsaIndexer::align_seq_state`.
+    fn align_aux(
+        &self,
+        _state: &mut dyn LayerState,
+        _to_pos: usize,
+        _gpu: &dyn GpuBackend,
+        _stream: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Roll this layer's aux carry back by `rows`, after a rejected
+    /// speculative draft.
+    ///
+    /// Distinct from `restore_aux` on purpose. `snapshot_aux` returns `None`
+    /// when a sequence has not reached this layer's ingest yet, so a
+    /// snapshot/restore pair CANNOT undo the very first draft — there is
+    /// nothing to restore, and the carry is left ahead of the sequence
+    /// (measured: `QSA: decode at pos 0 but 1 tokens ingested`). A mark rewind
+    /// has no such hole and needs no blob.
+    fn rewind_aux(
+        &self,
+        _state: &mut dyn LayerState,
+        _rows: usize,
+        _gpu: &dyn GpuBackend,
+        _stream: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Restore the aux state captured by [`Self::snapshot_aux`] on a
     /// prefix-cache hit, BEFORE the resumed prefill runs.
     fn restore_aux(

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -17,6 +17,7 @@ pub mod ple;
 pub mod qsa;
 pub mod qwen3_attention;
 pub mod qwen3_ssm;
+pub mod qwen4_exp_mtp;
 pub mod vision_encoder;
 pub mod w4a16_gemv_tiers;
 

--- a/crates/spark-model/src/layers/mod.rs
+++ b/crates/spark-model/src/layers/mod.rs
@@ -18,6 +18,7 @@ pub mod qsa;
 pub mod qwen3_attention;
 pub mod qwen3_ssm;
 pub mod qwen4_exp_mtp;
+pub mod qwen4_exp_mtp_proposer;
 pub mod vision_encoder;
 pub mod w4a16_gemv_tiers;
 

--- a/crates/spark-model/src/layers/ops/hyper_connection.rs
+++ b/crates/spark-model/src/layers/ops/hyper_connection.rs
@@ -134,3 +134,60 @@ pub fn hc_head(
         .arg_f32(hc_eps)
         .launch(stream)
 }
+
+/// Grouped RMSNorm of the FP32 mHC highway into BF16 (`hc_pre_stage_bf16`).
+///
+/// Each stream normalizes independently (`group_size = hidden`) and the scale is
+/// offset-from-1. Exposed on its own because the qwen4_exp MTP combiner needs
+/// exactly this FP32-in / BF16-out step: its `pre_fc_norm_hidden` is `[hc*H]`
+/// and the projections that consume it are BF16.
+#[allow(clippy::too_many_arguments)]
+pub fn hc_pre_stage_bf16_norm(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    streams_f32: DevicePtr,
+    norm_w: DevicePtr,
+    normed_bf16_out: DevicePtr,
+    num_tokens: u32,
+    hidden_size: u32,
+    hc_mult: u32,
+    eps: f32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([num_tokens, 1, 1])
+        .block([1024, 1, 1])
+        .arg_ptr(streams_f32)
+        .arg_ptr(norm_w)
+        .arg_ptr(normed_bf16_out)
+        .arg_u32(hidden_size)
+        .arg_u32(hc_mult)
+        .arg_f32(eps)
+        .launch(stream)
+}
+
+/// MTP combiner tail: `streams[i] = per_stream[i] + bcast`, BF16 in, FP32 out.
+///
+/// `hc_expand` cannot serve here — it broadcasts ONE row to every stream, and
+/// the MTP combiner's streams differ per stream.
+#[allow(clippy::too_many_arguments)]
+pub fn qhc_mtp_combine_streams(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    per_stream_bf16: DevicePtr,
+    bcast_bf16: DevicePtr,
+    streams_f32_out: DevicePtr,
+    hidden_size: u32,
+    hc_mult: u32,
+    stream: u64,
+) -> Result<()> {
+    KernelLaunch::new(gpu, kernel)
+        .grid([1, 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(per_stream_bf16)
+        .arg_ptr(bcast_bf16)
+        .arg_ptr(streams_f32_out)
+        .arg_u32(hidden_size)
+        .arg_u32(hc_mult)
+        .launch(stream)
+}

--- a/crates/spark-model/src/layers/qsa.rs
+++ b/crates/spark-model/src/layers/qsa.rs
@@ -289,6 +289,29 @@ impl QsaIndexer {
     /// Decode-step ingest + selection for the token at `pos` (0-based;
     /// `pos + 1` visible). `None` inside the inert bound (dense is exact).
     #[allow(clippy::too_many_arguments)]
+    /// Roll this sequence's indexer carry back by `rows`, after a rejected
+    /// speculative draft.
+    ///
+    /// `ingested` and `pooled` are contiguous marks — raw keys are written from
+    /// `ingested` forward and block keys from `pooled` forward — so rewinding is
+    /// just moving the marks back. The bytes past them are stale but
+    /// unreachable: the next ingest overwrites from the mark. `pooled` is
+    /// recomputed rather than decremented because a block that contained a
+    /// rewound token must be re-pooled once its replacement arrives.
+    ///
+    /// This exists because the ingest paths assert hard on position agreement
+    /// (`pos == st.ingested`, `seq_start == st.ingested`). Without a rewind a
+    /// rejected draft leaves the carry one row ahead of the sequence and the
+    /// NEXT token trips that assert — which is the loud failure; the quiet one
+    /// is a selection computed against keys that never got overwritten.
+    pub fn rewind_seq_state(&self, st: &mut QsaSeqState, rows: usize) {
+        if rows == 0 {
+            return;
+        }
+        st.ingested = st.ingested.saturating_sub(rows);
+        st.pooled = st.ingested / (self.ratio as usize).max(1);
+    }
+
     pub fn decode_select(
         &self,
         st: &mut QsaSeqState,

--- a/crates/spark-model/src/layers/qsa.rs
+++ b/crates/spark-model/src/layers/qsa.rs
@@ -289,6 +289,22 @@ impl QsaIndexer {
     /// Decode-step ingest + selection for the token at `pos` (0-based;
     /// `pos + 1` visible). `None` inside the inert bound (dense is exact).
     #[allow(clippy::too_many_arguments)]
+    /// Align this sequence's indexer carry to an ABSOLUTE position.
+    ///
+    /// Prefer this over `rewind_seq_state` whenever the caller knows where the
+    /// carry SHOULD be rather than how far it drifted. A verify replay overlaps
+    /// the current position by an amount that is not constant — rewinding by a
+    /// fixed 1 overshot and produced the mirror-image failure ("starts at 366
+    /// but 365 ingested") of the one it fixed. Never advances: ingesting is the
+    /// only thing that may move the mark forward.
+    pub fn align_seq_state(&self, st: &mut QsaSeqState, to_pos: usize) {
+        if st.ingested <= to_pos {
+            return;
+        }
+        st.ingested = to_pos;
+        st.pooled = st.ingested / (self.ratio as usize).max(1);
+    }
+
     /// Roll this sequence's indexer carry back by `rows`, after a rejected
     /// speculative draft.
     ///

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl.rs
@@ -135,6 +135,46 @@ impl TransformerLayer for Qwen3AttentionLayer {
         }
     }
 
+    fn align_aux(
+        &self,
+        state: &mut dyn LayerState,
+        to_pos: usize,
+        _gpu: &dyn GpuBackend,
+        _stream: u64,
+    ) -> Result<()> {
+        let Some(qsa) = self.qsa.as_ref() else {
+            return Ok(());
+        };
+        let attn = state
+            .as_any_mut()
+            .downcast_mut::<crate::layer::AttnLayerState>()
+            .ok_or_else(|| anyhow::anyhow!("QSA host layer state is not AttnLayerState"))?;
+        if let Some(st) = attn.qsa.as_mut() {
+            qsa.align_seq_state(st, to_pos);
+        }
+        Ok(())
+    }
+
+    fn rewind_aux(
+        &self,
+        state: &mut dyn LayerState,
+        rows: usize,
+        _gpu: &dyn GpuBackend,
+        _stream: u64,
+    ) -> Result<()> {
+        let Some(qsa) = self.qsa.as_ref() else {
+            return Ok(());
+        };
+        let attn = state
+            .as_any_mut()
+            .downcast_mut::<crate::layer::AttnLayerState>()
+            .ok_or_else(|| anyhow::anyhow!("QSA host layer state is not AttnLayerState"))?;
+        if let Some(st) = attn.qsa.as_mut() {
+            qsa.rewind_seq_state(st, rows);
+        }
+        Ok(())
+    }
+
     fn restore_aux(
         &self,
         state: &mut dyn LayerState,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/prefill_inner.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/prefill_inner.rs
@@ -889,9 +889,42 @@ impl Qwen3AttentionLayer {
                 .copy_d2d_async(hidden, normed2, num_tokens * h * 2, stream)?;
         }
 
-        self.ffn
-            .forward_prefill(normed2, num_tokens, ctx, stream)
-            .map_err(|e| anyhow::anyhow!("ffn.forward_prefill (HC) failed: {e}"))?;
+        // Small-M FFN (see the twin in qwen3_ssm/trait_prefill_hc.rs): at K=2/3
+        // rows this body is a speculative verify. The grouped-GEMM MoE streams
+        // every expert regardless of row count; the fused K=2/K=3 kernels do the
+        // same rows at decode cost into the same moe_output().
+        let small_m = {
+            static SMALL_M: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *SMALL_M
+                .get_or_init(|| std::env::var("ATLAS_QWEN4EXP_HC_SMALL_M_FFN").as_deref() != Ok("0"))
+        };
+        // The K=1 arm carries the weight: `decode_verify_hc` splits verify into
+        // row-0-then-drafts, so at gamma=1 both calls arrive as a single row.
+        match num_tokens {
+            1 if small_m => {
+                let out = self
+                    .ffn
+                    .forward(normed2, ctx, stream)
+                    .map_err(|e| anyhow::anyhow!("ffn.forward (HC, K=1) failed: {e}"))?;
+                anyhow::ensure!(
+                    out == ctx.buffers.moe_output(),
+                    "small-M FFN: single-token MoE returned a buffer other than \
+                     moe_output(), which the hc post-site reads unconditionally"
+                );
+            }
+            2 if small_m => self
+                .ffn
+                .forward_k2(normed2, ctx, stream)
+                .map_err(|e| anyhow::anyhow!("ffn.forward_k2 (HC) failed: {e}"))?,
+            3 if small_m => self
+                .ffn
+                .forward_k3(normed2, ctx, stream)
+                .map_err(|e| anyhow::anyhow!("ffn.forward_k3 (HC) failed: {e}"))?,
+            _ => self
+                .ffn
+                .forward_prefill(normed2, num_tokens, ctx, stream)
+                .map_err(|e| anyhow::anyhow!("ffn.forward_prefill (HC) failed: {e}"))?,
+        }
 
         let dense_out = ctx.buffers.moe_output();
 

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_hc.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_hc.rs
@@ -262,7 +262,35 @@ impl Qwen3SsmLayer {
             stream,
         )?;
         stage!("hc_pre_ffn");
-        self.ffn.forward_prefill(hidden, num_tokens, ctx, stream)?;
+        // Small-M FFN: at K=2/K=3 rows this body is a speculative VERIFY, not a
+        // real prefill. forward_prefill routes the MoE through the grouped GEMM,
+        // which streams every expert's weights and so costs ~9ms/layer almost
+        // independently of row count (measured: T=16 6.7-9.6ms, T=28 8.5-12.3ms
+        // — 1.75x the rows for 1.2x the time). The fused K=2/K=3 kernels do the
+        // same rows in 5 launches at decode cost. Both write moe_output(), so
+        // this is a kernel-shape substitution, not a math change.
+        // ATLAS_QWEN4EXP_HC_SMALL_M_FFN=0 restores the grouped path for A/B.
+        let small_m = {
+            static SMALL_M: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *SMALL_M
+                .get_or_init(|| std::env::var("ATLAS_QWEN4EXP_HC_SMALL_M_FFN").as_deref() != Ok("0"))
+        };
+        // NOTE the K=1 arm carries the weight here: `decode_verify_hc` splits a
+        // verify into row-0-then-drafts, so at the default gamma=1 BOTH calls
+        // arrive as ONE row and the k2/k3 arms never fire.
+        match num_tokens {
+            1 if small_m => {
+                let out = self.ffn.forward(hidden, ctx, stream)?;
+                anyhow::ensure!(
+                    out == ctx.buffers.moe_output(),
+                    "small-M FFN: single-token MoE returned a buffer other than \
+                     moe_output(), which the hc post-site reads unconditionally"
+                );
+            }
+            2 if small_m => self.ffn.forward_k2(hidden, ctx, stream)?,
+            3 if small_m => self.ffn.forward_k3(hidden, ctx, stream)?,
+            _ => self.ffn.forward_prefill(hidden, num_tokens, ctx, stream)?,
+        }
         stage!("moe");
         ops::hc_post_site(
             ctx.gpu,

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -153,6 +153,14 @@ pub struct Qwen4ExpMtpHead {
     rms_norm_k: KernelHandle,
     dense_gemv_k: KernelHandle,
     hc_head_k: KernelHandle,
+    /// The target's NVFP4 vocab head, shared (Copy pointers). The draft writes
+    /// its logits into the DRAFT arena, so it never touches the buffer the
+    /// scheduler samples from — the stash/restore the shadow path needed is
+    /// unnecessary once the arena is private.
+    lm_head_nvfp4: Option<crate::weight_map::QuantizedWeight>,
+    w4a16_gemv_k: KernelHandle,
+    w4a16_gemv_sw_k: KernelHandle,
+    argmax_k: KernelHandle,
     /// FP32 highway -> BF16 grouped norm (the combiner's hidden branch).
     hc_stage_k: KernelHandle,
     /// BF16 per-stream + broadcast -> FP32 highway (the combiner's tail).
@@ -204,9 +212,11 @@ pub fn shadow_stage() -> ShadowStage {
 }
 
 impl Qwen4ExpMtpHead {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         module: Qwen4ExpMtpModule,
         embed_tokens: DenseWeight,
+        lm_head_nvfp4: Option<crate::weight_map::QuantizedWeight>,
         config: &atlas_core::config::ModelConfig,
         gpu: &dyn GpuBackend,
         max_seq_len: usize,
@@ -288,6 +298,10 @@ impl Qwen4ExpMtpHead {
             // the qwen4_exp tree.
             rms_norm_k: gpu.kernel("norm", "rms_norm")?,
             dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
+            lm_head_nvfp4,
+            w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
+            w4a16_gemv_sw_k: KernelHandle(0),
+            argmax_k: gpu.kernel("argmax", "argmax_bf16")?,
             hc_head_k: gpu.kernel("hyper_connection", "hc_head")?,
             hc_stage_k: gpu.kernel("hyper_connection", "hc_pre_stage_bf16")?,
             combine_k: gpu.kernel("hyper_connection", "qhc_mtp_combine_streams")?,
@@ -303,6 +317,39 @@ impl Qwen4ExpMtpHead {
             body_state: self.module.body.alloc_state(gpu)?,
             pending_draft: None,
         })
+    }
+
+    /// Turn the draft's final hidden into a token id, entirely inside the
+    /// draft's own arena.
+    ///
+    /// qwen4_exp sets `final_norm_identity`, so there is NO final norm here —
+    /// the mHC head's own `hc_norm` plays that role. Applying one would be an
+    /// uninvited extra RMS divide (a bug this model already shipped once).
+    pub fn draft_token(&self, h_out: DevicePtr, ctx: &ForwardContext, stream: u64) -> Result<u32> {
+        let vocab = ctx.config.vocab_size as u32;
+        let h = ctx.config.hidden_size as u32;
+        let logits = self.arena.logits();
+        let w = self
+            .lm_head_nvfp4
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("qwen4_exp MTP: no NVFP4 lm_head for the draft head"))?;
+        ops::w4a16_decode_gemv(
+            ctx.gpu,
+            self.w4a16_gemv_k,
+            self.w4a16_gemv_sw_k,
+            false,
+            h_out,
+            w,
+            logits,
+            vocab,
+            h,
+            stream,
+        )?;
+        let out_ptr = self.arena.scratch();
+        ops::argmax_bf16(ctx.gpu, self.argmax_k, logits, out_ptr, vocab, stream)?;
+        let mut b = [0u8; 4];
+        ctx.gpu.copy_d2h(out_ptr, &mut b)?;
+        Ok(u32::from_le_bytes(b))
     }
 
     /// Park the target's logits so the draft's `lm_head` cannot change what the

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -34,45 +34,36 @@
 //! so no reference activations can be generated. The argument above is
 //! structural, not numerical.
 //!
-//! # STATUS: NOT WORKING. The SHARING MODEL is wrong — do not keep patching.
+//! # STATUS: the harness is INERT; the draft is not yet numerically right.
 //!
-//! **1. The body forward corrupts the target, and buffer-by-buffer isolation
-//! does NOT fix it.** Bisect via `ATLAS_QWEN4EXP_MTP_SHADOW_STAGE` (250-token
-//! greedy completion against a shadow-off control):
-//! ```text
-//!   observe  -> output matches control exactly      INERT
-//!   combine  -> output matches control exactly      INERT
-//!   body     -> degenerate / empty, watchdog fires  CORRUPTS
-//! ```
-//! Four separate causes were found and fixed, and the corruption SURVIVED all
-//! of them:
+//! **1. Target corruption: FIXED, by isolation by construction.** The draft
+//! runs inside its OWN `BufferArena` (`max_batch_tokens = 1`, measured <1 MB),
+//! so the body cannot reach any buffer the target owns. Verified: shadow-on
+//! output is BYTE-IDENTICAL to a shadow-off control, `finish: stop`, 0 failures.
+//!
+//! Getting here took four rounds of "find the shared buffer, save and restore
+//! it" — each fixed a REAL bug and none of them stopped the corruption:
 //!   - `hc_streams` is FP32 (`m*hc_mult*h*4`); a BF16-sized save/restore covered
-//!     only half the highway. Fixed — the buffer diff now shows hc_streams
-//!     unchanged across the body, so that restore is proven correct.
-//!   - `head_scratch` was under-allocated by `hc_lowrank*4` = 1280 B, because
-//!     `hc_head_lowrank`'s split layout is `t*(hc*h + rank)*4`, not `hc*h*4`.
-//!     A real heap overflow. Fixed.
-//!   - a local `MTP_META_OFFSET = 40960` sat inside the target's metadata block
-//!     table region; now uses the shared 49152. Latent at long context. Fixed.
-//!   - `hc_post` / `hc_lowrank_scratch` / `norm_output` (every buffer the diff
-//!     named) are now saved and restored around the body. Fixed.
+//!     only half the highway.
+//!   - `head_scratch` was under-allocated by `hc_lowrank*4` = 1280 B: a real
+//!     heap overflow, because `hc_head_lowrank`'s split layout is
+//!     `t*(hc*h + rank)*4`, not `hc*h*4`.
+//!   - a local `MTP_META_OFFSET = 40960` sat inside the target's metadata
+//!     block-table region (the shared constant is 49152).
+//!   - `hc_post` / `hc_lowrank_scratch` / `norm_output` were all restored too.
+//! ★ THE LESSON: enumerating shared buffers to save NEVER converged, because a
+//! full decoder layer touches state this file cannot name. One private arena
+//! did it, and let every save/restore be deleted. Isolate structurally; do not
+//! enumerate.
 //!
-//! ★ CONCLUSION: the corruption is NOT in `ctx.buffers`. Enumerating buffers to
-//! save is the wrong strategy — the draft body inherits the target's whole
-//! `ForwardContext` via `..*ctx` and shares everything reachable through it,
-//! including state that is not a buffer this file can name. The sound fix is
-//! ISOLATION BY CONSTRUCTION: give the draft its OWN `BufferArena` (sized for
-//! T=1, a few MB) and build its `ForwardContext` from that, so it cannot reach
-//! the target's state at all. Do that before spending another round here.
-//!
-//! **2. The combiner is dtype-mismatched.** Same root discovery: the highway is
+//! **2. NEXT BLOCKER — the combiner is dtype-mismatched.** Same root discovery: the highway is
 //! FP32, but `rms_norm_strided` / `dense_gemv` / `residual_add` are BF16 ops, so
 //! this reads the FP32 streams as BF16 and writes BF16 back into an FP32 buffer.
 //! The draft is therefore numerically meaningless and the 0% accept rate
 //! measured so far says NOTHING about the combiner reading. Needs FP32-aware
 //! ops (no BF16->FP32 convert primitive exists today).
 //!
-//! **3. The combiner READING is genuinely open — two candidates.** The `[10240]`
+//! **3. Then: the combiner READING is genuinely open — two candidates.** The `[10240]`
 //! grouped-norm width argues for the per-stream form implemented here. But the
 //! loader's own note says the body runs "MIDDLE mHC mixing only — the proposer
 //! owns BOTH ENDS", i.e. the proposer is expected to supply an `hc_expand` at
@@ -102,11 +93,6 @@ use spark_runtime::kv_cache::{KvCacheConfig, KvCacheDtype, PagedKvCache};
 // to be shared rather than mirrored"; this is the third caller.
 use crate::layers::mtp_meta::MTP_META_OFFSET;
 
-/// Bytes of `hc_post` (and `hc_comb`) saved around the draft body. Both are
-/// `m * hc_mult * {1,hc_mult} * 4`; the draft is a single row, so a small fixed
-/// slab covers the rows it can touch.
-const HC_POST_SAVE_BYTES: usize = 256;
-
 /// Per-sequence MTP draft state.
 pub struct Qwen4ExpMtpState {
     pub block_table: Vec<u32>,
@@ -134,14 +120,6 @@ struct MtpBuffers {
     residual: DevicePtr,
     /// `[hc_mult * hidden]` low-rank head scratch.
     head_scratch: DevicePtr,
-    /// Save slots for the OTHER shared buffers the draft body writes. The
-    /// buffer diff (`ATLAS_QWEN4EXP_MTP_DIFF=1`) named exactly these three, and
-    /// reasoning that they "look transient" is what kept the corruption alive
-    /// through several rounds — so they are saved and restored like the highway
-    /// rather than argued about.
-    hc_post_save: DevicePtr,
-    hc_lowrank_save: DevicePtr,
-    norm_output_save: DevicePtr,
     /// `[vocab]` BF16. The shadow step reuses the TARGET's `lm_head` (so the
     /// draft's logits go through the same quantization ladder the real token
     /// did), and that writes `buffers.logits()` — the buffer the scheduler is
@@ -154,6 +132,15 @@ pub struct Qwen4ExpMtpHead {
     module: Qwen4ExpMtpModule,
     embed_tokens: DenseWeight,
     kv_cache: Mutex<PagedKvCache>,
+    /// ★ THE DRAFT'S OWN BUFFER ARENA — isolation by CONSTRUCTION.
+    ///
+    /// The draft body used to inherit the target's `ForwardContext` (and so its
+    /// arena) via `..*ctx`. Four rounds of "find the shared buffer, save and
+    /// restore it" each fixed a real bug and none of them stopped the target's
+    /// output being corrupted, because a full decoder layer touches state this
+    /// file cannot enumerate. Sized for ONE token, so the draft physically
+    /// cannot reach anything the target owns.
+    arena: spark_runtime::buffers::BufferArena,
     buf: MtpBuffers,
     rms_norm_k: KernelHandle,
     rms_norm_strided_k: KernelHandle,
@@ -252,10 +239,23 @@ impl Qwen4ExpMtpHead {
             (num_blocks * bs * kvh * hd * 2 * 2) as f64 / 1e9,
         );
 
+        // T=1 arena for the draft. `max_batch_tokens = 1` keeps every
+        // token-scaled buffer at one row; `max_seq_len` still sizes the scratch
+        // block-table region, and kv_block_size must match this head's own pool.
+        let free_before = gpu.free_memory().unwrap_or(0);
+        let arena = spark_runtime::buffers::BufferArena::new(config, 1, max_seq_len, 16, 1, gpu)?;
+        let free_after = gpu.free_memory().unwrap_or(0);
+        tracing::info!(
+            "qwen4_exp MTP head: private T=1 buffer arena costs {:.3} GB. The draft \
+             runs entirely inside it, so it cannot reach the target's buffers.",
+            (free_before.saturating_sub(free_after)) as f64 / 1e9,
+        );
+
         Ok(Self {
             module,
             embed_tokens,
             kv_cache: Mutex::new(kv_cache),
+            arena,
             buf: MtpBuffers {
                 streams: gpu.alloc(streams_bytes)?,
                 normed_streams: gpu.alloc(streams_bytes)?,
@@ -270,9 +270,6 @@ impl Qwen4ExpMtpHead {
                 // alone) under-allocates by `rank*4` = 1280 B and the collapse
                 // writes past the end of the allocation. Measured, not guessed.
                 head_scratch: gpu.alloc((hc * h + config.hc_lowrank.max(1)) * 4)?,
-                hc_post_save: gpu.alloc(HC_POST_SAVE_BYTES)?,
-                hc_lowrank_save: gpu.alloc((hc * h + config.hc_lowrank.max(1)) * 4)?,
-                norm_output_save: gpu.alloc(row)?,
                 logits_stash: gpu.alloc(config.vocab_size * 2)?,
             },
             // Atlas's offset-from-1 rms_norm, NOT V4's `rms_norm_vanilla`:
@@ -422,7 +419,9 @@ impl Qwen4ExpMtpHead {
             .map(|(_, p, n)| crate::speculative::hidden_fingerprint(ctx.gpu, *p, *n / 2))
             .collect();
 
-        let body_streams = ctx.buffers.hc_streams();
+        // The draft's highway lives in the DRAFT's arena, not the target's.
+        // Nothing below writes a buffer the target owns.
+        let body_streams = self.arena.hc_streams();
         ctx.gpu
             .copy_d2d_async(target_streams, self.buf.streams, hc_bytes, stream)?;
 
@@ -509,26 +508,7 @@ impl Qwen4ExpMtpHead {
             return Ok(());
         }
 
-        // ★ SAVE the other shared buffers the body writes. Named by the buffer
-        // diff, not by reasoning: hc_post, hc_lowrank_scratch, norm_output.
-        let lr_bytes = (hc as usize * h as usize + ctx.config.hc_lowrank.max(1)) * 4;
-        let saves: [(DevicePtr, DevicePtr, usize); 3] = [
-            (
-                ctx.buffers.hc_post(),
-                self.buf.hc_post_save,
-                HC_POST_SAVE_BYTES,
-            ),
-            (
-                ctx.buffers.hc_lowrank_scratch(),
-                self.buf.hc_lowrank_save,
-                lr_bytes,
-            ),
-            (ctx.buffers.norm_output(), self.buf.norm_output_save, row),
-        ];
-        for (src, dst, n) in saves {
-            ctx.gpu.copy_d2d_async(src, dst, n, stream)?;
-        }
-
+        // No save/restore of target buffers: the draft runs in its own arena.
         // ── 3. Body decode against the module's OWN cache ──
         let mut kv_cache = self.kv_cache.lock().expect("mtp kv cache poisoned");
         let bs = kv_cache.block_size();
@@ -573,6 +553,8 @@ impl Qwen4ExpMtpHead {
             routed_lora_layers: None,
             midchunk_capture: None,
             moe_lora_route: crate::layer::MoeLoraRoute::Skip,
+            // ★ the draft's OWN arena — the whole point of this design.
+            buffers: &self.arena,
             ..*ctx
         };
 
@@ -596,9 +578,6 @@ impl Qwen4ExpMtpHead {
         if body_res.is_err() {
             ctx.gpu
                 .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
-            for (dst, src, n) in saves {
-                ctx.gpu.copy_d2d_async(src, dst, n, stream)?;
-            }
             body_res?;
         }
 
@@ -635,10 +614,6 @@ impl Qwen4ExpMtpHead {
         // exactly how this bug first showed up (a truncated, rewritten answer).
         ctx.gpu
             .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
-        // …and the other three, same contract: restore before any return.
-        for (dst, src, n) in saves {
-            ctx.gpu.copy_d2d_async(src, dst, n, stream)?;
-        }
 
         if diff {
             ctx.gpu.synchronize(stream).ok();

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -365,11 +365,15 @@ impl Qwen4ExpMtpHead {
             return Ok(());
         }
         st.seq_len = st.seq_len.saturating_sub(rows);
-        if let Some(blob) = st.pre_draft_aux.take() {
-            self.module
-                .body
-                .restore_aux(st.body_state.as_mut(), &blob, gpu, stream)?;
-        }
+        // MARK REWIND, not snapshot/restore. `snapshot_aux` returns None until
+        // the sequence has reached the layer's ingest, so the snapshot pair
+        // cannot undo the FIRST draft — it leaves the carry ahead of the
+        // sequence and the next draft dies on
+        // `QSA: decode at pos 0 but 1 tokens ingested`. Measured, not theorised.
+        self.module
+            .body
+            .rewind_aux(st.body_state.as_mut(), rows, gpu, stream)?;
+        st.pre_draft_aux = None;
         Ok(())
     }
 

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -106,6 +106,19 @@ pub struct Qwen4ExpMtpState {
     /// Shadow mode: the token drafted at the PREVIOUS decode step, awaiting
     /// comparison against the token the target actually emits this step.
     pub pending_draft: Option<u32>,
+    /// How many drafts the last `propose` produced, so `after_verify` knows how
+    /// many rows to unwind when some are rejected.
+    pub last_num_drafted: usize,
+    /// Rows the draft must unwind before its next round. Set by `after_verify`
+    /// (which gets no GPU handle) and APPLIED at the top of the next `propose`,
+    /// where `ctx.gpu` is available. Deferring is safe: nothing reads the draft
+    /// body's state in between.
+    pub pending_rewind: usize,
+    /// The draft BODY's aux carry (its own QSA indexer state) snapshotted before
+    /// this round's drafts. The draft body advances its carry exactly like the
+    /// target does, and its ingest asserts `pos == ingested` — so a rejected
+    /// draft must rewind it or the NEXT draft trips that assert.
+    pub pre_draft_aux: Option<Vec<u8>>,
 }
 
 /// Private device buffers. The head owns every buffer it writes so it cannot
@@ -316,7 +329,61 @@ impl Qwen4ExpMtpHead {
             seq_len: 0,
             body_state: self.module.body.alloc_state(gpu)?,
             pending_draft: None,
+            last_num_drafted: 0,
+            pending_rewind: 0,
+            pre_draft_aux: None,
         })
+    }
+
+    /// Snapshot the draft body's own carry before a round of drafts.
+    pub fn snapshot_draft_aux(
+        &self,
+        st: &Qwen4ExpMtpState,
+        gpu: &dyn GpuBackend,
+        stream: u64,
+    ) -> Result<Option<Vec<u8>>> {
+        self.module
+            .body
+            .snapshot_aux(st.body_state.as_ref(), gpu, stream)
+    }
+
+    /// Rewind the draft body's own state by `rows` after a rejected draft.
+    ///
+    /// Mirrors the target-side rollback: the draft advanced its seq_len, its KV
+    /// and its QSA carry for every row it produced, but only the accepted ones
+    /// are real. The KV past `seq_len` is left alone — the next draft overwrites
+    /// it — but the QSA carry must be restored, because its ingest asserts hard
+    /// on `pos == ingested`.
+    pub fn rewind_draft(
+        &self,
+        st: &mut Qwen4ExpMtpState,
+        rows: usize,
+        gpu: &dyn GpuBackend,
+        stream: u64,
+    ) -> Result<()> {
+        if rows == 0 {
+            return Ok(());
+        }
+        st.seq_len = st.seq_len.saturating_sub(rows);
+        if let Some(blob) = st.pre_draft_aux.take() {
+            self.module
+                .body
+                .restore_aux(st.body_state.as_mut(), &blob, gpu, stream)?;
+        }
+        Ok(())
+    }
+
+    /// Scratch the draft writes its post-mHC-head hidden into. Lives in the
+    /// draft's own arena, so it cannot collide with the target's.
+    pub fn draft_h_out(&self) -> DevicePtr {
+        self.arena.hidden_states()
+    }
+
+    /// The DRAFT's highway after a `draft_hidden` call. Chaining a second draft
+    /// feeds this back in as the next step's input — draft j+1 continues from
+    /// the body's own state, not the target's.
+    pub fn draft_streams(&self) -> DevicePtr {
+        self.arena.hc_streams()
     }
 
     /// Turn the draft's final hidden into a token id, entirely inside the

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! qwen4_exp MTP draft head — the combiner + body forward.
+//!
+//! ```text
+//!   normed  = grouped_rms_norm(target_hc_streams, pre_fc_norm_hidden)  // [hc,H]
+//!   streams = fc_hidden · normed
+//!           + broadcast(fc_embedding · rms_norm(embed, pre_fc_norm_embedding))
+//!   body.decode(streams, …, own kv cache, seq_len)     // MIDDLE mHC + QSA + MoE
+//!   h_out   = hc_head(streams)                          // is_last mHC
+//! ```
+//!
+//! The caller finishes with its own `final_norm_apply` + `lm_head` + argmax, so
+//! this file never duplicates the target's LM-head quantization handling.
+//!
+//! # Why the combiner consumes STREAMS, not a collapsed hidden
+//!
+//! DeepSeek-V4's MTP norms a collapsed `[H]` hidden and then calls `hc_expand`
+//! to replicate it into streams. qwen4_exp does NOT: its
+//! `mtp.pre_fc_norm_hidden` is `[hc_mult*hidden]` = `[10240]`, and a norm
+//! weight's width is what it normalizes. `HcLowRank::norm_w` documents that
+//! exact shape as "a GROUPED RMSNorm scale: the streams normalize
+//! independently inside the vector, group_size = hidden" — so this combiner
+//! takes the four-stream highway directly and its OUTPUT is the body's
+//! highway. There is no `hc_expand` on this path.
+//!
+//! That reading is what makes `fc_hidden [2560,2560]` consistent: it is applied
+//! PER STREAM, not to a 10240-wide vector (which it could not consume). The
+//! alternative — collapse-then-expand — would require `pre_fc_norm_hidden` to
+//! be `[2560]`. It is not.
+//!
+//! ⚠ UNVERIFIED AGAINST A GOLDEN. HF's `modeling_qwen4_exp.py` carries
+//! `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]` and ships no MTP class,
+//! so no reference activations can be generated. The argument above is
+//! structural, not numerical. `ATLAS_QWEN4EXP_MTP_SHADOW=1` exists to settle it
+//! empirically: a wrong combiner costs ~100% of ACCEPTANCE and 0% of
+//! correctness, so a near-zero shadow accept rate falsifies it.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+use crate::layer::{ForwardContext, LayerState};
+use crate::layers::ops;
+use crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule;
+use crate::weight_map::DenseWeight;
+use spark_runtime::kv_cache::{KvCacheConfig, KvCacheDtype, PagedKvCache};
+
+/// Scratch offset for the MTP body's attention metadata. Mirrors the
+/// DeepSeek-V4 head's use of a DISTINCT offset so the draft forward does not
+/// clobber the target metadata the main decode wrote at 32768.
+const MTP_META_OFFSET: usize = 40960;
+
+/// Per-sequence MTP draft state.
+pub struct Qwen4ExpMtpState {
+    pub block_table: Vec<u32>,
+    pub seq_len: usize,
+    pub body_state: Box<dyn LayerState>,
+    /// Shadow mode: the token drafted at the PREVIOUS decode step, awaiting
+    /// comparison against the token the target actually emits this step.
+    pub pending_draft: Option<u32>,
+}
+
+/// Private device buffers. The head owns every buffer it writes so it cannot
+/// alias the target's live state — the failure mode that "does not error, it
+/// yields ~0% accept".
+struct MtpBuffers {
+    /// `[hc_mult * hidden]` — the target's streams, copied in.
+    streams: DevicePtr,
+    /// `[hc_mult * hidden]` — grouped-normed streams.
+    normed_streams: DevicePtr,
+    /// `[hidden]` scratch: embedding, its norm, its projection.
+    embed: DevicePtr,
+    normed_embed: DevicePtr,
+    embed_proj: DevicePtr,
+    /// `[hidden]` single-stream scratch the body collapses into.
+    body_scratch: DevicePtr,
+    residual: DevicePtr,
+    /// `[hc_mult * hidden]` low-rank head scratch.
+    head_scratch: DevicePtr,
+}
+
+pub struct Qwen4ExpMtpHead {
+    module: Qwen4ExpMtpModule,
+    embed_tokens: DenseWeight,
+    kv_cache: Mutex<PagedKvCache>,
+    buf: MtpBuffers,
+    rms_norm_k: KernelHandle,
+    rms_norm_strided_k: KernelHandle,
+    dense_gemv_k: KernelHandle,
+    residual_add_k: KernelHandle,
+    hc_head_k: KernelHandle,
+    /// Shadow counters: drafts made, drafts that matched the target's token.
+    shadow_drafts: AtomicU64,
+    shadow_hits: AtomicU64,
+}
+
+/// `ATLAS_QWEN4EXP_MTP_SHADOW=1` — run the draft head alongside normal decode
+/// and log how often its draft matches the token the target actually emits.
+/// Produces NO speculation: nothing is fed back, the scheduler is untouched.
+pub fn shadow_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("ATLAS_QWEN4EXP_MTP_SHADOW").as_deref() == Ok("1"))
+}
+
+impl Qwen4ExpMtpHead {
+    pub fn new(
+        module: Qwen4ExpMtpModule,
+        embed_tokens: DenseWeight,
+        config: &atlas_core::config::ModelConfig,
+        gpu: &dyn GpuBackend,
+        max_seq_len: usize,
+    ) -> Result<Self> {
+        let h = config.hidden_size;
+        let hc = config.hc_mult.max(1);
+        let row = h * 2;
+        let streams_bytes = hc * row;
+
+        // The body was built with `attn_idx = 0`, so this pool needs exactly
+        // ONE layer — and the body must NEVER be handed the main model's pool,
+        // where index 0 is full-attention layer 0's live K/V.
+        let kv_config = KvCacheConfig {
+            block_size: 16,
+            num_kv_heads: config.num_key_value_heads,
+            head_dim: config.head_dim,
+            num_layers: 1,
+            dtype: KvCacheDtype::Bf16,
+            layer_dtypes: vec![],
+            layer_dims: vec![],
+            cache_blocks_per_seq: None,
+        };
+        let num_blocks = max_seq_len / kv_config.block_size + 2;
+        let (bs, kvh, hd) = (
+            kv_config.block_size,
+            kv_config.num_kv_heads,
+            kv_config.head_dim,
+        );
+        let kv_cache = PagedKvCache::new(kv_config, num_blocks, gpu)?;
+        tracing::info!(
+            "qwen4_exp MTP head: private KV pool {} blocks x {} tok = {} tokens, \
+             {} kv_heads x {} head_dim BF16 (~{:.2} GB). This is allocated AFTER \
+             the main pool and is therefore OUTSIDE the util pledge.",
+            num_blocks,
+            bs,
+            num_blocks * bs,
+            kvh,
+            hd,
+            (num_blocks * bs * kvh * hd * 2 * 2) as f64 / 1e9,
+        );
+
+        Ok(Self {
+            module,
+            embed_tokens,
+            kv_cache: Mutex::new(kv_cache),
+            buf: MtpBuffers {
+                streams: gpu.alloc(streams_bytes)?,
+                normed_streams: gpu.alloc(streams_bytes)?,
+                embed: gpu.alloc(row)?,
+                normed_embed: gpu.alloc(row)?,
+                embed_proj: gpu.alloc(row)?,
+                body_scratch: gpu.alloc(row)?,
+                residual: gpu.alloc(row)?,
+                head_scratch: gpu.alloc(streams_bytes.max(row * 4))?,
+            },
+            // Atlas's offset-from-1 rms_norm, NOT V4's `rms_norm_vanilla`:
+            // this checkpoint's norm weights are offset-from-1 like the rest of
+            // the qwen4_exp tree.
+            rms_norm_k: gpu.kernel("rms_norm", "rms_norm")?,
+            rms_norm_strided_k: gpu.kernel("rms_norm", "rms_norm_strided")?,
+            dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
+            residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
+            hc_head_k: gpu.kernel("hyper_connection", "hc_head")?,
+            shadow_drafts: AtomicU64::new(0),
+            shadow_hits: AtomicU64::new(0),
+        })
+    }
+
+    pub fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Qwen4ExpMtpState> {
+        Ok(Qwen4ExpMtpState {
+            block_table: Vec::new(),
+            seq_len: 0,
+            body_state: self.module.body.alloc_state(gpu)?,
+            pending_draft: None,
+        })
+    }
+
+    /// Record a shadow observation and return the running accept rate.
+    pub fn shadow_observe(&self, drafted: Option<u32>, actual: u32) {
+        if let Some(d) = drafted {
+            self.shadow_drafts.fetch_add(1, Ordering::Relaxed);
+            if d == actual {
+                self.shadow_hits.fetch_add(1, Ordering::Relaxed);
+            }
+            let n = self.shadow_drafts.load(Ordering::Relaxed);
+            if n.is_multiple_of(32) {
+                let hits = self.shadow_hits.load(Ordering::Relaxed);
+                tracing::info!(
+                    "qwen4_exp MTP shadow: {hits}/{n} drafts matched the target \
+                     ({:.1}% accept). NO speculation is running — this measures \
+                     whether the combiner reading is right.",
+                    100.0 * hits as f64 / n as f64
+                );
+            }
+        }
+    }
+
+    /// One draft step. Writes the draft's final hidden state (post-mHC-head,
+    /// pre-LM-head) into `h_out`; the caller applies its own final norm and LM
+    /// head. `target_streams` is the target's four-stream highway for the
+    /// position that just produced `last_token`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn draft_hidden(
+        &self,
+        last_token: u32,
+        target_streams: DevicePtr,
+        position: usize,
+        state: &mut Qwen4ExpMtpState,
+        h_out: DevicePtr,
+        ctx: &ForwardContext,
+        stream: u64,
+    ) -> Result<()> {
+        let h = ctx.config.hidden_size as u32;
+        let hc = ctx.config.hc_mult.max(1) as u32;
+        let eps = ctx.config.rms_norm_eps as f32;
+        let row = h as usize * 2;
+
+        // Copy the target's streams into private memory FIRST. The body writes
+        // through its own highway, and the target's buffer must not be touched.
+        ctx.gpu
+            .copy_d2d_async(target_streams, self.buf.streams, hc as usize * row, stream)?;
+
+        // ── 1. Embedding branch ──
+        let src = self.embed_tokens.weight.offset(last_token as usize * row);
+        ctx.gpu.copy_d2d_async(src, self.buf.embed, row, stream)?;
+        ops::rms_norm(
+            ctx.gpu,
+            self.rms_norm_k,
+            self.buf.embed,
+            &self.module.pre_fc_norm_embedding,
+            self.buf.normed_embed,
+            1,
+            h,
+            eps,
+            stream,
+        )?;
+        ops::dense_gemv(
+            ctx.gpu,
+            self.dense_gemv_k,
+            self.buf.normed_embed,
+            &self.module.fc_embedding,
+            self.buf.embed_proj,
+            h,
+            h,
+            stream,
+        )?;
+
+        // ── 2. Hidden branch: GROUPED norm, then fc_hidden PER STREAM ──
+        // `rms_norm_strided` applies ONE weight to every row it normalizes, but
+        // each stream owns its own `[hidden]` slice of the `[hc*hidden]` scale
+        // — so this is one call per stream, each over that stream's rows with
+        // `row_stride = hc*hidden`. At T=1 that is a single row per call.
+        for i in 0..hc as usize {
+            let off = i * row;
+            let w = DenseWeight {
+                weight: self.module.pre_fc_norm_hidden.weight.offset(off),
+            };
+            ops::rms_norm_strided(
+                ctx.gpu,
+                self.rms_norm_strided_k,
+                self.buf.streams.offset(off),
+                &w,
+                self.buf.normed_streams.offset(off),
+                1,
+                1,
+                h,
+                eps,
+                hc * h,
+                stream,
+            )?;
+            // fc_hidden is shared across streams; apply it to this stream and
+            // add the (broadcast) embedding projection in place.
+            ops::dense_gemv(
+                ctx.gpu,
+                self.dense_gemv_k,
+                self.buf.normed_streams.offset(off),
+                &self.module.fc_hidden,
+                self.buf.streams.offset(off),
+                h,
+                h,
+                stream,
+            )?;
+            ops::residual_add(
+                ctx.gpu,
+                self.residual_add_k,
+                self.buf.streams.offset(off),
+                self.buf.embed_proj,
+                h,
+                stream,
+            )?;
+        }
+
+        // ── 3. Body decode against the module's OWN cache ──
+        let mut kv_cache = self.kv_cache.lock().expect("mtp kv cache poisoned");
+        let bs = kv_cache.block_size();
+        let blocks_needed = (state.seq_len / bs) + 1;
+        while state.block_table.len() < blocks_needed {
+            state.block_table.push(kv_cache.alloc_block()?);
+        }
+        // Same layout + same shared packer the DeepSeek-V4 head uses, at a
+        // DISTINCT scratch offset so this never clobbers the target metadata.
+        let meta_base = ctx.buffers.scratch().offset(MTP_META_OFFSET);
+        let block_idx = state.block_table[state.seq_len / bs];
+        let global_slot = (block_idx as i64) * (bs as i64) + ((state.seq_len % bs) as i64);
+        let meta_buf = super::mtp_meta::pack_mtp_attn_meta(
+            position as u32,
+            global_slot,
+            (state.seq_len + 1) as i32,
+            &state.block_table,
+            ctx.buffers.scratch_bytes().saturating_sub(MTP_META_OFFSET),
+        )?;
+        ctx.gpu.copy_h2d_async(&meta_buf, meta_base, stream)?;
+        let meta = crate::layer::AttnMetadataDev {
+            positions: meta_base,
+            positions_h: meta_base,
+            positions_w: meta_base,
+            slot: meta_base.offset(8),
+            seq_len: meta_base.offset(16),
+            block_table: meta_base.offset(256),
+            max_blocks_per_seq: state.block_table.len() as u32,
+            num_seqs: 1,
+            seq_slot: DevicePtr(0),
+            moe_row_adapter: DevicePtr::NULL,
+        };
+
+        let mtp_ctx = ForwardContext {
+            attn_metadata: Some(meta),
+            // The draft body must not issue an EP all-reduce: it is rank-0 only
+            // and `ensure_loadable` refuses ep_world_size > 1 outright.
+            comm: None,
+            // Host-built metadata + H2D uploads are illegal under capture.
+            graph_capture: false,
+            host_token_ids: None,
+            routed_lora_layers: None,
+            midchunk_capture: None,
+            moe_lora_route: crate::layer::MoeLoraRoute::Skip,
+            ..*ctx
+        };
+
+        let mut disk_block_ids: Vec<u32> = Vec::new();
+        let mut disk_last_offloaded: Vec<u32> = vec![0u32; 1];
+        self.module.body.decode(
+            self.buf.body_scratch,
+            self.buf.residual,
+            state.body_state.as_mut(),
+            &mut kv_cache,
+            state.seq_len,
+            &mut state.block_table,
+            &mut disk_block_ids,
+            &mut disk_last_offloaded,
+            &mtp_ctx,
+            stream,
+        )?;
+        drop(kv_cache);
+
+        // ── 4. mHC head: collapse the module's streams → h_out ──
+        // qwen4_exp's head is LOW-RANK, which is exactly the arm DeepSeek-V4's
+        // MTP asserts against; call the low-rank collapse directly.
+        let head = self
+            .module
+            .hc_head
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("qwen4_exp MTP: module has no hc_head"))?;
+        let lowrank = head.lowrank.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("qwen4_exp MTP: hc_head is not low-rank; this model's is")
+        })?;
+        ops::hc_head_lowrank(
+            ctx.gpu,
+            self.hc_head_k,
+            self.buf.streams,
+            lowrank,
+            h_out,
+            self.buf.head_scratch,
+            1,
+            h,
+            hc,
+            eps,
+            stream,
+        )?;
+
+        state.seq_len += 1;
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -34,22 +34,36 @@
 //! so no reference activations can be generated. The argument above is
 //! structural, not numerical.
 //!
-//! # STATUS: NOT WORKING. Three open defects, in the order they must be fixed.
+//! # STATUS: NOT WORKING. The SHARING MODEL is wrong — do not keep patching.
 //!
-//! **1. The body forward corrupts the target.** Bisect via
-//! `ATLAS_QWEN4EXP_MTP_SHADOW_STAGE` (measured, 250-token greedy completion
-//! against a shadow-off control):
+//! **1. The body forward corrupts the target, and buffer-by-buffer isolation
+//! does NOT fix it.** Bisect via `ATLAS_QWEN4EXP_MTP_SHADOW_STAGE` (250-token
+//! greedy completion against a shadow-off control):
 //! ```text
 //!   observe  -> output matches control exactly      INERT
 //!   combine  -> output matches control exactly      INERT
 //!   body     -> degenerate / empty, watchdog fires  CORRUPTS
 //! ```
-//! So the combiner and the highway save/restore are proven clean, and the draft
-//! BODY mutates state the target still needs. One cause was found and fixed —
-//! `hc_streams` is FP32 (`m*hc_mult*h*4`), and sizing the save/restore as BF16
-//! restored only HALF the highway — but that fix changed the SYMPTOM (degenerate
-//! text -> empty text) without curing it. At least one more shared-state
-//! dependency remains unidentified. Do not enable `body`/`full`.
+//! Four separate causes were found and fixed, and the corruption SURVIVED all
+//! of them:
+//!   - `hc_streams` is FP32 (`m*hc_mult*h*4`); a BF16-sized save/restore covered
+//!     only half the highway. Fixed — the buffer diff now shows hc_streams
+//!     unchanged across the body, so that restore is proven correct.
+//!   - `head_scratch` was under-allocated by `hc_lowrank*4` = 1280 B, because
+//!     `hc_head_lowrank`'s split layout is `t*(hc*h + rank)*4`, not `hc*h*4`.
+//!     A real heap overflow. Fixed.
+//!   - a local `MTP_META_OFFSET = 40960` sat inside the target's metadata block
+//!     table region; now uses the shared 49152. Latent at long context. Fixed.
+//!   - `hc_post` / `hc_lowrank_scratch` / `norm_output` (every buffer the diff
+//!     named) are now saved and restored around the body. Fixed.
+//!
+//! ★ CONCLUSION: the corruption is NOT in `ctx.buffers`. Enumerating buffers to
+//! save is the wrong strategy — the draft body inherits the target's whole
+//! `ForwardContext` via `..*ctx` and shares everything reachable through it,
+//! including state that is not a buffer this file can name. The sound fix is
+//! ISOLATION BY CONSTRUCTION: give the draft its OWN `BufferArena` (sized for
+//! T=1, a few MB) and build its `ForwardContext` from that, so it cannot reach
+//! the target's state at all. Do that before spending another round here.
 //!
 //! **2. The combiner is dtype-mismatched.** Same root discovery: the highway is
 //! FP32, but `rms_norm_strided` / `dense_gemv` / `residual_add` are BF16 ops, so
@@ -79,10 +93,19 @@ use crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule;
 use crate::weight_map::DenseWeight;
 use spark_runtime::kv_cache::{KvCacheConfig, KvCacheDtype, PagedKvCache};
 
-/// Scratch offset for the MTP body's attention metadata. Mirrors the
-/// DeepSeek-V4 head's use of a DISTINCT offset so the draft forward does not
-/// clobber the target metadata the main decode wrote at 32768.
-const MTP_META_OFFSET: usize = 40960;
+// Use the SHARED constant (49152), not a local one. An earlier local 40960 sat
+// INSIDE the region the target's metadata slab reserves for its block table
+// (32768 + 256 + 4 bytes/block ⇒ 49152 covers 4096 blocks = 65536 tokens). It
+// happens not to collide at short contexts — the target only fills as many
+// entries as it has blocks — which is exactly what makes it the kind of latent
+// bug that shows up first at long context. mtp_meta.rs says the constant "wanted
+// to be shared rather than mirrored"; this is the third caller.
+use crate::layers::mtp_meta::MTP_META_OFFSET;
+
+/// Bytes of `hc_post` (and `hc_comb`) saved around the draft body. Both are
+/// `m * hc_mult * {1,hc_mult} * 4`; the draft is a single row, so a small fixed
+/// slab covers the rows it can touch.
+const HC_POST_SAVE_BYTES: usize = 256;
 
 /// Per-sequence MTP draft state.
 pub struct Qwen4ExpMtpState {
@@ -111,6 +134,14 @@ struct MtpBuffers {
     residual: DevicePtr,
     /// `[hc_mult * hidden]` low-rank head scratch.
     head_scratch: DevicePtr,
+    /// Save slots for the OTHER shared buffers the draft body writes. The
+    /// buffer diff (`ATLAS_QWEN4EXP_MTP_DIFF=1`) named exactly these three, and
+    /// reasoning that they "look transient" is what kept the corruption alive
+    /// through several rounds — so they are saved and restored like the highway
+    /// rather than argued about.
+    hc_post_save: DevicePtr,
+    hc_lowrank_save: DevicePtr,
+    norm_output_save: DevicePtr,
     /// `[vocab]` BF16. The shadow step reuses the TARGET's `lm_head` (so the
     /// draft's logits go through the same quantization ladder the real token
     /// did), and that writes `buffers.logits()` — the buffer the scheduler is
@@ -233,7 +264,15 @@ impl Qwen4ExpMtpHead {
                 embed_proj: gpu.alloc(row)?,
                 body_scratch: gpu.alloc(row)?,
                 residual: gpu.alloc(row)?,
-                head_scratch: gpu.alloc(streams_bytes.max(row * 4))?,
+                // `hc_head_lowrank`'s decode-split layout is
+                // `t * (hc_mult*h + hc_lowrank) * 4` — normed FP32 [t, hc*H]
+                // THEN low FP32 [t, rank]. Sizing this `hc*h*4` (the streams
+                // alone) under-allocates by `rank*4` = 1280 B and the collapse
+                // writes past the end of the allocation. Measured, not guessed.
+                head_scratch: gpu.alloc((hc * h + config.hc_lowrank.max(1)) * 4)?,
+                hc_post_save: gpu.alloc(HC_POST_SAVE_BYTES)?,
+                hc_lowrank_save: gpu.alloc((hc * h + config.hc_lowrank.max(1)) * 4)?,
+                norm_output_save: gpu.alloc(row)?,
                 logits_stash: gpu.alloc(config.vocab_size * 2)?,
             },
             // Atlas's offset-from-1 rms_norm, NOT V4's `rms_norm_vanilla`:
@@ -350,6 +389,39 @@ impl Qwen4ExpMtpHead {
         // clean precisely BECAUSE it only ever touched, and then restored, that
         // same first half.
         let hc_bytes = hc as usize * h as usize * 4;
+
+        // ── DIAGNOSTIC (ATLAS_QWEN4EXP_MTP_DIFF=1) ──
+        // The bisect proved the BODY forward dirties state the target still
+        // needs, but not WHICH buffer. Rather than keep guessing, fingerprint
+        // the shared buffers either side of the call and name the ones that
+        // changed. Taken BEFORE the combiner runs, so the baseline is the
+        // TARGET's state — an earlier version sampled it after the combiner had
+        // already written hc_streams, which made hc_streams a false positive.
+        let diff = std::env::var("ATLAS_QWEN4EXP_MTP_DIFF").as_deref() == Ok("1");
+        let probes: Vec<(&str, DevicePtr, usize)> = if diff {
+            ctx.gpu.synchronize(stream).ok();
+            vec![
+                ("hc_streams", ctx.buffers.hc_streams(), hc_bytes.min(4096)),
+                ("hc_post", ctx.buffers.hc_post(), 256),
+                ("hc_comb", ctx.buffers.hc_comb(), 256),
+                ("hc_lowrank_scratch", ctx.buffers.hc_lowrank_scratch(), 4096),
+                ("hidden_states", ctx.buffers.hidden_states(), row),
+                ("residual", ctx.buffers.residual(), row),
+                ("norm_output", ctx.buffers.norm_output(), row),
+                (
+                    "scratch@target_meta",
+                    ctx.buffers.scratch().offset(32768),
+                    4096,
+                ),
+            ]
+        } else {
+            Vec::new()
+        };
+        let before: Vec<u64> = probes
+            .iter()
+            .map(|(_, p, n)| crate::speculative::hidden_fingerprint(ctx.gpu, *p, *n / 2))
+            .collect();
+
         let body_streams = ctx.buffers.hc_streams();
         ctx.gpu
             .copy_d2d_async(target_streams, self.buf.streams, hc_bytes, stream)?;
@@ -437,6 +509,26 @@ impl Qwen4ExpMtpHead {
             return Ok(());
         }
 
+        // ★ SAVE the other shared buffers the body writes. Named by the buffer
+        // diff, not by reasoning: hc_post, hc_lowrank_scratch, norm_output.
+        let lr_bytes = (hc as usize * h as usize + ctx.config.hc_lowrank.max(1)) * 4;
+        let saves: [(DevicePtr, DevicePtr, usize); 3] = [
+            (
+                ctx.buffers.hc_post(),
+                self.buf.hc_post_save,
+                HC_POST_SAVE_BYTES,
+            ),
+            (
+                ctx.buffers.hc_lowrank_scratch(),
+                self.buf.hc_lowrank_save,
+                lr_bytes,
+            ),
+            (ctx.buffers.norm_output(), self.buf.norm_output_save, row),
+        ];
+        for (src, dst, n) in saves {
+            ctx.gpu.copy_d2d_async(src, dst, n, stream)?;
+        }
+
         // ── 3. Body decode against the module's OWN cache ──
         let mut kv_cache = self.kv_cache.lock().expect("mtp kv cache poisoned");
         let bs = kv_cache.block_size();
@@ -504,6 +596,9 @@ impl Qwen4ExpMtpHead {
         if body_res.is_err() {
             ctx.gpu
                 .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
+            for (dst, src, n) in saves {
+                ctx.gpu.copy_d2d_async(src, dst, n, stream)?;
+            }
             body_res?;
         }
 
@@ -540,6 +635,28 @@ impl Qwen4ExpMtpHead {
         // exactly how this bug first showed up (a truncated, rewritten answer).
         ctx.gpu
             .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
+        // …and the other three, same contract: restore before any return.
+        for (dst, src, n) in saves {
+            ctx.gpu.copy_d2d_async(src, dst, n, stream)?;
+        }
+
+        if diff {
+            ctx.gpu.synchronize(stream).ok();
+            let changed: Vec<&str> = probes
+                .iter()
+                .zip(before.iter())
+                .filter(|((_, p, n), b)| {
+                    crate::speculative::hidden_fingerprint(ctx.gpu, *p, *n / 2) != **b
+                })
+                .map(|((name, _, _), _)| *name)
+                .collect();
+            tracing::info!(
+                "qwen4_exp MTP diff: buffers changed across the draft body = {:?} \
+                 (hc_streams should NOT appear — it is restored above; anything \
+                 else that appears is shared state the target still needs)",
+                changed
+            );
+        }
         collapse?;
 
         state.seq_len += 1;

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -32,9 +32,40 @@
 //! ⚠ UNVERIFIED AGAINST A GOLDEN. HF's `modeling_qwen4_exp.py` carries
 //! `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]` and ships no MTP class,
 //! so no reference activations can be generated. The argument above is
-//! structural, not numerical. `ATLAS_QWEN4EXP_MTP_SHADOW=1` exists to settle it
-//! empirically: a wrong combiner costs ~100% of ACCEPTANCE and 0% of
-//! correctness, so a near-zero shadow accept rate falsifies it.
+//! structural, not numerical.
+//!
+//! # STATUS: NOT WORKING. Three open defects, in the order they must be fixed.
+//!
+//! **1. The body forward corrupts the target.** Bisect via
+//! `ATLAS_QWEN4EXP_MTP_SHADOW_STAGE` (measured, 250-token greedy completion
+//! against a shadow-off control):
+//! ```text
+//!   observe  -> output matches control exactly      INERT
+//!   combine  -> output matches control exactly      INERT
+//!   body     -> degenerate / empty, watchdog fires  CORRUPTS
+//! ```
+//! So the combiner and the highway save/restore are proven clean, and the draft
+//! BODY mutates state the target still needs. One cause was found and fixed —
+//! `hc_streams` is FP32 (`m*hc_mult*h*4`), and sizing the save/restore as BF16
+//! restored only HALF the highway — but that fix changed the SYMPTOM (degenerate
+//! text -> empty text) without curing it. At least one more shared-state
+//! dependency remains unidentified. Do not enable `body`/`full`.
+//!
+//! **2. The combiner is dtype-mismatched.** Same root discovery: the highway is
+//! FP32, but `rms_norm_strided` / `dense_gemv` / `residual_add` are BF16 ops, so
+//! this reads the FP32 streams as BF16 and writes BF16 back into an FP32 buffer.
+//! The draft is therefore numerically meaningless and the 0% accept rate
+//! measured so far says NOTHING about the combiner reading. Needs FP32-aware
+//! ops (no BF16->FP32 convert primitive exists today).
+//!
+//! **3. The combiner READING is genuinely open — two candidates.** The `[10240]`
+//! grouped-norm width argues for the per-stream form implemented here. But the
+//! loader's own note says the body runs "MIDDLE mHC mixing only — the proposer
+//! owns BOTH ENDS", i.e. the proposer is expected to supply an `hc_expand` at
+//! the front, which this form has no place for; that argues for a collapse-then-
+//! `hc_expand` form, which would equally explain the square `fc_hidden`. Decide
+//! it by implementing both behind `ATLAS_QWEN4EXP_MTP_COMBINER` and comparing
+//! shadow accept rates — but only AFTER (1) and (2), or the comparison is noise.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -80,6 +111,12 @@ struct MtpBuffers {
     residual: DevicePtr,
     /// `[hc_mult * hidden]` low-rank head scratch.
     head_scratch: DevicePtr,
+    /// `[vocab]` BF16. The shadow step reuses the TARGET's `lm_head` (so the
+    /// draft's logits go through the same quantization ladder the real token
+    /// did), and that writes `buffers.logits()` — the buffer the scheduler is
+    /// about to sample from. The target's logits are parked here first and put
+    /// back afterwards, so the draft cannot change what the model emits.
+    logits_stash: DevicePtr,
 }
 
 pub struct Qwen4ExpMtpHead {
@@ -105,6 +142,39 @@ pub fn shadow_enabled() -> bool {
     *ON.get_or_init(|| std::env::var("ATLAS_QWEN4EXP_MTP_SHADOW").as_deref() == Ok("1"))
 }
 
+/// How far the shadow step runs — a BISECTION handle, not a feature.
+///
+/// Shadow mode was observed to change the target's own output (a thinking-loop
+/// degeneration, watchdog-forced `</think>`), which means something in the draft
+/// step mutates state the target still needs. Rather than guess which buffer,
+/// this walks the step forward one stage at a time and the operator watches for
+/// the first stage whose output stops matching the shadow-off control.
+///
+/// `ATLAS_QWEN4EXP_MTP_SHADOW_STAGE` = observe | combine | body | full (default).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ShadowStage {
+    /// argmax the target's logits and count only. Touches NOTHING else.
+    Observe,
+    /// + the combiner (writes `hc_streams`, then restores it).
+    Combine,
+    /// + the draft body forward.
+    Body,
+    /// + the draft's own final norm / LM head / argmax.
+    Full,
+}
+
+pub fn shadow_stage() -> ShadowStage {
+    static S: std::sync::OnceLock<ShadowStage> = std::sync::OnceLock::new();
+    *S.get_or_init(
+        || match std::env::var("ATLAS_QWEN4EXP_MTP_SHADOW_STAGE").as_deref() {
+            Ok("observe") => ShadowStage::Observe,
+            Ok("combine") => ShadowStage::Combine,
+            Ok("body") => ShadowStage::Body,
+            _ => ShadowStage::Full,
+        },
+    )
+}
+
 impl Qwen4ExpMtpHead {
     pub fn new(
         module: Qwen4ExpMtpModule,
@@ -116,7 +186,8 @@ impl Qwen4ExpMtpHead {
         let h = config.hidden_size;
         let hc = config.hc_mult.max(1);
         let row = h * 2;
-        let streams_bytes = hc * row;
+        // FP32 highway (4 B/elem) — see the note in `draft_hidden`.
+        let streams_bytes = hc * h * 4;
 
         // The body was built with `attn_idx = 0`, so this pool needs exactly
         // ONE layer — and the body must NEVER be handed the main model's pool,
@@ -163,12 +234,13 @@ impl Qwen4ExpMtpHead {
                 body_scratch: gpu.alloc(row)?,
                 residual: gpu.alloc(row)?,
                 head_scratch: gpu.alloc(streams_bytes.max(row * 4))?,
+                logits_stash: gpu.alloc(config.vocab_size * 2)?,
             },
             // Atlas's offset-from-1 rms_norm, NOT V4's `rms_norm_vanilla`:
             // this checkpoint's norm weights are offset-from-1 like the rest of
             // the qwen4_exp tree.
-            rms_norm_k: gpu.kernel("rms_norm", "rms_norm")?,
-            rms_norm_strided_k: gpu.kernel("rms_norm", "rms_norm_strided")?,
+            rms_norm_k: gpu.kernel("norm", "rms_norm")?,
+            rms_norm_strided_k: gpu.kernel("norm", "rms_norm_strided")?,
             dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
             residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
             hc_head_k: gpu.kernel("hyper_connection", "hc_head")?,
@@ -186,6 +258,29 @@ impl Qwen4ExpMtpHead {
         })
     }
 
+    /// Park the target's logits so the draft's `lm_head` cannot change what the
+    /// model emits. MUST be paired with [`Self::restore_logits`].
+    pub fn stash_logits(
+        &self,
+        gpu: &dyn GpuBackend,
+        logits: DevicePtr,
+        vocab: usize,
+        stream: u64,
+    ) -> Result<()> {
+        gpu.copy_d2d_async(logits, self.buf.logits_stash, vocab * 2, stream)
+    }
+
+    /// Put the target's logits back after the draft has used the buffer.
+    pub fn restore_logits(
+        &self,
+        gpu: &dyn GpuBackend,
+        logits: DevicePtr,
+        vocab: usize,
+        stream: u64,
+    ) -> Result<()> {
+        gpu.copy_d2d_async(self.buf.logits_stash, logits, vocab * 2, stream)
+    }
+
     /// Record a shadow observation and return the running accept rate.
     pub fn shadow_observe(&self, drafted: Option<u32>, actual: u32) {
         if let Some(d) = drafted {
@@ -194,7 +289,7 @@ impl Qwen4ExpMtpHead {
                 self.shadow_hits.fetch_add(1, Ordering::Relaxed);
             }
             let n = self.shadow_drafts.load(Ordering::Relaxed);
-            if n.is_multiple_of(32) {
+            if n.is_multiple_of(16) {
                 let hits = self.shadow_hits.load(Ordering::Relaxed);
                 tracing::info!(
                     "qwen4_exp MTP shadow: {hits}/{n} drafts matched the target \
@@ -226,10 +321,38 @@ impl Qwen4ExpMtpHead {
         let eps = ctx.config.rms_norm_eps as f32;
         let row = h as usize * 2;
 
-        // Copy the target's streams into private memory FIRST. The body writes
-        // through its own highway, and the target's buffer must not be touched.
+        // ★ THE BODY'S HIGHWAY IS `ctx.buffers.hc_streams()`, NOT a buffer we
+        // can hand it. `decode_inner_hc` reads and writes the multi-stream state
+        // through that buffer directly — the `hidden` argument is only the
+        // single-stream scratch hc_pre collapses into. Two consequences, both
+        // measured the hard way (0/240 accept AND a corrupted, truncated target
+        // response when this was got wrong):
+        //
+        //   1. the combiner's output must be written INTO `hc_streams`, or the
+        //      body silently runs on the target's highway and the draft is
+        //      meaningless;
+        //   2. that highway is PERSISTENT per-sequence state, so it must be
+        //      saved and put back, or the draft destroys the target's next step.
+        //
+        // `buf.streams` is the save slot; the combiner reads from it and writes
+        // into `hc_streams`.
+        //
+        // ★★ THE HIGHWAY IS FP32, NOT BF16. `BufferSizes` allocates it as
+        // `m * hc_mult * h * 4` with the comment "the residual streams grow
+        // large across the blocks ... so BF16 storage swamps the small
+        // per-layer signal at scale and collapses generation".
+        //
+        // Sizing this as BF16 was a REAL corruption: the save/restore covered
+        // only the first HALF of the highway, so the body's full-width FP32
+        // writes survived the restore and poisoned every later target step
+        // (measured: a thinking-loop degeneration, watchdog-forced `</think>`,
+        // truncated answer). The bisect is the proof — the `combine` stage was
+        // clean precisely BECAUSE it only ever touched, and then restored, that
+        // same first half.
+        let hc_bytes = hc as usize * h as usize * 4;
+        let body_streams = ctx.buffers.hc_streams();
         ctx.gpu
-            .copy_d2d_async(target_streams, self.buf.streams, hc as usize * row, stream)?;
+            .copy_d2d_async(target_streams, self.buf.streams, hc_bytes, stream)?;
 
         // ── 1. Embedding branch ──
         let src = self.embed_tokens.weight.offset(last_token as usize * row);
@@ -281,12 +404,16 @@ impl Qwen4ExpMtpHead {
             )?;
             // fc_hidden is shared across streams; apply it to this stream and
             // add the (broadcast) embedding projection in place.
+            //
+            // Destination is `body_streams` (= ctx.buffers.hc_streams()), which
+            // is where the body will look. `buf.streams` must stay untouched —
+            // it is the target's saved highway, restored below.
             ops::dense_gemv(
                 ctx.gpu,
                 self.dense_gemv_k,
                 self.buf.normed_streams.offset(off),
                 &self.module.fc_hidden,
-                self.buf.streams.offset(off),
+                body_streams.offset(off),
                 h,
                 h,
                 stream,
@@ -294,11 +421,20 @@ impl Qwen4ExpMtpHead {
             ops::residual_add(
                 ctx.gpu,
                 self.residual_add_k,
-                self.buf.streams.offset(off),
+                body_streams.offset(off),
                 self.buf.embed_proj,
                 h,
                 stream,
             )?;
+        }
+
+        // BISECTION: stop after the combiner, restoring the highway. If the
+        // target's output is clean here but dirty at `body`, the body forward
+        // owns the corruption.
+        if shadow_stage() < ShadowStage::Body {
+            ctx.gpu
+                .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
+            return Ok(());
         }
 
         // ── 3. Body decode against the module's OWN cache ──
@@ -350,7 +486,9 @@ impl Qwen4ExpMtpHead {
 
         let mut disk_block_ids: Vec<u32> = Vec::new();
         let mut disk_last_offloaded: Vec<u32> = vec![0u32; 1];
-        self.module.body.decode(
+        // Result captured, NOT `?`: an early return here would leave the
+        // draft's streams in the target's persistent highway.
+        let body_res = self.module.body.decode(
             self.buf.body_scratch,
             self.buf.residual,
             state.body_state.as_mut(),
@@ -361,8 +499,13 @@ impl Qwen4ExpMtpHead {
             &mut disk_last_offloaded,
             &mtp_ctx,
             stream,
-        )?;
+        );
         drop(kv_cache);
+        if body_res.is_err() {
+            ctx.gpu
+                .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
+            body_res?;
+        }
 
         // ── 4. mHC head: collapse the module's streams → h_out ──
         // qwen4_exp's head is LOW-RANK, which is exactly the arm DeepSeek-V4's
@@ -375,10 +518,12 @@ impl Qwen4ExpMtpHead {
         let lowrank = head.lowrank.as_ref().ok_or_else(|| {
             anyhow::anyhow!("qwen4_exp MTP: hc_head is not low-rank; this model's is")
         })?;
-        ops::hc_head_lowrank(
+        // Collapse the DRAFT's highway (which the body just wrote through
+        // `body_streams`), not the saved target one.
+        let collapse = ops::hc_head_lowrank(
             ctx.gpu,
             self.hc_head_k,
-            self.buf.streams,
+            body_streams,
             lowrank,
             h_out,
             self.buf.head_scratch,
@@ -387,7 +532,15 @@ impl Qwen4ExpMtpHead {
             hc,
             eps,
             stream,
-        )?;
+        );
+
+        // ★ RESTORE THE TARGET'S HIGHWAY, unconditionally and before returning
+        // any error. `hc_streams` is persistent per-sequence state: leaving the
+        // draft's streams in it corrupts every subsequent target step, which is
+        // exactly how this bug first showed up (a truncated, rewritten answer).
+        ctx.gpu
+            .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
+        collapse?;
 
         state.seq_len += 1;
         Ok(())

--- a/crates/spark-model/src/layers/qwen4_exp_mtp.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp.rs
@@ -34,43 +34,48 @@
 //! so no reference activations can be generated. The argument above is
 //! structural, not numerical.
 //!
-//! # STATUS: the harness is INERT; the draft is not yet numerically right.
+//! # STATUS: the draft head WORKS — 86.5% shadow accept, harness inert.
 //!
-//! **1. Target corruption: FIXED, by isolation by construction.** The draft
-//! runs inside its OWN `BufferArena` (`max_batch_tokens = 1`, measured <1 MB),
-//! so the body cannot reach any buffer the target owns. Verified: shadow-on
-//! output is BYTE-IDENTICAL to a shadow-off control, `finish: stop`, 0 failures.
+//! Measured (250-token greedy completion, `ATLAS_QWEN4EXP_MTP_SHADOW=1`):
+//! ```text
+//!   shadow off -> full answer, finish: stop
+//!   shadow on  -> BYTE-IDENTICAL output, finish: stop, 0 failures
+//!   accept      -> 83/96 drafts matched the target's next token = 86.5%
+//! ```
+//! ★ That accept rate VALIDATES the per-stream combiner reading empirically.
+//! The alternative (collapse-then-`hc_expand`) is not needed and was removed.
 //!
-//! Getting here took four rounds of "find the shared buffer, save and restore
-//! it" — each fixed a REAL bug and none of them stopped the corruption:
-//!   - `hc_streams` is FP32 (`m*hc_mult*h*4`); a BF16-sized save/restore covered
-//!     only half the highway.
-//!   - `head_scratch` was under-allocated by `hc_lowrank*4` = 1280 B: a real
-//!     heap overflow, because `hc_head_lowrank`'s split layout is
-//!     `t*(hc*h + rank)*4`, not `hc*h*4`.
-//!   - a local `MTP_META_OFFSET = 40960` sat inside the target's metadata
-//!     block-table region (the shared constant is 49152).
-//!   - `hc_post` / `hc_lowrank_scratch` / `norm_output` were all restored too.
-//! ★ THE LESSON: enumerating shared buffers to save NEVER converged, because a
-//! full decoder layer touches state this file cannot name. One private arena
-//! did it, and let every save/restore be deleted. Isolate structurally; do not
-//! enumerate.
+//! What it took, in the order the bugs were found — every one invisible to
+//! review, each caught only by running it:
+//!   1. kernel module is `norm::rms_norm`, not `rms_norm::rms_norm` (the engine
+//!      refused to start rather than serve on a null handle).
+//!   2. the hook must live in `decode_a.rs`: `decode_batch_dispatch` returns
+//!      early for n == 1, so a hook on the batched path never fires here.
+//!   3. the body's highway is `ctx.buffers.hc_streams()`, not a buffer you can
+//!      hand it, and it is PERSISTENT per-sequence state.
+//!   4. that highway is FP32 (`m*hc_mult*h*4`), not BF16.
+//!   5. `head_scratch` needs `t*(hc*h + hc_lowrank)*4`; sizing it `hc*h*4` is a
+//!      1280 B heap overflow.
+//!   6. `MTP_META_OFFSET` must be the SHARED 49152.
+//!   7. ★ the decisive one: buffer-by-buffer isolation NEVER converged. A full
+//!      decoder layer touches state the caller cannot enumerate. Giving the
+//!      draft its OWN `BufferArena` (T=1, <1 MB) fixed it at once and let every
+//!      save/restore be deleted. ISOLATE STRUCTURALLY; DO NOT ENUMERATE.
+//!   8. the combiner must be dtype-correct across the FP32/BF16 seam:
+//!      `hc_pre_stage_bf16` (FP32 highway -> BF16 grouped norm, offset-from-1,
+//!      per-stream RMS — the model's own kernel for exactly this) then BF16
+//!      GEMVs then `qhc_mtp_combine_streams` (BF16 -> FP32 highway). Running
+//!      BF16 ops directly over the FP32 highway is SILENT garbage, and it is
+//!      what made every earlier accept measurement meaningless.
 //!
-//! **2. NEXT BLOCKER — the combiner is dtype-mismatched.** Same root discovery: the highway is
-//! FP32, but `rms_norm_strided` / `dense_gemv` / `residual_add` are BF16 ops, so
-//! this reads the FP32 streams as BF16 and writes BF16 back into an FP32 buffer.
-//! The draft is therefore numerically meaningless and the 0% accept rate
-//! measured so far says NOTHING about the combiner reading. Needs FP32-aware
-//! ops (no BF16->FP32 convert primitive exists today).
+//! # NOT YET SPECULATION
 //!
-//! **3. Then: the combiner READING is genuinely open — two candidates.** The `[10240]`
-//! grouped-norm width argues for the per-stream form implemented here. But the
-//! loader's own note says the body runs "MIDDLE mHC mixing only — the proposer
-//! owns BOTH ENDS", i.e. the proposer is expected to supply an `hc_expand` at
-//! the front, which this form has no place for; that argues for a collapse-then-
-//! `hc_expand` form, which would equally explain the square `fc_hidden`. Decide
-//! it by implementing both behind `ATLAS_QWEN4EXP_MTP_COMBINER` and comparing
-//! shadow accept rates — but only AFTER (1) and (2), or the comparison is noise.
+//! `--speculative` still produces no speedup: this drafts and scores, nothing
+//! is fed back. The verify path is the remaining work — `decode_batched` and
+//! `decode_verify_multi` both refuse under the highway (they keep their own
+//! residual, which the highway replaces), so K-row verification has to route
+//! through `prefill_inner_hc`, and a rejected draft needs QSA/PLE rewind that
+//! has no API today. 86.5% accept is what makes that work worth doing.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -118,6 +123,9 @@ struct MtpBuffers {
     /// `[hidden]` single-stream scratch the body collapses into.
     body_scratch: DevicePtr,
     residual: DevicePtr,
+    /// `[hc_mult * hidden]` BF16 — `fc_hidden` applied per stream, before the
+    /// combine tail writes the FP32 highway.
+    per_stream: DevicePtr,
     /// `[hc_mult * hidden]` low-rank head scratch.
     head_scratch: DevicePtr,
     /// `[vocab]` BF16. The shadow step reuses the TARGET's `lm_head` (so the
@@ -143,10 +151,12 @@ pub struct Qwen4ExpMtpHead {
     arena: spark_runtime::buffers::BufferArena,
     buf: MtpBuffers,
     rms_norm_k: KernelHandle,
-    rms_norm_strided_k: KernelHandle,
     dense_gemv_k: KernelHandle,
-    residual_add_k: KernelHandle,
     hc_head_k: KernelHandle,
+    /// FP32 highway -> BF16 grouped norm (the combiner's hidden branch).
+    hc_stage_k: KernelHandle,
+    /// BF16 per-stream + broadcast -> FP32 highway (the combiner's tail).
+    combine_k: KernelHandle,
     /// Shadow counters: drafts made, drafts that matched the target's token.
     shadow_drafts: AtomicU64,
     shadow_hits: AtomicU64,
@@ -269,6 +279,7 @@ impl Qwen4ExpMtpHead {
                 // THEN low FP32 [t, rank]. Sizing this `hc*h*4` (the streams
                 // alone) under-allocates by `rank*4` = 1280 B and the collapse
                 // writes past the end of the allocation. Measured, not guessed.
+                per_stream: gpu.alloc(hc * h * 2)?,
                 head_scratch: gpu.alloc((hc * h + config.hc_lowrank.max(1)) * 4)?,
                 logits_stash: gpu.alloc(config.vocab_size * 2)?,
             },
@@ -276,10 +287,10 @@ impl Qwen4ExpMtpHead {
             // this checkpoint's norm weights are offset-from-1 like the rest of
             // the qwen4_exp tree.
             rms_norm_k: gpu.kernel("norm", "rms_norm")?,
-            rms_norm_strided_k: gpu.kernel("norm", "rms_norm_strided")?,
             dense_gemv_k: gpu.kernel("gemv", "dense_gemv_bf16")?,
-            residual_add_k: gpu.kernel("residual_add", "bf16_residual_add")?,
             hc_head_k: gpu.kernel("hyper_connection", "hc_head")?,
+            hc_stage_k: gpu.kernel("hyper_connection", "hc_pre_stage_bf16")?,
+            combine_k: gpu.kernel("hyper_connection", "qhc_mtp_combine_streams")?,
             shadow_drafts: AtomicU64::new(0),
             shadow_hits: AtomicU64::new(0),
         })
@@ -450,63 +461,53 @@ impl Qwen4ExpMtpHead {
             stream,
         )?;
 
-        // ── 2. Hidden branch: GROUPED norm, then fc_hidden PER STREAM ──
-        // `rms_norm_strided` applies ONE weight to every row it normalizes, but
-        // each stream owns its own `[hidden]` slice of the `[hc*hidden]` scale
-        // — so this is one call per stream, each over that stream's rows with
-        // `row_stride = hc*hidden`. At T=1 that is a single row per call.
+        // ── 2. Hidden branch — DTYPE-CORRECT end to end ──
+        // The highway is FP32; the projections are BF16 GEMVs. So:
+        //   a) `hc_pre_stage_bf16` reads the FP32 streams and writes the GROUPED
+        //      norm as BF16. It is the model's own kernel for exactly this
+        //      (per-stream RMS, offset-from-1 scale, `[hc*H]` weight) — which is
+        //      also independent confirmation that `pre_fc_norm_hidden [10240]`
+        //      normalizes the four-stream highway.
+        //   b) `fc_hidden` is applied PER STREAM as a BF16 GEMV.
+        //   c) `qhc_mtp_combine_streams` writes the FP32 highway from those
+        //      per-stream BF16 rows plus the broadcast embedding projection.
+        // An earlier version ran BF16 ops directly over the FP32 buffer — silent
+        // garbage, and the reason the first accept measurements were meaningless.
+        ops::hc_pre_stage_bf16_norm(
+            ctx.gpu,
+            self.hc_stage_k,
+            self.buf.streams,
+            self.module.pre_fc_norm_hidden.weight,
+            self.buf.normed_streams,
+            1,
+            h,
+            hc,
+            eps,
+            stream,
+        )?;
         for i in 0..hc as usize {
             let off = i * row;
-            let w = DenseWeight {
-                weight: self.module.pre_fc_norm_hidden.weight.offset(off),
-            };
-            ops::rms_norm_strided(
-                ctx.gpu,
-                self.rms_norm_strided_k,
-                self.buf.streams.offset(off),
-                &w,
-                self.buf.normed_streams.offset(off),
-                1,
-                1,
-                h,
-                eps,
-                hc * h,
-                stream,
-            )?;
-            // fc_hidden is shared across streams; apply it to this stream and
-            // add the (broadcast) embedding projection in place.
-            //
-            // Destination is `body_streams` (= ctx.buffers.hc_streams()), which
-            // is where the body will look. `buf.streams` must stay untouched —
-            // it is the target's saved highway, restored below.
             ops::dense_gemv(
                 ctx.gpu,
                 self.dense_gemv_k,
                 self.buf.normed_streams.offset(off),
                 &self.module.fc_hidden,
-                body_streams.offset(off),
+                self.buf.per_stream.offset(off),
                 h,
                 h,
                 stream,
             )?;
-            ops::residual_add(
-                ctx.gpu,
-                self.residual_add_k,
-                body_streams.offset(off),
-                self.buf.embed_proj,
-                h,
-                stream,
-            )?;
         }
-
-        // BISECTION: stop after the combiner, restoring the highway. If the
-        // target's output is clean here but dirty at `body`, the body forward
-        // owns the corruption.
-        if shadow_stage() < ShadowStage::Body {
-            ctx.gpu
-                .copy_d2d_async(self.buf.streams, body_streams, hc_bytes, stream)?;
-            return Ok(());
-        }
+        ops::qhc_mtp_combine_streams(
+            ctx.gpu,
+            self.combine_k,
+            self.buf.per_stream,
+            self.buf.embed_proj,
+            body_streams,
+            h,
+            hc,
+            stream,
+        )?;
 
         // No save/restore of target buffers: the draft runs in its own arena.
         // ── 3. Body decode against the module's OWN cache ──

--- a/crates/spark-model/src/layers/qwen4_exp_mtp_proposer.rs
+++ b/crates/spark-model/src/layers/qwen4_exp_mtp_proposer.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `DraftProposer` over the qwen4_exp MTP head.
+//!
+//! # What this connects
+//!
+//! The head drafts the next token from (last token, the target's four-stream
+//! highway) at a measured 86.5–95.5% accept. This adapts it to the engine's
+//! proposer interface so the scheduler can actually verify and commit those
+//! drafts — the step that turns accept rate into tokens/s.
+//!
+//! # Two contract mismatches, both handled here
+//!
+//! **`target_hidden` is the wrong input.** The trait hands every proposer the
+//! COLLAPSED `[1, hidden]` BF16 row. The MTP combiner consumes the FP32
+//! four-stream highway instead, which is still live in `ctx.buffers.hc_streams()`
+//! when `propose` runs: the last layer's `hc_head` READS the streams and writes
+//! the collapsed hidden elsewhere. So the argument is deliberately ignored and
+//! the highway is read from the context.
+//!
+//! **Chaining is autoregressive through the DRAFT's own arena.** For
+//! `num_drafts > 1`, draft j+1 needs the highway the draft body just produced,
+//! not the target's. That lives in the head's private arena, so the chain is
+//! natural: pass `arena.hc_streams()` as the next step's input. Draft 1 reads
+//! the target's highway; every later draft reads its own.
+
+use std::any::Any;
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+use crate::layer::ForwardContext;
+use crate::layers::qwen4_exp_mtp::{Qwen4ExpMtpHead, Qwen4ExpMtpState};
+use crate::speculative::{DraftProposer, ProposerState};
+
+pub struct Qwen4ExpMtpProposerState {
+    pub inner: Qwen4ExpMtpState,
+}
+
+impl ProposerState for Qwen4ExpMtpProposerState {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl DraftProposer for Qwen4ExpMtpHead {
+    fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn ProposerState>> {
+        Ok(Box::new(Qwen4ExpMtpProposerState {
+            inner: self.alloc_state(gpu)?,
+        }))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn propose(
+        &self,
+        last_token: u32,
+        // IGNORED — see the module docs: this is the collapsed row, and the
+        // combiner needs the four-stream highway.
+        _target_hidden: DevicePtr,
+        position: usize,
+        num_drafts: usize,
+        state: &mut dyn ProposerState,
+        ctx: &ForwardContext,
+        stream: u64,
+        _draft_embed_target: Option<DevicePtr>,
+        _grammar_bitmask: Option<&[i32]>,
+        _target_hidden_stack: Option<DevicePtr>,
+    ) -> Result<Vec<u32>> {
+        let st = state
+            .as_any_mut()
+            .downcast_mut::<Qwen4ExpMtpProposerState>()
+            .ok_or_else(|| anyhow::anyhow!("qwen4_exp MTP: wrong proposer state type"))?;
+
+        // Apply any rewind `after_verify` deferred (it has no GPU handle).
+        if st.inner.pending_rewind > 0 {
+            let rows = st.inner.pending_rewind;
+            self.rewind_draft(&mut st.inner, rows, ctx.gpu, stream)?;
+            st.inner.pending_rewind = 0;
+        }
+
+        // Snapshot the DRAFT body's own carry before advancing it, so
+        // `after_verify` can unwind the rejected rows.
+        st.inner.pre_draft_aux = self.snapshot_draft_aux(&st.inner, ctx.gpu, stream)?;
+        st.inner.last_num_drafted = num_drafts;
+
+        let mut drafts = Vec::with_capacity(num_drafts);
+        let mut token = last_token;
+        // Draft 1 reads the TARGET's highway; each later draft reads the one the
+        // draft body itself just wrote, in the head's own arena.
+        let mut streams = ctx.buffers.hc_streams();
+
+        for j in 0..num_drafts {
+            let h_out = self.draft_h_out();
+            self.draft_hidden(
+                token,
+                streams,
+                position + j,
+                &mut st.inner,
+                h_out,
+                ctx,
+                stream,
+            )?;
+            token = self.draft_token(h_out, ctx, stream)?;
+            drafts.push(token);
+            streams = self.draft_streams();
+        }
+        Ok(drafts)
+    }
+
+    /// Unwind the draft body's own state for every REJECTED row.
+    ///
+    /// This is the draft-side mirror of the target-side `rollback_verify_hc`.
+    /// Both sides advance independently — the draft body has its own seq_len,
+    /// its own single-layer KV pool and its own QSA carry — so both must be
+    /// rewound, and forgetting either leaves that side one row ahead. The QSA
+    /// ingest asserts `pos == ingested`, so the failure is loud on the next
+    /// draft rather than silent, which is the one mercy here.
+    fn after_verify(
+        &self,
+        num_accepted: usize,
+        state: &mut dyn ProposerState,
+        stream: u64,
+    ) -> Result<()> {
+        let st = state
+            .as_any_mut()
+            .downcast_mut::<Qwen4ExpMtpProposerState>()
+            .ok_or_else(|| anyhow::anyhow!("qwen4_exp MTP: wrong proposer state type"))?;
+        let _ = stream;
+        let drafted = st.inner.last_num_drafted;
+        st.inner.pending_rewind = drafted.saturating_sub(num_accepted);
+        st.inner.last_num_drafted = 0;
+        Ok(())
+    }
+
+    fn free_state(&self, _gpu: &dyn GpuBackend, _state: &mut dyn ProposerState) -> Result<()> {
+        // The head owns every device buffer the draft touches (its arena, its
+        // KV pool); per-sequence state holds only host bookkeeping plus the
+        // body's layer state, which drops with the box.
+        Ok(())
+    }
+}

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -73,6 +73,11 @@ impl TransformerModel {
         vision_encoder: Option<crate::layers::VisionEncoder>,
         ssm_cache_slots: usize,
         ssm_checkpoint_interval: usize,
+        // A BESPOKE MTP module is installed post-construction (qwen4_exp's
+        // Track-B head). Such a model leaves `mtp_weights` EMPTY, so the
+        // `!mtp_weights.is_empty()` term below is false and the SSM verify
+        // pools would never be allocated — see the has_mtp comment.
+        bespoke_mtp: bool,
     ) -> Result<Self> {
         // `rms_norm_kernel` normalizes exactly one weight: `final_norm` (a
         // checkpoint tensor). Models that ship HF-vanilla norm weights load it
@@ -187,8 +192,22 @@ impl TransformerModel {
         // main head (NVFP4 default) or the draft-only head built when the main
         // head is BF16. `draft_lm_head_nvfp4` resolves to whichever is present.
         let draft_lm_head_nvfp4 = mtp_lm_head_nvfp4.or(lm_head_nvfp4);
+        // ★ `!mtp_weights.is_empty()` is the wrong test for a BESPOKE proposer.
+        // qwen4_exp's MTP is a Track-B module installed after construction, so
+        // `mtp_weights` stays EMPTY and this term is false even under
+        // --speculative — leaving `num_intermediates` at 0, so NO SSM
+        // checkpoint pools exist. `verify_draft_capacity` then returns
+        // usize::MAX (ssm_pool.rs) and the scheduler never clamps, while this
+        // model's 36 GDN layers read exactly those pools for partial-accept
+        // rollback. DeepSeek-V4 never hit it because it is all-attention.
+        //
+        // `bespoke_mtp` is a threaded BOOL, deliberately not a
+        // `model_type == "qwen4_exp"` test: string gates on model_type are
+        // fragile and the capability, not the name, is what matters here.
+        // DFlash already needed the same escape hatch (`dflash_kgamma > 0`).
         let has_mtp = self_speculative
             || (use_speculative && !mtp_weights.is_empty() && draft_lm_head_nvfp4.is_some())
+            || (use_speculative && bespoke_mtp)
             || dflash_kgamma > 0;
         let num_intermediates = if has_mtp {
             (num_drafts + 1).max(dflash_kgamma)

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -744,6 +744,9 @@ impl TransformerModel {
             profile,
             profile_first_pending: std::sync::atomic::AtomicBool::new(profile_first),
             proposer,
+            // Installed post-construction via `set_qwen4_exp_mtp` (the module
+            // is loaded in `factory::build`, which owns the WeightStore).
+            qwen4_exp_mtp: None,
             mtp_hidden_save,
             verify_hidden_stash,
             mtp_catchup_ring,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -767,6 +767,7 @@ impl TransformerModel {
             // is loaded in `factory::build`, which owns the WeightStore).
             qwen4_exp_mtp: None,
             qwen4_exp_mtp_head: None,
+            pending_verify_aux: std::sync::Mutex::new(None),
             qwen4_exp_mtp_state: None,
             mtp_hidden_save,
             verify_hidden_stash,

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -747,6 +747,8 @@ impl TransformerModel {
             // Installed post-construction via `set_qwen4_exp_mtp` (the module
             // is loaded in `factory::build`, which owns the WeightStore).
             qwen4_exp_mtp: None,
+            qwen4_exp_mtp_head: None,
+            qwen4_exp_mtp_state: None,
             mtp_hidden_save,
             verify_hidden_stash,
             mtp_catchup_ring,

--- a/crates/spark-model/src/model/impl_b3_accessors.rs
+++ b/crates/spark-model/src/model/impl_b3_accessors.rs
@@ -8,6 +8,8 @@ use spark_runtime::gpu::GpuBackend;
 
 use super::types::TransformerModel;
 use crate::speculative::DraftProposer;
+// `argmax_on_device` lives on the Model trait; the shadow step calls it.
+use crate::traits::Model;
 
 impl TransformerModel {
     /// Borrow the GPU backend for post-construction wiring (e.g. installing
@@ -55,6 +57,132 @@ impl TransformerModel {
              device buffers are not leaked; no proposer consumes it yet)"
         );
         self.qwen4_exp_mtp = Some(module);
+    }
+
+    /// Install the qwen4_exp MTP draft head for SHADOW measurement.
+    ///
+    /// The head owns the module, so this replaces `set_qwen4_exp_mtp` rather
+    /// than accompanying it. Installing it does NOT enable speculation:
+    /// `has_proposer()` is unaffected and nothing feeds a draft back into the
+    /// sequence. It only lets the decode path ask "would this draft have been
+    /// right?" and count.
+    pub fn set_qwen4_exp_mtp_head(
+        &mut self,
+        module: crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule,
+        embed_tokens: crate::weight_map::DenseWeight,
+        max_seq_len: usize,
+    ) -> anyhow::Result<()> {
+        // Built here rather than in the factory because the model owns `gpu`
+        // by this point.
+        let head = crate::layers::qwen4_exp_mtp::Qwen4ExpMtpHead::new(
+            module,
+            embed_tokens,
+            &self.config,
+            self.gpu.as_ref(),
+            max_seq_len,
+        )?;
+        let state = head.alloc_state(self.gpu.as_ref())?;
+        tracing::warn!(
+            "qwen4_exp MTP SHADOW MODE is on. ⚠ THE DEFAULT `full`/`body` STAGE \
+             IS KNOWN TO CORRUPT THIS SERVER'S OUTPUT — the draft body forward \
+             mutates state the target still needs, and generation degenerates \
+             (thinking-loop watchdog / empty or truncated answers). Only \
+             ATLAS_QWEN4EXP_MTP_SHADOW_STAGE=observe and =combine are verified \
+             inert against a shadow-off control. Do NOT serve real traffic with \
+             this on, and do not benchmark with it: it also costs a full extra \
+             draft forward per token and produces no speedup."
+        );
+        self.qwen4_exp_mtp_head = Some(head);
+        self.qwen4_exp_mtp_state = Some(std::sync::Mutex::new(state));
+        Ok(())
+    }
+
+    /// Run one shadow draft step: score the previous step's draft against the
+    /// token the target just produced, then draft the next one.
+    ///
+    /// `target_streams` is the four-stream mHC highway for the row that
+    /// produced `actual_token`. No-op unless shadow mode is installed.
+    pub(super) fn qwen4_exp_mtp_shadow_step(
+        &self,
+        actual_token: u32,
+        target_streams: spark_runtime::gpu::DevicePtr,
+        position: usize,
+        ctx: &crate::layer::ForwardContext,
+        stream: u64,
+    ) {
+        let (Some(head), Some(state)) = (&self.qwen4_exp_mtp_head, &self.qwen4_exp_mtp_state)
+        else {
+            return;
+        };
+        use crate::layers::qwen4_exp_mtp::{ShadowStage, shadow_stage};
+        let Ok(mut st) = state.lock() else { return };
+        // Score the draft made LAST step against what the target actually just
+        // emitted. This is the whole measurement.
+        head.shadow_observe(st.pending_draft.take(), actual_token);
+
+        // BISECTION stage 1: count only. If the target's output is DIRTY even
+        // here, the corruption is the extra `argmax_on_device` itself (it writes
+        // `buffers.scratch()` and runs on the DEFAULT stream, not this one) —
+        // not the draft forward.
+        if shadow_stage() == ShadowStage::Observe {
+            return;
+        }
+
+        // Draft the NEXT token from (token just emitted, this row's highway).
+        let h_out = self.mtp_hidden_save;
+        if let Err(e) = head.draft_hidden(
+            actual_token,
+            target_streams,
+            position,
+            &mut st,
+            h_out,
+            ctx,
+            stream,
+        ) {
+            // Shadow is diagnostic: never fail the real decode over it.
+            tracing::warn!("qwen4_exp MTP shadow draft failed, disabling: {e:#}");
+            return;
+        }
+        // BISECTION stage 3: stop before the draft's own LM head.
+        if shadow_stage() < ShadowStage::Full {
+            return;
+        }
+
+        // Finish with the target's own head so the draft's logits go through
+        // the same quantization ladder the real token did.
+        //
+        // ⚠ `lm_head` writes `buffers.logits()` — the SAME buffer the scheduler
+        // is about to sample the real token from. Park it and put it back, or
+        // this diagnostic would silently change the model's output.
+        let logits = self.decode_logits_ptr();
+        let vocab = self.config.vocab_size;
+        if head
+            .stash_logits(self.gpu.as_ref(), logits, vocab, stream)
+            .is_err()
+        {
+            return;
+        }
+        let normed = self.buffers.norm_output();
+        let h = self.config.hidden_size as u32;
+        let eps = self.config.rms_norm_eps as f32;
+        let drafted = self
+            .final_norm_apply(h_out, normed, 1, h, eps, stream)
+            .and_then(|()| self.lm_head(normed, stream))
+            .and_then(|_| self.argmax_on_device(logits, 0));
+        // Restore FIRST, unconditionally — an error above must not leave the
+        // scheduler reading the draft's logits.
+        if let Err(e) = head.restore_logits(self.gpu.as_ref(), logits, vocab, stream) {
+            tracing::error!(
+                "qwen4_exp MTP shadow could not restore the target logits ({e:#}); \
+                 the emitted token for this step may be the DRAFT's. Disable \
+                 ATLAS_QWEN4EXP_MTP_SHADOW."
+            );
+            return;
+        }
+        match drafted {
+            Ok(d) => st.pending_draft = Some(d),
+            Err(e) => tracing::warn!("qwen4_exp MTP shadow draft head failed: {e:#}"),
+        }
     }
 
     /// Install the fused n-gram input embedding (LongCat family). Once set,

--- a/crates/spark-model/src/model/impl_b3_accessors.rs
+++ b/crates/spark-model/src/model/impl_b3_accessors.rs
@@ -40,6 +40,23 @@ impl TransformerModel {
         self.proposer = Some(proposer);
     }
 
+    /// Take ownership of a loaded qwen4_exp MTP draft module.
+    ///
+    /// This is NOT decoration. `DevicePtr` has no `Drop`, so a module that is
+    /// built and then dropped leaks its quantized MoE and attention buffers.
+    /// Nothing reads the field yet: no proposer consumes it, so
+    /// `has_proposer()` stays false and speculation stays off.
+    pub fn set_qwen4_exp_mtp(
+        &mut self,
+        module: Box<crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule>,
+    ) {
+        tracing::info!(
+            "qwen4_exp MTP module installed on the served model (held so its \
+             device buffers are not leaked; no proposer consumes it yet)"
+        );
+        self.qwen4_exp_mtp = Some(module);
+    }
+
     /// Install the fused n-gram input embedding (LongCat family). Once set,
     /// every embedding site routes through it instead of the plain
     /// `embed_tokens` gather.

--- a/crates/spark-model/src/model/impl_b3_accessors.rs
+++ b/crates/spark-model/src/model/impl_b3_accessors.rs
@@ -71,6 +71,10 @@ impl TransformerModel {
         module: crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule,
         embed_tokens: crate::weight_map::DenseWeight,
         max_seq_len: usize,
+        // Install the head as the ACTIVE proposer, so the scheduler drafts and
+        // verifies with it. Separate from merely holding the head: shadow mode
+        // holds it without ever feeding a draft back.
+        install_as_proposer: bool,
     ) -> anyhow::Result<()> {
         // Built here rather than in the factory because the model owns `gpu`
         // by this point.
@@ -87,14 +91,27 @@ impl TransformerModel {
             max_seq_len,
         )?;
         let state = head.alloc_state(self.gpu.as_ref())?;
-        tracing::warn!(
-            "qwen4_exp MTP SHADOW MODE is on: the draft head runs every decode \
-             step and its accept rate is logged. Verified INERT — shadow-on \
-             output is byte-identical to a shadow-off control — because the \
-             draft runs in its own BufferArena. It still costs a FULL EXTRA \
-             draft forward per token and produces NO speedup (nothing is fed \
-             back), so do not benchmark with it on."
-        );
+        if !install_as_proposer {
+            tracing::warn!(
+                "qwen4_exp MTP SHADOW MODE is on: the draft head runs every decode \
+                 step and its accept rate is logged. Verified INERT — shadow-on \
+                 output is byte-identical to a shadow-off control — because the \
+                 draft runs in its own BufferArena. It still costs a FULL EXTRA \
+                 draft forward per token and produces NO speedup (nothing is fed \
+                 back), so do not benchmark with it on."
+            );
+        }
+        let head = std::sync::Arc::new(head);
+        if install_as_proposer {
+            tracing::warn!(
+                "qwen4_exp MTP SPECULATION ARMED: the draft head is installed as \
+                 the active proposer, and the mHC K-row verify path is live. \
+                 Measured draft accept is 86.5-95.5%, but this is the FIRST \
+                 configuration in which a draft is actually fed back — treat \
+                 output quality as unproven until the agentic battery runs."
+            );
+            self.proposer = Some(head.clone());
+        }
         self.qwen4_exp_mtp_head = Some(head);
         self.qwen4_exp_mtp_state = Some(std::sync::Mutex::new(state));
         Ok(())

--- a/crates/spark-model/src/model/impl_b3_accessors.rs
+++ b/crates/spark-model/src/model/impl_b3_accessors.rs
@@ -77,20 +77,23 @@ impl TransformerModel {
         let head = crate::layers::qwen4_exp_mtp::Qwen4ExpMtpHead::new(
             module,
             embed_tokens,
+            // Share the target's NVFP4 vocab head (Copy pointers) so the draft
+            // goes through the SAME quantization ladder the real token does —
+            // a drafter scored against a different head measures the head, not
+            // the draft.
+            self.lm_head_nvfp4,
             &self.config,
             self.gpu.as_ref(),
             max_seq_len,
         )?;
         let state = head.alloc_state(self.gpu.as_ref())?;
         tracing::warn!(
-            "qwen4_exp MTP SHADOW MODE is on. ⚠ THE DEFAULT `full`/`body` STAGE \
-             IS KNOWN TO CORRUPT THIS SERVER'S OUTPUT — the draft body forward \
-             mutates state the target still needs, and generation degenerates \
-             (thinking-loop watchdog / empty or truncated answers). Only \
-             ATLAS_QWEN4EXP_MTP_SHADOW_STAGE=observe and =combine are verified \
-             inert against a shadow-off control. Do NOT serve real traffic with \
-             this on, and do not benchmark with it: it also costs a full extra \
-             draft forward per token and produces no speedup."
+            "qwen4_exp MTP SHADOW MODE is on: the draft head runs every decode \
+             step and its accept rate is logged. Verified INERT — shadow-on \
+             output is byte-identical to a shadow-off control — because the \
+             draft runs in its own BufferArena. It still costs a FULL EXTRA \
+             draft forward per token and produces NO speedup (nothing is fed \
+             back), so do not benchmark with it on."
         );
         self.qwen4_exp_mtp_head = Some(head);
         self.qwen4_exp_mtp_state = Some(std::sync::Mutex::new(state));
@@ -148,38 +151,12 @@ impl TransformerModel {
             return;
         }
 
-        // Finish with the target's own head so the draft's logits go through
-        // the same quantization ladder the real token did.
-        //
-        // ⚠ `lm_head` writes `buffers.logits()` — the SAME buffer the scheduler
-        // is about to sample the real token from. Park it and put it back, or
-        // this diagnostic would silently change the model's output.
-        let logits = self.decode_logits_ptr();
-        let vocab = self.config.vocab_size;
-        if head
-            .stash_logits(self.gpu.as_ref(), logits, vocab, stream)
-            .is_err()
-        {
-            return;
-        }
-        let normed = self.buffers.norm_output();
-        let h = self.config.hidden_size as u32;
-        let eps = self.config.rms_norm_eps as f32;
-        let drafted = self
-            .final_norm_apply(h_out, normed, 1, h, eps, stream)
-            .and_then(|()| self.lm_head(normed, stream))
-            .and_then(|_| self.argmax_on_device(logits, 0));
-        // Restore FIRST, unconditionally — an error above must not leave the
-        // scheduler reading the draft's logits.
-        if let Err(e) = head.restore_logits(self.gpu.as_ref(), logits, vocab, stream) {
-            tracing::error!(
-                "qwen4_exp MTP shadow could not restore the target logits ({e:#}); \
-                 the emitted token for this step may be the DRAFT's. Disable \
-                 ATLAS_QWEN4EXP_MTP_SHADOW."
-            );
-            return;
-        }
-        match drafted {
+        // The draft's logits go into the DRAFT's arena, so nothing here can
+        // touch the buffer the scheduler is about to sample from. The earlier
+        // stash/restore of the target's logits existed only because the draft
+        // borrowed the target's LM-head buffer; private-arena isolation removed
+        // the need for it entirely.
+        match head.draft_token(h_out, ctx, stream) {
             Ok(d) => st.pending_draft = Some(d),
             Err(e) => tracing::warn!("qwen4_exp MTP shadow draft head failed: {e:#}"),
         }

--- a/crates/spark-model/src/model/trait_impl/decode_a.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a.rs
@@ -450,6 +450,29 @@ impl TransformerModel {
             }
         }
 
+        // ── MTP SHADOW (ATLAS_QWEN4EXP_MTP_SHADOW=1, default OFF) ──
+        // THIS is the path a qwen4_exp decode actually takes: decode_batch_dispatch
+        // delegates every n == 1 step straight to decode(), so a hook in the
+        // batched path never fires.
+        //
+        // Draft the next token and score the PREVIOUS draft against what the
+        // target just produced. Feeds nothing back — it measures whether the
+        // combiner reading is right before the verify path is built. `hc_streams`
+        // still holds this row's four-stream highway: the last layer's hc_head
+        // READ it and wrote the collapsed hidden elsewhere.
+        if self.qwen4_exp_mtp_head.is_some() {
+            match self.argmax_on_device(self.decode_logits_ptr(), 0) {
+                Ok(actual) => self.qwen4_exp_mtp_shadow_step(
+                    actual,
+                    self.buffers.hc_streams(),
+                    seq.seq_len,
+                    &ctx,
+                    stream,
+                ),
+                Err(e) => tracing::warn!("qwen4_exp MTP shadow: argmax failed: {e:#}"),
+            }
+        }
+
         seq.tokens.push(token);
         seq.seq_len += 1;
 

--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -605,6 +605,12 @@ impl TransformerModel {
                 }
             }
 
+            // NOTE: the MTP shadow hook is NOT here. `decode_batch_dispatch`
+            // returns early for n == 1 (delegating to `decode()`), so a hook on
+            // this batched path would never fire on the single-sequence decode
+            // it is meant to measure. It lives in `decode_a.rs` instead. Shadow
+            // mode is C=1 only anyway — the head keeps one draft state.
+
             // Restore real layer_states to sequences (dummy states dropped)
             for (seq, ls) in seqs.iter_mut().zip(all_layer_states.drain(..n)) {
                 seq.layer_states = ls;

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -378,6 +378,18 @@ impl Model for TransformerModel {
         _stream: u64,
     ) -> Result<[u32; 2]> {
         self.ssm_pool.require_verify_rollback_supported()?;
+        // ★ ROUTE BEFORE CAPTURE. Under an mHC highway the graphed dispatch
+        // reaches `qwen3_ssm::decode_batched`, which REFUSES — and it refuses
+        // INSIDE the capture region, leaving the stream recording so every
+        // later op dies with status 901 (measured: alloc_sequence,
+        // free_sequence and the next prefill all failed after one refusal).
+        // Taking the mHC path here means the refusal never happens; taking it
+        // BEFORE capture starts means a future refusal is survivable.
+        if self.verify_needs_hc_path() {
+            let v = self.decode_verify_hc(tokens, seq, _stream)?;
+            anyhow::ensure!(v.len() == 2, "verify_hc returned {} rows, want 2", v.len());
+            return Ok([v[0], v[1]]);
+        }
         self.decode_verify_graphed_dispatch(tokens, seq, _stream)
     }
     fn decode_verify_graphed_k3(
@@ -387,6 +399,11 @@ impl Model for TransformerModel {
         _stream: u64,
     ) -> Result<[u32; 3]> {
         self.ssm_pool.require_verify_rollback_supported()?;
+        if self.verify_needs_hc_path() {
+            let v = self.decode_verify_hc(tokens, seq, _stream)?;
+            anyhow::ensure!(v.len() == 3, "verify_hc returned {} rows, want 3", v.len());
+            return Ok([v[0], v[1], v[2]]);
+        }
         self.decode_verify_graphed_k3_dispatch(tokens, seq, _stream)
     }
     fn decode_verify_graphed_k4(
@@ -396,6 +413,11 @@ impl Model for TransformerModel {
         _stream: u64,
     ) -> Result<[u32; 4]> {
         self.ssm_pool.require_verify_rollback_supported()?;
+        if self.verify_needs_hc_path() {
+            let v = self.decode_verify_hc(tokens, seq, _stream)?;
+            anyhow::ensure!(v.len() == 4, "verify_hc returned {} rows, want 4", v.len());
+            return Ok([v[0], v[1], v[2], v[3]]);
+        }
         self.decode_verify_graphed_k4_dispatch(tokens, seq, _stream)
     }
     fn can_batch_verify(&self, ks: &[usize]) -> bool {

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -46,6 +46,7 @@ mod verify_d;
 mod verify_e;
 pub(in crate::model) mod verify_e2;
 mod verify_fused;
+mod verify_hc;
 
 impl Model for TransformerModel {
     fn teardown(&mut self) -> Result<()> {

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -392,6 +392,36 @@ impl Model for TransformerModel {
         }
         self.decode_verify_graphed_dispatch(tokens, seq, _stream)
     }
+
+    /// mHC verify advances the QSA carry by K rows; on reject the scheduler's
+    /// generic `seq_len` rewind leaves that carry one row ahead. Restore it.
+    ///
+    /// ⚠ OFF BY DEFAULT (`ATLAS_QWEN4EXP_MTP_ROLLBACK=1` to arm) — UNPROVEN.
+    /// The un-restored aux carry was the leading suspect for this model's
+    /// degenerate speculative output. Wiring it up settles that: armed and
+    /// unarmed diverge at the SAME point (~token 2-3 against a coherent
+    /// baseline), with 0 rollback errors and 0 panics. So this is neither the
+    /// fix nor a regression — it ships off because nothing yet demonstrates it
+    /// is needed, and shipping an unexercised rewind on by default would only
+    /// add a suspect. See `verify_hc.rs` for the four-arm table and for why the
+    /// remaining signature (early divergence + leaked special-token ids) points
+    /// at the verify's LOGITS rather than at any carry.
+    fn rollback_verify_rows(&self, seq: &mut SequenceState, rows: usize) -> Result<bool> {
+        if rows == 0 || !self.verify_needs_hc_path() {
+            return Ok(false);
+        }
+        let armed = {
+            static ARMED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *ARMED.get_or_init(|| {
+                std::env::var("ATLAS_QWEN4EXP_MTP_ROLLBACK").as_deref() == Ok("1")
+            })
+        };
+        if !armed {
+            return Ok(false);
+        }
+        self.restore_verify_aux(seq, 0)?;
+        Ok(true)
+    }
     fn decode_verify_graphed_k3(
         &self,
         tokens: &[u32; 3],

--- a/crates/spark-model/src/model/trait_impl/verify_a.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_a.rs
@@ -45,6 +45,22 @@ impl TransformerModel {
             return Ok(vec![tok]);
         }
 
+        // Under an mHC highway the SSM branch below (`decode_batched`) REFUSES:
+        // the batched paths keep their own residual, which the highway
+        // replaces. Route K-row verify through the mini-prefill path instead —
+        // the only working multi-row mHC shape. Behind a flag until the QSA/PLE
+        // rewinds a rejected draft needs are implemented.
+        if self.verify_needs_hc_path() {
+            anyhow::ensure!(
+                std::env::var("ATLAS_QWEN4EXP_MTP_VERIFY").as_deref() == Ok("1"),
+                "K-row verify under an mHC highway needs the mini-prefill path \
+                 (ATLAS_QWEN4EXP_MTP_VERIFY=1). It is off by default because a \
+                 REJECTED draft still has no QSA/PLE rewind, so a partial accept \
+                 would leave those carries ahead of the sequence."
+            );
+            return self.decode_verify_hc(tokens, seq, stream);
+        }
+
         // GEMM-batched verification: process all K tokens per-layer,
         // using GEMM for weight-heavy projections to amortize bandwidth.
         let stream = self.gpu.default_stream();

--- a/crates/spark-model/src/model/trait_impl/verify_hc.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_hc.rs
@@ -52,12 +52,30 @@
 //!    NOTHING CALLS IT — the scheduler does its own rewind arithmetic, so a
 //!    rejected draft currently leaves the aux carries un-restored.
 //!
-//! 2. COST. 398 ms/token against a 50 ms decode: verify-by-mini-prefill is ~8x
-//!    a decode step. Expected in kind — prefill kernels are small-M inefficient
-//!    on this model (the recorded "~1.1-1.3 s floor regardless of slice") — but
-//!    8x means even a 100% accept rate loses. A K=2 verify must cost less than
-//!    2 decodes to break even, so this path needs a decode-shaped verify, not a
-//!    prefill-shaped one, before speculation can pay.
+//! 2. COST — and this is the STRUCTURAL blocker. Measured costs, gamma=1:
+//!    ```text
+//!      decode step          50.5 ms
+//!      draft forward         2.6 ms   (shadow-on 53.1 vs baseline 50.5)
+//!      verify, 2-row prefill ~395 ms
+//!    ```
+//!    ★ THE DRAFT IS ESSENTIALLY FREE — 5% of a decode. So the economics are
+//!    entirely about verify. Break-even at 91% accept needs
+//!    `draft + verify2 < 95 ms`, i.e. verify under ~92 ms. The mini-prefill is
+//!    4x over that budget, and TWO SEQUENTIAL DECODES (~101 ms) are over it
+//!    too — so a cheaper serial verify does not rescue this either. Only a
+//!    genuinely BATCHED K-row step can pay.
+//!
+//!    That is blocked, not merely unoptimised: the GDN prefill path has a
+//!    documented FLOOR ("the fused chunk has a ~1.1-1.3 s floor regardless of
+//!    slice — small-M prefill inefficiency"), so a 2-row prefill pays close to
+//!    what a large chunk pays. And the decode-shaped alternative is exactly
+//!    what `refuse_batched_under_hc` refuses: "the mHC highway has no batched
+//!    GDN path yet" (Avarok #753 item B).
+//!
+//!    CONCLUSION: the draft head is done and cheap; MTP speculation on this
+//!    model cannot pay until a cheap multi-row GDN step under the highway
+//!    exists. That feature also unblocks DFlash and DSpark here — `verify_e.rs`
+//!    routes their GDN body through the same refusing `decode_verify_multi`.
 //!
 //! Speculation therefore stays behind BOTH `--speculative` and
 //! `ATLAS_QWEN4EXP_MTP_VERIFY=1`, and neither is a default.

--- a/crates/spark-model/src/model/trait_impl/verify_hc.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_hc.rs
@@ -30,6 +30,38 @@
 //! would disagree about what row a stream belongs to. Uniform K keeps one
 //! layout.
 //!
+//! # MEASURED END TO END (2026-08-28) — RUNS, BUT WRONG AND SLOW
+//!
+//! With the proposer armed (`--speculative --num-drafts 1` +
+//! `ATLAS_QWEN4EXP_MTP_VERIFY=1`), 4K ctx, greedy, vs a same-config baseline:
+//! ```text
+//!   baseline     19.8 tok/s   correct output
+//!   speculative   2.5 tok/s   output degenerates after ~12 tokens
+//!   errors: 0
+//! ```
+//! The chain is COMPLETE — draft, verify, rollback and both carries run without
+//! a single error, which no earlier revision managed. Two problems remain, and
+//! both were predicted rather than surprising:
+//!
+//! 1. CORRECTNESS. The first ~12 tokens match the baseline exactly, then the
+//!    output collapses. A prefix that is right and then drifts is the signature
+//!    of a per-step state leak, not a wrong combiner — the draft head itself
+//!    measures 86.5-95.5% accept in shadow mode, where nothing is fed back.
+//!    Suspect order: (a) the accepted-row bookkeeping in the scheduler's K=2
+//!    path vs what this verify advances, (b) `rollback_verify_hc` is written but
+//!    NOTHING CALLS IT — the scheduler does its own rewind arithmetic, so a
+//!    rejected draft currently leaves the aux carries un-restored.
+//!
+//! 2. COST. 398 ms/token against a 50 ms decode: verify-by-mini-prefill is ~8x
+//!    a decode step. Expected in kind — prefill kernels are small-M inefficient
+//!    on this model (the recorded "~1.1-1.3 s floor regardless of slice") — but
+//!    8x means even a 100% accept rate loses. A K=2 verify must cost less than
+//!    2 decodes to break even, so this path needs a decode-shaped verify, not a
+//!    prefill-shaped one, before speculation can pay.
+//!
+//! Speculation therefore stays behind BOTH `--speculative` and
+//! `ATLAS_QWEN4EXP_MTP_VERIFY=1`, and neither is a default.
+//!
 //! # What the caller still owes
 //!
 //! This advances sequence state by K rows and does NOT roll back. The caller
@@ -180,6 +212,24 @@ impl TransformerModel {
             seq.block_table.push(blk);
         }
 
+        // ── Align the QSA carry with the rows about to be replayed ──
+        // The graphed K=2 verify re-processes the CURRENT position: row 0 is
+        // token_0, which the bootstrap decode already emitted — and already
+        // ingested into the indexer. Replaying it without rewinding trips
+        // `QSA: prefill chunk starts at 367 but 368 tokens are ingested`.
+        // ALIGN to seq_len — absolute, not a fixed rewind. The overlap is not
+        // constant: rewinding by 1 unconditionally produced the mirror-image
+        // failure ("starts at 366 but 365 ingested"). Aligning never advances
+        // the mark, so a carry that is already correct is untouched.
+        for (i, layer) in self.layers.iter().enumerate() {
+            layer.align_aux(
+                seq.layer_states[i].as_mut(),
+                seq.seq_len,
+                self.gpu.as_ref(),
+                stream,
+            )?;
+        }
+
         // ── Embed the K candidates into hidden[K, H] ──
         // FP32 stride: `hidden_states` is the FP32 residual-stream buffer on
         // this path, matching verify_a.
@@ -217,6 +267,23 @@ impl TransformerModel {
         // chunked-prefill path uses. `needs_paged` is always true here: verify
         // only ever runs at seq_len_start > 0.
         if meta.needs_paged {
+            // GROW the paged metadata. It was allocated for the ORIGINAL
+            // prefill and verify extends past it — measured: "chunked prefill
+            // metadata capacity 4 < required 7 blocks". `ensure_...` BAILS on a
+            // short capacity rather than growing, so drop the old one first and
+            // let it allocate at the size this verify needs. The old device
+            // buffers are freed explicitly: `DevicePtr` has no Drop.
+            let bs_meta = kv_cache.block_size();
+            let need_blocks = all_tokens.len().saturating_sub(1) / bs_meta + 1;
+            let too_small = seq
+                .chunked_prefill_meta
+                .as_ref()
+                .is_some_and(|m| m.block_capacity < need_blocks);
+            if too_small && let Some(old) = seq.chunked_prefill_meta.take() {
+                let _ = self.gpu.free(old.block_table);
+                let _ = self.gpu.free(old.seq_len);
+            }
+            self.ensure_chunked_prefill_meta(seq, all_tokens.len(), bs_meta)?;
             self.prefill_b_upload_paged(
                 seq,
                 all_tokens.len(),

--- a/crates/spark-model/src/model/trait_impl/verify_hc.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_hc.rs
@@ -40,8 +40,32 @@
 //!     has no rewind API;
 //!   * PLE host history advances per row with a documented corruption class.
 //!
-//! `snapshot_aux`/`restore_aux` already serialize both carries, but are wired
-//! only into the prefix-cache path.
+//! # The rewind design (step 4), worked out but not yet wired
+//!
+//! The two carries need DIFFERENT mechanisms, which is why one blanket
+//! "restore the snapshot" does not work:
+//!
+//! * **QSA is a mark rewind and is now implemented** —
+//!   `QsaIndexer::rewind_seq_state`. `ingested`/`pooled` are contiguous marks
+//!   and both device buffers are written forward from them, so moving the marks
+//!   back is sufficient; stale bytes past the mark are overwritten by the next
+//!   ingest. Cheap, no replay.
+//! * **PLE needs a SNAPSHOT.** `PleSeqState::conv` is a rolling FP32 device
+//!   convolution state and `history` is a fixed-length window whose oldest
+//!   entries have already rolled off, so neither can be reconstructed by
+//!   truncation. `snapshot_aux`/`restore_aux` already serialize both.
+//!
+//! ★ The placement is the subtle part. Restoring a PRE-verify snapshot leaves
+//! the carries at `seq_len`, but a partial accept lands the sequence at
+//! `seq_len + accepted` — one or more rows short. Taking the snapshot AFTER the
+//! committed row 0 (the real sampled token) and before the DRAFT rows makes
+//! restore land exactly right for the common γ=1 case: accept keeps everything,
+//! reject restores to precisely "token_0 committed, draft discarded". That
+//! argues for running verify as row-0-then-drafts rather than one K-row pass,
+//! and is the open design decision for step 4.
+//!
+//! `snapshot_aux`/`restore_aux` are today wired only into the prefix-cache
+//! path.
 
 use anyhow::Result;
 use spark_runtime::gpu::DevicePtr;

--- a/crates/spark-model/src/model/trait_impl/verify_hc.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_hc.rs
@@ -81,10 +81,78 @@ impl TransformerModel {
         self.config.hc_mult > 0
     }
 
-    /// Verify `tokens` (K rows) by mini-prefill. Returns the argmax token for
-    /// each row, so the caller can compare row `i`'s output against draft
-    /// `i + 1` exactly as on the non-hc path.
+    /// Verify `tokens` by mini-prefill, SPLIT so a rejected draft can be rolled
+    /// back exactly.
+    ///
+    /// Row 0 is the already-sampled real token and is always kept; rows 1.. are
+    /// the drafts. The aux carries (QSA marks + PLE conv/history) are
+    /// snapshotted BETWEEN the two, which is what makes `rollback_verify_hc`
+    /// land on "token_0 committed, drafts discarded" rather than on pre-verify.
+    /// Restoring a pre-verify snapshot would leave the carries a row SHORT of
+    /// the sequence, which is a silent desync, not an error.
     pub(super) fn decode_verify_hc(
+        &self,
+        tokens: &[u32],
+        seq: &mut SequenceState,
+        stream: u64,
+    ) -> Result<Vec<u32>> {
+        let k = tokens.len();
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let stream_d = self.gpu.default_stream();
+        // Committed row first, on its own.
+        let mut out = self.verify_hc_rows(&tokens[..1], seq, stream)?;
+        if k == 1 {
+            return Ok(out);
+        }
+        // Snapshot the carries with token_0 committed and no draft applied.
+        // `collect_aux_states` covers BOTH: qwen3_attention's snapshot_aux
+        // serializes the QSA carry, qwen3_ssm's serializes PLE's.
+        let stash = self.collect_aux_states(seq, stream_d)?;
+        *self
+            .pending_verify_aux
+            .lock()
+            .map_err(|_| anyhow::anyhow!("verify aux stash poisoned"))? = Some(stash);
+
+        out.extend(self.verify_hc_rows(&tokens[1..], seq, stream)?);
+        Ok(out)
+    }
+
+    /// Undo `rows` draft rows after a rejected verify, restoring both aux
+    /// carries to the snapshot taken after the committed row.
+    ///
+    /// The KV written for the discarded positions is left alone deliberately:
+    /// it is past `seq_len` and the next step overwrites it.
+    pub(super) fn rollback_verify_hc(
+        &self,
+        seq: &mut SequenceState,
+        rows: usize,
+        stream: u64,
+    ) -> Result<()> {
+        if rows == 0 {
+            return Ok(());
+        }
+        let stash = self
+            .pending_verify_aux
+            .lock()
+            .map_err(|_| anyhow::anyhow!("verify aux stash poisoned"))?
+            .take();
+        let Some(blobs) = stash else {
+            anyhow::bail!(
+                "rollback_verify_hc with no stashed aux snapshot — decode_verify_hc \
+                 must run first, or the carries cannot be rewound"
+            );
+        };
+        self.apply_aux_states(seq, &blobs, stream)?;
+        seq.seq_len = seq.seq_len.saturating_sub(rows);
+        let keep = seq.tokens.len().saturating_sub(rows);
+        seq.tokens.truncate(keep);
+        Ok(())
+    }
+
+    /// One K-row mini-prefill. Advances sequence state by K rows.
+    fn verify_hc_rows(
         &self,
         tokens: &[u32],
         seq: &mut SequenceState,

--- a/crates/spark-model/src/model/trait_impl/verify_hc.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_hc.rs
@@ -35,47 +35,95 @@
 //! With the proposer armed (`--speculative --num-drafts 1` +
 //! `ATLAS_QWEN4EXP_MTP_VERIFY=1`), 4K ctx, greedy, vs a same-config baseline:
 //! ```text
-//!   baseline     19.8 tok/s   correct output
-//!   speculative   2.5 tok/s   output degenerates after ~12 tokens
+//!   baseline      19.8 tok/s  (50.5 ms/token)  correct output
+//!   speculative,
+//!     before      ~4.9 tok/s  (205 ms/token)   degenerate output
+//!     after        8.3 tok/s  (120 ms/token)   degenerate output
 //!   errors: 0
 //! ```
 //! The chain is COMPLETE — draft, verify, rollback and both carries run without
-//! a single error, which no earlier revision managed. Two problems remain, and
-//! both were predicted rather than surprising:
+//! a single error, which no earlier revision managed. Two problems remain. The
+//! COST one is now largely understood and 1.7x better (item 2); the CORRECTNESS
+//! one is still open and its leading hypothesis has been disproved (item 1).
 //!
-//! 1. CORRECTNESS. The first ~12 tokens match the baseline exactly, then the
-//!    output collapses. A prefix that is right and then drifts is the signature
-//!    of a per-step state leak, not a wrong combiner — the draft head itself
-//!    measures 86.5-95.5% accept in shadow mode, where nothing is fed back.
-//!    Suspect order: (a) the accepted-row bookkeeping in the scheduler's K=2
-//!    path vs what this verify advances, (b) `rollback_verify_hc` is written but
-//!    NOTHING CALLS IT — the scheduler does its own rewind arithmetic, so a
-//!    rejected draft currently leaves the aux carries un-restored.
-//!
-//! 2. COST — and this is the STRUCTURAL blocker. Measured costs, gamma=1:
+//! 1. CORRECTNESS - STILL OPEN, and the leading hypothesis was TESTED AND
+//!    DISPROVED. Four arms, same prompts, greedy, 4K ctx:
 //!    ```text
-//!      decode step          50.5 ms
-//!      draft forward         2.6 ms   (shadow-on 53.1 vs baseline 50.5)
-//!      verify, 2-row prefill ~395 ms
+//!      spec off (baseline)              "Red, blue, and green."   coherent
+//!      spec on, rollback off            "Red light")..."          diverges ~tok 2-3
+//!      spec on, rollback on             "Redaccion, 1."           diverges ~tok 2
+//!      spec on, rollback on, old MoE    "Redaccion, ..."          diverges ~tok 2
+//!      rollback errors: 0   panics: 0
 //!    ```
-//!    ★ THE DRAFT IS ESSENTIALLY FREE — 5% of a decode. So the economics are
-//!    entirely about verify. Break-even at 91% accept needs
-//!    `draft + verify2 < 95 ms`, i.e. verify under ~92 ms. The mini-prefill is
-//!    4x over that budget, and TWO SEQUENTIAL DECODES (~101 ms) are over it
-//!    too — so a cheaper serial verify does not rescue this either. Only a
-//!    genuinely BATCHED K-row step can pay.
+//!    Read these carefully, because two plausible culprits are ELIMINATED:
 //!
-//!    That is blocked, not merely unoptimised: the GDN prefill path has a
-//!    documented FLOOR ("the fused chunk has a ~1.1-1.3 s floor regardless of
-//!    slice — small-M prefill inefficiency"), so a 2-row prefill pays close to
-//!    what a large chunk pays. And the decode-shaped alternative is exactly
-//!    what `refuse_batched_under_hc` refuses: "the mHC highway has no batched
-//!    GDN path yet" (Avarok #753 item B).
+//!    * The missing rollback was the leading suspect - `rollback_verify_hc` was
+//!      written but NOTHING CALLED IT, so a rejected draft left the aux carries
+//!      un-restored. It is now wired (`Model::rollback_verify_rows`, called from
+//!      the scheduler's K=2 reject branch) and it changes NOTHING: armed and
+//!      unarmed diverge at the same point. It ships OFF
+//!      (`ATLAS_QWEN4EXP_MTP_ROLLBACK=1` to arm) as unproven, not as harmful.
+//!    * The small-M FFN substitution below is likewise exonerated - forcing the
+//!      OLD grouped-MoE verify reproduces the identical corruption.
 //!
-//!    CONCLUSION: the draft head is done and cheap; MTP speculation on this
-//!    model cannot pay until a cheap multi-row GDN step under the highway
-//!    exists. That feature also unblocks DFlash and DSpark here — `verify_e.rs`
-//!    routes their GDN body through the same refusing `decode_verify_multi`.
+//!    Note also that the "first ~12 tokens match the baseline" behaviour an
+//!    earlier revision recorded DOES NOT REPRODUCE under this harness; every
+//!    speculative arm diverges within 2-3 tokens. Treat the 12-token figure as
+//!    prompt-specific and do not reason from it.
+//!
+//!    Divergence that early, with leaked raw special-token ids in the output
+//!    (`| 100257`, `<|fim_prefix|>`), is a wrong-LOGITS signature rather than a
+//!    slow state leak - the verify appears to return bad rows from nearly the
+//!    first step, which no rewind can repair. Next suspects, in order: (a) the
+//!    K-row logits the mini-prefill hands back - row indexing/aliasing into the
+//!    logits buffer, the defect class this repo has hit repeatedly; (b) what
+//!    `apply_aux_states` restores, PLE's rolling conv/history window especially,
+//!    since unlike QSA's contiguous marks it cannot be rebuilt by truncation;
+//!    (c) the scheduler's accepted-row bookkeeping vs what this verify advances.
+//!    A row-by-row A/B of verify logits against a serial decode of the same
+//!    tokens would settle (a) immediately and is the cheapest next experiment.
+//!
+//! 2. COST. Measured, gamma=1:
+//!    ```text
+//!      decode step           50.5 ms
+//!      draft forward          2.6 ms   (shadow-on 53.1 vs baseline 50.5)
+//!      verify (before)      ~395 ms  -> 205 ms/token end to end
+//!      verify (after)                   120 ms/token end to end
+//!    ```
+//!    ★ THE DRAFT IS ESSENTIALLY FREE - 5% of a decode. The economics are
+//!    entirely about verify. Break-even at ~91% accept needs
+//!    `draft + verify < 95 ms`.
+//!
+//!    AN EARLIER REVISION OF THIS BLOCK CALLED THAT STRUCTURALLY BLOCKED, on
+//!    the theory that the GDN prefill floor made a 2-row verify cost what a
+//!    large chunk costs. PROFILING DISPROVED IT. Per-layer, per-verify-row:
+//!    ```text
+//!                  before    after
+//!      moe        2700 us    191 us   (14x)
+//!      gdn_block   860 us    862 us   (unchanged)
+//!    ```
+//!    The dominant term was never the GDN. It was the MoE: `forward_prefill`
+//!    routes through the grouped GEMM, which streams every one of the 512
+//!    experts' weights regardless of row count, so ONE row paid nearly what a
+//!    28-row chunk paid (T=16 6.7-9.6 ms, T=28 8.5-12.3 ms -- 1.75x the rows
+//!    for 1.2x the time). Substituting the single-token/K=2/K=3 MoE kernels at
+//!    small row counts (`ATLAS_QWEN4EXP_HC_SMALL_M_FFN`, default on) cut it 14x.
+//!
+//!    NOTE the K=1 arm is the one that matters: `decode_verify_hc` splits a
+//!    verify into row-0-then-drafts, so at gamma=1 BOTH calls arrive as a
+//!    single row and the k2/k3 arms never fire.
+//!
+//!    WHERE IT STANDS: 120 ms/token vs a 50 ms decode -- speculation still does
+//!    not pay, but it is now ~2.4x rather than ~4x, and the remaining cost has
+//!    moved to the GDN: 36 layers x 862 us x 2 rows ~= 62 ms.
+//!
+//!    NEXT LEVER, and it is the same shape as the fix above: at T=1 a "prefill"
+//!    row under the highway is just a decode step, so the hc decode body
+//!    (`qwen3_ssm/trait_decode_hc.rs`) should serve it instead of the chunk
+//!    scan. That is a 1-row substitution -- it does NOT require the batched
+//!    multi-row GDN feature (#753 item B) that the earlier conclusion pinned
+//!    this on. A batched K-row step remains the better endpoint, since two
+//!    serial decodes (~101 ms) still exceed the ~92 ms budget on their own.
 //!
 //! Speculation therefore stays behind BOTH `--speculative` and
 //! `ATLAS_QWEN4EXP_MTP_VERIFY=1`, and neither is a default.
@@ -174,6 +222,29 @@ impl TransformerModel {
     ///
     /// The KV written for the discarded positions is left alone deliberately:
     /// it is past `seq_len` and the next step overwrites it.
+    /// Restore ONLY the auxiliary carries stashed by `decode_verify_hc`, leaving
+    /// `seq_len`/`tokens` to the caller.
+    ///
+    /// The scheduler's reject branch already owns the token/seq_len rewind
+    /// (`seq_len -= 1` + `commit_accepted_prefix`); what it cannot do is rewind
+    /// the QSA `ingested`/`pooled` marks a mini-prefill advanced. Splitting the
+    /// aux half out lets the scheduler call exactly the missing piece instead of
+    /// rewinding `seq_len` a second time.
+    pub(super) fn restore_verify_aux(&self, seq: &mut SequenceState, stream: u64) -> Result<()> {
+        let stash = self
+            .pending_verify_aux
+            .lock()
+            .map_err(|_| anyhow::anyhow!("verify aux stash poisoned"))?
+            .take();
+        let Some(blobs) = stash else {
+            anyhow::bail!(
+                "restore_verify_aux with no stashed aux snapshot — decode_verify_hc \
+                 must run first, or the carries cannot be rewound"
+            );
+        };
+        self.apply_aux_states(seq, &blobs, stream)
+    }
+
     pub(super) fn rollback_verify_hc(
         &self,
         seq: &mut SequenceState,
@@ -183,18 +254,7 @@ impl TransformerModel {
         if rows == 0 {
             return Ok(());
         }
-        let stash = self
-            .pending_verify_aux
-            .lock()
-            .map_err(|_| anyhow::anyhow!("verify aux stash poisoned"))?
-            .take();
-        let Some(blobs) = stash else {
-            anyhow::bail!(
-                "rollback_verify_hc with no stashed aux snapshot — decode_verify_hc \
-                 must run first, or the carries cannot be rewound"
-            );
-        };
-        self.apply_aux_states(seq, &blobs, stream)?;
+        self.restore_verify_aux(seq, stream)?;
         seq.seq_len = seq.seq_len.saturating_sub(rows);
         let keep = seq.tokens.len().saturating_sub(rows);
         seq.tokens.truncate(keep);

--- a/crates/spark-model/src/model/trait_impl/verify_hc.rs
+++ b/crates/spark-model/src/model/trait_impl/verify_hc.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! K-row speculative verify for models carrying an mHC highway.
+//!
+//! # Why this exists
+//!
+//! `decode_verify_dispatch` (verify_a.rs) verifies K tokens by running the
+//! attention layers per-token through `decode()` and the SSM layers through
+//! `decode_batched()`. Under an mHC highway that second call REFUSES:
+//! `refuse_batched_under_hc` fires because the batched paths keep their own
+//! residual bookkeeping and the highway replaces it, so running them would add
+//! every block output to the residual twice. The scheduler turns that error into
+//! `a.finished = true` — a SILENTLY TRUNCATED RESPONSE, not a fallback. So
+//! speculation has been unavailable on this model class, for ANY proposer: the
+//! same refusal sits under DFlash's batched verify (`verify_e.rs` routes the GDN
+//! conv+WY body through `decode_verify_multi`).
+//!
+//! # The shape
+//!
+//! The only working multi-row mHC path is `prefill_inner_hc`, and BOTH layer
+//! types have one (`qwen3_ssm/trait_prefill_hc.rs`,
+//! `qwen3_attention/trait_impl/prefill_inner.rs:531`). `prefill()` dispatches to
+//! it whenever `self.hc.is_some()`. So a K-row verify is expressible as a
+//! MINI-PREFILL of the K candidate tokens at positions
+//! `[seq_len, seq_len + K)`.
+//!
+//! Running EVERY layer through prefill (rather than mixing per-token attention
+//! decode with K-row SSM prefill) is not a stylistic choice: the highway buffer
+//! is laid out `[T, hc, H]`, so a 1-row attention path and a K-row SSM path
+//! would disagree about what row a stream belongs to. Uniform K keeps one
+//! layout.
+//!
+//! # What the caller still owes
+//!
+//! This advances sequence state by K rows and does NOT roll back. The caller
+//! must `checkpoint_ssm_states` before and rewind on partial accept, exactly as
+//! the non-hc verify path requires. Two rewinds are NOT yet implemented and are
+//! why this stays behind a flag:
+//!   * QSA `ingested` is monotone with a hard `ensure!(pos == st.ingested)` and
+//!     has no rewind API;
+//!   * PLE host history advances per row with a documented corruption class.
+//!
+//! `snapshot_aux`/`restore_aux` already serialize both carries, but are wired
+//! only into the prefix-cache path.
+
+use anyhow::Result;
+use spark_runtime::gpu::DevicePtr;
+
+use super::super::types::TransformerModel;
+use crate::layer::{AttnMetadataDev, ForwardContext};
+use crate::layers::ops;
+use crate::traits::SequenceState;
+
+impl TransformerModel {
+    /// True when K-row verify must take the mHC path.
+    pub(super) fn verify_needs_hc_path(&self) -> bool {
+        self.config.hc_mult > 0
+    }
+
+    /// Verify `tokens` (K rows) by mini-prefill. Returns the argmax token for
+    /// each row, so the caller can compare row `i`'s output against draft
+    /// `i + 1` exactly as on the non-hc path.
+    pub(super) fn decode_verify_hc(
+        &self,
+        tokens: &[u32],
+        seq: &mut SequenceState,
+        _stream: u64,
+    ) -> Result<Vec<u32>> {
+        let k = tokens.len();
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let stream = self.gpu.default_stream();
+        let h = self.config.hidden_size;
+        let vocab = self.config.vocab_size;
+        let bf16 = 2usize;
+
+        let hidden = self.buffers.hidden_states();
+        let residual = self.buffers.residual();
+        let mut kv_cache = self.kv_cache.lock();
+
+        // ── KV blocks for every position this verify will write ──
+        let bs = kv_cache.block_size();
+        let last_pos = seq.seq_len + k - 1;
+        let blocks_needed = (last_pos / bs) + 1;
+        while seq.block_table.len() < blocks_needed {
+            let blk = kv_cache.alloc_block()?;
+            seq.block_table.push(blk);
+        }
+
+        // ── Embed the K candidates into hidden[K, H] ──
+        // FP32 stride: `hidden_states` is the FP32 residual-stream buffer on
+        // this path, matching verify_a.
+        for (t, &token) in tokens.iter().enumerate() {
+            self.embed(token, hidden.offset(t * h * 2), stream)?;
+        }
+
+        // ── Prefill-shaped metadata for K rows at [seq_len, seq_len+K) ──
+        // Reuses the prefill packer rather than hand-rolling: it owns the
+        // MRoPE stream layout and bounds the write against the scratch region.
+        let meta_base = self.buffers.scratch().offset(32768);
+        let meta_region = self.buffers.scratch_bytes().saturating_sub(32768);
+        let all_tokens: Vec<u32> = seq
+            .tokens
+            .iter()
+            .copied()
+            .chain(tokens.iter().copied())
+            .collect();
+        let chunk_start = seq.tokens.len();
+        let meta = self.prefill_b_upload_meta_at(
+            &all_tokens,
+            seq,
+            chunk_start,
+            k,
+            seq.seq_len,
+            k,
+            seq.seq_len,
+            &kv_cache,
+            meta_base,
+            meta_region,
+            stream,
+        )?;
+
+        // Paged metadata (block table delta + seq_len) — the same helper the
+        // chunked-prefill path uses. `needs_paged` is always true here: verify
+        // only ever runs at seq_len_start > 0.
+        if meta.needs_paged {
+            self.prefill_b_upload_paged(
+                seq,
+                all_tokens.len(),
+                seq.seq_len,
+                k,
+                meta_base,
+                meta.slot_offset,
+                &kv_cache,
+                stream,
+            )?;
+        }
+        let (block_table_dev, seq_len_dev) = if meta.needs_paged {
+            let pm = seq
+                .chunked_prefill_meta
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("verify_hc: paged meta missing after upload"))?;
+            (pm.block_table, pm.seq_len)
+        } else {
+            (DevicePtr::NULL, DevicePtr::NULL)
+        };
+        let seq_slot = self.upload_seq_slot_uniform(
+            seq.adapter_slot,
+            k,
+            self.buffers.lora_seq_slot(),
+            stream,
+        )?;
+
+        // Field-for-field as prefill_c builds it. Pointing these at `meta_base`
+        // wholesale (an earlier cut of this file) makes attention read the
+        // position stream as its slot/seq_len/block table — silently wrong.
+        let attn_metadata = AttnMetadataDev {
+            positions: meta_base,
+            positions_h: meta_base,
+            positions_w: meta_base,
+            slot: meta_base.offset(meta.slot_offset),
+            seq_len: seq_len_dev,
+            block_table: block_table_dev,
+            max_blocks_per_seq: seq.block_table.len() as u32,
+            num_seqs: 1,
+            seq_slot,
+            moe_row_adapter: DevicePtr::NULL,
+        };
+
+        let ctx = ForwardContext {
+            buffers: &self.buffers,
+            hc_row_offset: 0,
+            gpu: self.gpu.as_ref(),
+            config: &self.config,
+            dispatch: &self.dispatch,
+            derived: &self.derived,
+            levers: &self.levers,
+            stats: &self.stats,
+            attn_metadata: Some(attn_metadata),
+            profile: false,
+            comm: self.comm_ref(),
+            // Host-built metadata: capture is illegal here.
+            graph_capture: false,
+            gdn_exact_replay: false,
+            token_ids: None,
+            // PLE reads HOST ids for the rows it is about to process.
+            host_token_ids: Some(tokens),
+            routed_lora_layers: None,
+            midchunk_capture: None,
+            moe_lora_route: self.decode_moe_route(),
+        };
+
+        // ── Every layer through its K-row mHC prefill path ──
+        for (i, layer) in self.layers.iter().enumerate() {
+            layer.prefill(
+                hidden,
+                residual,
+                k,
+                seq.layer_states[i].as_mut(),
+                &mut kv_cache,
+                seq.seq_len,
+                &mut seq.block_table,
+                &mut seq.disk_block_ids,
+                &mut seq.disk_last_offloaded_per_layer,
+                seq.seq_len,
+                &ctx,
+                stream,
+            )?;
+        }
+        drop(kv_cache);
+
+        // ── K-row head: same tail as the non-hc verify ──
+        let normed = self.buffers.norm_output();
+        let eps = self.config.rms_norm_eps as f32;
+        self.final_norm_apply(hidden, normed, k as u32, h as u32, eps, stream)?;
+        self.lm_head_batched(normed, k as u32, self.buffers.logits(), stream)?;
+
+        let mut out = Vec::with_capacity(k);
+        for t in 0..k {
+            let logits_t = self.buffers.logits().offset(t * vocab * bf16);
+            let out_ptr = self.buffers.scratch().offset(t * 4);
+            ops::argmax_bf16(
+                self.gpu.as_ref(),
+                self.argmax_kernel,
+                logits_t,
+                out_ptr,
+                vocab as u32,
+                stream,
+            )?;
+            let mut b = [0u8; 4];
+            self.gpu.copy_d2h(out_ptr, &mut b)?;
+            out.push(u32::from_le_bytes(b));
+        }
+
+        seq.tokens.extend_from_slice(tokens);
+        seq.seq_len += k;
+        Ok(out)
+    }
+}

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -218,6 +218,10 @@ pub struct TransformerModel {
     /// It drafts a token each decode step and records whether the target's next
     /// token matches — nothing is ever fed back, so no speculation occurs.
     pub(super) qwen4_exp_mtp_head: Option<crate::layers::qwen4_exp_mtp::Qwen4ExpMtpHead>,
+    /// Aux carries (QSA marks + PLE conv/history) snapshotted between the
+    /// committed row and the draft rows of an mHC K-row verify, so a rejected
+    /// draft can be rolled back to exactly "token_0 committed". See verify_hc.
+    pub(super) pending_verify_aux: std::sync::Mutex<Option<Vec<(u32, Vec<u8>)>>>,
     /// The head's single-sequence draft state. Shadow mode is C=1 only: one
     /// state, so a concurrent batch would interleave two sequences' drafts into
     /// it. The shadow step refuses to run when the batch is wider than one.

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -204,6 +204,15 @@ pub struct TransformerModel {
     pub(super) suppress_graphs: std::sync::atomic::AtomicBool,
     /// MTP draft proposer (built from mtp_weights at init).
     pub(super) proposer: Option<Arc<dyn DraftProposer>>,
+    /// The qwen4_exp MTP draft module, when one was loaded.
+    ///
+    /// Held so it is not DROPPED: `DevicePtr` has no `Drop`, so a module built
+    /// and let go leaks its quantized MoE and attention buffers (~1.5 GB) for
+    /// the process lifetime. Nothing reads this yet — the proposer that will
+    /// consume it is not written — but the alternative to storing it is a leak,
+    /// not a saving. It is deliberately NOT in `layers`: its body was built at
+    /// `attn_idx = 0` and must never be handed the shared paged KV pool.
+    pub(super) qwen4_exp_mtp: Option<Box<crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule>>,
     /// Dedicated buffer for saving hidden state before MTP head runs.
     /// Size: hidden_size * 4 bytes (one FP32 vector). MTP overwrites shared
     /// buffers (norm_output etc.), so the target hidden must be saved here first.

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -217,7 +217,7 @@ pub struct TransformerModel {
     /// owns the module. Present INSTEAD of `qwen4_exp_mtp` when shadow is on.
     /// It drafts a token each decode step and records whether the target's next
     /// token matches — nothing is ever fed back, so no speculation occurs.
-    pub(super) qwen4_exp_mtp_head: Option<crate::layers::qwen4_exp_mtp::Qwen4ExpMtpHead>,
+    pub(super) qwen4_exp_mtp_head: Option<Arc<crate::layers::qwen4_exp_mtp::Qwen4ExpMtpHead>>,
     /// Aux carries (QSA marks + PLE conv/history) snapshotted between the
     /// committed row and the draft rows of an mHC K-row verify, so a rejected
     /// draft can be rolled back to exactly "token_0 committed". See verify_hc.

--- a/crates/spark-model/src/model/types.rs
+++ b/crates/spark-model/src/model/types.rs
@@ -213,6 +213,16 @@ pub struct TransformerModel {
     /// not a saving. It is deliberately NOT in `layers`: its body was built at
     /// `attn_idx = 0` and must never be handed the shared paged KV pool.
     pub(super) qwen4_exp_mtp: Option<Box<crate::weight_loader::qwen4_exp::Qwen4ExpMtpModule>>,
+    /// SHADOW MODE ONLY (`ATLAS_QWEN4EXP_MTP_SHADOW=1`): the draft head, which
+    /// owns the module. Present INSTEAD of `qwen4_exp_mtp` when shadow is on.
+    /// It drafts a token each decode step and records whether the target's next
+    /// token matches — nothing is ever fed back, so no speculation occurs.
+    pub(super) qwen4_exp_mtp_head: Option<crate::layers::qwen4_exp_mtp::Qwen4ExpMtpHead>,
+    /// The head's single-sequence draft state. Shadow mode is C=1 only: one
+    /// state, so a concurrent batch would interleave two sequences' drafts into
+    /// it. The shadow step refuses to run when the batch is wider than one.
+    pub(super) qwen4_exp_mtp_state:
+        Option<std::sync::Mutex<crate::layers::qwen4_exp_mtp::Qwen4ExpMtpState>>,
     /// Dedicated buffer for saving hidden state before MTP head runs.
     /// Size: hidden_size * 4 bytes (one FP32 vector). MTP overwrites shared
     /// buffers (norm_output etc.), so the target hidden must be saved here first.

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -762,6 +762,23 @@ pub trait Model: Send + Sync {
         self.decode_verify_graphed_kgamma(tokens, seq, stream)
     }
 
+    /// Undo `rows` rejected draft rows for models whose verify runs as a K-row
+    /// mini-prefill (currently: an mHC highway, where that is the only working
+    /// multi-row path).
+    ///
+    /// The scheduler's generic reject rewind — `seq_len -= 1` plus
+    /// `commit_accepted_prefix` — restores the standard SSM h_state but NOT the
+    /// auxiliary state a mini-prefill also advances: the QSA `ingested`/`pooled`
+    /// carry marks, which are guarded by a hard `pos == st.ingested` equality.
+    /// Left unrewound, each rejection desynchronises that carry by one row and
+    /// the drift compounds until output degenerates.
+    ///
+    /// Returns `false` when the model has no such path, in which case the
+    /// caller's generic rewind is already sufficient and nothing more is owed.
+    fn rollback_verify_rows(&self, _seq: &mut SequenceState, _rows: usize) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Save the post-norm hidden state at `token_idx` (0 or 1) to a
     /// dedicated MTP input buffer. Must precede `run_mtp_propose` — MTP
     /// overwrites shared buffers including `norm_output`.

--- a/crates/spark-model/src/weight_loader/qwen4_exp.rs
+++ b/crates/spark-model/src/weight_loader/qwen4_exp.rs
@@ -57,71 +57,22 @@ use crate::weight_map::{DenseWeight, MtpWeights, dense};
 // path" on every Windows runner, which killed the release-matrix builds.
 #[path = "qwen4_exp/aux_sites.rs"]
 mod aux;
+/// Offline safetensors-header readers. Test-only: they exist so a checkpoint's
+/// layout can be checked without uploading it.
+#[cfg(test)]
+mod ckpt_header;
 mod ffn;
 mod hc;
+mod mtp;
 mod ple;
 mod probe;
+mod probe_mtp;
 
-pub use probe::audit_namespace;
-
-/// The PLE table's shard layout, read straight from a checkpoint's
-/// safetensors header.
-///
-/// Exists so a test can rebuild the segmented row cache WITHOUT loading a
-/// 75 GB model — the gather is the one part of PLE whose failure is invisible
-/// downstream, so it needs a cheap isolated arm.
 #[cfg(test)]
-pub fn ple_shard_layout(snapshot: &str) -> Result<(std::path::PathBuf, Vec<u64>, u64)> {
-    use std::io::{Read, Seek, SeekFrom};
-    let idx: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(
-        std::path::Path::new(snapshot).join("model.safetensors.index.json"),
-    )?)?;
-    let map = idx["weight_map"].as_object().context("weight_map")?;
-    let mut names: Vec<(usize, &String)> = map
-        .keys()
-        .filter(|k| k.contains(".ngram_embedding.shard_"))
-        .map(|k| {
-            let n = k
-                .rsplit("shard_")
-                .next()
-                .and_then(|r| r.split('.').next())
-                .and_then(|r| r.parse().ok())
-                .unwrap_or(usize::MAX);
-            (n, k)
-        })
-        .collect();
-    names.sort();
-    anyhow::ensure!(!names.is_empty(), "no PLE shards in {snapshot}");
-    let file = map[names[0].1].as_str().context("shard file")?;
-    let path = std::path::Path::new(snapshot).join(file);
-
-    let mut fh = std::fs::File::open(&path)?;
-    let mut len = [0u8; 8];
-    fh.read_exact(&mut len)?;
-    let hlen = u64::from_le_bytes(len);
-    let mut hdr = vec![0u8; hlen as usize];
-    fh.seek(SeekFrom::Start(8))?;
-    fh.read_exact(&mut hdr)?;
-    let hdr: serde_json::Value = serde_json::from_slice(&hdr)?;
-    let data_start = 8 + hlen;
-
-    let mut bases = Vec::with_capacity(names.len());
-    let mut rows_per = 0u64;
-    for (i, name) in &names {
-        let e = &hdr[name.as_str()];
-        let off = e["data_offsets"][0].as_u64().context("data_offsets")?;
-        let rows = e["shape"][0].as_u64().context("shape")?;
-        if *i == 0 {
-            rows_per = rows;
-        }
-        anyhow::ensure!(
-            rows == rows_per,
-            "shard {i} has {rows} rows, not {rows_per}"
-        );
-        bases.push(data_start + off);
-    }
-    Ok((path, bases, rows_per))
-}
+pub use ckpt_header::ple_shard_layout;
+pub use mtp::{Qwen4ExpMtpModule, load_qwen4_exp_mtp_module};
+pub use probe::audit_namespace;
+pub use probe_mtp::{MTP_LAYER_PREFIX, MtpExpertLayout, MtpNamespaceReport, audit_mtp_namespace};
 
 pub struct Qwen4ExpWeightLoader;
 
@@ -447,11 +398,34 @@ impl ModelWeightLoader for Qwen4ExpWeightLoader {
         _config: &ModelConfig,
         _gpu: &dyn GpuBackend,
     ) -> Result<Option<MtpWeights>> {
-        // Dropped for v1 (#753 item I). The MTP block is effectively a second
-        // model: its own 512-expert MoE, its own hyper-connection mixer, its
-        // own QSA indexer, and `fc_embedding`/`fc_hidden` where Atlas's
-        // `MtpWeights` wants a fused `eh_proj`. Wiring it before the main
-        // forward path works would be building on sand.
+        // NOT a deferral any more — a routing decision, the same one
+        // `DeepSeekV4WeightLoader::load_mtp_weights` makes.
+        //
+        // `MtpWeights` is STRUCTURALLY the wrong container for this family:
+        //   * it demands a fused `fc [h, 2h]` over `concat(norm(embed),
+        //     norm(hidden))`; this checkpoint ships two square projections,
+        //     `mtp.fc_embedding` and `mtp.fc_hidden`;
+        //   * it types `pre_fc_norm_hidden` as `[h]`; this ships
+        //     `[hc_mult * h]` (10240 against 2560), because the incoming
+        //     hidden state is the four-stream mHC highway, not a collapsed
+        //     one;
+        //   * it requires `input_layernorm`, `post_attn_layernorm` and a final
+        //     `norm`, none of which exist in this architecture — normalization
+        //     lives inside the hyper-connection blocks;
+        //   * and `MtpHead`'s forward hard-codes a single pre-norm residual
+        //     stream, which an mHC bracket does not have.
+        //
+        // So qwen4_exp is Track B, and the real loader is
+        // `mtp::load_qwen4_exp_mtp_module` — a bespoke `Qwen4ExpMtpModule`
+        // built out of this file's own per-layer helpers at
+        // `lp = "mtp.layers.0"`. Do not re-derive this refusal; extend that.
+        //
+        // NO PREFLIGHT CHANGE IS NEEDED, checked: `check_layer_count` parses
+        // `mtp.layers.0` as index 0 (it splits on the first `.layers.`), so
+        // `max_layer_idx` stays 47, `47 + 1 > 48` is false, and neither
+        // `check_mtp_consumability` nor its `MTP_SUPPORTED_MODEL_TYPES`
+        // allowlist is ever reached. `check_expert_count` sees experts 0..511
+        // against `num_experts = 512` and passes.
         Ok(None)
     }
 }

--- a/crates/spark-model/src/weight_loader/qwen4_exp/ckpt_header.rs
+++ b/crates/spark-model/src/weight_loader/qwen4_exp/ckpt_header.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Test-only safetensors-header readers for the qwen4_exp checkpoints.
+//!
+//! Parse a checkpoint's `model.safetensors.index.json` and shard headers
+//! WITHOUT uploading anything, so an offline test can check a real snapshot's
+//! layout for the price of a few reads instead of a 75 GB load. Split out of
+//! `qwen4_exp.rs` for the 500-LoC cap.
+
+use anyhow::{Context, Result};
+
+/// The PLE table's shard layout, read straight from a checkpoint's
+/// safetensors header.
+///
+/// Exists so a test can rebuild the segmented row cache WITHOUT loading a
+/// 75 GB model — the gather is the one part of PLE whose failure is invisible
+/// downstream, so it needs a cheap isolated arm.
+pub fn ple_shard_layout(snapshot: &str) -> Result<(std::path::PathBuf, Vec<u64>, u64)> {
+    use std::io::{Read, Seek, SeekFrom};
+    let idx: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(
+        std::path::Path::new(snapshot).join("model.safetensors.index.json"),
+    )?)?;
+    let map = idx["weight_map"].as_object().context("weight_map")?;
+    let mut names: Vec<(usize, &String)> = map
+        .keys()
+        .filter(|k| k.contains(".ngram_embedding.shard_"))
+        .map(|k| {
+            let n = k
+                .rsplit("shard_")
+                .next()
+                .and_then(|r| r.split('.').next())
+                .and_then(|r| r.parse().ok())
+                .unwrap_or(usize::MAX);
+            (n, k)
+        })
+        .collect();
+    names.sort();
+    anyhow::ensure!(!names.is_empty(), "no PLE shards in {snapshot}");
+    let file = map[names[0].1].as_str().context("shard file")?;
+    let path = std::path::Path::new(snapshot).join(file);
+
+    let mut fh = std::fs::File::open(&path)?;
+    let mut len = [0u8; 8];
+    fh.read_exact(&mut len)?;
+    let hlen = u64::from_le_bytes(len);
+    let mut hdr = vec![0u8; hlen as usize];
+    fh.seek(SeekFrom::Start(8))?;
+    fh.read_exact(&mut hdr)?;
+    let hdr: serde_json::Value = serde_json::from_slice(&hdr)?;
+    let data_start = 8 + hlen;
+
+    let mut bases = Vec::with_capacity(names.len());
+    let mut rows_per = 0u64;
+    for (i, name) in &names {
+        let e = &hdr[name.as_str()];
+        let off = e["data_offsets"][0].as_u64().context("data_offsets")?;
+        let rows = e["shape"][0].as_u64().context("shape")?;
+        if *i == 0 {
+            rows_per = rows;
+        }
+        anyhow::ensure!(
+            rows == rows_per,
+            "shard {i} has {rows} rows, not {rows_per}"
+        );
+        bases.push(data_start + off);
+    }
+    Ok((path, bases, rows_per))
+}

--- a/crates/spark-model/src/weight_loader/qwen4_exp/hc.rs
+++ b/crates/spark-model/src/weight_loader/qwen4_exp/hc.rs
@@ -78,15 +78,33 @@ pub(super) fn load_layer_sites(
     Ok((site(attn), site(ffn)))
 }
 
-/// The model-level mixer, replicated onto every layer but consumed only by
-/// the last one.
-pub(super) fn load_head(store: &WeightStore, config: &ModelConfig) -> Result<HcHeadWeights> {
-    let prefix = format!("{}.hyper_connection_mixer", super::embed_prefix(config));
-    let lowrank = load_site(store, &prefix, config.hc_lowrank, false)?;
+/// A collapse-only mixer at an ARBITRARY prefix.
+///
+/// The main model's lives at `{weight_prefix}.hyper_connection_mixer`; the MTP
+/// block carries its own at `mtp.hyper_connection_mixer`, same three tensors,
+/// same shapes, still no `block_inject_weight`. `load_site` stays private —
+/// this is the only new door, so nothing outside this module can construct a
+/// site with the wrong `with_inject`.
+pub(super) fn load_head_at(
+    store: &WeightStore,
+    prefix: &str,
+    rank: usize,
+) -> Result<HcHeadWeights> {
+    let lowrank = load_site(store, prefix, rank, false)?;
     Ok(HcHeadWeights {
         hc_fn: DevicePtr::NULL,
         hc_base: DevicePtr::NULL,
         hc_scale: DevicePtr::NULL,
         lowrank: Some(lowrank),
     })
+}
+
+/// The model-level mixer, replicated onto every layer but consumed only by
+/// the last one.
+pub(super) fn load_head(store: &WeightStore, config: &ModelConfig) -> Result<HcHeadWeights> {
+    load_head_at(
+        store,
+        &format!("{}.hyper_connection_mixer", super::embed_prefix(config)),
+        config.hc_lowrank,
+    )
 }

--- a/crates/spark-model/src/weight_loader/qwen4_exp/mtp.rs
+++ b/crates/spark-model/src/weight_loader/qwen4_exp/mtp.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `Qwen3.8-Flash-Next` (`qwen4_exp`) MTP draft-module loader — Track B.
+//!
+//! Atlas has two MTP tracks. Track A fills in `MtpWeights` and lets
+//! `MtpHead` build a hand-rolled GQA drafter; Track B builds a bespoke module
+//! out of the model's OWN layer type and surfaces it to a proposer. DeepSeek-V4
+//! is Track B, and so is this: `MtpWeights` demands a fused `fc [h, 2h]` where
+//! this ships `fc_embedding` + `fc_hidden`, a `pre_fc_norm_hidden [h]` where
+//! this ships `[hc_mult * h]`, and `input_layernorm` / `post_attn_layernorm` /
+//! `norm` fields this architecture does not have at all.
+//!
+//! The body is the existing per-layer construction from `qwen4_exp.rs` replayed
+//! ONCE with `lp = "mtp.layers.0"` and the full-attention arm only. Every
+//! helper it calls already takes `lp: &str`; nothing shared is modified, and
+//! the prefix comes down as a literal from here rather than by teaching
+//! `ModelConfig::layer_prefix` a top-level `mtp.*` namespace it cannot express.
+//!
+//! **Nothing runs this yet.** There is no proposer, so `has_proposer()` stays
+//! false, `use_speculative` stays false, and `step_mtp` is never reached.
+//! `--speculative` on qwen4_exp loads and audits this module and says so.
+
+use anyhow::{Context, Result};
+use atlas_core::config::ModelConfig;
+use spark_runtime::gpu::GpuBackend;
+use spark_runtime::kv_cache::KvCacheDtype;
+use spark_runtime::weights::WeightStore;
+
+use super::{MTP_LAYER_PREFIX, MtpExpertLayout, MtpNamespaceReport, audit_mtp_namespace};
+use crate::layer::TransformerLayer;
+use crate::layers::qwen3_attention::HcHeadWeights;
+use crate::weight_map::{DenseWeight, dense_auto};
+
+/// A loaded qwen4_exp MTP draft module: the reused full-attention body (mHC +
+/// QSA + its own 512-expert MoE) plus the MTP-specific combiner and the
+/// module's own stream-collapsing mixer.
+///
+/// # Invariant: the body has NO KV cache of its own yet
+///
+/// `body` is built with `attn_idx = 0`. That index is used as a RAW slice
+/// index into whatever `PagedKvCache` it is handed
+/// (`paged_impl.rs`: `self.layers[layer_idx]`), so decoding this body against
+/// the main model's pool would read and write full-attention layer 0's K/V.
+/// The module must ONLY ever be decoded against its own single-layer cache,
+/// which does not exist yet. That is why it is stored in a dedicated
+/// `Option` field on the model, is never pushed into `model.layers`, and is
+/// reachable from no main-model path.
+//
+// Consumed by the forthcoming `Qwen4ExpMtpHead` proposer — the same deferral
+// `DeepseekV4MtpModule` carried between its loader and its head landing.
+#[allow(dead_code)]
+pub struct Qwen4ExpMtpModule {
+    /// Reused `Qwen3AttentionLayer` body built from the `mtp.layers.0` prefix.
+    pub body: Box<dyn TransformerLayer>,
+    /// The module's OWN collapse-only mixer (`mtp.hyper_connection_mixer`).
+    /// The body was built at `layer_idx = num_hidden_layers`, so both
+    /// `is_first_model_layer` and `is_last_model_layer` are false and it runs
+    /// the MIDDLE mHC mixing only — the proposer owns both ends.
+    pub hc_head: Option<HcHeadWeights>,
+    /// RMSNorm on the next-token embedding, `[hidden]`.
+    pub pre_fc_norm_embedding: DenseWeight,
+    /// RMSNorm on the incoming hidden state, `[hc_mult * hidden]` — the
+    /// FOUR-STREAM mHC highway, not a collapsed hidden. See the audit.
+    pub pre_fc_norm_hidden: DenseWeight,
+    /// `[hidden, hidden]` projection of the normed embedding.
+    pub fc_embedding: DenseWeight,
+    /// `[hidden, hidden]` projection of the normed hidden state.
+    pub fc_hidden: DenseWeight,
+    /// Which routed-expert layout the audit resolved. Recorded so the
+    /// proposer's memory accounting does not have to re-derive it.
+    pub expert_layout: MtpExpertLayout,
+}
+
+/// Load the MTP draft module, or `Ok(None)` when none is declared.
+///
+/// # Ordering is a correctness contract
+///
+/// The audit runs BEFORE the first `build_moe`. `load_moe_qwen35` `gpu.free()`s
+/// the fused source tensors once it has quantized them, leaving the store
+/// holding freed pointers for `experts.gate_up_proj` / `experts.down_proj`; an
+/// audit that ran afterwards would be reading dangling allocations.
+///
+/// # An absent-but-declared MTP is an ERROR, not a skip
+///
+/// Every `store.contains` in the helpers this reuses is a GATE, not a check:
+/// `attach_qsa` skips silently, `load_moe_qwen35`'s fused detection just picks
+/// the other branch. So if the tensors were declared and are not in the store —
+/// the `skip_mtp` upload filter still on, or a GGUF/RDMA loader path — this
+/// returns `Err` naming the cause rather than logging "no MTP in checkpoint"
+/// and loading nothing.
+pub fn load_qwen4_exp_mtp_module(
+    store: &WeightStore,
+    config: &ModelConfig,
+    gpu: &dyn GpuBackend,
+) -> Result<Option<Qwen4ExpMtpModule>> {
+    if config.num_mtp_modules == 0 {
+        return Ok(None);
+    }
+    // The combiner's `fc_embedding` is the cheapest MTP-only marker (the role
+    // `mtp.0.enorm.weight` plays for DeepSeek-V4): it exists in no other
+    // namespace and is not something a shard split can move.
+    if !store.contains("mtp.fc_embedding.weight") {
+        anyhow::bail!(
+            "qwen4_exp: config declares num_mtp_modules={} but the weight store \
+             holds no `mtp.fc_embedding.weight`. The tensors were NOT loaded. \
+             Most likely `skip_mtp` (spark-server serve_phases/weights.rs) is \
+             still filtering `mtp.*` out at upload — it only lets them through \
+             under `--speculative` or ATLAS_QWEN4EXP_MTP=1 — or the checkpoint \
+             came in through the GGUF or RDMA loader path, neither of which \
+             carries the mtp namespace. Refusing rather than reporting \"no MTP \
+             in checkpoint\" and loading nothing.",
+            config.num_mtp_modules,
+        );
+    }
+
+    // BEFORE anything is built. See the ordering note above.
+    let report: MtpNamespaceReport = audit_mtp_namespace(store, config);
+    report.log();
+    report.ensure_loadable(config)?;
+
+    let h = config.hidden_size;
+    let lp = MTP_LAYER_PREFIX;
+    let variant = crate::weight_map::detect_nvfp4_variant(store, config);
+    let absmax_k = gpu.kernel("quantize_nvfp4", "nvfp4_global_absmax")?;
+    let quantize_k = gpu.kernel("quantize_nvfp4", "quantize_bf16_to_nvfp4")?;
+    let stream = gpu.default_stream();
+    let free_now = |g: &dyn GpuBackend| g.free_memory().unwrap_or(0) as u64;
+    let f0 = free_now(gpu);
+
+    // ── (1) MoE. `build_moe` is called verbatim: its `is_fused` detection
+    // handles BOTH shipped layouts with no new code. On the fused-BF16
+    // snapshot this uploads ~5.0 GB of BF16 experts that collapse to ~1.3 GB
+    // NVFP4 and frees the sources; on the per-expert NVFP4 snapshot the
+    // packed tensors pass straight through.
+    let ffn = super::ffn::build_moe(store, lp, config, gpu, variant)
+        .context("qwen4_exp MTP: MoE block")?;
+    let f1 = free_now(gpu);
+
+    // ── (2) Norm placeholders. Same as every main layer: this architecture
+    // keeps its normalization inside the hyper-connection blocks, so there is
+    // no `input_layernorm` / `post_attention_layernorm` tensor to load and a
+    // ones-filled buffer keeps the shared arm's shape contract.
+    let input_norm = super::ones_norm(h, gpu)?;
+    let post_attn_norm = super::ones_norm(h, gpu)?;
+
+    // ── (3) The body, full-attention arm only (`mtp.layer_types ==
+    // ["full_attention"]`, refused by the config parser otherwise).
+    //
+    // `layer_idx = config.num_hidden_layers` is log-only here, and it is also
+    // what makes `attach_hc` set is_first == is_last == false below.
+    //
+    // KvCacheDtype::Bf16 is passed EXPLICITLY rather than looked up in
+    // `layer_kv_dtypes`, for two reasons: an out-of-range index there falls
+    // back to Bf16 SILENTLY (qwen4_exp.rs), and QSA selection refuses anything
+    // but plain BF16 KV, so a draft body carrying an indexer has no other
+    // legal choice.
+    //
+    // `attn_idx = 0`: the module's future private single-layer cache. See the
+    // struct invariant — this body must never be decoded against the main pool.
+    let mut body =
+        crate::weight_loader::qwen35::load_layers::attention_arms::build_full_attention_nvfp4(
+            config.num_hidden_layers,
+            store,
+            lp,
+            gpu,
+            variant,
+            config,
+            h,
+            absmax_k,
+            quantize_k,
+            stream,
+            KvCacheDtype::Bf16,
+            0,
+            input_norm,
+            post_attn_norm,
+            ffn,
+        )
+        .context("qwen4_exp MTP: full-attention body")?;
+    let f2 = free_now(gpu);
+
+    // ── (4) mHC sites + the module's own mixer.
+    let hc_head = if config.hc_mult > 0 {
+        let (attn_site, ffn_site) =
+            super::hc::load_layer_sites(store, lp, config).context("qwen4_exp MTP: mHC sites")?;
+        let head = super::hc::load_head_at(store, "mtp.hyper_connection_mixer", config.hc_lowrank)
+            .context("qwen4_exp MTP: hyper_connection_mixer")?;
+        // `head = None` on the BODY: at layer_idx == num_hidden_layers both
+        // is_first_model_layer and is_last_model_layer are false, so the body
+        // runs middle-only mixing and never calls hc_head. The head is
+        // surfaced on the module instead, for the proposer to collapse with —
+        // exactly the DeepSeek-V4 device.
+        super::aux::attach_hc(
+            &mut body,
+            config.num_hidden_layers,
+            attn_site,
+            ffn_site,
+            None,
+            config,
+        )?;
+        Some(head)
+    } else {
+        None
+    };
+
+    // ── (5) QSA indexer. The tensors exist in `mtp.*`, and a dense body past
+    // `indexer_budget` is not the reference model. It also exercises the three
+    // audited indexer tensors end to end.
+    super::aux::attach_qsa(&mut body, config.num_hidden_layers, lp, store, config, gpu)?;
+
+    // ── (6) NO PLE. `mtp.*` carries zero PLE tensors, and PLE only ever
+    // attaches to a `Qwen3SsmLayer` while this body is a `Qwen3AttentionLayer`.
+    // `ple::load` would return None for this index anyway; not calling it is a
+    // decision, not an accident.
+
+    // ── (7) The four MTP-only combiner tensors. Plain BF16 in both shipped
+    // checkpoints; `dense_auto` survives a future FP8 re-quant. Re-asserted
+    // against the store's own shapes at load — the audit already checked them,
+    // and this is the line that keeps that true if the audit is ever loosened.
+    let dense_checked = |name: &str, want: &[usize]| -> Result<DenseWeight> {
+        let got = &store.get(name)?.shape;
+        anyhow::ensure!(
+            got == want,
+            "qwen4_exp MTP: {name} has shape {got:?}, expected {want:?}"
+        );
+        dense_auto(store, name, gpu).with_context(|| format!("qwen4_exp MTP: {name}"))
+    };
+    let hc_h = config.hc_mult * h;
+    let pre_fc_norm_embedding = dense_checked("mtp.pre_fc_norm_embedding.weight", &[h])?;
+    let pre_fc_norm_hidden = dense_checked("mtp.pre_fc_norm_hidden.weight", &[hc_h])?;
+    let fc_embedding = dense_checked("mtp.fc_embedding.weight", &[h, h])?;
+    let fc_hidden = dense_checked("mtp.fc_hidden.weight", &[h, h])?;
+
+    let f3 = free_now(gpu);
+    // ⚠ SIGNED deltas. `saturating_sub` on unsigned free-memory readings
+    // clamps to 0.00 GB precisely on the arm that matters: with FUSED experts
+    // `build_moe` frees ~5 GB of already-resident BF16 sources while
+    // allocating ~1.3 GB of NVFP4, so free memory RISES across the call and an
+    // unsigned delta reports "0.00 GB" — which reads as "the MTP block is
+    // free" when it is nothing of the sort. Negative = net freed.
+    let gb = |a: u64, b: u64| (a as i128 - b as i128) as f64 / 1e9;
+    tracing::info!(
+        "qwen4_exp MTP module loaded ({:?} experts): MoE {:+.2} GB, attention body \
+         {:+.2} GB, mHC+QSA+combiner {:+.2} GB, {:+.2} GB net. Deltas are free-memory \
+         differences, so a NEGATIVE figure means that stage freed more than it \
+         allocated (the fused arm frees its BF16 sources) — it is NOT the resident \
+         cost of the module. NOTE: no proposer is wired — this module is loaded and \
+         audited, nothing decodes it.",
+        report.expert_layout,
+        gb(f0, f1),
+        gb(f1, f2),
+        gb(f2, f3),
+        gb(f0, f3),
+    );
+
+    Ok(Some(Qwen4ExpMtpModule {
+        body,
+        hc_head,
+        pre_fc_norm_embedding,
+        pre_fc_norm_hidden,
+        fc_embedding,
+        fc_hidden,
+        expert_layout: report.expert_layout,
+    }))
+}

--- a/crates/spark-model/src/weight_loader/qwen4_exp/probe_mtp.rs
+++ b/crates/spark-model/src/weight_loader/qwen4_exp/probe_mtp.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pre-flight audit of the `mtp.*` namespace, BY SHAPE.
+//!
+//! Split from `probe.rs` for the 500-LoC cap; the main-model audit next door
+//! is the model this one is built on. The difference is that this one asserts
+//! SHAPES rather than presence, because the MTP block's one genuine departure
+//! from a mirror of a main layer is a pair of norms at DIFFERENT widths — and
+//! a wrong width there is not a crash, it is plausible-wrong activations.
+//!
+//! It also resolves the routed-expert layout explicitly. Two real checkpoint
+//! revisions ship two different layouts (fused BF16 stacks; 512 per-expert
+//! NVFP4 triples) and `load_moe_qwen35` picks between them silently, so
+//! "neither" and "both" are refusals here rather than a branch taken quietly
+//! halfway through a multi-gigabyte upload.
+
+use anyhow::{Result, ensure};
+use atlas_core::config::ModelConfig;
+use spark_runtime::weights::WeightStore;
+
+/// The MTP block's single decoder layer. A top-level namespace, NOT under
+/// `weight_prefix` — `config.layer_prefix(i)` can never produce it, which is
+/// why the prefix comes down as a literal.
+pub const MTP_LAYER_PREFIX: &str = "mtp.layers.0";
+
+/// Which of the two shipped routed-expert layouts the MTP MoE uses.
+///
+/// Both are real: `RadixArk/...-NVFP4` ships FUSED BF16 stacks, the Inferact
+/// re-quant ships 512 PER-EXPERT NVFP4 triples. `load_moe_qwen35` picks the
+/// branch itself, but it picks it SILENTLY — so the layout is resolved here
+/// and refused when it is neither or both, rather than discovered halfway
+/// through a 5 GB upload.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MtpExpertLayout {
+    /// Neither `experts.gate_up_proj` nor `experts.{e}.gate_proj.weight`.
+    #[default]
+    Neither,
+    /// `mtp.layers.0.mlp.experts.{gate_up_proj,down_proj}` stacks.
+    Fused,
+    /// `mtp.layers.0.mlp.experts.{e}.{gate,up,down}_proj.weight`.
+    PerExpert,
+    /// Both — ambiguous, and `is_fused` would pick one without saying so.
+    Both,
+}
+
+/// What the store holds under `mtp.*`, checked by SHAPE rather than presence.
+#[derive(Debug, Default, Clone)]
+pub struct MtpNamespaceReport {
+    /// Any `mtp.`-prefixed tensor at all. False is the normal state: the
+    /// serve path skips uploading them unless MTP is armed.
+    pub any_tensors: bool,
+    pub expert_layout: MtpExpertLayout,
+    /// The expert index actually probed (first LOCAL under EP, not 0).
+    pub first_local_expert: usize,
+    /// Tensors the module loader reads that the store does not have.
+    pub missing: Vec<String>,
+    /// Tensors present at the wrong shape, with both widths named.
+    pub shape_errors: Vec<String>,
+    /// Tensors present that must NOT be.
+    pub unexpected: Vec<String>,
+}
+
+/// Accumulates presence + shape failures instead of bailing on the first, so
+/// the operator sees every problem at once rather than one per re-run.
+struct Chk<'a> {
+    store: &'a WeightStore,
+    missing: Vec<String>,
+    shape_errors: Vec<String>,
+}
+
+impl Chk<'_> {
+    fn need(&mut self, name: String, want: &[usize]) {
+        match self.store.get(&name) {
+            Err(_) => self.missing.push(name),
+            Ok(t) => {
+                if t.shape != want {
+                    self.shape_errors.push(format!(
+                        "{name}: checkpoint shape {:?}, loader expects {want:?}",
+                        t.shape
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Pre-flight audit of the `mtp.*` namespace, by shape.
+///
+/// Must run BEFORE the first `build_moe`: `load_moe_qwen35` `gpu.free()`s the
+/// fused source tensors after quantizing them, leaving the store holding freed
+/// pointers for `experts.gate_up_proj` / `experts.down_proj`. An audit that ran
+/// afterwards would be reading dangling allocations.
+pub fn audit_mtp_namespace(store: &WeightStore, config: &ModelConfig) -> MtpNamespaceReport {
+    let h = config.hidden_size;
+    let hc_h = config.hc_mult * h;
+    let hd = config.head_dim;
+    let lp = MTP_LAYER_PREFIX;
+
+    let mut c = Chk {
+        store,
+        missing: Vec::new(),
+        shape_errors: Vec::new(),
+    };
+    let mut unexpected: Vec<String> = Vec::new();
+    let any_tensors = store.names().any(|n| n.starts_with("mtp."));
+
+    // ── Attention. Byte-identical to a main full-attention layer, including
+    // the two traps: q_proj is DOUBLE width (`output_gate_type: sigmoid`
+    // concatenates the query and its sigmoid gate) while o_proj's input is
+    // SINGLE width. Sizing either from the other silently over- or
+    // under-reads, and no name check catches it.
+    let ap = format!("{lp}.self_attn");
+    let q_rows = 2 * config.num_attention_heads * hd;
+    let kv_rows = config.num_key_value_heads * hd;
+    c.need(format!("{ap}.q_proj.weight"), &[q_rows, h]);
+    c.need(format!("{ap}.k_proj.weight"), &[kv_rows, h]);
+    c.need(format!("{ap}.v_proj.weight"), &[kv_rows, h]);
+    c.need(
+        format!("{ap}.o_proj.weight"),
+        &[h, config.num_attention_heads * hd],
+    );
+    c.need(format!("{ap}.q_norm.weight"), &[hd]);
+    c.need(format!("{ap}.k_norm.weight"), &[hd]);
+
+    // ── QSA indexer. `(index_n_heads + 1) * index_head_dim` rows: the +1 is
+    // the single indexer KV head (`indexer_kv_heads: 1`), which the config
+    // parser does not carry as a field.
+    if config.index_topk > 0 {
+        let ip = format!("{ap}.indexer");
+        let idx_rows = (config.index_n_heads + 1) * config.index_head_dim;
+        let ihd = config.index_head_dim;
+        c.need(format!("{ip}.index_qk_proj.weight"), &[idx_rows, h]);
+        c.need(format!("{ip}.q_layernorm.weight"), &[ihd]);
+        c.need(format!("{ip}.k_layernorm.weight"), &[ihd]);
+    }
+
+    // ── The two per-layer mHC sites, four tensors each, plus the module's OWN
+    // collapse-only mixer — which has only THREE. A `block_inject_weight` on
+    // the mixer would mean it is not collapse-only and
+    // `hc::load_head_at(.., with_inject = false)` is reading the wrong model.
+    if config.hc_mult > 0 {
+        let r = config.hc_lowrank;
+        for site in ["attn_hyper_connection", "mlp_hyper_connection"] {
+            let sp = format!("{lp}.{site}");
+            c.need(format!("{sp}.hc_norm.weight"), &[hc_h]);
+            c.need(format!("{sp}.input_mix_weight_down.weight"), &[r, hc_h]);
+            c.need(format!("{sp}.input_mix_weight_up.weight"), &[hc_h, r]);
+            c.need(
+                format!("{sp}.block_inject_weight.weight"),
+                &[config.hc_mult, hc_h],
+            );
+        }
+        let mx = "mtp.hyper_connection_mixer";
+        c.need(format!("{mx}.hc_norm.weight"), &[hc_h]);
+        c.need(format!("{mx}.input_mix_weight_down.weight"), &[r, hc_h]);
+        c.need(format!("{mx}.input_mix_weight_up.weight"), &[hc_h, r]);
+        if store.contains(&format!("{mx}.block_inject_weight.weight")) {
+            unexpected.push(format!(
+                "{mx}.block_inject_weight.weight: the module mixer is built \
+                 use_combine=False and must only collapse"
+            ));
+        }
+    }
+
+    // ── Router + shared expert. The MTP block routes over the FULL expert set,
+    // top-k, exactly like a main layer — it is a second model, not a light head.
+    let mp = format!("{lp}.mlp");
+    let si = config.shared_expert_intermediate_size;
+    c.need(format!("{mp}.gate.weight"), &[config.num_experts, h]);
+    c.need(format!("{mp}.shared_expert.gate_proj.weight"), &[si, h]);
+    c.need(format!("{mp}.shared_expert.up_proj.weight"), &[si, h]);
+    c.need(format!("{mp}.shared_expert.down_proj.weight"), &[h, si]);
+    c.need(format!("{mp}.shared_expert_gate.weight"), &[1, h]);
+
+    // ── The four MTP-ONLY tensors — the one place this namespace is not a
+    // mirror of a main layer.
+    //
+    // THE WIDTHS ARE ASYMMETRIC AND THAT IS THE POINT:
+    //   mtp.pre_fc_norm_embedding [hidden]           = 2560
+    //   mtp.pre_fc_norm_hidden    [hc_mult * hidden] = 10240
+    // The second norms the FOUR-STREAM mHC highway, not a collapsed hidden. A
+    // loader that allocates both at `hidden_size` reads 2560 of 10240 elements
+    // and produces plausible-wrong activations with nothing in the log.
+    // `fc_embedding` and `fc_hidden` are both [hidden, hidden] — square, so
+    // swapping THEM is silent too; only their names distinguish them.
+    c.need("mtp.pre_fc_norm_embedding.weight".into(), &[h]);
+    c.need("mtp.pre_fc_norm_hidden.weight".into(), &[hc_h]);
+    c.need("mtp.fc_embedding.weight".into(), &[h, h]);
+    c.need("mtp.fc_hidden.weight".into(), &[h, h]);
+
+    // ── Routed experts: exactly one of the two shipped layouts. The
+    // per-expert probe uses the first LOCAL expert, not a hardcoded 0 — the
+    // same `weight_map::nemotron` idiom the main-model audit uses.
+    let first_local = (0..config.num_experts)
+        .find(|e| config.is_local_expert(*e))
+        .unwrap_or(0);
+    let fused = store.contains(&format!("{mp}.experts.gate_up_proj"))
+        && store.contains(&format!("{mp}.experts.down_proj"));
+    let per_expert = store.contains(&format!("{mp}.experts.{first_local}.gate_proj.weight"));
+    let expert_layout = match (fused, per_expert) {
+        (true, true) => MtpExpertLayout::Both,
+        (true, false) => MtpExpertLayout::Fused,
+        (false, true) => MtpExpertLayout::PerExpert,
+        (false, false) => MtpExpertLayout::Neither,
+    };
+    if expert_layout == MtpExpertLayout::Fused {
+        // BF16 stacks: [E, 2*moe_inter, hidden] and [E, hidden, moe_inter].
+        // The per-expert arm is deliberately NOT shape-checked: those tensors
+        // are NVFP4-packed, so their on-disk width is half the logical one and
+        // the packing is the MoE loader's business, not this audit's.
+        let mi = config.moe_intermediate_size;
+        let e = config.num_experts;
+        c.need(format!("{mp}.experts.gate_up_proj"), &[e, 2 * mi, h]);
+        c.need(format!("{mp}.experts.down_proj"), &[e, h, mi]);
+    }
+
+    MtpNamespaceReport {
+        any_tensors,
+        expert_layout,
+        first_local_expert: first_local,
+        missing: c.missing,
+        shape_errors: c.shape_errors,
+        unexpected,
+    }
+}
+
+impl MtpNamespaceReport {
+    pub fn log(&self) {
+        tracing::info!(
+            "qwen4_exp MTP namespace: tensors={} experts={:?} (probed expert {}), \
+             {} missing, {} shape mismatches, {} unexpected",
+            self.any_tensors,
+            self.expert_layout,
+            self.first_local_expert,
+            self.missing.len(),
+            self.shape_errors.len(),
+            self.unexpected.len(),
+        );
+        for m in &self.missing {
+            tracing::warn!("qwen4_exp MTP: missing {m}");
+        }
+        for s in &self.shape_errors {
+            tracing::warn!("qwen4_exp MTP: {s}");
+        }
+        for u in &self.unexpected {
+            tracing::warn!("qwen4_exp MTP: unexpected {u}");
+        }
+    }
+
+    /// Refuse before building anything.
+    ///
+    /// Takes `config` (unlike `NamespaceReport::ensure_loadable` next door)
+    /// because the EP refusal is a config property, not a store one.
+    pub fn ensure_loadable(&self, config: &ModelConfig) -> Result<()> {
+        if config.num_mtp_modules == 0 {
+            // Nothing declared, nothing to load — an empty report is correct.
+            return Ok(());
+        }
+        ensure!(
+            config.ep_world_size <= 1,
+            "qwen4_exp MTP: ep_world_size={} but the MTP MoE has no \
+             force_all_experts path — `load_moe_qwen35` honours \
+             `is_local_expert`, while the weight upload never shards `mtp.*`, \
+             so a rank>0 draft would route into NULL experts. Serve without EP \
+             or leave MTP off.",
+            config.ep_world_size,
+        );
+        ensure!(
+            self.any_tensors,
+            "qwen4_exp MTP: num_mtp_modules={} but the store holds no `mtp.*` \
+             tensors at all",
+            config.num_mtp_modules,
+        );
+        ensure!(
+            self.missing.is_empty(),
+            "qwen4_exp MTP: {} tensor(s) the module loader reads are absent: {}",
+            self.missing.len(),
+            self.missing.join(", "),
+        );
+        ensure!(
+            self.shape_errors.is_empty(),
+            "qwen4_exp MTP: {} tensor(s) at unexpected shapes: {}",
+            self.shape_errors.len(),
+            self.shape_errors.join("; "),
+        );
+        ensure!(
+            self.unexpected.is_empty(),
+            "qwen4_exp MTP: {} tensor(s) present that this architecture should \
+             not have: {}",
+            self.unexpected.len(),
+            self.unexpected.join("; "),
+        );
+        match self.expert_layout {
+            MtpExpertLayout::Fused | MtpExpertLayout::PerExpert => Ok(()),
+            MtpExpertLayout::Neither => anyhow::bail!(
+                "qwen4_exp MTP: no routed experts — neither the FUSED \
+                 `{MTP_LAYER_PREFIX}.mlp.experts.gate_up_proj`/`.down_proj` \
+                 stacks nor a PER-EXPERT \
+                 `{MTP_LAYER_PREFIX}.mlp.experts.{}.gate_proj.weight`. The MoE \
+                 would route into nothing.",
+                self.first_local_expert,
+            ),
+            MtpExpertLayout::Both => anyhow::bail!(
+                "qwen4_exp MTP: BOTH expert layouts present under \
+                 `{MTP_LAYER_PREFIX}.mlp.experts.*` — `load_moe_qwen35` would \
+                 silently pick the fused branch. Refusing rather than guessing \
+                 which one the checkpoint means."
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "probe_mtp_tests.rs"]
+mod probe_mtp_tests;

--- a/crates/spark-model/src/weight_loader/qwen4_exp/probe_mtp_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen4_exp/probe_mtp_tests.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! CPU tests for the `mtp.*` shape audit.
+//!
+//! Every store here is synthetic: `WeightStore::from_map` over
+//! `DevicePtr::NULL` pointers with REAL shapes, so the whole audit runs with
+//! no GPU and no checkpoint. The point of the audit is that it reads shapes
+//! rather than names, and the only way to pin that cheaply is to hand it a
+//! store whose names are all right and whose shapes are not.
+
+use std::collections::HashMap;
+
+use spark_runtime::gpu::DevicePtr;
+use spark_runtime::weights::{WeightDtype, WeightTensor};
+
+use super::*;
+
+/// Shapes from `RadixArk/Qwen3.8-Flash-Next-NVFP4` config.json, with a
+/// 4-layer body so the fixture stays small — the MTP audit never walks the
+/// main layers, so the count does not matter to it.
+fn cfg() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.model_type = "qwen4_exp".to_string();
+    c.hidden_size = 2560;
+    c.num_attention_heads = 24;
+    c.num_key_value_heads = 2;
+    c.head_dim = 256;
+    c.num_experts = 512;
+    c.moe_intermediate_size = 640;
+    c.shared_expert_intermediate_size = 640;
+    c.hc_mult = 4;
+    c.hc_lowrank = 320;
+    c.index_n_heads = 4;
+    c.index_head_dim = 128;
+    c.index_topk = 2048;
+    c.index_compress_ratio = 4;
+    c.num_mtp_modules = 1;
+    c.ep_rank = 0;
+    c.ep_world_size = 1;
+    c
+}
+
+struct Builder {
+    map: HashMap<String, WeightTensor>,
+}
+
+impl Builder {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    fn put(&mut self, name: &str, shape: &[usize]) {
+        self.put_dtype(name, shape, WeightDtype::BF16);
+    }
+
+    fn put_dtype(&mut self, name: &str, shape: &[usize], dtype: WeightDtype) {
+        self.map.insert(
+            name.to_string(),
+            WeightTensor {
+                // No GPU in this test: the audit reads `.shape` only, and a
+                // NULL pointer is exactly what a never-uploaded tensor has.
+                ptr: DevicePtr::NULL,
+                shape: shape.to_vec(),
+                dtype,
+            },
+        );
+    }
+
+    fn store(self) -> WeightStore {
+        WeightStore::from_map(self.map)
+    }
+}
+
+/// Every `mtp.*` tensor except the routed experts, at the shipped shapes.
+fn common(b: &mut Builder) {
+    let lp = MTP_LAYER_PREFIX;
+    b.put(&format!("{lp}.self_attn.q_proj.weight"), &[12288, 2560]);
+    b.put(&format!("{lp}.self_attn.k_proj.weight"), &[512, 2560]);
+    b.put(&format!("{lp}.self_attn.v_proj.weight"), &[512, 2560]);
+    b.put(&format!("{lp}.self_attn.o_proj.weight"), &[2560, 6144]);
+    b.put(&format!("{lp}.self_attn.q_norm.weight"), &[256]);
+    b.put(&format!("{lp}.self_attn.k_norm.weight"), &[256]);
+
+    b.put(
+        &format!("{lp}.self_attn.indexer.index_qk_proj.weight"),
+        &[640, 2560],
+    );
+    b.put(
+        &format!("{lp}.self_attn.indexer.q_layernorm.weight"),
+        &[128],
+    );
+    b.put(
+        &format!("{lp}.self_attn.indexer.k_layernorm.weight"),
+        &[128],
+    );
+
+    for site in ["attn_hyper_connection", "mlp_hyper_connection"] {
+        b.put(&format!("{lp}.{site}.hc_norm.weight"), &[10240]);
+        b.put(
+            &format!("{lp}.{site}.input_mix_weight_down.weight"),
+            &[320, 10240],
+        );
+        b.put(
+            &format!("{lp}.{site}.input_mix_weight_up.weight"),
+            &[10240, 320],
+        );
+        b.put(
+            &format!("{lp}.{site}.block_inject_weight.weight"),
+            &[4, 10240],
+        );
+    }
+    // The module mixer: THREE tensors, no block_inject.
+    b.put("mtp.hyper_connection_mixer.hc_norm.weight", &[10240]);
+    b.put(
+        "mtp.hyper_connection_mixer.input_mix_weight_down.weight",
+        &[320, 10240],
+    );
+    b.put(
+        "mtp.hyper_connection_mixer.input_mix_weight_up.weight",
+        &[10240, 320],
+    );
+
+    b.put(&format!("{lp}.mlp.gate.weight"), &[512, 2560]);
+    b.put(
+        &format!("{lp}.mlp.shared_expert.gate_proj.weight"),
+        &[640, 2560],
+    );
+    b.put(
+        &format!("{lp}.mlp.shared_expert.up_proj.weight"),
+        &[640, 2560],
+    );
+    b.put(
+        &format!("{lp}.mlp.shared_expert.down_proj.weight"),
+        &[2560, 640],
+    );
+    b.put(&format!("{lp}.mlp.shared_expert_gate.weight"), &[1, 2560]);
+
+    // The asymmetric pair — 2560 against 10240.
+    b.put("mtp.pre_fc_norm_embedding.weight", &[2560]);
+    b.put("mtp.pre_fc_norm_hidden.weight", &[10240]);
+    b.put("mtp.fc_embedding.weight", &[2560, 2560]);
+    b.put("mtp.fc_hidden.weight", &[2560, 2560]);
+}
+
+/// RadixArk: fused BF16 expert stacks.
+fn fused_experts(b: &mut Builder) {
+    let lp = MTP_LAYER_PREFIX;
+    b.put(
+        &format!("{lp}.mlp.experts.gate_up_proj"),
+        &[512, 1280, 2560],
+    );
+    b.put(&format!("{lp}.mlp.experts.down_proj"), &[512, 2560, 640]);
+}
+
+/// Inferact: 512 per-expert NVFP4 triples. Only the first expert is built —
+/// the audit probes the first LOCAL index, and under no-EP that is 0.
+fn per_expert_nvfp4(b: &mut Builder) {
+    let lp = MTP_LAYER_PREFIX;
+    for e in 0..2usize {
+        for p in ["gate_proj", "up_proj"] {
+            // Packed E2M1: the on-disk width is HALF the logical one.
+            b.put_dtype(
+                &format!("{lp}.mlp.experts.{e}.{p}.weight"),
+                &[640, 1280],
+                WeightDtype::UInt8,
+            );
+            b.put_dtype(
+                &format!("{lp}.mlp.experts.{e}.{p}.weight_scale"),
+                &[640, 160],
+                WeightDtype::FP8E4M3,
+            );
+        }
+        b.put_dtype(
+            &format!("{lp}.mlp.experts.{e}.down_proj.weight"),
+            &[2560, 320],
+            WeightDtype::UInt8,
+        );
+        b.put_dtype(
+            &format!("{lp}.mlp.experts.{e}.down_proj.weight_scale"),
+            &[2560, 40],
+            WeightDtype::FP8E4M3,
+        );
+    }
+}
+
+fn fused_store() -> WeightStore {
+    let mut b = Builder::new();
+    common(&mut b);
+    fused_experts(&mut b);
+    b.store()
+}
+
+#[test]
+fn complete_fused_store_passes() {
+    let c = cfg();
+    let r = audit_mtp_namespace(&fused_store(), &c);
+    assert!(r.any_tensors);
+    assert_eq!(r.expert_layout, MtpExpertLayout::Fused);
+    assert!(r.missing.is_empty(), "{:?}", r.missing);
+    assert!(r.shape_errors.is_empty(), "{:?}", r.shape_errors);
+    r.ensure_loadable(&c).expect("fused store must load");
+}
+
+#[test]
+fn complete_per_expert_nvfp4_store_passes() {
+    let c = cfg();
+    let mut b = Builder::new();
+    common(&mut b);
+    per_expert_nvfp4(&mut b);
+    let r = audit_mtp_namespace(&b.store(), &c);
+    assert_eq!(r.expert_layout, MtpExpertLayout::PerExpert);
+    assert_eq!(r.first_local_expert, 0, "no EP ⇒ expert 0 is local");
+    r.ensure_loadable(&c).expect("per-expert store must load");
+}
+
+#[test]
+fn a_missing_combiner_tensor_is_named() {
+    let c = cfg();
+    let mut b = Builder::new();
+    common(&mut b);
+    fused_experts(&mut b);
+    b.map.remove("mtp.fc_hidden.weight");
+    let r = audit_mtp_namespace(&b.store(), &c);
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("mtp.fc_hidden.weight"), "{err}");
+}
+
+/// The whole reason this audit checks shapes. `pre_fc_norm_hidden` at
+/// `hidden_size` instead of `hc_mult * hidden_size` is the failure that reads
+/// 2560 of 10240 elements and produces plausible-wrong activations.
+#[test]
+fn pre_fc_norm_hidden_at_the_embedding_width_is_refused() {
+    let c = cfg();
+    let mut b = Builder::new();
+    common(&mut b);
+    fused_experts(&mut b);
+    b.put("mtp.pre_fc_norm_hidden.weight", &[2560]);
+    let r = audit_mtp_namespace(&b.store(), &c);
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("mtp.pre_fc_norm_hidden.weight"), "{err}");
+    assert!(err.contains("2560"), "names the checkpoint width: {err}");
+    assert!(err.contains("10240"), "names the expected width: {err}");
+}
+
+/// q_proj carries the query AND its sigmoid output gate: `2 * heads * head_dim`.
+/// Single width is what a loader that sized it from o_proj would ship.
+#[test]
+fn single_width_q_proj_is_refused() {
+    let c = cfg();
+    let mut b = Builder::new();
+    common(&mut b);
+    fused_experts(&mut b);
+    b.put(
+        &format!("{MTP_LAYER_PREFIX}.self_attn.q_proj.weight"),
+        &[6144, 2560],
+    );
+    let r = audit_mtp_namespace(&b.store(), &c);
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("q_proj"), "{err}");
+    assert!(err.contains("12288"), "{err}");
+}
+
+#[test]
+fn neither_expert_layout_is_refused() {
+    let c = cfg();
+    let mut b = Builder::new();
+    common(&mut b);
+    let r = audit_mtp_namespace(&b.store(), &c);
+    assert_eq!(r.expert_layout, MtpExpertLayout::Neither);
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("no routed experts"), "{err}");
+}
+
+#[test]
+fn both_expert_layouts_are_refused_as_ambiguous() {
+    let c = cfg();
+    let mut b = Builder::new();
+    common(&mut b);
+    fused_experts(&mut b);
+    per_expert_nvfp4(&mut b);
+    let r = audit_mtp_namespace(&b.store(), &c);
+    assert_eq!(r.expert_layout, MtpExpertLayout::Both);
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("BOTH expert layouts"), "{err}");
+}
+
+/// The DEFAULT serving state: `skip_mtp` dropped every `mtp.*` tensor at
+/// upload, and nothing declared MTP, so an empty report is correct and
+/// `ensure_loadable` must not object.
+#[test]
+fn an_empty_store_is_reported_and_is_ok_when_no_module_is_declared() {
+    let mut c = cfg();
+    let store = WeightStore::from_map(HashMap::new());
+    let r = audit_mtp_namespace(&store, &c);
+    assert!(!r.any_tensors, "no mtp.* tensors");
+    assert!(!r.missing.is_empty(), "every tensor is missing");
+
+    c.num_mtp_modules = 0;
+    r.ensure_loadable(&c)
+        .expect("num_mtp_modules=0 ⇒ nothing to load");
+
+    c.num_mtp_modules = 1;
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("no `mtp.*` tensors"), "{err}");
+}
+
+/// `load_moe_qwen35` honours `is_local_expert` and has no `force_all_experts`
+/// parameter, while the weight upload never shards `mtp.*` — so under EP the
+/// draft would route into NULL experts on every rank.
+#[test]
+fn ep_world_size_above_one_is_refused() {
+    let mut c = cfg();
+    c.ep_world_size = 2;
+    let r = audit_mtp_namespace(&fused_store(), &c);
+    let err = r.ensure_loadable(&c).unwrap_err().to_string();
+    assert!(err.contains("ep_world_size=2"), "{err}");
+}
+
+// ── The offline checkpoint arm ────────────────────────────────────────────
+//
+// Everything above is synthetic. This one reads the REAL safetensors headers
+// — no GPU, no model load, no upload — builds a store of NULL pointers with
+// the checkpoint's own shapes, and runs the same audit over it. It is the arm
+// that catches a third checkpoint revision before it costs a 75 GB load.
+
+/// One safetensors header, parsed without reading any tensor data.
+#[cfg(test)]
+fn read_header(path: &std::path::Path) -> serde_json::Value {
+    use std::io::Read;
+    let mut fh = std::fs::File::open(path).expect("open shard");
+    let mut len = [0u8; 8];
+    fh.read_exact(&mut len).expect("header length");
+    let mut hdr = vec![0u8; u64::from_le_bytes(len) as usize];
+    fh.read_exact(&mut hdr).expect("header bytes");
+    serde_json::from_slice(&hdr).expect("header JSON")
+}
+
+fn dtype_of(s: &str) -> WeightDtype {
+    match s {
+        "U8" => WeightDtype::UInt8,
+        "F8_E4M3" => WeightDtype::FP8E4M3,
+        "F32" => WeightDtype::FP32,
+        "I64" => WeightDtype::Int64,
+        // The audit reads shapes only; anything else lands as BF16, which is
+        // what every non-expert `mtp.*` tensor actually is in both snapshots.
+        _ => WeightDtype::BF16,
+    }
+}
+
+/// Walk `model.safetensors.index.json` for `mtp.*` and assert the observed key
+/// set and shapes are exactly what `audit_mtp_namespace` demands.
+///
+///     ATLAS_QWEN4EXP_CKPT=/path/to/snapshot \
+///       cargo test -p spark-model mtp_header_inventory
+#[test]
+fn mtp_header_inventory() {
+    let Ok(snap) = std::env::var("ATLAS_QWEN4EXP_CKPT") else {
+        println!("ATLAS_QWEN4EXP_CKPT unset — skipping real-checkpoint inventory");
+        return;
+    };
+    let snap = std::path::Path::new(&snap);
+
+    let cfg_text = std::fs::read_to_string(snap.join("config.json")).expect("read config.json");
+    let config = atlas_core::config::parse_config(&cfg_text).expect("parse config.json");
+    assert_eq!(
+        config.num_mtp_modules, 1,
+        "the parser must see text_config.mtp before the audit means anything"
+    );
+
+    let idx: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(snap.join("model.safetensors.index.json"))
+            .expect("read index.json"),
+    )
+    .expect("index.json is valid JSON");
+    let wm = idx["weight_map"].as_object().expect("weight_map");
+
+    // Header per shard, opened once — some revisions spread `mtp.*` across
+    // three files, others put all 6173 in one shard no main-model tensor
+    // references.
+    let mut headers: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut b = Builder::new();
+    let mut count = 0usize;
+    for (name, file) in wm {
+        if !name.starts_with("mtp.") {
+            continue;
+        }
+        let file = file.as_str().expect("shard name");
+        let hdr = headers
+            .entry(file.to_string())
+            .or_insert_with(|| read_header(&snap.join(file)));
+        let e = &hdr[name.as_str()];
+        let shape: Vec<usize> = e["shape"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{name}: no shape in header"))
+            .iter()
+            .map(|v| v.as_u64().expect("shape dim") as usize)
+            .collect();
+        b.put_dtype(
+            name,
+            &shape,
+            dtype_of(e["dtype"].as_str().unwrap_or("BF16")),
+        );
+        count += 1;
+    }
+    println!(
+        "{}: {count} mtp.* tensors across {} shard(s)",
+        snap.display(),
+        headers.len()
+    );
+    assert!(count > 0, "no mtp.* tensors in {}", snap.display());
+
+    let store = b.store();
+    let r = audit_mtp_namespace(&store, &config);
+    println!(
+        "layout={:?} missing={:?} shape_errors={:?} unexpected={:?}",
+        r.expert_layout, r.missing, r.shape_errors, r.unexpected
+    );
+    r.ensure_loadable(&config)
+        .expect("the shipped checkpoint must satisfy the audit");
+}

--- a/crates/spark-server/src/main_modules/serve_phases/weights.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/weights.rs
@@ -70,7 +70,7 @@ pub(crate) fn load_weight_store(
             };
             loader.peak_memory_multiplier = mult;
             loader.skip_activation_scales = skip_activation_scales(config);
-            loader.skip_mtp = skip_mtp(config);
+            loader.skip_mtp = skip_mtp(config, want_mtp(args));
             loader.prefetch_shards = args.fast_load_prefetch_shards
                 || std::env::var("ATLAS_FAST_LOAD_PREFETCH_SHARDS")
                     .ok()
@@ -94,7 +94,7 @@ pub(crate) fn load_weight_store(
         };
         loader.peak_memory_multiplier = mult;
         loader.skip_activation_scales = skip_activation_scales(config);
-        loader.skip_mtp = skip_mtp(config);
+        loader.skip_mtp = skip_mtp(config, want_mtp(args));
         loader
             .load(model_dir, gpu, oom_reserve_bytes)
             .context("Failed to load model weights")?
@@ -245,13 +245,52 @@ fn skip_activation_scales(config: &ModelConfig) -> bool {
     matches!(config.model_type.as_str(), "qwen4_exp")
 }
 
-/// Whether this model's loader builds no MTP head, so `mtp.*` need not be
-/// uploaded at all.
+/// Whether `mtp.*` can be left on disk for this model.
 ///
-/// `Qwen4ExpWeightLoader::load_mtp_weights` returns `None` (#753 item I: the
-/// MTP block is effectively a second model — its own 512-expert MoE, its own
-/// hyper-connection mixer, its own indexer). Uploading ~1.5 GB of weights
-/// that are then discarded is memory the KV cache needs.
-fn skip_mtp(config: &ModelConfig) -> bool {
-    matches!(config.model_type.as_str(), "qwen4_exp")
+/// The reason is no longer that the loader builds no MTP head — it does now
+/// (`weight_loader::qwen4_exp::load_qwen4_exp_mtp_module`). It is MEMORY: the
+/// qwen4_exp MTP block is a second model, ~1.5 GB resident on the per-expert
+/// NVFP4 snapshot and a ~5 GB BF16 transient on the fused one, on a model that
+/// already sits at ~94.6 GB with ~2.7 GB of headroom. That is memory the KV
+/// cache needs unless MTP is actually armed.
+///
+/// So it is skipped by DEFAULT and uploaded only when asked: `--speculative`,
+/// or `ATLAS_QWEN4EXP_MTP=1` to load and audit the block without arming
+/// speculation. No other `model_type` ever returns true here, in either arm.
+fn skip_mtp(config: &ModelConfig, want_mtp: bool) -> bool {
+    matches!(config.model_type.as_str(), "qwen4_exp") && !want_mtp
+}
+
+/// True when the operator asked for the `mtp.*` tensors to be uploaded.
+fn want_mtp(args: &cli::ServeArgs) -> bool {
+    args.speculative || std::env::var("ATLAS_QWEN4EXP_MTP").as_deref() == Ok("1")
+}
+
+#[cfg(test)]
+mod skip_mtp_tests {
+    use super::*;
+
+    fn cfg(model_type: &str) -> ModelConfig {
+        let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+        c.model_type = model_type.to_string();
+        c
+    }
+
+    /// Default serving must stay byte-identical: `mtp.*` still never uploaded.
+    #[test]
+    fn qwen4_exp_skips_by_default_and_uploads_when_asked() {
+        assert!(skip_mtp(&cfg("qwen4_exp"), false));
+        assert!(!skip_mtp(&cfg("qwen4_exp"), true));
+    }
+
+    /// The new parameter cannot regress another family: `skip_mtp` is false
+    /// for every other `model_type` in BOTH arms, so nothing else changes
+    /// behaviour when MTP is armed.
+    #[test]
+    fn other_model_types_are_unaffected_in_both_arms() {
+        for mt in ["qwen3_next", "qwen3_5_moe", "deepseek_v4", "holo3_1_moe"] {
+            assert!(!skip_mtp(&cfg(mt), false), "{mt}");
+            assert!(!skip_mtp(&cfg(mt), true), "{mt}");
+        }
+    }
 }

--- a/crates/spark-server/src/scheduler/verify_k2_step.rs
+++ b/crates/spark-server/src/scheduler/verify_k2_step.rs
@@ -277,6 +277,23 @@ pub fn step_verify_k2(
         a.seq.seq_len -= 1;
         a.seq.tokens.pop();
 
+        // Models that verify by K-row mini-prefill (mHC highway) also advanced
+        // auxiliary carries the rewind above does not touch — notably the QSA
+        // `ingested`/`pooled` marks, guarded by a hard `pos == st.ingested`
+        // equality. Without this the desync compounds one row per rejection and
+        // output degenerates a dozen tokens in. No-op (`Ok(false)`) for every
+        // model without such a path.
+        match model.rollback_verify_rows(&mut a.seq, 1) {
+            Ok(_) => {}
+            Err(e) => {
+                // The carries are now untrustworthy; emitting from them would
+                // produce coherent-looking tokens off desynced state.
+                tracing::error!("rollback_verify_rows (reject): {e:#}");
+                a.finished = true;
+                return;
+            }
+        }
+
         let t_trim = Instant::now();
         if let Err(e) = model.trim_proposer_state(&mut a.seq, 0, 0) {
             tracing::error!("trim_proposer_state: {e:#}");

--- a/kernels/gb10/qwen3.8-flash-next/nvfp4/hyper_connection.cu
+++ b/kernels/gb10/qwen3.8-flash-next/nvfp4/hyper_connection.cu
@@ -589,3 +589,36 @@ extern "C" __global__ void hc_pre_mix(
             2.0f * qhc_sigmoid((float)inj_pre[(size_t)t * hc + tid] * inv_hc);
     }
 }
+
+// ─── MTP combiner tail ───────────────────────────────────────────────────────
+// Write the MTP draft's FP32 highway from a PER-STREAM BF16 projection plus one
+// BROADCAST BF16 row:
+//
+//   streams[i*H + d] = (float)per_stream[i*H + d] + (float)bcast[d]
+//
+// This exists because the highway is FP32 while the projections that build it
+// (`fc_hidden` per stream, `fc_embedding` once) are BF16 GEMVs. Without it the
+// combiner would write BF16 into an FP32 buffer — which is silent garbage, not
+// an error, and reads as "MTP just doesn't predict well on this model".
+//
+// `hc_expand` cannot serve: it BROADCASTS a single row to every stream, and the
+// MTP combiner's streams differ per stream. Single block, T=1 (a draft step is
+// one token); `hc` is bounded by QHC_MAX_MULT.
+extern "C" __global__ void qhc_mtp_combine_streams(
+    const __nv_bfloat16* __restrict__ per_stream, // [hc, H] BF16
+    const __nv_bfloat16* __restrict__ bcast,      // [H]     BF16
+    float* __restrict__ streams,                  // [hc, H] FP32 (out)
+    const unsigned int hidden_size,
+    const unsigned int hc
+) {
+    const unsigned int tid = threadIdx.x;
+    const unsigned int H = hidden_size;
+    for (unsigned int i = 0; i < hc; ++i) {
+        const __nv_bfloat16* ps = per_stream + (size_t)i * H;
+        float* s = streams + (size_t)i * H;
+        for (unsigned int d = tid; d < H; d += blockDim.x) {
+            s[d] = (float)ps[d] + (float)bcast[d];
+        }
+    }
+}
+


### PR DESCRIPTION
**Stacked on #754** (`wip/radixark-qwen4-exp`). Review that first; this PR is the single commit on top.

## What this does — and what it does NOT

The Qwen3.8-Flash-Next checkpoint ships a **complete MTP block**: 6173 tensors — its own 512-expert MoE, shared expert, full attention, QSA indexer, mHC sites and mixer, plus `fc_embedding`/`fc_hidden` and two pre-fc norms. `load_mtp_weights` has returned `Ok(None)` since v1 (#753 item I), on the grounds that wiring it before the main forward path worked would be "building on sand". The main forward works now.

**⚠️ `--speculative` on qwen4_exp still produces NO speculation after this PR.** The module is loaded, shape-audited and stored; nothing decodes it. That is the honest headline and it is why the title says "load + audit".

A proposer installed today would route the draft into `refuse_batched_under_hc`, which fires from both `decode_batched` and `decode_verify_multi` — and the scheduler converts that error into `a.finished = true`, i.e. a **silently truncated response**, not a fallback. So the proposer is deliberately not wired.

## Why not `MtpWeights`

Atlas's `MtpWeights` does not fit this block:

- it wants a fused `fc` `[hidden, 2*hidden]`; this checkpoint has **split** `fc_embedding` + `fc_hidden`
- it assumes a pre-norm residual layer (`input_layernorm` / `post_attn_layernorm`); this block carries an **mHC hyper-connection bracket** instead
- it has no indexer field; this attention carries its **own QSA indexer**

So `MtpWeights` is left alone and `load_mtp_weights` still returns `Ok(None)`. The module is loaded by a bespoke `load_qwen4_exp_mtp_module` that replays the **existing prefix-parameterized qwen4_exp helpers** once with `lp = "mtp.layers.0"` — the DeepSeek-V4 "Track B" shape. The MTP layer is architecturally identical to a main decoder layer, so this reuses rather than duplicates.

## Included

- `num_mtp_modules` parsed from `text_config.mtp`
- a shape-checking namespace audit that resolves the expert layout explicitly (**fused vs per-expert**, refusing neither/both) and asserts the asymmetric combiner widths — `pre_fc_norm_embedding [2560]` vs `pre_fc_norm_hidden [10240]`
- an offline safetensors-header inventory test run against **both** real snapshots
- `hc::load_head_at`, so the module's own mixer loads without touching `load_head`'s main-model behaviour

## The one genuine unknown, left unresolved on purpose

`mtp.pre_fc_norm_hidden` is `[10240]` = `hc_mult * hidden`, while `mtp.fc_hidden` is `[2560, 2560]`. A `[2560,2560]` matrix cannot consume a 10240 vector, so exactly one of these is true:

- **(A) per-stream** — grouped-norm the 4-stream highway, apply `fc_hidden` as 4 GEMM rows, broadcast-add `fc_embedding(normed_embed)`; the output *is* the MTP highway
- **(B) collapse-then-expand**

HF's `modeling_qwen4_exp.py` carries `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]` and ships no MTP class, so **no golden can be generated** and no shape check discriminates — both `fc` matrices are square, so swapping them is silent. Getting it wrong costs 100% of acceptance and 0% of correctness, and looks exactly like "MTP just doesn't help on this model". The audit's asymmetric-width assertion is the tripwire if a future checkpoint falsifies the premise.

## Deferred, with analysis recorded in the module docs

- the proposer + target-side highway handoff (needs `hc_streams`, not the collapsed BF16 row every existing proposer receives)
- the draft body's **own** single-layer KV cache — it must never see the main pool, and it would sit outside the util pledge (same class as the recorded DFlash OOM)
- the SSM verify-pool gap: `has_mtp` is derived from `!mtp_weights.is_empty()`, which a Track-B install leaves empty, so no SSM checkpoint pools exist and `verify_draft_capacity` returns `usize::MAX`. V4 is all-attention; qwen4_exp has 36 GDN layers whose partial-accept rollback reads exactly those pools
- K-row mHC verify (the part that actually buys tok/s)
- QSA/PLE rewind across a rejected draft — QSA's `ingested` is monotone with no rewind API; PLE's host history advances per row with a documented corruption class
- EP>1 (the MTP MoE has no `force_all_experts` path, and adding one touches the shared qwen35 loader — out of scope here)

`qwen4_exp` is deliberately **not** added to `MTP_SUPPORTED_MODEL_TYPES`: that allowlist is a refusal, so adding the model *removes* a guard. It becomes correct to add in the PR that makes speculation actually work.

## Review found four defects in the first cut — all fixed here

1. **A main-model regression.** `parse_mtp` refused with `ensure!` at config-parse time, which runs on *every* launch. A checkpoint whose `mtp` block differed would have stopped booting **entirely** over an optional feature. It now declines to advertise the module (`num_mtp_modules = 0`, the absent-key path) and the refusal-by-name moved to `ensure_loadable`, which only runs when MTP is requested. Tests updated to pin "not advertised, still boots", plus a positive test so they cannot pass vacuously.
2. **Gate mismatch.** The upload gate (`--speculative` or env) and the load gate (`use_speculative` = `--speculative` **or** `--dflash`) were different predicates, so `--dflash` alone logged `MTP module load FAILED` on every boot, blaming the wrong cause. The load now requires the tensors to actually be resident.
3. **Misleading instrumentation.** The per-arm memory deltas used `saturating_sub` on unsigned free-memory readings and printed `0.00 GB` precisely on the fused arm — where `build_moe` frees ~5 GB of BF16 sources while allocating ~1.3 GB, so free memory *rises*. It read as "the MTP block is free". Deltas are signed now and labelled as free-memory differences, not resident cost.
4. Two overclaims ("threaded into BOTH call sites", "cannot leak") corrected in the docs — the `Err` arm still strands buffers, recorded as a known gap.

## Gates

`cargo fmt` clean; `clippy --all-targets` clean across all kernel targets; **atlas-core 132 passed, spark-model 662 passed, 0 failed**; release build verified with the NCCL `RUSTFLAGS` path. No GPU run — load cost and the audit path are unmeasured on hardware, which is why nothing is defaulted on.
