### PR TITLE
fix(gate): scope concurrency driver coverage

### DIFF
--- a/crates/atlas-plugin/src/gate/amnesty.rs
+++ b/crates/atlas-plugin/src/gate/amnesty.rs
@@ -4,18 +4,15 @@
 //!
 //! # The grant
 //!
-//! There is no current grant. Two have completed the full lifecycle here —
-//! pinned, re-earned, emptied: PR #701's three coverage-policy boundary files,
-//! and PR #648's KV-budget accounting fix
-//! (`crates/spark-model/src/factory/build.rs`, blob
-//! `01068a74c5068fb65b25b044d7580df3b36e39ed`).
+//! PR #816 corrects the coverage assigned to the flat concurrency benchmark
+//! driver. The policy file is itself a verdict boundary, so its final reviewed
+//! blob would otherwise invalidate all ten records before the corrected rule
+//! could classify later changes. The grant covers that one blob and no other
+//! path.
 //!
-//! #648's grant was emptied when every required gate had a record newer than
-//! `AMNESTY_EPOCH` — the ten taken at `0c402bac00` for #754 — which is exactly
-//! the condition `amnesty_expires_once_every_gate_has_a_fresh_record` exists to
-//! detect, and it detected it. The machinery below stays because the next
-//! bootstrap should not have to re-derive it, and an empty table is fail-closed
-//! by construction: every lookup falls through to "not excused".
+//! PR #701 and PR #648 completed this same lifecycle: pinned, re-earned, then
+//! emptied after every required gate had a fresh record. The expiry test below
+//! requires the same removal for this grant.
 //!
 //! A grant covers only the final reviewed blobs of the listed files. It is
 //! the same mechanism accepted for the 2026-08-16 governance bootstrap:
@@ -45,7 +42,7 @@
 //! own landing would then invalidate everything it exists to protect. It is
 //! covered only by `GATE_MACHINERY`'s cargo-test rationale, like the rest of
 //! the gate bookkeeping. Compensations: the table's exact contents are pinned
-//! by `the_table_is_exactly_the_pr_648_grant` (paths, OID format, grant
+//! by `the_table_is_exactly_the_pr_816_grant` (paths, OID format, grant
 //! text), every application is logged loudly by `check.rs`, CODEOWNERS
 //! review covers the gate directory, and the gate already executes
 //! PR-checkout code — so this adds no new attack class, only a reviewed
@@ -74,37 +71,21 @@ pub struct AmnestyEntry {
     pub grant: &'static str,
 }
 
-/// End of the PR #648 grant day: 2026-08-28T00:00:00Z. A record counts as
+/// End of the PR #816 grant day: 2026-08-30T00:00:00Z. A record counts as
 /// fresh only when it postdates the whole grant day.
-/// (The PR #701 grant used 1_787_356_800, end of 2026-08-21 UTC; its table
-/// was emptied once every gate re-recorded past that epoch.)
-pub const AMNESTY_EPOCH: u64 = 1_787_875_200;
+pub const AMNESTY_EPOCH: u64 = 1_788_048_000;
 
-/// The PR #648 grant: one file, the KV-budget accounting fix.
+/// The PR #816 grant: exactly the reviewed coverage-policy blob.
 ///
-/// `factory/build.rs`'s self-relative (auto) KV budget charged the weight
-/// loader's transient footprint (checkpoint mapping/staging, ~the size of the
-/// safetensors file) as if it were permanent — measured free-delta ~61 GB vs
-/// ~27 GB actual steady state on a 27B NVFP4 load (bug shipped in #281). At
-/// 0.85 util the phantom alone overruns the decode-floor budget on any box,
-/// making the gate unpassable while the fix — being a `crates/` change —
-/// would invalidate the nine records already earned on this branch. Exactly
-/// the bootstrap shape PR #701 established; same mechanism, one pinned file.
-///
-/// The prior PR #701 grant covered three boundary files whose landing
-/// invalidated all ten GPU records before the narrower test-only rule could
-/// help. Every required gate was re-recorded at 2026-08-22, past that grant's
-/// epoch, and its table was emptied —
-/// `amnesty_expires_once_every_gate_has_a_fresh_record`
-/// asserts exactly that and demands such removal, which is the designed end of
-/// a one-time grant rather than a change of policy.
-///
-/// The mechanism is deliberately kept rather than deleted: the module docs
-/// record why a content-pinned grant was preferred to a path waiver, and
-/// `excused_by` plus its tests stay exercised so the next bootstrap does not
-/// have to re-derive it. An empty table is fail-closed by construction — every
-/// lookup falls through to "not excused".
-pub const ONE_TIME_AMNESTY: [AmnestyEntry; 0] = [];
+/// This does not claim that a benchmark passed. It prevents the old mapping
+/// from demanding unrelated campaigns to validate a deterministic policy
+/// correction. Any later edit changes the blob OID and restores all-ten
+/// invalidation.
+pub const ONE_TIME_AMNESTY: [AmnestyEntry; 1] = [AmnestyEntry {
+    path: "crates/atlas-plugin/src/gate/coverage.rs",
+    head_blob_oid: "ff3f5109bc3159555bb518b7c4d132d5335ad3fd",
+    grant: "PR #816 scopes the flat concurrency driver to its own benchmark gate",
+}];
 
 /// Whether the one-time grant excuses `path` at `head`.
 pub fn excused(root: &Path, head: &str, path: &str) -> bool {

--- a/crates/atlas-plugin/src/gate/amnesty_tests.rs
+++ b/crates/atlas-plugin/src/gate/amnesty_tests.rs
@@ -145,14 +145,11 @@ fn invalidating_paths_drops_exactly_what_the_grant_excuses() {
     );
 }
 
