### PR TITLE
ci(canary): cover the upgrade path, which is the one that breaks

### DIFF
--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -47,9 +47,21 @@ jobs:
           # inherit whatever a runner image happens to have on PATH.
           prefix="$RUNNER_TEMP/atlasctl-bin"
           mkdir -p "$prefix"
-          ATLASCTL_INSTALL_DIR="$prefix" \
-            curl --fail --silent --show-error --location --retry 3 --retry-delay 5 \
-              https://atlasinference.io/install.sh | sh
+          # EXPORTED, not prefixed onto the pipeline. `VAR=x curl ... | sh` sets
+          # VAR for CURL, which does not read it -- `sh` runs in a separate
+          # process that never sees it. The installer therefore ignored the
+          # private prefix entirely and installed to ~/.local/bin, which is on a
+          # runner's PATH, so the next step found *a* binary and the job passed.
+          # The isolation this prefix exists to provide was never in effect.
+          export ATLASCTL_INSTALL_DIR="$prefix"
+          curl --fail --silent --show-error --location --retry 3 --retry-delay 5 \
+            https://atlasinference.io/install.sh | sh
+          # Prove it landed where we asked, rather than inferring it from PATH.
+          [ -x "$prefix/atlasctl" ] || {
+            echo "::error::the installer did not honour ATLASCTL_INSTALL_DIR=$prefix"
+            ls -la "$prefix" || true
+            exit 1
+          }
           echo "$prefix" >> "$GITHUB_PATH"
 
       # The install above is a FIRST install, and a first install is the one
@@ -81,9 +93,9 @@ jobs:
             exit 1
           }
 
-          ATLASCTL_INSTALL_DIR="$prefix" \
-            curl --fail --silent --show-error --location --retry 3 --retry-delay 5 \
-              https://atlasinference.io/install.sh | sh
+          export ATLASCTL_INSTALL_DIR="$prefix"
+          curl --fail --silent --show-error --location --retry 3 --retry-delay 5 \
+            https://atlasinference.io/install.sh | sh
 
           restored=$(sha256sum "$prefix/atlasctl" | cut -d" " -f1)
           if [ "$restored" = "$tampered" ]; then
@@ -108,77 +120,6 @@ jobs:
             echo "::error::atlasctl shipped only $count recipes; the vendored corpus is missing or truncated"
             exit 1
           }
-
-  # Windows had no canary at all. `install.ps1` is served from the front page to
-  # every Windows visitor -- the page picks by detected OS, so those visitors have
-  # no other command to fall back to -- and nothing watched it in production.
-  #
-  # It is also the installer most likely to break quietly: this project has
-  # already shipped Windows-only defects that passed every Linux check (a rename
-  # over a running file, an `Instant` subtraction that panicked on a freshly
-  # booted host, a `canonicalize` that resolved into `C:\$Extend\$Deleted`).
-  # A POSIX-shaped assumption is invisible until a Windows machine runs it.
-  windows-installer:
-    name: production one-liner (Windows)
-    runs-on: windows-latest
-    timeout-minutes: 15
-    steps:
-      - name: Install atlasctl the way the website tells Windows people to
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          # A private prefix, for the same reason as the aarch64 job: prove the
-          # installer works rather than inherit the runner image's PATH.
-          $prefix = Join-Path $env:RUNNER_TEMP 'atlasctl-bin'
-          New-Item -ItemType Directory -Force -Path $prefix | Out-Null
-          $env:ATLASCTL_INSTALL_DIR = $prefix
-          # The exact one-liner the site prints for a Windows visitor.
-          irm https://atlasinference.io/install.ps1 | iex
-          "$prefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: It runs, and it knows its recipes
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $exe = Join-Path $env:RUNNER_TEMP 'atlasctl-bin\atlasctl.exe'
-          & $exe --version
-          # Same corpus check as aarch64: a binary shipped without its recipes
-          # fails here rather than in a user's terminal.
-          $count = (& $exe recipe list | Select-Object -Skip 1 | Where-Object { $_.Trim() }).Count
-          Write-Host "recipes: $count"
-          if ($count -lt 10) {
-            Write-Host "::error::atlasctl shipped only $count recipes; the vendored corpus is missing or truncated"
-            exit 1
-          }
-
-      # The same upgrade-path hole the aarch64 job had: a first install is the
-      # one shape that has never broken. Trailing bytes leave a PE image runnable
-      # and its --version unchanged, so this reaches the branch that must decide
-      # on CONTENT rather than on the version string.
-      - name: Re-running the installer over a differing build REPLACES it
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $prefix = Join-Path $env:RUNNER_TEMP 'atlasctl-bin'
-          $exe = Join-Path $prefix 'atlasctl.exe'
-          $before = (& $exe --version | Out-String).Trim()
-          Add-Content -Path $exe -Value "`n# canary marker" -Encoding Ascii
-          $tampered = (Get-FileHash $exe -Algorithm SHA256).Hash
-          $after = (& $exe --version | Out-String).Trim()
-          if ($before -ne $after) {
-            Write-Host "::error::tampering changed the reported version ($before -> $after);"
-            Write-Host "this test can no longer reach the same-version/different-content branch"
-            exit 1
-          }
-          $env:ATLASCTL_INSTALL_DIR = $prefix
-          irm https://atlasinference.io/install.ps1 | iex
-          $restored = (Get-FileHash $exe -Algorithm SHA256).Hash
-          if ($restored -eq $tampered) {
-            Write-Host "::error::the installer left the modified binary in place."
-            Write-Host "It decided an upgrade was unnecessary, or announced one and did not perform it."
-            exit 1
-          }
-          Write-Host "replaced: $tampered -> $restored"
 
   pages:
     name: the pages the site links to

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -52,6 +52,49 @@ jobs:
               https://atlasinference.io/install.sh | sh
           echo "$prefix" >> "$GITHUB_PATH"
 
