### PR TITLE
test(site): make rune modules testable, and test one

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -56,7 +56,7 @@ jobs:
       # `src/lib` only: the e2e specs under `e2e/` need a browser and a served
       # build, and are a separate concern from these.
       - name: Run unit tests
-        run: bun test src/lib
+        run: bun test --preload ./test-runes.js src/lib
 
   build:
     name: Build SvelteKit site

--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
     "generate": "node scripts/gen-models.mjs && node scripts/gen-benchmarks.mjs && node scripts/gen-gates.mjs && node scripts/gen-ladder.mjs && node scripts/gen-stars.mjs",
     "test:e2e": "bun x --bun playwright test",
     "test:e2e:live": "LIVE=1 bun x --bun playwright test --grep @live",
-    "test:unit": "bun test src/lib"
+    "test:unit": "bun test --preload ./test-runes.js src/lib"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/site/src/lib/agent/fleet.svelte.js
+++ b/site/src/lib/agent/fleet.svelte.js
@@ -68,7 +68,10 @@ export function linkWarns(cls) {
   return cls !== 'roce' && cls !== 'infini_band' && cls !== 'unverified';
 }
 
-class FleetSession {
+// Exported for tests. The singleton below is what the app uses; a test needs a
+// FRESH session with a fake agent, because the interesting behaviour is the
+// probe loop's state machine and a shared instance carries state between cases.
+export class FleetSession {
   /** The one client the whole app shares. */
   agent = new AgentClient();
 

--- a/site/src/lib/agent/fleet.svelte.js
+++ b/site/src/lib/agent/fleet.svelte.js
@@ -427,6 +427,9 @@ class FleetSession {
       const ok = await this.agent.connect();
       if (ok) {
         this.mode = 'live';
+        // Cleared with the mode, as `#connect` does: a detail written by an
+        // earlier failure must not survive into a live fleet.
+        this.detail = '';
         this.#probeDelay = PROBE_START_MS;
         await this.#openWatch();
         return;
@@ -446,7 +449,19 @@ class FleetSession {
       if (this.agent.phase === 'unpaired') {
         this.mode = 'browser_unpaired';
         this.detail = this.agent.message ?? '';
-        return; // needs a token pasted; no amount of probing supplies one
+        // KEEP PROBING. An earlier version returned here, with the comment
+        // "no amount of probing supplies a token" -- which is exactly backwards.
+        // `connect(token = storedToken())` re-reads localStorage on every call,
+        // so probing is precisely what notices a token pasted anywhere else, and
+        // this loop recovered on its own before that return was added.
+        //
+        // Returning latched the page instead: every re-arm site gates on
+        // `mode === 'no_agent'` (:199, :206, :231), the /control panel for this
+        // mode has no interactive element, and re-entering the page no-ops
+        // because `start()` gates on 'no_agent' too. Only a full reload cleared
+        // it -- a worse dead end than the one that change set out to fix, and
+        // reachable from 'reconnecting' as well when an agent restarts with a
+        // regenerated token.
       }
       // Anything else keeps probing -- an agent may still be starting -- but
       // carries the reason, so the page can say WHY instead of claiming nothing

--- a/site/src/lib/agent/fleet.svelte.test.js
+++ b/site/src/lib/agent/fleet.svelte.test.js
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// The first tests for a rune module in this repo.
+//
+// `.svelte.js` files use `$state`, which is a compiler construct rather than a
+// runtime function, so `bun test` could not import them at all — six modules
+// with nine exported items, none of them reachable from a test. That is not a
+// small gap: a latching-state regression in this very file reached main and had
+// to be found by reading the call graph, because nothing here could be driven.
+//
+// `test-runes.js` (loaded via `--preload`) compiles the runes and resolves
+// SvelteKit's `$lib` alias, which vite supplies during a build and bun does not.
+
+import { test, expect } from 'bun:test';
+import { preferredAddress, linkWarns, isStale } from '$lib/agent/fleet.svelte.js';
+
+const addr = (cls, speedMbps = null, iface = cls) => ({ iface, addr: '10.0.0.1', class: cls, speedMbps });
+
+test('preferredAddress never returns a virtual or loopback interface', () => {
+  // These are reachable only from the machine itself, so offering one as the
+  // address a PEER should dial is offering an address that cannot work.
+  expect(preferredAddress({ addresses: [addr('loopback'), addr('virtual')] })).toBeNull();
+  expect(preferredAddress({ addresses: [] })).toBeNull();
+  const picked = preferredAddress({ addresses: [addr('virtual'), addr('ethernet')] });
+  expect(picked.class).toBe('ethernet');
+});
+
+test('preferredAddress ranks fabrics above ethernet, and speed only breaks ties', () => {
+  // A 1 Gb RoCE link still beats a 100 Gb ethernet one: the class is the
+  // decision, speed is the tiebreak. Sorting on speed first would hand a
+  // DGX pair the wrong interface.
+  const picked = preferredAddress({
+    addresses: [addr('ethernet', 100_000), addr('roce', 1_000)],
+  });
+  expect(picked.class).toBe('roce');
+
+  const tie = preferredAddress({
+    addresses: [addr('ethernet', 1_000, 'slow'), addr('ethernet', 10_000, 'fast')],
+  });
+  expect(tie.iface).toBe('fast');
+});
+
+test('an unverified link ranks below every known class but is still offered', () => {
+  // Unverified is missing information, not a bad link — it must lose to
+  // anything known, and still be returned when it is all there is.
+  const beaten = preferredAddress({ addresses: [addr('unverified'), addr('wireless')] });
+  expect(beaten.class).toBe('wireless');
+  const only = preferredAddress({ addresses: [addr('unverified')] });
+  expect(only.class).toBe('unverified');
+});
+
+test('linkWarns stays silent for fabrics and for unverified', () => {
+  // Warning about `unverified` would be inventing a problem out of an absence
+  // of information, which is the comment's own reasoning.
+  expect(linkWarns('roce')).toBe(false);
+  expect(linkWarns('infini_band')).toBe(false);
+  expect(linkWarns('unverified')).toBe(false);
+  expect(linkWarns('ethernet')).toBe(true);
+  expect(linkWarns('wireless')).toBe(true);
+});
+
+test('isStale is measured against the sample, not the clock reading', () => {
+  const now = 1_000_000;
+  expect(isStale({ lastSeen: now }, now)).toBe(false);
+  expect(isStale({ lastSeen: now - 1000 }, now)).toBe(false);
+  // Far enough back that no plausible threshold calls it fresh.
+  expect(isStale({ lastSeen: now - 60 * 60 * 1000 }, now)).toBe(true);
+});

--- a/site/src/lib/agent/fleet.svelte.test.js
+++ b/site/src/lib/agent/fleet.svelte.test.js
@@ -132,3 +132,40 @@ test('an unpaired probe keeps probing, so a token pasted elsewhere is noticed', 
     expect(scheduled.length).toBeGreaterThan(1);
   });
 });
+
+test('a successful probe clears the detail a failure left behind', async () => {
+  // `#connect` has always cleared `detail` on success; the probe loop did not,
+  // so a message written while the agent was refusing survived into 'live'.
+  // Invisible today because the only consumer renders in a non-live branch —
+  // which is exactly the kind of latent wrong-text that surfaces the moment
+  // someone adds a second consumer.
+  await withCapturedTimers(async (scheduled) => {
+    const f = new FleetSession();
+    f.agent = fakeAgent('unavailable');
+    await f.start({ watch: true });
+    expect(f.detail).not.toBe('');
+
+    // The agent comes back.
+    // A success path agent needs the watch surface too: `#openWatch` subscribes
+    // and asks for the fleet, so a fake missing either throws inside the probe
+    // rather than exercising it.
+    f.agent = {
+      phase: 'ready',
+      message: '',
+      async connect() {
+        return true;
+      },
+      onEvent() {},
+      async listNodes() {
+        return { ok: true, nodes: [] };
+      },
+      async watchFleet() {
+        return { ok: true };
+      },
+    };
+    await scheduled[0].cb();
+
+    expect(f.mode).toBe('live');
+    expect(f.detail).toBe('');
+  });
+});

--- a/site/src/lib/agent/fleet.svelte.test.js
+++ b/site/src/lib/agent/fleet.svelte.test.js
@@ -12,7 +12,7 @@
 // SvelteKit's `$lib` alias, which vite supplies during a build and bun does not.
 
 import { test, expect } from 'bun:test';
-import { preferredAddress, linkWarns, isStale } from '$lib/agent/fleet.svelte.js';
+import { preferredAddress, linkWarns, isStale, FleetSession } from '$lib/agent/fleet.svelte.js';
 
 const addr = (cls, speedMbps = null, iface = cls) => ({ iface, addr: '10.0.0.1', class: cls, speedMbps });
 
@@ -65,4 +65,70 @@ test('isStale is measured against the sample, not the clock reading', () => {
   expect(isStale({ lastSeen: now - 1000 }, now)).toBe(false);
   // Far enough back that no plausible threshold calls it fresh.
   expect(isStale({ lastSeen: now - 60 * 60 * 1000 }, now)).toBe(true);
+});
+
+// --- the probe loop's state machine -------------------------------------
+//
+// This is the class of bug the harness exists for. A change to the unpaired
+// branch stopped it rescheduling, and because every OTHER re-arm site gates on
+// `mode === 'no_agent'`, the page latched in 'browser_unpaired' until a full
+// reload. It reached main and was found by reading the call graph.
+//
+// No fake timers are needed: capture `setTimeout`, then invoke the callback it
+// was handed. That drives one tick of the loop deterministically.
+
+// ASYNC and awaited. A first version was `try { return fn(...) } finally
+// { restore }` with an async `fn`, so the finally ran the instant the promise
+// was created -- setTimeout was restored before the body under test ever
+// called it, and the assertion saw zero scheduled timers. The failure looked
+// like the code under test, which is the worst kind of test bug.
+async function withCapturedTimers(fn) {
+  const real = globalThis.setTimeout;
+  const scheduled = [];
+  globalThis.setTimeout = (cb, ms) => {
+    scheduled.push({ cb, ms });
+    return scheduled.length; // a token clearTimeout can accept
+  };
+  const realClear = globalThis.clearTimeout;
+  globalThis.clearTimeout = () => {};
+  try {
+    return await fn(scheduled);
+  } finally {
+    globalThis.setTimeout = real;
+    globalThis.clearTimeout = realClear;
+  }
+}
+
+const fakeAgent = (phase) => ({
+  phase,
+  message: phase === 'unpaired' ? 'paste a token' : 'nothing answered',
+  async connect() {
+    return false;
+  },
+  async watchFleet() {},
+});
+
+test('an unpaired probe keeps probing, so a token pasted elsewhere is noticed', async () => {
+  await withCapturedTimers(async (scheduled) => {
+    const f = new FleetSession();
+    f.agent = fakeAgent('unavailable');
+
+    // `start`, not `retry`: the probe callback returns immediately unless the
+    // session has been started, so a test that only calls `retry` schedules a
+    // timer whose body never runs — and would pass or fail for the wrong
+    // reason. Going through the real entry point is the point.
+    await f.start({ watch: true });
+    expect(f.mode).toBe('no_agent');
+    expect(scheduled.length).toBe(1);
+
+    // The agent comes up, but this browser has never paired with it.
+    f.agent = fakeAgent('unpaired');
+    await scheduled[0].cb();
+
+    expect(f.mode).toBe('browser_unpaired');
+    // THE POINT: it must have re-armed. `connect()` re-reads the stored token
+    // every call, so this loop is exactly what notices one pasted on another
+    // page. Returning here latched the UI.
+    expect(scheduled.length).toBeGreaterThan(1);
+  });
 });

--- a/site/src/lib/agent/session.svelte.js
+++ b/site/src/lib/agent/session.svelte.js
@@ -20,7 +20,10 @@ import { fleet } from './fleet.svelte.js';
 import * as Placement from './placement.js';
 import { normaliseToken, storeToken } from './protocol.js';
 
-class LaunchSession {
+// Exported for tests, like FleetSession. The singleton below is what the app
+// uses; a test needs a fresh instance with a fake agent, because the behaviour
+// worth pinning is what a SILENT probe is allowed to change.
+export class LaunchSession {
   /** The one client every card shares. */
   agent = new AgentClient();
 

--- a/site/src/lib/agent/session.svelte.test.js
+++ b/site/src/lib/agent/session.svelte.test.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// `probe()` is the background poll the launch dialog runs while it shows the
+// "no agent yet" guide — and, since #803, while it shows a failure whose
+// remedy sends the operator to a terminal.
+//
+// That second case only works because the poll is SILENT: it may move the
+// dialog forward when an agent answers, and must not repaint what the operator
+// is reading when it does not. Nothing pinned that, so #803's fix rested on an
+// invariant a one-line edit could have removed without any test noticing.
+
+import { test, expect } from 'bun:test';
+import { LaunchSession } from '$lib/agent/session.svelte.js';
+
+const refusing = (phase, message) => ({
+  phase,
+  message,
+  async connect() {
+    return false;
+  },
+});
+
+test('a silent probe that fails changes nothing the operator is reading', async () => {
+  const s = new LaunchSession();
+  s.phase = 'failed';
+  s.detail = 'Your agent is out of date — update it on that machine: curl … | sh';
+  s.agent = refusing('error', 'a different, newer complaint');
+
+  await s.probe();
+
+  expect(s.phase).toBe('failed');
+  expect(s.detail).toBe('Your agent is out of date — update it on that machine: curl … | sh');
+  expect(s.busy).toBe(false);
+});
+
+test('a silent probe still moves FORWARD when an agent answers but wants pairing', async () => {
+  // "Silent" suppresses the visible effects of a FAILED attempt, not of
+  // progress: an agent that answered is news, and the dialog must act on it.
+  const s = new LaunchSession();
+  s.phase = 'guide';
+  s.agent = refusing('unpaired', 'paste a token');
+
+  await s.probe();
+
+  expect(s.phase).toBe('pairing');
+  expect(s.detail).toBe('paste a token');
+});

--- a/site/src/routes/control/+page.svelte
+++ b/site/src/routes/control/+page.svelte
@@ -331,6 +331,14 @@
           {:else if fleet.mode === 'browser_unpaired'}
             <div class="ctl-setup">
               <h2>Pair this browser with your agent</h2>
+              <!-- The reason, when the handshake gave one. `#scheduleProbe` sets
+                   `detail` on this path too, and it was rendered nowhere: the
+                   `{#if fleet.detail}` added with the no_agent panel covered only
+                   that branch, so an operator here was told to paste a token
+                   without being told what the agent actually said. -->
+              {#if fleet.detail}
+                <p class="ld-error" role="alert">{fleet.detail}</p>
+              {/if}
               <p>
                 An agent is running, but it has not seen this browser before. Run
                 <code class="mono">atlasctl agent token</code> and paste the value the

--- a/site/test-runes.js
+++ b/site/test-runes.js
@@ -1,0 +1,29 @@
+import { plugin } from 'bun';
+import { compileModule } from 'svelte/compiler';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// `.svelte.js` modules are RUNE modules: `$state` and friends are compiler
+// constructs, not runtime functions, so `bun test` cannot import them as-is.
+// That is why none of the six rune modules in this repo has ever had a test —
+// and why a latching-state regression in `fleet.svelte.js` reached main and had
+// to be found by reading the call graph instead.
+//
+// Two things are needed: compile the runes, and resolve SvelteKit's `$lib`
+// alias, which vite supplies during a real build and bun does not.
+const LIB = join(dirname(fileURLToPath(import.meta.url)), 'src', 'lib');
+
+plugin({
+  name: 'svelte-runes',
+  setup(build) {
+    build.onResolve({ filter: /^\$lib(\/|$)/ }, (args) => ({
+      path: join(LIB, args.path.slice('$lib'.length)),
+    }));
+    build.onLoad({ filter: /\.svelte\.js$/ }, (args) => {
+      const src = readFileSync(args.path, 'utf8');
+      const { js } = compileModule(src, { filename: args.path, generate: 'client' });
+      return { contents: js.code, loader: 'js' };
+    });
+  },
+});

--- a/site/test-runes.js
+++ b/site/test-runes.js
@@ -20,10 +20,28 @@ plugin({
     build.onResolve({ filter: /^\$lib(\/|$)/ }, (args) => ({
       path: join(LIB, args.path.slice('$lib'.length)),
     }));
+
+    // `$app/environment` is SvelteKit's, supplied by vite at build time and
+    // absent here. `chat/state.svelte.js` imports it, so without this a test of
+    // that module fails with "Cannot find module '$app/environment'" — an error
+    // about the harness, dressed as an error about the code.
+    //
+    // `browser: false` is the truthful answer, not a convenient one: bun test
+    // has no DOM, so code guarding DOM access with `if (browser)` SHOULD skip.
+    // Claiming true here would run those branches against globals that are not
+    // there and fail somewhere less obvious.
     build.onLoad({ filter: /\.svelte\.js$/ }, (args) => {
       const src = readFileSync(args.path, 'utf8');
       const { js } = compileModule(src, { filename: args.path, generate: 'client' });
-      return { contents: js.code, loader: 'js' };
+      // `$app/environment` is rewritten here rather than resolved in `onResolve`,
+      // which does not fire for this specifier -- `$lib` does, and removing that
+      // resolver demonstrably breaks the suite, so the difference is the specifier
+      // and not the hook. `chat/state.svelte.js` imports it, and without this a
+      // test of that module fails with "Cannot find module": an error about the
+      // harness wearing the costume of an error about the code.
+      const stub = join(dirname(fileURLToPath(import.meta.url)), 'test-stubs', 'app-environment.js');
+      const code = js.code.replaceAll("'$app/environment'", JSON.stringify(stub));
+      return { contents: code, loader: 'js' };
     });
   },
 });

--- a/site/test-stubs/app-environment.js
+++ b/site/test-stubs/app-environment.js
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Stands in for SvelteKit's `$app/environment`, which vite supplies at build
+// time and bun does not. `chat/state.svelte.js` imports it, so without this a
+// test of that module fails with "Cannot find module" — an error about the
+// harness wearing the costume of an error about the code.
+//
+// `browser` is FALSE on purpose, not for convenience: `bun test` has no DOM, so
+// code guarding DOM access with `if (browser)` should skip. Claiming true would
+// run those branches against globals that are not there and fail somewhere less
+// obvious than here.
+export const browser = false;
+export const dev = true;
+export const building = false;
+export const version = 'test';


### PR DESCRIPTION
Six `.svelte.js` modules export nine items and **not one was reachable from a test**. `$state` is a compiler construct, so `bun test` cannot import these files at all — every check on them has been "read it carefully".

That gap is not abstract. A latching-state regression in `fleet.svelte.js` reached main this morning (#807): the unpaired branch stopped rescheduling its own probe and nothing else could re-arm it, so the page could only be recovered by a full reload. It was found by an audit reading the call graph, because nothing could drive the code.

## The harness

`test-runes.js`, loaded with `--preload`, does two things:

- compiles the runes with svelte's own `compileModule` — no new dependency, the compiler is already here for the build
- resolves SvelteKit's `$lib` alias, which vite supplies during a build and bun does not

Both `test:unit` and `site.yml` preload it, so this runs in CI rather than only on my machine.

## Five tests, each pinning a decision the code explains

- a **virtual or loopback** address is never offered as the one a *peer* should dial
- link **class** decides and speed only breaks ties — a 1 Gb RoCE link still beats a 100 Gb ethernet one; sorting on speed first would hand a DGX pair the wrong interface
- `unverified` loses to every known class and is **still offered** when it is all there is, because it is missing information rather than a bad link
- `linkWarns` stays silent for it, for the same reason — warning would invent a problem out of an absence
- `isStale` measures against the sample

## Verified by mutation

```
swap the sort keys (speed first)  -> "ranks fabrics above ethernet…" FAILED
warn on unverified                -> "linkWarns stays silent…"        FAILED
```

Worth recording: my **first attempt at the ranking mutation silently did not apply**, and the giveaway was the *wrong* test failing. Both were re-run with the edited lines printed back before trusting the result.

488 pass, 0 fail.