### PR TITLE
fix(site): the launch dialog stopped watching in the one state that sends you away

### DIFF
--- a/site/src/lib/agent/protocol.js
+++ b/site/src/lib/agent/protocol.js
@@ -218,7 +218,14 @@ export function versionAdvice(page, min, max, installCommand) {
     return {
       ok: false,
       side: 'agent',
-      message: `Your agent is out of date — it speaks protocol ${min === max ? min : `${min}–${max}`}, this page speaks ${page}. Update it on that machine: ${installCommand}`
+        // The closing sentence is a promise both callers keep. `client` hands
+        // this message to the launch dialog and to the fleet page, and each
+        // re-probes while showing it, so an agent that restarts on the new
+        // version is picked up without the visitor returning to the browser.
+        // Worth saying out loud: the remedy sends them to a terminal on another
+        // machine, and the reasonable assumption otherwise is that the page has
+        // given up and is waiting to be clicked.
+      message: `Your agent is out of date — it speaks protocol ${min === max ? min : `${min}–${max}`}, this page speaks ${page}. Update it on that machine: ${installCommand} — this page picks it up on its own once you have.`
     };
   }
   return {

--- a/site/src/lib/components/LaunchDialog.svelte
+++ b/site/src/lib/components/LaunchDialog.svelte
@@ -58,14 +58,25 @@
 
   // Keep probing while we are waiting for the user to start an agent, so the
   // dialog advances by itself the moment one appears.
+  //
+  // 'failed' waits too, and for the same reason. It is not only the state where
+  // nothing answered: it is where an agent answered and was REFUSED, and the
+  // commonest refusal is a protocol mismatch, whose message ends by telling the
+  // visitor to run an installer on that machine. So the dialog sends someone to
+  // a terminal and then, alone among its states, does not watch for them coming
+  // back -- the upgraded agent restarts, speaks the right protocol, and the page
+  // keeps showing the old complaint until a human clicks Try again. Polling here
+  // costs nothing extra: `probe()` is silent, so a failure that persists leaves
+  // this panel exactly as it is, and only success moves the dialog forward.
+  const WATCHED = ['guide', 'failed'];
   $effect(() => {
-    if (launch.phase !== 'guide' || launch.openRecipe === null) return;
+    if (!WATCHED.includes(launch.phase) || launch.openRecipe === null) return;
     let cancelled = false;
     let delay = 1200;
     const tick = async () => {
       if (cancelled) return;
       await launch.probe();
-      if (cancelled || launch.phase !== 'guide') return;
+      if (cancelled || !WATCHED.includes(launch.phase)) return;
       // Back off so a dialog left open does not poll forever at full rate.
       delay = Math.min(delay * 1.4, 8000);
       timer = setTimeout(tick, delay);


### PR DESCRIPTION
Follow-on to the report that prompted #122 / atlas-recipes#135 — the visitor who was told *"Your agent is out of date … Update it on that machine"*. Those PRs fixed the installer so the command works. This fixes what the page does while they go and run it.

## The bug

`LaunchDialog` polls while it shows the "no agent yet" guide, and states the intent in its own header:

> starting the agent in a terminal advances the dialog on its own — the user never has to come back and click retry.

The poll is gated on `phase === 'guide'`. A protocol mismatch is not that phase: an agent **did** answer and was refused, so `client.svelte.js` sets `phase = 'error'` and the session maps it to `'failed'` — a static message plus a Try again button.

That message ends by telling the visitor to run an installer on the other machine. **So the one state that deliberately sends someone to a terminal is the one state that does not watch for them coming back.** They update the agent, it restarts speaking protocol 4, and the page keeps showing the old complaint until a human clicks.

## The fix

Poll in `'failed'` as well as `'guide'`.

Nothing else has to change, because `probe()` is already silent by design — `#connect(…, {silent: true})` suppresses every visible effect of a *failed* attempt, so a mismatch that persists leaves the panel exactly as it is, and only success advances. The existing 1.2s→8s backoff applies unchanged.

With that true, the message can say so. It now ends `— this page picks it up on its own once you have.` Both consumers of `versionAdvice` keep that promise: the launch dialog after this change, and the fleet page already, which maps the same refusal to `'no_agent'` and calls `#scheduleProbe()`.

## Verification, and the test I did not write

This repo has **no component tests and no rune-module harness** — none of the six `.svelte.js` modules has a test file. Adding one for this would mean standing up a DOM harness; and a test asserting that a two-element array contains `'failed'` would be decorative, which this project's guidelines rule out. So, stated plainly rather than papered over:

- `bun test src/lib` — 483 pass, 0 fail
- `LaunchDialog.svelte` compiled through the Svelte compiler directly: **0 warnings**
- `versionAdvice(4, 1, 1, …)` called directly, to read the sentence a visitor actually gets:

```
Your agent is out of date — it speaks protocol 1, this page speaks 4.
Update it on that machine: curl X | sh — this page picks it up on its own once you have.
```

That is the exact message from the original report, with the new ending.

`svelte-check` and `vite build` could not run locally (sandbox tempdir denial, and local Node 18 vs rolldown's `styleText`); CI covers both.