### PR TITLE
fix(bench): control concurrency warmup prompts

### DIFF
--- a/crates/atlas-plugin/src/benchmarks/concurrency.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency.rs
@@ -102,6 +102,7 @@ const CODE_TASK: &str = "Ignore the reference text above. Task: write a complete
 /// its whole cell vacuous. 80%: a natural stop a few tokens early is fine; a
 /// 49-token burst against a 512-token budget is not a throughput measurement.
 const VACUITY_FLOOR: f64 = 0.8;
+const WARM_CACHE_FLOOR: f64 = 0.8;
 
 /// What one completed request actually delivered — the evidence a cell's
 /// tok/s stands on. `http::ChatOutcome` already parses all of this from the
@@ -110,6 +111,7 @@ const VACUITY_FLOOR: f64 = 0.8;
 #[derive(Clone, Debug, Default)]
 struct RequestEvidence {
     completion_tokens: usize,
+    prompt_tokens: usize,
     cached_prompt_tokens: usize,
     finish_reason: Option<String>,
     server_ttft_ms: Option<f64>,
@@ -127,9 +129,11 @@ fn cell_is_vacuous(requests: &[RequestEvidence], osl: usize) -> bool {
 
 fn cache_is_uncontrolled(requests: &[RequestEvidence], warmup: usize) -> bool {
     warmup > 0
-        && requests
-            .iter()
-            .any(|request| request.cached_prompt_tokens == 0)
+        && requests.iter().any(|request| {
+            request.prompt_tokens == 0
+                || (request.cached_prompt_tokens as f64)
+                    < WARM_CACHE_FLOOR * request.prompt_tokens as f64
+        })
 }
 
 /// The prompt identities one cell executes before and during measurement.
@@ -169,6 +173,18 @@ impl CellRow {
     }
     fn min_cached_prompt(&self) -> Option<usize> {
         self.requests.iter().map(|r| r.cached_prompt_tokens).min()
+    }
+    fn min_cached_prompt_pct(&self) -> Option<f64> {
+        self.requests
+            .iter()
+            .map(|request| {
+                if request.prompt_tokens == 0 {
+                    0.0
+                } else {
+                    request.cached_prompt_tokens as f64 / request.prompt_tokens as f64 * 100.0
+                }
+            })
+            .reduce(f64::min)
     }
     /// Clean and above the vacuity floor — the only rows metrics may quote.
     fn comparable(&self) -> bool {
@@ -310,6 +326,7 @@ impl ConcurrencySweep {
                     tokens += o.completion_tokens;
                     requests.push(RequestEvidence {
                         completion_tokens: o.completion_tokens,
+                        prompt_tokens: o.prompt_tokens,
                         cached_prompt_tokens: o.cached_prompt_tokens,
                         finish_reason: o.finish_reason.clone(),
                         server_ttft_ms: o.server_ttft_ms,
@@ -325,8 +342,8 @@ impl ConcurrencySweep {
         let vacuous = cell_is_vacuous(&requests, self.osl);
         // Matching prompt bytes reach the intended setup, but the endpoint's
         // usage is the oracle for whether the measured request actually used
-        // cached prompt state. A requested warm path with a zero or omitted
-        // cached-token count is a different instrument.
+        // the warmed prompt. A small shared chat-template prefix is not enough:
+        // require a material cached fraction of each measured prompt.
         let cache_uncontrolled = cache_is_uncontrolled(&requests, self.warmup);
         handle.info(evidence_line(isl, conc, &requests));
         if vacuous {
@@ -345,7 +362,8 @@ impl ConcurrencySweep {
         if cache_uncontrolled {
             handle.warn(format!(
                 "isl {isl} conc {conc}: warm-up was requested but at least one measured request \
-                 reported zero cached prompt tokens — this cell is NOT comparable"
+                 reported less than {:.0}% of its prompt as cached — this cell is NOT comparable",
+                WARM_CACHE_FLOOR * 100.0,
             ));
         }
         Ok(CellRow {
@@ -500,6 +518,14 @@ impl ConcurrencySweep {
         {
             m.insert("min_cached_prompt_tokens".to_string(), min as f64);
         }
+        if let Some(min) = self
+            .rows
+            .iter()
+            .filter_map(CellRow::min_cached_prompt_pct)
+            .reduce(f64::min)
+        {
+            m.insert("min_cached_prompt_pct".to_string(), min);
+        }
         m.insert(
             "vacuous_cells".to_string(),
             self.rows.iter().filter(|r| r.vacuous).count() as f64,
@@ -522,7 +548,7 @@ fn evidence_line(isl: usize, conc: usize, requests: &[RequestEvidence]) -> Strin
         .collect();
     let cached: Vec<String> = requests
         .iter()
-        .map(|r| r.cached_prompt_tokens.to_string())
+        .map(|r| format!("{}/{}", r.cached_prompt_tokens, r.prompt_tokens))
         .collect();
     let mut finish: BTreeMap<&str, usize> = BTreeMap::new();
     for r in requests {

--- a/crates/atlas-plugin/src/benchmarks/concurrency.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency.rs
@@ -102,6 +102,10 @@ const CODE_TASK: &str = "Ignore the reference text above. Task: write a complete
 /// its whole cell vacuous. 80%: a natural stop a few tokens early is fine; a
 /// 49-token burst against a 512-token budget is not a throughput measurement.
 const VACUITY_FLOOR: f64 = 0.8;
+// `make_prompt` puts the distinguishing tag at byte zero of message content;
+// a wrong tag can share only the chat-template prefix, about 12 tokens against
+// the minimum 128-token ISL. An exact warmed prompt is block-aligned near the
+// full length, so 80% separates substantial reuse from incidental template KV.
 const WARM_CACHE_FLOOR: f64 = 0.8;
 
 /// What one completed request actually delivered — the evidence a cell's

--- a/crates/atlas-plugin/src/benchmarks/concurrency.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency.rs
@@ -55,8 +55,8 @@ pub const DESCRIPTOR: BenchmarkDescriptor = BenchmarkDescriptor {
              (C=1/4/8/16, isl 512, osl 320 via the variant's param_overrides) and \
              self-verdicts against gate-filled per-rung floors; a sweep with any vacuous \
              cell or request error never passes, whatever the floors say.",
-    duration_hint: "~15–45 min",
-    updated: "2026-08-15",
+    duration_hint: "~25–90 min",
+    updated: "2026-08-29",
     needs_confirmation: false,
     // A latency/throughput curve is meaningful for any served model; there is
     // no threshold here tied to a checkpoint.
@@ -122,6 +122,23 @@ fn cell_is_vacuous(requests: &[RequestEvidence], osl: usize) -> bool {
     requests
         .iter()
         .any(|r| (r.completion_tokens as f64) < VACUITY_FLOOR * osl as f64)
+}
+
+/// The prompt identities one cell executes before and during measurement.
+/// Keeping the policy in one value makes the cache-state claim testable
+/// without substituting a fake HTTP implementation for the benchmark.
+#[derive(Debug, PartialEq, Eq)]
+struct PromptPlan {
+    warmup_rounds: Vec<Vec<String>>,
+    measured: Vec<String>,
+}
+
+fn prompt_plan(conc: usize, warmup: usize) -> PromptPlan {
+    let measured: Vec<String> = (0..conc).map(|i| format!("c{i}")).collect();
+    PromptPlan {
+        warmup_rounds: vec![measured.clone(); warmup],
+        measured,
+    }
 }
 
 #[derive(Default)]
@@ -231,23 +248,34 @@ impl ConcurrencySweep {
 
     async fn run_cell(&mut self, isl: usize, conc: usize) -> Result<CellRow> {
         let handle = self.handle()?.clone();
-        for w in 0..self.warmup {
+        let plan = prompt_plan(conc, self.warmup);
+        for (w, tags) in plan.warmup_rounds.iter().enumerate() {
             handle.check_cancelled()?;
             handle.status(format!(
-                "isl {isl} · conc {conc} · warmup {}/{}",
+                "isl {isl} · conc {conc} · warmup round {}/{}",
                 w + 1,
                 self.warmup
             ));
-            // Warm-up uses the SAME prompt the measured batch will use, which is
-            // the point: it primes the prefix cache so the timed requests measure
-            // the warm path rather than a one-off cold prefill.
-            let _ = self.one(isl, "warm".to_string()).await;
+            // Prime every exact prompt the measured batch will use. A single
+            // unrelated `warm` tag leaves all measured prompts cold, while
+            // reusing c0/c1/... across later rungs produces a history-dependent
+            // mixture of cached and new prompts. A failed warm-up invalidates
+            // the declared setup instead of silently changing the instrument.
+            for tag in tags {
+                self.one(isl, tag.clone()).await.with_context(|| {
+                    format!("isl {isl} conc {conc}: warm-up prompt {tag} failed")
+                })?;
+            }
         }
         handle.check_cancelled()?;
         handle.status(format!("isl {isl} · conc {conc} · {conc} in flight"));
 
         let batch_start = Instant::now();
-        let futures: Vec<_> = (0..conc).map(|i| self.one(isl, format!("c{i}"))).collect();
+        let futures: Vec<_> = plan
+            .measured
+            .into_iter()
+            .map(|tag| self.one(isl, tag))
+            .collect();
         let outcomes = futures::future::join_all(futures).await;
         let wall = batch_start.elapsed().as_secs_f64().max(1e-6);
 
@@ -523,8 +551,9 @@ impl Benchmark for ConcurrencySweep {
             ),
             ParamSpec::new(
                 "warmup",
-                "Warm-up requests",
-                "Unmeasured requests per cell, priming the prefix cache.",
+                "Warm-up rounds",
+                "Unmeasured rounds per cell. Each round runs every exact prompt in the measured \
+                 batch so prefix-cache state is controlled before timing.",
                 ParamKind::Int { min: 0, max: 8 },
                 ParamValue::Int(1),
             ),

--- a/crates/atlas-plugin/src/benchmarks/concurrency.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency.rs
@@ -110,6 +110,7 @@ const VACUITY_FLOOR: f64 = 0.8;
 #[derive(Clone, Debug, Default)]
 struct RequestEvidence {
     completion_tokens: usize,
+    cached_prompt_tokens: usize,
     finish_reason: Option<String>,
     server_ttft_ms: Option<f64>,
     server_tps: Option<f64>,
@@ -122,6 +123,13 @@ fn cell_is_vacuous(requests: &[RequestEvidence], osl: usize) -> bool {
     requests
         .iter()
         .any(|r| (r.completion_tokens as f64) < VACUITY_FLOOR * osl as f64)
+}
+
+fn cache_is_uncontrolled(requests: &[RequestEvidence], warmup: usize) -> bool {
+    warmup > 0
+        && requests
+            .iter()
+            .any(|request| request.cached_prompt_tokens == 0)
 }
 
 /// The prompt identities one cell executes before and during measurement.
@@ -152,15 +160,19 @@ struct CellRow {
     errors: usize,
     requests: Vec<RequestEvidence>,
     vacuous: bool,
+    cache_uncontrolled: bool,
 }
 
 impl CellRow {
     fn min_completion(&self) -> Option<usize> {
         self.requests.iter().map(|r| r.completion_tokens).min()
     }
+    fn min_cached_prompt(&self) -> Option<usize> {
+        self.requests.iter().map(|r| r.cached_prompt_tokens).min()
+    }
     /// Clean and above the vacuity floor — the only rows metrics may quote.
     fn comparable(&self) -> bool {
-        self.errors == 0 && !self.vacuous
+        self.errors == 0 && !self.vacuous && !self.cache_uncontrolled
     }
 }
 
@@ -298,6 +310,7 @@ impl ConcurrencySweep {
                     tokens += o.completion_tokens;
                     requests.push(RequestEvidence {
                         completion_tokens: o.completion_tokens,
+                        cached_prompt_tokens: o.cached_prompt_tokens,
                         finish_reason: o.finish_reason.clone(),
                         server_ttft_ms: o.server_ttft_ms,
                         server_tps: o.server_tps,
@@ -310,6 +323,11 @@ impl ConcurrencySweep {
             }
         }
         let vacuous = cell_is_vacuous(&requests, self.osl);
+        // Matching prompt bytes reach the intended setup, but the endpoint's
+        // usage is the oracle for whether the measured request actually used
+        // cached prompt state. A requested warm path with a zero or omitted
+        // cached-token count is a different instrument.
+        let cache_uncontrolled = cache_is_uncontrolled(&requests, self.warmup);
         handle.info(evidence_line(isl, conc, &requests));
         if vacuous {
             handle.warn(format!(
@@ -324,6 +342,12 @@ impl ConcurrencySweep {
                     .unwrap_or(0),
             ));
         }
+        if cache_uncontrolled {
+            handle.warn(format!(
+                "isl {isl} conc {conc}: warm-up was requested but at least one measured request \
+                 reported zero cached prompt tokens — this cell is NOT comparable"
+            ));
+        }
         Ok(CellRow {
             isl,
             conc,
@@ -334,6 +358,7 @@ impl ConcurrencySweep {
             errors,
             requests,
             vacuous,
+            cache_uncontrolled,
         })
     }
 
@@ -351,6 +376,7 @@ impl ConcurrencySweep {
                 Column::right("E2E p50", 9),
                 Column::right("tok/s", 8),
                 Column::right("min tok", 7),
+                Column::right("min cache", 9),
                 Column::right("err", 4),
             ],
         );
@@ -374,6 +400,11 @@ impl ConcurrencySweep {
                 },
                 Cell::new(
                     r.min_completion()
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "—".into()),
+                ),
+                Cell::new(
+                    r.min_cached_prompt()
                         .map(|v| v.to_string())
                         .unwrap_or_else(|| "—".into()),
                 ),
@@ -461,9 +492,21 @@ impl ConcurrencySweep {
         if let Some(min) = self.rows.iter().filter_map(CellRow::min_completion).min() {
             m.insert("min_completion_tokens".to_string(), min as f64);
         }
+        if let Some(min) = self
+            .rows
+            .iter()
+            .filter_map(CellRow::min_cached_prompt)
+            .min()
+        {
+            m.insert("min_cached_prompt_tokens".to_string(), min as f64);
+        }
         m.insert(
             "vacuous_cells".to_string(),
             self.rows.iter().filter(|r| r.vacuous).count() as f64,
+        );
+        m.insert(
+            "cache_uncontrolled_cells".to_string(),
+            self.rows.iter().filter(|r| r.cache_uncontrolled).count() as f64,
         );
         m
     }
@@ -477,6 +520,10 @@ fn evidence_line(isl: usize, conc: usize, requests: &[RequestEvidence]) -> Strin
         .iter()
         .map(|r| r.completion_tokens.to_string())
         .collect();
+    let cached: Vec<String> = requests
+        .iter()
+        .map(|r| r.cached_prompt_tokens.to_string())
+        .collect();
     let mut finish: BTreeMap<&str, usize> = BTreeMap::new();
     for r in requests {
         *finish
@@ -487,8 +534,9 @@ fn evidence_line(isl: usize, conc: usize, requests: &[RequestEvidence]) -> Strin
     let sttft: Vec<f64> = requests.iter().filter_map(|r| r.server_ttft_ms).collect();
     let stps: Vec<f64> = requests.iter().filter_map(|r| r.server_tps).collect();
     let mut line = format!(
-        "evidence isl {isl} conc {conc}: tok [{}] · finish [{}]",
+        "evidence isl {isl} conc {conc}: tok [{}] · cached [{}] · finish [{}]",
         toks.join(","),
+        cached.join(","),
         finish.join(",")
     );
     if let Some(v) = stats::percentile(&sttft, 50) {
@@ -646,6 +694,7 @@ impl Benchmark for ConcurrencySweep {
         if self.cursor >= self.cells.len() {
             let errors: usize = self.rows.iter().map(|r| r.errors).sum();
             let vacuous = self.rows.iter().filter(|r| r.vacuous).count();
+            let cache_uncontrolled = self.rows.iter().filter(|r| r.cache_uncontrolled).count();
             // The verdict is computed over the SAME metrics map the gate
             // record carries (see `verdict::sweep_verdict`), so the two can
             // never disagree about a rung's value. Floors all-zero keeps the
@@ -656,6 +705,7 @@ impl Benchmark for ConcurrencySweep {
                 self.rows.len(),
                 errors,
                 vacuous,
+                cache_uncontrolled,
                 VACUITY_FLOOR * 100.0,
                 &self.floors,
             );

--- a/crates/atlas-plugin/src/benchmarks/concurrency.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency.rs
@@ -398,7 +398,7 @@ impl ConcurrencySweep {
                 Column::right("E2E p50", 9),
                 Column::right("tok/s", 8),
                 Column::right("min tok", 7),
-                Column::right("min cache", 9),
+                Column::right("min cache%", 10),
                 Column::right("err", 4),
             ],
         );
@@ -415,7 +415,7 @@ impl ConcurrencySweep {
                 // A vacuous cell's tok/s is printed struck with a marker, not
                 // hidden: the number is evidence of the failure, it is just
                 // not comparable to anything.
-                if r.vacuous {
+                if r.vacuous || r.cache_uncontrolled {
                     Cell::styled(format!("{:.1}*", r.throughput), CellStyle::Bad)
                 } else {
                     Cell::styled(format!("{:.1}", r.throughput), CellStyle::Good)
@@ -426,8 +426,8 @@ impl ConcurrencySweep {
                         .unwrap_or_else(|| "—".into()),
                 ),
                 Cell::new(
-                    r.min_cached_prompt()
-                        .map(|v| v.to_string())
+                    r.min_cached_prompt_pct()
+                        .map(|v| format!("{v:.0}"))
                         .unwrap_or_else(|| "—".into()),
                 ),
                 Cell::styled(

--- a/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
@@ -227,6 +227,14 @@ fn a_requested_warm_path_requires_observed_cached_tokens() {
     missing_usage.prompt_tokens = 0;
     missing_usage.cached_prompt_tokens = 0;
     assert!(cache_is_uncontrolled(&[missing_usage], 1));
+
+    let mut b = configured(vec![4], vec![512]);
+    b.rows.push(missed);
+    let table = b.table();
+    assert_eq!(table.columns[10].title, "min cache%");
+    assert_eq!(table.rows[0][8].style, CellStyle::Bad);
+    assert_eq!(table.rows[0][8].text, "100.0*");
+    assert_eq!(table.rows[0][10].text, "0");
 }
 
 // ---- metrics map ------------------------------------------------------------
@@ -257,8 +265,6 @@ fn metrics_map_reports_the_comparable_curve_and_the_evidence_floor() {
     assert_eq!(m.get("c1_ttft_p50_ms"), Some(&120.0));
     assert_eq!(m.get("c4_ttft_p50_ms"), Some(&150.0));
     assert_eq!(m.get("peak_aggregate_tok_s"), Some(&100.0));
-    // The floor sees THROUGH the exclusion: the 1-token requests are the
-    // record of what went wrong.
     assert_eq!(m.get("min_completion_tokens"), Some(&1.0));
     assert_eq!(m.get("min_cached_prompt_tokens"), Some(&512.0));
     assert_eq!(m.get("min_cached_prompt_pct"), Some(&100.0));
@@ -279,8 +285,6 @@ fn metrics_map_with_no_comparable_cells_still_reports_evidence() {
     assert_eq!(m.get("min_completion_tokens"), Some(&0.0));
     assert_eq!(m.get("vacuous_cells"), Some(&1.0));
 }
-
-// ---- self-verdict (C1 pattern, gate promotion 2026-08-15) -------------------
 
 use super::verdict::{Floors, sweep_verdict};
 use crate::result::VerdictKind;
@@ -330,9 +334,6 @@ fn committed_floors() -> Floors {
     }
 }
 
-/// The calibrated ladder against its committed floors — the PASS the gate
-/// machinery requires now that the sweep is REQUIRED. The reason names every
-/// gated rung so the record reads as evidence, not a bare verdict.
 #[test]
 fn a_clean_sweep_that_clears_every_floor_passes() {
     let m = ladder(&[
@@ -435,8 +436,6 @@ fn a_gated_rung_with_no_comparable_cell_fails_as_inconclusive() {
     assert!(v.reason.contains("peak"), "{}", v.reason);
 }
 
-/// Request errors fail the sweep gating or not — an errored cell's numbers
-/// are not comparable, and the floors cannot buy them back.
 #[test]
 fn request_errors_fail_the_sweep_in_both_modes() {
     let m = ladder(&[("c1_aggregate_tok_s", 999.0)]);

--- a/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
@@ -212,6 +212,9 @@ fn a_requested_warm_path_requires_observed_cached_tokens() {
     assert!(!missed.comparable());
     assert_eq!(missed.min_cached_prompt(), Some(0));
     assert_eq!(missed.min_cached_prompt_pct(), Some(0.0));
+    assert!(
+        evidence_line(512, 4, &missed.requests).contains("cached [512/512,512/512,0/512,512/512]")
+    );
 
     assert!(!cache_is_uncontrolled(&missed.requests, 0));
     assert!(!cache_is_uncontrolled(&[evidence(128), evidence(128)], 1));
@@ -384,9 +387,6 @@ fn a_sweep_below_one_floor_fails_naming_the_cell() {
     assert_eq!(v.kind, VerdictKind::Pass, "{}", v.reason);
 }
 
-/// Floors all zero (the schema default) keep the pre-gate info verdicts, both
-/// arms verbatim: a standalone sweep has no committed ladder to be judged
-/// against.
 #[test]
 fn all_floors_zero_keeps_the_info_verdicts() {
     let m = ladder(&[("c1_aggregate_tok_s", 25.5)]);

--- a/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
@@ -88,6 +88,31 @@ fn reconfiguring_clears_prior_rows() {
     assert!(b.rows.is_empty() && b.cursor == 0);
 }
 
+#[test]
+fn warmup_and_measurement_share_the_complete_prompt_set() {
+    let b = configured(vec![4], vec![512]);
+    let plan = prompt_plan(4, 2);
+
+    assert!(prompt_plan(4, 0).warmup_rounds.is_empty());
+    assert_eq!(plan.measured, ["c0", "c1", "c2", "c3"]);
+    assert_eq!(
+        plan.warmup_rounds,
+        [plan.measured.clone(), plan.measured.clone()]
+    );
+    let warmup_prompts: Vec<_> = plan.warmup_rounds[0]
+        .iter()
+        .map(|tag| b.cell_prompt(512, tag))
+        .collect();
+    let measured_prompts: Vec<_> = plan
+        .measured
+        .iter()
+        .map(|tag| b.cell_prompt(512, tag))
+        .collect();
+
+    assert_eq!(warmup_prompts, measured_prompts);
+    assert_ne!(b.cell_prompt(512, "warm"), measured_prompts[0]);
+}
+
 // ---- fixture selection ------------------------------------------------------
 
 /// The default is the natural code-generation fixture — the 2026-08-15

--- a/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
@@ -17,6 +17,7 @@ fn configured(concs: Vec<i64>, isls: Vec<i64>) -> ConcurrencySweep {
 fn evidence(completion_tokens: usize) -> RequestEvidence {
     RequestEvidence {
         completion_tokens,
+        cached_prompt_tokens: 1,
         finish_reason: Some("length".into()),
         server_ttft_ms: None,
         server_tps: None,
@@ -45,6 +46,7 @@ fn row(
         errors: 0,
         requests,
         vacuous,
+        cache_uncontrolled: false,
     }
 }
 
@@ -205,6 +207,21 @@ fn a_vacuous_cell_is_not_comparable_and_an_errored_cell_is_not_either() {
     assert!(!errored.comparable());
 }
 
+#[test]
+fn a_requested_warm_path_requires_observed_cached_tokens() {
+    let osl = 128;
+    let mut missed = row(4, 100.0, Some(50.0), vec![evidence(128); 4], osl);
+    missed.requests[2].cached_prompt_tokens = 0;
+    missed.cache_uncontrolled = cache_is_uncontrolled(&missed.requests, 1);
+
+    assert!(missed.cache_uncontrolled);
+    assert!(!missed.comparable());
+    assert_eq!(missed.min_cached_prompt(), Some(0));
+
+    assert!(!cache_is_uncontrolled(&missed.requests, 0));
+    assert!(!cache_is_uncontrolled(&[evidence(128), evidence(128)], 1));
+}
+
 // ---- metrics map ------------------------------------------------------------
 
 /// The sweep previously emitted NO metrics at all — nothing for a future
@@ -236,7 +253,9 @@ fn metrics_map_reports_the_comparable_curve_and_the_evidence_floor() {
     // The floor sees THROUGH the exclusion: the 1-token requests are the
     // record of what went wrong.
     assert_eq!(m.get("min_completion_tokens"), Some(&1.0));
+    assert_eq!(m.get("min_cached_prompt_tokens"), Some(&1.0));
     assert_eq!(m.get("vacuous_cells"), Some(&1.0));
+    assert_eq!(m.get("cache_uncontrolled_cells"), Some(&0.0));
 }
 
 #[test]
@@ -321,7 +340,7 @@ fn a_clean_sweep_that_clears_every_floor_passes() {
         vec![(1, 17.0), (4, 35.0), (8, 52.0), (16, 73.5)]
     );
     assert_eq!(floors.peak, 73.5);
-    let v = sweep_verdict(&m, 4, 0, 0, 80.0, &floors);
+    let v = sweep_verdict(&m, 4, 0, 0, 0, 80.0, &floors);
     assert_eq!(v.kind, VerdictKind::Pass, "{}", v.reason);
     for rung in ["C1", "C4", "C8", "C16", "peak"] {
         assert!(v.reason.contains(rung), "{}", v.reason);
@@ -342,7 +361,7 @@ fn a_sweep_below_one_floor_fails_naming_the_cell() {
         ("c16_aggregate_tok_s", 98.9),
         ("peak_aggregate_tok_s", 98.9),
     ]);
-    let v = sweep_verdict(&m, 4, 0, 0, 80.0, &committed);
+    let v = sweep_verdict(&m, 4, 0, 0, 0, 80.0, &committed);
     assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
     assert!(v.reason.contains("C=8"), "{}", v.reason);
     assert!(
@@ -352,7 +371,7 @@ fn a_sweep_below_one_floor_fails_naming_the_cell() {
     );
     // Exactly on the floor passes — inclusive, like the BENCH.toml bound.
     let m = ladder(&[("c8_aggregate_tok_s", c8_floor)]);
-    let v = sweep_verdict(&m, 1, 0, 0, 80.0, &floors(0.0, 0.0, c8_floor, 0.0, 0.0));
+    let v = sweep_verdict(&m, 1, 0, 0, 0, 80.0, &floors(0.0, 0.0, c8_floor, 0.0, 0.0));
     assert_eq!(v.kind, VerdictKind::Pass, "{}", v.reason);
 }
 
@@ -362,14 +381,14 @@ fn a_sweep_below_one_floor_fails_naming_the_cell() {
 #[test]
 fn all_floors_zero_keeps_the_info_verdicts() {
     let m = ladder(&[("c1_aggregate_tok_s", 25.5)]);
-    let clean = sweep_verdict(&m, 4, 0, 0, 80.0, &Floors::default());
+    let clean = sweep_verdict(&m, 4, 0, 0, 0, 80.0, &Floors::default());
     assert_eq!(clean.kind, VerdictKind::Info, "{}", clean.reason);
     assert!(
         clean.reason.contains("no request errors"),
         "{}",
         clean.reason
     );
-    let vac = sweep_verdict(&m, 4, 0, 2, 80.0, &Floors::default());
+    let vac = sweep_verdict(&m, 4, 0, 2, 0, 80.0, &Floors::default());
     assert_eq!(vac.kind, VerdictKind::Info, "{}", vac.reason);
     assert!(vac.reason.contains("not comparable"), "{}", vac.reason);
 }
@@ -386,7 +405,7 @@ fn vacuous_cells_fail_a_gating_sweep_regardless_of_the_floors() {
         ("c16_aggregate_tok_s", 999.0),
         ("peak_aggregate_tok_s", 999.0),
     ]);
-    let v = sweep_verdict(&m, 4, 0, 1, 80.0, &floors(24.0, 43.0, 63.0, 94.0, 94.0));
+    let v = sweep_verdict(&m, 4, 0, 1, 0, 80.0, &floors(24.0, 43.0, 63.0, 94.0, 94.0));
     assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
     assert!(v.reason.contains("INCONCLUSIVE"), "{}", v.reason);
     assert!(v.reason.contains("vacuity floor"), "{}", v.reason);
@@ -398,12 +417,12 @@ fn vacuous_cells_fail_a_gating_sweep_regardless_of_the_floors() {
 fn a_gated_rung_with_no_comparable_cell_fails_as_inconclusive() {
     // C=16 gated but absent from the metrics (its only cell was excluded).
     let m = ladder(&[("c1_aggregate_tok_s", 25.5)]);
-    let v = sweep_verdict(&m, 4, 0, 0, 80.0, &floors(0.0, 0.0, 0.0, 94.0, 0.0));
+    let v = sweep_verdict(&m, 4, 0, 0, 0, 80.0, &floors(0.0, 0.0, 0.0, 94.0, 0.0));
     assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
     assert!(v.reason.contains("C=16"), "{}", v.reason);
     assert!(v.reason.contains("INCONCLUSIVE"), "{}", v.reason);
     // Same for the peak floor.
-    let v = sweep_verdict(&m, 4, 0, 0, 80.0, &floors(0.0, 0.0, 0.0, 0.0, 94.0));
+    let v = sweep_verdict(&m, 4, 0, 0, 0, 80.0, &floors(0.0, 0.0, 0.0, 0.0, 94.0));
     assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
     assert!(v.reason.contains("peak"), "{}", v.reason);
 }
@@ -414,10 +433,25 @@ fn a_gated_rung_with_no_comparable_cell_fails_as_inconclusive() {
 fn request_errors_fail_the_sweep_in_both_modes() {
     let m = ladder(&[("c1_aggregate_tok_s", 999.0)]);
     for f in [Floors::default(), floors(24.0, 43.0, 63.0, 94.0, 94.0)] {
-        let v = sweep_verdict(&m, 4, 2, 0, 80.0, &f);
+        let v = sweep_verdict(&m, 4, 2, 0, 0, 80.0, &f);
         assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
         assert!(v.reason.contains("2 request(s) failed"), "{}", v.reason);
     }
+}
+
+#[test]
+fn an_unobserved_warm_cache_cannot_clear_the_gate() {
+    let m = ladder(&[
+        ("c1_aggregate_tok_s", 999.0),
+        ("c4_aggregate_tok_s", 999.0),
+        ("c8_aggregate_tok_s", 999.0),
+        ("c16_aggregate_tok_s", 999.0),
+        ("peak_aggregate_tok_s", 999.0),
+    ]);
+    let v = sweep_verdict(&m, 4, 0, 0, 1, 80.0, &floors(24.0, 43.0, 63.0, 94.0, 94.0));
+
+    assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
+    assert!(v.reason.contains("cached prompt tokens"), "{}", v.reason);
 }
 
 /// The descriptor couples each floor param to the metric its BENCH.toml bound

--- a/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
@@ -17,7 +17,8 @@ fn configured(concs: Vec<i64>, isls: Vec<i64>) -> ConcurrencySweep {
 fn evidence(completion_tokens: usize) -> RequestEvidence {
     RequestEvidence {
         completion_tokens,
-        cached_prompt_tokens: 1,
+        prompt_tokens: 512,
+        cached_prompt_tokens: 512,
         finish_reason: Some("length".into()),
         server_ttft_ms: None,
         server_tps: None,
@@ -217,9 +218,22 @@ fn a_requested_warm_path_requires_observed_cached_tokens() {
     assert!(missed.cache_uncontrolled);
     assert!(!missed.comparable());
     assert_eq!(missed.min_cached_prompt(), Some(0));
+    assert_eq!(missed.min_cached_prompt_pct(), Some(0.0));
 
     assert!(!cache_is_uncontrolled(&missed.requests, 0));
     assert!(!cache_is_uncontrolled(&[evidence(128), evidence(128)], 1));
+
+    let mut boundary = evidence(128);
+    boundary.prompt_tokens = 100;
+    boundary.cached_prompt_tokens = 80;
+    assert!(!cache_is_uncontrolled(&[boundary.clone()], 1));
+    boundary.cached_prompt_tokens = 79;
+    assert!(cache_is_uncontrolled(&[boundary], 1));
+
+    let mut missing_usage = evidence(128);
+    missing_usage.prompt_tokens = 0;
+    missing_usage.cached_prompt_tokens = 0;
+    assert!(cache_is_uncontrolled(&[missing_usage], 1));
 }
 
 // ---- metrics map ------------------------------------------------------------
@@ -253,7 +267,8 @@ fn metrics_map_reports_the_comparable_curve_and_the_evidence_floor() {
     // The floor sees THROUGH the exclusion: the 1-token requests are the
     // record of what went wrong.
     assert_eq!(m.get("min_completion_tokens"), Some(&1.0));
-    assert_eq!(m.get("min_cached_prompt_tokens"), Some(&1.0));
+    assert_eq!(m.get("min_cached_prompt_tokens"), Some(&512.0));
+    assert_eq!(m.get("min_cached_prompt_pct"), Some(&100.0));
     assert_eq!(m.get("vacuous_cells"), Some(&1.0));
     assert_eq!(m.get("cache_uncontrolled_cells"), Some(&0.0));
 }
@@ -451,7 +466,7 @@ fn an_unobserved_warm_cache_cannot_clear_the_gate() {
     let v = sweep_verdict(&m, 4, 0, 0, 1, 80.0, &floors(24.0, 43.0, 63.0, 94.0, 94.0));
 
     assert_eq!(v.kind, VerdictKind::Fail, "{}", v.reason);
-    assert!(v.reason.contains("cached prompt tokens"), "{}", v.reason);
+    assert!(v.reason.contains("cached-prompt fraction"), "{}", v.reason);
 }
 
 /// The descriptor couples each floor param to the metric its BENCH.toml bound

--- a/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_tests.rs
@@ -61,9 +61,6 @@ fn cells_are_isl_major() {
 fn defaults_are_the_campaign_sweep() {
     let b = ConcurrencySweep::default();
     let v = ParamValues::defaults(&b.parameters());
-    // The PARAM DEFAULTS are what actually runs — `configure()` rebuilds
-    // from these, so a descriptor blurb saying "1 → 32" proves nothing on
-    // its own. This assertion is the only thing that pins the sweep.
     assert_eq!(v.int_list("concurrencies").unwrap(), &[1, 2, 4, 8, 16, 32]);
     assert_eq!(v.int_list("isls").unwrap(), &[128, 512, 1024, 2048]);
     assert_eq!(v.usize("osl").unwrap(), 128);
@@ -176,13 +173,9 @@ fn prompt_mode_help_does_not_claim_to_force_the_budget() {
     );
 }
 
-// ---- vacuity floor ----------------------------------------------------------
-
 #[test]
 fn vacuity_flags_any_request_below_80_pct_of_osl() {
     let osl = 100;
-    // Exactly at the floor is NOT vacuous (a natural stop a few tokens early
-    // is fine); one token below it is.
     assert!(!cell_is_vacuous(&[evidence(80), evidence(100)], osl));
     assert!(cell_is_vacuous(&[evidence(79), evidence(100)], osl));
     // ONE short request poisons the whole cell — its wall time is in the

--- a/crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs
@@ -17,8 +17,9 @@
 //! * VACUOUS cells make a gating run INCONCLUSIVE (a failing verdict), never
 //!   PASS: an aggregate that divides undelivered tokens' wall time into real
 //!   tokens cannot clear a throughput floor, however large it prints.
-//! * a requested warm path with no observed cached prompt tokens is likewise
-//!   INCONCLUSIVE: matching request bytes do not prove the cache served them.
+//! * a requested warm path without a material observed cached-prompt fraction
+//!   is likewise INCONCLUSIVE: matching request bytes do not prove the cache
+//!   served them, and a small shared template prefix is not the named setup.
 
 use std::collections::BTreeMap;
 
@@ -70,7 +71,7 @@ pub(crate) fn sweep_verdict(
         return if vacuous > 0 || cache_uncontrolled > 0 {
             Verdict::info(format!(
                 "{cells} cells, {vacuous} below the vacuity floor ({vacuity_floor_pct:.0}% \
-                 of osl), {cache_uncontrolled} without observed warm-cache use — flagged \
+                 of osl), {cache_uncontrolled} without sufficient observed warm-cache use — flagged \
                  rows' tok/s are not comparable"
             ))
         } else {
@@ -89,7 +90,7 @@ pub(crate) fn sweep_verdict(
     if cache_uncontrolled > 0 {
         return Verdict::fail(format!(
             "INCONCLUSIVE: {cache_uncontrolled} of {cells} cells requested warm-up but a \
-             measured request reported zero cached prompt tokens"
+             measured request did not report a material cached-prompt fraction"
         ));
     }
     let mut basis = Vec::new();

--- a/crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs
+++ b/crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs
@@ -17,6 +17,8 @@
 //! * VACUOUS cells make a gating run INCONCLUSIVE (a failing verdict), never
 //!   PASS: an aggregate that divides undelivered tokens' wall time into real
 //!   tokens cannot clear a throughput floor, however large it prints.
+//! * a requested warm path with no observed cached prompt tokens is likewise
+//!   INCONCLUSIVE: matching request bytes do not prove the cache served them.
 
 use std::collections::BTreeMap;
 
@@ -52,6 +54,7 @@ pub(crate) fn sweep_verdict(
     cells: usize,
     errors: usize,
     vacuous: usize,
+    cache_uncontrolled: usize,
     vacuity_floor_pct: f64,
     floors: &Floors,
 ) -> Verdict {
@@ -64,10 +67,11 @@ pub(crate) fn sweep_verdict(
     if !floors.gating() {
         // The pre-gate behaviour, verbatim: a standalone sweep has no
         // committed ladder to be judged against.
-        return if vacuous > 0 {
+        return if vacuous > 0 || cache_uncontrolled > 0 {
             Verdict::info(format!(
                 "{cells} cells, {vacuous} below the vacuity floor ({vacuity_floor_pct:.0}% \
-                 of osl) — flagged rows' tok/s are not comparable"
+                 of osl), {cache_uncontrolled} without observed warm-cache use — flagged \
+                 rows' tok/s are not comparable"
             ))
         } else {
             Verdict::info(format!(
@@ -80,6 +84,12 @@ pub(crate) fn sweep_verdict(
             "INCONCLUSIVE: {vacuous} of {cells} cells below the vacuity floor \
              ({vacuity_floor_pct:.0}% of osl) — undelivered tokens cannot clear a \
              throughput floor, whatever the aggregate prints"
+        ));
+    }
+    if cache_uncontrolled > 0 {
+        return Verdict::fail(format!(
+            "INCONCLUSIVE: {cache_uncontrolled} of {cells} cells requested warm-up but a \
+             measured request reported zero cached prompt tokens"
         ));
     }
     let mut basis = Vec::new();

--- a/kernels/gb10/qwen3.8-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.8-27b/BENCH.toml
@@ -303,7 +303,12 @@ from the 2026-08-15 hand-built batched calibration serve, NOT from a \
 certified run on the pinned profile (fp8 KV, 8 Marconi slots, 4K context \
 change the memory geometry). They stand untouched as placeholders until the \
 first batched certified run on this profile; re-cut all five together from \
-that run's cells."""
+that run's cells. \
+★ WARM-UP SEMANTICS CHANGED: historical records sent one unrelated `warm` \
+prompt per cell, then measured `c0..cN`; later rungs also reused prompts from \
+earlier rungs. `warmup = 1` now runs every exact measured prompt once before \
+timing. Existing records and floors predate that controlled-cache instrument \
+and cannot calibrate it; the first certified rerun must replace them."""
 
 # ★ PLACEMENT: a [benchmarks.*] sub-table attaches to the MOST RECENT
 # [[benchmarks]] header above it. This serve pin was first committed ABOVE


### PR DESCRIPTION
## Summary

The concurrency sweep claimed each unmeasured warm-up used the same prompt as its measured batch. It actually warmed one prompt tagged `warm`, then measured prompts tagged `c0`, `c1`, and so on. Because the tag is the first prompt content and prefix caching is enabled, the setup did not prime the named measured prompts.

This change makes `warmup` count full rounds. Each round runs every exact measured prompt before timing the same prompt set. A failed warm-up now fails cell setup.

The measured responses then provide the runtime oracle. A warmed cell is comparable only when every request reports at least 80% of its prompt tokens as cached. Missing usage or a smaller partial-prefix hit makes a gating sweep `INCONCLUSIVE` before throughput floors are checked.

Refs #812.

## Broken setup and proof

The old rung history was:

```text
warm-up: warm
C1:      c0
C4:      c0 c1 c2 c3
C8:      c0 c1 c2 c3 c4 c5 c6 c7
```

The explicit warm-up was unrelated, while later rungs reused a growing subset of prompts measured by earlier rungs. The ladder mixed cached and new prompts according to prior rung history.

The repaired prompt plan is consumed directly by `run_cell`. Its test requires two C4 warm-up rounds to equal two complete copies of `c0..c3`, requires `warmup=0` to schedule no warm-up, and proves the historical `warm` prompt differs from the measured bytes.

Replacing the repaired rounds with `[[warm], [warm]]` fails the exact prompt-plan test.

## Runtime oracle and mutants

Equal request bytes show the setup targets the intended cache key. They do not prove the runtime served the request from that cache. A nonzero hit is also insufficient because the wrong prompt can share a small chat-template prefix.

The repaired partitions are:

- warmed request at 80/100 cached prompt tokens: comparable
- warmed request at 79/100: uncontrolled
- warmed request with missing usage: uncontrolled
- intentionally cold `warmup=0` with zero cache: comparable
- gating ladder at 999 tok/s with one uncontrolled warmed cell: fail as `INCONCLUSIVE`

Replayed mutants:

1. Historical `warm` tag instead of the measured prompt set fails the prompt-plan oracle.
2. Removing the cache condition from `CellRow::comparable` fails the comparability oracle.
3. Removing the gating cache guard lets the 999 tok/s bad ladder pass and fails the verdict oracle.
4. Replacing the 80% check with `cached_prompt_tokens != 0` lets the 79/100 partial hit survive and fails the boundary oracle.

Records now include `min_cached_prompt_tokens`, `min_cached_prompt_pct`, and `cache_uncontrolled_cells`. Run evidence prints cached versus total prompt tokens for every request.

## Verification

- [x] `cargo test -p atlas-plugin benchmarks::concurrency -- --nocapture` (21 passed)
- [x] `cargo clippy -p atlas-plugin --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Replayed all four known-bad mutants above and required the named tests to fail
- [ ] Authentic current-SHA concurrency run on exclusive GB10 hardware

No Spark run was used for this PR validation.

## Record boundary

This is a functional benchmark-instrument change. Existing concurrency records and floors were measured with mixed or unobserved cache state and are not comparable to the repaired instrument. `BENCH.toml` states that boundary instead of changing a floor without a new measurement.

The current coverage policy maps the flat concurrency driver to all ten mandatory gates. PR #816 narrows that deterministic path mapping while keeping shared HTTP, server, model, kernel, policy, and boundary files fail-closed. Once that policy is reviewed, this instrument still requires an authentic current-SHA `concurrency-sweep` record and new floors before review completion.

The longer duration hint is intentional. `warmup=1` now executes one exact warm-up request per measured request, so setup cost scales with concurrency.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
