### PR TITLE
a11y(motion): the three places that move without asking

### DIFF
--- a/site/src/lib/components/deck/Deck.svelte
+++ b/site/src/lib/components/deck/Deck.svelte
@@ -348,4 +348,22 @@
       display: none;
     }
   }
+
+  /* Slide.svelte in this same directory already honours this; the deck that
+     MOVES the slides did not. `.dk-track` carries a 620ms full-viewport
+     translation — the exact motion the preference exists for — and `.dk-edge`
+     slides its arrows in.
+
+     Only motion is dropped. The background and opacity fades stay: they cause
+     none of what the setting is about, and removing them would make the deck
+     snap rather than settle. */
+  @media (prefers-reduced-motion: reduce) {
+    .dk-track {
+      transition: none;
+    }
+    .dk-edge {
+      transition: opacity 200ms ease;
+      translate: none;
+    }
+  }
 </style>

--- a/site/src/styles/mobile.css
+++ b/site/src/styles/mobile.css
@@ -368,3 +368,12 @@ img, svg, video { max-width: 100%; }
   .dock-body { overflow-y: visible; padding-bottom: 2rem; }
   .dt-log { max-height: 45vh; }
 }
+
+/* The burger bars rotate into a cross and slide (`top`), and the drawer slides
+   down from -6px. Both are motion; the opacity halves are not and stay, so the
+   cross still fades rather than snapping. `.nav-burger span`, not
+   `.nav-toggle span`: the transition lives on the inner bars. */
+@media (prefers-reduced-motion: reduce) {
+  .nav-burger span { transition: opacity 0.18s; }
+  .nav-drawer { animation: none; }
+}

--- a/site/src/styles/news.css
+++ b/site/src/styles/news.css
@@ -49,3 +49,12 @@
   border-bottom: 1px solid rgba(124, 92, 255, 0.35);
 }
 .ann-cta:hover { border-bottom-color: var(--accent); }
+
+/* A hover lift is small, but it is still a transform. Dropping only the
+   transition would leave the -3px jump applying INSTANTLY, which is worse than
+   animating it — so the translate goes too. `border-color` is what actually
+   signals the hover, and it stays. */
+@media (prefers-reduced-motion: reduce) {
+  .news-card { transition: border-color 0.2s; }
+  .news-card:hover { transform: none; }
+}


### PR DESCRIPTION
Eight files honour `prefers-reduced-motion`. Three that move did not:

| file | motion |
|---|---|
| `deck/Deck.svelte` | `.dk-track` — a **620ms full-viewport translate** — and `.dk-edge` sliding its arrows in |
| `styles/mobile.css` | `.nav-burger span` rotating and sliding into a cross; `.nav-drawer` sliding down from -6px |
| `styles/news.css` | `.news-card` lifting 3px on hover |

`deck/Slide.svelte`, in the **same directory**, already honours the preference — so the slides were guarded and the thing that *moves* them was not.

## Only motion is dropped

The opacity and background fades stay: they are not what the setting is about, and removing them would make the deck snap rather than settle, and the burger cross vanish rather than fade.

`styles/ladder.css` is **deliberately untouched** — its only transition is `border-color, color`, which is not motion. A blanket guard over every `transition:` would have caught it and been wrong.

`news.css` needed **both halves**: dropping only the transition leaves `:hover { transform: translateY(-3px) }` applying *instantly* — a jump, worse than the animation it replaced.

## Selectors were verified, not guessed

The first draft targeted `.dk-rail` and `.nav-toggle span` — **neither carries a transition** — and would have shipped three guards that did nothing. Each selector is now cross-checked against the rule it neutralises.

Unit **446 pass**, build clean, **12** reduced-motion blocks in the built CSS.