### PR TITLE
gdn: pointer-table twins for wyN K=5..16 (batched-verify foundation, behavior-neutral)

### DIFF
--- a/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
+++ b/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
@@ -349,6 +349,73 @@ pub fn gdn_decode_wyn(
         .launch(stream)
 }
 
+/// Cross-sequence batched-verify launch of the wyN pointer-table twins
+/// (`gated_delta_rule_wy{5..16}_table` / `_f16_table`): `state_is_table`
+/// is compiled into the symbol, so the argument list is identical to
+/// [`gdn_decode_wyn`] — but the STATE arguments mean something different
+/// and batching is the point:
+/// - `h_tables`   = the layer's staged table slice: slab 0 holds one
+///   per-sequence H base pointer per entry (`VERIFY_WY_TABLE_SEQS` slots).
+/// - `hi_tables`  = slab 1 (Hi0); consecutive Hi slabs follow at
+///   `VERIFY_WY_TABLE_SEQS`-entry stride.
+/// - `slab_entry_stride` MUST be `VERIFY_WY_TABLE_SEQS as u32` — the
+///   kernel reinterprets the contiguous-form stride argument as "pointer
+///   entries between Hi slabs".
+/// Tables are staged by `upload_verify_wy_tables` (verify_e2.rs) into a
+/// fixed buffer refreshed pre-replay, so the launch is CUDA-graph-stable.
+#[allow(clippy::too_many_arguments)]
+// provenance-id: 526f6e616c6420522e205374657369616b
+#[allow(dead_code)] // seam 2026-09-01: consumer = the dispatcher 5..=16 arm, next change
+pub fn gdn_decode_wyn_table(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    h_tables: DevicePtr,
+    query: DevicePtr,
+    key: DevicePtr,
+    value: DevicePtr,
+    gate: DevicePtr,
+    beta: DevicePtr,
+    output: DevicePtr,
+    hi_tables: DevicePtr,
+    slab_entry_stride: u32,
+    batch_size: u32,
+    num_k_heads: u32,
+    num_v_heads: u32,
+    k_dim: u32,
+    v_dim: u32,
+    qk_stride: u32,
+    v_stride: u32,
+    gb_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    anyhow::ensure!(
+        !h_tables.is_null() && !hi_tables.is_null(),
+        "gdn_decode_wyn_table: staged pointer tables are required (NULL table \
+         means upload_verify_wy_tables declined — run the per-sequence loop)"
+    );
+    KernelLaunch::new(gpu, kernel)
+        .grid([num_v_heads, batch_size, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h_tables)
+        .arg_ptr(query)
+        .arg_ptr(key)
+        .arg_ptr(value)
+        .arg_ptr(gate)
+        .arg_ptr(beta)
+        .arg_ptr(output)
+        .arg_ptr(hi_tables)
+        .arg_u32(slab_entry_stride)
+        .arg_u32(batch_size)
+        .arg_u32(num_k_heads)
+        .arg_u32(num_v_heads)
+        .arg_u32(k_dim)
+        .arg_u32(v_dim)
+        .arg_u32(qk_stride)
+        .arg_u32(v_stride)
+        .arg_u32(gb_stride)
+        .launch(stream)
+}
+
 /// Fused 2-token conv1d sliding window update + SiLU.
 ///
 /// Each thread handles one channel independently. The 2-token dependency

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -431,6 +431,9 @@ impl Qwen3SsmLayer {
             ),
             gdn_wyn_k: init_kernels::wyn_kernels(gpu),
             gdn_wyn_f16_k: init_kernels::wyn_f16_kernels(gpu),
+            // provenance-id: 526f6e616c6420522e205374657369616b
+            gdn_wyn_table_k: init_kernels::wyn_table_kernels(gpu),
+            gdn_wyn_f16_table_k: init_kernels::wyn_f16_table_kernels(gpu),
             h_state_bytes: nv * vd * kd * 4, // FP32 [nv, kd, vd] transposed for coalescing
             conv_state_bytes: conv_dim * d_conv * 4, // FP32 [conv_dim, d_conv]
             qkvz_fp8: None,

--- a/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
@@ -68,3 +68,44 @@ pub(super) fn wyn_f16_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
         crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_f16"),
     ]
 }