+      # The install above is a FIRST install, and a first install is the one
+      # shape of this script that has never been broken: with nothing on disk
+      # the installer takes its plain "copy it in" path. Every upgrade bug lives
+      # in the other paths, and one shipped on 2026-08-29 -- the branch for "same
+      # version string, different build" printed "replacing it" and copied
+      # nothing, so an operator on a stale agent was told the upgrade succeeded
+      # and kept running the old protocol. This canary passed throughout.
+      #
+      # Reproduce that exact shape: keep the version string identical and change
+      # only the CONTENT. Appending bytes past the end of an ELF leaves it
+      # runnable and `--version` unchanged, while its sha256 differs -- which is
+      # precisely the case the installer must decide on content rather than on
+      # the version it prints.
+      - name: Re-running the installer over a differing build REPLACES it
+        run: |
+          set -euo pipefail
+          prefix="$RUNNER_TEMP/atlasctl-bin"
+          before_version=$("$prefix/atlasctl" --version)
+          printf '\n# canary marker\n' >> "$prefix/atlasctl"
+          tampered=$(sha256sum "$prefix/atlasctl" | cut -d" " -f1)
+          # Still runnable, and still claiming the same version: without that the
+          # test would be exercising the ordinary upgrade path instead.
+          after_tamper=$("$prefix/atlasctl" --version)
+          [ "$before_version" = "$after_tamper" ] || {
+            echo "::error::tampering changed the reported version ($before_version -> $after_tamper);"
+            echo "this test can no longer reach the same-version/different-content branch"
+            exit 1
+          }
+
+          ATLASCTL_INSTALL_DIR="$prefix" \
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 5 \
+              https://atlasinference.io/install.sh | sh
+
+          restored=$(sha256sum "$prefix/atlasctl" | cut -d" " -f1)
+          if [ "$restored" = "$tampered" ]; then
+            echo "::error::the installer left the modified binary in place."
+            echo "It decided an upgrade was unnecessary, or announced one and did not perform it."
+            echo "Operators on a stale build are being told they are up to date."
+            exit 1
+          fi
+          echo "replaced: $tampered -> $restored"
+          "$prefix/atlasctl" --version
+
       - name: It runs, and it knows its recipes
         run: |
           set -euo pipefail

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -82,7 +82,16 @@ jobs:
           set -euo pipefail
           prefix="$RUNNER_TEMP/atlasctl-bin"
           before_version=$("$prefix/atlasctl" --version)
-          printf '\n# canary marker\n' >> "$prefix/atlasctl"
+          # Replace by RENAME, not by appending in place. The install above
+          # starts the agent, so the binary is being executed and a write to it
+          # fails with ETXTBSY ("Text file busy"). install.sh has the same
+          # constraint and solves it the same way -- `install` to a temp name
+          # then `mv -f` -- because a rename swaps the directory entry while the
+          # running process keeps the old inode.
+          cp "$prefix/atlasctl" "$prefix/.atlasctl.tampered"
+          printf '\n# canary marker\n' >> "$prefix/.atlasctl.tampered"
+          chmod 0755 "$prefix/.atlasctl.tampered"
+          mv -f "$prefix/.atlasctl.tampered" "$prefix/atlasctl"
           tampered=$(sha256sum "$prefix/atlasctl" | cut -d" " -f1)
           # Still runnable, and still claiming the same version: without that the
           # test would be exercising the ordinary upgrade path instead.

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -109,6 +109,77 @@ jobs:
             exit 1
           }
 
