### PR TITLE
test(cutlass): SFB swizzle parity harness at real MoE shapes + CUTLASS grouped-MoE evaluation notes

### DIFF
--- a/crates/spark-runtime/src/cutlass/tests/mod.rs
+++ b/crates/spark-runtime/src/cutlass/tests/mod.rs
@@ -10,6 +10,7 @@ use std::ffi::c_void;
 
 mod bf16;
 mod nvfp4;
+mod sfb_parity;
 
 pub(super) const CUDA_MEMCPY_HOST_TO_DEVICE: i32 = 1;
 pub(super) const CUDA_MEMCPY_DEVICE_TO_HOST: i32 = 2;

--- a/crates/spark-runtime/src/cutlass/tests/sfb_parity.rs
+++ b/crates/spark-runtime/src/cutlass/tests/sfb_parity.rs
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Numeric parity for the SFB weight-scale swizzle (`pack_weight_sfb`).
+//!
+//! ## Why this exists
+//!
+//! `pack_weight_sfb` has two source-layout modes and its doc comment claims
+//! "Output layout is identical either way":
+//!
+//! * `src_n_major = false` — Atlas-transposed `[K/16, N]`, indexed
+//!   `scales[group * n + col]`
+//! * `src_n_major = true`  — checkpoint-native `[N, K/16]`, indexed
+//!   `scales[col * (k/16) + group]`
+//!
+//! That claim is a PROPERTY, not a fixture: for any scale matrix `A` of shape
+//! `[N, K/16]`, packing `A` n-major must byte-match packing `Aᵀ` k-major.
+//! Both are supposed to be the same swizzle over the same logical values, so
+//! no golden data is needed to test it.
+//!
+//! It matters because **qwen4_exp is the only model that takes the n-major
+//! fallback** — Holo and qwen35 build the transposed `gate_ptrs_t` and take
+//! the other branch — and enabling CUTLASS grouped MoE on qwen4_exp measured
+//! +30% prefill but destabilised generation (not bit-exact; a controlled
+//! agentic A/B went from 6/6 passing to not completing, with the model
+//! hallucinating that its own output was being corrupted). A rarely-exercised
+//! swizzle branch is the leading suspect, and before this file the branch had
+//! no test coverage at all.
+//!
+//! ## What a failure here means, and what it does not
+//!
+//! These tests validate the packer's INTERNAL consistency: that the two source
+//! indexings address the same logical element. They deliberately build a DENSE
+//! `[N, K/16]` source, so they do **not** prove that qwen4_exp's real
+//! checkpoint scales are dense with row stride exactly `k/16`. A padded or
+//! strided scale tensor would make the n-major read wrong in production while
+//! these tests still pass. If everything here is green, that stride assumption
+//! against a real checkpoint is the next thing to check — the packer takes a
+//! bare pointer and is told only `n` and `k`, so it cannot detect the
+//! difference itself.
+//!
+//! GPU tests: `#[ignore]` per repo convention.
+//! ```text
+//! cargo test -p spark-runtime --release sfb_ -- --ignored --nocapture
+//! ```
+
+use super::*;
+
+/// Bytes in the swizzled SFB atom for a given `(n, k)`.
+///
+/// Mirrors `MoeLayer::build_cutlass_grouped_sfb`'s `sfb_len`: the atom is
+/// padded to 128 in N and to 4 in the K/16 scale-group axis. Kept as a
+/// separate copy on purpose — if the two ever disagree, the allocation and
+/// the kernel's writes disagree, and this test should be the thing that says
+/// so rather than a silent heap overwrite in production.
+fn sfb_len(n: usize, k: usize) -> usize {
+    n.div_ceil(128) * 128 * (k / 16).div_ceil(4) * 4
+}
+
+/// A deterministic, non-symmetric E4M3 byte for logical position `(row, col)`.
+///
+/// Non-symmetric in the two indices on purpose: a packer that transposed its
+/// source by mistake would still produce matching output for any pattern that
+/// is symmetric under `(row, col) -> (col, row)`, so such a pattern could not
+/// detect the very bug this file exists to find.
+///
+/// Restricted to `0x00..=0x7E`: `0x7F` is NaN in E4M3, and the packer's output
+/// type is `float_ue4m3_t` — UNSIGNED — so negative inputs are outside the
+/// meaningful domain for a weight scale and would only test clamping.
+fn scale_byte(row: usize, col: usize, salt: u64) -> u8 {
+    let h = (row as u64)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add((col as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9))
+        .wrapping_add(salt);
+    ((h >> 24) % 0x7F) as u8
+}
+
+/// Device buffer that frees itself, so an assertion failure cannot leak it.
+struct DevBuf(*mut c_void);
+
+impl DevBuf {
+    fn alloc(bytes: usize) -> Self {
+        let mut p: *mut c_void = std::ptr::null_mut();
+        cuda_check(unsafe { cudaMalloc(&mut p, bytes) }, "cudaMalloc");
+        Self(p)
+    }
+
+    fn upload(src: &[u8]) -> Self {
+        let b = Self::alloc(src.len());
+        cuda_check(
+            unsafe {
+                cudaMemcpy(
+                    b.0,
+                    src.as_ptr() as *const c_void,
+                    src.len(),
+                    CUDA_MEMCPY_HOST_TO_DEVICE,
+                )
+            },
+            "cudaMemcpy H2D",
+        );
+        b
+    }
+
+    fn zeroed(bytes: usize) -> Self {
+        Self::upload(&vec![0u8; bytes])
+    }
+
+    fn download(&self, bytes: usize) -> Vec<u8> {
+        let mut out = vec![0u8; bytes];
+        cuda_check(
+            unsafe {
+                cudaMemcpy(
+                    out.as_mut_ptr() as *mut c_void,
+                    self.0,
+                    bytes,
+                    CUDA_MEMCPY_DEVICE_TO_HOST,
+                )
+            },
+            "cudaMemcpy D2H",
+        );
+        out
+    }
+
+    fn addr(&self) -> u64 {
+        self.0 as u64
+    }
+}
+
+impl Drop for DevBuf {
+    fn drop(&mut self) {
+        unsafe { cudaFree(self.0) };
+    }
+}
+
+/// Pack one `[N, K/16]` scale matrix through BOTH source layouts and return
+/// the two SFB atoms.
+///
+/// `a_n_major` is row-major `[N, K/16]`. The k-major arm transposes it on the
+/// HOST into `[K/16, N]` — the same logical matrix, the layout the Atlas
+/// transposed path would have produced — and packs that with
+/// `src_n_major = false`.
+///
+/// The output buffers are zero-filled first: the SFB atom is padded (N to 128,
+/// K/16 to 4) and the kernel only writes the live region, so comparing raw
+/// buffers would otherwise compare uninitialised padding and fail for reasons
+/// that have nothing to do with the swizzle.
+fn pack_both_ways(n: usize, k: usize, salt: u64) -> (Vec<u8>, Vec<u8>) {
+    let groups = k / 16;
+    let len = sfb_len(n, k);
+
+    let mut a_n_major = vec![0u8; n * groups];
+    for row in 0..n {
+        for g in 0..groups {
+            a_n_major[row * groups + g] = scale_byte(row, g, salt);
+        }
+    }
+    // [N, K/16] -> [K/16, N]
+    let mut a_k_major = vec![0u8; groups * n];
+    for row in 0..n {
+        for g in 0..groups {
+            a_k_major[g * n + row] = a_n_major[row * groups + g];
+        }
+    }
+
+    let src_n = DevBuf::upload(&a_n_major);
+    let src_k = DevBuf::upload(&a_k_major);
+    let out_n = DevBuf::zeroed(len);
+    let out_k = DevBuf::zeroed(len);
+
+    pack_weight_sfb(src_n.addr(), out_n.addr(), n as u32, k as u32, true, 0)
+        .expect("pack_weight_sfb (n-major)");
+    pack_weight_sfb(src_k.addr(), out_k.addr(), n as u32, k as u32, false, 0)
+        .expect("pack_weight_sfb (k-major)");
+    cuda_check(unsafe { cudaDeviceSynchronize() }, "cudaDeviceSynchronize");
+
+    (out_n.download(len), out_k.download(len))
+}
+
+/// Compare two SFB atoms and panic with a diagnosis rather than just a count.
+///
+/// The mismatch COUNT distinguishes the likely causes on its own: a handful of
+/// differing bytes points at an edge/padding case, while "almost every byte"
+/// means the two arms addressed different elements throughout — a transposed
+/// or wrongly-strided read.
+fn assert_sfb_eq(n: usize, k: usize, got_n: &[u8], got_k: &[u8]) {
+    assert_eq!(got_n.len(), got_k.len(), "SFB length disagreement");
+    let diffs: Vec<usize> = got_n
+        .iter()
+        .zip(got_k.iter())
+        .enumerate()
+        .filter(|(_, (a, b))| a != b)
+        .map(|(i, _)| i)
+        .collect();
+    if diffs.is_empty() {
+        return;
+    }
+    let nonzero = got_n.iter().filter(|b| **b != 0).count();
+    let show: Vec<String> = diffs
+        .iter()
+        .take(8)
+        .map(|&i| format!("[{i}] n-major={:#04x} k-major={:#04x}", got_n[i], got_k[i]))
+        .collect();
+    panic!(
+        "SFB parity FAILED for n={n} k={k}: {} of {} bytes differ \
+         ({} bytes are live in the n-major atom).\n  {}\n\
+         The two source layouts are supposed to be the same swizzle over the \
+         same values, so any difference means one of the two indexings in \
+         pack_weight_sfb_group addresses the wrong element. qwen4_exp is the \
+         only model on the n-major path.",
+        diffs.len(),
+        got_n.len(),
+        nonzero,
+        show.join("\n  ")
+    );
+}
+
+/// qwen4_exp gate/up projection: `(n, k) = (moe_intermediate, hidden)`.
+///
+/// Read from the shipping checkpoint's `config.json`
+/// (Qwen3.8-Flash-Next-NVFP4): `hidden_size = 2560`,
+/// `moe_intermediate_size = 640`, 512 experts over 48 layers. These are the
+/// exact dims the grouped MoE runs, and the ones the CUTLASS enablement
+/// measured +30% prefill on before generation destabilised.
+///
+/// The shared expert has `shared_expert_intermediate_size = 640` — the same
+/// shape — so it needs no separate case.
+#[test]
+#[ignore = "requires GPU"]
+fn sfb_layout_parity_qwen4exp_gate_up() {
+    let (n, k) = (640, 2560);
+    let (a, b) = pack_both_ways(n, k, 0xA1);
+    assert_sfb_eq(n, k, &a, &b);
+}
+
+/// qwen4_exp down projection: dims swap to `(hidden, moe_intermediate)`.
+///
+/// Its own case rather than a loop entry because `down` is where the two axes
+/// trade places — N becomes 2560 and K/16 becomes 40 — so a bug that depends
+/// on their relative magnitude shows here and not in gate/up.
+#[test]
+#[ignore = "requires GPU"]
+fn sfb_layout_parity_qwen4exp_down() {
+    let (n, k) = (2560, 640);
+    let (a, b) = pack_both_ways(n, k, 0xD0);
+    assert_sfb_eq(n, k, &a, &b);
+}
+
+/// The other production model whose loader builds SFB atoms:
+/// holo-3.1-35b-a3b (`hidden_size = 2048`, `moe_intermediate_size = 512`).
+///
+/// Holo reaches the packer through the TRANSPOSED path, not the n-major
+/// fallback, so parity here is the control: if qwen4_exp's shapes were to fail
+/// while these pass, the fault is specific to the shapes rather than to the
+/// n-major indexing, and vice versa.
+///
+/// ★ Every shape in this file is fully aligned in both axes, because every
+/// real one is: N is a multiple of 128 (640, 2560, 512, 2048) and K/16 is a
+/// multiple of 4 (160, 40, 128, 32). The SFB atom's padding path — N rounded
+/// to 128, K/16 rounded to 4 — is therefore NOT exercised by any shipping
+/// model, and consequently not by these tests. That is a deliberate
+/// consequence of testing real shapes only; a synthetic unaligned case would
+/// cover it, at the cost of asserting behaviour no model depends on.
+#[test]
+#[ignore = "requires GPU"]
+fn sfb_layout_parity_holo35b() {
+    for &(n, k) in &[
+        (512, 2048), // gate/up: (moe_intermediate, hidden)
+        (2048, 512), // down:    (hidden, moe_intermediate)
+    ] {
+        let (a, b) = pack_both_ways(n, k, n as u64 * 31 + k as u64);
+        assert_sfb_eq(n, k, &a, &b);
+    }
+}
+
+/// The swizzle must be a permutation of the source values, not a
+/// value-transforming pass.
+///
+/// Parity alone cannot catch a fault that corrupts BOTH arms identically — two
+/// wrongs agreeing still pass `assert_sfb_eq`. This checks the packed atom
+/// against the source as a multiset: every source scale must appear in the
+/// output the same number of times, with the padding accounted for separately.
+///
+/// Values round-trip `E4M3 byte -> float -> ue4m3 -> byte`. That is
+/// bit-preserving for the non-negative finite domain used here (both types
+/// share the E4M3 field layout for positive values), so an exact multiset
+/// compare is the right assertion rather than an approximate one.
+#[test]
+#[ignore = "requires GPU"]
+fn sfb_swizzle_preserves_values() {
+    let (n, k) = (640, 2560);
+    let groups = k / 16;
+    let len = sfb_len(n, k);
+
+    let mut src = vec![0u8; n * groups];
+    for row in 0..n {
+        for g in 0..groups {
+            src[row * groups + g] = scale_byte(row, g, 0x5E);
+        }
+    }
+    let d_src = DevBuf::upload(&src);
+    let d_out = DevBuf::zeroed(len);
+    pack_weight_sfb(d_src.addr(), d_out.addr(), n as u32, k as u32, true, 0)
+        .expect("pack_weight_sfb");
+    cuda_check(unsafe { cudaDeviceSynchronize() }, "cudaDeviceSynchronize");
+    let out = d_out.download(len);
+
+    let mut want = [0usize; 256];
+    for b in &src {
+        want[*b as usize] += 1;
+    }
+    let mut got = [0usize; 256];
+    for b in &out {
+        got[*b as usize] += 1;
+    }
+    // The atom is larger than the live region; the surplus is the zero fill.
+    let padding = len - n * groups;
+    got[0] = got[0].saturating_sub(padding);
+
+    for v in 0..256usize {
+        assert_eq!(
+            got[v], want[v],
+            "value {v:#04x}: swizzle emitted {} occurrences, source had {} \
+             (n={n} k={k}). The SFB pack must PERMUTE the scales, so any \
+             change in the multiset means values are being dropped, \
+             duplicated, or altered — which parity between the two source \
+             layouts cannot detect on its own.",
+            got[v], want[v]
+        );
+    }
+}