+
+/// Cross-sequence batched-verify pointer-table twins of [`wyn_kernels`]
+/// (`state_is_table` compiled in as 1). ADDITIVE symbols: the contiguous
+/// forms above keep their exact signatures, so the shared
+/// `gdn_decode_wyn` launch (also used by the per-target wy17) is never
+/// perturbed. Same index contract as `wyn_kernels`.
+// provenance-id: 526f6e616c6420522e205374657369616b
+pub(super) fn wyn_table_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
+    [
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_table"),
+    ]
+}
+
+/// FP16 twins of [`wyn_table_kernels`]; same index contract.
+pub(super) fn wyn_f16_table_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
+    [
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_f16_table"),
+    ]
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -338,6 +338,11 @@ pub struct Qwen3SsmLayer {
     /// HARD ERROR at dispatch (never a silent FP32 fallback over FP16
     /// state). provenance-id: 526f6e616c6420522e205374657369616b
     gdn_wyn_f16_k: [KernelHandle; 12],
+    /// Pointer-table twins for the cross-sequence batched verify
+    /// (K=5..16, `state_is_table` compiled in); index = K - 5.
+    gdn_wyn_table_k: [KernelHandle; 12],
+    /// FP16 twins of the above; same index contract.
+    gdn_wyn_f16_table_k: [KernelHandle; 12],
     // State allocation sizes (pre-computed from config)
     h_state_bytes: usize,
     conv_state_bytes: usize,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
@@ -45,6 +45,35 @@ impl Qwen3SsmLayer {
         (k.0 != 0).then_some(k)
     }
 
+    /// The pointer-table wyN twin for the CROSS-SEQUENCE batched verify at
+    /// width `num_tokens` ∈ {5..16} (`state_is_table` compiled in), or
+    /// `None` when out of range / module absent / `ATLAS_GDN_WYN=0` — the
+    /// caller then runs the per-sequence loop, byte-identical math. FP16
+    /// pool routing mirrors [`Self::wyn_kernel`]: over an f16 h pool only
+    /// the f16 twin is correct, and a zero twin handle returns None so the
+    /// caller's f16 refusal path (`require_wy_f16`) fires instead of
+    /// corruption.
+    // Seam marker 2026-09-01: consumed by the batched-verify dispatcher's
+    // 5..=16 arm (the NEXT change, gated on unit tests + nsys aim). Dead
+    // until then by design — the foundation ships behavior-neutral.
+    // provenance-id: 526f6e616c6420522e205374657369616b
+    #[allow(dead_code)]
+    pub(super) fn wyn_table_kernel(
+        &self,
+        num_tokens: usize,
+        wyn_enabled: bool,
+    ) -> Option<KernelHandle> {
+        if !(5..=16).contains(&num_tokens) || !wyn_enabled {
+            return None;
+        }
+        let k = if super::ssm_h_fp16_enabled() {
+            self.gdn_wyn_f16_table_k[num_tokens - 5]
+        } else {
+            self.gdn_wyn_table_k[num_tokens - 5]
+        };
+        (k.0 != 0).then_some(k)
+    }
+
     /// Fused pool-layout WY verify arm for K = `args.num_tokens`:
     /// conv1d+L2norm epilogue (single fused launch writing every rollback
     /// snapshot inline when `gdn_verify_fused_conv_kn` is present and the

--- a/kernels/gb10/common/gated_delta_rule_wyn.cu
+++ b/kernels/gb10/common/gated_delta_rule_wyn.cu
@@ -58,7 +58,18 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // Same contract as wy2/wy3/wy4:
+    // 0 = h_state / h_state_inter_base are CONTIGUOUS bases indexed by
+    //     (b*num_v_heads+vh), Hi_t at t*inter_stride_floats — the C=1
+    //     chain-verify form, byte-identical to the original;
+    // 1 = both args are device POINTER TABLES: h_state is a slab of
+    //     `batch_size` per-sequence H base pointers, h_state_inter_base
+    //     points at the Hi0 slab, and `inter_stride_floats` is
+    //     REINTERPRETED as the number of POINTER ENTRIES between
+    //     consecutive Hi slabs (= VERIFY_WY_TABLE_SEQS). This reaches
+    //     Hi_t for any t without adding K-1 arguments.
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -69,10 +80,23 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
     const unsigned int kh = vh / hr;
     const unsigned int hv = k_dim * v_dim;
 
-    float* H = h_state + ((b * num_v_heads + vh) * hv);
-    // Per-(b, vh) offset into the intermediate pool. Each Hi_t base ptr =
-    // h_state_inter_base + t * inter_stride_floats + ((b*nv+vh)*hv).
-    float* Hi_base = h_state_inter_base + ((b * num_v_heads + vh) * hv);
+    const unsigned long long head_off = (unsigned long long)vh * hv;
+    const unsigned long long flat_off =
+        (unsigned long long)(b * num_v_heads + vh) * hv;
+    float* H = state_is_table ? ((float* const*)h_state)[b] + head_off
+                              : h_state + flat_off;
+    // Per-t Hi pointers, hoisted once per block. Contiguous form: base +
+    // t*stride at the (b, vh) offset (identical math to the original
+    // Hi_base). Table form: slab t's per-sequence entry, plus head_off.
+    float* Hi_ptrs[K_TOKENS - 1];
+    #pragma unroll
+    for (int t = 0; t < K_TOKENS - 1; t++) {
+        Hi_ptrs[t] = state_is_table
+            ? ((float* const*)h_state_inter_base)[b + (unsigned long long)t * inter_stride_floats]
+                  + head_off
+            : h_state_inter_base + flat_off
+                  + (unsigned long long)t * inter_stride_floats;
+    }
 
     // ── Load q, k, gate, beta into SMEM ──
     __shared__ float sk[K_TOKENS][128];
@@ -182,7 +206,7 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
                 h2 = sg[t] * h2 + sk[t][j + 2] * vn[t];
                 h3 = sg[t] * h3 + sk[t][j + 3] * vn[t];
                 if (t < K_TOKENS - 1) {
-                    float* Hi_t = Hi_base + t * inter_stride_floats;
+                    float* Hi_t = Hi_ptrs[t];
                     Hi_t[(j + 0) * v_dim + tid] = h0;
                     Hi_t[(j + 1) * v_dim + tid] = h1;
                     Hi_t[(j + 2) * v_dim + tid] = h2;
@@ -234,7 +258,36 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
             h_state, query, key, value, gate, beta, output,                   \
             h_state_inter_base, inter_stride_floats, batch_size,              \
             num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
-            gb_stride);                                                       \
+            gb_stride, 0u);                                                   \
+    }                                                                         \
+    /* Cross-sequence batched-verify twin: same impl, state args are     */   \
+    /* device POINTER TABLES (see the impl's state_is_table contract).   */   \
+    /* ADDITIVE symbol so the contiguous form's signature (shared with   */   \
+    /* the per-target wy17 launches via gdn_decode_wyn) never changes.   */   \
+    extern "C" __global__ void gated_delta_rule_wy##K##_table(                \
+        float* __restrict__ h_state,                                          \
+        const __nv_bfloat16* __restrict__ query,                              \
+        const __nv_bfloat16* __restrict__ key,                                \
+        const __nv_bfloat16* __restrict__ value,                              \
+        const float* __restrict__ gate,                                       \
+        const float* __restrict__ beta,                                       \
+        __nv_bfloat16* __restrict__ output,                                   \
+        float* __restrict__ h_state_inter_base,                               \
+        unsigned int inter_stride_floats,                                     \
+        unsigned int batch_size,                                              \
+        unsigned int num_k_heads,                                             \
+        unsigned int num_v_heads,                                             \
+        unsigned int k_dim,                                                   \
+        unsigned int v_dim,                                                   \
+        unsigned int qk_stride,                                               \
+        unsigned int v_stride,                                                \
+        unsigned int gb_stride                                                \
+    ) {                                                                       \
+        gated_delta_rule_wyn_impl<K>(                                         \
+            h_state, query, key, value, gate, beta, output,                   \
+            h_state_inter_base, inter_stride_floats, batch_size,              \
+            num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
+            gb_stride, 1u);                                                   \
     }
 
 ATLAS_WYN_INSTANTIATE(5)
