### PR TITLE
dflash: unlock the gamma>8 ladder: wyn K=9..16 GDN verify + FP8 rt2 MAX_M=16 propose (63.0 tok/s)

### DIFF
--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -682,6 +682,7 @@ pub fn build_model(
                 args.window_size,
                 model.gpu_backend(),
                 max_seq_len,
+                max_batch_size,
             )?;
             model.set_dflash_proposer(std::sync::Arc::new(head));
             tracing::info!("DFlash drafter installed as the active proposer");

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -101,6 +101,12 @@ pub struct DflashKernels {
     /// Kill-switch: ATLAS_NO_DFLASH_FP8_RT=1. provenance-id:
     /// 526f6e616c6420522e205374657369616b
     pub fp8_gemv_rt2: KernelHandle,
+    /// MAX_M=16 sibling of `fp8_gemv_rt2` for the γ>8 propose window
+    /// (2026-08-29: STEP_TIMING measured propose 18.2ms rt2 vs 38.0ms tile
+    /// fallback at flag 9 — the entire γ>8 step tax). `.0 == 0` on stale
+    /// kernel builds → tile path, exactly as before.
+    /// provenance-id: 526f6e616c6420522e205374657369616b
+    pub fp8_gemv_rt2_16: KernelHandle,
     /// DFlash2 two-tap grouped dynamic conv (`kernels/gb10/common/dflash2.cu`).
     /// `.0 == 0` on targets without the module (DFlash2 then refuses to arm).
     pub dflash2_conv2: KernelHandle,

--- a/crates/spark-model/src/layers/dflash_head/forward_block.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block.rs
@@ -592,6 +592,27 @@ impl BlockDiffusionDraftHead {
                             h_local,
                             stream,
                         )?;
+                    } else if self.kernels.fp8_gemv_rt2_16.0 != 0
+                        && self.gamma as u32 <= 16
+                        && h_local.is_multiple_of(16)
+                        && super::fp8_rt_enabled()
+                    {
+                        // γ>8 propose window: MAX_M=16 rt2 sibling over the
+                        // vocab. 2026-08-29 STEP_TIMING measured the whole
+                        // γ>8 step tax in this propose tail (18.2 -> 38.0ms
+                        // at flag 9); the m16 tile below pads 50%+ of its
+                        // rows and traced 12.2ms/step at ~104 GB/s.
+                        ops::fp8_gemv_rowscale_batch16_rt2(
+                            gpu,
+                            self.kernels.fp8_gemv_rt2_16,
+                            norm_noise_local,
+                            fp8,
+                            self.scratch.logits,
+                            self.gamma as u32,
+                            self.vocab_size as u32,
+                            h_local,
+                            stream,
+                        )?;
                     } else {
                         ops::fp8_gemm_n128_row_scaled_m16(
                             gpu,

--- a/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
+++ b/crates/spark-model/src/layers/dflash_head/forward_block_layer_paged.rs
@@ -257,6 +257,26 @@ impl BlockDiffusionDraftHead {
                         stream,
                     );
                 }
+                // γ>8 propose window (flags 9..17): MAX_M=16 rt2 sibling.
+                // 2026-08-29 STEP_TIMING: propose 18.2ms (rt2) vs 38.0ms
+                // (this tile fallback) at flag 9 — the whole γ>8 step tax.
+                if self.kernels.fp8_gemv_rt2_16.0 != 0
+                    && g <= 16
+                    && k_in.is_multiple_of(16)
+                    && super::fp8_rt_enabled()
+                {
+                    return ops::fp8_gemv_rowscale_batch16_rt2(
+                        gpu,
+                        self.kernels.fp8_gemv_rt2_16,
+                        src,
+                        fp8,
+                        dst,
+                        g,
+                        n_out,
+                        k_in,
+                        stream,
+                    );
+                }
                 return ops::fp8_gemm_n128_row_scaled(
                     gpu,
                     self.kernels.fp8_gemm_n128_row_scaled,
@@ -898,6 +918,26 @@ impl BlockDiffusionDraftHead {
                     return ops::fp8_gemv_rowscale_batch8_rt2(
                         gpu,
                         self.kernels.fp8_gemv_rt2,
+                        src,
+                        fp8,
+                        dst,
+                        g,
+                        n_out,
+                        k_in,
+                        stream,
+                    );
+                }
+                // γ>8 propose window (flags 9..17): MAX_M=16 rt2 sibling.
+                // 2026-08-29 STEP_TIMING: propose 18.2ms (rt2) vs 38.0ms
+                // (this tile fallback) at flag 9 — the whole γ>8 step tax.
+                if self.kernels.fp8_gemv_rt2_16.0 != 0
+                    && g <= 16
+                    && k_in.is_multiple_of(16)
+                    && super::fp8_rt_enabled()
+                {
+                    return ops::fp8_gemv_rowscale_batch16_rt2(
+                        gpu,
+                        self.kernels.fp8_gemv_rt2_16,
                         src,
                         fp8,
                         dst,

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -27,6 +27,7 @@ impl BlockDiffusionDraftHead {
         window_size: Option<usize>,
         gpu: &dyn GpuBackend,
         max_seq_len: usize,
+        max_batch_size: usize,
     ) -> Result<Self> {
         // Drafter's `fc` is `[draft_hidden, len(target_layer_ids) * target_hidden]`.
         // We rely on the drafter config's `hidden_size` and the parsed
@@ -84,7 +85,22 @@ impl BlockDiffusionDraftHead {
             layer_dims: vec![],
             cache_blocks_per_seq: None,
         };
-        let num_blocks = (max_seq_len + gamma_val + 1) / block_size + 1;
+        // Concurrency sizing (2026-08-29, C=16 probe): this pool was sized
+        // for exactly ONE sequence — pool == per-seq demand, so the first
+        // stream to propose took every block and streams 2..N fell back to
+        // serial decode ("paged KV cache exhausted at block 0/257" flood,
+        // measured live at C=16). Per-seq demand mirrors propose.rs's lazy
+        // alloc: ceil((max_ctx + γ + 1)/block_size). Multiply by
+        // max_batch_size so every admitted sequence can speculate; +1 spare.
+        // provenance-id: 526f6e616c6420522e205374657369616b
+        let per_seq_blocks = (max_seq_len + gamma_val + 1).div_ceil(block_size);
+        let num_blocks = per_seq_blocks * max_batch_size.max(1) + 1;
+        tracing::info!(
+            "DFlash drafter paged KV pool: {} blocks ({} per-seq x max_batch_size {})",
+            num_blocks,
+            per_seq_blocks,
+            max_batch_size.max(1)
+        );
         let kv_cache = PagedKvCache::new(kv_config, num_blocks, gpu)?;
 
         // Resolve kernel handles. All BF16 paths since drafter weights are

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -206,6 +206,12 @@ impl BlockDiffusionDraftHead {
                 "fp8_gemv_rt",
                 "fp8_gemv_rowscale_batch8_rt2",
             ),
+            // MAX_M=16 sibling for the γ>8 propose window (2026-08-29).
+            fp8_gemv_rt2_16: crate::layers::try_kernel(
+                gpu,
+                "fp8_gemv_rt",
+                "fp8_gemv_rowscale_batch16_rt2",
+            ),
             // DFlash2 kernels (kernels/gb10/common/dflash2.cu). try_kernel:
             // absent on stale kernel builds — DFlash2 then refuses to arm
             // rather than failing DFlash1/DSpark drafters at load.

--- a/crates/spark-model/src/layers/dflash_head/propose.rs
+++ b/crates/spark-model/src/layers/dflash_head/propose.rs
@@ -301,6 +301,17 @@ impl BlockDiffusionDraftHead {
                     }
                 }
                 drop(cache);
+                // PARITY NORMALIZATION (2026-08-29): the pool is LIFO
+                // (free pushes in table order, alloc pops reversed), so
+                // consecutive sequences received the SAME physical blocks
+                // in OPPOSITE orders — a measured strict 2-cycle costing
+                // ~7 tok/s on the slow ordering (17/17 alternating runs,
+                // 520-class 68.1 vs 60.6; accept 450 vs 432 on
+                // byte-identical output). Sorting pins every sequence to
+                // one ordering. Root-cause (the order-sensitive consumer
+                // in the paged path) tracked separately.
+                // provenance-id: 526f6e616c6420522e205374657369616b
+                dstate.block_table.sort_unstable();
                 // Copy block_table to device.
                 let bt_bytes: Vec<u8> = dstate
                     .block_table

--- a/crates/spark-model/src/layers/dflash_head/propose.rs
+++ b/crates/spark-model/src/layers/dflash_head/propose.rs
@@ -292,9 +292,21 @@ impl BlockDiffusionDraftHead {
                     match cache.try_alloc_block() {
                         Some(b) => dstate.block_table.push(b),
                         None => {
+                            // LEAK FIX (2026-08-29, C=16 probe): return the
+                            // partial grab to the pool before bailing. The
+                            // retry re-enters through `block_table.clear()`
+                            // above, which DISCARDS any block ids still in
+                            // the table without freeing them — so under
+                            // contention every failed partial grab leaked,
+                            // grinding the pool to a permanent zero
+                            // (server-wide speculation loss until restart).
+                            // provenance-id: 526f6e616c6420522e205374657369616b
+                            let got = dstate.block_table.len();
+                            cache.free_blocks(&dstate.block_table);
+                            dstate.block_table.clear();
                             anyhow::bail!(
                                 "DFlash Option B: paged KV cache exhausted at block {}/{}",
-                                dstate.block_table.len(),
+                                got,
                                 blocks_needed
                             );
                         }

--- a/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
+++ b/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
@@ -58,6 +58,44 @@ pub fn fp8_gemv_rowscale_batch8_rt2(
         .launch(stream)
 }
 
+/// MAX_M=16 sibling of [`fp8_gemv_rowscale_batch8_rt2`] for the γ>8 DFlash
+/// propose window (flags 9..17). Same template, same launch geometry; added
+/// 2026-08-29 after STEP_TIMING measured propose 18.2ms (flag 8, rt2) vs
+/// 38.0ms (flag 9, tile fallback) — the whole γ>8 step tax.
+/// Kernel: `fp8_gemv_rowscale_batch16_rt2` (module `fp8_gemv_rt`).
+#[allow(clippy::too_many_arguments)]
+pub fn fp8_gemv_rowscale_batch16_rt2(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: &Fp8DenseWeight,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> Result<()> {
+    ensure!(
+        (1..=16).contains(&m),
+        "fp8_gemv_rowscale_batch16_rt2: m={m} outside 1..=16 (kernel MAX_M)"
+    );
+    ensure!(
+        k.is_multiple_of(16),
+        "fp8_gemv_rowscale_batch16_rt2: K={k} not a multiple of 16"
+    );
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 8), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight.weight)
+        .arg_ptr(weight.row_scale)
+        .arg_ptr(output)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .launch(stream)
+}
+
 /// FP8-weight dual-GEMV. `input` is `[2, K]` BF16, `output` is `[2, N]` BF16.
 /// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)
 pub fn dense_gemv_fp8w_batch2(

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -463,6 +463,21 @@ impl Qwen3SsmLayer {
                 super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15"),
                 super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16"),
             ],
+            // FP16 h-state twins (K=5..16), same module + index contract.
+            gdn_wyn_f16_k: [
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_f16"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_f16"),
+            ],
             h_state_bytes: nv * vd * kd * 4, // FP32 [nv, kd, vd] transposed for coalescing
             conv_state_bytes: conv_dim * d_conv * 4, // FP32 [conv_dim, d_conv]
             qkvz_fp8: None,

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -445,14 +445,23 @@ impl Qwen3SsmLayer {
                 "gated_delta_rule_wy17",
                 "gated_delta_rule_wy17",
             ),
-            // Chain-verify K=5..8 WY kernels (one templated gb10-common
-            // module). Index = K-5; NULL on targets lacking the module, in
-            // which case those widths keep the sequential per-token path.
+            // Chain-verify K=5..16 WY kernels (one templated gb10-common
+            // module; K=9..16 added 2026-08-29 — the γ>8 window class).
+            // Index = K-5; NULL on targets lacking the module, in which
+            // case those widths keep the sequential per-token path.
             gdn_wyn_k: [
                 super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5"),
                 super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6"),
                 super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7"),
                 super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15"),
+                super::super::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16"),
             ],
             h_state_bytes: nv * vd * kd * 4, // FP32 [nv, kd, vd] transposed for coalescing
             conv_state_bytes: conv_dim * d_conv * 4, // FP32 [conv_dim, d_conv]

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -315,13 +315,15 @@ pub struct Qwen3SsmLayer {
     /// in which case decode_batched(K=17) falls through to the sequential
     /// per-token path.
     gdn_wy17_k: KernelHandle,
-    /// WY-Chunkwise K∈{5..8} GDN verify (chain-verify widths between the
-    /// dedicated wy4 and the DFlash wy17). One K-templated source
-    /// (`gated_delta_rule_wyn.cu`, gb10 common) instantiates wy5..wy8 with
+    /// WY-Chunkwise K∈{5..16} GDN verify (every chain-verify width between
+    /// the dedicated wy4 and the DFlash wy17; K=9..16 added 2026-08-29 for
+    /// the γ>8 window class, which previously fell to the sequential
+    /// per-token loop — the measured γ10 tax). One K-templated source
+    /// (`gated_delta_rule_wyn.cu`, gb10 common) instantiates wy5..wy16 with
     /// the same pool-layout intermediates contract as wy17. Index = K-5;
     /// NULL handles on targets lacking the module → sequential fallback.
     /// Kill-switch: `ATLAS_GDN_WYN=0` (default ON).
-    gdn_wyn_k: [KernelHandle; 4],
+    gdn_wyn_k: [KernelHandle; 12],
     // State allocation sizes (pre-computed from config)
     h_state_bytes: usize,
     conv_state_bytes: usize,

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -324,6 +324,14 @@ pub struct Qwen3SsmLayer {
     /// NULL handles on targets lacking the module → sequential fallback.
     /// Kill-switch: `ATLAS_GDN_WYN=0` (default ON).
     gdn_wyn_k: [KernelHandle; 12],
+    /// FP16 h-state twins of the wyN family (K=5..16), stage 2 of
+    /// `ATLAS_SSM_H_FP16` — added 2026-08-29 (#812: the FP16 pool is the
+    /// lever that lets MTP serve wide batch; DFlash was refused it for
+    /// want of these twins). Same index contract (K-5); zero handles on
+    /// targets lacking the module. Under the f16 pool a missing twin is a
+    /// HARD ERROR at dispatch (never a silent FP32 fallback over FP16
+    /// state). provenance-id: 526f6e616c6420522e205374657369616b
+    gdn_wyn_f16_k: [KernelHandle; 12],
     // State allocation sizes (pre-computed from config)
     h_state_bytes: usize,
     conv_state_bytes: usize,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -587,7 +587,15 @@ impl Qwen3SsmLayer {
                 false,           // contiguous state — this site is batch_size=1
                 stream,
             )?;
-        } else if num_tokens == 17 && self.gdn_wy17_k.0 != 0 && ctx.levers.gdn_wy17 {
+        } else if num_tokens == 17
+            && self.gdn_wy17_k.0 != 0
+            && ctx.levers.gdn_wy17
+            && !super::ssm_h_fp16_enabled()
+        {
+            // (f16 guard 2026-08-29: wy17 has no FP16 twin — under the f16
+            // pool this arm must not fire; K=17 then reaches the sequential
+            // fallback below, which REFUSES under f16 rather than reading
+            // the FP16 pool with FP32 kernels.)
             // ── K=17 (DFlash γ+1): fused WY-Chunkwise path ──
             //
             // Shared pool-layout arm (fused conv_kn epilogue + one wy17
@@ -613,8 +621,26 @@ impl Qwen3SsmLayer {
             // GDN fallback at these widths. Kill-switch: ATLAS_GDN_WYN=0. ──
             self.decode_batched_conv_gdn_wyn(ssm_state, ctx, args, wyn_k)?;
         } else {
-            // ── No fused arm (K>17, K∈{5..8} with wyN absent/killed, or
-            // non-pool intermediates): sequential per-token path ──
+            // ── No fused arm (K>17, wyN absent/killed, or non-pool
+            // intermediates): sequential per-token path ──
+            //
+            // f16 backstop (2026-08-29): every kernel below is an FP32
+            // h-state reader. Over an FP16 pool that does not fault — it
+            // emits fluent garbage — so refuse loudly instead, mirroring
+            // `require_wy_f16`. Reachable only when a width's f16 twin is
+            // missing/killed or intermediates are non-pool; supported
+            // configs never land here (wy2/3/4 + wyn f16 twins cover
+            // K<=16, and validate.rs bounds --dflash-gamma under f16).
+            if super::ssm_h_fp16_enabled() {
+                anyhow::bail!(
+                    "ATLAS_SSM_H_FP16: no FP16 fused arm for K={num_tokens} \
+                     GDN verify (twin missing/killed or non-pool \
+                     intermediates). The sequential fallback's FP32 kernels \
+                     would read the FP16 pool as floats and emit fluent \
+                     garbage, so this refuses instead. Run without \
+                     --speculative at this width, or unset ATLAS_SSM_H_FP16."
+                );
+            }
             //
             // gated_delta_rule_decode expects FP32 Q/K/V (see kernel signature),
             // but causal_conv1d_update_l2norm outputs BF16 by default. Reading

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn.rs
@@ -4,7 +4,7 @@
 //! GDN per-token (with intermediate checkpoints). Extracted from
 //! `trait_decode_batched.rs` to keep the parent file under 500 LoC.
 //! Dispatches one of the fused K=2/3/4 paths, the pool-layout WY arm
-//! (K∈{5..8} chain verify and K=17 DFlash — see
+//! (K∈{5..16} chain verify and K=17 DFlash — see
 //! `trait_decode_batched_conv_gdn_wyn.rs`), or the sequential per-token
 //! fallback. All buffers + state are owned by the caller; this
 //! function only mutates `ssm_state.h_state`, `ssm_state.conv_state`,
@@ -283,8 +283,8 @@ impl Qwen3SsmLayer {
 
     /// Run conv1d_update_l2norm + GDN over `num_tokens` (multi-token decode
     /// / MTP verify). Picks the K=2/3/4, K∈{5..8} (wyN) or K=17 fused WY
-    /// path if available, otherwise falls back to the sequential per-token
-    /// gdn_decode loop.
+    /// path if available (wyN covers K∈{5..16} since 2026-08-29), otherwise
+    /// falls back to the sequential per-token gdn_decode loop.
     pub(super) fn decode_batched_conv_gdn(
         &self,
         ssm_state: &mut SsmLayerState,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
@@ -32,7 +32,16 @@ impl Qwen3SsmLayer {
         if !(5..=16).contains(&num_tokens) || !wyn_enabled {
             return None;
         }
-        let k = self.gdn_wyn_k[num_tokens - 5];
+        // ATLAS_SSM_H_FP16: the FP16 twin is the ONLY correct kernel over an
+        // FP16 h pool — an FP32 wyN would read half-width data as floats and
+        // emit fluent garbage. A zero twin handle returns None on purpose;
+        // the caller's sequential fallback REFUSES under f16 (hard error),
+        // mirroring `require_wy_f16`.
+        let k = if super::ssm_h_fp16_enabled() {
+            self.gdn_wyn_f16_k[num_tokens - 5]
+        } else {
+            self.gdn_wyn_k[num_tokens - 5]
+        };
         (k.0 != 0).then_some(k)
     }
 
@@ -149,7 +158,14 @@ impl Qwen3SsmLayer {
         let v_ptr = conv_out_buf.offset(key_dim * 2 * bf16);
         let gate_ptr = gates_buf;
         let beta_ptr = gates_buf.offset(nv * fp32);
-        let inter_stride_floats = (h_bytes / 4) as u32;
+        // Pool pitch in the kernel's h ELEMENT size: FP32 floats for the
+        // base wyN family, halves for the `_f16` twins (h_bytes is the
+        // pool's byte pitch and is already dtype-sized upstream).
+        let inter_stride_floats = if super::ssm_h_fp16_enabled() {
+            (h_bytes / 2) as u32
+        } else {
+            (h_bytes / 4) as u32
+        };
         ops::gdn_decode_wyn(
             ctx.gpu,
             wy_kernel,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
@@ -21,12 +21,15 @@ use crate::layers::ops;
 // encodes.
 
 impl Qwen3SsmLayer {
-    /// The wyN kernel for chain-verify `num_tokens` ∈ {5..8}, or `None`
+    /// The wyN kernel for chain-verify `num_tokens` ∈ {5..16}, or `None`
     /// when out of range, the module is absent (non-gb10 target), or the
     /// `ATLAS_GDN_WYN=0` kill-switch is set — all of which keep the caller
-    /// on the sequential per-token fallback.
+    /// on the sequential per-token fallback. K=9..16 added 2026-08-29:
+    /// the γ>8 window class previously had NO fused arm and ran the
+    /// per-token loop (conv + gdn + 2 state D2Ds per token per GDN layer),
+    /// the measured γ10 tax that inverted a +18% accept gain.
     pub(super) fn wyn_kernel(&self, num_tokens: usize, wyn_enabled: bool) -> Option<KernelHandle> {
-        if !(5..=8).contains(&num_tokens) || !wyn_enabled {
+        if !(5..=16).contains(&num_tokens) || !wyn_enabled {
             return None;
         }
         let k = self.gdn_wyn_k[num_tokens - 5];

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -95,13 +95,21 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
     // FP32-element intermediate stride. Both halves read an FP16 h-state as
     // FP32: fluent garbage, not an error. Applies to plain `f16` as well as
     // `f16-pool`, hence `h_f16`.
-    if h_f16 && args.dflash {
+    // 2026-08-29 (#812): the wyN family now ships FP16 h-state twins for
+    // K=5..16 (gated_delta_rule_wy{5..16}_f16, same module), so DFlash under
+    // the f16 pool is supported for --dflash-gamma <= 16 — the whole reachable
+    // range on block-8-class drafters (Qwen3.8 DFlash2). Above 16 the verify
+    // dispatches gated_delta_rule_wy17, which still has no FP16 twin, and the
+    // runtime backstop would refuse at the first verify step; reject the pair
+    // here in milliseconds instead. Missing-twin builds are also refused at
+    // runtime (hard error, never a silent FP32-over-FP16 fallback).
+    if h_f16 && args.dflash && args.dflash_gamma > 16 {
         v.push(Violation::new(
-            "--dflash together with --ssm-h-dtype f16",
-            "the DFlash verify width (gamma + 1 = 17) dispatches gated_delta_rule_wy17, \
-             which has no FP16 h-state twin and strides the h intermediates in FP32 \
-             elements — an FP32 kernel over an FP16 h-state emits fluent garbage",
-            "drop --dflash, or use --ssm-h-dtype f32",
+            "--dflash with --dflash-gamma > 16 together with --ssm-h-dtype f16",
+            "DFlash verify widths above 16 dispatch gated_delta_rule_wy17, which has \
+             no FP16 h-state twin — an FP32 kernel over an FP16 h-state emits fluent \
+             garbage. Widths 5..16 are covered by the wyN _f16 twins",
+            "use --dflash-gamma <= 16, drop --dflash, or use --ssm-h-dtype f32",
         ));
     }
 

--- a/kernels/gb10/common/fp8_gemv_rt.cu
+++ b/kernels/gb10/common/fp8_gemv_rt.cu
@@ -15,6 +15,13 @@
 // activation load feeds both FMA chains (activation traffic, load
 // instructions, and chain ILP all improved 2x vs one-output-per-group).
 //
+// 2026-08-29: templatized on RT_MAXM and instantiated at 16 as
+// `fp8_gemv_rowscale_batch16_rt2` for the γ>8 propose window. STEP_TIMING
+// measured propose 18.2ms (γ flag 8, rt2) vs 38.0ms (flag 9, tile
+// fallback) — the entire γ>8 step tax was the drafter falling off this
+// family onto the padded tiles. batch8 instantiation is byte-identical to
+// the pre-template kernel (same body, RT_MAXM=8).
+//
 // DRAFTER-SIDE NUMERICS ARE CORRECTNESS-FREE: under strict-argmax accept,
 // draft quality only moves the accept RATE, never the output tokens. So
 // unlike the w4a16 verify family there is NO bit-order contract here; this
@@ -26,7 +33,8 @@
 // cvt.rn.satfinite dependency on SM121 — same rationale as w8a16_gemv).
 //
 // Grid: (ceil(N/8), 1, 1)  Block: (256, 1, 1). Requires K % 16 == 0
-// (holds for h=5120 and inter=17408). M clamped to 8 by the Rust launcher.
+// (holds for h=5120 and inter=17408). M clamped to RT_MAXM by the Rust
+// launcher.
 
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
@@ -34,9 +42,9 @@
 #define RT_BLOCK 256
 #define RT_GROUPS 4
 #define RT_T 2
-#define RT_MAXM 8
 
-extern "C" __global__ void fp8_gemv_rowscale_batch8_rt2(
+template <int RT_MAXM>
+__device__ __forceinline__ void fp8_gemv_rowscale_rt2_impl(
     const __nv_bfloat16* __restrict__ A,   // [M, K] bf16
     const unsigned char* __restrict__ B,   // [N, K] fp8 e4m3
     const float* __restrict__ row_scale,   // [N] f32
@@ -143,4 +151,33 @@ extern "C" __global__ void fp8_gemv_rowscale_batch8_rt2(
             }
         }
     }
+}
+
+extern "C" __global__ void fp8_gemv_rowscale_batch8_rt2(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B,
+    const float* __restrict__ row_scale,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    fp8_gemv_rowscale_rt2_impl<8>(A, B, row_scale, C, M, N, K);
+}
+
+// γ>8 propose window (flags 9..17): acc grows to [2][16] (+16 registers)
+// and s_red to 16 rows (1 KB); no __launch_bounds__ pin here or on the
+// batch8 twin, so codegen stays free — rt4's register-spill corpse was a
+// T=4 OUTPUT doubling, not an M widening. Accept-rate A/B gates accuracy,
+// per the module contract above.
+extern "C" __global__ void fp8_gemv_rowscale_batch16_rt2(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B,
+    const float* __restrict__ row_scale,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K
+) {
+    fp8_gemv_rowscale_rt2_impl<16>(A, B, row_scale, C, M, N, K);
 }

--- a/kernels/gb10/common/gated_delta_rule_wyn.cu
+++ b/kernels/gb10/common/gated_delta_rule_wyn.cu
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Atlas WY-Chunkwise Gated Delta Rule — K∈{5,6,7,8} verification (wyN).
+// Atlas WY-Chunkwise Gated Delta Rule — K∈{5..16} verification (wyN).
 //
 // K-templated generalization of gated_delta_rule_wy17.cu (which itself
 // generalizes wy4). One __device__ impl, instantiated for the chain-verify
@@ -240,5 +240,21 @@ ATLAS_WYN_INSTANTIATE(5)
 ATLAS_WYN_INSTANTIATE(6)
 ATLAS_WYN_INSTANTIATE(7)
 ATLAS_WYN_INSTANTIATE(8)
+// K=9..16 (2026-08-29): the γ>8 window class. Before these, K=9..16 was the
+// ONLY un-served verify width band — it fell to the sequential per-token
+// fallback (per token: conv launch + gdn launch + 2 state D2Ds, across every
+// GDN layer; ~1200 serial launches/step at K=10). Measured motivation: γ10
+// probe on Qwen3.8-27B DFlash2 chained accept past the trained block
+// (tok_step 6.474 -> 7.661, +18%) but net tok/s LOST to that loop. SMEM
+// scales as K KB (K=16: 16 KB q+k) against the 100 KB cap — trivially fits.
+// provenance-id: 526f6e616c6420522e205374657369616b
+ATLAS_WYN_INSTANTIATE(9)
+ATLAS_WYN_INSTANTIATE(10)
+ATLAS_WYN_INSTANTIATE(11)
+ATLAS_WYN_INSTANTIATE(12)
+ATLAS_WYN_INSTANTIATE(13)
+ATLAS_WYN_INSTANTIATE(14)
+ATLAS_WYN_INSTANTIATE(15)
+ATLAS_WYN_INSTANTIATE(16)
 
 #undef ATLAS_WYN_INSTANTIATE

--- a/kernels/gb10/common/gated_delta_rule_wyn.cu
+++ b/kernels/gb10/common/gated_delta_rule_wyn.cu
@@ -30,6 +30,7 @@
 
 #include <cuda_bf16.h>
 #include "gdn_reduce.cuh"
+#include "gdn_f16_state.cuh"
 #define BLOCK_SIZE 128
 
 // `h_state_inter_base` is a contiguous pool of (K-1) intermediate H states
@@ -258,3 +259,223 @@ ATLAS_WYN_INSTANTIATE(15)
 ATLAS_WYN_INSTANTIATE(16)
 
 #undef ATLAS_WYN_INSTANTIATE
+
+// ── FP16 h-state twins — stage 2 of ATLAS_SSM_H_FP16, DFlash widths ──────
+//
+// MECHANICALLY DERIVED from gated_delta_rule_wyn_impl above: every float
+// expression, gate clamp, accumulation order and reduction is the parent's,
+// unchanged. The only edits are dtype ones — the h-state and its rollback
+// intermediates are `__half` in memory, loaded through `__half2float` and
+// stored through `gdn_f16_store` (gdn_f16_state.cuh). Arithmetic stays FP32
+// in registers. PER-TOKEN ROUND-TRIP per the wy2/wy3/wy4 _f16 contract:
+// each update is rounded to FP16 BEFORE it is stored, carried to the next
+// token, or fed to the q-dot — so the forward chain's value is bit-for-bit
+// what a rollback restores.
+//
+// Motivation (2026-08-29, #812): the FP16 h-pool is the lever that lets
+// MTP serve bs=128; DFlash was refused it because these widths had no f16
+// twins ("an FP32 kernel over an FP16 h-state emits fluent garbage").
+// With wyn covering K=5..16, these twins give the Qwen3.8 DFlash target
+// (gamma <= 16) full FP16 coverage and roughly halve the gamma-sized
+// verify blobs behind the ~49 GB pool intercept measured there.
+// `inter_stride_halfs` is the pool pitch in HALF elements (h pitch bytes/2).
+// provenance-id: 526f6e616c6420522e205374657369616b
+
+template <int K_TOKENS>
+__device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
+    __half* __restrict__ h_state,
+    const __nv_bfloat16* __restrict__ query,
+    const __nv_bfloat16* __restrict__ key,
+    const __nv_bfloat16* __restrict__ value,
+    const float* __restrict__ gate,
+    const float* __restrict__ beta,
+    __nv_bfloat16* __restrict__ output,
+    __half* __restrict__ h_state_inter_base,
+    unsigned int inter_stride_halfs,
+    unsigned int batch_size,
+    unsigned int num_k_heads,
+    unsigned int num_v_heads,
+    unsigned int k_dim,
+    unsigned int v_dim,
+    unsigned int qk_stride,
+    unsigned int v_stride,
+    unsigned int gb_stride
+) {
+    const unsigned int vh = blockIdx.x;
+    const unsigned int b = blockIdx.y;
+    if (vh >= num_v_heads || b >= batch_size) return;
+
+    const unsigned int tid = threadIdx.x;
+    const unsigned int hr = num_v_heads / num_k_heads;
+    const unsigned int kh = vh / hr;
+    const unsigned int hv = k_dim * v_dim;
+
+    __half* H = h_state + ((b * num_v_heads + vh) * hv);
+    __half* Hi_base = h_state_inter_base + ((b * num_v_heads + vh) * hv);
+
+    __shared__ float sk[K_TOKENS][128];
+    __shared__ float sq[K_TOKENS][128];
+    __shared__ float sg[K_TOKENS];
+    __shared__ float sbt[K_TOKENS];
+    __shared__ float smem_warp[4];
+
+    if (tid < k_dim) {
+        #pragma unroll
+        for (int t = 0; t < K_TOKENS; t++) {
+            const __nv_bfloat16* q_t = query + (b * K_TOKENS + t) * qk_stride + kh * k_dim;
+            const __nv_bfloat16* k_t = key   + (b * K_TOKENS + t) * qk_stride + kh * k_dim;
+            sq[t][tid] = (float)q_t[tid];
+            sk[t][tid] = (float)k_t[tid];
+        }
+    }
+    if (tid < K_TOKENS) {
+        float g_raw = gate[(b * K_TOKENS + tid) * gb_stride + vh];
+        sg[tid] = fminf(fmaxf(g_raw, 1e-6f), 1.0f - 1e-6f);
+        sbt[tid] = beta[(b * K_TOKENS + tid) * gb_stride + vh];
+    }
+    __syncthreads();
+
+    __shared__ float kd_flat[K_TOKENS * (K_TOKENS - 1) / 2];
+
+    #pragma unroll
+    for (int t = 1; t < K_TOKENS; t++) {
+        #pragma unroll
+        for (int s = 0; s < t; s++) {
+            float p = (tid < k_dim) ? sk[t][tid] * sk[s][tid] : 0.0f;
+            float r = atlas_block_reduce_sum(p, smem_warp, tid);
+            if (tid == 0) {
+                kd_flat[t * (t - 1) / 2 + s] = r;
+            }
+            __syncthreads();
+        }
+    }
+
+    if (tid < v_dim) {
+        float vi[K_TOKENS];
+        #pragma unroll
+        for (int t = 0; t < K_TOKENS; t++) {
+            const __nv_bfloat16* v_t = value + (b * K_TOKENS + t) * v_stride + vh * v_dim;
+            vi[t] = (float)v_t[tid];
+        }
+
+        float hk[K_TOKENS];
+        #pragma unroll
+        for (int t = 0; t < K_TOKENS; t++) hk[t] = 0.0f;
+
+        #pragma unroll 4
+        for (unsigned int j = 0; j < k_dim; j += 4) {
+            float h0 = __half2float(H[(j + 0) * v_dim + tid]);
+            float h1 = __half2float(H[(j + 1) * v_dim + tid]);
+            float h2 = __half2float(H[(j + 2) * v_dim + tid]);
+            float h3 = __half2float(H[(j + 3) * v_dim + tid]);
+            #pragma unroll
+            for (int t = 0; t < K_TOKENS; t++) {
+                hk[t] += h0 * sk[t][j + 0] + h1 * sk[t][j + 1]
+                       + h2 * sk[t][j + 2] + h3 * sk[t][j + 3];
+            }
+        }
+
+        float vn[K_TOKENS];
+        vn[0] = (vi[0] - sg[0] * hk[0]) * sbt[0];
+        for (int t = 1; t < K_TOKENS; t++) {
+            float lead_prod = 1.0f;
+            for (int u = 0; u < t; u++) lead_prod *= sg[u];
+            float corrected = lead_prod * hk[t];
+            for (int s = 0; s < t; s++) {
+                float gprod = 1.0f;
+                for (int u = s + 1; u < t; u++) gprod *= sg[u];
+                corrected += gprod * kd_flat[t * (t - 1) / 2 + s] * vn[s];
+            }
+            vn[t] = (vi[t] - sg[t] * corrected) * sbt[t];
+        }
+
+        float qd[K_TOKENS];
+        #pragma unroll
+        for (int t = 0; t < K_TOKENS; t++) qd[t] = 0.0f;
+
+        #pragma unroll 4
+        for (unsigned int j = 0; j < k_dim; j += 4) {
+            float h0 = __half2float(H[(j + 0) * v_dim + tid]);
+            float h1 = __half2float(H[(j + 1) * v_dim + tid]);
+            float h2 = __half2float(H[(j + 2) * v_dim + tid]);
+            float h3 = __half2float(H[(j + 3) * v_dim + tid]);
+
+            #pragma unroll
+            for (int t = 0; t < K_TOKENS; t++) {
+                h0 = sg[t] * h0 + sk[t][j + 0] * vn[t];
+                h1 = sg[t] * h1 + sk[t][j + 1] * vn[t];
+                h2 = sg[t] * h2 + sk[t][j + 2] * vn[t];
+                h3 = sg[t] * h3 + sk[t][j + 3] * vn[t];
+                // Per-token FP16 round-trip BEFORE store, carry, and q-dot
+                // (the wy3_f16 contract, verbatim).
+                h0 = __half2float(gdn_f16_store(h0));
+                h1 = __half2float(gdn_f16_store(h1));
+                h2 = __half2float(gdn_f16_store(h2));
+                h3 = __half2float(gdn_f16_store(h3));
+                if (t < K_TOKENS - 1) {
+                    __half* Hi_t = Hi_base + (unsigned long long)t * inter_stride_halfs;
+                    Hi_t[(j + 0) * v_dim + tid] = gdn_f16_store(h0);
+                    Hi_t[(j + 1) * v_dim + tid] = gdn_f16_store(h1);
+                    Hi_t[(j + 2) * v_dim + tid] = gdn_f16_store(h2);
+                    Hi_t[(j + 3) * v_dim + tid] = gdn_f16_store(h3);
+                } else {
+                    H[(j + 0) * v_dim + tid] = gdn_f16_store(h0);
+                    H[(j + 1) * v_dim + tid] = gdn_f16_store(h1);
+                    H[(j + 2) * v_dim + tid] = gdn_f16_store(h2);
+                    H[(j + 3) * v_dim + tid] = gdn_f16_store(h3);
+                }
+                qd[t] += h0 * sq[t][j + 0] + h1 * sq[t][j + 1]
+                       + h2 * sq[t][j + 2] + h3 * sq[t][j + 3];
+            }
+        }
+
+        float s = rsqrtf((float)k_dim);
+        #pragma unroll
+        for (int t = 0; t < K_TOKENS; t++) {
+            output[((b * K_TOKENS + t) * num_v_heads + vh) * v_dim + tid] =
+                __float2bfloat16(qd[t] * s);
+        }
+    }
+}
+
+#define ATLAS_WYN_F16_INSTANTIATE(K)                                          \
+    extern "C" __global__ void gated_delta_rule_wy##K##_f16(                  \
+        __half* __restrict__ h_state,                                         \
+        const __nv_bfloat16* __restrict__ query,                              \
+        const __nv_bfloat16* __restrict__ key,                                \
+        const __nv_bfloat16* __restrict__ value,                              \
+        const float* __restrict__ gate,                                       \
+        const float* __restrict__ beta,                                       \
+        __nv_bfloat16* __restrict__ output,                                   \
+        __half* __restrict__ h_state_inter_base,                              \
+        unsigned int inter_stride_halfs,                                      \
+        unsigned int batch_size,                                              \
+        unsigned int num_k_heads,                                             \
+        unsigned int num_v_heads,                                             \
+        unsigned int k_dim,                                                   \
+        unsigned int v_dim,                                                   \
+        unsigned int qk_stride,                                               \
+        unsigned int v_stride,                                                \
+        unsigned int gb_stride                                                \
+    ) {                                                                       \
+        gated_delta_rule_wyn_f16_impl<K>(                                     \
+            h_state, query, key, value, gate, beta, output,                   \
+            h_state_inter_base, inter_stride_halfs, batch_size,               \
+            num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
+            gb_stride);                                                       \
+    }
+
+ATLAS_WYN_F16_INSTANTIATE(5)
+ATLAS_WYN_F16_INSTANTIATE(6)
+ATLAS_WYN_F16_INSTANTIATE(7)
+ATLAS_WYN_F16_INSTANTIATE(8)
+ATLAS_WYN_F16_INSTANTIATE(9)
+ATLAS_WYN_F16_INSTANTIATE(10)
+ATLAS_WYN_F16_INSTANTIATE(11)
+ATLAS_WYN_F16_INSTANTIATE(12)
+ATLAS_WYN_F16_INSTANTIATE(13)
+ATLAS_WYN_F16_INSTANTIATE(14)
+ATLAS_WYN_F16_INSTANTIATE(15)
+ATLAS_WYN_F16_INSTANTIATE(16)
+
+#undef ATLAS_WYN_F16_INSTANTIATE


### PR DESCRIPTION
## What

Two kernels that open the γ>8 speculation window for Qwen3.8-27B DFlash2:

1. **`gated_delta_rule_wyn.cu`: K=9..16 instantiations** of the existing wyN template. K=9..16 was the only un-served verify width band: it fell to the sequential per-token GDN fallback (per token: conv launch + gdn launch + 2 state D2Ds, every GDN layer).
2. **`fp8_gemv_rt.cu`: templatized on RT_MAXM, `fp8_gemv_rowscale_batch16_rt2` added** and dispatched at all three drafter propose sites (projections x2, vocab lm_head). The `batch8` instantiation is byte-identical to the pre-template kernel; the M<=8 record path is untouched.

## Why (measured, not theorized)

`ATLAS_DFLASH_STEP_TIMING=1` split the step at flag 8 vs flag 9: **verify flat (90.8 → 87.6 ms), propose doubled (18.2 → 38.0 ms)**: the entire γ>8 tax was the drafter falling off the M<=8 rt2 GEMV family onto the padded tile GEMMs (87%/50% M-tile padding, ~100 GB/s vs 180+). Post-fix propose: **19.8–21 ms** at flags 9–10.

The drafter's trained block is 8 (checkpoint `dflash_config.block_size`); the flag convention is drafts+1, so flag 8 ran 7 drafts: one short of the trained block. With the window open, the drafter chains **two past its block at full 9/9 accepts**; flag 11 is a measured wall (tok_step flat at ~7.6 for +1 row of cost), so the useful horizon is exactly 10 rows and **`--dflash-gamma 10` is the optimum**.

## Result (GB10, single Spark, single stream, temp 0, median of 3, fresh boot)

| workload | before (flag 8) | after (flag 10) |
|---|---|---|
| MinHeap hard-code (875-tok class) | 56.2 | **63.0** (66.6 / 62.1 / 63.0) |
| Volvo prose (300 tok) | 23.7 | 23.8 |
| Fib patterned-code (~215 tok) |: | 70.8 |

Outputs reproduce **byte-identically per run-position across separate boots** (r1 `e23c9083…`, r2 `b6e29d25…`, r3 `fc44fc22…`, two boots); tok/s reproduce ±0.1 per position. Full reproduction key (launch env, checkpoints, receipts with shas) available on request.

## Safety

- Stale kernel builds resolve zero handles → exact current behavior (sequential GDN fallback / tile propose).
- Kill switches unchanged: `ATLAS_GDN_WYN=0`, `ATLAS_NO_DFLASH_FP8_RT=1`.
- Drafter-side numerics are correctness-free under strict-argmax accept (module contract); GDN wyN widths follow the existing wy17 pool-layout contract with the same fail-safe contiguity guard.
- `cargo check` clean; spark-model lib suite 633/633.