### PR DESCRIPTION
Adds the first test coverage for `pack_weight_sfb`, and records what a full
CUTLASS grouped-MoE evaluation on qwen4_exp found.

## The code

`pack_weight_sfb` has two source-layout modes and its doc comment claims
*"Output layout is identical either way"*:

* `src_n_major = false` — Atlas-transposed `[K/16, N]`, `scales[group*n + col]`
* `src_n_major = true`  — checkpoint-native `[N, K/16]`, `scales[col*(k/16) + group]`

That claim had **no test coverage at all**, and **qwen4_exp is the only model
that takes the n-major fallback** — Holo and qwen35 build the transposed
`gate_ptrs_t` and take the other branch. A rarely-exercised swizzle was the
leading suspect for CUTLASS grouped MoE not being bit-exact on this model.

The claim is a PROPERTY, not a fixture: for any scale matrix `A` of shape
`[N, K/16]`, packing `A` n-major must byte-match packing `Aᵀ` k-major. So the
tests need no golden data.

Shapes are read from the shipping checkpoints rather than invented:

| model | source | gate/up (n,k) | down (n,k) |
|---|---|---|---|
| qwen4_exp | hidden 2560, moe_intermediate 640 | (640, 2560) | (2560, 640) |
| holo-3.1-35b-a3b | hidden 2048, moe_intermediate 512 | (512, 2048) | (2048, 512) |

