### PR TITLE
fix(site): the unpaired branch latched the page instead of healing it

### DIFF
--- a/site/src/lib/agent/fleet.svelte.js
+++ b/site/src/lib/agent/fleet.svelte.js
@@ -427,6 +427,9 @@ class FleetSession {
       const ok = await this.agent.connect();
       if (ok) {
         this.mode = 'live';
+        // Cleared with the mode, as `#connect` does: a detail written by an
+        // earlier failure must not survive into a live fleet.
+        this.detail = '';
         this.#probeDelay = PROBE_START_MS;
         await this.#openWatch();
         return;
@@ -446,7 +449,19 @@ class FleetSession {
       if (this.agent.phase === 'unpaired') {
         this.mode = 'browser_unpaired';
         this.detail = this.agent.message ?? '';
-        return; // needs a token pasted; no amount of probing supplies one
+        // KEEP PROBING. An earlier version returned here, with the comment
+        // "no amount of probing supplies a token" -- which is exactly backwards.
+        // `connect(token = storedToken())` re-reads localStorage on every call,
+        // so probing is precisely what notices a token pasted anywhere else, and
+        // this loop recovered on its own before that return was added.
+        //
+        // Returning latched the page instead: every re-arm site gates on
+        // `mode === 'no_agent'` (:199, :206, :231), the /control panel for this
+        // mode has no interactive element, and re-entering the page no-ops
+        // because `start()` gates on 'no_agent' too. Only a full reload cleared
+        // it -- a worse dead end than the one that change set out to fix, and
+        // reachable from 'reconnecting' as well when an agent restarts with a
+        // regenerated token.
       }
       // Anything else keeps probing -- an agent may still be starting -- but
       // carries the reason, so the page can say WHY instead of claiming nothing

--- a/site/src/routes/control/+page.svelte
+++ b/site/src/routes/control/+page.svelte
@@ -331,6 +331,14 @@
           {:else if fleet.mode === 'browser_unpaired'}
             <div class="ctl-setup">
               <h2>Pair this browser with your agent</h2>
+              <!-- The reason, when the handshake gave one. `#scheduleProbe` sets
+                   `detail` on this path too, and it was rendered nowhere: the
+                   `{#if fleet.detail}` added with the no_agent panel covered only
+                   that branch, so an operator here was told to paste a token
+                   without being told what the agent actually said. -->
+              {#if fleet.detail}
+                <p class="ld-error" role="alert">{fleet.detail}</p>
+              {/if}
               <p>
                 An agent is running, but it has not seen this browser before. Run
                 <code class="mono">atlasctl agent token</code> and paste the value the


### PR DESCRIPTION
Found by an audit of **#805 — my own merged fix**. It introduced a worse dead end than the one it removed.

## The regression

`#scheduleProbe` returned on `'unpaired'` without rescheduling, justified by a comment: *"no amount of probing supplies a token"*.

That is exactly backwards. `connect(token = storedToken())` (`client.svelte.js:76`) re-reads localStorage on **every call** — so probing is precisely what notices a token pasted anywhere else, and **this loop recovered on its own before that return was added.**

With the return, the page latches:

- every re-arm site gates on `mode === 'no_agent'` (`fleet.svelte.js:199, :206, :231`)
- the `/control` panel for `'browser_unpaired'` has **no interactive element** — no token field, no button
- the only `fleet.retry()` caller is in `LaunchDialog`, which is mounted on the home page and never on `/control`
- re-entering the page no-ops, because `start()` also gates on `'no_agent'`

**Only a full reload cleared it.** Reachable from `'reconnecting'` too, when an agent restarts with a regenerated token.

So: set the mode, carry the reason, and keep probing.

## Two more from the same audit

- **The `detail` on this path was rendered nowhere.** The `{#if fleet.detail}` I added alongside #805 covered only the `no_agent` branch, so an operator on `'browser_unpaired'` was told to paste a token without being told what the agent actually said.
- **A successful probe set `mode = 'live'` without clearing `detail`**, unlike `#connect`. Not visible today — the only consumer sits in a non-live branch — but it is a stale message waiting for a second consumer.

## Verification

`bun test src/lib` — 483 pass, 1571 assertions. Both touched components compile with 0 warnings.

No rune-module harness exists in this repo (none of the six `.svelte.js` modules has one), so the latching itself is verified by reading the call graph rather than by a test — the same limitation stated on #803 and #805, and the reason this needed an audit to find.