### PR TITLE
dflash: serve the record shape by default (66.6 tok/s, zero flags)

### DIFF
--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -148,10 +148,18 @@ pub fn build_model(
         // a DFlash2 checkpoint states its trained block size inside
         // `dflash_config`, and the top-level field's default of 16 must not
         // shadow it. --dflash-gamma still wins over both.
-        config.dflash_gamma = Some(
-            args.gamma
-                .unwrap_or(args.drafter_config.effective_block_size()),
-        );
+        //
+        // MUST go through `default_dflash_gamma`, this value sizes the SSM
+        // pools (uniform K = γ+1), and the HEAD resolves its own γ through
+        // the same helper. When this said `block_size` while the head said
+        // block+2, the pools came up one verify row short and the first
+        // DFlash step died with "SSM MTP intermediate buffers not allocated
+        // (h=8, conv=9, num_tokens=10)" mid-graph-capture.
+        config.dflash_gamma = Some(args.gamma.unwrap_or_else(|| {
+            crate::layers::qwen3_ssm::default_dflash_gamma(
+                args.drafter_config.effective_block_size(),
+            )
+        }));
         tracing::info!(
             "DFlash: target layer capture indices = {:?} (drafter target_layer_ids, \
              used directly), γ = {:?}",

--- a/crates/spark-model/src/layers/dflash_head.rs
+++ b/crates/spark-model/src/layers/dflash_head.rs
@@ -318,7 +318,9 @@ pub struct DflashProposerState {
     /// EAGLE-fix one-shot: when set, the next `propose()` skips its internal
     /// decode-append because the verify step (K=2 accept) already appended
     /// row 0 + row 1 in EAGLE order before calling propose. Consumed (reset to
-    /// false) by propose. Only set under ATLAS_DFLASH_EAGLE_FIX=1.
+    /// false) by propose. Set on the EAGLE-fix path, which is DEFAULT-ON
+    /// (`ATLAS_DFLASH_EAGLE_FIX=0` is the kill switch, not `=1` the opt-in , 
+    /// see verify_k2_step.rs and verify_dflash_step.rs, both `!= Some("0")`).
     pub skip_next_decode_append: bool,
     /// Allocation cap for `ctx_hidden_acc` (in slot count). Mirrors the
     /// `max_seq_len` build arg so we can clamp without re-fetching it.

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -71,10 +71,23 @@ impl BlockDiffusionDraftHead {
         let head_dim = weights.config.head_dim;
         let vocab_size = weights.config.vocab_size;
         // The HEAD's gamma is the SSOT the serve layer reads back, so the
-        // drafter's own trained block size must win here — `block_size` alone
-        // is the top-level field, whose serde default of 16 silently shadows
-        // a DFlash2 checkpoint that states 8 in `dflash_config`.
-        let gamma_val = gamma.unwrap_or(weights.config.effective_block_size());
+        // drafter's checkpoint must drive the default here — `block_size`
+        // alone is the top-level field, whose serde default of 16 silently
+        // shadows a DFlash2 checkpoint that states 8 in `dflash_config`.
+        //
+        // Default = trained block size + 2, not the block size itself: these
+        // drafters chain past their trained block (measured on Qwen3.8-27B
+        // DFlash2, block 8 — gamma 8 is 7 drafts, one short; gamma 10 holds
+        // full-block 9/9 accepts and is the fastest measured serve, 63.0 vs
+        // 56.2 tok/s on GB10). Clamped to MAX_F16_TWIN_DFLASH_GAMMA so a
+        // block-16-class drafter resolves to 15, the widest verify width
+        // (K = 16) with kernel coverage across both h-state dtypes — never
+        // into wy17+, which the f16 path refuses and no wyN twin serves.
+        // An explicit --dflash-gamma still wins unconditionally.
+        let gamma_val = gamma.unwrap_or_else(|| {
+            (weights.config.effective_block_size() + 2)
+                .min(crate::layers::qwen3_ssm::MAX_F16_TWIN_DFLASH_GAMMA)
+        });
 
         // Allocate the drafter's paged FP8 KV cache. One multi-layer cache,
         // sized for `max_seq_len + γ + 1` positions (prompt + γ drafts +

--- a/crates/spark-model/src/layers/dflash_head/from_weights.rs
+++ b/crates/spark-model/src/layers/dflash_head/from_weights.rs
@@ -71,22 +71,17 @@ impl BlockDiffusionDraftHead {
         let head_dim = weights.config.head_dim;
         let vocab_size = weights.config.vocab_size;
         // The HEAD's gamma is the SSOT the serve layer reads back, so the
-        // drafter's checkpoint must drive the default here — `block_size`
+        // drafter's checkpoint must drive the default here, `block_size`
         // alone is the top-level field, whose serde default of 16 silently
         // shadows a DFlash2 checkpoint that states 8 in `dflash_config`.
         //
-        // Default = trained block size + 2, not the block size itself: these
-        // drafters chain past their trained block (measured on Qwen3.8-27B
-        // DFlash2, block 8 — gamma 8 is 7 drafts, one short; gamma 10 holds
-        // full-block 9/9 accepts and is the fastest measured serve, 63.0 vs
-        // 56.2 tok/s on GB10). Clamped to MAX_F16_TWIN_DFLASH_GAMMA so a
-        // block-16-class drafter resolves to 15, the widest verify width
-        // (K = 16) with kernel coverage across both h-state dtypes — never
-        // into wy17+, which the f16 path refuses and no wyN twin serves.
-        // An explicit --dflash-gamma still wins unconditionally.
+        // Default = `default_dflash_gamma` (trained block + 2, clamped), the
+        // SSOT the serve preflights size their pools and reserves from too.
+        // Resolve it HERE ONLY through that helper: an independent spelling
+        // here is how the head came to run gamma 10 against intermediates
+        // reserved for K=9. An explicit --dflash-gamma still wins.
         let gamma_val = gamma.unwrap_or_else(|| {
-            (weights.config.effective_block_size() + 2)
-                .min(crate::layers::qwen3_ssm::MAX_F16_TWIN_DFLASH_GAMMA)
+            crate::layers::qwen3_ssm::default_dflash_gamma(weights.config.effective_block_size())
         });
 
         // Allocate the drafter's paged FP8 KV cache. One multi-layer cache,

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -132,6 +132,32 @@ pub const MAX_F16_TWIN_K: usize = 16;
 /// The largest `--dflash-gamma` whose verify width still has an FP16 twin.
 pub const MAX_F16_TWIN_DFLASH_GAMMA: usize = MAX_F16_TWIN_K - 1;
 
+/// The served DFlash gamma for a drafter of this trained block size, when
+/// no `--dflash-gamma` was given.
+///
+/// THE SSOT, and it must stay that way: the drafter head resolves its gamma
+/// through this, and so does every preflight that sizes a pool or a reserve
+/// from a peeked `dflash_config.block_size`. Two spellings of this rule is
+/// how the SSM MTP intermediates came to be reserved for K=9 while verify
+/// asked for K=10, a hard error at the first verify step, mid-graph-capture.
+///
+/// `block + 2`, because these drafters chain PAST their trained block:
+/// measured on Qwen3.8-27B DFlash2 (block 8), gamma 8 runs 7 drafts, one
+/// short, while gamma 10 holds full-block 9/9 accepts and is the fastest
+/// measured serve (63.0 vs 56.2 tok/s on GB10, 2026-08-29).
+///
+/// Clamped to `MAX_F16_TWIN_DFLASH_GAMMA` so a block-16-class drafter lands
+/// on 15, the widest verify width with kernel coverage under both h-state
+/// dtypes, instead of gamma 18 / K=19, which no wyN kernel serves.
+pub const fn default_dflash_gamma(trained_block_size: usize) -> usize {
+    let bumped = trained_block_size + 2;
+    if bumped > MAX_F16_TWIN_DFLASH_GAMMA {
+        MAX_F16_TWIN_DFLASH_GAMMA
+    } else {
+        bumped
+    }
+}
+
 /// `--ssm-h-dtype f16` (legacy `ATLAS_SSM_H_FP16`).
 pub fn ssm_h_fp16_enabled() -> bool {
     flags().h_f16

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -406,7 +406,8 @@ mod trait_prefill_proj;
 mod trait_prefill_recur;
 
 pub use gdn_flags::{
-    GdnFlags, MAX_F16_TWIN_DFLASH_GAMMA, MAX_F16_TWIN_K, gdn_fused_norm_enabled,
+    GdnFlags, MAX_F16_TWIN_DFLASH_GAMMA, MAX_F16_TWIN_K, default_dflash_gamma,
+    gdn_fused_norm_enabled,
     ssm_batched_recurrent_enabled, ssm_h_dtype_bits, ssm_h_f16_pool_enabled, ssm_h_fp16_enabled,
     verify_exact_enabled,
 };

--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -663,7 +663,7 @@ pub(crate) fn load_model(
             .map(|(s, c)| spark_model::factory::DflashBuildArgs {
                 drafter_store: s,
                 drafter_config: c.clone(),
-                gamma: args.dflash_gamma, // None → head resolves effective_block_size()
+                gamma: args.dflash_gamma, // None → head resolves via default_dflash_gamma()
                 window_size: if args.dflash_window_size > 0 {
                     Some(args.dflash_window_size)
                 } else {

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -71,6 +71,7 @@ pub(crate) fn preflight_reserve(
     // the miss direction is over-reserve, never under.
     let pool_num_drafts = if args.dflash {
         peek_dflash_block_size(args.draft_model.as_deref())
+            .map(spark_model::layers::qwen3_ssm::default_dflash_gamma)
             .unwrap_or_else(|| args.resolved_dflash_gamma(None))
     } else {
         args.resolved_num_drafts()
@@ -455,8 +456,11 @@ fn peek_dflash_block_size(draft_model: Option<&str>) -> Option<usize> {
 /// from the drafter's checkpoint via the same peek the pool reserve uses.
 pub(crate) fn spec_reserve_tokens(args: &cli::ServeArgs) -> usize {
     if args.dflash {
-        let gamma = peek_dflash_block_size(args.draft_model.as_deref())
-            .unwrap_or_else(|| args.resolved_dflash_gamma(None));
+        let gamma = args.dflash_gamma.unwrap_or_else(|| {
+            peek_dflash_block_size(args.draft_model.as_deref())
+                .map(spark_model::layers::qwen3_ssm::default_dflash_gamma)
+                .unwrap_or_else(|| args.resolved_dflash_gamma(None))
+        });
         gamma + 1
     } else if args.speculative || args.self_speculative || args.ngram_speculative {
         args.resolved_num_drafts() + 2

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -167,8 +167,18 @@ impl SchedLevers {
             mtp_minp: on_unless("ATLAS_NO_MTP_MINP"),
             mtp_verify_sample: on_unless("ATLAS_NO_MTP_VERIFY_SAMPLE"),
 
-            dflash_masked_verify: opt_in("ATLAS_DFLASH_MASKED_VERIFY"),
-            dflash_seam_serial: opt_in("ATLAS_DFLASH_SEAM_SERIAL"),
+            // DEFAULT-ON since 2026-08-31: masked_verify, seam_serial and
+            // spec_think are three of the levers behind the 63.0 tok/s
+            // record serve (Qwen3.8-27B + DFlash2, γ=10, GB10, 2026-08-29 —
+            // 56.2 -> 63.0 with the record env; RECORDS_LEDGER holds the
+            // reproduction key). A default `spark serve --dflash` previously
+            // shipped none of them, so out-of-the-box DFlash ran the slow
+            // shape of its own engine. `=0` restores each legacy path for
+            // A/B; `=1` remains a harmless no-op in every existing recipe.
+            dflash_masked_verify: on_unless_zero("ATLAS_DFLASH_MASKED_VERIFY"),
+            dflash_seam_serial: on_unless_zero("ATLAS_DFLASH_SEAM_SERIAL"),
+            // NOT graduated: the record env runs adaptive OFF (γ scheduling
+            // is static at the measured optimum); opt-in remains correct.
             dflash_adaptive: opt_in("ATLAS_DFLASH_ADAPTIVE"),
             dflash_serial_append: opt_in("ATLAS_DFLASH_SERIAL_APPEND"),
             // DEFAULT-ON since 2026-08-19: without the unified ctx commit the
@@ -180,7 +190,9 @@ impl SchedLevers {
             // count +31% (PR #604). `ATLAS_DFLASH_UNIFIED_CTX=0` restores the
             // legacy append for A/B.
             dflash_unified_ctx: on_unless_zero("ATLAS_DFLASH_UNIFIED_CTX"),
-            dflash_spec_think: opt_in("ATLAS_DFLASH_SPEC_THINK"),
+            // Third of the graduated record levers — see the 2026-08-31
+            // comment above dflash_masked_verify.
+            dflash_spec_think: on_unless_zero("ATLAS_DFLASH_SPEC_THINK"),
             dflash_gate_pin_c2: on_unless_zero("ATLAS_DFLASH_GATE_PIN_C2"),
             dflash_batch_verify: on_unless_zero("ATLAS_DFLASH_BATCH_VERIFY"),
             dflash_adaptive_min: num("ATLAS_DFLASH_ADAPTIVE_MIN", 2.0),

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -169,7 +169,7 @@ impl SchedLevers {
 
             // DEFAULT-ON since 2026-08-31: masked_verify, seam_serial and
             // spec_think are three of the levers behind the 63.0 tok/s
-            // record serve (Qwen3.8-27B + DFlash2, γ=10, GB10, 2026-08-29 —
+            // record serve (Qwen3.8-27B + DFlash2, γ=10, GB10, 2026-08-29 , 
             // 56.2 -> 63.0 with the record env; RECORDS_LEDGER holds the
             // reproduction key). A default `spark serve --dflash` previously
             // shipped none of them, so out-of-the-box DFlash ran the slow
@@ -190,7 +190,7 @@ impl SchedLevers {
             // count +31% (PR #604). `ATLAS_DFLASH_UNIFIED_CTX=0` restores the
             // legacy append for A/B.
             dflash_unified_ctx: on_unless_zero("ATLAS_DFLASH_UNIFIED_CTX"),
-            // Third of the graduated record levers — see the 2026-08-31
+            // Third of the graduated record levers, see the 2026-08-31
             // comment above dflash_masked_verify.
             dflash_spec_think: on_unless_zero("ATLAS_DFLASH_SPEC_THINK"),
             dflash_gate_pin_c2: on_unless_zero("ATLAS_DFLASH_GATE_PIN_C2"),


### PR DESCRIPTION
A default `spark serve --dflash` did not serve the configuration that set
the records. It served a slower shape of the same engine, and every number
we have published came from a launch line that knew the incantation.

This makes the defaults **The measured configuration.**

## What changes

**Gamma.** The drafter head's default gamma was the checkpoint's trained
block size. On Qwen3.8-27B DFlash2 that is 8, which runs 7 drafts, one
short. These drafters chain past their trained block: at gamma 10 the
verify holds full-block 9/9 accepts. Default becomes `block + 2`, clamped
to `MAX_F16_TWIN_DFLASH_GAMMA` so a block-16-class drafter lands on 15
rather than gamma 18 / K=19, which no wyN kernel serves. An explicit
`--dflash-gamma` still wins everywhere.

**Three levers graduate from opt-in to default-on**, using the same
`on_unless_zero` pattern `unified_ctx` already uses:
`ATLAS_DFLASH_MASKED_VERIFY`, `ATLAS_DFLASH_SEAM_SERIAL`,
`ATLAS_DFLASH_SPEC_THINK`. `=0` restores each legacy path for A/B, and
`=1` stays a harmless no-op, so every existing recipe remains correct.
`dflash_adaptive` deliberately stays opt-in: the record runs it off.

## One SSOT, because three spellings cost a run

The block-size-to-gamma rule existed independently in the head's
`from_weights`, the serve preflight's pool and reserve sizing, and
`factory::build`'s `config.dflash_gamma`. Raising only the head left the
pools sizing for the old value, and the first verify step died
mid-graph-capture:

```
SSM MTP intermediate buffers not allocated (need K-1 h + K conv;
h_state_intermediates.len()=8, conv_state_intermediates.len()=9,
num_tokens=10)
```

All four sites now resolve through `qwen3_ssm::default_dflash_gamma()`.

## Measured

Qwen3.8-27B NVFP4 + DFlash2, single DGX Spark, single stream, clocks
unpinned. Launched with **zero `ATLAS_DFLASH_*` variables and no gamma
flag**, which is the point: this is the out-of-the-box path.

| bench | runs | median | tokens | output sha |
|---|---|---|---|---|
| MinHeap (code) | 66.6 / 66.6 / 66.5 | **66.6** | 839 | `e23c9083` x3 |
| Volvo (prose)  | 24.7 / 24.7 / 24.7 | **24.7** | 300 | `90c1fca8` x3 |

Against the 2026-08-29 records on the same box: MinHeap 63.0 median from
66.6 / 62.1 / 63.0, Volvo 23.8 from 23.9 / 23.3 / 23.8.

From a CUDA/C centric tuning background, the repeatability is the result
worth reading here rather than the throughput.
The record sets cycled three different outputs by run position (`e23c9083` / `b6e29d25` / `fc44fc22`).

These sets produced one output each, byte for byte, three times.
Token counts are identical to the record class, so the comparison is
length-matched rather than slope-corrected. 

I am not claiming a cause for the variance collapse; main has moved a long way since `244d42f6` and
`dflash_batch_verify` landed default-on in #818, both of which touch this
path.

