### PR TITLE
fix(tests): the matrix never sees a server come up

### DIFF
--- a/tests/run_all_models.py
+++ b/tests/run_all_models.py
@@ -356,7 +356,15 @@ def ready_marker(port: int) -> str:
     downstream connection resets looked exactly like a model regression.
     Match the address we asked for, so a wrong bind cannot read as ready.
     """
-    return f"Listening on {SERVE_BIND}:{port}"
+    # Matched case-insensitively against a lower-cased log: the server does not
+    # start the line with the word. It logs
+    #   `Atlas is listening on 0.0.0.0:8888 — reachable from any host ...`
+    # so the old exact substring `Listening on 0.0.0.0:8888` matched nothing,
+    # wait_listening never saw the server come up, and EVERY model in the roster
+    # failed on a 600s startup timeout while the container sat there serving
+    # requests perfectly well. A readiness check that cannot observe readiness
+    # reports a healthy build as a total regression.
+    return f"listening on {SERVE_BIND}:{port}"
 
 
 def wait_listening(host: str, name: str, port: int,
@@ -371,17 +379,17 @@ def wait_listening(host: str, name: str, port: int,
             print(f"    [{host}/{name}] container exited unexpectedly")
             return False
         r = docker_on(host, f"logs {name} 2>&1", check=False, capture=True)
-        log = r.stdout
+        log = r.stdout.lower()
         if marker in log:
             return True
-        if "Listening on" in log:
+        if "listening on" in log:
             # Bound, but not where we asked. Fail fast and name the cause —
             # never let this fall through to a probe that will be refused.
             print(f"    [{host}/{name}] bound the WRONG address: expected "
                   f"'{marker}'. Not reachable from this harness — check the "
                   f"--bind argument and the container network mode.")
             return False
-        if "Error:" in log and "ERROR" in log:
+        if "error:" in log and "error" in log:
             print(f"    [{host}/{name}] error detected in log")
             return False
         time.sleep(10)


### PR DESCRIPTION
## The bug

`ready_marker` returns the exact substring `Listening on 0.0.0.0:8888`. The server does not start that line with the word — it logs:

```
WARN spark::main_modules::serve_router: Atlas is listening on 0.0.0.0:8888 — reachable from any host on the network. ...
```

Lower-case `listening`, and prefixed by `Atlas is`. The substring matches nothing, so `wait_listening` polls to `STARTUP_TIMEOUT` (600s) and returns `False` — **for every model in the roster**, while the container is serving requests perfectly well.

A readiness check that cannot observe readiness reports a completely healthy build as a total regression, and spends ten minutes per model doing it.

## Observed

A roster run sat 9 minutes on its first model with no suite child process and an idle GPU. Meanwhile:

```
$ curl -s http://127.0.0.1:8888/v1/models
{"object":"list","data":[{"id":"unsloth/Qwen3.8-27B-NVFP4",...,"max_model_len":32768}]}
```

The server was up the entire time. After this change the same run reaches its suite within a minute.

## The fix

Compare against a lower-cased log. That survives both the prefix and the case.

What the marker is *for* is unchanged and still load-bearing: it pins the address the harness asked for, so a server that bound `127.0.0.1` cannot read as ready. The wrong-bind branch is matched the same way and still fires — verified:

| case | result |
|---|---|
| old marker vs. real log line | no match (the bug) |
| new marker vs. real log line | match |
| new marker vs. a `127.0.0.1` bind | no match, and the wrong-bind branch fires |

The `Error:`/`ERROR` early-exit branch is lower-cased alongside it, since it reads the same variable.

## Why it was not noticed

Nothing in CI runs this harness — it needs a GB10 and real checkpoints, so it only ever runs by hand on a box like the DGX pair. The log line evidently changed after the last hand-run.