### PR TITLE
fix(site): build the run command from the flagship recipe instead of repeating it

### DIFF
--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -56,7 +56,19 @@ export const nvidiaInceptionUrl = 'https://www.nvidia.com/en-us/startups/';
 export const tagline =
   'Pure Rust inference, from the device in your hand to the datacenter rack.';
 
-// --- commands (one flagship recipe, kept in lockstep with static/install.sh)
+// --- commands (one flagship recipe) ------------------------------------------
+//
+// The recipe name has a SECOND home, in another repository: the installer's
+// closing hint, `scripts/install.sh` in Avarok-Cybersecurity/atlas-recipes
+// (`info "    $BIN_NAME run <recipe>"`). A constant cannot span repos, so that
+// copy has to be changed by hand when this one changes.
+//
+// The previous note here said "kept in lockstep with static/install.sh". There
+// is no such file in this repository, so a maintainer following it found
+// nothing and the lockstep it asked for could not happen.
+//
+// `llms.txt` needs no such care: gen-llms.mjs emits `data.runCommandRaw`, so it
+// follows this constant on its own.
 export const flagshipRecipe = 'qwen3.6-35b-a3b-fp8-mtp';
 export const quickInstall = 'cargo install atlasctl';
 /// Where install.sh is served from. One authority: the join one-liner in

--- a/site/src/lib/data.js
+++ b/site/src/lib/data.js
@@ -67,8 +67,13 @@ export const runCommand = `curl -fsSL ${installerUrl} | sh`;
 /// `run` dies with the terminal that started it, and the machine silently
 /// leaves the fleet the next time someone closes an ssh session.
 export const startAgentCommand = 'atlasctl agent install';
-export const runCommandRaw =
-  'atlasctl run qwen3.6-35b-a3b-fp8-mtp';
+/// Built from `flagshipRecipe`, not repeating it. The constant existed and was
+/// referenced by nothing while its value sat hardcoded eleven lines below —
+/// so changing the flagship recipe would have updated the obvious place and
+/// left the command the site tells people to copy pointing at the old one.
+/// `installerUrl` above already states this rule: "a second copy is how the two
+/// drift".
+export const runCommandRaw = `atlasctl run ${flagshipRecipe}`;
 
 // --- hardware acknowledgment (modest banner) ---------------------------------
 // --- announcement band (the strip above the hero) ----------------------------

--- a/site/src/lib/data.test.js
+++ b/site/src/lib/data.test.js
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// `flagshipRecipe` existed, was referenced by nothing, and its value sat
+// hardcoded eleven lines below inside `runCommandRaw` — the command the site
+// tells people to copy. Changing the flagship recipe would have updated the
+// obvious place and silently left the page advertising the old one.
+
+import { expect, test } from 'bun:test';
+import { flagshipRecipe, runCommandRaw, runCommand, installerUrl } from './data.js';
+
+test('the command the page shows is built from the flagship recipe, not a copy of it', () => {
+  expect(runCommandRaw).toContain(flagshipRecipe);
+  expect(runCommandRaw).toBe(`atlasctl run ${flagshipRecipe}`);
+});
+
+test('the same rule holds for the installer URL it already applied to', () => {
+  expect(runCommand).toContain(installerUrl);
+});
+
+// A recipe name reaches a terminal, so it must not carry anything a shell
+// would act on. This is data, not user input, but it is data that is rendered
+// into a copyable command.
+test('the flagship recipe is a plain recipe name', () => {
+  expect(flagshipRecipe).toMatch(/^[a-z0-9][a-z0-9._-]*$/);
+  expect(runCommandRaw).not.toMatch(/[;&|`$(){}<>]/);
+});


### PR DESCRIPTION
`flagshipRecipe` was exported, **referenced by nothing**, and its value sat hardcoded eleven lines below:

```js
export const flagshipRecipe = 'qwen3.6-35b-a3b-fp8-mtp';
...
export const runCommandRaw = 'atlasctl run qwen3.6-35b-a3b-fp8-mtp';
```

`runCommandRaw` is **what the site tells people to copy** (`GetRunning.svelte:66`). So changing the flagship recipe means editing the constant named `flagshipRecipe` — the obvious place — and leaving the page advertising the old one, with nothing to catch it: the constant has no other reader.

## The file already states the rule

Five lines up, for the installer URL:

> One authority: the join one-liner in `joincommand.js` builds on this too, and a second copy is how the two drift.

The same doctrine, applied to one constant and violated for the next. The section comment even claims the recipe is *"kept in lockstep"*.

## How it was found

By looking for exported symbols nothing imports. **Most of those were false positives** — `selectText` and `redditUrl` are used inside their own defining file, which my first pass excluded — but this one was real, and *the reason it looked dead is the bug*.

## Tests

`data.test.js` was the last module in `src/lib` with no tests. It pins the derivation, the same rule for `installerUrl`, and that the recipe name carries nothing a shell would act on — it is data, but data rendered into a command someone pastes. Hardcoding a drifted value fails it **2 pass / 1 fail**.

**Rendered output is unchanged**, verified in the built `index.html`. Unit **449 pass**, build clean.