### PR TITLE
ci(site): let production be redeployed on demand

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,6 +21,12 @@ on:
   # branches whose PRs have not merged yet (gen-gates.mjs walks all heads).
   schedule:
     - cron: '17 6 * * *'
+  # Manual redeploy. Without this the only ways to refresh production are a push
+  # touching the paths above and the 06:17 cron -- so a fix that ships from
+  # another repo (the installers, copied from atlas-recipes main at build time)
+  # cannot be published on demand. An operator who needs one live has to wait
+  # for the cron or fabricate an unrelated site commit to trigger a deploy.
+  workflow_dispatch:
 
 concurrency:
   group: site-${{ github.ref }}
@@ -147,7 +153,7 @@ jobs:
   deploy:
     name: Deploy to avarok via rsync
     needs: build
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     environment:
       name: production-site


### PR DESCRIPTION
## Why

The site serves `install.sh` and `install.ps1` by copying them from **atlas-recipes main at build time** — they are versioned next to the binaries they install, not duplicated here. That means a fix to those files ships from a repo whose pushes this workflow does not watch.

The triggers were `push` (filtered to `site/**`, `.benchmarks/**`, `site.yml`), the 06:17 cron, plus the PR/merge-queue legs that only build. So publishing an installer fix meant **waiting for the cron or fabricating an unrelated site commit** — for the headline command on the front page.

This is not hypothetical: an installer fix landed on atlas-recipes main tonight ([atlas-recipes#132](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/132)) and is still not live, with no way to publish it.

## What

- `workflow_dispatch:` added to `on:`.
- The deploy job's guard gates on `github.event_name`, so a dispatch would have built and silently **not published**. `workflow_dispatch` is admitted there too; the `refs/heads/main` half is unchanged.

## Verification

Parsed rather than eyeballed — this file's `on:` block is 2-space indented while its jobs are 4, which is easy to get wrong:

```
triggers: ['merge_group', 'pull_request', 'push', 'schedule', 'workflow_dispatch']
deploy-if includes dispatch: True
```

`site.yml` is itself in the push paths filter, so merging this triggers the deploy that publishes the pending installer fix — the change tests itself on landing.