### PR TITLE
blog: name the answer engines in robots.txt, as the site already does

### DIFF
--- a/blog/static/robots.txt
+++ b/blog/static/robots.txt
@@ -1,4 +1,62 @@
+# Atlas blog — https://blog.atlasinference.io
+#
+# Notes from the inference layer, on an open source project. Being found is the
+# point, so nothing here is disallowed.
+#
+# Answer engines are named explicitly rather than left to the wildcard, because
+# several of them treat an absent named rule as a reason to be conservative —
+# the same reasoning, and the same list, as site/static/robots.txt. The two
+# files are deliberately parallel: a crawler that is welcome on the product site
+# is welcome on the writing that explains it.
+
 User-agent: *
 Allow: /
+
+# Search
+User-agent: Googlebot
+Allow: /
+User-agent: Bingbot
+Allow: /
+User-agent: DuckDuckBot
+Allow: /
+
+# Answer engines and AI crawlers
+User-agent: GPTBot
+Allow: /
+User-agent: OAI-SearchBot
+Allow: /
+User-agent: ChatGPT-User
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: Claude-User
+Allow: /
+User-agent: Claude-SearchBot
+Allow: /
+User-agent: anthropic-ai
+Allow: /
+User-agent: PerplexityBot
+Allow: /
+User-agent: Perplexity-User
+Allow: /
+User-agent: Google-Extended
+Allow: /
+User-agent: Applebot
+Allow: /
+User-agent: Applebot-Extended
+Allow: /
+User-agent: Amazonbot
+Allow: /
+User-agent: meta-externalagent
+Allow: /
+User-agent: cohere-ai
+Allow: /
+User-agent: YouBot
+Allow: /
+
+# A summary of this host, generated from the post index at build time, lives at
+# https://blog.atlasinference.io/llms.txt — a comment rather than a directive,
+# because llms.txt is not part of the robots exclusion standard and a made-up
+# directive is ignored at best and a parse error at worst.
 
 Sitemap: https://blog.atlasinference.io/sitemap.xml


### PR DESCRIPTION
One file. `blog/static/robots.txt` goes from four lines to the same shape `site/static/robots.txt` has had all along.

## Why

The site names twenty crawlers explicitly and says why in a comment at the top: several answer engines treat the absence of a named rule as a reason to be conservative. The blog was shipping the stub:

```
User-agent: *
Allow: /

Sitemap: https://blog.atlasinference.io/sitemap.xml
```

That reasoning applies harder here than it does on the product site. The blog is the property whose whole job is to be quoted — a post exists so that someone asking a question gets an answer with a source attached, and the crawlers that build those answers are exactly the ones the wildcard was leaving to guess.

## What changed

The agent list is copied from the site rather than rewritten, and I diffed the two to confirm they're identical. That's the point: a crawler welcome on the product site should be welcome on the writing that explains it, and two hand-maintained lists drift.

Nothing is disallowed, because nothing here is private. The `Sitemap:` line is unchanged.

The pointer to `/llms.txt` is a **comment, not a directive**. llms.txt isn't part of the robots exclusion standard; a made-up directive is ignored by well-behaved parsers and a syntax error in strict ones, and neither is worth the line. The generated llms.txt is discoverable at its well-known path already.

## Verified

`bun run build` clean, and `build/robots.txt` is the new file — it's a static asset, so there's no route to regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
