### PR TITLE
gdn: switch on the K=5..16 batched verify (#837 stacked) — 201.0 tok/s C=16 median, byte-identical

### DIFF
--- a/crates/spark-model/src/layer/transformer_layer.rs
+++ b/crates/spark-model/src/layer/transformer_layer.rs
@@ -33,8 +33,14 @@ mod default_loops;
 /// is a pure host-side layout change). 48 GDN layers x 4 tables x 32
 /// entries x 8 B = 48 KB.
 pub const VERIFY_WY_TABLE_SEQS: usize = 32;
-/// Tables per GDN layer: h_state + Hi0..Hi2 (K=4 verify → 3 intermediates).
-pub const VERIFY_WY_TABLES_PER_LAYER: usize = 4;
+/// Tables per GDN layer: h_state + Hi0..Hi14 (K=16 verify → 15
+/// intermediates). 4 → 16 (2026-09-01): the wyN pointer-table twins
+/// extend the cross-sequence batched verify to K=5..16, so the staging
+/// gate `(2..=THIS)` must admit gamma-width verifies; at 4 every K>4
+/// batch silently declined to the per-sequence loop (measured 09-01:
+/// 187,392 wy10 launches = 27.7% of GPU time in a C=16 prose window).
+/// Cost: 48 layers x 16 x 32 x 8 B = 192 KB of host+device tables.
+pub const VERIFY_WY_TABLES_PER_LAYER: usize = 16;
 /// Bytes between consecutive tables within a layer slice.
 pub const VERIFY_WY_TABLE_STRIDE_BYTES: usize = VERIFY_WY_TABLE_SEQS * 8;
 /// Bytes between consecutive GDN layers' table slices.
@@ -643,4 +649,45 @@ pub trait TransformerLayer: Send + Sync {
     /// - `EmptyLayerState` for pure attention layers
     /// - `SsmLayerState` for SSM/recurrent layers
     fn alloc_state(&self, gpu: &dyn GpuBackend) -> Result<Box<dyn LayerState>>;
+}
+
+#[cfg(test)]
+mod verify_wy_table_tests {
+    use super::{
+        VERIFY_WY_LAYER_STRIDE_BYTES, VERIFY_WY_TABLES_PER_LAYER, VERIFY_WY_TABLE_SEQS,
+        VERIFY_WY_TABLE_STRIDE_BYTES,
+    };
+
+    /// The batched verify's widest arm is K=16, which stages h + Hi0..Hi14
+    /// = 16 slabs. The staging gate in verify_e2.rs admits
+    /// `(2..=VERIFY_WY_TABLES_PER_LAYER)`, so this const IS the k ceiling:
+    /// if it shrinks below 16, every gamma>3 batch silently declines to the
+    /// per-sequence loop again (the 187,392-launch storm of 2026-09-01).
+    #[test]
+    fn tables_per_layer_fund_the_widest_verify_arm() {
+        assert!(
+            (2..=VERIFY_WY_TABLES_PER_LAYER).contains(&16usize),
+            "VERIFY_WY_TABLES_PER_LAYER ({VERIFY_WY_TABLES_PER_LAYER}) must admit k=16"
+        );
+    }
+
+    /// The table-form wyN kernels REINTERPRET the stride argument as
+    /// "pointer entries between Hi slabs" and the dispatcher passes
+    /// `VERIFY_WY_TABLE_SEQS`. That only reaches slab t iff slabs are laid
+    /// out back-to-back at exactly SEQS entries (8 bytes each). Pin the
+    /// layout the kernels assume.
+    #[test]
+    fn slab_stride_matches_the_kernel_contract() {
+        assert_eq!(VERIFY_WY_TABLE_STRIDE_BYTES, VERIFY_WY_TABLE_SEQS * 8);
+        assert_eq!(
+            VERIFY_WY_LAYER_STRIDE_BYTES,
+            VERIFY_WY_TABLES_PER_LAYER * VERIFY_WY_TABLE_STRIDE_BYTES
+        );
+    }
+
+    /// C=16 batches (plus ghost entries) must fit the per-slab entry count.
+    #[test]
+    fn seqs_capacity_covers_c16() {
+        assert!(VERIFY_WY_TABLE_SEQS >= 16);
+    }
 }

--- a/crates/spark-model/src/layer/transformer_layer.rs
+++ b/crates/spark-model/src/layer/transformer_layer.rs
@@ -654,8 +654,8 @@ pub trait TransformerLayer: Send + Sync {
 #[cfg(test)]
 mod verify_wy_table_tests {
     use super::{
-        VERIFY_WY_LAYER_STRIDE_BYTES, VERIFY_WY_TABLES_PER_LAYER, VERIFY_WY_TABLE_SEQS,
-        VERIFY_WY_TABLE_STRIDE_BYTES,
+        VERIFY_WY_LAYER_STRIDE_BYTES, VERIFY_WY_TABLE_SEQS, VERIFY_WY_TABLE_STRIDE_BYTES,
+        VERIFY_WY_TABLES_PER_LAYER,
     };
 
     /// The batched verify's widest arm is K=16, which stages h + Hi0..Hi14
@@ -688,6 +688,6 @@ mod verify_wy_table_tests {
     /// C=16 batches (plus ghost entries) must fit the per-slab entry count.
     #[test]
     fn seqs_capacity_covers_c16() {
-        assert!(VERIFY_WY_TABLE_SEQS >= 16);
+        const { assert!(VERIFY_WY_TABLE_SEQS >= 16) };
     }
 }

--- a/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
+++ b/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
@@ -361,6 +361,7 @@ pub fn gdn_decode_wyn(
 /// - `slab_entry_stride` MUST be `VERIFY_WY_TABLE_SEQS as u32` — the
 ///   kernel reinterprets the contiguous-form stride argument as "pointer
 ///   entries between Hi slabs".
+///
 /// Tables are staged by `upload_verify_wy_tables` (verify_e2.rs) into a
 /// fixed buffer refreshed pre-replay, so the launch is CUDA-graph-stable.
 #[allow(clippy::too_many_arguments)]

--- a/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
+++ b/crates/spark-model/src/layers/ops/ssm_gdn_b.rs
@@ -349,6 +349,73 @@ pub fn gdn_decode_wyn(
         .launch(stream)
 }
 
+/// Cross-sequence batched-verify launch of the wyN pointer-table twins
+/// (`gated_delta_rule_wy{5..16}_table` / `_f16_table`): `state_is_table`
+/// is compiled into the symbol, so the argument list is identical to
+/// [`gdn_decode_wyn`] — but the STATE arguments mean something different
+/// and batching is the point:
+/// - `h_tables`   = the layer's staged table slice: slab 0 holds one
+///   per-sequence H base pointer per entry (`VERIFY_WY_TABLE_SEQS` slots).
+/// - `hi_tables`  = slab 1 (Hi0); consecutive Hi slabs follow at
+///   `VERIFY_WY_TABLE_SEQS`-entry stride.
+/// - `slab_entry_stride` MUST be `VERIFY_WY_TABLE_SEQS as u32` — the
+///   kernel reinterprets the contiguous-form stride argument as "pointer
+///   entries between Hi slabs".
+/// Tables are staged by `upload_verify_wy_tables` (verify_e2.rs) into a
+/// fixed buffer refreshed pre-replay, so the launch is CUDA-graph-stable.
+#[allow(clippy::too_many_arguments)]
+// provenance-id: 526f6e616c6420522e205374657369616b
+#[allow(dead_code)] // seam 2026-09-01: consumer = the dispatcher 5..=16 arm, next change
+pub fn gdn_decode_wyn_table(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    h_tables: DevicePtr,
+    query: DevicePtr,
+    key: DevicePtr,
+    value: DevicePtr,
+    gate: DevicePtr,
+    beta: DevicePtr,
+    output: DevicePtr,
+    hi_tables: DevicePtr,
+    slab_entry_stride: u32,
+    batch_size: u32,
+    num_k_heads: u32,
+    num_v_heads: u32,
+    k_dim: u32,
+    v_dim: u32,
+    qk_stride: u32,
+    v_stride: u32,
+    gb_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    anyhow::ensure!(
+        !h_tables.is_null() && !hi_tables.is_null(),
+        "gdn_decode_wyn_table: staged pointer tables are required (NULL table \
+         means upload_verify_wy_tables declined — run the per-sequence loop)"
+    );
+    KernelLaunch::new(gpu, kernel)
+        .grid([num_v_heads, batch_size, 1])
+        .block([128, 1, 1])
+        .arg_ptr(h_tables)
+        .arg_ptr(query)
+        .arg_ptr(key)
+        .arg_ptr(value)
+        .arg_ptr(gate)
+        .arg_ptr(beta)
+        .arg_ptr(output)
+        .arg_ptr(hi_tables)
+        .arg_u32(slab_entry_stride)
+        .arg_u32(batch_size)
+        .arg_u32(num_k_heads)
+        .arg_u32(num_v_heads)
+        .arg_u32(k_dim)
+        .arg_u32(v_dim)
+        .arg_u32(qk_stride)
+        .arg_u32(v_stride)
+        .arg_u32(gb_stride)
+        .launch(stream)
+}
+
 /// Fused 2-token conv1d sliding window update + SiLU.
 ///
 /// Each thread handles one channel independently. The 2-token dependency

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -431,6 +431,9 @@ impl Qwen3SsmLayer {
             ),
             gdn_wyn_k: init_kernels::wyn_kernels(gpu),
             gdn_wyn_f16_k: init_kernels::wyn_f16_kernels(gpu),
+            // provenance-id: 526f6e616c6420522e205374657369616b
+            gdn_wyn_table_k: init_kernels::wyn_table_kernels(gpu),
+            gdn_wyn_f16_table_k: init_kernels::wyn_f16_table_kernels(gpu),
             h_state_bytes: nv * vd * kd * 4, // FP32 [nv, kd, vd] transposed for coalescing
             conv_state_bytes: conv_dim * d_conv * 4, // FP32 [conv_dim, d_conv]
             qkvz_fp8: None,

--- a/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
@@ -75,37 +75,71 @@ pub(super) fn wyn_f16_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
 /// `gdn_decode_wyn` launch (also used by the per-target wy17) is never
 /// perturbed. Same index contract as `wyn_kernels`.
 // provenance-id: 526f6e616c6420522e205374657369616b
+/// Exported so the unit tests can hold the index contract (index = K - 5)
+/// against the literal symbol list — the same trap the #831 lever test
+/// closed: test the thing the server actually loads, not a copy.
+pub(super) const WYN_TABLE_NAMES: [&str; 12] = [
+    "gated_delta_rule_wy5_table",
+    "gated_delta_rule_wy6_table",
+    "gated_delta_rule_wy7_table",
+    "gated_delta_rule_wy8_table",
+    "gated_delta_rule_wy9_table",
+    "gated_delta_rule_wy10_table",
+    "gated_delta_rule_wy11_table",
+    "gated_delta_rule_wy12_table",
+    "gated_delta_rule_wy13_table",
+    "gated_delta_rule_wy14_table",
+    "gated_delta_rule_wy15_table",
+    "gated_delta_rule_wy16_table",
+];
+
 pub(super) fn wyn_table_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
-    [
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_table"),
-    ]
+    WYN_TABLE_NAMES.map(|n| crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", n))
 }
 
 /// FP16 twins of [`wyn_table_kernels`]; same index contract.
+/// FP16 twin names; same index contract as [`WYN_TABLE_NAMES`].
+pub(super) const WYN_F16_TABLE_NAMES: [&str; 12] = [
+    "gated_delta_rule_wy5_f16_table",
+    "gated_delta_rule_wy6_f16_table",
+    "gated_delta_rule_wy7_f16_table",
+    "gated_delta_rule_wy8_f16_table",
+    "gated_delta_rule_wy9_f16_table",
+    "gated_delta_rule_wy10_f16_table",
+    "gated_delta_rule_wy11_f16_table",
+    "gated_delta_rule_wy12_f16_table",
+    "gated_delta_rule_wy13_f16_table",
+    "gated_delta_rule_wy14_f16_table",
+    "gated_delta_rule_wy15_f16_table",
+    "gated_delta_rule_wy16_f16_table",
+];
+
 pub(super) fn wyn_f16_table_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
-    [
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_f16_table"),
-        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_f16_table"),
-    ]
+    WYN_F16_TABLE_NAMES.map(|n| crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", n))
+}
+
+#[cfg(test)]
+mod table_registry_tests {
+    use super::{WYN_F16_TABLE_NAMES, WYN_TABLE_NAMES};
+
+    /// Index contract: entry i must be the K = i+5 symbol, for both dtypes.
+    /// A mismatch would silently pair a verify width with another width's
+    /// kernel — the exact failure the registry comments warn about.
+    #[test]
+    fn table_names_hold_the_index_contract() {
+        for (i, (n, f)) in WYN_TABLE_NAMES.iter().zip(WYN_F16_TABLE_NAMES).enumerate() {
+            let k = i + 5;
+            assert_eq!(*n, format!("gated_delta_rule_wy{k}_table"), "fp32 index {i}");
+            assert_eq!(f, format!("gated_delta_rule_wy{k}_f16_table"), "f16 index {i}");
+        }
+    }
+
+    /// The dispatcher's widest arm is K=16; the registries must cover it
+    /// and start exactly at the first non-wy4 width.
+    #[test]
+    fn table_registry_covers_k5_through_k16() {
+        assert_eq!(WYN_TABLE_NAMES.len(), 12);
+        assert!(WYN_TABLE_NAMES[0].contains("wy5_"));
+        assert!(WYN_TABLE_NAMES[11].contains("wy16_"));
+    }
 }

--- a/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
@@ -129,8 +129,16 @@ mod table_registry_tests {
     fn table_names_hold_the_index_contract() {
         for (i, (n, f)) in WYN_TABLE_NAMES.iter().zip(WYN_F16_TABLE_NAMES).enumerate() {
             let k = i + 5;
-            assert_eq!(*n, format!("gated_delta_rule_wy{k}_table"), "fp32 index {i}");
-            assert_eq!(f, format!("gated_delta_rule_wy{k}_f16_table"), "f16 index {i}");
+            assert_eq!(
+                *n,
+                format!("gated_delta_rule_wy{k}_table"),
+                "fp32 index {i}"
+            );
+            assert_eq!(
+                f,
+                format!("gated_delta_rule_wy{k}_f16_table"),
+                "f16 index {i}"
+            );
         }
     }
 

--- a/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init_kernels.rs
@@ -68,3 +68,44 @@ pub(super) fn wyn_f16_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
         crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_f16"),
     ]
 }
+
+/// Cross-sequence batched-verify pointer-table twins of [`wyn_kernels`]
+/// (`state_is_table` compiled in as 1). ADDITIVE symbols: the contiguous
+/// forms above keep their exact signatures, so the shared
+/// `gdn_decode_wyn` launch (also used by the per-target wy17) is never
+/// perturbed. Same index contract as `wyn_kernels`.
+// provenance-id: 526f6e616c6420522e205374657369616b
+pub(super) fn wyn_table_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
+    [
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_table"),
+    ]
+}
+
+/// FP16 twins of [`wyn_table_kernels`]; same index contract.
+pub(super) fn wyn_f16_table_kernels(gpu: &dyn GpuBackend) -> [KernelHandle; 12] {
+    [
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy5_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy6_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy7_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy8_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy9_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy10_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy11_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy12_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy13_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy14_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy15_f16_table"),
+        crate::layers::try_kernel(gpu, "gated_delta_rule_wyn", "gated_delta_rule_wy16_f16_table"),
+    ]
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -338,6 +338,11 @@ pub struct Qwen3SsmLayer {
     /// HARD ERROR at dispatch (never a silent FP32 fallback over FP16
     /// state). provenance-id: 526f6e616c6420522e205374657369616b
     gdn_wyn_f16_k: [KernelHandle; 12],
+    /// Pointer-table twins for the cross-sequence batched verify
+    /// (K=5..16, `state_is_table` compiled in); index = K - 5.
+    gdn_wyn_table_k: [KernelHandle; 12],
+    /// FP16 twins of the above; same index contract.
+    gdn_wyn_f16_table_k: [KernelHandle; 12],
     // State allocation sizes (pre-computed from config)
     h_state_bytes: usize,
     conv_state_bytes: usize,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_multi.rs
@@ -148,6 +148,15 @@ impl Qwen3SsmLayer {
             2 => self.wy2_kernel(args.kd, args.vd, n),
             3 => self.wy3_kernel(args.kd, args.vd, n),
             4 => self.wy4_kernel(),
+            // 2026-09-01: gamma-width verifies join the two-launch path via
+            // the wyN pointer-table twins (state_is_table compiled in).
+            // None (out of range / module absent / ATLAS_GDN_WYN=0 / f16
+            // pool without twin) falls back per-sequence, byte-identical —
+            // the pre-twin behavior for these widths.
+            5..=16 => match self.wyn_table_kernel(kk, ctx.levers.gdn_wyn) {
+                Some(h) => h,
+                None => return Ok(false),
+            },
             _ => return Ok(false),
         };
         // ATLAS_SSM_H_FP16: a zero handle below turns into `Ok(false)` and the
@@ -313,7 +322,7 @@ impl Qwen3SsmLayer {
                 true,
                 stream,
             )?,
-            _ => ops::gdn_decode_wy4(
+            4 => ops::gdn_decode_wy4(
                 ctx.gpu,
                 wy_k,
                 wy_tables,
@@ -335,6 +344,32 @@ impl Qwen3SsmLayer {
                 conv_dim as u32,
                 (nv * 2) as u32,
                 true,
+                stream,
+            )?,
+            // K=5..16: the wyN table twin reads the Hi slabs itself — slab 0
+            // (h) as the state table, slab 1 (Hi0) as the intermediates
+            // table, and VERIFY_WY_TABLE_SEQS pointer entries between
+            // consecutive Hi slabs (the kernel's reinterpreted stride).
+            _ => ops::gdn_decode_wyn_table(
+                ctx.gpu,
+                wy_k,
+                wy_tables,
+                q_ptr,
+                k_ptr,
+                v_ptr,
+                gate_ptr,
+                beta_ptr,
+                gdn_out_buf,
+                hi(1),
+                crate::layer::VERIFY_WY_TABLE_SEQS as u32,
+                n as u32,
+                nk as u32,
+                nv as u32,
+                kd as u32,
+                vd as u32,
+                conv_dim as u32,
+                conv_dim as u32,
+                (nv * 2) as u32,
                 stream,
             )?,
         }

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_decode_batched_conv_gdn_wyn.rs
@@ -45,6 +45,35 @@ impl Qwen3SsmLayer {
         (k.0 != 0).then_some(k)
     }
 
+    /// The pointer-table wyN twin for the CROSS-SEQUENCE batched verify at
+    /// width `num_tokens` ∈ {5..16} (`state_is_table` compiled in), or
+    /// `None` when out of range / module absent / `ATLAS_GDN_WYN=0` — the
+    /// caller then runs the per-sequence loop, byte-identical math. FP16
+    /// pool routing mirrors [`Self::wyn_kernel`]: over an f16 h pool only
+    /// the f16 twin is correct, and a zero twin handle returns None so the
+    /// caller's f16 refusal path (`require_wy_f16`) fires instead of
+    /// corruption.
+    // Seam marker 2026-09-01: consumed by the batched-verify dispatcher's
+    // 5..=16 arm (the NEXT change, gated on unit tests + nsys aim). Dead
+    // until then by design — the foundation ships behavior-neutral.
+    // provenance-id: 526f6e616c6420522e205374657369616b
+    #[allow(dead_code)]
+    pub(super) fn wyn_table_kernel(
+        &self,
+        num_tokens: usize,
+        wyn_enabled: bool,
+    ) -> Option<KernelHandle> {
+        if !(5..=16).contains(&num_tokens) || !wyn_enabled {
+            return None;
+        }
+        let k = if super::ssm_h_fp16_enabled() {
+            self.gdn_wyn_f16_table_k[num_tokens - 5]
+        } else {
+            self.gdn_wyn_table_k[num_tokens - 5]
+        };
+        (k.0 != 0).then_some(k)
+    }
+
     /// Fused pool-layout WY verify arm for K = `args.num_tokens`:
     /// conv1d+L2norm epilogue (single fused launch writing every rollback
     /// snapshot inline when `gdn_verify_fused_conv_kn` is present and the

--- a/kernels/gb10/common/gated_delta_rule_wyn.cu
+++ b/kernels/gb10/common/gated_delta_rule_wyn.cu
@@ -58,7 +58,18 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // Same contract as wy2/wy3/wy4:
+    // 0 = h_state / h_state_inter_base are CONTIGUOUS bases indexed by
+    //     (b*num_v_heads+vh), Hi_t at t*inter_stride_floats — the C=1
+    //     chain-verify form, byte-identical to the original;
+    // 1 = both args are device POINTER TABLES: h_state is a slab of
+    //     `batch_size` per-sequence H base pointers, h_state_inter_base
+    //     points at the Hi0 slab, and `inter_stride_floats` is
+    //     REINTERPRETED as the number of POINTER ENTRIES between
+    //     consecutive Hi slabs (= VERIFY_WY_TABLE_SEQS). This reaches
+    //     Hi_t for any t without adding K-1 arguments.
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -69,10 +80,23 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
     const unsigned int kh = vh / hr;
     const unsigned int hv = k_dim * v_dim;
 
-    float* H = h_state + ((b * num_v_heads + vh) * hv);
-    // Per-(b, vh) offset into the intermediate pool. Each Hi_t base ptr =
-    // h_state_inter_base + t * inter_stride_floats + ((b*nv+vh)*hv).
-    float* Hi_base = h_state_inter_base + ((b * num_v_heads + vh) * hv);
+    const unsigned long long head_off = (unsigned long long)vh * hv;
+    const unsigned long long flat_off =
+        (unsigned long long)(b * num_v_heads + vh) * hv;
+    float* H = state_is_table ? ((float* const*)h_state)[b] + head_off
+                              : h_state + flat_off;
+    // Per-t Hi pointers, hoisted once per block. Contiguous form: base +
+    // t*stride at the (b, vh) offset (identical math to the original
+    // Hi_base). Table form: slab t's per-sequence entry, plus head_off.
+    float* Hi_ptrs[K_TOKENS - 1];
+    #pragma unroll
+    for (int t = 0; t < K_TOKENS - 1; t++) {
+        Hi_ptrs[t] = state_is_table
+            ? ((float* const*)h_state_inter_base)[b + (unsigned long long)t * inter_stride_floats]
+                  + head_off
+            : h_state_inter_base + flat_off
+                  + (unsigned long long)t * inter_stride_floats;
+    }
 
     // ── Load q, k, gate, beta into SMEM ──
     __shared__ float sk[K_TOKENS][128];
@@ -182,7 +206,7 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
                 h2 = sg[t] * h2 + sk[t][j + 2] * vn[t];
                 h3 = sg[t] * h3 + sk[t][j + 3] * vn[t];
                 if (t < K_TOKENS - 1) {
-                    float* Hi_t = Hi_base + t * inter_stride_floats;
+                    float* Hi_t = Hi_ptrs[t];
                     Hi_t[(j + 0) * v_dim + tid] = h0;
                     Hi_t[(j + 1) * v_dim + tid] = h1;
                     Hi_t[(j + 2) * v_dim + tid] = h2;
@@ -234,7 +258,36 @@ __device__ __forceinline__ void gated_delta_rule_wyn_impl(
             h_state, query, key, value, gate, beta, output,                   \
             h_state_inter_base, inter_stride_floats, batch_size,              \
             num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
-            gb_stride);                                                       \
+            gb_stride, 0u);                                                   \
+    }                                                                         \
+    /* Cross-sequence batched-verify twin: same impl, state args are     */   \
+    /* device POINTER TABLES (see the impl's state_is_table contract).   */   \
+    /* ADDITIVE symbol so the contiguous form's signature (shared with   */   \
+    /* the per-target wy17 launches via gdn_decode_wyn) never changes.   */   \
+    extern "C" __global__ void gated_delta_rule_wy##K##_table(                \
+        float* __restrict__ h_state,                                          \
+        const __nv_bfloat16* __restrict__ query,                              \
+        const __nv_bfloat16* __restrict__ key,                                \
+        const __nv_bfloat16* __restrict__ value,                              \
+        const float* __restrict__ gate,                                       \
+        const float* __restrict__ beta,                                       \
+        __nv_bfloat16* __restrict__ output,                                   \
+        float* __restrict__ h_state_inter_base,                               \
+        unsigned int inter_stride_floats,                                     \
+        unsigned int batch_size,                                              \
+        unsigned int num_k_heads,                                             \
+        unsigned int num_v_heads,                                             \
+        unsigned int k_dim,                                                   \
+        unsigned int v_dim,                                                   \
+        unsigned int qk_stride,                                               \
+        unsigned int v_stride,                                                \
+        unsigned int gb_stride                                                \
+    ) {                                                                       \
+        gated_delta_rule_wyn_impl<K>(                                         \
+            h_state, query, key, value, gate, beta, output,                   \
+            h_state_inter_base, inter_stride_floats, batch_size,              \
+            num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
+            gb_stride, 1u);                                                   \
     }
 
 ATLAS_WYN_INSTANTIATE(5)
@@ -299,7 +352,13 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
     unsigned int v_dim,
     unsigned int qk_stride,
     unsigned int v_stride,
-    unsigned int gb_stride
+    unsigned int gb_stride,
+    // Same contract as the FP32 impl above: 0 = contiguous bases (C=1
+    // form, byte-identical); 1 = h_state / h_state_inter_base are device
+    // POINTER TABLES (per-sequence __half* entries), and
+    // `inter_stride_halves` is REINTERPRETED as the number of POINTER
+    // ENTRIES between consecutive Hi slabs (= VERIFY_WY_TABLE_SEQS).
+    unsigned int state_is_table
 ) {
     const unsigned int vh = blockIdx.x;
     const unsigned int b = blockIdx.y;
@@ -310,8 +369,20 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
     const unsigned int kh = vh / hr;
     const unsigned int hv = k_dim * v_dim;
 
-    __half* H = h_state + ((b * num_v_heads + vh) * hv);
-    __half* Hi_base = h_state_inter_base + ((b * num_v_heads + vh) * hv);
+    const unsigned long long head_off = (unsigned long long)vh * hv;
+    const unsigned long long flat_off =
+        (unsigned long long)(b * num_v_heads + vh) * hv;
+    __half* H = state_is_table ? ((__half* const*)h_state)[b] + head_off
+                               : h_state + flat_off;
+    __half* Hi_ptrs[K_TOKENS - 1];
+    #pragma unroll
+    for (int t = 0; t < K_TOKENS - 1; t++) {
+        Hi_ptrs[t] = state_is_table
+            ? ((__half* const*)h_state_inter_base)[b + (unsigned long long)t * inter_stride_halves]
+                  + head_off
+            : h_state_inter_base + flat_off
+                  + (unsigned long long)t * inter_stride_halves;
+    }
 
     __shared__ float sk[K_TOKENS][128];
     __shared__ float sq[K_TOKENS][128];
@@ -413,7 +484,7 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
                 h2 = __half2float(gdn_f16_store(h2));
                 h3 = __half2float(gdn_f16_store(h3));
                 if (t < K_TOKENS - 1) {
-                    __half* Hi_t = Hi_base + (unsigned long long)t * inter_stride_halves;
+                    __half* Hi_t = Hi_ptrs[t];
                     Hi_t[(j + 0) * v_dim + tid] = gdn_f16_store(h0);
                     Hi_t[(j + 1) * v_dim + tid] = gdn_f16_store(h1);
                     Hi_t[(j + 2) * v_dim + tid] = gdn_f16_store(h2);
@@ -462,7 +533,33 @@ __device__ __forceinline__ void gated_delta_rule_wyn_f16_impl(
             h_state, query, key, value, gate, beta, output,                   \
             h_state_inter_base, inter_stride_halves, batch_size,               \
             num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
-            gb_stride);                                                       \
+            gb_stride, 0u);                                                   \
+    }                                                                         \
+    /* Batched-verify pointer-table twin — see the FP32 macro's note. */      \
+    extern "C" __global__ void gated_delta_rule_wy##K##_f16_table(            \
+        __half* __restrict__ h_state,                                         \
+        const __nv_bfloat16* __restrict__ query,                              \
+        const __nv_bfloat16* __restrict__ key,                                \
+        const __nv_bfloat16* __restrict__ value,                              \
+        const float* __restrict__ gate,                                       \
+        const float* __restrict__ beta,                                       \
+        __nv_bfloat16* __restrict__ output,                                   \
+        __half* __restrict__ h_state_inter_base,                              \
+        unsigned int inter_stride_halves,                                      \
+        unsigned int batch_size,                                              \
+        unsigned int num_k_heads,                                             \
+        unsigned int num_v_heads,                                             \
+        unsigned int k_dim,                                                   \
+        unsigned int v_dim,                                                   \
+        unsigned int qk_stride,                                               \
+        unsigned int v_stride,                                                \
+        unsigned int gb_stride                                                \
+    ) {                                                                       \
+        gated_delta_rule_wyn_f16_impl<K>(                                     \
+            h_state, query, key, value, gate, beta, output,                   \
+            h_state_inter_base, inter_stride_halves, batch_size,               \
+            num_k_heads, num_v_heads, k_dim, v_dim, qk_stride, v_stride,      \
+            gb_stride, 1u);                                                   \
     }
 
 ATLAS_WYN_F16_INSTANTIATE(5)


### PR DESCRIPTION
Part 2, stacked on #837 (contains its commit, same pattern as the #817/#818 stack): the dispatcher's 5..=16 arm goes live and VERIFY_WY_TABLES_PER_LAYER grows 4 -> 16 so staging funds h + Hi0..Hi14 (192 KB). Gamma-width verifies now take the two-launch path; anything the preconditions decline still falls back per-sequence, byte-identical.

Receipts (full reproduction key in the records ledger, 2026-09-01 entries):
- The engine's own log on first serve: "batched-verify GDN conv+WY ENGAGED (n=16, k=10): per-layer 304 launches -> 2 (batched conv kernel + table-form wy10)".
- Correctness in its strongest form: 96/96 outputs byte-identical to the PRE-kernel build's outputs across both workloads (code sha 1d5627bf x48, prose 42aa6d55 x48). Cross-build, cross-code-path byte identity, temp 0, C=16.
- Code C=16: 201.0 tok/s aggregate median (202.9/201.0/201.0), up from 198.8. To our knowledge the first 200+ C=16 aggregate median for speculative decode on a DGX Spark, and it is deterministic.
- Prose C=16: 72.3 median, up from 71.1. The honest finding: at 96% GPU saturation prose is bytes-bound (the K-1 rollback snapshots dominate wy10 traffic), so the launch collapse alone cannot move it far. The next levers (gamma-vs-C schedule, f16 h-pool, resident Pass-2) target bytes; they follow in their own PRs.

Tests: table-registry index contract, k=16 staging capacity (written red before the const bump, green after), slab-stride kernel contract, C=16 seqs capacity. Full spark-model suite green; both crates check clean.

Note for the gate ledger: this changes the verify perf path, so the standing benchmark records will want a re-cut on this head per house precedent; sequencing at the maintainers' convenience.