@@ -299,7 +352,13 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // Same contract as the FP32 impl above: 0 = contiguous bases (C=1
+    // form, byte-identical); 1 = h_state / h_state_inter_base are device
+    // POINTER TABLES (per-sequence __half* entries), and
+    // `inter_stride_halves` is REINTERPRETED as the number of POINTER
+    // ENTRIES between consecutive Hi slabs (= VERIFY_WY_TABLE_SEQS).
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -310,8 +369,20 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
     const unsigned int kh = vh / hr;
     const unsigned int hv = k_dim * v_dim;
 
-    __half* H = h_state + ((b * num_v_heads + vh) * hv);
-    __half* Hi_base = h_state_inter_base + ((b * num_v_heads + vh) * hv);
+    const unsigned long long head_off = (unsigned long long)vh * hv;
+    const unsigned long long flat_off =
+        (unsigned long long)(b * num_v_heads + vh) * hv;
+    __half* H = state_is_table ? ((__half* const*)h_state)[b] + head_off
+                               : h_state + flat_off;
+    __half* Hi_ptrs[K_TOKENS - 1];
+    #pragma unroll
+    for (int t = 0; t < K_TOKENS - 1; t++) {
+        Hi_ptrs[t] = state_is_table
+            ? ((__half* const*)h_state_inter_base)[b + (unsigned long long)t * inter_stride_halves]
+                  + head_off
+            : h_state_inter_base + flat_off
+                  + (unsigned long long)t * inter_stride_halves;
+    }
 
     __shared__ float sk[K_TOKENS][128];
     __shared__ float sq[K_TOKENS][128];