Holo takes the transposed path, so it is the control: a failure confined to
qwen4_exp's shapes would separate an indexing fault from a shape-dependent one.

A fourth test compares the packed atom against its source as a **multiset**,
because parity alone cannot catch a fault that corrupts both arms identically —
two wrongs agreeing still pass a parity check.

**All four pass**, so the n-major indexing is exonerated as the cause of the
non-bit-exactness.

### Limits, deliberate and documented in the file

* The tests build a **dense** `[N, K/16]` source, so they do not prove that the
  real checkpoint scales are dense with row stride exactly `k/16`. The kernel
  takes a bare pointer and only `n` and `k`, so a padded stride would mis-read
  in production while these still pass. That is now the leading hypothesis.
* Every real shape is aligned in both axes (N a multiple of 128, K/16 a
  multiple of 4), so the SFB atom's padding path is exercised by no shipping
  model and therefore not here either.

### Running

```
cargo test -p spark-runtime --release sfb_ -- --ignored --nocapture
```

`CUTLASS_HOME` must be set. Without it the whole `cutlass::tests` module is
`cfg`'d out and cargo reports "0 tests" — a green run that proves nothing.

## Notes: CUTLASS grouped MoE evaluation on qwen4_exp

Recorded here because it contradicts the standing note that CUTLASS is
default-off on quality grounds. Measured on GB10, EP=2 across two nodes, on one
binary (this base + #820 + a QSA/PLE teardown leak fix + #781), with CUTLASS as
the only variable.

**Prefill**, 132K prompt tokens, 3 reps each:

| arm | reps (tok/s) | mean |
|---|---|---|
| off | 644 / 641 / 646 | 643.7 |
| on  | 762 / 767 / 767 | 765.3 |

**+19.0%** — and that is a floor: this run had only `ATLAS_HOLO_MOE_GROUPED_CUTLASS`
set, so the down projection was still on the ptrtable kernel.
`ATLAS_HOLO_MOE_GROUPED_DOWN` is a **separate gate**.

**Agentic battery** (`agentic-webserver`, 3 iterations, thinking ON @
`reasoning_effort=low`, preserve-thinking, model-card sampling, 32K/2seqs):

| arm | turns | Σwall | s/turn | verdict |
|---|---|---|---|---|
| off | 16 / 10 / 23 = 49 | 1163 s | 23.69 | 3/3 pass, 6/6 steps, 3/3 directions |
| on  | 10 / 12 / 11 = 33 | 708 s  | 21.35 | 3/3 pass, 6/6 steps, 3/3 directions |

The previously recorded failure — did not complete by turn 17, 15 corruption
episodes, 48 KB trajectory against 17–19 KB — **did not reproduce**.

**What this does not establish.** The Σwall gap should not be quoted as a
CUTLASS result: the off arm's turn spread (10–23) overlaps the on arm's (10–12),
so at n=3 this battery is noisy and Σwall is dominated by turn count rather than
throughput. The defensible efficiency signal is s/turn, ~10% better, consistent
with the prefill number. Nor can the reversal be attributed to one cause — the
earlier failure was single-node on an older stack, so both the topology and the
code changed.

**Still true:** CUTLASS is not bit-exact. A greedy temp-0 probe over identical
prompts gave identical output on deterministic tasks (integers 1–60, verbatim
identifiers — no dropped underscores) and materially different output on
open-ended code generation (different algorithm, `pub struct` vs `struct`).
Both outputs were clean: divergent, not corrupt.

**Operational note.** Verify the arm is actually armed by checking the serve log
for `CUTLASS grouped SFB: built ... experts`. A zero count means the flags were
inert and the run silently measured the baseline — which would look like a clean
pass.

Suggested reading of the evidence: adopt behind the flag for EP=2, but do not
flip the default yet — n=3 on a battery this noisy is not enough to overturn a
default set for quality, and the non-bit-exactness is still unexplained.


## Update: kernel-level breakdown (nsys), answering "faster kernel or fewer launches?"

The evaluation above measured end-to-end and agentic-battery numbers but could not
say *why* CUTLASS wins — specifically whether the win is a faster kernel or
fewer/fused launches (CUTLASS issues one grouped call; the native path could in
principle issue more). That question decides the whole de-CUTLASS design space: a
launch-count win is recoverable with a scheduling/fusion change and no new kernel;
a kernel-throughput win needs the SM120 block-scaled MMA rewritten natively, which
brings the same non-bit-exactness CUTLASS has.

**Method.** `nsys` (not `ncu` — `ncu`'s kernel replay caused two single-node OOM
hard locks and one EP-side memory spike during this investigation; `nsys` traces
without replaying and has a much lower, more predictable footprint). EP=2, one
`nsys launch`-wrapped rank + one plain rank, identical 8192-ctx/util-0.5 config,
identical prompt (~3.85K tokens), CUTLASS as the only variable. Captured with
`nsys start`/`stop` scoped to just the prefill request, read back with
`nsys stats --report cuda_gpu_kern_sum` (gives per-kernel total time *and*
instance count from one capture).

**Result — same launch count, much faster kernel:**

| kernel | native | CUTLASS on |
|---|---|---|
| MoE grouped GEMM | `moe_w4a16_grouped_gemm_ptrtable`, 38.3% of GPU time, **288 launches**, 6.86ms avg | CUTLASS block-scaled grouped GEMM, 5.8% of GPU time, **288 launches**, 0.67ms avg |
| **speedup** | | **10.2x per launch** (1.976s -> 0.194s total) |
| request wall time | 6.1s | 4.4s (-28%) |

Launch count is **identical (288 = 288)** — CUTLASS does not fuse or reduce the
number of grouped-GEMM calls here. The entire win is per-kernel throughput.

**Clean-A/B sanity check.** `qsa_prefill_attn` (unrelated to MoE, 24 launches in
both arms) measured 792.4ms native vs 791.1ms CUTLASS — a -0.16% difference,
i.e. unchanged within noise. Its *share* of GPU time rose from 15.4% to 23.8%
purely because the MoE kernel shrank underneath it (a smaller denominator), not
because it got slower. This confirms the two captures are a clean, isolated A/B
and nothing else in the pipeline shifted.

**What the CUTLASS kernel actually is**, read from the unmangled symbol in the
capture: `MainloopSm120ArrayTmaWarpSpecializedBlockScaled` over
`SM120::BLOCKSCALED::SM120_16x8x64_TN_VS<e2m1, e2m1, float, ue4m3>` — the SM120
block-scaled FP4 tensor-core MMA, TMA-pipelined, `GemmUniversal` with
`GroupProblemShape` for the grouped dispatch. This confirms the standing
hypothesis for why CUTLASS is not bit-exact: the block-scaled instruction
requires **both** operands in e2m1 (W4A4), while the native kernel feeds BF16
activations (W4A16, `moe_w4a16_grouped_gemm.cu:149`). That is a strictly
different, lossier numeric contract than a fusion or scheduling change could
ever be — so the quality cost cannot be separated from the speedup on this
instruction.

**Conclusion for de-CUTLASS.** Since the win is confirmed kernel-throughput at
matched launch count, "fuse the launches" (a CUTLASS-free structural fix) cannot
recover it. Matching this natively means implementing the SM120 block-scaled MMA
by hand (the `native-blockscaled-mma` proposal from the earlier design pass) —
the highest-effort, highest-ceiling path on that pass's board — and it inherits
the same W4A4 quality cost CUTLASS has, because that cost is intrinsic to the
instruction, not to CUTLASS's use of it.
