### PR TITLE
fix(site): five ways the onboarding path still assumed a unix visitor

### DIFF
--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -129,4 +129,25 @@ jobs:
               ;;
           esac
 
+          # The SAME check for the Windows line, which is the ONLY command a
+          # Windows visitor is given. `install.sh` got this check because the SPA
+          # fallback answers 200 with the HOMEPAGE rather than 404 -- the failure
+          # that took /control down -- and install.ps1 is served by that same
+          # fallback out of that same static dir, so it fails the same way. Piped
+          # into `iex`, an HTML body is not a 404 anyone can read: it is a wall of
+          # parse errors, on the platform with the least fallback.
+          head=$(curl --fail --silent --show-error --location \
+                   --retry 3 --retry-delay 5 https://atlasinference.io/install.ps1 | head -1)
+          case "$head" in
+            '<'*)
+              echo "::error::/install.ps1 served HTML -- the SPA fallback is answering for it: $head"
+              fail=1
+              ;;
+            '#'*) echo "ok   /install.ps1 -> $head" ;;
+            *)
+              echo "::error::/install.ps1 does not start with a comment; it served: $head"
+              fail=1
+              ;;
+          esac
+
           exit "$fail"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -116,6 +116,26 @@ jobs:
           ATLAS_BASELINES_ROOT: ${{ github.workspace }}/tests/baselines
           GH_TOKEN: ${{ github.token }}
 
+      # A page's <title> can vanish while the rest of its head survives: a layout
+      # title and a page title compete for one head slot, and /control shipped for
+      # a day with the homepage's title because the layout's won. The deployed
+      # canary caught it -- after the deploy. Catch it here, before.
+      - name: Every route kept its own title
+        # `working-directory: site` is this job's default, so no `cd`.
+        run: |
+          fail=0
+          check() { # file  expected-substring
+            got=$(grep -o '<title>[^<]*' "build/$1" | head -1)
+            case "$got" in
+              *"$2"*) echo "ok   $1 -> $got" ;;
+              *) echo "::error::build/$1 has title \"$got\", expected one containing \"$2\""; fail=1 ;;
+            esac
+          }
+          check index.html     'Atlas, pure Rust inference'
+          check control.html   'Control plane'
+          check diligence.html 'Verification steps'
+          exit "$fail"
+
       - name: Upload site artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/site/src/lib/agent/client.svelte.js
+++ b/site/src/lib/agent/client.svelte.js
@@ -6,6 +6,7 @@
 // is an ordinary state, not an exception. The Run button treats "no agent" as
 // something to explain, not something to fail on.
 