+  # Windows had no canary at all. `install.ps1` is served from the front page to
+  # every Windows visitor -- the page picks by detected OS, so those visitors have
+  # no other command to fall back to -- and nothing watched it in production.
+  #
+  # It is also the installer most likely to break quietly: this project has
+  # already shipped Windows-only defects that passed every Linux check (a rename
+  # over a running file, an `Instant` subtraction that panicked on a freshly
+  # booted host, a `canonicalize` that resolved into `C:\$Extend\$Deleted`).
+  # A POSIX-shaped assumption is invisible until a Windows machine runs it.
+  windows-installer:
+    name: production one-liner (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Install atlasctl the way the website tells Windows people to
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # A private prefix, for the same reason as the aarch64 job: prove the
+          # installer works rather than inherit the runner image's PATH.
+          $prefix = Join-Path $env:RUNNER_TEMP 'atlasctl-bin'
+          New-Item -ItemType Directory -Force -Path $prefix | Out-Null
+          $env:ATLASCTL_INSTALL_DIR = $prefix
+          # The exact one-liner the site prints for a Windows visitor.
+          irm https://atlasinference.io/install.ps1 | iex
+          "$prefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: It runs, and it knows its recipes
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = Join-Path $env:RUNNER_TEMP 'atlasctl-bin\atlasctl.exe'
+          & $exe --version
+          # Same corpus check as aarch64: a binary shipped without its recipes
+          # fails here rather than in a user's terminal.
+          $count = (& $exe recipe list | Select-Object -Skip 1 | Where-Object { $_.Trim() }).Count
+          Write-Host "recipes: $count"
+          if ($count -lt 10) {
+            Write-Host "::error::atlasctl shipped only $count recipes; the vendored corpus is missing or truncated"
+            exit 1
+          }
+
+      # The same upgrade-path hole the aarch64 job had: a first install is the
+      # one shape that has never broken. Trailing bytes leave a PE image runnable
+      # and its --version unchanged, so this reaches the branch that must decide
+      # on CONTENT rather than on the version string.
+      - name: Re-running the installer over a differing build REPLACES it
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $prefix = Join-Path $env:RUNNER_TEMP 'atlasctl-bin'
+          $exe = Join-Path $prefix 'atlasctl.exe'
+          $before = (& $exe --version | Out-String).Trim()
+          Add-Content -Path $exe -Value "`n# canary marker" -Encoding Ascii
+          $tampered = (Get-FileHash $exe -Algorithm SHA256).Hash
+          $after = (& $exe --version | Out-String).Trim()
+          if ($before -ne $after) {
+            Write-Host "::error::tampering changed the reported version ($before -> $after);"
+            Write-Host "this test can no longer reach the same-version/different-content branch"
+            exit 1
+          }
+          $env:ATLASCTL_INSTALL_DIR = $prefix
+          irm https://atlasinference.io/install.ps1 | iex
+          $restored = (Get-FileHash $exe -Algorithm SHA256).Hash
+          if ($restored -eq $tampered) {
+            Write-Host "::error::the installer left the modified binary in place."
+            Write-Host "It decided an upgrade was unnecessary, or announced one and did not perform it."
+            exit 1
+          }
+          Write-Host "replaced: $tampered -> $restored"
+
   pages:
     name: the pages the site links to
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Why

The canary installs into a clean prefix, so it only ever exercised a **first** install — the one shape of `install.sh` that has never been broken. Every upgrade bug lives in the other branches, and one shipped tonight: the *"same version string, different build"* case printed **"replacing it"** and copied nothing ([atlas-recipes#135](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/135)). **This canary ran green throughout.**

## What it found before merging

Dispatched against live production rather than merged on faith, and it failed twice — both times for real reasons:

**1. The private prefix was never in effect.** `ATLASCTL_INSTALL_DIR="$prefix" curl … | sh` sets the variable for **curl**; `sh` is a separate process across the pipe and never sees it. The installer used its default and wrote to `~/.local/bin`, which is on a runner's PATH — so the next step found *a* binary and the job passed. The step's own comment ("prove the installer works, not inherit whatever a runner image happens to have on PATH") was untrue. Now exported, and the binary's presence at that path is asserted rather than inferred.

**2. `Text file busy`.** The install starts the agent, so the binary is being executed and cannot be written in place. `install.sh` is under the identical constraint and already solves it — write a temp name, `mv -f` over it, because a rename swaps the directory entry while the running process keeps the old inode. The canary now does the same, which is also a truer simulation of upgrading a machine with a live agent.

## Green, with the evidence

```
[atlas] atlasctl 0.1.7 is installed, but the published build differs — replacing it
replaced: 28ee7593ac3f51a987385fe6d3615d73092627a3… -> <new>
atlasctl 0.1.7
```

That is precisely the branch that was broken, now doing the thing it announces.

## Split out: Windows

A Windows job was written and **removed from this branch**. It fails for a real and unrelated reason: **no Windows asset has ever been published**. `v0.4.1` was cut 2026-08-28T05:45Z; `x86_64-pc-windows-msvc` was added to the release matrix at 15:53Z the same day. So the front page hands every Windows visitor `irm … install.ps1 | iex`, which downloads a file that does not exist.

That is worth fixing by **publishing a release** (release PR atlas-recipes#88, which is user-gated because it publishes binaries) — not by merging a permanently red canary. The job is held and should land the day Windows binaries ship.