@@ -413,7 +484,7 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
                 h2 = __half2float(gdn_f16_store(h2));
                 h3 = __half2float(gdn_f16_store(h3));
                 if (t < K_TOKENS - 1) {
-                    __half* Hi_t = Hi_base + (unsigned long long)t * inter_stride_halves;
+                    __half* Hi_t = Hi_ptrs[t];
                     Hi_t[(j + 0) * v_dim + tid] = gdn_f16_store(h0);
                     Hi_t[(j + 1) * v_dim + tid] = gdn_f16_store(h1);
                     Hi_t[(j + 2) * v_dim + tid] = gdn_f16_store(h2);
@@ -462,7 +533,33 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
             h_state, query, key, value, gate, beta, output,                   \
             h_state_inter_base, inter_stride_halves, batch_size,               \
             num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
-            gb_stride);                                                       \
+            gb_stride, 0u);                                                   \
+    }                                                                         \
+    /* Batched-verify pointer-table twin — see the FP32 macro's note. */      \
+    extern "C" __global__ void gated_delta_rule_wy##K##_f16_table(            \
+        __half* __restrict__ h_state,                                         \
+        const __nv_bfloat16* __restrict__ query,                              \
+        const __nv_bfloat16* __restrict__ key,                                \
+        const __nv_bfloat16* __restrict__ value,                              \
+        const float* __restrict__ gate,                                       \
+        const float* __restrict__ beta,                                       \
+        __nv_bfloat16* __restrict__ output,                                   \
+        __half* __restrict__ h_state_inter_base,                              \
+        unsigned int inter_stride_halves,                                      \
+        unsigned int batch_size,                                              \
+        unsigned int num_k_heads,                                             \
+        unsigned int num_v_heads,                                             \
+        unsigned int k_dim,                                                   \
+        unsigned int v_dim,                                                   \
+        unsigned int qk_stride,                                               \
+        unsigned int v_stride,                                                \
+        unsigned int gb_stride                                                \
+    ) {                                                                       \
+        gated_delta_rule_wyn_f16_impl<K>(                                     \
+            h_state, query, key, value, gate, beta, output,                   \
+            h_state_inter_base, inter_stride_halves, batch_size,               \
+            num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
+            gb_stride, 1u);                                                   \
     }
 
 ATLAS_WYN_F16_INSTANTIATE(5)


### PR DESCRIPTION
Part 1 of the batched K=gamma GDN verify work (the C=16 lane). BEHAVIOR-NEUTRAL by construction: nothing dispatches to the new code yet, so this merges with zero risk and no gate impact.

What it adds, all additive:
- `state_is_table` pointer-table addressing inside both wyN impls (K=5..16), the exact mode wy2/3/4 already carry: when flagged, each block resolves its sequence's H and Hi_t through per-sequence device pointer tables instead of contiguous strides.
- 24 new symbols (`gated_delta_rule_wy{5..16}_table` + `_f16_table`) with the flag compiled in. Every pre-existing symbol keeps a byte-identical signature (constant 0 internally), so the shared `gdn_decode_wyn` launch and the per-target wy17 kernels are untouched.
- Rust side: table-kernel registries (testable name consts), the f16-routed `wyn_table_kernel` selector, and the `gdn_decode_wyn_table` launch wrapper.

Measured motivation (nsys node-trace, 2026-09-01, C=16): `gated_delta_rule_wy10` running per-sequence was the #1 kernel in the entire engine on BOTH workloads: 187,392 launches / 27.7% of GPU time on prose, 59,904 / 24.5% on code, 16 x 48 x steps exactly.

Part 2 (stacked next) flips the dispatcher and carries the tests + receipts.
