### PR TITLE
fix(site): a welcome that names no protocol was treated as compatible

### DIFF
--- a/site/src/lib/agent/client.svelte.js
+++ b/site/src/lib/agent/client.svelte.js
@@ -168,14 +168,23 @@ export class AgentClient {
     if (!welcome) {
       return this.#abandon(socket, 'unavailable');
     }
-    if (PROTOCOL_VERSION < welcome.protocol_min || PROTOCOL_VERSION > welcome.protocol_max) {
-      this.message = versionAdvice(
-        PROTOCOL_VERSION,
-        welcome.protocol_min,
-        welcome.protocol_max,
-        // This agent is on 127.0.0.1, so the visitor's own OS is its OS.
-        currentInstall().command
-      ).message;
+    // `versionAdvice` decides, rather than this comparison deciding and
+    // `versionAdvice` only narrating. The two had drifted: a welcome frame
+    // missing `protocol_min`/`protocol_max` made BOTH comparisons `false`
+    // -- undefined compares false either way -- so an agent that never said
+    // which protocol it speaks was treated as compatible and sent `hello`.
+    // The refusal for exactly that case already existed inside
+    // `versionAdvice` and was unreachable from here, with tests covering a
+    // path production could not take.
+    const advice = versionAdvice(
+      PROTOCOL_VERSION,
+      welcome.protocol_min,
+      welcome.protocol_max,
+      // This agent is on 127.0.0.1, so the visitor's own OS is its OS.
+      currentInstall().command
+    );
+    if (!advice.ok) {
+      this.message = advice.message;
       return this.#abandon(socket, 'error');
     }
 

--- a/site/src/lib/agent/protocol.test.js
+++ b/site/src/lib/agent/protocol.test.js
@@ -104,6 +104,14 @@ test('a version mismatch names the side that is behind', () => {
   expect(pageOld.message).toContain('Shift-R');
   // A welcome with no usable versions must not guess a side at random.
   expect(versionAdvice(4, undefined, null, UNIX).ok).toBe(false);
+  // NUMERIC STRINGS specifically, because they are what a sloppy JSON
+  // encoder actually emits and they are the case a relational comparison
+  // gets wrong quietly: `4 < "1"` and `4 > "4"` are both false, so a
+  // hand-rolled range check waves them through as compatible. Only a type
+  // check catches them, and the client now routes this decision here rather
+  // than comparing for itself.
+  expect(versionAdvice(4, '1', '4', UNIX).ok).toBe(false);
+  expect(versionAdvice(4, '4', '4', UNIX).ok).toBe(false);
 });
 
 // An agent that omits a detail field is not hypothetical — an older build


### PR DESCRIPTION
Third finding from the onboarding-path audit (after #803 and #805).

## The bypass

`client.svelte.js` decided compatibility with its own comparison, and called `versionAdvice` only to *narrate* the result:

```js
if (PROTOCOL_VERSION < welcome.protocol_min || PROTOCOL_VERSION > welcome.protocol_max)
```

The two drifted. With `protocol_min`/`protocol_max` **absent**, both comparisons are `false` — `undefined` compares false either way — so an agent that never said which protocol it speaks fell through as *compatible* and was sent `hello`.

**Numeric strings do the same thing and are likelier.** `4 < "1"` and `4 > "4"` are both `false`, so a welcome carrying `"1"`/`"4"` over JSON was waved through by a range check that only a *type* check catches.

`versionAdvice` already refuses both, and its branch written for exactly this — *"The agent did not say which protocol it speaks"* — was **unreachable from production**. The tests covering it were exercising a path that could not occur.

## The fix

Route the decision through `versionAdvice`: one place decides, the same place explains, and those existing tests now pin real behaviour.

Verified against the live function:

| welcome | before | after |
|---|---|---|
| `undefined` / `undefined` | accepted | refused |
| `null` / `null` | accepted | refused |
| `"1"` / `"4"` (JSON strings) | **accepted** | refused |
| `1` / `4` | accepted | accepted |
| `1` / `1` (too old) | refused | refused |

## Tests, and what they do not cover

Numeric strings added explicitly, because they are what a sloppy encoder emits and the case a relational comparison gets wrong *quietly*. I confirmed they **execute** — the suite's `expect()` count moves 1569 → 1571 — rather than trusting a pass count, since a skipped assertion also "passes".

Stated plainly: these pin `versionAdvice`, which was always correct. They would catch someone loosening it; they would **not** catch someone reverting the client to inline comparisons, because this repo still has no rune or component harness. The client change is verified by reading and by the table above, not by a test.