### PR TITLE
fix(site): the pairing panel pointed at a control that is not on the page

### DIFF
--- a/site/src/routes/control/+page.svelte
+++ b/site/src/routes/control/+page.svelte
@@ -333,9 +333,10 @@
               <h2>Pair this browser with your agent</h2>
               <p>
                 An agent is running, but it has not seen this browser before. Run
-                <code class="mono">atlasctl agent token</code> and paste the value the
-                launch dialog asks for. This is separate from pairing machines to each
-                other.
+                <code class="mono">atlasctl agent token</code> and paste the value into the
+                launch dialog on the <a href="/">home page</a> — that is where the token
+                field lives, not here. This page notices on its own once you have; it keeps
+                looking. This is separate from pairing machines to each other.
               </p>
             </div>
           {:else}


### PR DESCRIPTION
Found while checking that #807's fix actually helps the operator it unblocks.

## The gap

`/control`'s `browser_unpaired` panel said:

> Run `atlasctl agent token` and paste the value **the launch dialog asks for**.

That dialog is `LaunchDialog`, mounted in `routes/+page.svelte:46` **and nowhere else**. So an operator reading this on `/control` is sent to a token field that is not on the page they are looking at — no link, no hint where to find it.

This is the panel #807 just made reachable from a silent probe. Making a dead end reachable is only an improvement if what it says can actually be acted on.

## The change

It names the home page, links to it, and says the field is not here rather than leaving that to be discovered.

It also states that **this page notices on its own** — which is true again as of #807. The probe had stopped rescheduling on this path, so the page could not leave the state without a full reload. Saying it before that fix would have been another promise the code did not keep, which is the defect this whole series has been about.

## Verification

Component compiles with 0 warnings; 483 tests pass.

Note: my first attempt at this edit mangled the paragraph — the sentence spans four lines and I replaced two, dropping the `atlasctl agent token` command and leaving a stray `other.`. Caught by printing the rendered block back before committing, and rewritten as a whole `<p>` rather than by line surgery.