### PR TITLE
fix(canary): a curl-into-head pipeline failed the canary with the site healthy

### DIFF
--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -119,8 +119,17 @@ jobs:
 
           # The one-liner the launch dialog prints. If this is not a shell
           # script, every install instruction on the site is wrong.
-          head=$(curl --fail --silent --show-error --location \
-                   --retry 3 --retry-delay 5 https://atlasinference.io/install.sh | head -1)
+          # The body is captured whole and the first line taken from the
+          # VARIABLE. Piping curl into `head -1` looks equivalent and is not:
+          # `head` exits after one line, curl gets EPIPE, and under this step's
+          # `set -euo pipefail` that fails the whole canary with curl's exit 23
+          # -- a write error, reported as if the site were down. It is a race on
+          # how fast curl finishes, so it passed for weeks and then failed with
+          # the site perfectly healthy (2026-08-29 04:05, in the same run that
+          # confirmed /control.html had been fixed).
+          body=$(curl --fail --silent --show-error --location \
+                   --retry 3 --retry-delay 5 https://atlasinference.io/install.sh)
+          head=$(printf '%s' "$body" | head -1)
           case "$head" in
             '#!'*) echo "ok   /install.sh -> $head" ;;
             *)
@@ -136,8 +145,9 @@ jobs:
           # fallback out of that same static dir, so it fails the same way. Piped
           # into `iex`, an HTML body is not a 404 anyone can read: it is a wall of
           # parse errors, on the platform with the least fallback.
-          head=$(curl --fail --silent --show-error --location \
-                   --retry 3 --retry-delay 5 https://atlasinference.io/install.ps1 | head -1)
+          body=$(curl --fail --silent --show-error --location \
+                   --retry 3 --retry-delay 5 https://atlasinference.io/install.ps1)
+          head=$(printf '%s' "$body" | head -1)
           case "$head" in
             '<'*)
               echo "::error::/install.ps1 served HTML -- the SPA fallback is answering for it: $head"


### PR DESCRIPTION
The install canary failed at 04:05 today **in the same run that confirmed `/control.html` had been
fixed**:

```
ok   / -> <title>Atlas, pure Rust inference for DGX Spark</title>
ok   /control.html -> <title>Control plane — Atlas</title>
ok   /control -> 200 (fallback, not an error)
##[error]Process completed with exit code 23.
```

**23 is curl's write error, not an HTTP one** (that is 22). The only pipe in the step is
`curl … | head -1`: `head` exits after one line, curl gets EPIPE writing the rest, and the step's
`set -euo pipefail` turns that into a failure reported as though the site were down. It is a race on
whether curl finishes first — which is why it passed for weeks.

Both such pipelines — the pre-existing `install.sh` check and the `install.ps1` one I added in #798 —
now capture the body and take the first line from the variable. That is the pattern the title check
three blocks up already uses, and it cannot EPIPE. What is checked is unchanged; a genuine HTTP
failure still aborts through `--fail`.

### Honest about the evidence

**I could not reproduce the EPIPE on demand from this box** — it did not fire against `install.sh` or
against the 100 KB homepage. The diagnosis rests on three things: the exit code is specifically a
*write* error, the pipeline is the only writer in the step, and the failure lands between the
`/control` line and the `/install.sh` line.

The fix is worth making even if that reading were wrong: capturing the body removes a class of false
failure without changing what the canary tests.

A canary that cries wolf is worse than no canary. The last *real* failure here sat unnoticed for a
day, and a flaky one teaches everyone to stop reading it.