### PR TITLE
fix(qsa,ple): free per-sequence device state on sequence teardown (~739 MB/request leak)

### DIFF
--- a/crates/spark-model/src/layer/transformer_layer.rs
+++ b/crates/spark-model/src/layer/transformer_layer.rs
@@ -643,4 +643,28 @@ pub trait TransformerLayer: Send + Sync {
     /// - `EmptyLayerState` for pure attention layers
     /// - `SsmLayerState` for SSM/recurrent layers
     fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn LayerState>>;
+
+    /// Release the per-sequence state `alloc_state` produced, plus anything
+    /// the layer attached to it lazily afterwards.
+    ///
+    /// Called once per sequence from the teardown chokepoint
+    /// (`free_sequence_dispatch`). The default no-op is correct for layers
+    /// whose state owns no device memory (`EmptyLayerState`) and for state
+    /// that comes from a pool reclaimed by slot (`SsmLayerState`'s h/conv,
+    /// released via `ssm_pool.release_slot`).
+    ///
+    /// It exists because `LayerState` implementors hold BARE `DevicePtr`s:
+    /// dropping the box reclaims the host struct and leaks the device buffer.
+    /// The QSA indexer carry (~739 MB per request at 200K context across the
+    /// 12 full-attention layers) and the PLE conv carry both leaked this way.
+    /// On unified memory such a leak is invisible to RSS and reported as N/A
+    /// by `nvidia-smi`, so it surfaces only as the host exhausting RAM with no
+    /// process to blame.
+    ///
+    /// MUST be idempotent — teardown can run after a partial failure. Callers
+    /// log errors and continue rather than aborting: a sequence that cannot
+    /// free its state is still finished, and bailing would strand the rest.
+    fn release_state(&self, _state: &mut dyn LayerState, _gpu: &dyn GpuBackend) -> Result<()> {
+        Ok(())
+    }
 }

--- a/crates/spark-model/src/layers/ple/layer.rs
+++ b/crates/spark-model/src/layers/ple/layer.rs
@@ -145,6 +145,27 @@ impl PleLayer {
         })
     }
 
+    /// Release one sequence's PLE carry.
+    ///
+    /// Same shape of defect as the QSA indexer carry: `conv` is a bare
+    /// `DevicePtr`, so dropping `PleSeqState` frees nothing. Individually
+    /// small (~147 KB) and below the 32 MB allocation-trace threshold, which
+    /// is exactly why it stayed invisible — but it is one per SSM layer (36
+    /// on qwen4_exp) per sequence, and it never comes back.
+    ///
+    /// Idempotent: `conv` is nulled once freed.
+    pub fn release_seq_state(&self, st: &mut PleSeqState, gpu: &dyn GpuBackend) -> Result<()> {
+        if st.conv.is_null() {
+            return Ok(());
+        }
+        let r = gpu.free(st.conv);
+        st.conv = DevicePtr(0);
+        st.history.clear();
+        st.prestaged_va = None;
+        st.last_staged_va = 0;
+        r
+    }
+
     // `reset` + `prestage` live in `aux_state.rs` (≤500 LoC split).
 
     // Marconi aux-state (snapshot_aux / restore_aux) moved to

--- a/crates/spark-model/src/layers/qsa.rs
+++ b/crates/spark-model/src/layers/qsa.rs
@@ -186,6 +186,37 @@ impl QsaIndexer {
         })
     }
 
