### PR TITLE
fix(site): the silent probe could not leave the dead end it created

### DIFF
--- a/site/src/lib/agent/fleet.svelte.js
+++ b/site/src/lib/agent/fleet.svelte.js
@@ -431,6 +431,28 @@ class FleetSession {
         await this.#openWatch();
         return;
       }
+      // An agent that ANSWERED and was refused is not silence, and the rule above
+      // allows exactly this: a silent probe may move the page forward when an
+      // agent answers. Only `ok` was handled here, so it could not.
+      //
+      // `#connect` has always got this right, and session.svelte.js does too --
+      // the same event with three handlers, one of which did nothing. The cost
+      // was a dead end the page could not leave: install an agent whose browser
+      // token this browser has never seen and `connect()` returns false, so the
+      // mode stayed 'no_agent' and the operator read "Nothing is running here
+      // yet" plus "this page will continue on its own" while it retried an
+      // identically-failing handshake forever. The panel that tells them what to
+      // do already existed and was simply unreachable from here.
+      if (this.agent.phase === 'unpaired') {
+        this.mode = 'browser_unpaired';
+        this.detail = this.agent.message ?? '';
+        return; // needs a token pasted; no amount of probing supplies one
+      }
+      // Anything else keeps probing -- an agent may still be starting -- but
+      // carries the reason, so the page can say WHY instead of claiming nothing
+      // is there. A refused handshake otherwise rendered as "nothing is
+      // running", which is false.
+      this.detail = this.agent.message ?? this.detail;
       this.#probeDelay = Math.min(this.#probeDelay * PROBE_FACTOR, PROBE_MAX_MS);
       this.#scheduleProbe();
     }, this.#probeDelay);

--- a/site/src/routes/control/+page.svelte
+++ b/site/src/routes/control/+page.svelte
@@ -343,6 +343,14 @@
                  invitation rather than an error. -->
             <div class="ctl-setup">
               <h2>Nothing is running here yet</h2>
+              <!-- A refused handshake is not an empty machine. The probe now carries
+                   the reason here (a protocol mismatch names the installer to run),
+                   and without showing it this panel told an operator whose agent WAS
+                   running that nothing was -- then promised to continue on its own
+                   while retrying a handshake that fails the same way every time. -->
+              {#if fleet.detail}
+                <p class="ld-error" role="alert">{fleet.detail}</p>
+              {/if}
               <p>
                 Atlas runs on your hardware, not ours. Install the agent on a machine
                 and this page becomes its control panel.


### PR DESCRIPTION
Found by an independent audit of the onboarding path. Same defect class as #803, in the fleet path rather than the launch dialog.

## The dead end

`#scheduleProbe` handled only success. Everything else fell through to "back off and try again" — **including the case where an agent answered and was refused**, which is not silence, and which the rule directly above it already permits acting on:

> Silent: a poll the user did not ask for must not repaint what they are reading. It may only move the page forward, **when an agent answers**.

The same event has three handlers. `#connect` (`fleet.svelte.js:303`) and `session.svelte.js:148` both treat `'unpaired'` as forward progress. The silent probe did nothing with it.

So: install an agent whose browser token this browser has never seen. `connect()` returns false, the mode stays `'no_agent'`, and the operator reads **"Nothing is running here yet"** followed by **"this page will continue on its own"** — while it retries an identically-failing handshake until someone reloads. The panel that tells them exactly what to do (*"Pair this browser with your agent"*, run `atlasctl agent token`) **already existed and was unreachable from here.**

## Two fixes

1. `'unpaired'` moves to that panel and **stops** probing — no amount of probing supplies a token. Anything else keeps probing, since an agent may still be starting, but now carries the reason forward.

2. **The reason is rendered.** `versionAdvice`'s message was computed, stored on `fleet.detail`, and displayed nowhere — so an out-of-date agent produced the generic install panel headed "Nothing is running here yet", about a machine that was demonstrably running something. The `no_agent` panel now shows the detail when there is one, so a refused handshake names the installer to run instead of denying the agent exists.

`FleetPill`'s silence is deliberate and unchanged: `summarize` returns `show:false` for any mode but `'live'` because *"the one place that pitches the agent is the page that exists to explain it"*. This makes that page actually do it.

## Verification, and the test I did not write

Still no component or rune-module harness in this repo — none of the six `.svelte.js` modules has a test file, so there is nothing to hang this on without standing one up. Stated rather than papered over:

- both touched components compiled through the Svelte compiler: **0 warnings**
- `bun test src/lib`: **483 pass, 0 fail**