+import { currentInstall } from '$lib/install/host.svelte.js';
 import {
   AGENT_URL,
   PROTOCOL_VERSION,
@@ -171,7 +172,9 @@ export class AgentClient {
       this.message = versionAdvice(
         PROTOCOL_VERSION,
         welcome.protocol_min,
-        welcome.protocol_max
+        welcome.protocol_max,
+        // This agent is on 127.0.0.1, so the visitor's own OS is its OS.
+        currentInstall().command
       ).message;
       return this.#abandon(socket, 'error');
     }

--- a/site/src/lib/agent/joincommand.js
+++ b/site/src/lib/agent/joincommand.js
@@ -28,13 +28,38 @@ import { installerUrl, powershellInstallerUrl } from '../data.js';
  * @param {{code: string, addresses: string[]}|null} join
  * @returns {string}
  */
-export function joinCommand(join, grantControl = false) {
+/**
+ * The `code@host,host` operand itself, unquoted and unwrapped.
+ *
+ * Extracted because THREE places need it and two of them used to get it by
+ * string surgery on the finished command: `shortForm` took everything after the
+ * last space, which quietly became `'code@host'` -- quotes and all, on screen --
+ * the moment the sh line started quoting its operand. A shared builder cannot
+ * drift like that.
+ *
+ * @param {{code: string, addresses: string[]}|null} join
+ * @returns {string} '' when there is no usable code or no dialable address
+ */
+export function joinOperand(join) {
   const code = typeof join?.code === 'string' ? join.code.trim() : '';
   // Same reasoning as the host allowlist: this ends up in a shell line.
   if (!code || !CODE_OK.test(code)) return '';
   const hosts = dialableAddresses(join?.addresses);
   if (hosts.length === 0) return '';
-  const base = `curl -fsSL ${installerUrl} | sh -s -- --join ${code}@${hosts.join(',')}`;
+  return `${code}@${hosts.join(',')}`;
+}
+
+export function joinCommand(join, grantControl = false) {
+  const operand = joinOperand(join);
+  if (!operand) return '';
+  // SINGLE-QUOTED, for the same reason the PowerShell line below is. HOST_OK
+  // admits `[` and `]` so a bracketed IPv6 address can reach this string, and
+  // bare brackets in an operand are a GLOB: zsh — the default shell on macOS —
+  // refuses the whole line with `no matches found` rather than running it. No
+  // address we mint today is bracketed, so this is latent, not broken; it stops
+  // being latent the first time an address carries a port or a v6 literal.
+  // Nothing needs escaping inside the quotes: CODE_OK and HOST_OK both exclude `'`.
+  const base = `curl -fsSL ${installerUrl} | sh -s -- --join '${operand}'`;
   // The grant is a VISIBLE flag on the line the operator pastes, never an
   // implication of joining. It is also the only direction that does what
   // someone adding a GPU box actually wants: it is written into THAT machine's
@@ -61,10 +86,8 @@ export function joinCommand(join, grantControl = false) {
  * @returns {string}
  */
 export function joinCommandPowerShell(join, grantControl = false) {
-  const code = typeof join?.code === 'string' ? join.code.trim() : '';
-  if (!code || !CODE_OK.test(code)) return '';
-  const hosts = dialableAddresses(join?.addresses);
-  if (hosts.length === 0) return '';
+  const operand = joinOperand(join);
+  if (!operand) return '';
   // The operand is SINGLE-QUOTED, and that is load-bearing. Unquoted, a comma
   // in PowerShell's argument mode builds an ARRAY — `-Join a@h1,h2` binds
   // `@('a@h1','h2')` and stringifies it with a SPACE, so the far machine
@@ -77,7 +100,7 @@ export function joinCommandPowerShell(join, grantControl = false) {
   // unknown parameter and silently install without joining.
   const base =
     `& ([scriptblock]::Create((irm ${powershellInstallerUrl}))) ` +
-    `-Join '${code}@${hosts.join(',')}'`;
+    `-Join '${operand}'`;
   return grantControl ? `${base} -GrantControl` : base;
 }
 

--- a/site/src/lib/agent/joincommand.test.js
+++ b/site/src/lib/agent/joincommand.test.js
@@ -13,7 +13,7 @@ import {
 
 test('an ordinary invitation renders one pasteable line', () => {
   const cmd = joinCommand({ code: '12345678', addresses: ['10.10.10.1'] });
-  expect(cmd).toContain('--join 12345678@10.10.10.1');
+  expect(cmd).toContain("--join '12345678@10.10.10.1'");
   expect(cmd).toContain('install.sh');
   expect(cmd.split('\n')).toHaveLength(1);
 });
@@ -70,7 +70,7 @@ test('every network the inviter offered reaches the pasted line', () => {
     code: '71673005',
     addresses: ['10.10.10.9', '10.10.10.13', '192.168.68.68']
   });
-  expect(cmd).toContain('--join 71673005@10.10.10.9,10.10.10.13,192.168.68.68');
+  expect(cmd).toContain("--join '71673005@10.10.10.9,10.10.10.13,192.168.68.68'");
 });
 
 test('order is preserved, because it is the inviter\'s link ranking', () => {
@@ -87,7 +87,7 @@ test('loopback never reaches the command, at any position', () => {
     code: '12345678',
     addresses: ['127.0.0.1', '10.0.0.9', '::1', '127.0.1.1']
   });
-  expect(cmd).toContain('--join 12345678@10.0.0.9');
+  expect(cmd).toContain("--join '12345678@10.0.0.9'");
   expect(cmd).not.toContain('127.');
   expect(cmd).not.toContain('::1');
 });
@@ -190,4 +190,13 @@ describe('joinCommandPowerShell', () => {
     const cmd = joinCommandPowerShell({ code: '-abc1234', addresses: ['10.0.0.1'] });
     if (cmd) expect(cmd).toContain("-Join '-abc1234@10.0.0.1'");
   });
+});
+
+// The quoting is not cosmetic: an unquoted bracketed host is a glob, and zsh
+// (macOS's default shell) refuses the line outright with `no matches found`
+// instead of running it. Brackets survive dialableAddresses by design.
+test('a bracketed IPv6 host stays inside quotes, so no shell globs it', () => {
+  const cmd = joinCommand({ code: '12345678', addresses: ['[fe80::1]'] });
+  expect(cmd).toContain("--join '12345678@[fe80::1]'");
+  expect(cmd).not.toMatch(/--join [^']*\[/);
 });

--- a/site/src/lib/agent/joinwindow.js
+++ b/site/src/lib/agent/joinwindow.js
@@ -13,7 +13,7 @@
 // machine, comes back, and the counter claims minutes that are gone. Computing
 // against `mintedAtMs + expiresInS` cannot drift.
 
-import { bestAddress, joinCommand } from './joincommand.js';
+import { bestAddress, joinCommand, joinOperand } from './joincommand.js';
 
 /**
  * How long the guide watches for the new machine before escalating: the
@@ -136,7 +136,7 @@ export function groupedCode(code) {
 /**
  * The carry-note tail — `CODE@HOST` — or ''.
  *
- * Extracted from `joinCommand`'s output rather than rebuilt, so it can never
+ * Built from the same operand builder `joinCommand` uses, so it can never
  * disagree with the line on screen and never renders half a credential: if
  * there is no complete command, there is no tail.
  *
@@ -144,9 +144,10 @@ export function groupedCode(code) {
  * @returns {string}
  */
 export function shortForm(join) {
-  const cmd = joinCommand(join);
-  if (!cmd) return '';
-  return cmd.slice(cmd.lastIndexOf(' ') + 1);
+  // From the shared builder, NOT by slicing the finished command: that took
+  // everything after the last space, so it inherited the sh line's quotes and
+  // rendered them on screen.
+  return joinOperand(join);
 }
 
 /**

--- a/site/src/lib/agent/joinwindow.test.js
+++ b/site/src/lib/agent/joinwindow.test.js
@@ -18,7 +18,7 @@ import {
   shortForm,
   stalled
 } from './joinwindow.js';
-import { joinCommand } from './joincommand.js';
+import { joinCommand, joinCommandPowerShell } from './joincommand.js';
 
 // --- normalizeJoinReply ------------------------------------------------------
 
@@ -145,7 +145,14 @@ test('odd lengths group without a trailing space', () => {
 test('the carry tail matches the command it came from', () => {
   const join = { code: '84315907', addresses: ['10.10.10.1'] };
   expect(shortForm(join)).toBe('84315907@10.10.10.1');
-  expect(joinCommand(join).endsWith(shortForm(join))).toBe(true);
+  // The invariant is that the tail on screen IS the operand in the command --
+  // not that it is the command's last characters. `endsWith` stopped being able
+  // to say that when the sh operand gained its quotes; both now come from
+  // joinOperand, so assert the relationship that actually matters.
+  expect(joinCommand(join)).toContain(`'${shortForm(join)}'`);
+  expect(joinCommandPowerShell(join)).toContain(`'${shortForm(join)}'`);
+  // and the tail itself is never quoted: it is prose on screen, not a paste.
+  expect(shortForm(join)).not.toContain("'");
 });
 
 test('shortForm is empty exactly when joinCommand is — never half a credential', () => {

--- a/site/src/lib/agent/protocol.js
+++ b/site/src/lib/agent/protocol.js
@@ -33,7 +33,6 @@
 // mDNS is link-local — it does not cross a router and is off on plenty of
 // managed networks — so without it the page could only reach machines on one
 // broadcast domain. Additive, but the handshake is exact-match by design.
-import { installerUrl } from '../data.js';
 
 export const PROTOCOL_VERSION = 4;
 
@@ -182,19 +181,35 @@ export function describeError(error) {
  * - the PAGE is behind — the browser is holding a cached bundle, and no amount
  *   of updating the agent will fix it. That one is a hard reload.
  *
+ * The remedy is a command, and which command depends on the machine. This
+ * advice is always about the LOOPBACK agent -- `AGENT_URL` is 127.0.0.1 -- so
+ * the machine being advised about is the one the browser is running on, the one
+ * whose OS the page actually knows. It was still handing every visitor
+ * `curl … | sh`, so a Windows operator with a stale agent was told to paste a
+ * line PowerShell cannot parse: precisely the failure the install-command module
+ * was written to end.
+ *
+ * The command is passed IN rather than detected here, so this module stays pure
+ * and, more importantly, so there is one detection path. A second sniff is how
+ * the hero and the control page end up disagreeing about which machine the
+ * visitor is on -- worse than either answer alone.
+ *
  * @param {number} page this bundle's `PROTOCOL_VERSION`
  * @param {number} min the agent's lowest supported version
  * @param {number} max the agent's highest
+ * @param {string} installCommand the install one-liner for THIS visitor's OS,
+ *   from `currentInstall().command`. No default: the caller knows the host and
+ *   this module does not, and guessing is the bug being fixed.
  * @returns {{ok: true} | {ok: false, side: 'agent'|'page', message: string}}
  */
-export function versionAdvice(page, min, max) {
+export function versionAdvice(page, min, max, installCommand) {
   if (!Number.isInteger(page) || !Number.isInteger(min) || !Number.isInteger(max)) {
     // A malformed welcome is not a version mismatch, and guessing which side is
     // behind from a non-number would name a remedy at random.
     return {
       ok: false,
       side: 'agent',
-      message: `The agent did not say which protocol it speaks, so this page cannot tell whether it is compatible. Reinstall the agent: curl -fsSL ${installerUrl} | sh`
+      message: `The agent did not say which protocol it speaks, so this page cannot tell whether it is compatible. Reinstall the agent: ${installCommand}`
     };
   }
   if (page >= min && page <= max) return { ok: true };
@@ -203,7 +218,7 @@ export function versionAdvice(page, min, max) {
     return {
       ok: false,
       side: 'agent',
-      message: `Your agent is out of date — it speaks protocol ${min === max ? min : `${min}–${max}`}, this page speaks ${page}. Update it on that machine: curl -fsSL ${installerUrl} | sh`
+      message: `Your agent is out of date — it speaks protocol ${min === max ? min : `${min}–${max}`}, this page speaks ${page}. Update it on that machine: ${installCommand}`
     };
   }
   return {

--- a/site/src/lib/agent/protocol.test.js
+++ b/site/src/lib/agent/protocol.test.js
@@ -15,6 +15,11 @@ import {
   PROTOCOL_VERSION,
 } from './protocol.js';
 
+// The remedy is now the CALLER's to supply, because only the caller knows
+// which machine the visitor is on. These tests pass the unix line except
+// where they are specifically about a Windows visitor.
+const UNIX = 'curl -fsSL https://atlasinference.io/install.sh | sh';
+
 test('a token check answers "no" for junk instead of throwing', () => {
   for (const junk of [undefined, null, 42, {}, [], true]) {
     expect(looksLikeToken(junk)).toBe(false);
@@ -90,15 +95,15 @@ test('the codes the agent actually sends still read as sentences', () => {
 // versionAdvice is the first thing an operator sees when a fleet of older
 // agents meets a newer page, so its two branches must name different remedies.
 test('a version mismatch names the side that is behind', () => {
-  expect(versionAdvice(PROTOCOL_VERSION, 1, PROTOCOL_VERSION).ok).toBe(true);
-  const agentOld = versionAdvice(4, 1, 2);
+  expect(versionAdvice(PROTOCOL_VERSION, 1, PROTOCOL_VERSION, UNIX).ok).toBe(true);
+  const agentOld = versionAdvice(4, 1, 2, UNIX);
   expect(agentOld.side).toBe('agent');
   expect(agentOld.message).toContain('install.sh');
-  const pageOld = versionAdvice(2, 3, 4);
+  const pageOld = versionAdvice(2, 3, 4, UNIX);
   expect(pageOld.side).toBe('page');
   expect(pageOld.message).toContain('Shift-R');
   // A welcome with no usable versions must not guess a side at random.
-  expect(versionAdvice(4, undefined, null).ok).toBe(false);
+  expect(versionAdvice(4, undefined, null, UNIX).ok).toBe(false);
 });
 
 // An agent that omits a detail field is not hypothetical — an older build
@@ -140,10 +145,10 @@ test('a detail the agent DID send is still shown', () => {
 // dead end at exactly the wrong moment.
 test('the reinstall instructions are built from the declared installer URL', async () => {
   const { installerUrl } = await import('../data.js');
-  const agentOld = versionAdvice(4, 1, 2);
+  const agentOld = versionAdvice(4, 1, 2, UNIX);
   expect(agentOld.side).toBe('agent');
   expect(agentOld.message).toContain(installerUrl);
 
-  const noVersion = versionAdvice(4, undefined, null);
+  const noVersion = versionAdvice(4, undefined, null, UNIX);
   expect(noVersion.message).toContain(installerUrl);
 });

--- a/site/src/lib/agent/version.test.js
+++ b/site/src/lib/agent/version.test.js
@@ -2,18 +2,25 @@
 
 import { test, expect } from 'bun:test';
 import { versionAdvice } from './protocol.js';
+import { installCommandFor } from '../install/platform.js';
+import { installerUrl, powershellInstallerUrl } from '../data.js';
+
+// The remedy is now the CALLER's to supply, because only the caller knows
+// which machine the visitor is on. These tests pass the unix line except
+// where they are specifically about a Windows visitor.
+const UNIX = 'curl -fsSL https://atlasinference.io/install.sh | sh';
 
 test('a version the agent supports is not a problem', () => {
-  expect(versionAdvice(4, 4, 4)).toEqual({ ok: true });
-  expect(versionAdvice(3, 1, 4)).toEqual({ ok: true });
-  expect(versionAdvice(1, 1, 4)).toEqual({ ok: true });
+  expect(versionAdvice(4, 4, 4, UNIX)).toEqual({ ok: true });
+  expect(versionAdvice(3, 1, 4, UNIX)).toEqual({ ok: true });
+  expect(versionAdvice(1, 1, 4, UNIX)).toEqual({ ok: true });
 });
 
 test('an out-of-date agent is named as the agent, with the line that fixes it', () => {
   // The common case the day protocol 4 shipped: every existing agent speaks
   // something older. "Update whichever is older" made the operator work out
   // which side was behind from two numbers they have no reason to care about.
-  const a = versionAdvice(4, 1, 1);
+  const a = versionAdvice(4, 1, 1, UNIX);
   expect(a.ok).toBe(false);
   expect(a.side).toBe('agent');
   expect(a.message).toContain('Your agent is out of date');
@@ -23,11 +30,27 @@ test('an out-of-date agent is named as the agent, with the line that fixes it', 
   expect(a.message).toContain('on that machine');
 });
 
+// The whole point of the parameter: a Windows operator with a stale agent used
+// to be handed `curl … | sh`, which PowerShell cannot parse. The advice is about
+// the LOOPBACK agent, so the visitor's own OS is the right one to ask about.
+test('a Windows visitor is told to run the Windows line, not curl', () => {
+  const win = installCommandFor('windows', {
+    shellUrl: installerUrl,
+    powershellUrl: powershellInstallerUrl
+  }).command;
+  const a = versionAdvice(4, 1, 1, win);
+  expect(a.ok).toBe(false);
+  expect(a.message).toContain('install.ps1');
+  expect(a.message).not.toContain('curl');
+  // and the unix visitor is unchanged
+  expect(versionAdvice(4, 1, 1, UNIX).message).toContain('install.sh');
+});
+
 test('a stale page is named as the page, because updating the agent cannot fix it', () => {
   // A browser holding a cached bundle against a newer agent. Telling this
   // operator to reinstall the agent sends them to the wrong machine to fix a
   // problem that lives in their own tab.
-  const a = versionAdvice(3, 4, 4);
+  const a = versionAdvice(3, 4, 4, UNIX);
   expect(a.ok).toBe(false);
   expect(a.side).toBe('page');
   expect(a.message).toContain('This page is out of date');
@@ -36,15 +59,15 @@ test('a stale page is named as the page, because updating the agent cannot fix i
 });
 
 test('a single supported version reads as one number, not a range', () => {
-  expect(versionAdvice(4, 2, 2).message).toContain('protocol 2,');
-  expect(versionAdvice(4, 1, 3).message).toContain('1–3');
+  expect(versionAdvice(4, 2, 2, UNIX).message).toContain('protocol 2,');
+  expect(versionAdvice(4, 1, 3, UNIX).message).toContain('1–3');
 });
 
 test('a welcome that carries no version is not guessed at', () => {
   // Deciding which side is behind from a non-number would name a remedy at
   // random, and half the time send the operator to the wrong machine.
   for (const bad of [undefined, null, 'four', NaN, 1.5]) {
-    const a = versionAdvice(4, bad, bad);
+    const a = versionAdvice(4, bad, bad, UNIX);
     expect(a.ok).toBe(false);
     expect(a.message).toContain('did not say');
   }

--- a/site/src/lib/components/GetRunning.svelte
+++ b/site/src/lib/components/GetRunning.svelte
@@ -63,12 +63,12 @@
         <h3>Prefer to inspect first?</h3>
         <p class="run-note">{getRunning.inspectNote}</p>
         <div class="hero-cmd" style="margin-top:0.6rem">
-          <span class="prompt">$</span>
+          <span class="prompt">{install.prompt}</span>
           <code bind:this={quickEl}>{quickInstall}</code>
           <button type="button" class="copy-btn" onclick={() => copy(quickInstall, quickEl)}>{copied === quickInstall ? copyLabel(copyState) : 'Copy'}</button>
         </div>
         <div class="hero-cmd" style="margin-top:0.5rem">
-          <span class="prompt">$</span>
+          <span class="prompt">{install.prompt}</span>
           <code bind:this={rawEl}>{runCommandRaw}</code>
           <button type="button" class="copy-btn" onclick={() => copy(runCommandRaw, rawEl)}>{copied === runCommandRaw ? copyLabel(copyState) : 'Copy'}</button>
         </div>

--- a/site/src/lib/components/LaunchDialog.svelte
+++ b/site/src/lib/components/LaunchDialog.svelte
@@ -18,7 +18,7 @@
   import CommandRow from './CommandRow.svelte';
   import { modal } from '$lib/modal.js';
   import { describe } from '$lib/agent/placement.js';
-  import { joinCommand } from '$lib/agent/joincommand.js';
+  import { joinCommand, joinCommandPowerShell } from '$lib/agent/joincommand.js';
   import LaunchModal from './LaunchModal.svelte';
 
   let tokenInput = $state('');
@@ -28,6 +28,13 @@
   // disagree, and did: the guard tested `launch.join` (an object) while the
   // command it rendered could be the empty string.
   const joinCmd = $derived(joinCommand(launch.join));
+  // BOTH lines, exactly as JoinGuide shows them. The operator is standing at
+  // the machine being added and this one cannot see it, so guessing its
+  // platform is guessing about a computer that is not here -- and the wrong
+  // single line is a paste that fails on the far machine, where they have the
+  // least context. This surface offered only the sh line; a Windows GPU box
+  // invited from here got a command it cannot run.
+  const joinCmdPs = $derived(joinCommandPowerShell(launch.join));
   let dialogEl = $state(null);
 
   // `install`, not `run`: `run` holds the terminal and the agent dies with it.
@@ -142,6 +149,10 @@
           </p>
           {#if joinCmd}
             <CommandRow command={joinCmd} extra="ld-place-cmd" />
+            {#if joinCmdPs}
+              <p class="ld-place-sub">Or, if that machine runs Windows:</p>
+              <CommandRow command={joinCmdPs} extra="ld-place-cmd" />
+            {/if}
             <p class="ld-watching">
               <span class="ld-pulse" aria-hidden="true"></span>
               Watching for it — this dialog will continue on its own.

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -114,7 +114,10 @@
 </script>
 
 <svelte:head>
-  <title>Atlas, pure Rust inference for DGX Spark</title>
+  <!-- No <title> here. A layout title and a page title compete for the single
+       head slot and the LAYOUT's wins, so /control shipped with the homepage's
+       title while its own two <meta>s came through -- the page head renders,
+       only its title is discarded. Every route owns its own title instead. -->
   <link rel="canonical" href={canonical} />
   {@html `<script type="application/ld+json">${ldjson}<\/script>`}
 </svelte:head>

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -20,6 +20,10 @@
   import LaunchDialog from '$lib/components/LaunchDialog.svelte';
 </script>
 
+<svelte:head>
+  <title>Atlas, pure Rust inference for DGX Spark</title>
+</svelte:head>
+
 <Nav />
 <AnnouncementBanner />
 <Hero />


### PR DESCRIPTION
An audit of the first-run path, reading **both sides** of every contract (page ↔ installer ↔ Rust
CLI), plus a production regression the install canary had been red on since 2026-08-28.

| # | where | what a real user hits |
|---|---|---|
| 0 | `routes/+layout.svelte` | **`/control` shipped with the homepage's title for a day** |
| 1 | `agent/protocol.js:197,206` | "Your agent is out of date — update it: `curl … \| sh`", shown to Windows visitors |
| 2 | `components/LaunchDialog.svelte` | "add a machine that can run this" offers only the sh join line |
| 3 | `.github/workflows/install-canary.yml` | a deploy that drops `/install.ps1` serves HTML into `iex`, silently |
| 4 | `agent/joincommand.js` | unquoted sh operand — a bracketed IPv6 host is a glob, and zsh refuses the line |
| 5 | `components/GetRunning.svelte` | `$` prompt drawn beside commands shown to Windows visitors |

### 0 — the title regression

`/control.html` served a document titled *"Atlas, pure Rust inference for DGX Spark"*. Not the deploy
and not the URL shape: bisected by downloading the `marketing-site` artifact from each build that
day, the first build after #772 already had it, while `diligence.html` was fine throughout.

The page's `<svelte:head>` renders — I proved it by building with a marker `<meta>` inside it, which
comes through. Only its `<title>` is discarded: a layout title and a page title compete for one head
slot and the **layout's** wins. Diligence escaped because its title comes from a nested component and
its page sets none.

So the layout stops owning a title and every route owns its own. Verified by building all three.

The canary caught this *after* the deploy — a day of wrong tab, wrong bookmark and wrong share
preview for the page the whole fleet UX runs on. `site.yml` now asserts each route's title against
its built HTML **before** the artifact is uploaded; the guard was exercised both ways.

### 1 — the interesting one

That advice is always about the **loopback** agent (`AGENT_URL` is `ws://127.0.0.1`), so the machine
being advised about is the one the browser is on — the one machine whose OS the page genuinely knows.

The command is now passed in rather than detected inside `protocol.js`. That keeps the module pure,
but the real reason is SSOT: `install/host.svelte.js` exists precisely so the hero and the control
page cannot disagree about the visitor's machine, and a second sniff would reopen that.

### 4 had a tail

Quoting the sh operand broke `shortForm`, which derived the carry-note tail by slicing everything
after the command's **last space** — so it rendered the quotes on screen. Rather than patch the
slice, both now come from one `joinOperand` builder. Its test asserted `endsWith`, which could no
longer express the intent; it now asserts what was meant — the tail on screen **is** the operand in
the line — plus that the tail is never quoted, since it is prose rather than a paste.

### Verification

483 site tests pass. New cases pin the Windows remedy, the quoted operand and a bracketed IPv6 host;
the title fix is verified by building all three routes and reading the output.

_No perf paths touched._