-/// The PR #648 grant is exactly the one KV-budget file in that change.
-/// Placeholder OIDs keep this test red until the final-content pin commit.
-/// (The PR #701 grant — three boundary files — completed this same lifecycle:
-/// pinned, re-earned, emptied.)
+/// The PR #816 grant is exactly the final coverage-policy blob.
 #[test]
-fn the_table_is_exactly_the_pr_648_grant() {
+fn the_table_is_exactly_the_pr_816_grant() {
     let paths: Vec<&str> = ONE_TIME_AMNESTY.iter().map(|e| e.path).collect();
-    // The grant has exactly two legal shapes: PR #648's single accounting-fix
+    // The grant has exactly two legal shapes: PR #816's single policy
     // file, or EMPTY once `amnesty_expires_once_every_gate_has_a_fresh_record`
     // has demanded its removal. Anything else is the grant growing, which is
     // what this test exists to prevent. Removal is the designed end of a
@@ -160,8 +157,8 @@ fn the_table_is_exactly_the_pr_648_grant() {
     if !paths.is_empty() {
         assert_eq!(
             paths,
-            vec!["crates/spark-model/src/factory/build.rs"],
-            "the grant must not grow beyond PR #648's KV-budget fix"
+            vec!["crates/atlas-plugin/src/gate/coverage.rs"],
+            "the grant must not grow beyond PR #816's coverage-policy blob"
         );
     }
     for entry in &ONE_TIME_AMNESTY {
@@ -177,7 +174,7 @@ fn the_table_is_exactly_the_pr_648_grant() {
             entry.path
         );
         assert!(
-            entry.grant.contains("PR #648"),
+            entry.grant.contains("PR #816"),
             "{} lacks its grant",
             entry.path
         );

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -181,6 +181,12 @@ pub const TEST_ONLY_RUST_MODULES: &[TestOnlyRustModule] = &[
         name: "tests",
         declared_path: Some("lora_tests.rs"),
     },
+    TestOnlyRustModule {
+        path: "crates/atlas-plugin/src/benchmarks/concurrency_tests.rs",
+        parent: "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        name: "concurrency_tests",
+        declared_path: Some("concurrency_tests.rs"),
+    },
 ];
 
 fn is_test_only_rust_module(path: &str) -> bool {
@@ -227,6 +233,15 @@ const fn other_driver(prefix: &'static str, mine: &'static str) -> Exclusion {
     }
 }
 
+/// The concurrency benchmark's two production files are flat files rather
+/// than a driver directory. Name both exactly: a directory-shaped prefix such
+/// as `benchmarks/concurrency` matches neither file, while excluding the whole
+/// `benchmarks` directory would also hide shared HTTP and statistics code that
+/// can change several instruments.
+const fn concurrency_driver(prefix: &'static str, rationale: &'static str) -> Exclusion {
+    other_driver(prefix, rationale)
+}
+
 const TTFT_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
     other_driver(
@@ -244,6 +259,14 @@ const TTFT_EXCLUDES: &[Exclusion] = &[
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ssm_poison",
         "the SSM poison driver cannot change what a first-token latency probe measures",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change what a first-token latency probe measures",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change what a first-token latency probe measures",
     ),
 ];
 
@@ -265,6 +288,14 @@ const BFCL_EXCLUDES: &[Exclusion] = &[
         "crates/atlas-plugin/src/benchmarks/ssm_poison",
         "the SSM poison driver cannot change a tool-calling accuracy score",
     ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change a tool-calling accuracy score",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change a tool-calling accuracy score",
+    ),
 ];
 
 const AGENTIC_EXCLUDES: &[Exclusion] = &[
@@ -284,6 +315,14 @@ const AGENTIC_EXCLUDES: &[Exclusion] = &[
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ssm_poison",
         "the SSM poison driver cannot change whether the agent's webserver task succeeds",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change whether the agent's webserver task succeeds",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change whether the agent's webserver task succeeds",
     ),
 ];
 
@@ -313,6 +352,14 @@ const SSM_POISON_EXCLUDES: &[Exclusion] = &[
     other_driver(
         "crates/atlas-plugin/src/benchmarks/contamination",
         "the contamination driver cannot change whether an identical replay returns identical bytes",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change whether an identical replay returns identical bytes",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change whether an identical replay returns identical bytes",
     ),
 ];
 
@@ -376,6 +423,14 @@ const DECODE_FLOOR_EXCLUDES: &[Exclusion] = &[
         "crates/atlas-plugin/src/benchmarks/ssm_poison",
         "the SSM poison driver cannot change the server's single-user decode rate",
     ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change the server's single-user decode rate",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change the server's single-user decode rate",
+    ),
 ];
 
 /// What the cross-contamination candidate ignores: gate bookkeeping and the
@@ -395,6 +450,14 @@ const CONTAMINATION_EXCLUDES: &[Exclusion] = &[
     other_driver(
         "crates/atlas-plugin/src/benchmarks/agentic",
         "the agentic driver cannot change whether one request's state leaks into another's output",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change whether one request's state leaks into another",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change whether one request's state leaks into another",
     ),
 ];
 
@@ -420,6 +483,14 @@ const VISION_EXCLUDES: &[Exclusion] = &[
     other_driver(
         "crates/atlas-plugin/src/benchmarks/contamination",
         "the contamination driver cannot change how an image is patched or how many tokens it becomes",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "the concurrency request planner cannot change image preprocessing or encoder tokens",
+    ),
+    concurrency_driver(
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+        "the concurrency verdict cannot change image preprocessing or encoder tokens",
     ),
 ];
 

--- a/crates/atlas-plugin/src/gate/coverage_map_tests.rs
+++ b/crates/atlas-plugin/src/gate/coverage_map_tests.rs
@@ -279,6 +279,39 @@ fn a_driver_change_invalidates_only_its_own_gate() {
     assert_eq!(hit, ["bfcl-subset", "bfcl-subset-echolp"]);
 }
 
+/// The concurrency driver is made of flat files, unlike the directory-shaped
+/// drivers above. Exact-file exclusions must keep it attached to its own gate
+/// without forgiving shared benchmark plumbing or a lookalike neighbor.
+#[test]
+fn the_flat_concurrency_driver_invalidates_only_its_own_gate() {
+    for path in [
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+    ] {
+        assert_eq!(
+            coverage::invalidated_by([path]),
+            ["concurrency-sweep"],
+            "{path} must re-open exactly the instrument it implements"
+        );
+    }
+
+    for path in [
+        "crates/atlas-plugin/src/http.rs",
+        "crates/atlas-plugin/src/benchmarks/stats.rs",
+        "crates/atlas-plugin/src/benchmarks/transcript.rs",
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs.bak",
+        "crates/spark-server/src/scheduler/mod.rs",
+        "kernels/gb10/common/paged_decode_attn_fp8.cu",
+        "crates/atlas-plugin/src/gate/coverage.rs",
+    ] {
+        assert_eq!(
+            coverage::invalidated_by([path]),
+            REQUIRED_GATES,
+            "nearby or shared path {path} escaped the fail-closed boundary"
+        );
+    }
+}
+
 /// Gate BOOKKEEPING does not re-open GPU measurements — the change that
 /// motivated this whole module.
 ///

--- a/crates/atlas-plugin/src/gate/coverage_promotion_tests.rs
+++ b/crates/atlas-plugin/src/gate/coverage_promotion_tests.rs
@@ -117,7 +117,8 @@ fn the_candidate_is_owed_for_its_own_driver_and_not_for_other_drivers() {
 /// weakened anything: what used to accrue DEBT now INVALIDATES — engine and
 /// kernel paths, each gate's own driver (the pins are the benchmark, and the
 /// decode-floor driver is a directory since the C1 split), and the usage
-/// plumbing the accept pin reads. Another driver's file still owes neither.
+/// plumbing the accept pin reads. This audit narrows only the flat concurrency
+/// driver; the decode-floor driver's existing coverage is unchanged here.
 #[test]
 fn the_promoted_gates_invalidate_where_they_used_to_accrue_debt() {
     for id in ["decode-floor", "concurrency-sweep"] {
@@ -139,13 +140,21 @@ fn the_promoted_gates_invalidate_where_they_used_to_accrue_debt() {
         "kernels/gb10/common/paged_decode_attn_fp8.cu",
         "crates/spark-server/src/openai/encode_stream.rs",
         "crates/atlas-plugin/src/benchmarks/decode_floor/mod.rs",
-        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
-        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
     ] {
         let hit = coverage::invalidated_by([path]);
         assert!(
             hit.contains(&"decode-floor") && hit.contains(&"concurrency-sweep"),
             "{path} must invalidate both promoted gates: {hit:?}"
+        );
+    }
+    for path in [
+        "crates/atlas-plugin/src/benchmarks/concurrency.rs",
+        "crates/atlas-plugin/src/benchmarks/concurrency_verdict.rs",
+    ] {
+        assert_eq!(
+            coverage::invalidated_by([path]),
+            ["concurrency-sweep"],
+            "the flat concurrency driver belongs to the concurrency instrument only: {path}"
         );
     }
     let hit = coverage::invalidated_by(["crates/atlas-plugin/src/benchmarks/bfcl/report.rs"]);

--- a/crates/atlas-plugin/src/gate/test_only_coverage_tests.rs
+++ b/crates/atlas-plugin/src/gate/test_only_coverage_tests.rs
@@ -124,6 +124,8 @@ fn test_looking_neighbours_remain_fail_closed() {
         "crates/atlas-core/src/config/gguf/not_really_tests.rs",
         "crates/atlas-core/src/config/gguf.rs",
         "crates/atlas-core/src/config.rs",
+        "crates/atlas-plugin/src/benchmarks/concurrency_tests.rs.bak",
+        "crates/atlas-plugin/src/benchmarks/concurrency_tests/helper.rs",
     ] {
         let invalidated = coverage::invalidated_by([path]);
         assert_eq!(
@@ -137,13 +139,17 @@ fn test_looking_neighbours_remain_fail_closed() {
 #[test]
 fn a_production_change_cannot_hide_beside_an_exempt_test_change() {
     for module in TEST_ONLY_RUST_MODULES {
-        let invalidated = coverage::invalidated_by([module.path, module.parent]);
-        assert_eq!(
-            invalidated.len(),
-            REQUIRED.len(),
-            "{} hid the production change to {}: {invalidated:?}",
-            module.path,
+        let parent_only = coverage::invalidated_by([module.parent]);
+        assert!(
+            !parent_only.is_empty(),
+            "{} is registered as a production parent but invalidates no gate",
             module.parent
+        );
+        let with_test = coverage::invalidated_by([module.path, module.parent]);
+        assert_eq!(
+            with_test, parent_only,
+            "{} changed the coverage owed by its production parent {}",
+            module.path, module.parent
         );
     }
 }


### PR DESCRIPTION
## Claim

The two production files for `concurrency-sweep` are flat files. The current coverage table excludes directory-shaped benchmark drivers from unrelated gates but never classifies `concurrency.rs` or `concurrency_verdict.rs`. A change to either therefore falls through to all ten mandatory GPU gates.

This PR makes those exact files invalidate only `concurrency-sweep`. It also registers `concurrency_tests.rs` as a test-only Rust module after proving its only module edge is guarded by `#[cfg(test)]`.

## Reproduction

Before this change:

```rust
coverage::invalidated_by([
    "crates/atlas-plugin/src/benchmarks/concurrency.rs",
])
```

returned every mandatory gate, including BFCL, vision, video, agentic, TTFT, SSM poisoning, and decode floor. None of those instruments imports or executes the concurrency driver.

## Boundary kept fail-closed

The exclusions name the two production files exactly. They do not exempt the benchmark directory. Tests require shared HTTP, statistics, transcript, server, kernel, lookalike, and coverage-policy paths to continue invalidating all ten gates. `concurrency-sweep` still invalidates for both production files.

The test-only exemption is also exact. A proof test scans the Rust tree, requires the registered `#[cfg(test)]` and `#[path]` edge, rejects a second path/include edge, and keeps neighboring test-looking paths fail-closed.

## RST evidence

Two known-bad mutants were replayed locally:

1. Replacing the exact file exclusions with `benchmarks/concurrency` restored the all-ten result. `the_flat_concurrency_driver_invalidates_only_its_own_gate` failed with the exact unexpected gate set.
2. Removing the concurrency test module from the test-only decision reopened GPU gates. `registered_test_modules_do_not_invalidate_gpu_records` failed on that exact path.

The repaired code rejects both mutants.

## Local verification

```text
cargo test -p atlas-plugin gate:: -- --nocapture
224 passed, 0 failed

cargo clippy -p atlas-plugin --tests -- -D warnings
PASS

cargo fmt --check
PASS

git diff --check
PASS
```

## Bootstrap status

The one-time grant is pinned to only the final `coverage.rs` blob `ff3f5109bc3159555bb518b7c4d132d5335ad3fd`. Any later edit changes the OID and restores all-ten invalidation. The expiry test requires removal after every required gate has a record newer than the grant epoch. No benchmark result is inferred by this policy test.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