+    /// Release one sequence's indexer carry.
+    ///
+    /// `QsaSeqState` holds bare `DevicePtr`s, so dropping the struct frees
+    /// nothing. Without this every finished sequence left
+    /// `max_tokens * hd * 2` (raw) + `max_tokens/ratio * hd * 2` (pooled)
+    /// bytes on the device for EACH full-attention layer — at 200K context
+    /// and 12 such layers, ~739 MB per request. On unified memory that is
+    /// invisible to RSS and to `nvidia-smi`, so it surfaced only as the host
+    /// running out of RAM with no process to blame.
+    ///
+    /// Idempotent: each pointer is nulled as it is freed, so a second call
+    /// (or a release after a partial failure) cannot double-free. A failure
+    /// on the first buffer still attempts the second — leaking the rest
+    /// because the first free failed is the bug this exists to prevent.
+    pub fn release_seq_state(&self, st: &mut QsaSeqState, gpu: &dyn GpuBackend) -> Result<()> {
+        let mut first_err: Option<anyhow::Error> = None;
+        for p in [&mut st.raw_keys, &mut st.block_keys] {
+            if p.is_null() {
+                continue;
+            }
+            if let Err(e) = gpu.free(*p) {
+                first_err.get_or_insert(e);
+            }
+            *p = DevicePtr(0);
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
     pub fn inert_bound(&self) -> usize {
         (self.budget + self.ratio - 1) as usize
     }

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl.rs
@@ -283,6 +283,34 @@ impl TransformerLayer for Qwen3AttentionLayer {
         Ok(Box::new(crate::layer::AttnLayerState::default()))
     }
 
+    /// Free the QSA indexer carry this sequence lazily attached.
+    ///
+    /// `alloc_state` hands back an EMPTY `AttnLayerState`; the buffers appear
+    /// later, on first use, via `qsa_seq_state`. So the thing to release is
+    /// not what `alloc_state` returned — it is whatever the sequence grew.
+    /// `take()` makes this idempotent and leaves the state in the same shape
+    /// `alloc_state` produced.
+    ///
+    /// A layer with no QSA indexer (plain attention) never populates the
+    /// field, so the `take()` yields `None` and this costs nothing.
+    fn release_state(&self, state: &mut dyn LayerState, gpu: &dyn GpuBackend) -> Result<()> {
+        let Some(attn) = state
+            .as_any_mut()
+            .downcast_mut::<crate::layer::AttnLayerState>()
+        else {
+            return Ok(());
+        };
+        let Some(mut st) = attn.qsa.take() else {
+            return Ok(());
+        };
+        let Some(qsa) = self.qsa.as_ref() else {
+            // Buffers exist but the indexer is gone: nothing can size or
+            // free them correctly, and guessing would be worse than saying so.
+            anyhow::bail!("release_state: QSA seq state present but layer has no QSA indexer");
+        };
+        qsa.release_seq_state(&mut st, gpu)
+    }
+
     fn transpose_moe_for_prefill(
         &mut self,
         gpu: &dyn GpuBackend,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_layer.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_layer.rs
@@ -409,6 +409,28 @@ impl TransformerLayer for Qwen3SsmLayer {
     fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn LayerState>> {
         self.alloc_state_inner(gpu)
     }
+
+    /// Free the PLE carry this sequence lazily attached.
+    ///
+    /// Only the `ple` field — the h/conv state in `SsmLayerState` is pooled
+    /// and released by slot in `free_sequence_dispatch`, so freeing it here
+    /// would be a double free. The PLE conv buffer is the one piece that is
+    /// allocated per sequence and owned by nothing.
+    fn release_state(&self, state: &mut dyn LayerState, gpu: &dyn GpuBackend) -> Result<()> {
+        let Some(ssm) = state
+            .as_any_mut()
+            .downcast_mut::<crate::layer::SsmLayerState>()
+        else {
+            return Ok(());
+        };
+        let Some(mut st) = ssm.ple.take() else {
+            return Ok(());
+        };
+        let Some(ple) = self.ple.as_ref() else {
+            anyhow::bail!("release_state: PLE seq state present but layer has no PLE");
+        };
+        ple.release_seq_state(&mut st, gpu)
+    }
 }
 
 /// The PLE per-seq carry from a sequence's [`SsmLayerState`], lazily created

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -137,6 +137,26 @@ impl TransformerModel {
             self.ssm_pool.release_slot(slot);
         }
 
+        // Release per-sequence layer state that is NOT pooled: the QSA indexer
+        // carry (12 full-attention layers x ~61.6 MB at 200K ctx) and the PLE
+        // conv carry. Both are bare `DevicePtr`s inside the layer state, so
+        // dropping `seq.layer_states` reclaims the host structs and leaks the
+        // device buffers — ~739 MB per request, invisible to RSS on unified
+        // memory and reported as N/A by `nvidia-smi`, which is why it read as
+        // "the box is growing" with no process to blame.
+        //
+        // Errors are logged, not propagated: this runs on the teardown path,
+        // and a sequence that cannot free its state is still finished. Bailing
+        // here would strand the KV blocks and prefix refs released below —
+        // trading a leak for a worse one.
+        for (layer_idx, ls) in seq.layer_states.iter_mut().enumerate() {
+            if let Some(layer) = self.layers.get(layer_idx)
+                && let Err(e) = layer.release_state(ls.as_mut(), self.gpu.as_ref())
+            {
+                tracing::error!("free_sequence: release_state(layer {layer_idx}): {e:#}");
+            }
+        }
+
         // Task #25: release this sequence's LoRA slot ref (the single terminal
         // chokepoint every stamped seq routes through — normal stop/EOS/length,
         // error/abort, prefill-error frees, and swap-out spill). Guarded by the

--- a/crates/spark-runtime/src/cuda_backend.rs
+++ b/crates/spark-runtime/src/cuda_backend.rs
@@ -124,7 +124,13 @@ pub struct AtlasCudaBackend {
     /// (`cutlass.rs:246`) and FlashInfer (`flashinfer.rs:145`) call
     /// `cuMemAlloc_v2` directly rather than through this allocator, so freeing
     /// the ledger cannot invalidate a static that outlives the model.
-    live_allocs: parking_lot::Mutex<std::collections::HashSet<u64>>,
+    /// Pointer -> size. The size is carried because the driver will not report
+    /// it back: without it `sweep_unreleased` can say how MANY allocations had
+    /// no owner but never how much memory they held, and on unified memory
+    /// (where every `cuMemAlloc` consumes host RAM) the bytes are the number
+    /// that matters. Tracking them also lets `free` name what it released, so
+    /// an alloc/free trail can be diffed by pointer to find what accumulates.
+    live_allocs: parking_lot::Mutex<std::collections::HashMap<u64, usize>>,
     /// Default CUDA stream handle (from the process CUDA host).
     default_stream: u64,
     /// CUDA context handle for cross-thread binding.
@@ -160,7 +166,7 @@ impl AtlasCudaBackend {
         );
 
         Ok(Self {
-            live_allocs: parking_lot::Mutex::new(std::collections::HashSet::new()),
+            live_allocs: parking_lot::Mutex::new(std::collections::HashMap::new()),
             registry,
             debug_sync_kernels: std::env::var("ATLAS_DEBUG_SYNC_KERNELS").as_deref() == Ok("1"),
             op_cache: crate::op_cache::OpCache::new(),
@@ -171,30 +177,54 @@ impl AtlasCudaBackend {
 
     /// This model's kernel modules, for the paths that need the registry
     /// directly rather than through `GpuBackend`.
-    pub(crate) fn record_alloc(&self, ptr: crate::gpu::DevicePtr) {
-        self.live_allocs.lock().insert(ptr.0);
+    pub(crate) fn record_alloc(&self, ptr: crate::gpu::DevicePtr, bytes: usize) {
+        self.live_allocs.lock().insert(ptr.0, bytes);
     }
 
-    pub(crate) fn forget_alloc(&self, ptr: crate::gpu::DevicePtr) {
-        self.live_allocs.lock().remove(&ptr.0);
+    /// Drop `ptr` from the ledger, returning the size it was recorded with.
+    ///
+    /// `None` means the pointer was not on the ledger — a double free, or an
+    /// allocation that bypassed this allocator (CUTLASS and FlashInfer call
+    /// `cuMemAlloc_v2` directly). Callers use the size only for tracing, so
+    /// `None` is not an error.
+    pub(crate) fn forget_alloc(&self, ptr: crate::gpu::DevicePtr) -> Option<usize> {
+        self.live_allocs.lock().remove(&ptr.0)
+    }
+
+    /// Live allocation count and total bytes currently on the ledger.
+    ///
+    /// The running total is what makes a slow device-side leak visible: RSS
+    /// does not show CUDA allocations on unified memory and `nvidia-smi`
+    /// reports N/A there, so without this the only symptom is the host running
+    /// out of RAM with no process to blame.
+    pub fn live_bytes(&self) -> (usize, u64) {
+        let g = self.live_allocs.lock();
+        (g.len(), g.values().map(|b| *b as u64).sum())
     }
 
     /// Free every allocation this backend made and nobody released.
     ///
     /// The backstop for allocations no `ModelResource` covers — chiefly the
     /// loaders' fused weights, which are owned by layer structs rather than by
-    /// any pool. Returns how many were reclaimed and their total bytes is not
-    /// tracked (the driver does not report per-pointer size), so the count is
-    /// the diagnostic: a non-zero count after a clean teardown names how many
-    /// allocations have no owner.
+    /// any pool. Returns how many were reclaimed; their total bytes is logged
+    /// alongside, since the ledger now carries per-pointer sizes. A non-zero
+    /// count after a clean teardown names how many allocations have no owner,
+    /// and the bytes say whether that matters.
     ///
     /// Runs LAST in teardown, after every `ModelResource::release`, so it only
     /// ever sees what those missed — and each `free` here has already been
     /// removed from the ledger by `forget_alloc`, so it cannot double-free.
     pub fn sweep_unreleased(&self) -> usize {
-        let outstanding: Vec<u64> = self.live_allocs.lock().drain().collect();
+        let outstanding: Vec<(u64, usize)> = self.live_allocs.lock().drain().collect();
         let count = outstanding.len();
-        for raw in outstanding {
+        let bytes: u64 = outstanding.iter().map(|(_, b)| *b as u64).sum();
+        if count > 0 {
+            tracing::warn!(
+                "sweep: {count} unreleased allocations totalling {:.2} GB",
+                bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+            );
+        }
+        for (raw, _) in outstanding {
             // Bypass `free`: the ledger is already drained, and a failure here
             // must not abort the rest of the sweep.
             let status = unsafe { cuMemFree_v2(raw) };

--- a/crates/spark-runtime/src/cuda_backend/gpu_copy.rs
+++ b/crates/spark-runtime/src/cuda_backend/gpu_copy.rs
@@ -19,10 +19,11 @@
 //!   supply their own `len()`, so a host over-run is not expressible.
 //! * The DEVICE end is UNCHECKED. `copy_d2d_impl` in particular takes a bare
 //!   `bytes` that is validated against neither allocation. It cannot be checked
-//!   here: `AtlasCudaBackend::live_allocs` is a `HashSet<u64>` of base pointers
-//!   with no sizes, and callers legitimately pass interior pointers from
-//!   `DevicePtr::offset`, so there is nothing to compare against. Sizing a
-//!   device copy correctly is the CALLER's obligation.
+//!   here: `AtlasCudaBackend::live_allocs` maps base pointer -> size, but
+//!   callers legitimately pass interior pointers from `DevicePtr::offset`,
+//!   which are absent from the ledger and indistinguishable from a bad
+//!   pointer, so a lookup miss cannot be treated as an error. Sizing a device
+//!   copy correctly remains the CALLER's obligation.
 //!
 //! The Metal backend does check its device end (`metal_backend.rs`), because a
 //! `metal::Buffer` knows its own `length()`. The divergence is real, not an

--- a/crates/spark-runtime/src/cuda_backend/gpu_impl.rs
+++ b/crates/spark-runtime/src/cuda_backend/gpu_impl.rs
@@ -118,16 +118,23 @@ impl GpuBackend for AtlasCudaBackend {
                 total as f64 / (1024.0 * 1024.0 * 1024.0),
             );
         }
-        self.record_alloc(DevicePtr(dptr));
+        self.record_alloc(DevicePtr(dptr), bytes);
         // Large-allocation tracing for memory attribution (GB10 unified
         // memory: every cuMemAlloc consumes host RAM, and a runtime alloc
         // outside the util pledge is how the box ends up in swap). Debug
         // level so production INFO stays quiet; RUST_LOG=spark_runtime=debug
         // turns the trail on.
+        //
+        // The running live total rides along because the per-alloc size alone
+        // cannot distinguish churn from a leak: a 96 MB buffer allocated and
+        // freed every step looks identical in the trail to one that is never
+        // released. `live` climbing across steps is the leak signal.
         if bytes >= 32 * 1024 * 1024 {
+            let (n, live) = self.live_bytes();
             tracing::debug!(
-                "alloc {:.1} MB (device ptr {dptr:#x})",
-                bytes as f64 / (1024.0 * 1024.0)
+                "alloc {:.1} MB (device ptr {dptr:#x}) live={:.2} GB in {n} allocs",
+                bytes as f64 / (1024.0 * 1024.0),
+                live as f64 / (1024.0 * 1024.0 * 1024.0)
             );
         }
         Ok(DevicePtr(dptr))
@@ -143,7 +150,7 @@ impl GpuBackend for AtlasCudaBackend {
                  Check system swap space: swapon --show"
             );
         }
-        self.record_alloc(DevicePtr(dptr));
+        self.record_alloc(DevicePtr(dptr), bytes);
         Ok(DevicePtr(dptr))
     }
 
@@ -153,7 +160,22 @@ impl GpuBackend for AtlasCudaBackend {
         }
         // Off the ledger BEFORE the free: an entry that survives a successful
         // free would be double-freed at teardown.
-        self.forget_alloc(ptr);
+        //
+        // The size comes back from the ledger so the free trail can be diffed
+        // against the alloc trail by pointer — the query that names what is
+        // accumulating. `None` is a pointer this allocator never handed out
+        // (CUTLASS and FlashInfer allocate directly), which is not an error.
+        if let Some(bytes) = self.forget_alloc(ptr)
+            && bytes >= 32 * 1024 * 1024
+        {
+            let (n, live) = self.live_bytes();
+            tracing::debug!(
+                "free {:.1} MB (device ptr {:#x}) live={:.2} GB in {n} allocs",
+                bytes as f64 / (1024.0 * 1024.0),
+                ptr.0,
+                live as f64 / (1024.0 * 1024.0 * 1024.0)
+            );
+        }
         let status = unsafe { cuMemFree_v2(ptr.0) };
         // A context that is already being destroyed reports every free as
         // failing, and at process exit that is the normal case, not an error:


### PR DESCRIPTION
`QsaSeqState` and `PleSeqState` hold bare `DevicePtr`s. Dropping the layer
state reclaimed the host struct and leaked the device buffers behind it —
nothing ever called `gpu.free`.

## The measurement

On qwen4_exp at 200K ctx, driving requests with growing context:

```
live >=32MB allocations:  196 -> 208 -> 220 -> 232 -> 244
host used (gx10):        82.1 -> 83.8 -> 85.4 -> 87.6 -> 90.7 GB
host used (dgx-00):      85.4 -> 87.0 -> 88.3 -> 90.3 -> 92.9 GB
```

Exactly **+12 allocations per request, linear, no plateau**. Every one of them
48.8 MB — `max_tokens * hd * 2` = 200000 x 128 x 2, so sized by config rather
than by prompt length, which is why it did not vary with input size. qwen4_exp
has exactly 12 full-attention layers, one `raw_keys` each, plus the 12.8 MB
`block_keys` beside it: **~739 MB per request that never comes back**.

Both EP ranks climb identically, since both run all 12 attention layers.

`PleSeqState::conv` has the same defect on the 36 SSM layers. At ~147 KB it
sits below the 32 MB allocation-trace threshold, which is why only QSA was
ever visible.

## Why it was invisible

On GB10 unified memory, CUDA allocations appear in no `/proc` counter, are
absent from process RSS, and `nvidia-smi` reports memory as N/A. The symptom
was a host climbing to 118 GB of 121 with page cache squeezed to nothing,
while the only candidate process showed a 16 GB RSS. Attributing it needs the
carveout computed by subtraction:

```
MemTotal - MemFree - Cached - AnonPages - Slab - PageTables - KernelStack
```

which read 97.5 GB against a ~67 GB util pledge.

## The fix

`TransformerLayer::release_state`, the counterpart to the existing
`alloc_state`, defaulted to a no-op so only the two layers that own unpooled
per-sequence device memory implement it. (`SsmLayerState`'s h/conv is pooled
and released by slot — freeing it here would be a double free.)

`free_sequence_dispatch` — the terminal chokepoint every finished sequence
routes through, on every path: stop/EOS/length, error/abort, prefill-error
free, swap-out spill — now calls it per layer. Errors are logged rather than
propagated: bailing there would strand the KV blocks and prefix-cache refs
released further down, trading a leak for a worse one.

Note the buffers are attached lazily on first use, not by `alloc_state`, so
what `release_state` frees is whatever the sequence actually grew. `take()`
makes it idempotent.

## Ledger changes

The allocator ledger was a `HashSet<u64>` of bare pointers, so
`sweep_unreleased` could report how MANY allocations had no owner but never
how much memory they held — its own doc comment conceded this. It is now a
`HashMap<u64, usize>`:

- `sweep_unreleased` logs total bytes leaked, not just a count.
- `free` traces what it releases, so alloc/free trails can be diffed by
  pointer — the query that names what accumulates.
- Both traces carry a running live total. Without it, a buffer allocated and
  freed every step is indistinguishable in the log from one never released.

The existing `>=32MB` alloc trace already existed for exactly this failure
("a runtime alloc outside the util pledge is how the box ends up in swap") but
is `RUST_LOG=spark_runtime=debug`, so it is dark under the usual `info`.

## Testing

- `cargo build --release --all-targets` and `cargo clippy --release
  --all-targets` clean (`ATLAS_TARGET_MODEL=*`).
- 632 tests pass. One video-decode test fails only under parallel execution
  (`/tmp` contention on the test box); it passes in isolation and is unrelated.
- Verified live on the EP=2 qwen4_exp config (200K ctx, util 0.55): the
  ledger's live total is flat across requests where it previously climbed
  ~585 MB each, and no `release_state` errors are logged.

Introduced in 0a56d8f8b (the Flash-Next integration stack); this is a
correctness fix independent of #820, which touches the same file for
performance.
